### PR TITLE
docs: refresh BrainBar tool wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,9 @@
 
 ---
 
-## BrainBar Tool Status
+## BrainBar Native Tools
 
-All BrainBar tools are now implemented natively in Swift (PR #135, 2026-03-30):
+Current native Swift BrainBar tools (PR #135, 2026-03-30):
 - **brain_search** — FTS5 hybrid search with BM25 ranking, AND matching, ANSI formatted output
 - **brain_store** — Store chunks with tags and importance
 - **brain_recall** — Stats mode (counts, enrichment %) or context mode (session lookup by conversation_id)


### PR DESCRIPTION
## Summary
- replace stale BrainBar tool status framing in `CLAUDE.md`
- describe the current native Swift BrainBar tools without leftover stub-era wording

## Testing
- not run (docs-only change)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh BrainBar native tools section wording in CLAUDE.md
> Updates the section header and introductory sentence in [CLAUDE.md](https://github.com/EtanHey/brainlayer/pull/139/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) to use clearer, present-tense phrasing. The listed tools and their descriptions are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2f2a5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->