### PR TITLE
feat: mid-run backend fallback for enrichment

### DIFF
--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -495,8 +495,7 @@ def call_llm(prompt: str, timeout: int = 240, backend: Optional[str] = None) -> 
         if _check_fallback_available(effective):
             fallback = "ollama" if effective == "mlx" else "mlx"
             print(
-                f"  FALLBACK: {_consecutive_failures} consecutive failures on {effective}, "
-                f"switching to {fallback}",
+                f"  FALLBACK: {_consecutive_failures} consecutive failures on {effective}, switching to {fallback}",
                 file=sys.stderr,
             )
             _fallback_active = True
@@ -507,8 +506,7 @@ def call_llm(prompt: str, timeout: int = 240, backend: Optional[str] = None) -> 
         elif _consecutive_failures == _FALLBACK_THRESHOLD:
             # Only log once when threshold is first hit
             print(
-                f"  WARNING: {_consecutive_failures} consecutive failures on {effective}, "
-                f"no fallback available",
+                f"  WARNING: {_consecutive_failures} consecutive failures on {effective}, no fallback available",
                 file=sys.stderr,
             )
 

--- a/tests/test_enrichment_fallback.py
+++ b/tests/test_enrichment_fallback.py
@@ -28,8 +28,10 @@ class TestCallLlmFallback:
 
     def test_failure_increments_counter(self):
         """Failed call increments consecutive failure counter."""
-        with patch.object(enrichment, "call_mlx", return_value=None), \
-             patch.object(enrichment, "_check_fallback_available", return_value=False):
+        with (
+            patch.object(enrichment, "call_mlx", return_value=None),
+            patch.object(enrichment, "_check_fallback_available", return_value=False),
+        ):
             result = enrichment.call_llm("test prompt", backend="mlx")
         assert result is None
         assert enrichment._consecutive_failures == 1
@@ -37,9 +39,11 @@ class TestCallLlmFallback:
     def test_fallback_triggers_after_threshold(self):
         """After N consecutive failures, switches to fallback backend."""
         enrichment._consecutive_failures = 2  # One more failure will trigger threshold (3)
-        with patch.object(enrichment, "call_mlx", return_value=None), \
-             patch.object(enrichment, "call_glm", return_value='{"summary":"fallback"}'), \
-             patch.object(enrichment, "_check_fallback_available", return_value=True):
+        with (
+            patch.object(enrichment, "call_mlx", return_value=None),
+            patch.object(enrichment, "call_glm", return_value='{"summary":"fallback"}'),
+            patch.object(enrichment, "_check_fallback_available", return_value=True),
+        ):
             result = enrichment.call_llm("test prompt", backend="mlx")
         assert result == '{"summary":"fallback"}'
         assert enrichment._fallback_active is True
@@ -47,8 +51,10 @@ class TestCallLlmFallback:
     def test_fallback_stays_active_once_triggered(self):
         """Once fallback is active, subsequent calls use fallback directly."""
         enrichment._fallback_active = True
-        with patch.object(enrichment, "call_glm", return_value='{"summary":"via fallback"}') as mock_glm, \
-             patch.object(enrichment, "call_mlx") as mock_mlx:
+        with (
+            patch.object(enrichment, "call_glm", return_value='{"summary":"via fallback"}') as mock_glm,
+            patch.object(enrichment, "call_mlx") as mock_mlx,
+        ):
             result = enrichment.call_llm("test prompt", backend="mlx")
         assert result == '{"summary":"via fallback"}'
         mock_glm.assert_called_once()
@@ -57,8 +63,10 @@ class TestCallLlmFallback:
     def test_no_fallback_when_unavailable(self):
         """If fallback backend isn't running, don't switch."""
         enrichment._consecutive_failures = 2
-        with patch.object(enrichment, "call_mlx", return_value=None), \
-             patch.object(enrichment, "_check_fallback_available", return_value=False):
+        with (
+            patch.object(enrichment, "call_mlx", return_value=None),
+            patch.object(enrichment, "_check_fallback_available", return_value=False),
+        ):
             result = enrichment.call_llm("test prompt", backend="mlx")
         assert result is None
         assert enrichment._fallback_active is False
@@ -66,9 +74,11 @@ class TestCallLlmFallback:
     def test_ollama_to_mlx_fallback(self):
         """Fallback works in reverse: ollama primary → mlx fallback."""
         enrichment._consecutive_failures = 2
-        with patch.object(enrichment, "call_glm", return_value=None), \
-             patch.object(enrichment, "call_mlx", return_value='{"summary":"mlx ok"}'), \
-             patch.object(enrichment, "_check_fallback_available", return_value=True):
+        with (
+            patch.object(enrichment, "call_glm", return_value=None),
+            patch.object(enrichment, "call_mlx", return_value='{"summary":"mlx ok"}'),
+            patch.object(enrichment, "_check_fallback_available", return_value=True),
+        ):
             result = enrichment.call_llm("test prompt", backend="ollama")
         assert result == '{"summary":"mlx ok"}'
         assert enrichment._fallback_active is True
@@ -86,8 +96,12 @@ class TestRunEnrichmentResetsState:
         with patch.object(enrichment, "VectorStore") as mock_vs:
             mock_store = mock_vs.return_value
             mock_store.get_enrichment_stats.return_value = {
-                "enriched": 0, "enrichable": 0, "remaining": 0,
-                "skipped": 0, "percent": "0", "total_chunks": 0,
+                "enriched": 0,
+                "enrichable": 0,
+                "remaining": 0,
+                "skipped": 0,
+                "percent": "0",
+                "total_chunks": 0,
                 "by_intent": {},
             }
             try:


### PR DESCRIPTION
## Summary
- When MLX crashes mid-batch (Abort trap: 6), pipeline now auto-switches to Ollama after 3 consecutive failures
- Prevents losing entire enrichment batches when the primary backend dies
- Fallback availability is checked once and cached for the run
- State resets on each `run_enrichment()` call

## Context
The nightly enrichment window (11pm-11am) has been failing because MLX crashes ~1 minute into each run. All subsequent chunks fail with "Connection refused". With this change, the pipeline detects the crash pattern and falls back to Ollama automatically.

## Test plan
- [x] 9 new tests in `test_enrichment_fallback.py`
- [x] Full suite: 478 passed, 2 skipped
- [x] Manual verification: 3 chunks enriched successfully via MLX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stateful mid-run backend switching logic in the enrichment pipeline; incorrect switching/caching could mask transient failures or route load to an unintended backend, but the change is localized and covered by new tests.
> 
> **Overview**
> Prevents enrichment runs from dying when the primary local LLM backend crashes mid-batch by adding **mid-run automatic fallback** in `call_llm` after 3 consecutive failures, including a one-time/cached availability probe and a retry of the failed chunk on the fallback backend.
> 
> Resets fallback state at the start of each `run_enrichment()` invocation, and adds a new test suite (`test_enrichment_fallback.py`) covering failure counting, threshold switching, stickiness of the fallback mode, reverse fallback direction (Ollama→MLX), cached availability checks, and state reset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19c6c86643f34dafcc8a6c7e821c48374aed1800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented mid-run fallback mechanism for LLM calls that automatically switches to a fallback backend after detecting consecutive failures on the primary backend, with availability checks and state tracking.

* **Tests**
  * Added comprehensive test suite for fallback behavior including state management, backend switching transitions, and availability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->