### PR TITLE
fix: skip Supabase stats sync when credentials are not configured

### DIFF
--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -1793,15 +1793,22 @@ def index_fast(
             f"\n[bold green]✓[/] Indexed [bold]{total_chunks:,}[/] chunks from [bold]{len(jsonl_files):,}[/] files in [bold]{elapsed_total / 60:.1f}[/] minutes"
         )
 
-        # Sync enrichment stats to Supabase (best-effort)
+        # Sync enrichment stats to Supabase (best-effort, only if configured)
         try:
-            from ..pipeline.enrichment import DEFAULT_DB_PATH, _sync_stats_to_supabase
-            from ..vector_store import VectorStore
+            from ..pipeline.enrichment import (
+                DEFAULT_DB_PATH,
+                SUPABASE_SERVICE_KEY,
+                SUPABASE_URL,
+                _sync_stats_to_supabase,
+            )
 
-            store = VectorStore(DEFAULT_DB_PATH)
-            _sync_stats_to_supabase(store)
-            store.close()
-            rprint("[dim]Synced enrichment stats to Supabase[/]")
+            if SUPABASE_URL and SUPABASE_SERVICE_KEY:
+                from ..vector_store import VectorStore
+
+                store = VectorStore(DEFAULT_DB_PATH)
+                _sync_stats_to_supabase(store)
+                store.close()
+                rprint("[dim]Synced enrichment stats to Supabase[/]")
         except Exception as e:
             rprint(f"[dim]Supabase stats sync skipped: {e}[/]")
 


### PR DESCRIPTION
## Summary                                                                                                               
- Gate the Supabase enrichment stats sync on `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` being set                         
- Prevents the misleading "Synced enrichment stats to Supabase" message when no credentials are configured               
                                                                                                                           
## Test plan                                                                                                             
- [ ] Run `brainlayer index` without Supabase env vars — confirm no sync message appears                                 
- [ ] Run `brainlayer index` with both vars set — confirm sync message still appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supabase enrichment-stats sync during indexing now executes only when both required credentials are configured, skipping the sync step if either credential is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Supabase stats sync in `index_fast` when credentials are not configured
> Previously, the `index_fast` command attempted to sync enrichment stats to Supabase unconditionally, which would fail or behave unexpectedly when `SUPABASE_URL` or `SUPABASE_SERVICE_KEY` were not set. Now, a guard checks for both credentials before importing `VectorStore`, opening the store, and calling `_sync_stats_to_supabase`. No message is printed when the sync is skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized add6fac.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->