### PR TITLE
docs: Phase 10a — MkDocs Material docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 build/
 *.egg-info/
 *.egg
+site/
 
 # Testing
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-14%20tools-green.svg)](https://modelcontextprotocol.io)
 [![Tests](https://img.shields.io/badge/tests-266%20passing-brightgreen.svg)](#testing)
+[![Docs](https://img.shields.io/badge/docs-etanhey.github.io%2Fbrainlayer-blue.svg)](https://etanhey.github.io/brainlayer)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,141 @@
+# Architecture
+
+BrainLayer is a Python package with no external service dependencies. Everything runs locally.
+
+## Overview
+
+```mermaid
+graph TD
+    subgraph Sources
+        A1["Claude Code<br/>~/.claude/projects/*.jsonl"]
+        A2["WhatsApp<br/>exported .txt"]
+        A3["YouTube<br/>transcripts"]
+        A4["Markdown<br/>.md files"]
+        A5["Claude Desktop<br/>JSON export"]
+        A6["Manual<br/>brainlayer_store MCP tool"]
+    end
+
+    subgraph Pipeline
+        B1["Extract<br/>parse conversations"]
+        B2["Classify<br/>content type + value"]
+        B3["Chunk<br/>AST-aware splitting"]
+        B4["Embed<br/>bge-large-en-v1.5"]
+    end
+
+    subgraph Storage
+        C["SQLite + sqlite-vec<br/>~/.local/share/brainlayer/brainlayer.db"]
+    end
+
+    subgraph Post-Processing
+        D1["Chunk Enrichment<br/>10-field LLM metadata"]
+        D2["Session Enrichment<br/>decisions, learnings"]
+        D3["Brain Graph<br/>HDBSCAN clustering"]
+    end
+
+    subgraph Interfaces
+        E1["MCP Server<br/>brainlayer-mcp (14 tools)"]
+        E2["CLI<br/>brainlayer"]
+        E3["FastAPI Daemon<br/>:8787"]
+        E4["TUI Dashboard"]
+    end
+
+    A1 & A2 & A3 & A4 & A5 --> B1
+    A6 --> C
+    B1 --> B2 --> B3 --> B4 --> C
+    C --> D1 & D2 & D3
+    C --> E1 & E2 & E3 & E4
+```
+
+## Pipeline Stages
+
+### Stage 1: Extract
+
+Parses source files into individual messages with metadata.
+
+- **Claude Code**: JSONL conversation files from `~/.claude/projects/`
+- **Content-addressable storage**: System prompts are deduplicated via SHA-256 hash
+- **Session detection**: Groups messages into sessions by ID and temporal proximity
+
+### Stage 2: Classify
+
+Each message is classified by content type and value:
+
+| Type | Value | Action |
+|------|-------|--------|
+| `ai_code` | HIGH | Preserve verbatim |
+| `stack_trace` | HIGH | Preserve exact (never split) |
+| `user_message` | HIGH | Preserve |
+| `assistant_text` | MEDIUM | Preserve |
+| `file_read` | MEDIUM | Context-dependent |
+| `git_diff` | MEDIUM | Extract changed entities |
+| `build_log` | LOW | Summarize |
+| `dir_listing` | LOW | Structure only |
+| `noise` | SKIP | Filter out |
+
+### Stage 3: Chunk
+
+Splits content into indexable chunks (~500 tokens):
+
+- **AST-aware chunking** with tree-sitter for code
+- **Sentence-boundary splitting** for prose
+- **Stack traces are never split**
+- **10-20% overlap** between chunks for context continuity
+
+### Stage 4: Embed
+
+Generates vector embeddings:
+
+- **Model**: `bge-large-en-v1.5` via sentence-transformers
+- **Dimensions**: 1024
+- **Acceleration**: MPS on Apple Silicon, CPU elsewhere
+- **Load time**: ~8s (vs ~30s with Ollama embeddings)
+
+### Stage 5: Index
+
+Stores chunks with metadata in SQLite + sqlite-vec:
+
+- **WAL mode** for concurrent reads
+- **`busy_timeout = 5000ms`** for multi-process safety
+- **Metadata**: project, content_type, source_file, char_count, created_at, source
+
+## Search
+
+BrainLayer uses hybrid search — combining semantic similarity with keyword matching.
+
+### Semantic Search
+
+Vector similarity search using sqlite-vec. The query is embedded with the same bge-large model, then matched against stored chunk embeddings.
+
+### Keyword Search
+
+FTS5 full-text search on chunk content. Catches exact matches that semantic search might miss (specific function names, error codes, etc.).
+
+### Reciprocal Rank Fusion (RRF)
+
+Both result sets are merged using RRF: `score = Σ 1/(k + rank_i)` where k=60. This produces better results than either search alone.
+
+## Storage
+
+Everything lives in a single SQLite database file:
+
+```
+~/.local/share/brainlayer/brainlayer.db  (~1.4GB for 260K+ chunks)
+```
+
+Key tables:
+
+- **chunks** — content, embeddings, metadata, enrichment fields
+- **chunks_vec** — sqlite-vec virtual table for vector search
+- **chunks_fts** — FTS5 virtual table for keyword search
+- **session_context** — session metadata (project, branch, plan)
+- **session_enrichments** — session-level analysis results
+- **prompts** — deduplicated system prompts (SHA-256 keyed)
+
+## Concurrency
+
+Multiple processes can safely access the database:
+
+- **WAL mode** allows concurrent readers
+- **busy_timeout = 5000ms** waits for write locks
+- **Retry logic** with backoff on `SQLITE_BUSY`
+- **Thread-local connections** in parallel enrichment workers

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,64 @@
+# Configuration
+
+All BrainLayer configuration is via environment variables. No config files needed.
+
+## Environment Variables
+
+### Core
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BRAINLAYER_DB` | `~/.local/share/brainlayer/brainlayer.db` | Database file path. Set to override the default location. |
+
+### Enrichment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BRAINLAYER_ENRICH_BACKEND` | auto-detect | LLM backend: `mlx` or `ollama`. Auto-detects Apple Silicon → MLX, else Ollama. |
+| `BRAINLAYER_ENRICH_MODEL` | `glm-4.7-flash` | Ollama model name for enrichment |
+| `BRAINLAYER_MLX_MODEL` | `mlx-community/Qwen2.5-Coder-14B-Instruct-4bit` | MLX model identifier |
+| `BRAINLAYER_OLLAMA_URL` | `http://127.0.0.1:11434/api/generate` | Ollama API endpoint |
+| `BRAINLAYER_MLX_URL` | `http://127.0.0.1:8080/v1/chat/completions` | MLX server endpoint |
+| `BRAINLAYER_STALL_TIMEOUT` | `300` | Seconds before killing a stuck enrichment chunk |
+| `BRAINLAYER_HEARTBEAT_INTERVAL` | `25` | Log progress every N chunks during enrichment |
+
+### Privacy
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BRAINLAYER_SANITIZE_EXTRA_NAMES` | (empty) | Comma-separated names to redact from indexed content |
+| `BRAINLAYER_SANITIZE_USE_SPACY` | `true` | Use spaCy NER for PII detection during indexing |
+
+## Database Location
+
+The database path is resolved in this order:
+
+1. `BRAINLAYER_DB` environment variable (highest priority)
+2. Legacy path `~/.local/share/zikaron/zikaron.db` (if it exists — for migration)
+3. Canonical path `~/.local/share/brainlayer/brainlayer.db` (default for fresh installs)
+
+## Data Sources
+
+BrainLayer reads from these locations by default:
+
+| Source | Location |
+|--------|----------|
+| Claude Code conversations | `~/.claude/projects/` |
+| Deduplicated system prompts | `~/.local/share/brainlayer/prompts/` |
+| Daemon socket | `/tmp/brainlayer.sock` |
+| Enrichment lock | `/tmp/brainlayer-enrichment.lock` |
+
+## Scheduled Tasks (macOS)
+
+BrainLayer includes launchd plist templates for automated operation:
+
+| Service | Schedule | Description |
+|---------|----------|-------------|
+| `com.brainlayer.index` | Every 30 minutes | Incremental indexing of new conversations |
+| `com.brainlayer.enrich` | Every hour | Enrich up to 500 new chunks per run |
+
+Install with:
+
+```bash
+brainlayer init  # Includes launchd setup option
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,10 @@
+# Contributing
+
+See the [CONTRIBUTING.md](https://github.com/EtanHey/brainlayer/blob/main/CONTRIBUTING.md) in the repository root for full contribution guidelines, including:
+
+- Development setup
+- Project structure
+- Running tests
+- Pull request process
+- Key patterns and conventions
+- How to add an MCP tool

--- a/docs/enrichment.md
+++ b/docs/enrichment.md
@@ -1,0 +1,102 @@
+# Enrichment
+
+BrainLayer enriches indexed chunks with structured metadata using a local LLM. Think of it as a librarian cataloging every conversation snippet.
+
+## Chunk Enrichment
+
+Each chunk gets 10 metadata fields:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `summary` | 1-2 sentence gist | "Debugging Telegram bot message drops under load" |
+| `tags` | Topic tags (comma-separated) | "telegram, debugging, performance" |
+| `importance` | Relevance score 1-10 | 8 (architectural decision) vs 2 (directory listing) |
+| `intent` | What was happening | `debugging`, `designing`, `implementing`, `configuring`, `deciding`, `reviewing` |
+| `primary_symbols` | Key code entities | "TelegramBot, handleMessage, grammy" |
+| `resolved_query` | Question this answers (HyDE-style) | "How does the Telegram bot handle rate limiting?" |
+| `epistemic_level` | How proven is this | `hypothesis`, `substantiated`, `validated` |
+| `version_scope` | System state context | "grammy 1.32, Node 22" |
+| `debt_impact` | Technical debt signal | `introduction`, `resolution`, `none` |
+| `external_deps` | Libraries/APIs mentioned | "grammy, Supabase, Railway" |
+
+### Running Enrichment
+
+```bash
+# Basic (50 chunks at a time)
+brainlayer enrich
+
+# Larger batches
+brainlayer enrich --batch-size=100
+
+# Process up to 5000 chunks
+brainlayer enrich --max=5000
+
+# With parallel workers
+brainlayer enrich --parallel=3
+```
+
+### Source-Aware Thresholds
+
+Not all chunks are worth enriching. BrainLayer automatically skips chunks that are too short:
+
+| Source | Minimum Length | Reason |
+|--------|---------------|--------|
+| Claude Code | 50 characters | Code context needs substance |
+| WhatsApp / Telegram | 15 characters | Short messages can still be meaningful |
+
+Skipped chunks are tagged as `skipped:too_short` and excluded from enrichment stats.
+
+## Session Enrichment
+
+Session-level analysis extracts structured insights from entire conversations:
+
+```bash
+brainlayer enrich-sessions
+brainlayer enrich-sessions --project my-project --since 2026-01-01
+brainlayer enrich-sessions --stats   # Show progress
+```
+
+Session enrichment extracts:
+
+- **Summary** — what the session was about
+- **Decisions** — architectural and implementation choices made
+- **Corrections** — mistakes caught and fixed
+- **Learnings** — new knowledge gained
+- **Patterns** — recurring approaches identified
+- **Quality scores** — code quality, communication quality
+
+## LLM Backends
+
+Two local backends are supported:
+
+| Backend | Best for | Speed | How to start |
+|---------|----------|-------|-------------|
+| **MLX** | Apple Silicon (M1/M2/M3) | 21-87% faster | `python3 -m mlx_lm.server --model mlx-community/Qwen2.5-Coder-14B-Instruct-4bit --port 8080` |
+| **Ollama** | Any platform | ~1s/chunk (short), ~13s (long) | `ollama serve` + `ollama pull glm4` |
+
+Backend is auto-detected: Apple Silicon defaults to MLX, everything else to Ollama. Override with:
+
+```bash
+BRAINLAYER_ENRICH_BACKEND=mlx brainlayer enrich
+BRAINLAYER_ENRICH_BACKEND=ollama brainlayer enrich
+```
+
+### Performance Tips
+
+- Set `"think": false` in Ollama API calls — GLM-4.7 defaults to thinking mode, adding 350+ tokens and 20s delay for no benefit
+- Use `PYTHONUNBUFFERED=1` for log visibility in background processes
+- MLX parallel workers: each gets its own DB connection (thread-local)
+
+## Stall Detection
+
+If a chunk takes too long (default: 5 minutes), it's automatically killed and skipped:
+
+```bash
+BRAINLAYER_STALL_TIMEOUT=300 brainlayer enrich  # 5 min default
+```
+
+Progress is logged every N chunks:
+
+```bash
+BRAINLAYER_HEARTBEAT_INTERVAL=25 brainlayer enrich  # Log every 25 chunks
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,62 @@
+# BrainLayer
+
+> Persistent memory for AI agents. Search, think, recall — across every conversation you've ever had.
+
+**Your AI agent forgets everything between sessions.** Every architecture decision, every debugging session, every preference you've expressed — gone.
+
+BrainLayer fixes this. It's a **local-first memory layer** that gives any MCP-compatible AI agent the ability to remember, think, and recall across conversations.
+
+## Key Features
+
+- **14 MCP tools** — think, recall, search, session analysis, file history, and more
+- **Local-first** — SQLite + sqlite-vec, single file, no cloud, no Docker
+- **Hybrid search** — semantic vectors + keyword, merged with Reciprocal Rank Fusion
+- **10-field enrichment** — summary, tags, importance, intent, and more via local LLM
+- **Multi-source** — Claude Code, WhatsApp, YouTube, Markdown, Claude Desktop, manual
+- **Works everywhere** — Claude Code, Cursor, Zed, VS Code, any MCP client
+
+## Quick Example
+
+```bash
+pip install brainlayer
+brainlayer init              # Interactive setup wizard
+brainlayer index             # Index your conversations
+```
+
+Add to Claude Code (`~/.claude.json`):
+```json
+{
+  "mcpServers": {
+    "brainlayer": {
+      "command": "brainlayer-mcp"
+    }
+  }
+}
+```
+
+Your agent now has persistent memory. Ask it:
+
+- *"What approach did I use for auth last month?"* → `brainlayer_think`
+- *"Show me everything about this file"* → `brainlayer_recall`
+- *"What was I working on yesterday?"* → `brainlayer_current_context`
+- *"Remember this for later"* → `brainlayer_store`
+
+## Architecture Overview
+
+```mermaid
+graph LR
+    A["Claude Code / Cursor / Zed"] -->|MCP| B["BrainLayer MCP Server<br/>14 tools"]
+    B --> C["Hybrid Search<br/>semantic + keyword (RRF)"]
+    C --> D["SQLite + sqlite-vec<br/>single .db file"]
+
+    E["Conversations<br/>JSONL / WhatsApp / YouTube"] --> F["Pipeline"]
+    F -->|extract → classify → chunk → embed| D
+    G["Local LLM<br/>Ollama / MLX"] -->|enrich| D
+```
+
+## Next Steps
+
+- [Quick Start](quickstart.md) — full setup guide
+- [MCP Tools Reference](mcp-tools.md) — all 14 tools documented
+- [Configuration](configuration.md) — environment variables and options
+- [Architecture](architecture.md) — how it works under the hood

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,206 @@
+# MCP Tools Reference
+
+BrainLayer exposes 14 MCP tools, organized into two categories.
+
+## Intelligence Layer
+
+These tools go beyond raw search — they understand intent and context.
+
+### brainlayer_think
+
+Given your current task context, retrieves relevant past decisions, patterns, and bugs. Groups results by intent category.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `context` | string | Yes | What you're currently working on |
+| `project` | string | No | Filter to a specific project |
+| `max_results` | integer | No | Maximum results (default: 10) |
+
+**Returns:** Markdown with results grouped by category (decisions, bugs, patterns, implementations).
+
+**Use when:** Starting a new task, making architectural decisions, or debugging.
+
+---
+
+### brainlayer_recall
+
+File-based or topic-based recall. "What happened with this file?" or "What do I know about deployment?"
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_path` | string | No* | File to recall history for |
+| `topic` | string | No* | Topic to recall knowledge about |
+| `project` | string | No | Filter to a specific project |
+| `max_results` | integer | No | Maximum results (default: 10) |
+
+*At least one of `file_path` or `topic` is required.
+
+**Returns:** Markdown with relevant chunks, session context, and file interactions.
+
+**Use when:** Investigating a file's history, or gathering knowledge about a specific topic.
+
+---
+
+### brainlayer_current_context
+
+Lightweight — what projects, branches, files, and active plan were you working on recently? No embedding needed.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hours` | integer | No | How many hours back to look (default: 24) |
+
+**Returns:** Structured summary of recent activity.
+
+**Use when:** Starting a conversation, to understand current state.
+
+---
+
+### brainlayer_sessions
+
+Browse recent sessions by project and date range.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | No | Filter to a specific project |
+| `days` | integer | No | How many days back (default: 7, max: 365) |
+| `limit` | integer | No | Maximum sessions (default: 20, max: 100) |
+
+**Returns:** Markdown list of sessions with ID, project, branch, plan, and start time.
+
+---
+
+### brainlayer_session_summary
+
+Session-level analysis: decisions made, corrections, learnings, quality scores.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | Yes | Session ID to summarize |
+
+**Returns:** Markdown with decisions, corrections, learnings, patterns, and quality metrics.
+
+**Use when:** Reviewing what happened in a specific session.
+
+---
+
+### brainlayer_store
+
+Persist a memory (idea, decision, learning, mistake, etc.) for future retrieval.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `content` | string | Yes | The memory content to store |
+| `type` | string | Yes | Memory type: idea, mistake, decision, learning, todo, bookmark, note, journal |
+| `project` | string | No | Project to scope the memory |
+| `tags` | array[string] | No | Tags for categorization |
+| `importance` | integer | No | Importance score 1-10 |
+
+**Returns:** Chunk ID and related existing memories.
+
+**Use when:** An agent discovers something worth remembering for future sessions.
+
+---
+
+## Search & Context
+
+Core search and retrieval tools.
+
+### brainlayer_search
+
+Hybrid semantic + keyword search with filters.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query |
+| `project` | string | No | Filter by project |
+| `content_type` | string | No | Filter: `ai_code`, `stack_trace`, `user_message`, `assistant_text`, `file_read`, `git_diff` |
+| `num_results` | integer | No | Results to return (default: 5, max: 100) |
+| `source` | string | No | Filter: `claude_code`, `whatsapp`, `youtube`, `all` |
+| `tag` | string | No | Filter by enrichment tag |
+| `intent` | string | No | Filter: `debugging`, `designing`, `configuring`, `discussing`, `deciding`, `implementing`, `reviewing` |
+| `importance_min` | integer | No | Minimum importance score (1-10) |
+
+**Returns:** Matched chunks with content, metadata, similarity scores.
+
+---
+
+### brainlayer_context
+
+Get surrounding conversation chunks for a search result.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `chunk_id` | string | Yes | Chunk ID from a search result |
+| `before` | integer | No | Chunks before (default: 3, max: 50) |
+| `after` | integer | No | Chunks after (default: 3, max: 50) |
+
+**Returns:** The target chunk plus surrounding conversation context.
+
+---
+
+### brainlayer_file_timeline
+
+Full interaction history of a file across all sessions.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_path` | string | Yes | File path to look up |
+| `project` | string | No | Filter by project |
+| `limit` | integer | No | Maximum entries (default: 50) |
+
+**Returns:** Chronological timeline of all interactions with the file.
+
+---
+
+### brainlayer_operations
+
+Logical operation groups — read/edit/test cycles within a session.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | Yes | Session to analyze |
+
+**Returns:** Grouped operations showing the read→edit→test workflow patterns.
+
+---
+
+### brainlayer_regression
+
+What changed since a file last worked? Diff-based regression analysis.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_path` | string | Yes | File to analyze |
+| `project` | string | No | Filter by project |
+
+**Returns:** Changes since the file's last known-good state.
+
+---
+
+### brainlayer_plan_links
+
+Connect sessions to implementation plans and phases.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `plan_name` | string | No | Filter by plan name |
+| `session_id` | string | No | Filter by session |
+| `project` | string | No | Filter by project |
+
+**Returns:** Session-to-plan linkage with phase information.
+
+---
+
+### brainlayer_stats
+
+Knowledge base statistics.
+
+**Returns:** Total chunks, projects, content types, enrichment progress, and source breakdown.
+
+---
+
+### brainlayer_list_projects
+
+List all indexed projects.
+
+**Returns:** Project names with chunk counts.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,128 @@
+# Quick Start
+
+## Installation
+
+```bash
+pip install brainlayer
+```
+
+### Optional extras
+
+```bash
+pip install "brainlayer[brain]"     # Brain graph visualization (HDBSCAN + UMAP)
+pip install "brainlayer[cloud]"     # Cloud backfill (Gemini Batch API)
+pip install "brainlayer[youtube]"   # YouTube transcript indexing
+pip install "brainlayer[ast]"       # AST-aware code chunking (tree-sitter)
+```
+
+## Setup
+
+Run the interactive wizard:
+
+```bash
+brainlayer init
+```
+
+This will:
+
+1. Check for Claude Code conversations in `~/.claude/projects/`
+2. Detect your hardware (Apple Silicon → MLX, otherwise Ollama)
+3. Configure your LLM backend for enrichment
+4. Create the database at `~/.local/share/brainlayer/brainlayer.db`
+
+## Index Your Conversations
+
+```bash
+brainlayer index
+```
+
+This parses your Claude Code conversations (JSONL files), classifies content, chunks it with sentence boundaries, generates embeddings (bge-large-en-v1.5), and stores everything in the SQLite database.
+
+## Connect to Your Editor
+
+### Claude Code
+
+Add to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "brainlayer": {
+      "command": "brainlayer-mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+Add in Cursor's MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "brainlayer": {
+      "command": "brainlayer-mcp"
+    }
+  }
+}
+```
+
+### Zed
+
+Add to `settings.json`:
+
+```json
+{
+  "context_servers": {
+    "brainlayer": {
+      "command": { "path": "brainlayer-mcp" }
+    }
+  }
+}
+```
+
+### VS Code
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "brainlayer": {
+      "command": "brainlayer-mcp"
+    }
+  }
+}
+```
+
+## Enrich (Optional)
+
+Add structured metadata to your indexed content using a local LLM:
+
+```bash
+brainlayer enrich
+```
+
+This adds summary, tags, importance scores, intent classification, and more to each chunk. See [Enrichment](enrichment.md) for details.
+
+## Verify
+
+```bash
+brainlayer stats              # Check your knowledge base
+brainlayer search "auth"      # Test a search
+```
+
+## CLI Reference
+
+```bash
+brainlayer init               # Interactive setup wizard
+brainlayer index              # Index new conversations
+brainlayer search "query"     # Semantic + keyword search
+brainlayer enrich             # Run LLM enrichment on new chunks
+brainlayer enrich-sessions    # Session-level analysis
+brainlayer stats              # Database statistics
+brainlayer brain-export       # Generate brain graph JSON
+brainlayer export-obsidian    # Export to Obsidian vault
+brainlayer dashboard          # Interactive TUI dashboard
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: BrainLayer
+site_description: Persistent memory for AI agents — search, think, recall across every conversation
+site_url: https://etanhey.github.io/brainlayer
+repo_url: https://github.com/EtanHey/brainlayer
+repo_name: EtanHey/brainlayer
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Quick Start: quickstart.md
+    - Configuration: configuration.md
+  - Reference:
+    - MCP Tools: mcp-tools.md
+    - Architecture: architecture.md
+    - Enrichment: enrichment.md
+  - Guides:
+    - Data Locations: data-locations.md
+    - Enrichment Runbook: enrichment-runbook.md
+    - Local Models: local-models-guide.md
+    - MCP Config: mcp-config.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,14 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
 ]
+docs = [
+    "mkdocs-material>=9.5.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/EtanHey/brainlayer"
 Repository = "https://github.com/EtanHey/brainlayer"
-Documentation = "https://github.com/EtanHey/brainlayer#readme"
+Documentation = "https://etanhey.github.io/brainlayer"
 Issues = "https://github.com/EtanHey/brainlayer/issues"
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Phase 10a of the Layers v2 Launch plan — documentation site using MkDocs Material.

### New Pages (7)
- **index.md** — landing page with mermaid architecture diagram, feature highlights
- **quickstart.md** — installation, setup wizard, editor configs (Claude Code, Cursor, Zed, VS Code)
- **mcp-tools.md** — all 14 MCP tools with full parameter tables, returns, use-when guidance
- **architecture.md** — pipeline stages (extract→classify→chunk→embed), search internals (RRF), storage schema, concurrency
- **enrichment.md** — 10 enrichment fields, source-aware thresholds, session enrichment, MLX vs Ollama backends
- **configuration.md** — all 12 `BRAINLAYER_*` env vars with defaults, data locations, scheduled tasks
- **contributing.md** — links to CONTRIBUTING.md

### Configuration
- MkDocs Material theme: dark/light toggle, mermaid fences, code copy, search
- Nav integrates existing guides (data-locations, enrichment-runbook, local-models, mcp-config)
- `docs` optional dep: `pip install "brainlayer[docs]"` for mkdocs-material

### Other Changes
- README: added docs badge linking to GitHub Pages
- pyproject.toml: Documentation URL → `https://etanhey.github.io/brainlayer`
- .gitignore: added `site/` (MkDocs build output)

## Test plan
- [x] 266 tests pass, 2 skipped
- [x] ruff check clean
- [ ] CodeRabbit review
- [ ] `mkdocs build` succeeds (after `pip install ".[docs]"`)
- [ ] `mkdocs gh-deploy` publishes to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus an optional dependency/URL update; no runtime or data-path code is modified.
> 
> **Overview**
> Adds a MkDocs Material documentation site (`mkdocs.yml`) and new `docs/` pages covering quickstart, configuration, MCP tools reference, architecture, and enrichment, plus a short contributing pointer page.
> 
> Updates packaging metadata to support `pip install "brainlayer[docs]"` and switches the `Documentation` project URL to the GitHub Pages site; also adds a README docs badge and ignores MkDocs `site/` build output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ca8d998b4cae6610c2ee3e7b300eeca958f9bcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->