### PR TITLE
Fix queue fallback for Swift brain_store

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -311,7 +311,7 @@ final class BrainBarServer: @unchecked Sendable {
             default:
                 let response = router.handle(request)
                 if toolCall.name == "brain_store", !isToolError(response) {
-                    publishStoredChunk(response: response, arguments: toolCall.arguments)
+                    publishStoredChunks(response: response, arguments: toolCall.arguments)
                 }
                 return response
             }
@@ -561,15 +561,25 @@ final class BrainBarServer: @unchecked Sendable {
         return (name, arguments)
     }
 
-    private func publishStoredChunk(response: [String: Any], arguments: [String: Any]) {
-        guard let stored = extractStoredChunk(from: response),
-              let content = arguments["content"] as? String,
-              let tags = arguments["tags"] as? [String],
-              !tags.isEmpty else {
-            return
+    private func publishStoredChunks(response: [String: Any], arguments: [String: Any]) {
+        if let stored = extractStoredChunk(from: response),
+           let content = arguments["content"] as? String,
+           let tags = arguments["tags"] as? [String] {
+            publishStoredChunk(stored: stored, content: content, tags: tags, importance: arguments["importance"] as? Int ?? 5)
         }
 
-        let importance = arguments["importance"] as? Int ?? 5
+        for flushed in extractFlushedQueuedChunks(from: response) {
+            publishStoredChunk(
+                stored: flushed.storedChunk,
+                content: flushed.content,
+                tags: flushed.tags,
+                importance: flushed.importance
+            )
+        }
+    }
+
+    private func publishStoredChunk(stored: StoreResultPayload, content: String, tags: [String], importance: Int) {
+        guard !tags.isEmpty else { return }
         let tagSet = Set(tags)
         for (clientFD, client) in Array(clients) {
             if let agentID = client.agentID,
@@ -602,21 +612,30 @@ final class BrainBarServer: @unchecked Sendable {
         }
     }
 
+    private func extractFlushedQueuedChunks(from response: [String: Any]) -> [(storedChunk: StoreResultPayload, content: String, tags: [String], importance: Int)] {
+        guard let result = response["result"] as? [String: Any],
+              let items = result["_brainbarFlushedQueuedChunks"] as? [[String: Any]] else {
+            return []
+        }
+
+        return items.compactMap { item in
+            guard let stored = storedChunkPayload(from: item),
+                  let content = item["content"] as? String,
+                  let tags = item["tags"] as? [String] else {
+                return nil
+            }
+            let importance = item["importance"] as? Int ?? 5
+            return (stored, content, tags, importance)
+        }
+    }
+
     private func extractStoredChunk(from response: [String: Any]) -> StoreResultPayload? {
         guard let result = response["result"] as? [String: Any] else {
             return nil
         }
         if let stored = result["_brainbarStoredChunk"] as? [String: Any],
-           let chunkID = stored["chunk_id"] as? String {
-            let rowID: Int64
-            if let intRowID = stored["rowid"] as? Int64 {
-                rowID = intRowID
-            } else if let intRowID = stored["rowid"] as? Int {
-                rowID = Int64(intRowID)
-            } else {
-                return nil
-            }
-            return StoreResultPayload(chunkID: chunkID, rowID: rowID)
+           let payload = storedChunkPayload(from: stored) {
+            return payload
         }
         guard let content = result["content"] as? [[String: Any]],
               let text = content.first?["text"] as? String,
@@ -625,6 +644,21 @@ final class BrainBarServer: @unchecked Sendable {
             return nil
         }
         return payload
+    }
+
+    private func storedChunkPayload(from payload: [String: Any]) -> StoreResultPayload? {
+        guard let chunkID = payload["chunk_id"] as? String else {
+            return nil
+        }
+        let rowID: Int64
+        if let intRowID = payload["rowid"] as? Int64 {
+            rowID = intRowID
+        } else if let intRowID = payload["rowid"] as? Int {
+            rowID = Int64(intRowID)
+        } else {
+            return nil
+        }
+        return StoreResultPayload(chunkID: chunkID, rowID: rowID)
     }
 
     private func jsonString<T: Encodable>(_ payload: T) -> String {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -14,6 +14,8 @@ final class BrainDatabase: @unchecked Sendable {
     """
     private static let ftsColumns = "content, summary, tags, resolved_query, chunk_id UNINDEXED"
     private static let ftsOptions = "prefix='2 3 4', tokenize='unicode61 remove_diacritics 2'"
+    private static let defaultPendingStoreMaxLines = 10_000
+    private static let pendingStoreMaxLinesEnv = "BRAINBAR_PENDING_STORES_MAX_LINES"
 
     struct DashboardStats: Sendable, Equatable {
         let chunkCount: Int
@@ -498,7 +500,9 @@ final class BrainDatabase: @unchecked Sendable {
             sqlite3_bind_int(stmt, 7, Int32(content.count))
             bindText(Self.previewText(summary: "", content: content), to: stmt, index: 8)
         }
-        let rowID = sqlite3_last_insert_rowid(db)
+        guard let rowID = try chunkRowID(forChunkID: chunkID) else {
+            throw DBError.noResult
+        }
         if refreshStatistics {
             refreshSearchStatisticsBestEffort()
         }
@@ -555,75 +559,78 @@ final class BrainDatabase: @unchecked Sendable {
 
     func flushPendingStores() -> [FlushedPendingStore] {
         let path = pendingStorePath()
-        let snapshot: Data
+        Self.pendingStoreFileLock.lock()
+        defer { Self.pendingStoreFileLock.unlock() }
+
         do {
-            Self.pendingStoreFileLock.lock()
-            defer { Self.pendingStoreFileLock.unlock() }
-
-            guard FileManager.default.fileExists(atPath: path.path) else { return [] }
-            guard let data = readPendingStoreData(at: path) else {
-                NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
-                return []
-            }
-            snapshot = data
-        }
-        let lines = Self.pendingStoreLines(from: snapshot)
-
-        guard !lines.isEmpty else { return [] }
-
-        let decoder = JSONDecoder()
-        var flushed: [FlushedPendingStore] = []
-        var remaining: [Data] = []
-
-        for (lineIndex, line) in lines.enumerated() {
-            let item: PendingStoreItem
-            do {
-                item = try decoder.decode(PendingStoreItem.self, from: line)
-            } catch {
-                remaining.append(line)
-                continue
-            }
-
-            let queueID = Self.pendingStoreQueueID(for: item, lineIndex: lineIndex)
-            let replayLine = Self.pendingStoreReplayLine(for: item, queueID: queueID) ?? line
-            do {
-                if try hasStoredQueuedItem(queueID: queueID) {
-                    continue
+            return try Self.withPendingStoreProcessLock(for: path) {
+                guard FileManager.default.fileExists(atPath: path.path) else { return [] }
+                guard let snapshot = readPendingStoreData(at: path) else {
+                    NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
+                    return []
                 }
-            } catch {
-                NSLog("[BrainBar] Failed pending store dedupe lookup for %@: %@", queueID, String(describing: error))
-                remaining.append(replayLine)
-                continue
-            }
+                let lines = Self.pendingStoreLines(from: snapshot)
 
-            do {
-                let stored = try store(
-                    content: item.content,
-                    tags: item.tags,
-                    importance: item.importance,
-                    source: item.source,
-                    queueID: queueID,
-                    refreshStatistics: false
-                )
-                flushed.append(
-                    FlushedPendingStore(
-                        storedChunk: stored,
-                        content: item.content,
-                        tags: item.tags,
-                        importance: item.importance
-                    )
-                )
-            } catch {
-                NSLog("[BrainBar] Failed to flush pending store item: %@", String(describing: error))
-                remaining.append(replayLine)
-            }
-        }
+                guard !lines.isEmpty else { return [] }
 
-        rewritePendingStoreFile(path: path, snapshot: snapshot, remainingLines: remaining)
-        if !flushed.isEmpty {
-            refreshSearchStatisticsBestEffort()
+                let decoder = JSONDecoder()
+                var flushed: [FlushedPendingStore] = []
+                var remaining: [Data] = []
+
+                for (lineIndex, line) in lines.enumerated() {
+                    let item: PendingStoreItem
+                    do {
+                        item = try decoder.decode(PendingStoreItem.self, from: line)
+                    } catch {
+                        remaining.append(line)
+                        continue
+                    }
+
+                    let queueID = Self.pendingStoreQueueID(for: item, lineIndex: lineIndex)
+                    let replayLine = Self.pendingStoreReplayLine(for: item, queueID: queueID) ?? line
+                    do {
+                        if try hasStoredQueuedItem(queueID: queueID) {
+                            continue
+                        }
+                    } catch {
+                        NSLog("[BrainBar] Failed pending store dedupe lookup for %@: %@", queueID, String(describing: error))
+                        remaining.append(replayLine)
+                        continue
+                    }
+
+                    do {
+                        let stored = try store(
+                            content: item.content,
+                            tags: item.tags,
+                            importance: item.importance,
+                            source: item.source,
+                            queueID: queueID,
+                            refreshStatistics: false
+                        )
+                        flushed.append(
+                            FlushedPendingStore(
+                                storedChunk: stored,
+                                content: item.content,
+                                tags: item.tags,
+                                importance: item.importance
+                            )
+                        )
+                    } catch {
+                        NSLog("[BrainBar] Failed to flush pending store item: %@", String(describing: error))
+                        remaining.append(replayLine)
+                    }
+                }
+
+                rewritePendingStoreFile(path: path, snapshot: snapshot, remainingLines: remaining)
+                if !flushed.isEmpty {
+                    refreshSearchStatisticsBestEffort()
+                }
+                return flushed
+            }
+        } catch {
+            NSLog("[BrainBar] Failed to lock pending stores queue for flush: %@", String(describing: error))
+            return []
         }
-        return flushed
     }
 
     func searchCandidates(
@@ -1490,31 +1497,25 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func appendPendingStoreLine(_ line: Data, to path: URL) throws {
-        let fd = open(path.path, O_WRONLY | O_CREAT | O_APPEND, 0o600)
-        guard fd >= 0 else {
-            let message = String(cString: strerror(errno))
-            throw DBError.exec(SQLITE_CANTOPEN, "failed to open pending store queue for append: \(message)")
-        }
-        defer { Darwin.close(fd) }
-        try Self.enforcePendingStoreFileMode(fd: fd, path: path)
-
-        try line.withUnsafeBytes { rawBuffer in
-            guard var baseAddress = rawBuffer.baseAddress else { return }
-            var remaining = rawBuffer.count
-
-            while remaining > 0 {
-                let written = Darwin.write(fd, baseAddress, remaining)
-                if written < 0 {
-                    if errno == EINTR {
-                        continue
-                    }
-                    let message = String(cString: strerror(errno))
-                    throw DBError.exec(SQLITE_IOERR, "failed to append pending store queue line: \(message)")
-                }
-
-                remaining -= written
-                baseAddress = baseAddress.advanced(by: written)
+        try Self.withPendingStoreProcessLock(for: path) {
+            let fd = open(path.path, O_RDWR | O_CREAT | O_APPEND, 0o600)
+            guard fd >= 0 else {
+                let message = String(cString: strerror(errno))
+                throw DBError.exec(SQLITE_CANTOPEN, "failed to open pending store queue for append: \(message)")
             }
+            defer { Darwin.close(fd) }
+            try Self.enforcePendingStoreFileMode(fd: fd, path: path)
+
+            let existingLineCount = Self.pendingStoreLines(from: readPendingStoreData(at: path) ?? Data()).count
+            let maxLines = Self.pendingStoreMaxLines()
+            guard existingLineCount < maxLines else {
+                throw DBError.exec(
+                    SQLITE_FULL,
+                    "pending store queue is full (\(existingLineCount)/\(maxLines) lines); refusing to append another fallback item"
+                )
+            }
+
+            try Self.writeAll(line, to: fd, context: "append pending store queue line")
         }
     }
 
@@ -1546,6 +1547,96 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         return lines
+    }
+
+    private static func pendingStoreMaxLines() -> Int {
+        let rawValue = ProcessInfo.processInfo.environment[pendingStoreMaxLinesEnv]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let rawValue, let parsed = Int(rawValue), parsed > 0 else {
+            return defaultPendingStoreMaxLines
+        }
+        return parsed
+    }
+
+    private static func pendingStoreLockPath(for path: URL) -> URL {
+        path.deletingLastPathComponent().appendingPathComponent(".\(path.lastPathComponent).lock")
+    }
+
+    private static func withPendingStoreProcessLock<T>(for path: URL, _ body: () throws -> T) throws -> T {
+        let lockPath = pendingStoreLockPath(for: path)
+        try FileManager.default.createDirectory(
+            at: lockPath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let fd = open(lockPath.path, O_RDWR | O_CREAT, 0o600)
+        guard fd >= 0 else {
+            let message = String(cString: strerror(errno))
+            throw DBError.exec(SQLITE_CANTOPEN, "failed to open pending store queue lock: \(message)")
+        }
+        defer { Darwin.close(fd) }
+        try enforcePendingStoreFileMode(fd: fd, path: lockPath)
+
+        guard flock(fd, LOCK_EX) == 0 else {
+            let message = String(cString: strerror(errno))
+            throw DBError.exec(SQLITE_IOERR, "failed to lock pending store queue: \(message)")
+        }
+        defer { flock(fd, LOCK_UN) }
+
+        return try body()
+    }
+
+    private static func writeAll(_ data: Data, to fd: Int32, context: String) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard var baseAddress = rawBuffer.baseAddress else { return }
+            var remaining = rawBuffer.count
+
+            while remaining > 0 {
+                let written = Darwin.write(fd, baseAddress, remaining)
+                if written < 0 {
+                    if errno == EINTR {
+                        continue
+                    }
+                    let message = String(cString: strerror(errno))
+                    throw DBError.exec(SQLITE_IOERR, "failed to \(context): \(message)")
+                }
+                guard written > 0 else {
+                    throw DBError.exec(SQLITE_IOERR, "failed to \(context): write returned 0")
+                }
+
+                remaining -= written
+                baseAddress = baseAddress.advanced(by: written)
+            }
+        }
+    }
+
+    private static func writePrivateAtomic(_ data: Data, to path: URL) throws {
+        let directory = path.deletingLastPathComponent()
+        let temporaryPath = directory.appendingPathComponent(".\(path.lastPathComponent).\(UUID().uuidString).tmp")
+        let fd = open(temporaryPath.path, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC, 0o600)
+        guard fd >= 0 else {
+            let message = String(cString: strerror(errno))
+            throw DBError.exec(SQLITE_CANTOPEN, "failed to create private pending store queue temp file: \(message)")
+        }
+
+        do {
+            defer { Darwin.close(fd) }
+            try enforcePendingStoreFileMode(fd: fd, path: temporaryPath)
+            try writeAll(data, to: fd, context: "write pending store queue temp file")
+            guard fsync(fd) == 0 else {
+                let message = String(cString: strerror(errno))
+                throw DBError.exec(SQLITE_IOERR, "failed to sync pending store queue temp file: \(message)")
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryPath)
+            throw error
+        }
+
+        guard rename(temporaryPath.path, path.path) == 0 else {
+            let message = String(cString: strerror(errno))
+            try? FileManager.default.removeItem(at: temporaryPath)
+            throw DBError.exec(SQLITE_IOERR, "failed to replace pending store queue atomically: \(message)")
+        }
     }
 
     private static func enforcePendingStoreFileMode(fd: Int32? = nil, path: URL) throws {
@@ -1689,9 +1780,6 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func rewritePendingStoreFile(path: URL, snapshot: Data, remainingLines: [Data]) {
-        Self.pendingStoreFileLock.lock()
-        defer { Self.pendingStoreFileLock.unlock() }
-
         do {
             let current = (try? Data(contentsOf: path)) ?? Data()
             let appendedLines: [Data]
@@ -1713,7 +1801,7 @@ final class BrainDatabase: @unchecked Sendable {
                 data.append(line)
                 data.append(0x0A)
             }
-            try data.write(to: path, options: .atomic)
+            try Self.writePrivateAtomic(data, to: path)
             try Self.enforcePendingStoreFileMode(path: path)
         } catch {
             NSLog("[BrainBar] Failed to rewrite pending stores queue: %@", String(describing: error))

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -554,19 +554,20 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func flushPendingStores() -> [FlushedPendingStore] {
-        Self.pendingStoreFileLock.lock()
         let path = pendingStorePath()
-        guard FileManager.default.fileExists(atPath: path.path) else {
-            Self.pendingStoreFileLock.unlock()
-            return []
-        }
-        guard let snapshot = readPendingStoreData(at: path) else {
-            Self.pendingStoreFileLock.unlock()
-            NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
-            return []
+        let snapshot: Data
+        do {
+            Self.pendingStoreFileLock.lock()
+            defer { Self.pendingStoreFileLock.unlock() }
+
+            guard FileManager.default.fileExists(atPath: path.path) else { return [] }
+            guard let data = readPendingStoreData(at: path) else {
+                NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
+                return []
+            }
+            snapshot = data
         }
         let lines = Self.pendingStoreLines(from: snapshot)
-        Self.pendingStoreFileLock.unlock()
 
         guard !lines.isEmpty else { return [] }
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1469,7 +1469,8 @@ final class BrainDatabase: @unchecked Sendable {
         try execute("""
             CREATE INDEX IF NOT EXISTS idx_chunks_brainbar_queue_id
             ON chunks(json_extract(metadata, '$.brainbar_queue_id'))
-            WHERE json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL
+            WHERE json_valid(metadata)
+              AND json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL
         """)
     }
 
@@ -1579,11 +1580,7 @@ final class BrainDatabase: @unchecked Sendable {
             queueID: queueID,
             queuedAt: item.queuedAt
         )
-        guard var data = try? JSONEncoder().encode(replayItem) else {
-            return nil
-        }
-        data.append(0x0A)
-        return data
+        return try? JSONEncoder().encode(replayItem)
     }
 
     private static func deterministicPendingStoreQueueID(
@@ -1648,7 +1645,8 @@ final class BrainDatabase: @unchecked Sendable {
         let sql = """
             SELECT 1
             FROM chunks
-            WHERE json_extract(metadata, '$.brainbar_queue_id') = ?
+            WHERE json_valid(metadata)
+              AND json_extract(metadata, '$.brainbar_queue_id') = ?
             LIMIT 1
         """
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -42,6 +42,50 @@ final class BrainDatabase: @unchecked Sendable {
         let rowID: Int64
     }
 
+    struct PendingStoreItem: Codable, Sendable {
+        let content: String
+        let tags: [String]
+        let importance: Int
+        let source: String
+        let queueID: String?
+        let queuedAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case content
+            case tags
+            case importance
+            case source
+            case queueID = "queue_id"
+            case queuedAt = "queued_at"
+        }
+
+        init(
+            content: String,
+            tags: [String],
+            importance: Int,
+            source: String,
+            queueID: String? = nil,
+            queuedAt: String? = nil
+        ) {
+            self.content = content
+            self.tags = tags
+            self.importance = importance
+            self.source = source
+            self.queueID = queueID
+            self.queuedAt = queuedAt
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            content = try container.decode(String.self, forKey: .content)
+            tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
+            importance = try container.decodeIfPresent(Int.self, forKey: .importance) ?? 5
+            source = try container.decodeIfPresent(String.self, forKey: .source) ?? "mcp"
+            queueID = try container.decodeIfPresent(String.self, forKey: .queueID)
+            queuedAt = try container.decodeIfPresent(String.self, forKey: .queuedAt)
+        }
+    }
+
     struct ConversationChunk: Sendable, Equatable, Identifiable {
         let chunkID: String
         let content: String
@@ -416,24 +460,35 @@ final class BrainDatabase: @unchecked Sendable {
         return results
     }
 
-    func store(content: String, tags: [String], importance: Int, source: String) throws -> StoredChunk {
+    func store(
+        content: String,
+        tags: [String],
+        importance: Int,
+        source: String,
+        queueID: String? = nil,
+        refreshStatistics: Bool = true
+    ) throws -> StoredChunk {
         guard let db else { throw DBError.notOpen }
         let chunkID = "brainbar-\(UUID().uuidString.lowercased().prefix(12))"
         let tagsJSON = (try? encodeJSON(tags)) ?? "[]"
+        let metadataJSON = Self.storeMetadataJSON(queueID: queueID)
         let sql = """
             INSERT INTO chunks (id, content, metadata, source_file, tags, importance, source, content_type, char_count, preview_text)
-            VALUES (?, ?, '{}', 'brainbar-store', ?, ?, ?, 'user_message', ?, ?)
+            VALUES (?, ?, ?, 'brainbar-store', ?, ?, ?, 'user_message', ?, ?)
         """
         try runWriteStatement(on: db, sql: sql, retries: 3) { stmt in
             bindText(chunkID, to: stmt, index: 1)
             bindText(content, to: stmt, index: 2)
-            bindText(tagsJSON, to: stmt, index: 3)
-            sqlite3_bind_int(stmt, 4, Int32(importance))
-            bindText(source, to: stmt, index: 5)
-            sqlite3_bind_int(stmt, 6, Int32(content.count))
-            bindText(Self.previewText(summary: "", content: content), to: stmt, index: 7)
+            bindText(metadataJSON, to: stmt, index: 3)
+            bindText(tagsJSON, to: stmt, index: 4)
+            sqlite3_bind_int(stmt, 5, Int32(importance))
+            bindText(source, to: stmt, index: 6)
+            sqlite3_bind_int(stmt, 7, Int32(content.count))
+            bindText(Self.previewText(summary: "", content: content), to: stmt, index: 8)
         }
-        try refreshSearchStatistics()
+        if refreshStatistics {
+            refreshSearchStatisticsBestEffort()
+        }
         return StoredChunk(chunkID: chunkID, rowID: sqlite3_last_insert_rowid(db))
     }
 
@@ -449,6 +504,100 @@ final class BrainDatabase: @unchecked Sendable {
                 }
             }
         }
+    }
+
+    func shouldQueueStoreError(_ error: Error) -> Bool {
+        guard let dbError = error as? DBError else { return false }
+        switch dbError {
+        case .prepare, .step, .exec:
+            return true
+        case .notOpen, .open, .noResult, .invalidPragma:
+            return false
+        }
+    }
+
+    func queuePendingStore(content: String, tags: [String], importance: Int, source: String) throws {
+        let path = pendingStorePath()
+        try FileManager.default.createDirectory(
+            at: path.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let item = PendingStoreItem(
+            content: content,
+            tags: tags,
+            importance: importance,
+            source: source,
+            queueID: UUID().uuidString.lowercased(),
+            queuedAt: Self.timestamp()
+        )
+        let data = try JSONEncoder().encode(item)
+        guard let line = String(data: data, encoding: .utf8) else {
+            throw DBError.exec(SQLITE_MISUSE, "failed to encode pending store item")
+        }
+        if FileManager.default.fileExists(atPath: path.path),
+           let handle = try? FileHandle(forWritingTo: path) {
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data((line + "\n").utf8))
+            return
+        }
+        try Data((line + "\n").utf8).write(to: path, options: .atomic)
+    }
+
+    @discardableResult
+    func flushPendingStores() -> Int {
+        let path = pendingStorePath()
+        guard FileManager.default.fileExists(atPath: path.path) else { return 0 }
+        guard let text = try? String(contentsOf: path, encoding: .utf8) else {
+            NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
+            return 0
+        }
+
+        let lines = text.split(whereSeparator: \.isNewline).map(String.init)
+        guard !lines.isEmpty else { return 0 }
+
+        let decoder = JSONDecoder()
+        var flushed = 0
+        var remaining: [String] = []
+
+        for line in lines {
+            guard let data = line.data(using: .utf8) else {
+                remaining.append(line)
+                continue
+            }
+            let item: PendingStoreItem
+            do {
+                item = try decoder.decode(PendingStoreItem.self, from: data)
+            } catch {
+                remaining.append(line)
+                continue
+            }
+
+            if let queueID = item.queueID, (try? hasStoredQueuedItem(queueID: queueID)) == true {
+                continue
+            }
+
+            do {
+                _ = try store(
+                    content: item.content,
+                    tags: item.tags,
+                    importance: item.importance,
+                    source: item.source,
+                    queueID: item.queueID,
+                    refreshStatistics: false
+                )
+                flushed += 1
+            } catch {
+                NSLog("[BrainBar] Failed to flush pending store item: %@", String(describing: error))
+                remaining.append(line)
+            }
+        }
+
+        rewritePendingStoreFile(path: path, remainingLines: remaining)
+        if flushed > 0 {
+            refreshSearchStatisticsBestEffort()
+        }
+        return flushed
     }
 
     func searchCandidates(
@@ -1287,6 +1436,55 @@ final class BrainDatabase: @unchecked Sendable {
     private func refreshSearchStatistics() throws {
         try execute("ANALYZE chunks")
         try execute("ANALYZE chunks_fts")
+    }
+
+    private func refreshSearchStatisticsBestEffort() {
+        do {
+            try refreshSearchStatistics()
+        } catch {
+            NSLog("[BrainBar] Non-fatal search statistics refresh failure: %@", String(describing: error))
+        }
+    }
+
+    private func pendingStorePath() -> URL {
+        if let override = ProcessInfo.processInfo.environment["BRAINBAR_PENDING_STORES_PATH"],
+           !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        return URL(fileURLWithPath: path).deletingLastPathComponent().appendingPathComponent("pending-stores.jsonl")
+    }
+
+    private static func storeMetadataJSON(queueID: String?) -> String {
+        guard let queueID else { return "{}" }
+        return #"{"brainbar_queue_id":"\#(queueID)"}"#
+    }
+
+    private func hasStoredQueuedItem(queueID: String) throws -> Bool {
+        guard let db else { throw DBError.notOpen }
+        var stmt: OpaquePointer?
+        let sql = "SELECT 1 FROM chunks WHERE metadata = ? LIMIT 1"
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        bindText(Self.storeMetadataJSON(queueID: queueID), to: stmt, index: 1)
+        return sqlite3_step(stmt) == SQLITE_ROW
+    }
+
+    private func rewritePendingStoreFile(path: URL, remainingLines: [String]) {
+        guard !remainingLines.isEmpty else {
+            try? FileManager.default.removeItem(at: path)
+            return
+        }
+        let tmp = path.appendingPathExtension("tmp")
+        do {
+            try Data((remainingLines.joined(separator: "\n") + "\n").utf8).write(to: tmp, options: .atomic)
+            if FileManager.default.fileExists(atPath: path.path) {
+                try FileManager.default.removeItem(at: path)
+            }
+            try FileManager.default.moveItem(at: tmp, to: path)
+        } catch {
+            NSLog("[BrainBar] Failed to rewrite pending stores queue: %@", String(describing: error))
+        }
     }
 
     private func tableColumns(name: String, on db: OpaquePointer) throws -> Set<String> {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -568,7 +568,7 @@ final class BrainDatabase: @unchecked Sendable {
         var flushed: [FlushedPendingStore] = []
         var remaining: [Data] = []
 
-        for line in lines {
+        for (lineIndex, line) in lines.enumerated() {
             let item: PendingStoreItem
             do {
                 item = try decoder.decode(PendingStoreItem.self, from: line)
@@ -577,7 +577,7 @@ final class BrainDatabase: @unchecked Sendable {
                 continue
             }
 
-            let queueID = Self.pendingStoreQueueID(for: item)
+            let queueID = Self.pendingStoreQueueID(for: item, lineIndex: lineIndex)
             do {
                 if try hasStoredQueuedItem(queueID: queueID) {
                     continue
@@ -1556,7 +1556,7 @@ final class BrainDatabase: @unchecked Sendable {
         return queueID
     }
 
-    private static func pendingStoreQueueID(for item: PendingStoreItem) -> String {
+    private static func pendingStoreQueueID(for item: PendingStoreItem, lineIndex: Int) -> String {
         if let queueID = normalizedQueueID(item.queueID) {
             return queueID
         }
@@ -1564,7 +1564,8 @@ final class BrainDatabase: @unchecked Sendable {
             content: item.content,
             tags: item.tags,
             importance: item.importance,
-            source: item.source
+            source: item.source,
+            lineIndex: lineIndex
         )
     }
 
@@ -1572,7 +1573,8 @@ final class BrainDatabase: @unchecked Sendable {
         content: String,
         tags: [String],
         importance: Int,
-        source: String
+        source: String,
+        lineIndex: Int
     ) -> String {
         var hash: UInt64 = 0xcbf29ce484222325
 
@@ -1610,6 +1612,10 @@ final class BrainDatabase: @unchecked Sendable {
             mix(Data(bytes))
         }
         mix(source)
+        var encodedLineIndex = Int64(lineIndex).littleEndian
+        withUnsafeBytes(of: &encodedLineIndex) { bytes in
+            mix(Data(bytes))
+        }
 
         return String(format: "brainbar-pending-%016llx", hash)
     }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -578,13 +578,14 @@ final class BrainDatabase: @unchecked Sendable {
             }
 
             let queueID = Self.pendingStoreQueueID(for: item, lineIndex: lineIndex)
+            let replayLine = Self.pendingStoreReplayLine(for: item, queueID: queueID) ?? line
             do {
                 if try hasStoredQueuedItem(queueID: queueID) {
                     continue
                 }
             } catch {
                 NSLog("[BrainBar] Failed pending store dedupe lookup for %@: %@", queueID, String(describing: error))
-                remaining.append(line)
+                remaining.append(replayLine)
                 continue
             }
 
@@ -607,7 +608,7 @@ final class BrainDatabase: @unchecked Sendable {
                 )
             } catch {
                 NSLog("[BrainBar] Failed to flush pending store item: %@", String(describing: error))
-                remaining.append(line)
+                remaining.append(replayLine)
             }
         }
 
@@ -1567,6 +1568,22 @@ final class BrainDatabase: @unchecked Sendable {
             source: item.source,
             lineIndex: lineIndex
         )
+    }
+
+    private static func pendingStoreReplayLine(for item: PendingStoreItem, queueID: String) -> Data? {
+        let replayItem = PendingStoreItem(
+            content: item.content,
+            tags: item.tags,
+            importance: item.importance,
+            source: item.source,
+            queueID: queueID,
+            queuedAt: item.queuedAt
+        )
+        guard var data = try? JSONEncoder().encode(replayItem) else {
+            return nil
+        }
+        data.append(0x0A)
+        return data
     }
 
     private static func deterministicPendingStoreQueueID(

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -114,7 +114,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     private var db: OpaquePointer?
     private let path: String
-    private let pendingStoreFileLock = NSLock()
+    private static let pendingStoreFileLock = NSLock()
     private(set) var isOpen = false
 
     init(path: String) {
@@ -186,11 +186,7 @@ final class BrainDatabase: @unchecked Sendable {
             ON chunks(created_at)
         """)
 
-        try execute("""
-            CREATE INDEX IF NOT EXISTS idx_chunks_brainbar_queue_id
-            ON chunks(json_extract(metadata, '$.brainbar_queue_id'))
-            WHERE json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL
-        """)
+        try ensurePendingStoreQueueIndex()
 
         try ensureAuxiliarySchema()
         try refreshSearchStatistics()
@@ -298,6 +294,8 @@ final class BrainDatabase: @unchecked Sendable {
             FROM kg_relations
             WHERE relation_type != 'co_occurs_with'
         """)
+
+        try ensurePendingStoreQueueIndex()
     }
 
     func close() {
@@ -533,8 +531,8 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func queuePendingStore(content: String, tags: [String], importance: Int, source: String) throws {
-        pendingStoreFileLock.lock()
-        defer { pendingStoreFileLock.unlock() }
+        Self.pendingStoreFileLock.lock()
+        defer { Self.pendingStoreFileLock.unlock() }
 
         let path = pendingStorePath()
         try FileManager.default.createDirectory(
@@ -549,25 +547,14 @@ final class BrainDatabase: @unchecked Sendable {
             queueID: UUID().uuidString.lowercased(),
             queuedAt: Self.timestamp()
         )
-        let data = try JSONEncoder().encode(item)
-        guard let line = String(data: data, encoding: .utf8) else {
-            throw DBError.exec(SQLITE_MISUSE, "failed to encode pending store item")
-        }
-        if FileManager.default.fileExists(atPath: path.path) {
-            guard let handle = try? FileHandle(forWritingTo: path) else {
-                throw DBError.exec(SQLITE_CANTOPEN, "failed to open pending store queue for append")
-            }
-            defer { try? handle.close() }
-            try handle.seekToEnd()
-            try handle.write(contentsOf: Data((line + "\n").utf8))
-            return
-        }
-        try Data((line + "\n").utf8).write(to: path, options: .atomic)
+        var line = try JSONEncoder().encode(item)
+        line.append(0x0A)
+        try appendPendingStoreLine(line, to: path)
     }
 
     func flushPendingStores() -> [FlushedPendingStore] {
-        pendingStoreFileLock.lock()
-        defer { pendingStoreFileLock.unlock() }
+        Self.pendingStoreFileLock.lock()
+        defer { Self.pendingStoreFileLock.unlock() }
 
         let path = pendingStorePath()
         guard FileManager.default.fileExists(atPath: path.path) else { return [] }
@@ -1477,12 +1464,48 @@ final class BrainDatabase: @unchecked Sendable {
         }
     }
 
+    private func ensurePendingStoreQueueIndex() throws {
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_chunks_brainbar_queue_id
+            ON chunks(json_extract(metadata, '$.brainbar_queue_id'))
+            WHERE json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL
+        """)
+    }
+
     private func pendingStorePath() -> URL {
         if let override = ProcessInfo.processInfo.environment["BRAINBAR_PENDING_STORES_PATH"],
            !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return URL(fileURLWithPath: override)
         }
         return URL(fileURLWithPath: path).deletingLastPathComponent().appendingPathComponent("pending-stores.jsonl")
+    }
+
+    private func appendPendingStoreLine(_ line: Data, to path: URL) throws {
+        let fd = open(path.path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        guard fd >= 0 else {
+            let message = String(cString: strerror(errno))
+            throw DBError.exec(SQLITE_CANTOPEN, "failed to open pending store queue for append: \(message)")
+        }
+        defer { Darwin.close(fd) }
+
+        try line.withUnsafeBytes { rawBuffer in
+            guard var baseAddress = rawBuffer.baseAddress else { return }
+            var remaining = rawBuffer.count
+
+            while remaining > 0 {
+                let written = Darwin.write(fd, baseAddress, remaining)
+                if written < 0 {
+                    if errno == EINTR {
+                        continue
+                    }
+                    let message = String(cString: strerror(errno))
+                    throw DBError.exec(SQLITE_IOERR, "failed to append pending store queue line: \(message)")
+                }
+
+                remaining -= written
+                baseAddress = baseAddress.advanced(by: written)
+            }
+        }
     }
 
     private func readPendingStoreLines(at path: URL) -> [Data]? {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -498,10 +498,11 @@ final class BrainDatabase: @unchecked Sendable {
             sqlite3_bind_int(stmt, 7, Int32(content.count))
             bindText(Self.previewText(summary: "", content: content), to: stmt, index: 8)
         }
+        let rowID = sqlite3_last_insert_rowid(db)
         if refreshStatistics {
             refreshSearchStatisticsBestEffort()
         }
-        return StoredChunk(chunkID: chunkID, rowID: sqlite3_last_insert_rowid(db))
+        return StoredChunk(chunkID: chunkID, rowID: rowID)
     }
 
     /// Async wrapper for store() — runs DB write off the main thread.
@@ -554,14 +555,19 @@ final class BrainDatabase: @unchecked Sendable {
 
     func flushPendingStores() -> [FlushedPendingStore] {
         Self.pendingStoreFileLock.lock()
-        defer { Self.pendingStoreFileLock.unlock() }
-
         let path = pendingStorePath()
-        guard FileManager.default.fileExists(atPath: path.path) else { return [] }
-        guard let lines = readPendingStoreLines(at: path) else {
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            Self.pendingStoreFileLock.unlock()
+            return []
+        }
+        guard let snapshot = readPendingStoreData(at: path) else {
+            Self.pendingStoreFileLock.unlock()
             NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
             return []
         }
+        let lines = Self.pendingStoreLines(from: snapshot)
+        Self.pendingStoreFileLock.unlock()
+
         guard !lines.isEmpty else { return [] }
 
         let decoder = JSONDecoder()
@@ -612,7 +618,7 @@ final class BrainDatabase: @unchecked Sendable {
             }
         }
 
-        rewritePendingStoreFile(path: path, remainingLines: remaining)
+        rewritePendingStoreFile(path: path, snapshot: snapshot, remainingLines: remaining)
         if !flushed.isEmpty {
             refreshSearchStatisticsBestEffort()
         }
@@ -1483,12 +1489,13 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func appendPendingStoreLine(_ line: Data, to path: URL) throws {
-        let fd = open(path.path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        let fd = open(path.path, O_WRONLY | O_CREAT | O_APPEND, 0o600)
         guard fd >= 0 else {
             let message = String(cString: strerror(errno))
             throw DBError.exec(SQLITE_CANTOPEN, "failed to open pending store queue for append: \(message)")
         }
         defer { Darwin.close(fd) }
+        try Self.enforcePendingStoreFileMode(fd: fd, path: path)
 
         try line.withUnsafeBytes { rawBuffer in
             guard var baseAddress = rawBuffer.baseAddress else { return }
@@ -1510,11 +1517,11 @@ final class BrainDatabase: @unchecked Sendable {
         }
     }
 
-    private func readPendingStoreLines(at path: URL) -> [Data]? {
-        guard let data = try? Data(contentsOf: path) else {
-            return nil
-        }
+    private func readPendingStoreData(at path: URL) -> Data? {
+        try? Data(contentsOf: path)
+    }
 
+    private static func pendingStoreLines(from data: Data) -> [Data] {
         var lines: [Data] = []
         var start = data.startIndex
 
@@ -1538,6 +1545,22 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         return lines
+    }
+
+    private static func enforcePendingStoreFileMode(fd: Int32? = nil, path: URL) throws {
+        if let fd {
+            guard fchmod(fd, 0o600) == 0 else {
+                let message = String(cString: strerror(errno))
+                throw DBError.exec(SQLITE_IOERR, "failed to set pending store queue permissions: \(message)")
+            }
+            return
+        }
+
+        do {
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path.path)
+        } catch {
+            throw DBError.exec(SQLITE_IOERR, "failed to set pending store queue permissions: \(error)")
+        }
     }
 
     private static func storeMetadataJSON(queueID: String?) -> String {
@@ -1653,21 +1676,44 @@ final class BrainDatabase: @unchecked Sendable {
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
         defer { sqlite3_finalize(stmt) }
         bindText(queueID, to: stmt, index: 1)
-        return sqlite3_step(stmt) == SQLITE_ROW
+        let stepRC = sqlite3_step(stmt)
+        switch stepRC {
+        case SQLITE_ROW:
+            return true
+        case SQLITE_DONE:
+            return false
+        default:
+            throw DBError.step(stepRC)
+        }
     }
 
-    private func rewritePendingStoreFile(path: URL, remainingLines: [Data]) {
-        guard !remainingLines.isEmpty else {
-            try? FileManager.default.removeItem(at: path)
-            return
-        }
+    private func rewritePendingStoreFile(path: URL, snapshot: Data, remainingLines: [Data]) {
+        Self.pendingStoreFileLock.lock()
+        defer { Self.pendingStoreFileLock.unlock() }
+
         do {
+            let current = (try? Data(contentsOf: path)) ?? Data()
+            let appendedLines: [Data]
+            if current.count >= snapshot.count && current.prefix(snapshot.count).elementsEqual(snapshot) {
+                appendedLines = Self.pendingStoreLines(from: Data(current.dropFirst(snapshot.count)))
+            } else {
+                NSLog("[BrainBar] Skipping pending store queue rewrite because the file changed outside the snapshot")
+                return
+            }
+
+            let finalLines = remainingLines + appendedLines
+            guard !finalLines.isEmpty else {
+                try? FileManager.default.removeItem(at: path)
+                return
+            }
+
             var data = Data()
-            for line in remainingLines {
+            for line in finalLines {
                 data.append(line)
                 data.append(0x0A)
             }
             try data.write(to: path, options: .atomic)
+            try Self.enforcePendingStoreFileMode(path: path)
         } catch {
             NSLog("[BrainBar] Failed to rewrite pending stores queue: %@", String(describing: error))
         }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -42,6 +42,13 @@ final class BrainDatabase: @unchecked Sendable {
         let rowID: Int64
     }
 
+    struct FlushedPendingStore: Sendable {
+        let storedChunk: StoredChunk
+        let content: String
+        let tags: [String]
+        let importance: Int
+    }
+
     struct PendingStoreItem: Codable, Sendable {
         let content: String
         let tags: [String]
@@ -534,8 +541,10 @@ final class BrainDatabase: @unchecked Sendable {
         guard let line = String(data: data, encoding: .utf8) else {
             throw DBError.exec(SQLITE_MISUSE, "failed to encode pending store item")
         }
-        if FileManager.default.fileExists(atPath: path.path),
-           let handle = try? FileHandle(forWritingTo: path) {
+        if FileManager.default.fileExists(atPath: path.path) {
+            guard let handle = try? FileHandle(forWritingTo: path) else {
+                throw DBError.exec(SQLITE_CANTOPEN, "failed to open pending store queue for append")
+            }
             defer { try? handle.close() }
             try handle.seekToEnd()
             try handle.write(contentsOf: Data((line + "\n").utf8))
@@ -544,20 +553,19 @@ final class BrainDatabase: @unchecked Sendable {
         try Data((line + "\n").utf8).write(to: path, options: .atomic)
     }
 
-    @discardableResult
-    func flushPendingStores() -> Int {
+    func flushPendingStores() -> [FlushedPendingStore] {
         let path = pendingStorePath()
-        guard FileManager.default.fileExists(atPath: path.path) else { return 0 }
+        guard FileManager.default.fileExists(atPath: path.path) else { return [] }
         guard let text = try? String(contentsOf: path, encoding: .utf8) else {
             NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
-            return 0
+            return []
         }
 
         let lines = text.split(whereSeparator: \.isNewline).map(String.init)
-        guard !lines.isEmpty else { return 0 }
+        guard !lines.isEmpty else { return [] }
 
         let decoder = JSONDecoder()
-        var flushed = 0
+        var flushed: [FlushedPendingStore] = []
         var remaining: [String] = []
 
         for line in lines {
@@ -578,7 +586,7 @@ final class BrainDatabase: @unchecked Sendable {
             }
 
             do {
-                _ = try store(
+                let stored = try store(
                     content: item.content,
                     tags: item.tags,
                     importance: item.importance,
@@ -586,7 +594,14 @@ final class BrainDatabase: @unchecked Sendable {
                     queueID: item.queueID,
                     refreshStatistics: false
                 )
-                flushed += 1
+                flushed.append(
+                    FlushedPendingStore(
+                        storedChunk: stored,
+                        content: item.content,
+                        tags: item.tags,
+                        importance: item.importance
+                    )
+                )
             } catch {
                 NSLog("[BrainBar] Failed to flush pending store item: %@", String(describing: error))
                 remaining.append(line)
@@ -594,7 +609,7 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         rewritePendingStoreFile(path: path, remainingLines: remaining)
-        if flushed > 0 {
+        if !flushed.isEmpty {
             refreshSearchStatisticsBestEffort()
         }
         return flushed
@@ -1456,7 +1471,12 @@ final class BrainDatabase: @unchecked Sendable {
 
     private static func storeMetadataJSON(queueID: String?) -> String {
         guard let queueID else { return "{}" }
-        return #"{"brainbar_queue_id":"\#(queueID)"}"#
+        let payload = ["brainbar_queue_id": queueID]
+        guard let data = try? JSONEncoder().encode(payload),
+              let text = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return text
     }
 
     private func hasStoredQueuedItem(queueID: String) throws -> Bool {
@@ -1475,13 +1495,8 @@ final class BrainDatabase: @unchecked Sendable {
             try? FileManager.default.removeItem(at: path)
             return
         }
-        let tmp = path.appendingPathExtension("tmp")
         do {
-            try Data((remainingLines.joined(separator: "\n") + "\n").utf8).write(to: tmp, options: .atomic)
-            if FileManager.default.fileExists(atPath: path.path) {
-                try FileManager.default.removeItem(at: path)
-            }
-            try FileManager.default.moveItem(at: tmp, to: path)
+            try Data((remainingLines.joined(separator: "\n") + "\n").utf8).write(to: path, options: .atomic)
         } catch {
             NSLog("[BrainBar] Failed to rewrite pending stores queue: %@", String(describing: error))
         }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -114,6 +114,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     private var db: OpaquePointer?
     private let path: String
+    private let pendingStoreFileLock = NSLock()
     private(set) var isOpen = false
 
     init(path: String) {
@@ -183,6 +184,12 @@ final class BrainDatabase: @unchecked Sendable {
         try execute("""
             CREATE INDEX IF NOT EXISTS idx_chunks_created_at
             ON chunks(created_at)
+        """)
+
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_chunks_brainbar_queue_id
+            ON chunks(json_extract(metadata, '$.brainbar_queue_id'))
+            WHERE json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL
         """)
 
         try ensureAuxiliarySchema()
@@ -526,6 +533,9 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func queuePendingStore(content: String, tags: [String], importance: Int, source: String) throws {
+        pendingStoreFileLock.lock()
+        defer { pendingStoreFileLock.unlock() }
+
         let path = pendingStorePath()
         try FileManager.default.createDirectory(
             at: path.deletingLastPathComponent(),
@@ -556,6 +566,9 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func flushPendingStores() -> [FlushedPendingStore] {
+        pendingStoreFileLock.lock()
+        defer { pendingStoreFileLock.unlock() }
+
         let path = pendingStorePath()
         guard FileManager.default.fileExists(atPath: path.path) else { return [] }
         guard let lines = readPendingStoreLines(at: path) else {
@@ -578,7 +591,13 @@ final class BrainDatabase: @unchecked Sendable {
             }
 
             let queueID = Self.pendingStoreQueueID(for: item)
-            if (try? hasStoredQueuedItem(queueID: queueID)) == true {
+            do {
+                if try hasStoredQueuedItem(queueID: queueID) {
+                    continue
+                }
+            } catch {
+                NSLog("[BrainBar] Failed pending store dedupe lookup for %@: %@", queueID, String(describing: error))
+                remaining.append(line)
                 continue
             }
 
@@ -1580,11 +1599,16 @@ final class BrainDatabase: @unchecked Sendable {
     private func hasStoredQueuedItem(queueID: String) throws -> Bool {
         guard let db else { throw DBError.notOpen }
         var stmt: OpaquePointer?
-        let sql = "SELECT 1 FROM chunks WHERE metadata = ? LIMIT 1"
+        let sql = """
+            SELECT 1
+            FROM chunks
+            WHERE json_extract(metadata, '$.brainbar_queue_id') = ?
+            LIMIT 1
+        """
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
         defer { sqlite3_finalize(stmt) }
-        bindText(Self.storeMetadataJSON(queueID: queueID), to: stmt, index: 1)
+        bindText(queueID, to: stmt, index: 1)
         return sqlite3_step(stmt) == SQLITE_ROW
     }
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -516,8 +516,10 @@ final class BrainDatabase: @unchecked Sendable {
     func shouldQueueStoreError(_ error: Error) -> Bool {
         guard let dbError = error as? DBError else { return false }
         switch dbError {
-        case .prepare, .step, .exec:
-            return true
+        case .prepare(let rc), .step(let rc):
+            return Self.isRetryableQueueErrorCode(rc)
+        case .exec(let rc, _):
+            return Self.isRetryableQueueErrorCode(rc)
         case .notOpen, .open, .noResult, .invalidPragma:
             return false
         }
@@ -556,32 +558,27 @@ final class BrainDatabase: @unchecked Sendable {
     func flushPendingStores() -> [FlushedPendingStore] {
         let path = pendingStorePath()
         guard FileManager.default.fileExists(atPath: path.path) else { return [] }
-        guard let text = try? String(contentsOf: path, encoding: .utf8) else {
+        guard let lines = readPendingStoreLines(at: path) else {
             NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
             return []
         }
-
-        let lines = text.split(whereSeparator: \.isNewline).map(String.init)
         guard !lines.isEmpty else { return [] }
 
         let decoder = JSONDecoder()
         var flushed: [FlushedPendingStore] = []
-        var remaining: [String] = []
+        var remaining: [Data] = []
 
         for line in lines {
-            guard let data = line.data(using: .utf8) else {
-                remaining.append(line)
-                continue
-            }
             let item: PendingStoreItem
             do {
-                item = try decoder.decode(PendingStoreItem.self, from: data)
+                item = try decoder.decode(PendingStoreItem.self, from: line)
             } catch {
                 remaining.append(line)
                 continue
             }
 
-            if let queueID = item.queueID, (try? hasStoredQueuedItem(queueID: queueID)) == true {
+            let queueID = Self.pendingStoreQueueID(for: item)
+            if (try? hasStoredQueuedItem(queueID: queueID)) == true {
                 continue
             }
 
@@ -591,7 +588,7 @@ final class BrainDatabase: @unchecked Sendable {
                     tags: item.tags,
                     importance: item.importance,
                     source: item.source,
-                    queueID: item.queueID,
+                    queueID: queueID,
                     refreshStatistics: false
                 )
                 flushed.append(
@@ -1469,14 +1466,115 @@ final class BrainDatabase: @unchecked Sendable {
         return URL(fileURLWithPath: path).deletingLastPathComponent().appendingPathComponent("pending-stores.jsonl")
     }
 
+    private func readPendingStoreLines(at path: URL) -> [Data]? {
+        guard let data = try? Data(contentsOf: path) else {
+            return nil
+        }
+
+        var lines: [Data] = []
+        var start = data.startIndex
+
+        func appendLine(_ range: Range<Data.Index>) {
+            guard !range.isEmpty else { return }
+            var line = Data(data[range])
+            if line.last == 0x0D {
+                line.removeLast()
+            }
+            guard !line.isEmpty else { return }
+            lines.append(line)
+        }
+
+        for index in data.indices where data[index] == 0x0A {
+            appendLine(start..<index)
+            start = data.index(after: index)
+        }
+
+        if start < data.endIndex {
+            appendLine(start..<data.endIndex)
+        }
+
+        return lines
+    }
+
     private static func storeMetadataJSON(queueID: String?) -> String {
-        guard let queueID else { return "{}" }
+        guard let queueID = normalizedQueueID(queueID) else { return "{}" }
         let payload = ["brainbar_queue_id": queueID]
         guard let data = try? JSONEncoder().encode(payload),
               let text = String(data: data, encoding: .utf8) else {
             return "{}"
         }
         return text
+    }
+
+    private static func normalizedQueueID(_ queueID: String?) -> String? {
+        guard let queueID = queueID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !queueID.isEmpty else {
+            return nil
+        }
+        return queueID
+    }
+
+    private static func pendingStoreQueueID(for item: PendingStoreItem) -> String {
+        if let queueID = normalizedQueueID(item.queueID) {
+            return queueID
+        }
+        return deterministicPendingStoreQueueID(
+            content: item.content,
+            tags: item.tags,
+            importance: item.importance,
+            source: item.source
+        )
+    }
+
+    private static func deterministicPendingStoreQueueID(
+        content: String,
+        tags: [String],
+        importance: Int,
+        source: String
+    ) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+
+        func mix(_ byte: UInt8) {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+
+        func mix(_ data: Data) {
+            for byte in data {
+                mix(byte)
+            }
+        }
+
+        func mix(length: Int) {
+            var value = UInt64(length).littleEndian
+            withUnsafeBytes(of: &value) { bytes in
+                mix(Data(bytes))
+            }
+        }
+
+        func mix(_ string: String) {
+            let data = Data(string.utf8)
+            mix(length: data.count)
+            mix(data)
+        }
+
+        mix(content)
+        mix(length: tags.count)
+        for tag in tags {
+            mix(tag)
+        }
+        var encodedImportance = Int64(importance).littleEndian
+        withUnsafeBytes(of: &encodedImportance) { bytes in
+            mix(Data(bytes))
+        }
+        mix(source)
+
+        return String(format: "brainbar-pending-%016llx", hash)
+    }
+
+    private static func isRetryableQueueErrorCode(_ rc: Int32) -> Bool {
+        let primaryCode = rc & 0xFF
+        return primaryCode == SQLITE_BUSY || primaryCode == SQLITE_LOCKED
     }
 
     private func hasStoredQueuedItem(queueID: String) throws -> Bool {
@@ -1490,13 +1588,18 @@ final class BrainDatabase: @unchecked Sendable {
         return sqlite3_step(stmt) == SQLITE_ROW
     }
 
-    private func rewritePendingStoreFile(path: URL, remainingLines: [String]) {
+    private func rewritePendingStoreFile(path: URL, remainingLines: [Data]) {
         guard !remainingLines.isEmpty else {
             try? FileManager.default.removeItem(at: path)
             return
         }
         do {
-            try Data((remainingLines.joined(separator: "\n") + "\n").utf8).write(to: path, options: .atomic)
+            var data = Data()
+            for line in remainingLines {
+                data.append(line)
+                data.append(0x0A)
+            }
+            try data.write(to: path, options: .atomic)
         } catch {
             NSLog("[BrainBar] Failed to rewrite pending stores queue: %@", String(describing: error))
         }

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -242,16 +242,34 @@ final class MCPRouter: @unchecked Sendable {
         guard let db = database else {
             throw ToolError.noDatabase
         }
-        let stored = try db.store(content: content, tags: tags, importance: importance, source: "mcp")
-        return ToolOutput(
-            text: Formatters.formatStoreResult(chunkId: stored.chunkID),
-            metadata: [
-                "_brainbarStoredChunk": [
-                    "chunk_id": stored.chunkID,
-                    "rowid": stored.rowID
+        do {
+            let stored = try db.store(content: content, tags: tags, importance: importance, source: "mcp")
+            let flushedCount = db.flushPendingStores()
+            return ToolOutput(
+                text: Formatters.formatStoreResult(chunkId: stored.chunkID),
+                metadata: [
+                    "queued": false,
+                    "flushed_count": flushedCount,
+                    "_brainbarStoredChunk": [
+                        "chunk_id": stored.chunkID,
+                        "rowid": stored.rowID
+                    ]
                 ]
-            ]
-        )
+            )
+        } catch {
+            guard db.shouldQueueStoreError(error) else {
+                throw error
+            }
+            do {
+                try db.queuePendingStore(content: content, tags: tags, importance: importance, source: "mcp")
+                return ToolOutput(
+                    text: Formatters.formatStoreResult(chunkId: "", queued: true),
+                    metadata: ["queued": true]
+                )
+            } catch {
+                throw error
+            }
+        }
     }
 
     private func handleBrainRecall(_ args: [String: Any]) throws -> ToolOutput {

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -269,15 +269,11 @@ final class MCPRouter: @unchecked Sendable {
             guard db.shouldQueueStoreError(error) else {
                 throw error
             }
-            do {
-                try db.queuePendingStore(content: content, tags: tags, importance: importance, source: "mcp")
-                return ToolOutput(
-                    text: Formatters.formatStoreResult(chunkId: "", queued: true),
-                    metadata: ["queued": true]
-                )
-            } catch {
-                throw error
-            }
+            try db.queuePendingStore(content: content, tags: tags, importance: importance, source: "mcp")
+            return ToolOutput(
+                text: Formatters.formatStoreResult(chunkId: "", queued: true),
+                metadata: ["queued": true]
+            )
         }
     }
 

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -244,16 +244,25 @@ final class MCPRouter: @unchecked Sendable {
         }
         do {
             let stored = try db.store(content: content, tags: tags, importance: importance, source: "mcp")
-            let flushedCount = db.flushPendingStores()
+            let flushedStores = db.flushPendingStores()
             return ToolOutput(
                 text: Formatters.formatStoreResult(chunkId: stored.chunkID),
                 metadata: [
                     "queued": false,
-                    "flushed_count": flushedCount,
+                    "flushed_count": flushedStores.count,
                     "_brainbarStoredChunk": [
                         "chunk_id": stored.chunkID,
                         "rowid": stored.rowID
-                    ]
+                    ],
+                    "_brainbarFlushedQueuedChunks": flushedStores.map { flushed in
+                        [
+                            "chunk_id": flushed.storedChunk.chunkID,
+                            "rowid": flushed.storedChunk.rowID,
+                            "content": flushed.content,
+                            "tags": flushed.tags,
+                            "importance": flushed.importance
+                        ] as [String: Any]
+                    }
                 ]
             )
         } catch {

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -87,6 +87,50 @@ final class DatabaseTests: XCTestCase {
         XCTAssertTrue(exists, "injection_events table must exist")
     }
 
+    func testQueueIDExpressionIndexExists() throws {
+        let sql = try sqliteMasterSQL(name: "idx_chunks_brainbar_queue_id", path: tempDBPath)
+
+        XCTAssertTrue(sql.contains("json_extract(metadata, '$.brainbar_queue_id')"))
+        XCTAssertTrue(sql.contains("WHERE json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL"))
+    }
+
+    func testQueueIDLookupUsesExpressionIndex() throws {
+        db.exec("""
+            INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type, char_count, source, tags, importance, preview_text
+            ) VALUES (
+                'queued-indexed',
+                'Queued chunk metadata lookup',
+                '{"brainbar_queue_id":"brainbar-pending-lookup"}',
+                'brainbar-store',
+                'brainbar',
+                'assistant_text',
+                28,
+                'mcp',
+                '[]',
+                5,
+                'Queued chunk metadata lookup'
+            )
+        """)
+
+        let plan = try sqliteQueryPlan(
+            path: tempDBPath,
+            sql: """
+                EXPLAIN QUERY PLAN
+                SELECT 1
+                FROM chunks
+                WHERE json_extract(metadata, '$.brainbar_queue_id') = ?
+                LIMIT 1
+            """,
+            binds: ["brainbar-pending-lookup"]
+        )
+
+        XCTAssertTrue(
+            plan.contains(where: { $0.localizedCaseInsensitiveContains("idx_chunks_brainbar_queue_id") }),
+            "Queue ID dedupe lookups should use the dedicated expression index"
+        )
+    }
+
     func testUpsertSubscriptionRecoversMissingPubSubTables() throws {
         db.exec("DROP TABLE IF EXISTS brainbar_subscriptions")
         db.exec("DROP TABLE IF EXISTS brainbar_agents")
@@ -595,6 +639,35 @@ private func sqliteStatCount(for tables: [String], path: String) throws -> Int {
                 }
             }
         )
+    }
+}
+
+private func sqliteQueryPlan(path: String, sql: String, binds: [String]) throws -> [String] {
+    try withSQLiteConnection(path: path) { db in
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else {
+            throw NSError(domain: "DatabaseTests", code: Int(rc))
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        for (index, value) in binds.enumerated() {
+            sqlite3_bind_text(
+                stmt,
+                Int32(index + 1),
+                value,
+                -1,
+                unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            )
+        }
+
+        var details: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let text = sqlite3_column_text(stmt, 3) {
+                details.append(String(cString: text))
+            }
+        }
+        return details
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -94,6 +94,31 @@ final class DatabaseTests: XCTestCase {
         XCTAssertTrue(sql.contains("WHERE json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL"))
     }
 
+    func testQueueIDExpressionIndexMigratesExistingSchema() throws {
+        let legacyPath = NSTemporaryDirectory() + "brainbar-legacy-\(UUID().uuidString).db"
+        try sqliteExecWrite(
+            path: legacyPath,
+            sql: """
+                CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    content TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}'
+                )
+            """
+        )
+        defer {
+            try? FileManager.default.removeItem(atPath: legacyPath)
+            try? FileManager.default.removeItem(atPath: legacyPath + "-wal")
+            try? FileManager.default.removeItem(atPath: legacyPath + "-shm")
+        }
+
+        let legacyDB = BrainDatabase(path: legacyPath)
+        defer { legacyDB.close() }
+
+        let sql = try sqliteMasterSQL(name: "idx_chunks_brainbar_queue_id", path: legacyPath)
+        XCTAssertTrue(sql.contains("json_extract(metadata, '$.brainbar_queue_id')"))
+    }
+
     func testQueueIDLookupUsesExpressionIndex() throws {
         db.exec("""
             INSERT INTO chunks (
@@ -679,6 +704,25 @@ private func withSQLiteConnection<T>(path: String, body: (OpaquePointer) throws 
     }
     defer { sqlite3_close(db) }
     return try body(db)
+}
+
+private func sqliteExecWrite(path: String, sql: String) throws {
+    var db: OpaquePointer?
+    let rc = sqlite3_open_v2(
+        path,
+        &db,
+        SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+        nil
+    )
+    guard rc == SQLITE_OK, let db else {
+        throw NSError(domain: "DatabaseTests", code: Int(rc))
+    }
+    defer { sqlite3_close(db) }
+
+    let execRC = sqlite3_exec(db, sql, nil, nil, nil)
+    guard execRC == SQLITE_OK else {
+        throw NSError(domain: "DatabaseTests", code: Int(execRC))
+    }
 }
 
 private func scalarString(

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -91,7 +91,8 @@ final class DatabaseTests: XCTestCase {
         let sql = try sqliteMasterSQL(name: "idx_chunks_brainbar_queue_id", path: tempDBPath)
 
         XCTAssertTrue(sql.contains("json_extract(metadata, '$.brainbar_queue_id')"))
-        XCTAssertTrue(sql.contains("WHERE json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL"))
+        XCTAssertTrue(sql.contains("json_valid(metadata)"))
+        XCTAssertTrue(sql.contains("json_extract(metadata, '$.brainbar_queue_id') IS NOT NULL"))
     }
 
     func testQueueIDExpressionIndexMigratesExistingSchema() throws {
@@ -119,6 +120,34 @@ final class DatabaseTests: XCTestCase {
         XCTAssertTrue(sql.contains("json_extract(metadata, '$.brainbar_queue_id')"))
     }
 
+    func testQueueIDExpressionIndexMigratesExistingSchemaWithMalformedMetadata() throws {
+        let legacyPath = NSTemporaryDirectory() + "brainbar-legacy-malformed-\(UUID().uuidString).db"
+        try sqliteExecWrite(
+            path: legacyPath,
+            sql: """
+                CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    content TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}'
+                );
+                INSERT INTO chunks (id, content, metadata)
+                VALUES ('legacy-bad-metadata', 'Legacy malformed metadata row', '{not json');
+            """
+        )
+        defer {
+            try? FileManager.default.removeItem(atPath: legacyPath)
+            try? FileManager.default.removeItem(atPath: legacyPath + "-wal")
+            try? FileManager.default.removeItem(atPath: legacyPath + "-shm")
+        }
+
+        let legacyDB = BrainDatabase(path: legacyPath)
+        defer { legacyDB.close() }
+
+        XCTAssertTrue(legacyDB.isOpen)
+        let sql = try sqliteMasterSQL(name: "idx_chunks_brainbar_queue_id", path: legacyPath)
+        XCTAssertTrue(sql.contains("json_valid(metadata)"))
+    }
+
     func testQueueIDLookupUsesExpressionIndex() throws {
         db.exec("""
             INSERT INTO chunks (
@@ -144,7 +173,8 @@ final class DatabaseTests: XCTestCase {
                 EXPLAIN QUERY PLAN
                 SELECT 1
                 FROM chunks
-                WHERE json_extract(metadata, '$.brainbar_queue_id') = ?
+                WHERE json_valid(metadata)
+                  AND json_extract(metadata, '$.brainbar_queue_id') = ?
                 LIMIT 1
             """,
             binds: ["brainbar-pending-lookup"]

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -708,6 +708,31 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(contents.filter { $0 == "Legacy queue line without queue id" }.count, 1)
     }
 
+    func testBrainStoreLegacyQueuePreservesDuplicatePayloadLines() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let legacyLine = """
+        {"content":"Repeated legacy queue payload","tags":["queued"],"importance":4,"source":"mcp"}
+        """
+        try (legacyLine + "\n" + legacyLine + "\n").write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+
+        let flushed = db.flushPendingStores()
+        XCTAssertEqual(flushed.count, 2)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path))
+
+        let contents = try chunkContents(path: dbPath)
+        XCTAssertEqual(contents.filter { $0 == "Repeated legacy queue payload" }.count, 2)
+    }
+
     func testQueuePendingStorePreservesConcurrentFirstWrites() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -765,6 +765,7 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))
         let compactedQueue = try String(contentsOf: queuePath, encoding: .utf8)
         XCTAssertTrue(compactedQueue.contains("queue_id"))
+        XCTAssertFalse(compactedQueue.contains("\n\n"))
 
         try sqliteExec(path: dbPath, sql: "DROP TRIGGER fail_second_repeated_legacy_insert")
 

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -481,7 +481,7 @@ final class MCPRouterTests: XCTestCase {
 
     // MARK: - brain_store queue fallback
 
-    func testBrainStoreQueuesWhenWritePrepareFails() throws {
+    func testBrainStoreQueuesWhenWriteHitsTransientSQLiteLock() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -489,9 +489,15 @@ final class MCPRouterTests: XCTestCase {
         setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
         defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
 
-        let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
         defer { db.close() }
-        db.exec("DROP TABLE chunks")
+        db.exec("PRAGMA busy_timeout = 1")
+
+        let lockDB = try openSQLiteConnection(path: dbPath)
+        defer { sqlite3_close(lockDB) }
+        XCTAssertEqual(sqlite3_exec(lockDB, "BEGIN IMMEDIATE", nil, nil, nil), SQLITE_OK)
+        defer { sqlite3_exec(lockDB, "ROLLBACK", nil, nil, nil) }
 
         let router = MCPRouter()
         router.setDatabase(db)
@@ -503,7 +509,7 @@ final class MCPRouterTests: XCTestCase {
             "params": [
                 "name": "brain_store",
                 "arguments": [
-                    "content": "Store should queue after prepare failure",
+                    "content": "Store should queue after transient SQLite lock",
                     "tags": ["queue-fallback"],
                     "importance": 7
                 ] as [String: Any]
@@ -513,12 +519,12 @@ final class MCPRouterTests: XCTestCase {
         let result = response["result"] as? [String: Any]
         let text = ((result?["content"] as? [[String: Any]])?.first?["text"] as? String) ?? ""
 
-        XCTAssertNotEqual(result?["isError"] as? Bool, true, "brain_store should queue instead of surfacing an error")
+        XCTAssertNotEqual(result?["isError"] as? Bool, true, "brain_store should queue instead of surfacing a transient lock")
         XCTAssertTrue(text.localizedCaseInsensitiveContains("queued"))
         XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))
 
         let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
-        XCTAssertTrue(queuedText.contains("Store should queue after prepare failure"))
+        XCTAssertTrue(queuedText.contains("Store should queue after transient SQLite lock"))
     }
 
     func testBrainStoreFlushesPendingQueueAfterSuccessfulStore() throws {
@@ -618,6 +624,107 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertTrue(contents.contains("Live write tolerates malformed queue lines"))
     }
 
+    func testBrainStoreFlushKeepsInvalidUTF8QueueLines() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let invalidLine = Data([0xC3, 0x28, 0x0A])
+        let validLine = Data("""
+        {"content":"Queued valid item survives invalid utf8 sibling","tags":["queued"],"importance":4,"source":"mcp"}
+        """.utf8)
+        try (invalidLine + validLine + Data([0x0A])).write(to: queuePath, options: .atomic)
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 23,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Live write tolerates invalid utf8 queue lines",
+                    "tags": ["live"],
+                    "importance": 5
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = response["result"] as? [String: Any]
+        XCTAssertNil(result?["isError"])
+        XCTAssertEqual(result?["flushed_count"] as? Int, 1)
+        let flushed = result?["_brainbarFlushedQueuedChunks"] as? [[String: Any]]
+        XCTAssertEqual(flushed?.count, 1)
+        XCTAssertEqual(flushed?.first?["content"] as? String, "Queued valid item survives invalid utf8 sibling")
+
+        let remainingData = try Data(contentsOf: queuePath)
+        XCTAssertEqual(remainingData, invalidLine)
+
+        let contents = try chunkContents(path: dbPath)
+        XCTAssertTrue(contents.contains("Queued valid item survives invalid utf8 sibling"))
+        XCTAssertTrue(contents.contains("Live write tolerates invalid utf8 queue lines"))
+    }
+
+    func testBrainStoreLegacyQueueLinesStayIdempotentAcrossReplay() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let legacyLine = """
+        {"content":"Legacy queue line without queue id","tags":["queued"],"importance":4,"source":"mcp"}
+        """
+        try (legacyLine + "\n").write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+
+        let firstFlush = db.flushPendingStores()
+        XCTAssertEqual(firstFlush.count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path))
+
+        let metadata = try chunkMetadata(path: dbPath, content: "Legacy queue line without queue id")
+        XCTAssertNotNil(metadata)
+        XCTAssertTrue(metadata?.contains("brainbar_queue_id") == true)
+
+        try (legacyLine + "\n").write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let secondFlush = db.flushPendingStores()
+        XCTAssertTrue(secondFlush.isEmpty)
+
+        let contents = try chunkContents(path: dbPath)
+        XCTAssertEqual(contents.filter { $0 == "Legacy queue line without queue id" }.count, 1)
+    }
+
+    func testShouldQueueOnlyTransientSQLiteStoreErrors() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
+        defer { db.close() }
+
+        XCTAssertTrue(db.shouldQueueStoreError(BrainDatabase.DBError.prepare(SQLITE_BUSY)))
+        XCTAssertTrue(db.shouldQueueStoreError(BrainDatabase.DBError.step(SQLITE_LOCKED)))
+        XCTAssertTrue(db.shouldQueueStoreError(BrainDatabase.DBError.exec(SQLITE_BUSY, "database is busy")))
+
+        XCTAssertFalse(db.shouldQueueStoreError(BrainDatabase.DBError.prepare(SQLITE_ERROR)))
+        XCTAssertFalse(db.shouldQueueStoreError(BrainDatabase.DBError.step(SQLITE_CORRUPT)))
+        XCTAssertFalse(db.shouldQueueStoreError(BrainDatabase.DBError.exec(SQLITE_CANTOPEN, "cannot open database")))
+        XCTAssertFalse(db.shouldQueueStoreError(NSError(domain: "test", code: 1)))
+    }
+
     // MARK: - Notifications (no id)
 
     func testNotificationDoesNotRequireResponse() {
@@ -662,4 +769,40 @@ private func chunkContents(path: String) throws -> [String] {
         }
     }
     return results
+}
+
+private func chunkMetadata(path: String, content: String) throws -> String? {
+    var db: OpaquePointer?
+    let rc = sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil)
+    guard rc == SQLITE_OK, let db else {
+        throw NSError(domain: "MCPRouterTests", code: Int(rc))
+    }
+    defer { sqlite3_close(db) }
+
+    var stmt: OpaquePointer?
+    let sql = "SELECT metadata FROM chunks WHERE content = ? ORDER BY rowid DESC LIMIT 1"
+    let prepareRC = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+    guard prepareRC == SQLITE_OK else {
+        throw NSError(domain: "MCPRouterTests", code: Int(prepareRC))
+    }
+    defer { sqlite3_finalize(stmt) }
+
+    let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    sqlite3_bind_text(stmt, 1, content, -1, transient)
+    guard sqlite3_step(stmt) == SQLITE_ROW else {
+        return nil
+    }
+    guard let value = sqlite3_column_text(stmt, 0) else {
+        return nil
+    }
+    return String(cString: value)
+}
+
+private func openSQLiteConnection(path: String) throws -> OpaquePointer {
+    var db: OpaquePointer?
+    let rc = sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil)
+    guard rc == SQLITE_OK, let db else {
+        throw NSError(domain: "MCPRouterTests", code: Int(rc))
+    }
+    return db
 }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -6,6 +6,7 @@
 // - tools/call: dispatch to tool handler by name
 
 import XCTest
+import SQLite3
 @testable import BrainBar
 
 final class MCPRouterTests: XCTestCase {
@@ -478,6 +479,137 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertTrue(text.contains("result"), "Should contain formatted result text")
     }
 
+    // MARK: - brain_store queue fallback
+
+    func testBrainStoreQueuesWhenWritePrepareFails() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
+        defer { db.close() }
+        db.exec("DROP TABLE chunks")
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Store should queue after prepare failure",
+                    "tags": ["queue-fallback"],
+                    "importance": 7
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = response["result"] as? [String: Any]
+        let text = ((result?["content"] as? [[String: Any]])?.first?["text"] as? String) ?? ""
+
+        XCTAssertNotEqual(result?["isError"] as? Bool, true, "brain_store should queue instead of surfacing an error")
+        XCTAssertTrue(text.localizedCaseInsensitiveContains("queued"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))
+
+        let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
+        XCTAssertTrue(queuedText.contains("Store should queue after prepare failure"))
+    }
+
+    func testBrainStoreFlushesPendingQueueAfterSuccessfulStore() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let queuedPayload = """
+        {"content":"Queued item should flush","tags":["queued"],"importance":4,"source":"mcp"}
+        """
+        try queuedPayload.write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 21,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Live write triggers flush",
+                    "tags": ["live"],
+                    "importance": 5
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = response["result"] as? [String: Any]
+        XCTAssertNil(result?["isError"])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path), "successful store should drain the pending queue")
+
+        let contents = try chunkContents(path: dbPath)
+        XCTAssertTrue(contents.contains("Queued item should flush"))
+        XCTAssertTrue(contents.contains("Live write triggers flush"))
+    }
+
+    func testBrainStoreFlushKeepsMalformedQueueLines() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let seededQueue = """
+        not-json
+        {"content":"Queued valid item survives malformed sibling","tags":["queued"],"importance":4,"source":"mcp"}
+        """
+        try seededQueue.write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 22,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Live write tolerates malformed queue lines",
+                    "tags": ["live"],
+                    "importance": 5
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = response["result"] as? [String: Any]
+        XCTAssertNil(result?["isError"])
+
+        let remainingText = try String(contentsOf: queuePath, encoding: .utf8)
+        XCTAssertEqual(remainingText.trimmingCharacters(in: .whitespacesAndNewlines), "not-json")
+
+        let contents = try chunkContents(path: dbPath)
+        XCTAssertTrue(contents.contains("Queued valid item survives malformed sibling"))
+        XCTAssertTrue(contents.contains("Live write tolerates malformed queue lines"))
+    }
+
     // MARK: - Notifications (no id)
 
     func testNotificationDoesNotRequireResponse() {
@@ -491,4 +623,35 @@ final class MCPRouterTests: XCTestCase {
         // Notifications should return empty/nil response (no id to respond to)
         XCTAssertTrue(response.isEmpty || response["id"] == nil)
     }
+}
+
+private func makeTempTestDirectory() -> URL {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+}
+
+private func chunkContents(path: String) throws -> [String] {
+    var db: OpaquePointer?
+    let rc = sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil)
+    guard rc == SQLITE_OK, let db else {
+        throw NSError(domain: "MCPRouterTests", code: Int(rc))
+    }
+    defer { sqlite3_close(db) }
+
+    var stmt: OpaquePointer?
+    let sql = "SELECT content FROM chunks ORDER BY rowid ASC"
+    let prepareRC = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+    guard prepareRC == SQLITE_OK else {
+        throw NSError(domain: "MCPRouterTests", code: Int(prepareRC))
+    }
+    defer { sqlite3_finalize(stmt) }
+
+    var results: [String] = []
+    while sqlite3_step(stmt) == SQLITE_ROW {
+        if let value = sqlite3_column_text(stmt, 0) {
+            results.append(String(cString: value))
+        }
+    }
+    return results
 }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -486,8 +486,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let dbPath = tempDir.appendingPathComponent("brainbar.db").path
         let db = BrainDatabase(path: dbPath)
@@ -532,8 +532,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let queuedPayload = """
         {"content":"Queued item should flush","tags":["queued"],"importance":4,"source":"mcp"}
@@ -579,8 +579,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let seededQueue = """
         not-json
@@ -629,8 +629,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let invalidLine = Data([0xC3, 0x28, 0x0A])
         let validLine = Data("""
@@ -679,8 +679,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let legacyLine = """
         {"content":"Legacy queue line without queue id","tags":["queued"],"importance":4,"source":"mcp"}
@@ -713,8 +713,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let legacyLine = """
         {"content":"Repeated legacy queue payload","tags":["queued"],"importance":4,"source":"mcp"}
@@ -738,8 +738,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let legacyLine = """
         {"content":"Repeated legacy queue payload with transient failure","tags":["queued"],"importance":4,"source":"mcp"}
@@ -782,8 +782,8 @@ final class MCPRouterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
-        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
 
         let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
         defer { db.close() }
@@ -812,6 +812,52 @@ final class MCPRouterTests: XCTestCase {
         let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
         let lines = queuedText.split(whereSeparator: \.isNewline)
         XCTAssertEqual(lines.count, iterations)
+    }
+
+    func testQueuePendingStoreCreatesPrivateQueueFile() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
+
+        let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
+        defer { db.close() }
+
+        try db.queuePendingStore(
+            content: "Private queued content",
+            tags: ["queued"],
+            importance: 5,
+            source: "mcp"
+        )
+
+        XCTAssertEqual(try posixPermissions(path: queuePath), 0o600)
+    }
+
+    func testBrainStoreFlushRewriteKeepsQueueFilePrivate() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
+
+        let seededQueue = """
+        not-json
+        {"content":"Private rewritten queued item","tags":["queued"],"importance":4,"source":"mcp"}
+        """
+        try seededQueue.write(to: queuePath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queuePath.path)
+
+        let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
+        defer { db.close() }
+
+        let flushed = db.flushPendingStores()
+
+        XCTAssertEqual(flushed.count, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))
+        XCTAssertEqual(try posixPermissions(path: queuePath), 0o600)
     }
 
     func testShouldQueueOnlyTransientSQLiteStoreErrors() throws {
@@ -850,6 +896,23 @@ private func makeTempTestDirectory() -> URL {
     let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
     return dir
+}
+
+private func setPendingStoreQueuePath(_ path: URL) -> () -> Void {
+    let previous = ProcessInfo.processInfo.environment["BRAINBAR_PENDING_STORES_PATH"]
+    setenv("BRAINBAR_PENDING_STORES_PATH", path.path, 1)
+    return {
+        if let previous {
+            setenv("BRAINBAR_PENDING_STORES_PATH", previous, 1)
+        } else {
+            unsetenv("BRAINBAR_PENDING_STORES_PATH")
+        }
+    }
+}
+
+private func posixPermissions(path: URL) throws -> Int {
+    let attributes = try FileManager.default.attributesOfItem(atPath: path.path)
+    return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0
 }
 
 private func chunkContents(path: String) throws -> [String] {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -733,6 +733,49 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(contents.filter { $0 == "Repeated legacy queue payload" }.count, 2)
     }
 
+    func testBrainStoreLegacyQueueDuplicateSurvivesPartialFlushCompaction() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let legacyLine = """
+        {"content":"Repeated legacy queue payload with transient failure","tags":["queued"],"importance":4,"source":"mcp"}
+        """
+        try (legacyLine + "\n" + legacyLine + "\n").write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+
+        try sqliteExec(path: dbPath, sql: """
+            CREATE TRIGGER fail_second_repeated_legacy_insert
+            BEFORE INSERT ON chunks
+            WHEN NEW.content = 'Repeated legacy queue payload with transient failure'
+                 AND (SELECT COUNT(*) FROM chunks WHERE content = NEW.content) > 0
+            BEGIN
+                SELECT RAISE(ABORT, 'fail second repeated legacy insert');
+            END;
+        """)
+
+        let firstFlush = db.flushPendingStores()
+        XCTAssertEqual(firstFlush.count, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))
+        let compactedQueue = try String(contentsOf: queuePath, encoding: .utf8)
+        XCTAssertTrue(compactedQueue.contains("queue_id"))
+
+        try sqliteExec(path: dbPath, sql: "DROP TRIGGER fail_second_repeated_legacy_insert")
+
+        let secondFlush = db.flushPendingStores()
+        XCTAssertEqual(secondFlush.count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path))
+
+        let contents = try chunkContents(path: dbPath)
+        XCTAssertEqual(contents.filter { $0 == "Repeated legacy queue payload with transient failure" }.count, 2)
+    }
+
     func testQueuePendingStorePreservesConcurrentFirstWrites() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -858,6 +901,20 @@ private func chunkMetadata(path: String, content: String) throws -> String? {
         return nil
     }
     return String(cString: value)
+}
+
+private func sqliteExec(path: String, sql: String) throws {
+    var db: OpaquePointer?
+    let rc = sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil)
+    guard rc == SQLITE_OK, let db else {
+        throw NSError(domain: "MCPRouterTests", code: Int(rc))
+    }
+    defer { sqlite3_close(db) }
+
+    let execRC = sqlite3_exec(db, sql, nil, nil, nil)
+    guard execRC == SQLITE_OK else {
+        throw NSError(domain: "MCPRouterTests", code: Int(execRC))
+    }
 }
 
 private func openSQLiteConnection(path: String) throws -> OpaquePointer {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -708,6 +708,43 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(contents.filter { $0 == "Legacy queue line without queue id" }.count, 1)
     }
 
+    func testQueuePendingStorePreservesConcurrentFirstWrites() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+
+        let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
+        defer { db.close() }
+
+        let iterations = 24
+        let failureLock = NSLock()
+        var failures: [String] = []
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            do {
+                try db.queuePendingStore(
+                    content: "Concurrent queue item \(index)",
+                    tags: ["queued"],
+                    importance: 5,
+                    source: "mcp"
+                )
+            } catch {
+                failureLock.lock()
+                failures.append(String(describing: error))
+                failureLock.unlock()
+            }
+        }
+
+        XCTAssertTrue(failures.isEmpty, "queuePendingStore should serialize concurrent first writes without errors: \(failures)")
+
+        let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
+        let lines = queuedText.split(whereSeparator: \.isNewline)
+        XCTAssertEqual(lines.count, iterations)
+    }
+
     func testShouldQueueOnlyTransientSQLiteStoreErrors() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -557,6 +557,10 @@ final class MCPRouterTests: XCTestCase {
 
         let result = response["result"] as? [String: Any]
         XCTAssertNil(result?["isError"])
+        XCTAssertEqual(result?["flushed_count"] as? Int, 1)
+        let flushed = result?["_brainbarFlushedQueuedChunks"] as? [[String: Any]]
+        XCTAssertEqual(flushed?.count, 1)
+        XCTAssertEqual(flushed?.first?["content"] as? String, "Queued item should flush")
         XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path), "successful store should drain the pending queue")
 
         let contents = try chunkContents(path: dbPath)
@@ -601,6 +605,10 @@ final class MCPRouterTests: XCTestCase {
 
         let result = response["result"] as? [String: Any]
         XCTAssertNil(result?["isError"])
+        XCTAssertEqual(result?["flushed_count"] as? Int, 1)
+        let flushed = result?["_brainbarFlushedQueuedChunks"] as? [[String: Any]]
+        XCTAssertEqual(flushed?.count, 1)
+        XCTAssertEqual(flushed?.first?["content"] as? String, "Queued valid item survives malformed sibling")
 
         let remainingText = try String(contentsOf: queuePath, encoding: .utf8)
         XCTAssertEqual(remainingText.trimmingCharacters(in: .whitespacesAndNewlines), "not-json")

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -835,6 +835,44 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(try posixPermissions(path: queuePath), 0o600)
     }
 
+    func testQueuePendingStoreRejectsAppendsPastConfiguredLineCap() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
+        let restoreMaxLines = setPendingStoreQueueMaxLines(3)
+        defer { restoreMaxLines() }
+
+        let db = BrainDatabase(path: tempDir.appendingPathComponent("brainbar.db").path)
+        defer { db.close() }
+
+        for index in 0..<3 {
+            try db.queuePendingStore(
+                content: "Queued item \(index)",
+                tags: ["queued"],
+                importance: 5,
+                source: "mcp"
+            )
+        }
+
+        XCTAssertThrowsError(try db.queuePendingStore(
+            content: "Rejected queued item",
+            tags: ["queued"],
+            importance: 5,
+            source: "mcp"
+        ))
+
+        let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
+        let lines = queuedText.split(whereSeparator: \.isNewline)
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertTrue(queuedText.contains("Queued item 0"))
+        XCTAssertTrue(queuedText.contains("Queued item 2"))
+        XCTAssertFalse(queuedText.contains("Rejected queued item"))
+        XCTAssertEqual(try posixPermissions(path: queuePath), 0o600)
+    }
+
     func testBrainStoreFlushRewriteKeepsQueueFilePrivate() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -906,6 +944,19 @@ private func setPendingStoreQueuePath(_ path: URL) -> () -> Void {
             setenv("BRAINBAR_PENDING_STORES_PATH", previous, 1)
         } else {
             unsetenv("BRAINBAR_PENDING_STORES_PATH")
+        }
+    }
+}
+
+private func setPendingStoreQueueMaxLines(_ maxLines: Int) -> () -> Void {
+    let key = "BRAINBAR_PENDING_STORES_MAX_LINES"
+    let previous = ProcessInfo.processInfo.environment[key]
+    setenv(key, String(maxLines), 1)
+    return {
+        if let previous {
+            setenv(key, previous, 1)
+        } else {
+            unsetenv(key)
         }
     }
 }

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -796,7 +796,16 @@ final class SocketIntegrationTests: XCTestCase {
                     guard let clLine = headerStr.split(separator: "\r\n").first(where: { $0.hasPrefix("Content-Length:") }) else {
                         break
                     }
-                    let cl = Int(clLine.split(separator: ":")[1].trimmingCharacters(in: .whitespaces)) ?? 0
+                    let headerParts = clLine.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+                    guard headerParts.count == 2,
+                          let cl = Int(headerParts[1].trimmingCharacters(in: .whitespaces)),
+                          cl >= 0 else {
+                        throw NSError(
+                            domain: "test",
+                            code: 5,
+                            userInfo: [NSLocalizedDescriptionKey: "Malformed Content-Length header"]
+                        )
+                    }
                     let bodyStart = headerEnd.upperBound
                     guard buffer.count >= bodyStart + cl else {
                         break

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -342,8 +342,15 @@ final class SocketIntegrationTests: XCTestCase {
 
         server.stop()
         let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let previousQueuePath = ProcessInfo.processInfo.environment["BRAINBAR_PENDING_STORES_PATH"]
         setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
-        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        defer {
+            if let previousQueuePath {
+                setenv("BRAINBAR_PENDING_STORES_PATH", previousQueuePath, 1)
+            } else {
+                unsetenv("BRAINBAR_PENDING_STORES_PATH")
+            }
+        }
         server = BrainBarServer(socketPath: testSocketPath, dbPath: dbPath)
         server.start()
         Thread.sleep(forTimeInterval: 0.2)

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -328,6 +328,78 @@ final class SocketIntegrationTests: XCTestCase {
         XCTAssertFalse(clearedText.contains("Live push message for agent live"), "Acked chunk should no longer be unread")
     }
 
+    func testFlushedQueuedStoreAlsoPushesChannelNotification() throws {
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("brainbar-flush-notify-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let queuedPayload = """
+        {"content":"Queued subscriber message","tags":["agent-message"],"importance":4,"source":"mcp"}
+        """
+        try queuedPayload.write(to: queuePath, atomically: true, encoding: .utf8)
+
+        server.stop()
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer { unsetenv("BRAINBAR_PENDING_STORES_PATH") }
+        server = BrainBarServer(socketPath: testSocketPath, dbPath: dbPath)
+        server.start()
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let subscriberFD = try connectClient()
+        defer { close(subscriberFD) }
+
+        try initializeClient(fd: subscriberFD, name: "subscriber-flush")
+        try sendMCPRequest(on: subscriberFD, request: [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_subscribe",
+                "arguments": [
+                    "agent_id": "agent-flush",
+                    "tags": ["agent-message"]
+                ] as [String: Any]
+            ]
+        ])
+        _ = try readMCPMessage(fd: subscriberFD)
+
+        _ = try sendMCPRequest([
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": "2024-11-05",
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": "publisher-flush", "version": "1.0"]
+            ]
+        ])
+
+        let publishResponse = try sendMCPRequest([
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Live trigger message",
+                    "tags": ["agent-message"],
+                    "importance": 6
+                ] as [String: Any]
+            ]
+        ])
+        XCTAssertNil(publishResponse["error"])
+
+        let notifications = try readMCPMessages(fd: subscriberFD, expectedCount: 2)
+        let receivedContents = notifications.compactMap {
+            ($0["params"] as? [String: Any])?["content"] as? String
+        }
+
+        XCTAssertEqual(Set(receivedContents), Set(["Live trigger message", "Queued subscriber message"]))
+    }
+
     func testDeadSubscriberDoesNotBlockLiveSubscriberNotification() throws {
         let deadFD = try connectClient()
         try initializeClient(fd: deadFD, name: "dead-subscriber")
@@ -699,24 +771,35 @@ final class SocketIntegrationTests: XCTestCase {
     }
 
     private func readMCPMessage(fd: Int32, timeout: TimeInterval = 5.0) throws -> [String: Any] {
+        return try readMCPMessages(fd: fd, expectedCount: 1, timeout: timeout).first ?? [:]
+    }
+
+    private func readMCPMessages(fd: Int32, expectedCount: Int, timeout: TimeInterval = 5.0) throws -> [[String: Any]] {
         var buffer = Data()
         var readBuf = [UInt8](repeating: 0, count: 65536)
         let deadline = Date().addingTimeInterval(timeout)
+        var messages: [[String: Any]] = []
 
         while Date() < deadline {
             let n = read(fd, &readBuf, readBuf.count)
             if n > 0 {
                 buffer.append(contentsOf: readBuf[0..<n])
-                // Try to parse Content-Length framed response
-                if let headerEnd = buffer.range(of: Data("\r\n\r\n".utf8)) {
+                while let headerEnd = buffer.range(of: Data("\r\n\r\n".utf8)) {
                     let headerStr = String(data: buffer[buffer.startIndex..<headerEnd.lowerBound], encoding: .utf8) ?? ""
-                    if let clLine = headerStr.split(separator: "\r\n").first(where: { $0.hasPrefix("Content-Length:") }) {
-                        let cl = Int(clLine.split(separator: ":")[1].trimmingCharacters(in: .whitespaces)) ?? 0
-                        let bodyStart = headerEnd.upperBound
-                        if buffer.count >= bodyStart + cl {
-                            let bodyData = buffer[bodyStart..<(bodyStart + cl)]
-                            return try JSONSerialization.jsonObject(with: bodyData) as? [String: Any] ?? [:]
-                        }
+                    guard let clLine = headerStr.split(separator: "\r\n").first(where: { $0.hasPrefix("Content-Length:") }) else {
+                        break
+                    }
+                    let cl = Int(clLine.split(separator: ":")[1].trimmingCharacters(in: .whitespaces)) ?? 0
+                    let bodyStart = headerEnd.upperBound
+                    guard buffer.count >= bodyStart + cl else {
+                        break
+                    }
+                    let bodyData = buffer[bodyStart..<(bodyStart + cl)]
+                    let message = try JSONSerialization.jsonObject(with: bodyData) as? [String: Any] ?? [:]
+                    messages.append(message)
+                    buffer.removeSubrange(buffer.startIndex..<(bodyStart + cl))
+                    if messages.count == expectedCount {
+                        return messages
                     }
                 }
             } else if n == 0 {


### PR DESCRIPTION
## Summary
- add the documented `pending-stores.jsonl` dead-letter queue to the active Swift BrainBar `brain_store` path
- piggyback-flush queued stores on the next successful Swift write so the live MCP route now matches the intended fallback architecture
- harden the Swift queue path after review by making metadata encoding safe, avoiding destructive append/rewrite behavior, and publishing subscriber notifications for flushed queued writes
- make post-store `ANALYZE` refresh best-effort so an already-persisted write cannot surface as a false caller-visible failure

## Root Cause
The queue bug was routing, not retry policy. In this environment `brain_store` traffic is handled by Swift BrainBar over `/tmp/brainbar.sock`, so SQLite failures on that path bypassed the existing Python sidecar queue entirely.

## Architecture
This PR restores the documented write path on the active Swift route:

`WAL + 30s timeout -> pending-stores.jsonl dead-letter queue -> piggyback reconciler`

## Verification
Green for the changed scope:
- `swift test --package-path /Users/etanheyman/Gits/brainlayer/brain-bar --filter MCPRouterTests/testBrainStore` -> 3 passed
- `swift test --package-path /Users/etanheyman/Gits/brainlayer/brain-bar --filter SocketIntegrationTests/testFlushedQueuedStoreAlsoPushesChannelNotification` -> 1 passed
- `swift test --package-path /Users/etanheyman/Gits/brainlayer/brain-bar` -> 278 passed
- `pytest tests/test_write_queue.py` -> 13 passed

Additional branch gate verification during push:
- `pytest unit suite` -> 1781 passed, 2 skipped, 75 deselected, 1 xfailed
- `pytest MCP tool registration` -> 3 passed
- `pytest isolated eval and hook routing` -> 32 passed
- `bun test suite` -> 1 passed
- `test_fts5_determinism.sh` -> passed

## Out Of Scope
This PR does not change Python dependency hygiene.

During earlier local exploration, a broad unscoped `pytest` collection in a different environment had exposed pre-existing dependency drift unrelated to this Swift queue fix:
- missing `deepchecks`
- `numba` vs `numpy 2.4` mismatch

Proposed follow-up: handle that separately in a dependency-maintenance PR by pinning or upgrading the affected packages and re-baselining the full Python environment.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `brain_store` queue fallback to handle transient SQLite lock errors in BrainBar
> - `MCPRouter.handleBrainStore` now catches transient SQLite lock/busy errors and queues the store to a file-backed JSONL queue instead of failing, returning `queued: true` in the response metadata.
> - On successful stores, any pending queued items are flushed and returned alongside the main stored chunk in `_brainbarFlushedQueuedChunks`.
> - `BrainBarServer` adds `publishStoredChunks` to publish channel notifications for both the directly stored chunk and any flushed queued chunks.
> - `BrainDatabase` gains a file-backed pending store queue with process-level flock locking, capacity enforcement via env var, atomic writes, 0600 permissions, and an expression index on `chunks(metadata->$.brainbar_queue_id)` for deduplication.
> - Risk: the new expression index is created on every `openAndConfigure()` call; existing databases with malformed metadata are handled via migration logic in tests but behavior on production legacy schemas should be verified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4355fa9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-disk queued fallback for transient store failures with per-item importance and defaulting, deterministic queue IDs, deduplicated replay, and flushed queued items delivered alongside live stores.
  * Optional selective refresh of search statistics and faster queue-id lookup for efficient replay.

* **Tests**
  * Expanded unit and integration tests covering queuing, flushing, concurrency, malformed-queue tolerance, idempotency, and socket notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a disk-backed dead-letter queue and replay/dedupe logic for `brain_store`, changing write-time error handling and introducing a new persistence path that could affect data integrity and notification delivery if buggy.
> 
> **Overview**
> **Fixes `brain_store` reliability under transient SQLite lock/busy errors** by queuing failed writes to a `pending-stores.jsonl` file (path override via `BRAINBAR_PENDING_STORES_PATH`) instead of surfacing an error, then piggyback-flushing that queue on the next successful store.
> 
> **Adds idempotent replay/deduplication** by writing a `brainbar_queue_id` into chunk metadata, creating an expression index on `json_extract(metadata, '$.brainbar_queue_id')`, and skipping queued items already persisted.
> 
> **Updates live push behavior and responses** so `brain_store` responses include `queued`, `flushed_count`, and `_brainbarFlushedQueuedChunks`, and `BrainBarServer` now publishes channel notifications for both the immediate stored chunk and any flushed queued chunks. Search `ANALYZE` refresh after store is now best-effort to avoid turning post-write maintenance failures into user-visible errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5938be67fedcf70da6deb9e08f7c62b772e83c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->