### PR TITLE
feat: Phase 6 — Sentiment + Conversation Analysis

### DIFF
--- a/docs/plans/2026-02-25-phase-6-sentiment.md
+++ b/docs/plans/2026-02-25-phase-6-sentiment.md
@@ -1,0 +1,414 @@
+# Phase 6: Sentiment + Conversation Analysis — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extract frustration, positive, confusion, and satisfaction signals from conversation chunks using two-tier detection (rule-based + LLM enrichment).
+
+**Architecture:** 3 new columns on `chunks` table (`sentiment_label`, `sentiment_score`, `sentiment_signals`). Tier 1: fast rule-based pattern matching on `user_message` chunks (bilingual EN+HE). Tier 2: add sentiment fields to existing LLM enrichment prompt. New `sentiment` filter on `brain_search` MCP tool. New `brainlayer sentiment` CLI command for batch backfill.
+
+**Tech Stack:** Python, sqlite-vec (APSW), regex patterns, existing enrichment pipeline (Ollama/MLX)
+
+---
+
+### Task 1: Schema — Add sentiment columns to chunks table
+
+**Files:**
+- Modify: `src/brainlayer/vector_store.py:116-151` (column definitions + indexes)
+- Test: `tests/test_phase6_sentiment.py` (new file)
+
+**Step 1: Write the failing test**
+
+```python
+# tests/test_phase6_sentiment.py
+"""Phase 6: Sentiment + Conversation Analysis tests."""
+import json
+from pathlib import Path
+from brainlayer.vector_store import VectorStore
+
+
+def test_sentiment_columns_exist(tmp_path):
+    """Sentiment columns are created in chunks table."""
+    store = VectorStore(tmp_path / "test.db")
+    cursor = store.conn.cursor()
+    cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+    assert "sentiment_label" in cols
+    assert "sentiment_score" in cols
+    assert "sentiment_signals" in cols
+
+
+def test_sentiment_index_exists(tmp_path):
+    """Sentiment label index is created for fast filtering."""
+    store = VectorStore(tmp_path / "test.db")
+    cursor = store.conn.cursor()
+    indexes = {row[1] for row in cursor.execute("PRAGMA index_list(chunks)")}
+    assert "idx_chunks_sentiment" in indexes
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/etanheyman/Gits/brainlayer/.claude/worktrees/phase-6-sentiment && python3 -m pytest tests/test_phase6_sentiment.py -v`
+Expected: FAIL — columns don't exist yet
+
+**Step 3: Write minimal implementation**
+
+In `vector_store.py`, add to the column migration list (~line 138):
+```python
+            # Phase 6: Sentiment columns
+            ("sentiment_label", "TEXT"),   # frustration|confusion|positive|satisfaction|neutral
+            ("sentiment_score", "REAL"),   # -1.0 (frustration) to +1.0 (positive)
+            ("sentiment_signals", "TEXT"), # JSON array of matched signals
+```
+
+Add index (~line 152):
+```python
+            ("idx_chunks_sentiment", "sentiment_label"),
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_phase6_sentiment.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+---
+
+### Task 2: Rule-based sentiment analyzer module
+
+**Files:**
+- Create: `src/brainlayer/pipeline/sentiment.py`
+- Test: `tests/test_phase6_sentiment.py` (add tests)
+
+**Step 1: Write failing tests**
+
+```python
+def test_analyze_sentiment_frustration():
+    """Detects frustration in text."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("what the fuck, this is broken again")
+    assert result["label"] == "frustration"
+    assert result["score"] < -0.5
+    assert len(result["signals"]) > 0
+
+
+def test_analyze_sentiment_positive():
+    """Detects positive sentiment."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("wow this is amazing, works perfectly!")
+    assert result["label"] == "positive"
+    assert result["score"] > 0.5
+
+
+def test_analyze_sentiment_confusion():
+    """Detects confusion."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("I don't understand, wait what? how does this work?")
+    assert result["label"] == "confusion"
+    assert result["score"] < 0
+
+
+def test_analyze_sentiment_satisfaction():
+    """Detects satisfaction (task done, thanks)."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("perfect, thanks! that's exactly what I needed")
+    assert result["label"] == "satisfaction"
+    assert result["score"] > 0.5
+
+
+def test_analyze_sentiment_neutral():
+    """Neutral text gets neutral label."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("please read the file at src/main.py")
+    assert result["label"] == "neutral"
+    assert -0.3 <= result["score"] <= 0.3
+
+
+def test_analyze_sentiment_hebrew_frustration():
+    """Detects Hebrew frustration markers."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("לעזאזל, זה לא עובד בכלל")
+    assert result["label"] == "frustration"
+    assert result["score"] < -0.5
+
+
+def test_analyze_sentiment_hebrew_positive():
+    """Detects Hebrew positive markers."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("מדהים! עובד מעולה")
+    assert result["label"] == "positive"
+    assert result["score"] > 0.5
+
+
+def test_analyze_sentiment_returns_matched_signals():
+    """Signals list contains the actual matched patterns."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("damn this bug is so frustrating")
+    assert "damn" in result["signals"] or "frustrating" in result["signals"]
+
+
+def test_analyze_sentiment_empty_text():
+    """Empty text returns neutral."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+    result = analyze_sentiment("")
+    assert result["label"] == "neutral"
+    assert result["score"] == 0.0
+    assert result["signals"] == []
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_phase6_sentiment.py::test_analyze_sentiment_frustration -v`
+Expected: FAIL — module doesn't exist
+
+**Step 3: Implement sentiment analyzer**
+
+Create `src/brainlayer/pipeline/sentiment.py` with:
+- `FRUSTRATION_PATTERNS`: EN + HE regex patterns
+- `POSITIVE_PATTERNS`: EN + HE regex patterns
+- `CONFUSION_PATTERNS`: EN + HE regex patterns
+- `SATISFACTION_PATTERNS`: EN + HE regex patterns
+- `analyze_sentiment(text: str) -> dict`: Returns `{"label": str, "score": float, "signals": list[str]}`
+- Score calculation: weighted sum of matched patterns, normalized to [-1, 1]
+- Label thresholds: frustration (<-0.3), confusion (-0.3 to 0 with confusion patterns), positive (>0.3), satisfaction (>0.3 with satisfaction patterns), neutral (else)
+
+**Step 4: Run all sentiment tests**
+
+Run: `python3 -m pytest tests/test_phase6_sentiment.py -v`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+---
+
+### Task 3: VectorStore — update_sentiment method + sentiment filter on search
+
+**Files:**
+- Modify: `src/brainlayer/vector_store.py` (add `update_sentiment()`, add `sentiment_filter` to `search()` and `hybrid_search()`)
+- Test: `tests/test_phase6_sentiment.py` (add tests)
+
+**Step 1: Write failing tests**
+
+```python
+def test_update_sentiment(tmp_path):
+    """Can write and read back sentiment metadata."""
+    store = VectorStore(tmp_path / "test.db")
+    # Insert a test chunk
+    store.add_chunks(
+        ids=["test-1"],
+        documents=["what the fuck is this error"],
+        metadatas=[{"source_file": "test.jsonl", "project": "test"}],
+        embeddings=[[0.1] * 1024],
+    )
+    store.update_sentiment("test-1", "frustration", -0.8, ["wtf"])
+    cursor = store.conn.cursor()
+    row = list(cursor.execute(
+        "SELECT sentiment_label, sentiment_score, sentiment_signals FROM chunks WHERE id = ?",
+        ["test-1"]
+    ))[0]
+    assert row[0] == "frustration"
+    assert row[1] == -0.8
+    assert json.loads(row[2]) == ["wtf"]
+
+
+def test_search_sentiment_filter(tmp_path):
+    """Search can filter by sentiment_label."""
+    store = VectorStore(tmp_path / "test.db")
+    emb = [0.1] * 1024
+    store.add_chunks(
+        ids=["pos-1", "neg-1"],
+        documents=["great work", "this is broken"],
+        metadatas=[
+            {"source_file": "a.jsonl", "project": "test"},
+            {"source_file": "b.jsonl", "project": "test"},
+        ],
+        embeddings=[emb, emb],
+    )
+    store.update_sentiment("pos-1", "positive", 0.8, ["great"])
+    store.update_sentiment("neg-1", "frustration", -0.7, ["broken"])
+    results = store.search(
+        query_embedding=emb, n_results=10, sentiment_filter="frustration"
+    )
+    ids = [m.get("id") or m.get("chunk_id") for m in results["metadatas"][0]]
+    # Only frustration chunks returned
+    assert "neg-1" in [r for r in results["documents"][0] if "broken" in r] or len(results["documents"][0]) == 1
+```
+
+**Step 2: Run tests to verify they fail**
+
+**Step 3: Implement**
+
+- Add `update_sentiment(chunk_id, label, score, signals)` method on VectorStore (same retry pattern as `update_enrichment`)
+- Add `sentiment_filter: Optional[str] = None` param to `search()` and `hybrid_search()`
+- Add WHERE clause: `c.sentiment_label = ?` when filter is set
+
+**Step 4: Run tests, verify pass**
+
+**Step 5: Commit**
+
+---
+
+### Task 4: MCP — Add sentiment filter to brain_search
+
+**Files:**
+- Modify: `src/brainlayer/mcp/__init__.py` (add `sentiment` param to brain_search tool schema + dispatcher)
+- Test: `tests/test_phase6_sentiment.py` (add test)
+
+**Step 1: Write failing test**
+
+```python
+def test_brain_search_schema_has_sentiment():
+    """brain_search tool schema includes sentiment parameter."""
+    import asyncio
+    from brainlayer.mcp import server
+    # Get tool list
+    tools = asyncio.run(server.list_tools())
+    brain_search = next(t for t in tools if t.name == "brain_search")
+    props = brain_search.inputSchema.get("properties", {})
+    assert "sentiment" in props
+    assert props["sentiment"]["type"] == "string"
+```
+
+**Step 2: Run test to verify it fails**
+
+**Step 3: Implement**
+
+In `mcp/__init__.py`:
+- Add `sentiment` to the brain_search tool schema (enum: frustration, confusion, positive, satisfaction, neutral)
+- Pass `sentiment` through `_brain_search()` → `_search()` → `store.hybrid_search(sentiment_filter=...)`
+
+**Step 4: Run tests, verify pass**
+
+**Step 5: Commit**
+
+---
+
+### Task 5: CLI — `brainlayer sentiment` batch command
+
+**Files:**
+- Modify: `src/brainlayer/cli/__init__.py` (add `sentiment` command)
+- Test: `tests/test_phase6_sentiment.py` (add test)
+
+**Step 1: Write failing test**
+
+```python
+def test_sentiment_cli_processes_chunks(tmp_path):
+    """CLI sentiment command processes user_message chunks."""
+    from brainlayer.pipeline.sentiment import batch_analyze_sentiment
+    store = VectorStore(tmp_path / "test.db")
+    store.add_chunks(
+        ids=["u1"],
+        documents=["this is incredibly frustrating!"],
+        metadatas=[{"source_file": "t.jsonl", "project": "test", "content_type": "user_message"}],
+        embeddings=[[0.1] * 1024],
+    )
+    # Manually set content_type since add_chunks may not set it
+    store.conn.cursor().execute("UPDATE chunks SET content_type = 'user_message' WHERE id = 'u1'")
+    processed = batch_analyze_sentiment(store, batch_size=10, max_chunks=100)
+    assert processed >= 1
+    row = list(store.conn.cursor().execute(
+        "SELECT sentiment_label FROM chunks WHERE id = 'u1'"
+    ))[0]
+    assert row[0] == "frustration"
+```
+
+**Step 2: Run test to verify it fails**
+
+**Step 3: Implement**
+
+- `batch_analyze_sentiment(store, batch_size, max_chunks)` in `sentiment.py`: queries chunks WHERE content_type = 'user_message' AND sentiment_label IS NULL, runs `analyze_sentiment()`, calls `store.update_sentiment()`
+- CLI `sentiment` command in `cli/__init__.py`: wrapper with rich progress bar
+
+**Step 4: Run tests, verify pass**
+
+**Step 5: Commit**
+
+---
+
+### Task 6: Enrichment integration — Add sentiment to LLM enrichment prompt
+
+**Files:**
+- Modify: `src/brainlayer/pipeline/enrichment.py` (extend prompt + parse response)
+- Modify: `src/brainlayer/vector_store.py` (extend `update_enrichment` with sentiment fields)
+- Test: `tests/test_phase6_sentiment.py` (add test)
+
+**Step 1: Write failing test**
+
+```python
+def test_enrichment_prompt_includes_sentiment():
+    """LLM enrichment prompt asks for sentiment fields."""
+    from brainlayer.pipeline.enrichment import ENRICHMENT_PROMPT
+    assert "sentiment_label" in ENRICHMENT_PROMPT
+    assert "sentiment_score" in ENRICHMENT_PROMPT
+```
+
+**Step 2: Run test to verify it fails**
+
+**Step 3: Implement**
+
+- Add `sentiment_label`, `sentiment_score`, `sentiment_signals` to `ENRICHMENT_PROMPT` JSON template
+- Add sentiment parsing in `_parse_enrichment_response()`
+- Extend `update_enrichment()` to accept `sentiment_label`, `sentiment_score`, `sentiment_signals` params
+- LLM enrichment only overwrites sentiment if rule-based didn't already set it (rule-based = confident, LLM = fallback for ambiguous)
+
+**Step 4: Run tests, verify pass**
+
+**Step 5: Commit**
+
+---
+
+### Task 7: Full integration test + run baseline tests
+
+**Files:**
+- Test: `tests/test_phase6_sentiment.py` (add integration test)
+
+**Step 1: Write integration test**
+
+```python
+def test_full_sentiment_pipeline(tmp_path):
+    """End-to-end: insert chunk → rule-based sentiment → search by sentiment."""
+    store = VectorStore(tmp_path / "test.db")
+    from brainlayer.pipeline.sentiment import analyze_sentiment, batch_analyze_sentiment
+
+    emb = [0.1] * 1024
+    store.add_chunks(
+        ids=["angry-1", "happy-1", "neutral-1"],
+        documents=[
+            "what the hell, nothing works anymore",
+            "this is perfect, exactly what I wanted!",
+            "please update the config file",
+        ],
+        metadatas=[
+            {"source_file": "a.jsonl", "project": "test", "content_type": "user_message"},
+            {"source_file": "b.jsonl", "project": "test", "content_type": "user_message"},
+            {"source_file": "c.jsonl", "project": "test", "content_type": "user_message"},
+        ],
+        embeddings=[emb, emb, emb],
+    )
+    # Set content_type
+    for cid, ct in [("angry-1", "user_message"), ("happy-1", "user_message"), ("neutral-1", "user_message")]:
+        store.conn.cursor().execute("UPDATE chunks SET content_type = ? WHERE id = ?", [ct, cid])
+
+    processed = batch_analyze_sentiment(store)
+    assert processed == 3
+
+    # Search by sentiment
+    results = store.search(query_embedding=emb, n_results=10, sentiment_filter="frustration")
+    docs = results["documents"][0]
+    assert any("hell" in d or "nothing works" in d for d in docs)
+```
+
+**Step 2: Run ALL tests (phase 6 + baseline)**
+
+Run: `python3 -m pytest tests/test_phase6_sentiment.py -v && python3 -m pytest tests/ -x -q --ignore=tests/test_vector_store.py --ignore=tests/test_engine.py --ignore=tests/test_think_recall_integration.py`
+
+**Step 3: Commit all Phase 6 work**
+
+---
+
+### Task 8: Update collab.md + create PR
+
+**Step 1:** Update collab.md Messages with commit summary
+**Step 2:** Create PR with `gh pr create`
+**Step 3:** Poll for CI + reviews
+**Step 4:** Address review feedback
+**Step 5:** Merge

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -301,6 +301,67 @@ def clear(confirm: bool = typer.Option(False, "--yes", "-y", help="Skip confirma
 
 
 @app.command()
+def sentiment(
+    batch_size: int = typer.Option(500, "--batch-size", "-b", help="Chunks per batch"),
+    max_chunks: int = typer.Option(0, "--max", "-m", help="Max chunks (0=unlimited)"),
+    stats_only: bool = typer.Option(False, "--stats", help="Show sentiment stats and exit"),
+) -> None:
+    """Run rule-based sentiment analysis on user_message chunks."""
+    try:
+        from ..paths import DEFAULT_DB_PATH
+        from ..pipeline.sentiment import batch_analyze_sentiment
+        from ..vector_store import VectorStore
+
+        store = VectorStore(DEFAULT_DB_PATH)
+
+        if stats_only:
+            cursor = store.conn.cursor()
+            total_user = list(cursor.execute(
+                "SELECT COUNT(*) FROM chunks WHERE content_type = 'user_message'"
+            ))[0][0]
+            analyzed = list(cursor.execute(
+                "SELECT COUNT(*) FROM chunks WHERE sentiment_label IS NOT NULL"
+            ))[0][0]
+            by_label = dict(cursor.execute(
+                "SELECT sentiment_label, COUNT(*) FROM chunks WHERE sentiment_label IS NOT NULL GROUP BY sentiment_label"
+            ))
+            console.print(f"[bold]User messages:[/] {total_user}")
+            console.print(f"[bold]Analyzed:[/] {analyzed}")
+            console.print(f"[bold]Remaining:[/] {total_user - analyzed}")
+            if by_label:
+                for label, count in sorted(by_label.items(), key=lambda x: -x[1]):
+                    console.print(f"  {label}: {count}")
+            store.close()
+            return
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            console=console,
+        ) as progress:
+            # Count total to process
+            cursor = store.conn.cursor()
+            remaining = list(cursor.execute(
+                "SELECT COUNT(*) FROM chunks WHERE content_type = 'user_message' AND sentiment_label IS NULL"
+            ))[0][0]
+            if max_chunks > 0:
+                remaining = min(remaining, max_chunks)
+
+            task = progress.add_task("Analyzing sentiment...", total=remaining)
+            processed = batch_analyze_sentiment(store, batch_size=batch_size, max_chunks=max_chunks)
+            progress.update(task, completed=processed)
+
+        console.print(f"[bold green]Done![/] Processed {processed} chunks.")
+        store.close()
+    except Exception as e:
+        rprint(f"[bold red]Error:[/] {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
 def analyze_style(
     whatsapp_limit: int = typer.Option(1000, "--whatsapp-limit", "-w", help="Number of WhatsApp messages to analyze"),
     claude_export: Path = typer.Option(

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -602,6 +602,11 @@ Returns: Markdown text or structured JSON depending on the route taken.""",
                         "type": "string",
                         "description": "Filter results up to this date (ISO 8601, e.g. '2026-02-19')",
                     },
+                    "sentiment": {
+                        "type": "string",
+                        "enum": ["frustration", "confusion", "positive", "satisfaction", "neutral"],
+                        "description": "Filter by sentiment label (Phase 6)",
+                    },
                     "num_results": {
                         "type": "integer",
                         "default": 5,
@@ -834,6 +839,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
                 importance_min=arguments.get("importance_min"),
                 date_from=arguments.get("date_from"),
                 date_to=arguments.get("date_to"),
+                sentiment=arguments.get("sentiment"),
                 num_results=arguments.get("num_results", 5),
                 before=max(0, min(arguments.get("before", 3), 50)),
                 after=max(0, min(arguments.get("after", 3), 50)),
@@ -885,6 +891,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
                 importance_min=arguments.get("importance_min"),
                 date_from=arguments.get("date_from"),
                 date_to=arguments.get("date_to"),
+                sentiment=arguments.get("sentiment"),
             )
         )
 
@@ -998,6 +1005,7 @@ async def _brain_search(
     importance_min: float | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    sentiment: str | None = None,
     num_results: int = 5,
     before: int = 3,
     after: int = 3,
@@ -1061,6 +1069,7 @@ async def _brain_search(
             importance_min=importance_min,
             date_from=date_from,
             date_to=date_to,
+            sentiment=sentiment,
             num_results=num_results,
             max_results=max_results,
         )
@@ -1100,6 +1109,7 @@ async def _brain_search(
         importance_min=importance_min,
         date_from=date_from,
         date_to=date_to,
+        sentiment=sentiment,
     )
 
 
@@ -1215,6 +1225,7 @@ async def _search(
     importance_min: float | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    sentiment: str | None = None,
 ):
     """Execute a hybrid search query (semantic + keyword via RRF)."""
     try:
@@ -1261,6 +1272,7 @@ async def _search(
             importance_min=importance_min,
             date_from=date_from,
             date_to=date_to,
+            sentiment_filter=sentiment,
         )
 
         if not results["documents"][0]:

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -193,6 +193,7 @@ VALID_INTENTS = [
 ]
 VALID_EPISTEMIC = ["hypothesis", "substantiated", "validated"]
 VALID_DEBT_IMPACT = ["introduction", "resolution", "none"]
+VALID_SENTIMENTS = ["frustration", "confusion", "positive", "satisfaction", "neutral"]
 
 ENRICHMENT_PROMPT = """You are a metadata extraction assistant. Analyze this conversation chunk and return ONLY a JSON object.
 
@@ -214,7 +215,10 @@ Return this exact JSON structure:
   "epistemic_level": "<one of: hypothesis, substantiated, validated>",
   "version_scope": "<version or system state discussed, or null>",
   "debt_impact": "<one of: introduction, resolution, none>",
-  "external_deps": ["<libraries or external APIs used>"]
+  "external_deps": ["<libraries or external APIs used>"],
+  "sentiment_label": "<one of: frustration, confusion, positive, satisfaction, neutral>",
+  "sentiment_score": <float from -1.0 (max frustration) to 1.0 (max positive)>,
+  "sentiment_signals": ["<words/phrases that indicate the sentiment>"]
 }}
 
 TAG RULES:
@@ -245,6 +249,18 @@ DEBT_IMPACT:
 - none: Neither introducing nor resolving debt
 
 EXTERNAL_DEPS: Libraries, APIs, services referenced (e.g., "ollama", "supabase", "react-force-graph-3d"). Empty array if none.
+
+SENTIMENT_LABEL: Detect the emotional tone of the human user in this chunk.
+- frustration: Anger, annoyance, things not working ("damn", "wtf", "broken again")
+- confusion: Not understanding, asking for clarification ("I don't understand", "wait what?")
+- positive: Excitement, praise, amazement ("amazing", "incredible", "wow")
+- satisfaction: Task done, gratitude, approval ("thanks", "perfect", "exactly what I needed")
+- neutral: No strong emotion (most code/config chunks)
+Note: Only user_message chunks have meaningful sentiment. For ai_code/assistant_text, use "neutral".
+
+SENTIMENT_SCORE: -1.0 = maximum frustration, 0.0 = neutral, 1.0 = maximum positive.
+
+SENTIMENT_SIGNALS: List the specific words or phrases that indicate the sentiment. Empty array if neutral.
 
 Return ONLY the JSON object, no other text."""
 
@@ -546,6 +562,20 @@ def _enrich_one(
 
     enrichment = parse_enrichment(response)
     if enrichment:
+        # Only set sentiment from LLM if rule-based hasn't already set it
+        # (rule-based is high-confidence for obvious cases)
+        sentiment_label = enrichment.get("sentiment_label")
+        sentiment_score = enrichment.get("sentiment_score")
+        sentiment_signals = enrichment.get("sentiment_signals")
+        if sentiment_label and sentiment_label not in VALID_SENTIMENTS:
+            sentiment_label = None
+        existing_sentiment = chunk.get("sentiment_label")
+        if existing_sentiment:
+            # Rule-based already classified — don't overwrite
+            sentiment_label = None
+            sentiment_score = None
+            sentiment_signals = None
+
         store.update_enrichment(
             chunk_id=chunk["id"],
             summary=enrichment.get("summary"),
@@ -558,6 +588,9 @@ def _enrich_one(
             version_scope=enrichment.get("version_scope"),
             debt_impact=enrichment.get("debt_impact"),
             external_deps=enrichment.get("external_deps"),
+            sentiment_label=sentiment_label,
+            sentiment_score=sentiment_score,
+            sentiment_signals=sentiment_signals,
         )
         return True
     return False

--- a/src/brainlayer/pipeline/sentiment.py
+++ b/src/brainlayer/pipeline/sentiment.py
@@ -1,0 +1,243 @@
+"""Rule-based sentiment analysis for conversation chunks.
+
+Tier 1 of Phase 6: fast pattern matching on known frustration, positive,
+confusion, and satisfaction signals. Bilingual (EN + HE).
+
+Tier 2 (LLM enrichment) is handled by extending the enrichment prompt
+in enrichment.py — this module covers rule-based detection only.
+
+Usage:
+    from brainlayer.pipeline.sentiment import analyze_sentiment, batch_analyze_sentiment
+
+    # Single chunk
+    result = analyze_sentiment("what the fuck, this is broken")
+    # {"label": "frustration", "score": -0.85, "signals": ["fuck", "broken"]}
+
+    # Batch process
+    from brainlayer.vector_store import VectorStore
+    store = VectorStore(db_path)
+    processed = batch_analyze_sentiment(store, batch_size=500)
+"""
+
+import re
+from typing import Any, Dict, List
+
+# --- Pattern definitions ---
+# Each pattern: (compiled_regex, weight, signal_name)
+# Weights: 0.0-1.0 indicating signal strength
+
+FRUSTRATION_PATTERNS = [
+    # English - strong
+    (re.compile(r"\bwhat the (?:fuck|hell|heck)\b", re.I), 1.0, "wtf"),
+    (re.compile(r"\bfuck(?:ing|ed|s)?\b", re.I), 0.9, "fuck"),
+    (re.compile(r"\bshit(?:ty)?\b", re.I), 0.8, "shit"),
+    (re.compile(r"\bdamn(?:it|ed)?\b", re.I), 0.7, "damn"),
+    (re.compile(r"\bcrap\b", re.I), 0.5, "crap"),
+    (re.compile(r"\bwtf\b", re.I), 0.9, "wtf"),
+    # English - moderate
+    (re.compile(r"\bfrustrat(?:ing|ed|ion)\b", re.I), 0.8, "frustrating"),
+    (re.compile(r"\bannoying\b", re.I), 0.6, "annoying"),
+    (re.compile(r"\brigid(?:iculous)?\b", re.I), 0.5, "ridiculous"),
+    (re.compile(r"\bterrible\b", re.I), 0.6, "terrible"),
+    (re.compile(r"\bhate this\b", re.I), 0.7, "hate this"),
+    (re.compile(r"\bugh+\b", re.I), 0.5, "ugh"),
+    (re.compile(r"\bfml\b", re.I), 0.8, "fml"),
+    # English - contextual (something is broken)
+    (re.compile(r"\b(?:is |still |keeps? )?broken\b", re.I), 0.6, "broken"),
+    (re.compile(r"\bnothing works\b", re.I), 0.7, "nothing works"),
+    (re.compile(r"\bdoesn'?t work\b", re.I), 0.4, "doesn't work"),
+    (re.compile(r"\bwhy (?:the hell |the fuck |on earth )?(?:is|does|won'?t|can'?t|isn'?t)\b", re.I), 0.5, "why..."),
+    (re.compile(r"\bagain[!?]+\b", re.I), 0.4, "again!"),
+    # Hebrew
+    (re.compile(r"\bלעזאזל\b"), 0.9, "לעזאזל"),
+    (re.compile(r"\bחרא\b"), 0.8, "חרא"),
+    (re.compile(r"\bזה לא עובד\b"), 0.6, "לא עובד"),
+    (re.compile(r"\bמעצבן\b"), 0.7, "מעצבן"),
+    (re.compile(r"\bנמאס\b"), 0.7, "נמאס"),
+    (re.compile(r"\bבלאגן\b"), 0.5, "בלאגן"),
+    (re.compile(r"\bשבור\b"), 0.5, "שבור"),
+]
+
+POSITIVE_PATTERNS = [
+    # English - strong
+    (re.compile(r"\bamazing\b", re.I), 0.8, "amazing"),
+    (re.compile(r"\bincredible\b", re.I), 0.8, "incredible"),
+    (re.compile(r"\bawesome\b", re.I), 0.7, "awesome"),
+    (re.compile(r"\bperfect(?:ly)?\b", re.I), 0.8, "perfect"),
+    (re.compile(r"\bbrilliant\b", re.I), 0.7, "brilliant"),
+    (re.compile(r"\bexcellent\b", re.I), 0.7, "excellent"),
+    (re.compile(r"\bfantastic\b", re.I), 0.7, "fantastic"),
+    (re.compile(r"\bbeautiful\b", re.I), 0.6, "beautiful"),
+    # English - moderate
+    (re.compile(r"\bgreat\b", re.I), 0.5, "great"),
+    (re.compile(r"\bnice\b", re.I), 0.4, "nice"),
+    (re.compile(r"\blove (?:it|this)\b", re.I), 0.7, "love it"),
+    (re.compile(r"\bwow\b", re.I), 0.6, "wow"),
+    (re.compile(r"\bworks? (?:perfectly|great|well|beautifully)\b", re.I), 0.7, "works great"),
+    # Hebrew
+    (re.compile(r"\bמדהים\b"), 0.8, "מדהים"),
+    (re.compile(r"\bמעולה\b"), 0.7, "מעולה"),
+    (re.compile(r"\bנהדר\b"), 0.6, "נהדר"),
+    (re.compile(r"\bמושלם\b"), 0.8, "מושלם"),
+    (re.compile(r"\bיופי\b"), 0.5, "יופי"),
+    (re.compile(r"\bסבבה\b"), 0.4, "סבבה"),
+    (re.compile(r"\bאחלה\b"), 0.5, "אחלה"),
+]
+
+CONFUSION_PATTERNS = [
+    # English
+    (re.compile(r"\bi don'?t understand\b", re.I), 0.8, "don't understand"),
+    (re.compile(r"\bwait,? what\??\b", re.I), 0.7, "wait what"),
+    (re.compile(r"\bconfus(?:ed|ing)\b", re.I), 0.7, "confused"),
+    (re.compile(r"\bwhat do you mean\b", re.I), 0.6, "what do you mean"),
+    (re.compile(r"\bhow does this work\b", re.I), 0.5, "how does this work"),
+    (re.compile(r"\bmakes? no sense\b", re.I), 0.7, "makes no sense"),
+    (re.compile(r"\blost\b", re.I), 0.4, "lost"),
+    (re.compile(r"\bhuh\?+\b", re.I), 0.5, "huh?"),
+    (re.compile(r"\?\?+", re.I), 0.4, "??"),
+    # Hebrew
+    (re.compile(r"\bלא מבין\b"), 0.8, "לא מבין"),
+    (re.compile(r"\bמבלבל\b"), 0.7, "מבלבל"),
+    (re.compile(r"\bמה זה\b"), 0.4, "מה זה"),
+    (re.compile(r"\bרגע מה\b"), 0.6, "רגע מה"),
+]
+
+SATISFACTION_PATTERNS = [
+    # English
+    (re.compile(r"\bthanks?(?:!| a lot| so much)?\b", re.I), 0.5, "thanks"),
+    (re.compile(r"\bthank you\b", re.I), 0.5, "thank you"),
+    (re.compile(r"\bexactly what I (?:needed|wanted)\b", re.I), 0.8, "exactly what I needed"),
+    (re.compile(r"\bthat'?s? (?:it|right|correct)\b", re.I), 0.4, "that's it"),
+    (re.compile(r"\bwell done\b", re.I), 0.6, "well done"),
+    (re.compile(r"\bgood job\b", re.I), 0.5, "good job"),
+    (re.compile(r"\bnailed it\b", re.I), 0.7, "nailed it"),
+    (re.compile(r"\bship it\b", re.I), 0.6, "ship it"),
+    (re.compile(r"\blgtm\b", re.I), 0.5, "lgtm"),
+    # Hebrew
+    (re.compile(r"\bתודה\b"), 0.5, "תודה"),
+    (re.compile(r"\bבדיוק מה שרציתי\b"), 0.8, "בדיוק מה שרציתי"),
+    (re.compile(r"\bמצוין\b"), 0.6, "מצוין"),
+]
+
+
+def _match_patterns(text: str, patterns: list) -> List[tuple]:
+    """Match text against pattern list. Returns [(signal_name, weight), ...]."""
+    matches = []
+    for regex, weight, signal_name in patterns:
+        if regex.search(text):
+            matches.append((signal_name, weight))
+    return matches
+
+
+def analyze_sentiment(text: str) -> Dict[str, Any]:
+    """Analyze sentiment of a text chunk using rule-based pattern matching.
+
+    Returns:
+        {"label": str, "score": float, "signals": list[str]}
+        label: frustration|confusion|positive|satisfaction|neutral
+        score: -1.0 (max negative) to +1.0 (max positive)
+        signals: list of matched pattern names
+    """
+    if not text or not text.strip():
+        return {"label": "neutral", "score": 0.0, "signals": []}
+
+    frustration = _match_patterns(text, FRUSTRATION_PATTERNS)
+    positive = _match_patterns(text, POSITIVE_PATTERNS)
+    confusion = _match_patterns(text, CONFUSION_PATTERNS)
+    satisfaction = _match_patterns(text, SATISFACTION_PATTERNS)
+
+    # Calculate weighted scores per category
+    frust_score = sum(w for _, w in frustration) if frustration else 0
+    pos_score = sum(w for _, w in positive) if positive else 0
+    conf_score = sum(w for _, w in confusion) if confusion else 0
+    sat_score = sum(w for _, w in satisfaction) if satisfaction else 0
+
+    # Determine dominant category
+    # Negative categories: frustration, confusion
+    # Positive categories: positive, satisfaction
+    neg_total = frust_score + conf_score * 0.5
+    pos_total = pos_score + sat_score
+
+    # Normalize score to [-1, 1]
+    raw = pos_total - neg_total
+    max_magnitude = max(abs(raw), 1.0)
+    score = max(-1.0, min(1.0, raw / max_magnitude))
+
+    # Collect all signals
+    all_signals = (
+        [s for s, _ in frustration]
+        + [s for s, _ in confusion]
+        + [s for s, _ in positive]
+        + [s for s, _ in satisfaction]
+    )
+
+    # Label selection: pick the strongest category
+    categories = [
+        ("frustration", frust_score, frustration),
+        ("confusion", conf_score, confusion),
+        ("positive", pos_score, positive),
+        ("satisfaction", sat_score, satisfaction),
+    ]
+    categories.sort(key=lambda x: x[1], reverse=True)
+
+    if categories[0][1] == 0:
+        return {"label": "neutral", "score": 0.0, "signals": []}
+
+    top_label = categories[0][0]
+
+    # If frustration and satisfaction both present, frustration wins (user frustrated
+    # even if they said thanks)
+    if frust_score > 0 and sat_score > 0 and frust_score >= sat_score:
+        top_label = "frustration"
+
+    # Satisfaction requires positive-like signals too (not just "thanks" alone)
+    if top_label == "satisfaction" and sat_score < 0.6 and pos_score == 0:
+        top_label = "neutral"
+        score = score * 0.5  # dampen
+
+    return {"label": top_label, "score": round(score, 3), "signals": all_signals}
+
+
+def batch_analyze_sentiment(
+    store: Any,
+    batch_size: int = 500,
+    max_chunks: int = 0,
+) -> int:
+    """Batch-process user_message chunks through rule-based sentiment analysis.
+
+    Only processes chunks where sentiment_label IS NULL and content_type = 'user_message'.
+
+    Args:
+        store: VectorStore instance
+        batch_size: chunks per batch
+        max_chunks: max total chunks to process (0 = unlimited)
+
+    Returns:
+        Number of chunks processed.
+    """
+    cursor = store.conn.cursor()
+
+    limit_clause = f"LIMIT {max_chunks}" if max_chunks > 0 else ""
+
+    rows = list(
+        cursor.execute(
+            f"""SELECT id, content FROM chunks
+               WHERE content_type = 'user_message'
+               AND sentiment_label IS NULL
+               ORDER BY created_at DESC
+               {limit_clause}"""
+        )
+    )
+
+    processed = 0
+    for chunk_id, content in rows:
+        result = analyze_sentiment(content or "")
+        store.update_sentiment(
+            chunk_id,
+            label=result["label"],
+            score=result["score"],
+            signals=result["signals"],
+        )
+        processed += 1
+
+    return processed

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -136,6 +136,10 @@ class VectorStore:
             ("external_deps", "TEXT"),  # JSON array of libraries/APIs
             # Phase 3: created_at for date filtering
             ("created_at", "TEXT"),  # ISO 8601 timestamp of when chunk was created/ingested
+            # Phase 6: Sentiment columns
+            ("sentiment_label", "TEXT"),   # frustration|confusion|positive|satisfaction|neutral
+            ("sentiment_score", "REAL"),   # -1.0 (frustration) to +1.0 (positive)
+            ("sentiment_signals", "TEXT"), # JSON array of matched signal strings
         ]:
             if col not in existing_cols:
                 cursor.execute(f"ALTER TABLE chunks ADD COLUMN {col} {typ}")
@@ -149,6 +153,7 @@ class VectorStore:
             ("idx_chunks_importance", "importance"),
             ("idx_chunks_enriched", "enriched_at"),
             ("idx_chunks_created", "created_at"),
+            ("idx_chunks_sentiment", "sentiment_label"),
         ]:
             cursor.execute(f"CREATE INDEX IF NOT EXISTS {idx} ON chunks({col})")
 
@@ -529,6 +534,7 @@ class VectorStore:
         importance_min: Optional[float] = None,
         date_from: Optional[str] = None,
         date_to: Optional[str] = None,
+        sentiment_filter: Optional[str] = None,
     ) -> Dict[str, List]:
         """Search chunks by embedding or text."""
 
@@ -573,6 +579,9 @@ class VectorStore:
             if date_to:
                 where_clauses.append("c.created_at <= ?")
                 filter_params.append(date_to)
+            if sentiment_filter:
+                where_clauses.append("c.sentiment_label = ?")
+                filter_params.append(sentiment_filter)
 
             where_sql = ""
             if where_clauses:
@@ -827,6 +836,7 @@ class VectorStore:
         importance_min: Optional[float] = None,
         date_from: Optional[str] = None,
         date_to: Optional[str] = None,
+        sentiment_filter: Optional[str] = None,
         k: int = 60,
     ) -> Dict[str, List]:
         """Hybrid search combining semantic (vector) + keyword (FTS5) via Reciprocal Rank Fusion."""
@@ -845,6 +855,7 @@ class VectorStore:
             importance_min=importance_min,
             date_from=date_from,
             date_to=date_to,
+            sentiment_filter=sentiment_filter,
         )
 
         # Build semantic rank map: chunk_content -> rank
@@ -878,6 +889,9 @@ class VectorStore:
         if date_to:
             fts_extra.append("AND c.created_at <= ?")
             fts_params.append(date_to)
+        if sentiment_filter:
+            fts_extra.append("AND c.sentiment_label = ?")
+            fts_params.append(sentiment_filter)
         fts_params.append(n_results * 3)
 
         fts_results = list(
@@ -1136,6 +1150,9 @@ class VectorStore:
         version_scope: Optional[str] = None,
         debt_impact: Optional[str] = None,
         external_deps: Optional[List[str]] = None,
+        sentiment_label: Optional[str] = None,
+        sentiment_score: Optional[float] = None,
+        sentiment_signals: Optional[List[str]] = None,
     ) -> None:
         """Update enrichment metadata for a chunk."""
         cursor = self.conn.cursor()
@@ -1174,6 +1191,15 @@ class VectorStore:
         if external_deps is not None:
             sets.append("external_deps = ?")
             params.append(json.dumps(external_deps))
+        if sentiment_label is not None:
+            sets.append("sentiment_label = ?")
+            params.append(sentiment_label)
+        if sentiment_score is not None:
+            sets.append("sentiment_score = ?")
+            params.append(sentiment_score)
+        if sentiment_signals is not None:
+            sets.append("sentiment_signals = ?")
+            params.append(json.dumps(sentiment_signals))
 
         params.append(chunk_id)
         # Retry on SQLITE_BUSY — concurrent access from daemon/MCP/enrichment
@@ -1182,6 +1208,38 @@ class VectorStore:
         for attempt in range(3):
             try:
                 cursor.execute(f"UPDATE chunks SET {', '.join(sets)} WHERE id = ?", params)
+                return
+            except apsw.BusyError:
+                if attempt < 2:
+                    _time.sleep(0.5 * (attempt + 1))
+                else:
+                    raise
+
+    def update_sentiment(
+        self,
+        chunk_id: str,
+        label: str,
+        score: float,
+        signals: Optional[List[str]] = None,
+    ) -> None:
+        """Update sentiment metadata for a chunk.
+
+        Args:
+            chunk_id: Chunk to update
+            label: frustration|confusion|positive|satisfaction|neutral
+            score: -1.0 to +1.0
+            signals: List of matched signal strings
+        """
+        cursor = self.conn.cursor()
+        import time as _time
+
+        params: list = [label, score, json.dumps(signals or []), chunk_id]
+        for attempt in range(3):
+            try:
+                cursor.execute(
+                    "UPDATE chunks SET sentiment_label = ?, sentiment_score = ?, sentiment_signals = ? WHERE id = ?",
+                    params,
+                )
                 return
             except apsw.BusyError:
                 if attempt < 2:

--- a/tests/test_phase6_sentiment.py
+++ b/tests/test_phase6_sentiment.py
@@ -1,0 +1,267 @@
+"""Phase 6: Sentiment + Conversation Analysis tests."""
+
+import json
+from typing import List
+
+from brainlayer.vector_store import VectorStore
+
+
+def _insert_chunks(store: VectorStore, ids: List[str], documents: List[str],
+                   metadatas: List[dict], embeddings: List[list]) -> None:
+    """Helper to insert test chunks using upsert_chunks API."""
+    chunks = []
+    for i, (cid, doc, meta) in enumerate(zip(ids, documents, metadatas)):
+        chunks.append({
+            "id": cid,
+            "content": doc,
+            "metadata": meta,
+            "source_file": meta.get("source_file", "test.jsonl"),
+            "project": meta.get("project"),
+            "content_type": meta.get("content_type"),
+            "char_count": len(doc),
+            "source": meta.get("source", "claude_code"),
+        })
+    store.upsert_chunks(chunks, embeddings)
+
+
+# --- Task 1: Schema tests ---
+
+
+def test_sentiment_columns_exist(tmp_path):
+    """Sentiment columns are created in chunks table."""
+    store = VectorStore(tmp_path / "test.db")
+    cursor = store.conn.cursor()
+    cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+    assert "sentiment_label" in cols
+    assert "sentiment_score" in cols
+    assert "sentiment_signals" in cols
+
+
+def test_sentiment_index_exists(tmp_path):
+    """Sentiment label index is created for fast filtering."""
+    store = VectorStore(tmp_path / "test.db")
+    cursor = store.conn.cursor()
+    indexes = {row[1] for row in cursor.execute("PRAGMA index_list(chunks)")}
+    assert "idx_chunks_sentiment" in indexes
+
+
+# --- Task 2: Rule-based sentiment analyzer ---
+
+
+def test_analyze_sentiment_frustration():
+    """Detects frustration in text."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("what the fuck, this is broken again")
+    assert result["label"] == "frustration"
+    assert result["score"] < -0.5
+    assert len(result["signals"]) > 0
+
+
+def test_analyze_sentiment_positive():
+    """Detects positive sentiment."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("wow this is amazing, works perfectly!")
+    assert result["label"] == "positive"
+    assert result["score"] > 0.5
+
+
+def test_analyze_sentiment_confusion():
+    """Detects confusion."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("I don't understand, wait what? how does this work?")
+    assert result["label"] == "confusion"
+    assert result["score"] < 0
+
+
+def test_analyze_sentiment_satisfaction():
+    """Detects satisfaction (task done, thanks)."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("perfect, thanks! that's exactly what I needed")
+    assert result["label"] == "satisfaction"
+    assert result["score"] > 0.5
+
+
+def test_analyze_sentiment_neutral():
+    """Neutral text gets neutral label."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("please read the file at src/main.py")
+    assert result["label"] == "neutral"
+    assert -0.3 <= result["score"] <= 0.3
+
+
+def test_analyze_sentiment_hebrew_frustration():
+    """Detects Hebrew frustration markers."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("לעזאזל, זה לא עובד בכלל")
+    assert result["label"] == "frustration"
+    assert result["score"] < -0.5
+
+
+def test_analyze_sentiment_hebrew_positive():
+    """Detects Hebrew positive markers."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("מדהים! עובד מעולה")
+    assert result["label"] == "positive"
+    assert result["score"] > 0.5
+
+
+def test_analyze_sentiment_returns_matched_signals():
+    """Signals list contains the actual matched patterns."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("damn this bug is so frustrating")
+    assert any(s in result["signals"] for s in ["damn", "frustrating"])
+
+
+def test_analyze_sentiment_empty_text():
+    """Empty text returns neutral."""
+    from brainlayer.pipeline.sentiment import analyze_sentiment
+
+    result = analyze_sentiment("")
+    assert result["label"] == "neutral"
+    assert result["score"] == 0.0
+    assert result["signals"] == []
+
+
+# --- Task 3: VectorStore sentiment methods ---
+
+
+def test_update_sentiment(tmp_path):
+    """Can write and read back sentiment metadata."""
+    store = VectorStore(tmp_path / "test.db")
+    _insert_chunks(
+        store,
+        ids=["test-1"],
+        documents=["what the fuck is this error"],
+        metadatas=[{"source_file": "test.jsonl", "project": "test"}],
+        embeddings=[[0.1] * 1024],
+    )
+    store.update_sentiment("test-1", "frustration", -0.8, ["wtf"])
+    cursor = store.conn.cursor()
+    row = list(
+        cursor.execute(
+            "SELECT sentiment_label, sentiment_score, sentiment_signals FROM chunks WHERE id = ?",
+            ["test-1"],
+        )
+    )[0]
+    assert row[0] == "frustration"
+    assert row[1] == -0.8
+    assert json.loads(row[2]) == ["wtf"]
+
+
+def test_search_sentiment_filter(tmp_path):
+    """Search can filter by sentiment_label."""
+    store = VectorStore(tmp_path / "test.db")
+    emb = [0.1] * 1024
+    _insert_chunks(
+        store,
+        ids=["pos-1", "neg-1"],
+        documents=["great work", "this is broken"],
+        metadatas=[
+            {"source_file": "a.jsonl", "project": "test"},
+            {"source_file": "b.jsonl", "project": "test"},
+        ],
+        embeddings=[emb, emb],
+    )
+    store.update_sentiment("pos-1", "positive", 0.8, ["great"])
+    store.update_sentiment("neg-1", "frustration", -0.7, ["broken"])
+    results = store.search(query_embedding=emb, n_results=10, sentiment_filter="frustration")
+    docs = results["documents"][0]
+    assert len(docs) == 1
+    assert "broken" in docs[0]
+
+
+# --- Task 4: MCP schema test ---
+
+
+def test_brain_search_schema_has_sentiment():
+    """brain_search tool schema includes sentiment parameter."""
+    import asyncio
+
+    from brainlayer.mcp import list_tools
+
+    tools = asyncio.run(list_tools())
+    brain_search = next(t for t in tools if t.name == "brain_search")
+    props = brain_search.inputSchema.get("properties", {})
+    assert "sentiment" in props
+    assert props["sentiment"]["type"] == "string"
+
+
+# --- Task 5: Batch processing ---
+
+
+def test_batch_analyze_sentiment(tmp_path):
+    """Batch command processes user_message chunks."""
+    from brainlayer.pipeline.sentiment import batch_analyze_sentiment
+
+    store = VectorStore(tmp_path / "test.db")
+    _insert_chunks(
+        store,
+        ids=["u1"],
+        documents=["this is incredibly frustrating!"],
+        metadatas=[{"source_file": "t.jsonl", "project": "test", "content_type": "user_message"}],
+        embeddings=[[0.1] * 1024],
+    )
+    processed = batch_analyze_sentiment(store, batch_size=10, max_chunks=100)
+    assert processed >= 1
+    row = list(store.conn.cursor().execute("SELECT sentiment_label FROM chunks WHERE id = 'u1'"))[0]
+    assert row[0] == "frustration"
+
+
+# --- Task 6: Enrichment integration ---
+
+
+def test_enrichment_prompt_includes_sentiment():
+    """LLM enrichment prompt asks for sentiment fields."""
+    from brainlayer.pipeline.enrichment import ENRICHMENT_PROMPT
+
+    assert "sentiment_label" in ENRICHMENT_PROMPT
+    assert "sentiment_score" in ENRICHMENT_PROMPT
+
+
+# --- Task 7: Full integration test ---
+
+
+def test_full_sentiment_pipeline(tmp_path):
+    """End-to-end: insert chunk -> rule-based sentiment -> search by sentiment."""
+    from brainlayer.pipeline.sentiment import batch_analyze_sentiment
+
+    store = VectorStore(tmp_path / "test.db")
+    emb = [0.1] * 1024
+    _insert_chunks(
+        store,
+        ids=["angry-1", "happy-1", "neutral-1"],
+        documents=[
+            "what the hell, nothing works anymore",
+            "this is perfect, exactly what I wanted!",
+            "please update the config file",
+        ],
+        metadatas=[
+            {"source_file": "a.jsonl", "project": "test", "content_type": "user_message"},
+            {"source_file": "b.jsonl", "project": "test", "content_type": "user_message"},
+            {"source_file": "c.jsonl", "project": "test", "content_type": "user_message"},
+        ],
+        embeddings=[emb, emb, emb],
+    )
+
+    processed = batch_analyze_sentiment(store)
+    assert processed == 3
+
+    # Search by sentiment
+    results = store.search(query_embedding=emb, n_results=10, sentiment_filter="frustration")
+    docs = results["documents"][0]
+    assert len(docs) == 1
+    assert any("hell" in d or "nothing works" in d for d in docs)
+
+    # Positive filter
+    results = store.search(query_embedding=emb, n_results=10, sentiment_filter="positive")
+    docs = results["documents"][0]
+    assert len(docs) == 1
+    assert any("perfect" in d for d in docs)


### PR DESCRIPTION
## Summary

- **3 new columns** on `chunks` table: `sentiment_label`, `sentiment_score`, `sentiment_signals` + index
- **Rule-based sentiment analyzer** (Tier 1): pattern matching for frustration, positive, confusion, satisfaction — bilingual EN+HE, processes `user_message` chunks
- **LLM enrichment extension** (Tier 2): sentiment fields added to enrichment prompt, rule-based has priority (won't be overwritten by LLM)
- **MCP `brain_search`** gains `sentiment` filter parameter (enum: frustration, confusion, positive, satisfaction, neutral)
- **CLI `brainlayer sentiment`** command for batch backfill with progress bar + `--stats` for distribution
- **17 new tests**, 316 baseline pass, lint clean

## Feeds into

- Phase 7 (Frustration Incident Pipeline) — coachClaude queries `brain_search(sentiment="frustration")` to investigate bad interactions
- Entity metadata — golem interaction quality scores
- Persona growth — each golem learns interaction preferences

## Test plan

- [x] Schema: sentiment columns + index created on fresh DB
- [x] Rule-based: EN frustration, positive, confusion, satisfaction detection
- [x] Rule-based: HE frustration + positive detection (לעזאזל, מדהים)
- [x] Rule-based: neutral text, empty text, signal extraction
- [x] VectorStore: update_sentiment write/read roundtrip
- [x] VectorStore: search with sentiment_filter returns only matching chunks
- [x] MCP: brain_search tool schema includes sentiment parameter
- [x] Batch: batch_analyze_sentiment processes user_message chunks
- [x] Enrichment: prompt includes sentiment_label and sentiment_score
- [x] Integration: insert → analyze → search by sentiment end-to-end
- [x] Baseline: 316 existing tests still pass
- [x] Lint: ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core DB schema and search query construction, so mistakes could break indexing/search or produce incorrect filtering. Changes are additive and well-covered by new tests, but will apply to all users’ databases and search paths.
> 
> **Overview**
> Adds *Phase 6 sentiment support* across storage, analysis, and retrieval.
> 
> `chunks` now stores `sentiment_label`, `sentiment_score`, and `sentiment_signals` (plus an index), with `VectorStore.search()`/`hybrid_search()` gaining a `sentiment_filter` and a new `update_sentiment()` helper for writes.
> 
> Introduces a bilingual (EN+HE) rule-based analyzer (`pipeline/sentiment.py`) plus a `brainlayer sentiment` CLI command to backfill/inspect sentiment on `user_message` chunks; extends the LLM enrichment prompt to emit sentiment fields but avoids overwriting rule-based sentiment when already set.
> 
> Exposes sentiment filtering through MCP by adding a `sentiment` parameter to `brain_search`/`brainlayer_search`, and adds a new test suite (`tests/test_phase6_sentiment.py`) covering schema, analyzer behavior, batch processing, enrichment prompt changes, and end-to-end sentiment-filtered search.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fc6f1a7b9cad4a18c6fe606173cd1b050a7c2e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->