### PR TITLE
Cleanup profane raw-user chunks via aggregation

### DIFF
--- a/scripts/cleanup-profanity-chunks.py
+++ b/scripts/cleanup-profanity-chunks.py
@@ -9,21 +9,22 @@ import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+from brainlayer.paths import get_db_path
 
-DEFAULT_DB = Path.home() / ".local/share/brainlayer/brainlayer.db"
+DB_PATH = get_db_path()
 TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z'-]{2,}")
 PROFANITY_RE = re.compile(r"\b(fuck(?:ing|er|ers)?|motherfuck(?:er|ers)?|wtf)\b", re.IGNORECASE)
 STOPWORDS = {
-    "about", "after", "again", "and", "app", "are", "but", "can", "dont", "for", "from", "get", "got",
-    "have", "just", "lets", "like", "need", "not", "now", "our", "out", "really", "still", "that",
-    "the", "their", "them", "then", "this", "tonight", "very", "want", "were", "what", "when", "with", "you",
-    "your",
+    "about", "after", "again", "and", "app", "are", "but", "can", "dont", "for", "from", "get", "got", "have",
+    "just", "lets", "like", "need", "not", "now", "our", "out", "really", "still", "that", "the", "their", "them",
+    "then", "this", "tonight", "very", "want", "were", "what", "when", "with", "you", "your",
 }
-
 
 def log(message):
     print(f"[cleanup-profanity] {message}", file=sys.stderr)
-
 
 def compact(text, limit=96, sanitize=False):
     text = re.sub(r"\s+", " ", text or "").strip()
@@ -31,14 +32,12 @@ def compact(text, limit=96, sanitize=False):
         text = PROFANITY_RE.sub("[redacted]", text)
     return text if len(text) <= limit else text[:limit].rsplit(" ", 1)[0] + "..."
 
-
 def parse_tags(raw):
     try:
         value = json.loads(raw or "[]")
         return [tag for tag in value if isinstance(tag, str)]
     except json.JSONDecodeError:
         return []
-
 
 def tokenize(text, include_profanity=False):
     terms = []
@@ -50,7 +49,6 @@ def tokenize(text, include_profanity=False):
             continue
         terms.append(token)
     return terms
-
 
 def fetch_rows(conn):
     return conn.execute(
@@ -67,15 +65,22 @@ def fetch_rows(conn):
         """
     ).fetchall()
 
+def parse_metadata(raw):
+    try:
+        return json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+def session_id_for_row(row):
+    return row["conversation_id"] or parse_metadata(row["metadata"]).get("session_id") or "unknown"
 
 def cluster_rows(rows):
     grouped = defaultdict(list)
     for row in rows:
         day = (row["created_at"] or "")[:10]
-        session_id = row["conversation_id"] or json.loads(row["metadata"] or "{}").get("session_id") or "unknown"
+        session_id = session_id_for_row(row)
         grouped[(row["project"] or "unknown", day, session_id)].append(row)
     return {key: group for key, group in grouped.items() if len(group) >= 3}
-
 
 def build_doc_freq(rows):
     df = Counter()
@@ -83,7 +88,6 @@ def build_doc_freq(rows):
         for token in set(tokenize(row["content"])):
             df[token] += 1
     return len(rows), df
-
 
 def top_terms(cluster, total_docs, df):
     tf = Counter()
@@ -96,10 +100,9 @@ def top_terms(cluster, total_docs, df):
     )
     return [term for term, _, _ in ranked[:3]] or ["frustration", "repeat", "user"]
 
-
 def build_aggregate(cluster, total_docs, df):
     cluster = sorted(cluster, key=lambda row: (row["created_at"] or "", row["id"]))
-    project, day, session_id = cluster[0]["project"] or "unknown", (cluster[0]["created_at"] or "")[:10], cluster[0]["conversation_id"] or "unknown"
+    project, day, session_id = cluster[0]["project"] or "unknown", (cluster[0]["created_at"] or "")[:10], session_id_for_row(cluster[0])
     keywords = top_terms(cluster, total_docs, df)
     keyword_text = ", ".join(keywords)
     first_raw = compact(cluster[0]["content"])
@@ -137,7 +140,6 @@ def build_aggregate(cluster, total_docs, df):
         "content_hash": hashlib.sha256(f"{agg_id}|{content}".encode()).hexdigest(),
     }
 
-
 def archive_originals(conn, cluster, agg_id, now_iso):
     for row in cluster:
         conn.execute(
@@ -148,7 +150,6 @@ def archive_originals(conn, cluster, agg_id, now_iso):
             """,
             (agg_id, now_iso, row["id"]),
         )
-
 
 def run_cleanup(db_path, dry_run=False):
     conn = sqlite3.connect(db_path)
@@ -183,15 +184,13 @@ def run_cleanup(db_path, dry_run=False):
     conn.close()
     return stats
 
-
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Aggregate repeated profane raw-user chunks into sanitized frustration summaries.")
-    parser.add_argument("--db", default=str(DEFAULT_DB), help="SQLite DB path")
+    parser.add_argument("--db", default=str(DB_PATH), help="SQLite DB path")
     parser.add_argument("--dry-run", action="store_true", help="Report clusters without writing")
     args = parser.parse_args(argv)
     run_cleanup(args.db, dry_run=args.dry_run)
     return 0
-
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/cleanup-profanity-chunks.py
+++ b/scripts/cleanup-profanity-chunks.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import math
+import re
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_DB = Path.home() / ".local/share/brainlayer/brainlayer.db"
+TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z'-]{2,}")
+PROFANITY_RE = re.compile(r"\b(fuck(?:ing|er|ers)?|motherfuck(?:er|ers)?|wtf)\b", re.IGNORECASE)
+STOPWORDS = {
+    "about", "after", "again", "and", "app", "are", "but", "can", "dont", "for", "from", "get", "got",
+    "have", "just", "lets", "like", "need", "not", "now", "our", "out", "really", "still", "that",
+    "the", "their", "them", "then", "this", "tonight", "very", "want", "were", "what", "when", "with", "you",
+    "your",
+}
+
+
+def log(message):
+    print(f"[cleanup-profanity] {message}", file=sys.stderr)
+
+
+def compact(text, limit=96, sanitize=False):
+    text = re.sub(r"\s+", " ", text or "").strip()
+    if sanitize:
+        text = PROFANITY_RE.sub("[redacted]", text)
+    return text if len(text) <= limit else text[:limit].rsplit(" ", 1)[0] + "..."
+
+
+def parse_tags(raw):
+    try:
+        value = json.loads(raw or "[]")
+        return [tag for tag in value if isinstance(tag, str)]
+    except json.JSONDecodeError:
+        return []
+
+
+def tokenize(text, include_profanity=False):
+    terms = []
+    for token in TOKEN_RE.findall((text or "").lower()):
+        token = token.strip("'")
+        if len(token) < 3 or token in STOPWORDS:
+            continue
+        if not include_profanity and PROFANITY_RE.fullmatch(token):
+            continue
+        terms.append(token)
+    return terms
+
+
+def fetch_rows(conn):
+    return conn.execute(
+        """
+        SELECT id, content, metadata, source_file, project, content_type, tags, importance, created_at, conversation_id
+        FROM chunks
+        WHERE id LIKE 'rt-%'
+          AND content_type = 'user_message'
+          AND archived = 0
+          AND aggregated_into IS NULL
+          AND archived_at IS NULL
+          AND lower(content) GLOB '*fuck*'
+        ORDER BY created_at, id
+        """
+    ).fetchall()
+
+
+def cluster_rows(rows):
+    grouped = defaultdict(list)
+    for row in rows:
+        day = (row["created_at"] or "")[:10]
+        session_id = row["conversation_id"] or json.loads(row["metadata"] or "{}").get("session_id") or "unknown"
+        grouped[(row["project"] or "unknown", day, session_id)].append(row)
+    return {key: group for key, group in grouped.items() if len(group) >= 3}
+
+
+def build_doc_freq(rows):
+    df = Counter()
+    for row in rows:
+        for token in set(tokenize(row["content"])):
+            df[token] += 1
+    return len(rows), df
+
+
+def top_terms(cluster, total_docs, df):
+    tf = Counter()
+    for row in cluster:
+        tf.update(tokenize(row["content"]))
+        tf.update(tokenize(row["project"] or ""))
+    ranked = sorted(
+        ((term, count * (math.log((1 + total_docs) / (1 + df.get(term, 0))) + 1.0), count) for term, count in tf.items()),
+        key=lambda item: (-item[1], -item[2], item[0]),
+    )
+    return [term for term, _, _ in ranked[:3]] or ["frustration", "repeat", "user"]
+
+
+def build_aggregate(cluster, total_docs, df):
+    cluster = sorted(cluster, key=lambda row: (row["created_at"] or "", row["id"]))
+    project, day, session_id = cluster[0]["project"] or "unknown", (cluster[0]["created_at"] or "")[:10], cluster[0]["conversation_id"] or "unknown"
+    keywords = top_terms(cluster, total_docs, df)
+    keyword_text = ", ".join(keywords)
+    first_raw = compact(cluster[0]["content"])
+    last_raw = compact(cluster[-1]["content"])
+    anchor_row = next((row for row in cluster if re.search(r"\b(ship|shipped|shipping|build|deploy|deployed|merge|merged)\b", row["content"] or "", re.IGNORECASE)), cluster[len(cluster) // 2])
+    anchor_raw = compact(anchor_row["content"])
+    content = (
+        f"[USER FRUSTRATION {len(cluster)}x on {day}] Top themes: {keyword_text}. "
+        f"First: {compact(cluster[0]['content'], sanitize=True)}. Last: {compact(cluster[-1]['content'], sanitize=True)}."
+    )
+    raw_terms = Counter(token for row in cluster for token in tokenize(row["content"], include_profanity=True))
+    focus = [token for token in tokenize(anchor_row["content"], include_profanity=True) if token in {"ship", "shipped", "shipping", "build", "deploy", "deployed", "merge", "merged"}]
+    raw_search = " ".join(dict.fromkeys(["fucking", *re.findall(r"[a-zA-Z]+", project.lower()), *focus, *[term for term, _ in raw_terms.most_common(8)]]))
+    tags = sorted({tag for row in cluster for tag in parse_tags(row["tags"])} | {"user-frustration-aggregated"})
+    agg_id = "agg-frustration-" + hashlib.sha1(f"{project}|{day}|{session_id}".encode()).hexdigest()[:16]
+    metadata = json.dumps(
+        {"aggregation": "profanity-cleanup-v1", "session_id": session_id, "aggregated_from": [row["id"] for row in cluster], "count": len(cluster)},
+        ensure_ascii=False,
+    )
+    return {
+        "id": agg_id,
+        "content": content,
+        "metadata": metadata,
+        "source_file": cluster[0]["source_file"],
+        "project": project,
+        "content_type": "user_message",
+        "char_count": len(content),
+        "tags": json.dumps(tags, ensure_ascii=False),
+        "summary": content[:200],
+        "importance": max((row["importance"] or 0) for row in cluster),
+        "created_at": cluster[0]["created_at"],
+        "conversation_id": session_id,
+        "resolved_query": raw_search,
+        "resolved_queries": json.dumps([raw_search, first_raw, anchor_raw, last_raw], ensure_ascii=False),
+        "content_hash": hashlib.sha256(f"{agg_id}|{content}".encode()).hexdigest(),
+    }
+
+
+def archive_originals(conn, cluster, agg_id, now_iso):
+    for row in cluster:
+        conn.execute(
+            """
+            UPDATE chunks
+            SET aggregated_into = ?, archived = 1, archived_at = ?, value_type = 'ARCHIVED'
+            WHERE id = ?
+            """,
+            (agg_id, now_iso, row["id"]),
+        )
+
+
+def run_cleanup(db_path, dry_run=False):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = fetch_rows(conn)
+    clusters = cluster_rows(rows)
+    stats = {"clusters": len(clusters), "aggregated": sum(len(group) for group in clusters.values()), "archived": sum(len(group) for group in clusters.values())}
+    log(f"clusters={stats['clusters']} aggregated={stats['aggregated']} archived={stats['archived']} dry_run={str(dry_run).lower()} rows={len(rows)}")
+    if dry_run or not clusters:
+        conn.close()
+        return stats
+    total_docs, df = build_doc_freq(rows)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    with conn:
+        for cluster in clusters.values():
+            aggregate = build_aggregate(cluster, total_docs, df)
+            conn.execute(
+                """
+                INSERT INTO chunks (
+                    id, content, metadata, source_file, project, content_type, char_count, tags,
+                    summary, importance, created_at, conversation_id, resolved_query, resolved_queries, content_hash
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    aggregate["id"], aggregate["content"], aggregate["metadata"], aggregate["source_file"], aggregate["project"],
+                    aggregate["content_type"], aggregate["char_count"], aggregate["tags"], aggregate["summary"], aggregate["importance"],
+                    aggregate["created_at"], aggregate["conversation_id"], aggregate["resolved_query"], aggregate["resolved_queries"],
+                    aggregate["content_hash"],
+                ),
+            )
+            archive_originals(conn, cluster, aggregate["id"], now_iso)
+    conn.close()
+    return stats
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Aggregate repeated profane raw-user chunks into sanitized frustration summaries.")
+    parser.add_argument("--db", default=str(DEFAULT_DB), help="SQLite DB path")
+    parser.add_argument("--dry-run", action="store_true", help="Report clusters without writing")
+    args = parser.parse_args(argv)
+    run_cleanup(args.db, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cleanup_profanity_chunks.py
+++ b/tests/test_cleanup_profanity_chunks.py
@@ -1,0 +1,150 @@
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "cleanup-profanity-chunks.py"
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("cleanup_profanity_chunks", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "profanity-cleanup.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            metadata TEXT NOT NULL,
+            source_file TEXT NOT NULL,
+            project TEXT,
+            content_type TEXT,
+            value_type TEXT,
+            char_count INTEGER,
+            tags TEXT,
+            summary TEXT,
+            importance REAL,
+            created_at TEXT,
+            conversation_id TEXT,
+            resolved_query TEXT,
+            resolved_queries TEXT,
+            aggregated_into TEXT,
+            archived_at TEXT,
+            archived INTEGER DEFAULT 0,
+            content_hash TEXT
+        );
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content, summary, tags, resolved_query, resolved_queries, chunk_id UNINDEXED
+        );
+        CREATE TRIGGER chunks_fts_insert AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, resolved_queries, chunk_id)
+            VALUES (new.content, new.summary, new.tags, new.resolved_query, new.resolved_queries, new.id);
+        END;
+        CREATE TRIGGER chunks_fts_update
+        AFTER UPDATE OF content, summary, tags, resolved_query, resolved_queries ON chunks BEGIN
+            DELETE FROM chunks_fts WHERE chunk_id = old.id;
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, resolved_queries, chunk_id)
+            VALUES (new.content, new.summary, new.tags, new.resolved_query, new.resolved_queries, new.id);
+        END;
+        """
+    )
+    rows = [
+        ("rt-a1", "Mehayom lets fucking ship this build tonight", "mehayom", "2026-04-15T20:27:18.000Z", "sess-1", ["shipping", "build"], 7.0),
+        ("rt-a2", "Mehayom fix the fucking build and ship", "mehayom", "2026-04-15T20:28:18.000Z", "sess-1", ["shipping", "rtl"], 8.0),
+        ("rt-a3", "Mehayom we are fucking shipping after build fix", "mehayom", "2026-04-15T20:29:18.000Z", "sess-1", ["shipping", "android"], 6.0),
+        ("rt-b1", "Mini app fucking auth bug", "mini", "2026-04-15T10:00:00.000Z", "sess-2", ["auth"], 5.0),
+        ("rt-b2", "Mini app fucking auth still broken", "mini", "2026-04-15T10:01:00.000Z", "sess-2", ["auth"], 5.0),
+    ]
+    for chunk_id, content, project, created_at, session_id, tags, importance in rows:
+        conn.execute(
+            """
+            INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type, char_count,
+                tags, summary, importance, created_at, conversation_id
+            ) VALUES (?, ?, ?, ?, ?, 'user_message', ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chunk_id,
+                content,
+                json.dumps({"session_id": session_id}),
+                f"/tmp/{session_id}.jsonl",
+                project,
+                len(content),
+                json.dumps(tags),
+                content[:200],
+                importance,
+                created_at,
+                session_id,
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_dry_run_reports_changes_without_writing(tmp_path, capsys):
+    module = load_script()
+    db_path = make_db(tmp_path)
+
+    stats = module.run_cleanup(str(db_path), dry_run=True)
+
+    assert stats == {"clusters": 1, "aggregated": 3, "archived": 3}
+    stderr = capsys.readouterr().err
+    assert "clusters=1" in stderr
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM chunks WHERE aggregated_into IS NOT NULL").fetchone()[0] == 0
+    conn.close()
+
+
+def test_execute_aggregates_cluster_and_preserves_searchability(tmp_path, capsys):
+    module = load_script()
+    db_path = make_db(tmp_path)
+
+    stats = module.run_cleanup(str(db_path), dry_run=False)
+
+    assert stats == {"clusters": 1, "aggregated": 3, "archived": 3}
+    stderr = capsys.readouterr().err
+    assert "archived=3" in stderr
+    conn = sqlite3.connect(db_path)
+    agg = conn.execute(
+        """
+        SELECT id, content, tags, importance, created_at, resolved_query, resolved_queries
+        FROM chunks
+        WHERE id LIKE 'agg-frustration-%'
+        """
+    ).fetchone()
+    assert agg is not None
+    assert "[USER FRUSTRATION 3x on 2026-04-15]" in agg[1]
+    assert "user-frustration-aggregated" in agg[2]
+    assert agg[3] == 8.0
+    assert agg[4] == "2026-04-15T20:27:18.000Z"
+    assert "fucking" in (agg[5] or "")
+    assert "ship" in (agg[6] or "")
+    originals = conn.execute(
+        "SELECT COUNT(*) FROM chunks WHERE id IN ('rt-a1','rt-a2','rt-a3') AND aggregated_into = ? AND archived = 1 AND archived_at IS NOT NULL",
+        (agg[0],),
+    ).fetchone()[0]
+    assert originals == 3
+    untouched = conn.execute(
+        "SELECT COUNT(*) FROM chunks WHERE id IN ('rt-b1','rt-b2') AND aggregated_into IS NULL AND archived = 0"
+    ).fetchone()[0]
+    assert untouched == 2
+    match = conn.execute(
+        """
+        SELECT c.id
+        FROM chunks_fts f
+        JOIN chunks c ON c.id = f.chunk_id
+        WHERE chunks_fts MATCH ? AND c.aggregated_into IS NULL AND c.archived_at IS NULL
+        ORDER BY rank
+        """,
+        ('"fucking" AND "ship" AND "mehayom"',),
+    ).fetchall()
+    assert [row[0] for row in match] == [agg[0]]
+    conn.close()

--- a/tests/test_cleanup_profanity_chunks.py
+++ b/tests/test_cleanup_profanity_chunks.py
@@ -56,9 +56,33 @@ def make_db(tmp_path: Path) -> Path:
         """
     )
     rows = [
-        ("rt-a1", "Mehayom lets fucking ship this build tonight", "mehayom", "2026-04-15T20:27:18.000Z", None, ["shipping", "build"], 7.0),
-        ("rt-a2", "Mehayom fix the fucking build and ship", "mehayom", "2026-04-15T20:28:18.000Z", "sess-1", ["shipping", "rtl"], 8.0),
-        ("rt-a3", "Mehayom we are fucking shipping after build fix", "mehayom", "2026-04-15T20:29:18.000Z", "sess-1", ["shipping", "android"], 6.0),
+        (
+            "rt-a1",
+            "Mehayom lets fucking ship this build tonight",
+            "mehayom",
+            "2026-04-15T20:27:18.000Z",
+            None,
+            ["shipping", "build"],
+            7.0,
+        ),
+        (
+            "rt-a2",
+            "Mehayom fix the fucking build and ship",
+            "mehayom",
+            "2026-04-15T20:28:18.000Z",
+            "sess-1",
+            ["shipping", "rtl"],
+            8.0,
+        ),
+        (
+            "rt-a3",
+            "Mehayom we are fucking shipping after build fix",
+            "mehayom",
+            "2026-04-15T20:29:18.000Z",
+            "sess-1",
+            ["shipping", "android"],
+            6.0,
+        ),
         ("rt-b1", "Mini app fucking auth bug", "mini", "2026-04-15T10:00:00.000Z", "sess-2", ["auth"], 5.0),
         ("rt-b2", "Mini app fucking auth still broken", "mini", "2026-04-15T10:01:00.000Z", "sess-2", ["auth"], 5.0),
     ]

--- a/tests/test_cleanup_profanity_chunks.py
+++ b/tests/test_cleanup_profanity_chunks.py
@@ -56,13 +56,14 @@ def make_db(tmp_path: Path) -> Path:
         """
     )
     rows = [
-        ("rt-a1", "Mehayom lets fucking ship this build tonight", "mehayom", "2026-04-15T20:27:18.000Z", "sess-1", ["shipping", "build"], 7.0),
+        ("rt-a1", "Mehayom lets fucking ship this build tonight", "mehayom", "2026-04-15T20:27:18.000Z", None, ["shipping", "build"], 7.0),
         ("rt-a2", "Mehayom fix the fucking build and ship", "mehayom", "2026-04-15T20:28:18.000Z", "sess-1", ["shipping", "rtl"], 8.0),
         ("rt-a3", "Mehayom we are fucking shipping after build fix", "mehayom", "2026-04-15T20:29:18.000Z", "sess-1", ["shipping", "android"], 6.0),
         ("rt-b1", "Mini app fucking auth bug", "mini", "2026-04-15T10:00:00.000Z", "sess-2", ["auth"], 5.0),
         ("rt-b2", "Mini app fucking auth still broken", "mini", "2026-04-15T10:01:00.000Z", "sess-2", ["auth"], 5.0),
     ]
     for chunk_id, content, project, created_at, session_id, tags, importance in rows:
+        metadata_session_id = "sess-1" if chunk_id == "rt-a1" else session_id
         conn.execute(
             """
             INSERT INTO chunks (
@@ -73,7 +74,7 @@ def make_db(tmp_path: Path) -> Path:
             (
                 chunk_id,
                 content,
-                json.dumps({"session_id": session_id}),
+                json.dumps({"session_id": metadata_session_id}),
                 f"/tmp/{session_id}.jsonl",
                 project,
                 len(content),
@@ -84,6 +85,27 @@ def make_db(tmp_path: Path) -> Path:
                 session_id,
             ),
         )
+    conn.execute(
+        """
+        INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type, char_count,
+            tags, summary, importance, created_at, conversation_id
+        ) VALUES (?, ?, ?, ?, ?, 'user_message', ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "rt-bad-metadata",
+            "Mini app fucking parser edge case",
+            "{bad json",
+            "/tmp/bad.jsonl",
+            "mini",
+            len("Mini app fucking parser edge case"),
+            json.dumps(["auth"]),
+            "Mini app fucking parser edge case",
+            4.0,
+            "2026-04-15T11:00:00.000Z",
+            None,
+        ),
+    )
     conn.commit()
     conn.close()
     return db_path
@@ -115,7 +137,7 @@ def test_execute_aggregates_cluster_and_preserves_searchability(tmp_path, capsys
     conn = sqlite3.connect(db_path)
     agg = conn.execute(
         """
-        SELECT id, content, tags, importance, created_at, resolved_query, resolved_queries
+        SELECT id, content, tags, importance, created_at, resolved_query, resolved_queries, conversation_id
         FROM chunks
         WHERE id LIKE 'agg-frustration-%'
         """
@@ -127,15 +149,17 @@ def test_execute_aggregates_cluster_and_preserves_searchability(tmp_path, capsys
     assert agg[4] == "2026-04-15T20:27:18.000Z"
     assert "fucking" in (agg[5] or "")
     assert "ship" in (agg[6] or "")
+    assert agg[7] == "sess-1"
     originals = conn.execute(
-        "SELECT COUNT(*) FROM chunks WHERE id IN ('rt-a1','rt-a2','rt-a3') AND aggregated_into = ? AND archived = 1 AND archived_at IS NOT NULL",
+        "SELECT value_type FROM chunks WHERE id IN ('rt-a1','rt-a2','rt-a3') AND aggregated_into = ? AND archived = 1 AND archived_at IS NOT NULL",
         (agg[0],),
-    ).fetchone()[0]
-    assert originals == 3
+    ).fetchall()
+    assert len(originals) == 3
+    assert {row[0] for row in originals} == {"ARCHIVED"}
     untouched = conn.execute(
-        "SELECT COUNT(*) FROM chunks WHERE id IN ('rt-b1','rt-b2') AND aggregated_into IS NULL AND archived = 0"
+        "SELECT COUNT(*) FROM chunks WHERE id IN ('rt-b1','rt-b2','rt-bad-metadata') AND aggregated_into IS NULL AND archived = 0"
     ).fetchone()[0]
-    assert untouched == 2
+    assert untouched == 3
     match = conn.execute(
         """
         SELECT c.id


### PR DESCRIPTION
## Summary
- add `scripts/cleanup-profanity-chunks.py` as a stdlib-only one-time cleanup script for repeated profane `rt-*` raw-user chunks
- group by `(project, DATE(created_at), conversation_id)` and aggregate only `3+`-item bursts into a single sanitized `[USER FRUSTRATION Nx on YYYY-MM-DD]` chunk
- archive originals non-destructively via `aggregated_into`, `archived`, `archived_at`, and `value_type='ARCHIVED'`
- preserve direct retrievability by storing raw query anchors in `resolved_query` / `resolved_queries`
- add `tests/test_cleanup_profanity_chunks.py` covering dry-run behavior, archival, and FTS retrievability

## Live Cleanup
- Date checked: `2026-04-16`
- Prompt count was stale: live DB had `990` `rt-*` rows matching `lower(content) GLOB '*fuck*'`, but the raw-user scope described by the task was `869` `content_type='user_message'` rows
- Dry-run on live DB: `clusters=99 aggregated=792 archived=792 rows=869`
- Applied on backup copy first, then on canonical `~/.local/share/brainlayer/brainlayer.db`
- Post-apply live DB: `99` aggregate rows, `792` archived originals, `77` remaining `1-2x` bursts untouched
- Post-refresh verification: project-scoped FTS for `"fucking" AND "ship" AND "mehayom"` returns an aggregate row before the old Mehayom assistant-text explainer chunk; the raw Mehayom user burst is hidden behind `aggregated_into`/`archived_at`

## Verification
- `pytest -q tests/test_cleanup_profanity_chunks.py tests/test_chunk_lifecycle.py`
  - `34 passed, 2 warnings in 6.14s`
- `pytest -q tests/test_cleanup_profanity_chunks.py`
  - `2 passed in 0.04s`
- `python3 scripts/cleanup-profanity-chunks.py --dry-run`
  - before apply: `[cleanup-profanity] clusters=99 aggregated=792 archived=792 dry_run=true rows=869`
  - after apply: `[cleanup-profanity] clusters=0 aggregated=0 archived=0 dry_run=true rows=77`
- `time python3 scripts/cleanup-profanity-chunks.py`
  - live apply completed in about `0.5s`

## Full Suite Note
- `pytest -q` on this clean worktree still reports 7 failures in existing live-store baseline/search tests:
  - `tests/test_eval_baselines.py::TestMemoryRetrieval::test_whoop_discussion_findable`
  - `tests/test_eval_baselines.py::TestTemporalQueries::test_recent_week_chunks_exist`
  - `tests/test_eval_baselines.py::TestPromptHookEntityInjection::test_no_entity_in_generic_query`
  - `tests/test_follow_up_rewrite.py::test_follow_up_route_uses_session_context_for_search`
  - `tests/test_prompt_classification.py::test_knowledge_route_injects_chunks`
  - `tests/test_vector_store.py::TestSchema::test_created_at_coverage`
  - `tests/test_vector_store.py::TestSearchMetadata::test_results_have_created_at`
- The new cleanup tests pass; the branch does not add any new failures in its own coverage.

## Review Note
- Local `cr review --plain` was invoked on the staged diff but did not return a verdict and had to be treated as unavailable after hanging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a database maintenance script for aggregating and archiving chunk records in the system.

* **Tests**
  * Added comprehensive test coverage for the chunk aggregation and archival workflow, including verification of data integrity and search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add script to aggregate and archive profane raw user chunks in SQLite
> - Adds [cleanup-profanity-chunks.py](https://github.com/EtanHey/brainlayer/pull/244/files#diff-05f6f209cbb0f1f7b1338cb0494c913fb23825d530238b7eb4628a013c9320ff), a CLI script that queries the `chunks` table for unarchived `user_message` rows containing profanity, groups them by project/day/session, and aggregates clusters of 3+ rows into a single sanitized chunk.
> - Each aggregate is inserted with TF-IDF-derived keywords, merged tags (including `user-frustration-aggregated`), and a `resolved_query` for search; original rows are marked archived and linked to the aggregate.
> - A `--dry-run` flag reports cluster counts without writing any changes to the DB.
> - Adds pytest coverage in [test_cleanup_profanity_chunks.py](https://github.com/EtanHey/brainlayer/pull/244/files#diff-7ce119a722b92b362abfed76c81ad3c2e32ba8a9d7d775648a7ab0a8ae9608d9) verifying dry-run isolation, aggregate content correctness, archival of originals, and FTS searchability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee49a63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->