### PR TITLE
feat(brainbar): stamp builds with git commit + UTC time in Info.plist

### DIFF
--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -18,6 +18,42 @@ PLIST_SRC="$BUNDLE_DIR/$PLIST_FILENAME"
 PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_FILENAME"
 LAUNCH_DOMAIN="gui/$(id -u)"
 SOCKET_PATH="${BRAINBAR_SOCKET_PATH:-/tmp/brainbar.sock}"
+PLIST_BUDDY="/usr/libexec/PlistBuddy"
+
+git_commit() {
+    git -C "$PACKAGE_DIR" rev-parse HEAD
+}
+
+git_describe() {
+    git -C "$PACKAGE_DIR" describe --always --dirty
+}
+
+build_time_utc() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+plist_set_string() {
+    local plist_path="$1"
+    local key="$2"
+    local value="$3"
+
+    if "$PLIST_BUDDY" -c "Print :$key" "$plist_path" >/dev/null 2>&1; then
+        "$PLIST_BUDDY" -c "Set :$key $value" "$plist_path"
+    else
+        "$PLIST_BUDDY" -c "Add :$key string $value" "$plist_path"
+    fi
+}
+
+stamp_info_plist() {
+    local plist_path="$1"
+    local commit_sha="$2"
+    local describe_ref="$3"
+    local build_utc="$4"
+
+    plist_set_string "$plist_path" "GitCommit" "$commit_sha"
+    plist_set_string "$plist_path" "GitDescribe" "$describe_ref"
+    plist_set_string "$plist_path" "BuildTimeUTC" "$build_utc"
+}
 
 bootout_launchagent() {
     launchctl bootout "$LAUNCH_DOMAIN/$PLIST_LABEL" 2>/dev/null || true
@@ -87,6 +123,15 @@ mkdir -p "$APP_DIR/Contents/Resources"
 
 cp "$BUNDLE_DIR/Info.plist" "$APP_DIR/Contents/"
 cp "$BINARY" "$APP_DIR/Contents/MacOS/BrainBar"
+
+COMMIT_SHA="$(git_commit)"
+DESCRIBE_REF="$(git_describe)"
+BUILD_UTC="$(build_time_utc)"
+stamp_info_plist "$APP_DIR/Contents/Info.plist" "$COMMIT_SHA" "$DESCRIBE_REF" "$BUILD_UTC"
+echo "[build-app] Stamped Info.plist:"
+echo "  GitCommit=$COMMIT_SHA"
+echo "  GitDescribe=$DESCRIBE_REF"
+echo "  BuildTimeUTC=$BUILD_UTC"
 
 # Developer signing keeps TCC permissions stable across rebuilds.
 echo "[build-app] Signing..."

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -38,9 +38,9 @@ plist_set_string() {
     local value="$3"
 
     if "$PLIST_BUDDY" -c "Print :$key" "$plist_path" >/dev/null 2>&1; then
-        "$PLIST_BUDDY" -c "Set :$key $value" "$plist_path"
+        "$PLIST_BUDDY" -c "Set :$key \"$value\"" "$plist_path"
     else
-        "$PLIST_BUDDY" -c "Add :$key string $value" "$plist_path"
+        "$PLIST_BUDDY" -c "Add :$key string \"$value\"" "$plist_path"
     fi
 }
 


### PR DESCRIPTION
## Summary
- stamp BrainBar builds with `GitCommit`, `GitDescribe`, and `BuildTimeUTC` in `Info.plist`
- write the stamp during `brain-bar/build-app.sh` before signing so deployed bundles carry provenance
- keep the PR atomic to the build script only

## Why
- Phase B needs direct provenance on the installed bundle so old-version resurrection is diagnosable in seconds instead of by filesystem archaeology
- this is the first guardrail before rejecting non-canonical installs in the next step

## Verification
- `bash -n brain-bar/build-app.sh`
- `uv sync --extra dev --extra cloud`
- `uv run --extra dev pytest -v --tb=short tests/test_git_learning.py::test_brain_learn_git_seeds_single_repo_without_duplicates tests/test_phase3_digest.py::test_digest_content_returns_structured_result tests/test_phase3_digest.py::test_digest_content_creates_chunk tests/test_phase3_digest.py::test_digest_content_extracts_entities tests/test_phase3_digest.py::test_digest_content_applies_sentiment tests/test_phase3_digest.py::test_digest_content_confidence_tiers tests/test_phase3_digest.py::test_digest_extracts_action_items tests/test_phase3_digest.py::test_full_digest_pipeline tests/test_smart_search_entity_dedup.py::TestDigestEntityDedup::test_digest_deduplicates_repeated_entity_mentions tests/test_smart_search_entity_dedup.py::TestDigestEntityDedup::test_digest_deduplicates_case_variants`
- `bash scripts/run_tests.sh`

## Context
- Collab: `orchestrator/collab/2026-05-01-brainlayer-split-brain-architecture-decision.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build-script-only change that adds metadata to the generated `.app` bundle; main risk is build failures on environments lacking `git` metadata or `PlistBuddy` behavior differences.
> 
> **Overview**
> Adds build provenance stamping to `brain-bar/build-app.sh` by writing `GitCommit`, `GitDescribe`, and `BuildTimeUTC` into the generated app bundle’s `Info.plist` (via `PlistBuddy`) *before* codesigning, and logs the stamped values during the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e4ae971c8e3fea8bb3b2011045bbe7b83f1322b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stamp brain-bar app bundle Info.plist with git commit and UTC build time
> Updates [build-app.sh](https://github.com/EtanHey/brainlayer/pull/264/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb) to write `GitCommit`, `GitDescribe`, and `BuildTimeUTC` keys into `Info.plist` after copying it into the app bundle. Three helper functions capture the git SHA, descriptive ref, and RFC3339 UTC timestamp, and a `plist_set_string` helper uses `PlistBuddy` to add or update each key. The stamped values are printed to stdout during the build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e4ae97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now embeds Git metadata (commit reference and descriptive tag) and a UTC build timestamp into the app bundle and logs these values during the build, improving traceability and build diagnostics prior to code signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->