### PR TITLE
feat: HTTP API for KG — digest, person, store, entity endpoints

### DIFF
--- a/src/brainlayer/daemon.py
+++ b/src/brainlayer/daemon.py
@@ -1031,6 +1031,221 @@ async def session_detail(session_id: str, page: int = 1, per_page: int = 50, con
 
 
 # ──────────────────────────────────────────────
+# Knowledge Graph API (6PM integration bridge)
+# ──────────────────────────────────────────────
+
+
+class DigestRequest(BaseModel):
+    """Digest request — ingest raw content and extract entities/relations."""
+
+    content: str
+    title: Optional[str] = None
+    project: Optional[str] = None
+    participants: Optional[List[str]] = None
+
+
+class StoreRequest(BaseModel):
+    """Store request — persist a memory."""
+
+    content: str
+    type: Optional[str] = None
+    project: Optional[str] = None
+    tags: Optional[List[str]] = None
+    importance: Optional[int] = None
+    entity_id: Optional[str] = None
+
+
+class UpdateEntityRequest(BaseModel):
+    """Update entity metadata."""
+
+    metadata: Dict[str, Any]
+
+
+@app.post("/digest")
+async def api_digest(request: DigestRequest):
+    """Digest raw content — extract entities, relations, sentiment, action items.
+
+    This is the Convex → BrainLayer bridge for 6PM. Chat messages, onboarding
+    transcripts, and meeting notes are ingested here.
+    """
+    if not vector_store or not embedding_model:
+        raise HTTPException(status_code=503, detail="Not initialized")
+
+    from .pipeline.digest import digest_content
+
+    try:
+        result = await asyncio.to_thread(
+            digest_content,
+            content=request.content,
+            store=vector_store,
+            embed_fn=embedding_model.embed_query,
+            title=request.title,
+            project=request.project,
+            participants=request.participants,
+        )
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Digest failed: {e}")
+        raise HTTPException(status_code=500, detail="Digest failed")
+
+
+@app.get("/person/{name}")
+async def api_get_person(name: str, context: Optional[str] = None, num_memories: int = 10):
+    """Look up a person by name — entity profile + scoped memories.
+
+    Optimized for real-time lookups (~200-500ms). Returns entity metadata,
+    relations, and relevant memory chunks.
+    """
+    if not vector_store or not embedding_model:
+        raise HTTPException(status_code=503, detail="Not initialized")
+
+    from .pipeline.digest import entity_lookup
+
+    # Step 1: Entity lookup
+    entity = await asyncio.to_thread(
+        entity_lookup,
+        query=name,
+        store=vector_store,
+        embed_fn=embedding_model.embed_query,
+        entity_type="person",
+    )
+
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"No person entity found matching '{name}'")
+
+    entity_id = entity["id"]
+
+    # Step 2: Scoped memories
+    memories = []
+    if context:
+        query_embedding = await asyncio.to_thread(embedding_model.embed_query, context)
+        results = await asyncio.to_thread(
+            vector_store.hybrid_search,
+            query_embedding=query_embedding,
+            query_text=context,
+            n_results=num_memories,
+            entity_id=entity_id,
+        )
+        if results["documents"][0]:
+            for doc, meta in zip(results["documents"][0], results["metadatas"][0]):
+                memories.append(
+                    {
+                        "content": doc[:500],
+                        "type": meta.get("content_type", "unknown"),
+                        "date": meta.get("created_at", "")[:10] if meta.get("created_at") else None,
+                        "summary": meta.get("summary"),
+                    }
+                )
+    else:
+        entity_chunks = await asyncio.to_thread(vector_store.get_entity_chunks, entity_id, limit=num_memories)
+        for chunk in entity_chunks:
+            memories.append(
+                {
+                    "content": chunk["content"][:500] if chunk.get("content") else "",
+                    "type": chunk.get("content_type", "unknown"),
+                    "relevance": chunk.get("relevance"),
+                }
+            )
+
+    return {
+        "entity": entity,
+        "memories": memories,
+    }
+
+
+@app.post("/store")
+async def api_store(request: StoreRequest):
+    """Store a memory — ideas, decisions, learnings, constraints.
+
+    For 6PM: store extracted constraints, preferences, and meeting outcomes.
+    """
+    if not vector_store or not embedding_model:
+        raise HTTPException(status_code=503, detail="Not initialized")
+
+    from .store import store_memory
+
+    try:
+        result = await asyncio.to_thread(
+            store_memory,
+            store=vector_store,
+            embed_fn=embedding_model.embed_query,
+            content=request.content,
+            memory_type=request.type or "note",
+            project=request.project,
+            tags=request.tags,
+            importance=request.importance,
+            entity_id=request.entity_id,
+        )
+        return result
+    except Exception as e:
+        logger.error(f"Store failed: {e}")
+        raise HTTPException(status_code=500, detail="Store failed")
+
+
+@app.get("/entity/{entity_id}")
+async def api_get_entity(entity_id: str):
+    """Get entity by ID — metadata, relations, linked chunks."""
+    if not vector_store:
+        raise HTTPException(status_code=503, detail="Not initialized")
+
+    entity = await asyncio.to_thread(vector_store.get_entity, entity_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entity {entity_id} not found")
+
+    relations = await asyncio.to_thread(vector_store.get_entity_relations, entity_id)
+    chunks = await asyncio.to_thread(vector_store.get_entity_chunks, entity_id, limit=10)
+
+    return {
+        "entity": entity,
+        "relations": relations,
+        "chunks": [
+            {
+                "chunk_id": c["chunk_id"],
+                "content": c["content"][:300] if c.get("content") else "",
+                "relevance": c.get("relevance"),
+            }
+            for c in chunks
+        ],
+    }
+
+
+@app.patch("/entity/{entity_id}")
+async def api_update_entity(entity_id: str, request: UpdateEntityRequest):
+    """Update entity metadata — merge new keys into existing metadata.
+
+    For 6PM: update constraints like blocked_weekdays, preferred_times, etc.
+    """
+    if not vector_store:
+        raise HTTPException(status_code=503, detail="Not initialized")
+
+    # Get existing entity
+    entity = await asyncio.to_thread(vector_store.get_entity, entity_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entity {entity_id} not found")
+
+    # Merge metadata
+    existing_meta = entity.get("metadata") or {}
+    if isinstance(existing_meta, str):
+        try:
+            existing_meta = json.loads(existing_meta)
+        except json.JSONDecodeError:
+            existing_meta = {}
+    existing_meta.update(request.metadata)
+
+    # Update via upsert_entity (preserves existing fields)
+    await asyncio.to_thread(
+        vector_store.upsert_entity,
+        name=entity["name"],
+        entity_type=entity["entity_type"],
+        metadata=existing_meta,
+    )
+
+    return {"entity_id": entity_id, "metadata": existing_meta, "status": "updated"}
+
+
+# ──────────────────────────────────────────────
 # Server startup
 # ──────────────────────────────────────────────
 

--- a/tests/test_daemon_kg.py
+++ b/tests/test_daemon_kg.py
@@ -1,0 +1,198 @@
+"""Tests for Knowledge Graph HTTP API endpoints in the daemon."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create test client with mocked vector_store and embedding_model."""
+    import brainlayer.daemon as daemon_mod
+
+    # Mock the global state
+    mock_store = MagicMock()
+    mock_store.count.return_value = 100
+    mock_model = MagicMock()
+    mock_model.embed_query.return_value = [0.1] * 1024
+
+    # Set globals
+    daemon_mod.vector_store = mock_store
+    daemon_mod.embedding_model = mock_model
+
+    client = TestClient(daemon_mod.app, raise_server_exceptions=False)
+    yield client, mock_store, mock_model
+
+    # Cleanup
+    daemon_mod.vector_store = None
+    daemon_mod.embedding_model = None
+
+
+class TestDigestEndpoint:
+    """POST /digest tests."""
+
+    def test_digest_success(self, client):
+        client, mock_store, mock_model = client
+
+        with patch("brainlayer.pipeline.digest.digest_content") as mock_digest:
+            mock_digest.return_value = {
+                "digest_id": "digest-abc123",
+                "entities": [{"name": "Alice", "entity_type": "person"}],
+                "relations": [],
+                "sentiment": {"polarity": "neutral"},
+                "action_items": [],
+                "decisions": [],
+                "questions": [],
+                "stats": {"entities": 1},
+            }
+            resp = client.post(
+                "/digest",
+                json={"content": "Alice can't do Sundays", "participants": ["Alice"]},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["digest_id"] == "digest-abc123"
+            assert len(data["entities"]) == 1
+
+    def test_digest_empty_content(self, client):
+        client, _, _ = client
+
+        with patch("brainlayer.pipeline.digest.digest_content") as mock_digest:
+            mock_digest.side_effect = ValueError("content must be non-empty")
+            resp = client.post("/digest", json={"content": ""})
+            assert resp.status_code == 400
+
+
+class TestPersonEndpoint:
+    """GET /person/{name} tests."""
+
+    def test_person_found(self, client):
+        client, mock_store, mock_model = client
+
+        with patch("brainlayer.pipeline.digest.entity_lookup") as mock_lookup:
+            mock_lookup.return_value = {
+                "id": "ent-123",
+                "name": "Alice",
+                "entity_type": "person",
+                "metadata": {"role": "client"},
+            }
+            mock_store.get_entity_chunks.return_value = [
+                {
+                    "chunk_id": "c1",
+                    "content": "Alice prefers mornings",
+                    "content_type": "note",
+                    "relevance": 0.9,
+                }
+            ]
+            resp = client.get("/person/Alice")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["entity"]["name"] == "Alice"
+            assert len(data["memories"]) == 1
+
+    def test_person_not_found(self, client):
+        client, _, _ = client
+
+        with patch("brainlayer.pipeline.digest.entity_lookup") as mock_lookup:
+            mock_lookup.return_value = None
+            resp = client.get("/person/Nobody")
+            assert resp.status_code == 404
+
+    def test_person_with_context(self, client):
+        client, mock_store, mock_model = client
+
+        with patch("brainlayer.pipeline.digest.entity_lookup") as mock_lookup:
+            mock_lookup.return_value = {
+                "id": "ent-123",
+                "name": "Alice",
+                "entity_type": "person",
+            }
+            mock_store.hybrid_search.return_value = {
+                "documents": [["Alice said she's free Tuesday"]],
+                "metadatas": [[{"content_type": "user_message", "created_at": "2026-02-20", "summary": "scheduling"}]],
+            }
+            resp = client.get("/person/Alice?context=scheduling")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["memories"]) == 1
+
+
+class TestStoreEndpoint:
+    """POST /store tests."""
+
+    def test_store_success(self, client):
+        client, _, _ = client
+
+        with patch("brainlayer.store.store_memory") as mock_store_fn:
+            mock_store_fn.return_value = {
+                "chunk_id": "manual-abc",
+                "related": [],
+            }
+            resp = client.post(
+                "/store",
+                json={"content": "Alice prefers morning meetings", "type": "learning"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["chunk_id"] == "manual-abc"
+
+
+class TestEntityEndpoints:
+    """GET/PATCH /entity/{id} tests."""
+
+    def test_get_entity(self, client):
+        client, mock_store, _ = client
+
+        mock_store.get_entity.return_value = {
+            "id": "ent-123",
+            "name": "Alice",
+            "entity_type": "person",
+            "metadata": '{"role": "client"}',
+        }
+        mock_store.get_entity_relations.return_value = [
+            {
+                "relation_type": "works_with",
+                "target_name": "Bob",
+                "target_type": "person",
+                "direction": "outgoing",
+                "confidence": 0.9,
+            }
+        ]
+        mock_store.get_entity_chunks.return_value = [
+            {"chunk_id": "c1", "content": "Alice meeting notes", "relevance": 0.8}
+        ]
+
+        resp = client.get("/entity/ent-123")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entity"]["name"] == "Alice"
+        assert len(data["relations"]) == 1
+        assert len(data["chunks"]) == 1
+
+    def test_get_entity_not_found(self, client):
+        client, mock_store, _ = client
+        mock_store.get_entity.return_value = None
+
+        resp = client.get("/entity/nonexistent")
+        assert resp.status_code == 404
+
+    def test_update_entity_metadata(self, client):
+        client, mock_store, _ = client
+
+        mock_store.get_entity.return_value = {
+            "id": "ent-123",
+            "name": "Alice",
+            "entity_type": "person",
+            "metadata": '{"role": "client"}',
+        }
+
+        resp = client.patch(
+            "/entity/ent-123",
+            json={"metadata": {"blocked_weekdays": ["Sunday"], "preferred_time": "morning"}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Sunday" in data["metadata"]["blocked_weekdays"]
+        assert data["metadata"]["role"] == "client"  # preserved
+        assert data["metadata"]["preferred_time"] == "morning"  # added


### PR DESCRIPTION
## Summary
- Adds 5 KG endpoints to existing FastAPI daemon for **6PM ↔ BrainLayer integration**
- `POST /digest` — ingest raw content (transcripts, messages) → entities, relations, sentiment
- `GET /person/{name}` — person lookup with scoped memories (~200ms)
- `POST /store` — persist memories with optional entity linking
- `GET /entity/{id}` — entity details, relations, linked chunks
- `PATCH /entity/{id}` — merge metadata (e.g., `blocked_weekdays: ["Sunday"]`)

## Context
This is the Convex ↔ BrainLayer bridge pattern agreed with orcClaude in the 6PM collab sync.
6PM stores real-time data in Convex, BrainLayer handles long-term memory. These HTTP endpoints
let Convex actions call BrainLayer via simple `fetch()` calls.

## Test plan
- [x] 9 new tests in `test_daemon_kg.py` (mocked VectorStore + embedding model)
- [x] Full suite: 501 passed, 2 skipped
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public HTTP endpoints that write to the knowledge graph (including metadata updates), which increases surface area and could affect stored data; the `PATCH /entity/{id}` implementation may be runtime-broken due to an `upsert_entity` call that doesn’t match the `VectorStore.upsert_entity(entity_id, entity_type, name, ...)` signature.
> 
> **Overview**
> Adds a **Knowledge Graph API bridge** to the daemon for 6PM integration: `POST /digest` (ingest content into the KG pipeline), `POST /store` (persist a memory), `GET /person/{name}` (entity lookup plus relevant/filtered memories), and `GET`/`PATCH /entity/{entity_id}` (fetch entity/relations/chunks and merge-update entity metadata).
> 
> Introduces new request schemas (`DigestRequest`, `StoreRequest`, `UpdateEntityRequest`), runs blocking KG operations via `asyncio.to_thread`, and adds a new `test_daemon_kg.py` suite that exercises success/error paths with mocked `vector_store`/`embedding_model`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46438b71a4904a72361b0724a1494bd8e966c12d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added Knowledge Graph API bridge with five new endpoints for digesting content, looking up person information with related memories, storing tagged memories, querying entities and their relationships, and updating entity metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->