### PR TITLE
feat: enrichment retry with backoff and circuit breaker

### DIFF
--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -28,6 +28,7 @@ AIDEV-NOTE: Two prompt paths exist:
 
 import json
 import os
+import random
 import sys
 import threading
 import time
@@ -88,6 +89,14 @@ MLX_MODEL = os.environ.get("BRAINLAYER_MLX_MODEL", "mlx-community/Qwen2.5-Coder-
 STALL_TIMEOUT = int(os.environ.get("BRAINLAYER_STALL_TIMEOUT", "300"))  # 5 minutes default
 # Heartbeat: log progress every N chunks (min 1 to avoid ZeroDivisionError)
 HEARTBEAT_INTERVAL = max(1, int(os.environ.get("BRAINLAYER_HEARTBEAT_INTERVAL", "25")))
+# Retry: per-chunk retry with exponential backoff
+MAX_RETRIES = int(os.environ.get("BRAINLAYER_MAX_RETRIES", "2"))  # 0=no retry, 2=up to 3 attempts
+RETRY_BASE_DELAY = float(os.environ.get("BRAINLAYER_RETRY_BASE_DELAY", "2.0"))  # seconds
+RETRY_MAX_DELAY = float(os.environ.get("BRAINLAYER_RETRY_MAX_DELAY", "30.0"))  # cap
+# Circuit breaker: abort batch after N consecutive failures (backend probably dead)
+CIRCUIT_BREAKER_THRESHOLD = int(os.environ.get("BRAINLAYER_CIRCUIT_BREAKER", "10"))
+# MLX default timeout (shorter than Ollama — MLX should respond faster)
+MLX_DEFAULT_TIMEOUT = int(os.environ.get("BRAINLAYER_MLX_TIMEOUT", "60"))
 from ..paths import DEFAULT_DB_PATH
 
 # Supabase usage logging — track GLM calls even though they're free
@@ -393,7 +402,7 @@ def call_glm(prompt: str, timeout: int = 240) -> Optional[str]:
         return None
 
 
-def call_mlx(prompt: str, timeout: int = 240) -> Optional[str]:
+def call_mlx(prompt: str, timeout: int = MLX_DEFAULT_TIMEOUT) -> Optional[str]:
     """Call local MLX server via OpenAI-compatible API. Logs usage to Supabase."""
     try:
         start_ms = int(time.time() * 1000)
@@ -600,13 +609,12 @@ def _enrich_one(
 ) -> bool:
     """Enrich a single chunk. Returns True on success, False on failure.
 
+    Retries up to MAX_RETRIES times with exponential backoff + jitter on LLM failure.
+    This absorbs transient MLX crashes and connection blips without losing the chunk.
+
     Args:
         store_or_path: VectorStore instance (sequential) or Path (parallel, uses thread-local store).
         backend: Override backend for LLM calls.
-
-    Stall detection: if the LLM call takes longer than STALL_TIMEOUT, it's logged
-    as a stall. The requests timeout in call_llm/call_glm already handles HTTP-level
-    timeouts, but this adds observability at the enrichment layer.
     """
     # In parallel mode, each thread gets its own VectorStore connection.
     if isinstance(store_or_path, Path):
@@ -621,17 +629,34 @@ def _enrich_one(
 
     prompt = build_prompt(chunk, context_chunks)
 
-    chunk_start = time.time()
-    response = call_llm(prompt, backend=backend)
-    chunk_duration = time.time() - chunk_start
+    # Retry loop with exponential backoff + jitter
+    response = None
+    for attempt in range(1 + MAX_RETRIES):
+        chunk_start = time.time()
+        response = call_llm(prompt, backend=backend)
+        chunk_duration = time.time() - chunk_start
 
-    # Stall detection: log warning if chunk took too long
-    if chunk_duration > STALL_TIMEOUT:
-        print(
-            f"  STALL: chunk {chunk['id'][:12]} took {chunk_duration:.0f}s "
-            f"(threshold: {STALL_TIMEOUT}s, chars: {chunk.get('char_count', '?')})",
-            file=sys.stderr,
-        )
+        # Stall detection
+        if chunk_duration > STALL_TIMEOUT:
+            print(
+                f"  STALL: chunk {chunk['id'][:12]} took {chunk_duration:.0f}s "
+                f"(threshold: {STALL_TIMEOUT}s, chars: {chunk.get('char_count', '?')})",
+                file=sys.stderr,
+            )
+
+        if response is not None:
+            break
+
+        # LLM returned None — retry with backoff
+        if attempt < MAX_RETRIES:
+            delay = min(RETRY_BASE_DELAY * (2**attempt), RETRY_MAX_DELAY)
+            jitter = random.uniform(0, delay * 0.3)
+            total_delay = delay + jitter
+            print(
+                f"  RETRY: chunk {chunk['id'][:12]} attempt {attempt + 2}/{1 + MAX_RETRIES} in {total_delay:.1f}s",
+                file=sys.stderr,
+            )
+            time.sleep(total_delay)
 
     enrichment = parse_enrichment(response)
     if enrichment:
@@ -679,6 +704,10 @@ def enrich_batch(
 ) -> Dict[str, int]:
     """Process one batch of unenriched chunks. Returns counts.
 
+    Circuit breaker: if CIRCUIT_BREAKER_THRESHOLD consecutive chunks fail,
+    the batch is aborted early (backend is probably dead). This prevents
+    wasting hours of compute on connection-refused errors.
+
     Args:
         parallel: Number of concurrent workers (1=sequential, >1=ThreadPoolExecutor).
                   MLX server supports concurrent requests. Ollama may not benefit.
@@ -692,6 +721,8 @@ def enrich_batch(
 
     success = 0
     failed = 0
+    consecutive_failures = 0
+    circuit_broken = False
 
     batch_start = time.time()
     last_heartbeat = batch_start
@@ -706,11 +737,27 @@ def enrich_batch(
                 try:
                     if future.result():
                         success += 1
+                        consecutive_failures = 0
                     else:
                         failed += 1
+                        consecutive_failures += 1
                 except Exception as e:
                     print(f"  Worker error: {e}", file=sys.stderr)
                     failed += 1
+                    consecutive_failures += 1
+
+                # Circuit breaker: abort if backend is clearly dead
+                if consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:
+                    circuit_broken = True
+                    print(
+                        f"  CIRCUIT BREAK: {consecutive_failures} consecutive failures, "
+                        f"aborting batch ({success} ok, {failed} fail)",
+                        file=sys.stderr,
+                    )
+                    # Cancel remaining futures
+                    for f in futures:
+                        f.cancel()
+                    break
 
                 done = success + failed
                 now = time.time()
@@ -727,8 +774,20 @@ def enrich_batch(
 
             if ok:
                 success += 1
+                consecutive_failures = 0
             else:
                 failed += 1
+                consecutive_failures += 1
+
+            # Circuit breaker
+            if consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:
+                circuit_broken = True
+                print(
+                    f"  CIRCUIT BREAK: {consecutive_failures} consecutive failures, "
+                    f"aborting batch ({success} ok, {failed} fail)",
+                    file=sys.stderr,
+                )
+                break
 
             done = success + failed
             now = time.time()
@@ -739,7 +798,12 @@ def enrich_batch(
                 )
                 last_heartbeat = now
 
-    return {"processed": len(chunks), "success": success, "failed": failed}
+    return {
+        "processed": success + failed,
+        "success": success,
+        "failed": failed,
+        "circuit_broken": circuit_broken,
+    }
 
 
 def mark_unenrichable(store: VectorStore) -> int:
@@ -857,6 +921,15 @@ def run_enrichment(
                 f"Batch done: +{result['success']} ok, +{result['failed']} fail | "
                 f"Total: {total_processed} ({rate:.1f}/s)"
             )
+
+            # Circuit breaker tripped — backend is dead, stop the run
+            if result.get("circuit_broken"):
+                print(
+                    "\nCircuit breaker tripped — stopping enrichment. "
+                    "Backend may be down. Check with: curl http://127.0.0.1:8080/v1/models",
+                    file=sys.stderr,
+                )
+                break
 
             # Sync stats to Supabase every 5 batches
             if total_processed % (batch_size * 5) < batch_size:

--- a/tests/test_enrichment_reliability.py
+++ b/tests/test_enrichment_reliability.py
@@ -1,0 +1,230 @@
+"""Tests for enrichment reliability — retry, circuit breaker, timeout config."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+from brainlayer.pipeline import enrichment
+
+
+class TestRetryWithBackoff:
+    """Per-chunk retry with exponential backoff."""
+
+    def test_success_on_first_attempt_no_retry(self):
+        """Successful LLM call doesn't trigger retry."""
+        store = MagicMock()
+        store.get_context.return_value = {"context": []}
+        chunk = {"id": "test-chunk-001", "content": "test", "content_type": "user_message"}
+
+        with (
+            patch.object(enrichment, "call_llm", return_value='{"summary":"ok","tags":["test"]}'),
+            patch.object(enrichment, "parse_enrichment", return_value={"summary": "ok", "tags": ["test"]}),
+            patch.object(enrichment, "MAX_RETRIES", 2),
+        ):
+            result = enrichment._enrich_one(store, chunk, with_context=False)
+
+        assert result is True
+
+    def test_retry_on_llm_failure(self):
+        """Failed LLM call retries up to MAX_RETRIES times."""
+        store = MagicMock()
+        chunk = {"id": "test-chunk-002", "content": "test", "content_type": "user_message"}
+
+        call_count = 0
+
+        def mock_call_llm(prompt, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return None  # Fail first 2 attempts
+            return '{"summary":"recovered","tags":["test"]}'
+
+        with (
+            patch.object(enrichment, "call_llm", side_effect=mock_call_llm),
+            patch.object(
+                enrichment,
+                "parse_enrichment",
+                side_effect=lambda r: {"summary": "recovered", "tags": ["test"]} if r else None,
+            ),
+            patch.object(enrichment, "MAX_RETRIES", 2),
+            patch.object(enrichment, "RETRY_BASE_DELAY", 0.01),  # Fast for tests
+            patch.object(enrichment, "RETRY_MAX_DELAY", 0.05),
+        ):
+            result = enrichment._enrich_one(store, chunk, with_context=False)
+
+        assert result is True
+        assert call_count == 3  # Initial + 2 retries
+
+    def test_all_retries_exhausted(self):
+        """Returns False after all retry attempts fail."""
+        store = MagicMock()
+        chunk = {"id": "test-chunk-003", "content": "test", "content_type": "user_message"}
+
+        with (
+            patch.object(enrichment, "call_llm", return_value=None),
+            patch.object(enrichment, "MAX_RETRIES", 1),
+            patch.object(enrichment, "RETRY_BASE_DELAY", 0.01),
+            patch.object(enrichment, "RETRY_MAX_DELAY", 0.05),
+        ):
+            result = enrichment._enrich_one(store, chunk, with_context=False)
+
+        assert result is False
+
+    def test_no_retry_when_max_retries_zero(self):
+        """MAX_RETRIES=0 means no retries, single attempt only."""
+        store = MagicMock()
+        chunk = {"id": "test-chunk-004", "content": "test", "content_type": "user_message"}
+        call_count = 0
+
+        def mock_call(prompt, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return None
+
+        with (
+            patch.object(enrichment, "call_llm", side_effect=mock_call),
+            patch.object(enrichment, "MAX_RETRIES", 0),
+        ):
+            result = enrichment._enrich_one(store, chunk, with_context=False)
+
+        assert result is False
+        assert call_count == 1
+
+    def test_backoff_increases_delay(self):
+        """Verify backoff delay increases between retries."""
+        store = MagicMock()
+        chunk = {"id": "test-chunk-005", "content": "test", "content_type": "user_message"}
+        delays = []
+
+        original_sleep = time.sleep
+
+        def mock_sleep(duration):
+            delays.append(duration)
+            # Don't actually sleep in tests
+
+        with (
+            patch.object(enrichment, "call_llm", return_value=None),
+            patch.object(enrichment, "MAX_RETRIES", 3),
+            patch.object(enrichment, "RETRY_BASE_DELAY", 1.0),
+            patch.object(enrichment, "RETRY_MAX_DELAY", 100.0),
+            patch("time.sleep", side_effect=mock_sleep),
+        ):
+            enrichment._enrich_one(store, chunk, with_context=False)
+
+        assert len(delays) == 3  # 3 retry sleeps
+        # Delays should generally increase (base * 2^attempt + jitter)
+        # With jitter it's not strictly monotonic, but base increases: 1, 2, 4
+        assert delays[0] < 3.0  # ~1.0 + up to 0.3 jitter
+        assert delays[1] < 5.0  # ~2.0 + up to 0.6 jitter
+
+
+class TestCircuitBreaker:
+    """Batch-level circuit breaker aborts on consecutive failures."""
+
+    def test_circuit_breaks_on_threshold(self):
+        """Batch aborts after CIRCUIT_BREAKER_THRESHOLD consecutive failures."""
+        store = MagicMock()
+        # Return 20 chunks but circuit should break after threshold
+        chunks = [{"id": f"chunk-{i}", "content": f"test {i}", "content_type": "user_message"} for i in range(20)]
+        store.get_unenriched_chunks.return_value = chunks
+
+        with (
+            patch.object(enrichment, "_enrich_one", return_value=False),
+            patch.object(enrichment, "CIRCUIT_BREAKER_THRESHOLD", 5),
+        ):
+            result = enrichment.enrich_batch(store, batch_size=20, parallel=1)
+
+        assert result["circuit_broken"] is True
+        # Should have stopped at threshold, not processed all 20
+        assert result["processed"] == 5
+        assert result["failed"] == 5
+        assert result["success"] == 0
+
+    def test_no_circuit_break_on_intermittent_failures(self):
+        """Intermittent failures (not consecutive) don't trigger circuit breaker."""
+        store = MagicMock()
+        chunks = [{"id": f"chunk-{i}", "content": f"test {i}", "content_type": "user_message"} for i in range(10)]
+        store.get_unenriched_chunks.return_value = chunks
+
+        # Alternate success/failure
+        results = [True, False, True, False, True, False, True, False, True, False]
+        call_idx = 0
+
+        def mock_enrich(*args, **kwargs):
+            nonlocal call_idx
+            r = results[call_idx]
+            call_idx += 1
+            return r
+
+        with (
+            patch.object(enrichment, "_enrich_one", side_effect=mock_enrich),
+            patch.object(enrichment, "CIRCUIT_BREAKER_THRESHOLD", 5),
+        ):
+            result = enrichment.enrich_batch(store, batch_size=10, parallel=1)
+
+        assert result["circuit_broken"] is False
+        assert result["processed"] == 10
+        assert result["success"] == 5
+        assert result["failed"] == 5
+
+    def test_circuit_break_resets_on_success(self):
+        """A single success resets the consecutive failure counter."""
+        store = MagicMock()
+        chunks = [{"id": f"chunk-{i}", "content": f"test {i}", "content_type": "user_message"} for i in range(15)]
+        store.get_unenriched_chunks.return_value = chunks
+
+        # 4 failures, 1 success, 4 failures, 1 success, etc — never hits threshold of 5
+        results = [False, False, False, False, True] * 3
+        call_idx = 0
+
+        def mock_enrich(*args, **kwargs):
+            nonlocal call_idx
+            r = results[call_idx]
+            call_idx += 1
+            return r
+
+        with (
+            patch.object(enrichment, "_enrich_one", side_effect=mock_enrich),
+            patch.object(enrichment, "CIRCUIT_BREAKER_THRESHOLD", 5),
+        ):
+            result = enrichment.enrich_batch(store, batch_size=15, parallel=1)
+
+        assert result["circuit_broken"] is False
+        assert result["processed"] == 15
+
+
+class TestMLXTimeout:
+    """MLX uses shorter default timeout."""
+
+    def test_mlx_default_timeout_is_60(self):
+        assert enrichment.MLX_DEFAULT_TIMEOUT == 60
+
+    def test_mlx_timeout_env_override(self):
+        """MLX timeout can be overridden via env var."""
+        import os
+
+        old = os.environ.get("BRAINLAYER_MLX_TIMEOUT")
+        try:
+            os.environ["BRAINLAYER_MLX_TIMEOUT"] = "120"
+            # Re-evaluate (module-level constant, so we test the pattern)
+            assert int(os.environ["BRAINLAYER_MLX_TIMEOUT"]) == 120
+        finally:
+            if old is not None:
+                os.environ["BRAINLAYER_MLX_TIMEOUT"] = old
+            else:
+                os.environ.pop("BRAINLAYER_MLX_TIMEOUT", None)
+
+
+class TestConfigConstants:
+    """Verify config constants have sensible defaults."""
+
+    def test_max_retries_default(self):
+        assert enrichment.MAX_RETRIES == 2
+
+    def test_retry_base_delay_default(self):
+        assert enrichment.RETRY_BASE_DELAY == 2.0
+
+    def test_retry_max_delay_default(self):
+        assert enrichment.RETRY_MAX_DELAY == 30.0
+
+    def test_circuit_breaker_threshold_default(self):
+        assert enrichment.CIRCUIT_BREAKER_THRESHOLD == 10


### PR DESCRIPTION
## Summary
- Per-chunk retry with exponential backoff (2 retries, 2s base, 30s cap, jitter)
- Circuit breaker: abort batch after 10 consecutive failures (backend dead)
- MLX timeout reduced from 240s to 60s (MLX is fast, no reason to wait 4 min)
- All values configurable via env vars
- `enrich_batch` returns `circuit_broken` flag; `run_enrichment` stops the run on trip

## Context
P3 from the brainlayer-fixes priority queue. The nightly enrichment window (11pm-11am) has been failing because MLX crashes ~1 minute in, and every subsequent chunk fails with "Connection refused" for the remaining 11 hours. With retry + circuit breaker, the pipeline absorbs transient crashes and stops early when the backend is truly dead.

## Test plan
- [x] 14 new tests in `test_enrichment_reliability.py`
- [x] Full suite: 483 passed, 2 skipped
- [x] Manual: 3 chunks enriched via MLX (separate verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core enrichment execution flow by adding retries, backoff sleeps, and early-abort behavior, which can alter throughput and stop runs sooner under failure conditions. Risk is mitigated by configurability via env vars and added unit tests.
> 
> **Overview**
> Adds **per-chunk retry** in `_enrich_one`, using configurable exponential backoff + jitter when `call_llm` returns `None`, while keeping stall warnings.
> 
> Adds a **batch-level circuit breaker** in `enrich_batch` that aborts after `CIRCUIT_BREAKER_THRESHOLD` consecutive failures (sequential and parallel), returns a new `circuit_broken` flag, and makes `run_enrichment` stop the run when tripped.
> 
> Reduces MLX default request timeout to `60s` (configurable) and introduces env-configurable constants for retries/backoff/circuit breaking, with a new `tests/test_enrichment_reliability.py` covering retry and circuit-break behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f5c8208b4e550f5a6d92f7ac367c3f7291408b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->