### PR TITLE
feat: R83 meta-research filter + entity staging column

### DIFF
--- a/migrations/003_raw_entities_json.sql
+++ b/migrations/003_raw_entities_json.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chunks ADD COLUMN raw_entities_json TEXT;

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import json
 import logging
 import os
 import random
+import re
 import time
-import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -47,6 +48,17 @@ RATE_LIMITS = {
     "batch": float(os.environ.get("BRAINLAYER_BATCH_RATE", "0")),  # no limit (async)
 }
 ENRICH_CONCURRENCY = int(os.environ.get("BRAINLAYER_ENRICH_CONCURRENCY", "10"))
+
+_META_RESEARCH_PATTERNS = [
+    re.compile(r"brain_search\s*\(", re.IGNORECASE),
+    re.compile(r"brain_search query=", re.IGNORECASE),
+    re.compile(r"search results? for ['\"]", re.IGNORECASE),
+    re.compile(r"Query \d+ for ['\"].*['\"] (degraded|scored|returned)", re.IGNORECASE),
+    re.compile(r"(eval|baseline|pilot) score:?\s*\d+(?:[./]\d+)*/5", re.IGNORECASE),
+    re.compile(r"Grade:?\s*\d/5", re.IGNORECASE),
+    re.compile(r"\[BrainLayer (auto|deep)\] Memories matching", re.IGNORECASE),
+    re.compile(r"['\"]?additionalContext['\"]?\s*:", re.IGNORECASE),
+]
 
 
 @dataclass
@@ -194,6 +206,12 @@ def _content_hash(content: str) -> str:
     return hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
 
 
+def is_meta_research(content: str) -> bool:
+    if not content:
+        return False
+    return any(pattern.search(content) for pattern in _META_RESEARCH_PATTERNS)
+
+
 def _is_duplicate_content(store, content: str) -> bool:
     """Check if content with the same hash already exists and is enriched.
 
@@ -225,6 +243,50 @@ def _ensure_content_hash_column(store) -> bool:
             return True
         except Exception:
             return False
+
+
+def _ensure_raw_entities_json_column(store) -> bool:
+    """Ensure the raw_entities_json staging column exists on chunks."""
+    try:
+        store.conn.cursor().execute("SELECT raw_entities_json FROM chunks LIMIT 0")
+        return True
+    except Exception:
+        try:
+            store.conn.cursor().execute("ALTER TABLE chunks ADD COLUMN raw_entities_json TEXT")
+            return True
+        except Exception:
+            return False
+
+
+def _normalize_chunk_tags(tags: Any) -> list[str]:
+    if isinstance(tags, str):
+        try:
+            decoded = json.loads(tags)
+        except json.JSONDecodeError:
+            decoded = [tags]
+        else:
+            tags = decoded
+    if isinstance(tags, list):
+        return [str(tag) for tag in tags if str(tag).strip()]
+    return []
+
+
+def _mark_meta_research(store, chunk: dict[str, Any]) -> None:
+    cursor = store.conn.cursor()
+    now = datetime.now(timezone.utc).isoformat()
+    tags = _normalize_chunk_tags(chunk.get("tags"))
+    if "meta-research" not in tags:
+        tags.append("meta-research")
+    cursor.execute(
+        "UPDATE chunks SET tags = ?, summary = NULL, enriched_at = ? WHERE id = ?",
+        (json.dumps(tags), now, chunk["id"]),
+    )
+    content = chunk.get("content", "")
+    if content:
+        try:
+            cursor.execute("UPDATE chunks SET content_hash = ? WHERE id = ?", (_content_hash(content), chunk["id"]))
+        except Exception:
+            pass
 
 
 def _backfill_content_hashes(store, limit: int = 1000) -> int:
@@ -292,30 +354,13 @@ def _apply_enrichment(store, chunk: dict[str, Any], enrichment: dict[str, Any]) 
         resolved_queries=resolved_queries,
     )
     entities = enrichment.get("entities", [])
-    if entities:
-        cursor = store.conn.cursor()
-        now = datetime.now(timezone.utc).isoformat()
-        for ent in entities:
-            name = ent.get("name", "").strip()
-            etype = ent.get("type", "").strip()
-            if not name or not etype:
-                continue
-            entity_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{etype}:{name.lower()}"))
-            try:
-                cursor.execute(
-                    """INSERT INTO kg_entities (id, entity_type, name, created_at, updated_at)
-                       VALUES (?, ?, ?, ?, ?)
-                       ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at""",
-                    (entity_id, etype, name, now, now),
-                )
-                cursor.execute(
-                    """INSERT INTO kg_entity_chunks (entity_id, chunk_id, context)
-                       VALUES (?, ?, ?)
-                       ON CONFLICT(entity_id, chunk_id) DO NOTHING""",
-                    (entity_id, chunk["id"], ent.get("relation")),
-                )
-            except Exception as exc:
-                logger.debug("Entity persistence failed for %s: %s", name, exc)
+    # AIDEV-NOTE: raw entities persisted to chunks.raw_entities_json staging column;
+    # R84b canonicalization pipeline will consume and populate kg_entities downstream.
+    if _ensure_raw_entities_json_column(store):
+        store.conn.cursor().execute(
+            "UPDATE chunks SET raw_entities_json = ? WHERE id = ?",
+            (json.dumps(entities), chunk["id"]),
+        )
     # Set content_hash after enrichment so dedup works next time
     content = chunk.get("content", "")
     if content:
@@ -340,9 +385,12 @@ def _enrich_single_chunk(
 
     Returns `(chunk, status, data)` where status is one of:
       - `"skip"`: content hash already enriched
+      - `"meta"`: chunk tagged as meta-research without a Gemini call
       - `"error"`: data is an error string
       - `"ok"`: data is the parsed enrichment dict
     """
+    if is_meta_research(chunk.get("content", "")):
+        return (chunk, "meta", None)
     if is_duplicate(chunk.get("content", "")):
         return (chunk, "skip", None)
 
@@ -387,6 +435,11 @@ def enrich_single(store, chunk_id: str, max_retries: int = 2) -> dict[str, Any] 
     chunk = store.get_chunk(chunk_id)
     if not chunk:
         logger.warning("enrich_single: chunk not found: %s", chunk_id)
+        return None
+
+    if is_meta_research(chunk.get("content", "")):
+        _mark_meta_research(store, chunk)
+        logger.info("enrich_single: tagged %s as meta-research without Gemini", chunk_id)
         return None
 
     try:
@@ -531,6 +584,7 @@ def enrich_realtime(
 
     # Ensure content_hash column exists for dedup
     _ensure_content_hash_column(store)
+    _ensure_raw_entities_json_column(store)
 
     client = _get_gemini_client()
     sanitizer = Sanitizer.from_env()
@@ -561,6 +615,10 @@ def enrich_realtime(
         for future in as_completed(futures):
             chunk, status, data = future.result()
             if status == "skip":
+                result.skipped += 1
+                continue
+            if status == "meta":
+                _mark_meta_research(store, chunk)
                 result.skipped += 1
                 continue
             if status == "error":
@@ -601,6 +659,7 @@ def enrich_batch(
         return result
 
     _ensure_content_hash_column(store)
+    _ensure_raw_entities_json_column(store)
 
     try:
         client = _get_gemini_client()
@@ -615,6 +674,10 @@ def enrich_batch(
     rate_limit = RATE_LIMITS.get("realtime", 0.2)
 
     for chunk in candidates:
+        if is_meta_research(chunk.get("content", "")):
+            _mark_meta_research(store, chunk)
+            result.skipped += 1
+            continue
         if _is_duplicate_content(store, chunk.get("content", "")):
             result.skipped += 1
             continue

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -7,6 +7,8 @@ LaunchAgent plist, and CLI integration.
 Target: 35+ tests per A-R2 acceptance criteria.
 """
 
+import json
+import sqlite3
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -607,6 +609,39 @@ def test_local_counts_failed_on_invalid_parse(monkeypatch):
     assert result.enriched == 0
 
 
+# ── Meta-research filter tests ───────────────────────────────────────────────
+
+
+def test_meta_research_filter_detects_common_patterns():
+    from brainlayer.enrichment_controller import is_meta_research
+
+    samples = [
+        "brain_search(query='crypto trading bot')",
+        'brain_search query="crypto trading bot"',
+        "Search results for 'crypto trading bot Ofir strategy'",
+        "Query 3 for 'crypto trading bot Ofir strategy' degraded from 2.4/5 to 2.2/5",
+        "Eval score: 2.6/5 after ingestion",
+        "Grade: 3/5",
+        "[BrainLayer auto] Memories matching: 5",
+        '{"hookEventName":"search","additionalContext":"tool payload"}',
+    ]
+
+    assert all(is_meta_research(sample) for sample in samples)
+
+
+def test_meta_research_filter_preserves_real_content():
+    from brainlayer.enrichment_controller import is_meta_research
+
+    samples = [
+        "We decided to keep the enrichment controller in a single file until the batch path is stabilized.",
+        "def build_index(query: str) -> list[str]:\n    return [query.strip()]",
+        "Ofir said the strategy should defer position sizing until volatility normalizes.",
+        "Conversation note: Etan wants the daemon restart deferred until after the migration lands.",
+    ]
+
+    assert all(not is_meta_research(sample) for sample in samples)
+
+
 # ── Apply enrichment tests ───────────────────────────────────────────────────
 
 
@@ -668,9 +703,29 @@ def test_apply_enrichment_sets_content_hash():
     _apply_enrichment(store, chunk, {"summary": "s"})
 
     expected_hash = _content_hash("test content")
-    cursor.execute.assert_called_once()
-    args = cursor.execute.call_args[0]
+    args = cursor.execute.call_args_list[-1][0]
     assert args[1] == (expected_hash, "c1")
+
+
+def test_apply_enrichment_persists_raw_entities():
+    from brainlayer.enrichment_controller import _apply_enrichment
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, raw_entities_json TEXT, content_hash TEXT)")
+    conn.execute("INSERT INTO chunks (id, raw_entities_json, content_hash) VALUES (?, NULL, NULL)", ("c1",))
+
+    store = MagicMock()
+    store.conn = conn
+    chunk = _candidate("c1", "test content")
+    entities = [
+        {"name": "Ofir", "type": "person", "relation": "described the strategy"},
+        {"name": "BrainLayer", "type": "project", "relation": "stores the chunk"},
+    ]
+
+    _apply_enrichment(store, chunk, {"summary": "s", "entities": entities})
+
+    row = conn.execute("SELECT raw_entities_json FROM chunks WHERE id = ?", ("c1",)).fetchone()
+    assert row == (json.dumps(entities),)
 
 
 # ── Telemetry tests ──────────────────────────────────────────────────────────

--- a/tests/test_enrichment_v2.py
+++ b/tests/test_enrichment_v2.py
@@ -215,6 +215,8 @@ def test_update_enrichment_persists_v2_json_fields_and_fts(tmp_path):
 
 
 def test_apply_enrichment_persists_entities_and_relation_context(tmp_path):
+    import json
+
     from brainlayer.enrichment_controller import _apply_enrichment
 
     store = VectorStore(tmp_path / "test.db")
@@ -240,24 +242,19 @@ def test_apply_enrichment_persists_entities_and_relation_context(tmp_path):
             },
         )
 
-        entity_rows = store.conn.cursor().execute("SELECT entity_type, name FROM kg_entities ORDER BY name").fetchall()
-        assert entity_rows == [("project", "BrainLayer"), ("technology", "SQLite")]
-
-        link_rows = store.conn.cursor().execute("SELECT context FROM kg_entity_chunks ORDER BY context").fetchall()
-        assert [row[0] for row in link_rows] == [
-            "storage engine for BrainLayer",
-            "uses SQLite for local-first storage",
-        ]
-
         chunk_row = (
             store.conn.cursor()
             .execute(
-                "SELECT key_facts, resolved_queries FROM chunks WHERE id = ?",
+                "SELECT key_facts, resolved_queries, raw_entities_json FROM chunks WHERE id = ?",
                 ("chunk-v2-entities",),
             )
             .fetchone()
         )
         assert json.loads(chunk_row[0]) == ["SQLite", "local-first"]
         assert len(json.loads(chunk_row[1])) == 3
+        assert json.loads(chunk_row[2]) == [
+            {"name": "BrainLayer", "type": "project", "relation": "uses SQLite for local-first storage"},
+            {"name": "SQLite", "type": "technology", "relation": "storage engine for BrainLayer"},
+        ]
     finally:
         store.close()


### PR DESCRIPTION
## Summary
- add `is_meta_research()` heuristics in `src/brainlayer/enrichment_controller.py` and skip Gemini for matched chunks while tagging them `meta-research`
- add `migrations/003_raw_entities_json.sql` and persist the raw Gemini `entities` array into `chunks.raw_entities_json`
- update controller tests with the three requested cases and align the existing staging expectation in `tests/test_enrichment_v2.py`

## Verification
- `pytest tests/test_enrichment_controller.py -q` -> 67 passed, 2 warnings
- `pytest tests/test_enrichment_controller.py::test_apply_enrichment_persists_raw_entities tests/test_enrichment_v2.py::test_apply_enrichment_persists_entities_and_relation_context -q` -> 2 passed, 2 warnings
- `pytest tests/ -q` remains red on branch because main already has unrelated failures in eval/vector-store coverage; I verified the following on clean `origin/main`: `tests/test_eval_baselines.py::TestMemoryRetrieval::test_whoop_discussion_findable`, `tests/test_eval_baselines.py::TestTemporalQueries::test_recent_week_chunks_exist`, `tests/test_eval_baselines.py::TestPromptHookEntityInjection::test_no_entity_in_generic_query`, `tests/test_vector_store.py::TestSchema::test_created_at_coverage`, and `tests/test_vector_store.py::TestSearchMetadata::test_results_have_created_at` all fail there too. During one branch-wide run, `tests/test_follow_up_rewrite.py::test_follow_up_route_uses_session_context_for_search` and `tests/test_prompt_classification.py::test_knowledge_route_injects_chunks` also failed, but both pass in isolated reruns on branch and on clean `origin/main`.

## References
- R83: `docs.local/claude-web/projects/brainlayer-r83-r85-entity-quality/R83-result.md`
- R84a: `docs.local/research/2026-04-11-r84a-kg-field-survey.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and handling of meta-research content to skip unnecessary processing steps.

* **Bug Fixes**
  * Improved entity storage mechanism for better data persistence and efficiency.

* **Tests**
  * Enhanced test coverage for meta-research detection and entity persistence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add meta-research filter and stage raw entities in `chunks.raw_entities_json`
> - Introduces `is_meta_research` in [enrichment_controller.py](https://github.com/EtanHey/brainlayer/pull/233/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb) using compiled regex patterns to detect log-like/meta-research content; matching chunks are tagged `meta-research`, have their summary cleared, and skip Gemini calls entirely.
> - Replaces insertion into `kg_entities`/`kg_entity_chunks` with writing the raw entities list as JSON into a new `chunks.raw_entities_json` column, added via [003_raw_entities_json.sql](https://github.com/EtanHey/brainlayer/pull/233/files#diff-4bca80f56d93cd47380e6413c9d2a2ed3aa29deb56b6b3ca6e9ac1d21627a336).
> - The column is auto-created at runtime via `_ensure_raw_entities_json_column` if the migration has not been applied.
> - Behavioral Change: entity data no longer populates `kg_entities` or `kg_entity_chunks`; it is now staged in `chunks.raw_entities_json` only.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6a7c8d4. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->