### PR TITLE
feat: R49 Phase 1 — Entity Contracts Schema

### DIFF
--- a/contracts/entity-types.yaml
+++ b/contracts/entity-types.yaml
@@ -1,0 +1,162 @@
+# R49 Entity Type Contracts — defines required/expected fields per entity type
+# Used by score_entity_health.py to evaluate entity completeness.
+#
+# Three requirement levels:
+#   required  — must be present for entity to be useful
+#   expected  — should be present for a well-maintained entity
+#   optional  — nice to have, not penalized if absent
+#
+# Health criteria define minimum viable thresholds for each type.
+
+version: "1.0"
+
+defaults:
+  memory_categories:
+    - identity
+    - relationships
+    - observations
+    - context
+    - actions
+    - meta
+
+entity_types:
+  agent:
+    required:
+      - name
+      - type
+      - description
+      - capabilities
+      - memory_domains
+    expected:
+      - status
+      - personality_traits
+      - tools_used
+      - scheduling_patterns
+    optional:
+      - version_history
+      - error_patterns
+      - performance_metrics
+    relationships:
+      min_required: 2
+      expected_types:
+        - USES
+        - MANAGES
+        - CREATED_BY
+        - PART_OF
+    memory_categories:
+      required:
+        - identity
+        - observations
+        - actions
+      expected:
+        - relationships
+        - context
+    health_criteria:
+      min_chunks: 10
+      max_stale_days: 30
+      min_relationships: 2
+
+  person:
+    required:
+      - name
+      - type
+      - description
+      - role
+    expected:
+      - affiliation
+      - domain
+      - first_seen_date
+      - key_interactions
+    optional:
+      - contact_info
+      - hard_constraints
+      - preferences
+    relationships:
+      min_required: 1
+      expected_types:
+        - CREATED_BY
+        - WORKS_ON
+        - OWNS
+    health_criteria:
+      min_chunks: 3
+      max_stale_days: 90
+      min_relationships: 1
+
+  tool:
+    required:
+      - name
+      - type
+      - description
+      - purpose
+    expected:
+      - status
+      - integration_status
+      - documentation_url
+      - known_issues
+    optional:
+      - version
+      - alternatives
+      - performance_notes
+    relationships:
+      min_required: 1
+      expected_types:
+        - USES
+        - PART_OF
+        - DEPENDS_ON
+    health_criteria:
+      min_chunks: 5
+      max_stale_days: 60
+      min_relationships: 1
+
+  project:
+    required:
+      - name
+      - type
+      - description
+      - status
+      - goals
+    expected:
+      - start_date
+      - stakeholders
+      - repository_url
+      - tech_stack
+    optional:
+      - end_date
+      - milestones
+      - budget
+    relationships:
+      min_required: 2
+      expected_types:
+        - PART_OF
+        - OWNED_BY
+        - USES
+        - DEPENDS_ON
+    health_criteria:
+      min_chunks: 10
+      max_stale_days: 14
+      min_relationships: 2
+
+  concept:
+    required:
+      - name
+      - type
+      - description
+      - domain
+    expected:
+      - definition
+      - related_concepts
+      - applications
+    optional:
+      - examples
+      - references
+      - history
+    relationships:
+      min_required: 1
+      expected_types:
+        - RELATED_TO
+        - PART_OF
+        - INFLUENCES
+    health_criteria:
+      min_chunks: 2
+      max_stale_days: 180
+      min_relationships: 1

--- a/scripts/score_entity_health.py
+++ b/scripts/score_entity_health.py
@@ -1,0 +1,322 @@
+"""R49 Phase 1 — Score entity health against type contracts.
+
+Evaluates every entity against its type contract and populates the
+entity_health table with completeness scores.
+
+Scoring algorithm (5 dimensions, weighted):
+  40% — Required field coverage
+  25% — Expected field coverage
+  15% — Relationship density (relative to type contract minimum)
+  10% — Chunk density (relative to type contract minimum)
+  10% — Recency (exponential decay, 90-day half-life)
+
+Health levels (Wikidata 5-tier):
+  5 — Very Detailed (0.85+)
+  4 — Detailed (0.65–0.84)
+  3 — Moderate (0.45–0.64)
+  2 — Basic (0.25–0.44)
+  1 — Stub (<0.25)
+
+Usage:
+  python scripts/score_entity_health.py [--db PATH] [--contracts PATH]
+"""
+
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+
+def load_contracts(contracts_path: str) -> Dict[str, Dict[str, Any]]:
+    """Load entity type contracts from YAML file.
+
+    Returns:
+        Dict mapping entity_type -> contract spec (required, expected, health_criteria, etc.)
+    """
+    with open(contracts_path) as f:
+        data = yaml.safe_load(f)
+    return data.get("entity_types", {})
+
+
+def classify_health_level(score: float) -> int:
+    """Classify a completeness score into a 1-5 health level.
+
+    5 — Very Detailed (0.85+)
+    4 — Detailed (0.65–0.84)
+    3 — Moderate (0.45–0.64)
+    2 — Basic (0.25–0.44)
+    1 — Stub (<0.25)
+    """
+    if score >= 0.85:
+        return 5
+    elif score >= 0.65:
+        return 4
+    elif score >= 0.45:
+        return 3
+    elif score >= 0.25:
+        return 2
+    else:
+        return 1
+
+
+def _get_entity_field_values(store, entity_id: str) -> Dict[str, Any]:
+    """Extract all known field values for an entity from its row + metadata."""
+    cursor = store._read_cursor()
+    row = list(cursor.execute(
+        """SELECT id, entity_type, name, metadata, description,
+                  canonical_name, confidence, importance, entity_subtype, status
+           FROM kg_entities WHERE id = ?""",
+        (entity_id,),
+    ))
+    if not row:
+        return {}
+
+    r = row[0]
+    metadata = json.loads(r[3]) if r[3] else {}
+
+    # Merge top-level columns and metadata into a flat field map
+    fields = {
+        "name": r[2],
+        "type": r[1],
+        "description": r[4] or metadata.get("description"),
+        "entity_subtype": r[8],
+        "status": r[9],
+    }
+
+    # Add all metadata keys as fields
+    for k, v in metadata.items():
+        if k not in fields:
+            fields[k] = v
+
+    return fields
+
+
+def _count_relationships(store, entity_id: str) -> int:
+    """Count total relationships (incoming + outgoing) for an entity."""
+    cursor = store._read_cursor()
+    out_count = list(cursor.execute(
+        "SELECT COUNT(*) FROM kg_relations WHERE source_id = ?", (entity_id,)
+    ))[0][0]
+    in_count = list(cursor.execute(
+        "SELECT COUNT(*) FROM kg_relations WHERE target_id = ?", (entity_id,)
+    ))[0][0]
+    return out_count + in_count
+
+
+def _count_chunks(store, entity_id: str) -> int:
+    """Count chunks linked to an entity."""
+    cursor = store._read_cursor()
+    return list(cursor.execute(
+        "SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?", (entity_id,)
+    ))[0][0]
+
+
+def _get_entity_updated_at(store, entity_id: str) -> Optional[str]:
+    """Get the most recent updated_at for an entity."""
+    cursor = store._read_cursor()
+    row = list(cursor.execute(
+        "SELECT updated_at FROM kg_entities WHERE id = ?", (entity_id,)
+    ))
+    if row and row[0][0]:
+        return row[0][0]
+    return None
+
+
+def score_entity(
+    store,
+    entity_id: str,
+    entity_type: str,
+    contract: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Score a single entity against its type contract.
+
+    Returns dict with: completeness_score, health_level, missing_required,
+    missing_expected, chunk_count, relationship_count.
+    """
+    fields = _get_entity_field_values(store, entity_id)
+    required_fields = contract.get("required", [])
+    expected_fields = contract.get("expected", [])
+    health_criteria = contract.get("health_criteria", {})
+
+    # 1. Required field coverage (40%)
+    if required_fields:
+        populated_required = sum(
+            1 for f in required_fields
+            if fields.get(f) is not None and fields.get(f) != ""
+        )
+        required_score = populated_required / len(required_fields)
+    else:
+        required_score = 1.0
+
+    missing_required = [
+        f for f in required_fields
+        if fields.get(f) is None or fields.get(f) == ""
+    ]
+
+    # 2. Expected field coverage (25%)
+    if expected_fields:
+        populated_expected = sum(
+            1 for f in expected_fields
+            if fields.get(f) is not None and fields.get(f) != ""
+        )
+        expected_score = populated_expected / len(expected_fields)
+    else:
+        expected_score = 1.0
+
+    missing_expected = [
+        f for f in expected_fields
+        if fields.get(f) is None or fields.get(f) == ""
+    ]
+
+    # 3. Relationship density (15%) — relative to contract minimum
+    relationship_count = _count_relationships(store, entity_id)
+    min_rels = health_criteria.get("min_relationships", 1)
+    rel_score = min(relationship_count / max(min_rels, 1), 1.0)
+
+    # 4. Chunk density (10%) — relative to contract minimum
+    chunk_count = _count_chunks(store, entity_id)
+    min_chunks = health_criteria.get("min_chunks", 1)
+    chunk_score = min(chunk_count / max(min_chunks, 1), 1.0)
+
+    # 5. Recency (10%) — exponential decay, 90-day half-life
+    updated_at = _get_entity_updated_at(store, entity_id)
+    if updated_at:
+        try:
+            # Handle both formats: with and without 'Z'
+            ts = updated_at.rstrip("Z")
+            updated_dt = datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
+            days_stale = max((now - updated_dt).total_seconds() / 86400, 0)
+            recency_score = math.pow(0.5, days_stale / 90.0)
+        except (ValueError, TypeError):
+            recency_score = 0.5  # Unknown date, assume moderate
+    else:
+        recency_score = 0.5  # No date, assume moderate
+
+    # Weighted combination
+    completeness_score = (
+        0.40 * required_score
+        + 0.25 * expected_score
+        + 0.15 * rel_score
+        + 0.10 * chunk_score
+        + 0.10 * recency_score
+    )
+
+    # Clamp to [0, 1]
+    completeness_score = max(0.0, min(1.0, completeness_score))
+
+    return {
+        "completeness_score": round(completeness_score, 4),
+        "health_level": classify_health_level(completeness_score),
+        "missing_required": missing_required,
+        "missing_expected": missing_expected,
+        "chunk_count": chunk_count,
+        "relationship_count": relationship_count,
+    }
+
+
+def score_all_entities(store, contracts: Dict[str, Dict[str, Any]]) -> int:
+    """Score all entities and persist results to entity_health table.
+
+    Returns number of entities scored.
+    """
+    cursor = store._read_cursor()
+    entities = list(cursor.execute(
+        "SELECT id, entity_type, name FROM kg_entities"
+    ))
+
+    scored = 0
+    write_cursor = store.conn.cursor()
+
+    for entity_id, entity_type, entity_name in entities:
+        # Find the contract — check direct type, then check parent type via hierarchy
+        contract = contracts.get(entity_type)
+        if contract is None:
+            # Try parent type from hierarchy
+            parent_row = list(cursor.execute(
+                "SELECT parent_type FROM entity_type_hierarchy WHERE child_type = ?",
+                (entity_type,),
+            ))
+            if parent_row:
+                contract = contracts.get(parent_row[0][1] if len(parent_row[0]) > 1 else parent_row[0][0])
+        if contract is None:
+            # Default: score with minimal contract
+            contract = {
+                "required": ["name", "type", "description"],
+                "expected": [],
+                "health_criteria": {"min_chunks": 1, "max_stale_days": 180, "min_relationships": 0},
+            }
+
+        result = score_entity(store, entity_id, entity_type, contract)
+
+        write_cursor.execute(
+            """INSERT INTO entity_health
+               (entity_name, completeness_score, health_level,
+                missing_required, missing_expected, chunk_count,
+                relationship_count, last_scored_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+               ON CONFLICT(entity_name) DO UPDATE SET
+                 completeness_score = excluded.completeness_score,
+                 health_level = excluded.health_level,
+                 missing_required = excluded.missing_required,
+                 missing_expected = excluded.missing_expected,
+                 chunk_count = excluded.chunk_count,
+                 relationship_count = excluded.relationship_count,
+                 last_scored_at = excluded.last_scored_at
+            """,
+            (
+                entity_name,
+                result["completeness_score"],
+                result["health_level"],
+                json.dumps(result["missing_required"]),
+                json.dumps(result["missing_expected"]),
+                result["chunk_count"],
+                result["relationship_count"],
+            ),
+        )
+        scored += 1
+
+    return scored
+
+
+def main():
+    """CLI entry point: score all entities in the production database."""
+    from brainlayer.paths import get_db_path
+    from brainlayer.vector_store import VectorStore
+
+    db_path = get_db_path()
+    contracts_path = Path(__file__).parent.parent / "contracts" / "entity-types.yaml"
+
+    if not contracts_path.exists():
+        print(f"ERROR: Contracts file not found at {contracts_path}")
+        sys.exit(1)
+
+    print(f"Loading contracts from {contracts_path}")
+    contracts = load_contracts(str(contracts_path))
+    print(f"Loaded {len(contracts)} entity type contracts")
+
+    print(f"Opening database at {db_path}")
+    store = VectorStore(db_path)
+
+    try:
+        scored = score_all_entities(store, contracts)
+        print(f"Scored {scored} entities")
+
+        # Print summary
+        cursor = store._read_cursor()
+        for level in range(5, 0, -1):
+            count = list(cursor.execute(
+                "SELECT COUNT(*) FROM entity_health WHERE health_level = ?", (level,)
+            ))[0][0]
+            labels = {5: "Very Detailed", 4: "Detailed", 3: "Moderate", 2: "Basic", 1: "Stub"}
+            print(f"  Level {level} ({labels[level]}): {count} entities")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -844,6 +844,22 @@ def entity_lookup(
         for e in evidence_raw
     ]
 
+    # R49: Include health data if available
+    completeness_score = None
+    health_level = None
+    try:
+        health_rows = list(
+            store._read_cursor().execute(
+                "SELECT completeness_score, health_level FROM entity_health WHERE entity_name = ?",
+                (entity["name"],),
+            )
+        )
+        if health_rows:
+            completeness_score = health_rows[0][0]
+            health_level = health_rows[0][1]
+    except Exception:
+        pass  # Table may not exist yet or entity not scored
+
     return {
         "id": entity_id,
         "name": entity["name"],
@@ -851,4 +867,6 @@ def entity_lookup(
         "metadata": entity.get("metadata", {}),
         "relations": relations,
         "evidence": evidence,
+        "completeness_score": completeness_score,
+        "health_level": health_level,
     }

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -583,6 +583,83 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         if "mention_type" not in ec_cols:
             cursor.execute("ALTER TABLE kg_entity_chunks ADD COLUMN mention_type TEXT")
 
+        # ── R49: Entity Contracts Schema ───────────────────────────────
+
+        # R49: entity_contracts table — defines required/expected fields per entity type
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS entity_contracts (
+                entity_type TEXT NOT NULL,
+                field_name TEXT NOT NULL,
+                field_type TEXT NOT NULL DEFAULT 'text',
+                requirement TEXT NOT NULL DEFAULT 'optional',
+                description TEXT,
+                PRIMARY KEY (entity_type, field_name)
+            )
+        """)
+
+        # R49: entity_health table — completeness scores per entity
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS entity_health (
+                entity_name TEXT PRIMARY KEY,
+                completeness_score REAL NOT NULL DEFAULT 0.0,
+                health_level INTEGER NOT NULL DEFAULT 1,
+                missing_required TEXT DEFAULT '[]',
+                missing_expected TEXT DEFAULT '[]',
+                chunk_count INTEGER NOT NULL DEFAULT 0,
+                relationship_count INTEGER NOT NULL DEFAULT 0,
+                last_scored_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            )
+        """)
+
+        # R49: entity_type_hierarchy — type taxonomy stored as data
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS entity_type_hierarchy (
+                child_type TEXT PRIMARY KEY,
+                parent_type TEXT,
+                description TEXT
+            )
+        """)
+
+        # R49: Seed type hierarchy with core types + subtypes
+        _type_hierarchy_seed = [
+            ("agent", "entity", "Autonomous AI agent or golem"),
+            ("person", "entity", "Human individual"),
+            ("tool", "entity", "Software tool or service"),
+            ("project", "entity", "Software project or initiative"),
+            ("concept", "entity", "Abstract concept, pattern, or domain idea"),
+            ("event", "entity", "Temporal event or occurrence"),
+            ("organization", "entity", "Company or group"),
+            ("golem", "agent", "Specialized AI agent in the golems ecosystem"),
+            ("platform", "tool", "Software platform or framework"),
+            ("skill", "concept", "Reusable AI skill or capability"),
+            ("decision", "concept", "Architectural or design decision"),
+        ]
+        for child, parent, desc in _type_hierarchy_seed:
+            cursor.execute(
+                "INSERT OR IGNORE INTO entity_type_hierarchy (child_type, parent_type, description) VALUES (?, ?, ?)",
+                (child, parent, desc),
+            )
+
+        # R49: ALTER kg_entities — add entity_subtype, status
+        if "entity_subtype" not in kg_entity_cols:
+            cursor.execute("ALTER TABLE kg_entities ADD COLUMN entity_subtype TEXT")
+        if "status" not in kg_entity_cols:
+            cursor.execute("ALTER TABLE kg_entities ADD COLUMN status TEXT DEFAULT 'active'")
+
+        # R49: ALTER kg_entity_chunks — add relation_tier, weight
+        if "relation_tier" not in ec_cols:
+            cursor.execute("ALTER TABLE kg_entity_chunks ADD COLUMN relation_tier INTEGER DEFAULT 4")
+        if "weight" not in ec_cols:
+            cursor.execute("ALTER TABLE kg_entity_chunks ADD COLUMN weight REAL DEFAULT 0.25")
+
+        # R49: Upgrade kg_entity_aliases — add valid_from, valid_to if missing
+        alias_cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_aliases)")}
+        if "valid_to" not in alias_cols:
+            cursor.execute("ALTER TABLE kg_entity_aliases ADD COLUMN valid_to TEXT")
+        # valid_from may already exist from original schema (as created_at) — ensure both names exist
+        if "valid_from" not in alias_cols:
+            cursor.execute("ALTER TABLE kg_entity_aliases ADD COLUMN valid_from TEXT")
+
         # kg_current_facts view
         cursor.execute("DROP VIEW IF EXISTS kg_current_facts")
         cursor.execute("""

--- a/tests/test_entity_contracts.py
+++ b/tests/test_entity_contracts.py
@@ -1,0 +1,540 @@
+"""Tests for R49 Phase 1 — Entity Contracts, Health Scoring, Type Hierarchy, Aliases.
+
+Tests cover:
+1. Schema: entity_contracts, entity_health, entity_type_hierarchy tables created
+2. Schema: kg_entity_aliases table upgraded with new columns
+3. Schema: kg_entities gets entity_subtype, status, updated_at columns
+4. Schema: kg_entity_chunks gets relation_tier, weight columns
+5. Contracts YAML loading and validation
+6. Health scoring algorithm (5-dimension weighted)
+7. Health level classification (5 tiers)
+8. Entity lookup includes completeness_score and health_level
+"""
+
+import json
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from brainlayer.vector_store import VectorStore
+
+# ── Fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path):
+    """Create a fresh VectorStore for testing."""
+    db_path = tmp_path / "test.db"
+    s = VectorStore(db_path)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def mock_embedding():
+    """Generate a deterministic 1024-dim embedding from text."""
+
+    def _embed(text: str) -> list[float]:
+        seed = sum(ord(c) for c in text[:50]) % 100
+        return [float(seed + i) / 1000.0 for i in range(1024)]
+
+    return _embed
+
+
+@pytest.fixture
+def contracts_path():
+    """Path to the entity-types.yaml contracts file."""
+    return Path(__file__).parent.parent / "contracts" / "entity-types.yaml"
+
+
+@pytest.fixture
+def populated_store(store, mock_embedding):
+    """Store with entities, relations, and chunks for health scoring tests."""
+    # Create an agent entity
+    store.upsert_entity(
+        entity_id="ent-coach",
+        entity_type="agent",
+        name="coachClaude",
+        metadata={"description": "Health coach", "capabilities": ["health_tracking"]},
+        embedding=mock_embedding("coachClaude"),
+        description="Health and habits coaching agent",
+    )
+
+    # Create a second entity for relations
+    store.upsert_entity(
+        entity_id="ent-brain",
+        entity_type="tool",
+        name="BrainLayer",
+        metadata={"description": "Memory layer", "purpose": "persistent memory"},
+        embedding=mock_embedding("BrainLayer"),
+        description="Persistent memory for AI agents",
+    )
+
+    # Create a person entity (minimal)
+    store.upsert_entity(
+        entity_id="ent-etan",
+        entity_type="person",
+        name="Etan",
+        metadata={"role": "developer"},
+        embedding=mock_embedding("Etan"),
+        description="Developer and owner",
+    )
+
+    # Add relation: coachClaude USES BrainLayer
+    store.add_relation(
+        relation_id="rel-coach-brain",
+        source_id="ent-coach",
+        target_id="ent-brain",
+        relation_type="USES",
+    )
+
+    # Add relation: coachClaude CREATED_BY Etan
+    store.add_relation(
+        relation_id="rel-coach-etan",
+        source_id="ent-coach",
+        target_id="ent-etan",
+        relation_type="CREATED_BY",
+    )
+
+    # Add some chunks linked to coachClaude
+    dummy_emb = mock_embedding("dummy chunk")
+    for i in range(5):
+        chunk_id = f"chunk-coach-{i}"
+        store.upsert_chunks(
+            [{"id": chunk_id, "content": f"Coach info chunk {i}", "metadata": {},
+              "source_file": "test", "project": "test", "content_type": "user_message",
+              "value_type": None, "char_count": 20}],
+            [dummy_emb],
+        )
+        store.link_entity_chunk("ent-coach", chunk_id, relevance=0.8 + i * 0.04)
+
+    # Add chunks to BrainLayer entity (3 chunks)
+    for i in range(3):
+        chunk_id = f"chunk-brain-{i}"
+        store.upsert_chunks(
+            [{"id": chunk_id, "content": f"BrainLayer info chunk {i}", "metadata": {},
+              "source_file": "test", "project": "test", "content_type": "user_message",
+              "value_type": None, "char_count": 20}],
+            [dummy_emb],
+        )
+        store.link_entity_chunk("ent-brain", chunk_id, relevance=0.9)
+
+    return store
+
+
+# ── 1. Schema Tests: New Tables ────────────────────────────────
+
+
+class TestEntityContractsSchema:
+    """Verify R49 schema additions exist after VectorStore init."""
+
+    def test_entity_contracts_table_exists(self, store):
+        cursor = store._read_cursor()
+        tables = {row[0] for row in cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        assert "entity_contracts" in tables
+
+    def test_entity_contracts_columns(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(entity_contracts)")}
+        expected = {"entity_type", "field_name", "field_type", "requirement", "description"}
+        assert expected.issubset(cols)
+
+    def test_entity_health_table_exists(self, store):
+        cursor = store._read_cursor()
+        tables = {row[0] for row in cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        assert "entity_health" in tables
+
+    def test_entity_health_columns(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(entity_health)")}
+        expected = {
+            "entity_name", "completeness_score", "health_level",
+            "missing_required", "missing_expected", "chunk_count",
+            "relationship_count", "last_scored_at",
+        }
+        assert expected.issubset(cols)
+
+    def test_entity_type_hierarchy_table_exists(self, store):
+        cursor = store._read_cursor()
+        tables = {row[0] for row in cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        assert "entity_type_hierarchy" in tables
+
+    def test_entity_type_hierarchy_columns(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(entity_type_hierarchy)")}
+        expected = {"child_type", "parent_type", "description"}
+        assert expected.issubset(cols)
+
+
+# ── 2. Schema Tests: Altered Columns ──────────────────────────
+
+
+class TestAlteredColumns:
+    """Verify ALTER TABLE additions to existing tables."""
+
+    def test_kg_entities_has_entity_subtype(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entities)")}
+        assert "entity_subtype" in cols
+
+    def test_kg_entities_has_status(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entities)")}
+        assert "status" in cols
+
+    def test_kg_entities_status_default_active(self, store, mock_embedding):
+        """New entities should default to status='active'."""
+        store.upsert_entity(
+            entity_id="ent-test",
+            entity_type="concept",
+            name="TestConcept",
+            embedding=mock_embedding("test"),
+        )
+        cursor = store._read_cursor()
+        row = list(cursor.execute(
+            "SELECT status FROM kg_entities WHERE id = ?", ("ent-test",)
+        ))
+        assert row[0][0] == "active"
+
+    def test_kg_entities_has_updated_at(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entities)")}
+        # updated_at already exists from original schema
+        assert "updated_at" in cols
+
+    def test_kg_entity_chunks_has_relation_tier(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_chunks)")}
+        assert "relation_tier" in cols
+
+    def test_kg_entity_chunks_has_weight(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_chunks)")}
+        assert "weight" in cols
+
+    def test_kg_entity_chunks_relation_tier_default(self, store, mock_embedding):
+        """New entity-chunk links should default to relation_tier=4, weight=0.25."""
+        store.upsert_entity(
+            entity_id="ent-tier",
+            entity_type="concept",
+            name="TierTest",
+            embedding=mock_embedding("tier"),
+        )
+        store.upsert_chunks(
+            [{"id": "chunk-tier-1", "content": "test", "metadata": {},
+              "source_file": "t", "project": "t", "content_type": "user_message",
+              "value_type": None, "char_count": 4}],
+            [mock_embedding("tier chunk")],
+        )
+        store.link_entity_chunk("ent-tier", "chunk-tier-1")
+        cursor = store._read_cursor()
+        row = list(cursor.execute(
+            "SELECT relation_tier, weight FROM kg_entity_chunks WHERE entity_id = ? AND chunk_id = ?",
+            ("ent-tier", "chunk-tier-1"),
+        ))
+        assert row[0][0] == 4  # default tier
+        assert row[0][1] == 0.25  # default weight
+
+
+# ── 3. Upgraded Aliases Table ──────────────────────────────────
+
+
+class TestEntityAliases:
+    """Verify kg_entity_aliases has R49 columns (alias_type upgraded, valid_from, valid_to)."""
+
+    def test_aliases_has_valid_from(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_aliases)")}
+        assert "valid_from" in cols
+
+    def test_aliases_has_valid_to(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_aliases)")}
+        assert "valid_to" in cols
+
+
+# ── 4. Contracts YAML ─────────────────────────────────────────
+
+
+class TestContractsYAML:
+    """Verify entity-types.yaml is valid and complete."""
+
+    def test_contracts_file_exists(self, contracts_path):
+        assert contracts_path.exists(), f"Expected contracts at {contracts_path}"
+
+    def test_contracts_yaml_parses(self, contracts_path):
+        with open(contracts_path) as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, dict)
+
+    def test_contracts_has_version(self, contracts_path):
+        with open(contracts_path) as f:
+            data = yaml.safe_load(f)
+        assert "version" in data
+
+    def test_contracts_has_required_entity_types(self, contracts_path):
+        with open(contracts_path) as f:
+            data = yaml.safe_load(f)
+        entity_types = data.get("entity_types", {})
+        for etype in ["agent", "person", "tool", "project", "concept"]:
+            assert etype in entity_types, f"Missing entity type: {etype}"
+
+    def test_each_type_has_required_fields(self, contracts_path):
+        with open(contracts_path) as f:
+            data = yaml.safe_load(f)
+        for etype, spec in data["entity_types"].items():
+            assert "required" in spec, f"{etype} missing 'required' field list"
+            assert "expected" in spec, f"{etype} missing 'expected' field list"
+            assert "health_criteria" in spec, f"{etype} missing 'health_criteria'"
+
+    def test_agent_type_has_name_description(self, contracts_path):
+        with open(contracts_path) as f:
+            data = yaml.safe_load(f)
+        agent = data["entity_types"]["agent"]
+        assert "name" in agent["required"]
+        assert "type" in agent["required"]
+        assert "description" in agent["required"]
+
+    def test_health_criteria_fields(self, contracts_path):
+        with open(contracts_path) as f:
+            data = yaml.safe_load(f)
+        for etype, spec in data["entity_types"].items():
+            hc = spec["health_criteria"]
+            assert "min_chunks" in hc, f"{etype} health_criteria missing min_chunks"
+            assert "max_stale_days" in hc, f"{etype} health_criteria missing max_stale_days"
+            assert "min_relationships" in hc, f"{etype} health_criteria missing min_relationships"
+
+
+# ── 5. Health Scoring Algorithm ────────────────────────────────
+
+
+class TestHealthScoring:
+    """Test the score_entity_health scoring algorithm."""
+
+    def test_score_module_importable(self):
+        """The scoring module should be importable."""
+        from scripts.score_entity_health import score_entity, load_contracts
+
+    def test_load_contracts(self, contracts_path):
+        from scripts.score_entity_health import load_contracts
+        contracts = load_contracts(str(contracts_path))
+        assert "agent" in contracts
+        assert "person" in contracts
+
+    def test_score_returns_required_fields(self, populated_store, contracts_path):
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        result = score_entity(
+            populated_store, "ent-coach", "agent", contracts["agent"]
+        )
+        assert "completeness_score" in result
+        assert "health_level" in result
+        assert "missing_required" in result
+        assert "missing_expected" in result
+        assert "chunk_count" in result
+        assert "relationship_count" in result
+
+    def test_score_range_0_to_1(self, populated_store, contracts_path):
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        result = score_entity(
+            populated_store, "ent-coach", "agent", contracts["agent"]
+        )
+        assert 0.0 <= result["completeness_score"] <= 1.0
+
+    def test_health_level_1_to_5(self, populated_store, contracts_path):
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        result = score_entity(
+            populated_store, "ent-coach", "agent", contracts["agent"]
+        )
+        assert 1 <= result["health_level"] <= 5
+
+    def test_health_level_classification(self):
+        """Verify the 5-tier classification boundaries."""
+        from scripts.score_entity_health import classify_health_level
+        assert classify_health_level(0.90) == 5  # Very Detailed
+        assert classify_health_level(0.85) == 5  # boundary
+        assert classify_health_level(0.84) == 4  # Detailed
+        assert classify_health_level(0.65) == 4  # boundary
+        assert classify_health_level(0.64) == 3  # Moderate
+        assert classify_health_level(0.45) == 3  # boundary
+        assert classify_health_level(0.44) == 2  # Basic
+        assert classify_health_level(0.25) == 2  # boundary
+        assert classify_health_level(0.24) == 1  # Stub
+        assert classify_health_level(0.0) == 1   # Stub
+
+    def test_chunk_count_accurate(self, populated_store, contracts_path):
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        result = score_entity(
+            populated_store, "ent-coach", "agent", contracts["agent"]
+        )
+        assert result["chunk_count"] == 5
+
+    def test_relationship_count_accurate(self, populated_store, contracts_path):
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        result = score_entity(
+            populated_store, "ent-coach", "agent", contracts["agent"]
+        )
+        assert result["relationship_count"] == 2
+
+    def test_missing_required_detected(self, populated_store, contracts_path):
+        """coachClaude doesn't have all required fields populated — detect gaps."""
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        result = score_entity(
+            populated_store, "ent-coach", "agent", contracts["agent"]
+        )
+        # capabilities is partially there in metadata, memory_domains is missing
+        assert isinstance(result["missing_required"], list)
+
+    def test_tool_entity_scoring(self, populated_store, contracts_path):
+        """BrainLayer (tool) should also get scored."""
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        result = score_entity(
+            populated_store, "ent-brain", "tool", contracts["tool"]
+        )
+        assert 0.0 <= result["completeness_score"] <= 1.0
+        assert result["chunk_count"] == 3
+
+    def test_stub_entity_low_score(self, store, mock_embedding, contracts_path):
+        """An entity with no chunks, no relations = very low score (Stub)."""
+        from scripts.score_entity_health import score_entity, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        store.upsert_entity(
+            entity_id="ent-stub",
+            entity_type="concept",
+            name="StubConcept",
+            embedding=mock_embedding("stub"),
+        )
+        result = score_entity(
+            store, "ent-stub", "concept", contracts["concept"]
+        )
+        assert result["health_level"] <= 2  # Stub or Basic
+        assert result["chunk_count"] == 0
+        assert result["relationship_count"] == 0
+
+
+# ── 6. Health Score Persistence ────────────────────────────────
+
+
+class TestHealthPersistence:
+    """Test that scores are written to entity_health table."""
+
+    def test_populate_entity_health(self, populated_store, contracts_path):
+        from scripts.score_entity_health import score_all_entities, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        score_all_entities(populated_store, contracts)
+
+        cursor = populated_store._read_cursor()
+        rows = list(cursor.execute(
+            "SELECT entity_name, completeness_score, health_level FROM entity_health"
+        ))
+        names = {row[0] for row in rows}
+        assert "coachClaude" in names
+        assert "BrainLayer" in names
+
+    def test_health_score_updates_on_rerun(self, populated_store, contracts_path):
+        """Running score_all_entities twice should upsert, not duplicate."""
+        from scripts.score_entity_health import score_all_entities, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        score_all_entities(populated_store, contracts)
+        score_all_entities(populated_store, contracts)
+
+        cursor = populated_store._read_cursor()
+        rows = list(cursor.execute("SELECT COUNT(*) FROM entity_health"))
+        # Should have exactly as many rows as entities, not doubled
+        entity_count = list(cursor.execute("SELECT COUNT(*) FROM kg_entities"))[0][0]
+        assert rows[0][0] == entity_count
+
+
+# ── 7. Entity Lookup Enhancement ───────────────────────────────
+
+
+class TestEntityLookupEnhanced:
+    """Verify brain_entity includes completeness_score and health_level."""
+
+    def test_entity_lookup_includes_health(self, populated_store, mock_embedding, contracts_path):
+        """After scoring, entity_lookup should include health data."""
+        from scripts.score_entity_health import score_all_entities, load_contracts
+        contracts = load_contracts(str(contracts_path))
+        score_all_entities(populated_store, contracts)
+
+        from brainlayer.pipeline.digest import entity_lookup
+        result = entity_lookup(
+            query="coachClaude",
+            store=populated_store,
+            embed_fn=mock_embedding,
+            entity_type="agent",
+        )
+        assert result is not None
+        assert "completeness_score" in result
+        assert "health_level" in result
+        assert isinstance(result["completeness_score"], float)
+        assert isinstance(result["health_level"], int)
+
+    def test_entity_lookup_no_health_when_unscored(self, store, mock_embedding):
+        """Before scoring runs, health fields should be None or absent."""
+        store.upsert_entity(
+            entity_id="ent-unscored",
+            entity_type="concept",
+            name="UnscoredConcept",
+            embedding=mock_embedding("unscored"),
+        )
+        from brainlayer.pipeline.digest import entity_lookup
+        result = entity_lookup(
+            query="UnscoredConcept",
+            store=store,
+            embed_fn=mock_embedding,
+        )
+        assert result is not None
+        # Should still return, just with None health data
+        assert result.get("completeness_score") is None
+        assert result.get("health_level") is None
+
+
+# ── 8. Type Hierarchy Data ─────────────────────────────────────
+
+
+class TestTypeHierarchy:
+    """Verify type hierarchy is populated with seed data."""
+
+    def test_hierarchy_has_seed_data(self, store):
+        """entity_type_hierarchy should contain core types."""
+        cursor = store._read_cursor()
+        rows = list(cursor.execute(
+            "SELECT child_type, parent_type FROM entity_type_hierarchy"
+        ))
+        hierarchy = {row[0]: row[1] for row in rows}
+        assert "agent" in hierarchy
+        assert "person" in hierarchy
+        assert "tool" in hierarchy
+        assert "project" in hierarchy
+        assert "concept" in hierarchy
+
+    def test_subtypes_mapped(self, store):
+        """Subtypes like golem->agent, platform->tool should exist."""
+        cursor = store._read_cursor()
+        rows = list(cursor.execute(
+            "SELECT child_type, parent_type FROM entity_type_hierarchy"
+        ))
+        hierarchy = {row[0]: row[1] for row in rows}
+        assert hierarchy.get("golem") == "agent"
+        assert hierarchy.get("platform") == "tool"
+        assert hierarchy.get("skill") == "concept"
+        assert hierarchy.get("decision") == "concept"

--- a/tests/test_kg_schema.py
+++ b/tests/test_kg_schema.py
@@ -89,6 +89,8 @@ class TestKGTableCreation:
             "valid_from",
             "valid_until",
             "group_id",
+            "entity_subtype",
+            "status",
         }
         assert cols == expected
 
@@ -116,7 +118,7 @@ class TestKGTableCreation:
     def test_kg_entity_chunks_columns(self, store):
         cursor = store._read_cursor()
         cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_chunks)")}
-        assert cols == {"entity_id", "chunk_id", "relevance", "context", "mention_type"}
+        assert cols == {"entity_id", "chunk_id", "relevance", "context", "mention_type", "relation_tier", "weight"}
 
     def test_source_project_id_column_on_chunks(self, store):
         cursor = store._read_cursor()


### PR DESCRIPTION
## Summary

- **R49 Phase 1 implementation**: Entity contract system for evaluating knowledge graph entity completeness
- Adds SQL tables: `entity_contracts`, `entity_health`, `entity_type_hierarchy`
- ALTERs existing tables: `kg_entities` (+entity_subtype, +status), `kg_entity_chunks` (+relation_tier, +weight), `kg_entity_aliases` (+valid_from, +valid_to)
- Creates `contracts/entity-types.yaml` with YAML contracts for 5 entity types (agent, person, tool, project, concept)
- Creates `scripts/score_entity_health.py` with 5-dimension weighted scoring algorithm (Wikidata-inspired 5-tier health levels)
- Enhances `brain_entity` MCP tool response to include `completeness_score` and `health_level`
- Seeds type hierarchy with core types + subtypes (golem->agent, platform->tool, skill->concept, decision->concept)
- 39 new TDD tests, 0 regressions on existing suite (240 passed)

Research reference: R49 (brainbar-b917124c-913) — Entity Contract Architecture

## Test plan

- [x] 39 new tests in `tests/test_entity_contracts.py` — all pass
- [x] Schema tests: 6 new tables/columns verified
- [x] ALTER tests: 7 column additions verified with defaults
- [x] Contracts YAML: 7 validation tests
- [x] Health scoring: 11 algorithm tests (boundary conditions, stub detection, accuracy)
- [x] Persistence: 2 upsert/idempotency tests
- [x] Entity lookup enhancement: 2 tests (with/without health data)
- [x] Type hierarchy: 2 seed data tests
- [x] Existing test suite: 240 passed, 6 skipped, 0 regressions
- [x] Pre-existing failure in test_phase3_digest (unrelated)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add R49 entity contracts schema with health scoring to the knowledge graph
> - Adds [contracts/entity-types.yaml](https://github.com/EtanHey/brainlayer/pull/119/files#diff-e89ce135c2bdf45e78695cb9c9ef9a52c50bb0bca5a52b4af86fd6473ac04c09) defining field requirements and health thresholds for `agent`, `person`, `tool`, `project`, and `concept` entity types.
> - Adds [scripts/score_entity_health.py](https://github.com/EtanHey/brainlayer/pull/119/files#diff-d7990bf9ac85efcecb7ff2d7299963e14962c95783badbd5f83a3135bd9a77c0) which scores each entity in `kg_entities` against its contract, computing a weighted `completeness_score` (0–1) and 5-tier `health_level`, then persists results to a new `entity_health` table.
> - Extends `VectorStore._init_db` in [vector_store.py](https://github.com/EtanHey/brainlayer/pull/119/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) to create `entity_contracts`, `entity_health`, and `entity_type_hierarchy` tables and adds `entity_subtype`/`status` columns to `kg_entities`, `relation_tier`/`weight` to `kg_entity_chunks`, and `valid_from`/`valid_to` to `kg_entity_aliases`.
> - Updates `entity_lookup` in [digest.py](https://github.com/EtanHey/brainlayer/pull/119/files#diff-7095fa2ccad4d7bba37257e8239d677d9e6a1cca5b3b1f0a51ec8a56fd191a9a) to attach `completeness_score` and `health_level` from `entity_health` to returned entity dicts.
> - Risk: `_init_db` now runs several `ALTER TABLE` and `DROP/CREATE VIEW` statements on every startup against existing databases.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 87774c5. 6 files reviewed, 3 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>scripts/score_entity_health.py — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 42](https://github.com/EtanHey/brainlayer/blob/87774c54d0b46a7a53825bed2074b8582f995e9f/scripts/score_entity_health.py#L42): If the YAML file is empty or contains only whitespace/comments, `yaml.safe_load(f)` returns `None`. The subsequent `data.get("entity_types", {})` will raise `AttributeError: 'NoneType' object has no attribute 'get'`. <b>[ Skipped comment generation ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->