### PR TITLE
feat: groq backend + on-demand enrichment

### DIFF
--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -872,12 +872,27 @@ def enrich(
     batch_size: int = typer.Option(50, "--batch-size", "-b", help="Chunks per batch"),
     max_chunks: int = typer.Option(0, "--max", "-m", help="Max chunks (0=unlimited)"),
     no_context: bool = typer.Option(False, "--no-context", help="Skip surrounding context"),
+    backend: str = typer.Option(
+        None, "--backend", help="LLM backend: ollama, mlx, groq (default: auto-detect)"
+    ),
+    recent: int = typer.Option(
+        None, "--recent", "-r", help="Only enrich chunks from the last N hours"
+    ),
     stats_only: bool = typer.Option(False, "--stats", help="Show progress and exit"),
 ) -> None:
     """Enrich chunks with LLM-generated metadata (summary, tags, importance, intent)."""
     try:
         from ..pipeline.enrichment import DEFAULT_DB_PATH, run_enrichment
         from ..vector_store import VectorStore
+
+        # Set backend override before run_enrichment reads ENRICH_BACKEND
+        if backend:
+            import os
+
+            import brainlayer.pipeline.enrichment as enrich_mod
+
+            os.environ["BRAINLAYER_ENRICH_BACKEND"] = backend
+            enrich_mod.ENRICH_BACKEND = backend
 
         if stats_only:
             store = VectorStore(DEFAULT_DB_PATH)
@@ -895,6 +910,7 @@ def enrich(
                 batch_size=batch_size,
                 max_chunks=max_chunks,
                 with_context=not no_context,
+                since_hours=recent,
             )
     except Exception as e:
         rprint(f"[bold red]Error:[/] {e}")

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -85,6 +85,11 @@ MLX_BASE_URL = MLX_URL.rsplit("/v1/", 1)[0] if "/v1/" in MLX_URL else MLX_URL.rs
 MODEL = os.environ.get("BRAINLAYER_ENRICH_MODEL", "glm-4.7-flash")
 MLX_MODEL = os.environ.get("BRAINLAYER_MLX_MODEL", "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit")
 
+# Groq cloud API (for NON-PRIVATE content only — sanitization enforced in _enrich_one)
+GROQ_API_KEY = os.environ.get("GROQ_API_KEY", "")
+GROQ_URL = os.environ.get("BRAINLAYER_GROQ_URL", "https://api.groq.com/openai/v1/chat/completions")
+GROQ_MODEL = os.environ.get("BRAINLAYER_GROQ_MODEL", "llama-3.3-70b-versatile")
+
 # Stall detection: max seconds a single chunk can take before being considered stalled
 STALL_TIMEOUT = int(os.environ.get("BRAINLAYER_STALL_TIMEOUT", "300"))  # 5 minutes default
 # Heartbeat: log progress every N chunks (min 1 to avoid ZeroDivisionError)
@@ -437,6 +442,53 @@ def call_mlx(prompt: str, timeout: int = MLX_DEFAULT_TIMEOUT) -> Optional[str]:
         return None
 
 
+def call_groq(prompt: str, timeout: int = 60) -> Optional[str]:
+    """Call Groq cloud API via OpenAI-compatible endpoint. Logs usage to Supabase.
+
+    PRIVACY: This sends content to Groq's cloud. Callers MUST sanitize content
+    before calling this function. The _enrich_one() function enforces this by
+    using build_external_prompt() with a Sanitizer when backend='groq'.
+    """
+    if not GROQ_API_KEY:
+        print("  Groq error: GROQ_API_KEY not set", file=sys.stderr)
+        return None
+    try:
+        start_ms = int(time.time() * 1000)
+        resp = requests.post(
+            GROQ_URL,
+            headers={
+                "Authorization": f"Bearer {GROQ_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": GROQ_MODEL,
+                "messages": [{"role": "user", "content": prompt}],
+                "response_format": {"type": "json_object"},
+            },
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        duration_ms = int(time.time() * 1000) - start_ms
+
+        # Extract token counts from OpenAI-compatible response
+        usage = data.get("usage", {})
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+
+        # Log to Supabase (best-effort)
+        _log_glm_usage(prompt_tokens, completion_tokens, duration_ms, model=f"groq:{GROQ_MODEL}")
+
+        # Extract response text
+        choices = data.get("choices", [])
+        if choices:
+            return choices[0].get("message", {}).get("content", "")
+        return None
+    except Exception as e:
+        print(f"  Groq error: {e}", file=sys.stderr)
+        return None
+
+
 # Mid-run fallback state — tracks consecutive failures for automatic backend switching.
 # When the primary backend crashes mid-run (e.g., MLX "Abort trap: 6"), the pipeline
 # automatically retries failed chunks on the fallback backend instead of losing the entire batch.
@@ -488,7 +540,10 @@ def call_llm(prompt: str, timeout: int = 240, backend: Optional[str] = None) -> 
         return None
 
     # Try primary backend
-    if effective == "mlx":
+    if effective == "groq":
+        # Groq is cloud-only, no local fallback mechanism
+        return call_groq(prompt, timeout=timeout)
+    elif effective == "mlx":
         result = call_mlx(prompt, timeout=timeout)
     else:
         result = call_glm(prompt, timeout=timeout)
@@ -627,7 +682,15 @@ def _enrich_one(
         ctx = store.get_context(chunk["id"], before=2, after=1)
         context_chunks = [c for c in ctx.get("context", []) if not c.get("is_target")]
 
-    prompt = build_prompt(chunk, context_chunks)
+    # External backends (groq) MUST use sanitized prompts — no raw PII to cloud
+    effective_backend = backend or ENRICH_BACKEND
+    if effective_backend == "groq":
+        from .sanitize import Sanitizer
+
+        sanitizer = Sanitizer.from_env()
+        prompt, _sanitize_result = build_external_prompt(chunk, sanitizer, context_chunks)
+    else:
+        prompt = build_prompt(chunk, context_chunks)
 
     # Retry loop with exponential backoff + jitter
     response = None
@@ -701,6 +764,7 @@ def enrich_batch(
     with_context: bool = True,
     parallel: int = 1,
     backend: Optional[str] = None,
+    since_hours: Optional[int] = None,
 ) -> Dict[str, int]:
     """Process one batch of unenriched chunks. Returns counts.
 
@@ -712,9 +776,10 @@ def enrich_batch(
         parallel: Number of concurrent workers (1=sequential, >1=ThreadPoolExecutor).
                   MLX server supports concurrent requests. Ollama may not benefit.
         backend: Override backend for LLM calls (used when run_enrichment detects fallback).
+        since_hours: Only enrich chunks from the last N hours (for on-demand enrichment).
     """
     types = content_types or HIGH_VALUE_TYPES
-    chunks = store.get_unenriched_chunks(batch_size=batch_size, content_types=types)
+    chunks = store.get_unenriched_chunks(batch_size=batch_size, content_types=types, since_hours=since_hours)
 
     if not chunks:
         return {"processed": 0, "success": 0, "failed": 0}
@@ -836,6 +901,7 @@ def run_enrichment(
     content_types: Optional[List[str]] = None,
     with_context: bool = True,
     parallel: int = 1,
+    since_hours: Optional[int] = None,
 ) -> None:
     """Run the enrichment pipeline until done or max reached."""
     global _consecutive_failures, _fallback_active, _fallback_available
@@ -849,7 +915,14 @@ def run_enrichment(
     try:
         # Check LLM backend is running — with auto-fallback
         active_backend = ENRICH_BACKEND
-        if active_backend == "mlx":
+        if active_backend == "groq":
+            if not GROQ_API_KEY:
+                raise RuntimeError(
+                    "GROQ_API_KEY not set. Get one from https://console.groq.com/keys\n"
+                    "Or use: op read 'op://development/GROQ_API_KEY/password'"
+                )
+            print(f"Backend: Groq ({GROQ_MODEL}) [cloud — sanitization enforced]")
+        elif active_backend == "mlx":
             try:
                 resp = requests.get(f"{MLX_BASE_URL}/v1/models", timeout=5)
                 resp.raise_for_status()
@@ -890,6 +963,8 @@ def run_enrichment(
         if stats["by_intent"]:
             print(f"Intent distribution: {stats['by_intent']}")
         print(f"Batch size: {batch_size}, Max: {max_chunks or 'unlimited'}, Parallel: {parallel}")
+        if since_hours:
+            print(f"Recent only: last {since_hours} hours")
         print("---")
 
         total_processed = 0
@@ -905,6 +980,7 @@ def run_enrichment(
                 with_context=with_context,
                 parallel=parallel,
                 backend=_run_backend,
+                since_hours=since_hours,
             )
 
             if result["processed"] == 0:
@@ -967,6 +1043,20 @@ if __name__ == "__main__":
         help="Concurrent workers (1=sequential, 3=recommended for MLX)",
     )
     parser.add_argument("--no-context", action="store_true", help="Skip surrounding context")
+    parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["ollama", "mlx", "groq"],
+        default=None,
+        help="LLM backend (default: auto-detect). groq sends to cloud with sanitization.",
+    )
+    parser.add_argument(
+        "--recent",
+        type=int,
+        default=None,
+        metavar="HOURS",
+        help="Only enrich chunks from the last N hours (on-demand mode)",
+    )
     parser.add_argument("--stats", action="store_true", help="Show enrichment stats and exit")
     parser.add_argument("--db", type=str, default=None, help="Database path")
     args = parser.parse_args()
@@ -985,10 +1075,17 @@ if __name__ == "__main__":
             print(f"Intent: {stats['by_intent']}")
         store.close()
     else:
+        # Set backend via env var if specified on CLI (affects module-level detection)
+        if args.backend:
+            os.environ["BRAINLAYER_ENRICH_BACKEND"] = args.backend
+            import brainlayer.pipeline.enrichment as _self
+            _self.ENRICH_BACKEND = args.backend
+
         run_enrichment(
             db_path=db,
             batch_size=args.batch_size,
             max_chunks=args.max,
             with_context=not args.no_context,
             parallel=args.parallel,
+            since_hours=args.recent,
         )

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -1221,11 +1221,15 @@ class VectorStore:
         content_types: Optional[List[str]] = None,
         min_char_count: Optional[int] = None,
         source: Optional[str] = None,
+        since_hours: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Get chunks that haven't been enriched yet, for batch processing.
 
         If min_char_count is not specified, uses source_aware_min_chars()
         to pick an appropriate threshold for the given source.
+
+        Args:
+            since_hours: Only return chunks created in the last N hours.
         """
         cursor = self._read_cursor()
 
@@ -1241,6 +1245,9 @@ class VectorStore:
             placeholders = ",".join("?" for _ in content_types)
             where.append(f"content_type IN ({placeholders})")
             params.extend(content_types)
+
+        if since_hours is not None:
+            where.append(f"created_at > datetime('now', '-{int(since_hours)} hours')")
 
         params.append(batch_size)
 

--- a/tests/test_groq_backend.py
+++ b/tests/test_groq_backend.py
@@ -1,0 +1,217 @@
+"""Tests for Groq backend in enrichment pipeline.
+
+Tests call_groq(), backend selection, privacy enforcement (sanitization),
+and CLI --backend flag.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from brainlayer.pipeline import enrichment
+
+# ── call_groq unit tests ──────────────────────────────────────────────
+
+
+class TestCallGroq:
+    """Test call_groq() function — OpenAI-compatible API call to Groq."""
+
+    def test_call_groq_exists(self):
+        """call_groq function should exist in the enrichment module."""
+        assert hasattr(enrichment, "call_groq")
+        assert callable(enrichment.call_groq)
+
+    def test_call_groq_success(self):
+        """Successful Groq API call returns response content."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": '{"summary":"test","tags":["groq"]}'}}],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("requests.post", return_value=mock_response) as mock_post,
+            patch.object(enrichment, "GROQ_API_KEY", "gsk_test123"),
+        ):
+            result = enrichment.call_groq("test prompt")
+
+        assert result == '{"summary":"test","tags":["groq"]}'
+        # Verify it called Groq API URL
+        call_args = mock_post.call_args
+        assert "groq.com" in call_args[0][0] or "groq.com" in str(call_args)
+
+    def test_call_groq_returns_none_on_error(self):
+        """Groq API error returns None (not raises)."""
+        with (
+            patch("requests.post", side_effect=Exception("Connection refused")),
+            patch.object(enrichment, "GROQ_API_KEY", "gsk_test123"),
+        ):
+            result = enrichment.call_groq("test prompt")
+        assert result is None
+
+    def test_call_groq_requires_api_key(self):
+        """call_groq returns None when GROQ_API_KEY is not set."""
+        with patch.object(enrichment, "GROQ_API_KEY", ""):
+            result = enrichment.call_groq("test prompt")
+        assert result is None
+
+    def test_call_groq_sends_auth_header(self):
+        """Groq API call includes Authorization: Bearer header."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "{}"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("requests.post", return_value=mock_response) as mock_post,
+            patch.object(enrichment, "GROQ_API_KEY", "gsk_test123"),
+        ):
+            enrichment.call_groq("test prompt")
+
+        call_kwargs = mock_post.call_args
+        headers = call_kwargs[1].get("headers") if call_kwargs[1] else call_kwargs.kwargs.get("headers")
+        assert headers is not None
+        assert "Bearer gsk_test123" in headers.get("Authorization", "")
+
+    def test_call_groq_uses_correct_model(self):
+        """Groq API call uses llama-3.3-70b-versatile model."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "{}"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("requests.post", return_value=mock_response) as mock_post,
+            patch.object(enrichment, "GROQ_API_KEY", "gsk_test123"),
+        ):
+            enrichment.call_groq("test prompt")
+
+        call_args = mock_post.call_args
+        json_body = call_args[1].get("json") if call_args[1] else call_args.kwargs.get("json")
+        assert json_body["model"] == "llama-3.3-70b-versatile"
+
+    def test_call_groq_logs_usage(self):
+        """Groq API call logs token usage to Supabase."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "{}"}}],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("requests.post", return_value=mock_response),
+            patch.object(enrichment, "GROQ_API_KEY", "gsk_test123"),
+            patch.object(enrichment, "_log_glm_usage") as mock_log,
+        ):
+            enrichment.call_groq("test prompt")
+
+        mock_log.assert_called_once()
+        # _log_glm_usage(prompt_tokens, completion_tokens, duration_ms, model=...)
+        args, kwargs = mock_log.call_args
+        assert args[0] == 100  # prompt_tokens
+        assert args[1] == 50  # completion_tokens
+        assert "groq" in kwargs.get("model", "")
+
+
+# ── Backend selection ──────────────────────────────────────────────────
+
+
+class TestGroqBackendSelection:
+    """Test that BRAINLAYER_ENRICH_BACKEND=groq routes to call_groq."""
+
+    def setup_method(self):
+        enrichment._consecutive_failures = 0
+        enrichment._fallback_active = False
+        enrichment._fallback_available = None
+
+    def test_call_llm_routes_to_groq(self):
+        """call_llm with backend='groq' calls call_groq."""
+        with patch.object(enrichment, "call_groq", return_value='{"summary":"ok"}') as mock_groq:
+            result = enrichment.call_llm("test prompt", backend="groq")
+        assert result == '{"summary":"ok"}'
+        mock_groq.assert_called_once()
+
+    def test_detect_backend_groq_from_env(self):
+        """BRAINLAYER_ENRICH_BACKEND=groq is recognized."""
+        with patch.dict(os.environ, {"BRAINLAYER_ENRICH_BACKEND": "groq"}):
+            backend = enrichment._detect_default_backend()
+        assert backend == "groq"
+
+
+# ── Privacy enforcement ────────────────────────────────────────────────
+
+
+class TestGroqPrivacy:
+    """Test that Groq backend enforces sanitization (no raw PII to cloud)."""
+
+    def test_enrich_one_uses_external_prompt_for_groq(self):
+        """When backend=groq, _enrich_one uses build_external_prompt with Sanitizer."""
+        store = MagicMock()
+        store.get_context.return_value = {"context": []}
+        chunk = {
+            "id": "test-chunk-groq-1",
+            "content": "Etan fixed the bug in auth.py",
+            "content_type": "user_message",
+            "project": "test",
+        }
+
+        with (
+            patch.object(
+                enrichment,
+                "build_external_prompt",
+                return_value=("sanitized prompt", MagicMock()),
+            ) as mock_ext_prompt,
+            patch.object(enrichment, "call_llm", return_value='{"summary":"ok","tags":["test"]}'),
+            patch.object(enrichment, "parse_enrichment", return_value={"summary": "ok", "tags": ["test"]}),
+        ):
+            result = enrichment._enrich_one(store, chunk, with_context=False, backend="groq")
+
+        assert result is True
+        mock_ext_prompt.assert_called_once()
+
+    def test_enrich_one_uses_local_prompt_for_mlx(self):
+        """When backend=mlx, _enrich_one uses build_prompt (no sanitization)."""
+        store = MagicMock()
+        store.get_context.return_value = {"context": []}
+        chunk = {
+            "id": "test-chunk-mlx-1",
+            "content": "test content",
+            "content_type": "user_message",
+            "project": "test",
+        }
+
+        with (
+            patch.object(enrichment, "build_prompt", return_value="local prompt") as mock_local_prompt,
+            patch.object(enrichment, "call_llm", return_value='{"summary":"ok","tags":["test"]}'),
+            patch.object(enrichment, "parse_enrichment", return_value={"summary": "ok", "tags": ["test"]}),
+        ):
+            result = enrichment._enrich_one(store, chunk, with_context=False, backend="mlx")
+
+        assert result is True
+        mock_local_prompt.assert_called_once()
+
+
+# ── Config constants ──────────────────────────────────────────────────
+
+
+class TestGroqConfig:
+    """Test Groq-specific configuration constants."""
+
+    def test_groq_url_default(self):
+        """Default Groq URL points to api.groq.com."""
+        assert hasattr(enrichment, "GROQ_URL")
+        assert "groq.com" in enrichment.GROQ_URL
+
+    def test_groq_model_default(self):
+        """Default Groq model is llama-3.3-70b-versatile."""
+        assert hasattr(enrichment, "GROQ_MODEL")
+        assert enrichment.GROQ_MODEL == "llama-3.3-70b-versatile"
+
+    def test_groq_api_key_from_env(self):
+        """GROQ_API_KEY is read from environment."""
+        assert hasattr(enrichment, "GROQ_API_KEY")

--- a/tests/test_recent_enrichment.py
+++ b/tests/test_recent_enrichment.py
@@ -1,0 +1,39 @@
+"""Tests for on-demand enrichment — --recent flag for enriching new chunks."""
+
+from unittest.mock import MagicMock
+
+from brainlayer.pipeline import enrichment
+
+
+class TestRecentEnrichment:
+    """Test --recent flag passes since_hours through the pipeline."""
+
+    def test_enrich_batch_passes_since_hours(self):
+        """enrich_batch passes since_hours to get_unenriched_chunks."""
+        store = MagicMock()
+        store.get_unenriched_chunks.return_value = []
+
+        result = enrichment.enrich_batch(store, batch_size=10, since_hours=6)
+
+        store.get_unenriched_chunks.assert_called_once()
+        call_kwargs = store.get_unenriched_chunks.call_args
+        assert call_kwargs[1].get("since_hours") == 6 or (
+            len(call_kwargs[0]) > 0 and 6 in call_kwargs[0]
+        )
+
+    def test_enrich_batch_none_since_hours_by_default(self):
+        """enrich_batch passes since_hours=None by default (all chunks)."""
+        store = MagicMock()
+        store.get_unenriched_chunks.return_value = []
+
+        enrichment.enrich_batch(store, batch_size=10)
+
+        call_kwargs = store.get_unenriched_chunks.call_args
+        assert call_kwargs[1].get("since_hours") is None
+
+    def test_run_enrichment_accepts_since_hours(self):
+        """run_enrichment accepts since_hours parameter."""
+        import inspect
+
+        sig = inspect.signature(enrichment.run_enrichment)
+        assert "since_hours" in sig.parameters


### PR DESCRIPTION
## Summary
- Add Groq cloud LLM backend for enrichment pipeline (`--backend groq`)
- Privacy enforced: `build_external_prompt()` + Sanitizer strips PII before any content reaches Groq cloud
- Add `--recent N` flag for on-demand enrichment of chunks from last N hours
- GROQ_API_KEY in 1Password (vault: development)

## Changes
| File | Change |
|------|--------|
| `enrichment.py` | `call_groq()`, `GROQ_*` config, `--backend`/`--recent` CLI args, privacy routing in `_enrich_one()` |
| `cli/__init__.py` | `--backend` and `--recent` options for `brainlayer enrich` |
| `vector_store.py` | `since_hours` param on `get_unenriched_chunks()` |
| `test_groq_backend.py` | 14 tests: call_groq, routing, privacy, config |
| `test_recent_enrichment.py` | 3 tests: since_hours threading |

## Usage
```bash
# Groq for non-private content (youtube transcripts, public docs)
GROQ_API_KEY=gsk_... brainlayer enrich --backend groq --max 100

# On-demand: enrich only recent chunks
brainlayer enrich --recent 2 --max 50
```

## Test plan
- [x] 520 tests pass (17 new), 0 failures
- [x] Lint clean (ruff)
- [x] Privacy: groq backend uses build_external_prompt() with Sanitizer
- [x] Local backends (mlx/ollama) unchanged — use build_prompt() as before
- [ ] Manual: `brainlayer enrich --backend groq --max 5` with real API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new cloud LLM backend (`groq`) and routes prompts through sanitization to avoid sending raw PII externally; misconfiguration or sanitization gaps could leak data. Also changes chunk selection SQL for `--recent`, which could affect enrichment coverage/performance.
> 
> **Overview**
> Adds an optional **Groq cloud backend** to the enrichment pipeline, including `call_groq()` (OpenAI-compatible) with usage logging and a required `GROQ_API_KEY`, and wires backend selection through `call_llm()` and the CLI via `--backend`.
> 
> Enforces **privacy for cloud calls** by switching `_enrich_one()` to use `build_external_prompt()` + `Sanitizer` when the effective backend is `groq`, while keeping local backends on the existing `build_prompt()` path.
> 
> Adds **on-demand enrichment** via `--recent HOURS`, threading `since_hours` through `run_enrichment()`/`enrich_batch()` into `VectorStore.get_unenriched_chunks()` to only fetch chunks created within the specified window. Includes new tests covering Groq routing/privacy and `since_hours` propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2b488c33c8f5a2e241f04f426cec9629d647956. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Groq as a cloud-based LLM backend option for enrichment
  * Added `--backend` flag to explicitly select enrichment backend (ollama, mlx, groq, or auto-detect)
  * Added `--recent` flag to enrich only chunks created within the specified number of hours

<!-- end of auto-generated comment: release notes by coderabbit.ai -->