### PR TITLE
security: add maxLength to all string MCP inputs (cyberMaster H2)

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -22,6 +22,23 @@ final class MCPRouter: @unchecked Sendable {
 
     private var database: BrainDatabase?
     let entityCache = EntityCache()
+    private static let defaultStringMaxLength = 256
+    private static let defaultStringArrayMaxItems = 100
+    private static let stringMaxLengths: [String: Int] = [
+        "action": 64,
+        "agent_id": 128,
+        "chunk_id": 128,
+        "content": 200_000,
+        "detail": 16,
+        "mode": 32,
+        "project": 256,
+        "query": 4_096,
+        "session_id": 128,
+        "tag": 128
+    ]
+    private static let stringArrayLimits: [String: (maxItems: Int, itemMaxLength: Int)] = [
+        "tags": (maxItems: 100, itemMaxLength: 128)
+    ]
 
     /// Inject database for tool handlers + load entity cache.
     func setDatabase(_ db: BrainDatabase) {
@@ -122,6 +139,7 @@ final class MCPRouter: @unchecked Sendable {
 
         // Dispatch to handler
         do {
+            try Self.validate(arguments: arguments, for: toolName)
             let output = try dispatchTool(name: toolName, arguments: arguments)
             var result: [String: Any] = [
                 "content": [
@@ -453,11 +471,119 @@ final class MCPRouter: @unchecked Sendable {
         return response
     }
 
+    private static func limitedInputSchema(_ schema: [String: Any]) -> [String: Any] {
+        return applyInputLimits(to: schema, fieldName: nil)
+    }
+
+    private static func applyInputLimits(to schema: [String: Any], fieldName: String?) -> [String: Any] {
+        var schema = schema
+        guard let type = schema["type"] as? String else {
+            return schema
+        }
+
+        switch type {
+        case "string":
+            if schema["maxLength"] == nil {
+                schema["maxLength"] = stringMaxLengths[fieldName ?? ""] ?? defaultStringMaxLength
+            }
+        case "array":
+            if var items = schema["items"] as? [String: Any] {
+                if (items["type"] as? String) == "string" {
+                    let limits = stringArrayLimits[fieldName ?? ""] ??
+                        (maxItems: defaultStringArrayMaxItems, itemMaxLength: defaultStringMaxLength)
+                    if schema["maxItems"] == nil {
+                        schema["maxItems"] = limits.maxItems
+                    }
+                    if items["maxLength"] == nil {
+                        items["maxLength"] = limits.itemMaxLength
+                    }
+                }
+                schema["items"] = applyInputLimits(to: items, fieldName: fieldName)
+            }
+        case "object":
+            if var properties = schema["properties"] as? [String: Any] {
+                for (propertyName, value) in properties {
+                    guard let propertySchema = value as? [String: Any] else { continue }
+                    properties[propertyName] = applyInputLimits(to: propertySchema, fieldName: propertyName)
+                }
+                schema["properties"] = properties
+            }
+        default:
+            break
+        }
+
+        return schema
+    }
+
+    private static func validate(arguments: [String: Any], for toolName: String) throws {
+        guard
+            let tool = toolDefinitions.first(where: { ($0["name"] as? String) == toolName }),
+            let schema = tool["inputSchema"] as? [String: Any]
+        else {
+            return
+        }
+
+        try validate(value: arguments, against: schema, fieldPath: "arguments")
+    }
+
+    private static func validate(value: Any, against schema: [String: Any], fieldPath: String) throws {
+        guard let type = schema["type"] as? String else {
+            return
+        }
+
+        switch type {
+        case "object":
+            guard let object = value as? [String: Any] else {
+                throw ToolError.schemaValidation("\(fieldPath) must be an object")
+            }
+            let required = schema["required"] as? [String] ?? []
+            for key in required where object[key] == nil || object[key] is NSNull {
+                throw ToolError.schemaValidation("\(key) is required")
+            }
+            if let properties = schema["properties"] as? [String: Any] {
+                for (propertyName, propertyValue) in object {
+                    guard
+                        !(propertyValue is NSNull),
+                        let propertySchema = properties[propertyName] as? [String: Any]
+                    else { continue }
+                    try validate(value: propertyValue, against: propertySchema, fieldPath: propertyName)
+                }
+            }
+        case "string":
+            guard let stringValue = value as? String else {
+                throw ToolError.schemaValidation("\(fieldPath) must be a string")
+            }
+            if let enumValues = schema["enum"] as? [String], !enumValues.contains(stringValue) {
+                throw ToolError.schemaValidation("\(fieldPath) must be one of \(enumValues.joined(separator: ", "))")
+            }
+            if let maxLength = schema["maxLength"] as? Int, stringValue.count > maxLength {
+                throw ToolError.schemaValidation(
+                    "\(fieldPath) length \(stringValue.count) exceeds maxLength \(maxLength)"
+                )
+            }
+        case "array":
+            guard let arrayValue = value as? [Any] else {
+                throw ToolError.schemaValidation("\(fieldPath) must be an array")
+            }
+            if let maxItems = schema["maxItems"] as? Int, arrayValue.count > maxItems {
+                throw ToolError.schemaValidation("\(fieldPath) item count \(arrayValue.count) exceeds maxItems \(maxItems)")
+            }
+            if let itemSchema = schema["items"] as? [String: Any] {
+                for (index, item) in arrayValue.enumerated() {
+                    try validate(value: item, against: itemSchema, fieldPath: "\(fieldPath)[\(index)]")
+                }
+            }
+        default:
+            break
+        }
+    }
+
     enum ToolError: LocalizedError {
         case unknownTool(String)
         case missingParameter(String)
         case noDatabase
         case notImplemented(String)
+        case schemaValidation(String)
 
         var errorDescription: String? {
             switch self {
@@ -465,6 +591,7 @@ final class MCPRouter: @unchecked Sendable {
             case .missingParameter(let param): return "Missing required parameter: \(param)"
             case .noDatabase: return "Database not available"
             case .notImplemented(let tool): return "\(tool) not yet implemented in BrainBar (use Python MCP server)"
+            case .schemaValidation(let message): return "Schema validation error: \(message)"
             }
         }
     }
@@ -508,7 +635,7 @@ final class MCPRouter: @unchecked Sendable {
             "name": "brain_search",
             "description": "Search through past conversations and learnings. Hybrid semantic + keyword search.",
             "annotations": MCPRouter.readOnlyAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "query": ["type": "string", "description": "Natural language search query"],
@@ -521,13 +648,13 @@ final class MCPRouter: @unchecked Sendable {
                     "detail": ["type": "string", "enum": ["compact", "full"], "description": "Result detail level"],
                 ] as [String: Any],
                 "required": ["query"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_store",
             "description": "Save decisions, learnings, mistakes, ideas, todos to memory.",
             "annotations": MCPRouter.writeAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "content": ["type": "string", "description": "Content to store"],
@@ -535,62 +662,62 @@ final class MCPRouter: @unchecked Sendable {
                     "importance": ["type": "integer", "description": "Importance score (1-10)"],
                 ] as [String: Any],
                 "required": ["content"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_recall",
             "description": "Get current working context, browse sessions, or inspect session details.",
             "annotations": MCPRouter.readOnlyAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "mode": ["type": "string", "enum": ["context", "sessions", "operations", "plan", "summary", "stats", "injections"], "description": "Recall mode"],
                     "session_id": ["type": "string", "description": "Session ID for operations/summary mode"],
                 ] as [String: Any],
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_entity",
             "description": "Look up a known entity in the knowledge graph.",
             "annotations": MCPRouter.readOnlyAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "query": ["type": "string", "description": "Entity name to look up"],
                 ] as [String: Any],
                 "required": ["query"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_digest",
             "description": "Ingest raw content (transcripts, docs, articles). Extracts entities, relations, action items.",
             "annotations": MCPRouter.writeAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "content": ["type": "string", "description": "Raw content to digest"],
                 ] as [String: Any],
                 "required": ["content"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_update",
             "description": "Update, archive, or merge existing memories.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "action": ["type": "string", "enum": ["update", "archive", "merge"], "description": "Action to perform"],
                     "chunk_id": ["type": "string", "description": "Chunk ID to update"],
                 ] as [String: Any],
                 "required": ["action", "chunk_id"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_expand",
             "description": "Drill into a specific search result. Returns full content + surrounding chunks.",
             "annotations": MCPRouter.readOnlyAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "chunk_id": ["type": "string", "description": "Chunk ID to expand"],
@@ -598,57 +725,57 @@ final class MCPRouter: @unchecked Sendable {
                     "after": ["type": "integer", "description": "Context chunks after (default: 3)"],
                 ] as [String: Any],
                 "required": ["chunk_id"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_tags",
             "description": "List, search, or suggest tags across the knowledge base.",
             "annotations": MCPRouter.readOnlyAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "query": ["type": "string", "description": "Optional search query to filter tags"],
                 ] as [String: Any],
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_subscribe",
             "description": "Subscribe an agent to push notifications for matching tags.",
             "annotations": MCPRouter.writeAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "agent_id": ["type": "string", "description": "Stable agent identifier"],
                     "tags": ["type": "array", "items": ["type": "string"], "description": "Tags to receive live notifications for"],
                 ] as [String: Any],
                 "required": ["agent_id", "tags"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_unsubscribe",
             "description": "Remove some or all tag subscriptions for an agent.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "agent_id": ["type": "string", "description": "Stable agent identifier"],
                     "tags": ["type": "array", "items": ["type": "string"], "description": "Optional subset of tags to remove"],
                 ] as [String: Any],
                 "required": ["agent_id"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
         [
             "name": "brain_ack",
             "description": "Acknowledge that an agent processed messages through the given chunk rowid.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
-            "inputSchema": [
+            "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "agent_id": ["type": "string", "description": "Stable agent identifier"],
                     "seq": ["type": "integer", "description": "Highest chunk rowid acknowledged by the agent"],
                 ] as [String: Any],
                 "required": ["agent_id", "seq"]
-            ] as [String: Any]
+            ] as [String: Any])
         ],
     ]
 }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -9,6 +9,54 @@ import XCTest
 import SQLite3
 @testable import BrainBar
 
+private func collectStringFields(in schema: [String: Any], path: String = "") -> [(String, [String: Any])] {
+    guard let type = schema["type"] as? String else {
+        return []
+    }
+
+    switch type {
+    case "string":
+        return [(path, schema)]
+    case "array":
+        if let items = schema["items"] as? [String: Any], (items["type"] as? String) == "string" {
+            return [("\(path)[]", items)]
+        }
+        return []
+    case "object":
+        let properties = schema["properties"] as? [String: Any] ?? [:]
+        return properties.flatMap { propertyName, value -> [(String, [String: Any])] in
+            guard let propertySchema = value as? [String: Any] else { return [] }
+            let nextPath = path.isEmpty ? propertyName : "\(path).\(propertyName)"
+            return collectStringFields(in: propertySchema, path: nextPath)
+        }
+    default:
+        return []
+    }
+}
+
+private func collectStringArrays(in schema: [String: Any], path: String = "") -> [(String, [String: Any], [String: Any])] {
+    guard let type = schema["type"] as? String else {
+        return []
+    }
+
+    switch type {
+    case "array":
+        if let items = schema["items"] as? [String: Any], (items["type"] as? String) == "string" {
+            return [(path, schema, items)]
+        }
+        return []
+    case "object":
+        let properties = schema["properties"] as? [String: Any] ?? [:]
+        return properties.flatMap { propertyName, value -> [(String, [String: Any], [String: Any])] in
+            guard let propertySchema = value as? [String: Any] else { return [] }
+            let nextPath = path.isEmpty ? propertyName : "\(path).\(propertyName)"
+            return collectStringArrays(in: propertySchema, path: nextPath)
+        }
+    default:
+        return []
+    }
+}
+
 final class MCPRouterTests: XCTestCase {
 
     // MARK: - Initialize
@@ -108,15 +156,23 @@ final class MCPRouterTests: XCTestCase {
         }
     }
 
-    func testEachToolHasExpectedAnnotations() throws {
+            "brain_entity": (true, false, true, false),
         let router = MCPRouter()
+            "brain_digest": (false, false, false, false),
         let request: [String: Any] = [
+            "brain_update": (false, false, true, false),
             "jsonrpc": "2.0",
+            "brain_expand": (true, false, true, false),
             "id": 12,
+            "brain_tags": (true, false, true, false),
             "method": "tools/list",
+            "brain_subscribe": (false, false, false, false),
         ]
+            "brain_unsubscribe": (false, false, true, false),
 
+            "brain_ack": (false, false, true, false),
         let response = router.handle(request)
+            XCTAssertEqual(annotations?["openWorldHint"] as? Bool, taxonomy.openWorld, "\(name) openWorldHint mismatch")
         let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
         let toolsByName = Dictionary(
             uniqueKeysWithValues: tools.compactMap { tool -> (String, [String: Any])? in
@@ -127,16 +183,6 @@ final class MCPRouterTests: XCTestCase {
 
         let expected: [String: (readOnly: Bool, destructive: Bool, idempotent: Bool, openWorld: Bool)] = [
             "brain_search": (true, false, true, false),
-            "brain_store": (false, false, false, false),
-            "brain_recall": (true, false, true, false),
-            "brain_entity": (true, false, true, false),
-            "brain_digest": (false, false, false, false),
-            "brain_update": (false, false, true, false),
-            "brain_expand": (true, false, true, false),
-            "brain_tags": (true, false, true, false),
-            "brain_subscribe": (false, false, false, false),
-            "brain_unsubscribe": (false, false, true, false),
-            "brain_ack": (false, false, true, false),
         ]
 
         XCTAssertEqual(toolsByName.count, expected.count)
@@ -147,7 +193,22 @@ final class MCPRouterTests: XCTestCase {
             XCTAssertEqual(annotations?["readOnlyHint"] as? Bool, taxonomy.readOnly, "\(name) readOnlyHint mismatch")
             XCTAssertEqual(annotations?["destructiveHint"] as? Bool, taxonomy.destructive, "\(name) destructiveHint mismatch")
             XCTAssertEqual(annotations?["idempotentHint"] as? Bool, taxonomy.idempotent, "\(name) idempotentHint mismatch")
-            XCTAssertEqual(annotations?["openWorldHint"] as? Bool, taxonomy.openWorld, "\(name) openWorldHint mismatch")
+            "brain_store": (false, false, false, false),
+            "brain_recall": (true, false, true, false),
+    func testEachToolHasExpectedAnnotations() throws {
+        for tool in MCPRouter.toolDefinitions {
+            let name = tool["name"] as? String ?? "unknown"
+            let schema = try XCTUnwrap(tool["inputSchema"] as? [String: Any], "\(name) missing inputSchema")
+
+            for (fieldPath, stringSchema) in collectStringFields(in: schema) {
+                XCTAssertNotNil(stringSchema["maxLength"] as? Int, "\(name).\(fieldPath) must declare maxLength")
+            }
+
+            for (fieldPath, arraySchema, itemSchema) in collectStringArrays(in: schema) {
+                XCTAssertNotNil(arraySchema["maxItems"] as? Int, "\(name).\(fieldPath) must declare maxItems")
+                XCTAssertNotNil(itemSchema["maxLength"] as? Int, "\(name).\(fieldPath)[] must declare maxLength")
+            }
+    func testEachToolSchemaBoundsStringInputs() throws {
         }
     }
 
@@ -190,6 +251,29 @@ final class MCPRouterTests: XCTestCase {
 
         XCTAssertNotNil(error, "Unknown tool should return JSON-RPC error")
         XCTAssertEqual(error?["code"] as? Int, -32601, "Should be method-not-found error")
+    }
+
+    func testBrainDigestRejectsOversizedContentAtSchemaLayer() throws {
+        let router = MCPRouter()
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_digest",
+                "arguments": [
+                    "content": String(repeating: "x", count: 200_001)
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+        let text = try XCTUnwrap(content.first?["text"] as? String)
+
+        XCTAssertEqual(result["isError"] as? Bool, true)
+        XCTAssertTrue(text.contains("Schema validation error"))
+        XCTAssertTrue(text.contains("content length 200001 exceeds maxLength 200000"))
     }
 
     func testBrainSubscribeToolIsServerHandled() throws {

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -211,6 +211,7 @@ def _apply_input_limits(node: Any, field_name: str | None = None) -> None:
     for prop_name, prop_schema in node.get("properties", {}).items():
         _apply_input_limits(prop_schema, prop_name)
 
+
 # --- Output schemas ---
 
 _MEMORY_ITEM_SCHEMA = {
@@ -381,140 +382,142 @@ Auto-routes based on input:
 - "history of X" / "discussed about X" → topic recall
 - Default → hybrid semantic + keyword search""",
             annotations=_READ_ONLY,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Natural language search query (e.g., 'how did I implement authentication', 'what happened with auth.ts', 'what am I working on')",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Natural language search query (e.g., 'how did I implement authentication', 'what happened with auth.ts', 'what am I working on')",
+                        },
+                        "project": {
+                            "type": "string",
+                            "description": "Filter by project name. Encoded/worktree names are auto-normalized.",
+                        },
+                        "file_path": {
+                            "type": "string",
+                            "description": "File path to search for (e.g., 'auth.ts'). Triggers file-aware routing: timeline + related knowledge. Add regression signals in query for regression analysis.",
+                        },
+                        "chunk_id": {
+                            "type": "string",
+                            "description": "Expand context around a specific chunk from a previous search result.",
+                        },
+                        "content_type": {
+                            "type": "string",
+                            "enum": [
+                                "ai_code",
+                                "stack_trace",
+                                "user_message",
+                                "assistant_text",
+                                "file_read",
+                                "git_diff",
+                            ],
+                            "description": "Filter by content type (search mode only)",
+                        },
+                        "source": {
+                            "type": "string",
+                            "enum": ["claude_code", "whatsapp", "youtube", "all"],
+                            "description": "Filter by data source (default: claude_code). Use 'all' to search everything.",
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Filter by tag (e.g. 'bug-fix', 'authentication', 'typescript')",
+                        },
+                        "intent": {
+                            "type": "string",
+                            "enum": [
+                                "debugging",
+                                "designing",
+                                "configuring",
+                                "discussing",
+                                "deciding",
+                                "implementing",
+                                "reviewing",
+                            ],
+                            "description": "Filter by intent classification",
+                        },
+                        "importance_min": {
+                            "type": "number",
+                            "description": "Minimum importance score (1-10)",
+                        },
+                        "date_from": {
+                            "type": "string",
+                            "description": "Filter results from this date (ISO 8601, e.g. '2026-02-01')",
+                        },
+                        "date_to": {
+                            "type": "string",
+                            "description": "Filter results up to this date (ISO 8601, e.g. '2026-02-19')",
+                        },
+                        "sentiment": {
+                            "type": "string",
+                            "enum": ["frustration", "confusion", "positive", "satisfaction", "neutral"],
+                            "description": "Filter by sentiment label (Phase 6)",
+                        },
+                        "num_results": {
+                            "type": "integer",
+                            "default": 5,
+                            "minimum": 1,
+                            "maximum": 100,
+                            "description": "Number of results to return (default: 5, max: 100)",
+                        },
+                        "before": {
+                            "type": "integer",
+                            "default": 3,
+                            "minimum": 0,
+                            "maximum": 50,
+                            "description": "Context chunks before target (chunk_id mode only)",
+                        },
+                        "after": {
+                            "type": "integer",
+                            "default": 3,
+                            "minimum": 0,
+                            "maximum": 50,
+                            "description": "Context chunks after target (chunk_id mode only)",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "default": 10,
+                            "description": "Maximum results for think/recall modes (default: 10)",
+                        },
+                        "entity_id": {
+                            "type": "string",
+                            "description": "Filter results to chunks linked to this entity ID. Used for per-person memory scoping (e.g., get only memories about a specific person). Bypasses routing rules.",
+                        },
+                        "sentiment_filter": {
+                            "type": "string",
+                            "enum": ["positive", "negative", "neutral", "mixed"],
+                            "description": "Filter results by sentiment label. Alias for 'sentiment' with standardized values.",
+                        },
+                        "content_type_filter": {
+                            "type": "string",
+                            "enum": [
+                                "user_message",
+                                "assistant_text",
+                                "ai_code",
+                                "learning",
+                                "decision",
+                                "bug_fix",
+                            ],
+                            "description": "Filter by content type. Alias for 'content_type' with extended value set including enrichment types.",
+                        },
+                        "source_filter": {
+                            "type": "string",
+                            "description": "Filter by source file pattern (SQL LIKE match, e.g. '%youtube%'). More flexible than 'source' enum.",
+                        },
+                        "correction_category": {
+                            "type": "string",
+                            "description": "Filter by correction type tag (e.g. 'correction:preference', 'correction:factual', 'correction:naming'). Matches chunks tagged with the given correction category.",
+                        },
+                        "detail": {
+                            "type": "string",
+                            "enum": ["compact", "full"],
+                            "default": "compact",
+                            "description": "Result detail level. 'compact' (default): returns snippet (150 chars), chunk_id, score, date, project, summary. 'full': returns full content + all metadata fields. Use 'full' when you need the complete text of a result.",
+                        },
                     },
-                    "project": {
-                        "type": "string",
-                        "description": "Filter by project name. Encoded/worktree names are auto-normalized.",
-                    },
-                    "file_path": {
-                        "type": "string",
-                        "description": "File path to search for (e.g., 'auth.ts'). Triggers file-aware routing: timeline + related knowledge. Add regression signals in query for regression analysis.",
-                    },
-                    "chunk_id": {
-                        "type": "string",
-                        "description": "Expand context around a specific chunk from a previous search result.",
-                    },
-                    "content_type": {
-                        "type": "string",
-                        "enum": [
-                            "ai_code",
-                            "stack_trace",
-                            "user_message",
-                            "assistant_text",
-                            "file_read",
-                            "git_diff",
-                        ],
-                        "description": "Filter by content type (search mode only)",
-                    },
-                    "source": {
-                        "type": "string",
-                        "enum": ["claude_code", "whatsapp", "youtube", "all"],
-                        "description": "Filter by data source (default: claude_code). Use 'all' to search everything.",
-                    },
-                    "tag": {
-                        "type": "string",
-                        "description": "Filter by tag (e.g. 'bug-fix', 'authentication', 'typescript')",
-                    },
-                    "intent": {
-                        "type": "string",
-                        "enum": [
-                            "debugging",
-                            "designing",
-                            "configuring",
-                            "discussing",
-                            "deciding",
-                            "implementing",
-                            "reviewing",
-                        ],
-                        "description": "Filter by intent classification",
-                    },
-                    "importance_min": {
-                        "type": "number",
-                        "description": "Minimum importance score (1-10)",
-                    },
-                    "date_from": {
-                        "type": "string",
-                        "description": "Filter results from this date (ISO 8601, e.g. '2026-02-01')",
-                    },
-                    "date_to": {
-                        "type": "string",
-                        "description": "Filter results up to this date (ISO 8601, e.g. '2026-02-19')",
-                    },
-                    "sentiment": {
-                        "type": "string",
-                        "enum": ["frustration", "confusion", "positive", "satisfaction", "neutral"],
-                        "description": "Filter by sentiment label (Phase 6)",
-                    },
-                    "num_results": {
-                        "type": "integer",
-                        "default": 5,
-                        "minimum": 1,
-                        "maximum": 100,
-                        "description": "Number of results to return (default: 5, max: 100)",
-                    },
-                    "before": {
-                        "type": "integer",
-                        "default": 3,
-                        "minimum": 0,
-                        "maximum": 50,
-                        "description": "Context chunks before target (chunk_id mode only)",
-                    },
-                    "after": {
-                        "type": "integer",
-                        "default": 3,
-                        "minimum": 0,
-                        "maximum": 50,
-                        "description": "Context chunks after target (chunk_id mode only)",
-                    },
-                    "max_results": {
-                        "type": "integer",
-                        "default": 10,
-                        "description": "Maximum results for think/recall modes (default: 10)",
-                    },
-                    "entity_id": {
-                        "type": "string",
-                        "description": "Filter results to chunks linked to this entity ID. Used for per-person memory scoping (e.g., get only memories about a specific person). Bypasses routing rules.",
-                    },
-                    "sentiment_filter": {
-                        "type": "string",
-                        "enum": ["positive", "negative", "neutral", "mixed"],
-                        "description": "Filter results by sentiment label. Alias for 'sentiment' with standardized values.",
-                    },
-                    "content_type_filter": {
-                        "type": "string",
-                        "enum": [
-                            "user_message",
-                            "assistant_text",
-                            "ai_code",
-                            "learning",
-                            "decision",
-                            "bug_fix",
-                        ],
-                        "description": "Filter by content type. Alias for 'content_type' with extended value set including enrichment types.",
-                    },
-                    "source_filter": {
-                        "type": "string",
-                        "description": "Filter by source file pattern (SQL LIKE match, e.g. '%youtube%'). More flexible than 'source' enum.",
-                    },
-                    "correction_category": {
-                        "type": "string",
-                        "description": "Filter by correction type tag (e.g. 'correction:preference', 'correction:factual', 'correction:naming'). Matches chunks tagged with the given correction category.",
-                    },
-                    "detail": {
-                        "type": "string",
-                        "enum": ["compact", "full"],
-                        "default": "compact",
-                        "description": "Result detail level. 'compact' (default): returns snippet (150 chars), chunk_id, score, date, project, summary. 'full': returns full content + all metadata fields. Use 'full' when you need the complete text of a result.",
-                    },
-                },
-                "required": ["query"],
-            }),
+                    "required": ["query"],
+                }
+            ),
         ),
         Tool(
             name="brain_store",
@@ -525,101 +528,103 @@ Type is auto-detected from content if omitted (e.g., "Always use bun" → decisi
 
 Returns: Structured JSON with `chunk_id` (string) and `related[]` (similar existing memories).""",
             annotations=_WRITE,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "content": {
-                        "type": "string",
-                        "description": "The text content to store (e.g., a decision, learning, idea)",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "The text content to store (e.g., a decision, learning, idea)",
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "idea",
+                                "mistake",
+                                "decision",
+                                "learning",
+                                "todo",
+                                "bookmark",
+                                "note",
+                                "journal",
+                                "issue",
+                            ],
+                            "description": "Memory type. Auto-detected from content if omitted.",
+                        },
+                        "project": {
+                            "type": "string",
+                            "description": "Optional: project name to scope the memory",
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional: tags for categorization (e.g., ['reliability', 'api'])",
+                        },
+                        "importance": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 10,
+                            "description": "Optional: importance score 1-10. Auto-scored from content if omitted.",
+                        },
+                        "confidence_score": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1,
+                            "description": "Decision confidence (0-1). Only for type=decision.",
+                        },
+                        "outcome": {
+                            "type": "string",
+                            "enum": ["pending", "validated", "reversed"],
+                            "description": "Decision outcome. Only for type=decision.",
+                        },
+                        "reversibility": {
+                            "type": "string",
+                            "enum": ["easy", "hard", "destructive"],
+                            "description": "How hard to reverse. Only for type=decision.",
+                        },
+                        "files_changed": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Files affected by this decision.",
+                        },
+                        "entity_id": {
+                            "type": "string",
+                            "description": "Link this memory to an entity (e.g., a person). The stored chunk will be linked via kg_entity_chunks for per-person memory retrieval.",
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": ["open", "in_progress", "done", "archived"],
+                            "description": "Issue lifecycle status. Only for type=issue. Defaults to 'open'.",
+                        },
+                        "severity": {
+                            "type": "string",
+                            "enum": ["critical", "high", "medium", "low"],
+                            "description": "Issue severity. Only for type=issue.",
+                        },
+                        "file_path": {
+                            "type": "string",
+                            "description": "Code file reference (e.g., 'src/brainlayer/mcp/__init__.py'). Only for type=issue.",
+                        },
+                        "function_name": {
+                            "type": "string",
+                            "description": "Function/method reference. Only for type=issue.",
+                        },
+                        "line_number": {
+                            "type": "integer",
+                            "description": "Line number reference. Only for type=issue.",
+                        },
+                        "supersedes": {
+                            "type": "string",
+                            "description": "Optional chunk_id to supersede. The old chunk is marked as superseded by this new one and removed from default search.",
+                        },
+                        "agent_id": {
+                            "type": "string",
+                            "description": "Optional stable agent identifier. Tags the stored chunk with the agent's identity for per-agent scoping and attribution.",
+                        },
                     },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "idea",
-                            "mistake",
-                            "decision",
-                            "learning",
-                            "todo",
-                            "bookmark",
-                            "note",
-                            "journal",
-                            "issue",
-                        ],
-                        "description": "Memory type. Auto-detected from content if omitted.",
-                    },
-                    "project": {
-                        "type": "string",
-                        "description": "Optional: project name to scope the memory",
-                    },
-                    "tags": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Optional: tags for categorization (e.g., ['reliability', 'api'])",
-                    },
-                    "importance": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 10,
-                        "description": "Optional: importance score 1-10. Auto-scored from content if omitted.",
-                    },
-                    "confidence_score": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 1,
-                        "description": "Decision confidence (0-1). Only for type=decision.",
-                    },
-                    "outcome": {
-                        "type": "string",
-                        "enum": ["pending", "validated", "reversed"],
-                        "description": "Decision outcome. Only for type=decision.",
-                    },
-                    "reversibility": {
-                        "type": "string",
-                        "enum": ["easy", "hard", "destructive"],
-                        "description": "How hard to reverse. Only for type=decision.",
-                    },
-                    "files_changed": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Files affected by this decision.",
-                    },
-                    "entity_id": {
-                        "type": "string",
-                        "description": "Link this memory to an entity (e.g., a person). The stored chunk will be linked via kg_entity_chunks for per-person memory retrieval.",
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["open", "in_progress", "done", "archived"],
-                        "description": "Issue lifecycle status. Only for type=issue. Defaults to 'open'.",
-                    },
-                    "severity": {
-                        "type": "string",
-                        "enum": ["critical", "high", "medium", "low"],
-                        "description": "Issue severity. Only for type=issue.",
-                    },
-                    "file_path": {
-                        "type": "string",
-                        "description": "Code file reference (e.g., 'src/brainlayer/mcp/__init__.py'). Only for type=issue.",
-                    },
-                    "function_name": {
-                        "type": "string",
-                        "description": "Function/method reference. Only for type=issue.",
-                    },
-                    "line_number": {
-                        "type": "integer",
-                        "description": "Line number reference. Only for type=issue.",
-                    },
-                    "supersedes": {
-                        "type": "string",
-                        "description": "Optional chunk_id to supersede. The old chunk is marked as superseded by this new one and removed from default search.",
-                    },
-                    "agent_id": {
-                        "type": "string",
-                        "description": "Optional stable agent identifier. Tags the stored chunk with the agent's identity for per-agent scoping and attribution.",
-                    },
-                },
-                "required": ["content"],
-            }),
+                    "required": ["content"],
+                }
+            ),
             outputSchema=_STORE_OUTPUT_SCHEMA,
         ),
         Tool(
@@ -635,27 +640,29 @@ Otherwise, memories are ordered by their entity-chunk relevance score.
 
 Designed for copilot agents that need full person context in a single call.""",
             annotations=_READ_ONLY,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Person name to look up (e.g., 'Avi Simon'). Searches by FTS + semantic match.",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Person name to look up (e.g., 'Avi Simon'). Searches by FTS + semantic match.",
+                        },
+                        "context": {
+                            "type": "string",
+                            "description": "Optional meeting/conversation context to rank memories by relevance (e.g., 'schedule a meeting next week about product roadmap').",
+                        },
+                        "num_memories": {
+                            "type": "integer",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Number of memory chunks to return (default: 10).",
+                        },
                     },
-                    "context": {
-                        "type": "string",
-                        "description": "Optional meeting/conversation context to rank memories by relevance (e.g., 'schedule a meeting next week about product roadmap').",
-                    },
-                    "num_memories": {
-                        "type": "integer",
-                        "default": 10,
-                        "minimum": 1,
-                        "maximum": 50,
-                        "description": "Number of memory chunks to return (default: 10).",
-                    },
-                },
-                "required": ["name"],
-            }),
+                    "required": ["name"],
+                }
+            ),
         ),
         Tool(
             name="brain_recall",
@@ -678,136 +685,147 @@ Smart routing when mode is omitted:
 - Capitalized proper noun (e.g. "BrainLayer", "Etan Heyman") → entity mode
 - Everything else → search mode""",
             annotations=_READ_ONLY,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Search query or entity name. Required for mode=search and mode=entity. Triggers smart mode detection when mode is omitted.",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query or entity name. Required for mode=search and mode=entity. Triggers smart mode detection when mode is omitted.",
+                        },
+                        "mode": {
+                            "type": "string",
+                            "enum": [
+                                "search",
+                                "entity",
+                                "context",
+                                "sessions",
+                                "operations",
+                                "plan",
+                                "summary",
+                                "stats",
+                            ],
+                            "description": "Recall mode. Auto-detected from query if omitted.",
+                        },
+                        "project": {
+                            "type": "string",
+                            "description": "Filter by project name.",
+                        },
+                        "hours": {
+                            "type": "integer",
+                            "default": 24,
+                            "description": "How many hours back to look (mode=context, default: 24)",
+                        },
+                        "days": {
+                            "type": "integer",
+                            "default": 7,
+                            "minimum": 1,
+                            "maximum": 365,
+                            "description": "How many days back (mode=sessions, default: 7)",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 1,
+                            "maximum": 100,
+                            "description": "Max sessions to return (mode=sessions, default: 20)",
+                        },
+                        "session_id": {
+                            "type": "string",
+                            "description": "Session ID (required for mode=operations/summary, optional for mode=plan)",
+                        },
+                        "plan_name": {
+                            "type": "string",
+                            "description": "Plan name (mode=plan, e.g. 'local-llm-integration')",
+                        },
+                        "entity_type": {
+                            "type": "string",
+                            "enum": [
+                                "person",
+                                "constraint",
+                                "preference",
+                                "life_event",
+                                "meeting",
+                                "location",
+                                "organization",
+                            ],
+                            "description": "Filter by entity type (mode=entity only)",
+                        },
+                        "file_path": {
+                            "type": "string",
+                            "description": "File path to search for (mode=search). Triggers file-aware routing.",
+                        },
+                        "chunk_id": {
+                            "type": "string",
+                            "description": "Expand context around a specific chunk (mode=search).",
+                        },
+                        "content_type": {
+                            "type": "string",
+                            "enum": [
+                                "ai_code",
+                                "stack_trace",
+                                "user_message",
+                                "assistant_text",
+                                "file_read",
+                                "git_diff",
+                            ],
+                            "description": "Filter by content type (mode=search only)",
+                        },
+                        "source": {
+                            "type": "string",
+                            "enum": ["claude_code", "whatsapp", "youtube", "all"],
+                            "description": "Filter by data source (mode=search, default: claude_code).",
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Filter by tag (mode=search, e.g. 'bug-fix')",
+                        },
+                        "intent": {
+                            "type": "string",
+                            "enum": [
+                                "debugging",
+                                "designing",
+                                "configuring",
+                                "discussing",
+                                "deciding",
+                                "implementing",
+                                "reviewing",
+                            ],
+                            "description": "Filter by intent classification (mode=search)",
+                        },
+                        "importance_min": {
+                            "type": "number",
+                            "description": "Minimum importance score 1-10 (mode=search)",
+                        },
+                        "date_from": {
+                            "type": "string",
+                            "description": "Filter results from this date (ISO 8601, mode=search)",
+                        },
+                        "date_to": {
+                            "type": "string",
+                            "description": "Filter results up to this date (ISO 8601, mode=search)",
+                        },
+                        "sentiment": {
+                            "type": "string",
+                            "enum": ["frustration", "confusion", "positive", "satisfaction", "neutral"],
+                            "description": "Filter by sentiment label (mode=search)",
+                        },
+                        "num_results": {
+                            "type": "integer",
+                            "default": 5,
+                            "minimum": 1,
+                            "maximum": 100,
+                            "description": "Number of results (mode=search, default: 5)",
+                        },
+                        "detail": {
+                            "type": "string",
+                            "enum": ["compact", "full"],
+                            "default": "compact",
+                            "description": "Result detail level (mode=search). 'compact': snippet + metadata. 'full': complete content.",
+                        },
                     },
-                    "mode": {
-                        "type": "string",
-                        "enum": ["search", "entity", "context", "sessions", "operations", "plan", "summary", "stats"],
-                        "description": "Recall mode. Auto-detected from query if omitted.",
-                    },
-                    "project": {
-                        "type": "string",
-                        "description": "Filter by project name.",
-                    },
-                    "hours": {
-                        "type": "integer",
-                        "default": 24,
-                        "description": "How many hours back to look (mode=context, default: 24)",
-                    },
-                    "days": {
-                        "type": "integer",
-                        "default": 7,
-                        "minimum": 1,
-                        "maximum": 365,
-                        "description": "How many days back (mode=sessions, default: 7)",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 20,
-                        "minimum": 1,
-                        "maximum": 100,
-                        "description": "Max sessions to return (mode=sessions, default: 20)",
-                    },
-                    "session_id": {
-                        "type": "string",
-                        "description": "Session ID (required for mode=operations/summary, optional for mode=plan)",
-                    },
-                    "plan_name": {
-                        "type": "string",
-                        "description": "Plan name (mode=plan, e.g. 'local-llm-integration')",
-                    },
-                    "entity_type": {
-                        "type": "string",
-                        "enum": [
-                            "person",
-                            "constraint",
-                            "preference",
-                            "life_event",
-                            "meeting",
-                            "location",
-                            "organization",
-                        ],
-                        "description": "Filter by entity type (mode=entity only)",
-                    },
-                    "file_path": {
-                        "type": "string",
-                        "description": "File path to search for (mode=search). Triggers file-aware routing.",
-                    },
-                    "chunk_id": {
-                        "type": "string",
-                        "description": "Expand context around a specific chunk (mode=search).",
-                    },
-                    "content_type": {
-                        "type": "string",
-                        "enum": [
-                            "ai_code",
-                            "stack_trace",
-                            "user_message",
-                            "assistant_text",
-                            "file_read",
-                            "git_diff",
-                        ],
-                        "description": "Filter by content type (mode=search only)",
-                    },
-                    "source": {
-                        "type": "string",
-                        "enum": ["claude_code", "whatsapp", "youtube", "all"],
-                        "description": "Filter by data source (mode=search, default: claude_code).",
-                    },
-                    "tag": {
-                        "type": "string",
-                        "description": "Filter by tag (mode=search, e.g. 'bug-fix')",
-                    },
-                    "intent": {
-                        "type": "string",
-                        "enum": [
-                            "debugging",
-                            "designing",
-                            "configuring",
-                            "discussing",
-                            "deciding",
-                            "implementing",
-                            "reviewing",
-                        ],
-                        "description": "Filter by intent classification (mode=search)",
-                    },
-                    "importance_min": {
-                        "type": "number",
-                        "description": "Minimum importance score 1-10 (mode=search)",
-                    },
-                    "date_from": {
-                        "type": "string",
-                        "description": "Filter results from this date (ISO 8601, mode=search)",
-                    },
-                    "date_to": {
-                        "type": "string",
-                        "description": "Filter results up to this date (ISO 8601, mode=search)",
-                    },
-                    "sentiment": {
-                        "type": "string",
-                        "enum": ["frustration", "confusion", "positive", "satisfaction", "neutral"],
-                        "description": "Filter by sentiment label (mode=search)",
-                    },
-                    "num_results": {
-                        "type": "integer",
-                        "default": 5,
-                        "minimum": 1,
-                        "maximum": 100,
-                        "description": "Number of results (mode=search, default: 5)",
-                    },
-                    "detail": {
-                        "type": "string",
-                        "enum": ["compact", "full"],
-                        "default": "compact",
-                        "description": "Result detail level (mode=search). 'compact': snippet + metadata. 'full': complete content.",
-                    },
-                },
-            }),
+                }
+            ),
         ),
         Tool(
             name="brain_digest",
@@ -825,203 +843,213 @@ How it differs from brain_store:
 - brain_store = fast write, minimal processing, optimized for immediate capture
 - brain_digest = slower deep enrichment, may call Gemini, intended for richer indexing""",
             annotations=_WRITE,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "mode": {
-                        "type": "string",
-                        "enum": ["digest", "enrich", "connect"],
-                        "description": "digest (default): ingest content and store. connect: search→connect→propose without storing (returns proposal). enrich: run realtime enrichment on existing DB chunks.",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "mode": {
+                            "type": "string",
+                            "enum": ["digest", "enrich", "connect"],
+                            "description": "digest (default): ingest content and store. connect: search→connect→propose without storing (returns proposal). enrich: run realtime enrichment on existing DB chunks.",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Raw text content to deeply digest and enrich (research, audit, transcript, article, meeting notes)",
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Optional title for the content",
+                        },
+                        "project": {
+                            "type": "string",
+                            "description": "Optional project name to associate with",
+                        },
+                        "participants": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional list of known participant names (improves entity extraction)",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 25,
+                            "minimum": 1,
+                            "maximum": 5000,
+                            "description": "For mode=enrich: max number of existing chunks to enrich via realtime mode.",
+                        },
                     },
-                    "content": {
-                        "type": "string",
-                        "description": "Raw text content to deeply digest and enrich (research, audit, transcript, article, meeting notes)",
-                    },
-                    "title": {
-                        "type": "string",
-                        "description": "Optional title for the content",
-                    },
-                    "project": {
-                        "type": "string",
-                        "description": "Optional project name to associate with",
-                    },
-                    "participants": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Optional list of known participant names (improves entity extraction)",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 25,
-                        "minimum": 1,
-                        "maximum": 5000,
-                        "description": "For mode=enrich: max number of existing chunks to enrich via realtime mode.",
-                    },
-                },
-                "required": [],
-            }),
+                    "required": [],
+                }
+            ),
         ),
         Tool(
             name="brain_entity",
             title="Entity Lookup",
             description="""Look up a known entity (person, project, technology) and its relationships from the knowledge graph. Use when asked about a specific named entity or to explore connections between entities. Returns entity details plus connected entities via kg_relations. Does NOT do fuzzy topic search — use brain_search for that.""",
             annotations=_READ_ONLY,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Entity name or search query (e.g., 'Etan Heyman', 'brainlayer', 'Cantaloupe AI')",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Entity name or search query (e.g., 'Etan Heyman', 'brainlayer', 'Cantaloupe AI')",
+                        },
+                        "entity_type": {
+                            "type": "string",
+                            "enum": [
+                                "person",
+                                "agent",
+                                "golem",
+                                "tool",
+                                "platform",
+                                "project",
+                                "technology",
+                                "library",
+                                "organization",
+                                "company",
+                                "topic",
+                                "concept",
+                                "workflow",
+                                "skill",
+                                "decision",
+                                "protocol",
+                                "health_metric",
+                                "community",
+                                "device",
+                                "event",
+                                "location",
+                            ],
+                            "description": "Optional: filter by entity type",
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": ["lookup", "list"],
+                            "default": "lookup",
+                            "description": "lookup: find specific entity by name (default). list: browse entities by type with pagination.",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 1,
+                            "maximum": 100,
+                            "description": "Max results for list action.",
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0,
+                            "description": "Pagination offset for list action.",
+                        },
                     },
-                    "entity_type": {
-                        "type": "string",
-                        "enum": [
-                            "person",
-                            "agent",
-                            "golem",
-                            "tool",
-                            "platform",
-                            "project",
-                            "technology",
-                            "library",
-                            "organization",
-                            "company",
-                            "topic",
-                            "concept",
-                            "workflow",
-                            "skill",
-                            "decision",
-                            "protocol",
-                            "health_metric",
-                            "community",
-                            "device",
-                            "event",
-                            "location",
-                        ],
-                        "description": "Optional: filter by entity type",
-                    },
-                    "action": {
-                        "type": "string",
-                        "enum": ["lookup", "list"],
-                        "default": "lookup",
-                        "description": "lookup: find specific entity by name (default). list: browse entities by type with pagination.",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 20,
-                        "minimum": 1,
-                        "maximum": 100,
-                        "description": "Max results for list action.",
-                    },
-                    "offset": {
-                        "type": "integer",
-                        "default": 0,
-                        "minimum": 0,
-                        "description": "Pagination offset for list action.",
-                    },
-                },
-                "required": [],
-            }),
+                    "required": [],
+                }
+            ),
         ),
         Tool(
             name="brain_expand",
             title="Expand Chunk Context",
             description="Deprecated. Use brain_search with detail='full' to get full chunk content, or brain_recall with conversation_id to get session context.",
             annotations=_READ_ONLY,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "chunk_id": {
-                        "type": "string",
-                        "description": "The chunk_id from a brain_search result to expand.",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "chunk_id": {
+                            "type": "string",
+                            "description": "The chunk_id from a brain_search result to expand.",
+                        },
+                        "context": {
+                            "type": "integer",
+                            "default": 3,
+                            "minimum": 0,
+                            "maximum": 20,
+                            "description": "Number of surrounding chunks to include (before and after). Default: 3.",
+                        },
                     },
-                    "context": {
-                        "type": "integer",
-                        "default": 3,
-                        "minimum": 0,
-                        "maximum": 20,
-                        "description": "Number of surrounding chunks to include (before and after). Default: 3.",
-                    },
-                },
-                "required": ["chunk_id"],
-            }),
+                    "required": ["chunk_id"],
+                }
+            ),
         ),
         Tool(
             name="brain_update",
             title="Update or Archive Memory",
             description="Deprecated. Use brain_store with supersedes param to replace a memory, or brain_archive/brain_supersede for lifecycle management.",
             annotations=_WRITE_IDEMPOTENT,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["update", "archive", "merge"],
-                        "description": "What to do: update fields, archive (soft-delete), or merge duplicates",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["update", "archive", "merge"],
+                            "description": "What to do: update fields, archive (soft-delete), or merge duplicates",
+                        },
+                        "chunk_id": {
+                            "type": "string",
+                            "description": "The chunk ID to update or archive. For merge, this is the chunk to keep.",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "New content (update only). Will be re-embedded.",
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "New tags (update only). Replaces existing tags.",
+                        },
+                        "importance": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 10,
+                            "description": "New importance score (update only).",
+                        },
+                        "merge_chunk_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "For merge: additional chunk IDs to archive (duplicates of chunk_id).",
+                        },
                     },
-                    "chunk_id": {
-                        "type": "string",
-                        "description": "The chunk ID to update or archive. For merge, this is the chunk to keep.",
-                    },
-                    "content": {
-                        "type": "string",
-                        "description": "New content (update only). Will be re-embedded.",
-                    },
-                    "tags": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "New tags (update only). Replaces existing tags.",
-                    },
-                    "importance": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 10,
-                        "description": "New importance score (update only).",
-                    },
-                    "merge_chunk_ids": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "For merge: additional chunk IDs to archive (duplicates of chunk_id).",
-                    },
-                },
-                "required": ["action", "chunk_id"],
-            }),
+                    "required": ["action", "chunk_id"],
+                }
+            ),
         ),
         Tool(
             name="brain_tags",
             title="Tag Discovery",
             description="Deprecated. Use brain_recall(mode='search', tag='prefix') to find tagged memories, or brain_store(tags=[...]) to tag when storing.",
             annotations=_READ_ONLY,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["list", "search", "suggest"],
-                        "description": "What to do: list top tags, search by prefix, or suggest tags for content.",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["list", "search", "suggest"],
+                            "description": "What to do: list top tags, search by prefix, or suggest tags for content.",
+                        },
+                        "pattern": {
+                            "type": "string",
+                            "description": "Tag prefix or pattern to match (required for action='search').",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Text content to suggest tags for (required for action='suggest').",
+                        },
+                        "project": {
+                            "type": "string",
+                            "description": "Optional: filter by project name (action='list' only).",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 1,
+                            "maximum": 200,
+                            "description": "Maximum number of tags to return (default: 20).",
+                        },
                     },
-                    "pattern": {
-                        "type": "string",
-                        "description": "Tag prefix or pattern to match (required for action='search').",
-                    },
-                    "content": {
-                        "type": "string",
-                        "description": "Text content to suggest tags for (required for action='suggest').",
-                    },
-                    "project": {
-                        "type": "string",
-                        "description": "Optional: filter by project name (action='list' only).",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 20,
-                        "minimum": 1,
-                        "maximum": 200,
-                        "description": "Maximum number of tags to return (default: 20).",
-                    },
-                },
-                "required": ["action"],
-            }),
+                    "required": ["action"],
+                }
+            ),
         ),
         Tool(
             name="brain_supersede",
@@ -1037,31 +1065,33 @@ health/finance/relationship content) requires safety_check='confirm' + confirm=t
 
 Returns: Structured JSON with action taken.""",
             annotations=_DESTRUCTIVE,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "old_chunk_id": {
-                        "type": "string",
-                        "description": "The chunk ID to mark as superseded.",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "old_chunk_id": {
+                            "type": "string",
+                            "description": "The chunk ID to mark as superseded.",
+                        },
+                        "new_chunk_id": {
+                            "type": "string",
+                            "description": "The chunk ID that replaces the old one.",
+                        },
+                        "safety_check": {
+                            "type": "string",
+                            "enum": ["auto", "confirm"],
+                            "default": "auto",
+                            "description": "Safety mode: 'auto' for technical facts (auto-supersedes), 'confirm' for personal data (requires confirm=true).",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Set to true to confirm superseding personal data (when safety_check='confirm').",
+                        },
                     },
-                    "new_chunk_id": {
-                        "type": "string",
-                        "description": "The chunk ID that replaces the old one.",
-                    },
-                    "safety_check": {
-                        "type": "string",
-                        "enum": ["auto", "confirm"],
-                        "default": "auto",
-                        "description": "Safety mode: 'auto' for technical facts (auto-supersedes), 'confirm' for personal data (requires confirm=true).",
-                    },
-                    "confirm": {
-                        "type": "boolean",
-                        "default": False,
-                        "description": "Set to true to confirm superseding personal data (when safety_check='confirm').",
-                    },
-                },
-                "required": ["old_chunk_id", "new_chunk_id"],
-            }),
+                    "required": ["old_chunk_id", "new_chunk_id"],
+                }
+            ),
         ),
         Tool(
             name="brain_archive",
@@ -1075,20 +1105,22 @@ Use this to clean up stale, outdated, or irrelevant memories without permanent d
 
 Returns: Structured JSON with chunk_id and optional reason.""",
             annotations=_DESTRUCTIVE,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "chunk_id": {
-                        "type": "string",
-                        "description": "The chunk ID to archive.",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "chunk_id": {
+                            "type": "string",
+                            "description": "The chunk ID to archive.",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Optional: reason for archiving (stored for audit trail).",
+                        },
                     },
-                    "reason": {
-                        "type": "string",
-                        "description": "Optional: reason for archiving (stored for audit trail).",
-                    },
-                },
-                "required": ["chunk_id"],
-            }),
+                    "required": ["chunk_id"],
+                }
+            ),
         ),
         Tool(
             name="brain_enrich",
@@ -1111,49 +1143,51 @@ Features:
 
 Pass stats=true to get enrichment progress without running anything.""",
             annotations=_WRITE,
-            inputSchema=_bounded_input_schema({
-                "type": "object",
-                "properties": {
-                    "mode": {
-                        "type": "string",
-                        "enum": ["realtime", "batch"],
-                        "default": "realtime",
-                        "description": "Enrichment mode: realtime (Gemini Flash) or batch (Gemini Batch API).",
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "mode": {
+                            "type": "string",
+                            "enum": ["realtime", "batch"],
+                            "default": "realtime",
+                            "description": "Enrichment mode: realtime (Gemini Flash) or batch (Gemini Batch API).",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 25,
+                            "minimum": 1,
+                            "maximum": 5000,
+                            "description": "Maximum number of chunks to process.",
+                        },
+                        "since_hours": {
+                            "type": "integer",
+                            "default": DEFAULT_REALTIME_ENRICH_SINCE_HOURS,
+                            "minimum": 1,
+                            "description": (
+                                "Only enrich chunks from the last N hours (realtime mode only). "
+                                f"Default: {DEFAULT_REALTIME_ENRICH_SINCE_HOURS}h."
+                            ),
+                        },
+                        "phase": {
+                            "type": "string",
+                            "enum": ["submit", "poll", "import", "run"],
+                            "default": "run",
+                            "description": "Batch phase: submit (upload), poll (check), import (results), run (all-in-one).",
+                        },
+                        "chunk_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional: specific chunk IDs to enrich (realtime mode only).",
+                        },
+                        "stats": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Return enrichment progress statistics without running enrichment.",
+                        },
                     },
-                    "limit": {
-                        "type": "integer",
-                        "default": 25,
-                        "minimum": 1,
-                        "maximum": 5000,
-                        "description": "Maximum number of chunks to process.",
-                    },
-                    "since_hours": {
-                        "type": "integer",
-                        "default": DEFAULT_REALTIME_ENRICH_SINCE_HOURS,
-                        "minimum": 1,
-                        "description": (
-                            "Only enrich chunks from the last N hours (realtime mode only). "
-                            f"Default: {DEFAULT_REALTIME_ENRICH_SINCE_HOURS}h."
-                        ),
-                    },
-                    "phase": {
-                        "type": "string",
-                        "enum": ["submit", "poll", "import", "run"],
-                        "default": "run",
-                        "description": "Batch phase: submit (upload), poll (check), import (results), run (all-in-one).",
-                    },
-                    "chunk_ids": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Optional: specific chunk IDs to enrich (realtime mode only).",
-                    },
-                    "stats": {
-                        "type": "boolean",
-                        "default": False,
-                        "description": "Return enrichment progress statistics without running enrichment.",
-                    },
-                },
-            }),
+                }
+            ),
         ),
     ]
 

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from copy import deepcopy
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -126,6 +127,89 @@ _DESTRUCTIVE = ToolAnnotations(
     idempotentHint=False,
     openWorldHint=False,
 )
+
+_DEFAULT_STRING_MAX_LENGTH = 256
+_DEFAULT_STRING_ARRAY_MAX_ITEMS = 100
+_INPUT_STRING_MAX_LENGTHS = {
+    "action": 64,
+    "agent_id": 128,
+    "chunk_id": 128,
+    "content": 200_000,
+    "content_type": 64,
+    "content_type_filter": 64,
+    "context": 4_096,
+    "correction_category": 128,
+    "date_from": 32,
+    "date_to": 32,
+    "detail": 16,
+    "entity_id": 128,
+    "entity_type": 64,
+    "file_path": 1_024,
+    "function_name": 256,
+    "intent": 32,
+    "mode": 32,
+    "name": 256,
+    "new_chunk_id": 128,
+    "old_chunk_id": 128,
+    "outcome": 32,
+    "pattern": 256,
+    "plan_name": 256,
+    "project": 256,
+    "query": 4_096,
+    "reason": 1_024,
+    "reversibility": 32,
+    "safety_check": 32,
+    "sentiment": 32,
+    "sentiment_filter": 32,
+    "session_id": 128,
+    "severity": 16,
+    "source": 32,
+    "source_filter": 512,
+    "status": 32,
+    "supersedes": 128,
+    "tag": 128,
+    "title": 512,
+    "type": 32,
+}
+_INPUT_STRING_ARRAY_LIMITS = {
+    "chunk_ids": {"max_items": 500, "item_max_length": 128},
+    "files_changed": {"max_items": 200, "item_max_length": 1_024},
+    "merge_chunk_ids": {"max_items": 100, "item_max_length": 128},
+    "participants": {"max_items": 100, "item_max_length": 256},
+    "tags": {"max_items": 100, "item_max_length": 128},
+}
+
+
+def _bounded_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Apply uniform input caps to string fields before exposing MCP schemas."""
+    bounded = deepcopy(schema)
+    _apply_input_limits(bounded)
+    return bounded
+
+
+def _apply_input_limits(node: Any, field_name: str | None = None) -> None:
+    if not isinstance(node, dict):
+        return
+
+    node_type = node.get("type")
+    if node_type == "string":
+        node.setdefault("maxLength", _INPUT_STRING_MAX_LENGTHS.get(field_name, _DEFAULT_STRING_MAX_LENGTH))
+        return
+
+    if node_type == "array":
+        items = node.get("items")
+        if isinstance(items, dict) and items.get("type") == "string":
+            limits = _INPUT_STRING_ARRAY_LIMITS.get(
+                field_name,
+                {"max_items": _DEFAULT_STRING_ARRAY_MAX_ITEMS, "item_max_length": _DEFAULT_STRING_MAX_LENGTH},
+            )
+            node.setdefault("maxItems", limits["max_items"])
+            items.setdefault("maxLength", limits["item_max_length"])
+        _apply_input_limits(items, field_name)
+        return
+
+    for prop_name, prop_schema in node.get("properties", {}).items():
+        _apply_input_limits(prop_schema, prop_name)
 
 # --- Output schemas ---
 
@@ -297,7 +381,7 @@ Auto-routes based on input:
 - "history of X" / "discussed about X" → topic recall
 - Default → hybrid semantic + keyword search""",
             annotations=_READ_ONLY,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "query": {
@@ -430,7 +514,7 @@ Auto-routes based on input:
                     },
                 },
                 "required": ["query"],
-            },
+            }),
         ),
         Tool(
             name="brain_store",
@@ -441,7 +525,7 @@ Type is auto-detected from content if omitted (e.g., "Always use bun" → decisi
 
 Returns: Structured JSON with `chunk_id` (string) and `related[]` (similar existing memories).""",
             annotations=_WRITE,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "content": {
@@ -535,7 +619,7 @@ Returns: Structured JSON with `chunk_id` (string) and `related[]` (similar exist
                     },
                 },
                 "required": ["content"],
-            },
+            }),
             outputSchema=_STORE_OUTPUT_SCHEMA,
         ),
         Tool(
@@ -551,7 +635,7 @@ Otherwise, memories are ordered by their entity-chunk relevance score.
 
 Designed for copilot agents that need full person context in a single call.""",
             annotations=_READ_ONLY,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "name": {
@@ -571,7 +655,7 @@ Designed for copilot agents that need full person context in a single call.""",
                     },
                 },
                 "required": ["name"],
-            },
+            }),
         ),
         Tool(
             name="brain_recall",
@@ -594,7 +678,7 @@ Smart routing when mode is omitted:
 - Capitalized proper noun (e.g. "BrainLayer", "Etan Heyman") → entity mode
 - Everything else → search mode""",
             annotations=_READ_ONLY,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "query": {
@@ -723,7 +807,7 @@ Smart routing when mode is omitted:
                         "description": "Result detail level (mode=search). 'compact': snippet + metadata. 'full': complete content.",
                     },
                 },
-            },
+            }),
         ),
         Tool(
             name="brain_digest",
@@ -741,7 +825,7 @@ How it differs from brain_store:
 - brain_store = fast write, minimal processing, optimized for immediate capture
 - brain_digest = slower deep enrichment, may call Gemini, intended for richer indexing""",
             annotations=_WRITE,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "mode": {
@@ -775,14 +859,14 @@ How it differs from brain_store:
                     },
                 },
                 "required": [],
-            },
+            }),
         ),
         Tool(
             name="brain_entity",
             title="Entity Lookup",
             description="""Look up a known entity (person, project, technology) and its relationships from the knowledge graph. Use when asked about a specific named entity or to explore connections between entities. Returns entity details plus connected entities via kg_relations. Does NOT do fuzzy topic search — use brain_search for that.""",
             annotations=_READ_ONLY,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "query": {
@@ -837,14 +921,14 @@ How it differs from brain_store:
                     },
                 },
                 "required": [],
-            },
+            }),
         ),
         Tool(
             name="brain_expand",
             title="Expand Chunk Context",
             description="Deprecated. Use brain_search with detail='full' to get full chunk content, or brain_recall with conversation_id to get session context.",
             annotations=_READ_ONLY,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "chunk_id": {
@@ -860,14 +944,14 @@ How it differs from brain_store:
                     },
                 },
                 "required": ["chunk_id"],
-            },
+            }),
         ),
         Tool(
             name="brain_update",
             title="Update or Archive Memory",
             description="Deprecated. Use brain_store with supersedes param to replace a memory, or brain_archive/brain_supersede for lifecycle management.",
             annotations=_WRITE_IDEMPOTENT,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "action": {
@@ -901,14 +985,14 @@ How it differs from brain_store:
                     },
                 },
                 "required": ["action", "chunk_id"],
-            },
+            }),
         ),
         Tool(
             name="brain_tags",
             title="Tag Discovery",
             description="Deprecated. Use brain_recall(mode='search', tag='prefix') to find tagged memories, or brain_store(tags=[...]) to tag when storing.",
             annotations=_READ_ONLY,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "action": {
@@ -937,7 +1021,7 @@ How it differs from brain_store:
                     },
                 },
                 "required": ["action"],
-            },
+            }),
         ),
         Tool(
             name="brain_supersede",
@@ -953,7 +1037,7 @@ health/finance/relationship content) requires safety_check='confirm' + confirm=t
 
 Returns: Structured JSON with action taken.""",
             annotations=_DESTRUCTIVE,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "old_chunk_id": {
@@ -977,7 +1061,7 @@ Returns: Structured JSON with action taken.""",
                     },
                 },
                 "required": ["old_chunk_id", "new_chunk_id"],
-            },
+            }),
         ),
         Tool(
             name="brain_archive",
@@ -991,7 +1075,7 @@ Use this to clean up stale, outdated, or irrelevant memories without permanent d
 
 Returns: Structured JSON with chunk_id and optional reason.""",
             annotations=_DESTRUCTIVE,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "chunk_id": {
@@ -1004,7 +1088,7 @@ Returns: Structured JSON with chunk_id and optional reason.""",
                     },
                 },
                 "required": ["chunk_id"],
-            },
+            }),
         ),
         Tool(
             name="brain_enrich",
@@ -1027,7 +1111,7 @@ Features:
 
 Pass stats=true to get enrichment progress without running anything.""",
             annotations=_WRITE,
-            inputSchema={
+            inputSchema=_bounded_input_schema({
                 "type": "object",
                 "properties": {
                     "mode": {
@@ -1069,7 +1153,7 @@ Pass stats=true to get enrichment progress without running anything.""",
                         "description": "Return enrichment progress statistics without running enrichment.",
                     },
                 },
-            },
+            }),
         ),
     ]
 

--- a/tests/test_mcp_input_schema_limits.py
+++ b/tests/test_mcp_input_schema_limits.py
@@ -1,0 +1,70 @@
+"""Tests for MCP input schema length limits."""
+
+import asyncio
+from typing import Any
+
+from mcp import types
+
+from brainlayer.mcp import list_tools, server
+
+
+def _get_tools():
+    return asyncio.run(list_tools())
+
+
+def _iter_string_fields(schema: dict[str, Any], path: str = ""):
+    schema_type = schema.get("type")
+    if schema_type == "string":
+        yield path, schema
+        return
+
+    if schema_type == "array":
+        items = schema.get("items")
+        if isinstance(items, dict) and items.get("type") == "string":
+            yield f"{path}[]", items
+        return
+
+    if schema_type == "object":
+        for prop_name, prop_schema in schema.get("properties", {}).items():
+            next_path = f"{path}.{prop_name}" if path else prop_name
+            yield from _iter_string_fields(prop_schema, next_path)
+
+
+def _iter_string_arrays(schema: dict[str, Any], path: str = ""):
+    schema_type = schema.get("type")
+    if schema_type == "array":
+        items = schema.get("items")
+        if isinstance(items, dict) and items.get("type") == "string":
+            yield path, schema, items
+        return
+
+    if schema_type == "object":
+        for prop_name, prop_schema in schema.get("properties", {}).items():
+            next_path = f"{path}.{prop_name}" if path else prop_name
+            yield from _iter_string_arrays(prop_schema, next_path)
+
+
+def test_all_string_input_fields_have_max_length_and_string_arrays_have_max_items():
+    for tool in _get_tools():
+        schema = tool.inputSchema
+        for field_path, string_schema in _iter_string_fields(schema):
+            assert "maxLength" in string_schema, f"{tool.name}.{field_path} is missing maxLength"
+
+        for field_path, array_schema, item_schema in _iter_string_arrays(schema):
+            assert "maxItems" in array_schema, f"{tool.name}.{field_path} is missing maxItems"
+            assert "maxLength" in item_schema, f"{tool.name}.{field_path}[] is missing maxLength"
+
+async def _call_brain_digest(arguments: dict[str, Any]):
+    handler = server.request_handlers[types.CallToolRequest]
+    request = types.CallToolRequest(params=types.CallToolRequestParams(name="brain_digest", arguments=arguments))
+    return await handler(request)
+
+
+def test_brain_digest_schema_rejects_oversized_content():
+    result = asyncio.run(_call_brain_digest({"content": "x" * 200_001})).root
+
+    assert result.isError is True
+    assert result.content, "Expected error content to be non-empty"
+    text = result.content[0].text
+    assert "Input validation error:" in text
+    assert "is too long" in text

--- a/tests/test_mcp_input_schema_limits.py
+++ b/tests/test_mcp_input_schema_limits.py
@@ -54,6 +54,7 @@ def test_all_string_input_fields_have_max_length_and_string_arrays_have_max_item
             assert "maxItems" in array_schema, f"{tool.name}.{field_path} is missing maxItems"
             assert "maxLength" in item_schema, f"{tool.name}.{field_path}[] is missing maxLength"
 
+
 async def _call_brain_digest(arguments: dict[str, Any]):
     handler = server.request_handlers[types.CallToolRequest]
     request = types.CallToolRequest(params=types.CallToolRequestParams(name="brain_digest", arguments=arguments))


### PR DESCRIPTION
## Summary

Adds `maxLength` to all string MCP inputs in the Python server and BrainBar router, plus schema-level regression tests and BrainBar-side request validation for oversize string payloads.

## Python MCP Field Limits

| Field | maxLength |
| --- | ---: |
| `action` | 64 |
| `agent_id` | 128 |
| `chunk_id` | 128 |
| `content` | 200000 |
| `content_type` | 64 |
| `content_type_filter` | 64 |
| `context` | 4096 |
| `correction_category` | 128 |
| `date_from` | 32 |
| `date_to` | 32 |
| `detail` | 16 |
| `entity_id` | 128 |
| `entity_type` | 64 |
| `file_path` | 1024 |
| `function_name` | 256 |
| `intent` | 32 |
| `mode` | 32 |
| `name` | 256 |
| `new_chunk_id` | 128 |
| `old_chunk_id` | 128 |
| `outcome` | 32 |
| `pattern` | 256 |
| `phase` | 256 |
| `plan_name` | 256 |
| `project` | 256 |
| `query` | 4096 |
| `reason` | 1024 |
| `reversibility` | 32 |
| `safety_check` | 32 |
| `sentiment` | 32 |
| `sentiment_filter` | 32 |
| `session_id` | 128 |
| `severity` | 16 |
| `source` | 32 |
| `source_filter` | 512 |
| `status` | 32 |
| `supersedes` | 128 |
| `tag` | 128 |
| `title` | 512 |
| `type` | 32 |

## Python MCP String Array Limits

| Field | maxItems | item maxLength |
| --- | ---: | ---: |
| `chunk_ids[]` | 500 | 128 |
| `files_changed[]` | 200 | 1024 |
| `merge_chunk_ids[]` | 100 | 128 |
| `participants[]` | 100 | 256 |
| `tags[]` | 100 | 128 |

## BrainBar Field Limits

| Field | maxLength |
| --- | ---: |
| `action` | 64 |
| `agent_id` | 128 |
| `chunk_id` | 128 |
| `content` | 200000 |
| `detail` | 16 |
| `mode` | 32 |
| `project` | 256 |
| `query` | 4096 |
| `session_id` | 128 |
| `tag` | 128 |

## BrainBar String Array Limits

| Field | maxItems | item maxLength |
| --- | ---: | ---: |
| `tags[]` | 100 | 128 |

## Verification

### Focused checks

```text
$ pytest tests/test_mcp_input_schema_limits.py
============================== 2 passed in 0.37s ==============================

$ swift test --package-path brain-bar --filter MCPRouterTests
Executed 19 tests, with 0 failures (0 unexpected)
```

### Repo-wide gate

```text
$ pytest
7 failed, 1865 passed, 8 skipped, 6 xfailed, 2 xpassed in 397.25s
```

Those 7 failures are pre-existing and reproduce on the clean main checkout as well:

```text
$ PYTHONPATH=/Users/etanheyman/Gits/brainlayer/src pytest tests/test_vector_store.py::TestSchema::test_created_at_coverage
FAILED tests/test_vector_store.py::TestSchema::test_created_at_coverage

$ PYTHONPATH=/Users/etanheyman/Gits/brainlayer/src pytest tests/test_eval_baselines.py::TestTemporalQueries::test_recent_week_chunks_exist
FAILED tests/test_eval_baselines.py::TestTemporalQueries::test_recent_week_chunks_exist

$ PYTHONPATH=/Users/etanheyman/Gits/brainlayer/src pytest tests/test_eval_baselines.py::TestPromptHookEntityInjection::test_no_entity_in_generic_query
FAILED tests/test_eval_baselines.py::TestPromptHookEntityInjection::test_no_entity_in_generic_query
```

### Review

`cr review --plain` surfaced one test hardening issue in `tests/test_mcp_input_schema_limits.py`; that guard was fixed. A second rerun hit the org review rate limit after the finding was already addressed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds strict schema-driven input validation on both the Swift router and Python MCP server, which can cause previously-accepted oversized requests to fail and may impact clients relying on larger payloads.
> 
> **Overview**
> **Adds schema-level input size limits and enforcement for MCP tool calls.** Swift `MCPRouter` now auto-applies default/per-field `maxLength` (and `maxItems`/item `maxLength` for string arrays) to exposed `inputSchema`s and validates `tools/call` arguments (type, required fields, enums, and size bounds) before dispatch, returning a `schemaValidation` error when violated.
> 
> On the Python MCP server, tool `inputSchema`s are wrapped with `_bounded_input_schema` to inject the same style of string and string-array limits. New regression tests in both Swift and Python assert every tool schema declares these bounds and that oversized `brain_digest.content` is rejected at the schema layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 456af109b9c4da5b65fc032f67df3ca797430610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input schema validation is now enforced for all tool calls, rejecting requests with oversized strings and array values
  * Automatic size constraints are applied to string and array input fields across all tools
  * Schema validation errors are now properly reported in tool call responses

* **Tests**
  * Added comprehensive test coverage for input schema validation and constraint enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `maxLength`/`maxItems` bounds and schema validation to all MCP tool string inputs
> - Adds per-field `maxLength` caps for string inputs and `maxItems`/per-item `maxLength` caps for string-array inputs to all MCP tool schemas in both the Python layer ([`__init__.py`](https://github.com/EtanHey/brainlayer/pull/254/files#diff-b707fe059f28de703d53819bf809ca800bef866d46fac9f5867e52568026f686)) and Swift layer ([`MCPRouter.swift`](https://github.com/EtanHey/brainlayer/pull/254/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f)).
> - Introduces a validation step in the `tools/call` dispatch path that enforces these schema constraints (type, enum membership, `maxLength`, `maxItems`) before the tool handler executes, returning a JSON-RPC error on failure.
> - Adds a new `ToolError.schemaValidation` case in Swift to surface validation failures with a descriptive message.
> - Tests verify that every exposed tool schema declares bounds on string/string-array fields and that `brain_digest` rejects content exceeding 200,000 characters.
> - Behavioral Change: `tools/call` now returns a schema validation error for inputs that exceed declared limits, where previously oversized inputs would reach the handler unchecked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 456af10.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->