### PR TITLE
feat: enable Gemini Flex tier for enrichment

### DIFF
--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -299,13 +299,16 @@ GEMINI_RESPONSE_SCHEMA = {
 
 
 def _build_gemini_config() -> dict[str, Any]:
-    service_tier = os.environ.get("BRAINLAYER_GEMINI_SERVICE_TIER", "flex")
     return {
         "response_mime_type": "application/json",
         "response_schema": GEMINI_RESPONSE_SCHEMA,
         "thinking_config": {"thinking_budget": 0},
-        "service_tier": service_tier,
+        "service_tier": _get_gemini_service_tier(),
     }
+
+
+def _get_gemini_service_tier() -> str:
+    return os.environ.get("BRAINLAYER_GEMINI_SERVICE_TIER", "flex")
 
 
 # ── Entity extraction via Gemini ───────────────────────────────────────────────
@@ -332,7 +335,7 @@ def call_gemini_for_extraction(prompt: str) -> Optional[str]:
             config={
                 "response_mime_type": "application/json",
                 "thinking_config": {"thinking_budget": 0},
-                "service_tier": os.environ.get("BRAINLAYER_GEMINI_SERVICE_TIER", "flex"),
+                "service_tier": _get_gemini_service_tier(),
                 "http_options": {"timeout": 30_000},
             },
         )

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -299,10 +299,12 @@ GEMINI_RESPONSE_SCHEMA = {
 
 
 def _build_gemini_config() -> dict[str, Any]:
+    service_tier = os.environ.get("BRAINLAYER_GEMINI_SERVICE_TIER", "flex")
     return {
         "response_mime_type": "application/json",
         "response_schema": GEMINI_RESPONSE_SCHEMA,
         "thinking_config": {"thinking_budget": 0},
+        "service_tier": service_tier,
     }
 
 
@@ -330,6 +332,7 @@ def call_gemini_for_extraction(prompt: str) -> Optional[str]:
             config={
                 "response_mime_type": "application/json",
                 "thinking_config": {"thinking_budget": 0},
+                "service_tier": os.environ.get("BRAINLAYER_GEMINI_SERVICE_TIER", "flex"),
                 "http_options": {"timeout": 30_000},
             },
         )

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -115,6 +115,34 @@ def test_enrich_realtime_sets_thinking_budget_zero_in_gemini_config(monkeypatch)
     assert captured["config"]["thinking_config"]["thinking_budget"] == 0
 
 
+def test_enrich_realtime_passes_flex_service_tier_in_gemini_config(monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    store = MagicMock()
+    store.get_enrichment_candidates.return_value = [_candidate()]
+    monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
+    monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
+    monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
+    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+
+    captured = {}
+
+    class FakeClient:
+        class _Models:
+            def generate_content(self, **kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(text='{"summary":"sum","tags":["python"]}')
+
+        def __init__(self):
+            self.models = self._Models()
+
+    monkeypatch.setattr(controller, "_get_gemini_client", lambda: FakeClient())
+
+    controller.enrich_realtime(store)
+
+    assert captured["config"]["service_tier"] == "flex"
+
+
 def test_enrich_realtime_calls_parse_enrichment_on_response(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
@@ -448,6 +476,16 @@ def test_build_gemini_config_disables_thinking():
 
     config = _build_gemini_config()
     assert config["thinking_config"]["thinking_budget"] == 0
+
+
+def test_build_gemini_config_allows_service_tier_override(monkeypatch):
+    from brainlayer.enrichment_controller import _build_gemini_config
+
+    monkeypatch.setenv("BRAINLAYER_GEMINI_SERVICE_TIER", "standard")
+
+    config = _build_gemini_config()
+
+    assert config["service_tier"] == "standard"
 
 
 def test_gemini_client_requires_api_key(monkeypatch):

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -120,6 +120,7 @@ def test_enrich_realtime_passes_flex_service_tier_in_gemini_config(monkeypatch):
 
     store = MagicMock()
     store.get_enrichment_candidates.return_value = [_candidate()]
+    monkeypatch.delenv("BRAINLAYER_GEMINI_SERVICE_TIER", raising=False)
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))


### PR DESCRIPTION
## Summary
- default Gemini enrichment requests to `service_tier="flex"` on the live controller path in `src/brainlayer/enrichment_controller.py`
- allow ops/tests to override with `BRAINLAYER_GEMINI_SERVICE_TIER` (for example `standard`)
- add RED/GREEN coverage that proves the realtime `generate_content(...)` call actually carries the tier flag

## Why
- R84b §8 Q2 locked Flex Inference as the preferred pass-2 path because it keeps the synchronous SDK flow and applies the 50% Flex discount with acceptable async backlog latency
- this PR is the actual tier switch on top of PR-A3's single-writer queue, token bucket, and SDK retry ownership
- the brief's `pipeline/enrichment.py` path was stale for this behavior; the live Gemini enrichment path is `enrichment_controller.py`

## Test plan
- `pytest tests/test_enrichment_controller.py -q -k "service_tier or override"`
- `pytest tests/test_enrichment_controller.py tests/test_enrichment_flex_integration.py -q`

## Context
- Collab: `/Users/etanheyman/Gits/orchestrator/collab/brainlayer-a5-a6-flex-restart-bundle.md`
- R84b design ref: `/Users/etanheyman/Gits/orchestrator/docs.local/plans/2026-04-11-kg-relationship-extraction/R84b-design.md` lines 281-290


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable Gemini Flex service tier for enrichment calls
> Adds a `service_tier` field to Gemini API requests in [enrichment_controller.py](https://github.com/EtanHey/brainlayer/pull/235/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb). A new helper `_get_gemini_service_tier()` reads `BRAINLAYER_GEMINI_SERVICE_TIER` from the environment, defaulting to `'flex'` when unset. Both `_build_gemini_config` and `call_gemini_for_extraction` now include this value in their Gemini configs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94e1245.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configurable Gemini service tier via environment variable (defaults to "flex").

* **Tests**
  * Added tests ensuring the chosen service tier is included in Gemini API calls and respects the environment setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->