### PR TITLE
fix: harden post-commit hook against non-UTF8 encoding

### DIFF
--- a/hooks/post-commit.py
+++ b/hooks/post-commit.py
@@ -14,16 +14,22 @@ import subprocess
 
 def main():
     try:
-        commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
+        commit_hash = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL)
+            .decode("utf-8", errors="replace")
+            .strip()
+        )
         commit_msg = (
-            subprocess.check_output(["git", "log", "-1", "--pretty=%B"], stderr=subprocess.DEVNULL).decode().strip()
+            subprocess.check_output(["git", "log", "-1", "--pretty=%B"], stderr=subprocess.DEVNULL)
+            .decode("utf-8", errors="replace")
+            .strip()
         )
         files_changed = (
             subprocess.check_output(
                 ["git", "diff-tree", "--no-commit-id", "-r", "--name-only", "HEAD"],
                 stderr=subprocess.DEVNULL,
             )
-            .decode()
+            .decode("utf-8", errors="replace")
             .strip()
             .split("\n")
         )
@@ -34,7 +40,9 @@ def main():
     # Detect project from repo root directory name
     try:
         repo_root = (
-            subprocess.check_output(["git", "rev-parse", "--show-toplevel"], stderr=subprocess.DEVNULL).decode().strip()
+            subprocess.check_output(["git", "rev-parse", "--show-toplevel"], stderr=subprocess.DEVNULL)
+            .decode("utf-8", errors="replace")
+            .strip()
         )
         project = os.path.basename(repo_root)
     except (subprocess.CalledProcessError, FileNotFoundError):

--- a/tests/test_post_commit_hook.py
+++ b/tests/test_post_commit_hook.py
@@ -1,0 +1,141 @@
+"""Tests for hooks/post-commit.py — ensures the hook survives non-UTF8
+subprocess output from git (commit messages with non-UTF8 encoding,
+legacy-imported commit metadata, or non-UTF8 file paths).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent / "hooks"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location(
+        "post_commit_hook",
+        HOOKS_DIR / "post-commit.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def captured_calls(monkeypatch):
+    """Stub out brainlayer.* modules so the hook can import them without
+    loading the real embedding model, and capture store_memory() calls.
+    """
+    calls = []
+
+    store_mod = types.ModuleType("brainlayer.store")
+
+    def fake_store_memory(**kwargs):
+        calls.append(kwargs)
+
+    store_mod.store_memory = fake_store_memory
+
+    vs_mod = types.ModuleType("brainlayer.vector_store")
+
+    class _FakeStore:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    vs_mod.VectorStore = _FakeStore
+
+    embed_mod = types.ModuleType("brainlayer.embeddings")
+
+    class _FakeModel:
+        def embed_query(self, text):
+            return [0.0] * 8
+
+    embed_mod.get_embedding_model = lambda: _FakeModel()
+
+    paths_mod = types.ModuleType("brainlayer.paths")
+    paths_mod.DEFAULT_DB_PATH = "/tmp/fake-brainlayer.db"
+
+    monkeypatch.setitem(sys.modules, "brainlayer.store", store_mod)
+    monkeypatch.setitem(sys.modules, "brainlayer.vector_store", vs_mod)
+    monkeypatch.setitem(sys.modules, "brainlayer.embeddings", embed_mod)
+    monkeypatch.setitem(sys.modules, "brainlayer.paths", paths_mod)
+
+    return calls
+
+
+def _make_fake_check_output(
+    commit_msg_bytes,
+    file_list_bytes=b"src/a.py\nsrc/b.py\n",
+    toplevel_bytes=b"/tmp/repo\n",
+):
+    def fake(cmd, **kwargs):
+        if "rev-parse" in cmd and "HEAD" in cmd:
+            return b"deadbeefcafe1234\n"
+        if "log" in cmd and "--pretty=%B" in cmd:
+            return commit_msg_bytes
+        if "diff-tree" in cmd:
+            return file_list_bytes
+        if "--show-toplevel" in cmd:
+            return toplevel_bytes
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    return fake
+
+
+def test_post_commit_handles_non_utf8_commit_message(captured_calls, monkeypatch):
+    """Discriminating test: non-UTF8 bytes in commit message must not crash
+    the hook. Fails before the fix (UnicodeDecodeError escapes the outer
+    try/except), passes after.
+    """
+    hook_mod = _load_hook()
+    monkeypatch.setattr(
+        hook_mod.subprocess,
+        "check_output",
+        _make_fake_check_output(commit_msg_bytes=b"Latin-1 commit \xff\xfe body\n"),
+    )
+
+    hook_mod.main()  # must not raise
+
+    assert len(captured_calls) == 1
+    assert "\ufffd" in captured_calls[0]["content"]
+
+
+def test_post_commit_handles_non_utf8_file_path(captured_calls, monkeypatch):
+    hook_mod = _load_hook()
+    monkeypatch.setattr(
+        hook_mod.subprocess,
+        "check_output",
+        _make_fake_check_output(
+            commit_msg_bytes=b"fix: something\n",
+            file_list_bytes=b"src/\xff\xfe.py\nsrc/b.py\n",
+        ),
+    )
+
+    hook_mod.main()  # must not raise
+
+    assert len(captured_calls) == 1
+    # U+FFFD must appear in the Files portion (from the non-UTF8 filename)
+    assert "\ufffd" in captured_calls[0]["content"]
+
+
+def test_post_commit_preserves_valid_utf8(captured_calls, monkeypatch):
+    """Sanity: valid UTF-8 (including non-ASCII) flows through unchanged."""
+    hook_mod = _load_hook()
+    monkeypatch.setattr(
+        hook_mod.subprocess,
+        "check_output",
+        _make_fake_check_output(
+            commit_msg_bytes="fix: 日本語 commit\n".encode("utf-8"),
+        ),
+    )
+
+    hook_mod.main()
+
+    assert len(captured_calls) == 1
+    content = captured_calls[0]["content"]
+    assert "\ufffd" not in content
+    assert "日本語" in content

--- a/tests/test_post_commit_hook.py
+++ b/tests/test_post_commit_hook.py
@@ -122,6 +122,28 @@ def test_post_commit_handles_non_utf8_file_path(captured_calls, monkeypatch):
     assert "\ufffd" in captured_calls[0]["content"]
 
 
+def test_post_commit_handles_non_utf8_repo_toplevel(captured_calls, monkeypatch):
+    """Non-UTF8 bytes returned by `git rev-parse --show-toplevel` must not
+    crash the hook. Exercises the fourth decode call in the second try block.
+    """
+    hook_mod = _load_hook()
+    monkeypatch.setattr(
+        hook_mod.subprocess,
+        "check_output",
+        _make_fake_check_output(
+            commit_msg_bytes=b"fix: something\n",
+            toplevel_bytes=b"/tmp/repo-\xff\xfe\n",
+        ),
+    )
+
+    hook_mod.main()  # must not raise
+
+    assert len(captured_calls) == 1
+    # The toplevel path decode feeds os.path.basename(...) which becomes the
+    # `project` kwarg passed to store_memory.
+    assert "\ufffd" in captured_calls[0]["project"]
+
+
 def test_post_commit_preserves_valid_utf8(captured_calls, monkeypatch):
     """Sanity: valid UTF-8 (including non-ASCII) flows through unchanged."""
     hook_mod = _load_hook()


### PR DESCRIPTION
## Summary
- Harden four `.decode()` calls in `hooks/post-commit.py` against non-UTF8 git output by passing `errors="replace"`
- Matches existing pattern in `src/brainlayer/pipeline/extract_markdown.py:50`
- Adds `tests/test_post_commit_hook.py` covering the non-UTF8 commit-message and file-path paths plus a valid-UTF-8 sanity test

## Root cause
The outer `try/except (CalledProcessError, FileNotFoundError)` at line 30 doesn't catch `UnicodeDecodeError`. On a commit whose message or file paths contain non-UTF8 bytes (e.g., `i18n.commitEncoding=latin-1`, legacy SVN-imported metadata, or non-UTF8 filesystem paths), the hook crashes with a traceback and `store_memory()` never runs — silently dropping that commit from BrainLayer indexing.

## Test plan
- [ ] `pytest tests/test_post_commit_hook.py -v`
- [ ] `pytest tests/ -m "not integration"`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced robustness when processing git commits and file paths containing non-UTF-8 characters, ensuring graceful error handling and recovery.

* **Tests**
  * Added comprehensive test coverage for character encoding scenarios, validating proper handling of non-UTF-8 inputs, Latin-1 encoded text, and multi-byte UTF-8 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden post-commit hook against non-UTF-8 git output
> Replaces plain `.decode()` calls in [post-commit.py](https://github.com/EtanHey/brainlayer/pull/241/files#diff-9adfa1984dbf3732d3d4774477fdc60f839d4ba192b171106cfd42c1ef8635f6) with `.decode('utf-8', errors='replace')` for all git subprocess outputs (commit hash, message, file paths, repo toplevel). This prevents `UnicodeDecodeError` when git returns non-UTF-8 bytes, substituting `U+FFFD` for undecodable bytes instead. Adds a test module covering non-UTF-8 commit messages, file paths, and repo paths, as well as a regression test confirming valid UTF-8 (including non-ASCII) passes through unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7c11c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->