### PR TITLE
feat: add lexical defense dictionary exports

### DIFF
--- a/scripts/export_lexical_defense_snapshot.py
+++ b/scripts/export_lexical_defense_snapshot.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from brainlayer.lexical_defense import load_lexical_defense_dictionary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export lexical-defense artifacts for downstream consumers.")
+    parser.add_argument(
+        "--format",
+        choices=("json", "voicelayer", "gbnf"),
+        default="json",
+        help="Output artifact format.",
+    )
+    parser.add_argument("--output", type=Path, required=True, help="Destination file path.")
+    args = parser.parse_args()
+
+    dictionary = load_lexical_defense_dictionary()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.format == "json":
+        payload = {
+            "version": dictionary.version,
+            "generated_at": dictionary.generated_at,
+            "entries": [
+                {
+                    "canonical": entry.canonical,
+                    "category": entry.category,
+                    "script": entry.script,
+                    "protect_from_split": entry.protect_from_split,
+                    "swift_override_priority": entry.swift_override_priority,
+                    "aliases": list(entry.aliases),
+                    "split_forms": list(entry.split_forms),
+                    "sources": list(entry.sources),
+                }
+                for entry in dictionary.entries
+            ],
+        }
+        args.output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        return 0
+
+    if args.format == "voicelayer":
+        args.output.write_text(
+            json.dumps(dictionary.voicelayer_snapshot(), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+
+    args.output.write_text(dictionary.whisper_entity_gbnf() + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/lexical_defense.py
+++ b/src/brainlayer/lexical_defense.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import unicodedata
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+DATA_PATH = Path(__file__).resolve().with_name("lexical_defense_dictionary.json")
+
+
+def _normalize_surface(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold().strip()
+    return "".join(ch for ch in normalized if ch.isalnum())
+
+
+@dataclass(frozen=True)
+class LexicalDefenseEntry:
+    canonical: str
+    category: str
+    script: str
+    protect_from_split: bool
+    swift_override_priority: int
+    aliases: tuple[str, ...]
+    split_forms: tuple[str, ...]
+    sources: tuple[str, ...]
+
+    @property
+    def all_surfaces(self) -> tuple[str, ...]:
+        surfaces = [self.canonical, *self.aliases, *self.split_forms]
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for surface in surfaces:
+            if surface not in seen:
+                deduped.append(surface)
+                seen.add(surface)
+        return tuple(deduped)
+
+
+class LexicalDefenseDictionary:
+    def __init__(self, version: str, generated_at: str, entries: list[LexicalDefenseEntry]):
+        self.version = version
+        self.generated_at = generated_at
+        self.entries = tuple(entries)
+        self.by_canonical = {entry.canonical: entry for entry in self.entries}
+        self.by_surface = self._build_surface_index()
+        self.replacement_map = self._build_replacement_map()
+
+    def _build_surface_index(self) -> dict[str, LexicalDefenseEntry]:
+        index: dict[str, LexicalDefenseEntry] = {}
+        for entry in self.entries:
+            for surface in entry.all_surfaces:
+                index[_normalize_surface(surface)] = entry
+        return index
+
+    def _build_replacement_map(self) -> dict[str, str]:
+        pairs: dict[str, str] = {}
+        for entry in self.entries:
+            for split_form in entry.split_forms:
+                pairs[split_form] = entry.canonical
+        return dict(sorted(pairs.items(), key=lambda item: (-len(item[0]), item[0])))
+
+    def lookup(self, surface: str) -> LexicalDefenseEntry | None:
+        return self.by_surface.get(_normalize_surface(surface))
+
+    def protected_entities(self) -> list[str]:
+        return [entry.canonical for entry in self.entries if entry.protect_from_split]
+
+    def grammar_literals(self) -> list[str]:
+        literals: set[str] = set()
+        for entry in self.entries:
+            literals.add(entry.canonical)
+            literals.update(entry.aliases)
+        return sorted(literals, key=lambda value: (-len(value), value.casefold()))
+
+    def slm_entity_lines(self) -> list[str]:
+        return [f"- {entry.canonical} [{entry.category}]" for entry in self.entries if entry.protect_from_split]
+
+    def swift_override_patterns(self) -> list[dict[str, str | int]]:
+        patterns: list[dict[str, str | int]] = []
+        for entry in sorted(self.entries, key=lambda item: (-item.swift_override_priority, item.canonical.casefold())):
+            for split_form in entry.split_forms:
+                patterns.append(
+                    {
+                        "match": split_form,
+                        "replacement": entry.canonical,
+                        "priority": entry.swift_override_priority,
+                    }
+                )
+        return patterns
+
+    def voicelayer_snapshot(self) -> dict[str, object]:
+        return {
+            "updated_at": self.generated_at,
+            "prompt_terms": self.protected_entities(),
+            "aliases": [
+                {"from": match, "to": replacement}
+                for match, replacement in self.replacement_map.items()
+            ],
+        }
+
+    def whisper_entity_gbnf(self) -> str:
+        protected = [entry for entry in self.entries if entry.protect_from_split]
+        lines = ["root ::= protected_entity", ""]
+        lines.append(
+            "protected_entity ::= "
+            + " | ".join(f"entity_{index}" for index, _entry in enumerate(protected))
+        )
+        lines.append("")
+        for index, entry in enumerate(protected):
+            literal = entry.canonical.replace("\\", "\\\\").replace('"', '\\"')
+            lines.append(f'entity_{index} ::= "{literal}"')
+        return "\n".join(lines)
+
+
+def _load_entries(payload: dict) -> list[LexicalDefenseEntry]:
+    return [
+        LexicalDefenseEntry(
+            canonical=item["canonical"],
+            category=item["category"],
+            script=item["script"],
+            protect_from_split=item["protect_from_split"],
+            swift_override_priority=item["swift_override_priority"],
+            aliases=tuple(item.get("aliases", [])),
+            split_forms=tuple(item.get("split_forms", [])),
+            sources=tuple(item.get("sources", [])),
+        )
+        for item in payload["entries"]
+    ]
+
+
+@lru_cache(maxsize=1)
+def load_lexical_defense_dictionary(path: Path | None = None) -> LexicalDefenseDictionary:
+    dictionary_path = path or DATA_PATH
+    payload = json.loads(dictionary_path.read_text(encoding="utf-8"))
+    return LexicalDefenseDictionary(
+        version=payload["version"],
+        generated_at=payload["generated_at"],
+        entries=_load_entries(payload),
+    )

--- a/src/brainlayer/lexical_defense.py
+++ b/src/brainlayer/lexical_defense.py
@@ -93,19 +93,13 @@ class LexicalDefenseDictionary:
         return {
             "updated_at": self.generated_at,
             "prompt_terms": self.protected_entities(),
-            "aliases": [
-                {"from": match, "to": replacement}
-                for match, replacement in self.replacement_map.items()
-            ],
+            "aliases": [{"from": match, "to": replacement} for match, replacement in self.replacement_map.items()],
         }
 
     def whisper_entity_gbnf(self) -> str:
         protected = [entry for entry in self.entries if entry.protect_from_split]
         lines = ["root ::= protected_entity", ""]
-        lines.append(
-            "protected_entity ::= "
-            + " | ".join(f"entity_{index}" for index, _entry in enumerate(protected))
-        )
+        lines.append("protected_entity ::= " + " | ".join(f"entity_{index}" for index, _entry in enumerate(protected)))
         lines.append("")
         for index, entry in enumerate(protected):
             literal = entry.canonical.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/brainlayer/lexical_defense_dictionary.json
+++ b/src/brainlayer/lexical_defense_dictionary.json
@@ -1,0 +1,246 @@
+{
+  "version": "2026-04-30.1",
+  "generated_at": "2026-04-30T01:50:00+03:00",
+  "entries": [
+    {
+      "canonical": "BrainLayer",
+      "category": "domain_entity",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 100,
+      "aliases": ["brainlayer"],
+      "split_forms": ["brain layer"],
+      "sources": ["wispr_dictionary", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "VoiceLayer",
+      "category": "domain_entity",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 100,
+      "aliases": ["voicelayer"],
+      "split_forms": ["voice layer", "voice slate"],
+      "sources": ["wispr_dictionary", "wispr_replacement", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "BrainBar",
+      "category": "domain_entity",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 95,
+      "aliases": ["brainbar"],
+      "split_forms": ["brain bar"],
+      "sources": ["wispr_dictionary", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "VoiceBar",
+      "category": "domain_entity",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 95,
+      "aliases": ["voicebar"],
+      "split_forms": ["voice bar"],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "repoGolem",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 92,
+      "aliases": ["repogolem"],
+      "split_forms": ["repo golem", "repo golden"],
+      "sources": ["wispr_dictionary", "wispr_replacement", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "orcClaude",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 92,
+      "aliases": ["orcclaude"],
+      "split_forms": ["orc claude", "orc-cloud"],
+      "sources": ["wispr_dictionary", "wispr_replacement", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "cmux",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 90,
+      "aliases": ["Cmux"],
+      "split_forms": [],
+      "sources": ["wispr_dictionary", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "CmuxLayer",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 89,
+      "aliases": ["cmuxlayer"],
+      "split_forms": ["cmux layer"],
+      "sources": ["wispr_dictionary", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "brainlayerCodex",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 88,
+      "aliases": [],
+      "split_forms": ["brain layer codex"],
+      "sources": ["manual_seed", "user_prompt"]
+    },
+    {
+      "canonical": "voicelayerCodex",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 88,
+      "aliases": [],
+      "split_forms": ["voice layer codex", "voice layer codex-s."],
+      "sources": ["wispr_replacement", "manual_seed", "user_prompt"]
+    },
+    {
+      "canonical": "skillCreatorClaude",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 84,
+      "aliases": [],
+      "split_forms": ["skill creator claude"],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "brain_search",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 82,
+      "aliases": [],
+      "split_forms": ["brain search"],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "brain_store",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 82,
+      "aliases": [],
+      "split_forms": ["brain store"],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "brain_entity",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 82,
+      "aliases": [],
+      "split_forms": ["brain entity"],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "golems.toml",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 80,
+      "aliases": [],
+      "split_forms": ["golems tomo"],
+      "sources": ["wispr_dictionary", "wispr_replacement", "manual_seed"]
+    },
+    {
+      "canonical": "CLAUDE.md",
+      "category": "dev_term",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 80,
+      "aliases": [],
+      "split_forms": [],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "Wispr Flow",
+      "category": "domain_entity",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 78,
+      "aliases": [],
+      "split_forms": [],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "Etan Heyman",
+      "category": "english_name",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 96,
+      "aliases": ["Etan", "Heyman", "etanheyman", "Etan Joseph Heyman"],
+      "split_forms": ["etan heyman"],
+      "sources": ["wispr_dictionary", "brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "etanheyman.com",
+      "category": "domain_entity",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 76,
+      "aliases": [],
+      "split_forms": ["etan heyman dot com"],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "etan@heyman.net",
+      "category": "domain_entity",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 76,
+      "aliases": [],
+      "split_forms": ["etan heyman net"],
+      "sources": ["wispr_dictionary", "manual_seed"]
+    },
+    {
+      "canonical": "Hershkovits",
+      "category": "english_name",
+      "script": "latin",
+      "protect_from_split": true,
+      "swift_override_priority": 94,
+      "aliases": [],
+      "split_forms": [],
+      "sources": ["manual_seed", "user_prompt"]
+    },
+    {
+      "canonical": "איתן היימן",
+      "category": "hebrew_name",
+      "script": "hebrew",
+      "protect_from_split": true,
+      "swift_override_priority": 98,
+      "aliases": [],
+      "split_forms": [],
+      "sources": ["brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "איתן ג'וסף היימן",
+      "category": "hebrew_name",
+      "script": "hebrew",
+      "protect_from_split": true,
+      "swift_override_priority": 97,
+      "aliases": [],
+      "split_forms": [],
+      "sources": ["brainlayer_kg", "manual_seed"]
+    },
+    {
+      "canonical": "מהיום",
+      "category": "domain_entity",
+      "script": "hebrew",
+      "protect_from_split": true,
+      "swift_override_priority": 86,
+      "aliases": ["MeHayom", "Mehayom"],
+      "split_forms": ["me hayom"],
+      "sources": ["wispr_dictionary", "brainlayer_kg", "manual_seed"]
+    }
+  ]
+}

--- a/tests/test_lexical_defense.py
+++ b/tests/test_lexical_defense.py
@@ -1,0 +1,52 @@
+from brainlayer.lexical_defense import DATA_PATH, load_lexical_defense_dictionary
+
+
+def test_dictionary_file_exists():
+    assert DATA_PATH.exists()
+
+
+def test_lookup_matches_split_forms_and_aliases():
+    dictionary = load_lexical_defense_dictionary()
+
+    assert dictionary.lookup("brain layer").canonical == "BrainLayer"
+    assert dictionary.lookup("repo golden").canonical == "repoGolem"
+    assert dictionary.lookup("etanheyman").canonical == "Etan Heyman"
+
+
+def test_hebrew_entries_are_present():
+    dictionary = load_lexical_defense_dictionary()
+
+    entry = dictionary.lookup("איתן היימן")
+
+    assert entry is not None
+    assert entry.category == "hebrew_name"
+    assert entry.protect_from_split is True
+
+
+def test_swift_override_patterns_are_priority_sorted():
+    dictionary = load_lexical_defense_dictionary()
+
+    patterns = dictionary.swift_override_patterns()
+
+    assert patterns[0]["priority"] >= patterns[-1]["priority"]
+    assert {"match": "brain layer", "replacement": "BrainLayer", "priority": 100} in patterns
+    assert {"match": "voice layer", "replacement": "VoiceLayer", "priority": 100} in patterns
+
+
+def test_voicelayer_snapshot_contains_prompt_terms_and_aliases():
+    dictionary = load_lexical_defense_dictionary()
+
+    snapshot = dictionary.voicelayer_snapshot()
+
+    assert "BrainLayer" in snapshot["prompt_terms"]
+    assert {"from": "brain layer", "to": "BrainLayer"} in snapshot["aliases"]
+
+
+def test_whisper_entity_gbnf_contains_protected_entities():
+    dictionary = load_lexical_defense_dictionary()
+
+    grammar = dictionary.whisper_entity_gbnf()
+
+    assert "root ::= protected_entity" in grammar
+    assert '"BrainLayer"' in grammar
+    assert '"איתן היימן"' in grammar


### PR DESCRIPTION
## Summary
- add a checked-in lexical-defense dictionary for Hebrew names, proper nouns, and recurring ecosystem terms
- add BrainLayer exports for VoiceLayer snapshot JSON and entity-only whisper GBNF
- add contract tests for lookup, Hebrew entries, Swift override ordering, and downstream export shapes

## Verification
- `pytest -q tests/test_lexical_defense.py`
- `ruff check src/brainlayer/lexical_defense.py tests/test_lexical_defense.py scripts/export_lexical_defense_snapshot.py`
- full pre-push gate passed:
  - `pytest unit suite` => `1787 passed, 2 skipped, 75 deselected, 1 xfailed`
  - `pytest MCP tool registration` => `3 passed`
  - `pytest isolated eval and hook routing` => `32 passed`
  - `bun test suite` => `1 pass`
  - `test_fts5_determinism.sh` => passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive (new module, data file, CLI, and tests) with no changes to existing runtime paths unless adopted by callers; main risk is downstream consumers relying on export/lookup semantics.
> 
> **Overview**
> Adds a checked-in lexical defense dictionary (`lexical_defense_dictionary.json`) plus a new `brainlayer.lexical_defense` module that loads it (LRU-cached), normalizes/looks up surfaces, and generates downstream artifacts (Swift override patterns, VoiceLayer snapshot JSON, and a Whisper protected-entity GBNF).
> 
> Introduces a CLI script `export_lexical_defense_snapshot.py` to export those artifacts in `json`, `voicelayer`, or `gbnf` formats, and adds unit tests covering lookup normalization (incl. Hebrew), export shapes, and ordering guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c2d43c4d0f68ae594e7fae37b7537e76764647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a lexical defense system to protect critical entities and terms from splitting or modification during processing.
  * Added export functionality for the protected entities dictionary, supporting JSON, VoiceLayer, and GBNF grammar formats.
  * Deployed a comprehensive dictionary of protected terms including domain entities, developer terminology, and person/entity names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lexical defense dictionary with multi-format export script
> - Introduces [`LexicalDefenseDictionary`](https://github.com/EtanHey/brainlayer/pull/262/files#diff-035dadaf40de7ebb7a927de84172e824d6e299fa74eac688730b8e5d5e1a9e21) wrapping a JSON data file with O(1) surface lookups, a pre-sorted replacement map, and methods for generating VoiceLayer snapshots, GBNF grammars, and Swift override patterns.
> - Adds [`export_lexical_defense_snapshot.py`](https://github.com/EtanHey/brainlayer/pull/262/files#diff-0e647068c59f8036ef4166843fbffff02004e8e32013ce99677d038cb1288036), a CLI script that loads the dictionary and writes output in `json`, `voicelayer`, or `gbnf` format to a specified path.
> - The dictionary loader is `lru_cache`-backed so repeated calls reuse the in-memory instance.
> - Surfaces are normalized via NFKC + casefolding before indexing to ensure consistent lookup behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61c2d43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->