### PR TITLE
fix: brain_digest embed method AttributeError

### DIFF
--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -1213,7 +1213,7 @@ async def _brain_digest(
             lambda: digest_content(
                 content=content,
                 store=store,
-                embed_fn=model.embed,
+                embed_fn=model.embed_query,
                 title=title,
                 project=norm_project,
                 participants=participants,
@@ -1245,7 +1245,7 @@ async def _brain_entity(
             lambda: entity_lookup(
                 query=query,
                 store=store,
-                embed_fn=model.embed,
+                embed_fn=model.embed_query,
                 entity_type=entity_type,
             ),
         )


### PR DESCRIPTION
## Summary
- `_brain_digest` and `_brain_entity` called `model.embed` which doesn't exist on `EmbeddingModel`
- Changed to `model.embed_query` (the correct method for `str → List[float]`)
- `_brain_get_person` already used `embed_query` correctly — this aligns the other two callers

## Impact
- **P0 blocker resolved**: `brain_digest` MCP tool was completely broken
- Unblocks 6PM chat UI Phase 5 integration
- Unblocks WhatsApp content digestion

## Test plan
- [x] 469 tests passed, 2 skipped, 0 failures
- [x] `test_phase3_digest.py` — 17 tests (digest pipeline + entity lookup)
- [x] `test_6pm_entity_upgrades.py` — entity upgrade tests
- [x] `test_daemon_kg.py` — KG daemon tests
- [x] No remaining `model.embed` (non-`embed_query`) calls in MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, targeted fix that only changes which embedding function is passed into `brain_digest`/`brain_entity`, primarily addressing a runtime AttributeError without altering data schemas or control flow.
> 
> **Overview**
> Fixes MCP `brain_digest` and `brain_entity` to pass `model.embed_query` (instead of the non-existent `model.embed`) into the digest/entity pipelines, aligning these tools with the embedding model API and restoring broken digest/entity lookup behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c0d0232ebab0c82d7c63216a03279298e8735fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated embedding methods for content digestion operations.
  * Refined embedding processing in entity lookup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->