### PR TITLE
chore: add pre-push regression gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Pre-push hook — regression harness gate
+#
+# NOT FRICTION — discipline. The 5-day regression cycle in this repo
+# exists because past pushes bypassed checks. This hook stops that.
+#
+# DO NOT BYPASS:
+#   git push --no-verify          ← sneaks past the hook
+#   chmod -x .githooks/pre-push   ← disables it
+#
+# DO NOT SILENCE FAILURES:
+#   A failing test = a real bug. The Zero-RMS Hang recurred Apr 2 → Apr 27
+#   because symptomatic fixes shipped without root-cause coverage.
+#   Treat each failure as CRITICAL REVIEW TIME.
+
+set -uo pipefail
+[ ! -f scripts/run_tests.sh ] && { echo "⚠️  no scripts/run_tests.sh — skipping"; exit 0; }
+bash scripts/run_tests.sh
+exit_status=$?
+
+if [ $exit_status -ne 0 ]; then
+  cat <<'BANNER'
+
+🛑 PUSH BLOCKED — regression harness failed.
+
+This is a real regression. DO NOT bypass with --no-verify or silence the test.
+  1. Read the failure carefully
+  2. Reproduce locally
+  3. Fix the underlying bug
+  4. If the test IS wrong, separate PR with rationale
+
+The 5-day regression cycle exists because past pushes bypassed checks.
+
+BANNER
+  exit $exit_status
+fi

--- a/BUGBOT_REVIEW_P6B.md
+++ b/BUGBOT_REVIEW_P6B.md
@@ -1,0 +1,243 @@
+# Bugbot Review: PR feat/p6b-pre-push-hook
+
+**Date**: 2026-04-27  
+**Reviewer**: @bugbot  
+**Status**: ✅ READY TO MERGE (with 2 minor recommendations)
+
+---
+
+## Summary
+
+This PR adds `.githooks/pre-push` as a regression gate and updates documentation to guide developers through hook installation. The implementation is solid and follows shell best practices. I've identified **0 critical bugs**, **1 moderate issue**, and **2 low-priority recommendations**.
+
+---
+
+## 🐛 Critical Issues
+
+**None found.** The hook implementation is correct.
+
+---
+
+## ⚠️ Moderate Issues
+
+### 1. **Pre-push hook does not validate it's being called as a git hook**
+
+**Location**: `.githooks/pre-push:1-37`
+
+**Problem**: The pre-push hook can be invoked directly (`./.githooks/pre-push`) or via `bash .githooks/pre-push`, which skips the git hook stdin/argument protocol. Git pre-push hooks receive stdin data about what refs are being pushed, but this hook ignores that data entirely.
+
+**Impact**: 
+- The hook runs all tests even if only docs are being pushed
+- The hook has no way to differentiate between different push scenarios (force push, new branch, etc.)
+- Manual invocation (e.g., in CI or local testing) works identically to git invocation, which may or may not be desirable
+
+**Current Behavior**: The hook acts as a "run all tests before any push" gate, regardless of what's being pushed.
+
+**Risk Level**: Low-Medium - This is intentional design for simplicity, but it means the hook can't optimize for doc-only changes or skip tests when pushing tags.
+
+**Recommendation**: This is acceptable for Phase 6b's requirements ("add pre-push regression gate"). If future optimization is needed, the hook could:
+```bash
+# Read stdin to detect what's being pushed
+while read local_ref local_sha remote_ref remote_sha; do
+  # Skip if only pushing tags
+  if [[ "$local_ref" =~ refs/tags/ ]]; then
+    exit 0
+  fi
+  # Could add logic to detect doc-only changes via git diff
+done
+```
+
+**Verdict**: Not a bug, but worth documenting that this hook is a "universal regression gate" rather than a "smart push filter."
+
+---
+
+## 📝 Low-Priority Recommendations
+
+### 2. **Hook lacks shebang validation on scripts/run_tests.sh**
+
+**Location**: `.githooks/pre-push:17`
+
+```16:18:.githooks/pre-push
+set -uo pipefail
+[ ! -f scripts/run_tests.sh ] && { echo "⚠️  no scripts/run_tests.sh — skipping"; exit 0; }
+bash scripts/run_tests.sh
+```
+
+**Analysis**: The hook checks if `scripts/run_tests.sh` exists but doesn't verify it's executable or has a valid shebang. This is fine since it invokes `bash scripts/run_tests.sh` explicitly, but could be clearer.
+
+**Risk Level**: Very Low - Current implementation is correct; this is a style preference.
+
+**Suggestion**: Consider one of:
+- Option A (current): Keep `bash scripts/run_tests.sh` ✅ (explicit, works even if file isn't +x)
+- Option B: Use `./scripts/run_tests.sh` and require the script to be executable
+- Option C: Add a check: `[ -x scripts/run_tests.sh ] || chmod +x scripts/run_tests.sh`
+
+**Verdict**: Current approach is fine. No change needed.
+
+---
+
+### 3. **Documentation asymmetry: README mentions hook, CONTRIBUTING explains why**
+
+**Location**: `README.md:198`, `CONTRIBUTING.md:12-16`
+
+**Analysis**: 
+- `README.md` line 198 says: `git config core.hooksPath .githooks     # install repo pre-push hook once per clone`
+- `CONTRIBUTING.md` lines 12-16 explain the purpose of the hook and what it does
+
+**Observation**: The README tells *how* to install the hook but not *why*. A first-time contributor might skip it or forget to run it.
+
+**Risk Level**: Very Low - This is a documentation preference, not a technical issue.
+
+**Suggestion**: Add one sentence to README.md explaining the purpose:
+```bash
+git config core.hooksPath .githooks     # install repo pre-push hook once per clone
+# The pre-push hook runs the full test suite before every push to prevent regressions
+```
+
+**Verdict**: Optional. Current documentation is adequate but could be more helpful.
+
+---
+
+## ✅ What Works Well
+
+1. **Clear messaging**: The banner text is direct and explains *why* the hook exists (5-day regression cycle)
+2. **Anti-bypass warning**: Lines 7-13 explicitly call out `--no-verify` and `chmod -x` as anti-patterns
+3. **Correct exit code propagation**: Line 19 captures `$exit_status` and line 35 exits with it
+4. **Defensive file check**: Line 17 gracefully handles missing `scripts/run_tests.sh`
+5. **Executable permission**: The file has correct `+x` permission (verified via test)
+6. **Bash syntax validation**: `bash -n .githooks/pre-push` passes (verified via test)
+7. **Documentation consistency**: Both README and CONTRIBUTING mention the hook installation step
+8. **Test coverage**: No direct tests for the hook itself, but that's acceptable for a 37-line script
+
+---
+
+## 🔍 Security Analysis
+
+### Potential Attack Vectors
+
+1. **Malicious `scripts/run_tests.sh`**: If an attacker can modify `scripts/run_tests.sh`, they can execute arbitrary code on every push. 
+   - **Mitigation**: This is a general supply-chain risk, not specific to this PR. The hook trusts the repo content.
+   - **Verdict**: Acceptable for a local git hook.
+
+2. **Shell injection via environment variables**: The hook uses `set -uo pipefail` which prevents undefined variable expansion, and doesn't interpolate any external input.
+   - **Verdict**: Safe.
+
+3. **Bypass via `--no-verify`**: Git allows `git push --no-verify` to skip hooks.
+   - **Mitigation**: Lines 7-9 warn against this. Can't be prevented at the git level.
+   - **Verdict**: Documented risk, not a bug.
+
+---
+
+## 🧪 Test Results
+
+I validated the following scenarios:
+
+### ✅ Syntax Validation
+```bash
+bash -n .githooks/pre-push          # PASS
+bash -n scripts/run_tests.sh        # PASS
+```
+
+### ✅ Executable Permission
+```bash
+test -x .githooks/pre-push          # PASS (confirmed executable)
+```
+
+### ✅ Manual Invocation
+```bash
+./.githooks/pre-push                # PASS (correctly fails when dependencies missing)
+```
+
+**Observed behavior**: Hook correctly invokes `scripts/run_tests.sh`, exits with 127 when pytest/bun are missing, and prints the blocking banner.
+
+### ✅ Documentation References
+- `README.md:198` mentions hook installation ✅
+- `CONTRIBUTING.md:12-16` explains hook purpose ✅
+
+---
+
+## 🎯 Verdict
+
+**This PR is ready to merge.**
+
+The pre-push hook implementation is correct, secure, and well-documented. The hook successfully:
+1. Blocks pushes when tests fail
+2. Provides clear messaging about why it exists
+3. Warns against bypassing it
+4. Gracefully handles missing test scripts
+5. Exits with the correct status code
+
+### Issues to Address (Optional)
+- **None required for merge**
+- Minor documentation enhancement (recommendation #3) could improve first-time contributor experience
+
+### No Blocking Issues
+- Issue #1 (ignoring git hook stdin) is **by design** and appropriate for Phase 6b
+- Issues #2 and #3 are **style preferences**, not bugs
+
+---
+
+## 📊 Comparison to Phase 4b Review
+
+In my previous review (BUGBOT_REVIEW.md), I found 3 bugs in `scripts/run_tests.sh`:
+1. ❌ **`pytest -x` flag** contradicted "never short-circuit" goal → **FIXED** (no `-x` flag in current version)
+2. ⚠️ **Hardcoded test reference** to `test_think_recall_integration.py` → **STILL PRESENT** but acceptable
+3. ⚠️ **TypeScript test assumes `uv` is installed** → **STILL PRESENT** but not in scope for this PR
+
+**This PR (Phase 6b)** focuses on the hook itself, not the test script. The hook correctly delegates to `scripts/run_tests.sh` and propagates its exit code.
+
+---
+
+## 🔗 Related Files Changed
+
+```
+.gitattributes                          # Test fixtures marked as linguist-generated
+.githooks/pre-push                      # ✅ New file (this review's focus)
+BUGBOT_REVIEW.md                        # Previous review (Phase 4b)
+CONTRIBUTING.md                         # Updated with hook installation step
+README.md                               # Updated with hook installation step
+scripts/generate-fixtures.sh            # Not reviewed (fixture generation)
+scripts/run_tests.sh                    # Previously reviewed in Phase 4b
+tests/fixtures/README.md                # Not reviewed (documentation)
+tests/fixtures/stale_index_query.json   # Not reviewed (test data)
+tests/stale_index_query.test.ts         # Previously reviewed in Phase 4b
+tests/test_run_tests_script.py          # Previously reviewed in Phase 4b
+tests/test_stale_index_fixture.py       # Previously reviewed in Phase 4b
+```
+
+---
+
+## 🎓 What I Learned
+
+This PR demonstrates excellent software engineering practices:
+1. **Small, focused scope**: One feature (hook) per PR
+2. **Documentation-first**: Hook is explained before merge
+3. **Defense in depth**: Warns against bypass techniques
+4. **User empathy**: Banner message explains *why* the gate exists
+
+The "5-day regression cycle" context (lines 4-6, 32) shows historical awareness and converts friction into discipline.
+
+---
+
+**Signed**: Bugbot 🤖
+
+---
+
+## Appendix: Full Hook Source Review
+
+I reviewed every line of `.githooks/pre-push`:
+
+| Line | Content | Analysis |
+|------|---------|----------|
+| 1 | `#!/usr/bin/env bash` | ✅ Correct shebang |
+| 2-6 | Header comment | ✅ Clear purpose statement |
+| 7-14 | Anti-bypass warnings | ✅ Excellent documentation |
+| 16 | `set -uo pipefail` | ✅ Best practice (strict mode) |
+| 17 | File existence check | ✅ Defensive programming |
+| 18 | `bash scripts/run_tests.sh` | ✅ Correct invocation |
+| 19 | `exit_status=$?` | ✅ Captures exit code |
+| 21-35 | Failure banner | ✅ Clear, actionable message |
+| 36 | Blank line | ✅ Style |
+| 37 | Final exit | ✅ Propagates correct exit code |
+
+**Zero bugs detected in the hook implementation.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,11 @@ git clone https://github.com/EtanHey/brainlayer.git
 cd brainlayer
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
+git config core.hooksPath .githooks
 ```
+
+The repo ships a pre-push regression gate in `.githooks/pre-push`. Set `core.hooksPath`
+once per clone so `git push` runs `scripts/run_tests.sh` before anything leaves your machine.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ brainlayer dashboard          # Interactive TUI
 
 ```bash
 pip install -e ".[dev]"
+git config core.hooksPath .githooks     # install repo pre-push hook once per clone
 pytest tests/                           # 1,848 Python tests
 pytest tests/ -m "not integration"      # Unit tests only (fast)
 ruff check src/ && ruff format src/     # Lint + format


### PR DESCRIPTION
## Summary
- add `.githooks/pre-push` with the exact regression-gate script and anti-bypass messaging requested for Phase 6b
- document `git config core.hooksPath .githooks` in README and CONTRIBUTING so each clone installs the repo hook path
- verify the hook locally against the merged `scripts/run_tests.sh`

## Test plan
- [x] `ruff check src/ tests/`
- [x] `bash -n .githooks/pre-push`
- [x] `bash -n scripts/run_tests.sh`
- [x] `./.githooks/pre-push`
  - local result: hook invoked `scripts/run_tests.sh`, preserved a real nonzero exit, ran the MCP registration pytest leg plus Bun fixture test, and printed the block banner
  - local failure source was environmental: `tests/test_eval_framework.py` imports `ranx` -> `numba`, which rejected local `NumPy 2.4`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local developer workflow (git hook + docs) and do not affect runtime code paths, but may block pushes for contributors if the test harness fails or dependencies are missing.
> 
> **Overview**
> Introduces a repo-managed `pre-push` git hook (`.githooks/pre-push`) that runs `scripts/run_tests.sh` and **blocks pushes on any non-zero exit**, printing an explicit anti-bypass banner; if the script is missing, it allows the push.
> 
> Updates `README.md` and `CONTRIBUTING.md` to instruct developers to enable the hook via `git config core.hooksPath .githooks`, and adds `BUGBOT_REVIEW_P6B.md` capturing the review notes for this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ee4ab67748c288d82de51e231f61aae83f06b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pre-push regression gate that runs `scripts/run_tests.sh` before pushes
> - Adds [.githooks/pre-push](.githooks/pre-push), a bash hook that runs `scripts/run_tests.sh` and blocks the push if tests fail, emitting a banner with the exit code.
> - If `scripts/run_tests.sh` is missing, the hook warns and exits 0 to avoid blocking contributors without the script.
> - Updates [README.md](https://github.com/EtanHey/brainlayer/pull/257/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [CONTRIBUTING.md](https://github.com/EtanHey/brainlayer/pull/257/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) with a one-time setup step: `git config core.hooksPath .githooks`.
> - Behavioral Change: hooks are opt-in per clone; developers who don't run the setup step won't have the gate applied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19ee4ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-push Git hook that runs the test suite and blocks pushes when tests fail to enforce quality checks.
  * Added guidance to configure the repository to use the custom hooks directory for local development.

* **Documentation**
  * Updated development and setup docs to include hook configuration and usage.
  * Added a review document summarizing the hook’s behavior, security notes, and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->