### PR TITLE
fix: parse enrichment sentiment fields

### DIFF
--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -821,6 +821,20 @@ def parse_enrichment(text: str) -> Optional[Dict[str, Any]]:
         if isinstance(debt_impact, str) and debt_impact.lower().strip() in VALID_DEBT_IMPACT:
             result["debt_impact"] = debt_impact.lower().strip()
 
+        sentiment_label = match.get("sentiment_label", "")
+        if isinstance(sentiment_label, str) and sentiment_label.lower().strip() in VALID_SENTIMENTS:
+            result["sentiment_label"] = sentiment_label.lower().strip()
+
+        sentiment_score = match.get("sentiment_score")
+        if isinstance(sentiment_score, (int, float)):
+            result["sentiment_score"] = max(-1.0, min(1.0, float(sentiment_score)))
+
+        sentiment_signals = match.get("sentiment_signals", [])
+        if isinstance(sentiment_signals, list):
+            cleaned = [str(s).strip() for s in sentiment_signals if isinstance(s, str) and s.strip()][:10]
+            if cleaned:
+                result["sentiment_signals"] = cleaned
+
         external_deps = match.get("external_deps", [])
         if isinstance(external_deps, list):
             cleaned = [str(d).strip().lower() for d in external_deps if isinstance(d, str) and d.strip()][:15]

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -836,7 +836,18 @@ def parse_enrichment(text: str) -> Optional[Dict[str, Any]]:
 
         sentiment_signals = match.get("sentiment_signals", [])
         if isinstance(sentiment_signals, list):
-            cleaned = [str(s).strip() for s in sentiment_signals if isinstance(s, str) and s.strip()][:10]
+            cleaned = []
+            seen = set()
+            for signal in sentiment_signals:
+                if not isinstance(signal, str):
+                    continue
+                normalized = signal.strip()
+                if not normalized or normalized in seen:
+                    continue
+                seen.add(normalized)
+                cleaned.append(normalized)
+                if len(cleaned) == 10:
+                    break
             if cleaned:
                 result["sentiment_signals"] = cleaned
 

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -28,6 +28,7 @@ AIDEV-NOTE: Two prompt paths exist:
 
 import json
 import logging
+import math
 import os
 import random
 import sys
@@ -826,7 +827,11 @@ def parse_enrichment(text: str) -> Optional[Dict[str, Any]]:
             result["sentiment_label"] = sentiment_label.lower().strip()
 
         sentiment_score = match.get("sentiment_score")
-        if isinstance(sentiment_score, (int, float)):
+        if (
+            isinstance(sentiment_score, (int, float))
+            and not isinstance(sentiment_score, bool)
+            and math.isfinite(float(sentiment_score))
+        ):
             result["sentiment_score"] = max(-1.0, min(1.0, float(sentiment_score)))
 
         sentiment_signals = match.get("sentiment_signals", [])

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -827,12 +827,13 @@ def parse_enrichment(text: str) -> Optional[Dict[str, Any]]:
             result["sentiment_label"] = sentiment_label.lower().strip()
 
         sentiment_score = match.get("sentiment_score")
-        if (
-            isinstance(sentiment_score, (int, float))
-            and not isinstance(sentiment_score, bool)
-            and math.isfinite(float(sentiment_score))
-        ):
-            result["sentiment_score"] = max(-1.0, min(1.0, float(sentiment_score)))
+        if isinstance(sentiment_score, (int, float)) and not isinstance(sentiment_score, bool):
+            try:
+                normalized_score = float(sentiment_score)
+            except (OverflowError, ValueError):
+                normalized_score = None
+            if normalized_score is not None and math.isfinite(normalized_score):
+                result["sentiment_score"] = max(-1.0, min(1.0, normalized_score))
 
         sentiment_signals = match.get("sentiment_signals", [])
         if isinstance(sentiment_signals, list):

--- a/tests/test_enrichment_v2.py
+++ b/tests/test_enrichment_v2.py
@@ -216,6 +216,44 @@ def test_parse_enrichment_skips_missing_sentiment_fields():
     assert "sentiment_signals" not in result
 
 
+def test_parse_enrichment_rejects_boolean_sentiment_score():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = json.dumps(
+        {
+            "summary": "The parser should reject malformed boolean sentiment scores.",
+            "tags": ["python", "parsing"],
+            "sentiment_label": "neutral",
+            "sentiment_score": True,
+        }
+    )
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert result["sentiment_label"] == "neutral"
+    assert "sentiment_score" not in result
+
+
+def test_parse_enrichment_rejects_non_finite_sentiment_score():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = """
+    {
+      "summary": "The parser should reject malformed non-finite sentiment scores.",
+      "tags": ["python", "parsing"],
+      "sentiment_label": "neutral",
+      "sentiment_score": NaN
+    }
+    """
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert result["sentiment_label"] == "neutral"
+    assert "sentiment_score" not in result
+
+
 def test_gemini_schema_supports_v2_fields():
     from brainlayer.enrichment_controller import GEMINI_RESPONSE_SCHEMA
 

--- a/tests/test_enrichment_v2.py
+++ b/tests/test_enrichment_v2.py
@@ -158,6 +158,64 @@ def test_parse_enrichment_keeps_legacy_resolved_query_when_plural_missing():
     assert "resolved_queries" not in result
 
 
+def test_parse_enrichment_extracts_sentiment_fields():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = json.dumps(
+        {
+            "summary": "The CLI is broken and the current output is unusable for the intended workflow.",
+            "tags": ["debugging", "cli"],
+            "sentiment_label": "frustration",
+            "sentiment_score": -0.6,
+            "sentiment_signals": ["damn", "broken"],
+        }
+    )
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert result["sentiment_label"] == "frustration"
+    assert result["sentiment_score"] == -0.6
+    assert result["sentiment_signals"] == ["damn", "broken"]
+
+
+def test_parse_enrichment_rejects_invalid_sentiment_label():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = json.dumps(
+        {
+            "summary": "The workflow completed successfully and the user is happy with the outcome.",
+            "tags": ["reviewing"],
+            "sentiment_label": "happy",
+            "sentiment_score": 0.8,
+            "sentiment_signals": ["works great"],
+        }
+    )
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert "sentiment_label" not in result
+
+
+def test_parse_enrichment_skips_missing_sentiment_fields():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = json.dumps(
+        {
+            "summary": "The parser should still return core enrichment fields when sentiment is omitted.",
+            "tags": ["python", "parsing"],
+        }
+    )
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert "sentiment_label" not in result
+    assert "sentiment_score" not in result
+    assert "sentiment_signals" not in result
+
+
 def test_gemini_schema_supports_v2_fields():
     from brainlayer.enrichment_controller import GEMINI_RESPONSE_SCHEMA
 

--- a/tests/test_enrichment_v2.py
+++ b/tests/test_enrichment_v2.py
@@ -254,6 +254,25 @@ def test_parse_enrichment_rejects_non_finite_sentiment_score():
     assert "sentiment_score" not in result
 
 
+def test_parse_enrichment_rejects_overflowing_integer_sentiment_score():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = json.dumps(
+        {
+            "summary": "The parser should reject sentiment scores that overflow float conversion.",
+            "tags": ["python", "parsing"],
+            "sentiment_label": "neutral",
+            "sentiment_score": 10**1000,
+        }
+    )
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert result["sentiment_label"] == "neutral"
+    assert "sentiment_score" not in result
+
+
 def test_parse_enrichment_normalizes_label_lowercase():
     from brainlayer.pipeline.enrichment import parse_enrichment
 

--- a/tests/test_enrichment_v2.py
+++ b/tests/test_enrichment_v2.py
@@ -254,6 +254,70 @@ def test_parse_enrichment_rejects_non_finite_sentiment_score():
     assert "sentiment_score" not in result
 
 
+def test_parse_enrichment_normalizes_label_lowercase():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = json.dumps(
+        {
+            "summary": "The parser should normalize mixed-case sentiment labels.",
+            "tags": ["python", "parsing"],
+            "sentiment_label": "FrUsTraTiOn",
+        }
+    )
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert result["sentiment_label"] == "frustration"
+
+
+def test_parse_enrichment_clamps_score_bounds():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    high = json.dumps(
+        {
+            "summary": "The parser should clamp scores above one.",
+            "tags": ["python", "parsing"],
+            "sentiment_label": "positive",
+            "sentiment_score": 2.5,
+        }
+    )
+    low = json.dumps(
+        {
+            "summary": "The parser should clamp scores below minus one.",
+            "tags": ["python", "parsing"],
+            "sentiment_label": "frustration",
+            "sentiment_score": -3.0,
+        }
+    )
+
+    high_result = parse_enrichment(high)
+    low_result = parse_enrichment(low)
+
+    assert high_result is not None
+    assert high_result["sentiment_score"] == 1.0
+    assert low_result is not None
+    assert low_result["sentiment_score"] == -1.0
+
+
+def test_parse_enrichment_deduplicates_signals_order_preserved():
+    from brainlayer.pipeline.enrichment import parse_enrichment
+
+    raw = json.dumps(
+        {
+            "summary": "The parser should deduplicate repeated sentiment signals.",
+            "tags": ["python", "parsing"],
+            "sentiment_label": "confusion",
+            "sentiment_signals": ["oops", "nah", "oops", "nah2", "nah"],
+        }
+    )
+
+    result = parse_enrichment(raw)
+
+    assert result is not None
+    assert result["sentiment_signals"] == ["oops", "nah", "nah2"]
+
+
 def test_gemini_schema_supports_v2_fields():
     from brainlayer.enrichment_controller import GEMINI_RESPONSE_SCHEMA
 


### PR DESCRIPTION
## Summary
- extract `sentiment_label`, `sentiment_score`, and `sentiment_signals` in `parse_enrichment()`
- add regression coverage for valid sentiment extraction, invalid-label rejection, and missing-field tolerance
- preserve the existing `_enrich_one()` DB write path, which already forwards parsed sentiment fields to `update_enrichment()`

## Root Cause
The r81 enrichment prompt asks Gemini for sentiment fields, but `parse_enrichment()` never extracted them. That left `sentiment_label`, `sentiment_score`, and `sentiment_signals` null even when the model returned them.

## Reviewer Context
sentiment extraction was missing from `parse_enrichment()` since the r81 prompt was introduced. The prompt asks Gemini for sentiment but the parser never extracted it — a classic integration gap between prompt engineer and code engineer.

## Test Plan
- `pytest -q tests/test_enrichment_v2.py -k sentiment`
- `pytest -q tests/test_enrichment_v2.py tests/test_phase2.py tests/test_enrichment_entity_schema.py tests/test_enrichment_reliability.py tests/test_groq_backend.py tests/test_concurrent_enrichment.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sentiment metadata parsing now validates labels, omits invalid labels, clamps numeric scores to the [-1.0, 1.0] range and omits non-finite scores; sentiment signals are cleaned, trimmed and limited to 10 entries.

* **Tests**
  * Added regression tests covering valid/invalid labels, numeric/clamped/rejected scores, signal trimming, and missing-sentiment cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parse_enrichment` to extract and validate sentiment fields from model response
> - Adds parsing for `sentiment_label`, `sentiment_score`, and `sentiment_signals` in [`parse_enrichment`](https://github.com/EtanHey/brainlayer/pull/237/files#diff-f30fc27c3e1df5a572ae8a21eef1e434636d0811e71432bffe3067d139131a2c).
> - `sentiment_label` is normalized to lowercase and validated against `VALID_SENTIMENTS`; `sentiment_score` is clamped to `[-1.0, 1.0]` and rejects booleans, non-finite values, and overflow integers; `sentiment_signals` is deduplicated (order-preserved), trimmed, and capped at 10 items.
> - Adds 9 tests in [`tests/test_enrichment_v2.py`](https://github.com/EtanHey/brainlayer/pull/237/files#diff-c061e23cf7f60d2e2426d4e34a0e921244225c07b8e3405ced0b47a7b379afc7) covering valid extraction, normalization, clamping, deduplication, and all rejection cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9514ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->