### PR TITLE
chore: clean up maintenance scripts and eval outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ claude.scratchpad.md
 # Claude Code project settings
 .claude/
 
+# Local eval outputs (tracked baselines remain tracked)
+tests/eval_results/
+
 # Progress trackers (ephemeral)
 scripts/.kg_rebuild_progress.json
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI](https://github.com/EtanHey/brainlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/EtanHey/brainlayer/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-12%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-1%2C498%20Python%20%2B%2054%20Swift-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-1%2C844%20Python%20%2B%2054%20Swift-brightgreen.svg)](#testing)
 [![Website](https://img.shields.io/badge/site-brainlayer.etanheyman.com-d4956a.svg)](https://brainlayer.etanheyman.com)
 
 Every architecture decision, every debugging session, every preference you've expressed — **gone between sessions.** You repeat yourself constantly. Your agent rediscovers bugs it already fixed.
@@ -195,7 +195,7 @@ brainlayer dashboard          # Interactive TUI
 
 ```bash
 pip install -e ".[dev]"
-pytest tests/                           # 1,498 Python tests
+pytest tests/                           # 1,844 Python tests
 pytest tests/ -m "not integration"      # Unit tests only (fast)
 ruff check src/ && ruff format src/     # Lint + format
 # BrainBar: 54 Swift tests via Xcode

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI](https://github.com/EtanHey/brainlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/EtanHey/brainlayer/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-12%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-1%2C844%20Python%20%2B%2054%20Swift-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-1%2C848%20Python%20%2B%2054%20Swift-brightgreen.svg)](#testing)
 [![Website](https://img.shields.io/badge/site-brainlayer.etanheyman.com-d4956a.svg)](https://brainlayer.etanheyman.com)
 
 Every architecture decision, every debugging session, every preference you've expressed — **gone between sessions.** You repeat yourself constantly. Your agent rediscovers bugs it already fixed.
@@ -195,7 +195,7 @@ brainlayer dashboard          # Interactive TUI
 
 ```bash
 pip install -e ".[dev]"
-pytest tests/                           # 1,844 Python tests
+pytest tests/                           # 1,848 Python tests
 pytest tests/ -m "not integration"      # Unit tests only (fast)
 ruff check src/ && ruff format src/     # Lint + format
 # BrainBar: 54 Swift tests via Xcode

--- a/scripts/install-karabiner-rule.sh
+++ b/scripts/install-karabiner-rule.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Merge BrainBar Karabiner complex modification into ~/.config/karabiner/karabiner.json
+# without overwriting existing rules. Requires Python 3.
+#
+# Usage: bash scripts/install-karabiner-rule.sh
+# From repo root, or any cwd (script resolves paths relative to repo).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RULE_JSON="$REPO_ROOT/brain-bar/karabiner/brainbar-f4.json"
+KARABINER_JSON="${HOME}/.config/karabiner/karabiner.json"
+
+if [[ ! -f "$RULE_JSON" ]]; then
+  echo "install-karabiner-rule: missing rule file: $RULE_JSON" >&2
+  exit 1
+fi
+
+RULE_JSON="$RULE_JSON" KARABINER_JSON="$KARABINER_JSON" python3 <<'PY'
+import json
+import os
+
+rule_path = os.environ["RULE_JSON"]
+kb_path = os.path.expanduser(os.environ["KARABINER_JSON"])
+
+with open(rule_path, encoding="utf-8") as f:
+    new_rule = json.load(f)
+
+if os.path.isfile(kb_path):
+    with open(kb_path, encoding="utf-8") as f:
+        data = json.load(f)
+else:
+    data = {"global": {}, "profiles": []}
+
+if "profiles" not in data or not data["profiles"]:
+    data["profiles"] = [
+        {
+            "name": "Default profile",
+            "complex_modifications": {"rules": []},
+        }
+    ]
+
+prof = data["profiles"][0]
+if "complex_modifications" not in prof:
+    prof["complex_modifications"] = {}
+if "rules" not in prof["complex_modifications"]:
+    prof["complex_modifications"]["rules"] = []
+
+rules = prof["complex_modifications"]["rules"]
+desc = new_rule.get("description", "")
+if any(r.get("description") == desc for r in rules):
+    print(f"Already installed (skip): {desc}")
+else:
+    rules.append(new_rule)
+    print(f"Added: {desc}")
+
+os.makedirs(os.path.dirname(kb_path), exist_ok=True)
+with open(kb_path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+
+print(f"Wrote: {kb_path}")
+print("Open Karabiner-Elements and enable the rule under Complex modifications.")
+PY

--- a/scripts/purge_orphaned_vectors.py
+++ b/scripts/purge_orphaned_vectors.py
@@ -4,6 +4,7 @@
 Orphans = vector entries whose chunk_id no longer exists in the chunks table.
 Deletes in batches through the vec0 virtual table interface using APSW + sqlite-vec.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -67,9 +68,9 @@ def iter_orphan_ids(conn, vec_rowids_table: str) -> Iterator[str]:
 
 def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
     """Delete orphaned entries from a vec0 virtual table in batches."""
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Purging orphans from {label}")
-    print(f"{'='*60}", flush=True)
+    print(f"{'=' * 60}", flush=True)
 
     total = count_orphan_ids(conn, vec_rowids_table)
     print(f"Found {total:,} orphaned vectors", flush=True)
@@ -88,9 +89,7 @@ def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
 
         for cid in batch:
             try:
-                conn.execute(
-                    f"DELETE FROM {vec_table} WHERE chunk_id = ?", (cid,)
-                )
+                conn.execute(f"DELETE FROM {vec_table} WHERE chunk_id = ?", (cid,))
                 deleted += 1
             except Exception as e:
                 errors += 1
@@ -101,8 +100,7 @@ def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
         rate = deleted / elapsed if elapsed > 0 else 0
         print(
             f"  Batch {batch_num}: {deleted:,}/{total:,} deleted "
-            f"({deleted*100/total:.1f}%) — {rate:.0f}/s"
-            + (f" [{errors} errors]" if errors else ""),
+            f"({deleted * 100 / total:.1f}%) — {rate:.0f}/s" + (f" [{errors} errors]" if errors else ""),
             flush=True,
         )
 
@@ -129,17 +127,13 @@ def main() -> None:
 
     # Pre-check
     total_vecs = conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0]
-    total_bins = conn.execute(
-        "SELECT COUNT(*) FROM chunk_vectors_binary_rowids"
-    ).fetchone()[0]
+    total_bins = conn.execute("SELECT COUNT(*) FROM chunk_vectors_binary_rowids").fetchone()[0]
     total_chunks = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
     print(f"chunk_vectors entries: {total_vecs:,}")
     print(f"chunk_vectors_binary entries: {total_bins:,}")
     print(f"chunks table rows: {total_chunks:,}")
 
-    deleted_float = purge_vec_table(
-        conn, "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors (float32)"
-    )
+    deleted_float = purge_vec_table(conn, "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors (float32)")
     deleted_binary = purge_vec_table(
         conn,
         "chunk_vectors_binary",
@@ -152,12 +146,8 @@ def main() -> None:
     conn.execute("PRAGMA wal_checkpoint(FULL)")
 
     # Post-check
-    remaining_vecs = conn.execute(
-        "SELECT COUNT(*) FROM chunk_vectors_rowids"
-    ).fetchone()[0]
-    remaining_bins = conn.execute(
-        "SELECT COUNT(*) FROM chunk_vectors_binary_rowids"
-    ).fetchone()[0]
+    remaining_vecs = conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0]
+    remaining_bins = conn.execute("SELECT COUNT(*) FROM chunk_vectors_binary_rowids").fetchone()[0]
     print("\nPost-purge:")
     print(f"  chunk_vectors: {remaining_vecs:,} (was {total_vecs:,})")
     print(f"  chunk_vectors_binary: {remaining_bins:,} (was {total_bins:,})")

--- a/scripts/purge_orphaned_vectors.py
+++ b/scripts/purge_orphaned_vectors.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import time
-from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 import apsw
@@ -55,15 +54,19 @@ def count_orphan_ids(conn, vec_rowids_table: str) -> int:
     return int(row[0]) if row else 0
 
 
-def iter_orphan_ids(conn, vec_rowids_table: str) -> Iterator[str]:
-    """Stream chunk IDs in the vec table that don't exist in chunks."""
-    for row in conn.execute(
-        f"""
+def get_orphan_batch(conn, vec_rowids_table: str, limit: int = BATCH_SIZE) -> list[str]:
+    """Fetch one bounded batch of orphan IDs from the vec shadow table."""
+    return [
+        row[0]
+        for row in conn.execute(
+            f"""
         SELECT vr.id FROM {vec_rowids_table} vr
         WHERE vr.id NOT IN (SELECT id FROM chunks)
-        """
-    ):
-        yield row[0]
+        LIMIT ?
+        """,
+            (limit,),
+        )
+    ]
 
 
 def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
@@ -83,9 +86,14 @@ def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
     errors = 0
     batch_num = 0
     start = time.time()
+    processed = 0
 
-    for batch in batched(iter_orphan_ids(conn, vec_rowids_table), BATCH_SIZE):
+    while True:
+        batch = get_orphan_batch(conn, vec_rowids_table, BATCH_SIZE)
+        if not batch:
+            break
         batch_num += 1
+        processed += len(batch)
 
         for cid in batch:
             try:
@@ -99,14 +107,17 @@ def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
         elapsed = time.time() - start
         rate = deleted / elapsed if elapsed > 0 else 0
         print(
-            f"  Batch {batch_num}: {deleted:,}/{total:,} deleted "
-            f"({deleted * 100 / total:.1f}%) — {rate:.0f}/s" + (f" [{errors} errors]" if errors else ""),
+            f"  Batch {batch_num}: {processed:,}/{total:,} processed, {deleted:,} deleted "
+            f"({processed * 100 / total:.1f}%) — {rate:.0f}/s" + (f" [{errors} errors]" if errors else ""),
             flush=True,
         )
 
         if batch_num % CHECKPOINT_EVERY == 0:
             conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
             print("  [WAL checkpoint]", flush=True)
+
+        if errors:
+            break
 
     elapsed = time.time() - start
     print(f"\nDone: {deleted:,} orphans purged from {label} in {elapsed:.1f}s")
@@ -124,37 +135,37 @@ def main() -> None:
     db_path = resolve_db_path(args.db_path)
     print(f"Database: {db_path}")
     conn = make_conn(db_path)
+    try:
+        # Pre-check
+        total_vecs = conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0]
+        total_bins = conn.execute("SELECT COUNT(*) FROM chunk_vectors_binary_rowids").fetchone()[0]
+        total_chunks = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        print(f"chunk_vectors entries: {total_vecs:,}")
+        print(f"chunk_vectors_binary entries: {total_bins:,}")
+        print(f"chunks table rows: {total_chunks:,}")
 
-    # Pre-check
-    total_vecs = conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0]
-    total_bins = conn.execute("SELECT COUNT(*) FROM chunk_vectors_binary_rowids").fetchone()[0]
-    total_chunks = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
-    print(f"chunk_vectors entries: {total_vecs:,}")
-    print(f"chunk_vectors_binary entries: {total_bins:,}")
-    print(f"chunks table rows: {total_chunks:,}")
+        deleted_float = purge_vec_table(conn, "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors (float32)")
+        deleted_binary = purge_vec_table(
+            conn,
+            "chunk_vectors_binary",
+            "chunk_vectors_binary_rowids",
+            "chunk_vectors_binary (bit)",
+        )
 
-    deleted_float = purge_vec_table(conn, "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors (float32)")
-    deleted_binary = purge_vec_table(
-        conn,
-        "chunk_vectors_binary",
-        "chunk_vectors_binary_rowids",
-        "chunk_vectors_binary (bit)",
-    )
+        # Final checkpoint
+        print("\nFinal WAL checkpoint...")
+        conn.execute("PRAGMA wal_checkpoint(FULL)")
 
-    # Final checkpoint
-    print("\nFinal WAL checkpoint...")
-    conn.execute("PRAGMA wal_checkpoint(FULL)")
-
-    # Post-check
-    remaining_vecs = conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0]
-    remaining_bins = conn.execute("SELECT COUNT(*) FROM chunk_vectors_binary_rowids").fetchone()[0]
-    print("\nPost-purge:")
-    print(f"  chunk_vectors: {remaining_vecs:,} (was {total_vecs:,})")
-    print(f"  chunk_vectors_binary: {remaining_bins:,} (was {total_bins:,})")
-    print(f"  Total deleted: {deleted_float + deleted_binary:,}")
-
-    conn.close()
-    print("\nDone. Run VACUUM separately to reclaim disk space.")
+        # Post-check
+        remaining_vecs = conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0]
+        remaining_bins = conn.execute("SELECT COUNT(*) FROM chunk_vectors_binary_rowids").fetchone()[0]
+        print("\nPost-purge:")
+        print(f"  chunk_vectors: {remaining_vecs:,} (was {total_vecs:,})")
+        print(f"  chunk_vectors_binary: {remaining_bins:,} (was {total_bins:,})")
+        print(f"  Total deleted: {deleted_float + deleted_binary:,}")
+        print("\nDone. Run VACUUM separately to reclaim disk space.")
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/scripts/purge_orphaned_vectors.py
+++ b/scripts/purge_orphaned_vectors.py
@@ -33,22 +33,14 @@ def make_conn(db_path: Path):
     return conn
 
 
-def batched(values: Iterable[str], batch_size: int) -> Iterator[list[str]]:
-    batch: list[str] = []
-    for value in values:
-        batch.append(value)
-        if len(batch) >= batch_size:
-            yield batch
-            batch = []
-    if batch:
-        yield batch
-
-
 def count_orphan_ids(conn, vec_rowids_table: str) -> int:
     row = conn.execute(
         f"""
         SELECT COUNT(*) FROM {vec_rowids_table} vr
-        WHERE vr.id NOT IN (SELECT id FROM chunks)
+        WHERE NOT EXISTS (
+            SELECT 1 FROM chunks c
+            WHERE c.id = vr.id
+        )
         """
     ).fetchone()
     return int(row[0]) if row else 0
@@ -61,7 +53,10 @@ def get_orphan_batch(conn, vec_rowids_table: str, limit: int = BATCH_SIZE) -> li
         for row in conn.execute(
             f"""
         SELECT vr.id FROM {vec_rowids_table} vr
-        WHERE vr.id NOT IN (SELECT id FROM chunks)
+        WHERE NOT EXISTS (
+            SELECT 1 FROM chunks c
+            WHERE c.id = vr.id
+        )
         LIMIT ?
         """,
             (limit,),

--- a/scripts/purge_orphaned_vectors.py
+++ b/scripts/purge_orphaned_vectors.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Purge orphaned vectors from chunk_vectors and chunk_vectors_binary vec0 tables.
+
+Orphans = vector entries whose chunk_id no longer exists in the chunks table.
+Deletes in batches through the vec0 virtual table interface using APSW + sqlite-vec.
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import apsw
+import sqlite_vec
+
+from brainlayer.paths import get_db_path
+
+BATCH_SIZE = 2000
+CHECKPOINT_EVERY = 5  # batches
+
+
+def resolve_db_path(db_path: str | None = None) -> Path:
+    return Path(db_path) if db_path else get_db_path()
+
+
+def make_conn(db_path: Path):
+    conn = apsw.Connection(str(db_path))
+    conn.enableloadextension(True)
+    conn.loadextension(sqlite_vec.loadable_path())
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=10000")
+    return conn
+
+
+def get_orphan_ids(conn, vec_rowids_table: str) -> list[str]:
+    """Get all chunk IDs in the vec table that don't exist in chunks."""
+    rows = conn.execute(f"""
+        SELECT vr.id FROM {vec_rowids_table} vr
+        WHERE vr.id NOT IN (SELECT id FROM chunks)
+    """).fetchall()
+    return [row[0] for row in rows]
+
+
+def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
+    """Delete orphaned entries from a vec0 virtual table in batches."""
+    print(f"\n{'='*60}")
+    print(f"Purging orphans from {label}")
+    print(f"{'='*60}", flush=True)
+
+    orphan_ids = get_orphan_ids(conn, vec_rowids_table)
+    total = len(orphan_ids)
+    print(f"Found {total:,} orphaned vectors", flush=True)
+
+    if total == 0:
+        print("Nothing to purge.")
+        return 0
+
+    deleted = 0
+    errors = 0
+    batch_num = 0
+    start = time.time()
+
+    for i in range(0, total, BATCH_SIZE):
+        batch = orphan_ids[i : i + BATCH_SIZE]
+        batch_num += 1
+
+        for cid in batch:
+            try:
+                conn.execute(
+                    f"DELETE FROM {vec_table} WHERE chunk_id = ?", (cid,)
+                )
+                deleted += 1
+            except Exception as e:
+                errors += 1
+                if errors <= 5:
+                    print(f"  Error deleting {cid}: {e}")
+
+        elapsed = time.time() - start
+        rate = deleted / elapsed if elapsed > 0 else 0
+        print(
+            f"  Batch {batch_num}: {deleted:,}/{total:,} deleted "
+            f"({deleted*100/total:.1f}%) — {rate:.0f}/s"
+            + (f" [{errors} errors]" if errors else ""),
+            flush=True,
+        )
+
+        if batch_num % CHECKPOINT_EVERY == 0:
+            conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            print("  [WAL checkpoint]", flush=True)
+
+    elapsed = time.time() - start
+    print(f"\nDone: {deleted:,} orphans purged from {label} in {elapsed:.1f}s")
+    if errors:
+        print(f"  ({errors} errors)")
+    return deleted
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", help="Path to the BrainLayer SQLite DB")
+    args = parser.parse_args()
+
+    db_path = resolve_db_path(args.db_path)
+    print(f"Database: {db_path}")
+    conn = make_conn(db_path)
+
+    # Pre-check
+    total_vecs = conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0]
+    total_bins = conn.execute(
+        "SELECT COUNT(*) FROM chunk_vectors_binary_rowids"
+    ).fetchone()[0]
+    total_chunks = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    print(f"chunk_vectors entries: {total_vecs:,}")
+    print(f"chunk_vectors_binary entries: {total_bins:,}")
+    print(f"chunks table rows: {total_chunks:,}")
+
+    deleted_float = purge_vec_table(
+        conn, "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors (float32)"
+    )
+    deleted_binary = purge_vec_table(
+        conn,
+        "chunk_vectors_binary",
+        "chunk_vectors_binary_rowids",
+        "chunk_vectors_binary (bit)",
+    )
+
+    # Final checkpoint
+    print("\nFinal WAL checkpoint...")
+    conn.execute("PRAGMA wal_checkpoint(FULL)")
+
+    # Post-check
+    remaining_vecs = conn.execute(
+        "SELECT COUNT(*) FROM chunk_vectors_rowids"
+    ).fetchone()[0]
+    remaining_bins = conn.execute(
+        "SELECT COUNT(*) FROM chunk_vectors_binary_rowids"
+    ).fetchone()[0]
+    print("\nPost-purge:")
+    print(f"  chunk_vectors: {remaining_vecs:,} (was {total_vecs:,})")
+    print(f"  chunk_vectors_binary: {remaining_bins:,} (was {total_bins:,})")
+    print(f"  Total deleted: {deleted_float + deleted_binary:,}")
+
+    conn.close()
+    print("\nDone. Run VACUUM separately to reclaim disk space.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/purge_orphaned_vectors.py
+++ b/scripts/purge_orphaned_vectors.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import time
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 import apsw
@@ -32,13 +33,36 @@ def make_conn(db_path: Path):
     return conn
 
 
-def get_orphan_ids(conn, vec_rowids_table: str) -> list[str]:
-    """Get all chunk IDs in the vec table that don't exist in chunks."""
-    rows = conn.execute(f"""
+def batched(values: Iterable[str], batch_size: int) -> Iterator[list[str]]:
+    batch: list[str] = []
+    for value in values:
+        batch.append(value)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def count_orphan_ids(conn, vec_rowids_table: str) -> int:
+    row = conn.execute(
+        f"""
+        SELECT COUNT(*) FROM {vec_rowids_table} vr
+        WHERE vr.id NOT IN (SELECT id FROM chunks)
+        """
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def iter_orphan_ids(conn, vec_rowids_table: str) -> Iterator[str]:
+    """Stream chunk IDs in the vec table that don't exist in chunks."""
+    for row in conn.execute(
+        f"""
         SELECT vr.id FROM {vec_rowids_table} vr
         WHERE vr.id NOT IN (SELECT id FROM chunks)
-    """).fetchall()
-    return [row[0] for row in rows]
+        """
+    ):
+        yield row[0]
 
 
 def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
@@ -47,8 +71,7 @@ def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
     print(f"Purging orphans from {label}")
     print(f"{'='*60}", flush=True)
 
-    orphan_ids = get_orphan_ids(conn, vec_rowids_table)
-    total = len(orphan_ids)
+    total = count_orphan_ids(conn, vec_rowids_table)
     print(f"Found {total:,} orphaned vectors", flush=True)
 
     if total == 0:
@@ -60,8 +83,7 @@ def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
     batch_num = 0
     start = time.time()
 
-    for i in range(0, total, BATCH_SIZE):
-        batch = orphan_ids[i : i + BATCH_SIZE]
+    for batch in batched(iter_orphan_ids(conn, vec_rowids_table), BATCH_SIZE):
         batch_num += 1
 
         for cid in batch:
@@ -92,6 +114,7 @@ def purge_vec_table(conn, vec_table: str, vec_rowids_table: str, label: str):
     print(f"\nDone: {deleted:,} orphans purged from {label} in {elapsed:.1f}s")
     if errors:
         print(f"  ({errors} errors)")
+        raise RuntimeError(f"Failed to purge {errors} orphaned vectors from {label}")
     return deleted
 
 

--- a/scripts/rebuild_vec0_tables.py
+++ b/scripts/rebuild_vec0_tables.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import time
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 import apsw
@@ -32,6 +33,38 @@ def make_conn(db_path: Path):
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA busy_timeout=30000")
     return conn
+
+
+def batched(values: Iterable[str], batch_size: int) -> Iterator[list[str]]:
+    batch: list[str] = []
+    for value in values:
+        batch.append(value)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def iter_valid_chunk_ids(conn, rowids_table: str) -> Iterator[str]:
+    for row in conn.execute(
+        f"SELECT id FROM {rowids_table} WHERE id IN (SELECT id FROM chunks)"
+    ):
+        yield row[0]
+
+
+def read_embedding_or_raise(conn, vec_table: str, chunk_id: str):
+    try:
+        row = conn.execute(
+            f"SELECT embedding FROM {vec_table} WHERE chunk_id = ?", (chunk_id,)
+        ).fetchone()
+    except Exception as exc:  # pragma: no cover - exercised via tests with fake conn
+        raise RuntimeError(
+            f"Failed to read embedding for {chunk_id} from {vec_table}"
+        ) from exc
+    if row is None:
+        raise RuntimeError(f"Missing embedding for {chunk_id} in {vec_table}")
+    return row[0]
 
 
 def rebuild_float32(conn):
@@ -56,32 +89,22 @@ def rebuild_float32(conn):
         )
     """)
 
-    # Read from vec0 in batches via the rowids table
-    all_ids = conn.execute(
-        "SELECT id FROM chunk_vectors_rowids WHERE id IN (SELECT id FROM chunks)"
-    ).fetchall()
-    all_ids = [r[0] for r in all_ids]
-
     inserted = 0
-    for i in range(0, len(all_ids), BATCH_SIZE):
-        batch_ids = all_ids[i : i + BATCH_SIZE]
+    for batch_ids in batched(iter_valid_chunk_ids(conn, "chunk_vectors_rowids"), BATCH_SIZE):
         for cid in batch_ids:
-            try:
-                row = conn.execute(
-                    "SELECT embedding FROM chunk_vectors WHERE chunk_id = ?", (cid,)
-                ).fetchone()
-                if row:
-                    conn.execute(
-                        "INSERT INTO _tmp_vec_backup (chunk_id, embedding) VALUES (?, ?)",
-                        (cid, row[0]),
-                    )
-                    inserted += 1
-            except Exception as e:
-                print(f"  Warning: skip {cid}: {e}")
+            embedding = read_embedding_or_raise(conn, "chunk_vectors", cid)
+            conn.execute(
+                "INSERT INTO _tmp_vec_backup (chunk_id, embedding) VALUES (?, ?)",
+                (cid, embedding),
+            )
+            inserted += 1
 
         elapsed = time.time() - t0
         rate = inserted / elapsed if elapsed > 0 else 0
         print(f"  Extracted {inserted:,}/{count:,} ({rate:.0f}/s)", flush=True)
+
+    if inserted != count:
+        raise RuntimeError(f"Backed up {inserted} float vectors but expected {count}")
 
     print(f"Step 1 done: {inserted:,} vectors backed up in {time.time()-t0:.1f}s")
 
@@ -106,8 +129,7 @@ def rebuild_float32(conn):
     reinserted = 0
     errors = 0
 
-    rows = conn.execute("SELECT chunk_id, embedding FROM _tmp_vec_backup").fetchall()
-    for cid, emb in rows:
+    for cid, emb in conn.execute("SELECT chunk_id, embedding FROM _tmp_vec_backup"):
         try:
             conn.execute(
                 "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
@@ -155,31 +177,24 @@ def rebuild_binary(conn):
         )
     """)
 
-    all_ids = conn.execute(
-        "SELECT id FROM chunk_vectors_binary_rowids WHERE id IN (SELECT id FROM chunks)"
-    ).fetchall()
-    all_ids = [r[0] for r in all_ids]
-
     inserted = 0
-    for i in range(0, len(all_ids), BATCH_SIZE):
-        batch_ids = all_ids[i : i + BATCH_SIZE]
+    for batch_ids in batched(
+        iter_valid_chunk_ids(conn, "chunk_vectors_binary_rowids"), BATCH_SIZE
+    ):
         for cid in batch_ids:
-            try:
-                row = conn.execute(
-                    "SELECT embedding FROM chunk_vectors_binary WHERE chunk_id = ?", (cid,)
-                ).fetchone()
-                if row:
-                    conn.execute(
-                        "INSERT INTO _tmp_binvec_backup (chunk_id, embedding) VALUES (?, ?)",
-                        (cid, row[0]),
-                    )
-                    inserted += 1
-            except Exception as e:
-                print(f"  Warning: skip {cid}: {e}")
+            embedding = read_embedding_or_raise(conn, "chunk_vectors_binary", cid)
+            conn.execute(
+                "INSERT INTO _tmp_binvec_backup (chunk_id, embedding) VALUES (?, ?)",
+                (cid, embedding),
+            )
+            inserted += 1
 
         elapsed = time.time() - t0
         rate = inserted / elapsed if elapsed > 0 else 0
         print(f"  Extracted {inserted:,}/{count:,} ({rate:.0f}/s)", flush=True)
+
+    if inserted != count:
+        raise RuntimeError(f"Backed up {inserted} binary vectors but expected {count}")
 
     print(f"Step 1 done: {inserted:,} vectors backed up in {time.time()-t0:.1f}s")
 
@@ -204,8 +219,7 @@ def rebuild_binary(conn):
     reinserted = 0
     errors = 0
 
-    rows = conn.execute("SELECT chunk_id, embedding FROM _tmp_binvec_backup").fetchall()
-    for cid, emb in rows:
+    for cid, emb in conn.execute("SELECT chunk_id, embedding FROM _tmp_binvec_backup"):
         try:
             conn.execute(
                 "INSERT INTO chunk_vectors_binary (chunk_id, embedding) VALUES (?, ?)",

--- a/scripts/rebuild_vec0_tables.py
+++ b/scripts/rebuild_vec0_tables.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Rebuild vec0 tables to reclaim space from orphaned/deleted vector slots.
+
+vec0 doesn't shrink partitions on DELETE — it just marks slots invalid.
+This script extracts valid vectors, drops the vec0 table (and all shadow tables),
+recreates it, and re-inserts the vectors.
+
+IMPORTANT: Stop all writers (enrichment, watcher) before running.
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import apsw
+import sqlite_vec
+
+from brainlayer.paths import get_db_path
+
+BATCH_SIZE = 5000
+
+
+def resolve_db_path(db_path: str | None = None) -> Path:
+    return Path(db_path) if db_path else get_db_path()
+
+
+def make_conn(db_path: Path):
+    conn = apsw.Connection(str(db_path))
+    conn.enableloadextension(True)
+    conn.loadextension(sqlite_vec.loadable_path())
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=30000")
+    return conn
+
+
+def rebuild_float32(conn):
+    print("\n" + "=" * 60)
+    print("Rebuilding chunk_vectors (float32)")
+    print("=" * 60, flush=True)
+
+    # Count valid entries
+    count = conn.execute(
+        "SELECT COUNT(*) FROM chunk_vectors_rowids WHERE id IN (SELECT id FROM chunks)"
+    ).fetchone()[0]
+    print(f"Valid vectors to preserve: {count:,}", flush=True)
+
+    # Step 1: Extract valid vectors to a temp table
+    print("Step 1: Extracting valid vectors to temp table...", flush=True)
+    t0 = time.time()
+    conn.execute("DROP TABLE IF EXISTS _tmp_vec_backup")
+    conn.execute("""
+        CREATE TABLE _tmp_vec_backup (
+            chunk_id TEXT PRIMARY KEY,
+            embedding BLOB
+        )
+    """)
+
+    # Read from vec0 in batches via the rowids table
+    all_ids = conn.execute(
+        "SELECT id FROM chunk_vectors_rowids WHERE id IN (SELECT id FROM chunks)"
+    ).fetchall()
+    all_ids = [r[0] for r in all_ids]
+
+    inserted = 0
+    for i in range(0, len(all_ids), BATCH_SIZE):
+        batch_ids = all_ids[i : i + BATCH_SIZE]
+        for cid in batch_ids:
+            try:
+                row = conn.execute(
+                    "SELECT embedding FROM chunk_vectors WHERE chunk_id = ?", (cid,)
+                ).fetchone()
+                if row:
+                    conn.execute(
+                        "INSERT INTO _tmp_vec_backup (chunk_id, embedding) VALUES (?, ?)",
+                        (cid, row[0]),
+                    )
+                    inserted += 1
+            except Exception as e:
+                print(f"  Warning: skip {cid}: {e}")
+
+        elapsed = time.time() - t0
+        rate = inserted / elapsed if elapsed > 0 else 0
+        print(f"  Extracted {inserted:,}/{count:,} ({rate:.0f}/s)", flush=True)
+
+    print(f"Step 1 done: {inserted:,} vectors backed up in {time.time()-t0:.1f}s")
+
+    # Step 2: Drop the vec0 table (drops all shadow tables)
+    print("Step 2: Dropping old vec0 table...", flush=True)
+    conn.execute("DROP TABLE IF EXISTS chunk_vectors")
+    print("  Dropped.")
+
+    # Step 3: Recreate
+    print("Step 3: Recreating vec0 table...", flush=True)
+    conn.execute("""
+        CREATE VIRTUAL TABLE chunk_vectors USING vec0(
+            chunk_id TEXT PRIMARY KEY,
+            embedding FLOAT[1024]
+        )
+    """)
+    print("  Created.")
+
+    # Step 4: Re-insert from backup
+    print("Step 4: Re-inserting vectors...", flush=True)
+    t0 = time.time()
+    reinserted = 0
+    errors = 0
+
+    rows = conn.execute("SELECT chunk_id, embedding FROM _tmp_vec_backup").fetchall()
+    for cid, emb in rows:
+        try:
+            conn.execute(
+                "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+                (cid, emb),
+            )
+            reinserted += 1
+        except Exception as e:
+            errors += 1
+            if errors <= 5:
+                print(f"  Insert error for {cid}: {e}")
+
+        if reinserted % 10000 == 0:
+            elapsed = time.time() - t0
+            rate = reinserted / elapsed if elapsed > 0 else 0
+            print(f"  Inserted {reinserted:,}/{inserted:,} ({rate:.0f}/s)", flush=True)
+
+    elapsed = time.time() - t0
+    print(f"Step 4 done: {reinserted:,} re-inserted in {elapsed:.1f}s ({errors} errors)")
+
+    # Step 5: Drop backup
+    conn.execute("DROP TABLE _tmp_vec_backup")
+    print("Backup table dropped.")
+
+    return reinserted
+
+
+def rebuild_binary(conn):
+    print("\n" + "=" * 60)
+    print("Rebuilding chunk_vectors_binary (bit)")
+    print("=" * 60, flush=True)
+
+    count = conn.execute(
+        "SELECT COUNT(*) FROM chunk_vectors_binary_rowids WHERE id IN (SELECT id FROM chunks)"
+    ).fetchone()[0]
+    print(f"Valid vectors to preserve: {count:,}", flush=True)
+
+    # Step 1: Extract
+    print("Step 1: Extracting valid vectors to temp table...", flush=True)
+    t0 = time.time()
+    conn.execute("DROP TABLE IF EXISTS _tmp_binvec_backup")
+    conn.execute("""
+        CREATE TABLE _tmp_binvec_backup (
+            chunk_id TEXT PRIMARY KEY,
+            embedding BLOB
+        )
+    """)
+
+    all_ids = conn.execute(
+        "SELECT id FROM chunk_vectors_binary_rowids WHERE id IN (SELECT id FROM chunks)"
+    ).fetchall()
+    all_ids = [r[0] for r in all_ids]
+
+    inserted = 0
+    for i in range(0, len(all_ids), BATCH_SIZE):
+        batch_ids = all_ids[i : i + BATCH_SIZE]
+        for cid in batch_ids:
+            try:
+                row = conn.execute(
+                    "SELECT embedding FROM chunk_vectors_binary WHERE chunk_id = ?", (cid,)
+                ).fetchone()
+                if row:
+                    conn.execute(
+                        "INSERT INTO _tmp_binvec_backup (chunk_id, embedding) VALUES (?, ?)",
+                        (cid, row[0]),
+                    )
+                    inserted += 1
+            except Exception as e:
+                print(f"  Warning: skip {cid}: {e}")
+
+        elapsed = time.time() - t0
+        rate = inserted / elapsed if elapsed > 0 else 0
+        print(f"  Extracted {inserted:,}/{count:,} ({rate:.0f}/s)", flush=True)
+
+    print(f"Step 1 done: {inserted:,} vectors backed up in {time.time()-t0:.1f}s")
+
+    # Step 2: Drop
+    print("Step 2: Dropping old vec0 binary table...", flush=True)
+    conn.execute("DROP TABLE IF EXISTS chunk_vectors_binary")
+    print("  Dropped.")
+
+    # Step 3: Recreate
+    print("Step 3: Recreating vec0 binary table...", flush=True)
+    conn.execute("""
+        CREATE VIRTUAL TABLE chunk_vectors_binary USING vec0(
+            chunk_id TEXT PRIMARY KEY,
+            embedding BIT[1024]
+        )
+    """)
+    print("  Created.")
+
+    # Step 4: Re-insert
+    print("Step 4: Re-inserting vectors...", flush=True)
+    t0 = time.time()
+    reinserted = 0
+    errors = 0
+
+    rows = conn.execute("SELECT chunk_id, embedding FROM _tmp_binvec_backup").fetchall()
+    for cid, emb in rows:
+        try:
+            conn.execute(
+                "INSERT INTO chunk_vectors_binary (chunk_id, embedding) VALUES (?, ?)",
+                (cid, emb),
+            )
+            reinserted += 1
+        except Exception as e:
+            errors += 1
+            if errors <= 5:
+                print(f"  Insert error for {cid}: {e}")
+
+        if reinserted % 10000 == 0:
+            elapsed = time.time() - t0
+            rate = reinserted / elapsed if elapsed > 0 else 0
+            print(f"  Inserted {reinserted:,}/{inserted:,} ({rate:.0f}/s)", flush=True)
+
+    elapsed = time.time() - t0
+    print(f"Step 4 done: {reinserted:,} re-inserted in {elapsed:.1f}s ({errors} errors)")
+
+    # Step 5: Drop backup
+    conn.execute("DROP TABLE _tmp_binvec_backup")
+    print("Backup table dropped.")
+
+    return reinserted
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", help="Path to the BrainLayer SQLite DB")
+    args = parser.parse_args()
+
+    db_path = resolve_db_path(args.db_path)
+    print(f"Database: {db_path}")
+    conn = make_conn(db_path)
+
+    # Pre-check
+    db_pages = conn.execute("PRAGMA page_count").fetchone()[0]
+    page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+    print(f"DB size: {db_pages * page_size / 1024**3:.2f} GB ({db_pages:,} pages)")
+
+    float_count = rebuild_float32(conn)
+    binary_count = rebuild_binary(conn)
+
+    # Checkpoint
+    print("\nFinal WAL checkpoint...", flush=True)
+    conn.execute("PRAGMA wal_checkpoint(FULL)")
+
+    # Post-check
+    db_pages = conn.execute("PRAGMA page_count").fetchone()[0]
+    freelist = conn.execute("PRAGMA freelist_count").fetchone()[0]
+    print("\nPost-rebuild:")
+    print(f"  Float vectors: {float_count:,}")
+    print(f"  Binary vectors: {binary_count:,}")
+    print(f"  DB pages: {db_pages:,} ({db_pages * page_size / 1024**3:.2f} GB)")
+    print(f"  Freelist: {freelist:,} pages ({freelist * page_size / 1024**2:.1f} MB)")
+    print("\nRun VACUUM to reclaim freelist space.")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rebuild_vec0_tables.py
+++ b/scripts/rebuild_vec0_tables.py
@@ -67,6 +67,13 @@ def read_embedding_or_raise(conn, vec_table: str, chunk_id: str):
     return row[0]
 
 
+def ensure_restore_succeeded(errors: int, backup_table: str, label: str) -> None:
+    if errors:
+        raise RuntimeError(
+            f"Failed to restore {label} ({errors} errors); backup preserved in {backup_table}"
+        )
+
+
 def rebuild_float32(conn):
     print("\n" + "=" * 60)
     print("Rebuilding chunk_vectors (float32)")
@@ -148,6 +155,8 @@ def rebuild_float32(conn):
 
     elapsed = time.time() - t0
     print(f"Step 4 done: {reinserted:,} re-inserted in {elapsed:.1f}s ({errors} errors)")
+
+    ensure_restore_succeeded(errors, "_tmp_vec_backup", "chunk_vectors")
 
     # Step 5: Drop backup
     conn.execute("DROP TABLE _tmp_vec_backup")
@@ -238,6 +247,8 @@ def rebuild_binary(conn):
 
     elapsed = time.time() - t0
     print(f"Step 4 done: {reinserted:,} re-inserted in {elapsed:.1f}s ({errors} errors)")
+
+    ensure_restore_succeeded(errors, "_tmp_binvec_backup", "chunk_vectors_binary")
 
     # Step 5: Drop backup
     conn.execute("DROP TABLE _tmp_binvec_backup")

--- a/scripts/run_decay_job.py
+++ b/scripts/run_decay_job.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Weekly decay maintenance job for BrainLayer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from brainlayer.decay_job import run_decay_job
+from brainlayer.paths import get_db_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run BrainLayer decay maintenance")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    parser.add_argument("--quiet", action="store_true", help="Silent unless error")
+    parser.add_argument("--dry-run", action="store_true", help="Compute changes without writing")
+    parser.add_argument("--batch-size", type=int, default=10_000, help="Rows per decay batch")
+    args = parser.parse_args()
+
+    db_path = get_db_path()
+
+    try:
+        stats = run_decay_job(db_path, dry_run=args.dry_run, batch_size=args.batch_size)
+    except Exception as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc), "db": str(db_path)}))
+        elif not args.quiet:
+            print(f"Decay job failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps({"db": str(db_path), **stats}))
+    elif not args.quiet:
+        print(
+            "Decay job complete: "
+            f"rows={stats['rows_processed']} archived={stats['archived_rows']} "
+            f"pinned={stats['pinned_rows']} avg_decay={stats['average_decay']:.4f} "
+            f"duration_s={stats['duration_seconds']:.2f} dry_run={stats['dry_run']}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -8,7 +8,8 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -217,27 +218,23 @@ class TestVectorMaintenanceScripts:
 
         assert list(batched((str(i) for i in range(5)), 2)) == [["0", "1"], ["2", "3"], ["4"]]
 
-    def test_purge_orphaned_vectors_batches_without_materializing(self):
-        from purge_orphaned_vectors import batched
+    def test_purge_orphaned_vectors_fetches_bounded_batch(self):
+        from purge_orphaned_vectors import get_orphan_batch
 
-        assert list(batched((str(i) for i in range(5)), 2)) == [["0", "1"], ["2", "3"], ["4"]]
-
-    def test_purge_orphaned_vectors_streams_orphan_ids(self):
-        from purge_orphaned_vectors import iter_orphan_ids
+        captured = {}
 
         class _Result:
             def __iter__(self):
                 yield ("chunk-1",)
                 yield ("chunk-2",)
 
-            def fetchall(self):  # pragma: no cover - should never be used
-                raise AssertionError("fetchall should not be used")
-
         class _Conn:
-            def execute(self, sql):
+            def execute(self, sql, params):
+                captured["params"] = params
                 return _Result()
 
-        assert list(iter_orphan_ids(_Conn(), "chunk_vectors_rowids")) == ["chunk-1", "chunk-2"]
+        assert get_orphan_batch(_Conn(), "chunk_vectors_rowids", limit=2) == ["chunk-1", "chunk-2"]
+        assert captured["params"] == (2,)
 
     def test_purge_orphaned_vectors_raises_when_delete_errors_occur(self, monkeypatch):
         import purge_orphaned_vectors
@@ -248,23 +245,62 @@ class TestVectorMaintenanceScripts:
             def fetchone(self):
                 return (2,)
 
-        class _IterResult:
-            def __iter__(self):
-                yield ("chunk-1",)
-                yield ("chunk-2",)
-
         class _Conn:
+            def __init__(self):
+                self.remaining = ["chunk-1", "chunk-2"]
+
             def execute(self, sql, params=None):
                 if sql.lstrip().startswith("SELECT COUNT(*)"):
                     return _CountResult()
                 if sql.lstrip().startswith("SELECT vr.id"):
-                    return _IterResult()
+                    limit = params[0]
+                    return ((cid,) for cid in self.remaining[:limit])
                 if sql.startswith("DELETE FROM") and params == ("chunk-2",):
                     raise RuntimeError("busy")
+                if sql.startswith("DELETE FROM"):
+                    self.remaining.remove(params[0])
                 return None
 
         with pytest.raises(RuntimeError, match="Failed to purge 1 orphaned vectors from chunk_vectors"):
             purge_orphaned_vectors.purge_vec_table(_Conn(), "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors")
+
+    def test_purge_orphaned_vectors_main_closes_connection_on_error(self, monkeypatch):
+        import purge_orphaned_vectors
+
+        conn = MagicMock()
+
+        class _CountResult:
+            def __init__(self, value):
+                self.value = value
+
+            def fetchone(self):
+                return (self.value,)
+
+        def fake_execute(sql, params=None):  # noqa: ARG001
+            if "chunk_vectors_rowids" in sql:
+                return _CountResult(1)
+            if "chunk_vectors_binary_rowids" in sql:
+                return _CountResult(1)
+            if "FROM chunks" in sql:
+                return _CountResult(1)
+            return None
+
+        conn.execute.side_effect = fake_execute
+        monkeypatch.setattr(
+            purge_orphaned_vectors.argparse.ArgumentParser, "parse_args", lambda self: SimpleNamespace(db_path=None)
+        )
+        monkeypatch.setattr(purge_orphaned_vectors, "resolve_db_path", lambda db_path=None: Path("/tmp/brainlayer.db"))
+        monkeypatch.setattr(purge_orphaned_vectors, "make_conn", lambda db_path: conn)
+        monkeypatch.setattr(
+            purge_orphaned_vectors,
+            "purge_vec_table",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            purge_orphaned_vectors.main()
+
+        conn.close.assert_called_once()
 
     def test_rebuild_vec0_tables_read_embedding_or_raise_returns_embedding(self):
         from rebuild_vec0_tables import read_embedding_or_raise

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 # Add scripts to path
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 HOOKS_DIR = Path(__file__).parent.parent / "hooks"
@@ -209,6 +211,48 @@ class TestVectorMaintenanceScripts:
 
         monkeypatch.setattr(rebuild_vec0_tables, "get_db_path", lambda: tmp_path / "brainlayer.db")
         assert rebuild_vec0_tables.resolve_db_path() == tmp_path / "brainlayer.db"
+
+    def test_rebuild_vec0_tables_batches_without_materializing(self):
+        from rebuild_vec0_tables import batched
+
+        assert list(batched((str(i) for i in range(5)), 2)) == [["0", "1"], ["2", "3"], ["4"]]
+
+    def test_rebuild_vec0_tables_read_embedding_or_raise_returns_embedding(self):
+        from rebuild_vec0_tables import read_embedding_or_raise
+
+        class _Result:
+            def fetchone(self):
+                return (b"embedding",)
+
+        class _Conn:
+            def execute(self, sql, params):
+                return _Result()
+
+        assert read_embedding_or_raise(_Conn(), "chunk_vectors", "chunk-1") == b"embedding"
+
+    def test_rebuild_vec0_tables_read_embedding_or_raise_raises_on_missing_row(self):
+        from rebuild_vec0_tables import read_embedding_or_raise
+
+        class _Result:
+            def fetchone(self):
+                return None
+
+        class _Conn:
+            def execute(self, sql, params):
+                return _Result()
+
+        with pytest.raises(RuntimeError, match="Missing embedding"):
+            read_embedding_or_raise(_Conn(), "chunk_vectors", "chunk-1")
+
+    def test_rebuild_vec0_tables_read_embedding_or_raise_raises_on_execute_error(self):
+        from rebuild_vec0_tables import read_embedding_or_raise
+
+        class _Conn:
+            def execute(self, sql, params):
+                raise RuntimeError("busy")
+
+        with pytest.raises(RuntimeError, match="Failed to read embedding"):
+            read_embedding_or_raise(_Conn(), "chunk_vectors", "chunk-1")
 
 
 # ── Session cleanup hook tests ──────────────────────────────────────────────

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -236,6 +236,32 @@ class TestVectorMaintenanceScripts:
         assert get_orphan_batch(_Conn(), "chunk_vectors_rowids", limit=2) == ["chunk-1", "chunk-2"]
         assert captured["params"] == (2,)
 
+    def test_purge_orphaned_vectors_uses_null_safe_orphan_queries(self):
+        from purge_orphaned_vectors import count_orphan_ids, get_orphan_batch
+
+        queries = []
+
+        class _CountResult:
+            def fetchone(self):
+                return (0,)
+
+        class _BatchResult:
+            def __iter__(self):
+                return iter(())
+
+        class _Conn:
+            def execute(self, sql, params=None):  # noqa: ARG002
+                queries.append(sql)
+                if "COUNT(*)" in sql:
+                    return _CountResult()
+                return _BatchResult()
+
+        conn = _Conn()
+        assert count_orphan_ids(conn, "chunk_vectors_rowids") == 0
+        assert get_orphan_batch(conn, "chunk_vectors_rowids", limit=2) == []
+        assert all("NOT EXISTS" in sql for sql in queries)
+        assert all("NOT IN" not in sql for sql in queries)
+
     def test_purge_orphaned_vectors_raises_when_delete_errors_occur(self, monkeypatch):
         import purge_orphaned_vectors
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -187,6 +187,30 @@ class TestWalCheckpoint:
         assert get_wal_size(db_path) == 1024
 
 
+class TestVectorMaintenanceScripts:
+    def test_purge_orphaned_vectors_uses_cli_db_path(self, tmp_path):
+        from purge_orphaned_vectors import resolve_db_path
+
+        assert resolve_db_path(str(tmp_path / "custom.db")) == tmp_path / "custom.db"
+
+    def test_purge_orphaned_vectors_uses_default_db_path(self, tmp_path, monkeypatch):
+        import purge_orphaned_vectors
+
+        monkeypatch.setattr(purge_orphaned_vectors, "get_db_path", lambda: tmp_path / "brainlayer.db")
+        assert purge_orphaned_vectors.resolve_db_path() == tmp_path / "brainlayer.db"
+
+    def test_rebuild_vec0_tables_uses_cli_db_path(self, tmp_path):
+        from rebuild_vec0_tables import resolve_db_path
+
+        assert resolve_db_path(str(tmp_path / "custom.db")) == tmp_path / "custom.db"
+
+    def test_rebuild_vec0_tables_uses_default_db_path(self, tmp_path, monkeypatch):
+        import rebuild_vec0_tables
+
+        monkeypatch.setattr(rebuild_vec0_tables, "get_db_path", lambda: tmp_path / "brainlayer.db")
+        assert rebuild_vec0_tables.resolve_db_path() == tmp_path / "brainlayer.db"
+
+
 # ── Session cleanup hook tests ──────────────────────────────────────────────
 
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -264,9 +264,7 @@ class TestVectorMaintenanceScripts:
                 return None
 
         with pytest.raises(RuntimeError, match="Failed to purge 1 orphaned vectors from chunk_vectors"):
-            purge_orphaned_vectors.purge_vec_table(
-                _Conn(), "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors"
-            )
+            purge_orphaned_vectors.purge_vec_table(_Conn(), "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors")
 
     def test_rebuild_vec0_tables_read_embedding_or_raise_returns_embedding(self):
         from rebuild_vec0_tables import read_embedding_or_raise

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -217,6 +217,57 @@ class TestVectorMaintenanceScripts:
 
         assert list(batched((str(i) for i in range(5)), 2)) == [["0", "1"], ["2", "3"], ["4"]]
 
+    def test_purge_orphaned_vectors_batches_without_materializing(self):
+        from purge_orphaned_vectors import batched
+
+        assert list(batched((str(i) for i in range(5)), 2)) == [["0", "1"], ["2", "3"], ["4"]]
+
+    def test_purge_orphaned_vectors_streams_orphan_ids(self):
+        from purge_orphaned_vectors import iter_orphan_ids
+
+        class _Result:
+            def __iter__(self):
+                yield ("chunk-1",)
+                yield ("chunk-2",)
+
+            def fetchall(self):  # pragma: no cover - should never be used
+                raise AssertionError("fetchall should not be used")
+
+        class _Conn:
+            def execute(self, sql):
+                return _Result()
+
+        assert list(iter_orphan_ids(_Conn(), "chunk_vectors_rowids")) == ["chunk-1", "chunk-2"]
+
+    def test_purge_orphaned_vectors_raises_when_delete_errors_occur(self, monkeypatch):
+        import purge_orphaned_vectors
+
+        monkeypatch.setattr(purge_orphaned_vectors.time, "time", lambda: 1_000_000.0)
+
+        class _CountResult:
+            def fetchone(self):
+                return (2,)
+
+        class _IterResult:
+            def __iter__(self):
+                yield ("chunk-1",)
+                yield ("chunk-2",)
+
+        class _Conn:
+            def execute(self, sql, params=None):
+                if sql.lstrip().startswith("SELECT COUNT(*)"):
+                    return _CountResult()
+                if sql.lstrip().startswith("SELECT vr.id"):
+                    return _IterResult()
+                if sql.startswith("DELETE FROM") and params == ("chunk-2",):
+                    raise RuntimeError("busy")
+                return None
+
+        with pytest.raises(RuntimeError, match="Failed to purge 1 orphaned vectors from chunk_vectors"):
+            purge_orphaned_vectors.purge_vec_table(
+                _Conn(), "chunk_vectors", "chunk_vectors_rowids", "chunk_vectors"
+            )
+
     def test_rebuild_vec0_tables_read_embedding_or_raise_returns_embedding(self):
         from rebuild_vec0_tables import read_embedding_or_raise
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -254,6 +254,12 @@ class TestVectorMaintenanceScripts:
         with pytest.raises(RuntimeError, match="Failed to read embedding"):
             read_embedding_or_raise(_Conn(), "chunk_vectors", "chunk-1")
 
+    def test_rebuild_vec0_tables_ensure_restore_succeeded_raises_when_backup_must_be_kept(self):
+        from rebuild_vec0_tables import ensure_restore_succeeded
+
+        with pytest.raises(RuntimeError, match="_tmp_vec_backup"):
+            ensure_restore_succeeded(1, "_tmp_vec_backup", "chunk_vectors")
+
 
 # ── Session cleanup hook tests ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add four maintenance scripts that were present locally but not tracked, including DB-safe vector maintenance helpers and a Karabiner installer for BrainBar
- make the vector maintenance scripts use repo-standard DB path resolution instead of an Etan-specific absolute path
- ignore local `tests/eval_results/` outputs and refresh the README Python test count to the verified total

## Verification
- `ruff check tests/test_lifecycle.py scripts/purge_orphaned_vectors.py scripts/rebuild_vec0_tables.py scripts/run_decay_job.py`
- `shellcheck scripts/install-karabiner-rule.sh`
- `python3 -m pytest tests/test_lifecycle.py -q` → `24 passed`
- `python3 scripts/purge_orphaned_vectors.py --help`
- `python3 scripts/rebuild_vec0_tables.py --help`
- `pytest tests/` on this branch → `5 failed, 1823 passed, 8 skipped, 6 xfailed, 2 xpassed`
- reproduced the same 5 failing tests on a clean `HEAD` archive, so the red full-suite failures predate this branch:
  - `tests/test_eval_baselines.py::TestMemoryRetrieval::test_whoop_discussion_findable`
  - `tests/test_eval_baselines.py::TestTemporalQueries::test_recent_week_chunks_exist`
  - `tests/test_eval_baselines.py::TestPromptHookEntityInjection::test_no_entity_in_generic_query`
  - `tests/test_vector_store.py::TestSchema::test_created_at_coverage`
  - `tests/test_vector_store.py::TestSearchMetadata::test_results_have_created_at`

## Notes
- deleted the untracked root session transcript `.txt` files during cleanup
- `cr review --plain` could not run because CodeRabbit returned a rate-limit error (`try after 21 minutes and 14 seconds`)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add database maintenance scripts for purging orphaned vectors and rebuilding vec0 tables
> - Adds [`scripts/purge_orphaned_vectors.py`](https://github.com/EtanHey/brainlayer/pull/238/files#diff-bdde44726945b81f6a2490e21253c05c20c682e1da3ce3f39d9623fbae91c80a) to delete vectors in `chunk_vectors` and `chunk_vectors_binary` whose IDs no longer exist in `chunks`, operating in configurable batches with periodic WAL checkpoints.
> - Adds [`scripts/rebuild_vec0_tables.py`](https://github.com/EtanHey/brainlayer/pull/238/files#diff-0ddae23f873ca2fd045e7f9702112e06ae4d71257b25b2ba2d8f4f4422ac53bf) to reconstruct vec0 virtual tables by backing up valid embeddings, dropping and recreating the tables, and reinserting preserved data with progress reporting.
> - Adds [`scripts/run_decay_job.py`](https://github.com/EtanHey/brainlayer/pull/238/files#diff-20fda2f3e06b0ef257b5fb11e903cd719980346fe212ee574cbaabd03fcd573c) as a CLI wrapper for the decay maintenance job, supporting `--json`, `--dry-run`, and `--batch-size` flags.
> - Adds [`scripts/install-karabiner-rule.sh`](https://github.com/EtanHey/brainlayer/pull/238/files#diff-ab2662c58c91382c434f423ea722fe6c574ccb9d4e93a3fc7f16d02bb6e46d2d) to idempotently merge a BrainBar Karabiner-Elements rule into the user's config without overwriting existing rules.
> - Adds tests in [`tests/test_lifecycle.py`](https://github.com/EtanHey/brainlayer/pull/238/files#diff-d8958c006f6b1824d907540b609b4a5dca8073cc0a24ae332363d855de6ae8bc) covering the new script helpers; updates `.gitignore` to exclude `tests/eval_results/` from version control.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6f5cd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->