### PR TITLE
security: Swift MCPRouter adds ToolAnnotations to all 11 tools (cyberMaster H1)

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -448,10 +448,43 @@ final class MCPRouter: @unchecked Sendable {
 
     // MARK: - Tool Definitions
 
+    private static func toolAnnotations(
+        readOnly: Bool,
+        destructive: Bool,
+        idempotent: Bool,
+        openWorld: Bool = false
+    ) -> [String: Any] {
+        [
+            "readOnlyHint": readOnly,
+            "destructiveHint": destructive,
+            "idempotentHint": idempotent,
+            "openWorldHint": openWorld,
+        ]
+    }
+
+    nonisolated(unsafe) static let readOnlyAnnotations = toolAnnotations(
+        readOnly: true,
+        destructive: false,
+        idempotent: true
+    )
+
+    nonisolated(unsafe) static let writeAnnotations = toolAnnotations(
+        readOnly: false,
+        destructive: false,
+        idempotent: false
+    )
+
+    nonisolated(unsafe) static let writeIdempotentAnnotations = toolAnnotations(
+        readOnly: false,
+        destructive: false,
+        idempotent: true
+    )
+
     nonisolated(unsafe) static let toolDefinitions: [[String: Any]] = [
         [
             "name": "brain_search",
             "description": "Search through past conversations and learnings. Hybrid semantic + keyword search.",
+            "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -470,6 +503,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_store",
             "description": "Save decisions, learnings, mistakes, ideas, todos to memory.",
+            "annotations": MCPRouter.writeAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -483,6 +517,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_recall",
             "description": "Get current working context, browse sessions, or inspect session details.",
+            "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -494,6 +529,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_entity",
             "description": "Look up a known entity in the knowledge graph.",
+            "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -505,6 +541,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_digest",
             "description": "Ingest raw content (transcripts, docs, articles). Extracts entities, relations, action items.",
+            "annotations": MCPRouter.writeAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -516,6 +553,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_update",
             "description": "Update, archive, or merge existing memories.",
+            "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -528,6 +566,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_expand",
             "description": "Drill into a specific search result. Returns full content + surrounding chunks.",
+            "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -541,6 +580,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_tags",
             "description": "List, search, or suggest tags across the knowledge base.",
+            "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -551,6 +591,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_subscribe",
             "description": "Subscribe an agent to push notifications for matching tags.",
+            "annotations": MCPRouter.writeAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -563,6 +604,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_unsubscribe",
             "description": "Remove some or all tag subscriptions for an agent.",
+            "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -575,6 +617,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_ack",
             "description": "Acknowledge that an agent processed messages through the given chunk rowid.",
+            "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": [
                 "type": "object",
                 "properties": [

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -107,6 +107,49 @@ final class MCPRouterTests: XCTestCase {
         }
     }
 
+    func testEachToolHasExpectedAnnotations() throws {
+        let router = MCPRouter()
+        let request: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/list",
+        ]
+
+        let response = router.handle(request)
+        let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
+        let toolsByName = Dictionary(
+            uniqueKeysWithValues: tools.compactMap { tool -> (String, [String: Any])? in
+                guard let name = tool["name"] as? String else { return nil }
+                return (name, tool)
+            }
+        )
+
+        let expected: [String: (readOnly: Bool, destructive: Bool, idempotent: Bool, openWorld: Bool)] = [
+            "brain_search": (true, false, true, false),
+            "brain_store": (false, false, false, false),
+            "brain_recall": (true, false, true, false),
+            "brain_entity": (true, false, true, false),
+            "brain_digest": (false, false, false, false),
+            "brain_update": (false, false, true, false),
+            "brain_expand": (true, false, true, false),
+            "brain_tags": (true, false, true, false),
+            "brain_subscribe": (false, false, false, false),
+            "brain_unsubscribe": (false, false, true, false),
+            "brain_ack": (false, false, true, false),
+        ]
+
+        XCTAssertEqual(toolsByName.count, expected.count)
+
+        for (name, taxonomy) in expected {
+            let annotations = toolsByName[name]?["annotations"] as? [String: Any]
+            XCTAssertNotNil(annotations, "\(name) must expose MCP tool annotations")
+            XCTAssertEqual(annotations?["readOnlyHint"] as? Bool, taxonomy.readOnly, "\(name) readOnlyHint mismatch")
+            XCTAssertEqual(annotations?["destructiveHint"] as? Bool, taxonomy.destructive, "\(name) destructiveHint mismatch")
+            XCTAssertEqual(annotations?["idempotentHint"] as? Bool, taxonomy.idempotent, "\(name) idempotentHint mismatch")
+            XCTAssertEqual(annotations?["openWorldHint"] as? Bool, taxonomy.openWorld, "\(name) openWorldHint mismatch")
+        }
+    }
+
     // MARK: - Tools call
 
     func testToolsCallDispatchesToHandler() throws {

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -92,6 +92,36 @@ final class SocketIntegrationTests: XCTestCase {
         let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]]
         XCTAssertNotNil(tools)
         XCTAssertEqual(tools?.count, 11)
+
+        let toolsByName = Dictionary(
+            uniqueKeysWithValues: (tools ?? []).compactMap { tool -> (String, [String: Any])? in
+                guard let name = tool["name"] as? String else { return nil }
+                return (name, tool)
+            }
+        )
+
+        let expected: [String: (readOnly: Bool, destructive: Bool, idempotent: Bool, openWorld: Bool)] = [
+            "brain_search": (true, false, true, false),
+            "brain_store": (false, false, false, false),
+            "brain_recall": (true, false, true, false),
+            "brain_entity": (true, false, true, false),
+            "brain_digest": (false, false, false, false),
+            "brain_update": (false, false, true, false),
+            "brain_expand": (true, false, true, false),
+            "brain_tags": (true, false, true, false),
+            "brain_subscribe": (false, false, false, false),
+            "brain_unsubscribe": (false, false, true, false),
+            "brain_ack": (false, false, true, false),
+        ]
+
+        for (name, taxonomy) in expected {
+            let annotations = toolsByName[name]?["annotations"] as? [String: Any]
+            XCTAssertNotNil(annotations, "\(name) must expose MCP tool annotations over socket transport")
+            XCTAssertEqual(annotations?["readOnlyHint"] as? Bool, taxonomy.readOnly, "\(name) readOnlyHint mismatch")
+            XCTAssertEqual(annotations?["destructiveHint"] as? Bool, taxonomy.destructive, "\(name) destructiveHint mismatch")
+            XCTAssertEqual(annotations?["idempotentHint"] as? Bool, taxonomy.idempotent, "\(name) idempotentHint mismatch")
+            XCTAssertEqual(annotations?["openWorldHint"] as? Bool, taxonomy.openWorld, "\(name) openWorldHint mismatch")
+        }
     }
 
     // MARK: - MCP tools/call brain_search over socket


### PR DESCRIPTION
## Summary
- add MCP `annotations` to all 11 Swift BrainBar tool declarations exposed by `tools/list`
- mirror the Python server taxonomy for overlapping tools and classify Swift-only transport tools by their implemented semantics
- lock the contract down with router-level and socket-level annotation assertions

## Why
Swift BrainBar is the default brainlayer transport via `.mcp.json.example` (`socat UNIX-CONNECT:/tmp/brainbar.sock`). It previously exposed tools with no `ToolAnnotations`, so MCP clients on the primary transport could not distinguish read-only, write, or idempotent operations.

## Tool Annotation Matrix

| Tool | readOnlyHint | destructiveHint | idempotentHint | openWorldHint | Notes |
| --- | --- | --- | --- | --- | --- |
| `brain_search` | `true` | `false` | `true` | `false` | Matches Python `READ_ONLY` |
| `brain_store` | `false` | `false` | `false` | `false` | Matches Python `WRITE` |
| `brain_recall` | `true` | `false` | `true` | `false` | Matches Python `READ_ONLY` |
| `brain_entity` | `true` | `false` | `true` | `false` | Matches Python `READ_ONLY` |
| `brain_digest` | `false` | `false` | `false` | `false` | Matches Python `WRITE` |
| `brain_update` | `false` | `false` | `true` | `false` | Matches Python `WRITE_IDEMPOTENT` |
| `brain_expand` | `true` | `false` | `true` | `false` | Matches Python `READ_ONLY` |
| `brain_tags` | `true` | `false` | `true` | `false` | Matches Python `READ_ONLY` |
| `brain_subscribe` | `false` | `false` | `false` | `false` | Swift transport-only; classified as `WRITE` because subscribe mutates live subscription state/generation |
| `brain_unsubscribe` | `false` | `false` | `true` | `false` | Swift transport-only; classified as `WRITE_IDEMPOTENT` because repeated unsubscribe is a no-op |
| `brain_ack` | `false` | `false` | `true` | `false` | Swift transport-only; classified as `WRITE_IDEMPOTENT` because ack uses monotonic `MAX(...)` updates |

## Validation
- `swift build --package-path brain-bar`
- `swift test --package-path brain-bar`

## Runtime Verify
- Manual BrainBar daemon restart + ad hoc `tools/list` verification skipped to avoid disrupting the local daemon.
- Coverage was added instead at the socket transport layer: `SocketIntegrationTests.testMCPToolsListOverSocket` now asserts annotations over the actual MCP socket path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is an additive schema/metadata change to `tools/list` plus new assertions in unit and socket integration tests; it doesn’t alter tool execution paths.
> 
> **Overview**
> Adds MCP `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to all 11 Swift `MCPRouter` tool definitions returned by `tools/list`, using shared helper constants to classify tools as read-only, write, or idempotent-write.
> 
> Locks the contract in with new tests that verify the expected annotation matrix both at the router level (`MCPRouterTests`) and end-to-end over the Unix socket transport (`SocketIntegrationTests`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10525d883666525a97ff295bd452d97f488f14db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP `ToolAnnotations` to all 11 tools in `MCPRouter`
> - Adds three precomputed annotation constants (`readOnlyAnnotations`, `writeAnnotations`, `writeIdempotentAnnotations`) in [MCPRouter.swift](https://github.com/EtanHey/brainlayer/pull/253/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f), each encoding `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`.
> - Attaches the appropriate annotation constant to all 11 tool definitions: read tools (`brain_search`, `brain_recall`, `brain_entity`, `brain_expand`, `brain_tags`) are marked read-only/idempotent; write tools use write or write-idempotent annotations.
> - Extends [MCPRouterTests.swift](https://github.com/EtanHey/brainlayer/pull/253/files#diff-6a1a5be7d76811bedc4d3f0ebcb2043c90a2a0119ea214a29764bcd53b19af15) and [SocketIntegrationTests.swift](https://github.com/EtanHey/brainlayer/pull/253/files#diff-eb094020d1436830931b80eca21b91c55f3fae6299895b70fb0ac70dd94e5b17) to assert correct annotation values for every tool.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10525d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->