### PR TITLE
docs: audit fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ The daemon (`brainlayer serve --http 8787`) exposes a FastAPI server used by the
 
 ---
 
-## MCP Server (3 Tools)
+## MCP Server (7 Tools)
 
 Add to `~/.claude/settings.json`:
 
@@ -255,13 +255,22 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
-### Available Tools (3)
+### Core Tools (3)
 
 | Tool | Description |
 |------|-------------|
 | `brain_search` | Unified semantic search — query, file_path, chunk_id, or filters. |
 | `brain_store` | Persist memories (ideas, decisions, learnings, mistakes). Auto-type/auto-importance. |
 | `brain_recall` | Proactive retrieval — current context, sessions, session summaries. |
+
+### Knowledge Graph Tools (4)
+
+| Tool | Description |
+|------|-------------|
+| `brain_digest` | Ingest raw content — entity extraction, relations, sentiment, action items. |
+| `brain_entity` | Look up entities in the knowledge graph — type, relations, evidence. |
+| `brain_update` | Update, archive, or merge existing memories. |
+| `brain_get_person` | Person lookup — entity details, interactions, preferences. |
 
 ### Backward Compatibility
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-7%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-525%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-510%20passing-brightgreen.svg)](#testing)
 [![Docs](https://img.shields.io/badge/docs-etanhey.github.io%2Fbrainlayer-blue.svg)](https://etanhey.github.io/brainlayer)
 
 ---
@@ -128,7 +128,7 @@ graph LR
 | `brain_digest` | Ingest raw content — entity extraction, relations, sentiment, action items. |
 | `brain_entity` | Look up entities in the knowledge graph — type, relations, evidence. |
 | `brain_update` | Update, archive, or merge existing memories. |
-| `brain_get_person` | Person lookup — entity details, interactions, preferences (~200ms). |
+| `brain_get_person` | Person lookup — entity details, interactions, preferences (~200-500ms). |
 
 ### Backward Compatibility
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ BrainLayer fixes this. It's a **local-first memory layer** that gives any MCP-co
 - **Multi-source** — Claude Code, WhatsApp, YouTube, Markdown, Claude Desktop, manual
 - **Works everywhere** — Claude Code, Cursor, Zed, VS Code, any MCP client
 
+All old `brainlayer_*` tool names (14 aliases) still work alongside new consolidated names.
+
 ## Quick Example
 
 ```bash

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -34,11 +34,13 @@ Persist a memory (idea, decision, learning, mistake, etc.) for future retrieval.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | Yes | The memory content to store |
-| `type` | string | No | Memory type: idea, mistake, decision, learning, todo, bookmark, note, journal (auto-detected if omitted) |
+| `type` | string | No | Memory type: idea, mistake, decision, learning, issue, todo, bookmark, note, journal (auto-detected if omitted) |
 | `project` | string | No | Project to scope the memory |
 | `tags` | array[string] | No | Tags for categorization |
 | `importance` | integer | No | Importance score 1-10 (auto-detected if omitted) |
 | `entity_id` | string | No | Link memory to a KG entity |
+
+Issue type supports lifecycle tracking: status (open→in_progress→done→archived), severity (critical/high/medium/low), and code references (file_path, function_name, line_number).
 
 **Returns:** Chunk ID and related existing memories.
 
@@ -92,6 +94,7 @@ Look up a known entity in the knowledge graph. Returns entity type, relations, a
 |-----------|------|----------|-------------|
 | `query` | string | Yes | Entity name or search query |
 | `entity_id` | string | No | Direct entity ID lookup |
+| `entity_type` | string | No | Filter by type: person, company, project, golem, technology, concept |
 
 **Returns:** Entity details (type, metadata), relations to other entities, and linked chunks.
 


### PR DESCRIPTION
Fixes from orchestrator docs audit: CLAUDE.md 3→7 tools, test badge 525→510, issue type docs, entity filtering param, backward compat note, person lookup timing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits updating tool listings/parameters and status badges with no runtime or API behavior changes.
> 
> **Overview**
> Updates documentation to reflect **7 MCP tools** by splitting into *core* vs *knowledge graph* tools, and adds a clear backward-compatibility note that old `brainlayer_*` tool aliases still work.
> 
> Expands MCP tool reference docs: `brain_store` now documents an `issue` memory type (with lifecycle/severity/code refs), `brain_entity` adds an `entity_type` filter parameter, and `brain_get_person` latency guidance is adjusted. Also refreshes the README tests badge count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ab2bade4149b1e09fdf488fff7fc3cbfea32f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->