### PR TITLE
fix: allow re-enrichment after summary reset

### DIFF
--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -204,7 +204,7 @@ def _is_duplicate_content(store, content: str) -> bool:
     try:
         cursor = store._read_cursor()
         row = cursor.execute(
-            "SELECT COUNT(*) FROM chunks WHERE content_hash = ? AND enriched_at IS NOT NULL",
+            "SELECT COUNT(*) FROM chunks WHERE content_hash = ? AND enriched_at IS NOT NULL AND summary IS NOT NULL",
             (content_h,),
         ).fetchone()
         return row[0] > 0 if row else False

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -314,6 +314,20 @@ def test_is_duplicate_returns_true_when_hash_exists_enriched():
     assert _is_duplicate_content(store, "content") is True
 
 
+def test_is_duplicate_returns_false_when_summary_cleared():
+    from brainlayer.enrichment_controller import _is_duplicate_content
+
+    store = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.return_value.fetchone.return_value = (0,)
+    store._read_cursor.return_value = cursor
+
+    assert _is_duplicate_content(store, "content") is False
+    query, params = cursor.execute.call_args[0]
+    assert "summary IS NOT NULL" in query
+    assert params == (_is_duplicate_content.__globals__["_content_hash"]("content"),)
+
+
 def test_is_duplicate_returns_false_when_hash_not_found():
     from brainlayer.enrichment_controller import _is_duplicate_content
 


### PR DESCRIPTION
## Summary
- tighten content-hash dedup to only skip chunks that still have both `enriched_at` and a non-null `summary`
- add a regression test covering the `summary IS NULL` case that caused cleared chunks to be treated as already enriched
- repair the live database by clearing `enriched_at` for chunks with `summary IS NULL`

## Verification
- `sqlite3 ~/.local/share/brainlayer/brainlayer.db "SELECT COUNT(*) FROM chunks WHERE summary IS NULL AND enriched_at IS NOT NULL;"` -> `0` after repair
- `pytest tests/test_enrichment_controller.py -q` -> `64 passed`
- live candidate check via repo code returned `dedup=False` for a chunk with `summary IS NULL AND enriched_at IS NULL`

## Runtime Status
- launch agent reloaded after the DB repair
- the new enrichment process is running and sampling shows active Gemini reads / parsing work
- it has not yet emitted a final `EnrichmentResult(...)` line, so log-based end-to-end verification is still pending


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_is_duplicate_content` to allow re-enrichment after summary reset
> Previously, `_is_duplicate_content` in [enrichment_controller.py](https://github.com/EtanHey/brainlayer/pull/231/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb) returned `True` for any chunk with a matching `content_hash` and `enriched_at` set, even if `summary` was NULL. This prevented re-enrichment after a summary was cleared. The SQL WHERE clause now requires both `enriched_at IS NOT NULL` and `summary IS NOT NULL` for a chunk to be considered a duplicate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d283055.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced deduplication checks to require complete enrichment metadata presence, ensuring content with missing details is correctly re-processed rather than skipped.

## Tests
* Added unit test validating deduplication behavior when enrichment data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->