### PR TITLE
docs: update tool count 3→7 for v3 KG tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
-[![MCP](https://img.shields.io/badge/MCP-3%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-266%20passing-brightgreen.svg)](#testing)
+[![MCP](https://img.shields.io/badge/MCP-7%20tools-green.svg)](https://modelcontextprotocol.io)
+[![Tests](https://img.shields.io/badge/tests-525%20passing-brightgreen.svg)](#testing)
 [![Docs](https://img.shields.io/badge/docs-etanhey.github.io%2Fbrainlayer-blue.svg)](https://etanhey.github.io/brainlayer)
 
 ---
@@ -19,6 +19,9 @@ BrainLayer fixes this. It's a **local-first memory layer** that gives any MCP-co
 "Show me everything about this file's history"     →  brain_recall
 "What was I working on yesterday?"                 →  brain_recall
 "Remember this decision for later"                 →  brain_store
+"Ingest this meeting transcript"                   →  brain_digest
+"What do we know about this person?"               →  brain_get_person
+"Look up the Domica project entity"                →  brain_entity
 ```
 
 ## Quick Start
@@ -86,9 +89,11 @@ That's it. Your agent now has persistent memory across every conversation.
 
 ```mermaid
 graph LR
-    A["Claude Code / Cursor / Zed"] -->|MCP| B["BrainLayer MCP Server<br/>3 tools"]
+    A["Claude Code / Cursor / Zed"] -->|MCP| B["BrainLayer MCP Server<br/>7 tools"]
     B --> C["Hybrid Search<br/>semantic + keyword (RRF)"]
     C --> D["SQLite + sqlite-vec<br/>single .db file"]
+    B --> KG["Knowledge Graph<br/>entities + relations"]
+    KG --> D
 
     E["Claude Code JSONL<br/>conversations"] --> F["Pipeline"]
     F -->|extract → classify → chunk → embed| D
@@ -106,7 +111,9 @@ graph LR
 | MCP Server | stdio-based, MCP SDK v1.26+, compatible with any MCP client |
 | Clustering | HDBSCAN + UMAP for brain graph visualization (optional) |
 
-## MCP Tools (3)
+## MCP Tools (7)
+
+### Core (3)
 
 | Tool | Description |
 |------|-------------|
@@ -114,13 +121,18 @@ graph LR
 | `brain_store` | Persist memories — ideas, decisions, learnings, mistakes. Auto-type/auto-importance. |
 | `brain_recall` | Proactive retrieval — current context, sessions, session summaries. |
 
+### Knowledge Graph (4)
+
+| Tool | Description |
+|------|-------------|
+| `brain_digest` | Ingest raw content — entity extraction, relations, sentiment, action items. |
+| `brain_entity` | Look up entities in the knowledge graph — type, relations, evidence. |
+| `brain_update` | Update, archive, or merge existing memories. |
+| `brain_get_person` | Person lookup — entity details, interactions, preferences (~200ms). |
+
 ### Backward Compatibility
 
-Old `brainlayer_*` names still work as aliases.
-
-- `brain_search` aliases: `brainlayer_search`, `brainlayer_context`, `brainlayer_stats`, `brainlayer_list_projects`, `brainlayer_file_timeline`, `brainlayer_operations`, `brainlayer_regression`, `brainlayer_plan_links`, `brainlayer_think`
-- `brain_store` alias: `brainlayer_store`
-- `brain_recall` aliases: `brainlayer_recall`, `brainlayer_current_context`, `brainlayer_sessions`, `brainlayer_session_summary`
+All 14 old `brainlayer_*` names still work as aliases.
 
 ## Enrichment
 
@@ -155,7 +167,7 @@ BRAINLAYER_ENRICH_BACKEND=mlx brainlayer enrich --batch-size=100
 
 | | BrainLayer | Mem0 | Zep/Graphiti | Letta | LangChain Memory |
 |---|:---:|:---:|:---:|:---:|:---:|
-| **MCP native** | 3 tools | 1 server | 1 server | No | No |
+| **MCP native** | 7 tools | 1 server | 1 server | No | No |
 | **Think / Recall** | Yes | No | No | No | No |
 | **Local-first** | SQLite | Cloud-first | Cloud-only | Docker+PG | Framework |
 | **Zero infra** | `pip install` | API key | API key | Docker | Multiple deps |
@@ -167,7 +179,8 @@ BRAINLAYER_ENRICH_BACKEND=mlx brainlayer enrich --batch-size=100
 BrainLayer is the only memory layer that:
 1. **Thinks before answering** — categorizes past knowledge by intent (decisions, bugs, patterns) instead of raw search results
 2. **Runs on a single file** — no database servers, no Docker, no cloud accounts
-3. **Works with every MCP client** — 3 tools, instant integration, zero SDK
+3. **Works with every MCP client** — 7 tools, instant integration, zero SDK
+4. **Knowledge graph** — entities, relations, and person lookup across all indexed data
 
 ## CLI Reference
 
@@ -227,7 +240,7 @@ BrainLayer can index conversations from multiple sources:
 
 ```bash
 pip install -e ".[dev]"
-pytest tests/                           # Full suite (268 tests)
+pytest tests/                           # Full suite (525 tests)
 pytest tests/ -m "not integration"      # Unit tests only (fast)
 ruff check src/                         # Linting
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ graph TD
     end
 
     subgraph Interfaces
-        E1["MCP Server<br/>brainlayer-mcp (3 tools)"]
+        E1["MCP Server<br/>brainlayer-mcp (7 tools)"]
         E2["CLI<br/>brainlayer"]
         E3["FastAPI Daemon<br/>:8787"]
         E4["TUI Dashboard"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ BrainLayer fixes this. It's a **local-first memory layer** that gives any MCP-co
 
 ## Key Features
 
-- **3 MCP tools** — brain_search, brain_store, brain_recall (old brainlayer_* names work as aliases)
+- **7 MCP tools** — 3 core (search, store, recall) + 4 knowledge graph (digest, entity, update, get_person)
 - **Local-first** — SQLite + sqlite-vec, single file, no cloud, no Docker
 - **Hybrid search** — semantic vectors + keyword, merged with Reciprocal Rank Fusion
 - **10-field enrichment** — summary, tags, importance, intent, and more via local LLM
@@ -45,7 +45,7 @@ Your agent now has persistent memory. Ask it:
 
 ```mermaid
 graph LR
-    A["Claude Code / Cursor / Zed"] -->|MCP| B["BrainLayer MCP Server<br/>3 tools"]
+    A["Claude Code / Cursor / Zed"] -->|MCP| B["BrainLayer MCP Server<br/>7 tools"]
     B --> C["Hybrid Search<br/>semantic + keyword (RRF)"]
     C --> D["SQLite + sqlite-vec<br/>single .db file"]
 
@@ -57,6 +57,6 @@ graph LR
 ## Next Steps
 
 - [Quick Start](quickstart.md) — full setup guide
-- [MCP Tools Reference](mcp-tools.md) — all 3 tools documented
+- [MCP Tools Reference](mcp-tools.md) — all 7 tools documented
 - [Configuration](configuration.md) — environment variables and options
 - [Architecture](architecture.md) — how it works under the hood

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-BrainLayer exposes **3 MCP tools** (Phase 4 consolidation).
+BrainLayer exposes **7 MCP tools** — 3 core (search/store/recall) + 4 knowledge graph (digest/entity/update/get_person).
 
 ## brain_search
 
@@ -23,6 +23,8 @@ Unified semantic search — pass `query`, `file_path`, `chunk_id`, or filters. A
 
 **Returns:** Markdown with matched chunks, context, or timeline depending on input.
 
+**Annotations:** `readOnlyHint: true`
+
 ---
 
 ## brain_store
@@ -36,6 +38,7 @@ Persist a memory (idea, decision, learning, mistake, etc.) for future retrieval.
 | `project` | string | No | Project to scope the memory |
 | `tags` | array[string] | No | Tags for categorization |
 | `importance` | integer | No | Importance score 1-10 (auto-detected if omitted) |
+| `entity_id` | string | No | Link memory to a KG entity |
 
 **Returns:** Chunk ID and related existing memories.
 
@@ -49,7 +52,7 @@ Proactive retrieval — current context, sessions, session summaries. Mode defau
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `mode` | string | No | `context` (default), `sessions`, `session_summary` |
+| `mode` | string | No | `context` (default), `sessions`, `session_summary`, `operations`, `plan`, `summary`, `stats` |
 | `session_id` | string | No | For session_summary mode |
 | `project` | string | No | Filter by project |
 | `days` | integer | No | Days back for sessions (default: 7, max: 365) |
@@ -58,7 +61,77 @@ Proactive retrieval — current context, sessions, session summaries. Mode defau
 
 **Returns:** Structured summary of recent activity, session list, or session-level analysis.
 
+**Annotations:** `readOnlyHint: true`
+
 **Use when:** Starting a conversation, reviewing sessions, or understanding current state.
+
+---
+
+## brain_digest
+
+Ingest raw content (transcripts, docs, articles, conversation blocks). Runs entity extraction, relation extraction, sentiment analysis, and action item detection.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `content` | string | Yes | Raw content to digest |
+| `source` | string | No | Source label (default: `digest`) |
+| `project` | string | No | Project to scope |
+| `participants` | array[string] | No | Known participants for entity linking |
+
+**Returns:** Digest summary with extracted entities, relations, sentiment, action items, decisions, and questions.
+
+**Use when:** Ingesting meeting transcripts, long documents, or conversation logs. Batch 5-10 messages for short chat — don't call per-message.
+
+---
+
+## brain_entity
+
+Look up a known entity in the knowledge graph. Returns entity type, relations, and evidence chunks.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Entity name or search query |
+| `entity_id` | string | No | Direct entity ID lookup |
+
+**Returns:** Entity details (type, metadata), relations to other entities, and linked chunks.
+
+**Annotations:** `readOnlyHint: true`
+
+**Use when:** Looking up people, projects, or concepts in the knowledge graph.
+
+---
+
+## brain_update
+
+Update, archive, or merge existing memories.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `update`, `archive`, or `merge` |
+| `chunk_id` | string | Yes | Target chunk ID |
+| `content` | string | No | New content (re-embeds if changed). For `update` action. |
+| `tags` | array[string] | No | New tags. For `update` action. |
+| `importance` | integer | No | New importance. For `update` action. |
+| `merge_chunk_ids` | array[string] | No | Chunk IDs to archive (kept chunk = `chunk_id`). For `merge` action. |
+
+**Returns:** Confirmation of the action taken.
+
+**Use when:** Preferences change ("actually Sundays work now"), deduplicating similar memories, or soft-deleting outdated information.
+
+---
+
+## brain_get_person
+
+Look up a person by name — returns entity details, recent interactions, preferences, and related memories. Optimized for real-time lookups (~200-500ms).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Person's name |
+| `project` | string | No | Scope to a project |
+
+**Returns:** Person entity with metadata, recent chunks, relations, and preferences.
+
+**Use when:** Need quick context about a person before a meeting, during a conversation, or for personalization.
 
 ---
 


### PR DESCRIPTION
## Summary
- Updates all stale "3 tools" references to "7 tools" across README, docs site (index, architecture, mcp-tools)
- Full MCP tools reference now documents all 7 tools with parameters, return types, and use cases
- Test count badge updated 266→525
- Architecture diagram includes Knowledge Graph node

## Test plan
- [ ] Docs render correctly (markdown format)
- [ ] No remaining stale "3 tools" references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates (README + docs site) with no runtime code changes; risk is limited to potential doc inaccuracies or broken rendering/links.
> 
> **Overview**
> Updates public docs to reflect the MCP server expanding from **3 to 7 tools**, adding Knowledge Graph capabilities (`brain_digest`, `brain_entity`, `brain_update`, `brain_get_person`) and documenting their parameters/usage in `docs/mcp-tools.md`.
> 
> Refreshes diagrams and marketing copy to include a Knowledge Graph node, updates backward-compat alias wording, and bumps the displayed test count/badges (e.g., 266→525).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a405487efa4d7f3b59fcd6e23b29b6c43d9ab8eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->