### PR TITLE
feat: correction mining pipeline + entity extraction (P5)

### DIFF
--- a/scripts/mine_corrections.py
+++ b/scripts/mine_corrections.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Mine correction-tagged chunks into correction pairs and promote them into the KG."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from brainlayer.paths import get_db_path
+from brainlayer.pipeline.correction_mining import mine_corrections, promote_corrections
+from brainlayer.vector_store import VectorStore
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Mine correction chunks into KG entities and aliases")
+    parser.add_argument("--min-confidence", type=float, default=0.8, help="Minimum confidence to promote into KG")
+    parser.add_argument("--skip-promotion", action="store_true", help="Only stage correction pairs")
+    args = parser.parse_args()
+
+    store = None
+    try:
+        store = VectorStore(get_db_path())
+        stats = {"mining": mine_corrections(store)}
+        if not args.skip_promotion:
+            stats["promotion"] = promote_corrections(store, min_confidence=args.min_confidence)
+        print(json.dumps(stats, indent=2, sort_keys=True))
+        return 0
+    finally:
+        if store is not None:
+            store.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/pipeline/correction_mining.py
+++ b/src/brainlayer/pipeline/correction_mining.py
@@ -1,0 +1,435 @@
+"""Mine correction-tagged chunks into structured correction pairs and KG facts."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from ..vector_store import VectorStore
+
+CORRECTION_TAGS = ("correction", "user-correction", "clarification")
+
+
+@dataclass(frozen=True)
+class PatternSpec:
+    regex: re.Pattern[str]
+    pattern_type: str
+
+
+@dataclass(frozen=True)
+class CorrectionMatch:
+    pattern_type: str
+    entity_name: str
+    attribute: str | None
+    old_value: str | None
+    new_value: str | None
+    confidence: float
+
+
+PATTERNS = [
+    PatternSpec(
+        re.compile(
+            r"(?:^|\bno[,.]?\s+)(?P<entity>[\w][\w\s]+?)\s+is\s+not\s+(?P<value>.+?)(?:[.,]|$)",
+            re.IGNORECASE,
+        ),
+        "negation",
+    ),
+    PatternSpec(
+        re.compile(
+            r"(?P<entity>[\w][\w\s]+?)\s+(?P<verb>works?\s+at|from|at)\s+(?P<value>.+?)(?:[.,]|$)",
+            re.IGNORECASE,
+        ),
+        "association",
+    ),
+    PatternSpec(
+        re.compile(
+            r"(?P<left>[\w][\w\s]+?)\s+(?:also\s+known\s+as|aka|=)\s+(?P<right>.+?)(?:[.,]|$)",
+            re.IGNORECASE,
+        ),
+        "alias",
+    ),
+    PatternSpec(
+        re.compile(
+            r"(?:^|no[,.]?\s+)?(?P<entity>[\w][\w\s]+?)\s+is\s+(?:actually\s+)?(?:a\s+)?(?P<value>.+?)(?:[.,]|$)",
+            re.IGNORECASE,
+        ),
+        "identity",
+    ),
+    PatternSpec(
+        re.compile(r"(?P<entity>[\u0590-\u05FF][\u0590-\u05FF\s]+?)\s+(?:זה|הוא|היא)\s+(?P<value>.+?)(?:[.,]|$)"),
+        "hebrew_identity",
+    ),
+]
+
+NON_ENTITY_SUBJECTS = {
+    "he",
+    "her",
+    "here",
+    "i",
+    "it",
+    "she",
+    "that",
+    "the",
+    "their",
+    "them",
+    "they",
+    "this",
+    "those",
+    "we",
+    "what",
+    "who",
+    "you",
+}
+NON_ENTITY_PREFIXES = ("working ", "making ", "being ")
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = re.sub(r"\s+", " ", value.strip(" \t\r\n.,"))
+    return cleaned or None
+
+
+def _looks_like_hebrew(value: str) -> bool:
+    return bool(re.search(r"[\u0590-\u05FF]", value))
+
+
+def _is_likely_entity_name(value: str | None) -> bool:
+    cleaned = _clean(value)
+    if not cleaned:
+        return False
+    lowered = cleaned.lower()
+    if lowered in NON_ENTITY_SUBJECTS:
+        return False
+    if any(lowered.startswith(prefix) for prefix in NON_ENTITY_PREFIXES):
+        return False
+    if _looks_like_hebrew(cleaned):
+        return True
+    tokens = cleaned.split()
+    return cleaned[0].isupper() or len(tokens) > 1
+
+
+def _association_attribute(verb: str) -> str:
+    normalized = verb.lower().strip()
+    if normalized.startswith("work"):
+        return "works_at"
+    if normalized == "from":
+        return "from"
+    return "at"
+
+
+def _build_match(spec: PatternSpec, match: re.Match[str]) -> CorrectionMatch | None:
+    groups = {key: _clean(value) for key, value in match.groupdict().items()}
+
+    if spec.pattern_type == "identity":
+        entity = groups["entity"]
+        value = groups["value"]
+        if not _is_likely_entity_name(entity):
+            return None
+        return CorrectionMatch(
+            pattern_type="identity",
+            entity_name=entity,
+            attribute=value,
+            old_value=None,
+            new_value=value,
+            confidence=0.85,
+        )
+
+    if spec.pattern_type == "hebrew_identity":
+        entity = groups["entity"]
+        value = groups["value"]
+        if not _is_likely_entity_name(entity):
+            return None
+        return CorrectionMatch(
+            pattern_type="hebrew_identity",
+            entity_name=entity,
+            attribute=value,
+            old_value=None,
+            new_value=value,
+            confidence=0.88,
+        )
+
+    if spec.pattern_type == "negation":
+        entity = groups["entity"]
+        value = groups["value"]
+        if not _is_likely_entity_name(entity):
+            return None
+        return CorrectionMatch(
+            pattern_type="negation",
+            entity_name=entity,
+            attribute="negated_fact",
+            old_value=value,
+            new_value=None,
+            confidence=0.7,
+        )
+
+    if spec.pattern_type == "association":
+        entity = groups["entity"]
+        value = groups["value"]
+        verb = groups["verb"] or ""
+        if not _is_likely_entity_name(entity) or not _is_likely_entity_name(value):
+            return None
+        return CorrectionMatch(
+            pattern_type="association",
+            entity_name=entity,
+            attribute=_association_attribute(verb),
+            old_value=None,
+            new_value=value,
+            confidence=0.9,
+        )
+
+    if spec.pattern_type == "alias":
+        left = groups["left"]
+        right = groups["right"]
+        canonical = right if _is_likely_entity_name(right) else left
+        alias = left if canonical == right else right
+        if not _is_likely_entity_name(canonical) or not alias:
+            return None
+        return CorrectionMatch(
+            pattern_type="alias",
+            entity_name=canonical,
+            attribute="alias",
+            old_value=alias,
+            new_value=canonical,
+            confidence=0.95,
+        )
+
+    return None
+
+
+def extract_corrections(text: str) -> list[CorrectionMatch]:
+    """Extract structured correction pairs from free text."""
+    matches: list[CorrectionMatch] = []
+    spans: list[tuple[int, int]] = []
+    for spec in PATTERNS:
+        for raw_match in spec.regex.finditer(text):
+            span = raw_match.span()
+            if any(not (span[1] <= seen[0] or span[0] >= seen[1]) for seen in spans):
+                continue
+            candidate = _build_match(spec, raw_match)
+            if candidate is not None:
+                matches.append(candidate)
+                spans.append(span)
+    return matches
+
+
+def mine_corrections(store: VectorStore) -> dict[str, Any]:
+    """Extract correction pairs from correction-tagged chunks into a staging table."""
+    cursor = store.conn.cursor()
+    placeholders = ", ".join("?" for _ in CORRECTION_TAGS)
+    rows = list(
+        store._read_cursor().execute(
+            f"""
+            SELECT DISTINCT c.id, c.content
+            FROM chunks c
+            JOIN chunk_tags ct ON ct.chunk_id = c.id
+            WHERE lower(ct.tag) IN ({placeholders})
+            ORDER BY c.id
+            """,
+            tuple(tag.lower() for tag in CORRECTION_TAGS),
+        )
+    )
+
+    stats: dict[str, Any] = {
+        "chunks_processed": len(rows),
+        "pairs_extracted": 0,
+        "by_pattern_type": {},
+    }
+
+    for chunk_id, content in rows:
+        cursor.execute("DELETE FROM correction_pairs WHERE chunk_id = ?", (chunk_id,))
+        extracted = extract_corrections(content)
+        for item in extracted:
+            cursor.execute(
+                """
+                INSERT INTO correction_pairs (
+                    chunk_id, pattern_type, entity_name, attribute, old_value, new_value, confidence
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    chunk_id,
+                    item.pattern_type,
+                    item.entity_name,
+                    item.attribute,
+                    item.old_value,
+                    item.new_value,
+                    item.confidence,
+                ),
+            )
+            stats["pairs_extracted"] += 1
+            stats["by_pattern_type"][item.pattern_type] = stats["by_pattern_type"].get(item.pattern_type, 0) + 1
+
+    stats["by_pattern_type"] = dict(sorted(stats["by_pattern_type"].items()))
+    return stats
+
+
+def _person_entity_id(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9\u0590-\u05ff]+", "-", name.lower()).strip("-")
+    return f"corr-person-{slug or uuid.uuid4().hex[:8]}"
+
+
+def _org_entity_id(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9\u0590-\u05ff]+", "-", name.lower()).strip("-")
+    return f"corr-org-{slug or uuid.uuid4().hex[:8]}"
+
+
+def _resolve_person_name(store: VectorStore, name: str) -> tuple[str, dict[str, Any] | None]:
+    exact = store.get_entity_by_name("person", name)
+    if exact is not None:
+        return name, exact
+
+    if len(name.split()) != 1:
+        return name, None
+
+    rows = list(
+        store._read_cursor().execute(
+            """
+            SELECT id, entity_type, name, metadata, created_at, updated_at,
+                   canonical_name, description, confidence, importance,
+                   valid_from, valid_until, group_id
+            FROM kg_entities
+            WHERE entity_type = 'person' AND lower(name) LIKE lower(?)
+            ORDER BY length(name) ASC
+            """,
+            (f"{name} %",),
+        )
+    )
+    if len(rows) != 1:
+        return name, None
+
+    row = rows[0]
+    return row[2], {
+        "id": row[0],
+        "entity_type": row[1],
+        "name": row[2],
+        "metadata": json.loads(row[3]) if row[3] else {},
+        "created_at": row[4],
+        "updated_at": row[5],
+        "canonical_name": row[6],
+        "description": row[7],
+        "confidence": row[8],
+        "importance": row[9],
+        "valid_from": row[10],
+        "valid_until": row[11],
+        "group_id": row[12],
+    }
+
+
+def _ensure_person(store: VectorStore, name: str, *, identity: str | None = None, confidence: float = 0.8) -> str:
+    resolved_name, existing = _resolve_person_name(store, name)
+    metadata = dict(existing["metadata"]) if existing else {}
+    if identity:
+        metadata["identity"] = identity
+    entity_id = existing["id"] if existing else _person_entity_id(resolved_name)
+    return store.upsert_entity(
+        entity_id,
+        "person",
+        resolved_name,
+        metadata=metadata,
+        confidence=confidence,
+        importance=0.7,
+        description=identity if identity and not _looks_like_hebrew(identity) else None,
+    )
+
+
+def _ensure_organization(store: VectorStore, name: str, confidence: float = 0.85) -> str:
+    existing = store.get_entity_by_name("organization", name)
+    entity_id = existing["id"] if existing else _org_entity_id(name)
+    return store.upsert_entity(
+        entity_id,
+        "organization",
+        name,
+        metadata={"source": "correction-mining"},
+        confidence=confidence,
+        importance=0.6,
+    )
+
+
+def promote_corrections(store: VectorStore, min_confidence: float = 0.8) -> dict[str, int]:
+    """Promote high-confidence correction pairs into KG entities, relations, and aliases."""
+    cursor = store.conn.cursor()
+    rows = list(
+        store._read_cursor().execute(
+            """
+            SELECT id, chunk_id, pattern_type, entity_name, attribute, old_value, new_value, confidence
+            FROM correction_pairs
+            ORDER BY id
+            """,
+        )
+    )
+
+    stats = {
+        "entities_upserted": 0,
+        "relations_created": 0,
+        "aliases_created": 0,
+        "manual_review": 0,
+    }
+    seen_entities: set[str] = set()
+
+    for _, chunk_id, pattern_type, entity_name, attribute, old_value, new_value, confidence in rows:
+        if pattern_type == "negation":
+            stats["manual_review"] += 1
+            if confidence < min_confidence:
+                continue
+
+        if confidence < min_confidence:
+            continue
+
+        if pattern_type in {"identity", "hebrew_identity"}:
+            entity_id = _ensure_person(store, entity_name, identity=new_value, confidence=confidence)
+            if entity_id not in seen_entities:
+                stats["entities_upserted"] += 1
+                seen_entities.add(entity_id)
+            store.link_entity_chunk(
+                entity_id, chunk_id, relevance=confidence, context="correction-mining", mention_type="explicit"
+            )
+            continue
+
+        if pattern_type == "association":
+            source_id = _ensure_person(store, entity_name, confidence=confidence)
+            target_id = _ensure_organization(store, new_value, confidence=confidence)
+            for entity_id in (source_id, target_id):
+                if entity_id not in seen_entities:
+                    stats["entities_upserted"] += 1
+                    seen_entities.add(entity_id)
+            relation_id = f"corr-rel-{uuid.uuid4().hex[:12]}"
+            store.add_relation(
+                relation_id,
+                source_id,
+                target_id,
+                attribute or "related_to",
+                confidence=confidence,
+                fact=f"{entity_name} {attribute.replace('_', ' ')} {new_value}" if attribute else None,
+                source_chunk_id=chunk_id,
+            )
+            store.link_entity_chunk(
+                source_id, chunk_id, relevance=confidence, context="correction-mining", mention_type="explicit"
+            )
+            store.link_entity_chunk(
+                target_id, chunk_id, relevance=confidence, context="correction-mining", mention_type="explicit"
+            )
+            stats["relations_created"] += 1
+            continue
+
+        if pattern_type == "alias":
+            entity_id = _ensure_person(store, entity_name, confidence=confidence)
+            if entity_id not in seen_entities:
+                stats["entities_upserted"] += 1
+                seen_entities.add(entity_id)
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO kg_entity_aliases (alias, entity_id, alias_type, created_at, valid_from)
+                VALUES (?, ?, 'correction', strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                """,
+                (old_value, entity_id),
+            )
+            stats["aliases_created"] += store.conn.changes()
+            store.link_entity_chunk(
+                entity_id, chunk_id, relevance=confidence, context="correction-mining", mention_type="explicit"
+            )
+            continue
+
+    return stats

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -501,6 +501,23 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_health_events_severity ON health_events(severity)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_health_events_created ON health_events(created_at)")
 
+        # ── Correction mining table ───────────────────────────────────────
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS correction_pairs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chunk_id TEXT NOT NULL,
+                pattern_type TEXT NOT NULL,
+                entity_name TEXT,
+                attribute TEXT,
+                old_value TEXT,
+                new_value TEXT,
+                confidence REAL DEFAULT 0.0,
+                created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_correction_pairs_chunk ON correction_pairs(chunk_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_correction_pairs_pattern ON correction_pairs(pattern_type)")
+
         # ── Knowledge Graph tables ──────────────────────────────────────
 
         cursor.execute("""

--- a/tests/test_correction_mining.py
+++ b/tests/test_correction_mining.py
@@ -1,0 +1,160 @@
+"""Tests for correction mining pipeline."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brainlayer.vector_store import VectorStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "test.db"
+    s = VectorStore(db_path)
+    yield s
+    s.close()
+
+
+def _insert_chunk(store: VectorStore, chunk_id: str, content: str, tags: list[str]) -> None:
+    store.conn.cursor().execute(
+        """
+        INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, tags, created_at
+        ) VALUES (?, ?, '{}', 'test.jsonl', 'brainlayer', 'note', ?, 'tests', ?, datetime('now'))
+        """,
+        (
+            chunk_id,
+            content,
+            len(content),
+            json.dumps(tags),
+        ),
+    )
+
+
+def test_extract_identity():
+    from brainlayer.pipeline.correction_mining import extract_corrections
+
+    matches = extract_corrections("Avi Simon is a developer.")
+
+    assert len(matches) == 1
+    assert matches[0].pattern_type == "identity"
+    assert matches[0].entity_name == "Avi Simon"
+    assert matches[0].attribute == "developer"
+    assert matches[0].old_value is None
+    assert matches[0].new_value == "developer"
+
+
+def test_extract_negation():
+    from brainlayer.pipeline.correction_mining import extract_corrections
+
+    matches = extract_corrections("Avi is not from Wix.")
+
+    assert len(matches) == 1
+    assert matches[0].pattern_type == "negation"
+    assert matches[0].entity_name == "Avi"
+    assert matches[0].old_value == "from Wix"
+    assert matches[0].new_value is None
+
+
+def test_extract_association():
+    from brainlayer.pipeline.correction_mining import extract_corrections
+
+    matches = extract_corrections("Avi works at Lightricks.")
+
+    assert len(matches) == 1
+    assert matches[0].pattern_type == "association"
+    assert matches[0].entity_name == "Avi"
+    assert matches[0].attribute == "works_at"
+    assert matches[0].new_value == "Lightricks"
+
+
+def test_extract_alias():
+    from brainlayer.pipeline.correction_mining import extract_corrections
+
+    matches = extract_corrections("EtanHey aka Etan Heyman")
+
+    assert len(matches) == 1
+    assert matches[0].pattern_type == "alias"
+    assert matches[0].entity_name == "Etan Heyman"
+    assert matches[0].old_value == "EtanHey"
+    assert matches[0].new_value == "Etan Heyman"
+
+
+def test_extract_hebrew():
+    from brainlayer.pipeline.correction_mining import extract_corrections
+
+    matches = extract_corrections("אבי הוא מפתח")
+
+    assert len(matches) == 1
+    assert matches[0].pattern_type == "hebrew_identity"
+    assert matches[0].entity_name == "אבי"
+    assert matches[0].new_value == "מפתח"
+
+
+def test_mine_corrections_from_chunks(store):
+    from brainlayer.pipeline.correction_mining import mine_corrections, promote_corrections
+
+    _insert_chunk(store, "chunk-1", "Avi Simon is a developer.", ["correction"])
+    _insert_chunk(store, "chunk-2", "Avi works at Lightricks.", ["clarification"])
+    _insert_chunk(store, "chunk-3", "EtanHey aka Etan Heyman", ["user-correction"])
+    _insert_chunk(store, "chunk-4", "Avi is not from Wix.", ["correction"])
+
+    stats = mine_corrections(store)
+
+    assert stats["chunks_processed"] == 4
+    assert stats["pairs_extracted"] == 4
+    assert stats["by_pattern_type"] == {
+        "alias": 1,
+        "association": 1,
+        "identity": 1,
+        "negation": 1,
+    }
+
+    promotion = promote_corrections(store, min_confidence=0.8)
+
+    assert promotion["entities_upserted"] >= 2
+    assert promotion["relations_created"] == 1
+    assert promotion["aliases_created"] == 1
+    assert promotion["manual_review"] == 1
+
+    person = store.get_entity_by_name("person", "Avi Simon")
+    assert person is not None
+    assert person["metadata"]["identity"] == "developer"
+
+    relations = store.get_entity_relations(person["id"], direction="outgoing")
+    assert any(rel["relation_type"] == "works_at" and rel["target_name"] == "Lightricks" for rel in relations)
+
+    alias_rows = list(
+        store._read_cursor().execute(
+            "SELECT alias, alias_type FROM kg_entity_aliases WHERE entity_id = ?",
+            (store.get_entity_by_name("person", "Etan Heyman")["id"],),
+        )
+    )
+    assert ("EtanHey", "correction") in alias_rows
+
+
+def test_correction_pairs_table(store):
+    cols = {row[1]: row[2] for row in store._read_cursor().execute("PRAGMA table_info(correction_pairs)")}
+
+    assert cols == {
+        "id": "INTEGER",
+        "chunk_id": "TEXT",
+        "pattern_type": "TEXT",
+        "entity_name": "TEXT",
+        "attribute": "TEXT",
+        "old_value": "TEXT",
+        "new_value": "TEXT",
+        "confidence": "REAL",
+        "created_at": "TEXT",
+    }
+
+
+def test_no_false_positives():
+    from brainlayer.pipeline.correction_mining import extract_corrections
+
+    assert extract_corrections("this is great") == []
+    assert extract_corrections("it is not ideal") == []
+    assert extract_corrections("working at home today") == []


### PR DESCRIPTION
## Summary
- Add regex-based correction mining pipeline extracting entity definitions, associations, aliases, negations from correction chunks
- Add `correction_pairs` table to VectorStore schema
- Add `scripts/mine_corrections.py` CLI for batch mining
- Add `src/brainlayer/pipeline/correction_mining.py` with pattern matching + entity promotion

## Test plan
- [x] `pytest tests/test_correction_mining.py -q`
- [x] `ruff check src/ scripts/`

P5 of overnight sprint. 49 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add correction mining pipeline with entity extraction and KG promotion
> - Adds [correction_mining.py](https://github.com/EtanHey/brainlayer/pull/206/files#diff-d1270699ba56a3c8a22ef2a898380b69f5c6600a4eba8bf6dada4111799d2c0e) with regex-based extraction of identity, negation, association, alias, and Hebrew identity corrections from tagged chunks into a `correction_pairs` staging table.
> - `promote_corrections` converts high-confidence staged corrections into knowledge graph entities, relations, and aliases, flagging low-confidence or negation entries for manual review.
> - Adds a [mine_corrections.py](https://github.com/EtanHey/brainlayer/pull/206/files#diff-d2e89f4c6c9e888f49d695458fe2dd86306c81a62688b1cf629f99c2d0da6921) CLI script that runs the full pipeline and prints aggregated stats as JSON.
> - Extends `VectorStore._init_readonly_db` in [vector_store.py](https://github.com/EtanHey/brainlayer/pull/206/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) to create the `correction_pairs` table and indexes on startup.
> - Behavioral Change: the `VectorStore` readonly init now executes DDL to create `correction_pairs` if it does not exist, affecting all store initializations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a4ce02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Correction mining pipeline extracts structured information from correction-tagged content with adjustable confidence levels
  * Extracted corrections can be promoted into the knowledge graph, supporting entity relationships, aliases, and identity mappings
  * New command-line utility for executing correction mining and promotion workflows

* **Tests**
  * Added comprehensive test coverage for correction extraction, mining, and promotion operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->