### PR TITLE
fix(brainbar): KG force-sim CPU pegging (task #22)

### DIFF
--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -8,7 +8,7 @@ struct KGCanvasView: View {
     @State private var scale: CGFloat = 1.0
     @State private var lastScale: CGFloat = 1.0
     @State private var draggedNodeId: String?
-    @State private var timerActive = true
+    @State private var simulation = KGSimulationController()
     @State private var canvasSize: CGSize = .zero
 
     var body: some View {
@@ -30,7 +30,7 @@ struct KGCanvasView: View {
             viewModel.loadGraph()
             startSimulation()
         }
-        .onDisappear { timerActive = false }
+        .onDisappear { simulation.stop() }
     }
 
     private var graphCanvas: some View {
@@ -136,12 +136,8 @@ struct KGCanvasView: View {
     // MARK: - Simulation timer
 
     private func startSimulation() {
-        Task { @MainActor in
-            while timerActive {
-                try? await Task.sleep(for: .milliseconds(33)) // ~30fps
-                viewModel.tick()
-            }
-        }
+        guard !simulation.timerActive else { return }
+        simulation.start { viewModel.tick() }
     }
 
     // MARK: - Stats overlay

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSimulationController.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSimulationController.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+@MainActor
+final class KGSimulationController {
+    typealias TickHandler = @MainActor () -> CGFloat
+    typealias SleepHandler = @Sendable (Duration) async -> Void
+
+    static let defaultFrameDuration: Duration = .milliseconds(33)
+    static let defaultEnergyThreshold: CGFloat = 0.01
+
+    private(set) var timerActive = false
+
+    private let frameDuration: Duration
+    private let energyThreshold: CGFloat
+    private let sleep: SleepHandler
+    private var simulationTask: Task<Void, Never>?
+
+    init(
+        frameDuration: Duration = KGSimulationController.defaultFrameDuration,
+        energyThreshold: CGFloat = KGSimulationController.defaultEnergyThreshold,
+        sleep: @escaping SleepHandler = { duration in
+            try? await Task.sleep(for: duration)
+        }
+    ) {
+        self.frameDuration = frameDuration
+        self.energyThreshold = energyThreshold
+        self.sleep = sleep
+    }
+
+    func start(tick: @escaping TickHandler) {
+        guard !timerActive else { return }
+
+        timerActive = true
+        simulationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.simulationTask = nil }
+
+            while self.timerActive && !Task.isCancelled {
+                await self.sleep(self.frameDuration)
+                guard self.timerActive && !Task.isCancelled else { break }
+
+                if tick() < self.energyThreshold {
+                    self.timerActive = false
+                }
+            }
+        }
+    }
+
+    func stop() {
+        timerActive = false
+        simulationTask?.cancel()
+        simulationTask = nil
+    }
+
+    deinit {
+        simulationTask?.cancel()
+    }
+}

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -96,8 +96,8 @@ final class KGViewModel: ObservableObject {
 
     // MARK: - Force-Directed Layout
 
-    func tick() {
-        guard nodes.count > 1 else { return }
+    func tick() -> CGFloat {
+        guard nodes.count > 1 else { return 0 }
 
         var forces = Array(repeating: CGVector.zero, count: nodes.count)
         let center = canvasCenter
@@ -142,12 +142,18 @@ final class KGViewModel: ObservableObject {
         }
 
         // Apply forces with damping
+        var totalKineticEnergy: CGFloat = 0
         for i in 0..<nodes.count {
             nodes[i].velocity.dx = (nodes[i].velocity.dx + forces[i].dx) * damping
             nodes[i].velocity.dy = (nodes[i].velocity.dy + forces[i].dy) * damping
             nodes[i].position.x += nodes[i].velocity.dx
             nodes[i].position.y += nodes[i].velocity.dy
+
+            let speedSq = (nodes[i].velocity.dx * nodes[i].velocity.dx) + (nodes[i].velocity.dy * nodes[i].velocity.dy)
+            totalKineticEnergy += 0.5 * speedSq
         }
+
+        return totalKineticEnergy
     }
 
     // MARK: - Helpers

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -315,3 +315,115 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertTrue(vm.selectedEntityChunks.first?.snippet.contains("Alice") ?? false)
     }
 }
+
+@MainActor
+final class KGCanvasSimulationTests: XCTestCase {
+    var db: BrainDatabase!
+    var tempDBPath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDBPath = NSTemporaryDirectory() + "brainbar-kgcanvas-test-\(UUID().uuidString).db"
+        db = BrainDatabase(path: tempDBPath)
+    }
+
+    override func tearDown() {
+        db.close()
+        try? FileManager.default.removeItem(atPath: tempDBPath)
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
+        super.tearDown()
+    }
+
+    func testStableGraphStopsWithinTwoSecondsWorthOfFrames() async {
+        let vm = KGViewModel(database: db)
+        vm.canvasCenter = CGPoint(x: 300, y: 250)
+        vm.nodes = makeStableFixture(center: vm.canvasCenter)
+        vm.edges = []
+
+        let controller = KGSimulationController(
+            frameDuration: .milliseconds(33),
+            sleep: { _ in await Task.yield() }
+        )
+
+        var tickCount = 0
+        controller.start {
+            tickCount += 1
+            return vm.tick()
+        }
+
+        await waitForSimulationToStop(controller)
+
+        XCTAssertFalse(controller.timerActive, "Stable graph should auto-stop once kinetic energy is low")
+        XCTAssertLessThanOrEqual(
+            tickCount,
+            60,
+            "Stopping within 60 frames matches ~2s on the real 30fps timer"
+        )
+    }
+
+    func testRestartAfterIdleStartsSimulationAgain() async {
+        let controller = KGSimulationController(
+            frameDuration: .milliseconds(33),
+            sleep: { _ in await Task.yield() }
+        )
+
+        var tickCount = 0
+        let tick: @MainActor () -> CGFloat = {
+            tickCount += 1
+            return 0
+        }
+
+        controller.start(tick: tick)
+        await waitForSimulationToStop(controller)
+
+        XCTAssertFalse(controller.timerActive, "Controller should go idle after crossing the energy threshold")
+
+        controller.start(tick: tick)
+        await waitForSimulationToStop(controller)
+
+        XCTAssertEqual(tickCount, 2, "A previously idle simulation should restart on the next appearance")
+    }
+
+    private func waitForSimulationToStop(_ controller: KGSimulationController, iterations: Int = 200) async {
+        for _ in 0..<iterations where controller.timerActive {
+            await Task.yield()
+        }
+    }
+
+    private func makeStableFixture(center: CGPoint) -> [KGNode] {
+        let radius: CGFloat = 66.0
+        return [
+            KGNode(
+                id: "a",
+                name: "Alice",
+                entityType: "person",
+                importance: 5,
+                position: CGPoint(x: center.x + radius, y: center.y),
+                velocity: .zero
+            ),
+            KGNode(
+                id: "b",
+                name: "BrainLayer",
+                entityType: "project",
+                importance: 5,
+                position: CGPoint(
+                    x: center.x - radius / 2,
+                    y: center.y + (sqrt(3) * radius / 2)
+                ),
+                velocity: .zero
+            ),
+            KGNode(
+                id: "c",
+                name: "Codex",
+                entityType: "agent",
+                importance: 5,
+                position: CGPoint(
+                    x: center.x - radius / 2,
+                    y: center.y - (sqrt(3) * radius / 2)
+                ),
+                velocity: .zero
+            ),
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- add an energy-threshold early-exit to the KG force simulation so the 30fps loop stops once the graph settles
- move simulation loop control into a restart-safe controller with a double-start guard and explicit stop on disappear
- add KG canvas simulation tests for stable-graph convergence and restart-after-idle behavior

## Test plan
- [x] `swift test --filter KGCanvas`
- [x] `swift test --filter KG`
- [x] repo-wide `pytest` run observed; failures are pre-existing and unrelated to this Swift-only change

## Notes
Pre-existing pytest failures on master unrelated to this Swift-only change: 4 failed + 21 errors in test_engine/test_think_recall (apsw.BusyError) + test_eval_baselines + test_vector_store. Will be tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches UI-driven concurrency and the force-simulation loop; bugs could lead to stalled layouts or simulations that don’t stop/restart correctly, but the change is localized and has new tests.
> 
> **Overview**
> Reduces Knowledge Graph canvas CPU usage by making the force-directed simulation **self-terminating** once the layout settles (based on a kinetic-energy threshold) instead of running a perpetual ~30fps loop.
> 
> Introduces a `KGSimulationController` to own the simulation task lifecycle (double-start guard, explicit `stop()` on view disappear), updates `KGViewModel.tick()` to return energy, and adds focused tests covering convergence-to-idle and restart-after-idle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f5a61713c3db3f7abb660f7168c8fc608518e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix knowledge graph force simulation CPU pegging by auto-stopping on energy convergence
> - Introduces [`KGSimulationController`](https://github.com/EtanHey/brainlayer/pull/249/files#diff-5ff902bf62411c18b25025ce38c6aa02be451a6c788546a8f62ef3d507e25e2d), a `@MainActor` controller that drives a frame-based loop (33ms per frame), automatically stopping when reported kinetic energy drops below a configurable threshold.
> - [`KGViewModel.tick()`](https://github.com/EtanHey/brainlayer/pull/249/files#diff-384764f4501f07db7b7b86112f3e6290507e8212dd906eddcd72ef885e1f6d8f) now returns total kinetic energy (`CGFloat`) so the controller can detect convergence.
> - [`KGCanvasView`](https://github.com/EtanHey/brainlayer/pull/249/files#diff-f0922477b04e3a45f9e72b62a4a14a34a1ecd464e0da4ce2f9424a3379e55963) replaces its manual `Task`/boolean timer with a `KGSimulationController` instance; `onDisappear` calls `simulation.stop()` to clean up.
> - Tests verify that a stable 3-node graph stops within ~60 frames and that the controller can restart after going idle.
> - Behavioral Change: the simulation loop now terminates on its own when the graph stabilizes rather than running indefinitely, eliminating the CPU peg.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c0f5a61. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->