### PR TITLE
fix: preserve BrainBar MCP initialize handshake under backpressure

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -6,6 +6,7 @@
 // - JSON-RPC router
 // - SQLite database (single-writer)
 
+import Darwin
 import Foundation
 
 final class BrainBarServer: @unchecked Sendable {
@@ -66,6 +67,13 @@ final class BrainBarServer: @unchecked Sendable {
         }
     }
 
+    private struct PendingWrite {
+        let data: Data
+        var totalWritten: Int
+        var lastProgressAt: UInt64
+        let onDelivered: (() -> Void)?
+    }
+
     private let socketPath: String
     private let dbPath: String
     private let providedDatabase: BrainDatabase?
@@ -76,9 +84,11 @@ final class BrainBarServer: @unchecked Sendable {
     private var router: MCPRouter!
     private var database: BrainDatabase!
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
-    /// Maximum EAGAIN retries before disconnecting a stalled client.
-    /// Each retry sleeps 1ms, so 10 retries = 10ms max blocking the serial queue.
-    static let maxWriteRetries = 10
+    /// Max time to wait for a backpressured client to become writable again.
+    /// Temporary bursts should survive; truly dead peers still get disconnected.
+    static let writeStallTimeoutMilliseconds: Int32 = 250
+    static let writeChunkSize = 4_096
+    static let writeRetrySleepMicroseconds: useconds_t = 2_000
     private let debugLogPath = "/tmp/brainbar-debug.log"
 
     private func debugLog(_ msg: String) {
@@ -99,7 +109,7 @@ final class BrainBarServer: @unchecked Sendable {
         debugLog("\(label) (\(data.count) bytes)\n  HEX: \(hex)\n  TEXT: \(text)")
     }
 
-    struct ClientState {
+    private struct ClientState {
         var source: DispatchSourceRead
         var framing: MCPFraming
         /// Whether this client uses Content-Length framing (LSP-style).
@@ -107,6 +117,8 @@ final class BrainBarServer: @unchecked Sendable {
         var usesContentLengthFraming: Bool = true
         var agentID: String?
         var subscribedTags: Set<String> = []
+        var pendingWrites: [PendingWrite] = []
+        var hasScheduledWriteRetry = false
     }
 
     init(socketPath: String? = nil, dbPath: String? = nil, database: BrainDatabase? = nil) {
@@ -326,7 +338,12 @@ final class BrainBarServer: @unchecked Sendable {
     }
 
     @discardableResult
-    private func sendResponse(fd: Int32, response: [String: Any], useContentLength: Bool = true) -> Bool {
+    private func sendResponse(
+        fd: Int32,
+        response: [String: Any],
+        useContentLength: Bool = true,
+        onDelivered: (() -> Void)? = nil
+    ) -> Bool {
         let framed: Data
         if useContentLength {
             guard let data = try? MCPFraming.encode(response) else { return false }
@@ -338,35 +355,94 @@ final class BrainBarServer: @unchecked Sendable {
             data.append(0x0A) // trailing \n
             framed = data
         }
-        return framed.withUnsafeBytes { ptr in
-            var totalWritten = 0
-            var eagainRetries = 0
-            while totalWritten < framed.count {
-                let n = write(fd, ptr.baseAddress!.advanced(by: totalWritten), framed.count - totalWritten)
-                if n < 0 {
-                    if errno == EAGAIN || errno == EWOULDBLOCK {
-                        eagainRetries += 1
-                        if eagainRetries > Self.maxWriteRetries {
-                            NSLog("[BrainBar] ⚠️ Write stalled on fd %d after %d EAGAIN retries (%d ms) — disconnecting dead client", fd, eagainRetries, eagainRetries - 1)
-                            disconnectClient(fd: fd)
-                            return false
-                        }
-                        usleep(1000) // 1 ms
-                        continue
-                    }
-                    NSLog("[BrainBar] Write error on fd %d: errno %d", fd, errno)
-                    disconnectClient(fd: fd)
-                    return false
-                }
-                if n == 0 {
-                    NSLog("[BrainBar] Write returned 0 on fd %d — peer closed", fd)
-                    disconnectClient(fd: fd)
-                    return false
-                }
-                totalWritten += n
-                eagainRetries = 0 // reset on successful partial write
+        return enqueueWrite(fd: fd, data: framed, onDelivered: onDelivered)
+    }
+
+    @discardableResult
+    private func enqueueWrite(fd: Int32, data: Data, onDelivered: (() -> Void)? = nil) -> Bool {
+        guard var state = clients[fd] else { return false }
+        state.pendingWrites.append(
+            PendingWrite(
+                data: data,
+                totalWritten: 0,
+                lastProgressAt: DispatchTime.now().uptimeNanoseconds,
+                onDelivered: onDelivered
+            )
+        )
+        clients[fd] = state
+        return flushPendingWrites(fd: fd)
+    }
+
+    @discardableResult
+    private func flushPendingWrites(fd: Int32) -> Bool {
+        guard var state = clients[fd] else { return false }
+        state.hasScheduledWriteRetry = false
+        clients[fd] = state
+
+        while var pending = clients[fd]?.pendingWrites.first {
+            let remaining = pending.data.count - pending.totalWritten
+            let nextChunkSize = min(remaining, Self.writeChunkSize)
+            let n = pending.data.withUnsafeBytes { ptr in
+                write(fd, ptr.baseAddress!.advanced(by: pending.totalWritten), nextChunkSize)
             }
-            return true
+            if n < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                if errno == EAGAIN || errno == EWOULDBLOCK {
+                    let now = DispatchTime.now().uptimeNanoseconds
+                    let stallDeadline = pending.lastProgressAt
+                        + UInt64(Self.writeStallTimeoutMilliseconds) * 1_000_000
+                    guard now < stallDeadline else {
+                        NSLog(
+                            "[BrainBar] ⚠️ Write stalled on fd %d for %d ms — disconnecting dead client",
+                            fd,
+                            Self.writeStallTimeoutMilliseconds
+                        )
+                        disconnectClient(fd: fd)
+                        return false
+                    }
+                    scheduleWriteRetryIfNeeded(fd: fd)
+                    return true
+                }
+                NSLog("[BrainBar] Write error on fd %d: errno %d", fd, errno)
+                disconnectClient(fd: fd)
+                return false
+            }
+            if n == 0 {
+                NSLog("[BrainBar] Write returned 0 on fd %d — peer closed", fd)
+                disconnectClient(fd: fd)
+                return false
+            }
+
+            pending.totalWritten += n
+            pending.lastProgressAt = DispatchTime.now().uptimeNanoseconds
+
+            guard var latest = clients[fd] else { return false }
+            latest.pendingWrites[0] = pending
+
+            if pending.totalWritten == pending.data.count {
+                let delivered = pending.onDelivered
+                latest.pendingWrites.removeFirst()
+                clients[fd] = latest
+                delivered?()
+            } else {
+                clients[fd] = latest
+            }
+        }
+
+        return clients[fd] != nil
+    }
+
+    private func scheduleWriteRetryIfNeeded(fd: Int32) {
+        guard var state = clients[fd], !state.hasScheduledWriteRetry else { return }
+        state.hasScheduledWriteRetry = true
+        clients[fd] = state
+
+        let retryDelay = DispatchTimeInterval.microseconds(Int(Self.writeRetrySleepMicroseconds))
+        queue.asyncAfter(deadline: .now() + retryDelay) { [weak self] in
+            guard let self, self.clients[fd] != nil else { return }
+            _ = self.flushPendingWrites(fd: fd)
         }
     }
 
@@ -593,10 +669,13 @@ final class BrainBarServer: @unchecked Sendable {
                 let delivered = sendResponse(
                     fd: clientFD,
                     response: notificationObject,
-                    useContentLength: client.usesContentLengthFraming
+                    useContentLength: client.usesContentLengthFraming,
+                    onDelivered: { [weak database] in
+                        try? database?.markDelivered(agentID: agentID, seq: stored.rowID)
+                    }
                 )
-                if delivered {
-                    try? database?.markDelivered(agentID: agentID, seq: stored.rowID)
+                if !delivered {
+                    continue
                 }
             }
         }

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -9,6 +9,7 @@ import XCTest
 final class SocketIntegrationTests: XCTestCase {
     let testSocketPath = "/tmp/brainbar-test-\(ProcessInfo.processInfo.processIdentifier).sock"
     var server: BrainBarServer!
+    var bufferedMessagesByFD: [Int32: Data] = [:]
 
     override func setUp() {
         super.setUp()
@@ -20,6 +21,7 @@ final class SocketIntegrationTests: XCTestCase {
     }
 
     override func tearDown() {
+        bufferedMessagesByFD.removeAll()
         server.stop()
         super.tearDown()
     }
@@ -412,6 +414,51 @@ final class SocketIntegrationTests: XCTestCase {
 
     // MARK: - C1: Write retry cap
 
+    func testInitializeHandshakeSurvivesBriefBackpressureBurst() throws {
+        let clientFD = try connectClient()
+        defer { close(clientFD) }
+        configureBackpressuredClient(fd: clientFD, receiveBufferSize: 1_024)
+
+        try sendMCPRequest(on: clientFD, request: [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": "2024-11-05",
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": "brief-pause", "version": "1.0"]
+            ]
+        ])
+        for id in 2...18 {
+            try sendMCPRequest(on: clientFD, request: [
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/list"
+            ])
+        }
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let initializeResponse = try readMCPMessage(fd: clientFD, timeout: 2.0)
+        XCTAssertNotNil(initializeResponse["result"], "Briefly backpressured clients should still receive the initialize handshake")
+
+        var lastResponse: [String: Any] = initializeResponse
+        for _ in 2...18 {
+            lastResponse = try readMCPMessage(fd: clientFD, timeout: 2.0)
+        }
+        let tools = (lastResponse["result"] as? [String: Any])?["tools"] as? [[String: Any]]
+        XCTAssertEqual(tools?.count, 11)
+
+        try sendMCPRequest(on: clientFD, request: [
+            "jsonrpc": "2.0",
+            "id": 81,
+            "method": "tools/list"
+        ])
+        let followUpResponse = try readMCPMessage(fd: clientFD, timeout: 2.0)
+        let followUpTools = (followUpResponse["result"] as? [String: Any])?["tools"] as? [[String: Any]]
+        XCTAssertEqual(followUpTools?.count, 11, "Client should remain connected after a short backpressure burst")
+    }
+
     func testServerDisconnectsStalledClient() throws {
         // Connect but never read — server should disconnect after max retries (10),
         // not block the serial queue forever.
@@ -669,35 +716,68 @@ final class SocketIntegrationTests: XCTestCase {
     }
 
     private func readMCPMessage(fd: Int32, timeout: TimeInterval = 5.0) throws -> [String: Any] {
-        var buffer = Data()
+        var buffer = bufferedMessagesByFD[fd] ?? Data()
         var readBuf = [UInt8](repeating: 0, count: 65536)
         let deadline = Date().addingTimeInterval(timeout)
 
         while Date() < deadline {
+            if let message = try decodeBufferedMCPMessage(fd: fd, buffer: &buffer) {
+                return message
+            }
+
             let n = read(fd, &readBuf, readBuf.count)
             if n > 0 {
                 buffer.append(contentsOf: readBuf[0..<n])
-                // Try to parse Content-Length framed response
-                if let headerEnd = buffer.range(of: Data("\r\n\r\n".utf8)) {
-                    let headerStr = String(data: buffer[buffer.startIndex..<headerEnd.lowerBound], encoding: .utf8) ?? ""
-                    if let clLine = headerStr.split(separator: "\r\n").first(where: { $0.hasPrefix("Content-Length:") }) {
-                        let cl = Int(clLine.split(separator: ":")[1].trimmingCharacters(in: .whitespaces)) ?? 0
-                        let bodyStart = headerEnd.upperBound
-                        if buffer.count >= bodyStart + cl {
-                            let bodyData = buffer[bodyStart..<(bodyStart + cl)]
-                            return try JSONSerialization.jsonObject(with: bodyData) as? [String: Any] ?? [:]
-                        }
-                    }
+                if let message = try decodeBufferedMCPMessage(fd: fd, buffer: &buffer) {
+                    return message
                 }
             } else if n == 0 {
+                bufferedMessagesByFD.removeValue(forKey: fd)
                 break // EOF
             } else if errno != EAGAIN && errno != EINTR && errno != EWOULDBLOCK {
+                bufferedMessagesByFD.removeValue(forKey: fd)
                 break
             }
             Thread.sleep(forTimeInterval: 0.01)
         }
 
+        bufferedMessagesByFD[fd] = buffer
         throw NSError(domain: "test", code: 4, userInfo: [NSLocalizedDescriptionKey: "Timeout reading response"])
+    }
+
+    private func decodeBufferedMCPMessage(fd: Int32, buffer: inout Data) throws -> [String: Any]? {
+        guard let headerEnd = buffer.range(of: Data("\r\n\r\n".utf8)) else {
+            bufferedMessagesByFD[fd] = buffer
+            return nil
+        }
+
+        let headerData = buffer[buffer.startIndex..<headerEnd.lowerBound]
+        let headerString = String(data: headerData, encoding: .utf8) ?? ""
+        guard let contentLengthLine = headerString
+            .components(separatedBy: "\r\n")
+            .first(where: { $0.hasPrefix("Content-Length:") }),
+              let separatorIndex = contentLengthLine.firstIndex(of: ":")
+        else {
+            bufferedMessagesByFD[fd] = buffer
+            return nil
+        }
+
+        let contentLength = Int(
+            contentLengthLine[contentLengthLine.index(after: separatorIndex)...]
+                .trimmingCharacters(in: .whitespaces)
+        ) ?? 0
+        let bodyStart = headerEnd.upperBound
+        guard buffer.count >= bodyStart + contentLength else {
+            bufferedMessagesByFD[fd] = buffer
+            return nil
+        }
+
+        let bodyRange = bodyStart..<(bodyStart + contentLength)
+        let bodyData = buffer[bodyRange]
+        let remaining = Data(buffer[bodyRange.upperBound...])
+        bufferedMessagesByFD[fd] = remaining
+        buffer = remaining
+        return try JSONSerialization.jsonObject(with: bodyData) as? [String: Any] ?? [:]
     }
 
     private func sendLineJSON(_ object: [String: Any], to handle: FileHandle) throws {
@@ -731,5 +811,13 @@ final class SocketIntegrationTests: XCTestCase {
             }
         }
         throw NSError(domain: "test", code: 5, userInfo: [NSLocalizedDescriptionKey: "Timeout reading line JSON"])
+    }
+
+    private func configureBackpressuredClient(fd: Int32, receiveBufferSize: Int32) {
+        var bufSize = receiveBufferSize
+        _ = setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &bufSize, socklen_t(MemoryLayout<Int32>.size))
+
+        var noSigPipe: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
     }
 }

--- a/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
+++ b/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
@@ -51,7 +51,11 @@ final class TextFormatterParityTests: XCTestCase {
             preferences: ["editor": "Neovim"],
             contactInfo: ["email": "etan@example.com"],
             relations: [
-                EntityCard.Relation(relationType: "works_on", targetName: "BrainLayer")
+                EntityCard.Relation(
+                    relationType: "works_on",
+                    targetName: "BrainLayer",
+                    direction: "outgoing"
+                )
             ],
             memories: [
                 EntityCard.Memory(type: "decision", date: "2026-03-29", content: "Chose Swift renderers for BrainBar parity.")


### PR DESCRIPTION
## Summary
- keep BrainBar socket writes non-blocking so a briefly backpressured client can still complete the MCP `initialize` handshake
- add a socket integration reproducer for the dropped-handshake case and preserve buffered Content-Length frames between test reads
- fix the stale `EntityCard.Relation` parity fixture so the BrainBar test target compiles on `main`

## Test plan
- [x] `swift test --package-path brain-bar --filter 'SocketIntegrationTests/testInitializeHandshakeSurvivesBriefBackpressureBurst|SocketIntegrationTests/testServerDisconnectsStalledClient|SocketIntegrationTests/testStdioAdapterBridgesInitializeAndSubscribe'`
- [x] `swift test --package-path brain-bar --filter 'SocketIntegrationTests|MCPFramingTests|MCPRouterTests|TextFormatterParityTests'` (socket/MCP framing coverage passed; unrelated baseline failures remain in `MCPRouterTests` and `TextFormatterParityTests` on current `main` expectations)
- [x] `bash brain-bar/build-app.sh` (build and bundle completed; LaunchAgent bootstrap failed locally with `Bootstrap failed: 5: Input/output error`)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BrainBar MCP initialize handshake to survive backpressure by replacing synchronous writes with async chunked flush
> - Replaces the synchronous write loop in `BrainBarServer.sendResponse` with an async, non-blocking queue: outbound data is enqueued via `enqueueWrite` and flushed in 4 KB chunks by `flushPendingWrites`.
> - On `EAGAIN`/`EWOULDBLOCK`, the server schedules a 2 ms retry instead of busy-waiting; clients are only disconnected after a 250 ms stall with no write progress.
> - Database `markDelivered` calls are deferred until the full payload has been written to the socket via an `onDelivered` callback, preventing premature delivery acknowledgment.
> - Adds a socket integration test (`testInitializeHandshakeSurvivesBriefBackpressureBurst`) that constrains the client receive buffer to trigger backpressure and verifies the initialize response and subsequent requests succeed.
> - Behavioral Change: responses are no longer delivered synchronously from the caller's perspective; delivery callbacks fire asynchronously after the socket write completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ddbd400. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->