### PR TITLE
refactor: harden enrichment controller for Gemini Flex throughput

### DIFF
--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -192,7 +192,9 @@ def _ensure_enrichment_columns(store) -> None:
         _ENRICHMENT_COLUMN_READY.add(key)
 
 
-def _get_store_rate_limiter(store, rate_per_second: float | None = None, burst: int | None = None) -> TokenBucket | None:
+def _get_store_rate_limiter(
+    store, rate_per_second: float | None = None, burst: int | None = None
+) -> TokenBucket | None:
     if rate_per_second is None:
         rate_per_second = RATE_LIMITS["realtime"]
     if rate_per_second <= 0:
@@ -484,7 +486,9 @@ def _retry_with_backoff(
             time.sleep(sleep_for)
 
 
-def _generate_content_with_rate_limit(client, model: str, prompt: str, config: dict[str, Any], limiter: TokenBucket | None):
+def _generate_content_with_rate_limit(
+    client, model: str, prompt: str, config: dict[str, Any], limiter: TokenBucket | None
+):
     if limiter is not None:
         limiter.acquire()
     return client.models.generate_content(
@@ -779,7 +783,9 @@ def enrich_realtime(
                     result.skipped += 1
                     continue
                 if status == "meta":
-                    _submit_write(store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk))
+                    _submit_write(
+                        store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk)
+                    )
                     result.skipped += 1
                     continue
                 if status == "error":

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -16,6 +16,7 @@ import logging
 import os
 import random
 import re
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -30,7 +31,9 @@ from .pipeline.enrichment import (
     build_prompt,
     parse_enrichment,
 )
+from .pipeline.rate_limiter import TokenBucket
 from .pipeline.sanitize import Sanitizer
+from .pipeline.write_queue import WriteQueue
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +51,19 @@ RATE_LIMITS = {
     "batch": float(os.environ.get("BRAINLAYER_BATCH_RATE", "0")),  # no limit (async)
 }
 ENRICH_CONCURRENCY = int(os.environ.get("BRAINLAYER_ENRICH_CONCURRENCY", "10"))
+WRITE_QUEUE_MAXSIZE = int(os.environ.get("BRAINLAYER_WRITE_QUEUE_MAXSIZE", "1000"))
+RATE_LIMIT_BURST = int(os.environ.get("BRAINLAYER_ENRICH_BURST", "10"))
+
+_WRITE_QUEUE_REGISTRY: dict[str, WriteQueue] = {}
+_WRITE_QUEUE_LOCK = threading.Lock()
+_ENRICHMENT_COLUMN_READY: set[str] = set()
+_ENRICHMENT_COLUMN_LOCK = threading.Lock()
+_RATE_LIMITER_REGISTRY: dict[tuple[str, float, int], TokenBucket] = {}
+_RATE_LIMITER_LOCK = threading.Lock()
+_STORE_OPERATION_COUNTS: dict[str, int] = {}
+_STORE_OPERATION_LOCK = threading.Lock()
+_STORE_OPERATION_CONDITION = threading.Condition(_STORE_OPERATION_LOCK)
+_STORE_CLOSING: set[str] = set()
 
 _META_RESEARCH_PATTERNS = [
     re.compile(r"brain_search\s*\(", re.IGNORECASE),
@@ -97,6 +113,136 @@ def get_unsubmitted_export_files(*args, **kwargs):
 # ── Gemini client ──────────────────────────────────────────────────────────────
 
 
+def _store_queue_key(store) -> str:
+    db_path = getattr(store, "db_path", None)
+    return str(db_path) if db_path is not None else f"store:{id(store)}"
+
+
+def _get_store_write_queue(store) -> WriteQueue:
+    key = _store_queue_key(store)
+    with _WRITE_QUEUE_LOCK:
+        write_queue = _WRITE_QUEUE_REGISTRY.get(key)
+        if write_queue is None:
+            write_queue = WriteQueue(maxsize=WRITE_QUEUE_MAXSIZE)
+            write_queue.start()
+            _WRITE_QUEUE_REGISTRY[key] = write_queue
+        return write_queue
+
+
+def _begin_store_operation(store) -> str:
+    key = _store_queue_key(store)
+    with _STORE_OPERATION_CONDITION:
+        while key in _STORE_CLOSING:
+            _STORE_OPERATION_CONDITION.wait()
+        _STORE_OPERATION_COUNTS[key] = _STORE_OPERATION_COUNTS.get(key, 0) + 1
+    return key
+
+
+def _end_store_operation(store) -> None:
+    key = _store_queue_key(store)
+    cleanup = False
+    with _STORE_OPERATION_CONDITION:
+        remaining = _STORE_OPERATION_COUNTS.get(key, 0) - 1
+        if remaining <= 0:
+            _STORE_OPERATION_COUNTS.pop(key, None)
+            _STORE_CLOSING.add(key)
+            cleanup = True
+        else:
+            _STORE_OPERATION_COUNTS[key] = remaining
+
+    if not cleanup:
+        return
+
+    try:
+        with _WRITE_QUEUE_LOCK:
+            write_queue = _WRITE_QUEUE_REGISTRY.pop(key, None)
+        if write_queue is not None:
+            write_queue.stop(timeout=1.0)
+
+        with _RATE_LIMITER_LOCK:
+            for limiter_key in list(_RATE_LIMITER_REGISTRY):
+                if limiter_key[0] == key:
+                    _RATE_LIMITER_REGISTRY.pop(limiter_key, None)
+
+        with _ENRICHMENT_COLUMN_LOCK:
+            _ENRICHMENT_COLUMN_READY.discard(key)
+    finally:
+        with _STORE_OPERATION_CONDITION:
+            _STORE_CLOSING.discard(key)
+            _STORE_OPERATION_CONDITION.notify_all()
+
+
+def _submit_write(store, name: str, callback) -> Any:
+    return _get_store_write_queue(store).submit(name, callback).result()
+
+
+def _ensure_enrichment_columns(store) -> None:
+    key = _store_queue_key(store)
+    with _ENRICHMENT_COLUMN_LOCK:
+        if key in _ENRICHMENT_COLUMN_READY:
+            return
+
+    def _ensure() -> None:
+        _ensure_content_hash_column(store)
+        _ensure_raw_entities_json_column(store)
+
+    _submit_write(store, "ensure-enrichment-columns", _ensure)
+
+    with _ENRICHMENT_COLUMN_LOCK:
+        _ENRICHMENT_COLUMN_READY.add(key)
+
+
+def _get_store_rate_limiter(store, rate_per_second: float | None = None, burst: int | None = None) -> TokenBucket | None:
+    if rate_per_second is None:
+        rate_per_second = RATE_LIMITS["realtime"]
+    if rate_per_second <= 0:
+        return None
+
+    burst = RATE_LIMIT_BURST if burst is None else burst
+    key = (_store_queue_key(store), rate_per_second, burst)
+    with _RATE_LIMITER_LOCK:
+        limiter = _RATE_LIMITER_REGISTRY.get(key)
+        if limiter is None:
+            limiter = TokenBucket(rate_per_sec=rate_per_second, burst=burst)
+            _RATE_LIMITER_REGISTRY[key] = limiter
+        return limiter
+
+
+def _get_chunk_readonly(store, chunk_id: str) -> dict[str, Any] | None:
+    if not hasattr(store, "_read_cursor"):
+        return store.get_chunk(chunk_id)
+
+    row = (
+        store._read_cursor()
+        .execute(
+            """SELECT id, content, metadata, source_file, project, content_type,
+                      value_type, tags, importance, created_at, summary,
+                      superseded_by, aggregated_into, archived_at
+               FROM chunks WHERE id = ?""",
+            (chunk_id,),
+        )
+        .fetchone()
+    )
+    if not row:
+        return None
+    return {
+        "id": row[0],
+        "content": row[1],
+        "metadata": row[2],
+        "source_file": row[3],
+        "project": row[4],
+        "content_type": row[5],
+        "value_type": row[6],
+        "tags": row[7],
+        "importance": row[8],
+        "created_at": row[9],
+        "summary": row[10],
+        "superseded_by": row[11],
+        "aggregated_into": row[12],
+        "archived_at": row[13],
+    }
+
+
 def _get_gemini_client():
     """Create Gemini client. Uses regional endpoint when GOOGLE_CLOUD_REGION is set."""
     try:
@@ -111,12 +257,10 @@ def _get_gemini_client():
     # Regional endpoint reduces latency from 11-12s (global) to 0.7s.
     # Set GOOGLE_CLOUD_REGION=us-central1 (or europe-west1, etc.) to enable.
     region = os.environ.get("GOOGLE_CLOUD_REGION")
+    http_options: dict[str, Any] = {"retry_options": {"attempts": 1}}
     if region:
-        return genai.Client(
-            api_key=api_key,
-            http_options={"api_version": "v1beta", "url": f"https://{region}-aiplatform.googleapis.com"},
-        )
-    return genai.Client(api_key=api_key)
+        http_options.update({"api_version": "v1beta", "url": f"https://{region}-aiplatform.googleapis.com"})
+    return genai.Client(api_key=api_key, http_options=http_options)
 
 
 GEMINI_RESPONSE_SCHEMA = {
@@ -329,7 +473,25 @@ def _retry_with_backoff(
                 raise
             delay = min(base_delay * (2**attempt), max_delay)
             jitter = random.uniform(0, delay * 0.5)
-            time.sleep(min(delay + jitter, max_delay))
+            sleep_for = min(delay + jitter, max_delay)
+            logger.warning(
+                "Retrying enrichment call after error %s (attempt %d/%d) in %.2fs",
+                exc,
+                attempt + 2,
+                max_retries + 1,
+                sleep_for,
+            )
+            time.sleep(sleep_for)
+
+
+def _generate_content_with_rate_limit(client, model: str, prompt: str, config: dict[str, Any], limiter: TokenBucket | None):
+    if limiter is not None:
+        limiter.acquire()
+    return client.models.generate_content(
+        model=model,
+        contents=prompt,
+        config=config,
+    )
 
 
 def _apply_enrichment(store, chunk: dict[str, Any], enrichment: dict[str, Any]) -> None:
@@ -379,6 +541,7 @@ def _enrich_single_chunk(
     sanitizer,
     *,
     is_duplicate,
+    rate_limiter: TokenBucket | None,
     max_retries: int,
 ) -> tuple[dict[str, Any], str, Any]:
     """Run dedup, prompt build, and API call for one chunk.
@@ -401,11 +564,7 @@ def _enrich_single_chunk(
 
     try:
         response = _retry_with_backoff(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=config,
-            ),
+            lambda: _generate_content_with_rate_limit(client, model, prompt, config, rate_limiter),
             max_retries=max_retries,
         )
         raw_response = getattr(response, "text", response)
@@ -432,63 +591,66 @@ def enrich_single(store, chunk_id: str, max_retries: int = 2) -> dict[str, Any] 
     if not AUTO_ENRICH_ENABLED:
         return None
 
-    chunk = store.get_chunk(chunk_id)
-    if not chunk:
-        logger.warning("enrich_single: chunk not found: %s", chunk_id)
-        return None
-
-    if is_meta_research(chunk.get("content", "")):
-        _mark_meta_research(store, chunk)
-        logger.info("enrich_single: tagged %s as meta-research without Gemini", chunk_id)
-        return None
-
+    _begin_store_operation(store)
     try:
-        client = _get_gemini_client()
-    except RuntimeError:
-        logger.debug("enrich_single: no Gemini API key, skipping enrichment for %s", chunk_id)
-        return None
+        _ensure_enrichment_columns(store)
 
-    sanitizer = Sanitizer.from_env()
-    try:
-        prompt, _sanitize_result = build_external_prompt(chunk, sanitizer)
-    except Exception as exc:
-        logger.warning("enrich_single: prompt build failed for %s: %s", chunk_id, exc)
-        return None
+        chunk = _get_chunk_readonly(store, chunk_id)
+        if not chunk:
+            logger.warning("enrich_single: chunk not found: %s", chunk_id)
+            return None
 
-    config = _build_gemini_config()
+        if is_meta_research(chunk.get("content", "")):
+            _submit_write(store, f"mark-meta:{chunk_id}", lambda: _mark_meta_research(store, chunk))
+            logger.info("enrich_single: tagged %s as meta-research without Gemini", chunk_id)
+            return None
 
-    def _call():
-        response = client.models.generate_content(
-            model=GEMINI_REALTIME_MODEL,
-            contents=prompt,
-            config=config,
-        )
-        return getattr(response, "text", None)
+        try:
+            client = _get_gemini_client()
+        except RuntimeError:
+            logger.debug("enrich_single: no Gemini API key, skipping enrichment for %s", chunk_id)
+            return None
 
-    try:
-        raw_response = _retry_with_backoff(
-            _call,
-            max_retries=max_retries,
-            base_delay=0.3,
-            max_delay=5.0,
-        )
-    except Exception as exc:
-        logger.warning("enrich_single: Gemini call failed for %s: %s", chunk_id, exc)
-        return None
+        sanitizer = Sanitizer.from_env()
+        try:
+            prompt, _sanitize_result = build_external_prompt(chunk, sanitizer)
+        except Exception as exc:
+            logger.warning("enrich_single: prompt build failed for %s: %s", chunk_id, exc)
+            return None
 
-    enrichment = parse_enrichment(raw_response)
-    if not enrichment:
-        logger.warning("enrich_single: invalid enrichment response for %s", chunk_id)
-        return None
+        config = _build_gemini_config()
+        rate_limiter = _get_store_rate_limiter(store)
 
-    try:
-        _apply_enrichment(store, chunk, enrichment)
-    except Exception as exc:
-        logger.warning("enrich_single: apply failed for %s: %s", chunk_id, exc)
-        return None
+        def _call():
+            response = _generate_content_with_rate_limit(client, GEMINI_REALTIME_MODEL, prompt, config, rate_limiter)
+            return getattr(response, "text", None)
 
-    logger.info("enrich_single: enriched %s with %d tags", chunk_id, len(enrichment.get("tags", [])))
-    return enrichment
+        try:
+            raw_response = _retry_with_backoff(
+                _call,
+                max_retries=max_retries,
+                base_delay=0.3,
+                max_delay=5.0,
+            )
+        except Exception as exc:
+            logger.warning("enrich_single: Gemini call failed for %s: %s", chunk_id, exc)
+            return None
+
+        enrichment = parse_enrichment(raw_response)
+        if not enrichment:
+            logger.warning("enrich_single: invalid enrichment response for %s", chunk_id)
+            return None
+
+        try:
+            _submit_write(store, f"apply-enrichment:{chunk_id}", lambda: _apply_enrichment(store, chunk, enrichment))
+        except Exception as exc:
+            logger.warning("enrich_single: apply failed for %s: %s", chunk_id, exc)
+            return None
+
+        logger.info("enrich_single: enriched %s with %d tags", chunk_id, len(enrichment.get("tags", [])))
+        return enrichment
+    finally:
+        _end_store_operation(store)
 
 
 def _call_local_backend(prompt: str, backend: str = "mlx") -> str | None:
@@ -573,66 +735,71 @@ def enrich_realtime(
     if rate_per_second is None:
         rate_per_second = RATE_LIMITS["realtime"]
 
-    start_time = time.monotonic()
-    _emit_enrichment_start("realtime", limit)
+    _begin_store_operation(store)
+    try:
+        start_time = time.monotonic()
+        _emit_enrichment_start("realtime", limit)
 
-    candidates = store.get_enrichment_candidates(limit=limit, since_hours=since_hours, chunk_ids=chunk_ids)
-    result = EnrichmentResult(mode="realtime", attempted=len(candidates), enriched=0, skipped=0, failed=0)
-    if not candidates:
-        _emit_enrichment_complete(result, 0)
-        return result
+        candidates = store.get_enrichment_candidates(limit=limit, since_hours=since_hours, chunk_ids=chunk_ids)
+        result = EnrichmentResult(mode="realtime", attempted=len(candidates), enriched=0, skipped=0, failed=0)
+        if not candidates:
+            _emit_enrichment_complete(result, 0)
+            return result
 
-    # Ensure content_hash column exists for dedup
-    _ensure_content_hash_column(store)
-    _ensure_raw_entities_json_column(store)
+        _ensure_enrichment_columns(store)
 
-    client = _get_gemini_client()
-    sanitizer = Sanitizer.from_env()
-    per_chunk_delay = (1.0 / rate_per_second) if rate_per_second > 0 else 0.0
-    config = _build_gemini_config()
+        client = _get_gemini_client()
+        sanitizer = Sanitizer.from_env()
+        config = _build_gemini_config()
+        rate_limiter = _get_store_rate_limiter(store, rate_per_second=rate_per_second)
 
-    def is_duplicate(content: str) -> bool:
-        return _is_duplicate_content(store, content)
+        def is_duplicate(content: str) -> bool:
+            return _is_duplicate_content(store, content)
 
-    with ThreadPoolExecutor(max_workers=ENRICH_CONCURRENCY) as executor:
-        futures = []
-        for index, chunk in enumerate(candidates):
-            futures.append(
-                executor.submit(
-                    _enrich_single_chunk,
-                    client,
-                    GEMINI_REALTIME_MODEL,
-                    config,
-                    chunk,
-                    sanitizer,
-                    is_duplicate=is_duplicate,
-                    max_retries=max_retries,
+        with ThreadPoolExecutor(max_workers=ENRICH_CONCURRENCY) as executor:
+            futures = []
+            for chunk in candidates:
+                futures.append(
+                    executor.submit(
+                        _enrich_single_chunk,
+                        client,
+                        GEMINI_REALTIME_MODEL,
+                        config,
+                        chunk,
+                        sanitizer,
+                        is_duplicate=is_duplicate,
+                        rate_limiter=rate_limiter,
+                        max_retries=max_retries,
+                    )
                 )
-            )
-            if per_chunk_delay > 0 and index < len(candidates) - 1:
-                time.sleep(per_chunk_delay)
 
-        for future in as_completed(futures):
-            chunk, status, data = future.result()
-            if status == "skip":
-                result.skipped += 1
-                continue
-            if status == "meta":
-                _mark_meta_research(store, chunk)
-                result.skipped += 1
-                continue
-            if status == "error":
-                result.failed += 1
-                result.errors.append(f"{chunk['id']}: {data}")
-                _emit_enrichment_error("realtime", chunk["id"], str(data))
-                continue
+            for future in as_completed(futures):
+                chunk, status, data = future.result()
+                if status == "skip":
+                    result.skipped += 1
+                    continue
+                if status == "meta":
+                    _submit_write(store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk))
+                    result.skipped += 1
+                    continue
+                if status == "error":
+                    result.failed += 1
+                    result.errors.append(f"{chunk['id']}: {data}")
+                    _emit_enrichment_error("realtime", chunk["id"], str(data))
+                    continue
 
-            _apply_enrichment(store, chunk, data)
-            result.enriched += 1
+                _submit_write(
+                    store,
+                    f"apply-enrichment:{chunk['id']}",
+                    lambda chunk=chunk, data=data: _apply_enrichment(store, chunk, data),
+                )
+                result.enriched += 1
 
-    duration_ms = (time.monotonic() - start_time) * 1000
-    _emit_enrichment_complete(result, duration_ms)
-    return result
+        duration_ms = (time.monotonic() - start_time) * 1000
+        _emit_enrichment_complete(result, duration_ms)
+        return result
+    finally:
+        _end_store_operation(store)
 
 
 def enrich_batch(
@@ -647,76 +814,82 @@ def enrich_batch(
     submit/poll/import workflow is not yet wired. This ensures unenriched
     chunks actually get processed instead of returning enriched=0.
     """
-    start_time = time.monotonic()
-    _emit_enrichment_start("batch", limit)
-
-    candidates = store.get_enrichment_candidates(limit=limit, chunk_ids=None)
-    result = EnrichmentResult(mode="batch", attempted=len(candidates), enriched=0, skipped=0, failed=0, errors=[])
-
-    if not candidates:
-        duration_ms = (time.monotonic() - start_time) * 1000
-        _emit_enrichment_complete(result, duration_ms)
-        return result
-
-    _ensure_content_hash_column(store)
-    _ensure_raw_entities_json_column(store)
-
+    _begin_store_operation(store)
     try:
-        client = _get_gemini_client()
-    except RuntimeError as exc:
-        result.errors.append(f"No Gemini client: {exc}")
+        start_time = time.monotonic()
+        _emit_enrichment_start("batch", limit)
+
+        candidates = store.get_enrichment_candidates(limit=limit, chunk_ids=None)
+        result = EnrichmentResult(mode="batch", attempted=len(candidates), enriched=0, skipped=0, failed=0, errors=[])
+
+        if not candidates:
+            duration_ms = (time.monotonic() - start_time) * 1000
+            _emit_enrichment_complete(result, duration_ms)
+            return result
+
+        _ensure_enrichment_columns(store)
+
+        try:
+            client = _get_gemini_client()
+        except RuntimeError as exc:
+            result.errors.append(f"No Gemini client: {exc}")
+            duration_ms = (time.monotonic() - start_time) * 1000
+            _emit_enrichment_complete(result, duration_ms)
+            return result
+
+        sanitizer = Sanitizer.from_env()
+        config = _build_gemini_config()
+        rate_limiter = _get_store_rate_limiter(store, rate_per_second=RATE_LIMITS.get("realtime", 0.2))
+
+        for chunk in candidates:
+            if is_meta_research(chunk.get("content", "")):
+                _submit_write(store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk))
+                result.skipped += 1
+                continue
+            if _is_duplicate_content(store, chunk.get("content", "")):
+                result.skipped += 1
+                continue
+
+            try:
+                prompt, _sanitize_result = build_external_prompt(chunk, sanitizer)
+            except Exception as exc:
+                result.failed += 1
+                result.errors.append(f"{chunk['id']}: prompt_build_error: {exc}")
+                continue
+
+            try:
+                response = _retry_with_backoff(
+                    lambda: _generate_content_with_rate_limit(
+                        client,
+                        GEMINI_REALTIME_MODEL,
+                        prompt,
+                        config,
+                        rate_limiter,
+                    ),
+                    max_retries=max_retries,
+                )
+                enrichment = parse_enrichment(response.text)
+                if not enrichment:
+                    result.failed += 1
+                    result.errors.append(f"{chunk['id']}: invalid_enrichment")
+                    _emit_enrichment_error("batch", chunk["id"], "invalid_enrichment")
+                    continue
+                _submit_write(
+                    store,
+                    f"apply-enrichment:{chunk['id']}",
+                    lambda chunk=chunk, enrichment=enrichment: _apply_enrichment(store, chunk, enrichment),
+                )
+                result.enriched += 1
+            except Exception as exc:
+                result.failed += 1
+                result.errors.append(f"{chunk['id']}: {exc}")
+                _emit_enrichment_error("batch", chunk["id"], str(exc))
+
         duration_ms = (time.monotonic() - start_time) * 1000
         _emit_enrichment_complete(result, duration_ms)
         return result
-
-    sanitizer = Sanitizer.from_env()
-    config = _build_gemini_config()
-    rate_limit = RATE_LIMITS.get("realtime", 0.2)
-
-    for chunk in candidates:
-        if is_meta_research(chunk.get("content", "")):
-            _mark_meta_research(store, chunk)
-            result.skipped += 1
-            continue
-        if _is_duplicate_content(store, chunk.get("content", "")):
-            result.skipped += 1
-            continue
-
-        try:
-            prompt, _sanitize_result = build_external_prompt(chunk, sanitizer)
-        except Exception as exc:
-            result.failed += 1
-            result.errors.append(f"{chunk['id']}: prompt_build_error: {exc}")
-            continue
-
-        try:
-            response = _retry_with_backoff(
-                lambda: client.models.generate_content(
-                    model=GEMINI_REALTIME_MODEL,
-                    contents=prompt,
-                    config=config,
-                ),
-                max_retries=max_retries,
-            )
-            enrichment = parse_enrichment(response.text)
-            if not enrichment:
-                result.failed += 1
-                result.errors.append(f"{chunk['id']}: invalid_enrichment")
-                _emit_enrichment_error("batch", chunk["id"], "invalid_enrichment")
-                continue
-            _apply_enrichment(store, chunk, enrichment)
-            result.enriched += 1
-        except Exception as exc:
-            result.failed += 1
-            result.errors.append(f"{chunk['id']}: {exc}")
-            _emit_enrichment_error("batch", chunk["id"], str(exc))
-
-        if rate_limit > 0:
-            time.sleep(1.0 / rate_limit)
-
-    duration_ms = (time.monotonic() - start_time) * 1000
-    _emit_enrichment_complete(result, duration_ms)
-    return result
+    finally:
+        _end_store_operation(store)
 
 
 def enrich_local(
@@ -726,37 +899,44 @@ def enrich_local(
     backend: str = "mlx",
 ) -> EnrichmentResult:
     """Enrich via local MLX/Ollama backend."""
-    start_time = time.monotonic()
-    _emit_enrichment_start("local", limit)
+    _begin_store_operation(store)
+    try:
+        start_time = time.monotonic()
+        _emit_enrichment_start("local", limit)
 
-    candidates = store.get_enrichment_candidates(limit=limit, chunk_ids=None)
-    result = EnrichmentResult(mode="local", attempted=len(candidates), enriched=0, skipped=0, failed=0)
+        candidates = store.get_enrichment_candidates(limit=limit, chunk_ids=None)
+        result = EnrichmentResult(mode="local", attempted=len(candidates), enriched=0, skipped=0, failed=0)
 
-    # Ensure content_hash column exists for dedup
-    _ensure_content_hash_column(store)
+        _ensure_enrichment_columns(store)
 
-    for chunk in candidates:
-        # Content-hash dedup
-        if _is_duplicate_content(store, chunk.get("content", "")):
-            result.skipped += 1
-            continue
-
-        try:
-            prompt = build_prompt(chunk)
-            raw_response = _retry_with_backoff(lambda: _call_local_backend(prompt, backend=backend), max_retries=2)
-            enrichment = parse_enrichment(raw_response)
-            if not enrichment:
-                result.failed += 1
-                result.errors.append(f"{chunk['id']}: invalid_enrichment")
-                _emit_enrichment_error("local", chunk["id"], "invalid_enrichment")
+        for chunk in candidates:
+            # Content-hash dedup
+            if _is_duplicate_content(store, chunk.get("content", "")):
+                result.skipped += 1
                 continue
-            _apply_enrichment(store, chunk, enrichment)
-            result.enriched += 1
-        except Exception as exc:  # noqa: BLE001
-            result.failed += 1
-            result.errors.append(f"{chunk['id']}: {exc}")
-            _emit_enrichment_error("local", chunk["id"], str(exc))
 
-    duration_ms = (time.monotonic() - start_time) * 1000
-    _emit_enrichment_complete(result, duration_ms)
-    return result
+            try:
+                prompt = build_prompt(chunk)
+                raw_response = _retry_with_backoff(lambda: _call_local_backend(prompt, backend=backend), max_retries=2)
+                enrichment = parse_enrichment(raw_response)
+                if not enrichment:
+                    result.failed += 1
+                    result.errors.append(f"{chunk['id']}: invalid_enrichment")
+                    _emit_enrichment_error("local", chunk["id"], "invalid_enrichment")
+                    continue
+                _submit_write(
+                    store,
+                    f"apply-enrichment:{chunk['id']}",
+                    lambda chunk=chunk, enrichment=enrichment: _apply_enrichment(store, chunk, enrichment),
+                )
+                result.enriched += 1
+            except Exception as exc:  # noqa: BLE001
+                result.failed += 1
+                result.errors.append(f"{chunk['id']}: {exc}")
+                _emit_enrichment_error("local", chunk["id"], str(exc))
+
+        duration_ms = (time.monotonic() - start_time) * 1000
+        _emit_enrichment_complete(result, duration_ms)
+        return result
+    finally:
+        _end_store_operation(store)

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -159,11 +159,6 @@ def _end_store_operation(store) -> None:
         if write_queue is not None:
             write_queue.stop(timeout=1.0)
 
-        with _RATE_LIMITER_LOCK:
-            for limiter_key in list(_RATE_LIMITER_REGISTRY):
-                if limiter_key[0] == key:
-                    _RATE_LIMITER_REGISTRY.pop(limiter_key, None)
-
         with _ENRICHMENT_COLUMN_LOCK:
             _ENRICHMENT_COLUMN_READY.discard(key)
     finally:

--- a/src/brainlayer/pipeline/rate_limiter.py
+++ b/src/brainlayer/pipeline/rate_limiter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import threading
+import time
+
+
+class TokenBucket:
+    def __init__(self, rate_per_sec: float, burst: int = 10):
+        self.rate_per_sec = rate_per_sec
+        self.burst = max(1, burst)
+        self._tokens = float(self.burst)
+        self._updated_at = time.monotonic()
+        self._condition = threading.Condition()
+
+    def acquire(self, n: int = 1) -> None:
+        if n <= 0:
+            raise ValueError("requested tokens must be positive")
+        if n > self.burst:
+            raise ValueError("requested tokens exceed burst capacity")
+        if self.rate_per_sec <= 0:
+            return
+
+        with self._condition:
+            while True:
+                now = time.monotonic()
+                elapsed = max(0.0, now - self._updated_at)
+                if elapsed:
+                    self._tokens = min(self.burst, self._tokens + (elapsed * self.rate_per_sec))
+                    self._updated_at = now
+
+                if self._tokens >= n:
+                    self._tokens -= n
+                    return
+
+                missing = n - self._tokens
+                wait_time = missing / self.rate_per_sec
+                self._condition.wait(timeout=wait_time)

--- a/src/brainlayer/pipeline/write_queue.py
+++ b/src/brainlayer/pipeline/write_queue.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+_STOP = object()
+
+
+class WriteQueueFullError(RuntimeError):
+    """Raised when the single-writer queue cannot accept more work."""
+
+
+@dataclass
+class WriteIntent:
+    name: str
+    callback: Callable[[], Any]
+    crash_on_error: bool = False
+    future: Future[Any] = field(default_factory=Future)
+
+    def execute(self) -> Any:
+        return self.callback()
+
+
+class WriteQueue:
+    def __init__(self, maxsize: int = 1000):
+        self._queue: queue.Queue[WriteIntent | object] = queue.Queue(maxsize=maxsize)
+        self._worker: threading.Thread | None = None
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        with self._lock:
+            if self._worker is not None and self._worker.is_alive():
+                return
+            self._worker = threading.Thread(target=self._run, name="brainlayer-write-worker", daemon=True)
+            self._worker.start()
+
+    def submit(
+        self,
+        name: str,
+        callback: Callable[[], Any],
+        *,
+        crash_on_error: bool = False,
+        timeout: float | None = 30.0,
+    ) -> Future[Any]:
+        self.start()
+        intent = WriteIntent(name=name, callback=callback, crash_on_error=crash_on_error)
+        try:
+            self._queue.put(intent, timeout=timeout)
+        except queue.Full as exc:
+            intent.future.set_exception(WriteQueueFullError(f"write queue is full: {name}"))
+            raise WriteQueueFullError(f"write queue is full: {name}") from exc
+        return intent.future
+
+    def stop(self, timeout: float = 5.0) -> None:
+        with self._lock:
+            worker = self._worker
+            if worker is None:
+                return
+        deadline = time.monotonic() + max(timeout, 0.0)
+        while worker.is_alive():
+            try:
+                self._queue.put(_STOP, timeout=0.05)
+                break
+            except queue.Full:
+                if time.monotonic() >= deadline:
+                    break
+        worker.join(timeout=timeout)
+        if not worker.is_alive():
+            with self._lock:
+                self._worker = None
+
+    def _run(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is _STOP:
+                self._queue.task_done()
+                break
+
+            assert isinstance(item, WriteIntent)
+            try:
+                result = item.execute()
+            except Exception as exc:
+                if not item.future.done():
+                    item.future.set_exception(exc)
+                self._queue.task_done()
+                if item.crash_on_error:
+                    break
+                continue
+
+            if not item.future.done():
+                item.future.set_result(result)
+            self._queue.task_done()
+
+        with self._lock:
+            self._worker = None

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -9,6 +9,9 @@ Target: 35+ tests per A-R2 acceptance criteria.
 
 import json
 import sqlite3
+import sys
+import threading
+import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -456,6 +459,74 @@ def test_gemini_client_requires_api_key(monkeypatch):
         _get_gemini_client()
 
 
+def test_gemini_sdk_retries_disabled(monkeypatch):
+    from brainlayer.enrichment_controller import _get_gemini_client
+
+    client_ctor = MagicMock(return_value=object())
+    fake_google = types.ModuleType("google")
+    fake_google.genai = SimpleNamespace(Client=client_ctor)
+
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.delenv("GOOGLE_GENERATIVE_AI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_CLOUD_REGION", raising=False)
+
+    _get_gemini_client()
+
+    _, kwargs = client_ctor.call_args
+    assert kwargs["http_options"]["retry_options"] == {"attempts": 1}
+
+
+def test_store_lifecycle_waits_for_cleanup_before_new_operations():
+    from brainlayer import enrichment_controller as controller
+
+    store = SimpleNamespace(db_path="/tmp/pr-a3-lifecycle.db")
+    key = controller._store_queue_key(store)
+    stop_started = threading.Event()
+    release_stop = threading.Event()
+    begin_finished = threading.Event()
+
+    old_queue = MagicMock()
+
+    def blocking_stop(timeout=1.0):  # noqa: ARG001
+        stop_started.set()
+        release_stop.wait(timeout=2)
+
+    old_queue.stop.side_effect = blocking_stop
+
+    with controller._WRITE_QUEUE_LOCK:
+        controller._WRITE_QUEUE_REGISTRY[key] = old_queue
+    with controller._STORE_OPERATION_CONDITION:
+        controller._STORE_OPERATION_COUNTS[key] = 1
+        controller._STORE_CLOSING.discard(key)
+
+    def cleanup():
+        controller._end_store_operation(store)
+
+    def begin_new_operation():
+        controller._begin_store_operation(store)
+        begin_finished.set()
+
+    cleanup_thread = threading.Thread(target=cleanup)
+    cleanup_thread.start()
+    assert stop_started.wait(timeout=1)
+
+    begin_thread = threading.Thread(target=begin_new_operation)
+    begin_thread.start()
+    assert not begin_finished.wait(timeout=0.05)
+
+    release_stop.set()
+    cleanup_thread.join(timeout=1)
+    begin_thread.join(timeout=1)
+
+    assert begin_finished.is_set()
+    with controller._STORE_OPERATION_CONDITION:
+        assert controller._STORE_OPERATION_COUNTS[key] == 1
+        assert key not in controller._STORE_CLOSING
+
+    controller._end_store_operation(store)
+
+
 # ── Rate limiting tests ──────────────────────────────────────────────────────
 
 
@@ -467,7 +538,7 @@ def test_rate_limits_defaults():
     assert RATE_LIMITS["batch"] == 0  # No limit for batch (async)
 
 
-def test_realtime_rate_limit_sleeps_between_chunks(monkeypatch):
+def test_realtime_rate_limit_acquires_token_per_chunk(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     store = MagicMock()
@@ -477,14 +548,17 @@ def test_realtime_rate_limit_sleeps_between_chunks(monkeypatch):
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
     monkeypatch.setattr(controller, "_get_gemini_client", lambda: _fake_gemini_client())
 
-    sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    acquires = []
+
+    class FakeLimiter:
+        def acquire(self, n=1):
+            acquires.append(n)
+
+    monkeypatch.setattr(controller, "_get_store_rate_limiter", lambda *args, **kwargs: FakeLimiter())
 
     controller.enrich_realtime(store, limit=3, rate_per_second=2.0)
 
-    # Should sleep between chunks (not after the last one)
-    assert len(sleeps) == 2
-    assert all(s == 0.5 for s in sleeps)  # 1/2.0 = 0.5s
+    assert acquires == [1, 1, 1]
 
 
 def test_realtime_no_sleep_when_rate_zero(monkeypatch):

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -527,6 +527,31 @@ def test_store_lifecycle_waits_for_cleanup_before_new_operations():
     controller._end_store_operation(store)
 
 
+def test_rate_limiter_survives_store_cleanup():
+    from brainlayer import enrichment_controller as controller
+
+    store = SimpleNamespace(db_path="/tmp/pr-a3-rate-limiter.db")
+    registry_key = controller._store_queue_key(store)
+    limiter_key = (registry_key, 5.0, 10)
+
+    with controller._RATE_LIMITER_LOCK:
+        controller._RATE_LIMITER_REGISTRY.pop(limiter_key, None)
+
+    try:
+        controller._begin_store_operation(store)
+        limiter = controller._get_store_rate_limiter(store, rate_per_second=5.0, burst=10)
+        controller._end_store_operation(store)
+
+        controller._begin_store_operation(store)
+        same_limiter = controller._get_store_rate_limiter(store, rate_per_second=5.0, burst=10)
+        controller._end_store_operation(store)
+
+        assert same_limiter is limiter
+    finally:
+        with controller._RATE_LIMITER_LOCK:
+            controller._RATE_LIMITER_REGISTRY.pop(limiter_key, None)
+
+
 # ── Rate limiting tests ──────────────────────────────────────────────────────
 
 

--- a/tests/test_enrichment_flex_integration.py
+++ b/tests/test_enrichment_flex_integration.py
@@ -62,7 +62,9 @@ def test_sustained_rate_no_contention(tmp_path, monkeypatch):
         monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: sanitizer))
 
         with ThreadPoolExecutor(max_workers=20) as pool:
-            results = list(pool.map(lambda chunk_id: controller.enrich_single(store, chunk_id, max_retries=0), chunk_ids))
+            results = list(
+                pool.map(lambda chunk_id: controller.enrich_single(store, chunk_id, max_retries=0), chunk_ids)
+            )
 
         assert all(result is not None for result in results)
         assert len(call_times) == 100

--- a/tests/test_enrichment_flex_integration.py
+++ b/tests/test_enrichment_flex_integration.py
@@ -1,0 +1,91 @@
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from brainlayer.store import store_memory
+from brainlayer.vector_store import VectorStore
+
+
+@pytest.mark.slow
+def test_sustained_rate_no_contention(tmp_path, monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    store = VectorStore(tmp_path / "test.db")
+    try:
+        chunk_ids = []
+        for index in range(100):
+            result = store_memory(
+                store=store,
+                embed_fn=None,
+                content=f"Decision {index}: keep writes serialized through one queue.",
+                memory_type="decision",
+                project="brainlayer",
+                tags=["architecture"],
+                importance=8,
+            )
+            chunk_ids.append(result["id"])
+
+        call_times = []
+        call_lock = threading.Lock()
+
+        class FakeClient:
+            class _Models:
+                def generate_content(self, **kwargs):  # noqa: ARG002
+                    with call_lock:
+                        call_times.append(time.monotonic())
+                    time.sleep(0.05)
+                    return SimpleNamespace(
+                        text=json.dumps(
+                            {
+                                "summary": "serialized enrichment",
+                                "tags": ["architecture"],
+                                "importance": 8,
+                                "intent": "deciding",
+                                "entities": [],
+                            }
+                        )
+                    )
+
+            def __init__(self):
+                self.models = self._Models()
+
+        sanitizer = SimpleNamespace(
+            sanitize=lambda text, metadata=None: SimpleNamespace(sanitized=text, replacements=[], pii_detected=False),
+        )
+
+        monkeypatch.setattr(controller, "_get_gemini_client", lambda: FakeClient())
+        monkeypatch.setattr(controller, "AUTO_ENRICH_ENABLED", True)
+        monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: sanitizer))
+
+        with ThreadPoolExecutor(max_workers=20) as pool:
+            results = list(pool.map(lambda chunk_id: controller.enrich_single(store, chunk_id, max_retries=0), chunk_ids))
+
+        assert all(result is not None for result in results)
+        assert len(call_times) == 100
+
+        steady_state_times = call_times[10:]
+        elapsed = steady_state_times[-1] - steady_state_times[0]
+        observed_rate = len(steady_state_times) / elapsed if elapsed > 0 else float("inf")
+        assert observed_rate <= 5.5
+
+        enriched_rows = list(
+            store.conn.cursor().execute(
+                "SELECT COUNT(*) FROM chunks WHERE resolved_query = ?",
+                ("serialized enrichment",),
+            )
+        )
+        assert enriched_rows[0][0] == 0
+
+        summaries = list(
+            store.conn.cursor().execute(
+                "SELECT COUNT(*) FROM chunks WHERE summary = ?",
+                ("serialized enrichment",),
+            )
+        )
+        assert summaries[0][0] == 100
+    finally:
+        store.close()

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,52 @@
+import time
+
+import pytest
+
+
+def test_token_bucket_rate():
+    from brainlayer.pipeline.rate_limiter import TokenBucket
+
+    bucket = TokenBucket(rate_per_sec=10.0, burst=1)
+
+    start = time.monotonic()
+    for _ in range(20):
+        bucket.acquire()
+    elapsed = time.monotonic() - start
+
+    assert elapsed >= 1.9
+
+
+def test_token_bucket_burst():
+    from brainlayer.pipeline.rate_limiter import TokenBucket
+
+    bucket = TokenBucket(rate_per_sec=20.0, burst=5)
+
+    start = time.monotonic()
+    for _ in range(5):
+        bucket.acquire()
+    initial_elapsed = time.monotonic() - start
+
+    sixth_start = time.monotonic()
+    bucket.acquire()
+    sixth_elapsed = time.monotonic() - sixth_start
+
+    assert initial_elapsed < 0.02
+    assert sixth_elapsed >= 0.045
+
+
+def test_token_bucket_rejects_non_positive_requests():
+    from brainlayer.pipeline.rate_limiter import TokenBucket
+
+    bucket = TokenBucket(rate_per_sec=20.0, burst=5)
+
+    with pytest.raises(ValueError, match="positive"):
+        bucket.acquire(0)
+
+
+def test_token_bucket_rejects_requests_above_burst():
+    from brainlayer.pipeline.rate_limiter import TokenBucket
+
+    bucket = TokenBucket(rate_per_sec=20.0, burst=5)
+
+    with pytest.raises(ValueError, match="burst capacity"):
+        bucket.acquire(6)

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -127,10 +127,7 @@ class TestSingleWriterQueue:
             raise_error,
             crash_on_error=True,
         )
-        futures = [
-            write_queue.submit(f"write-{index}", lambda idx=index: persisted.append(idx))
-            for index in range(9)
-        ]
+        futures = [write_queue.submit(f"write-{index}", lambda idx=index: persisted.append(idx)) for index in range(9)]
 
         with pytest.raises(RuntimeError, match="boom"):
             crash_future.result(timeout=2)

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -7,6 +7,7 @@ All tests use tmp_path fixtures (no real DB contention).
 """
 
 import json
+import threading
 from unittest.mock import MagicMock, patch
 
 import apsw
@@ -73,6 +74,85 @@ class TestQueueStore:
         # Last item should be the newest
         last_item = json.loads(lines[-1])
         assert last_item["content"] == "item-104"
+
+
+class TestSingleWriterQueue:
+    def test_single_worker_serializes_writes(self):
+        from brainlayer.pipeline.write_queue import WriteQueue
+
+        write_queue = WriteQueue(maxsize=32)
+        write_queue.start()
+
+        submission_order = []
+        persisted_order = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(6)
+        futures = [None] * 5
+
+        def submit_value(index: int) -> None:
+            barrier.wait()
+            with lock:
+                submission_order.append(index)
+                futures[index] = write_queue.submit(
+                    f"write-{index}",
+                    lambda idx=index: persisted_order.append(idx),
+                )
+
+        threads = [threading.Thread(target=submit_value, args=(i,)) for i in range(5)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join()
+        for future in futures:
+            future.result(timeout=2)
+
+        write_queue.stop()
+
+        assert persisted_order == submission_order
+
+    def test_queue_durability_on_crash(self):
+        from brainlayer.pipeline.write_queue import WriteQueue
+
+        write_queue = WriteQueue(maxsize=32)
+        write_queue.start()
+
+        persisted = []
+
+        def raise_error() -> None:
+            raise RuntimeError("boom")
+
+        crash_future = write_queue.submit(
+            "crash-write",
+            raise_error,
+            crash_on_error=True,
+        )
+        futures = [
+            write_queue.submit(f"write-{index}", lambda idx=index: persisted.append(idx))
+            for index in range(9)
+        ]
+
+        with pytest.raises(RuntimeError, match="boom"):
+            crash_future.result(timeout=2)
+
+        write_queue.start()
+        for future in futures:
+            future.result(timeout=2)
+
+        write_queue.stop()
+
+        assert persisted == list(range(9))
+
+    def test_submit_raises_when_queue_is_full(self):
+        from brainlayer.pipeline.write_queue import WriteQueue, WriteQueueFullError
+
+        write_queue = WriteQueue(maxsize=1)
+        write_queue.start = lambda: None
+        first_future = write_queue.submit("write-0", lambda: None)
+
+        with pytest.raises(WriteQueueFullError, match="write queue is full"):
+            write_queue.submit("write-1", lambda: None, timeout=0.01)
+        assert not first_future.done()
 
 
 class TestFlushPendingStores:


### PR DESCRIPTION
## Summary
- add a per-store single-writer queue so enrichment writes are serialized through one SQLite owner
- add a per-store token bucket rate limiter for Gemini calls, honoring `BRAINLAYER_ENRICH_RATE` with a default of `5/s` and burst `10`
- disable google-genai SDK internal retries so the enrichment controller owns retry behavior at the application layer

## Why
R86 Deep Research called out three architectural prerequisites before running Gemini Flash Flex inference at sustained rate against BrainLayer's SQLite-backed enrichment pipeline.

The current concurrent `enrich_single()` path can send at about `346.9 req/s` in the new integration RED test, versus the target ceiling of `<=5.5 req/s` after the initial burst. This PR closes that gap and removes direct multi-threaded write contention on SQLite.

## Implementation Notes
- actual live target is `src/brainlayer/enrichment_controller.py`
- `R84b-design.md` section 10.1 line 323 is stale and still references `src/brainlayer/pipeline/enrichment_controller.py`
- installed `google-genai` version is `1.63.0`; retry control is under `http_options.retry_options.attempts`, not a top-level `retry_options` client kwarg
- collab brief followed from `/Users/etanheyman/Gits/orchestrator/collab/brainlayer-pr-a3-enrichment-refactor.md`

## Tests
- `pytest tests/test_write_queue.py tests/test_rate_limiter.py -q`
- `pytest tests/test_enrichment_controller.py::test_store_lifecycle_waits_for_cleanup_before_new_operations tests/test_write_queue.py tests/test_rate_limiter.py -q`
- `pytest tests/test_enrichment_controller.py tests/test_write_queue.py tests/test_concurrent_enrichment.py tests/test_auto_enrich.py tests/test_rate_limiter.py tests/test_enrichment_flex_integration.py -q`
- `ruff check src/brainlayer/enrichment_controller.py src/brainlayer/pipeline/write_queue.py src/brainlayer/pipeline/rate_limiter.py tests/test_enrichment_controller.py tests/test_write_queue.py tests/test_rate_limiter.py tests/test_enrichment_flex_integration.py`

## Full Suite Context
`pytest tests/ -q` in this local environment still reports:
- 5 failures that reproduce on clean `origin/main` (`tests/test_eval_baselines.py`, `tests/test_vector_store.py`)
- 2 order-dependent prompt-hook failures caused by fixed test session IDs (`sess-1`, `sess-123`) contaminating dedup state across long runs

Those are out of scope for PR-A3 and pre-existing to this refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-store rate limiting for enrichment operations (token-bucket based) and a single-writer write queue for serialized DB updates.

* **Bug Fixes**
  * Improved API retry/backoff behavior with computed wait, logging, and safer retry attempts.
  * Coordinated shutdown and cleanup to avoid concurrent write/race issues.

* **Refactor**
  * Reworked enrichment control flow for safer concurrency and one-time enrichment staging initialization.

* **Tests**
  * Added unit and integration tests for rate limiter, write queue, and enrichment concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden enrichment controller with per-store write queues and token-bucket rate limiting for Gemini Flex throughput
> - Introduces [`WriteQueue`](https://github.com/EtanHey/brainlayer/pull/234/files#diff-028e18c6b9d6323db92e84de3c7576b433b342a0fc2f63dc7317dd977a2d4ac3) to serialize all database writes through a per-store background worker thread, replacing direct calls in `enrich_single`, `enrich_realtime`, `enrich_batch`, and `enrich_local`.
> - Introduces [`TokenBucket`](https://github.com/EtanHey/brainlayer/pull/234/files#diff-191c6be0bb25700483f4d33d6af54de47a86e9a53fd1ac7af26d04000e9c28ff) for per-store Gemini call pacing, replacing the fixed `time.sleep` loops previously used in `enrich_realtime` and `enrich_batch`.
> - Adds store lifecycle tracking via `_begin_store_operation`/`_end_store_operation` so write-queue workers are started on first use and cleanly shut down when all concurrent operations complete.
> - Disables Gemini SDK-level retries (`attempts=1`) and routes retry logic entirely through the existing `_retry_with_backoff` helper, which now logs a warning with the planned delay before each sleep.
> - Risk: all write paths are now asynchronous and serialized; any caller that previously relied on writes completing synchronously will now block on a `Future.result()` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90e8b58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->