### PR TITLE
Fix FTS5 recall for long multi-keyword searches

### DIFF
--- a/src/brainlayer/_helpers.py
+++ b/src/brainlayer/_helpers.py
@@ -39,8 +39,8 @@ def _escape_fts5_query(query: str, *, match_mode: str = "auto") -> str:
     We wrap each word in double quotes so they're treated as literal terms.
 
     match_mode:
-        "auto" — always AND (implicit via space). RRF fusion with semantic
-                  search already provides recall; FTS5 should maximize precision.
+        "auto" — use AND for 1-3 terms, OR for 4+ terms. Longer natural-language
+                  queries otherwise over-constrain FTS and collapse recall.
         "or"   — always OR (for entity search where any term should match).
     Empty/whitespace-only queries return an empty string so callers can skip FTS.
     """
@@ -57,9 +57,10 @@ def _escape_fts5_query(query: str, *, match_mode: str = "auto") -> str:
         return ""
     if match_mode == "or":
         joiner = " OR "
+    elif match_mode == "auto" and len(terms) >= 4:
+        joiner = " OR "
     else:
-        # Always AND (space = implicit AND in FTS5). Semantic search via RRF
-        # already handles recall — FTS5 should maximize precision.
+        # Space-separated terms in FTS5 are implicit AND.
         joiner = " "
     return joiner.join(terms)
 

--- a/tests/test_search_gaps.py
+++ b/tests/test_search_gaps.py
@@ -138,8 +138,8 @@ class TestTagFilterUsesIndex:
 # ── Gap H: FTS5 AND search returns intersection ────────────────────────────
 
 
-class TestAndSearchReturnsIntersection:
-    """Gap H: Multi-word FTS5 queries should use AND mode (intersection)."""
+class TestFts5AutoMode:
+    """Gap H: FTS5 auto mode should favor recall for long multi-word queries."""
 
     def test_escape_fts5_short_query_uses_and(self):
         """≤3 terms should use AND (space = implicit AND in FTS5)."""
@@ -149,19 +149,12 @@ class TestAndSearchReturnsIntersection:
         # Space-separated quoted terms = implicit AND in FTS5
         assert result == '"authentication" "middleware"'
 
-    def test_escape_fts5_long_query_uses_and(self):
-        """4+ terms should ALSO use AND, not OR — precision over recall.
-
-        Previously used OR for 4+ terms. Fixed to always use AND.
-        RRF fusion with semantic search already provides recall.
-        """
+    def test_escape_fts5_long_query_uses_or(self):
+        """4+ terms should use OR to avoid zero-result over-constrained MATCH queries."""
         from brainlayer._helpers import _escape_fts5_query
 
         result = _escape_fts5_query("authentication middleware session tokens")
-        # Should NOT contain OR — all terms must match
-        assert "OR" not in result
-        # Should be implicit AND (space-separated)
-        assert result == '"authentication" "middleware" "session" "tokens"'
+        assert result == '"authentication" OR "middleware" OR "session" OR "tokens"'
 
     def test_fts5_and_returns_intersection(self, tmp_path):
         """Search for 'alpha beta' should only return chunks containing BOTH words."""
@@ -195,6 +188,27 @@ class TestAndSearchReturnsIntersection:
 
         result = _escape_fts5_query("Avi Simon", match_mode="or")
         assert "OR" in result
+
+    def test_hybrid_search_long_query_uses_fts_or_and_returns_results(self, tmp_path, monkeypatch):
+        """Long multi-keyword searches should still surface partial lexical matches."""
+        store = _make_store(tmp_path)
+        expected = "owner profile and career work history"
+        _insert_chunk(store, expected)
+        _insert_chunk(store, "gardening notes and grocery list")
+
+        monkeypatch.setattr(
+            store,
+            "search",
+            lambda **kwargs: {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]},
+        )
+
+        results = store.hybrid_search(
+            query_embedding=[0.0] * 1024,
+            query_text="owner profile career work history years experience",
+            n_results=5,
+        )
+
+        assert expected in results["documents"][0]
 
     def test_empty_fts5_query_returns_no_match_expression(self):
         """Blank input should skip FTS instead of expanding to a match-all wildcard."""


### PR DESCRIPTION
## Summary
- switch FTS5 auto query escaping to use implicit AND for 1-3 terms and OR for 4+ terms
- add a regression test proving `hybrid_search()` returns a result for `owner profile career work history years experience` when semantic search contributes nothing
- update helper expectations so long multi-word searches no longer collapse to zero lexical matches

## Test plan
- [x] `pytest tests/test_search_gaps.py`
- [x] `pytest tests/test_search_gaps.py -k 'fts5_long_query_uses_or or hybrid_search_long_query_uses_fts_or_and_returns_results'`
- [x] `pytest tests/test_phase6_critical.py -q` (fails in unrelated compact-format test)
- [x] `pytest tests/test_enrichment_controller.py -q` (fails in unrelated enrichment-controller tests)
- [x] `pytest tests/test_vector_store.py -q` (errors due `apsw.BusyError: database is locked` on live DB fixture)
- [x] `pytest tests/` (repo-wide suite has many pre-existing unrelated failures/errors outside this change)

## Notes
- Full repo tests are not currently green in this environment, so this PR is scoped to the FTS fix plus regression coverage.
- Unrelated local worktree changes in `brain-bar/build-app.sh` and `2026-03-29-174250-read-collab-gitsorchestratorcollabphase5-har.txt` were intentionally left out.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix FTS5 recall for long multi-keyword searches by switching to OR matching for 4+ terms
> - In `auto` mode, [`_escape_fts5_query`](https://github.com/EtanHey/brainlayer/pull/152/files#diff-4907ced5d0b7045ab28d8c5aff8f436f469a3df00c0a709e6607db157ec125ec) now joins quoted terms with `OR` when there are 4 or more terms, instead of implicit `AND` (space-separated). Queries with 3 or fewer terms retain AND behavior.
> - Behavioral Change: `auto` mode results for long queries will broaden — documents matching any term are returned instead of only documents matching all terms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f951a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search recall for long multi-word queries (4+ terms) to help you find more relevant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->