### PR TITLE
fix: add missing logger import in MCP server

### DIFF
--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -1,7 +1,10 @@
 """BrainLayer MCP Server - Model Context Protocol interface for Claude Code."""
 
 import asyncio
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server


### PR DESCRIPTION
## Summary
- `brain_update` and `brain_recall` person-memory handler used `logger.error()` / `logger.warning()` without importing `logging` or defining `logger`
- Any `brain_update` call that hit the except block threw `NameError: name 'logger' is not defined`
- Added `import logging` + `logger = logging.getLogger(__name__)` at module top

## Test plan
- [x] 663 tests pass, 0 failures
- [ ] Verify `brain_update(action="update", ...)` works after MCP restart

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a standard `logging` import and module-level `logger`, affecting error-path behavior but not core tool logic or data handling.
> 
> **Overview**
> Fixes MCP server error handling by adding `import logging` and defining a module-level `logger` in `src/brainlayer/mcp/__init__.py`, preventing `NameError` when `brain_update`/person-memory handlers log warnings or errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e20cbc71a06305018b5107279cf720769b741ea5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added logging infrastructure to enhance diagnostic and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->