### PR TITLE
feat: overhaul BrainBar dashboard UX

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -223,6 +223,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             database: sharedDatabase
         )
         statusVC.onPreferredSizeChange = { [weak popover] size in
+            guard popover?.contentSize != size else { return }
             popover?.contentSize = size
         }
         popover.contentViewController = statusVC

--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -232,7 +232,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .sink { [weak self] stats, state in
                 self?.statusItem?.button?.image = SparklineRenderer.render(
                     state: state,
-                    values: stats.recentActivityBuckets
+                    values: stats.recentEnrichmentBuckets
                 )
                 self?.statusItem?.button?.contentTintColor = state.color
             }

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -79,9 +79,9 @@ final class BrainBarServer: @unchecked Sendable {
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
     /// Max time to wait for a backpressured client to become writable again.
     /// Temporary bursts should survive; truly dead peers still get disconnected.
-    static let writeStallTimeoutMilliseconds: Int32 = 2_000
-    static let writeChunkSize = 512
-    static let writeRetrySleepMicroseconds: useconds_t = 10_000
+    static let writeStallTimeoutMilliseconds: Int32 = 250
+    static let writeChunkSize = 4_096
+    static let writeRetrySleepMicroseconds: useconds_t = 2_000
     private let debugLogPath = "/tmp/brainbar-debug.log"
 
     private func debugLog(_ msg: String) {

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -6,6 +6,7 @@
 // - JSON-RPC router
 // - SQLite database (single-writer)
 
+import Darwin
 import Foundation
 
 final class BrainBarServer: @unchecked Sendable {
@@ -76,9 +77,11 @@ final class BrainBarServer: @unchecked Sendable {
     private var router: MCPRouter!
     private var database: BrainDatabase!
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
-    /// Maximum EAGAIN retries before disconnecting a stalled client.
-    /// Each retry sleeps 1ms, so 10 retries = 10ms max blocking the serial queue.
-    static let maxWriteRetries = 10
+    /// Max time to wait for a backpressured client to become writable again.
+    /// Temporary bursts should survive; truly dead peers still get disconnected.
+    static let writeStallTimeoutMilliseconds: Int32 = 2_000
+    static let writeChunkSize = 512
+    static let writeRetrySleepMicroseconds: useconds_t = 10_000
     private let debugLogPath = "/tmp/brainbar-debug.log"
 
     private func debugLog(_ msg: String) {
@@ -340,18 +343,29 @@ final class BrainBarServer: @unchecked Sendable {
         }
         return framed.withUnsafeBytes { ptr in
             var totalWritten = 0
-            var eagainRetries = 0
+            var lastProgressAt = DispatchTime.now().uptimeNanoseconds
             while totalWritten < framed.count {
-                let n = write(fd, ptr.baseAddress!.advanced(by: totalWritten), framed.count - totalWritten)
+                let remaining = framed.count - totalWritten
+                let nextChunkSize = min(remaining, Self.writeChunkSize)
+                let n = write(fd, ptr.baseAddress!.advanced(by: totalWritten), nextChunkSize)
                 if n < 0 {
+                    if errno == EINTR {
+                        continue
+                    }
                     if errno == EAGAIN || errno == EWOULDBLOCK {
-                        eagainRetries += 1
-                        if eagainRetries > Self.maxWriteRetries {
-                            NSLog("[BrainBar] ⚠️ Write stalled on fd %d after %d EAGAIN retries (%d ms) — disconnecting dead client", fd, eagainRetries, eagainRetries - 1)
+                        let now = DispatchTime.now().uptimeNanoseconds
+                        let stallDeadline = lastProgressAt
+                            + UInt64(Self.writeStallTimeoutMilliseconds) * 1_000_000
+                        guard now < stallDeadline else {
+                            NSLog(
+                                "[BrainBar] ⚠️ Write stalled on fd %d for %d ms — disconnecting dead client",
+                                fd,
+                                Self.writeStallTimeoutMilliseconds
+                            )
                             disconnectClient(fd: fd)
                             return false
                         }
-                        usleep(1000) // 1 ms
+                        usleep(Self.writeRetrySleepMicroseconds)
                         continue
                     }
                     NSLog("[BrainBar] Write error on fd %d: errno %d", fd, errno)
@@ -364,7 +378,7 @@ final class BrainBarServer: @unchecked Sendable {
                     return false
                 }
                 totalWritten += n
-                eagainRetries = 0 // reset on successful partial write
+                lastProgressAt = DispatchTime.now().uptimeNanoseconds
             }
             return true
         }

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -67,6 +67,13 @@ final class BrainBarServer: @unchecked Sendable {
         }
     }
 
+    private struct PendingWrite {
+        let data: Data
+        var totalWritten: Int
+        var lastProgressAt: UInt64
+        let onDelivered: (() -> Void)?
+    }
+
     private let socketPath: String
     private let dbPath: String
     private let providedDatabase: BrainDatabase?
@@ -102,7 +109,7 @@ final class BrainBarServer: @unchecked Sendable {
         debugLog("\(label) (\(data.count) bytes)\n  HEX: \(hex)\n  TEXT: \(text)")
     }
 
-    struct ClientState {
+    private struct ClientState {
         var source: DispatchSourceRead
         var framing: MCPFraming
         /// Whether this client uses Content-Length framing (LSP-style).
@@ -110,6 +117,8 @@ final class BrainBarServer: @unchecked Sendable {
         var usesContentLengthFraming: Bool = true
         var agentID: String?
         var subscribedTags: Set<String> = []
+        var pendingWrites: [PendingWrite] = []
+        var hasScheduledWriteRetry = false
     }
 
     init(socketPath: String? = nil, dbPath: String? = nil, database: BrainDatabase? = nil) {
@@ -329,7 +338,12 @@ final class BrainBarServer: @unchecked Sendable {
     }
 
     @discardableResult
-    private func sendResponse(fd: Int32, response: [String: Any], useContentLength: Bool = true) -> Bool {
+    private func sendResponse(
+        fd: Int32,
+        response: [String: Any],
+        useContentLength: Bool = true,
+        onDelivered: (() -> Void)? = nil
+    ) -> Bool {
         let framed: Data
         if useContentLength {
             guard let data = try? MCPFraming.encode(response) else { return false }
@@ -341,46 +355,94 @@ final class BrainBarServer: @unchecked Sendable {
             data.append(0x0A) // trailing \n
             framed = data
         }
-        return framed.withUnsafeBytes { ptr in
-            var totalWritten = 0
-            var lastProgressAt = DispatchTime.now().uptimeNanoseconds
-            while totalWritten < framed.count {
-                let remaining = framed.count - totalWritten
-                let nextChunkSize = min(remaining, Self.writeChunkSize)
-                let n = write(fd, ptr.baseAddress!.advanced(by: totalWritten), nextChunkSize)
-                if n < 0 {
-                    if errno == EINTR {
-                        continue
-                    }
-                    if errno == EAGAIN || errno == EWOULDBLOCK {
-                        let now = DispatchTime.now().uptimeNanoseconds
-                        let stallDeadline = lastProgressAt
-                            + UInt64(Self.writeStallTimeoutMilliseconds) * 1_000_000
-                        guard now < stallDeadline else {
-                            NSLog(
-                                "[BrainBar] ⚠️ Write stalled on fd %d for %d ms — disconnecting dead client",
-                                fd,
-                                Self.writeStallTimeoutMilliseconds
-                            )
-                            disconnectClient(fd: fd)
-                            return false
-                        }
-                        usleep(Self.writeRetrySleepMicroseconds)
-                        continue
-                    }
-                    NSLog("[BrainBar] Write error on fd %d: errno %d", fd, errno)
-                    disconnectClient(fd: fd)
-                    return false
-                }
-                if n == 0 {
-                    NSLog("[BrainBar] Write returned 0 on fd %d — peer closed", fd)
-                    disconnectClient(fd: fd)
-                    return false
-                }
-                totalWritten += n
-                lastProgressAt = DispatchTime.now().uptimeNanoseconds
+        return enqueueWrite(fd: fd, data: framed, onDelivered: onDelivered)
+    }
+
+    @discardableResult
+    private func enqueueWrite(fd: Int32, data: Data, onDelivered: (() -> Void)? = nil) -> Bool {
+        guard var state = clients[fd] else { return false }
+        state.pendingWrites.append(
+            PendingWrite(
+                data: data,
+                totalWritten: 0,
+                lastProgressAt: DispatchTime.now().uptimeNanoseconds,
+                onDelivered: onDelivered
+            )
+        )
+        clients[fd] = state
+        return flushPendingWrites(fd: fd)
+    }
+
+    @discardableResult
+    private func flushPendingWrites(fd: Int32) -> Bool {
+        guard var state = clients[fd] else { return false }
+        state.hasScheduledWriteRetry = false
+        clients[fd] = state
+
+        while var pending = clients[fd]?.pendingWrites.first {
+            let remaining = pending.data.count - pending.totalWritten
+            let nextChunkSize = min(remaining, Self.writeChunkSize)
+            let n = pending.data.withUnsafeBytes { ptr in
+                write(fd, ptr.baseAddress!.advanced(by: pending.totalWritten), nextChunkSize)
             }
-            return true
+            if n < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                if errno == EAGAIN || errno == EWOULDBLOCK {
+                    let now = DispatchTime.now().uptimeNanoseconds
+                    let stallDeadline = pending.lastProgressAt
+                        + UInt64(Self.writeStallTimeoutMilliseconds) * 1_000_000
+                    guard now < stallDeadline else {
+                        NSLog(
+                            "[BrainBar] ⚠️ Write stalled on fd %d for %d ms — disconnecting dead client",
+                            fd,
+                            Self.writeStallTimeoutMilliseconds
+                        )
+                        disconnectClient(fd: fd)
+                        return false
+                    }
+                    scheduleWriteRetryIfNeeded(fd: fd)
+                    return true
+                }
+                NSLog("[BrainBar] Write error on fd %d: errno %d", fd, errno)
+                disconnectClient(fd: fd)
+                return false
+            }
+            if n == 0 {
+                NSLog("[BrainBar] Write returned 0 on fd %d — peer closed", fd)
+                disconnectClient(fd: fd)
+                return false
+            }
+
+            pending.totalWritten += n
+            pending.lastProgressAt = DispatchTime.now().uptimeNanoseconds
+
+            guard var latest = clients[fd] else { return false }
+            latest.pendingWrites[0] = pending
+
+            if pending.totalWritten == pending.data.count {
+                let onDelivered = pending.onDelivered
+                latest.pendingWrites.removeFirst()
+                clients[fd] = latest
+                onDelivered?()
+            } else {
+                clients[fd] = latest
+            }
+        }
+
+        return clients[fd] != nil
+    }
+
+    private func scheduleWriteRetryIfNeeded(fd: Int32) {
+        guard var state = clients[fd], !state.hasScheduledWriteRetry else { return }
+        state.hasScheduledWriteRetry = true
+        clients[fd] = state
+
+        let retryDelay = DispatchTimeInterval.microseconds(Int(Self.writeRetrySleepMicroseconds))
+        queue.asyncAfter(deadline: .now() + retryDelay) { [weak self] in
+            guard let self, self.clients[fd] != nil else { return }
+            _ = self.flushPendingWrites(fd: fd)
         }
     }
 
@@ -607,10 +669,13 @@ final class BrainBarServer: @unchecked Sendable {
                 let delivered = sendResponse(
                     fd: clientFD,
                     response: notificationObject,
-                    useContentLength: client.usesContentLengthFraming
+                    useContentLength: client.usesContentLengthFraming,
+                    onDelivered: { [weak database] in
+                        try? database?.markDelivered(agentID: agentID, seq: stored.rowID)
+                    }
                 )
-                if delivered {
-                    try? database?.markDelivered(agentID: agentID, seq: stored.rowID)
+                if !delivered {
+                    continue
                 }
             }
         }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1928,9 +1928,12 @@ final class BrainDatabase: @unchecked Sendable {
         bindText(chunkJSON, to: stmt, index: 4)
         sqlite3_bind_int(stmt, 5, Int32(tokenCount))
         let stepRC = sqlite3_step(stmt)
-        let rowID = sqlite3_last_insert_rowid(db)
+        let rowID: Int64
         if stepRC == SQLITE_DONE {
+            rowID = sqlite3_last_insert_rowid(db)
             Self.postDashboardChangeNotification()
+        } else {
+            rowID = 0
         }
         return InjectionEvent(id: rowID, sessionID: sessionID, timestamp: ts, query: query, chunkIDs: chunkIDs, tokenCount: tokenCount)
     }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1944,7 +1944,7 @@ final class BrainDatabase: @unchecked Sendable {
         guard let db else { throw DBError.notOpen }
         var sql = "SELECT id, session_id, timestamp, query, chunk_ids, token_count FROM injection_events"
         if sessionID != nil { sql += " WHERE session_id = ?" }
-        sql += " ORDER BY timestamp DESC LIMIT ?"
+        sql += " ORDER BY timestamp DESC, id DESC LIMIT ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             throw DBError.prepare(sqlite3_errcode(db))

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -868,46 +868,32 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func recentActivityBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
-        guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
-        guard let db else { throw DBError.notOpen }
-
-        let bucketWidthSeconds = max(1, Double(activityWindowMinutes * 60) / Double(bucketCount))
-        let windowStart = Date().addingTimeInterval(Double(-activityWindowMinutes * 60))
-
-        var stmt: OpaquePointer?
-        let sql = """
-            SELECT datetime(created_at)
-            FROM chunks
-            WHERE datetime(created_at) >= datetime('now', ?)
-            ORDER BY datetime(created_at) ASC
-        """
-        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
-        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
-        defer { sqlite3_finalize(stmt) }
-        bindText("-\(activityWindowMinutes) minutes", to: stmt, index: 1)
-
-        var buckets = Array(repeating: 0, count: bucketCount)
-        let formatter = Self.sqliteDateFormatter
-
-        while sqlite3_step(stmt) == SQLITE_ROW {
-            guard let createdAtText = columnText(stmt, 0),
-                  let createdAt = formatter.date(from: createdAtText) else {
-                continue
-            }
-
-            let offset = createdAt.timeIntervalSince(windowStart)
-            if offset < 0 { continue }
-            if offset > Double(activityWindowMinutes * 60) { continue }
-
-            let rawIndex = Int(offset / bucketWidthSeconds)
-            let clampedIndex = min(max(rawIndex, 0), bucketCount - 1)
-            buckets[clampedIndex] += 1
-        }
-
-        return buckets
+        try recentBuckets(
+            activityWindowMinutes: activityWindowMinutes,
+            bucketCount: bucketCount,
+            timestampExpression: "datetime(created_at)",
+            additionalWhereClause: ""
+        )
     }
 
     private func recentEnrichmentBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
+        return try recentBuckets(
+            activityWindowMinutes: activityWindowMinutes,
+            bucketCount: bucketCount,
+            timestampExpression: "datetime(enriched_at)",
+            additionalWhereClause: """
+                AND enriched_at IS NOT NULL
+                  AND TRIM(enriched_at) != ''
+            """
+        )
+    }
+
+    private func recentBuckets(
+        activityWindowMinutes: Int,
+        bucketCount: Int,
+        timestampExpression: String,
+        additionalWhereClause: String
+    ) throws -> [Int] {
         guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
         guard let db else { throw DBError.notOpen }
 
@@ -916,12 +902,11 @@ final class BrainDatabase: @unchecked Sendable {
 
         var stmt: OpaquePointer?
         let sql = """
-            SELECT datetime(enriched_at)
+            SELECT \(timestampExpression)
             FROM chunks
-            WHERE enriched_at IS NOT NULL
-              AND TRIM(enriched_at) != ''
-              AND datetime(enriched_at) >= datetime('now', ?)
-            ORDER BY datetime(enriched_at) ASC
+            WHERE \(timestampExpression) >= datetime('now', ?)
+              \(additionalWhereClause)
+            ORDER BY \(timestampExpression) ASC
         """
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
@@ -932,12 +917,12 @@ final class BrainDatabase: @unchecked Sendable {
         let formatter = Self.sqliteDateFormatter
 
         while sqlite3_step(stmt) == SQLITE_ROW {
-            guard let enrichedAtText = columnText(stmt, 0),
-                  let enrichedAt = formatter.date(from: enrichedAtText) else {
+            guard let timestampText = columnText(stmt, 0),
+                  let timestamp = formatter.date(from: timestampText) else {
                 continue
             }
 
-            let offset = enrichedAt.timeIntervalSince(windowStart)
+            let offset = timestamp.timeIntervalSince(windowStart)
             if offset < 0 { continue }
             if offset > Double(activityWindowMinutes * 60) { continue }
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -20,8 +20,10 @@ final class BrainDatabase: @unchecked Sendable {
         let enrichedChunkCount: Int
         let pendingEnrichmentCount: Int
         let enrichmentPercent: Double
+        let enrichmentRatePerMinute: Double
         let databaseSizeBytes: Int64
         let recentActivityBuckets: [Int]
+        let recentEnrichmentBuckets: [Int]
     }
 
     struct SubscriberRecord: Sendable {
@@ -38,6 +40,25 @@ final class BrainDatabase: @unchecked Sendable {
     struct StoredChunk: Sendable {
         let chunkID: String
         let rowID: Int64
+    }
+
+    struct ConversationChunk: Sendable, Equatable, Identifiable {
+        let chunkID: String
+        let content: String
+        let contentType: String
+        let importance: Double
+        let createdAt: String
+        let summary: String
+        let isTarget: Bool
+
+        var id: String { chunkID }
+    }
+
+    struct ExpandedConversation: Sendable, Equatable, Identifiable {
+        let target: ConversationChunk
+        let entries: [ConversationChunk]
+
+        var id: String { target.chunkID }
     }
 
     private var db: OpaquePointer?
@@ -750,8 +771,10 @@ final class BrainDatabase: @unchecked Sendable {
                 enrichedChunkCount: 0,
                 pendingEnrichmentCount: 0,
                 enrichmentPercent: 0,
+                enrichmentRatePerMinute: 0,
                 databaseSizeBytes: databaseSizeBytes(),
-                recentActivityBuckets: []
+                recentActivityBuckets: [],
+                recentEnrichmentBuckets: []
             )
         }
 
@@ -760,7 +783,13 @@ final class BrainDatabase: @unchecked Sendable {
         let enrichedChunkCount = counts.enrichedChunkCount
         let pendingEnrichmentCount = max(0, chunkCount - enrichedChunkCount)
         let enrichmentPercent = chunkCount == 0 ? 0 : (Double(enrichedChunkCount) / Double(chunkCount)) * 100
+        let enrichmentRateWindowMinutes = min(max(activityWindowMinutes, 1), 2)
+        let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: enrichmentRateWindowMinutes)
         let recentActivityBuckets = try recentActivityBuckets(
+            activityWindowMinutes: activityWindowMinutes,
+            bucketCount: bucketCount
+        )
+        let recentEnrichmentBuckets = try recentEnrichmentBuckets(
             activityWindowMinutes: activityWindowMinutes,
             bucketCount: bucketCount
         )
@@ -770,8 +799,10 @@ final class BrainDatabase: @unchecked Sendable {
             enrichedChunkCount: enrichedChunkCount,
             pendingEnrichmentCount: pendingEnrichmentCount,
             enrichmentPercent: enrichmentPercent,
+            enrichmentRatePerMinute: enrichmentRatePerMinute,
             databaseSizeBytes: databaseSizeBytes(),
-            recentActivityBuckets: recentActivityBuckets
+            recentActivityBuckets: recentActivityBuckets,
+            recentEnrichmentBuckets: recentEnrichmentBuckets
         )
     }
 
@@ -874,6 +905,70 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         return buckets
+    }
+
+    private func recentEnrichmentBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
+        guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
+        guard let db else { throw DBError.notOpen }
+
+        let bucketWidthSeconds = max(1, Double(activityWindowMinutes * 60) / Double(bucketCount))
+        let windowStart = Date().addingTimeInterval(Double(-activityWindowMinutes * 60))
+
+        var stmt: OpaquePointer?
+        let sql = """
+            SELECT datetime(enriched_at)
+            FROM chunks
+            WHERE enriched_at IS NOT NULL
+              AND TRIM(enriched_at) != ''
+              AND datetime(enriched_at) >= datetime('now', ?)
+            ORDER BY datetime(enriched_at) ASC
+        """
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        bindText("-\(activityWindowMinutes) minutes", to: stmt, index: 1)
+
+        var buckets = Array(repeating: 0, count: bucketCount)
+        let formatter = Self.sqliteDateFormatter
+
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let enrichedAtText = columnText(stmt, 0),
+                  let enrichedAt = formatter.date(from: enrichedAtText) else {
+                continue
+            }
+
+            let offset = enrichedAt.timeIntervalSince(windowStart)
+            if offset < 0 { continue }
+            if offset > Double(activityWindowMinutes * 60) { continue }
+
+            let rawIndex = Int(offset / bucketWidthSeconds)
+            let clampedIndex = min(max(rawIndex, 0), bucketCount - 1)
+            buckets[clampedIndex] += 1
+        }
+
+        return buckets
+    }
+
+    private func recentEnrichmentRatePerMinute(windowMinutes: Int) throws -> Double {
+        guard windowMinutes > 0 else { return 0 }
+        guard let db else { throw DBError.notOpen }
+
+        var stmt: OpaquePointer?
+        let sql = """
+            SELECT COUNT(*)
+            FROM chunks
+            WHERE enriched_at IS NOT NULL
+              AND TRIM(enriched_at) != ''
+              AND datetime(enriched_at) >= datetime('now', ?)
+        """
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        bindText("-\(windowMinutes) minutes", to: stmt, index: 1)
+
+        guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
+        let count = Double(sqlite3_column_int(stmt, 0))
+        return count / Double(windowMinutes)
     }
 
     private func databaseSizeBytes() -> Int64 {
@@ -1347,7 +1442,8 @@ final class BrainDatabase: @unchecked Sendable {
         ]
 
         // Get surrounding chunks from same session using two separate queries
-        var context: [[String: Any]] = []
+        var beforeContext: [[String: Any]] = []
+        var afterContext: [[String: Any]] = []
 
         // Before chunks (reverse order, then flip)
         let beforeSQL = "SELECT id, content, content_type, importance, created_at, summary FROM chunks WHERE conversation_id = ? AND rowid < ? ORDER BY rowid DESC LIMIT ?"
@@ -1368,7 +1464,7 @@ final class BrainDatabase: @unchecked Sendable {
                     "summary": columnText(beforeStmt, 5) as Any
                 ])
             }
-            context.append(contentsOf: beforeChunks.reversed())
+            beforeContext = beforeChunks.reversed()
         }
 
         // After chunks
@@ -1380,7 +1476,7 @@ final class BrainDatabase: @unchecked Sendable {
             sqlite3_bind_int64(afterStmt, 2, targetRowID)
             sqlite3_bind_int(afterStmt, 3, Int32(after))
             while sqlite3_step(afterStmt) == SQLITE_ROW {
-                context.append([
+                afterContext.append([
                     "chunk_id": columnText(afterStmt, 0) as Any,
                     "content": columnText(afterStmt, 1) as Any,
                     "content_type": columnText(afterStmt, 2) as Any,
@@ -1391,7 +1487,54 @@ final class BrainDatabase: @unchecked Sendable {
             }
         }
 
-        return ["target": target, "context": context]
+        return [
+            "target": target,
+            "before_context": beforeContext,
+            "after_context": afterContext,
+            "context": beforeContext + afterContext
+        ]
+    }
+
+    func expandedConversation(id: String, before: Int = 3, after: Int = 3) throws -> ExpandedConversation {
+        let payload = try expandChunk(id: id, before: before, after: after)
+        guard let targetPayload = payload["target"] as? [String: Any] else {
+            throw DBError.noResult
+        }
+
+        let target = ConversationChunk(
+            chunkID: targetPayload["chunk_id"] as? String ?? "",
+            content: targetPayload["content"] as? String ?? "",
+            contentType: targetPayload["content_type"] as? String ?? "",
+            importance: targetPayload["importance"] as? Double ?? 0,
+            createdAt: targetPayload["created_at"] as? String ?? "",
+            summary: targetPayload["summary"] as? String ?? "",
+            isTarget: true
+        )
+
+        let beforeContext = ((payload["before_context"] as? [[String: Any]]) ?? []).map { item in
+            ConversationChunk(
+                chunkID: item["chunk_id"] as? String ?? "",
+                content: item["content"] as? String ?? "",
+                contentType: item["content_type"] as? String ?? "",
+                importance: item["importance"] as? Double ?? 0,
+                createdAt: item["created_at"] as? String ?? "",
+                summary: item["summary"] as? String ?? "",
+                isTarget: false
+            )
+        }
+        let afterContext = ((payload["after_context"] as? [[String: Any]]) ?? []).map { item in
+            ConversationChunk(
+                chunkID: item["chunk_id"] as? String ?? "",
+                content: item["content"] as? String ?? "",
+                contentType: item["content_type"] as? String ?? "",
+                importance: item["importance"] as? Double ?? 0,
+                createdAt: item["created_at"] as? String ?? "",
+                summary: item["summary"] as? String ?? "",
+                isTarget: false
+            )
+        }
+
+        return ExpandedConversation(target: target, entries: beforeContext + [target] + afterContext)
     }
 
     // MARK: - brain_entity: insert + lookup entities
@@ -1784,8 +1927,11 @@ final class BrainDatabase: @unchecked Sendable {
         bindText(query, to: stmt, index: 3)
         bindText(chunkJSON, to: stmt, index: 4)
         sqlite3_bind_int(stmt, 5, Int32(tokenCount))
-        sqlite3_step(stmt)
+        let stepRC = sqlite3_step(stmt)
         let rowID = sqlite3_last_insert_rowid(db)
+        if stepRC == SQLITE_DONE {
+            Self.postDashboardChangeNotification()
+        }
         return InjectionEvent(id: rowID, sessionID: sessionID, timestamp: ts, query: query, chunkIDs: chunkIDs, tokenCount: tokenCount)
     }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum DashboardMetricFormatter {
+    static func speedString(ratePerMinute: Double) -> String {
+        let perSecond = max(ratePerMinute, 0) / 60.0
+        return String(format: "%.2f/s", perSecond)
+    }
+}

--- a/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
@@ -11,7 +11,9 @@ enum DashboardMetricFormatter {
     }
 
     static func speedDisplay(ratePerMinute: Double) -> RateDisplay {
-        let clampedRate = max(ratePerMinute, 0)
+        guard let clampedRate = sanitizedRatePerMinute(ratePerMinute) else {
+            return RateDisplay(valueText: "0", unitText: "/min")
+        }
         if clampedRate == 0 {
             return RateDisplay(valueText: "0", unitText: "/min")
         }
@@ -31,8 +33,16 @@ enum DashboardMetricFormatter {
     }
 
     static func rateDetailString(ratePerMinute: Double) -> String {
-        let perSecond = max(ratePerMinute, 0) / 60.0
+        guard let clampedRate = sanitizedRatePerMinute(ratePerMinute) else {
+            return "0/s"
+        }
+        let perSecond = clampedRate / 60.0
         return "\(formattedRateValue(perSecond))/s"
+    }
+
+    private static func sanitizedRatePerMinute(_ ratePerMinute: Double) -> Double? {
+        guard ratePerMinute.isFinite else { return nil }
+        return max(ratePerMinute, 0)
     }
 
     private static func formattedRateValue(_ value: Double) -> String {

--- a/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
@@ -1,8 +1,52 @@
 import Foundation
 
 enum DashboardMetricFormatter {
+    struct RateDisplay: Equatable {
+        let valueText: String
+        let unitText: String
+
+        var text: String {
+            "\(valueText)\(unitText)"
+        }
+    }
+
+    static func speedDisplay(ratePerMinute: Double) -> RateDisplay {
+        let clampedRate = max(ratePerMinute, 0)
+        if clampedRate == 0 {
+            return RateDisplay(valueText: "0", unitText: "/min")
+        }
+        let perSecond = clampedRate / 60.0
+
+        if perSecond >= 1 {
+            return RateDisplay(valueText: formattedRateValue(perSecond), unitText: "/s")
+        }
+        if clampedRate >= 1 {
+            return RateDisplay(valueText: formattedRateValue(clampedRate), unitText: "/min")
+        }
+        return RateDisplay(valueText: formattedRateValue(clampedRate * 60.0), unitText: "/hr")
+    }
+
     static func speedString(ratePerMinute: Double) -> String {
+        speedDisplay(ratePerMinute: ratePerMinute).text
+    }
+
+    static func rateDetailString(ratePerMinute: Double) -> String {
         let perSecond = max(ratePerMinute, 0) / 60.0
-        return String(format: "%.2f/s", perSecond)
+        return "\(formattedRateValue(perSecond))/s"
+    }
+
+    private static func formattedRateValue(_ value: Double) -> String {
+        if value == 0 {
+            return "0"
+        }
+        if value >= 10 {
+            return String(Int(value.rounded()))
+        }
+
+        let string = String(format: "%.1f", value)
+        if string.hasSuffix(".0") {
+            return String(string.dropLast(2))
+        }
+        return string
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -102,6 +102,7 @@ struct PipelineActivityTracks: Sendable, Equatable {
         trailingBucketCount: Int = 2
     ) -> PipelineActivityTracks {
         let indicators = PipelineIndicators.derive(daemon: daemon, stats: stats)
+        let activityWindowLabel = windowLabel(activityWindowMinutes)
 
         let indexingRatePerMinute = recentRatePerMinute(
             values: stats.recentActivityBuckets,
@@ -113,8 +114,8 @@ struct PipelineActivityTracks: Sendable, Equatable {
             ? DashboardMetricFormatter.speedString(ratePerMinute: indexingRatePerMinute)
             : "idle"
         let indexingDetailText = recentWrites > 0
-            ? "\(recentWrites) chunks in last 30m"
-            : "No new chunks in last 30m"
+            ? "\(recentWrites) chunks in last \(activityWindowLabel)"
+            : "No new chunks in last \(activityWindowLabel)"
 
         let recentCompletions = stats.recentEnrichmentBuckets.reduce(0, +)
         let enrichmentDisplayRatePerMinute = displayedRatePerMinute(
@@ -134,13 +135,13 @@ struct PipelineActivityTracks: Sendable, Equatable {
 
         let enrichingDetailText: String
         if stats.pendingEnrichmentCount > 0, recentCompletions > 0 {
-            enrichingDetailText = "\(stats.pendingEnrichmentCount) pending · \(recentCompletions) done in last 30m"
+            enrichingDetailText = "\(stats.pendingEnrichmentCount) pending · \(recentCompletions) done in last \(activityWindowLabel)"
         } else if stats.pendingEnrichmentCount > 0 {
             enrichingDetailText = "\(stats.pendingEnrichmentCount) pending"
         } else if recentCompletions > 0 {
-            enrichingDetailText = "\(recentCompletions) done in last 30m"
+            enrichingDetailText = "\(recentCompletions) done in last \(activityWindowLabel)"
         } else {
-            enrichingDetailText = "No completions in last 30m"
+            enrichingDetailText = "No completions in last \(activityWindowLabel)"
         }
 
         return PipelineActivityTracks(
@@ -190,6 +191,17 @@ struct PipelineActivityTracks: Sendable, Equatable {
         let recentWindowMinutes = bucketWidthMinutes * Double(recentBucketCount)
         guard recentWindowMinutes > 0 else { return 0 }
         return Double(recentCount) / recentWindowMinutes
+    }
+
+    private static func windowLabel(_ activityWindowMinutes: Double) -> String {
+        guard activityWindowMinutes.isFinite, activityWindowMinutes > 0 else {
+            return "0m"
+        }
+        let roundedMinutes = activityWindowMinutes.rounded()
+        if roundedMinutes == activityWindowMinutes {
+            return "\(Int(roundedMinutes))m"
+        }
+        return "\(String(format: "%.1f", activityWindowMinutes))m"
     }
 }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -82,6 +82,117 @@ struct PipelineIndicators: Sendable, Equatable {
     }
 }
 
+struct PipelineActivityTrack: Sendable, Equatable {
+    let name: String
+    let symbolName: String
+    let status: PipelineIndicatorStatus
+    let rateText: String
+    let detailText: String
+    let values: [Int]
+}
+
+struct PipelineActivityTracks: Sendable, Equatable {
+    let indexing: PipelineActivityTrack
+    let enriching: PipelineActivityTrack
+
+    static func derive(
+        daemon: DaemonHealthSnapshot?,
+        stats: DashboardStats,
+        activityWindowMinutes: Double = 30,
+        trailingBucketCount: Int = 2
+    ) -> PipelineActivityTracks {
+        let indicators = PipelineIndicators.derive(daemon: daemon, stats: stats)
+
+        let indexingRatePerMinute = recentRatePerMinute(
+            values: stats.recentActivityBuckets,
+            activityWindowMinutes: activityWindowMinutes,
+            trailingBucketCount: trailingBucketCount
+        )
+        let recentWrites = stats.recentActivityBuckets.reduce(0, +)
+        let indexingRateText = recentWrites > 0
+            ? DashboardMetricFormatter.speedString(ratePerMinute: indexingRatePerMinute)
+            : "idle"
+        let indexingDetailText = recentWrites > 0
+            ? "\(recentWrites) chunks in last 30m"
+            : "No new chunks in last 30m"
+
+        let recentCompletions = stats.recentEnrichmentBuckets.reduce(0, +)
+        let enrichmentDisplayRatePerMinute = displayedRatePerMinute(
+            primaryRatePerMinute: stats.enrichmentRatePerMinute,
+            values: stats.recentEnrichmentBuckets,
+            activityWindowMinutes: activityWindowMinutes,
+            trailingBucketCount: trailingBucketCount
+        )
+        let enrichingRateText: String
+        if enrichmentDisplayRatePerMinute > 0 {
+            enrichingRateText = DashboardMetricFormatter.speedString(ratePerMinute: enrichmentDisplayRatePerMinute)
+        } else if indicators.enriching.status == .queued {
+            enrichingRateText = "queued"
+        } else {
+            enrichingRateText = "idle"
+        }
+
+        let enrichingDetailText: String
+        if stats.pendingEnrichmentCount > 0, recentCompletions > 0 {
+            enrichingDetailText = "\(stats.pendingEnrichmentCount) pending · \(recentCompletions) done in last 30m"
+        } else if stats.pendingEnrichmentCount > 0 {
+            enrichingDetailText = "\(stats.pendingEnrichmentCount) pending"
+        } else if recentCompletions > 0 {
+            enrichingDetailText = "\(recentCompletions) done in last 30m"
+        } else {
+            enrichingDetailText = "No completions in last 30m"
+        }
+
+        return PipelineActivityTracks(
+            indexing: PipelineActivityTrack(
+                name: "Indexing",
+                symbolName: "server.rack",
+                status: indicators.indexing.status,
+                rateText: indexingRateText,
+                detailText: indexingDetailText,
+                values: stats.recentActivityBuckets
+            ),
+            enriching: PipelineActivityTrack(
+                name: "Enriching",
+                symbolName: "sparkles",
+                status: indicators.enriching.status,
+                rateText: enrichingRateText,
+                detailText: enrichingDetailText,
+                values: stats.recentEnrichmentBuckets
+            )
+        )
+    }
+
+    static func displayedRatePerMinute(
+        primaryRatePerMinute: Double,
+        values: [Int],
+        activityWindowMinutes: Double = 30,
+        trailingBucketCount: Int = 2
+    ) -> Double {
+        let instantaneousRate = max(primaryRatePerMinute, 0)
+        guard instantaneousRate == 0 else { return instantaneousRate }
+        return recentRatePerMinute(
+            values: values,
+            activityWindowMinutes: activityWindowMinutes,
+            trailingBucketCount: trailingBucketCount
+        )
+    }
+
+    static func recentRatePerMinute(
+        values: [Int],
+        activityWindowMinutes: Double,
+        trailingBucketCount: Int
+    ) -> Double {
+        guard !values.isEmpty, activityWindowMinutes > 0 else { return 0 }
+        let recentBucketCount = max(1, min(trailingBucketCount, values.count))
+        let recentCount = values.suffix(recentBucketCount).reduce(0, +)
+        let bucketWidthMinutes = activityWindowMinutes / Double(values.count)
+        let recentWindowMinutes = bucketWidthMinutes * Double(recentBucketCount)
+        guard recentWindowMinutes > 0 else { return 0 }
+        return Double(recentCount) / recentWindowMinutes
+    }
+}
+
 enum PipelineState: String, Sendable, Equatable {
     case degraded
     case indexing

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -12,6 +12,76 @@ struct DaemonHealthSnapshot: Sendable, Equatable {
     let lastSeenAt: Date
 }
 
+enum PipelineIndicatorStatus: Sendable, Equatable {
+    case live
+    case queued
+    case idle
+    case unavailable
+
+    var label: String {
+        switch self {
+        case .live:
+            return "live"
+        case .queued:
+            return "queued"
+        case .idle:
+            return "idle"
+        case .unavailable:
+            return "offline"
+        }
+    }
+
+    var color: NSColor {
+        switch self {
+        case .live:
+            return .systemGreen
+        case .queued:
+            return .systemOrange
+        case .idle:
+            return .secondaryLabelColor
+        case .unavailable:
+            return .systemRed
+        }
+    }
+}
+
+struct PipelineIndicator: Sendable, Equatable {
+    let name: String
+    let status: PipelineIndicatorStatus
+}
+
+struct PipelineIndicators: Sendable, Equatable {
+    let indexing: PipelineIndicator
+    let enriching: PipelineIndicator
+
+    static func derive(daemon: DaemonHealthSnapshot?, stats: DashboardStats) -> PipelineIndicators {
+        let indexingStatus: PipelineIndicatorStatus
+        let enrichingStatus: PipelineIndicatorStatus
+
+        if daemon?.isResponsive != true {
+            indexingStatus = .unavailable
+            enrichingStatus = .unavailable
+        } else {
+            let recentWrites = stats.recentActivityBuckets.suffix(2).reduce(0, +)
+            let recentEnrichments = stats.recentEnrichmentBuckets.suffix(2).reduce(0, +)
+
+            indexingStatus = recentWrites > 0 ? .live : .idle
+            if recentEnrichments > 0 {
+                enrichingStatus = .live
+            } else if stats.pendingEnrichmentCount > 0 {
+                enrichingStatus = .queued
+            } else {
+                enrichingStatus = .idle
+            }
+        }
+
+        return PipelineIndicators(
+            indexing: PipelineIndicator(name: "Indexing", status: indexingStatus),
+            enriching: PipelineIndicator(name: "Enriching", status: enrichingStatus)
+        )
+    }
+}
+
 enum PipelineState: String, Sendable, Equatable {
     case degraded
     case indexing

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -6,6 +6,7 @@ enum SparklineRenderer {
     static func render(state: PipelineState, values: [Int], size: NSSize = NSSize(width: 44, height: 18)) -> NSImage {
         let width = max(Int(size.width.rounded(.up)), 1)
         let height = max(Int(size.height.rounded(.up)), 1)
+        let isCompact = height <= 20 || width <= 52
         let colorSpace = CGColorSpaceCreateDeviceRGB()
 
         guard let context = CGContext(
@@ -27,24 +28,40 @@ enum SparklineRenderer {
         context.setAllowsAntialiasing(true)
         context.setShouldAntialias(true)
 
-        let indicatorRect = CGRect(x: 1, y: CGFloat(height) - 7, width: 5, height: 5)
-        context.setFillColor(state.color.cgColor)
-        context.fillEllipse(in: indicatorRect)
-
         guard values.count > 1 else {
             return image(from: context, size: size)
         }
 
         let maxValue = max(values.max() ?? 0, 1)
-        let chartRect = CGRect(x: 8, y: 2, width: CGFloat(width) - 10, height: CGFloat(height) - 4)
+        let horizontalInset: CGFloat = isCompact ? 2 : 10
+        let verticalInset: CGFloat = isCompact ? 2 : 10
+        let chartRect = CGRect(
+            x: horizontalInset,
+            y: verticalInset,
+            width: max(CGFloat(width) - (horizontalInset * 2), 1),
+            height: max(CGFloat(height) - (verticalInset * 2), 1)
+        )
         let step = chartRect.width / CGFloat(max(values.count - 1, 1))
         let path = CGMutablePath()
+        var points: [CGPoint] = []
+
+        if !isCompact {
+            context.setStrokeColor(NSColor.separatorColor.withAlphaComponent(0.55).cgColor)
+            context.setLineWidth(1)
+            for fraction in [0.25, 0.5, 0.75] {
+                let y = chartRect.minY + chartRect.height * CGFloat(fraction)
+                context.move(to: CGPoint(x: chartRect.minX, y: y))
+                context.addLine(to: CGPoint(x: chartRect.maxX, y: y))
+            }
+            context.strokePath()
+        }
 
         for (index, value) in values.enumerated() {
             let x = chartRect.minX + CGFloat(index) * step
             let normalized = CGFloat(value) / CGFloat(maxValue)
             let y = chartRect.minY + normalized * chartRect.height
             let point = CGPoint(x: x, y: y)
+            points.append(point)
             if index == 0 {
                 path.move(to: point)
             } else {
@@ -52,9 +69,22 @@ enum SparklineRenderer {
             }
         }
 
+        if !isCompact, let first = points.first, let last = points.last {
+            let fill = CGMutablePath()
+            fill.move(to: CGPoint(x: first.x, y: chartRect.minY))
+            for point in points {
+                fill.addLine(to: point)
+            }
+            fill.addLine(to: CGPoint(x: last.x, y: chartRect.minY))
+            fill.closeSubpath()
+            context.addPath(fill)
+            context.setFillColor(state.color.withAlphaComponent(0.10).cgColor)
+            context.fillPath()
+        }
+
         context.addPath(path)
-        context.setStrokeColor(state.color.cgColor)
-        context.setLineWidth(1.6)
+        context.setStrokeColor(state.color.withAlphaComponent(0.85).cgColor)
+        context.setLineWidth(isCompact ? 1.6 : 2)
         context.setLineCap(.round)
         context.setLineJoin(.round)
         context.strokePath()

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -4,6 +4,10 @@ import Foundation
 
 enum SparklineRenderer {
     static func render(state: PipelineState, values: [Int], size: NSSize = NSSize(width: 44, height: 18)) -> NSImage {
+        render(color: state.color, values: values, size: size)
+    }
+
+    static func render(color: NSColor, values: [Int], size: NSSize = NSSize(width: 44, height: 18)) -> NSImage {
         let width = max(Int(size.width.rounded(.up)), 1)
         let height = max(Int(size.height.rounded(.up)), 1)
         let isCompact = height <= 20 || width <= 52
@@ -78,12 +82,12 @@ enum SparklineRenderer {
             fill.addLine(to: CGPoint(x: last.x, y: chartRect.minY))
             fill.closeSubpath()
             context.addPath(fill)
-            context.setFillColor(state.color.withAlphaComponent(0.10).cgColor)
+            context.setFillColor(color.withAlphaComponent(0.10).cgColor)
             context.fillPath()
         }
 
         context.addPath(path)
-        context.setStrokeColor(state.color.withAlphaComponent(0.85).cgColor)
+        context.setStrokeColor(color.withAlphaComponent(0.85).cgColor)
         context.setLineWidth(isCompact ? 1.6 : 2)
         context.setLineCap(.round)
         context.setLineJoin(.round)

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -39,8 +39,10 @@ final class StatsCollector: ObservableObject {
             enrichedChunkCount: 0,
             pendingEnrichmentCount: 0,
             enrichmentPercent: 0,
+            enrichmentRatePerMinute: 0,
             databaseSizeBytes: 0,
-            recentActivityBuckets: Array(repeating: 0, count: 12)
+            recentActivityBuckets: Array(repeating: 0, count: 12),
+            recentEnrichmentBuckets: Array(repeating: 0, count: 12)
         )
         self.state = .degraded
     }
@@ -88,8 +90,10 @@ final class StatsCollector: ObservableObject {
                     enrichedChunkCount: 0,
                     pendingEnrichmentCount: 0,
                     enrichmentPercent: 0,
+                    enrichmentRatePerMinute: 0,
                     databaseSizeBytes: 0,
-                    recentActivityBuckets: Array(repeating: 0, count: 12)
+                    recentActivityBuckets: Array(repeating: 0, count: 12),
+                    recentEnrichmentBuckets: Array(repeating: 0, count: 12)
                 )
             }
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -19,9 +19,10 @@ enum PopoverTab: Int, CaseIterable, Sendable {
     }
 
     var contentSize: NSSize {
-        // Fixed size for all tabs — changing NSPopover contentSize causes
-        // the popover to detach from its anchor and jump position.
-        NSSize(width: 620, height: 500)
+        // Keep a single utility-panel size across tabs. AppKit popovers do not
+        // handle repeated tab-triggered resizing cleanly; the earlier per-tab
+        // sizes caused content to squash and overflow when switching around.
+        NSSize(width: 560, height: 520)
     }
 }
 
@@ -43,15 +44,22 @@ final class StatusPopoverView: NSViewController {
     // Dashboard labels
     private let titleLabel = NSTextField(labelWithString: "BrainBar")
     private let statusLabel = NSTextField(labelWithString: "")
+    private let pipelineValueLabel = NSTextField(labelWithString: "")
     private let databaseSizeLabel = NSTextField(labelWithString: "")
-    private let chunkMetric = MetricTileView(title: "Chunks")
-    private let enrichedMetric = MetricTileView(title: "Enriched")
-    private let pendingMetric = MetricTileView(title: "Pending")
-    private let activityLabel = NSTextField(labelWithString: "Recent Activity")
+    private let chunkMetric = MetricTileView(title: "Chunks", accentColor: .systemBlue)
+    private let enrichedMetric = MetricTileView(title: "Enriched", accentColor: .systemGreen)
+    private let pendingMetric = MetricTileView(title: "Backlog", accentColor: .systemOrange)
+    private let rateMetric = MetricTileView(title: "Speed", accentColor: .systemPink)
+    private let indexingIndicator = PipelineIndicatorBadgeView(name: "Indexing")
+    private let enrichingIndicator = PipelineIndicatorBadgeView(name: "Enriching")
+    private let activityLabel = NSTextField(labelWithString: "Enrichment Throughput")
+    private let activityDetailLabel = NSTextField(labelWithString: "")
     private let enrichmentLabel = NSTextField(labelWithString: "")
     private let sparklineImageView = NSImageView(frame: .zero)
     private let daemonLabel = NSTextField(labelWithString: "")
     private let hotkeyLabel = NSTextField(labelWithString: "")
+    private let headerPanel = SurfacePanelView(cornerRadius: 14)
+    private let activityPanel = SurfacePanelView(cornerRadius: 14)
 
     // Lazily created tab content
     private var dashboardContent: NSView?
@@ -79,6 +87,8 @@ final class StatusPopoverView: NSViewController {
     override func loadView() {
         let size = PopoverTab.dashboard.contentSize
         view = NSView(frame: NSRect(origin: .zero, size: size))
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
         configureDashboardLabels()
         configureSegmentedControl()
         configureLayout()
@@ -169,15 +179,21 @@ final class StatusPopoverView: NSViewController {
     // MARK: - Dashboard Content
 
     private func configureDashboardLabels() {
-        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        titleLabel.font = .systemFont(ofSize: 18, weight: .bold)
         statusLabel.font = .systemFont(ofSize: 12, weight: .medium)
+        statusLabel.textColor = .secondaryLabelColor
+        pipelineValueLabel.font = .systemFont(ofSize: 16, weight: .semibold)
         databaseSizeLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
-        databaseSizeLabel.textColor = .secondaryLabelColor
+        databaseSizeLabel.textColor = .tertiaryLabelColor
         activityLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        activityDetailLabel.font = .systemFont(ofSize: 11, weight: .medium)
+        activityDetailLabel.textColor = .secondaryLabelColor
         enrichmentLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
-        enrichmentLabel.textColor = .secondaryLabelColor
+        enrichmentLabel.textColor = .tertiaryLabelColor
         daemonLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
         daemonLabel.textColor = .secondaryLabelColor
+        daemonLabel.maximumNumberOfLines = 2
+        daemonLabel.lineBreakMode = .byTruncatingTail
         hotkeyLabel.font = .systemFont(ofSize: 11, weight: .medium)
         hotkeyLabel.textColor = .secondaryLabelColor
         hotkeyLabel.maximumNumberOfLines = 2
@@ -185,62 +201,80 @@ final class StatusPopoverView: NSViewController {
 
         sparklineImageView.imageScaling = .scaleAxesIndependently
         sparklineImageView.wantsLayer = true
-        sparklineImageView.layer?.cornerRadius = 10
-        sparklineImageView.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        sparklineImageView.layer?.cornerRadius = 4
+        sparklineImageView.layer?.backgroundColor = NSColor.clear.cgColor
     }
 
     private func makeDashboardContent() -> NSView {
         if let existing = dashboardContent { return existing }
 
-        let headerStack = NSStackView(views: [
-            verticalStack([titleLabel, statusLabel]),
-            NSView(),
-            databaseSizeLabel,
-        ])
-        headerStack.orientation = .horizontal
-        headerStack.alignment = .centerY
+        let titleRow = NSStackView(views: [titleLabel, NSView(), pipelineValueLabel])
+        titleRow.orientation = .horizontal
+        titleRow.alignment = .firstBaseline
+        titleRow.spacing = 12
 
-        let metricsStack = NSStackView(views: [chunkMetric, enrichedMetric, pendingMetric])
-        metricsStack.orientation = .horizontal
-        metricsStack.distribution = .fillEqually
-        metricsStack.spacing = 8
+        let metaRow = NSStackView(views: [statusLabel, NSView(), enrichmentLabel, databaseSizeLabel])
+        metaRow.orientation = .horizontal
+        metaRow.alignment = .centerY
+        metaRow.spacing = 12
 
-        let activityHeader = NSStackView(views: [activityLabel, NSView(), enrichmentLabel])
+        let indicatorsRow = NSStackView(views: [indexingIndicator, enrichingIndicator, NSView()])
+        indicatorsRow.orientation = .horizontal
+        indicatorsRow.alignment = .centerY
+        indicatorsRow.spacing = 8
+
+        let metricsRow = NSStackView(views: [chunkMetric, enrichedMetric, pendingMetric, rateMetric])
+        metricsRow.orientation = .horizontal
+        metricsRow.distribution = .fillEqually
+        metricsRow.spacing = 10
+
+        let quitButton = NSButton(title: "Quit", target: self, action: #selector(quitBrainBar))
+        quitButton.bezelStyle = .rounded
+        quitButton.controlSize = .small
+
+        let footerRow = NSStackView(views: [daemonLabel, NSView(), hotkeyLabel, quitButton])
+        footerRow.orientation = .horizontal
+        footerRow.alignment = .centerY
+        footerRow.spacing = 10
+        hotkeyLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        daemonLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+        let headerStack = NSStackView(views: [titleRow, metaRow, indicatorsRow, metricsRow, footerRow])
+        headerStack.orientation = .vertical
+        headerStack.spacing = 10
+        let headerCard = headerPanel.wrap(
+            headerStack,
+            edgeInsets: NSEdgeInsets(top: 14, left: 14, bottom: 14, right: 14)
+        )
+
+        let activityHeader = NSStackView(views: [activityLabel, NSView(), activityDetailLabel])
         activityHeader.orientation = .horizontal
         activityHeader.alignment = .centerY
 
-        let refreshButton = NSButton(title: "Refresh", target: self, action: #selector(refreshDashboard))
-        let quitButton = NSButton(title: "Quit BrainBar", target: self, action: #selector(quitBrainBar))
-        let buttonRow = NSStackView(views: [refreshButton, quitButton, NSView()])
-        buttonRow.orientation = .horizontal
-        buttonRow.alignment = .centerY
-        buttonRow.spacing = 8
+        let activityStack = NSStackView(views: [activityHeader, sparklineImageView])
+        activityStack.orientation = .vertical
+        activityStack.spacing = 10
+        let activityCard = activityPanel.wrap(
+            activityStack,
+            edgeInsets: NSEdgeInsets(top: 14, left: 14, bottom: 14, right: 14)
+        )
 
         sparklineImageView.translatesAutoresizingMaskIntoConstraints = false
         hotkeyLabel.isHidden = hotkeyStatus == nil
 
-        // Stretch all rows to fill width
-        for row in [headerStack, metricsStack, activityHeader, sparklineImageView, buttonRow] as [NSView] {
+        for row in [headerCard, activityCard] as [NSView] {
             row.translatesAutoresizingMaskIntoConstraints = false
             row.setContentHuggingPriority(.defaultLow, for: .horizontal)
         }
 
-        let content = NSStackView(views: [
-            headerStack,
-            metricsStack,
-            activityHeader,
-            sparklineImageView,
-            daemonLabel,
-            hotkeyLabel,
-            buttonRow,
-        ])
+        let content = NSStackView(views: [headerCard, activityCard])
         content.orientation = .vertical
         content.alignment = .width
-        content.spacing = 12
-        content.edgeInsets = NSEdgeInsets(top: 4, left: 14, bottom: 14, right: 14)
+        content.spacing = 10
+        content.edgeInsets = NSEdgeInsets(top: 8, left: 14, bottom: 14, right: 14)
 
         NSLayoutConstraint.activate([
-            sparklineImageView.heightAnchor.constraint(equalToConstant: 80),
+            sparklineImageView.heightAnchor.constraint(equalToConstant: 188),
         ])
 
         dashboardContent = content
@@ -305,19 +339,32 @@ final class StatusPopoverView: NSViewController {
 
     private func render() {
         titleLabel.stringValue = "BrainBar"
-        statusLabel.stringValue = collector.state.label
-        statusLabel.textColor = collector.state.color
-        databaseSizeLabel.stringValue = byteString(collector.stats.databaseSizeBytes)
+        statusLabel.stringValue = collector.state == .indexing ? "Incoming writes active" :
+            (collector.state == .enriching ? "Backlog is being processed" :
+            (collector.state == .idle ? "Pipeline settled" : "Pipeline degraded"))
+        pipelineValueLabel.stringValue = collector.state.label
+        pipelineValueLabel.textColor = collector.state.color
+        headerPanel.backgroundColor = NSColor.underPageBackgroundColor.withAlphaComponent(0.92)
+        headerPanel.borderColor = NSColor.separatorColor.withAlphaComponent(0.45)
+        activityPanel.backgroundColor = NSColor.underPageBackgroundColor.withAlphaComponent(0.92)
+        activityPanel.borderColor = NSColor.separatorColor.withAlphaComponent(0.45)
+        databaseSizeLabel.stringValue = "\(byteString(collector.stats.databaseSizeBytes)) db"
+
+        let indicators = PipelineIndicators.derive(daemon: collector.daemon, stats: collector.stats)
+        indexingIndicator.setStatus(indicators.indexing.status)
+        enrichingIndicator.setStatus(indicators.enriching.status)
 
         chunkMetric.value = "\(collector.stats.chunkCount)"
         enrichedMetric.value = "\(collector.stats.enrichedChunkCount)"
         pendingMetric.value = "\(collector.stats.pendingEnrichmentCount)"
+        rateMetric.value = DashboardMetricFormatter.speedString(ratePerMinute: collector.stats.enrichmentRatePerMinute)
 
         enrichmentLabel.stringValue = "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched"
+        activityDetailLabel.stringValue = enrichmentActivitySummary(collector.stats)
         sparklineImageView.image = SparklineRenderer.render(
             state: collector.state,
-            values: collector.stats.recentActivityBuckets,
-            size: NSSize(width: 320, height: 42)
+            values: collector.stats.recentEnrichmentBuckets,
+            size: NSSize(width: 500, height: 188)
         )
 
         if let daemon = collector.daemon {
@@ -329,15 +376,12 @@ final class StatusPopoverView: NSViewController {
         if let hotkeyStatus {
             hotkeyLabel.isHidden = false
             hotkeyLabel.stringValue = hotkeyStatus.statusLine
+        } else {
+            hotkeyLabel.isHidden = true
         }
     }
 
     // MARK: - Actions
-
-    @objc
-    private func refreshDashboard() {
-        collector.refresh(force: true)
-    }
 
     @objc
     private func quitBrainBar() {
@@ -348,6 +392,14 @@ final class StatusPopoverView: NSViewController {
 
     private func byteString(_ value: Int64) -> String {
         ByteCountFormatter.string(fromByteCount: value, countStyle: .file)
+    }
+
+    private func enrichmentActivitySummary(_ stats: DashboardStats) -> String {
+        let recentCompletions = stats.recentEnrichmentBuckets.reduce(0, +)
+        if recentCompletions == 0 {
+            return "No completions in the last 30m"
+        }
+        return "\(recentCompletions) completions in the last 30m"
     }
 
     private func verticalStack(_ views: [NSView]) -> NSStackView {
@@ -381,7 +433,7 @@ struct PopoverInjectionTab: View {
     @State private var filterText = ""
 
     var body: some View {
-        InjectionFeedView(events: store.events, filterText: $filterText)
+        InjectionFeedView(store: store, filterText: $filterText)
             .padding(.horizontal, 8)
             .padding(.bottom, 8)
     }
@@ -402,7 +454,6 @@ struct PopoverGraphTab: View {
 private final class MetricTileView: NSView {
     private let titleLabel = NSTextField(labelWithString: "")
     private let valueLabel = NSTextField(labelWithString: "")
-
     var value: String {
         get { valueLabel.stringValue }
         set { valueLabel.stringValue = newValue }
@@ -411,18 +462,23 @@ private final class MetricTileView: NSView {
     override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
-        layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        layer?.backgroundColor = NSColor.clear.cgColor
+        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.35).cgColor
+        layer?.borderWidth = 0.8
     }
 
-    init(title: String) {
+    init(title: String, accentColor: NSColor) {
         super.init(frame: .zero)
         wantsLayer = true
-        layer?.cornerRadius = 10
+        layer?.cornerRadius = 6
 
         titleLabel.stringValue = title
-        titleLabel.font = .systemFont(ofSize: 11, weight: .medium)
+        titleLabel.font = .systemFont(ofSize: 10, weight: .medium)
         titleLabel.textColor = .secondaryLabelColor
-        valueLabel.font = .systemFont(ofSize: 18, weight: .semibold)
+        valueLabel.font = .monospacedDigitSystemFont(ofSize: 20, weight: .semibold)
+        valueLabel.textColor = .labelColor
+        valueLabel.lineBreakMode = .byClipping
+        valueLabel.maximumNumberOfLines = 1
 
         let stack = NSStackView(views: [titleLabel, valueLabel])
         stack.orientation = .vertical
@@ -438,6 +494,95 @@ private final class MetricTileView: NSView {
             stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
             heightAnchor.constraint(equalToConstant: 60),
         ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private final class PipelineIndicatorBadgeView: NSView {
+    private let dotView = NSView(frame: NSRect(x: 0, y: 0, width: 8, height: 8))
+    private let label = NSTextField(labelWithString: "")
+    private let name: String
+
+    init(name: String) {
+        self.name = name
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+
+        dotView.wantsLayer = true
+        dotView.layer?.cornerRadius = 4
+
+        label.font = .systemFont(ofSize: 11, weight: .medium)
+        label.textColor = .secondaryLabelColor
+
+        let stack = NSStackView(views: [dotView, label])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+            dotView.widthAnchor.constraint(equalToConstant: 8),
+            dotView.heightAnchor.constraint(equalToConstant: 8),
+        ])
+
+        layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.08).cgColor
+        setStatus(.idle)
+    }
+
+    func setStatus(_ status: PipelineIndicatorStatus) {
+        dotView.layer?.backgroundColor = status.color.cgColor
+        label.stringValue = "\(name) \(status.label)"
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private final class SurfacePanelView: NSView {
+    var backgroundColor: NSColor = .controlBackgroundColor {
+        didSet { needsDisplay = true }
+    }
+
+    var borderColor: NSColor = .separatorColor {
+        didSet { needsDisplay = true }
+    }
+
+    override var wantsUpdateLayer: Bool { true }
+
+    init(cornerRadius: CGFloat) {
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = cornerRadius
+    }
+
+    override func updateLayer() {
+        layer?.backgroundColor = backgroundColor.cgColor
+        layer?.borderColor = borderColor.cgColor
+        layer?.borderWidth = 1
+    }
+
+    func wrap(_ content: NSView, edgeInsets: NSEdgeInsets) -> NSView {
+        content.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(content)
+        NSLayoutConstraint.activate([
+            content.topAnchor.constraint(equalTo: topAnchor, constant: edgeInsets.top),
+            content.leadingAnchor.constraint(equalTo: leadingAnchor, constant: edgeInsets.left),
+            content.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -edgeInsets.right),
+            content.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -edgeInsets.bottom),
+        ])
+        return self
     }
 
     @available(*, unavailable)

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -46,16 +46,24 @@ final class StatusPopoverView: NSViewController {
     private let statusLabel = NSTextField(labelWithString: "")
     private let pipelineValueLabel = NSTextField(labelWithString: "")
     private let databaseSizeLabel = NSTextField(labelWithString: "")
-    private let chunkMetric = MetricTileView(title: "Chunks", accentColor: .systemBlue)
-    private let enrichedMetric = MetricTileView(title: "Enriched", accentColor: .systemGreen)
-    private let pendingMetric = MetricTileView(title: "Backlog", accentColor: .systemOrange)
-    private let rateMetric = MetricTileView(title: "Speed", accentColor: .systemPink)
+    private let chunkMetric = MetricTileView(title: "Chunks")
+    private let enrichedMetric = MetricTileView(title: "Enriched")
+    private let pendingMetric = MetricTileView(title: "Backlog")
+    private let rateMetric = MetricTileView(title: "Speed")
     private let indexingIndicator = PipelineIndicatorBadgeView(name: "Indexing")
     private let enrichingIndicator = PipelineIndicatorBadgeView(name: "Enriching")
-    private let activityLabel = NSTextField(labelWithString: "Enrichment Throughput")
-    private let activityDetailLabel = NSTextField(labelWithString: "")
+    private let activityLabel = NSTextField(labelWithString: "Pipeline Throughput")
     private let enrichmentLabel = NSTextField(labelWithString: "")
-    private let sparklineImageView = NSImageView(frame: .zero)
+    private let indexingActivityView = PipelineActivityRowView(
+        title: "Indexing",
+        symbolName: "server.rack",
+        accentColor: .systemBlue
+    )
+    private let enrichingActivityView = PipelineActivityRowView(
+        title: "Enriching",
+        symbolName: "sparkles",
+        accentColor: .systemPurple
+    )
     private let daemonLabel = NSTextField(labelWithString: "")
     private let hotkeyLabel = NSTextField(labelWithString: "")
     private let headerPanel = SurfacePanelView(cornerRadius: 14)
@@ -126,8 +134,10 @@ final class StatusPopoverView: NSViewController {
             content.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
         ])
 
-        preferredContentSize = tab.contentSize
-        onPreferredSizeChange?(tab.contentSize)
+        if preferredContentSize != tab.contentSize {
+            preferredContentSize = tab.contentSize
+            onPreferredSizeChange?(tab.contentSize)
+        }
     }
 
     // MARK: - Segmented Control
@@ -183,14 +193,14 @@ final class StatusPopoverView: NSViewController {
         statusLabel.font = .systemFont(ofSize: 12, weight: .medium)
         statusLabel.textColor = .secondaryLabelColor
         pipelineValueLabel.font = .systemFont(ofSize: 16, weight: .semibold)
-        databaseSizeLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
+        databaseSizeLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+        databaseSizeLabel.alignment = .right
         databaseSizeLabel.textColor = .tertiaryLabelColor
         activityLabel.font = .systemFont(ofSize: 12, weight: .semibold)
-        activityDetailLabel.font = .systemFont(ofSize: 11, weight: .medium)
-        activityDetailLabel.textColor = .secondaryLabelColor
-        enrichmentLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
+        enrichmentLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+        enrichmentLabel.alignment = .right
         enrichmentLabel.textColor = .tertiaryLabelColor
-        daemonLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
+        daemonLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .medium)
         daemonLabel.textColor = .secondaryLabelColor
         daemonLabel.maximumNumberOfLines = 2
         daemonLabel.lineBreakMode = .byTruncatingTail
@@ -198,11 +208,6 @@ final class StatusPopoverView: NSViewController {
         hotkeyLabel.textColor = .secondaryLabelColor
         hotkeyLabel.maximumNumberOfLines = 2
         hotkeyLabel.lineBreakMode = .byWordWrapping
-
-        sparklineImageView.imageScaling = .scaleAxesIndependently
-        sparklineImageView.wantsLayer = true
-        sparklineImageView.layer?.cornerRadius = 4
-        sparklineImageView.layer?.backgroundColor = NSColor.clear.cgColor
     }
 
     private func makeDashboardContent() -> NSView {
@@ -247,19 +252,13 @@ final class StatusPopoverView: NSViewController {
             edgeInsets: NSEdgeInsets(top: 14, left: 14, bottom: 14, right: 14)
         )
 
-        let activityHeader = NSStackView(views: [activityLabel, NSView(), activityDetailLabel])
-        activityHeader.orientation = .horizontal
-        activityHeader.alignment = .centerY
-
-        let activityStack = NSStackView(views: [activityHeader, sparklineImageView])
+        let activityStack = NSStackView(views: [activityLabel, indexingActivityView, enrichingActivityView])
         activityStack.orientation = .vertical
         activityStack.spacing = 10
         let activityCard = activityPanel.wrap(
             activityStack,
             edgeInsets: NSEdgeInsets(top: 14, left: 14, bottom: 14, right: 14)
         )
-
-        sparklineImageView.translatesAutoresizingMaskIntoConstraints = false
         hotkeyLabel.isHidden = hotkeyStatus == nil
 
         for row in [headerCard, activityCard] as [NSView] {
@@ -272,11 +271,6 @@ final class StatusPopoverView: NSViewController {
         content.alignment = .width
         content.spacing = 10
         content.edgeInsets = NSEdgeInsets(top: 8, left: 14, bottom: 14, right: 14)
-
-        NSLayoutConstraint.activate([
-            sparklineImageView.heightAnchor.constraint(equalToConstant: 188),
-        ])
-
         dashboardContent = content
         return content
     }
@@ -351,20 +345,36 @@ final class StatusPopoverView: NSViewController {
         databaseSizeLabel.stringValue = "\(byteString(collector.stats.databaseSizeBytes)) db"
 
         let indicators = PipelineIndicators.derive(daemon: collector.daemon, stats: collector.stats)
+        let enrichmentDisplayRatePerMinute = PipelineActivityTracks.displayedRatePerMinute(
+            primaryRatePerMinute: collector.stats.enrichmentRatePerMinute,
+            values: collector.stats.recentEnrichmentBuckets
+        )
+        let indexingRatePerMinute = PipelineActivityTracks.recentRatePerMinute(
+            values: collector.stats.recentActivityBuckets,
+            activityWindowMinutes: 30,
+            trailingBucketCount: 2
+        )
         indexingIndicator.setStatus(indicators.indexing.status)
         enrichingIndicator.setStatus(indicators.enriching.status)
 
-        chunkMetric.value = "\(collector.stats.chunkCount)"
-        enrichedMetric.value = "\(collector.stats.enrichedChunkCount)"
-        pendingMetric.value = "\(collector.stats.pendingEnrichmentCount)"
-        rateMetric.value = DashboardMetricFormatter.speedString(ratePerMinute: collector.stats.enrichmentRatePerMinute)
+        chunkMetric.value = integerString(collector.stats.chunkCount)
+        enrichedMetric.value = integerString(collector.stats.enrichedChunkCount)
+        pendingMetric.value = integerString(collector.stats.pendingEnrichmentCount)
+        rateMetric.value = DashboardMetricFormatter.speedString(ratePerMinute: enrichmentDisplayRatePerMinute)
 
         enrichmentLabel.stringValue = "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched"
-        activityDetailLabel.stringValue = enrichmentActivitySummary(collector.stats)
-        sparklineImageView.image = SparklineRenderer.render(
-            state: collector.state,
-            values: collector.stats.recentEnrichmentBuckets,
-            size: NSSize(width: 500, height: 188)
+        let activityTracks = PipelineActivityTracks.derive(daemon: collector.daemon, stats: collector.stats)
+        indexingActivityView.update(
+            track: activityTracks.indexing,
+            detailRateText: DashboardMetricFormatter.rateDetailString(
+                ratePerMinute: indexingRatePerMinute
+            )
+        )
+        enrichingActivityView.update(
+            track: activityTracks.enriching,
+            detailRateText: DashboardMetricFormatter.rateDetailString(
+                ratePerMinute: enrichmentDisplayRatePerMinute
+            )
         )
 
         if let daemon = collector.daemon {
@@ -394,20 +404,16 @@ final class StatusPopoverView: NSViewController {
         ByteCountFormatter.string(fromByteCount: value, countStyle: .file)
     }
 
+    private func integerString(_ value: Int) -> String {
+        NumberFormatter.localizedString(from: NSNumber(value: value), number: .decimal)
+    }
+
     private func enrichmentActivitySummary(_ stats: DashboardStats) -> String {
         let recentCompletions = stats.recentEnrichmentBuckets.reduce(0, +)
         if recentCompletions == 0 {
             return "No completions in the last 30m"
         }
         return "\(recentCompletions) completions in the last 30m"
-    }
-
-    private func verticalStack(_ views: [NSView]) -> NSStackView {
-        let stack = NSStackView(views: views)
-        stack.orientation = .vertical
-        stack.alignment = .leading
-        stack.spacing = 2
-        return stack
     }
 
     private func makePlaceholder(_ text: String) -> NSView {
@@ -467,7 +473,7 @@ private final class MetricTileView: NSView {
         layer?.borderWidth = 0.8
     }
 
-    init(title: String, accentColor: NSColor) {
+    init(title: String) {
         super.init(frame: .zero)
         wantsLayer = true
         layer?.cornerRadius = 6
@@ -476,13 +482,14 @@ private final class MetricTileView: NSView {
         titleLabel.font = .systemFont(ofSize: 10, weight: .medium)
         titleLabel.textColor = .secondaryLabelColor
         valueLabel.font = .monospacedDigitSystemFont(ofSize: 20, weight: .semibold)
+        valueLabel.alignment = .right
         valueLabel.textColor = .labelColor
         valueLabel.lineBreakMode = .byClipping
         valueLabel.maximumNumberOfLines = 1
 
         let stack = NSStackView(views: [titleLabel, valueLabel])
         stack.orientation = .vertical
-        stack.alignment = .leading
+        stack.alignment = .width
         stack.spacing = 4
         stack.translatesAutoresizingMaskIntoConstraints = false
 
@@ -494,6 +501,108 @@ private final class MetricTileView: NSView {
             stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
             heightAnchor.constraint(equalToConstant: 60),
         ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private final class PipelineActivityRowView: NSView {
+    private let iconView = NSImageView(frame: .zero)
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let rateLabel = NSTextField(labelWithString: "")
+    private let detailLabel = NSTextField(labelWithString: "")
+    private let sparklineImageView = NSImageView(frame: .zero)
+    private let accentColor: NSColor
+
+    init(title: String, symbolName: String, accentColor: NSColor) {
+        self.accentColor = accentColor
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 10
+        layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.05).cgColor
+
+        titleLabel.stringValue = title
+        titleLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        titleLabel.textColor = .secondaryLabelColor
+
+        if let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title) {
+            iconView.image = image
+        }
+        iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 12, weight: .medium)
+        iconView.contentTintColor = accentColor
+
+        rateLabel.font = .monospacedDigitSystemFont(ofSize: 16, weight: .semibold)
+        rateLabel.alignment = .right
+        rateLabel.textColor = .labelColor
+
+        detailLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+        detailLabel.alignment = .right
+        detailLabel.textColor = .tertiaryLabelColor
+        detailLabel.lineBreakMode = .byTruncatingTail
+        detailLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        sparklineImageView.imageScaling = .scaleAxesIndependently
+        sparklineImageView.wantsLayer = true
+        sparklineImageView.layer?.cornerRadius = 4
+        sparklineImageView.layer?.backgroundColor = NSColor.clear.cgColor
+
+        let titleRow = NSStackView(views: [iconView, titleLabel, NSView(), rateLabel])
+        titleRow.orientation = .horizontal
+        titleRow.alignment = .centerY
+        titleRow.spacing = 6
+
+        let stack = NSStackView(views: [titleRow, sparklineImageView, detailLabel])
+        stack.orientation = .vertical
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 10),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+            iconView.widthAnchor.constraint(equalToConstant: 14),
+            iconView.heightAnchor.constraint(equalToConstant: 14),
+            sparklineImageView.heightAnchor.constraint(equalToConstant: 56),
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 120),
+        ])
+    }
+
+    func update(track: PipelineActivityTrack, detailRateText: String) {
+        rateLabel.stringValue = track.rateText
+
+        if track.rateText == "idle" || track.rateText == "queued" {
+            detailLabel.stringValue = track.detailText
+        } else if track.rateText.contains("/s") {
+            detailLabel.stringValue = track.detailText
+        } else {
+            detailLabel.stringValue = "\(detailRateText) · \(track.detailText)"
+        }
+
+        let color = statusColor(for: track.status)
+        iconView.contentTintColor = color
+        sparklineImageView.image = SparklineRenderer.render(
+            color: color,
+            values: track.values,
+            size: NSSize(width: 500, height: 56)
+        )
+    }
+
+    private func statusColor(for status: PipelineIndicatorStatus) -> NSColor {
+        switch status {
+        case .live:
+            return accentColor
+        case .queued:
+            return .systemOrange
+        case .idle:
+            return .secondaryLabelColor
+        case .unavailable:
+            return .systemRed
+        }
     }
 
     @available(*, unavailable)

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -408,14 +408,6 @@ final class StatusPopoverView: NSViewController {
         NumberFormatter.localizedString(from: NSNumber(value: value), number: .decimal)
     }
 
-    private func enrichmentActivitySummary(_ stats: DashboardStats) -> String {
-        let recentCompletions = stats.recentEnrichmentBuckets.reduce(0, +)
-        if recentCompletions == 0 {
-            return "No completions in the last 30m"
-        }
-        return "\(recentCompletions) completions in the last 30m"
-    }
-
     private func makePlaceholder(_ text: String) -> NSView {
         let label = NSTextField(labelWithString: text)
         label.font = .systemFont(ofSize: 13)

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -5,6 +5,7 @@ struct InjectionFeedView: View {
     @Binding var filterText: String
     @State private var expandedEventIDs: Set<Int64> = []
     @State private var selectedConversation: BrainDatabase.ExpandedConversation?
+    @State private var conversationErrorMessage: String?
 
     private var filteredEvents: [InjectionEvent] {
         let trimmed = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -53,7 +54,12 @@ struct InjectionFeedView: View {
                             VStack(alignment: .leading, spacing: 6) {
                                 ForEach(event.chunkIDs, id: \.self) { chunkID in
                                     Button {
-                                        selectedConversation = try? store.expandedConversation(chunkID: chunkID)
+                                        do {
+                                            selectedConversation = try store.expandedConversation(chunkID: chunkID)
+                                            conversationErrorMessage = nil
+                                        } catch {
+                                            conversationErrorMessage = error.localizedDescription
+                                        }
                                     } label: {
                                         HStack {
                                             Text(chunkID)
@@ -79,6 +85,23 @@ struct InjectionFeedView: View {
         }
         .sheet(item: $selectedConversation) { conversation in
             ChunkConversationSheet(conversation: conversation)
+        }
+        .alert(
+            "Failed to load conversation",
+            isPresented: Binding(
+                get: { conversationErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        conversationErrorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK") {
+                conversationErrorMessage = nil
+            }
+        } message: {
+            Text(conversationErrorMessage ?? "Unknown error")
         }
     }
 

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 
 struct InjectionFeedView: View {
-    let events: [InjectionEvent]
+    @ObservedObject var store: InjectionStore
     @Binding var filterText: String
+    @State private var expandedEventIDs: Set<Int64> = []
+    @State private var selectedConversation: BrainDatabase.ExpandedConversation?
 
     private var filteredEvents: [InjectionEvent] {
         let trimmed = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return events }
+        guard !trimmed.isEmpty else { return store.events }
         let needle = trimmed.lowercased()
-        return events.filter { event in
+        return store.events.filter { event in
             event.sessionID.lowercased().contains(needle) ||
                 event.query.lowercased().contains(needle) ||
                 event.chunkIDs.joined(separator: " ").lowercased().contains(needle)
@@ -41,15 +43,50 @@ struct InjectionFeedView: View {
                         .foregroundStyle(.secondary)
 
                     if !event.chunkIDs.isEmpty {
-                        Text(event.chunkIDs.joined(separator: ", "))
-                            .font(.system(size: 10, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
+                        Button(expandedEventIDs.contains(event.id) ? "Hide conversation chunks" : "Show conversation chunks") {
+                            toggle(event.id)
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 11, weight: .semibold))
+
+                        if expandedEventIDs.contains(event.id) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                ForEach(event.chunkIDs, id: \.self) { chunkID in
+                                    Button {
+                                        selectedConversation = try? store.expandedConversation(chunkID: chunkID)
+                                    } label: {
+                                        HStack {
+                                            Text(chunkID)
+                                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                                .lineLimit(1)
+                                            Spacer()
+                                            Text("Open thread")
+                                                .font(.system(size: 10, weight: .semibold))
+                                        }
+                                    }
+                                    .buttonStyle(.borderless)
+                                }
+                            }
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
+                        }
                     }
                 }
                 .padding(.vertical, 2)
             }
             .listStyle(.plain)
+        }
+        .sheet(item: $selectedConversation) { conversation in
+            ChunkConversationSheet(conversation: conversation)
+        }
+    }
+
+    private func toggle(_ eventID: Int64) {
+        if expandedEventIDs.contains(eventID) {
+            expandedEventIDs.remove(eventID)
+        } else {
+            expandedEventIDs.insert(eventID)
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -65,15 +65,13 @@ final class InjectionStore: ObservableObject {
 
     deinit {
         pollTask?.cancel()
-        if isRunning {
-            let center = CFNotificationCenterGetDarwinNotifyCenter()
-            CFNotificationCenterRemoveObserver(
-                center,
-                Unmanaged.passUnretained(self).toOpaque(),
-                CFNotificationName(BrainDatabase.dashboardDidChangeNotification as CFString),
-                nil
-            )
-        }
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterRemoveObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            CFNotificationName(BrainDatabase.dashboardDidChangeNotification as CFString),
+            nil
+        )
         database.close()
     }
 

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -28,6 +28,9 @@ final class InjectionStore: ObservableObject {
 
     init(databasePath: String) throws {
         self.database = BrainDatabase(path: databasePath)
+        guard database.isOpen else {
+            throw BrainDatabase.DBError.notOpen
+        }
     }
 
     func start(sessionID: String? = nil, limit: Int = 50) {

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -1,68 +1,111 @@
+import CoreFoundation
 import Foundation
-import GRDB
+
+private func injectionStoreDarwinNotificationCallback(
+    center: CFNotificationCenter?,
+    observer: UnsafeMutableRawPointer?,
+    name: CFNotificationName?,
+    object: UnsafeRawPointer?,
+    userInfo: CFDictionary?
+) {
+    guard let observer else { return }
+    let store = Unmanaged<InjectionStore>.fromOpaque(observer).takeUnretainedValue()
+    Task { @MainActor in
+        store.handleDatabaseMutationNotification()
+    }
+}
 
 @MainActor
 final class InjectionStore: ObservableObject {
     @Published private(set) var events: [InjectionEvent] = []
 
-    private let dbQueue: DatabaseQueue
-    private var cancellable: AnyDatabaseCancellable?
+    private let database: BrainDatabase
+    private var pollTask: Task<Void, Never>?
+    private var isRunning = false
+    private var lastDataVersion: Int?
+    private var currentSessionID: String?
+    private var currentLimit = 50
 
     init(databasePath: String) throws {
-        dbQueue = try DatabaseQueue(path: databasePath)
+        self.database = BrainDatabase(path: databasePath)
     }
 
     func start(sessionID: String? = nil, limit: Int = 50) {
-        let observation = ValueObservation.tracking { db -> [InjectionEvent] in
-            let sql: String
-            let arguments: StatementArguments
-            if let sessionID {
-                sql = """
-                    SELECT id, session_id, timestamp, query, chunk_ids, token_count
-                    FROM injection_events
-                    WHERE session_id = ?
-                    ORDER BY timestamp DESC, id DESC
-                    LIMIT ?
-                """
-                arguments = [sessionID, limit]
-            } else {
-                sql = """
-                    SELECT id, session_id, timestamp, query, chunk_ids, token_count
-                    FROM injection_events
-                    ORDER BY timestamp DESC, id DESC
-                    LIMIT ?
-                """
-                arguments = [limit]
-            }
+        currentSessionID = sessionID
+        currentLimit = limit
 
-            let rows = try Row.fetchAll(db, sql: sql, arguments: arguments)
-            return try rows.map { row in
-                try InjectionEvent(
-                    row: [
-                        "id": row["id"] as Int64,
-                        "session_id": row["session_id"] as String,
-                        "timestamp": row["timestamp"] as String,
-                        "query": row["query"] as String,
-                        "chunk_ids": row["chunk_ids"] as String,
-                        "token_count": Int(row["token_count"] as Int64)
-                    ]
-                )
-            }
+        guard !isRunning else {
+            refresh(force: true)
+            return
         }
 
-        cancellable = observation.start(
-            in: dbQueue,
-            onError: { error in
-                NSLog("[BrainBar] InjectionStore observation error: %@", String(describing: error))
-            },
-            onChange: { [weak self] events in
-                self?.events = events
+        isRunning = true
+        installDarwinObserver()
+        refresh(force: true)
+
+        pollTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(250))
+                guard !Task.isCancelled else { break }
+                self.refresh(force: false)
             }
-        )
+        }
     }
 
     func stop() {
-        cancellable?.cancel()
-        cancellable = nil
+        pollTask?.cancel()
+        pollTask = nil
+
+        if isRunning {
+            removeDarwinObserver()
+        }
+
+        isRunning = false
+        database.close()
+    }
+
+    func expandedConversation(chunkID: String, before: Int = 3, after: Int = 3) throws -> BrainDatabase.ExpandedConversation {
+        try database.expandedConversation(id: chunkID, before: before, after: after)
+    }
+
+    fileprivate func handleDatabaseMutationNotification() {
+        refresh(force: false)
+    }
+
+    private func refresh(force: Bool) {
+        do {
+            let currentDataVersion = try database.dataVersion()
+            if force || currentDataVersion != lastDataVersion {
+                events = try database.listInjectionEvents(
+                    sessionID: currentSessionID,
+                    limit: currentLimit
+                )
+                lastDataVersion = currentDataVersion
+            }
+        } catch {
+            NSLog("[BrainBar] InjectionStore refresh failed: %@", String(describing: error))
+        }
+    }
+
+    private func installDarwinObserver() {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterAddObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            injectionStoreDarwinNotificationCallback,
+            BrainDatabase.dashboardDidChangeNotification as CFString,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    private func removeDarwinObserver() {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterRemoveObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            CFNotificationName(BrainDatabase.dashboardDidChangeNotification as CFString),
+            nil
+        )
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -61,6 +61,19 @@ final class InjectionStore: ObservableObject {
         }
 
         isRunning = false
+    }
+
+    deinit {
+        pollTask?.cancel()
+        if isRunning {
+            let center = CFNotificationCenterGetDarwinNotifyCenter()
+            CFNotificationCenterRemoveObserver(
+                center,
+                Unmanaged.passUnretained(self).toOpaque(),
+                CFNotificationName(BrainDatabase.dashboardDidChangeNotification as CFString),
+                nil
+            )
+        }
         database.close()
     }
 

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -1,6 +1,18 @@
 import CoreFoundation
 import Foundation
 
+final class InjectionStoreObserverBox: @unchecked Sendable {
+    weak var store: InjectionStore?
+}
+
+enum InjectionStoreDarwinObserver {
+    static func scheduleRefresh(observerBox: InjectionStoreObserverBox) {
+        Task { @MainActor [weak store = observerBox.store] in
+            store?.handleDatabaseMutationNotification()
+        }
+    }
+}
+
 private func injectionStoreDarwinNotificationCallback(
     center: CFNotificationCenter?,
     observer: UnsafeMutableRawPointer?,
@@ -9,10 +21,8 @@ private func injectionStoreDarwinNotificationCallback(
     userInfo: CFDictionary?
 ) {
     guard let observer else { return }
-    let store = Unmanaged<InjectionStore>.fromOpaque(observer).takeUnretainedValue()
-    Task { @MainActor in
-        store.handleDatabaseMutationNotification()
-    }
+    let observerBox = Unmanaged<InjectionStoreObserverBox>.fromOpaque(observer).takeUnretainedValue()
+    InjectionStoreDarwinObserver.scheduleRefresh(observerBox: observerBox)
 }
 
 @MainActor
@@ -20,6 +30,7 @@ final class InjectionStore: ObservableObject {
     @Published private(set) var events: [InjectionEvent] = []
 
     private let database: BrainDatabase
+    private let observerBox: InjectionStoreObserverBox
     private var pollTask: Task<Void, Never>?
     private var isRunning = false
     private var lastDataVersion: Int?
@@ -28,9 +39,11 @@ final class InjectionStore: ObservableObject {
 
     init(databasePath: String) throws {
         self.database = BrainDatabase(path: databasePath)
+        self.observerBox = InjectionStoreObserverBox()
         guard database.isOpen else {
             throw BrainDatabase.DBError.notOpen
         }
+        observerBox.store = self
     }
 
     func start(sessionID: String? = nil, limit: Int = 50) {
@@ -68,15 +81,13 @@ final class InjectionStore: ObservableObject {
 
     deinit {
         pollTask?.cancel()
-        let center = CFNotificationCenterGetDarwinNotifyCenter()
-        CFNotificationCenterRemoveObserver(
-            center,
-            Unmanaged.passUnretained(self).toOpaque(),
-            CFNotificationName(BrainDatabase.dashboardDidChangeNotification as CFString),
-            nil
-        )
+        if isRunning {
+            Self.removeDarwinObserver(observerBox: observerBox)
+        }
         database.close()
     }
+
+    var observerBoxForTesting: InjectionStoreObserverBox { observerBox }
 
     func expandedConversation(chunkID: String, before: Int = 3, after: Int = 3) throws -> BrainDatabase.ExpandedConversation {
         try database.expandedConversation(id: chunkID, before: before, after: after)
@@ -102,10 +113,18 @@ final class InjectionStore: ObservableObject {
     }
 
     private func installDarwinObserver() {
+        Self.addDarwinObserver(observerBox: observerBox)
+    }
+
+    private func removeDarwinObserver() {
+        Self.removeDarwinObserver(observerBox: observerBox)
+    }
+
+    nonisolated private static func addDarwinObserver(observerBox: InjectionStoreObserverBox) {
         let center = CFNotificationCenterGetDarwinNotifyCenter()
         CFNotificationCenterAddObserver(
             center,
-            Unmanaged.passUnretained(self).toOpaque(),
+            Unmanaged.passUnretained(observerBox).toOpaque(),
             injectionStoreDarwinNotificationCallback,
             BrainDatabase.dashboardDidChangeNotification as CFString,
             nil,
@@ -113,11 +132,11 @@ final class InjectionStore: ObservableObject {
         )
     }
 
-    private func removeDarwinObserver() {
+    nonisolated private static func removeDarwinObserver(observerBox: InjectionStoreObserverBox) {
         let center = CFNotificationCenterGetDarwinNotifyCenter()
         CFNotificationCenterRemoveObserver(
             center,
-            Unmanaged.passUnretained(self).toOpaque(),
+            Unmanaged.passUnretained(observerBox).toOpaque(),
             CFNotificationName(BrainDatabase.dashboardDidChangeNotification as CFString),
             nil
         )

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -18,9 +18,13 @@ struct KGCanvasView: View {
                 KGSidebarView(
                     entity: viewModel.selectedEntity,
                     chunks: viewModel.selectedEntityChunks,
+                    onOpenConversation: { viewModel.openConversation(chunkID: $0) },
                     onClose: { viewModel.selectNode(id: nil) }
                 )
             }
+        }
+        .sheet(item: $viewModel.selectedConversation) { conversation in
+            ChunkConversationSheet(conversation: conversation)
         }
         .onAppear {
             viewModel.loadGraph()

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct KGSidebarView: View {
     let entity: EntityCard?
     let chunks: [BrainDatabase.KGChunkRow]
+    let onOpenConversation: (String) -> Void
     let onClose: () -> Void
 
     var body: some View {
@@ -24,7 +25,7 @@ struct KGSidebarView: View {
                     }
                     if !chunks.isEmpty {
                         Divider()
-                        chunksSection
+                        chunksSection()
                     }
                 } else {
                     Text("Select a node")
@@ -74,10 +75,7 @@ struct KGSidebarView: View {
                     Text(rel.direction == "incoming" ? "←" : "→")
                         .font(.caption)
                         .foregroundColor(.secondary.opacity(0.6))
-                    Text(rel.relationType)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Text(rel.targetName)
+                    Text(rel.displayText)
                         .font(.caption.bold())
                         .lineLimit(1)
                 }
@@ -101,25 +99,46 @@ struct KGSidebarView: View {
         }
     }
 
-    @ViewBuilder
-    private var chunksSection: some View {
-        Text("Linked Chunks (\(chunks.count))")
-            .font(.subheadline.bold())
-        ForEach(Array(chunks.prefix(10).enumerated()), id: \.offset) { _, chunk in
-            VStack(alignment: .leading, spacing: 4) {
-                Text(chunk.snippet)
-                    .font(.caption)
-                    .lineLimit(4)
-                HStack(spacing: 8) {
-                    Label("\(chunk.importance)", systemImage: "star.fill")
-                    Label(String(format: "%.0f%%", chunk.relevance * 100), systemImage: "link")
+    private func chunksSection() -> some View {
+        let previewIndices = Array(0..<min(chunks.count, 10))
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Linked Chunks (\(chunks.count))")
+                .font(.subheadline.bold())
+            ForEach(previewIndices, id: \.self) { (index: Int) in
+                let chunk = chunks[index]
+                Button {
+                    onOpenConversation(chunk.chunkID)
+                } label: {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(chunk.snippet)
+                            .font(.caption)
+                            .lineLimit(4)
+                            .multilineTextAlignment(.leading)
+                        HStack(spacing: 8) {
+                            Text(importanceText(for: chunk))
+                            Text(relevanceText(for: chunk))
+                            Spacer()
+                            Text("Open")
+                                .font(.caption.bold())
+                                .foregroundColor(.accentColor)
+                        }
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    }
                 }
-                .font(.caption2)
-                .foregroundColor(.secondary)
+                .buttonStyle(.plain)
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary))
             }
-            .padding(8)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary))
         }
+    }
+
+    private func importanceText(for chunk: BrainDatabase.KGChunkRow) -> String {
+        "★ \(chunk.importance)"
+    }
+
+    private func relevanceText(for chunk: BrainDatabase.KGChunkRow) -> String {
+        "↳ \(Int((chunk.relevance * 100).rounded()))%"
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -7,6 +7,7 @@ final class KGViewModel: ObservableObject {
     @Published var selectedNodeId: String?
     @Published var selectedEntity: EntityCard?
     @Published var selectedEntityChunks: [BrainDatabase.KGChunkRow] = []
+    @Published var selectedConversation: BrainDatabase.ExpandedConversation?
 
     /// Set by KGCanvasView via GeometryReader — used for centering force
     var canvasCenter: CGPoint = CGPoint(x: 300, y: 250)
@@ -71,7 +72,12 @@ final class KGViewModel: ObservableObject {
         } else {
             selectedEntity = nil
             selectedEntityChunks = []
+            selectedConversation = nil
         }
+    }
+
+    func openConversation(chunkID: String) {
+        selectedConversation = try? database.expandedConversation(id: chunkID)
     }
 
     // MARK: - Hit Testing

--- a/brain-bar/Sources/BrainBar/Models/EntityCard.swift
+++ b/brain-bar/Sources/BrainBar/Models/EntityCard.swift
@@ -5,6 +5,19 @@ struct EntityCard: Equatable {
         let relationType: String
         let targetName: String
         let direction: String  // "outgoing" or "incoming"
+
+        init(relationType: String, targetName: String, direction: String = "outgoing") {
+            self.relationType = relationType
+            self.targetName = targetName
+            self.direction = direction
+        }
+
+        var displayText: String {
+            if direction == "incoming" {
+                return "\(targetName) \(relationType)"
+            }
+            return "\(relationType) \(targetName)"
+        }
     }
 
     struct Memory: Equatable {

--- a/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct ChunkConversationSheet: View {
+    let conversation: BrainDatabase.ExpandedConversation
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Conversation")
+                        .font(.title3.bold())
+                    Text(conversation.target.chunkID)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Close") { dismiss() }
+            }
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(conversation.entries) { entry in
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text(roleLabel(for: entry))
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 3)
+                                    .background(Capsule().fill(entry.isTarget ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.12)))
+                                Spacer()
+                                Text(String(entry.createdAt.prefix(19)))
+                                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if !entry.summary.isEmpty {
+                                Text(entry.summary)
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Text(entry.content)
+                                .font(.system(size: 13))
+                                .textSelection(.enabled)
+                        }
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(entry.isTarget ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(entry.isTarget ? Color.accentColor.opacity(0.35) : Color(nsColor: .separatorColor).opacity(0.35), lineWidth: 1)
+                        )
+                    }
+                }
+            }
+        }
+        .padding(18)
+        .frame(minWidth: 580, minHeight: 460)
+    }
+
+    private func roleLabel(for entry: BrainDatabase.ConversationChunk) -> String {
+        switch entry.contentType {
+        case "user_message":
+            return "User"
+        case "assistant_text":
+            return "Assistant"
+        default:
+            return entry.contentType.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -54,10 +54,114 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(indicators.enriching.status, .queued)
     }
 
-    func testDashboardMetricFormatterUsesChunksPerSecond() {
+    func testDashboardMetricFormatterUsesPerSecondForFastRates() {
         XCTAssertEqual(
-            DashboardMetricFormatter.speedString(ratePerMinute: 22.2),
-            "0.37/s"
+            DashboardMetricFormatter.speedString(ratePerMinute: 90),
+            "1.5/s"
+        )
+    }
+
+    func testDashboardMetricFormatterUsesPerMinuteForSubSecondRates() {
+        XCTAssertEqual(
+            DashboardMetricFormatter.speedString(ratePerMinute: 18),
+            "18/min"
+        )
+    }
+
+    func testDashboardMetricFormatterUsesPerHourForVerySlowRates() {
+        XCTAssertEqual(
+            DashboardMetricFormatter.speedString(ratePerMinute: 0.5),
+            "30/hr"
+        )
+    }
+
+    func testPipelineActivityTracksSplitIndexingFromEnrichment() {
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 100,
+            pendingEnrichmentCount: 20,
+            enrichmentPercent: 83.3,
+            enrichmentRatePerMinute: 18,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 6],
+            recentEnrichmentBuckets: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: Date()
+        )
+
+        let tracks = PipelineActivityTracks.derive(daemon: daemon, stats: stats)
+
+        XCTAssertEqual(tracks.indexing.symbolName, "server.rack")
+        XCTAssertEqual(tracks.indexing.rateText, "2/min")
+        XCTAssertEqual(tracks.enriching.symbolName, "sparkles")
+        XCTAssertEqual(tracks.enriching.rateText, "18/min")
+        XCTAssertEqual(tracks.enriching.status, .live)
+        XCTAssertEqual(tracks.indexing.status, .live)
+    }
+
+    func testPipelineActivityTracksShowQueuedEnrichmentWithNoRecentThroughput() {
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 90,
+            pendingEnrichmentCount: 30,
+            enrichmentPercent: 75,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: Array(repeating: 0, count: 12),
+            recentEnrichmentBuckets: Array(repeating: 0, count: 12)
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: Date()
+        )
+
+        let tracks = PipelineActivityTracks.derive(daemon: daemon, stats: stats)
+
+        XCTAssertEqual(tracks.enriching.status, .queued)
+        XCTAssertEqual(tracks.enriching.rateText, "queued")
+        XCTAssertEqual(tracks.indexing.rateText, "idle")
+    }
+
+    func testPipelineActivityTracksUseRecentEnrichmentThroughputWhenInstantaneousRateDropsToZero() {
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 100,
+            pendingEnrichmentCount: 20,
+            enrichmentPercent: 83.3,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: Array(repeating: 0, count: 12),
+            recentEnrichmentBuckets: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 6]
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: Date()
+        )
+
+        let tracks = PipelineActivityTracks.derive(daemon: daemon, stats: stats)
+
+        XCTAssertEqual(tracks.enriching.status, .live)
+        XCTAssertEqual(tracks.enriching.rateText, "2/min")
+    }
+
+    func testDashboardMetricFormatterSummarizesSecondaryRateUnits() {
+        XCTAssertEqual(
+            DashboardMetricFormatter.rateDetailString(ratePerMinute: 18),
+            "0.3/s"
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import BrainBar
+
+final class BrainBarUXLogicTests: XCTestCase {
+    func testPipelineIndicatorsCanShowIndexingAndEnrichingLiveAtTheSameTime() {
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 100,
+            pendingEnrichmentCount: 20,
+            enrichmentPercent: 83.3,
+            enrichmentRatePerMinute: 24,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 2, 4],
+            recentEnrichmentBuckets: [0, 0, 0, 1, 3]
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: Date()
+        )
+
+        let indicators = PipelineIndicators.derive(daemon: daemon, stats: stats)
+
+        XCTAssertEqual(indicators.indexing.status, .live)
+        XCTAssertEqual(indicators.enriching.status, .live)
+    }
+
+    func testPipelineIndicatorsShowQueuedEnrichmentWithoutRecentCompletions() {
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 100,
+            pendingEnrichmentCount: 20,
+            enrichmentPercent: 83.3,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0, 0]
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: Date()
+        )
+
+        let indicators = PipelineIndicators.derive(daemon: daemon, stats: stats)
+
+        XCTAssertEqual(indicators.indexing.status, .idle)
+        XCTAssertEqual(indicators.enriching.status, .queued)
+    }
+
+    func testDashboardMetricFormatterUsesChunksPerSecond() {
+        XCTAssertEqual(
+            DashboardMetricFormatter.speedString(ratePerMinute: 22.2),
+            "0.37/s"
+        )
+    }
+
+    func testIncomingRelationDisplayPutsEntityNameBeforeRelationVerb() {
+        let relation = EntityCard.Relation(
+            relationType: "coaches",
+            targetName: "coachClaude",
+            direction: "incoming"
+        )
+
+        XCTAssertEqual(relation.displayText, "coachClaude coaches")
+    }
+
+    func testOutgoingRelationDisplayKeepsRelationVerbBeforeEntityName() {
+        let relation = EntityCard.Relation(
+            relationType: "owns",
+            targetName: "brainlayer",
+            direction: "outgoing"
+        )
+
+        XCTAssertEqual(relation.displayText, "owns brainlayer")
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -158,6 +158,36 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(tracks.enriching.rateText, "2/min")
     }
 
+    func testPipelineActivityTracksDetailTextUsesConfiguredActivityWindow() {
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 100,
+            pendingEnrichmentCount: 20,
+            enrichmentPercent: 83.3,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 4, 6],
+            recentEnrichmentBuckets: [0, 0, 1, 3]
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: Date()
+        )
+
+        let tracks = PipelineActivityTracks.derive(
+            daemon: daemon,
+            stats: stats,
+            activityWindowMinutes: 15
+        )
+
+        XCTAssertEqual(tracks.indexing.detailText, "10 chunks in last 15m")
+        XCTAssertEqual(tracks.enriching.detailText, "20 pending · 4 done in last 15m")
+    }
+
     func testDashboardMetricFormatterSummarizesSecondaryRateUnits() {
         XCTAssertEqual(
             DashboardMetricFormatter.rateDetailString(ratePerMinute: 18),

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -165,6 +165,17 @@ final class BrainBarUXLogicTests: XCTestCase {
         )
     }
 
+    func testDashboardMetricFormatterGuardsAgainstNonFiniteRates() {
+        XCTAssertEqual(
+            DashboardMetricFormatter.speedString(ratePerMinute: .infinity),
+            "0/min"
+        )
+        XCTAssertEqual(
+            DashboardMetricFormatter.rateDetailString(ratePerMinute: .infinity),
+            "0/s"
+        )
+    }
+
     func testIncomingRelationDisplayPutsEntityNameBeforeRelationVerb() {
         let relation = EntityCard.Relation(
             relationType: "coaches",

--- a/brain-bar/Tests/BrainBarTests/ChunkConversationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/ChunkConversationTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import BrainBar
+
+final class ChunkConversationTests: XCTestCase {
+    private var db: BrainDatabase!
+    private var tempDBPath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDBPath = NSTemporaryDirectory() + "brainbar-chunk-conversation-\(UUID().uuidString).db"
+        db = BrainDatabase(path: tempDBPath)
+    }
+
+    override func tearDown() {
+        db.close()
+        try? FileManager.default.removeItem(atPath: tempDBPath)
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
+        super.tearDown()
+    }
+
+    func testExpandedConversationPlacesTargetBetweenBeforeAndAfterContext() throws {
+        for index in 1...5 {
+            try db.insertChunk(
+                id: "conv-\(index)",
+                content: "Conversation message \(index)",
+                sessionId: "conversation-thread",
+                project: "brainlayer",
+                contentType: index.isMultiple(of: 2) ? "assistant_text" : "user_message",
+                importance: 5
+            )
+        }
+
+        let conversation = try db.expandedConversation(id: "conv-3", before: 2, after: 2)
+
+        XCTAssertEqual(
+            conversation.entries.map(\.chunkID),
+            ["conv-1", "conv-2", "conv-3", "conv-4", "conv-5"]
+        )
+        XCTAssertEqual(conversation.target.chunkID, "conv-3")
+        XCTAssertTrue(conversation.entries[2].isTarget)
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -46,7 +46,9 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.pendingEnrichmentCount, 1)
         XCTAssertEqual(stats.enrichmentPercent, 50.0, accuracy: 0.001)
         XCTAssertEqual(stats.recentActivityBuckets.count, 6)
+        XCTAssertEqual(stats.recentEnrichmentBuckets.count, 6)
         XCTAssertGreaterThanOrEqual(stats.recentActivityBuckets.reduce(0, +), 2)
+        XCTAssertGreaterThanOrEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
     }
 
@@ -58,6 +60,7 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.pendingEnrichmentCount, 0)
         XCTAssertEqual(stats.enrichmentPercent, 0.0, accuracy: 0.001)
         XCTAssertEqual(stats.recentActivityBuckets, [0, 0, 0, 0])
+        XCTAssertEqual(stats.recentEnrichmentBuckets, [0, 0, 0, 0])
     }
 
     func testDashboardStatsCountsRecentISO8601Timestamps() throws {
@@ -78,6 +81,50 @@ final class DashboardTests: XCTestCase {
         let stats = try db.dashboardStats(activityWindowMinutes: 5, bucketCount: 5)
 
         XCTAssertEqual(stats.recentActivityBuckets.reduce(0, +), 1)
+    }
+
+    func testDashboardStatsTracksRecentEnrichmentSeparatelyFromIncomingWrites() throws {
+        try db.insertChunk(
+            id: "dash-enrichment-only",
+            content: "Older chunk enriched just now",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6
+        )
+        db.exec("""
+            UPDATE chunks
+            SET created_at = datetime('now', '-45 minutes'),
+                enriched_at = datetime('now')
+            WHERE id = 'dash-enrichment-only'
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.recentActivityBuckets.reduce(0, +), 0)
+        XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
+        XCTAssertGreaterThan(stats.enrichmentRatePerMinute, 0)
+    }
+
+    func testDashboardStatsCurrentEnrichmentRateDropsToZeroWhenPipelineIsIdle() throws {
+        try db.insertChunk(
+            id: "dash-stale-enrichment",
+            content: "Enriched earlier but not currently moving",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6
+        )
+        db.exec("""
+            UPDATE chunks
+            SET enriched_at = datetime('now', '-6 minutes')
+            WHERE id = 'dash-stale-enrichment'
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.enrichmentRatePerMinute, 0, accuracy: 0.001)
+        XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
     }
 
     func testDashboardDataVersionChangesAfterExternalWrite() throws {
@@ -134,8 +181,10 @@ final class DashboardTests: XCTestCase {
             enrichedChunkCount: 10,
             pendingEnrichmentCount: 0,
             enrichmentPercent: 100,
+            enrichmentRatePerMinute: 0,
             databaseSizeBytes: 4096,
-            recentActivityBuckets: [0, 0, 0, 0]
+            recentActivityBuckets: [0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0]
         )
 
         let state = PipelineState.derive(daemon: nil, stats: stats)
@@ -149,8 +198,10 @@ final class DashboardTests: XCTestCase {
             enrichedChunkCount: 10,
             pendingEnrichmentCount: 10,
             enrichmentPercent: 50,
+            enrichmentRatePerMinute: 0,
             databaseSizeBytes: 8192,
-            recentActivityBuckets: [0, 2, 3, 0]
+            recentActivityBuckets: [0, 2, 3, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0]
         )
         let daemon = DaemonHealthSnapshot(
             pid: 4242,
@@ -172,8 +223,10 @@ final class DashboardTests: XCTestCase {
             enrichedChunkCount: 20,
             pendingEnrichmentCount: 0,
             enrichmentPercent: 100,
+            enrichmentRatePerMinute: 2.5,
             databaseSizeBytes: 8192,
-            recentActivityBuckets: [0, 0, 4, 6]
+            recentActivityBuckets: [0, 0, 4, 6],
+            recentEnrichmentBuckets: [0, 0, 1, 2]
         )
         let daemon = DaemonHealthSnapshot(
             pid: 4242,
@@ -195,8 +248,10 @@ final class DashboardTests: XCTestCase {
             enrichedChunkCount: 12,
             pendingEnrichmentCount: 8,
             enrichmentPercent: 60,
+            enrichmentRatePerMinute: 0,
             databaseSizeBytes: 8192,
-            recentActivityBuckets: [0, 0, 0, 0]
+            recentActivityBuckets: [0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0]
         )
         let daemon = DaemonHealthSnapshot(
             pid: 4242,
@@ -218,8 +273,10 @@ final class DashboardTests: XCTestCase {
             enrichedChunkCount: 20,
             pendingEnrichmentCount: 0,
             enrichmentPercent: 100,
+            enrichmentRatePerMinute: 0,
             databaseSizeBytes: 8192,
-            recentActivityBuckets: [0, 0, 0, 0]
+            recentActivityBuckets: [0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0]
         )
         let daemon = DaemonHealthSnapshot(
             pid: 4242,

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -106,6 +106,28 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThan(stats.enrichmentRatePerMinute, 0)
     }
 
+    func testDashboardStatsCountsRecentISO8601EnrichmentTimestamps() throws {
+        try db.insertChunk(
+            id: "dash-enrichment-iso",
+            content: "Older chunk enriched by Python with ISO timestamp",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6
+        )
+        db.exec("""
+            UPDATE chunks
+            SET created_at = datetime('now', '-45 minutes'),
+                enriched_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            WHERE id = 'dash-enrichment-iso'
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 5, bucketCount: 5)
+
+        XCTAssertEqual(stats.recentActivityBuckets.reduce(0, +), 0)
+        XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
+    }
+
     func testDashboardStatsCurrentEnrichmentRateDropsToZeroWhenPipelineIsIdle() throws {
         try db.insertChunk(
             id: "dash-stale-enrichment",

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -205,7 +205,7 @@ final class DatabaseTests: XCTestCase {
     }
 
     func testRecordInjectionEventPersistsSessionQueryChunkIDsAndTokenCount() throws {
-        try db.recordInjectionEvent(
+        db.recordInjectionEvent(
             sessionID: "claude-session-1",
             query: "voicebar sleep recovery",
             chunkIDs: ["chunk-1", "chunk-2"],
@@ -221,22 +221,56 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(events.first?.tokenCount, 77)
     }
 
+    func testRecordInjectionEventReturnsZeroIDWhenInsertFails() throws {
+        let firstEvent = db.recordInjectionEvent(
+            sessionID: "session-1",
+            query: "first event",
+            chunkIDs: ["chunk-1"],
+            tokenCount: 10
+        )
+        XCTAssertGreaterThan(firstEvent.id, 0)
+
+        db.exec("PRAGMA busy_timeout = 1")
+
+        var lockDB: OpaquePointer?
+        XCTAssertEqual(sqlite3_open_v2(tempDBPath, &lockDB, SQLITE_OPEN_READWRITE, nil), SQLITE_OK)
+        guard let lockDB else {
+            XCTFail("Failed to open secondary lock connection")
+            return
+        }
+        defer { sqlite3_close(lockDB) }
+
+        XCTAssertEqual(sqlite3_exec(lockDB, "BEGIN IMMEDIATE", nil, nil, nil), SQLITE_OK)
+        defer { sqlite3_exec(lockDB, "ROLLBACK", nil, nil, nil) }
+
+        let failedEvent = db.recordInjectionEvent(
+            sessionID: "session-1",
+            query: "locked event",
+            chunkIDs: ["chunk-2"],
+            tokenCount: 20
+        )
+
+        XCTAssertEqual(failedEvent.id, 0)
+        let events = try db.listInjectionEvents(limit: 10)
+        XCTAssertEqual(events.map(\.query), ["first event"])
+    }
+
     func testListInjectionEventsFiltersBySessionAndNewestFirst() throws {
-        try db.recordInjectionEvent(
+        db.recordInjectionEvent(
             sessionID: "session-a",
             query: "older event",
             chunkIDs: ["old-1"],
             tokenCount: 10,
             timestamp: "2026-03-31T04:00:00.000Z"
         )
-        try db.recordInjectionEvent(
+        db.recordInjectionEvent(
             sessionID: "session-b",
             query: "other session",
             chunkIDs: ["other-1"],
             tokenCount: 20,
             timestamp: "2026-03-31T04:01:00.000Z"
         )
-        try db.recordInjectionEvent(
+        db.recordInjectionEvent(
             sessionID: "session-a",
             query: "newer event",
             chunkIDs: ["new-1", "new-2"],

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -283,6 +283,30 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(filtered.map(\.query), ["newer event", "older event"])
     }
 
+    func testListInjectionEventsUsesIDAsTieBreakerForMatchingTimestamps() throws {
+        db.recordInjectionEvent(
+            sessionID: "session-a",
+            query: "first same-second event",
+            chunkIDs: ["chunk-1"],
+            tokenCount: 10,
+            timestamp: "2026-03-31T04:02:00.000Z"
+        )
+        db.recordInjectionEvent(
+            sessionID: "session-a",
+            query: "second same-second event",
+            chunkIDs: ["chunk-2"],
+            tokenCount: 20,
+            timestamp: "2026-03-31T04:02:00.000Z"
+        )
+
+        let events = try db.listInjectionEvents(sessionID: "session-a", limit: 10)
+
+        XCTAssertEqual(
+            events.map(\.query),
+            ["second same-second event", "first same-second event"]
+        )
+    }
+
     // MARK: - Filter: project
 
     func testSearchFiltersByProject() throws {

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -20,7 +20,7 @@ final class InjectionStoreTests: XCTestCase {
     }
 
     func testStartPublishesExistingEventsImmediately() async throws {
-        try db.recordInjectionEvent(
+        db.recordInjectionEvent(
             sessionID: "session-1",
             query: "existing event",
             chunkIDs: ["chunk-1"],
@@ -43,7 +43,7 @@ final class InjectionStoreTests: XCTestCase {
         let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
         await MainActor.run { store.start() }
 
-        try db.recordInjectionEvent(
+        db.recordInjectionEvent(
             sessionID: "session-2",
             query: "new event",
             chunkIDs: ["chunk-a", "chunk-b"],
@@ -93,7 +93,7 @@ final class InjectionStoreTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(100))
         await MainActor.run { store.stop() }
 
-        try db.recordInjectionEvent(
+        db.recordInjectionEvent(
             sessionID: "session-3",
             query: "restart event",
             chunkIDs: ["chunk-restart"],
@@ -106,5 +106,14 @@ final class InjectionStoreTests: XCTestCase {
         let queries = await MainActor.run { store.events.map(\.query) }
         XCTAssertEqual(queries, ["restart event"])
         await MainActor.run { store.stop() }
+    }
+
+    @MainActor
+    func testInitThrowsWhenDatabaseCannotOpen() throws {
+        let directoryPath = NSTemporaryDirectory() + "brainbar-injection-store-dir-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: directoryPath, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: directoryPath) }
+
+        XCTAssertThrowsError(try InjectionStore(databasePath: directoryPath))
     }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -116,4 +116,23 @@ final class InjectionStoreTests: XCTestCase {
 
         XCTAssertThrowsError(try InjectionStore(databasePath: directoryPath))
     }
+
+    @MainActor
+    func testScheduledDarwinRefreshDoesNotRetainStoreAfterRelease() throws {
+        weak var weakStore: InjectionStore?
+        var observerBox: InjectionStoreObserverBox?
+
+        do {
+            let store = try InjectionStore(databasePath: tempDBPath)
+            observerBox = store.observerBoxForTesting
+            InjectionStoreDarwinObserver.scheduleRefresh(observerBox: observerBox!)
+            weakStore = store
+        }
+
+        XCTAssertNotNil(observerBox)
+        XCTAssertNil(
+            weakStore,
+            "Darwin notification refresh should capture the store weakly so teardown cannot hold it alive"
+        )
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -29,6 +29,7 @@ final class InjectionStoreTests: XCTestCase {
 
         let databasePath = tempDBPath!
         let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
+        defer { Task { @MainActor in store.stop() } }
         await MainActor.run { store.start() }
 
         try await Task.sleep(for: .milliseconds(150))
@@ -40,6 +41,7 @@ final class InjectionStoreTests: XCTestCase {
     func testObservationPublishesNewEventsAfterInsert() async throws {
         let databasePath = tempDBPath!
         let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
+        defer { Task { @MainActor in store.stop() } }
         await MainActor.run { store.start() }
 
         try db.recordInjectionEvent(
@@ -55,5 +57,31 @@ final class InjectionStoreTests: XCTestCase {
         let firstChunkIDs = await MainActor.run { store.events.first?.chunkIDs }
         XCTAssertEqual(firstQuery, "new event")
         XCTAssertEqual(firstChunkIDs, ["chunk-a", "chunk-b"])
+    }
+
+    func testExpandedConversationLoadsTargetChunkAndContext() async throws {
+        for index in 1...4 {
+            try db.insertChunk(
+                id: "inject-\(index)",
+                content: "Injection conversation \(index)",
+                sessionId: "inject-session",
+                project: "brainlayer",
+                contentType: index.isMultiple(of: 2) ? "assistant_text" : "user_message",
+                importance: 5
+            )
+        }
+
+        let databasePath = tempDBPath!
+        let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
+        defer { Task { @MainActor in store.stop() } }
+        let conversation = try await MainActor.run {
+            try store.expandedConversation(chunkID: "inject-2")
+        }
+
+        XCTAssertEqual(conversation.target.chunkID, "inject-2")
+        XCTAssertEqual(
+            conversation.entries.map(\.chunkID),
+            ["inject-1", "inject-2", "inject-3", "inject-4"]
+        )
     }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -29,19 +29,18 @@ final class InjectionStoreTests: XCTestCase {
 
         let databasePath = tempDBPath!
         let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
-        defer { Task { @MainActor in store.stop() } }
         await MainActor.run { store.start() }
 
         try await Task.sleep(for: .milliseconds(150))
 
         let queries = await MainActor.run { store.events.map(\.query) }
         XCTAssertEqual(queries, ["existing event"])
+        await MainActor.run { store.stop() }
     }
 
     func testObservationPublishesNewEventsAfterInsert() async throws {
         let databasePath = tempDBPath!
         let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
-        defer { Task { @MainActor in store.stop() } }
         await MainActor.run { store.start() }
 
         try db.recordInjectionEvent(
@@ -57,6 +56,7 @@ final class InjectionStoreTests: XCTestCase {
         let firstChunkIDs = await MainActor.run { store.events.first?.chunkIDs }
         XCTAssertEqual(firstQuery, "new event")
         XCTAssertEqual(firstChunkIDs, ["chunk-a", "chunk-b"])
+        await MainActor.run { store.stop() }
     }
 
     func testExpandedConversationLoadsTargetChunkAndContext() async throws {
@@ -73,7 +73,6 @@ final class InjectionStoreTests: XCTestCase {
 
         let databasePath = tempDBPath!
         let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
-        defer { Task { @MainActor in store.stop() } }
         let conversation = try await MainActor.run {
             try store.expandedConversation(chunkID: "inject-2")
         }
@@ -83,5 +82,29 @@ final class InjectionStoreTests: XCTestCase {
             conversation.entries.map(\.chunkID),
             ["inject-1", "inject-2", "inject-3", "inject-4"]
         )
+        await MainActor.run { store.stop() }
+    }
+
+    func testStoreCanRestartAfterStop() async throws {
+        let databasePath = tempDBPath!
+        let store = try await MainActor.run { try InjectionStore(databasePath: databasePath) }
+
+        await MainActor.run { store.start() }
+        try await Task.sleep(for: .milliseconds(100))
+        await MainActor.run { store.stop() }
+
+        try db.recordInjectionEvent(
+            sessionID: "session-3",
+            query: "restart event",
+            chunkIDs: ["chunk-restart"],
+            tokenCount: 9
+        )
+
+        await MainActor.run { store.start() }
+        try await Task.sleep(for: .milliseconds(250))
+
+        let queries = await MainActor.run { store.events.map(\.query) }
+        XCTAssertEqual(queries, ["restart event"])
+        await MainActor.run { store.stop() }
     }
 }

--- a/brain-bar/Tests/BrainBarTests/PopoverTabTests.swift
+++ b/brain-bar/Tests/BrainBarTests/PopoverTabTests.swift
@@ -35,19 +35,25 @@ final class PopoverTabTests: XCTestCase {
         XCTAssertEqual(PopoverTab.graph.label, "Graph")
     }
 
-    func testPopoverTabDashboardSizeIsCompact() {
-        XCTAssertEqual(PopoverTab.dashboard.contentSize.width, 360)
+    func testPopoverTabDashboardSizeIsUtilityPanel() {
+        XCTAssertEqual(PopoverTab.dashboard.contentSize.width, 560)
+        XCTAssertEqual(PopoverTab.dashboard.contentSize.height, 520)
+    }
+
+    func testPopoverTabsShareStablePanelSize() {
+        XCTAssertEqual(PopoverTab.injections.contentSize, PopoverTab.dashboard.contentSize)
+        XCTAssertEqual(PopoverTab.graph.contentSize, PopoverTab.dashboard.contentSize)
     }
 
     func testPopoverTabGraphSizeIsWiderThanDashboard() {
-        XCTAssertGreaterThan(
+        XCTAssertEqual(
             PopoverTab.graph.contentSize.width,
             PopoverTab.dashboard.contentSize.width
         )
     }
 
     func testPopoverTabGraphSizeIsTallerThanDashboard() {
-        XCTAssertGreaterThan(
+        XCTAssertEqual(
             PopoverTab.graph.contentSize.height,
             PopoverTab.dashboard.contentSize.height
         )

--- a/brain-bar/Tests/BrainBarTests/PopoverTabTests.swift
+++ b/brain-bar/Tests/BrainBarTests/PopoverTabTests.swift
@@ -52,7 +52,7 @@ final class PopoverTabTests: XCTestCase {
         )
     }
 
-    func testPopoverTabGraphSizeIsTallerThanDashboard() {
+    func testPopoverTabGraphSizeHasSameHeightAsDashboard() {
         XCTAssertEqual(
             PopoverTab.graph.contentSize.height,
             PopoverTab.dashboard.contentSize.height
@@ -165,6 +165,41 @@ final class PopoverTabTests: XCTestCase {
     }
 
     @MainActor
+    func testShowTabDoesNotRequestResizeWhenUtilityPanelSizeIsUnchanged() throws {
+        let db = BrainDatabase(path: tempDBPath)
+        defer { db.close() }
+        let injStore = try InjectionStore(databasePath: tempDBPath)
+        defer { injStore.stop() }
+
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
+        )
+        defer { collector.stop() }
+
+        let vc = StatusPopoverView(
+            collector: collector,
+            injectionStore: injStore,
+            database: db
+        )
+        _ = vc.view
+
+        var resizeRequests: [NSSize] = []
+        vc.onPreferredSizeChange = { size in
+            resizeRequests.append(size)
+        }
+
+        vc.showTab(.injections)
+        vc.showTab(.graph)
+        vc.showTab(.dashboard)
+
+        XCTAssertTrue(
+            resizeRequests.isEmpty,
+            "Stable-size tab switches should not ask AppKit to reposition the popover"
+        )
+    }
+
+    @MainActor
     func testCurrentTabTracksSelection() throws {
         let db = BrainDatabase(path: tempDBPath)
         defer { db.close() }
@@ -200,6 +235,7 @@ final class PopoverTabTests: XCTestCase {
 
     // MARK: - Helpers
 
+    @MainActor
     private func findSegmentedControl(in view: NSView) -> NSSegmentedControl? {
         for subview in view.subviews {
             if let segmented = subview as? NSSegmentedControl {

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -467,6 +467,30 @@ final class SocketIntegrationTests: XCTestCase {
         )
     }
 
+    func testBackpressuredClientDoesNotDelayHealthyClientBeforeTimeout() throws {
+        let stalledClientFD = try connectClient()
+        defer { close(stalledClientFD) }
+        configureBackpressuredClient(fd: stalledClientFD, receiveBufferSize: 1)
+
+        try sendMCPRequest(on: stalledClientFD, request: initializeRequest(id: 1, name: "blocked-client"))
+        for id in 2...80 {
+            try sendMCPRequest(on: stalledClientFD, request: toolsListRequest(id: id))
+        }
+
+        Thread.sleep(forTimeInterval: 0.05)
+
+        let startedAt = Date()
+        let healthyResponse = try sendMCPRequest(initializeRequest(id: 300, name: "healthy-before-timeout"))
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        XCTAssertNotNil(healthyResponse["result"])
+        XCTAssertLessThan(
+            elapsed,
+            Double(BrainBarServer.writeStallTimeoutMilliseconds) / 1000.0 * 0.7,
+            "A stalled client should not monopolize the serial queue before its timeout expires"
+        )
+    }
+
     func testStdioAdapterBridgesInitializeAndSubscribe() throws {
         let adapterPath = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -9,6 +9,7 @@ import XCTest
 final class SocketIntegrationTests: XCTestCase {
     let testSocketPath = "/tmp/brainbar-test-\(ProcessInfo.processInfo.processIdentifier).sock"
     var server: BrainBarServer!
+    var bufferedMessagesByFD: [Int32: Data] = [:]
 
     override func setUp() {
         super.setUp()
@@ -20,6 +21,7 @@ final class SocketIntegrationTests: XCTestCase {
     }
 
     override func tearDown() {
+        bufferedMessagesByFD.removeAll()
         server.stop()
         super.tearDown()
     }
@@ -410,54 +412,59 @@ final class SocketIntegrationTests: XCTestCase {
         XCTAssertEqual(notification["method"] as? String, "notifications/claude/channel")
     }
 
-    // MARK: - C1: Write retry cap
+    // MARK: - C1: Socket backpressure handling
 
-    func testServerDisconnectsStalledClient() throws {
-        // Connect but never read — server should disconnect after max retries (10),
-        // not block the serial queue forever.
-        let clientFD = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard clientFD >= 0 else { throw NSError(domain: "test", code: 1) }
+    func testServerSurvivesBriefClientBackpressure() throws {
+        let clientFD = try connectClient()
         defer { close(clientFD) }
+        configureBackpressuredClient(fd: clientFD, receiveBufferSize: 1_024)
 
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-            ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
-                _ = testSocketPath.withCString { src in strcpy(dest, src) }
-            }
-        }
-        let connectResult = withUnsafePointer(to: &addr) { addrPtr in
-            addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
-                connect(clientFD, ptr, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        XCTAssertEqual(connectResult, 0, "Should connect")
-
-        // Set tiny receive buffer to force EAGAIN on server-side writes
-        var bufSize: Int32 = 1
-        setsockopt(clientFD, SOL_SOCKET, SO_RCVBUF, &bufSize, socklen_t(MemoryLayout<Int32>.size))
-
-        // Send an initialize request
-        let json = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stall","version":"1"}}}"#
-        let header = "Content-Length: \(json.utf8.count)\r\n\r\n"
-        var frame = Data(header.utf8)
-        frame.append(Data(json.utf8))
-        frame.withUnsafeBytes { ptr in
-            _ = write(clientFD, ptr.baseAddress!, frame.count)
+        try sendMCPRequest(on: clientFD, request: initializeRequest(id: 1, name: "brief-stall"))
+        for id in 2...18 {
+            try sendMCPRequest(on: clientFD, request: toolsListRequest(id: id))
         }
 
-        // After the write stalls (tiny rcvbuf), server should disconnect within ~20ms (10 retries * 1ms + overhead)
-        // If it hangs > 200ms, the retry cap is broken.
-        // A second client should still be able to connect and get a response,
-        // proving the serial queue wasn't blocked.
-        Thread.sleep(forTimeInterval: 0.2)
+        // Simulate a client that is briefly busy before draining responses.
+        Thread.sleep(forTimeInterval: 0.1)
 
-        let secondResponse = try sendMCPRequest([
-            "jsonrpc": "2.0", "id": 99, "method": "initialize",
-            "params": ["protocolVersion": "2024-11-05", "capabilities": [:] as [String: Any],
-                       "clientInfo": ["name": "second", "version": "1.0"]]
-        ])
-        XCTAssertNotNil(secondResponse["result"], "Serial queue must not be blocked — second client should get response")
+        let initializeResponse = try readMCPMessage(fd: clientFD, timeout: 2.0)
+        XCTAssertNotNil(initializeResponse["result"])
+
+        var lastResponse: [String: Any] = initializeResponse
+        for _ in 2...18 {
+            lastResponse = try readMCPMessage(fd: clientFD, timeout: 2.0)
+        }
+        let tools = (lastResponse["result"] as? [String: Any])?["tools"] as? [[String: Any]]
+        XCTAssertEqual(tools?.count, 11)
+
+        try sendMCPRequest(on: clientFD, request: toolsListRequest(id: 81))
+        let followUpResponse = try readMCPMessage(fd: clientFD, timeout: 2.0)
+        let followUpTools = (followUpResponse["result"] as? [String: Any])?["tools"] as? [[String: Any]]
+        XCTAssertEqual(followUpTools?.count, 11, "Client should remain connected after a short backpressure burst")
+    }
+
+    func testServerDisconnectsPersistentlyStalledClientWithoutBlockingOthers() throws {
+        let deadClientFD = try connectClient()
+        defer { close(deadClientFD) }
+        configureBackpressuredClient(fd: deadClientFD, receiveBufferSize: 1)
+
+        try sendMCPRequest(on: deadClientFD, request: initializeRequest(id: 1, name: "dead-stall"))
+        for id in 2...80 {
+            try sendMCPRequest(on: deadClientFD, request: toolsListRequest(id: id))
+        }
+
+        let timeoutSeconds = Double(BrainBarServer.writeStallTimeoutMilliseconds) / 1000.0
+        Thread.sleep(forTimeInterval: timeoutSeconds + 0.35)
+
+        let secondStartedAt = Date()
+        let secondResponse = try sendMCPRequest(initializeRequest(id: 200, name: "healthy-client"))
+        XCTAssertNotNil(secondResponse["result"], "Dead client should not block the server forever")
+        XCTAssertLessThan(Date().timeIntervalSince(secondStartedAt), 1.0, "Server should recover promptly once the stalled client is dropped")
+
+        XCTAssertTrue(
+            try waitForSocketClosure(fd: deadClientFD, timeout: 1.0),
+            "Persistently stalled client should eventually be disconnected"
+        )
     }
 
     func testStdioAdapterBridgesInitializeAndSubscribe() throws {
@@ -669,35 +676,68 @@ final class SocketIntegrationTests: XCTestCase {
     }
 
     private func readMCPMessage(fd: Int32, timeout: TimeInterval = 5.0) throws -> [String: Any] {
-        var buffer = Data()
+        var buffer = bufferedMessagesByFD[fd] ?? Data()
         var readBuf = [UInt8](repeating: 0, count: 65536)
         let deadline = Date().addingTimeInterval(timeout)
 
         while Date() < deadline {
+            if let message = try decodeBufferedMCPMessage(fd: fd, buffer: &buffer) {
+                return message
+            }
+
             let n = read(fd, &readBuf, readBuf.count)
             if n > 0 {
                 buffer.append(contentsOf: readBuf[0..<n])
-                // Try to parse Content-Length framed response
-                if let headerEnd = buffer.range(of: Data("\r\n\r\n".utf8)) {
-                    let headerStr = String(data: buffer[buffer.startIndex..<headerEnd.lowerBound], encoding: .utf8) ?? ""
-                    if let clLine = headerStr.split(separator: "\r\n").first(where: { $0.hasPrefix("Content-Length:") }) {
-                        let cl = Int(clLine.split(separator: ":")[1].trimmingCharacters(in: .whitespaces)) ?? 0
-                        let bodyStart = headerEnd.upperBound
-                        if buffer.count >= bodyStart + cl {
-                            let bodyData = buffer[bodyStart..<(bodyStart + cl)]
-                            return try JSONSerialization.jsonObject(with: bodyData) as? [String: Any] ?? [:]
-                        }
-                    }
+                if let message = try decodeBufferedMCPMessage(fd: fd, buffer: &buffer) {
+                    return message
                 }
             } else if n == 0 {
+                bufferedMessagesByFD.removeValue(forKey: fd)
                 break // EOF
             } else if errno != EAGAIN && errno != EINTR && errno != EWOULDBLOCK {
+                bufferedMessagesByFD.removeValue(forKey: fd)
                 break
             }
             Thread.sleep(forTimeInterval: 0.01)
         }
 
+        bufferedMessagesByFD[fd] = buffer
         throw NSError(domain: "test", code: 4, userInfo: [NSLocalizedDescriptionKey: "Timeout reading response"])
+    }
+
+    private func decodeBufferedMCPMessage(fd: Int32, buffer: inout Data) throws -> [String: Any]? {
+        guard let headerEnd = buffer.range(of: Data("\r\n\r\n".utf8)) else {
+            bufferedMessagesByFD[fd] = buffer
+            return nil
+        }
+
+        let headerData = buffer[buffer.startIndex..<headerEnd.lowerBound]
+        let headerString = String(data: headerData, encoding: .utf8) ?? ""
+        guard let contentLengthLine = headerString
+            .components(separatedBy: "\r\n")
+            .first(where: { $0.hasPrefix("Content-Length:") }),
+              let separatorIndex = contentLengthLine.firstIndex(of: ":")
+        else {
+            bufferedMessagesByFD[fd] = buffer
+            return nil
+        }
+
+        let contentLength = Int(
+            contentLengthLine[contentLengthLine.index(after: separatorIndex)...]
+                .trimmingCharacters(in: .whitespaces)
+        ) ?? 0
+        let bodyStart = headerEnd.upperBound
+        guard buffer.count >= bodyStart + contentLength else {
+            bufferedMessagesByFD[fd] = buffer
+            return nil
+        }
+
+        let bodyRange = bodyStart..<(bodyStart + contentLength)
+        let bodyData = buffer[bodyRange]
+        let remaining = Data(buffer[bodyRange.upperBound...])
+        bufferedMessagesByFD[fd] = remaining
+        buffer = remaining
+        return try JSONSerialization.jsonObject(with: bodyData) as? [String: Any] ?? [:]
     }
 
     private func sendLineJSON(_ object: [String: Any], to handle: FileHandle) throws {
@@ -731,5 +771,56 @@ final class SocketIntegrationTests: XCTestCase {
             }
         }
         throw NSError(domain: "test", code: 5, userInfo: [NSLocalizedDescriptionKey: "Timeout reading line JSON"])
+    }
+
+    private func configureBackpressuredClient(fd: Int32, receiveBufferSize: Int32) {
+        var bufSize = receiveBufferSize
+        _ = setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &bufSize, socklen_t(MemoryLayout<Int32>.size))
+
+        var noSigPipe: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
+    }
+
+    private func initializeRequest(id: Int, name: String) -> [String: Any] {
+        [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": "2024-11-05",
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": name, "version": "1.0"]
+            ]
+        ]
+    }
+
+    private func toolsListRequest(id: Int) -> [String: Any] {
+        [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/list",
+        ]
+    }
+
+    private func waitForSocketClosure(fd: Int32, timeout: TimeInterval) throws -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        var buffer = [UInt8](repeating: 0, count: 65536)
+
+        while Date() < deadline {
+            let count = read(fd, &buffer, buffer.count)
+            if count == 0 {
+                return true
+            }
+            if count > 0 {
+                continue
+            }
+            if errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR {
+                Thread.sleep(forTimeInterval: 0.01)
+                continue
+            }
+            return true
+        }
+
+        return false
     }
 }

--- a/brain-bar/Tests/BrainBarTests/StabilityFixTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StabilityFixTests.swift
@@ -3,6 +3,7 @@
 // TDD: Written before implementation.
 // Covers: async store, search result dates, Enter key behavior, popover sizing.
 
+import AppKit
 import XCTest
 @testable import BrainBar
 
@@ -148,10 +149,33 @@ final class EnterKeySearchTests: XCTestCase {
 // MARK: - (4) Popover size should be stable
 
 final class PopoverSizeTests: XCTestCase {
+    private var tempDBPath: String!
 
+    override func setUp() {
+        super.setUp()
+        tempDBPath = NSTemporaryDirectory() + "brainbar-popover-size-\(UUID().uuidString).db"
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: tempDBPath)
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
+        super.tearDown()
+    }
+
+    @MainActor
     func testStatusPopoverViewFrameMatchesStableUtilityPanel() {
-        let frame = NSRect(x: 0, y: 0, width: 560, height: 520)
-        XCTAssertEqual(frame.width, 560)
-        XCTAssertEqual(frame.height, 520)
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
+        )
+        defer { collector.stop() }
+
+        let popoverView = StatusPopoverView(collector: collector)
+        _ = popoverView.view
+        popoverView.view.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(popoverView.view.frame.width, 560)
+        XCTAssertEqual(popoverView.view.frame.height, 520)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/StabilityFixTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StabilityFixTests.swift
@@ -145,14 +145,13 @@ final class EnterKeySearchTests: XCTestCase {
     }
 }
 
-// MARK: - (4) Popover size should be compact
+// MARK: - (4) Popover size should be stable
 
 final class PopoverSizeTests: XCTestCase {
 
-    func testStatusPopoverViewFrameIsCompact() {
-        // StatusPopoverView initial frame should not exceed 360x320
-        let frame = NSRect(x: 0, y: 0, width: 360, height: 320)
-        XCTAssertLessThanOrEqual(frame.width, 360)
-        XCTAssertLessThanOrEqual(frame.height, 320)
+    func testStatusPopoverViewFrameMatchesStableUtilityPanel() {
+        let frame = NSRect(x: 0, y: 0, width: 560, height: 520)
+        XCTAssertEqual(frame.width, 560)
+        XCTAssertEqual(frame.height, 520)
     }
 }

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -110,15 +110,13 @@ if [ -f "$PLIST_SRC" ]; then
     launchctl bootstrap "$LAUNCH_DOMAIN" "$PLIST_DST"
     launchctl kickstart -k "$LAUNCH_DOMAIN/$PLIST_LABEL"
     echo "[build-app] LaunchAgent installed — BrainBar will auto-restart after quit"
-fi
+    if ! wait_for_socket "$SOCKET_PATH"; then
+        echo "[build-app] ERROR: BrainBar did not recreate $SOCKET_PATH"
+        pgrep -fl BrainBar || true
+        exit 1
+    fi
 
-if ! wait_for_socket "$SOCKET_PATH"; then
-    echo "[build-app] ERROR: BrainBar did not recreate $SOCKET_PATH"
-    pgrep -fl BrainBar || true
-    exit 1
-fi
-
-python3 - <<'PY' "$SOCKET_PATH"
+    python3 - <<'PY' "$SOCKET_PATH"
 import os
 import socket
 import sys
@@ -133,6 +131,9 @@ except OSError as exc:
 finally:
     s.close()
 PY
+else
+    echo "[build-app] LaunchAgent plist missing at $PLIST_SRC — skipping auto-launch and socket verification"
+fi
 
 echo "[build-app] Done: $APP_DIR"
 echo "[build-app] Socket: $SOCKET_PATH"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -12,14 +12,57 @@ PACKAGE_DIR="$SCRIPT_DIR"
 BUNDLE_DIR="$SCRIPT_DIR/bundle"
 APP_DIR="${BRAINBAR_APP_DIR:-$HOME/Applications/BrainBar.app}"
 SIGN_IDENTITY="${BRAINBAR_CODESIGN_IDENTITY:-Apple Development: Etan Heyman (DXHB5E7P2D)}"
+PLIST_LABEL="com.brainlayer.brainbar"
+PLIST_FILENAME="$PLIST_LABEL.plist"
+PLIST_SRC="$BUNDLE_DIR/$PLIST_FILENAME"
+PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_FILENAME"
+LAUNCH_DOMAIN="gui/$(id -u)"
+SOCKET_PATH="${BRAINBAR_SOCKET_PATH:-/tmp/brainbar.sock}"
 
-# Kill any running BrainBar instances before installing
+bootout_launchagent() {
+    launchctl bootout "$LAUNCH_DOMAIN/$PLIST_LABEL" 2>/dev/null || true
+    if [ -f "$PLIST_DST" ]; then
+        launchctl bootout "$LAUNCH_DOMAIN" "$PLIST_DST" 2>/dev/null || true
+    fi
+}
+
+wait_for_brainbar_exit() {
+    for _ in $(seq 1 100); do
+        if ! pgrep -x BrainBar > /dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+wait_for_socket() {
+    local path="$1"
+    for _ in $(seq 1 100); do
+        if [ -S "$path" ]; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+# Stop LaunchAgent first so KeepAlive cannot race the rebuild and unlink the
+# freshly rebound socket from an older instance that is still terminating.
+echo "[build-app] Stopping LaunchAgent..."
+bootout_launchagent
+
+# Kill any running BrainBar instances before installing.
 if pgrep -x BrainBar > /dev/null 2>&1; then
     echo "[build-app] Stopping running BrainBar instances..."
     killall BrainBar 2>/dev/null || true
-    sleep 1
-    rm -f /tmp/brainbar.sock
+    if ! wait_for_brainbar_exit; then
+        echo "[build-app] ERROR: BrainBar did not exit cleanly"
+        pgrep -fl BrainBar || true
+        exit 1
+    fi
 fi
+rm -f "$SOCKET_PATH"
 
 echo "[build-app] Building BrainBar (release)..."
 swift build -c release --package-path "$PACKAGE_DIR"
@@ -60,17 +103,37 @@ fi
 /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -R "$APP_DIR"
 
 # Install LaunchAgent (expands path to actual APP_DIR)
-PLIST_NAME="com.brainlayer.brainbar.plist"
-PLIST_SRC="$BUNDLE_DIR/$PLIST_NAME"
-PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME"
 if [ -f "$PLIST_SRC" ]; then
     echo "[build-app] Installing LaunchAgent to $PLIST_DST..."
-    launchctl bootout "gui/$(id -u)/$PLIST_NAME" 2>/dev/null || true
+    bootout_launchagent
     sed "s|/Applications/BrainBar.app|$APP_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
-    launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+    launchctl bootstrap "$LAUNCH_DOMAIN" "$PLIST_DST"
+    launchctl kickstart -k "$LAUNCH_DOMAIN/$PLIST_LABEL"
     echo "[build-app] LaunchAgent installed — BrainBar will auto-restart after quit"
 fi
 
+if ! wait_for_socket "$SOCKET_PATH"; then
+    echo "[build-app] ERROR: BrainBar did not recreate $SOCKET_PATH"
+    pgrep -fl BrainBar || true
+    exit 1
+fi
+
+python3 - <<'PY' "$SOCKET_PATH"
+import os
+import socket
+import sys
+
+path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+try:
+    s.connect(path)
+except OSError as exc:
+    print(f"[build-app] ERROR: socket connect failed for {path}: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+finally:
+    s.close()
+PY
+
 echo "[build-app] Done: $APP_DIR"
-echo "[build-app] Socket: /tmp/brainbar.sock"
+echo "[build-app] Socket: $SOCKET_PATH"
 echo "[build-app] DB: ~/.local/share/brainlayer/brainlayer.db"


### PR DESCRIPTION
## Summary
- split dashboard throughput into explicit Indexing and Enriching rows with digit-stable metrics, recent-rate fallback, and right-aligned numeric layout
- stop fake-zero enrichment speeds by falling back to recent throughput when the instantaneous window drops to zero, and stop popover drift by avoiding redundant same-size resize requests across tab switches
- fix follow-on review issues in the branch: restart-safe `InjectionStore`, real popover-size regression coverage, and `build-app.sh` socket verification only when the LaunchAgent is actually installed

## Test plan
- `swift test --package-path brain-bar --filter 'BrainBarUXLogicTests|InjectionStoreTests|PopoverTabTests|StabilityFixTests'`
- `bash brain-bar/build-app.sh`

## Verification notes
- The focused BrainBar dashboard/popover/injection tests above passed on commit `638671e5`.
- `swift test --package-path brain-bar` is still red on this branch because of pre-existing knowledge-graph test failures/crashes outside this UX slice (`KGDatabaseTests` assertions and a `KGViewModelTests` index-out-of-range crash).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Overhaul BrainBar dashboard UX with pipeline indicators, activity tracks, and conversation drill-down
> - Redesigns the dashboard popover to a unified 560×520 panel with pipeline status badges (`PipelineIndicatorBadgeView`), a Speed metric tile, and two activity rows (`PipelineActivityRowView`) showing per-track sparklines and rate/detail strings; removes the old inline sparkline and Refresh button.
> - Adds `DashboardMetricFormatter` and `PipelineState` models (`PipelineIndicators`, `PipelineActivityTracks`) to compute and format indexing/enriching rates, statuses, and bucket-based sparkline data.
> - Extends `BrainDatabase` with enrichment rate and bucket queries, a typed `ExpandedConversation` model, and a Darwin notification posted on injection insert; `InjectionStore` is rewritten to use polling + Darwin notifications instead of GRDB ValueObservation.
> - Adds conversation drill-down throughout the UI: the injection feed and knowledge graph sidebar now let users open a `ChunkConversationSheet` displaying role, timestamp, and content for a chunk's conversation history.
> - Hardens `build-app.sh` to deterministically stop the LaunchAgent, wait for process exit, clean up the socket, and verify connectivity after bootstrapping.
> - Behavioral Change: the status bar sparkline now renders from `recentEnrichmentBuckets` instead of `recentActivityBuckets`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99a0d6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple runtime-critical paths (SQLite stats queries, injection event persistence/ordering, and socket write/backpressure handling) plus a sizable dashboard UI refactor, so regressions could affect live status rendering and client connectivity.
> 
> **Overview**
> **Dashboard UX overhaul:** the popover is redesigned into a stable 560×520 utility panel with new pipeline indicator badges and separate *Indexing*/*Enriching* activity rows (each with its own sparkline), plus a new `Speed` metric and digit-stable formatting via `DashboardMetricFormatter`.
> 
> **New enrichment telemetry:** `BrainDatabase.DashboardStats` now includes `recentEnrichmentBuckets` and `enrichmentRatePerMinute`, with new SQL helpers to bucket by `enriched_at` and compute a short-window completion rate; the menu-bar sparkline is switched to render enrichment activity.
> 
> **Conversation thread viewing:** adds typed `ExpandedConversation`/`ConversationChunk` models and `expandedConversation(...)`, introduces `ChunkConversationSheet`, and wires injection events and KG sidebar chunk links to open the surrounding thread for a selected chunk.
> 
> **Data + reliability fixes:** `InjectionStore` is rewritten to use `BrainDatabase` + Darwin notifications/data-version polling (removing GRDB observation), injection events use deterministic ordering (`timestamp DESC, id DESC`) and only post change notifications on successful insert, popover resizing is guarded to prevent drift, socket backpressure tests are expanded/cleaned up, and `build-app.sh` now safely stops the LaunchAgent and verifies socket recreation only when the agent is installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a0d6d1e5f246d4d8eb403cfeb797244d79604c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipeline status indicators for indexing and enriching operations with rate metrics
  * Added ability to view conversations with surrounding context for indexed chunks
  * New enrichment tracking with rate display and activity history

* **Bug Fixes**
  * Fixed unnecessary popover resizing when content size unchanged
  * Improved socket handling for stalled client connections

* **Improvements**
  * Redesigned dashboard layout with enhanced activity tracking visualization
  * Enhanced sparkline rendering with grid lines and improved styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->