### PR TITLE
fix: increase busy_timeout, don't circuit-break on DB locks

### DIFF
--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -877,9 +877,17 @@ def enrich_batch(
                         failed += 1
                         consecutive_failures += 1
                 except Exception as e:
-                    print(f"  Worker error: {e}", file=sys.stderr)
-                    failed += 1
-                    consecutive_failures += 1
+                    # DB lock errors are transient contention, not backend failures.
+                    # Don't count them toward circuit breaker.
+                    is_db_lock = "database is locked" in str(e) or "BusyError" in type(e).__name__
+                    if is_db_lock:
+                        print(f"  Worker DB lock (transient): {e}", file=sys.stderr)
+                        failed += 1
+                        # Don't increment consecutive_failures for DB locks
+                    else:
+                        print(f"  Worker error: {e}", file=sys.stderr)
+                        failed += 1
+                        consecutive_failures += 1
 
                 # Circuit breaker: abort if backend is clearly dead
                 if consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -18,7 +18,7 @@ def _set_busy_timeout_hook(conn: apsw.Connection) -> None:
     the Connection() constructor. Without busy_timeout set first, this PRAGMA
     fails with BusyError when other processes hold the DB lock.
     """
-    conn.setbusytimeout(10_000)  # 10 seconds
+    conn.setbusytimeout(30_000)  # 30 seconds — needed for parallel enrichment workers + MCP
 
 
 # Register busy_timeout hook BEFORE bestpractice hooks so it fires first.


### PR DESCRIPTION
## Summary
- **busy_timeout 10s → 30s** — parallel=3 workers + MCP instances caused contention spikes beyond 10s
- **DB lock errors excluded from circuit breaker** — `database is locked` is transient SQLite contention, not a dead backend. Previously, 10 consecutive DB locks tripped the circuit breaker and killed the run.

Evidence: enrichment ran 305/315 ok then circuit-broke on DB locks (not MLX), stopping prematurely.

## Test plan
- [x] 37 enrichment tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure accounting and SQLite busy-timeout behavior; could lengthen waits under heavy contention and may delay detection of genuinely failing workers if lock errors are misclassified.
> 
> **Overview**
> Improves parallel enrichment stability under SQLite contention by treating `database is locked`/`BusyError` worker exceptions as *transient* and excluding them from the circuit breaker’s consecutive-failure count.
> 
> Increases APSW connection `busy_timeout` from 10s to 30s (via the connection hook) to reduce spurious lock failures when multiple enrichment workers and MCP instances contend for the DB.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16e5c989da744a71232d998f1763e5a44bae3504. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to distinguish transient database lock errors from backend failures, preventing premature circuit-breaker interruptions.

* **Improvements**
  * Increased database connection timeout from 10 to 30 seconds to enhance stability and support parallel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->