### PR TITLE
fix(mcp): prevent MCP server hangs when DB locked by enrichment

### DIFF
--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -842,19 +842,19 @@ async def call_tool(name: str, arguments: dict[str, Any]):
         )
 
     elif name == "brain_store":
+        # AIDEV-NOTE: No timeout wrapper on writes — non-idempotent (UUID-based IDs).
+        # If timeout fires but executor thread completes, user retries = duplicate memory.
         imp = arguments.get("importance")
-        return await _with_timeout(
-            _store_new(
-                content=arguments["content"],
-                memory_type=arguments.get("type"),
-                project=arguments.get("project"),
-                tags=arguments.get("tags"),
-                importance=max(1, min(imp, 10)) if imp is not None else None,
-                confidence_score=arguments.get("confidence_score"),
-                outcome=arguments.get("outcome"),
-                reversibility=arguments.get("reversibility"),
-                files_changed=arguments.get("files_changed"),
-            )
+        return await _store_new(
+            content=arguments["content"],
+            memory_type=arguments.get("type"),
+            project=arguments.get("project"),
+            tags=arguments.get("tags"),
+            importance=max(1, min(imp, 10)) if imp is not None else None,
+            confidence_score=arguments.get("confidence_score"),
+            outcome=arguments.get("outcome"),
+            reversibility=arguments.get("reversibility"),
+            files_changed=arguments.get("files_changed"),
         )
 
     elif name == "brain_recall":
@@ -969,15 +969,14 @@ async def call_tool(name: str, arguments: dict[str, Any]):
         return await _with_timeout(_session_summary(session_id=arguments["session_id"]))
 
     elif name == "brainlayer_store":
+        # AIDEV-NOTE: No timeout wrapper on writes — same reason as brain_store above.
         imp = arguments.get("importance")
-        return await _with_timeout(
-            _store(
-                content=arguments["content"],
-                memory_type=arguments["type"],
-                project=arguments.get("project"),
-                tags=arguments.get("tags"),
-                importance=max(1, min(imp, 10)) if imp is not None else None,
-            )
+        return await _store(
+            content=arguments["content"],
+            memory_type=arguments["type"],
+            project=arguments.get("project"),
+            tags=arguments.get("tags"),
+            importance=max(1, min(imp, 10)) if imp is not None else None,
         )
 
     else:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -89,6 +89,7 @@ class VectorStore:
         # AIDEV-NOTE: busy_timeout is critical for multi-process access (daemon + MCP + enrichment).
         # Without this, concurrent writes get SQLITE_BUSY immediately and crash silently.
         cursor.execute("PRAGMA busy_timeout = 5000")
+        cursor.execute("PRAGMA journal_mode = WAL")
 
         # Create tables
         cursor.execute("""
@@ -1921,7 +1922,9 @@ class VectorStore:
         }
 
     def close(self) -> None:
-        """Close database connection."""
+        """Close database connections."""
+        if hasattr(self, "read_conn"):
+            self.read_conn.close()
         if hasattr(self, "conn"):
             self.conn.close()
 


### PR DESCRIPTION
## Summary

- Added readonly SQLite connection (`SQLITE_OPEN_READONLY`) for all read operations — never contends with enrichment writes in WAL mode
- Split 36 cursor call sites: 22 read methods use `_read_cursor()`, 14 write methods use `conn.cursor()`
- Wrapped all 17 MCP tool handlers with 15s asyncio timeout — returns `isError: true` with actionable message instead of hanging forever

## Root Cause

Enrichment pipeline holds write lock → shared apsw.Connection serializes all operations → MCP reads block on same connection → asyncio event loop freezes → Claude session hangs for 10+ minutes. Happened 3 times in one session (Feb 24).

## Test plan

- [x] Both files compile (`py_compile`)
- [x] Readonly connection opens, reads work, writes correctly blocked (`ReadOnlyError`)
- [x] `_with_timeout()` returns error on timeout, passes through on success
- [x] All read methods verified using readonly connection (grep audit)
- [x] All write methods verified still using write connection (grep audit)
- [ ] MCP server restart + live test with enrichment running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core DB connection/config and tool dispatch paths; while behavior is mainly fail-fast on contention, incorrect WAL/readonly handling could break queries or mask underlying DB issues.
> 
> **Overview**
> Prevents MCP server freezes under enrichment-induced SQLite locks by **adding a 15s timeout wrapper** around all read-style MCP tool handlers (including backward-compat `brainlayer_*` aliases), returning a clear `isError` result instead of hanging.
> 
> Updates `VectorStore` to **enable WAL mode** and introduce a **separate readonly APSW connection** used by read/query methods via `_read_cursor()`, reducing contention between MCP reads and concurrent enrichment writes; `close()` now shuts down both connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb58dfe1eefbbb0bcf5fdf32d24439dc7ab1fc59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added global query timeout protection so long-running queries now fail fast with a clear, user-facing timeout message and suggested remediation.

* **Performance**
  * Improved read-side database concurrency and reliability by introducing a separate read path, reducing contention and speeding read-heavy operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->