### PR TITLE
feat: add Claude Code BrainLayer plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "brainlayer",
+  "owner": {
+    "name": "Etan Heyman",
+    "url": "https://github.com/EtanHey"
+  },
+  "plugins": [
+    {
+      "name": "brainlayer",
+      "source": "./extensions/brainlayer-plugin"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ claude.scratchpad.md
 # MCP config (contains secrets)
 .mcp.json
 .mcp.json.bak
+!extensions/brainlayer-plugin/.mcp.json
 
 # Claude Code project settings
 .claude/

--- a/extensions/brainlayer-plugin/.claude-plugin/plugin.json
+++ b/extensions/brainlayer-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "brainlayer",
+  "description": "BrainLayer plugin for Claude Code. Uses BrainBar MCP for recall, queued observations, and session-stop sleep.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Etan Heyman",
+    "url": "https://github.com/EtanHey"
+  }
+}

--- a/extensions/brainlayer-plugin/.gitignore
+++ b/extensions/brainlayer-plugin/.gitignore
@@ -1,0 +1,1 @@
+.memory-queue.jsonl

--- a/extensions/brainlayer-plugin/.mcp.json
+++ b/extensions/brainlayer-plugin/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "brainlayer": {
+      "command": "socat",
+      "args": [
+        "STDIO",
+        "UNIX-CONNECT:/tmp/brainbar.sock"
+      ]
+    }
+  }
+}

--- a/extensions/brainlayer-plugin/hooks/hooks.json
+++ b/extensions/brainlayer-plugin/hooks/hooks.json
@@ -1,0 +1,53 @@
+{
+  "description": "BrainLayer Claude Code lifecycle hooks",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/tool-observe.sh",
+            "async": true,
+            "timeout": 2
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/tool-error.sh",
+            "async": true,
+            "timeout": 2
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-stop.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/extensions/brainlayer-plugin/hooks/session-start.sh
+++ b/extensions/brainlayer-plugin/hooks/session-start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+python3 "${PLUGIN_ROOT}/scripts/brainbar-hook.py" session-start

--- a/extensions/brainlayer-plugin/hooks/session-stop.sh
+++ b/extensions/brainlayer-plugin/hooks/session-stop.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+python3 "${PLUGIN_ROOT}/scripts/brainbar-hook.py" session-stop

--- a/extensions/brainlayer-plugin/hooks/tool-error.sh
+++ b/extensions/brainlayer-plugin/hooks/tool-error.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+python3 "${PLUGIN_ROOT}/scripts/brainbar-hook.py" tool-error

--- a/extensions/brainlayer-plugin/hooks/tool-observe.sh
+++ b/extensions/brainlayer-plugin/hooks/tool-observe.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+python3 "${PLUGIN_ROOT}/scripts/brainbar-hook.py" tool-observe

--- a/extensions/brainlayer-plugin/scripts/brainbar-hook.py
+++ b/extensions/brainlayer-plugin/scripts/brainbar-hook.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Thin Claude Code hook adapter for BrainBar MCP."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+MCP_SOCKET_PATH = "/tmp/brainbar.sock"
+
+
+def _plugin_root() -> Path:
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        return Path(env_root)
+    return Path(__file__).resolve().parents[1]
+
+
+def _queue_path() -> Path:
+    override = os.environ.get("BRAINLAYER_PLUGIN_QUEUE")
+    if override:
+        return Path(override)
+    plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA")
+    base_dir = Path(plugin_data) if plugin_data else _plugin_root()
+    return base_dir / ".memory-queue.jsonl"
+
+
+def _queue_module():
+    script_path = _plugin_root() / "scripts" / "queue-flusher.py"
+    spec = importlib.util.spec_from_file_location("queue_flusher", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_message(stream, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    stream.write(f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8"))
+    stream.write(body)
+    stream.flush()
+
+
+def _read_message(stream) -> dict[str, Any]:
+    headers = b""
+    while b"\r\n\r\n" not in headers:
+        chunk = stream.read(1)
+        if not chunk:
+            raise RuntimeError("unexpected EOF while reading MCP headers")
+        headers += chunk
+
+    header_text = headers.decode("utf-8")
+    content_length = None
+    for line in header_text.split("\r\n"):
+        if line.lower().startswith("content-length:"):
+            content_length = int(line.split(":", 1)[1].strip())
+            break
+
+    if content_length is None:
+        raise RuntimeError("missing Content-Length header")
+
+    body = stream.read(content_length)
+    if len(body) != content_length:
+        raise RuntimeError("short MCP body read")
+    return json.loads(body.decode("utf-8"))
+
+
+def call_mcp_tool(tool_name: str, arguments: dict[str, Any], socket_path: str = MCP_SOCKET_PATH) -> dict[str, Any]:
+    proc = subprocess.Popen(
+        ["socat", "STDIO", f"UNIX-CONNECT:{socket_path}"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+
+    try:
+        _write_message(
+            proc.stdin,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "brainlayer-plugin", "version": "0.1.0"},
+                },
+            },
+        )
+        _read_message(proc.stdout)
+
+        _write_message(proc.stdin, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+        _write_message(
+            proc.stdin,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            },
+        )
+
+        while True:
+            message = _read_message(proc.stdout)
+            if message.get("id") == 2:
+                if "error" in message:
+                    raise RuntimeError(message["error"])
+                return message.get("result", {})
+    finally:
+        proc.kill()
+        proc.wait(timeout=1)
+
+
+def _result_text(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    if isinstance(result, dict):
+        if isinstance(result.get("summary"), str):
+            return result["summary"]
+        content = result.get("content")
+        if isinstance(content, list):
+            texts = [item.get("text", "") for item in content if isinstance(item, dict)]
+            text = "\n".join(part for part in texts if part).strip()
+            if text:
+                return text
+    return json.dumps(result, ensure_ascii=True)
+
+
+def format_additional_context(text: str) -> dict[str, str]:
+    return {"additionalContext": text.strip()}
+
+
+def build_queue_event(hook_event: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    tool_name = payload.get("tool_name", "")
+    if tool_name.startswith("mcp__brainlayer__"):
+        return None
+
+    is_failure = hook_event == "PostToolUseFailure"
+    response = payload.get("tool_response") or payload.get("tool_result") or {}
+    return {
+        "hook_event": hook_event,
+        "session_id": payload.get("session_id"),
+        "cwd": payload.get("cwd"),
+        "tool_name": tool_name,
+        "tool_input": payload.get("tool_input", {}),
+        "tool_response": response,
+        "importance": 8 if is_failure else 5,
+        "tags": ["claude-code", "tool-observation"] + (["error"] if is_failure else []),
+        "captured_at": time.time(),
+    }
+
+
+def handle_session_start(
+    payload: dict[str, Any],
+    invoke_tool: Callable[[str, dict[str, Any]], Any] = call_mcp_tool,
+    deadline_ms: int = 200,
+) -> dict[str, str]:
+    started = time.perf_counter()
+    result = invoke_tool("brain_recall", {"mode": "context", "session_id": payload.get("session_id")})
+    text = _result_text(result).strip()
+    if not text:
+        return {}
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    if elapsed_ms > deadline_ms:
+        return {}
+    return format_additional_context(text)
+
+
+def _send_queue_batch_to_brainbar(batch: list[dict[str, Any]]) -> None:
+    for event in batch:
+        arguments = {
+            "content": json.dumps(
+                {
+                    "tool_name": event.get("tool_name"),
+                    "tool_input": event.get("tool_input"),
+                    "tool_response": event.get("tool_response"),
+                },
+                ensure_ascii=True,
+            ),
+            "tags": event.get("tags", []),
+            "importance": event.get("importance", 5),
+            "context": event.get("cwd"),
+            "session_id": event.get("session_id"),
+        }
+        call_mcp_tool("brain_store", arguments)
+
+
+def handle_tool_event(payload: dict[str, Any], hook_event: str, queue_path: Path | None = None) -> None:
+    event = build_queue_event(hook_event, payload)
+    if event is None:
+        return
+    queue_module = _queue_module()
+    queue_module.append_queue_event(queue_path or _queue_path(), event)
+
+
+def handle_stop(
+    payload: dict[str, Any],
+    queue_path: Path | None = None,
+    flush_queue_fn: Callable[[Path], int] | None = None,
+    invoke_tool: Callable[[str, dict[str, Any]], Any] = call_mcp_tool,
+) -> dict[str, str]:
+    resolved_queue = queue_path or _queue_path()
+    if flush_queue_fn is None:
+        queue_module = _queue_module()
+        flushed = queue_module.flush_queue(resolved_queue, _send_queue_batch_to_brainbar)
+    else:
+        flushed = flush_queue_fn(resolved_queue)
+
+    sleep_note = "triggered brain_sleep"
+    try:
+        invoke_tool(
+            "brain_sleep",
+            {
+                "mode": "plugin-stop",
+                "session_id": payload.get("session_id"),
+                "cwd": payload.get("cwd"),
+            },
+        )
+    except RuntimeError as exc:
+        if "brain_sleep" not in str(exc):
+            raise
+        sleep_note = "brain_sleep unavailable"
+
+    return {"systemMessage": f"BrainLayer queued {flushed} memory events and {sleep_note}."}
+
+
+def main() -> int:
+    action = sys.argv[1] if len(sys.argv) > 1 else ""
+    payload = json.loads(sys.stdin.read() or "{}")
+
+    if action == "session-start":
+        output = handle_session_start(payload)
+        if output:
+            print(json.dumps(output))
+        return 0
+    if action == "tool-observe":
+        handle_tool_event(payload, "PostToolUse")
+        return 0
+    if action == "tool-error":
+        handle_tool_event(payload, "PostToolUseFailure")
+        return 0
+    if action == "session-stop":
+        output = handle_stop(payload)
+        if output:
+            print(json.dumps(output))
+        return 0
+
+    print(json.dumps({"systemMessage": f"Unknown brainbar-hook action: {action}"}))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/brainlayer-plugin/scripts/brainbar-hook.py
+++ b/extensions/brainlayer-plugin/scripts/brainbar-hook.py
@@ -164,7 +164,10 @@ def handle_session_start(
     deadline_ms: int = 200,
 ) -> dict[str, str]:
     started = time.perf_counter()
-    result = invoke_tool("brain_recall", {"mode": "context", "session_id": payload.get("session_id")})
+    try:
+        result = invoke_tool("brain_recall", {"mode": "context", "session_id": payload.get("session_id")})
+    except RuntimeError:
+        return {}
     text = _result_text(result).strip()
     if not text:
         return {}

--- a/extensions/brainlayer-plugin/scripts/queue-flusher.py
+++ b/extensions/brainlayer-plugin/scripts/queue-flusher.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Append-only queue for plugin tool observations."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+def append_queue_event(queue_path: Path, event: dict[str, Any]) -> None:
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    with queue_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        handle.write(json.dumps(event, ensure_ascii=True) + "\n")
+        handle.flush()
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def read_queue_events(queue_path: Path) -> list[dict[str, Any]]:
+    if not queue_path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with queue_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                rows.append(json.loads(stripped))
+    return rows
+
+
+def flush_queue(queue_path: Path, sender: Callable[[list[dict[str, Any]]], None], batch_size: int = 50) -> int:
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    if not queue_path.exists():
+        queue_path.write_text("", encoding="utf-8")
+        return 0
+
+    with queue_path.open("r+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        raw_lines = [line for line in handle.readlines() if line.strip()]
+        events = [json.loads(line) for line in raw_lines]
+        try:
+            for start in range(0, len(events), batch_size):
+                sender(events[start : start + batch_size])
+        except Exception:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            return 0
+
+        handle.seek(0)
+        handle.truncate(0)
+        handle.flush()
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    return len(events)
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: queue-flusher.py <append|flush> <queue_path>", file=sys.stderr)
+        return 1
+
+    command = sys.argv[1]
+    queue_path = Path(sys.argv[2])
+
+    if command == "append":
+        append_queue_event(queue_path, json.loads(sys.stdin.read() or "{}"))
+        return 0
+
+    if command == "flush":
+        from importlib import util
+
+        hook_path = queue_path.resolve().parents[0]
+        plugin_root = hook_path.parent if hook_path.name == "scripts" else None
+        if plugin_root is None:
+            plugin_root = Path(__file__).resolve().parents[1]
+        spec = util.spec_from_file_location("brainbar_hook", plugin_root / "scripts" / "brainbar-hook.py")
+        module = util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        flushed = flush_queue(queue_path, module._send_queue_batch_to_brainbar)
+        print(flushed)
+        return 0
+
+    print(f"unknown command: {command}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/brainlayer-plugin/scripts/queue-flusher.py
+++ b/extensions/brainlayer-plugin/scripts/queue-flusher.py
@@ -41,18 +41,25 @@ def flush_queue(queue_path: Path, sender: Callable[[list[dict[str, Any]]], None]
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         raw_lines = [line for line in handle.readlines() if line.strip()]
         events = [json.loads(line) for line in raw_lines]
-        try:
-            for start in range(0, len(events), batch_size):
-                sender(events[start : start + batch_size])
-        except Exception:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-            return 0
+        sent_count = 0
+        remaining_events = []
+        for start in range(0, len(events), batch_size):
+            batch = events[start : start + batch_size]
+            try:
+                sender(batch)
+            except Exception:
+                remaining_events = events[start:]
+                break
+            sent_count += len(batch)
+        else:
+            remaining_events = []
 
         handle.seek(0)
-        handle.truncate(0)
+        handle.write("".join(json.dumps(event, ensure_ascii=True) + "\n" for event in remaining_events))
+        handle.truncate()
         handle.flush()
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-    return len(events)
+    return sent_count
 
 
 def main() -> int:

--- a/extensions/brainlayer-plugin/skills/memory/SKILL.md
+++ b/extensions/brainlayer-plugin/skills/memory/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: memory
+description: "Use BrainLayer memory deliberately: search before assumptions, store decisions after they are made, and recall current context when resuming work."
+---
+
+# BrainLayer Memory
+
+Use BrainLayer when session context is incomplete or when the task depends on prior decisions.
+
+- Run `brain_search` before answering architecture, project-history, preference, or "what did we decide" questions.
+- Run `brain_recall` when you need the current working context, recent session state, or session-linked summaries.
+- Run `brain_store` after decisions, corrections, failures, or milestones so the next Claude session can recover the why, not just the code diff.
+
+Before answering from memory, verify with `brain_search` instead of assuming.

--- a/tests/test_phase2_plugin_manifest.py
+++ b/tests/test_phase2_plugin_manifest.py
@@ -1,0 +1,90 @@
+"""Phase 2 plugin manifest and hook contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = REPO_ROOT / "extensions" / "brainlayer-plugin"
+MARKETPLACE_PATH = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_MANIFEST_PATH = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+PLUGIN_MCP_PATH = PLUGIN_ROOT / ".mcp.json"
+HOOKS_PATH = PLUGIN_ROOT / "hooks" / "hooks.json"
+SKILL_PATH = PLUGIN_ROOT / "skills" / "memory" / "SKILL.md"
+
+
+def _load_json(path: Path) -> dict:
+    assert path.exists(), f"expected file to exist: {path}"
+    return json.loads(path.read_text())
+
+
+def test_marketplace_catalog_lists_brainlayer_plugin():
+    marketplace = _load_json(MARKETPLACE_PATH)
+
+    assert marketplace["name"] == "brainlayer"
+    plugins = marketplace["plugins"]
+    assert plugins == [
+        {
+            "name": "brainlayer",
+            "source": "./extensions/brainlayer-plugin",
+        }
+    ]
+
+
+def test_plugin_manifest_has_brainlayer_identity():
+    manifest = _load_json(PLUGIN_MANIFEST_PATH)
+
+    assert manifest["name"] == "brainlayer"
+    assert "BrainLayer" in manifest["description"]
+    assert "version" in manifest
+
+
+def test_plugin_mcp_config_points_at_brainbar_socket():
+    mcp_config = _load_json(PLUGIN_MCP_PATH)
+
+    assert mcp_config == {
+        "mcpServers": {
+            "brainlayer": {
+                "command": "socat",
+                "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"],
+            }
+        }
+    }
+
+
+def test_hooks_register_phase2_lifecycle_events():
+    hooks_config = _load_json(HOOKS_PATH)["hooks"]
+
+    assert set(hooks_config) == {"SessionStart", "PostToolUse", "PostToolUseFailure", "Stop"}
+    assert hooks_config["SessionStart"][0]["hooks"][0]["type"] == "command"
+    assert hooks_config["PostToolUse"][0]["hooks"][0]["async"] is True
+    assert hooks_config["PostToolUseFailure"][0]["hooks"][0]["async"] is True
+
+
+@pytest.mark.parametrize(
+    ("script_name", "max_lines"),
+    [
+        ("session-start.sh", 25),
+        ("tool-observe.sh", 25),
+        ("tool-error.sh", 25),
+        ("session-stop.sh", 25),
+    ],
+)
+def test_shell_hooks_stay_thin(script_name: str, max_lines: int):
+    script_path = PLUGIN_ROOT / "hooks" / script_name
+    assert script_path.exists(), f"expected file to exist: {script_path}"
+    line_count = len(script_path.read_text().splitlines())
+    assert line_count <= max_lines
+
+
+def test_skill_teaches_search_store_and_recall_usage():
+    assert SKILL_PATH.exists(), f"expected file to exist: {SKILL_PATH}"
+
+    skill = SKILL_PATH.read_text()
+    assert "brain_search" in skill
+    assert "brain_store" in skill
+    assert "brain_recall" in skill
+    assert "before answering" in skill.lower()

--- a/tests/test_phase2_plugin_queue.py
+++ b/tests/test_phase2_plugin_queue.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import multiprocessing
 import threading
-import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -21,6 +21,11 @@ def _load_module(path: Path, name: str):
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def _process_writer(index: int, queue_path: str) -> None:
+    flusher = _load_module(QUEUE_FLUSHER_PATH, f"queue_flusher_process_{index}")
+    flusher.append_queue_event(Path(queue_path), {"hook_event": "PostToolUse", "index": index})
 
 
 def test_append_queue_event_writes_one_json_line(tmp_path):
@@ -49,6 +54,22 @@ def test_append_queue_event_is_safe_under_concurrent_writers(tmp_path):
         thread.start()
     for thread in threads:
         thread.join()
+
+    rows = [json.loads(line) for line in queue_path.read_text().splitlines()]
+    assert len(rows) == 100
+    assert {row["index"] for row in rows} == set(range(100))
+
+
+def test_append_queue_event_is_safe_under_concurrent_process_writers(tmp_path):
+    queue_path = tmp_path / ".memory-queue.jsonl"
+    ctx = multiprocessing.get_context("fork")
+    processes = [ctx.Process(target=_process_writer, args=(index, str(queue_path))) for index in range(100)]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join()
+        assert process.exitcode == 0
 
     rows = [json.loads(line) for line in queue_path.read_text().splitlines()]
     assert len(rows) == 100
@@ -93,20 +114,22 @@ def test_flush_queue_keeps_events_when_sender_fails(tmp_path):
 
 def test_handle_session_start_returns_additional_context_json():
     hook_helper = _load_module(HOOK_HELPER_PATH, "brainbar_hook")
+    observed_calls = []
 
-    started = time.perf_counter()
     output = hook_helper.handle_session_start(
         {"session_id": "sess-123", "cwd": "/tmp/project"},
-        invoke_tool=lambda tool, arguments: {
-            "tool": tool,
-            "arguments": arguments,
-            "summary": "Recent work: decay batch benchmark 2.47s",
-        },
+        invoke_tool=lambda tool, arguments: (
+            observed_calls.append((tool, arguments))
+            or {
+                "tool": tool,
+                "arguments": arguments,
+                "summary": "Recent work: decay batch benchmark 2.47s",
+            }
+        ),
     )
-    duration_ms = (time.perf_counter() - started) * 1000
 
-    assert duration_ms < 200
     assert output["additionalContext"].startswith("Recent work:")
+    assert observed_calls == [("brain_recall", {"mode": "context", "session_id": "sess-123"})]
 
 
 def test_handle_session_start_returns_empty_context_when_invoke_tool_fails():

--- a/tests/test_phase2_plugin_queue.py
+++ b/tests/test_phase2_plugin_queue.py
@@ -1,0 +1,164 @@
+"""Phase 2 plugin queue and hook helper tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = REPO_ROOT / "extensions" / "brainlayer-plugin"
+QUEUE_FLUSHER_PATH = PLUGIN_ROOT / "scripts" / "queue-flusher.py"
+HOOK_HELPER_PATH = PLUGIN_ROOT / "scripts" / "brainbar-hook.py"
+
+
+def _load_module(path: Path, name: str):
+    assert path.exists(), f"expected file to exist: {path}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_append_queue_event_writes_one_json_line(tmp_path):
+    flusher = _load_module(QUEUE_FLUSHER_PATH, "queue_flusher")
+    queue_path = tmp_path / ".memory-queue.jsonl"
+
+    flusher.append_queue_event(queue_path, {"hook_event": "PostToolUse", "tool_name": "Read"})
+
+    lines = queue_path.read_text().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["tool_name"] == "Read"
+
+
+def test_append_queue_event_is_safe_under_concurrent_writers(tmp_path):
+    flusher = _load_module(QUEUE_FLUSHER_PATH, "queue_flusher")
+    queue_path = tmp_path / ".memory-queue.jsonl"
+
+    threads = [
+        threading.Thread(
+            target=flusher.append_queue_event,
+            args=(queue_path, {"hook_event": "PostToolUse", "index": index}),
+        )
+        for index in range(100)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    rows = [json.loads(line) for line in queue_path.read_text().splitlines()]
+    assert len(rows) == 100
+    assert {row["index"] for row in rows} == set(range(100))
+
+
+def test_flush_queue_batches_and_clears_file_on_success(tmp_path):
+    flusher = _load_module(QUEUE_FLUSHER_PATH, "queue_flusher")
+    queue_path = tmp_path / ".memory-queue.jsonl"
+    sent_batches: list[list[dict]] = []
+
+    for index in range(3):
+        flusher.append_queue_event(queue_path, {"hook_event": "PostToolUse", "index": index})
+
+    flushed = flusher.flush_queue(queue_path, sent_batches.append, batch_size=2)
+
+    assert flushed == 3
+    assert sent_batches == [
+        [
+            {"hook_event": "PostToolUse", "index": 0},
+            {"hook_event": "PostToolUse", "index": 1},
+        ],
+        [{"hook_event": "PostToolUse", "index": 2}],
+    ]
+    assert queue_path.read_text() == ""
+
+
+def test_flush_queue_keeps_events_when_sender_fails(tmp_path):
+    flusher = _load_module(QUEUE_FLUSHER_PATH, "queue_flusher")
+    queue_path = tmp_path / ".memory-queue.jsonl"
+    flusher.append_queue_event(queue_path, {"hook_event": "PostToolUse", "index": 1})
+
+    def failing_sender(_batch):
+        raise RuntimeError("socket unavailable")
+
+    flushed = flusher.flush_queue(queue_path, failing_sender)
+
+    assert flushed == 0
+    rows = [json.loads(line) for line in queue_path.read_text().splitlines()]
+    assert rows == [{"hook_event": "PostToolUse", "index": 1}]
+
+
+def test_handle_session_start_returns_additional_context_json():
+    hook_helper = _load_module(HOOK_HELPER_PATH, "brainbar_hook")
+
+    started = time.perf_counter()
+    output = hook_helper.handle_session_start(
+        {"session_id": "sess-123", "cwd": "/tmp/project"},
+        invoke_tool=lambda tool, arguments: {
+            "tool": tool,
+            "arguments": arguments,
+            "summary": "Recent work: decay batch benchmark 2.47s",
+        },
+    )
+    duration_ms = (time.perf_counter() - started) * 1000
+
+    assert duration_ms < 200
+    assert output["additionalContext"].startswith("Recent work:")
+
+
+def test_build_queue_event_for_failure_marks_error_importance():
+    hook_helper = _load_module(HOOK_HELPER_PATH, "brainbar_hook")
+
+    event = hook_helper.build_queue_event(
+        "PostToolUseFailure",
+        {
+            "session_id": "sess-123",
+            "cwd": "/tmp/project",
+            "tool_name": "Bash",
+            "tool_input": {"command": "pytest"},
+            "tool_response": {"error": "exit 1"},
+        },
+    )
+
+    assert event["importance"] == 8
+    assert "error" in event["tags"]
+    assert event["tool_name"] == "Bash"
+
+
+def test_handle_stop_flushes_queue_and_triggers_brain_sleep(tmp_path):
+    hook_helper = _load_module(HOOK_HELPER_PATH, "brainbar_hook")
+    queue_path = tmp_path / ".memory-queue.jsonl"
+    queue_path.write_text('{"hook_event":"PostToolUse","tool_name":"Read"}\n')
+    observed_calls: list[tuple[str, dict]] = []
+
+    output = hook_helper.handle_stop(
+        {"session_id": "sess-123", "cwd": "/tmp/project"},
+        queue_path=queue_path,
+        flush_queue_fn=lambda path: 1,
+        invoke_tool=lambda tool, arguments: observed_calls.append((tool, arguments)) or {"ok": True},
+    )
+
+    assert observed_calls == [("brain_sleep", {"mode": "plugin-stop", "session_id": "sess-123", "cwd": "/tmp/project"})]
+    assert "queued 1 memory events" in output["systemMessage"].lower()
+
+
+def test_handle_stop_does_not_crash_when_brain_sleep_is_unavailable(tmp_path):
+    hook_helper = _load_module(HOOK_HELPER_PATH, "brainbar_hook")
+    queue_path = tmp_path / ".memory-queue.jsonl"
+    queue_path.write_text('{"hook_event":"PostToolUse","tool_name":"Read"}\n')
+
+    def missing_sleep(_tool, _arguments):
+        raise RuntimeError("Unknown tool: brain_sleep")
+
+    output = hook_helper.handle_stop(
+        {"session_id": "sess-123", "cwd": "/tmp/project"},
+        queue_path=queue_path,
+        flush_queue_fn=lambda path: 1,
+        invoke_tool=missing_sleep,
+    )
+
+    assert "queued 1 memory events" in output["systemMessage"].lower()
+    assert "brain_sleep unavailable" in output["systemMessage"].lower()

--- a/tests/test_phase2_plugin_queue.py
+++ b/tests/test_phase2_plugin_queue.py
@@ -109,6 +109,17 @@ def test_handle_session_start_returns_additional_context_json():
     assert output["additionalContext"].startswith("Recent work:")
 
 
+def test_handle_session_start_returns_empty_context_when_invoke_tool_fails():
+    hook_helper = _load_module(HOOK_HELPER_PATH, "brainbar_hook")
+
+    output = hook_helper.handle_session_start(
+        {"session_id": "sess-123", "cwd": "/tmp/project"},
+        invoke_tool=lambda tool, arguments: (_ for _ in ()).throw(RuntimeError("socket unavailable")),
+    )
+
+    assert output == {}
+
+
 def test_build_queue_event_for_failure_marks_error_importance():
     hook_helper = _load_module(HOOK_HELPER_PATH, "brainbar_hook")
 
@@ -162,3 +173,31 @@ def test_handle_stop_does_not_crash_when_brain_sleep_is_unavailable(tmp_path):
 
     assert "queued 1 memory events" in output["systemMessage"].lower()
     assert "brain_sleep unavailable" in output["systemMessage"].lower()
+
+
+def test_flush_queue_keeps_only_unsent_events_after_partial_failure(tmp_path):
+    flusher = _load_module(QUEUE_FLUSHER_PATH, "queue_flusher")
+    queue_path = tmp_path / ".memory-queue.jsonl"
+
+    for index in range(3):
+        flusher.append_queue_event(queue_path, {"hook_event": "PostToolUse", "index": index})
+
+    seen_batches: list[list[dict]] = []
+
+    def sender(batch):
+        seen_batches.append(batch)
+        if batch[-1]["index"] == 2:
+            raise RuntimeError("second batch failed")
+
+    flushed = flusher.flush_queue(queue_path, sender, batch_size=2)
+
+    assert flushed == 2
+    assert seen_batches == [
+        [
+            {"hook_event": "PostToolUse", "index": 0},
+            {"hook_event": "PostToolUse", "index": 1},
+        ],
+        [{"hook_event": "PostToolUse", "index": 2}],
+    ]
+    rows = [json.loads(line) for line in queue_path.read_text().splitlines()]
+    assert rows == [{"hook_event": "PostToolUse", "index": 2}]


### PR DESCRIPTION
## Summary
- add a Claude Code plugin under `extensions/brainlayer-plugin/` with plugin manifest, plugin-local `.mcp.json`, thin shell hooks, and a memory skill
- add a JSONL producer/consumer queue with `queue-flusher.py` and a thin `brainbar-hook.py` adapter that talks to BrainBar over the Unix socket
- add focused Phase 2 tests covering marketplace/plugin shape, async hook config, queue concurrency, stop fallback behavior, and skill guidance

## Verification
- `pytest tests/test_phase2_plugin_manifest.py tests/test_phase2_plugin_queue.py -v`
- `ruff check tests/test_phase2_plugin_manifest.py tests/test_phase2_plugin_queue.py extensions/brainlayer-plugin/scripts/brainbar-hook.py extensions/brainlayer-plugin/scripts/queue-flusher.py`
- `ruff format --check tests/test_phase2_plugin_manifest.py tests/test_phase2_plugin_queue.py extensions/brainlayer-plugin/scripts/brainbar-hook.py extensions/brainlayer-plugin/scripts/queue-flusher.py`
- `shellcheck extensions/brainlayer-plugin/hooks/*.sh`
- `claude plugin validate extensions/brainlayer-plugin`
- live Claude Code session with `--plugin-dir ./extensions/brainlayer-plugin --setting-sources local --include-hook-events` verified `SessionStart`, `PostToolUse`, `PostToolUseFailure`, and `Stop` hooks firing
- live stop-hook fallback verified: when BrainBar does not expose `brain_sleep`, the hook exits cleanly with `BrainLayer queued 2 memory events and brain_sleep unavailable.`

## Notes
- local dev install path is verified via `--plugin-dir`; marketplace catalog is included at repo root for `/plugin marketplace add EtanHey/brainlayer`
- CodeRabbit CLI pre-commit review surfaced only unrelated untracked-artifact findings outside the staged Phase 2 scope; no staged plugin files were implicated

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude Code BrainLayer plugin with lifecycle hooks and MCP memory integration
> - Adds a new Claude Code plugin at [extensions/brainlayer-plugin/](https://github.com/EtanHey/brainlayer/pull/228/files#diff-0674b9676f7106ef2158104e35efabbd891135ddd31a65746dd050db772de2fd) that connects to a local BrainBar MCP server over a UNIX socket (`/tmp/brainbar.sock`) via `socat`.
> - Registers four lifecycle hooks (SessionStart, PostToolUse, PostToolUseFailure, Stop) that invoke [brainbar-hook.py](https://github.com/EtanHey/brainlayer/pull/228/files#diff-f96efa78f17cea9d5fa997f5f213b82807d6de4f8db77e68cebb96a6fdc5e2c0) to recall context on session start, queue tool observations to a JSONL file, and flush memory to BrainBar on stop.
> - [queue-flusher.py](https://github.com/EtanHey/brainlayer/pull/228/files#diff-3f3df7dede1433716368e2744aac3bc6a6a8feed7a7e1b63e553d1d320f4b9d4) handles thread- and process-safe append and batched flush of queued events, preserving unsent events on partial failure.
> - Adds a [SKILL.md](https://github.com/EtanHey/brainlayer/pull/228/files#diff-53d3a7422f7692df597a4ef7189a0757ad74e3b783bc48daff41011d539a560b) guiding Claude to use `brain_search`, `brain_recall`, and `brain_store` tools during sessions.
> - Risk: the plugin requires the BrainBar daemon to be running and listening on `/tmp/brainbar.sock`; session-start context recall is silently skipped on connection failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cafecee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BrainLayer plugin for Claude Code: session recall at start, observation queuing during tool use, and shutdown flushing/sleep behavior.

* **Documentation**
  * Added memory skill guidance covering search, recall, and store patterns to preserve context.

* **Tests**
  * Added comprehensive tests for plugin manifest, lifecycle hooks, queueing, batching, concurrency, flushing behavior, and hook-based memory workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->