### PR TITLE
feat: install enrichment launch agent

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,11 +14,12 @@ All BrainLayer configuration is via environment variables. No config files neede
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BRAINLAYER_ENRICH_BACKEND` | auto-detect | LLM backend: `mlx` or `ollama`. Auto-detects Apple Silicon → MLX, else Ollama. |
+| `BRAINLAYER_ENRICH_BACKEND` | auto-detect | LLM backend: `mlx`, `ollama`, or Gemini realtime where the controller explicitly uses the Google API. Auto-detects Apple Silicon → MLX, else Ollama for local enrichment flows. |
 | `BRAINLAYER_ENRICH_MODEL` | `glm-4.7-flash` | Ollama model name for enrichment |
 | `BRAINLAYER_MLX_MODEL` | `mlx-community/Qwen2.5-Coder-14B-Instruct-4bit` | MLX model identifier |
 | `BRAINLAYER_OLLAMA_URL` | `http://127.0.0.1:11434/api/generate` | Ollama API endpoint |
 | `BRAINLAYER_MLX_URL` | `http://127.0.0.1:8080/v1/chat/completions` | MLX server endpoint |
+| `GOOGLE_API_KEY` | (empty) | Google AI API key used by realtime Gemini enrichment and the enrichment LaunchAgent installer |
 | `BRAINLAYER_STALL_TIMEOUT` | `300` | Seconds before killing a stuck enrichment chunk |
 | `BRAINLAYER_HEARTBEAT_INTERVAL` | `25` | Log progress every N chunks during enrichment |
 
@@ -54,10 +55,22 @@ BrainLayer includes launchd plist templates for automated operation:
 | Service | Schedule | Description |
 |---------|----------|-------------|
 | `com.brainlayer.index` | Every 30 minutes | Incremental indexing of new conversations |
-| `com.brainlayer.enrich` | Every hour | Enrich up to 500 new chunks per run |
+| `com.brainlayer.enrichment` | Every hour | Run realtime Gemini enrichment against recent chunks |
 
 Install with:
 
 ```bash
 brainlayer init  # Includes launchd setup option
 ```
+
+Manual install and control:
+
+```bash
+bash scripts/launchd/install.sh enrichment
+bash scripts/launchd/install.sh unload enrichment
+bash scripts/launchd/install.sh load enrichment
+```
+
+The enrichment agent renders to `~/Library/LaunchAgents/com.brainlayer.enrichment.plist`,
+reads `GOOGLE_API_KEY` from the current environment or `~/.zshrc` at install time,
+and logs to `~/Library/Logs/brainlayer-enrichment.log`.

--- a/docs/plans/2026-03-30-enrichment-launchagent.md
+++ b/docs/plans/2026-03-30-enrichment-launchagent.md
@@ -1,0 +1,85 @@
+# Enrichment LaunchAgent Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Install a macOS LaunchAgent that runs BrainLayer realtime Gemini enrichment automatically at login/boot with install-time API key resolution, low priority, stable logging, and simple start/stop commands.
+
+**Architecture:** Reuse the existing `scripts/launchd/com.brainlayer.enrichment.plist` template and `scripts/launchd/install.sh` flow instead of adding a second launcher path. The plist will run Python directly and call `brainlayer.enrichment_controller.enrich_realtime`, while the installer will resolve `GOOGLE_API_KEY` once from the environment or `~/.zshrc`, write the rendered plist into `~/Library/LaunchAgents/`, and expose simple `load` / `unload` convenience actions for the enrichment agent.
+
+**Tech Stack:** Python, launchd plist templates, bash installer script, pytest.
+
+---
+
+### Task 1: Tighten LaunchAgent contract with failing tests
+
+**Files:**
+- Modify: `tests/test_enrichment_controller.py`
+- Test: `tests/test_enrichment_controller.py`
+
+**Step 1: Write the failing tests**
+- Assert the enrichment plist uses Python to call `enrich_realtime`.
+- Assert the plist uses `Nice=10`.
+- Assert the plist logs to `~/Library/Logs/brainlayer-enrichment.log`.
+- Assert the installer script targets `~/Library/LaunchAgents/` and includes enrichment `load` / `unload` helpers.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_enrichment_controller.py -k 'enrichment_plist or launchagent' -v`
+
+**Step 3: Implement the minimal template/script updates**
+- Update plist placeholders and launch command.
+- Update installer commands and API key resolution flow.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_enrichment_controller.py -k 'enrichment_plist or launchagent' -v`
+
+### Task 2: Implement install-time API key resolution and load/unload helpers
+
+**Files:**
+- Modify: `scripts/launchd/install.sh`
+- Modify: `scripts/launchd/com.brainlayer.enrichment.plist`
+
+**Step 1: Resolve `GOOGLE_API_KEY` from env or `~/.zshrc`**
+- Keep install-time substitution only.
+- Fail clearly if no key can be resolved for enrichment install.
+
+**Step 2: Add rendered install target + helper actions**
+- Ensure install destination is `~/Library/LaunchAgents/com.brainlayer.enrichment.plist`.
+- Add convenience actions for loading and unloading the enrichment LaunchAgent.
+
+**Step 3: Keep launchd behavior aligned with requirements**
+- `RunAtLoad=true`
+- low priority via `Nice=10`
+- log to `~/Library/Logs/brainlayer-enrichment.log`
+
+### Task 3: Verify end-to-end and publish
+
+**Files:**
+- Modify: `docs/configuration.md`
+- Modify: `~/Gits/orchestrator/collab/native-apps-march30.md`
+
+**Step 1: Run focused tests**
+
+Run: `pytest tests/test_enrichment_controller.py -k 'enrichment_plist or launchagent' -v`
+
+**Step 2: Run broader repo verification**
+
+Run: `pytest`
+
+**Step 3: Install and exercise locally**
+
+Run:
+- `bash scripts/launchd/install.sh enrichment`
+- `bash scripts/launchd/install.sh load enrichment`
+- `launchctl list | grep com.brainlayer.enrichment`
+- `bash scripts/launchd/install.sh unload enrichment`
+
+**Step 4: Commit, push, and open PR**
+
+Run:
+- `git add ...`
+- `cr review --plain`
+- `git commit -m "feat: install enrichment launch agent"`
+- `git push -u origin codex/p4-enrichment-launchagent`
+- `gh pr create ...`

--- a/scripts/launchd/com.brainlayer.enrichment.plist
+++ b/scripts/launchd/com.brainlayer.enrichment.plist
@@ -5,29 +5,26 @@
     <key>Label</key>
     <string>com.brainlayer.enrichment</string>
 
-    <!-- Unified enrichment daemon — replaces com.brainlayer.enrich
-         Runs realtime enrichment hourly on recent chunks.
-         For batch/local modes, use the CLI or brain_enrich MCP tool. -->
+    <!-- Realtime Gemini enrichment LaunchAgent.
+         Runs once at login/load and then hourly. -->
 
     <key>ProgramArguments</key>
     <array>
-        <string>__BRAINLAYER_BIN__</string>
-        <string>enrich</string>
-        <string>--mode</string>
-        <string>realtime</string>
-        <string>--since-hours</string>
-        <string>24</string>
-        <string>--limit</string>
-        <string>50</string>
+        <string>__PYTHON3__</string>
+        <string>-c</string>
+        <string>import sys; sys.path.insert(0, "__BRAINLAYER_DIR__/src"); from brainlayer.paths import get_db_path; from brainlayer.vector_store import VectorStore; from brainlayer.enrichment_controller import enrich_realtime; store = VectorStore(get_db_path()); result = enrich_realtime(store=store, limit=50, since_hours=24); print(result); store.close()</string>
     </array>
+
+    <key>WorkingDirectory</key>
+    <string>__BRAINLAYER_DIR__</string>
 
     <key>StartInterval</key>
     <integer>3600</integer>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/enrichment.log</string>
+    <string>__HOME__/Library/Logs/brainlayer-enrichment.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/enrichment.err</string>
+    <string>__HOME__/Library/Logs/brainlayer-enrichment.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
@@ -35,20 +32,19 @@
         <string>/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin</string>
         <key>PYTHONUNBUFFERED</key>
         <string>1</string>
+        <key>PYTHONPATH</key>
+        <string>__BRAINLAYER_DIR__/src</string>
         <key>BRAINLAYER_STALL_TIMEOUT</key>
         <string>300</string>
         <key>GOOGLE_API_KEY</key>
         <string>__GOOGLE_API_KEY__</string>
-        <!-- Optional: set regional endpoint for lower latency -->
-        <!-- <key>GOOGLE_CLOUD_REGION</key>
-        <string>us-central1</string> -->
     </dict>
 
     <key>RunAtLoad</key>
     <true/>
 
     <key>Nice</key>
-    <integer>15</integer>
+    <integer>10</integer>
 
     <key>ProcessType</key>
     <string>Background</string>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -5,18 +5,20 @@
 #   ./scripts/launchd/install.sh              # Install all
 #   ./scripts/launchd/install.sh index        # Install indexing only
 #   ./scripts/launchd/install.sh enrich       # Install enrichment only
+#   ./scripts/launchd/install.sh load enrichment
+#   ./scripts/launchd/install.sh unload enrichment
 #   ./scripts/launchd/install.sh checkpoint   # Install WAL checkpoint only
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LAUNCH_DIR="$HOME/Library/LaunchAgents"
-LOG_DIR="$HOME/.local/share/brainlayer/logs"
+LOG_DIR="$HOME/Library/Logs"
 BRAINLAYER_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BRAINLAYER_BIN="${BRAINLAYER_BIN:-$(which brainlayer 2>/dev/null || echo "$HOME/.local/bin/brainlayer")}"
 PYTHON3="${PYTHON3:-$(which python3 2>/dev/null || echo "/usr/bin/python3")}"
 GROQ_API_KEY="${GROQ_API_KEY:-$(op item get GROQ_API_KEY --reveal --fields credential 2>/dev/null || echo "")}"
-GOOGLE_API_KEY="${GOOGLE_API_KEY:-$(op item get "Google AI API Key" --reveal --fields credential 2>/dev/null || echo "")}"
+GOOGLE_API_KEY="${GOOGLE_API_KEY:-}"
 
 if [ ! -x "$BRAINLAYER_BIN" ]; then
     echo "ERROR: brainlayer binary not found at $BRAINLAYER_BIN"
@@ -27,14 +29,56 @@ fi
 
 mkdir -p "$LAUNCH_DIR" "$LOG_DIR"
 
+resolve_google_api_key() {
+    if [ -n "${GOOGLE_API_KEY:-}" ]; then
+        printf '%s' "$GOOGLE_API_KEY"
+        return 0
+    fi
+
+    if [ -f "$HOME/.zshrc" ] && command -v zsh >/dev/null 2>&1; then
+        local sourced_key
+        sourced_key="$(zsh -lc 'source ~/.zshrc >/dev/null 2>&1; printf %s "${GOOGLE_API_KEY:-${GOOGLE_GENERATIVE_AI_API_KEY:-}}"' 2>/dev/null || true)"
+        if [ -n "$sourced_key" ]; then
+            printf '%s' "$sourced_key"
+            return 0
+        fi
+    fi
+
+    printf '%s' "${GOOGLE_GENERATIVE_AI_API_KEY:-}"
+}
+
+load_plist() {
+    local name="$1"
+    local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
+    launchctl unload "$dst" 2>/dev/null || true
+    launchctl load "$dst"
+    echo "  Loaded: com.brainlayer.${name}"
+}
+
+unload_plist() {
+    local name="$1"
+    local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
+    launchctl unload "$dst" 2>/dev/null || true
+    echo "  Unloaded: com.brainlayer.${name}"
+}
+
 install_plist() {
     local name="$1"
     local src="$SCRIPT_DIR/com.brainlayer.${name}.plist"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
+    local google_api_key="${GOOGLE_API_KEY:-}"
 
     if [ ! -f "$src" ]; then
         echo "ERROR: $src not found"
         return 1
+    fi
+
+    if [ "$name" = "enrichment" ] || [ "$name" = "enrich" ]; then
+        google_api_key="$(resolve_google_api_key)"
+        if [ -z "$google_api_key" ]; then
+            echo "ERROR: GOOGLE_API_KEY not found in environment or ~/.zshrc"
+            return 1
+        fi
     fi
 
     # Replace placeholders
@@ -44,23 +88,20 @@ install_plist() {
         -e "s|__BRAINLAYER_DIR__|$BRAINLAYER_DIR|g" \
         -e "s|__PYTHON3__|$PYTHON3|g" \
         -e "s|__GROQ_API_KEY__|$GROQ_API_KEY|g" \
-        -e "s|__GOOGLE_API_KEY__|$GOOGLE_API_KEY|g" \
+        -e "s|__GOOGLE_API_KEY__|$google_api_key|g" \
         "$src" > "$dst"
 
     echo "Installed: $dst"
-    echo "  Binary: $BRAINLAYER_BIN"
+    echo "  Python: $PYTHON3"
     echo "  Logs: $LOG_DIR/"
 
-    # Unload if already loaded, then load
-    launchctl bootout "gui/$(id -u)/com.brainlayer.${name}" 2>/dev/null || true
-    launchctl bootstrap "gui/$(id -u)" "$dst"
-    echo "  Loaded: com.brainlayer.${name}"
+    load_plist "$name"
 }
 
 remove_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
-    launchctl bootout "gui/$(id -u)/com.brainlayer.${name}" 2>/dev/null || true
+    unload_plist "$name"
     rm -f "$dst"
     echo "Removed: com.brainlayer.${name}"
 }
@@ -76,6 +117,12 @@ case "${1:-all}" in
     enrichment)
         # New unified enrichment plist (replaces enrich)
         install_plist enrichment
+        ;;
+    load)
+        load_plist "${2:-enrichment}"
+        ;;
+    unload)
+        unload_plist "${2:-enrichment}"
         ;;
     checkpoint)
         install_plist wal-checkpoint
@@ -94,11 +141,12 @@ case "${1:-all}" in
         remove_plist wal-checkpoint
         ;;
     *)
-        echo "Usage: $0 [index|enrich|enrichment|checkpoint|all|remove]"
+        echo "Usage: $0 [index|enrich|enrichment|load [name]|unload [name]|checkpoint|all|remove]"
         exit 1
         ;;
 esac
 
 echo ""
 echo "Done. Check logs at: $LOG_DIR/"
+echo "Enrichment label: com.brainlayer.enrichment"
 echo "Status: launchctl list | grep brainlayer"

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -900,9 +900,9 @@ def test_launchd_installer_supports_enrichment_load_and_unload():
 
     install_script = (Path(__file__).parent.parent / "scripts" / "launchd" / "install.sh").read_text()
     assert 'LAUNCH_DIR="$HOME/Library/LaunchAgents"' in install_script
-    assert 'load)' in install_script
-    assert 'unload)' in install_script
-    assert 'com.brainlayer.enrichment' in install_script
+    assert "load)" in install_script
+    assert "unload)" in install_script
+    assert "com.brainlayer.enrichment" in install_script
 
 
 def test_launchd_installer_reads_google_api_key_from_zshrc():

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -875,6 +875,44 @@ def test_enrichment_plist_has_start_interval():
     assert "3600" in content
 
 
+def test_enrichment_plist_invokes_python_enrich_realtime_entrypoint():
+    from pathlib import Path
+
+    plist_path = Path(__file__).parent.parent / "scripts" / "launchd" / "com.brainlayer.enrichment.plist"
+    content = plist_path.read_text()
+    assert "__PYTHON3__" in content
+    assert "brainlayer.enrichment_controller" in content
+    assert "enrich_realtime" in content
+
+
+def test_enrichment_plist_uses_low_priority_and_library_logs():
+    from pathlib import Path
+
+    plist_path = Path(__file__).parent.parent / "scripts" / "launchd" / "com.brainlayer.enrichment.plist"
+    content = plist_path.read_text()
+    assert "<key>Nice</key>" in content
+    assert "<integer>10</integer>" in content
+    assert "__HOME__/Library/Logs/brainlayer-enrichment.log" in content
+
+
+def test_launchd_installer_supports_enrichment_load_and_unload():
+    from pathlib import Path
+
+    install_script = (Path(__file__).parent.parent / "scripts" / "launchd" / "install.sh").read_text()
+    assert 'LAUNCH_DIR="$HOME/Library/LaunchAgents"' in install_script
+    assert 'load)' in install_script
+    assert 'unload)' in install_script
+    assert 'com.brainlayer.enrichment' in install_script
+
+
+def test_launchd_installer_reads_google_api_key_from_zshrc():
+    from pathlib import Path
+
+    install_script = (Path(__file__).parent.parent / "scripts" / "launchd" / "install.sh").read_text()
+    assert ".zshrc" in install_script
+    assert "GOOGLE_API_KEY" in install_script
+
+
 # ── Gemini model constant test ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- switch the enrichment LaunchAgent template to a Python entrypoint that imports and runs `brainlayer.enrichment_controller.enrich_realtime`
- render the agent into `~/Library/LaunchAgents`, resolve `GOOGLE_API_KEY` from the environment or `~/.zshrc` at install time, and add explicit `load` / `unload` convenience actions to the installer
- lower launch priority to `Nice=10`, move logging to `~/Library/Logs/brainlayer-enrichment.log`, and document the new launchd flow

## Test plan
- [x] `pytest tests/test_enrichment_controller.py -k 'enrichment_plist or launchd_installer' -v`
- [x] `pytest tests/test_enrichment_controller.py -v` (57 passed / 5 pre-existing failures in the same file unrelated to this LaunchAgent work)
- [x] `bash -n scripts/launchd/install.sh`
- [x] `bash scripts/launchd/install.sh enrichment`
- [x] `plutil -p ~/Library/LaunchAgents/com.brainlayer.enrichment.plist`
- [x] `bash scripts/launchd/install.sh unload enrichment`
- [x] `bash scripts/launchd/install.sh load enrichment`
- [x] `pytest -x` (stops on pre-existing failure: `tests/test_enrichment_controller.py::test_enrich_batch_uses_checkpoint_db_for_resume`)

## Notes
- `cr review --plain` was attempted twice. The first run surfaced a docs consistency issue that was fixed; the second run hit a rate limit before completing.
- The worktree still contains an unrelated user change in `brain-bar/build-app.sh`, which is intentionally excluded from this PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install macOS LaunchAgent for realtime Gemini enrichment
> - Adds [com.brainlayer.enrichment.plist](https://github.com/EtanHey/brainlayer/pull/151/files#diff-0aae57a309147ea4d1c82c7d669b582cfe5dfa28918361636f35341ce9c936b5), a macOS LaunchAgent that runs `enrich_realtime` (limit=50, since_hours=24) via Python on a scheduled interval with `Nice=10` and logs to `~/Library/Logs/brainlayer-enrichment.log`.
> - Updates [install.sh](https://github.com/EtanHey/brainlayer/pull/151/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756) with `resolve_google_api_key` (reads from environment or `~/.zshrc`), `load_plist`/`unload_plist` helpers, and new `load`, `unload`, and `enrichment` subcommands.
> - Installation fails fast if `GOOGLE_API_KEY` cannot be resolved; the key is baked into the rendered plist at install time.
> - Adds tests covering plist structure, installer subcommands, and API key resolution from `.zshrc`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40412a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini realtime enrichment mode alongside existing backends.
  * Enrichment service now auto-runs on macOS at login/boot.

* **Documentation**
  * Updated configuration guide with Gemini backend details and LaunchAgent installation instructions.
  * Added enrichment LaunchAgent implementation plan.

* **Changes**
  * Enrichment logs now write to ~/Library/Logs directory.
  * New `load`/`unload` commands for enrichment service management.
  * GOOGLE_API_KEY environment variable now required for Gemini enrichment.

* **Tests**
  * Added LaunchAgent and installer script validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->