### PR TITLE
fix: README tagline — 7 tools + KG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BrainLayer
 
-> Persistent memory for AI agents. Search, think, recall — across every conversation you've ever had.
+> Persistent memory and knowledge graph for AI agents — 7 MCP tools to search, store, recall, digest, and explore entities across every conversation.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)


### PR DESCRIPTION
Tagline was still 'Search, think, recall' from 3-tool era. Updated to reflect 7 tools and knowledge graph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates marketing/positioning text and does not affect runtime behavior.
> 
> **Overview**
> Updates the `README.md` tagline to reflect the current product scope (**7 MCP tools** and a **knowledge graph**) instead of the older “Search, think, recall” phrasing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd5654b54ac642ed95aa8b3449dbf8fd4affee7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product description to clarify knowledge graph capabilities and highlight the seven MCP tools available for searching, storing, recalling, digesting, and exploring entities across conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->