### PR TITLE
feat(engine): Think/Recall/Sessions intelligence layer

### DIFF
--- a/src/brainlayer/engine.py
+++ b/src/brainlayer/engine.py
@@ -1,0 +1,404 @@
+"""Think/Recall Engine — Intelligence layer for BrainLayer.
+
+Turns BrainLayer from "search your conversations" into "AI that remembers everything."
+
+Three capabilities:
+- think(context) — given current task, retrieve relevant past decisions/patterns
+- recall(file_path|topic) — proactive retrieval based on what you're working on
+- sessions(project, days) — browse sessions by date/project
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any
+
+from .vector_store import VectorStore
+
+logger = logging.getLogger(__name__)
+
+# Intent categories for grouping think results
+DECISION_INTENTS = {"deciding", "designing"}
+DEBUG_INTENTS = {"debugging"}
+IMPLEMENT_INTENTS = {"implementing", "configuring"}
+REVIEW_INTENTS = {"reviewing", "discussing"}
+
+
+@dataclass
+class ThinkResult:
+    """Structured result from think()."""
+
+    decisions: list[dict[str, Any]] = field(default_factory=list)
+    patterns: list[dict[str, Any]] = field(default_factory=list)
+    bugs: list[dict[str, Any]] = field(default_factory=list)
+    context: list[dict[str, Any]] = field(default_factory=list)
+    query: str = ""
+    total: int = 0
+
+    def format(self) -> str:
+        """Format as markdown for MCP response."""
+        if self.total == 0:
+            return "No relevant memories found."
+
+        parts = [f"## Relevant Memories for: {self.query}\n"]
+
+        if self.decisions:
+            parts.append("### Decisions & Design")
+            for item in self.decisions:
+                parts.append(_format_memory_item(item))
+
+        if self.patterns:
+            parts.append("\n### Patterns & Implementations")
+            for item in self.patterns:
+                parts.append(_format_memory_item(item))
+
+        if self.bugs:
+            parts.append("\n### Related Bugs & Fixes")
+            for item in self.bugs:
+                parts.append(_format_memory_item(item))
+
+        if self.context:
+            parts.append("\n### Related Context")
+            for item in self.context:
+                parts.append(_format_memory_item(item))
+
+        parts.append(f"\n*{self.total} memories retrieved*")
+        return "\n".join(parts)
+
+
+@dataclass
+class RecallResult:
+    """Structured result from recall()."""
+
+    file_history: list[dict[str, Any]] = field(default_factory=list)
+    related_chunks: list[dict[str, Any]] = field(default_factory=list)
+    session_summaries: list[dict[str, Any]] = field(default_factory=list)
+    target: str = ""
+
+    def format(self) -> str:
+        """Format as markdown for MCP response."""
+        if not self.file_history and not self.related_chunks:
+            return f"No recall data found for '{self.target}'."
+
+        parts = [f"## Recall: {self.target}\n"]
+
+        if self.file_history:
+            parts.append("### File History")
+            for item in self.file_history:
+                ts = (item.get("timestamp") or "?")[:19]
+                action = item.get("action", "?")
+                session = (item.get("session_id") or "?")[:8]
+                parts.append(f"- **{action}** at {ts} (session: {session})")
+
+        if self.session_summaries:
+            parts.append("\n### Sessions That Touched This")
+            for s in self.session_summaries:
+                sid = (s.get("session_id") or "?")[:8]
+                branch = s.get("branch") or "?"
+                plan = s.get("plan_name") or ""
+                ts = (s.get("started_at") or "?")[:19]
+                line = f"- {sid} | {branch}"
+                if plan:
+                    line += f" | plan: {plan}"
+                line += f" | {ts}"
+                parts.append(line)
+
+        if self.related_chunks:
+            parts.append("\n### Related Knowledge")
+            for item in self.related_chunks:
+                parts.append(_format_memory_item(item))
+
+        return "\n".join(parts)
+
+
+@dataclass
+class SessionInfo:
+    """A single session entry."""
+
+    session_id: str = ""
+    project: str = ""
+    branch: str = ""
+    started_at: str = ""
+    ended_at: str = ""
+    plan_name: str = ""
+    plan_phase: str = ""
+    files_changed: list[str] = field(default_factory=list)
+
+
+def _format_memory_item(item: dict[str, Any]) -> str:
+    """Format a single memory item as compact markdown."""
+    summary = item.get("summary") or ""
+    content = item.get("content", "")
+    date = (item.get("created_at") or "")[:10]
+    project = item.get("project", "")
+    importance = item.get("importance")
+
+    # Use summary if available, otherwise truncate content
+    display = summary if summary else (content[:200] + "..." if len(content) > 200 else content)
+
+    line = "- "
+    if date:
+        line += f"[{date}] "
+    if project:
+        line += f"({project}) "
+    if importance is not None and importance >= 7:
+        line += "**"
+    line += display
+    if importance is not None and importance >= 7:
+        line += "**"
+    return line
+
+
+def categorize_by_intent(items: list[dict[str, Any]]) -> ThinkResult:
+    """Categorize search results by their intent metadata."""
+    result = ThinkResult()
+
+    for item in items:
+        intent = item.get("intent", "")
+
+        if intent in DECISION_INTENTS:
+            result.decisions.append(item)
+        elif intent in DEBUG_INTENTS:
+            result.bugs.append(item)
+        elif intent in IMPLEMENT_INTENTS:
+            result.patterns.append(item)
+        else:
+            result.context.append(item)
+
+    result.total = len(items)
+    return result
+
+
+def think(
+    context: str,
+    store: VectorStore,
+    embed_fn: Any,
+    project: str | None = None,
+    max_results: int = 10,
+) -> ThinkResult:
+    """Given current task context, retrieve relevant past knowledge.
+
+    Args:
+        context: Free-text description of current task/context
+        store: VectorStore instance
+        embed_fn: Function that takes text and returns embedding vector
+        project: Optional project filter
+        max_results: Maximum results to return
+
+    Returns:
+        ThinkResult with categorized memories
+    """
+    if not context or not context.strip():
+        return ThinkResult(query=context or "")
+
+    query = context.strip()
+
+    # Generate embedding
+    query_embedding = embed_fn(query)
+
+    # Search with importance bias — prefer high-value memories
+    results = store.hybrid_search(
+        query_embedding=query_embedding,
+        query_text=query,
+        n_results=max_results,
+        project_filter=project,
+        importance_min=3.0,  # Skip low-importance noise
+    )
+
+    if not results["documents"][0]:
+        return ThinkResult(query=query)
+
+    # Build items with metadata
+    items = []
+    for doc, meta in zip(results["documents"][0], results["metadatas"][0]):
+        items.append(
+            {
+                "content": doc,
+                "summary": meta.get("summary"),
+                "intent": meta.get("intent", ""),
+                "importance": meta.get("importance"),
+                "project": meta.get("project", ""),
+                "created_at": meta.get("created_at", ""),
+                "content_type": meta.get("content_type", ""),
+                "tags": meta.get("tags", []),
+            }
+        )
+
+    result = categorize_by_intent(items)
+    result.query = query
+    return result
+
+
+def recall(
+    store: VectorStore,
+    embed_fn: Any | None = None,
+    file_path: str | None = None,
+    topic: str | None = None,
+    project: str | None = None,
+    max_results: int = 10,
+) -> RecallResult:
+    """Proactive smart retrieval based on file or topic.
+
+    Args:
+        store: VectorStore instance
+        embed_fn: Function that takes text and returns embedding vector (needed for topic recall)
+        file_path: File path to recall context for
+        topic: Topic to recall context for
+        project: Optional project filter
+        max_results: Maximum results to return
+
+    Returns:
+        RecallResult with file history, sessions, and related knowledge
+    """
+    target = file_path or topic or ""
+    result = RecallResult(target=target)
+
+    if file_path:
+        # Get file interaction timeline
+        timeline = store.get_file_timeline(file_path, project=project, limit=max_results * 2)
+        result.file_history = timeline
+
+        # Get sessions that touched this file
+        session_ids = list({t.get("session_id") for t in timeline if t.get("session_id")})
+        for sid in session_ids[:5]:
+            ctx = store.get_session_context(sid)
+            if ctx:
+                result.session_summaries.append(ctx)
+
+        # Search for related knowledge about this file
+        if embed_fn:
+            # Use filename as search query
+            fname = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
+            query_embedding = embed_fn(f"working on {fname}")
+            search_results = store.hybrid_search(
+                query_embedding=query_embedding,
+                query_text=fname,
+                n_results=max_results,
+                project_filter=project,
+            )
+            for doc, meta in zip(search_results["documents"][0], search_results["metadatas"][0]):
+                result.related_chunks.append(
+                    {
+                        "content": doc,
+                        "summary": meta.get("summary"),
+                        "intent": meta.get("intent", ""),
+                        "importance": meta.get("importance"),
+                        "project": meta.get("project", ""),
+                        "created_at": meta.get("created_at", ""),
+                    }
+                )
+
+    elif topic and embed_fn:
+        # Topic-based recall — search for related discussions
+        query_embedding = embed_fn(topic)
+        search_results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text=topic,
+            n_results=max_results,
+            project_filter=project,
+        )
+        for doc, meta in zip(search_results["documents"][0], search_results["metadatas"][0]):
+            result.related_chunks.append(
+                {
+                    "content": doc,
+                    "summary": meta.get("summary"),
+                    "intent": meta.get("intent", ""),
+                    "importance": meta.get("importance"),
+                    "project": meta.get("project", ""),
+                    "created_at": meta.get("created_at", ""),
+                }
+            )
+
+    return result
+
+
+def sessions(
+    store: VectorStore,
+    project: str | None = None,
+    days: int = 7,
+    limit: int = 20,
+) -> list[SessionInfo]:
+    """List recent sessions with metadata.
+
+    Args:
+        store: VectorStore instance
+        project: Optional project filter
+        days: How many days back to look
+        limit: Maximum sessions to return
+
+    Returns:
+        List of SessionInfo objects
+    """
+    cursor = store.conn.cursor()
+
+    date_from = (datetime.now() - timedelta(days=days)).isoformat()
+
+    where_clauses = ["started_at >= ?"]
+    params: list = [date_from]
+
+    if project:
+        where_clauses.append("project = ?")
+        params.append(project)
+
+    params.append(limit)
+
+    query = f"""
+        SELECT session_id, project, branch, started_at, ended_at,
+               plan_name, plan_phase, files_changed
+        FROM session_context
+        WHERE {" AND ".join(where_clauses)}
+        ORDER BY started_at DESC
+        LIMIT ?
+    """
+
+    rows = list(cursor.execute(query, params))
+
+    results = []
+    for row in rows:
+        files = []
+        if row[7]:
+            try:
+                files = json.loads(row[7])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        results.append(
+            SessionInfo(
+                session_id=row[0] or "",
+                project=row[1] or "",
+                branch=row[2] or "",
+                started_at=row[3] or "",
+                ended_at=row[4] or "",
+                plan_name=row[5] or "",
+                plan_phase=row[6] or "",
+                files_changed=files if isinstance(files, list) else [],
+            )
+        )
+
+    return results
+
+
+def format_sessions(session_list: list[SessionInfo], days: int = 7) -> str:
+    """Format sessions list as markdown."""
+    if not session_list:
+        return f"No sessions found in the last {days} days."
+
+    parts = [f"## Recent Sessions (last {days} days)\n"]
+
+    for s in session_list:
+        ts = s.started_at[:19] if s.started_at else "?"
+        line = f"- **{s.session_id[:8]}** | {s.project or '?'} | {s.branch or '?'}"
+        if s.plan_name:
+            line += f" | plan: {s.plan_name}"
+            if s.plan_phase:
+                line += f"/{s.plan_phase}"
+        line += f" | {ts}"
+        if s.files_changed:
+            line += f" | {len(s.files_changed)} files"
+        parts.append(line)
+
+    parts.append(f"\n*{len(session_list)} sessions*")
+    return "\n".join(parts)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,356 @@
+"""Tests for engine.py — Think/Recall/Sessions intelligence layer.
+
+Split into:
+- Unit tests: categorization, formatting (no DB/embedding needed)
+- Integration tests: real DB queries (marked slow, need DB)
+"""
+
+import pytest
+
+from brainlayer.engine import (
+    RecallResult,
+    SessionInfo,
+    ThinkResult,
+    _format_memory_item,
+    categorize_by_intent,
+    format_sessions,
+)
+
+# ── Unit Tests: Categorization ──────────────────────────────────────
+
+
+class TestCategorizeByIntent:
+    """Test intent-based categorization of search results."""
+
+    def test_empty_items(self):
+        """Empty input returns empty ThinkResult."""
+        result = categorize_by_intent([])
+        assert result.total == 0
+        assert result.decisions == []
+        assert result.patterns == []
+        assert result.bugs == []
+        assert result.context == []
+
+    def test_decisions_categorized(self):
+        """Items with deciding/designing intent go to decisions."""
+        items = [
+            {"content": "Decided to use JWT", "intent": "deciding", "importance": 8},
+            {"content": "Designed auth flow", "intent": "designing", "importance": 7},
+        ]
+        result = categorize_by_intent(items)
+        assert len(result.decisions) == 2
+        assert result.total == 2
+
+    def test_bugs_categorized(self):
+        """Items with debugging intent go to bugs."""
+        items = [
+            {"content": "Fixed EADDRINUSE crash", "intent": "debugging", "importance": 9},
+        ]
+        result = categorize_by_intent(items)
+        assert len(result.bugs) == 1
+        assert result.patterns == []
+
+    def test_patterns_categorized(self):
+        """Items with implementing/configuring intent go to patterns."""
+        items = [
+            {"content": "Implemented retry logic", "intent": "implementing"},
+            {"content": "Configured Railway env", "intent": "configuring"},
+        ]
+        result = categorize_by_intent(items)
+        assert len(result.patterns) == 2
+
+    def test_unknown_intent_goes_to_context(self):
+        """Items with unknown or empty intent go to context."""
+        items = [
+            {"content": "Some discussion", "intent": "discussing"},
+            {"content": "No intent", "intent": ""},
+            {"content": "None intent"},
+        ]
+        result = categorize_by_intent(items)
+        assert len(result.context) == 3
+
+    def test_mixed_intents(self):
+        """Mixed intents are categorized correctly."""
+        items = [
+            {"content": "Decision A", "intent": "deciding"},
+            {"content": "Bug fix B", "intent": "debugging"},
+            {"content": "Pattern C", "intent": "implementing"},
+            {"content": "Context D", "intent": "discussing"},
+            {"content": "Decision E", "intent": "designing"},
+        ]
+        result = categorize_by_intent(items)
+        assert len(result.decisions) == 2
+        assert len(result.bugs) == 1
+        assert len(result.patterns) == 1
+        assert len(result.context) == 1
+        assert result.total == 5
+
+
+# ── Unit Tests: Formatting ──────────────────────────────────────────
+
+
+class TestFormatMemoryItem:
+    """Test individual memory item formatting."""
+
+    def test_basic_format(self):
+        """Basic item with content only."""
+        item = {"content": "Some memory content"}
+        result = _format_memory_item(item)
+        assert "Some memory content" in result
+        assert result.startswith("- ")
+
+    def test_with_summary(self):
+        """Summary is used instead of content when available."""
+        item = {"content": "Long content...", "summary": "Short summary"}
+        result = _format_memory_item(item)
+        assert "Short summary" in result
+        assert "Long content" not in result
+
+    def test_with_date(self):
+        """Date is included when available."""
+        item = {"content": "Memory", "created_at": "2026-02-15T10:30:00"}
+        result = _format_memory_item(item)
+        assert "[2026-02-15]" in result
+
+    def test_with_project(self):
+        """Project is included when available."""
+        item = {"content": "Memory", "project": "golems"}
+        result = _format_memory_item(item)
+        assert "(golems)" in result
+
+    def test_high_importance_bold(self):
+        """High importance items (>=7) are bolded."""
+        item = {"content": "Critical decision", "importance": 8}
+        result = _format_memory_item(item)
+        assert "**" in result
+
+    def test_low_importance_not_bold(self):
+        """Low importance items are not bolded."""
+        item = {"content": "Minor note", "importance": 3}
+        result = _format_memory_item(item)
+        assert "**" not in result
+
+    def test_long_content_truncated(self):
+        """Content longer than 200 chars is truncated."""
+        item = {"content": "x" * 500}
+        result = _format_memory_item(item)
+        assert "..." in result
+        assert len(result) < 300
+
+
+class TestThinkResultFormat:
+    """Test ThinkResult markdown formatting."""
+
+    def test_empty_result(self):
+        """Empty result returns simple message."""
+        result = ThinkResult(query="test")
+        assert result.format() == "No relevant memories found."
+
+    def test_with_decisions(self):
+        """Results with decisions include decisions header."""
+        result = ThinkResult(
+            query="authentication",
+            decisions=[{"content": "Use JWT", "intent": "deciding"}],
+            total=1,
+        )
+        formatted = result.format()
+        assert "## Relevant Memories" in formatted
+        assert "### Decisions & Design" in formatted
+        assert "Use JWT" in formatted
+
+    def test_with_all_categories(self):
+        """All category headers appear when populated."""
+        result = ThinkResult(
+            query="test",
+            decisions=[{"content": "D"}],
+            patterns=[{"content": "P"}],
+            bugs=[{"content": "B"}],
+            context=[{"content": "C"}],
+            total=4,
+        )
+        formatted = result.format()
+        assert "Decisions & Design" in formatted
+        assert "Patterns & Implementations" in formatted
+        assert "Related Bugs & Fixes" in formatted
+        assert "Related Context" in formatted
+        assert "4 memories retrieved" in formatted
+
+    def test_empty_categories_hidden(self):
+        """Empty categories don't show headers."""
+        result = ThinkResult(
+            query="test",
+            decisions=[{"content": "D"}],
+            total=1,
+        )
+        formatted = result.format()
+        assert "Decisions & Design" in formatted
+        assert "Patterns" not in formatted
+        assert "Bugs" not in formatted
+
+
+class TestRecallResultFormat:
+    """Test RecallResult markdown formatting."""
+
+    def test_empty_result(self):
+        """Empty result returns message with target."""
+        result = RecallResult(target="auth.ts")
+        assert "auth.ts" in result.format()
+        assert "No recall data" in result.format()
+
+    def test_with_file_history(self):
+        """File history is formatted correctly."""
+        result = RecallResult(
+            target="auth.ts",
+            file_history=[
+                {"action": "Read", "timestamp": "2026-02-15T10:00:00", "session_id": "abc12345xyz"},
+                {"action": "Edit", "timestamp": "2026-02-15T10:05:00", "session_id": "abc12345xyz"},
+            ],
+        )
+        formatted = result.format()
+        assert "## Recall: auth.ts" in formatted
+        assert "### File History" in formatted
+        assert "**Read**" in formatted
+        assert "**Edit**" in formatted
+
+    def test_with_session_summaries(self):
+        """Session summaries are included."""
+        result = RecallResult(
+            target="auth.ts",
+            file_history=[{"action": "Read", "timestamp": "2026-02-15", "session_id": "abc12345"}],
+            session_summaries=[
+                {"session_id": "abc12345xyz", "branch": "feat/auth", "started_at": "2026-02-15T09:00:00"},
+            ],
+        )
+        formatted = result.format()
+        assert "Sessions That Touched This" in formatted
+        assert "feat/auth" in formatted
+
+
+class TestFormatSessions:
+    """Test sessions list formatting."""
+
+    def test_empty_sessions(self):
+        """Empty list returns message."""
+        result = format_sessions([], days=7)
+        assert "No sessions found" in result
+
+    def test_basic_sessions(self):
+        """Sessions are formatted with key info."""
+        sessions_list = [
+            SessionInfo(
+                session_id="abc12345xyz",
+                project="golems",
+                branch="feat/auth",
+                started_at="2026-02-15T10:00:00",
+            ),
+        ]
+        result = format_sessions(sessions_list, days=7)
+        assert "## Recent Sessions" in result
+        assert "abc12345" in result
+        assert "golems" in result
+        assert "feat/auth" in result
+
+    def test_session_with_plan(self):
+        """Sessions with plan info show it."""
+        sessions_list = [
+            SessionInfo(
+                session_id="abc12345xyz",
+                project="golems",
+                branch="main",
+                started_at="2026-02-15T10:00:00",
+                plan_name="brainlayer-launch",
+                plan_phase="phase-3",
+            ),
+        ]
+        result = format_sessions(sessions_list)
+        assert "brainlayer-launch" in result
+        assert "phase-3" in result
+
+    def test_session_count(self):
+        """Total session count is shown."""
+        sessions_list = [
+            SessionInfo(session_id=f"id{i}", project="p", started_at="2026-02-15") for i in range(3)
+        ]
+        result = format_sessions(sessions_list)
+        assert "3 sessions" in result
+
+
+# ── Integration Tests: DB Queries ────────────────────────────────────
+
+
+class TestSessionsIntegration:
+    """Test sessions() with real DB. Requires production DB."""
+
+    @pytest.fixture(scope="class")
+    def store(self):
+        from brainlayer.paths import DEFAULT_DB_PATH
+        from brainlayer.vector_store import VectorStore
+
+        s = VectorStore(DEFAULT_DB_PATH)
+        yield s
+        s.close()
+
+    def test_sessions_returns_list(self, store):
+        """sessions() returns a list of SessionInfo objects."""
+        from brainlayer.engine import sessions
+
+        result = sessions(store, days=30, limit=5)
+        assert isinstance(result, list)
+        for s in result:
+            assert isinstance(s, SessionInfo)
+            assert s.session_id
+
+    def test_sessions_ordered_by_date(self, store):
+        """Sessions are ordered most recent first."""
+        from brainlayer.engine import sessions
+
+        result = sessions(store, days=90, limit=10)
+        if len(result) >= 2:
+            # Most recent first
+            assert result[0].started_at >= result[1].started_at
+
+    def test_sessions_project_filter(self, store):
+        """Project filter limits results."""
+        from brainlayer.engine import sessions
+
+        all_sessions = sessions(store, days=90, limit=100)
+        if all_sessions:
+            project = all_sessions[0].project
+            if project:
+                filtered = sessions(store, project=project, days=90, limit=100)
+                for s in filtered:
+                    assert s.project == project
+
+
+class TestRecallFileIntegration:
+    """Test recall() with real DB for file-based recall (no embedding needed)."""
+
+    @pytest.fixture(scope="class")
+    def store(self):
+        from brainlayer.paths import DEFAULT_DB_PATH
+        from brainlayer.vector_store import VectorStore
+
+        s = VectorStore(DEFAULT_DB_PATH)
+        yield s
+        s.close()
+
+    def test_recall_unknown_file(self, store):
+        """Recall for unknown file returns empty result."""
+        from brainlayer.engine import recall
+
+        result = recall(store, file_path="nonexistent/file/path.xyz")
+        assert isinstance(result, RecallResult)
+        assert result.file_history == []
+
+    def test_recall_known_file(self, store):
+        """Recall for a known file returns history."""
+        from brainlayer.engine import recall
+
+        # Find a file that has interactions
+        cursor = store.conn.cursor()
+        rows = list(cursor.execute("SELECT file_path FROM file_interactions LIMIT 1"))
+        if rows:
+            fp = rows[0][0]
+            result = recall(store, file_path=fp)
+            assert len(result.file_history) > 0
+            assert result.target == fp


### PR DESCRIPTION
## Summary
- New `engine.py` module with three capabilities: think, recall, sessions
- **think(context)**: Given current task, retrieve categorized past knowledge (decisions, patterns, bugs, context)
- **recall(file_path|topic)**: Proactive retrieval — file timeline, session history, related knowledge
- **sessions(project, days)**: Browse recent sessions by date/project
- 3 new MCP tools wired into the server (11 total)
- 29 tests (24 unit + 5 integration), all pass in <2s

## Architecture
```
engine.py (pure logic, testable)
    ↕
mcp/__init__.py (async wrappers, MCP protocol)
    ↕
vector_store.py (DB queries)
```

## Test plan
- [x] 24 unit tests: categorization, formatting, edge cases (0.17s)
- [x] 5 integration tests: session queries, file recall with real DB (1.37s)
- [x] All 19 existing tests still pass (no regressions)
- [x] MCP tool list verified: 11 tools registered
- [x] Import verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new retrieval endpoints that query the vector DB and run embeddings via MCP, expanding the public tool surface and introducing new query/formatting paths that could impact performance or error handling.
> 
> **Overview**
> Introduces a new `engine.py` “Think/Recall/Sessions” layer that builds structured, markdown-formatted outputs for (1) context-aware memory retrieval (`think`) with intent-based grouping and an importance floor, (2) proactive file/topic recall (`recall`) combining file timelines, session context, and related hybrid search, and (3) recent session browsing (`sessions`) backed by direct `session_context` SQL queries.
> 
> Wires these capabilities into the MCP server as three new read-only tools (`brainlayer_think`, `brainlayer_recall`, `brainlayer_sessions`) with async wrappers that offload embedding + engine work to an executor. Adds a new `test_engine.py` suite covering categorization/formatting plus DB-backed integration checks for `sessions` and file-based `recall`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1773df201685407182ea13db7050dc9f04512d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->