### PR TITLE
fix: consume and debounce BrainBar fallback hotkey

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -7,6 +7,12 @@ import AppKit
 import Combine
 import SwiftUI
 
+enum BrainBarAppSupport {
+    static func hotkeyPermissionFailureMessage(permissions: HotkeyPermissionStatus) -> String {
+        "BrainBar could not start the fallback hotkey listener. Enable \(permissions.missingPermissionsMessage) in System Settings. The CGEventTap fallback requires both Input Monitoring and Accessibility."
+    }
+}
+
 // MARK: - App Delegate
 
 @MainActor
@@ -19,6 +25,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var quickCaptureHotkey: HotkeyManager?
     private var cancellables: Set<AnyCancellable> = []
     private var sharedDatabase: BrainDatabase?
+    private let hotkeyRouteStatus = HotkeyRouteStatus()
+    private var pendingBrainBarURLs: [URL] = []
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Single-instance enforcement: exit if another BrainBar is already running
@@ -51,6 +59,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
         )
         self.collector = collector
+        hotkeyRouteStatus.onFallbackChange = { [weak self] in
+            self?.configureQuickCaptureHotkey()
+        }
         configureStatusItem(with: collector)
         configureQuickCaptureHotkey()
     }
@@ -63,6 +74,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        ingestBrainBarURLs(urls)
     }
 
     @objc
@@ -90,8 +105,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let popover = NSPopover()
         popover.behavior = .transient
-        popover.contentSize = NSSize(width: 360, height: 270)
-        popover.contentViewController = NSHostingController(rootView: StatusPopoverView(collector: collector))
+        popover.contentSize = NSSize(width: 360, height: 320)
+        popover.contentViewController = NSHostingController(
+            rootView: StatusPopoverView(collector: collector, hotkeyStatus: hotkeyRouteStatus)
+        )
 
         Publishers.CombineLatest(collector.$stats, collector.$state)
             .receive(on: RunLoop.main)
@@ -109,6 +126,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func configureQuickCaptureHotkey() {
+        quickCaptureHotkey?.stop()
+        quickCaptureHotkey = nil
+
+        guard hotkeyRouteStatus.useCGEventTapFallback else {
+            hotkeyRouteStatus.refreshStatusLine(eventTapActive: false)
+            return
+        }
+
         let gesture = GestureStateMachine()
         gesture.onSingleTap = { [weak self] in
             self?.quickCapturePanel?.toggle()
@@ -119,13 +144,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let hotkey = HotkeyManager(gesture: gesture)
         hotkey.configure(keycodes: [118, 129], useModifierMode: false)
-        _ = hotkey.start()
-        quickCaptureHotkey = hotkey
+        let started = hotkey.start()
+        quickCaptureHotkey = started ? hotkey : nil
+        hotkeyRouteStatus.refreshStatusLine(eventTapActive: started)
+        if !started {
+            let permissions = HotkeyManager.permissionStatus()
+            let message = BrainBarAppSupport.hotkeyPermissionFailureMessage(permissions: permissions)
+            NSLog("[BrainBar.Hotkey] %@", message)
+
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = "BrainBar hotkey permission missing"
+            alert.informativeText = message
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        }
     }
 
     private func configureQuickCapture(database: BrainDatabase) {
         guard quickCapturePanel == nil else { return }
         quickCapturePanel = QuickCapturePanelController(db: database)
+        flushPendingBrainBarURLs()
+    }
+
+    private func ingestBrainBarURLs(_ urls: [URL]) {
+        for url in urls {
+            guard BrainBarURLAction.parse(url: url) != nil else { continue }
+            if quickCapturePanel != nil {
+                handleBrainBarURL(url)
+            } else {
+                pendingBrainBarURLs.append(url)
+            }
+        }
+    }
+
+    private func flushPendingBrainBarURLs() {
+        guard quickCapturePanel != nil, !pendingBrainBarURLs.isEmpty else { return }
+        let batch = pendingBrainBarURLs
+        pendingBrainBarURLs.removeAll()
+        for url in batch {
+            handleBrainBarURL(url)
+        }
+    }
+
+    private func handleBrainBarURL(_ url: URL) {
+        guard let action = BrainBarURLAction.parse(url: url) else {
+            NSLog("[BrainBar] Unhandled URL %@", url.absoluteString)
+            return
+        }
+        switch action {
+        case .toggle:
+            quickCapturePanel?.toggle()
+        case .search:
+            quickCapturePanel?.show(mode: .search)
+        }
     }
 }
 

--- a/brain-bar/Sources/BrainBar/HotkeyManager.swift
+++ b/brain-bar/Sources/BrainBar/HotkeyManager.swift
@@ -1,12 +1,100 @@
-// HotkeyManager.swift — Global hotkey detection via CGEventTap.
+// HotkeyManager.swift — Optional global hotkey via CGEventTap (fallback path).
 //
-// Ported from VoiceBar (PR #87). Uses .listenOnly tap (Input Monitoring
-// permission) with F4 as the default hotkey for BrainBar quick capture.
+// Primary hotkeys are expected from Karabiner Elements → `open brainbar://toggle`
+// or `brainbar://search` (see brain-bar/karabiner/brainbar-f4.json). This tap
+// is only started when the user enables “CGEventTap fallback” in the status
+// popover (Input Monitoring / Listen Events required).
 //
 // Gesture state machine: single tap = toggle panel, hold = not used (reserved).
 
+import ApplicationServices
 import CoreGraphics
 import Foundation
+
+struct HotkeyPermissionStatus: Equatable {
+    let inputMonitoringGranted: Bool
+    let accessibilityGranted: Bool
+
+    var isSatisfied: Bool {
+        inputMonitoringGranted && accessibilityGranted
+    }
+
+    var missingPermissionsMessage: String {
+        switch (inputMonitoringGranted, accessibilityGranted) {
+        case (false, false):
+            return "Input Monitoring and Accessibility"
+        case (false, true):
+            return "Input Monitoring"
+        case (true, false):
+            return "Accessibility"
+        case (true, true):
+            return "None"
+        }
+    }
+}
+
+final class HotkeyDebouncer {
+    private let window: TimeInterval
+    private var lastProcessedKeyDownAt: Date?
+
+    init(windowMs: Int = 300) {
+        window = Double(windowMs) / 1000.0
+    }
+
+    func shouldProcessKeyDown(at now: Date = Date()) -> Bool {
+        if let lastProcessedKeyDownAt, now.timeIntervalSince(lastProcessedKeyDownAt) < window {
+            return false
+        }
+        lastProcessedKeyDownAt = now
+        return true
+    }
+}
+
+enum HotkeyAction: Equatable {
+    case none
+    case keyDown
+    case keyUp
+}
+
+struct HotkeyEventDecision: Equatable {
+    let matchesHotkey: Bool
+    let shouldConsumeEvent: Bool
+    let action: HotkeyAction
+
+    static func make(
+        type: CGEventType,
+        keycode: Int64,
+        autorepeat: Int64,
+        targetKeycodes: Set<Int64>,
+        useModifierMode: Bool,
+        debouncer: HotkeyDebouncer,
+        now: Date = Date()
+    ) -> Self {
+        guard targetKeycodes.contains(keycode) else {
+            return Self(matchesHotkey: false, shouldConsumeEvent: false, action: .none)
+        }
+
+        if useModifierMode {
+            return Self(matchesHotkey: true, shouldConsumeEvent: true, action: .keyDown)
+        }
+
+        if autorepeat != 0 {
+            return Self(matchesHotkey: true, shouldConsumeEvent: false, action: .none)
+        }
+
+        switch type {
+        case .keyDown:
+            guard debouncer.shouldProcessKeyDown(at: now) else {
+                return Self(matchesHotkey: true, shouldConsumeEvent: false, action: .none)
+            }
+            return Self(matchesHotkey: true, shouldConsumeEvent: true, action: .keyDown)
+        case .keyUp:
+            return Self(matchesHotkey: true, shouldConsumeEvent: true, action: .keyUp)
+        default:
+            return Self(matchesHotkey: true, shouldConsumeEvent: false, action: .none)
+        }
+    }
+}
 
 // MARK: - Gesture State Machine
 
@@ -93,12 +181,14 @@ private final class TapContext: @unchecked Sendable {
     let gesture: GestureStateMachine
     let targetKeycodes: Set<Int64>
     let useModifierMode: Bool
+    let debouncer: HotkeyDebouncer
     var tap: CFMachPort?
 
-    init(gesture: GestureStateMachine, keycodes: Set<Int64>, modifierMode: Bool) {
+    init(gesture: GestureStateMachine, keycodes: Set<Int64>, modifierMode: Bool, debouncer: HotkeyDebouncer) {
         self.gesture = gesture
         targetKeycodes = keycodes
         useModifierMode = modifierMode
+        self.debouncer = debouncer
     }
 }
 
@@ -132,20 +222,34 @@ private func hotkeyCallback(
             if isDown { ctx.gesture.handleKeyDown() }
             else { ctx.gesture.handleKeyUp() }
         }
-    } else {
-        guard ctx.targetKeycodes.contains(keycode) else {
-            return Unmanaged.passUnretained(event)
-        }
-        let autorepeat = event.getIntegerValueField(.keyboardEventAutorepeat)
-        guard autorepeat == 0 else { return Unmanaged.passUnretained(event) }
-        let isDown = (type == .keyDown)
-        DispatchQueue.main.async {
-            if isDown { ctx.gesture.handleKeyDown() }
-            else { ctx.gesture.handleKeyUp() }
+        return nil
+    }
+
+    let decision = HotkeyEventDecision.make(
+        type: type,
+        keycode: keycode,
+        autorepeat: event.getIntegerValueField(.keyboardEventAutorepeat),
+        targetKeycodes: ctx.targetKeycodes,
+        useModifierMode: ctx.useModifierMode,
+        debouncer: ctx.debouncer
+    )
+
+    guard decision.matchesHotkey else {
+        return Unmanaged.passUnretained(event)
+    }
+
+    DispatchQueue.main.async {
+        switch decision.action {
+        case .keyDown:
+            ctx.gesture.handleKeyDown()
+        case .keyUp:
+            ctx.gesture.handleKeyUp()
+        case .none:
+            break
         }
     }
 
-    return Unmanaged.passUnretained(event)
+    return decision.shouldConsumeEvent ? nil : Unmanaged.passUnretained(event)
 }
 
 // MARK: - Hotkey Manager
@@ -157,17 +261,26 @@ final class HotkeyManager {
     private var useModifierMode: Bool = false
     private let gesture: GestureStateMachine
     private var tapContext: TapContext?
+    private let debouncer = HotkeyDebouncer()
 
     init(gesture: GestureStateMachine) {
         self.gesture = gesture
     }
 
-    static func hasPermission() -> Bool { CGPreflightListenEventAccess() }
+    static func permissionStatus() -> HotkeyPermissionStatus {
+        HotkeyPermissionStatus(
+            inputMonitoringGranted: CGPreflightListenEventAccess(),
+            accessibilityGranted: AXIsProcessTrusted()
+        )
+    }
+
+    static func hasPermission() -> Bool { permissionStatus().isSatisfied }
     static func requestPermission() { CGRequestListenEventAccess() }
 
     func start() -> Bool {
-        guard HotkeyManager.hasPermission() else {
-            NSLog("[BrainBar.Hotkey] Input Monitoring permission not granted")
+        let permissions = HotkeyManager.permissionStatus()
+        guard permissions.isSatisfied else {
+            NSLog("[BrainBar.Hotkey] Missing permission: %@", permissions.missingPermissionsMessage)
             HotkeyManager.requestPermission()
             return false
         }
@@ -181,14 +294,19 @@ final class HotkeyManager {
             )
         }
 
-        let ctx = TapContext(gesture: gesture, keycodes: targetKeycodes, modifierMode: useModifierMode)
+        let ctx = TapContext(
+            gesture: gesture,
+            keycodes: targetKeycodes,
+            modifierMode: useModifierMode,
+            debouncer: debouncer
+        )
         tapContext = ctx
         let ctxPtr = Unmanaged.passUnretained(ctx).toOpaque()
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .listenOnly,
+            options: .defaultTap,
             eventsOfInterest: mask,
             callback: hotkeyCallback,
             userInfo: ctxPtr

--- a/brain-bar/Tests/BrainBarTests/QuickCaptureTests.swift
+++ b/brain-bar/Tests/BrainBarTests/QuickCaptureTests.swift
@@ -131,6 +131,104 @@ final class QuickCaptureTests: XCTestCase {
         XCTAssertNotNil(manager)
     }
 
+    func testHotkeyPermissionStatusRequiresInputMonitoringAndAccessibility() {
+        let missingInput = HotkeyPermissionStatus(inputMonitoringGranted: false, accessibilityGranted: true)
+        XCTAssertFalse(missingInput.isSatisfied)
+        XCTAssertEqual(missingInput.missingPermissionsMessage, "Input Monitoring")
+
+        let missingAccessibility = HotkeyPermissionStatus(inputMonitoringGranted: true, accessibilityGranted: false)
+        XCTAssertFalse(missingAccessibility.isSatisfied)
+        XCTAssertEqual(missingAccessibility.missingPermissionsMessage, "Accessibility")
+
+        let missingBoth = HotkeyPermissionStatus(inputMonitoringGranted: false, accessibilityGranted: false)
+        XCTAssertFalse(missingBoth.isSatisfied)
+        XCTAssertEqual(missingBoth.missingPermissionsMessage, "Input Monitoring and Accessibility")
+    }
+
+    func testDebouncerRejectsRepeatedKeyDownsWithin300Milliseconds() {
+        let debouncer = HotkeyDebouncer(windowMs: 300)
+
+        XCTAssertTrue(debouncer.shouldProcessKeyDown(at: Date(timeIntervalSinceReferenceDate: 10)))
+        XCTAssertFalse(debouncer.shouldProcessKeyDown(at: Date(timeIntervalSinceReferenceDate: 10.2)))
+        XCTAssertTrue(debouncer.shouldProcessKeyDown(at: Date(timeIntervalSinceReferenceDate: 10.31)))
+    }
+
+    func testHotkeyEventDecisionConsumesMatchedNonRepeatingF4Events() {
+        let consumeDown = HotkeyEventDecision.make(
+            type: .keyDown,
+            keycode: 118,
+            autorepeat: 0,
+            targetKeycodes: [118, 129],
+            useModifierMode: false,
+            debouncer: HotkeyDebouncer(windowMs: 300),
+            now: Date(timeIntervalSinceReferenceDate: 20)
+        )
+        XCTAssertTrue(consumeDown.matchesHotkey)
+        XCTAssertTrue(consumeDown.shouldConsumeEvent)
+        XCTAssertEqual(consumeDown.action, .keyDown)
+
+        let consumeUp = HotkeyEventDecision.make(
+            type: .keyUp,
+            keycode: 118,
+            autorepeat: 0,
+            targetKeycodes: [118, 129],
+            useModifierMode: false,
+            debouncer: HotkeyDebouncer(windowMs: 300),
+            now: Date(timeIntervalSinceReferenceDate: 21)
+        )
+        XCTAssertTrue(consumeUp.matchesHotkey)
+        XCTAssertTrue(consumeUp.shouldConsumeEvent)
+        XCTAssertEqual(consumeUp.action, .keyUp)
+    }
+
+    func testHotkeyEventDecisionPassesThroughNonMatchingAndDebouncedEvents() {
+        let debouncer = HotkeyDebouncer(windowMs: 300)
+        _ = HotkeyEventDecision.make(
+            type: .keyDown,
+            keycode: 118,
+            autorepeat: 0,
+            targetKeycodes: [118],
+            useModifierMode: false,
+            debouncer: debouncer,
+            now: Date(timeIntervalSinceReferenceDate: 30)
+        )
+
+        let debounced = HotkeyEventDecision.make(
+            type: .keyDown,
+            keycode: 118,
+            autorepeat: 0,
+            targetKeycodes: [118],
+            useModifierMode: false,
+            debouncer: debouncer,
+            now: Date(timeIntervalSinceReferenceDate: 30.1)
+        )
+        XCTAssertTrue(debounced.matchesHotkey)
+        XCTAssertFalse(debounced.shouldConsumeEvent)
+        XCTAssertEqual(debounced.action, .none)
+
+        let nonMatching = HotkeyEventDecision.make(
+            type: .keyDown,
+            keycode: 96,
+            autorepeat: 0,
+            targetKeycodes: [118],
+            useModifierMode: false,
+            debouncer: HotkeyDebouncer(windowMs: 300),
+            now: Date(timeIntervalSinceReferenceDate: 31)
+        )
+        XCTAssertFalse(nonMatching.matchesHotkey)
+        XCTAssertFalse(nonMatching.shouldConsumeEvent)
+        XCTAssertEqual(nonMatching.action, .none)
+    }
+
+    func testBrainBarHotkeyFailureMessageMentionsBothPermissions() {
+        let message = BrainBarAppSupport.hotkeyPermissionFailureMessage(
+            permissions: HotkeyPermissionStatus(inputMonitoringGranted: false, accessibilityGranted: false)
+        )
+
+        XCTAssertTrue(message.contains("Input Monitoring"))
+        XCTAssertTrue(message.contains("Accessibility"))
+    }
+
     // MARK: - Gesture State Machine
 
     func testGestureKeyDownTransitionsToWaiting() {
@@ -154,5 +252,22 @@ final class QuickCaptureTests: XCTestCase {
         XCTAssertNotEqual(gesture.state, .idle)
         gesture.reset()
         XCTAssertEqual(gesture.state, .idle)
+    }
+
+    // MARK: - brainbar:// URL scheme
+
+    func testBrainBarURLParsesToggle() {
+        let url = URL(string: "brainbar://toggle")!
+        XCTAssertEqual(BrainBarURLAction.parse(url: url), .toggle)
+    }
+
+    func testBrainBarURLParsesSearch() {
+        let url = URL(string: "brainbar://search")!
+        XCTAssertEqual(BrainBarURLAction.parse(url: url), .search)
+    }
+
+    func testBrainBarURLRejectsOtherSchemes() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertNil(BrainBarURLAction.parse(url: url))
     }
 }


### PR DESCRIPTION
## Summary
- switch the fallback CGEvent tap from listen-only to default tap so matched F4 events are consumed instead of reaching Spotlight or Launchpad
- require both Input Monitoring and Accessibility for fallback hotkeys, logging the missing permission and surfacing startup failure in BrainBar with an explicit alert
- debounce repeated matched keyDown events within 300ms to stop rapid open-close oscillation
- add focused Swift tests for permission reporting, event consumption, debounce behavior, and the startup failure message

## Verification
- `swift test --package-path brain-bar --filter QuickCaptureTests`
- `swift test --package-path brain-bar`

## Notes
- This commit intentionally excludes unrelated local BrainBar worktree changes still present in `StatusPopoverView.swift`, `build-app.sh`, `Info.plist`, and untracked BrainBar files.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consume and debounce BrainBar fallback hotkey via CGEventTap
> - Switches the CGEventTap from listen-only to `defaultTap` so matching F4 key events are consumed (not propagated), with autorepeat and debounce filtering via the new `HotkeyDebouncer` class in [HotkeyManager.swift](https://github.com/EtanHey/brainlayer/pull/154/files#diff-e00318c489c9a24d43e5d426d6c317cb31dadbdb67fbfdb71b434ddf440116bc).
> - Startup now requires both Input Monitoring and Accessibility permissions; failures surface a user-facing alert with a description of which permissions are missing.
> - Adds a `brainbar://` URL handling pipeline in [BrainBarApp.swift](https://github.com/EtanHey/brainlayer/pull/154/files#diff-9577de6dd76be378361fd90c956077766066b55e943853da8d80bd0d672a7ca4) that queues incoming actions until the quick capture panel is ready, then flushes them.
> - Hotkey routing state is tracked via `hotkeyRouteStatus`; changes to the fallback setting trigger immediate hotkey reconfiguration.
> - Risk: events that previously passed through on keyDown will now be consumed by the app when the CGEventTap fallback is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86ebf4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added URL scheme support (`brainbar://toggle`, `brainbar://search`) enabling external control of the quick-capture panel and search functionality
  * Enhanced hotkey fallback mechanism for improved compatibility across different permission scenarios
  * Implemented event debouncing to prevent rapid repeated hotkey triggers

* **Improvements**
  * Refined permission error messages for clearer user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->