### PR TITLE
Fix enrichment retrieval quality regressions

### DIFF
--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -287,7 +287,16 @@ GEMINI_RESPONSE_SCHEMA = {
         "sentiment_score": {"type": "number"},
         "sentiment_signals": {"type": "array", "items": {"type": "string"}},
     },
-    "required": ["summary", "tags", "importance", "intent", "entities"],
+    "required": [
+        "summary",
+        "tags",
+        "importance",
+        "intent",
+        "entities",
+        "sentiment_label",
+        "sentiment_score",
+        "sentiment_signals",
+    ],
 }
 
 

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Optional
 
 from .embeddings import embed_chunks
 from .pipeline.chunk import Chunk
+from .pipeline.classify import looks_like_system_prompt
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
@@ -24,8 +25,21 @@ def index_chunks_to_sqlite(
     if not chunks:
         return 0
 
+    filtered_chunks = [
+        chunk
+        for chunk in chunks
+        if not chunk.metadata.get("is_system_prompt") and not looks_like_system_prompt(chunk.content)
+    ]
+
+    filtered_count = len(chunks) - len(filtered_chunks)
+    if filtered_count:
+        logger.info("Skipping %s system prompt chunks from %s", filtered_count, source_file)
+
+    if not filtered_chunks:
+        return 0
+
     # Generate embeddings
-    embedded_chunks = embed_chunks(chunks, on_progress=on_progress)
+    embedded_chunks = embed_chunks(filtered_chunks, on_progress=on_progress)
 
     if not embedded_chunks:
         return 0

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -11,6 +11,120 @@ from .phonetic import phonetic_key, phonetic_tokens
 class KGMixin:
     """Knowledge graph methods, mixed into VectorStore."""
 
+    @staticmethod
+    def _entity_row_to_dict(row: Any) -> Dict[str, Any]:
+        return {
+            "id": row[0],
+            "entity_type": row[1],
+            "name": row[2],
+            "metadata": json.loads(row[3]) if row[3] else {},
+            "created_at": row[4],
+            "updated_at": row[5],
+            "canonical_name": row[6],
+            "description": row[7],
+            "confidence": row[8],
+            "importance": row[9],
+            "valid_from": row[10],
+            "valid_until": row[11],
+            "group_id": row[12],
+            "parent_id": row[13] if len(row) > 13 else None,
+        }
+
+    def _fetch_entities_by_lower_name(self, name: str, entity_type: Optional[str] = None) -> List[Dict[str, Any]]:
+        cursor = self._read_cursor()
+        base_query = """
+            SELECT id, entity_type, name, metadata, created_at, updated_at,
+                   canonical_name, description, confidence, importance,
+                   valid_from, valid_until, group_id, parent_id
+            FROM kg_entities
+            WHERE LOWER(name) = LOWER(?)
+        """
+        params: list[Any] = [name]
+        if entity_type is not None:
+            base_query += " AND entity_type = ?"
+            params.append(entity_type)
+        rows = list(cursor.execute(base_query, params))
+        return [self._entity_row_to_dict(row) for row in rows]
+
+    def _entity_support_score(self, entity_id: str) -> tuple[int, int]:
+        cursor = self._read_cursor()
+        relation_count = list(
+            cursor.execute(
+                "SELECT COUNT(*) FROM kg_relations WHERE source_id = ? OR target_id = ?",
+                (entity_id, entity_id),
+            )
+        )[0][0]
+        chunk_count = list(cursor.execute("SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?", (entity_id,)))[0][0]
+        return relation_count, chunk_count
+
+    def _select_preferred_entity(self, entities: List[Dict[str, Any]]) -> Dict[str, Any]:
+        def score(entity: Dict[str, Any]) -> tuple[int, int, int, str]:
+            relation_count, chunk_count = self._entity_support_score(entity["id"])
+            display_score = 1 if entity["name"] != entity["name"].lower() else 0
+            return (relation_count, chunk_count, display_score, entity.get("created_at") or "")
+
+        return max(entities, key=score)
+
+    def normalize_case_variants(self, entity_type: str, name: str) -> Optional[Dict[str, Any]]:
+        """Merge case-only duplicates for one entity type and return the kept entity."""
+        matches = self._fetch_entities_by_lower_name(name, entity_type=entity_type)
+        if not matches:
+            return None
+
+        keep = self._select_preferred_entity(matches)
+        canonical_name = name.lower().replace(" ", "_")
+        now = datetime.now(timezone.utc).isoformat()
+
+        if len(matches) > 1:
+            from .pipeline.entity_resolution import merge_entities
+
+            for match in matches:
+                if match["id"] == keep["id"]:
+                    continue
+                merge_entities(self, keep["id"], match["id"])
+
+        self.conn.cursor().execute(
+            "UPDATE kg_entities SET canonical_name = ?, updated_at = ? WHERE id = ?",
+            (canonical_name, now, keep["id"]),
+        )
+        return self.get_entity(keep["id"])
+
+    def ensure_named_relation(
+        self,
+        source_type: str,
+        source_name: str,
+        target_type: str,
+        target_name: str,
+        relation_type: str,
+        *,
+        fact: Optional[str] = None,
+    ) -> Optional[str]:
+        """Ensure a named relation exists, resolving entities case-insensitively."""
+        source = self.get_entity_by_name(source_type, source_name)
+        target = self.get_entity_by_name(target_type, target_name)
+        if not source or not target:
+            return None
+
+        cursor = self._read_cursor()
+        existing = list(
+            cursor.execute(
+                "SELECT id FROM kg_relations WHERE source_id = ? AND target_id = ? AND relation_type = ?",
+                (source["id"], target["id"], relation_type),
+            )
+        )
+        if existing:
+            return existing[0][0]
+
+        relation_id = f"rel-{relation_type}:{source['id']}:{target['id']}"
+        relation_fact = fact or f"{source['name']} {relation_type.lower().replace('_', ' ')} {target['name']}"
+        return self.add_relation(
+            relation_id=relation_id,
+            source_id=source["id"],
+            target_id=target["id"],
+            relation_type=relation_type,
+            fact=relation_fact,
+        )
+
     def upsert_entity(
         self,
         entity_id: str,
@@ -35,6 +149,47 @@ class KGMixin:
         canon = canonical_name or name.lower().replace(" ", "_")
         conf = confidence if confidence is not None else 1.0
         imp = importance if importance is not None else 0.5
+
+        existing = self.normalize_case_variants(entity_type, name)
+        if existing is not None:
+            cursor.execute(
+                """
+                UPDATE kg_entities
+                SET metadata = ?,
+                    canonical_name = ?,
+                    description = ?,
+                    confidence = ?,
+                    importance = ?,
+                    valid_from = COALESCE(?, valid_from),
+                    valid_until = COALESCE(?, valid_until),
+                    group_id = COALESCE(?, group_id),
+                    parent_id = COALESCE(?, parent_id),
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    meta_json,
+                    canon,
+                    description,
+                    conf,
+                    imp,
+                    valid_from,
+                    valid_until,
+                    group_id,
+                    parent_id,
+                    now,
+                    existing["id"],
+                ),
+            )
+
+            if embedding is not None:
+                embedding_bytes = serialize_f32(embedding)
+                cursor.execute(
+                    "INSERT OR REPLACE INTO kg_vec_entities (entity_id, embedding) VALUES (?, ?)",
+                    (existing["id"], embedding_bytes),
+                )
+
+            return existing["id"]
 
         cursor.execute(
             """
@@ -185,55 +340,11 @@ class KGMixin:
         )
         if not rows:
             return None
-        row = rows[0]
-        return {
-            "id": row[0],
-            "entity_type": row[1],
-            "name": row[2],
-            "metadata": json.loads(row[3]) if row[3] else {},
-            "created_at": row[4],
-            "updated_at": row[5],
-            "canonical_name": row[6],
-            "description": row[7],
-            "confidence": row[8],
-            "importance": row[9],
-            "valid_from": row[10],
-            "valid_until": row[11],
-            "group_id": row[12],
-            "parent_id": row[13],
-        }
+        return self._entity_row_to_dict(rows[0])
 
     def get_entity_by_name(self, entity_type: str, name: str) -> Optional[Dict[str, Any]]:
         """Get an entity by type and name."""
-        cursor = self._read_cursor()
-        rows = list(
-            cursor.execute(
-                """SELECT id, entity_type, name, metadata, created_at, updated_at,
-                          canonical_name, description, confidence, importance,
-                          valid_from, valid_until, group_id, parent_id
-                   FROM kg_entities WHERE entity_type = ? AND name = ?""",
-                (entity_type, name),
-            )
-        )
-        if not rows:
-            return None
-        row = rows[0]
-        return {
-            "id": row[0],
-            "entity_type": row[1],
-            "name": row[2],
-            "metadata": json.loads(row[3]) if row[3] else {},
-            "created_at": row[4],
-            "updated_at": row[5],
-            "canonical_name": row[6],
-            "description": row[7],
-            "confidence": row[8],
-            "importance": row[9],
-            "valid_from": row[10],
-            "valid_until": row[11],
-            "group_id": row[12],
-            "parent_id": row[13],
-        }
+        return self.normalize_case_variants(entity_type, name)
 
     def get_entity_relations(self, entity_id: str, direction: str = "both") -> List[Dict[str, Any]]:
         """Get all relations for an entity."""
@@ -791,32 +902,17 @@ class KGMixin:
         """Resolve a string to a KG entity."""
         # 1. Exact name (case-insensitive)
         cursor = self._read_cursor()
-        rows = list(
-            cursor.execute(
-                """SELECT id, entity_type, name, metadata, created_at, updated_at,
-                          canonical_name, description, confidence, importance,
-                          valid_from, valid_until, group_id
-                   FROM kg_entities WHERE LOWER(name) = LOWER(?)""",
-                (name_or_alias,),
-            )
-        )
+        rows = self._fetch_entities_by_lower_name(name_or_alias)
         if rows:
-            row = rows[0]
-            return {
-                "id": row[0],
-                "entity_type": row[1],
-                "name": row[2],
-                "metadata": json.loads(row[3]) if row[3] else {},
-                "created_at": row[4],
-                "updated_at": row[5],
-                "canonical_name": row[6],
-                "description": row[7],
-                "confidence": row[8],
-                "importance": row[9],
-                "valid_from": row[10],
-                "valid_until": row[11],
-                "group_id": row[12],
-            }
+            normalized: List[Dict[str, Any]] = []
+            for match in rows:
+                if any(candidate["entity_type"] == match["entity_type"] for candidate in normalized):
+                    continue
+                normalized_entity = self.normalize_case_variants(match["entity_type"], name_or_alias)
+                if normalized_entity is not None:
+                    normalized.append(normalized_entity)
+            if normalized:
+                return self._select_preferred_entity(normalized)
 
         # 2. Exact alias
         result = self.get_entity_by_alias(name_or_alias)

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -54,7 +54,9 @@ class KGMixin:
                 (entity_id, entity_id),
             )
         )[0][0]
-        chunk_count = list(cursor.execute("SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?", (entity_id,)))[0][0]
+        chunk_count = list(cursor.execute("SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?", (entity_id,)))[
+            0
+        ][0]
         return relation_count, chunk_count
 
     def _select_preferred_entity(self, entities: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -127,6 +127,18 @@ class KGMixin:
             fact=relation_fact,
         )
 
+    def _maybe_seed_known_project_relations(self, entity_type: str, name: str) -> None:
+        if entity_type != "project" or name.lower() not in {"flowbar", "voicebar"}:
+            return
+        self.ensure_named_relation(
+            source_type="project",
+            source_name="FlowBar",
+            target_type="project",
+            target_name="VoiceBar",
+            relation_type="RENAMED_FROM",
+            fact="FlowBar was renamed to VoiceBar.",
+        )
+
     def upsert_entity(
         self,
         entity_id: str,
@@ -147,6 +159,7 @@ class KGMixin:
         """Insert or update a KG entity. Returns the entity ID."""
         cursor = self.conn.cursor()
         meta_json = json.dumps(metadata or {})
+        update_meta_json = json.dumps(metadata) if metadata is not None else None
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         canon = canonical_name or name.lower().replace(" ", "_")
         conf = confidence if confidence is not None else 1.0
@@ -157,11 +170,11 @@ class KGMixin:
             cursor.execute(
                 """
                 UPDATE kg_entities
-                SET metadata = ?,
-                    canonical_name = ?,
-                    description = ?,
-                    confidence = ?,
-                    importance = ?,
+                SET metadata = COALESCE(?, metadata),
+                    canonical_name = COALESCE(?, canonical_name),
+                    description = COALESCE(?, description),
+                    confidence = COALESCE(?, confidence),
+                    importance = COALESCE(?, importance),
                     valid_from = COALESCE(?, valid_from),
                     valid_until = COALESCE(?, valid_until),
                     group_id = COALESCE(?, group_id),
@@ -170,11 +183,11 @@ class KGMixin:
                 WHERE id = ?
                 """,
                 (
-                    meta_json,
-                    canon,
+                    update_meta_json,
+                    canonical_name,
                     description,
-                    conf,
-                    imp,
+                    confidence,
+                    importance,
                     valid_from,
                     valid_until,
                     group_id,
@@ -191,6 +204,7 @@ class KGMixin:
                     (existing["id"], embedding_bytes),
                 )
 
+            self._maybe_seed_known_project_relations(entity_type, existing["name"])
             return existing["id"]
 
         cursor.execute(
@@ -244,6 +258,7 @@ class KGMixin:
                 (stored_id, embedding_bytes),
             )
 
+        self._maybe_seed_known_project_relations(entity_type, name)
         return stored_id
 
     def add_relation(

--- a/src/brainlayer/pipeline/classify.py
+++ b/src/brainlayer/pipeline/classify.py
@@ -88,6 +88,16 @@ HIGH_VALUE_PATTERNS = [
     r"(?:todo|fixme|hack|workaround)",  # Code notes
 ]
 
+# Markers that strongly indicate agent/base-context system prompts rather than user content.
+SYSTEM_PROMPT_MARKERS = {
+    "# base context",
+    "## iron rules",
+    "> this context contains universal rules",
+    "claude.md instructions",
+    "agents.md instructions for",
+    "global agent instructions",
+}
+
 
 class ContentType(Enum):
     """Types of content in Claude Code conversations."""
@@ -221,6 +231,27 @@ def _has_high_value_signal(content: str) -> bool:
     return False
 
 
+def looks_like_system_prompt(content: str) -> bool:
+    """Detect agent/base-context prompt scaffolding that should not be indexed."""
+    stripped = content.strip()
+    if not stripped:
+        return False
+
+    lowered = stripped.lower()
+    if len(stripped) > 2000:
+        return True
+
+    score = sum(1 for marker in SYSTEM_PROMPT_MARKERS if marker in lowered)
+
+    if re.search(r"(?im)^(?:>\s*)?you are (?:codex|claude|[\w-]*(?:codex|claude)|a coding agent)\b", stripped):
+        score += 2
+
+    if re.search(r"(?im)^##\s*first:\s*load context\b", stripped):
+        score += 1
+
+    return score >= 2
+
+
 def _should_keep_user_message(content: str) -> bool:
     """
     Smart filtering for user messages.
@@ -349,8 +380,7 @@ def classify_content(entry: dict) -> ClassifiedContent | None:
         if not _should_keep_user_message(content):
             return None
 
-        # Check if it's a system prompt (first message, very long)
-        if len(content) > 2000:
+        if looks_like_system_prompt(content):
             return ClassifiedContent(
                 content=content,
                 content_type=ContentType.USER_MESSAGE,

--- a/src/brainlayer/pipeline/classify.py
+++ b/src/brainlayer/pipeline/classify.py
@@ -238,9 +238,6 @@ def looks_like_system_prompt(content: str) -> bool:
         return False
 
     lowered = stripped.lower()
-    if len(stripped) > 2000:
-        return True
-
     score = sum(1 for marker in SYSTEM_PROMPT_MARKERS if marker in lowered)
 
     if re.search(r"(?im)^(?:>\s*)?you are (?:codex|claude|[\w-]*(?:codex|claude)|a coding agent)\b", stripped):
@@ -249,7 +246,7 @@ def looks_like_system_prompt(content: str) -> bool:
     if re.search(r"(?im)^##\s*first:\s*load context\b", stripped):
         score += 1
 
-    return score >= 2
+    return score >= 2 or (score >= 1 and len(stripped) > 2000)
 
 
 def _should_keep_user_message(content: str) -> bool:

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -803,6 +803,15 @@ def entity_lookup(
     Returns:
         Dict with name, entity_type, relations, evidence, or None if not found.
     """
+    store.ensure_named_relation(
+        source_type="project",
+        source_name="FlowBar",
+        target_type="project",
+        target_name="VoiceBar",
+        relation_type="RENAMED_FROM",
+        fact="FlowBar was renamed to VoiceBar.",
+    )
+
     resolved = store.resolve_entity(query)
     if resolved and (entity_type is None or resolved["entity_type"] == entity_type):
         results = [resolved]

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -803,15 +803,6 @@ def entity_lookup(
     Returns:
         Dict with name, entity_type, relations, evidence, or None if not found.
     """
-    store.ensure_named_relation(
-        source_type="project",
-        source_name="FlowBar",
-        target_type="project",
-        target_name="VoiceBar",
-        relation_type="RENAMED_FROM",
-        fact="FlowBar was renamed to VoiceBar.",
-    )
-
     resolved = store.resolve_entity(query)
     if resolved and (entity_type is None or resolved["entity_type"] == entity_type):
         results = [resolved]

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -36,6 +36,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
+from .pipeline.classify import looks_like_system_prompt
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,8 @@ def store_memory(
         raise ValueError(f"type must be one of: {', '.join(VALID_MEMORY_TYPES)}")
 
     content = content.strip()
+    if looks_like_system_prompt(content):
+        raise ValueError("system prompt content is not stored in BrainLayer")
 
     # Clamp importance
     if importance is not None:

--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -56,6 +56,7 @@ def _fake_gemini_response(summary="Auto-enriched summary", tags=None):
             "resolved_query": "What extraction pattern was chosen?",
             "epistemic_level": "substantiated",
             "debt_impact": "none",
+            "entities": [],
         }
     )
 
@@ -189,6 +190,47 @@ class TestEnrichSingle:
         db_tags = json.loads(rows[0][1])
         assert "architecture" in db_tags
         assert "real-time" in db_tags
+
+    def test_enrich_single_persists_positive_sentiment(self, store, stored_chunk, monkeypatch):
+        """Known-positive chunks should persist sentiment_label from Gemini output."""
+        from brainlayer import enrichment_controller as ctrl
+
+        response = json.dumps(
+            {
+                "summary": "The migration finished cleanly and the user confirmed the CLI now works perfectly.",
+                "tags": ["cli", "migration"],
+                "importance": 7,
+                "intent": "reviewing",
+                "primary_symbols": [],
+                "resolved_query": "Did the CLI migration complete successfully?",
+                "epistemic_level": "validated",
+                "debt_impact": "resolution",
+                "entities": [],
+                "sentiment_label": "positive",
+                "sentiment_score": 0.8,
+                "sentiment_signals": ["works perfectly", "finished cleanly"],
+            }
+        )
+
+        client = _FakeGeminiClient(response_text=response)
+        monkeypatch.setattr(ctrl, "_get_gemini_client", lambda: client)
+        monkeypatch.setattr(ctrl, "AUTO_ENRICH_ENABLED", True)
+        _mock_sanitizer = SimpleNamespace(
+            sanitize=lambda text, metadata=None: SimpleNamespace(sanitized=text, replacements=[], pii_detected=False),
+        )
+        monkeypatch.setattr(ctrl, "Sanitizer", SimpleNamespace(from_env=lambda: _mock_sanitizer))
+
+        result = ctrl.enrich_single(store, stored_chunk)
+
+        assert result is not None
+        assert result["sentiment_label"] == "positive"
+        row = store.conn.cursor().execute(
+            "SELECT sentiment_label, sentiment_score, sentiment_signals FROM chunks WHERE id = ?",
+            (stored_chunk,),
+        ).fetchone()
+        assert row[0] == "positive"
+        assert row[1] == 0.8
+        assert json.loads(row[2]) == ["works perfectly", "finished cleanly"]
 
     def test_uses_low_retry_count(self, store, stored_chunk, monkeypatch):
         """enrich_single uses max_retries=2 by default (fast, not 12)."""

--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -57,6 +57,9 @@ def _fake_gemini_response(summary="Auto-enriched summary", tags=None):
             "epistemic_level": "substantiated",
             "debt_impact": "none",
             "entities": [],
+            "sentiment_label": "neutral",
+            "sentiment_score": 0.0,
+            "sentiment_signals": [],
         }
     )
 

--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -224,10 +224,14 @@ class TestEnrichSingle:
 
         assert result is not None
         assert result["sentiment_label"] == "positive"
-        row = store.conn.cursor().execute(
-            "SELECT sentiment_label, sentiment_score, sentiment_signals FROM chunks WHERE id = ?",
-            (stored_chunk,),
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT sentiment_label, sentiment_score, sentiment_signals FROM chunks WHERE id = ?",
+                (stored_chunk,),
+            )
+            .fetchone()
+        )
         assert row[0] == "positive"
         assert row[1] == 0.8
         assert json.loads(row[2]) == ["works perfectly", "finished cleanly"]

--- a/tests/test_brainstore.py
+++ b/tests/test_brainstore.py
@@ -281,6 +281,19 @@ class TestStoreValidation:
         )
         assert result["id"] is not None
 
+    def test_system_prompt_content_rejected(self, store, mock_embed):
+        """Prompt scaffolding should be rejected instead of polluting memory."""
+        from brainlayer.store import store_memory
+
+        with pytest.raises(ValueError, match="system prompt"):
+            store_memory(
+                store=store,
+                embed_fn=mock_embed,
+                content="# Base Context\n\nYou are a coding agent.\n\n## IRON RULES",
+                memory_type="note",
+                project="test",
+            )
+
 
 class TestStoreMCPIntegration:
     """Test that brain_store is properly wired into the MCP server."""

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -4,6 +4,7 @@ from brainlayer.pipeline.classify import (
     ContentType,
     ContentValue,
     classify_content,
+    looks_like_system_prompt,
 )
 
 
@@ -34,6 +35,21 @@ class TestClassifyContent:
         """Long first messages are likely system prompts."""
         long_content = "CLAUDE.md instructions " * 500  # >2000 chars
         entry = {"type": "user", "message": {"role": "user", "content": long_content}}
+        result = classify_content(entry)
+        assert result is not None
+        assert result.metadata.get("is_system_prompt") is True
+
+    def test_detects_system_prompt_markers(self):
+        """Known agent prompt scaffolding should be tagged even when shorter."""
+        content = """# Base Context
+
+You are Codex working inside the golems ecosystem.
+
+## IRON RULES
+- Search first
+- Store results
+"""
+        entry = {"type": "user", "message": {"role": "user", "content": content}}
         result = classify_content(entry)
         assert result is not None
         assert result.metadata.get("is_system_prompt") is True
@@ -100,3 +116,15 @@ class TestContentValue:
     def test_low_value_can_be_masked(self):
         """LOW value content can be summarized or masked."""
         assert ContentValue.LOW.value == "low"
+
+
+class TestSystemPromptDetection:
+    """Test reusable system prompt detection heuristics."""
+
+    def test_detects_base_context_markers(self):
+        content = "> This context contains universal rules\n\nYou are a coding agent."
+        assert looks_like_system_prompt(content) is True
+
+    def test_does_not_flag_normal_user_question(self):
+        content = "You are using SQLite here, right? Why does the lock happen?"
+        assert looks_like_system_prompt(content) is False

--- a/tests/test_context_pipeline.py
+++ b/tests/test_context_pipeline.py
@@ -270,6 +270,94 @@ class TestIndexPopulatesContext:
         assert row[0] == "abc-def-123"
         store.close()
 
+    def test_skips_system_prompt_chunks_marked_in_metadata(self, tmp_path):
+        """Chunks already tagged as system prompts should never be stored."""
+        from unittest.mock import patch
+
+        db_path = tmp_path / "test.db"
+        from brainlayer.pipeline.classify import ContentValue
+
+        chunks = [
+            Chunk(
+                content="# Base Context\nYou are Codex.\n## IRON RULES\n- Search first",
+                content_type=ContentType.USER_MESSAGE,
+                value=ContentValue.MEDIUM,
+                metadata={"session_id": "sess-001", "is_system_prompt": True},
+                char_count=63,
+            ),
+            Chunk(
+                content="Actual user question about database locking in enrichment",
+                content_type=ContentType.USER_MESSAGE,
+                value=ContentValue.HIGH,
+                metadata={"session_id": "sess-001"},
+                char_count=56,
+            ),
+        ]
+
+        with patch("brainlayer.index_new.embed_chunks") as mock_embed:
+            from brainlayer.embeddings import EmbeddedChunk
+            from brainlayer.index_new import index_chunks_to_sqlite
+
+            mock_embed.return_value = [EmbeddedChunk(chunk=chunks[1], embedding=[0.1] * 1024)]
+
+            count = index_chunks_to_sqlite(
+                chunks,
+                source_file="test.jsonl",
+                project="test-project",
+                db_path=db_path,
+            )
+
+        assert count == 1
+
+        store = VectorStore(db_path)
+        rows = list(store.conn.execute("SELECT content FROM chunks"))
+        assert rows == [("Actual user question about database locking in enrichment",)]
+        store.close()
+
+    def test_skips_system_prompt_chunks_by_content_pattern(self, tmp_path):
+        """Known prompt scaffolding should be filtered even if metadata was missing."""
+        from unittest.mock import patch
+
+        db_path = tmp_path / "test.db"
+        from brainlayer.pipeline.classify import ContentValue
+
+        chunks = [
+            Chunk(
+                content="> This context contains universal rules\n\nYou are a coding agent.\nFollow AGENTS.md.",
+                content_type=ContentType.USER_MESSAGE,
+                value=ContentValue.MEDIUM,
+                metadata={"session_id": "sess-001"},
+                char_count=86,
+            ),
+            Chunk(
+                content="Need a fix for the sentiment pipeline dropping sentiment_label",
+                content_type=ContentType.USER_MESSAGE,
+                value=ContentValue.HIGH,
+                metadata={"session_id": "sess-001"},
+                char_count=63,
+            ),
+        ]
+
+        with patch("brainlayer.index_new.embed_chunks") as mock_embed:
+            from brainlayer.embeddings import EmbeddedChunk
+            from brainlayer.index_new import index_chunks_to_sqlite
+
+            mock_embed.return_value = [EmbeddedChunk(chunk=chunks[1], embedding=[0.1] * 1024)]
+
+            count = index_chunks_to_sqlite(
+                chunks,
+                source_file="test.jsonl",
+                project="test-project",
+                db_path=db_path,
+            )
+
+        assert count == 1
+
+        store = VectorStore(db_path)
+        rows = list(store.conn.execute("SELECT content FROM chunks"))
+        assert rows == [("Need a fix for the sentiment pipeline dropping sentiment_label",)]
+        store.close()
+
 
 # ── get_context should work with populated fields ──
 

--- a/tests/test_enrichment_entity_schema.py
+++ b/tests/test_enrichment_entity_schema.py
@@ -62,6 +62,15 @@ def test_build_gemini_config_includes_response_schema():
     assert config["response_schema"] is GEMINI_RESPONSE_SCHEMA
 
 
+def test_gemini_response_schema_requires_sentiment_fields():
+    from brainlayer.enrichment_controller import GEMINI_RESPONSE_SCHEMA
+
+    required = set(GEMINI_RESPONSE_SCHEMA.get("required", []))
+    assert "sentiment_label" in required
+    assert "sentiment_score" in required
+    assert "sentiment_signals" in required
+
+
 # ── Prompt tests ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_kg_schema.py
+++ b/tests/test_kg_schema.py
@@ -172,9 +172,28 @@ class TestEntityCRUD:
         assert result is not None
         assert result["id"] == "proj-1"
 
+    def test_get_entity_by_name_is_case_insensitive(self, store):
+        store.upsert_entity("proj-1", "project", "brainlayer")
+        result = store.get_entity_by_name("project", "BrainLayer")
+        assert result is not None
+        assert result["id"] == "proj-1"
+
     def test_get_entity_by_name_not_found(self, store):
         result = store.get_entity_by_name("project", "nonexistent")
         assert result is None
+
+    def test_upsert_entity_merges_case_variants(self, store):
+        store.upsert_entity("proj-1", "project", "brainlayer")
+        returned_id = store.upsert_entity("proj-2", "project", "BrainLayer", metadata={"source": "manual"})
+
+        rows = list(
+            store._read_cursor().execute(
+                "SELECT id, name FROM kg_entities WHERE entity_type = 'project' AND LOWER(name) = 'brainlayer'"
+            )
+        )
+        assert len(rows) == 1
+        assert returned_id == "proj-1"
+        assert rows[0][0] == "proj-1"
 
     def test_upsert_multiple_entity_types(self, store):
         store.upsert_entity("person-1", "person", "Etan")

--- a/tests/test_kg_schema.py
+++ b/tests/test_kg_schema.py
@@ -195,6 +195,27 @@ class TestEntityCRUD:
         assert returned_id == "proj-1"
         assert rows[0][0] == "proj-1"
 
+    def test_upsert_case_variant_preserves_existing_optional_fields(self, store):
+        store.upsert_entity(
+            "proj-1",
+            "project",
+            "brainlayer",
+            metadata={"owner": "etan"},
+            description="Primary memory system",
+            confidence=0.9,
+            importance=0.8,
+        )
+
+        returned_id = store.upsert_entity("proj-2", "project", "BrainLayer")
+
+        entity = store.get_entity(returned_id)
+        assert entity is not None
+        assert entity["id"] == "proj-1"
+        assert entity["metadata"] == {"owner": "etan"}
+        assert entity["description"] == "Primary memory system"
+        assert entity["confidence"] == 0.9
+        assert entity["importance"] == 0.8
+
     def test_upsert_multiple_entity_types(self, store):
         store.upsert_entity("person-1", "person", "Etan")
         store.upsert_entity("company-1", "company", "Cantaloupe")

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -357,6 +357,69 @@ def test_entity_lookup_not_found(tmp_path):
     assert result is None
 
 
+def test_entity_lookup_merges_case_duplicate_entities(tmp_path):
+    """Lookup should collapse case-only dupes and return the entity with linked evidence."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    rich_id = store.upsert_entity("project-rich", "project", "brainlayer", embedding=dummy_embed("brainlayer"))
+    sparse_id = "project-sparse"
+    store.conn.cursor().execute(
+        """
+        INSERT INTO kg_entities (id, entity_type, name, metadata, canonical_name, created_at, updated_at)
+        VALUES (?, 'project', 'BrainLayer', '{}', NULL, '2026-04-13T00:00:00Z', '2026-04-13T00:00:00Z')
+        """,
+        (sparse_id,),
+    )
+    sqlite_id = store.upsert_entity("tech-sqlite", "technology", "SQLite", embedding=dummy_embed("sqlite"))
+    store.add_relation("rel-uses", rich_id, sqlite_id, "uses")
+    _insert_chunks(
+        store,
+        ["c-rich"],
+        ["brainlayer uses SQLite for local-first search"],
+        [{"source_file": "t.jsonl", "project": "test"}],
+        [dummy_embed("brainlayer uses sqlite")],
+    )
+    store.link_entity_chunk(rich_id, "c-rich", relevance=0.9, context="architecture note")
+
+    result = entity_lookup("BrainLayer", store, dummy_embed, entity_type="project")
+
+    assert result is not None
+    assert len(result["evidence"]) == 1
+    assert any(relation["target_name"] == "SQLite" for relation in result["relations"])
+    remaining = list(
+        store._read_cursor().execute(
+            "SELECT id FROM kg_entities WHERE entity_type = 'project' AND LOWER(name) = 'brainlayer'"
+        )
+    )
+    assert remaining == [(rich_id,)]
+
+
+def test_entity_lookup_adds_flowbar_voicebar_rename_relation(tmp_path):
+    """Lookup should seed the FlowBar -> VoiceBar rename edge when both entities exist."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    flowbar_id = store.upsert_entity("project-flowbar", "project", "FlowBar", embedding=dummy_embed("FlowBar"))
+    voicebar_id = store.upsert_entity("project-voicebar", "project", "VoiceBar", embedding=dummy_embed("VoiceBar"))
+
+    result = entity_lookup("VoiceBar", store, dummy_embed, entity_type="project")
+
+    assert result is not None
+    row = store._read_cursor().execute(
+        """
+        SELECT relation_type FROM kg_relations
+        WHERE source_id = ? AND target_id = ? AND relation_type = 'RENAMED_FROM'
+        """,
+        (flowbar_id, voicebar_id),
+    ).fetchone()
+    assert row == ("RENAMED_FROM",)
+
+
 # --- Task 5: Integration test ---
 
 

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -410,13 +410,17 @@ def test_entity_lookup_adds_flowbar_voicebar_rename_relation(tmp_path):
     result = entity_lookup("VoiceBar", store, dummy_embed, entity_type="project")
 
     assert result is not None
-    row = store._read_cursor().execute(
-        """
+    row = (
+        store._read_cursor()
+        .execute(
+            """
         SELECT relation_type FROM kg_relations
         WHERE source_id = ? AND target_id = ? AND relation_type = 'RENAMED_FROM'
         """,
-        (flowbar_id, voicebar_id),
-    ).fetchone()
+            (flowbar_id, voicebar_id),
+        )
+        .fetchone()
+    )
     assert row == ("RENAMED_FROM",)
 
 

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -397,19 +397,13 @@ def test_entity_lookup_merges_case_duplicate_entities(tmp_path):
     assert remaining == [(rich_id,)]
 
 
-def test_entity_lookup_adds_flowbar_voicebar_rename_relation(tmp_path):
-    """Lookup should seed the FlowBar -> VoiceBar rename edge when both entities exist."""
-    from brainlayer.pipeline.digest import entity_lookup
-
+def test_upsert_entity_adds_flowbar_voicebar_rename_relation(tmp_path):
+    """Project upserts should seed the FlowBar -> VoiceBar rename edge."""
     store = VectorStore(tmp_path / "test.db")
     dummy_embed = _dummy_embed
 
     flowbar_id = store.upsert_entity("project-flowbar", "project", "FlowBar", embedding=dummy_embed("FlowBar"))
     voicebar_id = store.upsert_entity("project-voicebar", "project", "VoiceBar", embedding=dummy_embed("VoiceBar"))
-
-    result = entity_lookup("VoiceBar", store, dummy_embed, entity_type="project")
-
-    assert result is not None
     row = (
         store._read_cursor()
         .execute(


### PR DESCRIPTION
## Summary
- filter agent/base-context system prompt contamination before embedding and reject it from `brain_store`
- require Gemini sentiment fields in the enrichment schema and add a positive-sentiment persistence regression
- normalize case-only KG duplicates for exact-name lookups, prevent future case-variant dupes on upsert, and seed the missing `FlowBar -> VoiceBar` `RENAMED_FROM` relation

## Verification
- `pytest tests/test_classify.py tests/test_context_pipeline.py tests/test_brainstore.py -q`
- `pytest tests/test_auto_enrich.py tests/test_enrichment_entity_schema.py tests/test_enrichment_v2.py tests/test_phase6_sentiment.py tests/test_enrichment_controller.py -q`
- `pytest tests/test_kg_schema.py tests/test_phase3_digest.py tests/test_hebrew_alias.py tests/test_entity_contracts.py tests/test_6pm_entity_upgrades.py -q`
- `pytest -q`

## Notes
- The focused suites above are green.
- Full `pytest -q` on this branch finished `1850 passed, 7 failed, 8 skipped, 6 xfailed, 2 xpassed`.
- The 7 failures are live-data / prompt-hook baselines outside this diff:
  - `tests/test_eval_baselines.py::TestMemoryRetrieval::test_whoop_discussion_findable`
  - `tests/test_eval_baselines.py::TestTemporalQueries::test_recent_week_chunks_exist`
  - `tests/test_eval_baselines.py::TestPromptHookEntityInjection::test_no_entity_in_generic_query`
  - `tests/test_follow_up_rewrite.py::test_follow_up_route_uses_session_context_for_search`
  - `tests/test_prompt_classification.py::test_knowledge_route_injects_chunks`
  - `tests/test_vector_store.py::TestSchema::test_created_at_coverage`
  - `tests/test_vector_store.py::TestSearchMetadata::test_results_have_created_at`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case-insensitive entity lookup and normalization for improved search accuracy.
  * Entity rename relationship tracking (e.g., mapping renamed entities).
  * Enhanced system prompt detection using pattern and marker-based heuristics.

* **Bug Fixes**
  * System prompt content is now filtered from memory storage and rejected on input.

* **Improvements**
  * Sentiment analysis now requires sentiment label, score, and signals for complete enrichment results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix enrichment retrieval quality by filtering system prompts and improving entity deduplication
> - Adds `looks_like_system_prompt` heuristic in [`classify.py`](https://github.com/EtanHey/brainlayer/pull/240/files#diff-b9b37837fd7dfac9e640f4ed051c5a5c3b791b3389ce7f5af1d36e6d2c5f5140) using marker strings and regexes; replaces the previous length-only check for system prompt detection
> - Filters system-prompt-flagged chunks before embedding in [`index_new.py`](https://github.com/EtanHey/brainlayer/pull/240/files#diff-3eb235a245c1358fe9f27dc834fcc7c992b79adc05b2488782ab2204f236218e), and blocks storage of system prompt content in [`store.py`](https://github.com/EtanHey/brainlayer/pull/240/files#diff-3f4ff41bcf437c9376f0c0bc397eca30e1b05c0d75d4e95ef1579366d7c4c707) with a `ValueError`
> - Adds case-insensitive entity resolution and merging in [`kg_repo.py`](https://github.com/EtanHey/brainlayer/pull/240/files#diff-38aa7f1f4a1b009ac93ee1e2c7dfd9d6b85220b1278bb2081ac1ea006a59675b): case-only duplicate entities are collapsed into a canonical entity on upsert/lookup
> - Seeds a `RENAMED_FROM` relation from `FlowBar` to `VoiceBar` when either entity is upserted
> - Expands `GEMINI_RESPONSE_SCHEMA` in [`enrichment_controller.py`](https://github.com/EtanHey/brainlayer/pull/240/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb) to require `sentiment_label`, `sentiment_score`, and `sentiment_signals` fields
> - Behavioral Change: `store_memory` now raises `ValueError` on system prompt content instead of persisting it; entity upserts with case-only name variants update the existing entity rather than creating a duplicate
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c55dbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->