### PR TITLE
docs: sync stale numbers, add KG spec and roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Semantic search across AI conversation history (sqlite-vec + bge-large-en-v1.5)
 - 10-field LLM enrichment pipeline (Ollama / MLX backends)
 - Brain graph visualization (HDBSCAN clustering + UMAP 3D layout)
-- MCP server with 8 tools for Claude Code, Zed, Cursor
+- MCP server with 7 tools (+ 14 backward-compatible aliases) for Claude Code, Zed, Cursor
 - Interactive setup wizard (`brainlayer init`)
 - Centralized artifact storage (`~/.local/share/brainlayer/storage/`)
 - Multi-source indexing: Claude Code, WhatsApp, YouTube, Markdown, Claude Desktop

--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 > Persistent memory and knowledge graph for AI agents — 7 MCP tools to search, store, recall, digest, and explore entities across every conversation.
 
+[![PyPI](https://img.shields.io/pypi/v/brainlayer.svg)](https://pypi.org/project/brainlayer/)
+[![CI](https://github.com/EtanHey/brainlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/EtanHey/brainlayer/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-7%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-510%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-698%20passing-brightgreen.svg)](#testing)
 [![Docs](https://img.shields.io/badge/docs-etanhey.github.io%2Fbrainlayer-blue.svg)](https://etanhey.github.io/brainlayer)
 
 ---
+
+**268,000+ chunks indexed** · **698 tests** · **Hybrid RRF search** · **7 MCP tools** · **Zero cloud dependencies**
 
 **Your AI agent forgets everything between sessions.** Every architecture decision, every debugging session, every preference you've expressed — gone. You repeat yourself constantly.
 
@@ -240,10 +244,14 @@ BrainLayer can index conversations from multiple sources:
 
 ```bash
 pip install -e ".[dev]"
-pytest tests/                           # Full suite (525 tests)
+pytest tests/                           # Full suite (698 tests)
 pytest tests/ -m "not integration"      # Unit tests only (fast)
 ruff check src/                         # Linting
 ```
+
+## Roadmap
+
+See [docs/roadmap.md](docs/roadmap.md) for planned features including boot context loading, compact search, pinned memories, and MCP Registry listing.
 
 ## Contributing
 

--- a/docs/kg-spec.md
+++ b/docs/kg-spec.md
@@ -1,0 +1,58 @@
+# Knowledge Graph Specification
+
+BrainLayer's knowledge graph (KG) stores structured entities and relations extracted from indexed conversations. This document specifies the entity types, relation types, and time-decay scoring model.
+
+## Entity Types
+
+| Type | Description |
+|------|-------------|
+| `person` | People mentioned in conversations |
+| `constraint` | Scheduling or resource constraints |
+| `preference` | User preferences and choices |
+| `life_event` | Date-bounded life events |
+| `meeting` | Meetings and appointments |
+| `location` | Physical or virtual locations |
+| `organization` | Companies, teams, groups |
+
+## Relation Types
+
+| Relation | Description |
+|----------|-------------|
+| `has_constraint` | Entity has a constraint |
+| `has_preference` | Entity has a preference |
+| `blocked_during` | Entity unavailable during period |
+| `attended` | Person attended a meeting/event |
+| `organized_by` | Meeting/event organized by person |
+| `knows` | Person knows another person |
+| `works_at` | Person works at organization |
+| `supersedes` | Newer entity replaces older one |
+| `held_at` | Meeting/event held at location |
+
+## Time-Decay Scoring
+
+Entity relevance decays over time using an exponential model:
+
+```
+score = confidence * importance * exp(-lambda * age_days)
+```
+
+| Entity Type | Lambda | Half-Life |
+|-------------|--------|-----------|
+| `constraint` | 0.0019 | ~365 days |
+| `preference` | 0.0077 | ~90 days |
+| `life_event` | 0 | No decay (date-bounded) |
+| `casual` | 0.0231 | ~30 days |
+| `meeting` | 0.0046 | ~150 days |
+
+- **confidence** (0-1): How certain we are about this fact
+- **importance** (0-1): How important this fact is
+- **age_days**: Days since entity creation
+- Default decay rate (when type is unknown): preference rate (0.0077)
+
+## Compatibility
+
+The KG spec is shared with Convex (`kgSpec.ts` in 6PM) to ensure consistent entity modeling across the ecosystem.
+
+## Source
+
+Defined in `src/brainlayer/kg/__init__.py`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,32 @@
+# Roadmap
+
+Planned features and improvements for BrainLayer.
+
+## Near-Term
+
+### Boot Context Loading
+Load relevant memories automatically when a new Claude Code session starts, replacing manual CLAUDE.md context with dynamically retrieved knowledge.
+
+### Compact Search
+Optimized search mode that returns condensed results for context-constrained environments (e.g., during conversation compaction).
+
+### Pinned Memories
+Allow users to pin critical memories (architectural decisions, conventions, preferences) so they always surface in context retrieval regardless of age or decay.
+
+## Medium-Term
+
+### MCP Registry Listing
+Publish BrainLayer to the official [MCP Registry](https://registry.modelcontextprotocol.io) for one-click installation.
+
+### Demo / Showcase
+Terminal recording (VHS) demonstrating search, store, recall, and entity lookup in a real workflow.
+
+### Architecture Decision Records
+Formalize key design decisions (sqlite-vec, RRF scoring, enrichment pipeline) as ADRs in `docs/adr/`.
+
+## Phase Plans
+
+Detailed implementation plans for specific features:
+
+- [Phase 3: Brain Digest](plans/2026-02-25-phase-3-brain-digest.md) — entity extraction, relations, sentiment analysis
+- [Phase 6: Sentiment Analysis](plans/2026-02-25-phase-6-sentiment.md) — communication style and sentiment pipeline

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,11 +34,13 @@ nav:
     - MCP Tools: mcp-tools.md
     - Architecture: architecture.md
     - Enrichment: enrichment.md
+    - KG Specification: kg-spec.md
   - Guides:
     - Data Locations: data-locations.md
     - Enrichment Runbook: enrichment-runbook.md
     - Local Models: local-models-guide.md
     - MCP Config: mcp-config.md
+  - Roadmap: roadmap.md
   - Contributing: contributing.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary
- Fix stale test counts in README badge (510 → 698) and testing section (525 → 698)
- Fix CHANGELOG tool count (8 → 7 tools + 14 backward-compatible aliases)
- Add PyPI and CI badges to README for recruiter credibility
- Add 268K+ chunks / 698 tests headline stats front-and-center in README
- Create `docs/kg-spec.md` documenting entity types, relation types, and time-decay scoring model
- Create `docs/roadmap.md` with planned features (boot context, compact search, pinned memories, MCP Registry)
- Add both new docs to mkdocs navigation

## Context
Part of Phase 8 (Docs & Portfolio) ecosystem cleanup — making repos recruiter-ready.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify mkdocs builds without errors
- [ ] Verify new docs pages render on docs site after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)