### PR TITLE
docs: add launch readiness audit from deep research

### DIFF
--- a/docs/research/launch-readiness-audit.md
+++ b/docs/research/launch-readiness-audit.md
@@ -1,0 +1,232 @@
+# BrainLayer launch readiness audit
+
+**BrainLayer enters a booming MCP ecosystem with a strong technical differentiator but needs strategic packaging to stand out.** The MCP protocol now powers **97 million monthly SDK downloads** across **10,000+ servers**, backed by the Linux Foundation's Agentic AI Foundation with Anthropic, Google, Microsoft, AWS, and OpenAI as members. BrainLayer's 12-tool suite with hybrid semantic+keyword search and LLM enrichment offers a genuine leap over the official MCP memory server (basic text matching on a JSON file) and a compelling open-source alternative to mem0's cloud-centric model. The window is open: memory is the fastest-growing MCP category, the official MCP Registry launched just months ago, and no dominant open-source MCP-native memory server has yet emerged.
+
+This audit covers the full launch surface — ecosystem requirements, competitive positioning, documentation, branding, distribution, and a prioritized checklist with effort estimates.
+
+---
+
+## The MCP ecosystem demands more than working code
+
+The MCP specification (latest: **2025-11-25**) has matured rapidly. Production-ready servers in 2026 must implement several features beyond basic tool definitions.
+
+**Tool annotations are now expected, not optional.** Clients like VS Code and Claude Desktop use `readOnlyHint` to skip confirmation dialogs, and `destructiveHint` and `idempotentHint` signal safety properties to agent orchestrators. BrainLayer's read tools should set `readOnlyHint: true`; write tools need `destructiveHint` and `idempotentHint` configured accurately. The spec also supports `openWorldHint` for tools interacting with external services (relevant for LLM enrichment calls).
+
+**Structured content with `outputSchema`** (added June 2025) lets tools return typed JSON alongside traditional text blocks. This is increasingly important as agents chain MCP tool outputs into downstream processing. BrainLayer should define output schemas for search results, memory stats, and context retrieval tools.
+
+**The Official MCP Registry** at `registry.modelcontextprotocol.io` is the single most important listing. Launched September 2025, it validates namespace ownership (GitHub username or DNS) and pings servers for uptime. Publishing requires a `server.json` metadata file and the `mcp-publisher` CLI. **There is no formal certification program** from Anthropic or third parties — the registry listing is the closest official stamp of legitimacy.
+
+Beyond the official registry, the directory landscape is fragmented but active. **MCP.so** lists 17,749 servers. **PulseMCP** tracks 8,610+ with weekly visitor estimates. **awesome-mcp-servers** on GitHub has **79.9K stars** and accepts PRs. **Smithery** hosts 2,200+ with automated install flows. **Glama.ai** manually reviews submissions across 5,867+ servers. BrainLayer should submit to all of these — each directory serves a different discovery audience.
+
+The top MCP servers share five patterns: **single clear purpose**, minimal configuration (zero-config or one API key), excellent documentation with JSON config examples, multi-transport support (stdio + Streamable HTTP), and active development cadence. Context7 (46K stars) succeeds by solving one universal pain point — outdated LLM training data. Playwright MCP (1.3M weekly visitors on PulseMCP) benefits from Microsoft backing and zero-config browser automation. Supabase MCP wraps a complete platform behind clear tool boundaries. BrainLayer should learn from these: **lead with the single pain point** (AI agents forget everything) rather than listing all 12 tools upfront.
+
+---
+
+## How BrainLayer should position against mem0 and the basic memory MCP
+
+**Mem0 is BrainLayer's most visible competitor**, with **~46,900 GitHub stars**, $24M in funding, 14 million PyPI downloads, and an AWS partnership as the exclusive memory provider for the Strands Agent SDK. Their hybrid architecture combines vector, key-value, and graph databases with LLM-powered memory extraction. They offer both open-source self-hosting and a managed cloud starting at $19/month.
+
+But mem0 has exploitable weaknesses. **It requires an external LLM API key** (default: OpenAI's gpt-4.1-nano) for basic operation, adding cost and latency. Its free tier caps at 10,000 memories and 1,000 API calls/month. The Letta team publicly challenged mem0's LOCOMO benchmark claims without receiving a response. And critically, **mem0 added MCP support as an afterthought** via a separate `mem0-mcp` repository — it was not designed as an MCP server from the ground up.
+
+BrainLayer's differentiation should center on three angles:
+
+**"MCP-native, not MCP-bolted-on."** BrainLayer IS an MCP server. Every design decision serves the MCP workflow. Mem0 is a memory platform that also exposes MCP tools. This distinction matters for developers who want memory that integrates seamlessly with Claude Code, Cursor, or VS Code without configuring separate services.
+
+**"No API keys required for core operation."** If BrainLayer can run fully locally without mandatory third-party LLM calls, this is a powerful differentiator. Position against mem0's OpenAI dependency: "Full persistent memory without sending your data to OpenAI."
+
+**"Drop-in upgrade from the official MCP memory server."** The official `@modelcontextprotocol/server-memory` stores entities, relations, and observations in a single JSON file with simple text matching. It has 9 CRUD tools and zero intelligence — no embeddings, no semantic search, no enrichment, no scalability. **This is BrainLayer's most compelling comparison:**
+
+| Capability | Official server-memory | BrainLayer |
+|---|---|---|
+| Search type | Text matching only | Semantic + keyword hybrid |
+| Embeddings | None | Full vector embeddings |
+| LLM enrichment | None | Auto-extraction, summarization |
+| Scale | Single JSON file | 268K+ chunks |
+| Multi-source indexing | No | Yes |
+| Tool count | 9 (basic CRUD) | 12 purpose-built tools |
+
+The **aitmpl.com "memory-integration"** template (4,703 downloads, #2 most-downloaded MCP on the Claude Code Templates marketplace with ~20.9K GitHub stars) is likely a thin wrapper around similar basic key-value storage. BrainLayer should submit to aitmpl.com and position explicitly as the production-grade alternative. The submission process is via GitHub PR to `davila7/claude-code-templates`.
+
+The broader AI memory landscape includes **Zep/Graphiti** (temporal knowledge graphs, 20K stars for Graphiti, but community edition deprecated — now cloud-only), **Letta/MemGPT** (OS-inspired memory tiers, agent self-editing), and **LangMem** (framework-locked to LangGraph). The trend is clear: **graph memory, temporal awareness, and cross-client memory sharing** are becoming table stakes. BrainLayer's roadmap should account for these expectations.
+
+---
+
+## GitHub repo and PyPI listing must sell in seconds
+
+**The "above the fold" content — what appears without scrolling — determines 80% of first impressions.** Analysis of successful AI tool repos reveals a consistent structure:
+
+The README should open with a branded banner image, 1-2 rows of badges (CI status, PyPI version, Python versions, license, downloads), a one-line tagline, and a **15-30 second demo GIF** created with VHS (Charmbracelet's scriptable terminal recorder). VHS generates reproducible GIFs from `.tape` files and integrates with GitHub Actions for auto-regeneration. Below the fold: a "Why BrainLayer?" section with 2-3 pain→solution points, a 3-5 line quickstart, a feature comparison table (✅/❌ format against mem0 and official server-memory), and an architecture diagram.
+
+**Essential badges for BrainLayer:** CI status (GitHub Actions), PyPI version, Python version support (3.10-3.13), license, monthly downloads (via pypistats), and code coverage (Codecov, aim for 80%+). Keep to two rows maximum.
+
+**PyPI optimization is straightforward but often neglected.** Use `pyproject.toml` (PEP 621), set `long_description_content_type = "text/markdown"` so the README renders directly on PyPI, include classifiers for `Topic :: Scientific/Engineering :: Artificial Intelligence` and `Typing :: Typed`, and populate all project URLs (Homepage, Documentation, Repository, Bug Tracker, Changelog, Discord). Publish via **Trusted Publishers** (GitHub Actions OIDC integration — no API tokens needed) using `pypa/gh-action-pypi-publish`. PyPI has no trending feature — discovery happens on GitHub, not PyPI. The package name `brainlayer` should be memorable and keyword-rich in metadata.
+
+**CI/CD should include more than tests.** The standard 2025 Python stack:
+- Test matrix across Python 3.10-3.13 on Ubuntu + macOS
+- **Ruff** for linting + formatting (replaces Black, isort, Flake8 — 10-100x faster)
+- **Mypy** or Pyright for type checking
+- **CodeQL** for security scanning (free for open-source, catches vulnerabilities in Python)
+- **Dependabot** with weekly schedule and auto-merge for patch updates
+- **Gitleaks** pre-commit hook to prevent secret leaks
+- Automated release workflow: git tag → tests → build → PyPI publish → GitHub Release with auto-generated notes
+
+SBOM generation via `cyclonedx-bom` signals enterprise readiness but is not critical for initial launch.
+
+---
+
+## MkDocs Material is the clear documentation choice
+
+**Every major Python AI project in 2025-2026 uses MkDocs with Material theme** — FastAPI, Pydantic, LlamaIndex, UV, Ruff, Polars. It installs via pip (no Node.js), configures through a single `mkdocs.yml`, auto-generates API references via the `mkdocstrings` plugin, and supports versioning through the `mike` plugin. Sphinx remains powerful but has a steeper learning curve. Docusaurus and Astro Starlight require Node.js — a friction point for a Python project's contributor base.
+
+**Recommended documentation architecture for BrainLayer's 12 tools + CLI:**
+
+```
+Getting Started (installation, quickstart, editor setup with tabs)
+├── Claude Code | Cursor | VS Code Copilot | Zed (tabbed content)
+Concepts (how persistent memory works, MCP basics)
+Tool Reference (auto-generated schemas + hand-written examples)
+├── Memory tools | Context tools | Management tools
+CLI Reference (auto-generated from Click/Typer)
+Python API Reference (auto-generated via mkdocstrings)
+Guides (configuration, advanced usage, multi-agent setups)
+Integrations (LangChain, CrewAI, LlamaIndex)
+Contributing + Changelog
+```
+
+**Tool documentation should be hybrid**: auto-generate the reference table (name, description, input/output schema) from MCP `tools/list` metadata, then hand-write usage examples, prompt suggestions, and use-case narratives around each auto-generated entry. The editor setup page should use MkDocs Material's **content tabs** feature to show configuration for Claude Code, Cursor, VS Code, and Zed side by side.
+
+**Start with docs-as-landing-page** (the FastAPI/Pydantic model) rather than building a separate marketing site. MkDocs Material supports custom hero sections via template overrides. Split to a separate landing page only when you need marketing content, pricing pages, or a significant non-developer audience. This is the approach that FastAPI used to reach 70K+ stars — the documentation IS the product website.
+
+---
+
+## Visual identity and social assets need to be ready on day one
+
+Successful open-source AI projects converge on **clean geometric SVG logos** with gradient accents — typically purple/blue/teal palettes that convey intelligence and trust. LangChain uses a playful emoji-based identity (🦜🔗), ChromaDB uses a prismatic gradient, mem0 uses a minimalist purple wordmark, and FastAPI uses a lightning bolt in a hexagon. BrainLayer should target a **layered brain/neural motif** in SVG format, with monochrome variants for dark and light backgrounds. Use Figma for design (free tier) and avoid AI-generated logos for final branding — the U.S. Copyright Office has ruled AI-generated images cannot be copyrighted.
+
+**Social media asset dimensions** (create these before launch):
+
+| Asset | Dimensions | Purpose |
+|---|---|---|
+| GitHub social preview | **1280 × 640 px** (PNG) | Repo link previews everywhere |
+| Open Graph / Twitter / LinkedIn | **1200 × 630 px** (PNG) | Universal social card |
+
+These two images cover all platforms. Center critical content (logo, name, tagline) to account for edge cropping. Use dark backgrounds — most developer audiences browse in dark mode. Test with Facebook Sharing Debugger and Twitter Card Validator before launch.
+
+**Demo strategy:** VHS-scripted GIF for the GitHub README (auto-regenerated in CI), asciinema player embeds for docs pages (lightweight, text-selectable), and short MP4 screen captures (<60 seconds) for Twitter/LinkedIn showing an agent conversation with persistent memory across sessions.
+
+---
+
+## Distribution requires simultaneous multi-channel activation
+
+**The launch sequence matters as much as the launch content.** GitHub Trending's algorithm rewards star velocity relative to historical average — a new repo getting 30-50 stars in 1-2 hours has a strong chance of trending. The key is driving traffic from **at least two external sources simultaneously** (e.g., Hacker News + Reddit, or Twitter + Dev.to) to avoid single-source detection.
+
+**MCP-specific distribution (submit to ALL before launch day):**
+- Official MCP Registry (`registry.modelcontextprotocol.io`) — publish via `mcp-publisher` CLI
+- awesome-mcp-servers PR (79.9K stars, the canonical list)
+- aitmpl.com / Claude Code Templates PR
+- PulseMCP, mcp.so, Glama.ai, Smithery, mcpservers.org, mcpserverfinder.com
+
+**Launch day execution:**
+- **Product Hunt** at 12:01 AM PT — recruit an experienced Hunter (Flo Merian is active for dev tools), prepare maker comment under 800 characters, 4-6 image gallery showing workflow. Weekends can work well for dev tools due to less competition.
+- **Show HN** at 8-9 AM ET — title format: `Show HN: BrainLayer – Open-source persistent memory for AI agents`. Link to GitHub repo, not a website. Add a detailed first comment with backstory and technical details. Respond to every comment.
+- **Twitter thread** with demo GIF — hook tweet ("AI agents have amnesia. I built an open-source fix. 🧵"), followed by problem → solution → demo → features → GitHub link with star CTA. Tag Simon Willison, swyx, Alex Albert.
+- **Reddit** to r/ClaudeAI and r/Python (stagger by 1-2 hours). Frame as sharing something useful, not self-promotion. Tutorial-style posts outperform announcements.
+
+**Post-launch week:** Cross-post blog to Dev.to and Medium with canonical URLs. Submit to There's An AI For That (2.5M subscribers), FutureTools, Ben's Bites, and the PulseMCP newsletter. Write a tutorial post: "How to Give Your AI Agent Persistent Memory in 5 Minutes." If Hacker News post underperforms, email `hn@ycombinator.com` for the second-chance pool.
+
+**MCP-specific communities to engage:** Official MCP Discord, r/ClaudeAI, the MCP X Community, Glama.ai Discord, and GitHub Discussions on `modelcontextprotocol/registry`.
+
+---
+
+## Feature roadmap: what ships before launch vs. after
+
+Based on patterns from mem0 (launched with simple API, added graph memory later), ChromaDB (launched with 4-function API, added cloud later), and LangChain (shipped fast, iterated weekly), the principle is clear: **launch with a polished core, ship everything else fast afterward.**
+
+**Before launch (non-negotiable):**
+- **Public docs website** (g) — every successful open-source AI tool has docs at launch. MkDocs Material can be deployed in a day.
+- **Security audit of dependencies** (e) — a single CVE in a dependency will torpedo credibility on Hacker News. Run `pip-audit`, CodeQL, and Dependabot before going public.
+- **CLI UX refresh with rich library** (d) — first impression from `pip install brainlayer` must be polished. Rich provides progress bars, tables, syntax highlighting with minimal effort.
+
+**Before launch (strongly recommended):**
+- **brainlayer_store write-side MCP tool** (b) — a memory system without an obvious write path through MCP will confuse users on day one. Even a basic version ships the complete read+write story.
+- **LLM backend flexibility** (f) — if launch requires an OpenAI API key, the "no API keys required" positioning collapses. Support at least OpenAI + Anthropic + one local option (Ollama) before launch.
+
+**After launch (v1.1):**
+- **Session-level enrichment** (a) — valuable but adds complexity. Ship after gathering user feedback on enrichment patterns.
+- **Document archiving** (c) — a power-user feature that can wait for the post-launch roadmap.
+
+---
+
+## The structured launch checklist
+
+### MUST HAVE before launch
+
+| Item | Why it matters | Effort | Tools/services |
+|---|---|---|---|
+| **Public docs site** on MkDocs Material | Every top AI tool launches with docs. No docs = no trust. | **8-12 hours** | MkDocs Material, mkdocstrings, GitHub Pages |
+| **Security audit of all dependencies** | One CVE kills HN credibility. 88% of MCP servers require credentials. | **4-6 hours** | pip-audit, CodeQL, Safety, Dependabot |
+| **Tool annotations on all 12 MCP tools** | Spec-required for modern MCP compliance. VS Code skips confirmations based on readOnlyHint. | **2-3 hours** | MCP spec reference |
+| **Professional README** with badges, demo GIF, comparison table | Above-the-fold content determines 80% of first impressions. | **6-8 hours** | VHS (demo GIF), Shields.io (badges), Mermaid (diagrams) |
+| **PyPI listing with full metadata** | Install via `pip install brainlayer` must work flawlessly with clean listing. | **2-3 hours** | pyproject.toml, Trusted Publishers, twine |
+| **CI/CD pipeline** (tests, linting, security scanning) | Green CI badge signals reliability. Automated publishing prevents release errors. | **4-6 hours** | GitHub Actions, Ruff, Mypy, CodeQL, Codecov |
+| **GitHub social preview image** (1280×640) | Every link share displays this image. No image = amateur signal. | **2-3 hours** | Figma or Canva |
+| **Open Graph image** (1200×630) | Twitter/LinkedIn/Discord link previews. | **1-2 hours** | Same design, different crop |
+| **Official MCP Registry submission** | The canonical listing. Backed by Anthropic, GitHub, Microsoft. | **2-3 hours** | mcp-publisher CLI, server.json |
+| **Editor setup configs** for Claude Code, Cursor, VS Code | Users need copy-pasteable JSON to start. Blocks adoption without it. | **3-4 hours** | Test across all editors |
+| **CLI UX polish with Rich library** (d) | First `pip install` → first command must feel polished. | **6-8 hours** | Rich, Typer or Click |
+| **LICENSE file** (Apache 2.0 or MIT) | Non-negotiable for enterprise adoption and awesome-list submissions. | **0.5 hours** | Choose Apache 2.0 for maximum enterprise friendliness |
+| **CONTRIBUTING.md and CODE_OF_CONDUCT.md** | Signals a healthy project. Required by many awesome-lists. | **1-2 hours** | Templates from GitHub |
+
+### SHOULD HAVE — significantly improves launch impact
+
+| Item | Why it matters | Effort | Tools/services |
+|---|---|---|---|
+| **brainlayer_store write-side MCP tool** (b) | Completes the read+write story. Users expect to write memories through MCP. | **8-16 hours** | Internal development |
+| **LLM backend flexibility** (f) — OpenAI + Anthropic + Ollama | "No vendor lock-in" positioning requires multi-backend support at launch. | **12-20 hours** | LiteLLM or custom adapter layer |
+| **Logo** — clean geometric SVG with variants | Every link, social share, and directory listing displays a logo. No logo = forgettable. | **4-8 hours** (Figma DIY) or **$200-500** (Fiverr/designer) | Figma, Inkscape |
+| **Comparison table** in README (vs mem0, vs official server-memory) | Developers deciding between options. Tables make the decision instant. | **2-3 hours** | Markdown table |
+| **Architecture diagram** (Mermaid or SVG) | Shows how BrainLayer fits between agents and storage. Builds understanding fast. | **2-3 hours** | Mermaid, Excalidraw, or Figma |
+| **awesome-mcp-servers PR submission** | 79.9K stars = massive visibility. PR process is straightforward. | **1-2 hours** | GitHub PR following CONTRIBUTING.md |
+| **Submit to 5+ MCP directories** | Each directory serves a different audience segment. | **3-4 hours** | PulseMCP, mcp.so, Glama, Smithery, mcpservers.org |
+| **aitmpl.com / Claude Code Templates submission** | 500K+ npm downloads, 20.9K stars. Direct competitor channel to memory-integration. | **2-3 hours** | GitHub PR |
+| **Discord server** | Every successful AI tool (mem0, ChromaDB, LangChain, Haystack) launched with Discord. | **2-3 hours** | Discord (free) |
+| **Launch blog post** — tutorial format | "How to give AI agents persistent memory in 5 minutes" outperforms announcements. | **4-6 hours** | Hashnode (custom domain) or own site |
+| **Pre-commit hooks** (Ruff, Mypy, Gitleaks) | Contributor experience + security hygiene. | **1-2 hours** | pre-commit framework |
+| **Output schemas** (`structuredContent`) for key tools | Modern MCP spec feature. Enables typed downstream processing of results. | **4-6 hours** | MCP SDK |
+
+### NICE TO HAVE — can come in v1.1
+
+| Item | Why it matters | Effort | Tools/services |
+|---|---|---|---|
+| **Session-level enrichment** (a) | Adds intelligence to memory management but increases scope. Ship after user feedback. | **16-24 hours** | Internal development |
+| **Migration guide from official server-memory** | Warmest audience = developers already using the basic MCP memory server. | **4-6 hours** | Docs page with step-by-step |
+| **Versioned docs** via mike plugin | Important once you have multiple releases. Not needed at v1.0. | **2-3 hours** | mike MkDocs plugin |
+| **Integration examples** (LangChain, CrewAI, LlamaIndex) | Expands BrainLayer's distribution through framework ecosystems. | **8-12 hours** | Per-framework code examples |
+| **SBOM generation** | Enterprise credibility signal. Executive Order compliance. | **2-3 hours** | cyclonedx-bom in CI |
+| **Automated changelog generation** | Professional release hygiene. | **2-3 hours** | python-semantic-release or release-drafter |
+| **YouTube demo video** (2-3 min) | Long-form discoverability. Embeddable in blog posts and directories. | **4-6 hours** | OBS Studio, simple editing |
+| **Streamable HTTP transport** (in addition to stdio) | Required for remote deployment and some IDE integrations. | **8-12 hours** | MCP SDK HTTP transport |
+
+### POST-LAUNCH roadmap
+
+| Item | Why it matters | Effort | Tools/services |
+|---|---|---|---|
+| **Document archiving** (c) | Power-user feature for managing memory lifecycle. | **12-20 hours** | Internal development |
+| **Graph memory support** | Market trend: mem0, Zep, Letta all have graph-based memory. Becoming table stakes. | **40-60 hours** | Neo4j or custom graph layer |
+| **Temporal awareness** (bi-temporal model) | Zep/Graphiti pioneered this. Tracks when events occurred vs. when ingested. | **30-40 hours** | Internal development |
+| **Cross-client memory sharing** | Users expect memory to travel across Cursor → Claude → VS Code. | **20-30 hours** | Shared storage backend |
+| **Separate landing page** (brainlayer.dev) | Needed when non-developer audience grows or pricing/cloud tier is added. | **16-24 hours** | Astro or Next.js |
+| **Framework integrations as first-class packages** | Distribution through LangChain/CrewAI/LlamaIndex ecosystems. | **20-30 hours** | Per-framework packages |
+| **Benchmarks** (search quality, latency, memory accuracy) | Credibility through data. Mem0 published benchmarks; BrainLayer should too. | **12-16 hours** | LOCOMO benchmark, custom eval suite |
+| **Multi-user/multi-agent scoping** | Enterprise requirement. Mem0 has user_id/agent_id/run_id scoping. | **20-30 hours** | Internal development |
+| **Product Hunt launch** (with prepared assets) | 500K+ possible reach. Save for when the product is polished and demo-ready. | **8-12 hours** prep | Product Hunt, recruit a Hunter |
+
+---
+
+## Competitive positioning: the three-sentence pitch
+
+For developer audiences: **"The official MCP memory server stores notes in a JSON file. Mem0 requires an OpenAI API key and a cloud account. BrainLayer gives your AI agents real memory — hybrid semantic search, LLM enrichment, 268K+ chunks — fully open source, fully local, fully MCP-native."**
+
+This pitch works because it acknowledges the two alternatives developers already know, states their limitations factually, and positions BrainLayer as the solution without superlatives. Lead with this framing in the README, Hacker News post, and Twitter launch thread. The comparison table does the rest.
+
+The total estimated effort for all MUST HAVE items is **42-61 hours**. Adding all SHOULD HAVE items brings the total to roughly **90-130 hours**. For a solo developer, this represents 2-3 weeks of focused work. The MUST HAVE list alone produces a credible, professional launch. The SHOULD HAVE list transforms it from credible to compelling.


### PR DESCRIPTION
## Summary
- Claude Desktop deep research results for BrainLayer v2 production launch
- MCP Registry requirements, mem0 competitive analysis, distribution strategy
- Informs phases 1, 5, 6, 7, 10 of the v2 launch plan

## Test plan
- [x] File renders correctly as markdown
- [x] No sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime/codepath changes; risk is limited to accuracy/maintenance of the guidance.
> 
> **Overview**
> Adds a new long-form research document, `docs/research/launch-readiness-audit.md`, that synthesizes MCP ecosystem launch requirements (e.g., tool annotations and `outputSchema`), competitive positioning guidance (notably vs `mem0` and `@modelcontextprotocol/server-memory`), and concrete distribution/branding/CI+PyPI recommendations.
> 
> Includes a prioritized pre-/post-launch checklist with effort estimates plus suggested messaging (three-sentence pitch) and channel-specific launch plan items (registry + directories, docs/README packaging).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1db22c0762e6e63a1978f901111fdba13e27ea63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive launch readiness audit documentation covering ecosystem requirements, competitive positioning, branding strategy, distribution planning, and a phased feature roadmap for the BrainLayer project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->