### PR TITLE
feat(brainbar): restore dashboard flow UI on Phase B main

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -21,6 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var injectionStore: InjectionStore?
     private var quickCapturePanel: QuickCapturePanelController?
     private var searchPanel: SearchPanelController?
+    private var dashboardPanel: BrainBarDashboardPanelController?
     private var quickCaptureHotkey: HotkeyManager?
     private weak var menuBarExtraWindow: NSWindow?
     private weak var discoveredMenuBarWindow: NSWindow?
@@ -48,8 +49,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         if launchMode == .menuBarWindow {
             UserDefaults.standard.removeObject(forKey: Self.menuBarWindowAutosaveKey)
-            installMenuBarWindowObservers()
-            startMenuBarWindowSync()
+            dashboardPanel = BrainBarDashboardPanelController(runtime: runtime)
         }
 
         let runningInstances = NSRunningApplication.runningApplications(
@@ -235,6 +235,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        if let dashboardPanel {
+            dashboardPanel.toggle()
+            return
+        }
+
         if let window = menuBarExtraWindow ?? discoverMenuBarWindow() {
             runtime.windowCoordinator.attach(window: window)
             ensureDefaultMenuBarWindowFrame(window)
@@ -272,7 +277,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func showDashboardPanel() {
+        guard launchMode == .menuBarWindow else {
+            toggleLegacySurface(nil)
+            return
+        }
+
+        dashboardPanel?.show()
+    }
+
     private func showMenuBarWindow(_ sender: Any?) {
+        if launchMode == .menuBarWindow, let dashboardPanel {
+            dashboardPanel.show()
+            return
+        }
+
         if let window = menuBarExtraWindow ?? discoverMenuBarWindow() {
             runtime.windowCoordinator.attach(window: window)
             ensureDefaultMenuBarWindowFrame(window)
@@ -843,13 +862,21 @@ struct BrainBarApp: App {
 
     var body: some Scene {
         MenuBarExtra(isInserted: .constant(launchMode == .menuBarWindow)) {
-            BrainBarWindowRootView(runtime: appDelegate.runtime)
+            Button("Open Dashboard") {
+                appDelegate.showDashboardPanel()
+            }
+
+            Button("Search BrainLayer") {
+                appDelegate.showSearchPanel()
+            }
+
+            Button("Capture Note") {
+                appDelegate.showQuickCapturePanel()
+            }
         } label: {
             BrainBarMenuBarLabel(runtime: appDelegate.runtime)
         }
-        .defaultSize(width: 900, height: 640)
-        .windowResizability(.contentMinSize)
-        .menuBarExtraStyle(.window)
+        .menuBarExtraStyle(.menu)
 
         Settings {
             EmptyView()

--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -1,0 +1,101 @@
+import AppKit
+import SwiftUI
+
+final class BrainBarDashboardPanel: NSPanel {
+    var onEscape: (() -> Void)?
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+
+    override func cancelOperation(_ sender: Any?) {
+        onEscape?()
+    }
+}
+
+@MainActor
+final class BrainBarDashboardPanelController {
+    static let autosaveName = "BrainBarPanel"
+    static let defaultSize = NSSize(width: 1_348, height: 1_078)
+    static let minSize = NSSize(width: 760, height: 560)
+
+    let panelForTesting: BrainBarDashboardPanel
+
+    private let panel: BrainBarDashboardPanel
+    private let runtime: BrainBarRuntime
+
+    init(runtime: BrainBarRuntime) {
+        self.runtime = runtime
+        panel = BrainBarDashboardPanel(
+            contentRect: NSRect(origin: .zero, size: Self.defaultSize),
+            styleMask: [.titled, .resizable, .closable, .nonactivatingPanel, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        panelForTesting = panel
+        configurePanel()
+    }
+
+    func toggle() {
+        if panel.isVisible {
+            dismiss()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        if !panel.isVisible, panel.frame.origin == .zero {
+            centerPanel()
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        panel.makeKeyAndOrderFront(nil)
+        panel.orderFrontRegardless()
+    }
+
+    func dismiss() {
+        panel.orderOut(nil)
+    }
+
+    private func configurePanel() {
+        panel.title = "BrainBar"
+        panel.titleVisibility = .visible
+        panel.titlebarAppearsTransparent = false
+        panel.isMovableByWindowBackground = true
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.minSize = Self.minSize
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .windowBackgroundColor
+        panel.isOpaque = true
+        panel.hasShadow = true
+        panel.onEscape = { [weak self] in
+            self?.dismiss()
+        }
+        let hostingController = NSHostingController(
+            rootView: BrainBarWindowRootView(runtime: runtime, managesWindowFrame: false)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+        hostingController.view.autoresizingMask = [.width, .height]
+        panel.contentViewController = hostingController
+        panel.setFrame(initialFrame(), display: false)
+        panel.setFrameAutosaveName(Self.autosaveName)
+    }
+
+    private func initialFrame() -> NSRect {
+        let size = Self.defaultSize
+        guard let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame else {
+            return NSRect(origin: .zero, size: size)
+        }
+
+        let origin = NSPoint(
+            x: screenFrame.midX - size.width / 2,
+            y: screenFrame.midY - size.height / 2
+        )
+        return NSRect(origin: origin, size: size)
+    }
+
+    private func centerPanel() {
+        panel.setFrame(initialFrame(), display: true)
+    }
+}

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -6,6 +6,8 @@ struct BrainBarWindowRootView: View {
     @ObservedObject var runtime: BrainBarRuntime
 
     @State private var selectedTab: BrainBarTab = .dashboard
+    @State private var hasActivatedInjectionsTab = false
+    @State private var hasActivatedGraphTab = false
     @State private var commandBarPanelState = QuickCapturePanelState()
     @State private var commandBarViewModel: QuickCaptureViewModel?
     @StateObject private var windowObserver: BrainBarWindowObserver
@@ -27,14 +29,18 @@ struct BrainBarWindowRootView: View {
 
             Divider()
 
-            Group {
-                switch selectedTab {
-                case .dashboard:
-                    dashboardContent
-                case .injections:
+            ZStack {
+                dashboardContent
+                    .brainBarTabVisibility(selectedTab == .dashboard)
+
+                if hasActivatedInjectionsTab || selectedTab == .injections {
                     injectionsContent
-                case .graph:
+                        .brainBarTabVisibility(selectedTab == .injections)
+                }
+
+                if hasActivatedGraphTab || selectedTab == .graph {
                     graphContent
+                        .brainBarTabVisibility(selectedTab == .graph)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -63,9 +69,13 @@ struct BrainBarWindowRootView: View {
         })
         .onAppear {
             ensureCommandBarViewModel()
+            activate(tab: selectedTab)
             if let action = runtime.requestedQuickAction {
                 handleRequestedQuickAction(action)
             }
+        }
+        .onChange(of: selectedTab) { _, newTab in
+            activate(tab: newTab)
         }
         .onReceive(runtime.$database) { _ in
             ensureCommandBarViewModel()
@@ -124,6 +134,26 @@ struct BrainBarWindowRootView: View {
         vm.setMode(action == .capture ? .capture : .search)
         vm.panelDidAppear()
         runtime.clearQuickActionRequest()
+    }
+
+    private func activate(tab: BrainBarTab) {
+        switch tab {
+        case .dashboard:
+            break
+        case .injections:
+            hasActivatedInjectionsTab = true
+        case .graph:
+            hasActivatedGraphTab = true
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func brainBarTabVisibility(_ isVisible: Bool) -> some View {
+        opacity(isVisible ? 1 : 0)
+            .allowsHitTesting(isVisible)
+            .accessibilityHidden(!isVisible)
     }
 }
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -9,8 +9,7 @@ struct BrainBarWindowRootView: View {
     @State private var selectedTab: BrainBarTab = .dashboard
     @State private var hasActivatedInjectionsTab = false
     @State private var hasActivatedGraphTab = false
-    @State private var commandBarPanelState = QuickCapturePanelState()
-    @State private var commandBarViewModel: QuickCaptureViewModel?
+    @State private var commandBarProvider = BrainBarCommandBarViewModelProvider()
     @StateObject private var windowObserver: BrainBarWindowObserver
 
     init(runtime: BrainBarRuntime, managesWindowFrame: Bool = true) {
@@ -68,7 +67,6 @@ struct BrainBarWindowRootView: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .background(windowAttachment)
         .onAppear {
-            ensureCommandBarViewModel()
             activate(tab: selectedTab)
             if let action = runtime.requestedQuickAction {
                 handleRequestedQuickAction(action)
@@ -77,8 +75,7 @@ struct BrainBarWindowRootView: View {
         .onChange(of: selectedTab) { _, newTab in
             activate(tab: newTab)
         }
-        .onReceive(runtime.$database) { _ in
-            ensureCommandBarViewModel()
+        .onChange(of: runtime.database != nil, initial: true) { _, _ in
             // DB just became available — replay any pending request that was
             // left in runtime.requestedQuickAction while we were still warming.
             if let action = runtime.requestedQuickAction {
@@ -129,15 +126,13 @@ struct BrainBarWindowRootView: View {
         }
     }
 
-    private func ensureCommandBarViewModel() {
-        guard commandBarViewModel == nil, let database = runtime.database else { return }
-        commandBarViewModel = QuickCaptureViewModel(db: database, panelState: commandBarPanelState)
+    private var commandBarViewModel: QuickCaptureViewModel? {
+        commandBarProvider.viewModel(database: runtime.database)
     }
 
     private func handleRequestedQuickAction(_ action: BrainBarQuickAction) {
-        ensureCommandBarViewModel()
         // If the DB isn't ready yet, leave the request in flight and replay
-        // when `onReceive(runtime.$database)` fires.
+        // when the runtime database readiness token changes.
         guard let vm = commandBarViewModel else { return }
         selectedTab = .dashboard
         vm.setMode(action == .capture ? .capture : .search)
@@ -154,6 +149,20 @@ struct BrainBarWindowRootView: View {
         case .graph:
             hasActivatedGraphTab = true
         }
+    }
+}
+
+@MainActor
+private final class BrainBarCommandBarViewModelProvider {
+    private let panelState = QuickCapturePanelState()
+    private var currentViewModel: QuickCaptureViewModel?
+
+    func viewModel(database: BrainDatabase?) -> QuickCaptureViewModel? {
+        guard let database else { return currentViewModel }
+        if currentViewModel == nil {
+            currentViewModel = QuickCaptureViewModel(db: database, panelState: panelState)
+        }
+        return currentViewModel
     }
 }
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -174,235 +174,496 @@ private struct BrainBarDashboardView: View {
     @ObservedObject var collector: StatsCollector
     let hotkeyStatus: String
 
-    @State private var previousBuckets: [Int] = []
-    @State private var pulseRevision = 0
+    @State private var previousWriteBuckets: [Int] = []
+    @State private var previousEnrichmentBuckets: [Int] = []
+    @State private var writePulseRevision = 0
+    @State private var enrichmentPulseRevision = 0
+    @State private var detailsExpanded = false
 
-    private var livePresentation: BrainBarLivePresentation {
-        BrainBarLivePresentation.derive(stats: collector.stats)
-    }
-
-    private var heroSparkline: NSImage {
-        SparklineRenderer.render(
-            state: collector.state,
-            values: collector.stats.recentEnrichmentBuckets,
-            size: NSSize(width: 360, height: 160),
-            accentColor: livePresentation.accentColor
-        )
+    private var flowSummary: DashboardFlowSummary {
+        DashboardFlowSummary.derive(daemon: collector.daemon, stats: collector.stats)
     }
 
     var body: some View {
         GeometryReader { proxy in
             let layout = BrainBarDashboardLayout(containerSize: proxy.size)
 
-            VStack(spacing: 0) {
-                hero(layout: layout)
-
-                VStack(spacing: layout.sectionSpacing) {
-                    HStack(alignment: .top, spacing: layout.gridSpacing) {
-                        BrainBarMetricCard(
-                            title: "Chunks",
-                            value: "\(collector.stats.chunkCount)",
-                            valueFontSize: layout.metricValueFontSize,
-                            minHeight: layout.metricCardMinHeight,
-                            cardPadding: layout.metricCardPadding
-                        )
-                        BrainBarMetricCard(
-                            title: "Enriched",
-                            value: "\(collector.stats.enrichedChunkCount)",
-                            valueFontSize: layout.metricValueFontSize,
-                            minHeight: layout.metricCardMinHeight,
-                            cardPadding: layout.metricCardPadding
-                        )
-                        BrainBarMetricCard(
-                            title: "Backlog",
-                            value: "\(collector.stats.pendingEnrichmentCount)",
-                            valueFontSize: layout.metricValueFontSize,
-                            minHeight: layout.metricCardMinHeight,
-                            cardPadding: layout.metricCardPadding
-                        )
-                        BrainBarMetricCard(
-                            title: "Last enriched",
-                            value: DashboardMetricFormatter.lastCompletionString(
-                                recentEnrichmentBuckets: collector.stats.recentEnrichmentBuckets
-                            ),
-                            valueFontSize: layout.metricValueFontSize,
-                            minHeight: layout.metricCardMinHeight,
-                            cardPadding: layout.metricCardPadding
-                        )
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: layout.sectionSpacing) {
+                    overviewCard(layout: layout)
+                    chartCards(layout: layout)
+                    agentPresenceStrip(layout: layout)
+                    if layout.usesQueueRail {
+                        queueRail(layout: layout)
                     }
-
-                    HStack(alignment: .top, spacing: layout.infoSpacing) {
-                        BrainBarInfoCard(
-                            title: "Pipeline",
-                            rows: [
-                                ("State", collector.state.label),
-                                (
-                                    "Recent writes",
-                                    DashboardMetricFormatter.activitySummaryString(
-                                        recentActivityBuckets: collector.stats.recentActivityBuckets
-                                    )
-                                ),
-                                ("Coverage", "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched"),
-                                ("DB", ByteCountFormatter.string(
-                                    fromByteCount: collector.stats.databaseSizeBytes,
-                                    countStyle: .file
-                                )),
-                            ]
-                        )
-
-                        BrainBarInfoCard(
-                            title: "Runtime",
-                            rows: [
-                                ("Hotkey", hotkeyStatus),
-                                ("Daemon", daemonSummary),
-                                ("Window", runtimeSummary),
-                            ]
-                        )
-                    }
+                    diagnostics(layout: layout)
                 }
-                .padding(.horizontal, layout.outerPadding)
-                .padding(.top, layout.outerPadding)
-                .padding(.bottom, layout.outerPadding)
+                .padding(layout.outerPadding)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-            .frame(width: proxy.size.width, height: layout.baseHeight, alignment: .top)
-            .scaleEffect(layout.scale, anchor: .top)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
         .onAppear {
-            previousBuckets = collector.stats.recentEnrichmentBuckets
+            previousWriteBuckets = collector.stats.recentActivityBuckets
+            previousEnrichmentBuckets = collector.stats.recentEnrichmentBuckets
+        }
+        .onChange(of: collector.stats.recentActivityBuckets) { _, newBuckets in
+            if BrainBarLivePulse.shouldPulse(previous: previousWriteBuckets, current: newBuckets) {
+                writePulseRevision += 1
+            }
+            previousWriteBuckets = newBuckets
         }
         .onChange(of: collector.stats.recentEnrichmentBuckets) { _, newBuckets in
-            if BrainBarLivePulse.shouldPulse(previous: previousBuckets, current: newBuckets) {
-                pulseRevision += 1
+            if BrainBarLivePulse.shouldPulse(previous: previousEnrichmentBuckets, current: newBuckets) {
+                enrichmentPulseRevision += 1
             }
-            previousBuckets = newBuckets
+            previousEnrichmentBuckets = newBuckets
         }
     }
 
-    private func hero(layout: BrainBarDashboardLayout) -> some View {
-        HStack(alignment: .bottom, spacing: 24) {
-            VStack(alignment: .leading, spacing: 14) {
-                Text("BrainLayer is \(collector.state.label.lowercased())")
-                    .font(.system(size: layout.heroTitleFontSize, weight: .bold))
+    @ViewBuilder
+    private func overviewCard(layout: BrainBarDashboardLayout) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: layout.gridSpacing) {
+                VStack(alignment: .leading, spacing: 12) {
+                    overviewNarrative(layout: layout)
+                    overviewCaption
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                Text(heroSubtitle)
-                    .font(.system(size: layout.heroSubtitleFontSize, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.82))
+                overviewMetaRow(layout: layout)
+                    .frame(width: layout.overviewStatsWidth)
+            }
 
-                HStack(spacing: 10) {
-                    BrainBarHeroBadge(text: livePresentation.badgeText)
-                    BrainBarHeroBadge(text: "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched")
+            VStack(alignment: .leading, spacing: layout.gridSpacing) {
+                overviewNarrative(layout: layout)
+                overviewMetaRow(layout: layout)
+                overviewCaption
+            }
+        }
+        .padding(layout.cardPadding)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(nsColor: .controlBackgroundColor),
+                            Color(nsColor: flowAccentColor).opacity(0.16),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color(nsColor: flowAccentColor).opacity(0.18), lineWidth: 1)
+        )
+    }
+
+    private func overviewNarrative(layout: BrainBarDashboardLayout) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(flowSummary.headline)
+                .font(.system(size: layout.overviewTitleFontSize, weight: .bold))
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(flowSummary.detail)
+                .font(.system(size: layout.overviewSubtitleFontSize, weight: .medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    overviewBadgeRow
                 }
 
-                Text(enrichmentSummary)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.72))
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        BrainBarHeroBadge(text: flowSummary.windowLabel)
+                        BrainBarHeroBadge(text: flowSummary.queue.status.label)
+                    }
+
+                    HStack(spacing: 8) {
+                        BrainBarHeroBadge(text: "Writes \(flowSummary.ingress.lastEventText)")
+                        BrainBarHeroBadge(text: "Enrichments \(flowSummary.enrichment.lastEventText)")
+                    }
+                }
             }
-
-            Spacer(minLength: 24)
-
-            VStack(alignment: .trailing, spacing: 10) {
-                BrainBarHeroSparkline(
-                    image: heroSparkline,
-                    values: collector.stats.recentEnrichmentBuckets,
-                    accentColor: Color(nsColor: livePresentation.accentColor),
-                    pulseRevision: pulseRevision
-                )
-                .frame(width: layout.sparklineWidth, height: layout.sparklineHeight)
-
-                Text(livePresentation.statusText)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.8))
-            }
-        }
-        .padding(.horizontal, layout.heroHorizontalPadding)
-        .padding(.vertical, layout.heroVerticalPadding)
-        .frame(maxWidth: .infinity, minHeight: layout.heroMinHeight, alignment: .leading)
-        .background(
-            LinearGradient(
-                colors: [
-                    Color(nsColor: .windowBackgroundColor),
-                    Color(nsColor: livePresentation.accentColor).opacity(0.88),
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-        )
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(Color.white.opacity(0.12))
-                .frame(height: 1)
         }
     }
 
-    private var heroSubtitle: String {
+    private var overviewCaption: some View {
+        Text("Live uses the last \(collector.stats.liveWindowMinutes)m. Trend cards use \(flowSummary.windowLabel.lowercased()).")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var overviewBadgeRow: some View {
+        Group {
+            BrainBarHeroBadge(text: flowSummary.windowLabel)
+            BrainBarHeroBadge(text: flowSummary.queue.status.label)
+            BrainBarHeroBadge(text: "Writes \(flowSummary.ingress.lastEventText)")
+            BrainBarHeroBadge(text: "Enrichments \(flowSummary.enrichment.lastEventText)")
+        }
+    }
+
+    private func overviewMetaRow(layout: BrainBarDashboardLayout) -> some View {
+        let columns = Array(
+            repeating: GridItem(.flexible(minimum: 130), spacing: layout.gridSpacing, alignment: .leading),
+            count: 2
+        )
+
+        return LazyVGrid(columns: columns, spacing: layout.gridSpacing) {
+            BrainBarOverviewStat(label: "Chunks", value: "\(collector.stats.chunkCount)")
+            BrainBarOverviewStat(label: "Enriched", value: "\(collector.stats.enrichedChunkCount)")
+            BrainBarOverviewStat(label: "Backlog", value: "\(collector.stats.pendingEnrichmentCount)")
+            BrainBarOverviewStat(label: "Coverage", value: "\(Int(collector.stats.enrichmentPercent.rounded()))%")
+        }
+    }
+
+    @ViewBuilder
+    private func chartCards(layout: BrainBarDashboardLayout) -> some View {
+        if layout.chartColumns == 2 {
+            HStack(alignment: .top, spacing: layout.gridSpacing) {
+                writesCard(layout: layout)
+                enrichmentsCard(layout: layout)
+            }
+        } else {
+            VStack(spacing: layout.gridSpacing) {
+                writesCard(layout: layout)
+                enrichmentsCard(layout: layout)
+            }
+        }
+    }
+
+    private func writesCard(layout: BrainBarDashboardLayout) -> some View {
+        BrainBarFlowLaneCard(
+            lane: flowSummary.ingress,
+            pulseRevision: writePulseRevision,
+            compact: layout.compactCards,
+            chartHeight: layout.sparklineHeight,
+            emphasize: true
+        )
+    }
+
+    private func enrichmentsCard(layout: BrainBarDashboardLayout) -> some View {
+        BrainBarFlowLaneCard(
+            lane: flowSummary.enrichment,
+            pulseRevision: enrichmentPulseRevision,
+            compact: layout.compactCards,
+            chartHeight: layout.sparklineHeight,
+            emphasize: true
+        )
+    }
+
+    private func queueRail(layout: BrainBarDashboardLayout) -> some View {
+        BrainBarQueueRail(
+            summary: flowSummary.queue,
+            coverageText: "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched",
+            compact: layout.compactCards
+        )
+    }
+
+    private func agentPresenceStrip(layout: BrainBarDashboardLayout) -> some View {
+        BrainBarAgentPresenceStrip(
+            activity: collector.agentActivity,
+            compact: layout.compactCards
+        )
+    }
+
+    @ViewBuilder
+    private func diagnostics(layout: BrainBarDashboardLayout) -> some View {
+        let flowCard = BrainBarDiagnosticCard(
+            title: "Flow",
+            rows: [
+                ("Writes", flowSummary.ingress.statusText),
+                ("Enrichment", flowSummary.enrichment.statusText),
+                ("Queue", flowSummary.queue.title),
+                ("Window", flowSummary.windowLabel),
+                ("DB", ByteCountFormatter.string(
+                    fromByteCount: collector.stats.databaseSizeBytes,
+                    countStyle: .file
+                )),
+            ],
+            columns: layout.diagnosticItemColumns
+        )
+
+        let runtimeCard = BrainBarDiagnosticCard(
+            title: "Runtime",
+            rows: [
+                ("Hotkey", hotkeyStatus),
+                ("Daemon", daemonSummary),
+                ("Agents", collector.agentActivity.summaryText),
+                ("State", collector.state.label),
+                ("Last seen", daemonLastSeenSummary),
+            ],
+            columns: layout.diagnosticItemColumns
+        )
+
+        VStack(alignment: .leading, spacing: 12) {
+            DisclosureGroup(isExpanded: $detailsExpanded) {
+                Group {
+                    if layout.diagnosticColumns == 2 {
+                        HStack(alignment: .top, spacing: layout.gridSpacing) {
+                            flowCard
+                            runtimeCard
+                        }
+                    } else {
+                        VStack(spacing: layout.gridSpacing) {
+                            flowCard
+                            runtimeCard
+                        }
+                    }
+                }
+                .padding(.top, 4)
+            } label: {
+                HStack(alignment: .center, spacing: 12) {
+                    Text("Runtime & Details")
+                        .font(.system(size: 14, weight: .semibold))
+                    Spacer(minLength: 8)
+                    Text("\(daemonSummary) · \(ByteCountFormatter.string(fromByteCount: collector.stats.databaseSizeBytes, countStyle: .file))")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(BrainBarDashboardCardStyle())
+    }
+
+    private var flowAccentColor: NSColor {
         switch collector.state {
         case .indexing:
-            return "Incoming writes are landing and enrichment is keeping pace."
+            return .systemBlue
         case .enriching:
-            return "Backlog is draining through the current enrichment stream."
+            return .systemGreen
         case .idle:
-            return "No fresh completions in the last minute. Window stays ready in the menu bar."
+            return .systemGray
         case .degraded:
-            return "The pipeline needs attention before live stats are trustworthy."
+            return .systemOrange
         }
-    }
-
-    private var enrichmentSummary: String {
-        let recentCompletions = collector.stats.recentEnrichmentBuckets.reduce(0, +)
-        if recentCompletions == 0 {
-            return "No completions in the last 30 minutes."
-        }
-        return "\(recentCompletions) completions in the last 30 minutes."
     }
 
     private var daemonSummary: String {
-        guard let daemon = collector.daemon else { return "Unavailable" }
+        guard let daemon = collector.daemon else { return "unavailable" }
         return "PID \(daemon.pid) · \(daemon.openConnections) sockets"
     }
 
-    private var runtimeSummary: String {
-        livePresentation.badgeText == "idle" ? "Hidden until reopened" : "Active live-state"
+    private var daemonLastSeenSummary: String {
+        guard let daemon = collector.daemon else { return "Unavailable" }
+        return DashboardMetricFormatter.lastEventString(
+            lastEventAt: daemon.lastSeenAt,
+            activityWindowMinutes: collector.stats.activityWindowMinutes
+        )
+    }
+}
+
+private struct BrainBarFlowLaneCard: View {
+    let lane: DashboardFlowLane
+    let pulseRevision: Int
+    let compact: Bool
+    let chartHeight: CGFloat
+    let emphasize: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 10 : 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(lane.name)
+                        .font(.system(size: emphasize ? (compact ? 16 : 18) : (compact ? 15 : 16), weight: .semibold))
+                    Text(lane.windowLabel)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 12)
+                BrainBarFlowStatusPill(
+                    text: lane.status.label,
+                    accentColor: Color(nsColor: lane.accentColor)
+                )
+            }
+
+            BrainBarHeroSparkline(
+                values: lane.values,
+                accentColor: lane.accentColor,
+                pulseRevision: pulseRevision
+            )
+            .frame(height: chartHeight)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 12) {
+                    BrainBarLaneMetric(label: "Rate", value: lane.rateText)
+                    BrainBarLaneMetric(label: "Volume", value: lane.volumeText)
+                    BrainBarLaneMetric(label: "Last event", value: lane.lastEventText)
+                    Spacer(minLength: 0)
+                }
+
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 12) {
+                        BrainBarLaneMetric(label: "Rate", value: lane.rateText)
+                        BrainBarLaneMetric(label: "Volume", value: lane.volumeText)
+                        Spacer(minLength: 0)
+                    }
+                    BrainBarLaneMetric(label: "Last event", value: lane.lastEventText)
+                }
+            }
+
+            Text(lane.statusText)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(compact ? 16 : 18)
+        .background(BrainBarDashboardCardStyle(emphasized: emphasize))
+    }
+}
+
+private struct BrainBarQueueRail: View {
+    let summary: DashboardQueueSummary
+    let coverageText: String
+    let compact: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 6 : 8) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center, spacing: 12) {
+                    queueHeader
+                    Spacer(minLength: 8)
+                    queueMetrics
+                }
+
+                VStack(alignment: .leading, spacing: compact ? 6 : 8) {
+                    queueHeader
+                    queueMetrics
+                }
+            }
+
+            Text(summary.detail)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(compact ? 10 : 12)
+        .background(BrainBarDashboardCardStyle())
+    }
+
+    private var queueHeader: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Label("Queue", systemImage: directionSymbolName)
+                .font(.system(size: compact ? 12 : 13, weight: .semibold))
+                .foregroundStyle(queueColor)
+
+            BrainBarFlowStatusPill(
+                text: summary.status.label,
+                accentColor: queueColor
+            )
+        }
+    }
+
+    private var queueMetrics: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 14) {
+                BrainBarLaneMetric(label: "Backlog", value: "\(summary.backlogCount)")
+                BrainBarLaneMetric(label: "Coverage", value: coverageText)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                BrainBarLaneMetric(label: "Backlog", value: "\(summary.backlogCount)")
+                BrainBarLaneMetric(label: "Coverage", value: coverageText)
+            }
+        }
+    }
+
+    private var queueColor: Color {
+        switch summary.status {
+        case .empty, .stable:
+            return Color(nsColor: .systemTeal)
+        case .draining:
+            return Color(nsColor: .systemGreen)
+        case .growing, .backlogged:
+            return Color(nsColor: .systemOrange)
+        case .unavailable:
+            return Color(nsColor: .systemRed)
+        }
+    }
+
+    private var directionSymbolName: String {
+        switch summary.status {
+        case .empty, .stable:
+            return "arrow.left.and.right"
+        case .draining:
+            return "arrow.down.right"
+        case .growing, .backlogged:
+            return "arrow.up.right"
+        case .unavailable:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    private var directionText: String {
+        switch summary.status {
+        case .empty:
+            return "Empty"
+        case .stable:
+            return "Balanced"
+        case .growing:
+            return "Growing"
+        case .draining:
+            return "Draining"
+        case .backlogged:
+            return "Stalled"
+        case .unavailable:
+            return "Offline"
+        }
     }
 }
 
 struct BrainBarDashboardLayout {
-    let baseHeight: CGFloat
-    let scale: CGFloat
+    let chartColumns: Int
+    let overviewMetricColumns: Int
+    let diagnosticColumns: Int
+    let diagnosticItemColumns: Int
+    let usesQueueRail: Bool
+    let compactCards: Bool
     let outerPadding: CGFloat
     let sectionSpacing: CGFloat
     let gridSpacing: CGFloat
-    let infoSpacing: CGFloat
-    let heroMinHeight: CGFloat
-    let heroHorizontalPadding: CGFloat
-    let heroVerticalPadding: CGFloat
-    let heroTitleFontSize: CGFloat
-    let heroSubtitleFontSize: CGFloat
+    let cardPadding: CGFloat
+    let overviewTitleFontSize: CGFloat
+    let overviewSubtitleFontSize: CGFloat
+    let overviewStatsWidth: CGFloat
     let metricCardMinHeight: CGFloat
-    let metricCardPadding: CGFloat
     let metricValueFontSize: CGFloat
-    let sparklineWidth: CGFloat
     let sparklineHeight: CGFloat
 
     init(containerSize: CGSize) {
-        let compact = containerSize.height < 620 || containerSize.width < 900
+        let compactHeight = containerSize.height < 620
+        let compactWidth = containerSize.width < 920
 
-        baseHeight = compact ? 520 : 584
-        scale = min(1, max(0.84, containerSize.height / baseHeight))
-        outerPadding = compact ? 14 : 20
-        sectionSpacing = compact ? 14 : 20
-        gridSpacing = compact ? 10 : 14
-        infoSpacing = compact ? 10 : 14
-        heroMinHeight = compact ? 188 : 220
-        heroHorizontalPadding = compact ? 20 : 24
-        heroVerticalPadding = compact ? 20 : 26
-        heroTitleFontSize = compact ? 24 : 28
-        heroSubtitleFontSize = compact ? 13 : 14
-        metricCardMinHeight = compact ? 74 : 86
-        metricCardPadding = compact ? 12 : 16
-        metricValueFontSize = compact ? 20 : 24
-        sparklineWidth = compact ? 280 : 320
-        sparklineHeight = compact ? 128 : 150
+        chartColumns = containerSize.width >= 980 ? 2 : 1
+        overviewMetricColumns = containerSize.width >= 980 ? 4 : 2
+        diagnosticColumns = containerSize.width >= 960 ? 2 : 1
+        diagnosticItemColumns = containerSize.width >= 820 ? 2 : 1
+        usesQueueRail = true
+
+        compactCards = compactWidth || compactHeight
+        outerPadding = compactCards ? 14 : 18
+        sectionSpacing = compactCards ? 12 : 16
+        gridSpacing = compactCards ? 10 : 14
+        cardPadding = compactCards ? 12 : 16
+        overviewTitleFontSize = compactCards ? 20 : 24
+        overviewSubtitleFontSize = compactCards ? 13 : 14
+        overviewStatsWidth = compactCards ? 292 : 340
+        metricCardMinHeight = compactCards ? 70 : 82
+        metricValueFontSize = compactCards ? 20 : 24
+        sparklineHeight = compactCards ? 102 : 116
     }
 }
 
@@ -457,33 +718,49 @@ private struct BrainBarMetricCard: View {
     }
 }
 
-private struct BrainBarInfoCard: View {
-    let title: String
-    let rows: [(String, String)]
+private struct BrainBarLaneMetric: View {
+    let label: String
+    let value: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+    }
+}
+
+private struct BrainBarDiagnosticCard: View {
+    let title: String
+    let rows: [(String, String)]
+    let columns: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(.system(size: 14, weight: .semibold))
 
-            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                HStack(alignment: .top) {
-                    Text(row.0)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.secondary)
-                    Spacer(minLength: 16)
-                    Text(row.1)
-                        .font(.system(size: 12, weight: .medium))
-                        .multilineTextAlignment(.trailing)
+            LazyVGrid(
+                columns: Array(
+                    repeating: GridItem(.flexible(minimum: 150), spacing: 10, alignment: .leading),
+                    count: columns
+                ),
+                alignment: .leading,
+                spacing: 10
+            ) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    BrainBarDiagnosticTile(label: row.0, value: row.1)
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(18)
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor))
-        )
+        .padding(14)
+        .background(BrainBarDashboardCardStyle())
     }
 }
 
@@ -499,10 +776,173 @@ private struct BrainBarHeroBadge: View {
     }
 }
 
-private struct BrainBarHeroSparkline: View {
-    let image: NSImage
-    let values: [Int]
+private struct BrainBarOverviewStat: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .lineLimit(1)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 11)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color(nsColor: .windowBackgroundColor).opacity(0.66))
+        )
+    }
+}
+
+private struct BrainBarAgentPresenceStrip: View {
+    let activity: AgentActivitySnapshot
+    let compact: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 8 : 10) {
+            HStack(alignment: .center, spacing: 12) {
+                Text("Live agents")
+                    .font(.system(size: compact ? 13 : 14, weight: .semibold))
+                Spacer(minLength: 8)
+                Text(activity.summaryText)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    ForEach(activity.presences, id: \.family) { presence in
+                        BrainBarAgentPresencePill(presence: presence)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(activity.presences, id: \.family) { presence in
+                        BrainBarAgentPresencePill(presence: presence)
+                    }
+                }
+            }
+
+            Text("Agent presence is separate from indexed writes. A live CLI does not imply new chunks landed.")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(compact ? 12 : 14)
+        .background(BrainBarDashboardCardStyle())
+    }
+}
+
+private struct BrainBarAgentPresencePill: View {
+    let presence: AgentPresence
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(Color(nsColor: presence.family.accentColor))
+                .frame(width: 8, height: 8)
+                .opacity(presence.isActive ? 1 : 0.25)
+            Text(presence.family.label)
+                .font(.system(size: 11, weight: .semibold))
+            Text("\(presence.count)")
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(
+                    Capsule()
+                        .fill(Color(nsColor: presence.family.accentColor).opacity(presence.isActive ? 0.18 : 0.08))
+                )
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            Capsule()
+                .fill(Color(nsColor: .windowBackgroundColor).opacity(0.66))
+        )
+        .overlay(
+            Capsule()
+                .stroke(Color(nsColor: presence.family.accentColor).opacity(presence.isActive ? 0.28 : 0.1), lineWidth: 1)
+        )
+    }
+}
+
+private struct BrainBarDiagnosticTile: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 12, weight: .semibold))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color(nsColor: .windowBackgroundColor).opacity(0.56))
+        )
+    }
+}
+
+private struct BrainBarDashboardCardStyle: View {
+    var emphasized = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: emphasized
+                        ? [
+                            Color(nsColor: .controlBackgroundColor).opacity(0.98),
+                            Color(nsColor: .windowBackgroundColor).opacity(0.92),
+                        ]
+                        : [
+                            Color(nsColor: .controlBackgroundColor).opacity(0.96),
+                            Color(nsColor: .controlBackgroundColor).opacity(0.94),
+                        ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.white.opacity(emphasized ? 0.08 : 0.04), lineWidth: 1)
+            )
+    }
+}
+
+private struct BrainBarFlowStatusPill: View {
+    let text: String
     let accentColor: Color
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(accentColor.opacity(0.16), in: Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(accentColor.opacity(0.28), lineWidth: 1)
+            )
+    }
+}
+
+private struct BrainBarHeroSparkline: View {
+    let values: [Int]
+    let accentColor: NSColor
     let pulseRevision: Int
 
     @State private var ringScale: CGFloat = 0.8
@@ -510,16 +950,26 @@ private struct BrainBarHeroSparkline: View {
 
     var body: some View {
         GeometryReader { proxy in
+            let renderSize = NSSize(
+                width: max(proxy.size.width.rounded(.up), 1),
+                height: max(proxy.size.height.rounded(.up), 1)
+            )
+            let image = SparklineRenderer.render(
+                state: .idle,
+                values: values,
+                size: renderSize,
+                accentColor: accentColor
+            )
             let endpoint = SparklineRenderer.endpoint(
                 values: values,
-                size: NSSize(width: proxy.size.width, height: proxy.size.height)
+                size: renderSize
             )
 
             ZStack(alignment: .topLeading) {
                 Image(nsImage: image)
                     .interpolation(.high)
                     .resizable()
-                    .scaledToFit()
+                    .frame(width: proxy.size.width, height: proxy.size.height)
 
                 if let endpoint {
                     let point = CGPoint(
@@ -528,16 +978,16 @@ private struct BrainBarHeroSparkline: View {
                     )
 
                     Circle()
-                        .stroke(accentColor.opacity(0.45), lineWidth: 2)
+                        .stroke(Color(nsColor: accentColor).opacity(0.45), lineWidth: 2)
                         .frame(width: 26, height: 26)
                         .scaleEffect(ringScale)
                         .opacity(ringOpacity)
                         .position(point)
 
                     Circle()
-                        .fill(accentColor)
+                        .fill(Color(nsColor: accentColor))
                         .frame(width: 9, height: 9)
-                        .shadow(color: accentColor.opacity(0.65), radius: 6)
+                        .shadow(color: Color(nsColor: accentColor).opacity(0.65), radius: 6)
                         .position(point)
                 }
             }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct BrainBarWindowRootView: View {
     @ObservedObject var runtime: BrainBarRuntime
+    private let managesWindowFrame: Bool
 
     @State private var selectedTab: BrainBarTab = .dashboard
     @State private var hasActivatedInjectionsTab = false
@@ -12,8 +13,9 @@ struct BrainBarWindowRootView: View {
     @State private var commandBarViewModel: QuickCaptureViewModel?
     @StateObject private var windowObserver: BrainBarWindowObserver
 
-    init(runtime: BrainBarRuntime) {
+    init(runtime: BrainBarRuntime, managesWindowFrame: Bool = true) {
         self.runtime = runtime
+        self.managesWindowFrame = managesWindowFrame
         _windowObserver = StateObject(
             wrappedValue: BrainBarWindowObserver(coordinator: runtime.windowCoordinator)
         )
@@ -57,16 +59,14 @@ struct BrainBarWindowRootView: View {
         .frame(
             minWidth: 760,
             idealWidth: 900,
-            maxWidth: 1_600,
+            maxWidth: .infinity,
             minHeight: 560,
             idealHeight: 640,
-            maxHeight: 1_200
+            maxHeight: .infinity
         )
-        .opacity(windowObserver.isContentReady ? 1 : 0)
+        .opacity(managesWindowFrame ? (windowObserver.isContentReady ? 1 : 0) : 1)
         .background(Color(nsColor: .windowBackgroundColor))
-        .background(WindowAttachmentView { window in
-            windowObserver.attach(window: window)
-        })
+        .background(windowAttachment)
         .onAppear {
             ensureCommandBarViewModel()
             activate(tab: selectedTab)
@@ -87,6 +87,15 @@ struct BrainBarWindowRootView: View {
         }
         .onReceive(runtime.$requestedQuickAction.compactMap { $0 }) { action in
             handleRequestedQuickAction(action)
+        }
+    }
+
+    @ViewBuilder
+    private var windowAttachment: some View {
+        if managesWindowFrame {
+            WindowAttachmentView { window in
+                windowObserver.attach(window: window)
+            }
         }
     }
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowState.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowState.swift
@@ -54,19 +54,23 @@ struct BrainBarLivePresentation: Equatable {
     let badgeText: String
     let statusText: String
 
-    static func derive(stats: BrainDatabase.DashboardStats) -> BrainBarLivePresentation {
-        if stats.enrichmentRatePerMinute > 0 {
+    static func derive(stats: BrainDatabase.DashboardStats, now: Date = Date()) -> BrainBarLivePresentation {
+        if stats.eventIsLive(stats.lastEnrichedAt, now: now) {
             return BrainBarLivePresentation(
                 sparklineStyle: .active,
-                badgeText: DashboardMetricFormatter.liveBadgeString(ratePerMinute: stats.enrichmentRatePerMinute),
-                statusText: "Live enrichment stream"
+                badgeText: "live now",
+                statusText: "Enrichments in the last 60s"
             )
         }
 
         return BrainBarLivePresentation(
             sparklineStyle: .idle,
-            badgeText: "idle",
-            statusText: "Idle — no enrichment in last 60s"
+            badgeText: DashboardMetricFormatter.lastEventString(
+                lastEventAt: stats.lastEnrichedAt,
+                activityWindowMinutes: stats.activityWindowMinutes,
+                now: now
+            ),
+            statusText: "No enrichments in the last 60s"
         )
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -15,12 +15,19 @@ final class BrainDatabase: @unchecked Sendable {
     private static let ftsColumns = "content, summary, tags, resolved_query, chunk_id UNINDEXED"
     private static let ftsOptions = "prefix='2 3 4', tokenize='unicode61 remove_diacritics 2'"
     private static let trigramFTSOptions = "tokenize='trigram'"
+    private static let synchronousTrigramBackfillChunkLimit = 10_000
     private static let defaultPendingStoreMaxLines = 10_000
     private static let pendingStoreMaxLinesEnv = "BRAINBAR_PENDING_STORES_MAX_LINES"
     private static let lexicalDefenseReplacements: [String: [String]] = [
         "hershkovitz": ["Hershkovits"],
         "hershkovits": ["Hershkovitz"]
     ]
+
+    enum TrigramStartupRepairDecision: Equatable {
+        case noRepairNeeded
+        case rebuildSynchronously
+        case skipBackfill
+    }
 
     struct DashboardStats: Sendable, Equatable {
         let chunkCount: Int
@@ -1899,16 +1906,17 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func rebuildTrigramFTSTable() throws {
+        try ensureTrigramFTSSchemaAndTriggers()
+        try execute("DELETE FROM chunks_fts_trigram")
+        try backfillTrigramFTSTable()
+    }
+
+    private func ensureTrigramFTSSchemaAndTriggers() throws {
         try execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts_trigram USING fts5(
                 \(Self.ftsColumns),
                 \(Self.trigramFTSOptions)
             )
-        """)
-        try execute("DELETE FROM chunks_fts_trigram")
-        try execute("""
-            INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
-            SELECT content, summary, tags, NULL, id FROM chunks
         """)
 
         try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_insert")
@@ -1936,26 +1944,69 @@ final class BrainDatabase: @unchecked Sendable {
         """)
     }
 
+    private func backfillTrigramFTSTable() throws {
+        try execute("""
+            INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
+            SELECT content, summary, tags, NULL, id FROM chunks
+        """)
+    }
+
     private func rebuildTrigramFTSTableIfNeeded() throws {
-        if try trigramFTSTableNeedsRebuild() {
+        let status = try trigramFTSStatus()
+        let decision = Self.trigramStartupRepairDecision(
+            tableExists: status.tableExists,
+            schemaIsValid: status.schemaIsValid,
+            chunkCount: status.chunkCount,
+            trigramCount: status.trigramCount
+        )
+
+        switch decision {
+        case .noRepairNeeded:
+            try ensureTrigramFTSSchemaAndTriggers()
+        case .rebuildSynchronously:
             try rebuildTrigramFTSTable()
+        case .skipBackfill:
+            try ensureTrigramFTSSchemaAndTriggers()
+            NSLog(
+                "[BrainBar] Skipping synchronous trigram FTS backfill at startup — chunks=%d trigram=%d. Run explicit maintenance to backfill.",
+                status.chunkCount,
+                status.trigramCount
+            )
         }
     }
 
-    private func trigramFTSTableNeedsRebuild() throws -> Bool {
-        guard let db else { throw DBError.notOpen }
-        guard let sql = try sqliteMasterSQL(name: "chunks_fts_trigram", on: db) else { return true }
-        let normalizedSQL = sql.lowercased()
-        guard normalizedSQL.contains("tokenize='trigram'"),
-              normalizedSQL.contains("summary"),
-              normalizedSQL.contains("resolved_query")
-        else {
-            return true
+    static func trigramStartupRepairDecision(
+        tableExists: Bool,
+        schemaIsValid: Bool,
+        chunkCount: Int,
+        trigramCount: Int
+    ) -> TrigramStartupRepairDecision {
+        if !tableExists || !schemaIsValid {
+            return .rebuildSynchronously
         }
+        if chunkCount == trigramCount {
+            return .noRepairNeeded
+        }
+        if chunkCount <= synchronousTrigramBackfillChunkLimit {
+            return .rebuildSynchronously
+        }
+        return .skipBackfill
+    }
+
+    private func trigramFTSStatus() throws -> (tableExists: Bool, schemaIsValid: Bool, chunkCount: Int, trigramCount: Int) {
+        guard let db else { throw DBError.notOpen }
+        guard let sql = try sqliteMasterSQL(name: "chunks_fts_trigram", on: db) else {
+            let chunkCount = try countRows(in: "chunks")
+            return (false, false, chunkCount, 0)
+        }
+        let normalizedSQL = sql.lowercased()
+        let schemaIsValid = normalizedSQL.contains("tokenize='trigram'") &&
+            normalizedSQL.contains("summary") &&
+            normalizedSQL.contains("resolved_query")
 
         let chunkCount = try countRows(in: "chunks")
         let trigramCount = try countRows(in: "chunks_fts_trigram")
-        return chunkCount != trigramCount
+        return (true, schemaIsValid, chunkCount, trigramCount)
     }
 
     private func countRows(in tableName: String) throws -> Int {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -14,8 +14,13 @@ final class BrainDatabase: @unchecked Sendable {
     """
     private static let ftsColumns = "content, summary, tags, resolved_query, chunk_id UNINDEXED"
     private static let ftsOptions = "prefix='2 3 4', tokenize='unicode61 remove_diacritics 2'"
+    private static let trigramFTSOptions = "tokenize='trigram'"
     private static let defaultPendingStoreMaxLines = 10_000
     private static let pendingStoreMaxLinesEnv = "BRAINBAR_PENDING_STORES_MAX_LINES"
+    private static let lexicalDefenseReplacements: [String: [String]] = [
+        "hershkovitz": ["Hershkovits"],
+        "hershkovits": ["Hershkovitz"]
+    ]
 
     struct DashboardStats: Sendable, Equatable {
         let chunkCount: Int
@@ -243,6 +248,7 @@ final class BrainDatabase: @unchecked Sendable {
         try ensureChunkColumns()
         try ensurePreviewTextTriggers()
         try rebuildFTSTableIfNeeded()
+        try rebuildTrigramFTSTable()
         try backfillPreviewText()
 
         try execute("""
@@ -321,8 +327,30 @@ final class BrainDatabase: @unchecked Sendable {
         """)
 
         try execute("""
+            CREATE TABLE IF NOT EXISTS kg_entity_aliases (
+                alias TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                alias_type TEXT DEFAULT 'name',
+                created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                valid_from TEXT,
+                valid_to TEXT,
+                PRIMARY KEY (alias, entity_id)
+            )
+        """)
+
+        try execute("""
             CREATE INDEX IF NOT EXISTS idx_kg_ec_entity
             ON kg_entity_chunks(entity_id)
+        """)
+
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_kg_alias_lookup
+            ON kg_entity_aliases(alias COLLATE NOCASE)
+        """)
+
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_kg_alias_entity
+            ON kg_entity_aliases(entity_id)
         """)
 
         try execute("""
@@ -361,8 +389,11 @@ final class BrainDatabase: @unchecked Sendable {
             WHERE relation_type != 'co_occurs_with'
         """)
 
+        try ensureChunkColumns()
         try ensurePendingStoreQueueIndex()
         try ensureKGEntityColumns()
+        try ensureKGEntityAliasTable()
+        try rebuildTrigramFTSTableIfNeeded()
     }
 
     func close() {
@@ -442,8 +473,8 @@ final class BrainDatabase: @unchecked Sendable {
         subscriberID: String? = nil,
         unreadOnly: Bool = false
     ) throws -> [[String: Any]] {
-        guard let db else { throw DBError.notOpen }
-        let sanitized = sanitizeFTS5Query(query)
+        guard db != nil else { throw DBError.notOpen }
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
         var subscribedTags: [String] = []
         var ackFloor: Int64 = 0
@@ -452,7 +483,84 @@ final class BrainDatabase: @unchecked Sendable {
             ackFloor = record.lastAckedSeq
         }
 
-        var conditions = ["chunks_fts MATCH ?"]
+        if !unreadOnly,
+           let exact = try exactChunkIDSearchResult(
+               query: trimmedQuery,
+               limit: limit,
+               project: project,
+               tag: tag,
+               importanceMin: importanceMin
+           ) {
+            return exact
+        }
+
+        let expandedQueries = expandedSearchQueries(trimmedQuery)
+        var results: [[String: Any]] = []
+        var seenChunkIDs = Set<String>()
+        var maxRowID: Int64 = 0
+
+        for expandedQuery in expandedQueries {
+            let searchResult = try runFTSSearch(
+                tableName: "chunks_fts",
+                matchQuery: sanitizeFTS5Query(expandedQuery),
+                limit: max(limit, 1),
+                project: project,
+                tag: tag,
+                importanceMin: importanceMin,
+                subscribedTags: subscribedTags,
+                ackFloor: ackFloor,
+                unreadOnly: unreadOnly
+            )
+            maxRowID = max(maxRowID, searchResult.maxRowID)
+            appendDeduped(searchResult.rows, to: &results, seenChunkIDs: &seenChunkIDs, limit: limit)
+            if results.count >= limit { break }
+        }
+
+        if results.count < limit {
+            for expandedQuery in expandedQueries {
+                let trigramQuery = sanitizeTrigramFTS5Query(expandedQuery)
+                guard !trigramQuery.isEmpty else { continue }
+                let searchResult = try runFTSSearch(
+                    tableName: "chunks_fts_trigram",
+                    matchQuery: trigramQuery,
+                    limit: max(limit, 1),
+                    project: project,
+                    tag: tag,
+                    importanceMin: importanceMin,
+                    subscribedTags: subscribedTags,
+                    ackFloor: ackFloor,
+                    unreadOnly: unreadOnly
+                )
+                maxRowID = max(maxRowID, searchResult.maxRowID)
+                appendDeduped(searchResult.rows, to: &results, seenChunkIDs: &seenChunkIDs, limit: limit)
+                if results.count >= limit { break }
+            }
+        }
+
+        if unreadOnly, let subscriberID, maxRowID > 0 {
+            try markDelivered(agentID: subscriberID, seq: maxRowID)
+        }
+
+        return results
+    }
+
+    private func runFTSSearch(
+        tableName: String,
+        matchQuery: String,
+        limit: Int,
+        project: String?,
+        tag: String?,
+        importanceMin: Double?,
+        subscribedTags: [String],
+        ackFloor: Int64,
+        unreadOnly: Bool
+    ) throws -> (rows: [[String: Any]], maxRowID: Int64) {
+        guard let db else { throw DBError.notOpen }
+        let allowedTables = ["chunks_fts", "chunks_fts_trigram"]
+        guard allowedTables.contains(tableName) else { throw DBError.exec(SQLITE_ERROR, "invalid FTS table") }
+
+        var subscribedTags = subscribedTags
+        var conditions = ["\(tableName) MATCH ?"]
         if project != nil { conditions.append("c.project = ?") }
         if let explicitTag = tag {
             conditions.append("c.tags LIKE ?")
@@ -470,7 +578,7 @@ final class BrainDatabase: @unchecked Sendable {
         let sql = """
             SELECT c.rowid, c.id, c.content, c.project, c.content_type, c.importance,
                    c.created_at, c.summary, c.tags, c.conversation_id, f.rank
-            FROM chunks_fts f
+            FROM \(tableName) f
             JOIN chunks c ON c.id = f.chunk_id
             WHERE \(conditions.joined(separator: " AND "))
             ORDER BY \(orderByClause)
@@ -483,7 +591,7 @@ final class BrainDatabase: @unchecked Sendable {
         defer { sqlite3_finalize(stmt) }
 
         var paramIdx: Int32 = 1
-        bindText(sanitized, to: stmt, index: paramIdx)
+        bindText(matchQuery, to: stmt, index: paramIdx)
         paramIdx += 1
         if let project {
             bindText(project, to: stmt, index: paramIdx)
@@ -516,27 +624,10 @@ final class BrainDatabase: @unchecked Sendable {
             // FTS5 rank is negative (lower = better match). Negate for a positive score.
             let rawRank = sqlite3_column_double(stmt, 10)
             let score = max(0, -rawRank)
-            results.append([
-                "rowid": Int(rowID),
-                "chunk_id": columnText(stmt, 1) as Any,
-                "content": columnText(stmt, 2) as Any,
-                "project": columnText(stmt, 3) as Any,
-                "content_type": columnText(stmt, 4) as Any,
-                "importance": sqlite3_column_double(stmt, 5),
-                "created_at": columnText(stmt, 6) as Any,
-                "summary": columnText(stmt, 7) as Any,
-                "preview_text": Self.previewText(summary: columnText(stmt, 7), content: columnText(stmt, 2)),
-                "tags": columnText(stmt, 8) as Any,
-                "session_id": columnText(stmt, 9) as Any,
-                "score": score
-            ])
+            results.append(searchRow(from: stmt, score: score))
         }
 
-        if unreadOnly, let subscriberID, maxRowID > 0 {
-            try markDelivered(agentID: subscriberID, seq: maxRowID)
-        }
-
-        return results
+        return (results, maxRowID)
     }
 
     func store(
@@ -1494,9 +1585,193 @@ final class BrainDatabase: @unchecked Sendable {
         return tokens.joined(separator: " ")
     }
 
+    private func sanitizeTrigramFTS5Query(_ query: String) -> String {
+        let cleaned = query
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "*", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return "" }
+        return "\"\(cleaned)\""
+    }
+
+    private func expandedSearchQueries(_ query: String) -> [String] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var variants = [trimmed]
+        let tokens = trimmed.split(separator: " ").map(String.init)
+        for token in tokens {
+            let replacements = lexicalDefenseReplacements(for: token) + kgAliasReplacements(for: token)
+            for replacement in replacements where replacement != token {
+                variants.append(replaceToken(token, with: replacement, in: trimmed))
+            }
+        }
+
+        var seen = Set<String>()
+        return variants.filter { seen.insert($0.lowercased()).inserted }
+    }
+
+    private func lexicalDefenseReplacements(for token: String) -> [String] {
+        let normalized = token
+            .trimmingCharacters(in: .punctuationCharacters.union(.whitespacesAndNewlines))
+            .lowercased()
+        return Self.lexicalDefenseReplacements[normalized] ?? []
+    }
+
+    private func kgAliasReplacements(for token: String) -> [String] {
+        guard let db else { return [] }
+        let normalized = normalizedAliasSurface(token)
+        guard normalized.count >= 3 else { return [] }
+
+        let sql = """
+            SELECT name FROM kg_entities
+            WHERE lower(replace(replace(replace(replace(name, '-', ''), '_', ''), '.', ''), ' ', '')) = ?
+            UNION
+            SELECT alias FROM kg_entity_aliases
+            WHERE lower(replace(replace(replace(replace(alias, '-', ''), '_', ''), '.', ''), ' ', '')) = ?
+            UNION
+            SELECT e.name
+            FROM kg_entity_aliases a
+            JOIN kg_entities e ON e.id = a.entity_id
+            WHERE lower(replace(replace(replace(replace(a.alias, '-', ''), '_', ''), '.', ''), ' ', '')) = ?
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+        defer { sqlite3_finalize(stmt) }
+        bindText(normalized, to: stmt, index: 1)
+        bindText(normalized, to: stmt, index: 2)
+        bindText(normalized, to: stmt, index: 3)
+
+        var replacements: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let value = columnText(stmt, 0), !value.isEmpty {
+                replacements.append(value)
+            }
+        }
+        return replacements
+    }
+
+    private func normalizedAliasSurface(_ value: String) -> String {
+        value
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: ".", with: "")
+            .replacingOccurrences(of: " ", with: "")
+    }
+
+    private func replaceToken(_ token: String, with replacement: String, in query: String) -> String {
+        guard let range = query.range(of: token) else { return query }
+        var copy = query
+        copy.replaceSubrange(range, with: replacement)
+        return copy
+    }
+
+    private func appendDeduped(
+        _ rows: [[String: Any]],
+        to results: inout [[String: Any]],
+        seenChunkIDs: inout Set<String>,
+        limit: Int
+    ) {
+        for row in rows {
+            guard results.count < limit else { return }
+            guard let chunkID = row["chunk_id"] as? String else { continue }
+            if seenChunkIDs.insert(chunkID).inserted {
+                results.append(row)
+            }
+        }
+    }
+
+    private func exactChunkIDSearchResult(
+        query: String,
+        limit: Int,
+        project: String?,
+        tag: String?,
+        importanceMin: Double?
+    ) throws -> [[String: Any]]? {
+        guard let db else { throw DBError.notOpen }
+        guard limit > 0, !query.contains(where: { $0.isWhitespace }), query.contains("-") else {
+            return nil
+        }
+
+        var conditions = ["c.id = ?"]
+        if project != nil { conditions.append("c.project = ?") }
+        if tag != nil { conditions.append("c.tags LIKE ?") }
+        if importanceMin != nil { conditions.append("c.importance >= ?") }
+
+        let sql = """
+            SELECT c.rowid, c.id, c.content, c.project, c.content_type, c.importance,
+                   c.created_at, c.summary, c.tags, c.conversation_id
+            FROM chunks c
+            WHERE \(conditions.joined(separator: " AND "))
+            LIMIT 1
+        """
+
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+
+        var paramIdx: Int32 = 1
+        bindText(query, to: stmt, index: paramIdx)
+        paramIdx += 1
+        if let project {
+            bindText(project, to: stmt, index: paramIdx)
+            paramIdx += 1
+        }
+        if let tag {
+            bindText("%\"\(tag)\"%", to: stmt, index: paramIdx)
+            paramIdx += 1
+        }
+        if let importanceMin {
+            sqlite3_bind_double(stmt, paramIdx, importanceMin)
+        }
+
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            return [searchRow(from: stmt, score: 1.0)]
+        }
+
+        return try chunkExists(id: query) ? [] : nil
+    }
+
+    private func chunkExists(id: String) throws -> Bool {
+        guard let db else { throw DBError.notOpen }
+        var stmt: OpaquePointer?
+        let sql = "SELECT 1 FROM chunks WHERE id = ? LIMIT 1"
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        bindText(id, to: stmt, index: 1)
+        return sqlite3_step(stmt) == SQLITE_ROW
+    }
+
+    private func searchRow(from stmt: OpaquePointer?, score: Double) -> [String: Any] {
+        let rowID = sqlite3_column_int64(stmt, 0)
+        return [
+            "rowid": Int(rowID),
+            "chunk_id": columnText(stmt, 1) as Any,
+            "content": columnText(stmt, 2) as Any,
+            "project": columnText(stmt, 3) as Any,
+            "content_type": columnText(stmt, 4) as Any,
+            "importance": sqlite3_column_double(stmt, 5),
+            "created_at": columnText(stmt, 6) as Any,
+            "summary": columnText(stmt, 7) as Any,
+            "preview_text": Self.previewText(summary: columnText(stmt, 7), content: columnText(stmt, 2)),
+            "tags": columnText(stmt, 8) as Any,
+            "session_id": columnText(stmt, 9) as Any,
+            "score": score
+        ]
+    }
+
     private func ensureChunkColumns() throws {
         guard let db else { throw DBError.notOpen }
         let existingColumns = try tableColumns(name: "chunks", on: db)
+        if !existingColumns.contains("summary") {
+            try execute("ALTER TABLE chunks ADD COLUMN summary TEXT")
+        }
+        if !existingColumns.contains("tags") {
+            try execute("ALTER TABLE chunks ADD COLUMN tags TEXT DEFAULT '[]'")
+        }
         if !existingColumns.contains("preview_text") {
             try execute("ALTER TABLE chunks ADD COLUMN preview_text TEXT")
         }
@@ -1504,6 +1779,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     private func ensureKGEntityColumns() throws {
         guard let db else { throw DBError.notOpen }
+        try ensureKGEntityTable()
         let existingColumns = try tableColumns(name: "kg_entities", on: db)
         if !existingColumns.contains("description") {
             try execute("ALTER TABLE kg_entities ADD COLUMN description TEXT")
@@ -1511,6 +1787,44 @@ final class BrainDatabase: @unchecked Sendable {
         if !existingColumns.contains("importance") {
             try execute("ALTER TABLE kg_entities ADD COLUMN importance REAL DEFAULT 0.5")
         }
+    }
+
+    private func ensureKGEntityTable() throws {
+        try execute("""
+            CREATE TABLE IF NOT EXISTS kg_entities (
+                id TEXT PRIMARY KEY,
+                entity_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                metadata TEXT DEFAULT '{}',
+                description TEXT,
+                importance REAL DEFAULT 0.5,
+                created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                UNIQUE(entity_type, name)
+            )
+        """)
+    }
+
+    private func ensureKGEntityAliasTable() throws {
+        try execute("""
+            CREATE TABLE IF NOT EXISTS kg_entity_aliases (
+                alias TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                alias_type TEXT DEFAULT 'name',
+                created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                valid_from TEXT,
+                valid_to TEXT,
+                PRIMARY KEY (alias, entity_id)
+            )
+        """)
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_kg_alias_lookup
+            ON kg_entity_aliases(alias COLLATE NOCASE)
+        """)
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_kg_alias_entity
+            ON kg_entity_aliases(entity_id)
+        """)
     }
 
     private func ensurePreviewTextTriggers() throws {
@@ -1584,6 +1898,79 @@ final class BrainDatabase: @unchecked Sendable {
         """)
     }
 
+    private func rebuildTrigramFTSTable() throws {
+        try execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts_trigram USING fts5(
+                \(Self.ftsColumns),
+                \(Self.trigramFTSOptions)
+            )
+        """)
+        try execute("DELETE FROM chunks_fts_trigram")
+        try execute("""
+            INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
+            SELECT content, summary, tags, NULL, id FROM chunks
+        """)
+
+        try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_insert")
+        try execute("""
+            CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_insert AFTER INSERT ON chunks BEGIN
+                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
+                VALUES (new.content, new.summary, new.tags, NULL, new.id);
+            END
+        """)
+
+        try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_delete")
+        try execute("""
+            CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_delete AFTER DELETE ON chunks BEGIN
+                DELETE FROM chunks_fts_trigram WHERE chunk_id = old.id;
+            END
+        """)
+
+        try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_update")
+        try execute("""
+            CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_update AFTER UPDATE ON chunks BEGIN
+                DELETE FROM chunks_fts_trigram WHERE chunk_id = old.id;
+                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
+                VALUES (new.content, new.summary, new.tags, NULL, new.id);
+            END
+        """)
+    }
+
+    private func rebuildTrigramFTSTableIfNeeded() throws {
+        if try trigramFTSTableNeedsRebuild() {
+            try rebuildTrigramFTSTable()
+        }
+    }
+
+    private func trigramFTSTableNeedsRebuild() throws -> Bool {
+        guard let db else { throw DBError.notOpen }
+        guard let sql = try sqliteMasterSQL(name: "chunks_fts_trigram", on: db) else { return true }
+        let normalizedSQL = sql.lowercased()
+        guard normalizedSQL.contains("tokenize='trigram'"),
+              normalizedSQL.contains("summary"),
+              normalizedSQL.contains("resolved_query")
+        else {
+            return true
+        }
+
+        let chunkCount = try countRows(in: "chunks")
+        let trigramCount = try countRows(in: "chunks_fts_trigram")
+        return chunkCount != trigramCount
+    }
+
+    private func countRows(in tableName: String) throws -> Int {
+        guard let db else { throw DBError.notOpen }
+        let allowedTables = ["chunks", "chunks_fts_trigram"]
+        guard allowedTables.contains(tableName) else { throw DBError.exec(SQLITE_ERROR, "invalid count table") }
+
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM \(tableName)", -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return 0 }
+        return Int(sqlite3_column_int64(stmt, 0))
+    }
+
     private func ftsTableNeedsRebuild() throws -> Bool {
         guard let db else { throw DBError.notOpen }
         guard let sql = try sqliteMasterSQL(name: "chunks_fts", on: db) else { return true }
@@ -1605,6 +1992,7 @@ final class BrainDatabase: @unchecked Sendable {
     private func refreshSearchStatistics() throws {
         try execute("ANALYZE chunks")
         try execute("ANALYZE chunks_fts")
+        try execute("ANALYZE chunks_fts_trigram")
     }
 
     private func refreshSearchStatisticsBestEffort() {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -291,11 +291,13 @@ final class BrainDatabase: @unchecked Sendable {
                 name TEXT NOT NULL,
                 metadata TEXT DEFAULT '{}',
                 description TEXT,
+                importance REAL DEFAULT 0.5,
                 created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 UNIQUE(entity_type, name)
             )
         """)
+        try ensureKGEntityColumns()
 
         try execute("""
             CREATE TABLE IF NOT EXISTS kg_relations (
@@ -360,6 +362,7 @@ final class BrainDatabase: @unchecked Sendable {
         """)
 
         try ensurePendingStoreQueueIndex()
+        try ensureKGEntityColumns()
     }
 
     func close() {
@@ -1499,6 +1502,17 @@ final class BrainDatabase: @unchecked Sendable {
         }
     }
 
+    private func ensureKGEntityColumns() throws {
+        guard let db else { throw DBError.notOpen }
+        let existingColumns = try tableColumns(name: "kg_entities", on: db)
+        if !existingColumns.contains("description") {
+            try execute("ALTER TABLE kg_entities ADD COLUMN description TEXT")
+        }
+        if !existingColumns.contains("importance") {
+            try execute("ALTER TABLE kg_entities ADD COLUMN importance REAL DEFAULT 0.5")
+        }
+    }
+
     private func ensurePreviewTextTriggers() throws {
         try execute("DROP TRIGGER IF EXISTS chunks_preview_text_insert")
         try execute("""
@@ -2371,7 +2385,7 @@ final class BrainDatabase: @unchecked Sendable {
         // Without this, the graph is mostly disconnected noise.
         let sql = """
             SELECT e.id, e.name, e.entity_type, e.description,
-                   COALESCE(CAST(json_extract(e.metadata, '$.importance') AS REAL), 5.0) AS importance
+                   COALESCE(e.importance, CAST(json_extract(e.metadata, '$.importance') AS REAL), 5.0) AS importance
             FROM kg_entities e
             WHERE EXISTS (
                 SELECT 1 FROM kg_relations r

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -26,6 +26,68 @@ final class BrainDatabase: @unchecked Sendable {
         let databaseSizeBytes: Int64
         let recentActivityBuckets: [Int]
         let recentEnrichmentBuckets: [Int]
+        let activityWindowMinutes: Int
+        let bucketCount: Int
+        let liveWindowMinutes: Int
+        let lastWriteAt: Date?
+        let lastEnrichedAt: Date?
+
+        init(
+            chunkCount: Int,
+            enrichedChunkCount: Int,
+            pendingEnrichmentCount: Int,
+            enrichmentPercent: Double,
+            enrichmentRatePerMinute: Double,
+            databaseSizeBytes: Int64,
+            recentActivityBuckets: [Int],
+            recentEnrichmentBuckets: [Int],
+            activityWindowMinutes: Int = 30,
+            bucketCount: Int = 12,
+            liveWindowMinutes: Int = 1,
+            lastWriteAt: Date? = nil,
+            lastEnrichedAt: Date? = nil
+        ) {
+            self.chunkCount = chunkCount
+            self.enrichedChunkCount = enrichedChunkCount
+            self.pendingEnrichmentCount = pendingEnrichmentCount
+            self.enrichmentPercent = enrichmentPercent
+            self.enrichmentRatePerMinute = enrichmentRatePerMinute
+            self.databaseSizeBytes = databaseSizeBytes
+            self.recentActivityBuckets = recentActivityBuckets
+            self.recentEnrichmentBuckets = recentEnrichmentBuckets
+            self.activityWindowMinutes = activityWindowMinutes
+            self.bucketCount = bucketCount
+            self.liveWindowMinutes = liveWindowMinutes
+            self.lastWriteAt = lastWriteAt
+            self.lastEnrichedAt = lastEnrichedAt
+        }
+
+        var recentWriteCount: Int {
+            recentActivityBuckets.reduce(0, +)
+        }
+
+        var recentEnrichmentCount: Int {
+            recentEnrichmentBuckets.reduce(0, +)
+        }
+
+        var writeRatePerMinute: Double {
+            guard activityWindowMinutes > 0 else { return 0 }
+            return Double(recentWriteCount) / Double(activityWindowMinutes)
+        }
+
+        func eventIsLive(_ date: Date?, now: Date = Date()) -> Bool {
+            guard let date else { return false }
+            let liveWindowSeconds = max(Double(liveWindowMinutes) * 60, 0)
+            return now.timeIntervalSince(date) < liveWindowSeconds
+        }
+
+        func hasRecentWriteActivity(now: Date = Date()) -> Bool {
+            eventIsLive(lastWriteAt, now: now) || recentWriteCount > 0
+        }
+
+        func hasRecentEnrichmentActivity(now: Date = Date()) -> Bool {
+            eventIsLive(lastEnrichedAt, now: now) || recentEnrichmentCount > 0
+        }
     }
 
     struct SubscriberRecord: Sendable {
@@ -947,6 +1009,7 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func dashboardStats(activityWindowMinutes: Int = 30, bucketCount: Int = 12) throws -> DashboardStats {
+        let liveWindowMinutes = 1
         guard bucketCount > 0 else {
             return DashboardStats(
                 chunkCount: 0,
@@ -956,17 +1019,20 @@ final class BrainDatabase: @unchecked Sendable {
                 enrichmentRatePerMinute: 0,
                 databaseSizeBytes: databaseSizeBytes(),
                 recentActivityBuckets: [],
-                recentEnrichmentBuckets: []
+                recentEnrichmentBuckets: [],
+                activityWindowMinutes: activityWindowMinutes,
+                bucketCount: bucketCount,
+                liveWindowMinutes: liveWindowMinutes
             )
         }
 
         let counts = try dashboardCounts()
+        let lastEvents = try dashboardLastEvents()
         let chunkCount = counts.chunkCount
         let enrichedChunkCount = counts.enrichedChunkCount
         let pendingEnrichmentCount = max(0, chunkCount - enrichedChunkCount)
         let enrichmentPercent = chunkCount == 0 ? 0 : (Double(enrichedChunkCount) / Double(chunkCount)) * 100
-        let enrichmentRateWindowMinutes = 1
-        let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: enrichmentRateWindowMinutes)
+        let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: liveWindowMinutes)
         let recentActivityBuckets = try recentActivityBuckets(
             activityWindowMinutes: activityWindowMinutes,
             bucketCount: bucketCount
@@ -984,7 +1050,12 @@ final class BrainDatabase: @unchecked Sendable {
             enrichmentRatePerMinute: enrichmentRatePerMinute,
             databaseSizeBytes: databaseSizeBytes(),
             recentActivityBuckets: recentActivityBuckets,
-            recentEnrichmentBuckets: recentEnrichmentBuckets
+            recentEnrichmentBuckets: recentEnrichmentBuckets,
+            activityWindowMinutes: activityWindowMinutes,
+            bucketCount: bucketCount,
+            liveWindowMinutes: liveWindowMinutes,
+            lastWriteAt: lastEvents.lastWriteAt,
+            lastEnrichedAt: lastEvents.lastEnrichedAt
         )
     }
 
@@ -1049,19 +1120,54 @@ final class BrainDatabase: @unchecked Sendable {
         )
     }
 
+    private func dashboardLastEvents() throws -> (lastWriteAt: Date?, lastEnrichedAt: Date?) {
+        guard let db else { throw DBError.notOpen }
+        let createdAtEpochSQL = Self.normalizedUnixEpochSQL(for: "created_at")
+        let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
+        let sql = """
+            SELECT
+                MAX(last_write_epoch),
+                MAX(last_enriched_epoch)
+            FROM (
+                SELECT
+                    \(createdAtEpochSQL) AS last_write_epoch,
+                    \(enrichedAtEpochSQL) AS last_enriched_epoch
+                FROM chunks
+            )
+        """
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
+
+        let lastWriteAt = sqlite3_column_type(stmt, 0) == SQLITE_NULL
+            ? nil
+            : Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 0)))
+        let lastEnrichedAt = sqlite3_column_type(stmt, 1) == SQLITE_NULL
+            ? nil
+            : Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 1)))
+        return (lastWriteAt: lastWriteAt, lastEnrichedAt: lastEnrichedAt)
+    }
+
     private func recentActivityBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
         guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
         guard let db else { throw DBError.notOpen }
 
         let bucketWidthSeconds = max(1, Double(activityWindowMinutes * 60) / Double(bucketCount))
         let windowStart = Date().addingTimeInterval(Double(-activityWindowMinutes * 60))
+        let createdAtEpochSQL = Self.normalizedUnixEpochSQL(for: "created_at")
 
         var stmt: OpaquePointer?
         let sql = """
-            SELECT datetime(created_at)
-            FROM chunks
-            WHERE datetime(created_at) >= datetime('now', ?)
-            ORDER BY datetime(created_at) ASC
+            SELECT created_epoch
+            FROM (
+                SELECT \(createdAtEpochSQL) AS created_epoch
+                FROM chunks
+            )
+            WHERE created_epoch IS NOT NULL
+              AND created_epoch >= unixepoch('now', ?)
+            ORDER BY created_epoch ASC
         """
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
@@ -1069,13 +1175,12 @@ final class BrainDatabase: @unchecked Sendable {
         bindText("-\(activityWindowMinutes) minutes", to: stmt, index: 1)
 
         var buckets = Array(repeating: 0, count: bucketCount)
-        let formatter = Self.sqliteDateFormatter
 
         while sqlite3_step(stmt) == SQLITE_ROW {
-            guard let createdAtText = columnText(stmt, 0),
-                  let createdAt = formatter.date(from: createdAtText) else {
+            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else {
                 continue
             }
+            let createdAt = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 0)))
 
             let offset = createdAt.timeIntervalSince(windowStart)
             if offset < 0 { continue }
@@ -1095,15 +1200,18 @@ final class BrainDatabase: @unchecked Sendable {
 
         let bucketWidthSeconds = max(1, Double(activityWindowMinutes * 60) / Double(bucketCount))
         let windowStart = Date().addingTimeInterval(Double(-activityWindowMinutes * 60))
+        let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
 
         var stmt: OpaquePointer?
         let sql = """
-            SELECT datetime(enriched_at)
-            FROM chunks
-            WHERE enriched_at IS NOT NULL
-              AND TRIM(enriched_at) != ''
-              AND datetime(enriched_at) >= datetime('now', ?)
-            ORDER BY datetime(enriched_at) ASC
+            SELECT enriched_epoch
+            FROM (
+                SELECT \(enrichedAtEpochSQL) AS enriched_epoch
+                FROM chunks
+            )
+            WHERE enriched_epoch IS NOT NULL
+              AND enriched_epoch >= unixepoch('now', ?)
+            ORDER BY enriched_epoch ASC
         """
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
@@ -1111,13 +1219,12 @@ final class BrainDatabase: @unchecked Sendable {
         bindText("-\(activityWindowMinutes) minutes", to: stmt, index: 1)
 
         var buckets = Array(repeating: 0, count: bucketCount)
-        let formatter = Self.sqliteDateFormatter
 
         while sqlite3_step(stmt) == SQLITE_ROW {
-            guard let enrichedAtText = columnText(stmt, 0),
-                  let enrichedAt = formatter.date(from: enrichedAtText) else {
+            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else {
                 continue
             }
+            let enrichedAt = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 0)))
 
             let offset = enrichedAt.timeIntervalSince(windowStart)
             if offset < 0 { continue }
@@ -1134,14 +1241,17 @@ final class BrainDatabase: @unchecked Sendable {
     private func recentEnrichmentRatePerMinute(windowMinutes: Int) throws -> Double {
         guard windowMinutes > 0 else { return 0 }
         guard let db else { throw DBError.notOpen }
+        let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
 
         var stmt: OpaquePointer?
         let sql = """
             SELECT COUNT(*)
-            FROM chunks
-            WHERE enriched_at IS NOT NULL
-              AND TRIM(enriched_at) != ''
-              AND datetime(enriched_at) >= datetime('now', ?)
+            FROM (
+                SELECT \(enrichedAtEpochSQL) AS enriched_epoch
+                FROM chunks
+            )
+            WHERE enriched_epoch IS NOT NULL
+              AND enriched_epoch >= unixepoch('now', ?)
         """
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
@@ -1151,6 +1261,18 @@ final class BrainDatabase: @unchecked Sendable {
         guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
         let count = Double(sqlite3_column_int(stmt, 0))
         return count / Double(windowMinutes)
+    }
+
+    private static func normalizedUnixEpochSQL(for column: String) -> String {
+        """
+        CASE
+            WHEN \(column) IS NULL OR TRIM(\(column)) = '' THEN NULL
+            WHEN substr(\(column), -1) = 'Z' THEN unixepoch(\(column))
+            WHEN substr(\(column), -6, 1) IN ('+', '-') THEN unixepoch(\(column))
+            WHEN instr(\(column), 'T') > 0 THEN unixepoch(\(column), 'utc')
+            ELSE unixepoch(\(column))
+        END
+        """
     }
 
     private func databaseSizeBytes() -> Int64 {

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -1,0 +1,198 @@
+import AppKit
+import Foundation
+
+enum AgentFamily: String, CaseIterable, Sendable {
+    case claude
+    case codex
+    case cursor
+    case gemini
+
+    var label: String {
+        switch self {
+        case .claude:
+            return "Claude"
+        case .codex:
+            return "Codex"
+        case .cursor:
+            return "Cursor"
+        case .gemini:
+            return "Gemini"
+        }
+    }
+
+    var accentColor: NSColor {
+        switch self {
+        case .claude:
+            return .systemIndigo
+        case .codex:
+            return .systemBlue
+        case .cursor:
+            return .systemGreen
+        case .gemini:
+            return .systemTeal
+        }
+    }
+}
+
+struct AgentPresence: Sendable, Equatable {
+    let family: AgentFamily
+    let count: Int
+
+    var isActive: Bool { count > 0 }
+}
+
+struct AgentActivitySnapshot: Sendable, Equatable {
+    let presences: [AgentPresence]
+
+    static let empty = AgentActivitySnapshot(
+        presences: AgentFamily.allCases.map { AgentPresence(family: $0, count: 0) }
+    )
+
+    var totalActiveAgents: Int {
+        presences.reduce(0) { $0 + $1.count }
+    }
+
+    func count(for family: AgentFamily) -> Int {
+        presences.first(where: { $0.family == family })?.count ?? 0
+    }
+
+    var summaryText: String {
+        switch totalActiveAgents {
+        case 0:
+            return "No agent CLIs live"
+        case 1:
+            return "1 agent CLI live"
+        default:
+            return "\(totalActiveAgents) agent CLIs live"
+        }
+    }
+}
+
+final class AgentActivityMonitor {
+    private let snapshotProvider: @Sendable () -> String?
+
+    init(snapshotProvider: @escaping @Sendable () -> String? = AgentActivityMonitor.captureProcessSnapshot) {
+        self.snapshotProvider = snapshotProvider
+    }
+
+    func sample() -> AgentActivitySnapshot {
+        guard let snapshot = snapshotProvider() else { return .empty }
+        return Self.parse(snapshot)
+    }
+
+    static func parse(_ snapshot: String) -> AgentActivitySnapshot {
+        var actualCounts = Dictionary(uniqueKeysWithValues: AgentFamily.allCases.map { ($0, 0) })
+        var wrapperCounts = Dictionary(uniqueKeysWithValues: AgentFamily.allCases.map { ($0, 0) })
+
+        for rawLine in snapshot.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            let parts = line.split(maxSplits: 2, omittingEmptySubsequences: true) { $0 == " " || $0 == "\t" }
+            guard parts.count == 3 else { continue }
+
+            let executable = String(parts[1]).lowercased()
+            let command = String(parts[2]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let lowerCommand = command.lowercased()
+
+            guard !isIgnoredProcess(executable: executable, command: lowerCommand) else { continue }
+
+            if let family = detectActualFamily(command: lowerCommand) {
+                actualCounts[family, default: 0] += 1
+                continue
+            }
+
+            if let family = detectWrapperFamily(executable: executable, command: lowerCommand) {
+                wrapperCounts[family, default: 0] += 1
+            }
+        }
+
+        let presences = AgentFamily.allCases.map { family in
+            let actual = actualCounts[family, default: 0]
+            let wrappers = wrapperCounts[family, default: 0]
+            return AgentPresence(family: family, count: actual > 0 ? actual : wrappers)
+        }
+
+        return AgentActivitySnapshot(presences: presences)
+    }
+
+    static func runSnapshotCommand(executableURL: URL, arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        // Drain stdout before waiting so verbose process lists cannot fill the pipe and deadlock tests.
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func captureProcessSnapshot() -> String? {
+        runSnapshotCommand(
+            executableURL: URL(fileURLWithPath: "/bin/ps"),
+            arguments: ["-axo", "pid=,ucomm=,args="]
+        )
+    }
+
+    private static func isIgnoredProcess(executable: String, command: String) -> Bool {
+        let noiseTokens = [
+            "/applications/claude.app",
+            "claude helper",
+            "crashpad",
+            "cursoruiviewservice",
+            "rg -n",
+            "awk ",
+            "grep ",
+            "ps -axo",
+        ]
+        if noiseTokens.contains(where: { command.contains($0) }) {
+            return true
+        }
+        if executable == "rg" || executable == "awk" || executable == "grep" {
+            return true
+        }
+        return false
+    }
+
+    private static func detectActualFamily(command: String) -> AgentFamily? {
+        if command.hasPrefix("claude ") || command.contains("/claude ") || command.contains(" brainlayerclaude") {
+            return .claude
+        }
+        if command.hasPrefix("codex ") || command.contains("/codex/codex ") || command.contains(" brainlayercodex") {
+            return .codex
+        }
+        if command.hasPrefix("cursor ") || command.contains("cursor agent") || command.contains(" brainlayercursor") {
+            return .cursor
+        }
+        if command.hasPrefix("gemini ") || command.contains("/gemini ") || command.contains(" brainlayergemini") {
+            return .gemini
+        }
+        return nil
+    }
+
+    private static func detectWrapperFamily(executable: String, command: String) -> AgentFamily? {
+        guard executable == "node" || executable == "bun" || executable == "python" || executable == "python3" else {
+            return nil
+        }
+        if command.contains("/.bun/bin/codex") {
+            return .codex
+        }
+        if command.contains("cursor agent") {
+            return .cursor
+        }
+        if command.contains(" gemini") {
+            return .gemini
+        }
+        return nil
+    }
+}

--- a/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
@@ -5,6 +5,11 @@ enum DashboardMetricFormatter {
         liveBadgeString(ratePerMinute: ratePerMinute)
     }
 
+    static func rateString(totalEvents: Int, activityWindowMinutes: Int) -> String {
+        guard activityWindowMinutes > 0 else { return "0/min" }
+        return speedString(ratePerMinute: Double(max(totalEvents, 0)) / Double(activityWindowMinutes))
+    }
+
     static func indexingString(
         recentActivityBuckets: [Int],
         activityWindowMinutes: Int = 30
@@ -22,28 +27,25 @@ enum DashboardMetricFormatter {
         recentActivityBuckets: [Int],
         activityWindowMinutes: Int = 30
     ) -> String {
-        let totalWrites = max(recentActivityBuckets.reduce(0, +), 0)
-        return "\(totalWrites) in \(activityWindowMinutes)m"
+        activitySummaryString(
+            totalEvents: recentActivityBuckets.reduce(0, +),
+            activityWindowMinutes: activityWindowMinutes
+        )
+    }
+
+    static func activitySummaryString(
+        totalEvents: Int,
+        activityWindowMinutes: Int = 30
+    ) -> String {
+        "\(max(totalEvents, 0)) in \(shortWindowLabel(minutes: activityWindowMinutes))"
     }
 
     static func lastCompletionString(
-        recentEnrichmentBuckets: [Int],
-        activityWindowMinutes: Int = 30
+        lastEventAt: Date?,
+        activityWindowMinutes: Int = 30,
+        now: Date = Date()
     ) -> String {
-        guard !recentEnrichmentBuckets.isEmpty else { return "30m+" }
-        guard let lastIndex = recentEnrichmentBuckets.lastIndex(where: { $0 > 0 }) else {
-            return "\(activityWindowMinutes)m+"
-        }
-
-        let bucketWidthMinutes = Double(activityWindowMinutes) / Double(recentEnrichmentBuckets.count)
-        let bucketsAgo = recentEnrichmentBuckets.count - 1 - lastIndex
-        let minutesAgo = Double(bucketsAgo) * bucketWidthMinutes
-
-        if minutesAgo < bucketWidthMinutes {
-            return "Just now"
-        }
-
-        return "\(Int(minutesAgo.rounded()))m ago"
+        lastEventString(lastEventAt: lastEventAt, activityWindowMinutes: activityWindowMinutes, now: now)
     }
 
     static func liveBadgeString(ratePerMinute: Double) -> String {
@@ -52,5 +54,39 @@ enum DashboardMetricFormatter {
             return "\(Int(clamped))/min"
         }
         return String(format: "%.1f/min", clamped)
+    }
+
+    static func lastEventString(
+        lastEventAt: Date?,
+        activityWindowMinutes: Int = 30,
+        now: Date = Date()
+    ) -> String {
+        guard let lastEventAt else {
+            return "\(shortWindowLabel(minutes: activityWindowMinutes))+"
+        }
+
+        let secondsAgo = max(now.timeIntervalSince(lastEventAt), 0)
+        if secondsAgo < 60 {
+            return "Just now"
+        }
+        if secondsAgo < 3600 {
+            let minutesAgo = Int((secondsAgo / 60).rounded(.up))
+            return "\(minutesAgo)m ago"
+        }
+
+        let hoursAgo = Int((secondsAgo / 3600).rounded(.up))
+        return "\(hoursAgo)h ago"
+    }
+
+    static func windowLabel(minutes: Int) -> String {
+        "Last \(shortWindowLabel(minutes: minutes))"
+    }
+
+    static func shortWindowLabel(minutes: Int) -> String {
+        guard minutes >= 60 else { return "\(minutes)m" }
+        if minutes % 60 == 0 {
+            return "\(minutes / 60)h"
+        }
+        return "\(minutes)m"
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -54,24 +54,34 @@ struct PipelineIndicators: Sendable, Equatable {
     let indexing: PipelineIndicator
     let enriching: PipelineIndicator
 
-    static func derive(daemon: DaemonHealthSnapshot?, stats: DashboardStats) -> PipelineIndicators {
+    static func derive(daemon: DaemonHealthSnapshot?, stats: DashboardStats, now: Date = Date()) -> PipelineIndicators {
+        let summary = DashboardFlowSummary.derive(daemon: daemon, stats: stats, now: now)
+
         let indexingStatus: PipelineIndicatorStatus
         let enrichingStatus: PipelineIndicatorStatus
 
-        if daemon?.isResponsive != true {
+        if summary.isUnavailable {
             indexingStatus = .unavailable
             enrichingStatus = .unavailable
         } else {
-            let recentWrites = stats.recentActivityBuckets.suffix(2).reduce(0, +)
-            let recentEnrichments = stats.recentEnrichmentBuckets.suffix(2).reduce(0, +)
+            indexingStatus = switch summary.ingress.status {
+            case .live:
+                .live
+            case .recent where summary.queue.status == .growing:
+                .queued
+            default:
+                .idle
+            }
 
-            indexingStatus = recentWrites > 0 ? .live : .idle
-            if recentEnrichments > 0 {
-                enrichingStatus = .live
-            } else if stats.pendingEnrichmentCount > 0 {
-                enrichingStatus = .queued
-            } else {
-                enrichingStatus = .idle
+            enrichingStatus = switch summary.enrichment.status {
+            case .live:
+                .live
+            case .recent where summary.queue.status == .draining:
+                .live
+            case .queued:
+                .queued
+            default:
+                stats.pendingEnrichmentCount > 0 ? .queued : .idle
             }
         }
 
@@ -82,21 +92,350 @@ struct PipelineIndicators: Sendable, Equatable {
     }
 }
 
+enum DashboardFlowLaneStatus: String, Sendable, Equatable {
+    case live
+    case recent
+    case draining
+    case queued
+    case idle
+    case unavailable
+
+    var label: String {
+        switch self {
+        case .live:
+            return "live"
+        case .recent:
+            return "recent"
+        case .draining:
+            return "draining"
+        case .queued:
+            return "queued"
+        case .idle:
+            return "idle"
+        case .unavailable:
+            return "offline"
+        }
+    }
+}
+
+enum DashboardQueueStatus: String, Sendable, Equatable {
+    case empty
+    case stable
+    case growing
+    case draining
+    case backlogged
+    case unavailable
+
+    var label: String {
+        switch self {
+        case .empty:
+            return "empty"
+        case .stable:
+            return "stable"
+        case .growing:
+            return "growing"
+        case .draining:
+            return "draining"
+        case .backlogged:
+            return "backlogged"
+        case .unavailable:
+            return "offline"
+        }
+    }
+}
+
+struct DashboardFlowLane: Sendable, Equatable {
+    let name: String
+    let status: DashboardFlowLaneStatus
+    let statusText: String
+    let windowLabel: String
+    let rateText: String
+    let volumeText: String
+    let lastEventText: String
+    let values: [Int]
+    let accentColor: NSColor
+}
+
+struct DashboardQueueSummary: Sendable, Equatable {
+    let status: DashboardQueueStatus
+    let backlogCount: Int
+    let title: String
+    let detail: String
+}
+
+struct DashboardFlowSummary: Sendable, Equatable {
+    let headline: String
+    let detail: String
+    let windowLabel: String
+    let ingress: DashboardFlowLane
+    let queue: DashboardQueueSummary
+    let enrichment: DashboardFlowLane
+
+    var isUnavailable: Bool {
+        ingress.status == .unavailable || enrichment.status == .unavailable || queue.status == .unavailable
+    }
+
+    static func derive(daemon: DaemonHealthSnapshot?, stats: DashboardStats, now: Date = Date()) -> DashboardFlowSummary {
+        let windowLabel = DashboardMetricFormatter.windowLabel(minutes: stats.activityWindowMinutes)
+        let ingressColor = NSColor.systemBlue
+        let enrichmentColor = NSColor.systemGreen
+
+        guard let daemon, daemon.isResponsive else {
+            return DashboardFlowSummary(
+                headline: "Pipeline visibility is degraded",
+                detail: "Daemon metrics are unavailable, so live flow state may be stale.",
+                windowLabel: windowLabel,
+                ingress: DashboardFlowLane(
+                    name: "Writes",
+                    status: .unavailable,
+                    statusText: "Unavailable",
+                    windowLabel: windowLabel,
+                    rateText: DashboardMetricFormatter.rateString(
+                        totalEvents: stats.recentWriteCount,
+                        activityWindowMinutes: stats.activityWindowMinutes
+                    ),
+                    volumeText: DashboardMetricFormatter.activitySummaryString(
+                        totalEvents: stats.recentWriteCount,
+                        activityWindowMinutes: stats.activityWindowMinutes
+                    ),
+                    lastEventText: DashboardMetricFormatter.lastEventString(
+                        lastEventAt: stats.lastWriteAt,
+                        activityWindowMinutes: stats.activityWindowMinutes,
+                        now: now
+                    ),
+                    values: stats.recentActivityBuckets,
+                    accentColor: ingressColor
+                ),
+                queue: DashboardQueueSummary(
+                    status: .unavailable,
+                    backlogCount: stats.pendingEnrichmentCount,
+                    title: "Queue visibility unavailable",
+                    detail: "\(stats.pendingEnrichmentCount) chunks pending"
+                ),
+                enrichment: DashboardFlowLane(
+                    name: "Enrichments",
+                    status: .unavailable,
+                    statusText: "Unavailable",
+                    windowLabel: windowLabel,
+                    rateText: DashboardMetricFormatter.rateString(
+                        totalEvents: stats.recentEnrichmentCount,
+                        activityWindowMinutes: stats.activityWindowMinutes
+                    ),
+                    volumeText: DashboardMetricFormatter.activitySummaryString(
+                        totalEvents: stats.recentEnrichmentCount,
+                        activityWindowMinutes: stats.activityWindowMinutes
+                    ),
+                    lastEventText: DashboardMetricFormatter.lastEventString(
+                        lastEventAt: stats.lastEnrichedAt,
+                        activityWindowMinutes: stats.activityWindowMinutes,
+                        now: now
+                    ),
+                    values: stats.recentEnrichmentBuckets,
+                    accentColor: enrichmentColor
+                )
+            )
+        }
+
+        let writesLive = stats.eventIsLive(stats.lastWriteAt, now: now)
+        let enrichmentsLive = stats.eventIsLive(stats.lastEnrichedAt, now: now)
+        let backlogCount = stats.pendingEnrichmentCount
+
+        let ingressStatus: DashboardFlowLaneStatus
+        if writesLive {
+            ingressStatus = .live
+        } else if stats.recentWriteCount > 0 {
+            ingressStatus = .recent
+        } else {
+            ingressStatus = .idle
+        }
+
+        let enrichmentStatus: DashboardFlowLaneStatus
+        if enrichmentsLive {
+            enrichmentStatus = .live
+        } else if backlogCount > 0 {
+            enrichmentStatus = stats.recentEnrichmentCount > 0 ? .recent : .queued
+        } else if stats.recentEnrichmentCount > 0 {
+            enrichmentStatus = .recent
+        } else {
+            enrichmentStatus = .idle
+        }
+
+        let queueStatus: DashboardQueueStatus
+        if backlogCount == 0 {
+            queueStatus = (stats.recentWriteCount > 0 || stats.recentEnrichmentCount > 0) ? .stable : .empty
+        } else if writesLive && !enrichmentsLive {
+            queueStatus = .growing
+        } else if enrichmentsLive && !writesLive {
+            queueStatus = .draining
+        } else if writesLive && enrichmentsLive {
+            queueStatus = .stable
+        } else if stats.recentEnrichmentCount > 0 {
+            queueStatus = .draining
+        } else {
+            queueStatus = .backlogged
+        }
+
+        let headline: String
+        let detail: String
+
+        if ingressStatus == .live && queueStatus == .stable && enrichmentStatus == .live {
+            headline = "Writes are landing and enrichments are shipping"
+            detail = "\(stats.recentWriteCount) writes and \(stats.recentEnrichmentCount) enrichments in \(windowLabel.lowercased())."
+        } else if ingressStatus == .live && queueStatus == .growing {
+            headline = "Writes are outrunning enrichments"
+            detail = "\(backlogCount) chunks are waiting while ingress is still active."
+        } else if backlogCount > 0 &&
+            (queueStatus == .draining || enrichmentStatus == .draining || enrichmentStatus == .live) {
+            headline = "Enrichment is draining backlog"
+            detail = "\(backlogCount) chunks remain queued, and completions are still moving."
+        } else if queueStatus == .backlogged || enrichmentStatus == .queued {
+            headline = "Backlog is waiting for enrichment"
+            detail = "\(backlogCount) chunks are queued with no enrichment in the live window."
+        } else if ingressStatus == .recent || enrichmentStatus == .recent {
+            headline = "The flow is cooling down"
+            detail = "Live activity is quiet, but recent movement is still visible in \(windowLabel.lowercased())."
+        } else {
+            headline = "The flow is idle"
+            detail = "No writes or enrichments landed in \(windowLabel.lowercased())."
+        }
+
+        let enrichmentStatusText: String
+        switch enrichmentStatus {
+        case .live:
+            enrichmentStatusText = "Enrichments live now"
+        case .draining:
+            enrichmentStatusText = "Recent enrichments are draining backlog"
+        case .queued:
+            enrichmentStatusText = "Backlog is queued without live enrichments"
+        case .recent:
+            enrichmentStatusText = "Recent enrichments in \(windowLabel.lowercased())"
+        case .idle:
+            enrichmentStatusText = "No recent enrichments"
+        case .unavailable:
+            enrichmentStatusText = "Unavailable"
+        }
+
+        return DashboardFlowSummary(
+            headline: headline,
+            detail: detail,
+            windowLabel: windowLabel,
+            ingress: DashboardFlowLane(
+                name: "Writes",
+                status: ingressStatus,
+                statusText: ingressStatus == .live ? "Ingress live now" : (ingressStatus == .recent ? "Recent writes in \(windowLabel.lowercased())" : "No recent writes"),
+                windowLabel: windowLabel,
+                rateText: DashboardMetricFormatter.rateString(
+                    totalEvents: stats.recentWriteCount,
+                    activityWindowMinutes: stats.activityWindowMinutes
+                ),
+                volumeText: DashboardMetricFormatter.activitySummaryString(
+                    totalEvents: stats.recentWriteCount,
+                    activityWindowMinutes: stats.activityWindowMinutes
+                ),
+                lastEventText: DashboardMetricFormatter.lastEventString(
+                    lastEventAt: stats.lastWriteAt,
+                    activityWindowMinutes: stats.activityWindowMinutes,
+                    now: now
+                ),
+                values: stats.recentActivityBuckets,
+                accentColor: ingressColor
+            ),
+            queue: DashboardQueueSummary(
+                status: queueStatus,
+                backlogCount: backlogCount,
+                title: queueTitle(status: queueStatus, backlogCount: backlogCount),
+                detail: queueDetail(
+                    status: queueStatus,
+                    backlogCount: backlogCount,
+                    stats: stats,
+                    windowLabel: windowLabel
+                )
+            ),
+            enrichment: DashboardFlowLane(
+                name: "Enrichments",
+                status: enrichmentStatus,
+                statusText: enrichmentStatusText,
+                windowLabel: windowLabel,
+                rateText: DashboardMetricFormatter.rateString(
+                    totalEvents: stats.recentEnrichmentCount,
+                    activityWindowMinutes: stats.activityWindowMinutes
+                ),
+                volumeText: DashboardMetricFormatter.activitySummaryString(
+                    totalEvents: stats.recentEnrichmentCount,
+                    activityWindowMinutes: stats.activityWindowMinutes
+                ),
+                lastEventText: DashboardMetricFormatter.lastEventString(
+                    lastEventAt: stats.lastEnrichedAt,
+                    activityWindowMinutes: stats.activityWindowMinutes,
+                    now: now
+                ),
+                values: stats.recentEnrichmentBuckets,
+                accentColor: enrichmentColor
+            )
+        )
+    }
+
+    private static func queueTitle(status: DashboardQueueStatus, backlogCount: Int) -> String {
+        switch status {
+        case .empty:
+            return "Queue empty"
+        case .stable:
+            return backlogCount == 0 ? "Flow balanced" : "Queue stable"
+        case .growing:
+            return "Queue growing"
+        case .draining:
+            return "Queue draining"
+        case .backlogged:
+            return "Queue backlogged"
+        case .unavailable:
+            return "Queue unavailable"
+        }
+    }
+
+    private static func queueDetail(
+        status: DashboardQueueStatus,
+        backlogCount: Int,
+        stats: DashboardStats,
+        windowLabel: String
+    ) -> String {
+        switch status {
+        case .empty:
+            return "No chunks are waiting for enrichment."
+        case .stable:
+            return backlogCount == 0
+                ? "Ingress and enrichment stayed balanced across \(windowLabel.lowercased())."
+                : "\(backlogCount) chunks queued while ingress and enrichment remain balanced."
+        case .growing:
+            return "\(backlogCount) chunks are accumulating faster than enrichments are landing."
+        case .draining:
+            return "\(backlogCount) chunks remain queued, but enrichments are still landing."
+        case .backlogged:
+            return "\(backlogCount) chunks are queued with no enrichments in the live window."
+        case .unavailable:
+            return "Queue state cannot be trusted until the daemon comes back."
+        }
+    }
+}
+
 enum PipelineState: String, Sendable, Equatable {
     case degraded
     case indexing
     case enriching
     case idle
 
-    static func derive(daemon: DaemonHealthSnapshot?, stats: DashboardStats) -> PipelineState {
-        guard let daemon else { return .degraded }
-        guard daemon.isResponsive else { return .degraded }
-
-        let recentWrites = stats.recentActivityBuckets.reduce(0, +)
-        if recentWrites > 0 {
+    static func derive(daemon: DaemonHealthSnapshot?, stats: DashboardStats, now: Date = Date()) -> PipelineState {
+        let summary = DashboardFlowSummary.derive(daemon: daemon, stats: stats, now: now)
+        if summary.isUnavailable {
+            return .degraded
+        }
+        if summary.ingress.status == .live || summary.ingress.status == .recent || summary.queue.status == .growing {
             return .indexing
         }
-        if stats.pendingEnrichmentCount > 0 {
+        if summary.enrichment.status == .live ||
+            summary.enrichment.status == .queued ||
+            (summary.enrichment.status == .recent && summary.queue.status == .draining) ||
+            summary.queue.status == .draining ||
+            summary.queue.status == .backlogged {
             return .enriching
         }
         return .idle
@@ -127,9 +466,9 @@ enum PipelineState: String, Sendable, Equatable {
         case .indexing:
             return .systemBlue
         case .enriching:
-            return .systemPurple
-        case .idle:
             return .systemGreen
+        case .idle:
+            return .systemGray
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -18,22 +18,29 @@ private func statsCollectorDarwinNotificationCallback(
 
 @MainActor
 final class StatsCollector: ObservableObject {
+    static let defaultActivityWindowMinutes = 60
+    static let defaultBucketCount = 12
+
     @Published private(set) var stats: DashboardStats
     @Published private(set) var daemon: DaemonHealthSnapshot?
+    @Published private(set) var agentActivity: AgentActivitySnapshot
     @Published private(set) var state: PipelineState
 
     private let database: BrainDatabase
     private let daemonMonitor: DaemonHealthMonitor
+    private let agentActivityMonitor: AgentActivityMonitor
     private var pollTask: Task<Void, Never>?
     private var isRunning = false
     private var lastDataVersion: Int?
 
     init(
         dbPath: String,
-        daemonMonitor: DaemonHealthMonitor
+        daemonMonitor: DaemonHealthMonitor,
+        agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor()
     ) {
         self.database = BrainDatabase(path: dbPath)
         self.daemonMonitor = daemonMonitor
+        self.agentActivityMonitor = agentActivityMonitor
         self.stats = DashboardStats(
             chunkCount: 0,
             enrichedChunkCount: 0,
@@ -41,9 +48,12 @@ final class StatsCollector: ObservableObject {
             enrichmentPercent: 0,
             enrichmentRatePerMinute: 0,
             databaseSizeBytes: 0,
-            recentActivityBuckets: Array(repeating: 0, count: 12),
-            recentEnrichmentBuckets: Array(repeating: 0, count: 12)
+            recentActivityBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
+            recentEnrichmentBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
+            activityWindowMinutes: Self.defaultActivityWindowMinutes,
+            bucketCount: Self.defaultBucketCount
         )
+        self.agentActivity = .empty
         self.state = .degraded
     }
 
@@ -73,11 +83,15 @@ final class StatsCollector: ObservableObject {
 
     func refresh(force: Bool = false) {
         let nextDaemon = daemonMonitor.sample()
+        agentActivity = agentActivityMonitor.sample()
 
         do {
             let currentDataVersion = try database.dataVersion()
             if force || currentDataVersion != lastDataVersion {
-                stats = try database.dashboardStats(activityWindowMinutes: 30, bucketCount: 12)
+                stats = try database.dashboardStats(
+                    activityWindowMinutes: Self.defaultActivityWindowMinutes,
+                    bucketCount: Self.defaultBucketCount
+                )
                 lastDataVersion = currentDataVersion
             }
             daemon = nextDaemon
@@ -92,8 +106,10 @@ final class StatsCollector: ObservableObject {
                     enrichmentPercent: 0,
                     enrichmentRatePerMinute: 0,
                     databaseSizeBytes: 0,
-                    recentActivityBuckets: Array(repeating: 0, count: 12),
-                    recentEnrichmentBuckets: Array(repeating: 0, count: 12)
+                    recentActivityBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
+                    recentEnrichmentBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
+                    activityWindowMinutes: Self.defaultActivityWindowMinutes,
+                    bucketCount: Self.defaultBucketCount
                 )
             }
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -338,10 +338,9 @@ final class StatusPopoverView: NSViewController {
     }
 
     private func render() {
+        let summary = DashboardFlowSummary.derive(daemon: collector.daemon, stats: collector.stats)
         titleLabel.stringValue = "BrainBar"
-        statusLabel.stringValue = collector.state == .indexing ? "Incoming writes active" :
-            (collector.state == .enriching ? "Backlog is being processed" :
-            (collector.state == .idle ? "Pipeline settled" : "Pipeline degraded"))
+        statusLabel.stringValue = summary.headline
         pipelineValueLabel.stringValue = collector.state.label
         pipelineValueLabel.textColor = collector.state.color
         headerPanel.backgroundColor = NSColor.underPageBackgroundColor.withAlphaComponent(0.92)
@@ -363,7 +362,7 @@ final class StatusPopoverView: NSViewController {
         activityDetailLabel.stringValue = enrichmentActivitySummary(collector.stats)
         sparklineImageView.image = SparklineRenderer.render(
             state: collector.state,
-            values: collector.stats.recentEnrichmentBuckets,
+            values: summary.enrichment.values,
             size: NSSize(width: 500, height: 188)
         )
 
@@ -397,9 +396,9 @@ final class StatusPopoverView: NSViewController {
     private func enrichmentActivitySummary(_ stats: DashboardStats) -> String {
         let recentCompletions = stats.recentEnrichmentBuckets.reduce(0, +)
         if recentCompletions == 0 {
-            return "No completions in the last 30m"
+            return "No completions in \(DashboardMetricFormatter.windowLabel(minutes: stats.activityWindowMinutes).lowercased())"
         }
-        return "\(recentCompletions) completions in the last 30m"
+        return "\(recentCompletions) completions in \(DashboardMetricFormatter.windowLabel(minutes: stats.activityWindowMinutes).lowercased())"
     }
 
     private func verticalStack(_ views: [NSView]) -> NSStackView {

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -6,80 +6,445 @@ struct InjectionFeedView: View {
     @State private var expandedEventIDs: Set<Int64> = []
     @State private var selectedConversation: BrainDatabase.ExpandedConversation?
 
-    private var filteredEvents: [InjectionEvent] {
-        let trimmed = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return store.events }
-        let needle = trimmed.lowercased()
-        return store.events.filter { event in
-            event.sessionID.lowercased().contains(needle) ||
-                event.query.lowercased().contains(needle) ||
-                event.chunkIDs.joined(separator: " ").lowercased().contains(needle)
-        }
-    }
+    private let accentPalette: [Color] = [
+        Color(red: 0.42, green: 0.62, blue: 0.98),
+        Color(red: 0.48, green: 0.82, blue: 0.70),
+        Color(red: 0.95, green: 0.74, blue: 0.43),
+        Color(red: 0.72, green: 0.58, blue: 0.96),
+        Color(red: 0.42, green: 0.84, blue: 0.88),
+    ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            TextField("Filter injections", text: $filterText)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12))
+        let snapshot = makePresentation()
+        GeometryReader { proxy in
+            let wideLayout = proxy.size.width >= 960
 
-            List(filteredEvents) { event in
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(event.sessionID)
-                            .font(.system(size: 11, weight: .semibold))
-                        Spacer()
-                        Text(String(event.timestamp.prefix(19)))
-                            .font(.system(size: 10, weight: .medium, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                    }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header(snapshot: snapshot)
+                    overviewStrip(snapshot: snapshot)
 
-                    Text(event.query)
-                        .font(.system(size: 12, weight: .medium))
-                        .lineLimit(2)
-
-                    Text(event.summaryLine)
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-
-                    if !event.chunkIDs.isEmpty {
-                        Button(expandedEventIDs.contains(event.id) ? "Hide conversation chunks" : "Show conversation chunks") {
-                            toggle(event.id)
+                    if snapshot.filteredEvents.isEmpty {
+                        emptyState
+                    } else if wideLayout {
+                        HStack(alignment: .top, spacing: 16) {
+                            feedColumn(snapshot: snapshot)
+                            sideRail(snapshot: snapshot)
+                                .frame(width: 260)
                         }
-                        .buttonStyle(.plain)
-                        .font(.system(size: 11, weight: .semibold))
-
-                        if expandedEventIDs.contains(event.id) {
-                            VStack(alignment: .leading, spacing: 6) {
-                                ForEach(event.chunkIDs, id: \.self) { chunkID in
-                                    Button {
-                                        selectedConversation = try? store.expandedConversation(chunkID: chunkID)
-                                    } label: {
-                                        HStack {
-                                            Text(chunkID)
-                                                .font(.system(size: 10, weight: .medium, design: .monospaced))
-                                                .lineLimit(1)
-                                            Spacer()
-                                            Text("Open thread")
-                                                .font(.system(size: 10, weight: .semibold))
-                                        }
-                                    }
-                                    .buttonStyle(.borderless)
-                                }
-                            }
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
+                    } else {
+                        VStack(alignment: .leading, spacing: 16) {
+                            feedColumn(snapshot: snapshot)
+                            sideRail(snapshot: snapshot)
                         }
                     }
                 }
-                .padding(.vertical, 2)
+                .padding(20)
             }
-            .listStyle(.plain)
+            .background(pageBackground)
         }
-        .sheet(item: $selectedConversation) { conversation in
-            ChunkConversationSheet(conversation: conversation)
+        .overlay {
+            if let conversation = selectedConversation {
+                ChunkConversationOverlay(
+                    conversation: conversation,
+                    onClose: { selectedConversation = nil }
+                )
+            }
         }
+    }
+
+    private func header(snapshot: InjectionPresentation.Snapshot) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Injections")
+                    .font(.system(size: 26, weight: .semibold, design: .rounded))
+                Text("Retrieval activity over the last hour, grouped into session bursts.")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 16)
+
+            VStack(alignment: .trailing, spacing: 8) {
+                TextField("Filter injections", text: $filterText)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12))
+                    .frame(minWidth: 220, maxWidth: 280)
+
+                if !filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text("Showing \(snapshot.filteredEvents.count) matching events")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func overviewStrip(snapshot: InjectionPresentation.Snapshot) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                overviewMetric(label: "Queries", value: "\(snapshot.summary.queryCount)")
+                overviewMetric(label: "Chunks", value: "\(snapshot.summary.chunkCount)")
+                overviewMetric(label: "Tokens", value: "\(snapshot.summary.tokenCount)")
+                overviewMetric(label: "Sessions", value: "\(snapshot.summary.activeSessionCount)")
+            }
+
+            HStack(alignment: .center, spacing: 12) {
+                Text("Last 1h")
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(Color.primary.opacity(0.06)))
+
+                Text("Activity ribbon")
+                    .font(.system(size: 13, weight: .semibold))
+
+                Spacer()
+
+                Text(latestEventText(snapshot: snapshot))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            ribbon(snapshot: snapshot)
+        }
+        .padding(18)
+        .background(cardBackground)
+    }
+
+    private func ribbon(snapshot: InjectionPresentation.Snapshot) -> some View {
+        let maxBucket = max(snapshot.ribbonBuckets.max() ?? 0, 1)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .bottom, spacing: 4) {
+                ForEach(Array(snapshot.ribbonBuckets.enumerated()), id: \.offset) { index, count in
+                    Capsule(style: .continuous)
+                        .fill(bucketColor(for: index, count: count, snapshot: snapshot))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: count == 0 ? 8 : 12 + CGFloat(count) / CGFloat(maxBucket) * 50)
+                }
+            }
+            .frame(height: 64, alignment: .bottom)
+
+            HStack {
+                Text("-60m")
+                Spacer()
+                Text("-30m")
+                Spacer()
+                Text("now")
+            }
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private func feedColumn(snapshot: InjectionPresentation.Snapshot) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ForEach(snapshot.bursts) { burst in
+                burstCard(burst)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func burstCard(_ burst: InjectionPresentation.Burst) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(InjectionPresentation.burstRangeText(start: burst.startDate, end: burst.endDate))
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    HStack(spacing: 8) {
+                        chip(text: burst.sessionID, tint: .blue)
+                        chip(text: "\(burst.queryCount) queries", tint: .neutral)
+                        chip(text: "\(burst.tokenCount) tok", tint: .green)
+                    }
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text("\(burst.chunkCount)")
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
+                    Text("retrieved chunks")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(burst.events) { event in
+                    eventRow(event)
+                }
+            }
+        }
+        .padding(18)
+        .background(cardBackground)
+    }
+
+    private func eventRow(_ event: InjectionEvent) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                Text(InjectionPresentation.shortTime(event.timestamp))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 48, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(event.query)
+                        .font(.system(size: 14, weight: .semibold))
+                        .lineLimit(3)
+
+                    HStack(spacing: 10) {
+                        Text("\(event.chunkCount) chunks")
+                        Text("\(event.tokenCount) tok")
+                        if !event.chunkIDs.isEmpty {
+                            Button(expandedEventIDs.contains(event.id) ? "Hide hits" : "Show hits") {
+                                toggle(event.id)
+                            }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 11, weight: .semibold))
+                        }
+                    }
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                    chunkRibbon(for: event)
+
+                    if expandedEventIDs.contains(event.id) {
+                        chunkList(for: event)
+                    }
+                }
+
+                Spacer(minLength: 10)
+
+                Button {
+                    if let firstChunk = event.chunkIDs.first {
+                        selectedConversation = try? store.expandedConversation(chunkID: firstChunk)
+                    }
+                } label: {
+                    Text("Open")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .disabled(event.chunkIDs.isEmpty)
+            }
+
+            Rectangle()
+                .fill(Color.primary.opacity(0.06))
+                .frame(height: 1)
+        }
+    }
+
+    private func chunkRibbon(for event: InjectionEvent) -> some View {
+        HStack(spacing: 4) {
+            ForEach(Array(event.chunkIDs.enumerated()), id: \.offset) { _, chunkID in
+                RoundedRectangle(cornerRadius: 999, style: .continuous)
+                    .fill(color(for: chunkID))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 8)
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.primary.opacity(0.04))
+        )
+    }
+
+    private func chunkList(for event: InjectionEvent) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(event.chunkIDs, id: \.self) { chunkID in
+                Button {
+                    selectedConversation = try? store.expandedConversation(chunkID: chunkID)
+                } label: {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(color(for: chunkID))
+                            .frame(width: 8, height: 8)
+                        Text(chunkID)
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .lineLimit(1)
+                        Spacer()
+                        Text("Open thread")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+    }
+
+    private func sideRail(snapshot: InjectionPresentation.Snapshot) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            sideRailCard(title: "Sessions · last hour") {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(snapshot.sessions.prefix(4)) { session in
+                        HStack {
+                            Text(session.sessionID)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            Spacer()
+                            Text("\(session.queryCount)q · \(session.tokenCount) tok")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(Color.primary.opacity(0.045))
+                        )
+                    }
+                }
+            }
+
+            sideRailCard(title: "Token pressure") {
+                VStack(alignment: .leading, spacing: 8) {
+                    railMetric(label: "Average", value: averageTokenText(snapshot: snapshot))
+                    railMetric(label: "Peak event", value: peakTokenText(snapshot: snapshot))
+                    railMetric(label: "Burst count", value: "\(snapshot.bursts.count)")
+                }
+            }
+
+            sideRailCard(title: "Signals") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(filterSignalText)
+                        .font(.system(size: 12, weight: .medium))
+                    if let highestChunkEvent = snapshot.windowEvents.max(by: { $0.chunkCount < $1.chunkCount }) {
+                        Text("Chunk-heavy: \(highestChunkEvent.chunkCount) hits on “\(highestChunkEvent.query)”")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("No injections match the current filter.")
+                .font(.system(size: 18, weight: .semibold))
+            Text("Clear the filter or wait for fresh retrieval activity to land.")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .padding(22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground)
+    }
+
+    private func overviewMetric(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+    }
+
+    private func sideRailCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+        .padding(16)
+        .background(cardBackground)
+    }
+
+    private func railMetric(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(size: 12, weight: .semibold))
+        }
+    }
+
+    private func chip(text: String, tint: BurstChipTint) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold))
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(
+                Capsule()
+                    .fill(tint.color.opacity(tint == .neutral ? 0.08 : 0.14))
+            )
+    }
+
+    private func color(for chunkID: String) -> Color {
+        let index = abs(chunkID.hashValue) % accentPalette.count
+        return accentPalette[index]
+    }
+
+    private func bucketColor(for index: Int, count: Int, snapshot: InjectionPresentation.Snapshot) -> Color {
+        guard count > 0 else { return Color.primary.opacity(0.08) }
+        let progress = Double(index) / Double(max(snapshot.ribbonBuckets.count - 1, 1))
+        return Color(
+            hue: 0.6 - progress * 0.18,
+            saturation: 0.55,
+            brightness: 0.94
+        )
+    }
+
+    private func averageTokenText(snapshot: InjectionPresentation.Snapshot) -> String {
+        guard !snapshot.windowEvents.isEmpty else { return "0 tok" }
+        let total = snapshot.windowEvents.reduce(0) { $0 + $1.tokenCount }
+        return "\(Int((Double(total) / Double(snapshot.windowEvents.count)).rounded())) tok"
+    }
+
+    private func peakTokenText(snapshot: InjectionPresentation.Snapshot) -> String {
+        guard let event = snapshot.windowEvents.max(by: { $0.tokenCount < $1.tokenCount }) else {
+            return "0 tok"
+        }
+        return "\(event.tokenCount) tok"
+    }
+
+    private func latestEventText(snapshot: InjectionPresentation.Snapshot) -> String {
+        guard let first = snapshot.filteredEvents.first else { return "No recent events" }
+        return "Latest · \(InjectionPresentation.shortTime(first.timestamp))"
+    }
+
+    private var filterSignalText: String {
+        let trimmed = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return "Showing the full retrieval stream."
+        }
+        return "Filtered by “\(trimmed)”"
+    }
+
+    private var pageBackground: some View {
+        LinearGradient(
+            colors: [
+                Color(nsColor: .windowBackgroundColor),
+                Color.accentColor.opacity(0.04),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .fill(Color(nsColor: .controlBackgroundColor))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+            )
     }
 
     private func toggle(_ eventID: Int64) {
@@ -87,6 +452,31 @@ struct InjectionFeedView: View {
             expandedEventIDs.remove(eventID)
         } else {
             expandedEventIDs.insert(eventID)
+        }
+    }
+
+    private func makePresentation(now: Date = Date()) -> InjectionPresentation.Snapshot {
+        InjectionPresentation.snapshot(
+            events: store.events,
+            filterText: filterText,
+            now: now,
+            bucketCount: 24
+        )
+    }
+}
+
+private extension InjectionFeedView {
+    enum BurstChipTint {
+        case neutral
+        case blue
+        case green
+
+        var color: Color {
+            switch self {
+            case .neutral: .primary
+            case .blue: .blue
+            case .green: .green
+            }
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+struct InjectionPresentation {
+    struct Snapshot: Equatable {
+        let filteredEvents: [InjectionEvent]
+        let windowEvents: [InjectionEvent]
+        let summary: Summary
+        let bursts: [Burst]
+        let ribbonBuckets: [Int]
+        let sessions: [SessionSummary]
+    }
+
+    struct Summary: Equatable {
+        let queryCount: Int
+        let chunkCount: Int
+        let tokenCount: Int
+        let activeSessionCount: Int
+    }
+
+    struct Burst: Equatable, Identifiable {
+        let sessionID: String
+        let startDate: Date
+        let endDate: Date
+        let events: [InjectionEvent]
+
+        var id: String {
+            "\(sessionID)|\(endDate.timeIntervalSince1970)"
+        }
+
+        var queryCount: Int { events.count }
+        var chunkCount: Int { events.reduce(0) { $0 + $1.chunkCount } }
+        var tokenCount: Int { events.reduce(0) { $0 + $1.tokenCount } }
+    }
+
+    struct SessionSummary: Equatable, Identifiable {
+        let sessionID: String
+        let queryCount: Int
+        let chunkCount: Int
+        let tokenCount: Int
+        let latestDate: Date
+
+        var id: String { sessionID }
+    }
+
+    static func snapshot(
+        events: [InjectionEvent],
+        filterText: String,
+        now: Date,
+        windowMinutes: Int = 60,
+        burstGapMinutes: Int = 8,
+        bucketCount: Int = 12
+    ) -> Snapshot {
+        let filteredEvents = filter(events: events, needle: filterText)
+        let parsedEvents = filteredEvents.compactMap { event in
+            parseDate(event.timestamp).map { ParsedEvent(event: event, date: $0) }
+        }
+        .sorted { $0.date > $1.date }
+
+        let windowStart = now.addingTimeInterval(-Double(windowMinutes) * 60.0)
+        let windowEvents = parsedEvents.filter { $0.date >= windowStart && $0.date <= now }
+
+        let summary = Summary(
+            queryCount: windowEvents.count,
+            chunkCount: windowEvents.reduce(0) { $0 + $1.event.chunkCount },
+            tokenCount: windowEvents.reduce(0) { $0 + $1.event.tokenCount },
+            activeSessionCount: Set(windowEvents.map(\.event.sessionID)).count
+        )
+
+        return Snapshot(
+            filteredEvents: filteredEvents,
+            windowEvents: windowEvents.map(\.event),
+            summary: summary,
+            bursts: makeBursts(from: windowEvents, burstGapMinutes: burstGapMinutes),
+            ribbonBuckets: makeRibbonBuckets(
+                from: windowEvents,
+                windowStart: windowStart,
+                now: now,
+                bucketCount: max(bucketCount, 1)
+            ),
+            sessions: makeSessions(from: windowEvents)
+        )
+    }
+
+    static func parseDate(_ timestamp: String) -> Date? {
+        if let date = fractionalISOFormatter().date(from: timestamp) {
+            return date
+        }
+        if let date = plainISOFormatter().date(from: timestamp) {
+            return date
+        }
+        if let date = sqliteTimestampFormatter().date(from: timestamp) {
+            return date
+        }
+        return nil
+    }
+
+    static func shortTime(_ timestamp: String) -> String {
+        guard let date = parseDate(timestamp) else {
+            return String(timestamp.prefix(16))
+        }
+        return shortTimeFormatter().string(from: date)
+    }
+
+    static func burstRangeText(start: Date, end: Date) -> String {
+        if Calendar.current.isDate(start, equalTo: end, toGranularity: .minute) {
+            return shortTimeFormatter().string(from: end)
+        }
+        let formatter = shortTimeFormatter()
+        return "\(formatter.string(from: start)) -> \(formatter.string(from: end))"
+    }
+
+    private struct ParsedEvent {
+        let event: InjectionEvent
+        let date: Date
+    }
+
+    private static func filter(events: [InjectionEvent], needle: String) -> [InjectionEvent] {
+        let trimmed = needle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return events }
+        let lowered = trimmed.lowercased()
+        return events.filter { event in
+            event.sessionID.lowercased().contains(lowered) ||
+                event.query.lowercased().contains(lowered) ||
+                event.chunkIDs.joined(separator: " ").lowercased().contains(lowered)
+        }
+    }
+
+    private static func makeBursts(from events: [ParsedEvent], burstGapMinutes: Int) -> [Burst] {
+        guard let first = events.first else { return [] }
+
+        let maxGap = Double(max(burstGapMinutes, 1)) * 60.0
+        var bursts: [Burst] = []
+        var currentSessionID = first.event.sessionID
+        var currentEvents = [first]
+        var newest = first.date
+        var oldest = first.date
+
+        func flush() {
+            bursts.append(
+                Burst(
+                    sessionID: currentSessionID,
+                    startDate: oldest,
+                    endDate: newest,
+                    events: currentEvents.map(\.event)
+                )
+            )
+        }
+
+        for parsed in events.dropFirst() {
+            let gap = oldest.timeIntervalSince(parsed.date)
+            if parsed.event.sessionID == currentSessionID, gap <= maxGap {
+                currentEvents.append(parsed)
+                oldest = parsed.date
+            } else {
+                flush()
+                currentSessionID = parsed.event.sessionID
+                currentEvents = [parsed]
+                newest = parsed.date
+                oldest = parsed.date
+            }
+        }
+
+        flush()
+        return bursts
+    }
+
+    private static func makeRibbonBuckets(
+        from events: [ParsedEvent],
+        windowStart: Date,
+        now: Date,
+        bucketCount: Int
+    ) -> [Int] {
+        var buckets = Array(repeating: 0, count: bucketCount)
+        let total = now.timeIntervalSince(windowStart)
+        guard total > 0 else { return buckets }
+
+        for parsed in events {
+            let elapsed = parsed.date.timeIntervalSince(windowStart)
+            guard elapsed >= 0 else { continue }
+            let ratio = min(max(elapsed / total, 0), 0.999_999)
+            let index = min(bucketCount - 1, Int(ratio * Double(bucketCount)))
+            buckets[index] += 1
+        }
+        return buckets
+    }
+
+    private static func makeSessions(from events: [ParsedEvent]) -> [SessionSummary] {
+        let grouped = Dictionary(grouping: events, by: \.event.sessionID)
+        return grouped.map { sessionID, values in
+            SessionSummary(
+                sessionID: sessionID,
+                queryCount: values.count,
+                chunkCount: values.reduce(0) { $0 + $1.event.chunkCount },
+                tokenCount: values.reduce(0) { $0 + $1.event.tokenCount },
+                latestDate: values.map(\.date).max() ?? .distantPast
+            )
+        }
+        .sorted {
+            if $0.queryCount == $1.queryCount {
+                return $0.latestDate > $1.latestDate
+            }
+            return $0.queryCount > $1.queryCount
+        }
+    }
+
+    private static func fractionalISOFormatter() -> ISO8601DateFormatter {
+        threadFormatter(
+            key: "brainbar.injection.fractional-iso",
+            create: {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                return formatter
+            }
+        )
+    }
+
+    private static func plainISOFormatter() -> ISO8601DateFormatter {
+        threadFormatter(
+            key: "brainbar.injection.plain-iso",
+            create: {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime]
+                return formatter
+            }
+        )
+    }
+
+    private static func sqliteTimestampFormatter() -> DateFormatter {
+        threadFormatter(
+            key: "brainbar.injection.sqlite-timestamp",
+            create: {
+                let formatter = DateFormatter()
+                formatter.calendar = Calendar(identifier: .gregorian)
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.timeZone = TimeZone(secondsFromGMT: 0)
+                formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSS"
+                return formatter
+            }
+        )
+    }
+
+    private static func shortTimeFormatter() -> DateFormatter {
+        threadFormatter(
+            key: "brainbar.injection.short-time",
+            create: {
+                let formatter = DateFormatter()
+                formatter.calendar = Calendar(identifier: .gregorian)
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.timeZone = TimeZone.current
+                formatter.dateFormat = "HH:mm"
+                return formatter
+            }
+        )
+    }
+
+    private static func threadFormatter<Formatter: NSObject>(
+        key: String,
+        create: () -> Formatter
+    ) -> Formatter {
+        let dictionary = Thread.current.threadDictionary
+        if let formatter = dictionary[key] as? Formatter {
+            return formatter
+        }
+        let formatter = create()
+        dictionary[key] = formatter
+        return formatter
+    }
+}

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -31,11 +31,14 @@ final class InjectionStore: ObservableObject {
     }
 
     func start(sessionID: String? = nil, limit: Int = 50) {
+        let parametersChanged = currentSessionID != sessionID || currentLimit != limit
         currentSessionID = sessionID
         currentLimit = limit
 
         guard !isRunning else {
-            refresh(force: true)
+            if parametersChanged {
+                refresh(force: true)
+            }
             return
         }
 

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasLayout.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasLayout.swift
@@ -1,0 +1,68 @@
+import CoreGraphics
+import Foundation
+
+enum KGAtlasLayout {
+    static func seededNodes(_ nodes: [KGNode], canvasSize: CGSize) -> [KGNode] {
+        let width = max(canvasSize.width, 640)
+        let height = max(canvasSize.height, 480)
+        let regionCenters = makeRegionCenters(canvasSize: CGSize(width: width, height: height))
+        let grouped = Dictionary(grouping: nodes.enumerated(), by: \.element.entityType)
+
+        var seeded = nodes
+        for (entityType, indexedNodes) in grouped {
+            let center = regionCenters[entityType] ?? CGPoint(x: width * 0.5, y: height * 0.5)
+            let sorted = indexedNodes.sorted {
+                if $0.element.importance == $1.element.importance {
+                    return $0.element.name.localizedCaseInsensitiveCompare($1.element.name) == .orderedAscending
+                }
+                return $0.element.importance > $1.element.importance
+            }
+
+            for (offset, indexed) in sorted.enumerated() {
+                seeded[indexed.offset].position = position(
+                    for: offset,
+                    total: sorted.count,
+                    center: center
+                )
+                seeded[indexed.offset].velocity = .zero
+            }
+        }
+
+        return seeded
+    }
+
+    private static func makeRegionCenters(canvasSize: CGSize) -> [String: CGPoint] {
+        let columns: [CGFloat] = [0.22, 0.5, 0.78]
+        let rows: [CGFloat] = [0.24, 0.5, 0.76]
+
+        return [
+            "person": CGPoint(x: canvasSize.width * columns[0], y: canvasSize.height * rows[0]),
+            "project": CGPoint(x: canvasSize.width * columns[1], y: canvasSize.height * rows[0]),
+            "tool": CGPoint(x: canvasSize.width * columns[2], y: canvasSize.height * rows[0]),
+            "technology": CGPoint(x: canvasSize.width * columns[0], y: canvasSize.height * rows[1]),
+            "agent": CGPoint(x: canvasSize.width * columns[1], y: canvasSize.height * rows[1]),
+            "company": CGPoint(x: canvasSize.width * columns[2], y: canvasSize.height * rows[1]),
+            "topic": CGPoint(x: canvasSize.width * columns[0], y: canvasSize.height * rows[2]),
+            "decision": CGPoint(x: canvasSize.width * columns[1], y: canvasSize.height * rows[2]),
+        ]
+    }
+
+    private static func position(for offset: Int, total: Int, center: CGPoint) -> CGPoint {
+        guard total > 1 else { return center }
+
+        if offset == 0 {
+            return center
+        }
+
+        let ring = Int(ceil((sqrt(Double(offset + 1)) - 1) / 2))
+        let indexInRing = offset - (ring * ring)
+        let countInRing = max(ring * 6, 1)
+        let angle = (Double(indexInRing) / Double(countInRing)) * Double.pi * 2
+        let radius = CGFloat(42 + ring * 30)
+
+        return CGPoint(
+            x: center.x + cos(angle) * radius,
+            y: center.y + sin(angle) * radius * 0.72
+        )
+    }
+}

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+struct KGAtlasPresentation {
+    struct Region: Equatable, Identifiable {
+        let entityType: String
+        let title: String
+        let nodes: [KGNode]
+
+        var id: String { entityType }
+    }
+
+    struct Snapshot: Equatable {
+        let regions: [Region]
+        let visibleNodes: [KGNode]
+        let visibleEdges: [KGEdge]
+        let selectedRegion: Region?
+    }
+
+    static func snapshot(
+        nodes: [KGNode],
+        edges: [KGEdge],
+        selectedNodeId: String?,
+        minimumImportance: Double
+    ) -> Snapshot {
+        let visibleNodes = nodes.filter { node in
+            node.importance >= minimumImportance || node.id == selectedNodeId
+        }
+
+        let visibleIDs = Set(visibleNodes.map(\.id))
+        let visibleEdges = edges.filter { visibleIDs.contains($0.sourceId) && visibleIDs.contains($0.targetId) }
+
+        let grouped = Dictionary(grouping: visibleNodes, by: \.entityType)
+        let regions: [Region] = orderedEntityTypes.compactMap { entityType in
+            guard let values = grouped[entityType], !values.isEmpty else { return nil }
+            return Region(
+                entityType: entityType,
+                title: title(for: entityType),
+                nodes: values.sorted {
+                    if $0.importance == $1.importance {
+                        return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                    }
+                    return $0.importance > $1.importance
+                }
+            )
+        }
+
+        let selectedRegion = regions.first { region in
+            region.nodes.contains { $0.id == selectedNodeId }
+        }
+
+        return Snapshot(
+            regions: regions,
+            visibleNodes: regions.flatMap { $0.nodes },
+            visibleEdges: visibleEdges,
+            selectedRegion: selectedRegion
+        )
+    }
+
+    static func title(for entityType: String) -> String {
+        switch entityType {
+        case "person": "People"
+        case "project": "Projects"
+        case "tool": "Tools"
+        case "technology": "Technology"
+        case "agent": "Agents"
+        case "company": "Companies"
+        case "topic": "Topics"
+        case "decision": "Decisions"
+        default: "Other"
+        }
+    }
+
+    private static let orderedEntityTypes = [
+        "person",
+        "project",
+        "tool",
+        "technology",
+        "agent",
+        "company",
+        "topic",
+        "decision",
+    ]
+}

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -2,94 +2,291 @@ import SwiftUI
 
 struct KGCanvasView: View {
     @ObservedObject var viewModel: KGViewModel
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var offset: CGSize = .zero
     @State private var lastDragOffset: CGSize = .zero
     @State private var scale: CGFloat = 1.0
     @State private var lastScale: CGFloat = 1.0
-    @State private var draggedNodeId: String?
-    @State private var simulation = KGSimulationController()
     @State private var canvasSize: CGSize = .zero
+    @State private var minimumImportance: Double = 3
+    @State private var hasLoadedGraph = false
+    @GestureState private var toolbarInteractionActive = false
 
-    var body: some View {
-        HStack(spacing: 0) {
-            graphCanvas
-            if viewModel.selectedEntity != nil {
-                KGSidebarView(
-                    entity: viewModel.selectedEntity,
-                    chunks: viewModel.selectedEntityChunks,
-                    onOpenConversation: { viewModel.openConversation(chunkID: $0) },
-                    onClose: { viewModel.selectNode(id: nil) }
-                )
-            }
-        }
-        .sheet(item: $viewModel.selectedConversation) { conversation in
-            ChunkConversationSheet(conversation: conversation)
-        }
-        .onAppear {
-            viewModel.loadGraph()
-            startSimulation()
-        }
-        .onDisappear { simulation.stop() }
+    private var atlas: KGAtlasPresentation.Snapshot {
+        KGAtlasPresentation.snapshot(
+            nodes: viewModel.nodes,
+            edges: viewModel.edges,
+            selectedNodeId: viewModel.selectedNodeId,
+            minimumImportance: minimumImportance
+        )
     }
 
-    private var graphCanvas: some View {
+    var body: some View {
+        GeometryReader { geo in
+            let sidebarVisible = geo.size.width >= 980 || viewModel.selectedEntity != nil
+
+            HStack(spacing: 0) {
+                ZStack(alignment: .topLeading) {
+                    atlasBackground
+                    graphCanvas(snapshot: atlas)
+                    atlasToolbar(snapshot: atlas)
+                    atlasOverview(snapshot: atlas)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                if sidebarVisible {
+                    KGSidebarView(
+                        entity: viewModel.selectedEntity,
+                        chunks: viewModel.selectedEntityChunks,
+                        onOpenConversation: { viewModel.openConversation(chunkID: $0) },
+                        onClose: { viewModel.selectNode(id: nil) }
+                    )
+                }
+            }
+            .background(pageBackground)
+            .overlay {
+                if let conversation = viewModel.selectedConversation {
+                    ChunkConversationOverlay(
+                        conversation: conversation,
+                        onClose: { viewModel.selectedConversation = nil }
+                    )
+                }
+            }
+            .onAppear {
+                setCanvas(size: geo.size)
+                if !hasLoadedGraph {
+                    viewModel.loadGraph()
+                    hasLoadedGraph = true
+                }
+            }
+            .onChange(of: geo.size) { _, newSize in
+                setCanvas(size: newSize)
+                guard hasLoadedGraph, !viewModel.nodes.isEmpty else { return }
+                viewModel.nodes = KGAtlasLayout.seededNodes(viewModel.nodes, canvasSize: newSize)
+            }
+        }
+    }
+
+    private func graphCanvas(snapshot: KGAtlasPresentation.Snapshot) -> some View {
         Canvas { context, size in
             var ctx = context
-            // Apply pan + zoom transform
             ctx.translateBy(x: offset.width + size.width / 2, y: offset.height + size.height / 2)
             ctx.scaleBy(x: scale, y: scale)
             ctx.translateBy(x: -size.width / 2, y: -size.height / 2)
 
-            let environment = EnvironmentValues()
-            let nodeIndex = Dictionary(uniqueKeysWithValues: viewModel.nodes.map { ($0.id, $0) })
+            var environment = EnvironmentValues()
+            environment.colorScheme = colorScheme
+            let nodeIndex = Dictionary(uniqueKeysWithValues: snapshot.visibleNodes.map { ($0.id, $0) })
 
-            // Draw edges first (behind nodes)
-            for edge in viewModel.edges {
-                guard let src = nodeIndex[edge.sourceId], let tgt = nodeIndex[edge.targetId] else { continue }
+            for region in snapshot.regions {
+                drawRegionBackdrop(region: region, in: &ctx, environment: environment)
+            }
+
+            for edge in snapshot.visibleEdges {
+                guard let source = nodeIndex[edge.sourceId], let target = nodeIndex[edge.targetId] else { continue }
                 let highlighted = viewModel.selectedNodeId == edge.sourceId || viewModel.selectedNodeId == edge.targetId
                 KGEdgeRenderer.draw(
-                    edge: edge, sourcePos: src.position, targetPos: tgt.position,
-                    isHighlighted: highlighted, in: &ctx, environment: environment
+                    edge: edge,
+                    sourcePos: source.position,
+                    targetPos: target.position,
+                    isHighlighted: highlighted,
+                    in: &ctx,
+                    environment: environment
                 )
             }
 
-            // Draw nodes
-            for node in viewModel.nodes {
+            for node in snapshot.visibleNodes {
                 KGNodeRenderer.draw(
                     node: node,
                     isSelected: node.id == viewModel.selectedNodeId,
-                    in: &ctx, environment: environment
+                    in: &ctx,
+                    environment: environment
                 )
             }
         }
         .background(
             GeometryReader { geo in
-                Color.black.opacity(0.85)
-                    .onAppear {
-                        canvasSize = geo.size
-                        viewModel.canvasCenter = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
-                    }
+                Color.clear
+                    .onAppear { setCanvas(size: geo.size) }
                     .onChange(of: geo.size) { _, newSize in
-                        canvasSize = newSize
-                        viewModel.canvasCenter = CGPoint(x: newSize.width / 2, y: newSize.height / 2)
+                        setCanvas(size: newSize)
                     }
             }
         )
         .overlay { ScrollWheelZoomView(scale: $scale) }
-        .gesture(tapGesture)
+        .allowsHitTesting(!toolbarInteractionActive)
+        .gesture(tapGesture(snapshot: snapshot))
         .gesture(dragGesture)
         .gesture(magnifyGesture)
-        .overlay(alignment: .topLeading) { statsOverlay }
+        .padding(18)
     }
 
-    // MARK: - Gestures
+    private var atlasBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: colorScheme == .dark
+                    ? [
+                        Color(red: 0.06, green: 0.07, blue: 0.10),
+                        Color(red: 0.09, green: 0.11, blue: 0.14),
+                    ]
+                    : [
+                        Color(red: 0.95, green: 0.95, blue: 0.92),
+                        Color(red: 0.90, green: 0.92, blue: 0.94),
+                    ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
 
-    private var tapGesture: some Gesture {
+            VStack(spacing: 64) {
+                ForEach(0..<4, id: \.self) { _ in
+                    Rectangle()
+                        .fill(Color.primary.opacity(colorScheme == .dark ? 0.05 : 0.04))
+                        .frame(height: 1)
+                }
+            }
+            .padding(.horizontal, 26)
+        }
+    }
+
+    private func atlasToolbar(snapshot: KGAtlasPresentation.Snapshot) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Knowledge atlas")
+                        .font(.system(size: 20, weight: .bold, design: .rounded))
+                    Text("\(snapshot.visibleNodes.count) entities · \(snapshot.visibleEdges.count) visible relations")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 12)
+
+                labelChip("importance ≥ \(Int(minimumImportance))")
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Altitude")
+                        .font(.system(size: 11, weight: .semibold))
+                    Spacer()
+                    Text("Lower values reveal more nodes")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                Slider(value: $minimumImportance, in: 0...10, step: 1)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(snapshot.regions) { region in
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(region.nodes.first?.color ?? .secondary)
+                                .frame(width: 8, height: 8)
+                            Text(region.title)
+                                .font(.system(size: 11, weight: .semibold))
+                            Text("\(region.nodes.count)")
+                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule()
+                                .fill(Color.primary.opacity(0.07))
+                        )
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: 420)
+        .background(toolbarBackground)
+        .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .onTapGesture {}
+        .simultaneousGesture(toolbarInteractionGesture)
+        .padding(20)
+    }
+
+    private func atlasOverview(snapshot: KGAtlasPresentation.Snapshot) -> some View {
+        VStack(alignment: .trailing, spacing: 10) {
+            if let selectedEntity = viewModel.selectedEntity {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text("Focus")
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    Text(selectedEntity.name)
+                        .font(.system(size: 14, weight: .bold))
+                    Text(selectedEntity.entityType.capitalized)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .trailing, spacing: 6) {
+                Text("Atlas regions")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.secondary)
+
+                ForEach(snapshot.regions) { region in
+                    HStack(spacing: 8) {
+                        Text(region.title)
+                            .font(.system(size: 11, weight: .semibold))
+                        Text("\(region.nodes.count)")
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(14)
+        .background(toolbarBackground)
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+    }
+
+    private func drawRegionBackdrop(
+        region: KGAtlasPresentation.Region,
+        in context: inout GraphicsContext,
+        environment: EnvironmentValues
+    ) {
+        guard !region.nodes.isEmpty else { return }
+
+        let xs = region.nodes.map { $0.position.x }
+        let ys = region.nodes.map { $0.position.y }
+        guard let minX = xs.min(), let maxX = xs.max(), let minY = ys.min(), let maxY = ys.max() else {
+            return
+        }
+
+        let rect = CGRect(
+            x: minX - 64,
+            y: minY - 52,
+            width: max((maxX - minX) + 128, 180),
+            height: max((maxY - minY) + 112, 132)
+        )
+
+        let tint = region.nodes.first?.color ?? .secondary
+        context.fill(
+            Ellipse().path(in: rect),
+            with: .color(tint.opacity(colorScheme == .dark ? 0.14 : 0.10))
+        )
+
+        let label = Text(region.title.uppercased())
+            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+            .foregroundColor(Color.primary.opacity(0.55))
+        context.draw(
+            context.resolve(label),
+            at: CGPoint(x: rect.midX, y: rect.minY - 14),
+            anchor: .center
+        )
+    }
+
+    private func tapGesture(snapshot: KGAtlasPresentation.Snapshot) -> some Gesture {
         SpatialTapGesture()
             .onEnded { value in
                 let point = canvasPoint(from: value.location, in: canvasSize)
-                if let node = viewModel.nodeAt(point: point) {
+                if let node = nodeAt(point: point, visibleNodes: snapshot.visibleNodes) {
                     viewModel.selectNode(id: node.id)
                 } else {
                     viewModel.selectNode(id: nil)
@@ -113,18 +310,14 @@ struct KGCanvasView: View {
     private var magnifyGesture: some Gesture {
         MagnifyGesture()
             .onChanged { value in
-                scale = max(0.2, min(5.0, lastScale * value.magnification))
+                scale = max(0.35, min(4.0, lastScale * value.magnification))
             }
             .onEnded { _ in
                 lastScale = scale
             }
     }
 
-    // MARK: - Coordinate transform
-
     private func canvasPoint(from screenPoint: CGPoint, in size: CGSize) -> CGPoint {
-        // Inverse of the canvas transform:
-        //   translate(offset + size/2) → scale → translate(-size/2)
         let cx = size.width / 2
         let cy = size.height / 2
         return CGPoint(
@@ -133,19 +326,52 @@ struct KGCanvasView: View {
         )
     }
 
-    // MARK: - Simulation timer
-
-    private func startSimulation() {
-        guard !simulation.timerActive else { return }
-        simulation.start { viewModel.tick() }
+    private func nodeAt(point: CGPoint, visibleNodes: [KGNode]) -> KGNode? {
+        for node in visibleNodes {
+            let dx = point.x - node.position.x
+            let dy = point.y - node.position.y
+            let dist = sqrt(dx * dx + dy * dy)
+            if dist <= node.radius + 4 {
+                return node
+            }
+        }
+        return nil
     }
 
-    // MARK: - Stats overlay
+    private func setCanvas(size: CGSize) {
+        guard size != .zero else { return }
+        canvasSize = size
+        viewModel.canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
+    }
 
-    private var statsOverlay: some View {
-        Text("\(viewModel.nodes.count) nodes · \(viewModel.edges.count) edges")
-            .font(.caption2)
-            .foregroundColor(.white.opacity(0.6))
-            .padding(6)
+    private var toolbarInteractionGesture: some Gesture {
+        DragGesture(minimumDistance: 0)
+            .updating($toolbarInteractionActive) { _, state, _ in
+                state = true
+            }
+    }
+
+    private var toolbarBackground: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(Color(nsColor: .windowBackgroundColor).opacity(colorScheme == .dark ? 0.82 : 0.9))
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            )
+    }
+
+    private var pageBackground: some View {
+        Color(nsColor: .windowBackgroundColor)
+    }
+
+    private func labelChip(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(Color.primary.opacity(0.08))
+            )
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGEdgeView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGEdgeView.swift
@@ -10,11 +10,14 @@ enum KGEdgeRenderer {
         in context: inout GraphicsContext,
         environment: EnvironmentValues
     ) {
+        let darkMode = environment.colorScheme == .dark
         var path = Path()
         path.move(to: sourcePos)
         path.addLine(to: targetPos)
 
-        let color: Color = isHighlighted ? .white : .gray.opacity(0.35)
+        let color: Color = isHighlighted
+            ? (darkMode ? .white : .black.opacity(0.8))
+            : (darkMode ? .gray.opacity(0.35) : .black.opacity(0.18))
         context.stroke(path, with: .color(color), lineWidth: isHighlighted ? 2 : 1)
 
         // Relation label at midpoint
@@ -24,7 +27,11 @@ enum KGEdgeRenderer {
         )
         let label = Text(edge.relationType)
             .font(.system(size: 8))
-            .foregroundColor(isHighlighted ? .white.opacity(0.9) : .gray.opacity(0.5))
+            .foregroundColor(
+                isHighlighted
+                    ? (darkMode ? .white.opacity(0.9) : .black.opacity(0.75))
+                    : (darkMode ? .gray.opacity(0.5) : .black.opacity(0.4))
+            )
         context.draw(context.resolve(label), at: mid, anchor: .center)
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGNodeView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGNodeView.swift
@@ -9,6 +9,7 @@ enum KGNodeRenderer {
         in context: inout GraphicsContext,
         environment: EnvironmentValues
     ) {
+        let darkMode = environment.colorScheme == .dark
         let r = node.radius
         let rect = CGRect(
             x: node.position.x - r,
@@ -19,12 +20,14 @@ enum KGNodeRenderer {
 
         // Circle fill
         let fillColor = isSelected
-            ? Color.white
+            ? (darkMode ? Color.white : Color.black)
             : node.color
         context.fill(Circle().path(in: rect), with: .color(fillColor.opacity(0.85)))
 
         // Border ring
-        let strokeColor = isSelected ? node.color : Color.white.opacity(0.4)
+        let strokeColor = isSelected
+            ? node.color
+            : (darkMode ? Color.white.opacity(0.4) : Color.black.opacity(0.22))
         context.stroke(
             Circle().path(in: rect),
             with: .color(strokeColor),
@@ -35,7 +38,7 @@ enum KGNodeRenderer {
         let label = Text(node.name)
             .font(.system(size: max(9, r * 0.55), weight: isSelected ? .bold : .medium))
             .underline(isSelected)
-            .foregroundColor(isSelected ? node.color : .white)
+            .foregroundColor(isSelected ? node.color : (darkMode ? .white : .black))
         context.draw(
             context.resolve(label),
             at: CGPoint(x: node.position.x, y: node.position.y + r + 12),

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -8,130 +8,216 @@ struct KGSidebarView: View {
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: true) {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 16) {
                 if let entity {
                     header(entity)
-                    if !entity.description.isEmpty {
-                        Text(entity.description)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(3)
-                    }
-                    Divider()
+                    synopsis(entity)
                     relationsSection(entity.relations)
                     if !entity.metadata.isEmpty {
-                        Divider()
                         metadataSection(entity.metadata)
                     }
-                    if !chunks.isEmpty {
-                        Divider()
-                        chunksSection()
-                    }
+                    chunksSection()
                 } else {
-                    Text("Select a node")
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    emptyState
                 }
             }
-            .padding(12)
+            .padding(18)
         }
-        .frame(width: 280)
-        .background(.ultraThinMaterial)
+        .frame(width: 320)
+        .background(
+            LinearGradient(
+                colors: [
+                    Color(nsColor: .controlBackgroundColor),
+                    Color.accentColor.opacity(0.03),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(Color.primary.opacity(0.08))
+                .frame(width: 1)
+        }
     }
 
     @ViewBuilder
     private func header(_ entity: EntityCard) -> some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(entity.name)
-                    .font(.headline)
-                Text(entity.entityType)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(.quaternary))
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(entity.name)
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(spacing: 8) {
+                        labelChip(entity.entityType.isEmpty ? "entity" : entity.entityType.capitalized, tint: .blue)
+                        labelChip("\(entity.relations.count) links", tint: .primary)
+                        labelChip("\(chunks.count) chunks", tint: .green)
+                    }
+                }
+
+                Spacer(minLength: 12)
+
+                Button(action: onClose) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
             }
-            Spacer()
-            Button(action: onClose) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
         }
+        .padding(16)
+        .background(sectionBackground)
+    }
+
+    @ViewBuilder
+    private func synopsis(_ entity: EntityCard) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Synopsis")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            if entity.description.isEmpty {
+                Text("No entity description is stored yet. Use relations and linked chunks as the primary drilldown.")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(entity.description)
+                    .font(.system(size: 13, weight: .medium))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .background(sectionBackground)
     }
 
     @ViewBuilder
     private func relationsSection(_ relations: [EntityCard.Relation]) -> some View {
-        if relations.isEmpty {
-            Text("No relations")
-                .font(.caption)
-                .foregroundColor(.secondary)
-        } else {
-            Text("Relations (\(relations.count))")
-                .font(.subheadline.bold())
-            ForEach(Array(relations.enumerated()), id: \.offset) { _, rel in
-                HStack(spacing: 4) {
-                    Text(rel.direction == "incoming" ? "←" : "→")
-                        .font(.caption)
-                        .foregroundColor(.secondary.opacity(0.6))
-                    Text(rel.displayText)
-                        .font(.caption.bold())
-                        .lineLimit(1)
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Relations")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            if relations.isEmpty {
+                Text("No graph relations yet.")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(relations.enumerated()), id: \.offset) { _, relation in
+                    HStack(alignment: .top, spacing: 10) {
+                        Text(relation.direction == "incoming" ? "←" : "→")
+                            .font(.system(size: 13, weight: .bold, design: .rounded))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 14)
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(relation.targetName)
+                                .font(.system(size: 13, weight: .semibold))
+                            Text(relation.relationType.replacingOccurrences(of: "_", with: " "))
+                                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+                    }
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(Color.primary.opacity(0.045))
+                    )
                 }
             }
         }
+        .padding(16)
+        .background(sectionBackground)
     }
 
     @ViewBuilder
     private func metadataSection(_ metadata: [String: String]) -> some View {
-        Text("Metadata")
-            .font(.subheadline.bold())
-        ForEach(Array(metadata.sorted(by: { $0.key < $1.key }).prefix(6)), id: \.key) { key, value in
-            HStack(spacing: 4) {
-                Text(key)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                Text(value)
-                    .font(.caption)
-                    .lineLimit(1)
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Metadata")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            ForEach(Array(metadata.sorted(by: { $0.key < $1.key }).prefix(6)), id: \.key) { key, value in
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(key)
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    Text(value)
+                        .font(.system(size: 13, weight: .medium))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(Color.primary.opacity(0.045))
+                )
             }
         }
+        .padding(16)
+        .background(sectionBackground)
     }
 
     private func chunksSection() -> some View {
-        let previewIndices = Array(0..<min(chunks.count, 10))
-        return VStack(alignment: .leading, spacing: 8) {
-            Text("Linked Chunks (\(chunks.count))")
-                .font(.subheadline.bold())
-            ForEach(previewIndices, id: \.self) { (index: Int) in
+        let previewIndices = Array(0..<min(chunks.count, 8))
+        return VStack(alignment: .leading, spacing: 12) {
+            Text("Linked chunks")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            ForEach(Array(previewIndices), id: \.self) { index in
                 let chunk = chunks[index]
                 Button {
                     onOpenConversation(chunk.chunkID)
                 } label: {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(chunk.snippet)
-                            .font(.caption)
-                            .lineLimit(4)
-                            .multilineTextAlignment(.leading)
-                        HStack(spacing: 8) {
-                            Text(importanceText(for: chunk))
-                            Text(relevanceText(for: chunk))
-                            Spacer()
-                            Text("Open")
-                                .font(.caption.bold())
-                                .foregroundColor(.accentColor)
-                        }
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                    }
+                    chunkCard(chunk)
                 }
                 .buttonStyle(.plain)
-                .padding(8)
+                .padding(14)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary))
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(Color.primary.opacity(0.045))
+                )
             }
         }
+        .padding(16)
+        .background(sectionBackground)
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Knowledge atlas")
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+            Text("Select a node to inspect its relations, metadata, and linked memory chunks.")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(sectionBackground)
+    }
+
+    private var sectionBackground: some View {
+        RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .fill(Color(nsColor: .windowBackgroundColor))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+            )
+    }
+
+    private func labelChip(_ text: String, tint: ChipTint) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(
+                Capsule()
+                    .fill(tint.color.opacity(tint == .primary ? 0.08 : 0.14))
+            )
     }
 
     private func importanceText(for chunk: BrainDatabase.KGChunkRow) -> String {
@@ -140,5 +226,42 @@ struct KGSidebarView: View {
 
     private func relevanceText(for chunk: BrainDatabase.KGChunkRow) -> String {
         "↳ \(Int((chunk.relevance * 100).rounded()))%"
+    }
+
+    private func chunkCard(_ chunk: BrainDatabase.KGChunkRow) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(chunk.snippet)
+                .font(.system(size: 13, weight: .medium))
+                .lineLimit(4)
+                .multilineTextAlignment(.leading)
+                .foregroundStyle(.primary)
+
+            HStack {
+                labelChip(importanceText(for: chunk), tint: .amber)
+                labelChip(relevanceText(for: chunk), tint: .green)
+                Spacer()
+                Text("Open thread")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+    }
+}
+
+private extension KGSidebarView {
+    enum ChipTint {
+        case primary
+        case blue
+        case green
+        case amber
+
+        var color: Color {
+            switch self {
+            case .primary: .primary
+            case .blue: .blue
+            case .green: .green
+            case .amber: .orange
+            }
+        }
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -34,7 +34,7 @@ final class KGViewModel: ObservableObject {
 
             let entityIds = Set(entityRows.map(\.id))
 
-            nodes = entityRows.map { row in
+            let seededNodes = entityRows.map { row in
                 KGNode(
                     id: row.id,
                     name: row.name,
@@ -42,6 +42,13 @@ final class KGViewModel: ObservableObject {
                     importance: row.importance
                 )
             }
+            nodes = KGAtlasLayout.seededNodes(
+                seededNodes,
+                canvasSize: CGSize(
+                    width: max(canvasCenter.x * 2, 640),
+                    height: max(canvasCenter.y * 2, 480)
+                )
+            )
 
             // Only include edges where both endpoints exist
             edges = relationRows.compactMap { row in

--- a/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
@@ -2,7 +2,16 @@ import SwiftUI
 
 struct ChunkConversationSheet: View {
     let conversation: BrainDatabase.ExpandedConversation
+    let onClose: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
+
+    init(
+        conversation: BrainDatabase.ExpandedConversation,
+        onClose: (() -> Void)? = nil
+    ) {
+        self.conversation = conversation
+        self.onClose = onClose
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -15,7 +24,7 @@ struct ChunkConversationSheet: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                Button("Close") { dismiss() }
+                Button("Close", action: close)
             }
 
             ScrollView {
@@ -62,6 +71,14 @@ struct ChunkConversationSheet: View {
         .frame(minWidth: 580, minHeight: 460)
     }
 
+    private func close() {
+        if let onClose {
+            onClose()
+        } else {
+            dismiss()
+        }
+    }
+
     private func roleLabel(for entry: BrainDatabase.ConversationChunk) -> String {
         switch entry.contentType {
         case "user_message":
@@ -71,5 +88,36 @@ struct ChunkConversationSheet: View {
         default:
             return entry.contentType.replacingOccurrences(of: "_", with: " ").capitalized
         }
+    }
+}
+
+struct ChunkConversationOverlay: View {
+    let conversation: BrainDatabase.ExpandedConversation
+    let onClose: () -> Void
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color.black.opacity(0.22))
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onClose)
+
+            ChunkConversationSheet(conversation: conversation, onClose: onClose)
+                .background(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .fill(Color(nsColor: .windowBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                )
+                .shadow(color: Color.black.opacity(0.18), radius: 24, y: 10)
+                .padding(28)
+                .frame(maxWidth: 940, maxHeight: .infinity)
+                .onTapGesture {}
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity)
+        .zIndex(30)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import BrainBar
+
+final class AgentActivityMonitorTests: XCTestCase {
+    func testParseSnapshotCountsEachAgentFamilyAndSkipsHelperNoise() {
+        let snapshot = """
+         2918 2.1.114 claude --dangerously-skip-permissions --resume 3679128a-f371-445f-82ba-b3946e2f20b6
+        13908 node node /Users/etanheyman/.bun/bin/codex --model gpt-5.4 --dangerously-bypass-approvals-and-sandbox
+        13909 codex /Users/etanheyman/.bun/install/global/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex --model gpt-5.4 --dangerously-bypass-approvals-and-sandbox
+        18001 cursor cursor agent --resume session-123
+        19001 gemini gemini --model gemini-2.5-pro
+         1355 Electron /Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler --monitor-self-annotation=ptype=crashpad-handler
+         1588 Claude\\ Helper /Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper --type=gpu-process
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .claude), 1)
+        XCTAssertEqual(activity.count(for: .codex), 1)
+        XCTAssertEqual(activity.count(for: .cursor), 1)
+        XCTAssertEqual(activity.count(for: .gemini), 1)
+        XCTAssertEqual(activity.totalActiveAgents, 4)
+    }
+
+    func testParseSnapshotRetainsFamiliesWithZeroCounts() {
+        let activity = AgentActivityMonitor.parse("")
+
+        XCTAssertEqual(activity.count(for: .claude), 0)
+        XCTAssertEqual(activity.count(for: .codex), 0)
+        XCTAssertEqual(activity.count(for: .cursor), 0)
+        XCTAssertEqual(activity.count(for: .gemini), 0)
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+        XCTAssertEqual(activity.summaryText, "No agent CLIs live")
+    }
+
+    func testParseSnapshotSkipsSearchCommandsThatMentionAgentNames() {
+        let snapshot = """
+        42029 rg rg -n claude\\|codex\\|cursor\\|gemini /Users/etanheyman/Gits
+        42030 awk awk BEGIN{IGNORECASE=1} /claude|codex|cursor|gemini/ {print}
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+    }
+
+    func testRunSnapshotCommandDrainsLargeStdoutWithoutDeadlocking() {
+        let script = "python3 -c \"print('codex ' * 20000)\""
+
+        let snapshot = AgentActivityMonitor.runSnapshotCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", script]
+        )
+
+        XCTAssertNotNil(snapshot)
+        XCTAssertGreaterThan(snapshot?.count ?? 0, 100_000)
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
@@ -40,4 +40,58 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
         controller.toggle()
         XCTAssertFalse(controller.panelForTesting.isVisible)
     }
+
+    func testCommandBarBecomesReadyWhenDatabaseWasInstalledWhilePanelWasHidden() {
+        let runtime = BrainBarRuntime()
+        let controller = BrainBarDashboardPanelController(runtime: runtime)
+        let tempDBPath = NSTemporaryDirectory() + "brainbar-commandbar-ready-\(UUID().uuidString).db"
+        let db = BrainDatabase(path: tempDBPath)
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: getpid())
+        )
+        defer {
+            collector.stop()
+            db.close()
+            controller.dismiss()
+            try? FileManager.default.removeItem(atPath: tempDBPath)
+            try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
+        }
+
+        // Match launch order: AppDelegate creates the hidden NSPanel before the
+        // async database install lands, then the user opens BrainBar later.
+        _ = controller.panelForTesting.contentViewController?.view
+        runMainRunLoop()
+
+        runtime.install(collector: collector, injectionStore: nil, database: db)
+        runMainRunLoop()
+
+        controller.show()
+        runMainRunLoop()
+
+        let field = controller.panelForTesting.contentView.flatMap {
+            findSubview(ofType: KeyHandlingCommandBarField.self, in: $0)
+        }
+        XCTAssertNotNil(
+            field,
+            "Command bar should create its ready text field when runtime.database was installed before the panel became visible."
+        )
+    }
+
+    private func runMainRunLoop() {
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    }
+
+    private func findSubview<T: NSView>(ofType type: T.Type, in root: NSView) -> T? {
+        if let match = root as? T {
+            return match
+        }
+        for subview in root.subviews {
+            if let match = findSubview(ofType: type, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
@@ -1,0 +1,43 @@
+import AppKit
+import XCTest
+@testable import BrainBar
+
+@MainActor
+final class BrainBarDashboardPanelControllerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "NSWindow Frame BrainBarPanel")
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "NSWindow Frame BrainBarPanel")
+        super.tearDown()
+    }
+
+    func testDashboardPanelUsesResizableUtilityWindowContract() {
+        let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
+        let panel = controller.panelForTesting
+
+        XCTAssertTrue(panel.styleMask.contains(.titled))
+        XCTAssertTrue(panel.styleMask.contains(.resizable))
+        XCTAssertTrue(panel.styleMask.contains(.closable))
+        XCTAssertTrue(panel.styleMask.contains(.nonactivatingPanel))
+        XCTAssertEqual(panel.frameAutosaveName, "BrainBarPanel")
+        XCTAssertEqual(BrainBarDashboardPanelController.defaultSize, NSSize(width: 1_348, height: 1_078))
+        XCTAssertEqual(panel.minSize, NSSize(width: 760, height: 560))
+        XCTAssertGreaterThanOrEqual(panel.frame.width, panel.minSize.width)
+        XCTAssertGreaterThanOrEqual(panel.frame.height, panel.minSize.height)
+        XCTAssertTrue(panel.canBecomeKey)
+        XCTAssertTrue(panel.canBecomeMain)
+    }
+
+    func testDashboardPanelToggleControlsVisibility() {
+        let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
+
+        controller.toggle()
+        XCTAssertTrue(controller.panelForTesting.isVisible)
+
+        controller.toggle()
+        XCTAssertFalse(controller.panelForTesting.isVisible)
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class BrainBarUXLogicTests: XCTestCase {
     func testPipelineIndicatorsCanShowIndexingAndEnrichingLiveAtTheSameTime() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
             enrichedChunkCount: 100,
@@ -11,7 +12,9 @@ final class BrainBarUXLogicTests: XCTestCase {
             enrichmentRatePerMinute: 24,
             databaseSizeBytes: 4_096,
             recentActivityBuckets: [0, 0, 0, 2, 4],
-            recentEnrichmentBuckets: [0, 0, 0, 1, 3]
+            recentEnrichmentBuckets: [0, 0, 0, 1, 3],
+            lastWriteAt: now.addingTimeInterval(-10),
+            lastEnrichedAt: now.addingTimeInterval(-6)
         )
         let daemon = DaemonHealthSnapshot(
             pid: 4242,
@@ -19,10 +22,10 @@ final class BrainBarUXLogicTests: XCTestCase {
             rssBytes: 1_024,
             uptime: 60,
             openConnections: 1,
-            lastSeenAt: Date()
+            lastSeenAt: now
         )
 
-        let indicators = PipelineIndicators.derive(daemon: daemon, stats: stats)
+        let indicators = PipelineIndicators.derive(daemon: daemon, stats: stats, now: now)
 
         XCTAssertEqual(indicators.indexing.status, .live)
         XCTAssertEqual(indicators.enriching.status, .live)
@@ -82,20 +85,92 @@ final class BrainBarUXLogicTests: XCTestCase {
     }
 
     func testDashboardMetricFormatterReportsApproximateLastCompletionAge() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+
         XCTAssertEqual(
             DashboardMetricFormatter.lastCompletionString(
-                recentEnrichmentBuckets: [0, 0, 0, 0, 1, 2],
-                activityWindowMinutes: 30
+                lastEventAt: now.addingTimeInterval(-30),
+                activityWindowMinutes: 60,
+                now: now
             ),
             "Just now"
         )
         XCTAssertEqual(
             DashboardMetricFormatter.lastCompletionString(
-                recentEnrichmentBuckets: [0, 1, 0, 0, 0, 0],
-                activityWindowMinutes: 30
+                lastEventAt: now.addingTimeInterval(-90),
+                activityWindowMinutes: 60,
+                now: now
             ),
-            "20m ago"
+            "2m ago"
         )
+    }
+
+    func testDashboardFlowSummaryCanShowIngressAndEnrichmentLiveTogether() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 100,
+            pendingEnrichmentCount: 20,
+            enrichmentPercent: 83.3,
+            enrichmentRatePerMinute: 24,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 2, 4],
+            recentEnrichmentBuckets: [0, 0, 0, 1, 3],
+            activityWindowMinutes: 60,
+            bucketCount: 5,
+            liveWindowMinutes: 1,
+            lastWriteAt: now.addingTimeInterval(-15),
+            lastEnrichedAt: now.addingTimeInterval(-10)
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: now
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: daemon, stats: stats, now: now)
+
+        XCTAssertEqual(summary.ingress.status, .live)
+        XCTAssertEqual(summary.queue.status, .stable)
+        XCTAssertEqual(summary.enrichment.status, .live)
+        XCTAssertEqual(summary.windowLabel, "Last 1h")
+    }
+
+    func testDashboardFlowSummaryKeepsRecentEnrichmentDistinctFromLiveNow() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 118,
+            pendingEnrichmentCount: 2,
+            enrichmentPercent: 98.3,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 1, 0, 0],
+            activityWindowMinutes: 60,
+            bucketCount: 5,
+            liveWindowMinutes: 1,
+            lastWriteAt: now.addingTimeInterval(-600),
+            lastEnrichedAt: now.addingTimeInterval(-90)
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: now
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: daemon, stats: stats, now: now)
+
+        XCTAssertEqual(summary.ingress.status, .idle)
+        XCTAssertEqual(summary.queue.status, .draining)
+        XCTAssertEqual(summary.enrichment.status, .recent)
+        XCTAssertEqual(summary.enrichment.lastEventText, "2m ago")
     }
 
     func testIncomingRelationDisplayPutsEntityNameBeforeRelationVerb() {
@@ -137,6 +212,7 @@ final class BrainBarUXLogicTests: XCTestCase {
     }
 
     func testLivePresentationUsesExplicitActiveAndIdleStatusText() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
         let activeStats = DashboardStats(
             chunkCount: 120,
             enrichedChunkCount: 100,
@@ -145,7 +221,8 @@ final class BrainBarUXLogicTests: XCTestCase {
             enrichmentRatePerMinute: 24,
             databaseSizeBytes: 4_096,
             recentActivityBuckets: [0, 0, 0, 2, 4],
-            recentEnrichmentBuckets: [0, 0, 0, 1, 3]
+            recentEnrichmentBuckets: [0, 0, 0, 1, 3],
+            lastEnrichedAt: now.addingTimeInterval(-8)
         )
         let idleStats = DashboardStats(
             chunkCount: 120,
@@ -159,26 +236,39 @@ final class BrainBarUXLogicTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            BrainBarLivePresentation.derive(stats: activeStats).statusText,
-            "Live enrichment stream"
+            BrainBarLivePresentation.derive(stats: activeStats, now: now).statusText,
+            "Enrichments in the last 60s"
         )
         XCTAssertEqual(
-            BrainBarLivePresentation.derive(stats: idleStats).statusText,
-            "Idle — no enrichment in last 60s"
+            BrainBarLivePresentation.derive(stats: idleStats, now: now).statusText,
+            "No enrichments in the last 60s"
         )
     }
 
-    func testDashboardLayoutCompactsForShortDashboardHeights() {
-        let layout = BrainBarDashboardLayout(containerSize: CGSize(width: 900, height: 500))
-
-        XCTAssertEqual(layout.outerPadding, 14)
-        XCTAssertLessThan(layout.scale, 1)
-    }
-
-    func testDashboardLayoutUsesCompactTokensForNarrowWindowWidths() {
+    func testDashboardLayoutStacksFlowCardsOnNarrowWidths() {
         let layout = BrainBarDashboardLayout(containerSize: CGSize(width: 820, height: 640))
 
-        XCTAssertEqual(layout.metricValueFontSize, 20)
-        XCTAssertEqual(layout.sparklineWidth, 280)
+        XCTAssertEqual(layout.chartColumns, 1)
+        XCTAssertEqual(layout.overviewMetricColumns, 2)
+        XCTAssertEqual(layout.diagnosticColumns, 1)
+        XCTAssertTrue(layout.usesQueueRail)
+    }
+
+    func testDashboardLayoutUsesSideBySideDiagnosticsInMediumWindows() {
+        let layout = BrainBarDashboardLayout(containerSize: CGSize(width: 1_020, height: 640))
+
+        XCTAssertEqual(layout.chartColumns, 2)
+        XCTAssertEqual(layout.overviewMetricColumns, 4)
+        XCTAssertEqual(layout.diagnosticColumns, 2)
+        XCTAssertTrue(layout.usesQueueRail)
+    }
+
+    func testDashboardLayoutExpandsToThreeColumnsWhenSpaceAllows() {
+        let layout = BrainBarDashboardLayout(containerSize: CGSize(width: 1_340, height: 760))
+
+        XCTAssertEqual(layout.chartColumns, 2)
+        XCTAssertEqual(layout.overviewMetricColumns, 4)
+        XCTAssertEqual(layout.diagnosticColumns, 2)
+        XCTAssertTrue(layout.usesQueueRail)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
@@ -31,6 +31,7 @@ final class BrainBarWindowStateTests: XCTestCase {
     }
 
     func testLivePresentationShowsRateBadgeWhenEnrichmentIsActive() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
             enrichedChunkCount: 100,
@@ -39,16 +40,19 @@ final class BrainBarWindowStateTests: XCTestCase {
             enrichmentRatePerMinute: 24,
             databaseSizeBytes: 4_096,
             recentActivityBuckets: [0, 0, 0, 2, 4],
-            recentEnrichmentBuckets: [0, 0, 0, 1, 3]
+            recentEnrichmentBuckets: [0, 0, 0, 1, 3],
+            lastWriteAt: now.addingTimeInterval(-12),
+            lastEnrichedAt: now.addingTimeInterval(-8)
         )
 
-        let presentation = BrainBarLivePresentation.derive(stats: stats)
+        let presentation = BrainBarLivePresentation.derive(stats: stats, now: now)
 
         XCTAssertEqual(presentation.sparklineStyle, .active)
-        XCTAssertEqual(presentation.badgeText, "24/min")
+        XCTAssertEqual(presentation.badgeText, "live now")
     }
 
-    func testLivePresentationShowsIdleBadgeWhenEnrichmentRateDropsToZero() {
+    func testLivePresentationShowsLastEventAgeWhenEnrichmentRateDropsToZero() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
             enrichedChunkCount: 100,
@@ -57,13 +61,16 @@ final class BrainBarWindowStateTests: XCTestCase {
             enrichmentRatePerMinute: 0,
             databaseSizeBytes: 4_096,
             recentActivityBuckets: [0, 0, 0, 2, 4],
-            recentEnrichmentBuckets: [4, 3, 1, 0, 0]
+            recentEnrichmentBuckets: [4, 3, 1, 0, 0],
+            lastWriteAt: now.addingTimeInterval(-30),
+            lastEnrichedAt: now.addingTimeInterval(-90)
         )
 
-        let presentation = BrainBarLivePresentation.derive(stats: stats)
+        let presentation = BrainBarLivePresentation.derive(stats: stats, now: now)
 
         XCTAssertEqual(presentation.sparklineStyle, .idle)
-        XCTAssertEqual(presentation.badgeText, "idle")
+        XCTAssertEqual(presentation.badgeText, "2m ago")
+        XCTAssertEqual(presentation.statusText, "No enrichments in the last 60s")
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -83,6 +83,35 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.recentActivityBuckets.reduce(0, +), 1)
     }
 
+    func testDashboardStatsCountsRecentNaiveLocalTimestamps() throws {
+        try db.insertChunk(
+            id: "dash-local-naive",
+            content: "Recent chunk written with a local wall-clock timestamp",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6
+        )
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+        let now = Date()
+
+        db.exec("""
+            UPDATE chunks
+            SET created_at = '\(formatter.string(from: now))'
+            WHERE id = 'dash-local-naive'
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 5, bucketCount: 5)
+
+        XCTAssertEqual(stats.recentActivityBuckets.reduce(0, +), 1)
+        let lastWriteAt = try XCTUnwrap(stats.lastWriteAt)
+        XCTAssertLessThan(abs(lastWriteAt.timeIntervalSince(now)), 5)
+    }
+
     func testDashboardStatsTracksRecentEnrichmentSeparatelyFromIncomingWrites() throws {
         try db.insertChunk(
             id: "dash-enrichment-only",
@@ -144,6 +173,36 @@ final class DashboardTests: XCTestCase {
 
         let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
 
+        XCTAssertEqual(stats.enrichmentRatePerMinute, 0, accuracy: 0.001)
+        XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
+    }
+
+    func testDashboardStatsCarriesExplicitWindowMetadataAndLastEventTimestamps() throws {
+        try db.insertChunk(
+            id: "dash-explicit-times",
+            content: "Fresh write with a slightly older enrichment event",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6
+        )
+        db.exec("""
+            UPDATE chunks
+            SET created_at = datetime('now'),
+                enriched_at = datetime('now', '-90 seconds')
+            WHERE id = 'dash-explicit-times'
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 60, bucketCount: 12)
+
+        XCTAssertEqual(stats.activityWindowMinutes, 60)
+        XCTAssertEqual(stats.bucketCount, 12)
+        XCTAssertEqual(stats.liveWindowMinutes, 1)
+        XCTAssertNotNil(stats.lastWriteAt)
+        XCTAssertNotNil(stats.lastEnrichedAt)
+        let lastWriteAt = try XCTUnwrap(stats.lastWriteAt)
+        let lastEnrichedAt = try XCTUnwrap(stats.lastEnrichedAt)
+        XCTAssertGreaterThan(lastWriteAt, lastEnrichedAt)
         XCTAssertEqual(stats.enrichmentRatePerMinute, 0, accuracy: 0.001)
         XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
     }

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -221,6 +221,124 @@ final class DatabaseTests: XCTestCase {
         XCTAssertTrue(results.isEmpty)
     }
 
+    func testSearchReturnsEmptyForBlankQuery() throws {
+        try db.insertChunk(
+            id: "blank-query-decoy",
+            content: "Blank searches should not hit arbitrary content.",
+            sessionId: "session-blank",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+
+        let results = try db.search(query: "   ", limit: 10)
+
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testSearchExactChunkIDShortCircuitsFTS() throws {
+        try db.insertChunk(
+            id: "brainbar-5ac50aa1-ed5",
+            content: "Exact chunk lookup should not require the identifier to appear in content.",
+            sessionId: "session-exact",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 9
+        )
+        try db.insertChunk(
+            id: "brainbar-d01",
+            content: "Decoy chunk mentions brainbar-5ac50aa1-ed5 but must not outrank the exact chunk id.",
+            sessionId: "session-decoy",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 9
+        )
+
+        let results = try db.search(query: "brainbar-5ac50aa1-ed5", limit: 10)
+
+        XCTAssertEqual(results.first?["chunk_id"] as? String, "brainbar-5ac50aa1-ed5")
+    }
+
+    func testSearchExactChunkIDRespectsProjectScope() throws {
+        try db.insertChunk(
+            id: "brainbar-scoped-001",
+            content: "Project-scoped exact id lookup should return only matching project chunks.",
+            sessionId: "session-scope",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 8
+        )
+
+        let scoped = try db.search(query: "brainbar-scoped-001", limit: 10, project: "brainlayer")
+        let wrongScope = try db.search(query: "brainbar-scoped-001", limit: 10, project: "voicelayer")
+
+        XCTAssertEqual(scoped.first?["chunk_id"] as? String, "brainbar-scoped-001")
+        XCTAssertTrue(wrongScope.isEmpty)
+    }
+
+    func testSearchUsesTrigramFTSForIdentifierSubstrings() throws {
+        try db.insertChunk(
+            id: "trigram-hit",
+            content: "stalker-golem queue note",
+            sessionId: "session-trigram",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+
+        let results = try db.search(query: "alker-go", limit: 10)
+
+        XCTAssertEqual(results.first?["chunk_id"] as? String, "trigram-hit")
+    }
+
+    func testSearchAliasExpansionPreservesMultiwordSemantics() throws {
+        try db.insertChunk(
+            id: "alias-good",
+            content: "Hershkovits reviewed the release plan yesterday.",
+            sessionId: "session-alias-good",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 8
+        )
+        try db.insertChunk(
+            id: "alias-bad",
+            content: "Met with Hershkovits yesterday.",
+            sessionId: "session-alias-bad",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 8
+        )
+
+        let results = try db.search(query: "Hershkovitz release plan", limit: 10)
+        let resultIDs = results.compactMap { $0["chunk_id"] as? String }
+
+        XCTAssertTrue(resultIDs.contains("alias-good"))
+        XCTAssertFalse(resultIDs.contains("alias-bad"))
+    }
+
+    func testSearchAliasExpansionNormalizesDotsConsistently() throws {
+        db.exec("""
+            INSERT INTO kg_entities (id, entity_type, name)
+            VALUES ('entity-openai', 'org', 'Open.AI');
+        """)
+        db.exec("""
+            INSERT INTO kg_entity_aliases (alias, entity_id)
+            VALUES ('OpenAI', 'entity-openai');
+        """)
+        try db.insertChunk(
+            id: "alias-dot",
+            content: "Open.AI roadmap review notes.",
+            sessionId: "session-alias-dot",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 8
+        )
+
+        let results = try db.search(query: "OpenAI roadmap", limit: 10)
+
+        XCTAssertEqual(results.first?["chunk_id"] as? String, "alias-dot")
+    }
+
     // MARK: - Store
 
     func testStoreCreatesChunk() throws {

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -186,6 +186,17 @@ final class DatabaseTests: XCTestCase {
         )
     }
 
+    func testLargeTrigramDesyncDoesNotForceSynchronousStartupRebuild() {
+        let decision = BrainDatabase.trigramStartupRepairDecision(
+            tableExists: true,
+            schemaIsValid: true,
+            chunkCount: 359_890,
+            trigramCount: 0
+        )
+
+        XCTAssertEqual(decision, .skipBackfill)
+    }
+
     func testUpsertSubscriptionRecoversMissingPubSubTables() throws {
         db.exec("DROP TABLE IF EXISTS brainbar_subscriptions")
         db.exec("DROP TABLE IF EXISTS brainbar_agents")

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import BrainBar
+
+final class InjectionPresentationTests: XCTestCase {
+    func testSnapshotBuildsBurstGroupsAndWindowSummary() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:58:00Z", query: "latest cc release", chunkIDs: ["chunk-1", "chunk-2"], tokenCount: 48),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:55:00Z", query: "extract transcript", chunkIDs: ["chunk-3"], tokenCount: 52),
+            makeEvent(id: 3, sessionID: "sess-a", timestamp: "2026-04-18T09:40:00Z", query: "why is ffmpeg stuck", chunkIDs: ["chunk-4", "chunk-5", "chunk-6"], tokenCount: 91),
+            makeEvent(id: 4, sessionID: "sess-b", timestamp: "2026-04-18T09:38:00Z", query: "brainbar graph empty", chunkIDs: ["chunk-7"], tokenCount: 40),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(
+            events: events,
+            filterText: "",
+            now: now,
+            windowMinutes: 60,
+            burstGapMinutes: 8,
+            bucketCount: 6
+        )
+
+        XCTAssertEqual(snapshot.summary.queryCount, 4)
+        XCTAssertEqual(snapshot.summary.chunkCount, 7)
+        XCTAssertEqual(snapshot.summary.tokenCount, 231)
+        XCTAssertEqual(snapshot.summary.activeSessionCount, 2)
+        XCTAssertEqual(snapshot.bursts.count, 3)
+        XCTAssertEqual(snapshot.bursts[0].sessionID, "sess-a")
+        XCTAssertEqual(snapshot.bursts[0].events.map { $0.id }, [1, 2])
+        XCTAssertEqual(snapshot.bursts[1].events.map { $0.id }, [3])
+        XCTAssertEqual(snapshot.bursts[2].sessionID, "sess-b")
+        XCTAssertEqual(snapshot.ribbonBuckets, [0, 0, 0, 1, 1, 2])
+    }
+
+    func testFilterMatchesSessionQueryAndChunkIDs() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-alpha", timestamp: "2026-04-18T09:58:00Z", query: "latest cc release", chunkIDs: ["chunk-a"], tokenCount: 12),
+            makeEvent(id: 2, sessionID: "sess-beta", timestamp: "2026-04-18T09:55:00Z", query: "brainbar graph", chunkIDs: ["chunk-b", "ops-note"], tokenCount: 24),
+        ]
+
+        let querySnapshot = InjectionPresentation.snapshot(
+            events: events,
+            filterText: "graph",
+            now: now
+        )
+        XCTAssertEqual(querySnapshot.filteredEvents.map { $0.id }, [2])
+
+        let sessionSnapshot = InjectionPresentation.snapshot(
+            events: events,
+            filterText: "alpha",
+            now: now
+        )
+        XCTAssertEqual(sessionSnapshot.filteredEvents.map { $0.id }, [1])
+
+        let chunkSnapshot = InjectionPresentation.snapshot(
+            events: events,
+            filterText: "ops-note",
+            now: now
+        )
+        XCTAssertEqual(chunkSnapshot.filteredEvents.map { $0.id }, [2])
+    }
+
+    private func makeEvent(
+        id: Int64,
+        sessionID: String,
+        timestamp: String,
+        query: String,
+        chunkIDs: [String],
+        tokenCount: Int
+    ) -> InjectionEvent {
+        InjectionEvent(
+            id: id,
+            sessionID: sessionID,
+            timestamp: timestamp,
+            query: query,
+            chunkIDs: chunkIDs,
+            tokenCount: tokenCount
+        )
+    }
+
+    private func isoDate(_ text: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: text)!
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/KGAtlasLayoutTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasLayoutTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import BrainBar
+
+final class KGAtlasLayoutTests: XCTestCase {
+    func testSeededNodesPlaceEntityTypesIntoStableRegions() {
+        let nodes = [
+            KGNode(id: "p1", name: "Etan Heyman", entityType: "person", importance: 9, position: .zero),
+            KGNode(id: "p2", name: "David Heyman", entityType: "person", importance: 6, position: .zero),
+            KGNode(id: "pr1", name: "brainlayer", entityType: "project", importance: 8, position: .zero),
+            KGNode(id: "t1", name: "mcp", entityType: "tool", importance: 7, position: .zero),
+        ]
+
+        let seeded = KGAtlasLayout.seededNodes(
+            nodes,
+            canvasSize: CGSize(width: 960, height: 640)
+        )
+
+        let personNodes = seeded.filter { $0.entityType == "person" }
+        let projectNode = seeded.first { $0.entityType == "project" }!
+        let toolNode = seeded.first { $0.entityType == "tool" }!
+
+        XCTAssertEqual(personNodes.count, 2)
+        XCTAssertLessThan(personNodes[0].position.x, projectNode.position.x)
+        XCTAssertLessThan(projectNode.position.x, toolNode.position.x)
+        XCTAssertLessThan(abs(personNodes[0].position.x - personNodes[1].position.x), 120)
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import BrainBar
+
+final class KGAtlasPresentationTests: XCTestCase {
+    func testSnapshotBuildsDeterministicRegions() {
+        let nodes = [
+            KGNode(id: "p1", name: "Etan Heyman", entityType: "person", importance: 9, position: .zero),
+            KGNode(id: "pr1", name: "brainlayer", entityType: "project", importance: 8, position: .zero),
+            KGNode(id: "t1", name: "mcp", entityType: "tool", importance: 6, position: .zero),
+        ]
+        let edges = [
+            KGEdge(sourceId: "p1", targetId: "pr1", relationType: "builds"),
+            KGEdge(sourceId: "pr1", targetId: "t1", relationType: "uses"),
+        ]
+
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: edges,
+            selectedNodeId: nil,
+            minimumImportance: 0
+        )
+
+        XCTAssertEqual(snapshot.regions.map { $0.title }, ["People", "Projects", "Tools"])
+        XCTAssertEqual(snapshot.regions.map { $0.nodes.count }, [1, 1, 1])
+        XCTAssertEqual(snapshot.visibleNodes.map { $0.id }, ["p1", "pr1", "t1"])
+        XCTAssertEqual(snapshot.visibleEdges.count, 2)
+    }
+
+    func testAltitudeFilterKeepsSelectedNodeVisible() {
+        let nodes = [
+            KGNode(id: "p1", name: "Etan Heyman", entityType: "person", importance: 9, position: .zero),
+            KGNode(id: "a1", name: "coachClaude", entityType: "agent", importance: 2, position: .zero),
+            KGNode(id: "t1", name: "mcp", entityType: "tool", importance: 7, position: .zero),
+        ]
+        let edges = [
+            KGEdge(sourceId: "p1", targetId: "a1", relationType: "uses"),
+            KGEdge(sourceId: "a1", targetId: "t1", relationType: "calls"),
+        ]
+
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: edges,
+            selectedNodeId: "a1",
+            minimumImportance: 5
+        )
+
+        XCTAssertEqual(snapshot.visibleNodes.map { $0.id }, ["p1", "t1", "a1"])
+        XCTAssertEqual(snapshot.visibleEdges.map { $0.id }, ["p1-uses-a1", "a1-calls-t1"])
+        XCTAssertEqual(snapshot.selectedRegion?.title, "Agents")
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -5,6 +5,7 @@
 //         fetchEntityChunks, linkEntityChunk, KGNode, KGEdge, KGViewModel.
 
 import XCTest
+import SQLite3
 @testable import BrainBar
 
 // MARK: - Database KG Query Tests
@@ -66,6 +67,25 @@ final class KGDatabaseTests: XCTestCase {
         let entities = try db.fetchKGEntities()
         XCTAssertEqual(entities.first?.entityType, "tool")
         XCTAssertEqual(entities.first?.name, "Vim")
+    }
+
+    func testFetchKGEntitiesUsesImportanceColumnWhenMetadataImportanceMissing() throws {
+        try db.insertEntity(id: "agent-a", type: "agent", name: "Agent A")
+        try db.insertEntity(id: "tool-b", type: "tool", name: "Tool B")
+        try db.insertRelation(sourceId: "agent-a", targetId: "tool-b", relationType: "uses")
+
+        guard let handle = db.dbHandle else {
+            XCTFail("Expected database handle")
+            return
+        }
+
+        XCTAssertEqual(sqlite3_exec(handle, "UPDATE kg_entities SET importance = 8.0 WHERE id = 'agent-a'", nil, nil, nil), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(handle, "UPDATE kg_entities SET importance = 2.0 WHERE id = 'tool-b'", nil, nil, nil), SQLITE_OK)
+
+        let entities = try db.fetchKGEntities()
+        XCTAssertEqual(entities.map(\.name), ["Agent A", "Tool B"])
+        XCTAssertEqual(entities.first?.importance, 8.0)
+        XCTAssertEqual(entities.last?.importance, 2.0)
     }
 
     func testFetchKGEntitiesEmptyDB() throws {

--- a/docs/plans/2026-04-18-brainbar-dashboard-flow-collab.md
+++ b/docs/plans/2026-04-18-brainbar-dashboard-flow-collab.md
@@ -1,0 +1,38 @@
+# BrainBar Dashboard Flow Collab
+
+## Goal
+Finish the second-pass BrainBar dashboard refactor without mixing `live agent CLIs` into `indexed writes` or letting the queue/runtime cards dominate the layout.
+
+## Agents
+- `main-codex`
+  Ownership:
+  - `brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift`
+  - `brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift`
+  - `src/brainlayer/pipeline/enrichment_tiers.py`
+  - `brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift`
+  - `tests/test_enrichment_tiers_agent_sources.py`
+- `clean-claude-ui`
+  Ownership:
+  - `brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift`
+
+## Constraints
+- Do not edit files outside your ownership.
+- Do not revert or restage another agent's work.
+- `clean-claude-ui` must `git add` only its owned file before commit.
+- `clean-claude-ui` may commit and push its owned UI change after tests pass.
+
+## Task Board
+| Task | Owner | Status |
+|------|-------|--------|
+| Add process-based agent family monitor | main-codex | done |
+| Extend enrichment tiering to non-Claude agent sources | main-codex | done |
+| Refactor dashboard layout to add agent strip and compact queue rail | clean-claude-ui | in_progress |
+| Collapse/demote runtime details behind disclosure | clean-claude-ui | in_progress |
+
+## Gates
+- `main-codex`: `swift test --filter AgentActivityMonitorTests`, `swift test --filter BrainBarUXLogicTests`, `pytest tests/test_enrichment_tiers.py tests/test_enrichment_tiers_agent_sources.py -q`
+- `clean-claude-ui`: `swift test --filter BrainBarUXLogicTests` before commit
+
+## Notes
+- Existing `brainlayerClaude -s` pane is bound to the dirty main repo checkout and stays read-only for critique only.
+- The clean-worktree Claude worker must run from `/Users/etanheyman/.config/superpowers/worktrees/brainlayer/fix-brainbar-dashboard-flow`.

--- a/docs/plans/2026-04-18-brainbar-dashboard-flow.md
+++ b/docs/plans/2026-04-18-brainbar-dashboard-flow.md
@@ -1,0 +1,206 @@
+# BrainBar Dashboard Flow Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the contradictory BrainBar dashboard hero with a synchronized, visual flow board that shows writes, enrichment, backlog, and live/idle state from one coherent time model.
+
+**Architecture:** Extend `DashboardStats` so the UI gets explicit window metadata and real last-event timestamps instead of inferring freshness from buckets. Derive a richer flow summary from daemon health, write activity, enrichment activity, and backlog, then rebuild the dashboard hero into dual visual lanes that share a single time window and separate “live right now” from “trend over the last window.”
+
+**Tech Stack:** Swift, SwiftUI, AppKit, XCTest, SQLite-backed `BrainDatabase`, existing BrainBar dashboard components.
+
+---
+
+### Task 1: Add explicit dashboard time semantics
+
+**Files:**
+- Modify: `brain-bar/Sources/BrainBar/BrainDatabase.swift`
+- Modify: `brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift`
+- Test: `brain-bar/Tests/BrainBarTests/DashboardTests.swift`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert `DashboardStats` carries:
+- `activityWindowMinutes`
+- `bucketCount`
+- `liveWindowMinutes`
+- `lastWriteAt`
+- `lastEnrichedAt`
+
+Also add a database test proving:
+- a chunk written now and enriched 90 seconds ago reports `lastWriteAt != nil`
+- `lastEnrichedAt != nil`
+- `enrichmentRatePerMinute == 0`
+- enrichment trend still contains the older completion
+
+**Step 2: Run test to verify it fails**
+
+Run: `swift test --filter DashboardTests`
+Expected: compile failure or assertion failure because `DashboardStats` does not yet expose the new time fields.
+
+**Step 3: Write minimal implementation**
+
+Update `DashboardStats` and `dashboardStats(...)` to include the new metadata and fetch `MAX(created_at)` / `MAX(enriched_at)` timestamps using the same SQLite date parsing already used for bucket generation.
+
+**Step 4: Run test to verify it passes**
+
+Run: `swift test --filter DashboardTests`
+Expected: the new stats tests pass and existing dashboard database tests still pass.
+
+### Task 2: Replace the single enum with a richer flow model
+
+**Files:**
+- Modify: `brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift`
+- Modify: `brain-bar/Sources/BrainBar/BrainBarWindowState.swift`
+- Modify: `brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift`
+- Test: `brain-bar/Tests/BrainBarTests/DashboardTests.swift`
+- Test: `brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift`
+- Test: `brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift`
+
+**Step 1: Write the failing tests**
+
+Add tests for a derived flow summary that can represent:
+- writes live + enrichments live at the same time
+- writes idle + enrichments draining backlog
+- writes idle + enrichments idle + backlog present
+- daemon unavailable
+
+Add formatter tests that require:
+- real last-event strings from actual timestamps, not bucket position
+- a stable “live now” badge that only reflects the configured live window
+
+**Step 2: Run test to verify it fails**
+
+Run: `swift test --filter BrainBarUXLogicTests`
+Run: `swift test --filter BrainBarWindowStateTests`
+Expected: failures because the richer flow summary and timestamp-driven formatting do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Introduce a derived dashboard flow model with:
+- a write lane state
+- an enrichment lane state
+- a backlog/queue state
+- a top-level narrative for the hero
+
+Keep `PipelineState` available for legacy consumers, but make it derive from the richer summary instead of directly from raw buckets.
+
+Replace bucket-inferred `lastCompletionString(...)` with a timestamp-based formatter and add a generic “time ago” helper for both writes and enrichments.
+
+**Step 4: Run test to verify it passes**
+
+Run: `swift test --filter BrainBarUXLogicTests`
+Run: `swift test --filter BrainBarWindowStateTests`
+Expected: new derivation and formatter tests pass without breaking the existing layout/token tests.
+
+### Task 3: Rebuild the dashboard into a dual-lane flow board
+
+**Files:**
+- Modify: `brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift`
+- Modify: `brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift`
+- Possibly modify: `brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift`
+- Test: `brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift`
+
+**Step 1: Write the failing tests**
+
+Add logic-level tests for any new copy helpers or layout-state helpers needed by the dashboard, including:
+- synchronized window labels
+- lane summaries using the same window value
+- idle copy that no longer contradicts a recent-trend graph
+
+**Step 2: Run test to verify it fails**
+
+Run: `swift test --filter BrainBarUXLogicTests`
+Expected: failures because the new helpers or derived labels are not implemented yet.
+
+**Step 3: Write minimal implementation**
+
+Rebuild `BrainBarDashboardView` so the hero becomes a flow board with:
+- a left lane for writes
+- a center queue/backlog card
+- a right lane for enrichments
+- shared window labeling
+- real last-write / last-enriched timestamps
+- live badges that are explicitly “now”
+- charts with stronger fill, endpoint emphasis, and separate colors for ingress vs enrichment
+
+Reuse the same derived flow summary everywhere in the window instead of mixing independent heuristics.
+
+If `StatusPopoverView` still shows contradictory wording after the model change, update it to consume the same derived summary.
+
+**Step 4: Run test to verify it passes**
+
+Run: `swift test --filter BrainBarUXLogicTests`
+Expected: the helper/copy tests pass and the dashboard remains readable under compact layout tests.
+
+### Task 4: Keep legacy/menu surfaces consistent
+
+**Files:**
+- Modify: `brain-bar/Sources/BrainBar/BrainBarApp.swift`
+- Modify: `brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift`
+- Test: `brain-bar/Tests/BrainBarTests/DashboardTests.swift`
+
+**Step 1: Write the failing tests**
+
+Add or extend tests that verify the status popover still loads and that the live/menu surfaces can continue rendering with the updated state/formatter interfaces.
+
+**Step 2: Run test to verify it fails**
+
+Run: `swift test --filter DashboardTests`
+Expected: failures if any legacy consumer still relies on removed copy or raw bucket inference.
+
+**Step 3: Write minimal implementation**
+
+Adapt menu-bar and popover consumers to:
+- use timestamp-safe formatting
+- use the derived summary or derived compatibility state
+- keep their visual contract simple and backward-safe
+
+**Step 4: Run test to verify it passes**
+
+Run: `swift test --filter DashboardTests`
+Expected: dashboard and popover tests pass together.
+
+### Task 5: Full verification and finish
+
+**Files:**
+- No code changes required unless regressions appear
+
+**Step 1: Run targeted Swift verification**
+
+Run:
+- `swift test --filter DashboardTests`
+- `swift test --filter BrainBarUXLogicTests`
+- `swift test --filter BrainBarWindowStateTests`
+
+Expected: all targeted dashboard/state suites pass.
+
+**Step 2: Run broader BrainBar verification**
+
+Run: `swift test --filter BrainBar`
+Expected: BrainBar package tests pass, or any unrelated pre-existing failures are called out explicitly before claiming completion.
+
+**Step 3: Summarize and store the decision**
+
+Use BrainLayer memory to store:
+- what changed
+- why synchronized time semantics were required
+- why fail-rate was excluded from this pass unless a truthful source is added
+
+**Step 4: Commit**
+
+```bash
+git add brain-bar/Sources/BrainBar/BrainDatabase.swift \
+        brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift \
+        brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift \
+        brain-bar/Sources/BrainBar/BrainBarWindowState.swift \
+        brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift \
+        brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift \
+        brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift \
+        brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift \
+        brain-bar/Sources/BrainBar/BrainBarApp.swift \
+        brain-bar/Tests/BrainBarTests/DashboardTests.swift \
+        brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift \
+        brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift \
+        docs/plans/2026-04-18-brainbar-dashboard-flow.md
+git commit -m "feat: redesign BrainBar dashboard flow board"
+```

--- a/docs/plans/2026-04-18-brainbar-injections-graph-hybrid.md
+++ b/docs/plans/2026-04-18-brainbar-injections-graph-hybrid.md
@@ -1,0 +1,132 @@
+# BrainBar Injections + Graph Hybrid Design
+
+## Decision
+
+Ship a hybrid of Claude Design `Concept A: Retrieval Theater / Atlas` with two selective ideas from `Concept B: Signal Stream / Observatory`.
+
+Use `A` as the primary visual language:
+- `Injections` becomes a retrieval surface instead of a raw list.
+- `Graph` becomes a stable atlas with a dominant inspector.
+
+Steal only two things from `B`:
+- grouped retrieval bursts so the feed shows rhythm instead of flat recency
+- a graph altitude control so low-importance nodes can be faded out without losing focus
+
+## Why
+
+`Concept A` maps best onto the real BrainBar data model and the current codebase.
+
+It works with:
+- `InjectionEvent` data that already has timestamp, session, query, chunk IDs, and token count
+- `KGViewModel` data that already has entity type, importance, relations, and chunk drilldown
+
+It also avoids the two main failure modes in the other concepts:
+- too much dashboard overlap (`Control Room`)
+- too much metaphor or custom behavior for a first ship (`Investigation Desk`, `Heatmap × Starfield`, `Command Transcript / Codex`)
+
+## Injections Target
+
+### Information hierarchy
+
+1. Top summary strip
+   - `last hour` window label
+   - query count
+   - chunk count
+   - token count
+   - active session count
+
+2. Activity ribbon
+   - 60-minute spark ribbon
+   - visible "now" marker
+   - burst intensity visible at a glance
+
+3. Burst feed
+   - events grouped into session bursts
+   - each burst has a compact header: time span, session, query count, token total
+   - each event row keeps:
+     - timestamp
+     - query text
+     - chunk count
+     - chunk attribution ribbon
+
+4. Right rail
+   - active sessions
+   - token pressure
+   - signal notes
+
+### Rules
+
+- The page must still work when there is only one event.
+- Filtering must work across session ID, query text, and chunk IDs.
+- Empty space is not acceptable; the rail should collapse when data is sparse.
+- The raw thread-opening affordance must remain.
+
+## Graph Target
+
+### Information hierarchy
+
+1. Stable atlas canvas
+   - stop presenting the graph as a black force-sim toy
+   - treat the canvas as named regions by entity type
+   - use a calmer background that works in both light and dark
+
+2. Inspector-first drilldown
+   - selected entity sidebar becomes the main reading surface
+   - relations and linked chunks stay prominent
+   - canvas supports the inspector instead of competing with it
+
+3. Atlas controls
+   - type legend / regions
+   - altitude slider backed by node importance
+   - optional minimap / overview overlay if it fits cleanly
+
+### Rules
+
+- Region naming should be deterministic from entity type.
+- Altitude filtering should never hide the currently selected node.
+- The graph must remain navigable if the sidebar is open.
+- The visual system must stop relying on pure black backgrounds.
+
+## Implementation Shape
+
+### New presentation helpers
+
+Add testable presentation helpers instead of embedding all behavior in SwiftUI bodies.
+
+- `InjectionPresentation`
+  - filters events
+  - groups events into session bursts
+  - computes top-strip stats
+  - computes ribbon buckets
+
+- `KGPresentation`
+  - groups nodes into atlas regions
+  - computes altitude-filtered visible nodes
+  - preserves selected node visibility
+
+### View changes
+
+- `InjectionFeedView`
+  - replace raw `List` layout with a custom scrollable composition
+  - summary strip + ribbon + burst feed + right rail
+
+- `KGCanvasView`
+  - add calmer canvas framing
+  - add top controls / legend / altitude
+  - support atlas overlays
+
+- `KGSidebarView`
+  - upgrade hierarchy and chunk cards so it feels like the graph's primary inspector
+
+## Out of Scope For This Pass
+
+- fixing the blank-state runtime bug on `Injections` and `Graph`
+- replacing the graph simulation with a full deterministic layout engine
+- adding new backend data not already available in BrainBar
+- changing dashboard again
+
+## Verification Target
+
+- Add failing tests first for burst grouping and altitude filtering.
+- Run targeted BrainBar Swift tests.
+- Relaunch the menu bar app and verify the redesigned tabs visually from the running build.

--- a/src/brainlayer/pipeline/enrichment_tiers.py
+++ b/src/brainlayer/pipeline/enrichment_tiers.py
@@ -3,8 +3,8 @@
 Assigns each chunk a processing tier based on source, content type, and age:
 
   T0 (IMMEDIATE): manual/digest — always enrich, highest priority
-  T1 (HOURLY):    recent claude_code chunks — hourly local enrichment
-  T2 (LAZY):      old claude_code backlog — lazy remote batch
+  T1 (HOURLY):    recent agent-session chunks — hourly local enrichment
+  T2 (LAZY):      old agent-session backlog — lazy remote batch
   T3 (EXPLICIT):  youtube transcripts — only when explicitly triggered
 
 Design note: tiers are IntEnum so T0 < T1 < T2 < T3 comparisons work naturally
@@ -20,8 +20,8 @@ from typing import List, Optional, Set
 
 class EnrichmentTier(IntEnum):
     T0_IMMEDIATE = 0  # manual / digest — enrich immediately
-    T1_HOURLY = 1  # recent claude_code — hourly local run
-    T2_LAZY = 2  # old claude_code backlog — lazy / remote batch
+    T1_HOURLY = 1  # recent agent-session chunks — hourly local run
+    T2_LAZY = 2  # old agent-session backlog — lazy / remote batch
     T3_EXPLICIT = 3  # youtube — explicit request only
 
 
@@ -44,7 +44,7 @@ SKIP_CONTENT_TYPES: frozenset = frozenset({"noise"})
 
 # Only these sources participate in the T1/T2 recency gate.
 # Unrecognised sources fall through to T2 (lazy backlog) rather than T1.
-T1_T2_SOURCES: frozenset = frozenset({"claude_code"})
+T1_T2_SOURCES: frozenset = frozenset({"claude_code", "codex_cli", "cursor_cli", "gemini_cli"})
 
 
 # ── Classifier ───────────────────────────────────────────────────────────
@@ -59,7 +59,7 @@ def classify_chunk_tier(
     """Return the enrichment tier for a chunk.
 
     Args:
-        source:        The chunk source field (e.g. "claude_code", "youtube", "manual").
+        source:        The chunk source field (e.g. "claude_code", "codex_cli", "youtube", "manual").
         content_type:  The chunk content_type field (e.g. "ai_code", "assistant_text").
         created_at:    ISO timestamp string when the chunk was created, or None.
         recency_days:  Window (days) for T1 vs T2 split (default 7).
@@ -84,7 +84,7 @@ def classify_chunk_tier(
     if source not in T1_T2_SOURCES:
         return EnrichmentTier.T2_LAZY
 
-    # Claude code: age determines tier.
+    # Agent-session sources: age determines tier.
     if _is_recent(created_at, recency_days):
         return EnrichmentTier.T1_HOURLY
     return EnrichmentTier.T2_LAZY
@@ -123,16 +123,16 @@ def get_tier_source_filter(tier: EnrichmentTier) -> Set[str]:
     Useful for building SQL IN clauses or filtering chunk lists.
 
     T0 → {manual, digest}
-    T1 → {claude_code}   (explicitly excludes youtube)
-    T2 → {claude_code}   (old backlog only)
+    T1 → {claude_code, codex_cli, cursor_cli, gemini_cli}   (explicitly excludes youtube)
+    T2 → {claude_code, codex_cli, cursor_cli, gemini_cli}   (old backlog only)
     T3 → {youtube}
     """
     if tier == EnrichmentTier.T0_IMMEDIATE:
         return set(T0_SOURCES)
     if tier == EnrichmentTier.T1_HOURLY:
-        return {"claude_code"}
+        return set(T1_T2_SOURCES)
     if tier == EnrichmentTier.T2_LAZY:
-        return {"claude_code"}
+        return set(T1_T2_SOURCES)
     if tier == EnrichmentTier.T3_EXPLICIT:
         return set(T3_SOURCES)
     return set()  # pragma: no cover

--- a/src/brainlayer/pipeline/session_enrichment.py
+++ b/src/brainlayer/pipeline/session_enrichment.py
@@ -23,6 +23,7 @@ import json
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from .enrichment_tiers import T1_T2_SOURCES
 from ..vector_store import VectorStore
 
 # Valid values for structured fields
@@ -357,14 +358,15 @@ def list_sessions_for_enrichment(
                 already_enriched.add(sid)
 
     # Method 2: Distinct source_files from chunks (catches sessions without git overlay)
-    source_query = """
+    source_placeholders = ",".join("?" for _ in T1_T2_SOURCES)
+    source_query = f"""
         SELECT DISTINCT source_file, project, COUNT(*) as cnt
         FROM chunks
-        WHERE source IS NULL OR source = 'claude_code'
+        WHERE source IS NULL OR source IN ({source_placeholders})
         GROUP BY source_file
         HAVING cnt >= 3
     """
-    for row in cursor.execute(source_query):
+    for row in cursor.execute(source_query, tuple(T1_T2_SOURCES)):
         source_file = row[0] or ""
         proj = row[1] or ""
 

--- a/src/brainlayer/pipeline/session_enrichment.py
+++ b/src/brainlayer/pipeline/session_enrichment.py
@@ -23,8 +23,8 @@ import json
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from .enrichment_tiers import T1_T2_SOURCES
 from ..vector_store import VectorStore
+from .enrichment_tiers import T1_T2_SOURCES
 
 # Valid values for structured fields
 VALID_INTENTS = [

--- a/tests/test_enrichment_tiers_agent_sources.py
+++ b/tests/test_enrichment_tiers_agent_sources.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta, timezone
+
+from brainlayer.pipeline.enrichment_tiers import EnrichmentTier, classify_chunk_tier, get_tier_source_filter
+
+
+def _recent(days_ago: int = 2) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+def _old(days_ago: int = 30) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+def test_recent_agent_cli_sources_are_hourly_candidates():
+    recent = _recent()
+
+    assert classify_chunk_tier("codex_cli", "assistant_text", recent) == EnrichmentTier.T1_HOURLY
+    assert classify_chunk_tier("cursor_cli", "assistant_text", recent) == EnrichmentTier.T1_HOURLY
+    assert classify_chunk_tier("gemini_cli", "assistant_text", recent) == EnrichmentTier.T1_HOURLY
+
+
+def test_old_agent_cli_sources_fall_back_to_lazy_backlog():
+    old = _old()
+
+    assert classify_chunk_tier("codex_cli", "assistant_text", old) == EnrichmentTier.T2_LAZY
+    assert classify_chunk_tier("cursor_cli", "assistant_text", old) == EnrichmentTier.T2_LAZY
+    assert classify_chunk_tier("gemini_cli", "assistant_text", old) == EnrichmentTier.T2_LAZY
+
+
+def test_hourly_source_filter_includes_all_agent_cli_families():
+    sources = get_tier_source_filter(EnrichmentTier.T1_HOURLY)
+
+    assert {"claude_code", "codex_cli", "cursor_cli", "gemini_cli"} <= sources

--- a/tests/test_session_enrichment.py
+++ b/tests/test_session_enrichment.py
@@ -526,6 +526,37 @@ class TestListSessionsForEnrichment:
         session_ids = [s[0] for s in sessions]
         assert sid not in session_ids
 
+    @pytest.mark.parametrize("source", ["codex_cli", "cursor_cli", "gemini_cli"])
+    def test_agent_cli_sessions_are_discovered_from_chunks(self, store, source):
+        """Agent-session sources beyond Claude are eligible for session enrichment."""
+        from brainlayer.pipeline.session_enrichment import list_sessions_for_enrichment
+
+        cursor = store.conn.cursor()
+        session_id = f"{source}-session"
+        source_file = f"/tmp/{session_id}.jsonl"
+
+        for idx in range(3):
+            cursor.execute(
+                """INSERT INTO chunks
+                   (id, content, metadata, source_file, project, content_type,
+                    value_type, char_count, source, created_at)
+                   VALUES (?, ?, '{}', ?, ?, 'assistant_text', 'HIGH', ?, ?, ?)""",
+                (
+                    f"{session_id}:c{idx}",
+                    f"{source} chunk {idx}",
+                    source_file,
+                    "brainlayer",
+                    len(f"{source} chunk {idx}"),
+                    source,
+                    f"2026-04-18T0{idx}:00:00Z",
+                ),
+            )
+
+        sessions = list_sessions_for_enrichment(store)
+        session_ids = [session[0] for session in sessions]
+
+        assert session_id in session_ids
+
 
 # ── End-to-End Enrichment Tests ─────────────────────────────────
 


### PR DESCRIPTION
## Summary
- rebase the BrainBar dashboard-flow UI restoration onto current `main`
- preserve Phase B build-stamp and canonical build-guard infrastructure from #264/#265
- drop the old `CLAUDE.md` post-merge deploy-check docs commit because the deploy-check workflow now lives in orchestrator via #60

## Verification
- `git diff --check origin/main...HEAD`
- pre-push hook on `fix/brainbar-dashboard-flow`: `1811 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration `3 passed`; isolated eval/hook routing `32 passed`; bun `1 pass`; `test_fts5_determinism.sh` PASS

## Notes
- First push attempt exposed live DB lock contention from `com.brainlayer.enrichment`/`com.brainlayer.watch`; exact failed tests passed after pausing those write-heavy launch agents (`3 passed in 21.60s`), then the full pre-push hook passed.
- W2 will add the Swift BrainBar FTS parity tests/implementation on top of this branch before final merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned dashboard: scrollable cards, dual-lane flow summary, detachable dashboard panel, optional queue rail; injection feed snapshotting with burst grouping
  * Agent activity monitoring showing running AI CLI presence
  * Deterministic graph atlas and revamped knowledge-graph sidebar
  * Improved search fallbacks including trigram-based matching

* **UI / UX**
  * Menu-bar popover with quick-action buttons; conversation overlay, unified card styling, command-bar readiness; time-based status badges and dark/light-aware graph visuals

* **Tests**
  * Extensive new unit tests across dashboard, search/FTS, injections, graph, panel controller, and agent monitoring

* **Documentation**
  * New implementation plans for dashboard flow and hybrid UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore BrainBar dashboard flow UI with knowledge graph atlas, injection feed, and agent presence
> - Replaces the menu bar extra window with a floating `NSPanel` managed by `BrainBarDashboardPanelController`, which remembers size/position, appears on all spaces, and hosts the root dashboard view
> - Rebuilds `BrainBarDashboardView` into a multi-card layout with separate write/enrichment pulse lanes, a queue rail, agent presence strip, sparkline cards, and a collapsible diagnostics section driven by a new `DashboardFlowSummary` model
> - Overhauls `InjectionFeedView` into a dashboard with burst grouping, activity ribbon, side-rail session/token metrics, and an overlay conversation viewer via the new `InjectionPresentation` snapshot pipeline
> - Adds trigram FTS5 support to `BrainDatabase` with schema migration, trigger-based sync, conditional startup rebuild/backfill, KG alias query expansion, and exact chunk-id short-circuit lookup
> - Expands `T1_T2_SOURCES` in `enrichment_tiers.py` to include `codex_cli`, `cursor_cli`, and `gemini_cli`, updating session discovery SQL and tier source filters accordingly
> - Introduces `AgentActivityMonitor` to sample live agent CLI processes and publish per-family presence counts to the dashboard via `StatsCollector`
> - Rebuilds the knowledge graph canvas with importance-based altitude filtering, entity-type region backdrops, seeded initial positions via `KGAtlasLayout`, and a redesigned sidebar; dark/light mode support added throughout
> - Risk: trigram FTS backfill is skipped at startup when chunk count exceeds the threshold, leaving the trigram index empty until a manual rebuild
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8588f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes BrainBar’s primary windowing behavior and adds new SQLite schema/migration + FTS search paths (including conditional trigram index rebuild/backfill) that could affect startup time and query correctness on existing databases.
> 
> **Overview**
> **BrainBar’s menu-bar surface is reworked**: the `MenuBarExtra` switches from a window-style surface to a menu with explicit actions (open dashboard/search/capture), and the main UI now opens in a floating `NSPanel` via `BrainBarDashboardPanelController` (with autosaved sizing/position and escape-to-dismiss).
> 
> **Dashboard & tabs are redesigned for “flow” visibility**: `BrainBarWindowRootView` refactors tab rendering/lifecycle (lazy activation + shared command bar VM), and `BrainBarDashboardView` becomes a scrollable, card-based layout with separate write/enrichment lane charts, queue/diagnostics sections, and a new agent-presence strip fed by `AgentActivityMonitor`.
> 
> **Search and schema/migrations expand**: `BrainDatabase` adds a trigram FTS table (`chunks_fts_trigram`) with triggers, analysis, and startup repair logic that may skip synchronous backfill on large desynced DBs; search now short-circuits exact chunk-id matches, expands queries via lexical/KG alias replacements (new `kg_entity_aliases` table + `kg_entities.importance` column), and falls back to trigram matches with deduping.
> 
> **Graph and injection UIs are overhauled**: `KGCanvasView` gains an atlas-style presentation (importance filtering, region backdrops, deterministic seeding via `KGAtlasLayout`, dark/light rendering tweaks, and updated sidebar styling), and `InjectionFeedView` becomes a richer, snapshot-driven feed (burst grouping, activity ribbon, side-rail metrics, and overlay-based conversation drilldown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8588f4f2f31f2650a6a663a25c50789c25f0717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Stability addendum
- Added commit `59b4025d30bc59ff9917973b4537a2f365df67f1`: `fix(brainbar): skip synchronous trigram backfill on large desynced DBs`.
- Root cause: BrainBar startup could synchronously rebuild `chunks_fts_trigram` on the live ~360K-chunk database before `/tmp/brainbar.sock` opened, cascading lock pressure into enrichment and MCP clients.
- Runtime guard: `synchronousTrigramBackfillChunkLimit = 10_000`; large desynced trigram tables now keep schema/triggers current and defer heavy backfill instead of blocking startup.
- Verification: RED→GREEN `testLargeTrigramDesyncDoesNotForceSynchronousStartupRebuild`; `swift test --filter DatabaseTests`; `bash scripts/run_tests.sh`; `swift test`.
- Follow-ups tracked in `docs.local/plans/2026-05-02-brainlayer-reliability-hardening/`: PR B explicit trigram maintenance command, PR D boot health contract.

### Command-bar readiness fix for dashboard NSPanel surface
- Added commit `b8588f4f2f31f2650a6a663a25c50789c25f0717`: `fix(brainbar): restore command bar readiness on already-set runtime database`.
- Root cause: `runtime.database` could be installed while the NSPanel/root view was hidden, leaving the command bar local view-model state nil and rendering `Warming memory…` until a later activation refreshed SwiftUI.
- Fix shape: command bar readiness now derives through a stable provider from the current `runtime.database`, covering already-set values and later readiness changes without relying only on a missed subscription edge.
- Verification: RED→GREEN `testCommandBarBecomesReadyWhenDatabaseWasInstalledWhilePanelWasHidden`; `swift test --filter BrainBarDashboardPanelControllerTests`; full `swift test` (`316/316`); `bash scripts/run_tests.sh` pre-push gate PASS.
- Scope: first-letter search latency and graph tab stalls are deferred to polish-pass Phase 1 / reliability-hardening Phase 2, not folded into this lifecycle fix.