### PR TITLE
fix: restore signed BrainBar rebuilds

### DIFF
--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -3,7 +3,7 @@
 #
 # Usage: bash brain-bar/build-app.sh
 #
-# Output: /Applications/BrainBar.app
+# Output: ~/Applications/BrainBar.app (override with BRAINBAR_APP_DIR)
 
 set -euo pipefail
 
@@ -11,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PACKAGE_DIR="$SCRIPT_DIR"
 BUNDLE_DIR="$SCRIPT_DIR/bundle"
 APP_DIR="${BRAINBAR_APP_DIR:-$HOME/Applications/BrainBar.app}"
+SIGN_IDENTITY="${BRAINBAR_CODESIGN_IDENTITY:-Apple Development: Etan Heyman (DXHB5E7P2D)}"
 
 # Kill any running BrainBar instances before installing
 if pgrep -x BrainBar > /dev/null 2>&1; then
@@ -44,9 +45,16 @@ mkdir -p "$APP_DIR/Contents/Resources"
 cp "$BUNDLE_DIR/Info.plist" "$APP_DIR/Contents/"
 cp "$BINARY" "$APP_DIR/Contents/MacOS/BrainBar"
 
-# Ad-hoc codesign
+# Developer signing keeps TCC permissions stable across rebuilds.
 echo "[build-app] Signing..."
-codesign --force --sign - "$APP_DIR"
+codesign --force --deep --sign "$SIGN_IDENTITY" --timestamp=none "$APP_DIR"
+
+echo "[build-app] Verifying signature..."
+if ! codesign -dv --verbose=4 "$APP_DIR" 2>&1 | grep -F "Authority=$SIGN_IDENTITY" >/dev/null; then
+    echo "[build-app] ERROR: Installed app is not signed with $SIGN_IDENTITY"
+    codesign -dv --verbose=4 "$APP_DIR" 2>&1
+    exit 1
+fi
 
 echo "[build-app] Done: $APP_DIR"
 echo "[build-app] Socket: /tmp/brainbar.sock"


### PR DESCRIPTION
## Summary
- replace ad-hoc BrainBar app signing with verified Apple Development signing so hotkey-related permissions can persist across rebuilds
- keep the existing install path but fail the build if the final bundle is not signed with the expected identity
- correct the build script output comment to match the actual default install path

## Verification
- swift test --package-path brain-bar
- bash brain-bar/build-app.sh
- codesign -dv --verbose=4 ~/Applications/BrainBar.app

## Notes
- I could not synthesize F4/Cmd+F4 from the shell because macOS denied terminal-driven keystroke injection ( -> System Events error 1002).
- TCC still shows no ListenEvent/Accessibility grants for the bundle on this machine until the user enables them.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore developer code-signing in BrainBar build script
> - Replaces ad-hoc (`--sign -`) codesigning with a named developer identity, sourced from `BRAINBAR_CODESIGN_IDENTITY` (defaults to `Apple Development: Etan Heyman`).
> - Adds `--deep` signing and a post-sign verification step in [build-app.sh](https://github.com/EtanHey/brainlayer/pull/153/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb) that exits non-zero if the installed app's authority doesn't match the expected identity.
> - Changes the default install path from the system `/Applications` to `~/Applications`, overridable via `BRAINBAR_APP_DIR`.
> - Behavioral Change: builds that previously succeeded with ad-hoc signing will now fail if the expected developer certificate is not available in the keychain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbf254b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build script configuration with environment variable support for app output directory and code-signing identity.
  * Enhanced code-signing process with developer signing and post-signature verification to ensure build integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->