### PR TITLE
fix: add missing json import in MCP server

### DIFF
--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -1,6 +1,7 @@
 """BrainLayer MCP Server - Model Context Protocol interface for Claude Code."""
 
 import asyncio
+import json
 import logging
 from typing import Any
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #50 — `brain_update` also used `json.dumps()` without `json` being imported at module level
- `json` was imported locally inside `_brain_search`, `_brain_recall`, and `_brain_entity` but not in `_brain_update`
- Moved `import json` to module level so all handlers can use it

## Test plan
- [x] 663 tests pass
- [ ] Verify `brain_update(action="update", ...)` works after MCP reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single missing import fix that only affects JSON serialization in the MCP tool handlers.
> 
> **Overview**
> Fixes a runtime error in the MCP server by adding a module-level `import json`, ensuring `brain_update` (and other handlers using `json.dumps`) can serialize responses without relying on function-local imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58fc455a121dd6c888ffa78ee438544020547ffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal module improvements and dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->