### PR TITLE
feat: add git-based continual learning mvp

### DIFF
--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -1090,6 +1090,52 @@ def git_overlay(
         store.close()
 
 
+def _run_brain_learn_git(repos_config: Path | None, since: str) -> None:
+    from ..git_learning import learn_git_history, load_repos_config
+    from ..vector_store import VectorStore
+
+    db_path = get_db_path()
+    store = VectorStore(db_path)
+    try:
+        repos = load_repos_config(repos_config)
+        result = learn_git_history(store=store, repos=repos, since=since)
+    finally:
+        store.close()
+
+    console.print(
+        f"[bold green]brain-learn[/] learned={result['learned']} "
+        f"skipped={result['skipped']} invalidations={result['invalidations']}"
+    )
+
+
+@app.command("brain-learn")
+def brain_learn(
+    git_mode: bool = typer.Option(False, "--git", help="Learn from git history"),
+    since: str = typer.Option("30d", "--since", help="Git history window, e.g. 30d"),
+    repos_config: Path = typer.Option(None, "--repos-config", help="Path to repos.json"),
+) -> None:
+    """Continuously learn patterns and migrations from git history."""
+    try:
+        if not git_mode:
+            raise typer.BadParameter("brain-learn currently requires --git")
+        _run_brain_learn_git(repos_config=repos_config, since=since)
+    except typer.BadParameter:
+        raise
+    except Exception as e:
+        rprint(f"[bold red]Error:[/] {e}")
+        raise typer.Exit(1)
+
+
+@app.command("brain_learn", hidden=True)
+def brain_learn_alias(
+    git_mode: bool = typer.Option(False, "--git", help="Learn from git history"),
+    since: str = typer.Option("30d", "--since", help="Git history window, e.g. 30d"),
+    repos_config: Path = typer.Option(None, "--repos-config", help="Path to repos.json"),
+) -> None:
+    """Alias for brain-learn to match existing plan notation."""
+    brain_learn(git_mode=git_mode, since=since, repos_config=repos_config)
+
+
 @app.command("group-operations")
 def group_operations(
     project: str = typer.Option(None, "--project", "-p", help="Only process specific project name"),

--- a/src/brainlayer/git_learning.py
+++ b/src/brainlayer/git_learning.py
@@ -1,0 +1,257 @@
+"""Git-based continual learning helpers for BrainLayer."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .vector_store import VectorStore
+
+CONVENTIONAL_RE = re.compile(
+    r"^(?P<kind>feat|fix|refactor)(?:\((?P<scope>[^)]+)\))?(?P<breaking>!)?:\s*(?P<summary>.+)$"
+)
+MIGRATION_PATTERNS = [
+    re.compile(r"migrate from (?P<old>.+?) to (?P<new>.+)", re.IGNORECASE),
+    re.compile(r"replace (?P<old>.+?) with (?P<new>.+)", re.IGNORECASE),
+    re.compile(r"switch from (?P<old>.+?) to (?P<new>.+)", re.IGNORECASE),
+]
+BREAKING_RE = re.compile(r"BREAKING CHANGE:", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ParsedCommit:
+    kind: str | None
+    scope: str | None
+    summary: str
+    breaking: bool
+    memory_type: str
+
+
+def get_repos_config_path() -> Path:
+    """Return the config path for tracked git repositories."""
+    env = os.environ.get("BRAINLAYER_REPOS")
+    if env:
+        return Path(env)
+    return Path.home() / ".brainlayer" / "repos.json"
+
+
+def ensure_repos_config(path: Path | None = None, default_repos: list[str] | None = None) -> Path:
+    """Ensure the repos config exists and is valid JSON."""
+    target = path or get_repos_config_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if not target.exists():
+        payload = {"repos": default_repos or []}
+        target.write_text(json.dumps(payload, indent=2) + "\n")
+    return target
+
+
+def load_repos_config(path: Path | None = None) -> list[Path]:
+    """Load tracked repos from the user-editable config."""
+    target = ensure_repos_config(path)
+    payload = json.loads(target.read_text() or "{}")
+    repos = payload.get("repos", [])
+    return [Path(repo).expanduser() for repo in repos]
+
+
+def parse_commit_message(message: str) -> ParsedCommit:
+    """Classify a commit message using a conventional-commit-first heuristic."""
+    message = message.strip()
+    first_line = message.splitlines()[0] if message else ""
+    conventional = CONVENTIONAL_RE.match(first_line)
+    breaking = bool(BREAKING_RE.search(message)) or (bool(conventional) and bool(conventional.group("breaking")))
+    if _extract_migration(message):
+        return ParsedCommit(
+            kind=conventional.group("kind") if conventional else None,
+            scope=conventional.group("scope") if conventional else None,
+            summary=conventional.group("summary") if conventional else first_line,
+            breaking=breaking,
+            memory_type="migration",
+        )
+    if conventional:
+        kind = conventional.group("kind")
+        memory_type = {"feat": "pattern", "fix": "error", "refactor": "decision"}[kind]
+        return ParsedCommit(
+            kind=kind,
+            scope=conventional.group("scope"),
+            summary=conventional.group("summary"),
+            breaking=breaking,
+            memory_type=memory_type,
+        )
+    return ParsedCommit(kind=None, scope=None, summary=first_line, breaking=breaking, memory_type="decision")
+
+
+def compute_cross_repo_importance(base_importance: float, repo_count: int) -> float:
+    """Boost importance when the same pattern shows up across many repos."""
+    if repo_count < 3:
+        return base_importance
+    return base_importance + 2.0
+
+
+def apply_migration_invalidation(
+    store: VectorStore,
+    repo: str,
+    commit_hash: str,
+    commit_message: str,
+    committed_at: float,
+) -> int:
+    """Weaken old git-memory pattern references when a migration commit is detected."""
+    migration = _extract_migration(commit_message)
+    if migration is None:
+        return 0
+
+    old_pattern, new_pattern = migration
+    invalidation_id = f"migration-{commit_hash}"
+    cursor = store.conn.cursor()
+    rowcount = (
+        cursor.execute(
+            """
+        UPDATE git_memories
+        SET strength = ROUND(strength * 0.3, 6),
+            invalidated_by = ?
+        WHERE invalidated_by IS NULL
+          AND (
+                lower(content) LIKE lower(?)
+             OR lower(commit_message) LIKE lower(?)
+             OR lower(COALESCE(tags, '')) LIKE lower(?)
+          )
+        """,
+            (invalidation_id, f"%{old_pattern}%", f"%{old_pattern}%", f"%{old_pattern}%"),
+        )
+        .getconnection()
+        .changes()
+    )
+    cursor.execute(
+        """
+        INSERT OR REPLACE INTO migration_events(
+            id, from_pattern, to_pattern, commit_hash, repo, detected_at, confidence, memories_weakened
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (invalidation_id, old_pattern, new_pattern, commit_hash, repo, committed_at, 0.9, rowcount),
+    )
+    return rowcount
+
+
+def learn_git_history(store: VectorStore, repos: list[Path], since: str = "30d") -> dict[str, Any]:
+    """Ingest recent conventional commits from tracked repositories."""
+    learned = 0
+    skipped = 0
+    invalidations = 0
+    for repo in repos:
+        for commit in _iter_commits(repo, since):
+            cursor = store.conn.cursor()
+            existing = cursor.execute(
+                "SELECT 1 FROM git_memories WHERE repo = ? AND commit_hash = ? LIMIT 1",
+                (repo.name, commit["commit_hash"]),
+            ).fetchone()
+            if existing:
+                skipped += 1
+                continue
+
+            parsed = parse_commit_message(commit["message"])
+            importance = 7.0 if parsed.memory_type == "migration" else 5.0
+            cursor.execute(
+                """
+                INSERT INTO git_memories(
+                    id, content, memory_type, commit_hash, repo, author, committed_at,
+                    affected_files, strength, half_life_days, confidence, retrieval_count,
+                    invalidated_by, commit_message, tags, importance
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"git-{uuid.uuid4().hex[:16]}",
+                    parsed.summary,
+                    parsed.memory_type,
+                    commit["commit_hash"],
+                    repo.name,
+                    commit["author"],
+                    commit["committed_at"],
+                    json.dumps(commit["files"]),
+                    1.0,
+                    90.0 if parsed.memory_type == "migration" else 30.0,
+                    0.7,
+                    0,
+                    None,
+                    commit["message"],
+                    json.dumps(_build_tags(parsed, repo.name)),
+                    compute_cross_repo_importance(importance, 1),
+                ),
+            )
+            learned += 1
+            invalidations += apply_migration_invalidation(
+                store=store,
+                repo=repo.name,
+                commit_hash=commit["commit_hash"],
+                commit_message=commit["message"],
+                committed_at=commit["committed_at"],
+            )
+    return {"learned": learned, "skipped": skipped, "invalidations": invalidations}
+
+
+def _build_tags(parsed: ParsedCommit, repo_name: str) -> list[str]:
+    tags = ["git", repo_name]
+    if parsed.kind:
+        tags.append(parsed.kind)
+    if parsed.breaking:
+        tags.append("breaking")
+    if parsed.memory_type == "migration":
+        tags.append("migration")
+    return tags
+
+
+def _extract_migration(message: str) -> tuple[str, str] | None:
+    for pattern in MIGRATION_PATTERNS:
+        match = pattern.search(message)
+        if match:
+            return match.group("old").strip(), match.group("new").strip()
+    return None
+
+
+def _iter_commits(repo: Path, since: str) -> list[dict[str, Any]]:
+    commits: list[dict[str, Any]] = []
+    hashes = subprocess.run(
+        ["git", "log", "--no-merges", f"--since={_git_since_arg(since)}", "--format=%H"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for commit_hash in [line.strip() for line in hashes.stdout.splitlines() if line.strip()]:
+        metadata = subprocess.run(
+            ["git", "show", "-s", "--format=%an%x1f%at%x1f%s%x1f%b", commit_hash],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        author, committed_at, subject, body = metadata.stdout.split("\x1f", maxsplit=3)
+        file_listing = subprocess.run(
+            ["git", "show", "--pretty=format:", "--name-only", commit_hash],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        files = [line.strip() for line in file_listing.stdout.splitlines() if line.strip()]
+        commits.append(
+            {
+                "commit_hash": commit_hash,
+                "author": author,
+                "committed_at": float(committed_at),
+                "message": subject if not body.strip() else f"{subject}\n\n{body.strip()}",
+                "files": files,
+            }
+        )
+    return commits
+
+
+def _git_since_arg(since: str) -> str:
+    match = re.fullmatch(r"(\d+)d", since)
+    if match:
+        return f"{match.group(1)} days ago"
+    return since

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -505,6 +505,87 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_phase_commits_project ON phase_commits(project)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_phase_commits_phase ON phase_commits(phase_name)")
 
+        # Git learning tables
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS git_memories (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                memory_type TEXT NOT NULL,
+                commit_hash TEXT NOT NULL,
+                repo TEXT NOT NULL,
+                author TEXT,
+                committed_at REAL NOT NULL,
+                affected_files TEXT,
+                strength REAL DEFAULT 1.0,
+                half_life_days REAL DEFAULT 30.0,
+                confidence REAL DEFAULT 0.7,
+                retrieval_count INTEGER DEFAULT 0,
+                invalidated_by TEXT,
+                commit_message TEXT,
+                tags TEXT,
+                importance REAL DEFAULT 5.0,
+                UNIQUE(repo, commit_hash)
+            )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_git_memories_repo ON git_memories(repo)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_git_memories_type ON git_memories(memory_type)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_git_memories_commit_time ON git_memories(committed_at)")
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS migration_events (
+                id TEXT PRIMARY KEY,
+                from_pattern TEXT NOT NULL,
+                to_pattern TEXT NOT NULL,
+                commit_hash TEXT NOT NULL,
+                repo TEXT NOT NULL,
+                detected_at REAL NOT NULL,
+                confidence REAL,
+                memories_weakened INTEGER DEFAULT 0
+            )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_migration_events_repo ON migration_events(repo)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_migration_events_commit_hash ON migration_events(commit_hash)")
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS file_cochanges (
+                file_a TEXT NOT NULL,
+                file_b TEXT NOT NULL,
+                repo TEXT NOT NULL,
+                cochange_count INTEGER DEFAULT 1,
+                last_cochange REAL,
+                PRIMARY KEY (file_a, file_b, repo)
+            )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_cochanges_repo ON file_cochanges(repo)")
+
+        cursor.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS git_memories_fts USING fts5(
+                content, commit_message, tags, git_memory_id UNINDEXED
+            )
+        """)
+        cursor.execute("DROP TRIGGER IF EXISTS git_memories_fts_insert")
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS git_memories_fts_insert AFTER INSERT ON git_memories BEGIN
+                INSERT INTO git_memories_fts(content, commit_message, tags, git_memory_id)
+                VALUES (new.content, new.commit_message, new.tags, new.id);
+            END
+        """)
+        cursor.execute("DROP TRIGGER IF EXISTS git_memories_fts_delete")
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS git_memories_fts_delete AFTER DELETE ON git_memories BEGIN
+                DELETE FROM git_memories_fts WHERE git_memory_id = old.id;
+            END
+        """)
+        cursor.execute("DROP TRIGGER IF EXISTS git_memories_fts_update")
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS git_memories_fts_update
+            AFTER UPDATE OF content, commit_message, tags ON git_memories BEGIN
+                DELETE FROM git_memories_fts WHERE git_memory_id = old.id;
+                INSERT INTO git_memories_fts(content, commit_message, tags, git_memory_id)
+                VALUES (new.content, new.commit_message, new.tags, new.id);
+            END
+        """)
+
         # source_project_id column
         if "source_project_id" not in existing_cols:
             cursor.execute("ALTER TABLE chunks ADD COLUMN source_project_id TEXT")

--- a/tests/test_git_learning.py
+++ b/tests/test_git_learning.py
@@ -1,0 +1,209 @@
+"""Tests for Phase 3 git-based continual learning MVP."""
+
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from brainlayer.cli import app
+from brainlayer.vector_store import VectorStore
+
+runner = CliRunner()
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+
+
+def _commit_file(repo: Path, rel_path: str, content: str, message: str) -> str:
+    path = repo / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    _git(repo, "add", rel_path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def test_git_learning_schema_tables_exist(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+
+    cursor = store.conn.cursor()
+    tables = {row[0] for row in cursor.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")}
+
+    assert "git_memories" in tables
+    assert "migration_events" in tables
+    assert "file_cochanges" in tables
+
+    fts_tables = {row[0] for row in cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    assert "git_memories_fts" in fts_tables
+
+
+def test_parse_commit_message_detects_conventional_and_breaking():
+    from brainlayer.git_learning import parse_commit_message
+
+    parsed = parse_commit_message(
+        "feat(parser)!: switch from REST API to GraphQL\n\nBREAKING CHANGE: remove old client"
+    )
+
+    assert parsed.kind == "feat"
+    assert parsed.scope == "parser"
+    assert parsed.breaking is True
+    assert parsed.memory_type == "migration"
+
+
+def test_brain_learn_git_seeds_single_repo_without_duplicates(tmp_path, monkeypatch):
+    from brainlayer.git_learning import ensure_repos_config
+
+    repo = tmp_path / "repo-one"
+    _init_repo(repo)
+    _commit_file(repo, "src/app.py", "print('one')\n", "feat: add app bootstrap")
+    _commit_file(repo, "src/app.py", "print('two')\n", "fix: handle startup failure")
+
+    db_path = tmp_path / "brainlayer.db"
+    config_path = tmp_path / "repos.json"
+    ensure_repos_config(config_path, default_repos=[str(repo)])
+
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+
+    first = runner.invoke(app, ["brain-learn", "--git", "--repos-config", str(config_path), "--since", "30d"])
+    assert first.exit_code == 0, first.stdout
+
+    second = runner.invoke(app, ["brain-learn", "--git", "--repos-config", str(config_path), "--since", "30d"])
+    assert second.exit_code == 0, second.stdout
+
+    store = VectorStore(db_path)
+    cursor = store.conn.cursor()
+    count = cursor.execute("SELECT COUNT(*) FROM git_memories").fetchone()[0]
+    repos = {row[0] for row in cursor.execute("SELECT DISTINCT repo FROM git_memories")}
+
+    assert count == 2
+    assert repos == {repo.name}
+
+
+def test_migration_commit_weakens_old_pattern_refs_and_logs_event(tmp_path):
+    from brainlayer.git_learning import apply_migration_invalidation
+
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO git_memories(
+            id, content, memory_type, commit_hash, repo, author, committed_at,
+            affected_files, strength, half_life_days, confidence, retrieval_count, invalidated_by,
+            commit_message, tags, importance
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "gm-old",
+            "Use REST API client adapters for new integrations",
+            "pattern",
+            "abc123",
+            "repo-one",
+            "Tester",
+            1_700_000_000.0,
+            json.dumps(["src/api.py"]),
+            1.0,
+            30.0,
+            0.8,
+            0,
+            None,
+            "feat: add REST API client",
+            json.dumps(["api", "rest"]),
+            5.0,
+        ),
+    )
+
+    weakened = apply_migration_invalidation(
+        store=store,
+        repo="repo-one",
+        commit_hash="def456",
+        commit_message="refactor: migrate from REST API to GraphQL",
+        committed_at=1_700_000_100.0,
+    )
+
+    row = cursor.execute(
+        "SELECT strength, invalidated_by FROM git_memories WHERE id = ?",
+        ("gm-old",),
+    ).fetchone()
+    event = cursor.execute(
+        "SELECT from_pattern, to_pattern, memories_weakened FROM migration_events WHERE commit_hash = ?",
+        ("def456",),
+    ).fetchone()
+
+    assert weakened == 1
+    assert row == (0.3, "migration-def456")
+    assert event == ("REST API", "GraphQL", 1)
+
+
+def test_cross_repo_consolidation_boosts_importance():
+    from brainlayer.git_learning import compute_cross_repo_importance
+
+    assert compute_cross_repo_importance(base_importance=5.0, repo_count=2) == 5.0
+    assert compute_cross_repo_importance(base_importance=5.0, repo_count=3) == 7.0
+
+
+def test_repos_config_is_user_editable(tmp_path):
+    from brainlayer.git_learning import ensure_repos_config, load_repos_config
+
+    config_path = tmp_path / "repos.json"
+    ensure_repos_config(config_path, default_repos=["/tmp/repo-a"])
+
+    config_path.write_text(json.dumps({"repos": ["/tmp/repo-b", "/tmp/repo-c"]}, indent=2) + "\n")
+
+    assert load_repos_config(config_path) == [Path("/tmp/repo-b"), Path("/tmp/repo-c")]
+
+
+def test_git_memories_fts_tracks_inserted_rows(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO git_memories(
+            id, content, memory_type, commit_hash, repo, author, committed_at,
+            affected_files, strength, half_life_days, confidence, retrieval_count,
+            invalidated_by, commit_message, tags, importance
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "gm-fts",
+            "Adopt GraphQL for external APIs",
+            "migration",
+            "ghi789",
+            "repo-two",
+            "Tester",
+            1_700_000_200.0,
+            json.dumps(["src/graphql.py"]),
+            1.0,
+            90.0,
+            0.9,
+            0,
+            None,
+            "refactor: migrate from REST API to GraphQL",
+            json.dumps(["graphql", "migration"]),
+            7.0,
+        ),
+    )
+
+    row = cursor.execute(
+        "SELECT git_memory_id FROM git_memories_fts WHERE git_memories_fts MATCH ?",
+        ("GraphQL",),
+    ).fetchone()
+    assert row == ("gm-fts",)


### PR DESCRIPTION
## Summary
- add a Phase 3 MVP `brain-learn --git` CLI path backed by a new `git_learning` module
- create `git_memories`, `migration_events`, `file_cochanges`, and `git_memories_fts` with sync triggers in `VectorStore`
- parse conventional commits, seed one or more repos from `repos.json`, dedupe on `(repo, commit_hash)`, and weaken old git-memory patterns on migration commits
- add focused tests for schema creation, FTS sync, repos config editing, single-repo ingestion, migration invalidation, and cross-repo importance boost logic

## Test plan
- `pytest tests/test_git_learning.py tests/test_cli_enrich.py tests/test_decay.py -v`
- `ruff check src/brainlayer/cli/__init__.py src/brainlayer/vector_store.py src/brainlayer/git_learning.py tests/test_git_learning.py tests/test_cli_enrich.py tests/test_decay.py`
- `ruff format --check src/brainlayer/cli/__init__.py src/brainlayer/vector_store.py src/brainlayer/git_learning.py tests/test_git_learning.py tests/test_cli_enrich.py tests/test_decay.py`

## Scope note
- This PR intentionally ships the Phase 3 MVP for tonight: single-repo/explicit repos config learning, schema bootstrap, migration invalidation, and consolidation math.
- Follow-ups for `--all`, daily LaunchAgent wiring, and search-surface unioning of `git_memories` are left for later if needed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git-based continual learning MVP to ingest commit history into vector store
> - Adds [git_learning.py](https://github.com/EtanHey/brainlayer/pull/229/files#diff-af09c67f0c05c956038eea5b53a31218b844a6f963343c970aabf26ce7594809) which scans configured repos for recent commits, classifies them (feat/fix/refactor → pattern/error/decision memory types), and inserts rows into a new `git_memories` table, skipping already-seen commit hashes.
> - Migration commits trigger weakening of older pattern memories referencing the previous technology and log a `migration_events` row.
> - Importance scores are boosted when the same pattern appears across 3+ repos via `compute_cross_repo_importance`.
> - Extends [vector_store.py](https://github.com/EtanHey/brainlayer/pull/229/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) schema with `git_memories`, `migration_events`, `file_cochanges`, and an FTS5 virtual table with sync triggers.
> - Exposes a `brain-learn --git` CLI subcommand in [cli/__init__.py](https://github.com/EtanHey/brainlayer/pull/229/files#diff-e66ce4ea8b0cf3331154cb15181cb09a7c593566e36380fd9215ff29d24ffd02) that reads a `repos.json` config and prints learned/skipped/invalidation counts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f02c9ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `brain-learn --git` CLI command to ingest Git commit history into the database
  * Configured repository tracking via JSON configuration files
  * Automatic detection of breaking changes and migrations in commits
  * Git memories stored with commit hashing, strength scoring, and decay tracking
  * Full-text search indexing for Git-sourced memories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->