### PR TITLE
docs: fix CLAUDE.md tools table (M11 + H5b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ brainlayer/
 │   │   ├── app.py
 │   │   ├── search.py
 │   │   └── views.py
-│   ├── mcp/                    # MCP server (8 tools)
+│   ├── mcp/                    # MCP server (14 tools)
 │   │   └── __init__.py
 │   └── pipeline/               # Processing stages
 │       ├── extract.py           # Stage 1: Parse JSONL conversations
@@ -267,7 +267,12 @@ Add to `~/.claude/settings.json`:
 | `brainlayer_operations` | `session_id` | — | Logical operation groups (read→edit→test) |
 | `brainlayer_regression` | `file_path` | `project` | Regression analysis (what changed since last success) |
 | `brainlayer_plan_links` | — | `plan_name`, `session_id`, `project` | Session ↔ plan linkage |
+| `brainlayer_think` | `context` | `project`, `max_results` (10) | Retrieve relevant past decisions, patterns, bugs for current task |
+| `brainlayer_recall` | — | `file_path`, `topic`, `project`, `max_results` (10) | Proactive context retrieval for a file or topic (one required) |
+| `brainlayer_sessions` | — | `project`, `days` (7), `limit` (20) | Browse recent Claude Code sessions with metadata |
+| `brainlayer_current_context` | — | `hours` (24) | Lightweight current working context (projects, branches, files) |
 | `brainlayer_session_summary` | `session_id` | — | Session enrichment: decisions, corrections, learnings |
+| `brainlayer_store` | `content`, `type` | `project`, `tags`, `importance` | Persistently store a memory (idea, decision, learning, etc.) |
 
 ### Search Parameters
 


### PR DESCRIPTION
## Summary
- **H5b**: Fixed file tree comment `(8 tools)` → `(14 tools)` to match actual MCP tool count
- **M11**: Added 5 missing tools to the Available Tools table: `brainlayer_think`, `brainlayer_recall`, `brainlayer_sessions`, `brainlayer_current_context`, `brainlayer_store`

Table now documents all 14 MCP tools with correct required/optional params and descriptions.

## Test plan
- [x] Verified tool count matches `src/brainlayer/mcp/__init__.py` (14 tools in `list_tools()`)
- [x] Documentation-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime behavior impact; risk is limited to potential documentation inaccuracies.
> 
> **Overview**
> Documentation-only update to `CLAUDE.md` to align MCP server docs with the actual **14 available tools**.
> 
> Fixes the file tree comment from *(8 tools)* to *(14 tools)* and extends the “Available Tools” table with five missing entries: `brainlayer_think`, `brainlayer_recall`, `brainlayer_sessions`, `brainlayer_current_context`, and `brainlayer_store` (including their required/optional params and descriptions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2787a69acdcf55eb14d5858751ecf7c6a7e18748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->