### PR TITLE
feat(brainbar): explicit trigram maintenance command (operator-triggered, lock-aware)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -444,6 +444,7 @@ private struct BrainBarDashboardView: View {
                 ("Daemon", daemonSummary),
                 ("Agents", collector.agentActivity.summaryText),
                 ("State", collector.state.label),
+                ("Trigram", trigramSummary),
                 ("Last seen", daemonLastSeenSummary),
             ],
             columns: layout.diagnosticItemColumns
@@ -463,6 +464,7 @@ private struct BrainBarDashboardView: View {
                             runtimeCard
                         }
                     }
+                    BrainBarTrigramProgress(stats: collector.stats)
                 }
                 .padding(.top, 4)
             } label: {
@@ -507,6 +509,30 @@ private struct BrainBarDashboardView: View {
             lastEventAt: daemon.lastSeenAt,
             activityWindowMinutes: collector.stats.activityWindowMinutes
         )
+    }
+
+    private var trigramSummary: String {
+        "\(collector.stats.trigramIndexedChunkCount)/\(collector.stats.chunkCount) · " +
+            String(format: "%.0f%%", collector.stats.trigramCoveragePercent)
+    }
+}
+
+private struct BrainBarTrigramProgress: View {
+    let stats: BrainDatabase.DashboardStats
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Trigram maintenance")
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer(minLength: 8)
+                Text("\(stats.trigramIndexedChunkCount)/\(stats.chunkCount)")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            ProgressView(value: min(stats.trigramCoveragePercent, 100), total: 100)
+        }
     }
 }
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -16,6 +16,7 @@ final class BrainDatabase: @unchecked Sendable {
     private static let ftsOptions = "prefix='2 3 4', tokenize='unicode61 remove_diacritics 2'"
     private static let trigramFTSOptions = "tokenize='trigram'"
     private static let synchronousTrigramBackfillChunkLimit = 10_000
+    static let maximumTrigramMaintenanceBatchSize = 10_000
     private static let defaultPendingStoreMaxLines = 10_000
     private static let pendingStoreMaxLinesEnv = "BRAINBAR_PENDING_STORES_MAX_LINES"
     private static let lexicalDefenseReplacements: [String: [String]] = [
@@ -2040,7 +2041,7 @@ final class BrainDatabase: @unchecked Sendable {
         progress: (TrigramMaintenanceProgress) -> Void = { _ in }
     ) throws -> TrigramMaintenanceProgress {
         try ensureTrigramFTSSchemaAndTriggers()
-        let batchSize = max(1, requestedBatchSize)
+        let batchSize = Self.normalizedTrigramMaintenanceBatchSize(requestedBatchSize)
         let total = try countRows(in: "chunks")
         let maxChunkRowID = try maxChunkRowID()
         var lastProcessedRowID: Int64 = 0
@@ -2124,8 +2125,13 @@ final class BrainDatabase: @unchecked Sendable {
         let rc = sqlite3_prepare_v2(db, "SELECT COALESCE(MAX(rowid), 0) FROM chunks", -1, &stmt, nil)
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
         defer { sqlite3_finalize(stmt) }
-        guard sqlite3_step(stmt) == SQLITE_ROW else { return 0 }
+        let stepRC = sqlite3_step(stmt)
+        guard stepRC == SQLITE_ROW else { throw DBError.step(stepRC) }
         return sqlite3_column_int64(stmt, 0)
+    }
+
+    static func normalizedTrigramMaintenanceBatchSize(_ requestedBatchSize: Int) -> Int {
+        min(max(1, requestedBatchSize), maximumTrigramMaintenanceBatchSize)
     }
 
     private func nextChunkBatchUpperRowID(after rowID: Int64, maxRowID: Int64, batchSize: Int) throws -> Int64? {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -2047,8 +2047,6 @@ final class BrainDatabase: @unchecked Sendable {
         var processed = 0
         let startedAt = Date()
 
-        try clearTrigramFTSTableInBatches(batchSize: batchSize, shouldCancel: shouldCancel)
-
         while processed < total,
               let upperRowID = try nextChunkBatchUpperRowID(
                 after: lastProcessedRowID,
@@ -2118,28 +2116,6 @@ final class BrainDatabase: @unchecked Sendable {
         )
         progress(done)
         return done
-    }
-
-    private func clearTrigramFTSTableInBatches(batchSize: Int, shouldCancel: () -> Bool) throws {
-        while try countRows(in: "chunks_fts_trigram") > 0 {
-            if shouldCancel() {
-                return
-            }
-
-            try withImmediateTransaction {
-                try executeUpdate(
-                    """
-                    DELETE FROM chunks_fts_trigram
-                    WHERE rowid IN (
-                        SELECT rowid FROM chunks_fts_trigram LIMIT ?
-                    )
-                    """,
-                    binds: { stmt in
-                        sqlite3_bind_int(stmt, 1, Int32(batchSize))
-                    }
-                )
-            }
-        }
     }
 
     private func maxChunkRowID() throws -> Int64 {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -2042,12 +2042,19 @@ final class BrainDatabase: @unchecked Sendable {
         try ensureTrigramFTSSchemaAndTriggers()
         let batchSize = max(1, requestedBatchSize)
         let total = try countRows(in: "chunks")
+        let maxChunkRowID = try maxChunkRowID()
+        var lastProcessedRowID: Int64 = 0
         var processed = 0
         let startedAt = Date()
 
         try clearTrigramFTSTableInBatches(batchSize: batchSize, shouldCancel: shouldCancel)
 
-        while processed < total {
+        while processed < total,
+              let upperRowID = try nextChunkBatchUpperRowID(
+                after: lastProcessedRowID,
+                maxRowID: maxChunkRowID,
+                batchSize: batchSize
+              ) {
             if shouldCancel() {
                 let cancelled = TrigramMaintenanceProgress(
                     state: .cancelled,
@@ -2059,23 +2066,35 @@ final class BrainDatabase: @unchecked Sendable {
                 return cancelled
             }
 
-            let offset = processed
             try withImmediateTransaction {
+                try executeUpdate(
+                    """
+                    DELETE FROM chunks_fts_trigram
+                    WHERE chunk_id IN (
+                        SELECT id FROM chunks WHERE rowid > ? AND rowid <= ?
+                    )
+                    """,
+                    binds: { stmt in
+                        sqlite3_bind_int64(stmt, 1, lastProcessedRowID)
+                        sqlite3_bind_int64(stmt, 2, upperRowID)
+                    }
+                )
                 try executeUpdate(
                     """
                     INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
                     SELECT content, summary, tags, NULL, id
                     FROM chunks
+                    WHERE rowid > ? AND rowid <= ?
                     ORDER BY rowid ASC
-                    LIMIT ? OFFSET ?
                     """,
                     binds: { stmt in
-                        sqlite3_bind_int(stmt, 1, Int32(batchSize))
-                        sqlite3_bind_int(stmt, 2, Int32(offset))
+                        sqlite3_bind_int64(stmt, 1, lastProcessedRowID)
+                        sqlite3_bind_int64(stmt, 2, upperRowID)
                     }
                 )
             }
 
+            lastProcessedRowID = upperRowID
             processed = min(processed + batchSize, total)
             let running = TrigramMaintenanceProgress(
                 state: .running,
@@ -2121,6 +2140,46 @@ final class BrainDatabase: @unchecked Sendable {
                 )
             }
         }
+    }
+
+    private func maxChunkRowID() throws -> Int64 {
+        guard let db else { throw DBError.notOpen }
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, "SELECT COALESCE(MAX(rowid), 0) FROM chunks", -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return 0 }
+        return sqlite3_column_int64(stmt, 0)
+    }
+
+    private func nextChunkBatchUpperRowID(after rowID: Int64, maxRowID: Int64, batchSize: Int) throws -> Int64? {
+        guard let db else { throw DBError.notOpen }
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(
+            db,
+            """
+            SELECT rowid
+            FROM (
+                SELECT rowid
+                FROM chunks
+                WHERE rowid > ? AND rowid <= ?
+                ORDER BY rowid ASC
+                LIMIT ?
+            )
+            ORDER BY rowid DESC
+            LIMIT 1
+            """,
+            -1,
+            &stmt,
+            nil
+        )
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int64(stmt, 1, rowID)
+        sqlite3_bind_int64(stmt, 2, maxRowID)
+        sqlite3_bind_int(stmt, 3, Int32(batchSize))
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        return sqlite3_column_int64(stmt, 0)
     }
 
     private static func estimatedSecondsRemaining(startedAt: Date, processed: Int, total: Int) -> Double? {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -29,6 +29,32 @@ final class BrainDatabase: @unchecked Sendable {
         case skipBackfill
     }
 
+    struct TrigramMaintenanceProgress: Sendable, Equatable {
+        enum State: String, Sendable, Equatable {
+            case running
+            case done
+            case cancelled
+            case failed
+        }
+
+        let state: State
+        let processed: Int
+        let total: Int
+        let etaSeconds: Double?
+
+        var metadata: [String: Any] {
+            var payload: [String: Any] = [
+                "state": state.rawValue,
+                "processed": processed,
+                "total": total,
+            ]
+            if let etaSeconds {
+                payload["eta_seconds"] = etaSeconds
+            }
+            return payload
+        }
+    }
+
     struct DashboardStats: Sendable, Equatable {
         let chunkCount: Int
         let enrichedChunkCount: Int
@@ -43,6 +69,7 @@ final class BrainDatabase: @unchecked Sendable {
         let liveWindowMinutes: Int
         let lastWriteAt: Date?
         let lastEnrichedAt: Date?
+        let trigramIndexedChunkCount: Int
 
         init(
             chunkCount: Int,
@@ -57,7 +84,8 @@ final class BrainDatabase: @unchecked Sendable {
             bucketCount: Int = 12,
             liveWindowMinutes: Int = 1,
             lastWriteAt: Date? = nil,
-            lastEnrichedAt: Date? = nil
+            lastEnrichedAt: Date? = nil,
+            trigramIndexedChunkCount: Int = 0
         ) {
             self.chunkCount = chunkCount
             self.enrichedChunkCount = enrichedChunkCount
@@ -72,6 +100,7 @@ final class BrainDatabase: @unchecked Sendable {
             self.liveWindowMinutes = liveWindowMinutes
             self.lastWriteAt = lastWriteAt
             self.lastEnrichedAt = lastEnrichedAt
+            self.trigramIndexedChunkCount = trigramIndexedChunkCount
         }
 
         var recentWriteCount: Int {
@@ -99,6 +128,11 @@ final class BrainDatabase: @unchecked Sendable {
 
         func hasRecentEnrichmentActivity(now: Date = Date()) -> Bool {
             eventIsLive(lastEnrichedAt, now: now) || recentEnrichmentCount > 0
+        }
+
+        var trigramCoveragePercent: Double {
+            guard chunkCount > 0 else { return 100 }
+            return (Double(trigramIndexedChunkCount) / Double(chunkCount)) * 100
         }
     }
 
@@ -1174,7 +1208,8 @@ final class BrainDatabase: @unchecked Sendable {
             bucketCount: bucketCount,
             liveWindowMinutes: liveWindowMinutes,
             lastWriteAt: lastEvents.lastWriteAt,
-            lastEnrichedAt: lastEvents.lastEnrichedAt
+            lastEnrichedAt: lastEvents.lastEnrichedAt,
+            trigramIndexedChunkCount: (try? countRows(in: "chunks_fts_trigram")) ?? 0
         )
     }
 
@@ -1997,6 +2032,102 @@ final class BrainDatabase: @unchecked Sendable {
             INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
             SELECT content, summary, tags, NULL, id FROM chunks
         """)
+    }
+
+    func triggerTrigramRebuild(
+        batchSize requestedBatchSize: Int = 1_000,
+        shouldCancel: () -> Bool = { false },
+        progress: (TrigramMaintenanceProgress) -> Void = { _ in }
+    ) throws -> TrigramMaintenanceProgress {
+        try ensureTrigramFTSSchemaAndTriggers()
+        let batchSize = max(1, requestedBatchSize)
+        let total = try countRows(in: "chunks")
+        var processed = 0
+        let startedAt = Date()
+
+        try clearTrigramFTSTableInBatches(batchSize: batchSize, shouldCancel: shouldCancel)
+
+        while processed < total {
+            if shouldCancel() {
+                let cancelled = TrigramMaintenanceProgress(
+                    state: .cancelled,
+                    processed: processed,
+                    total: total,
+                    etaSeconds: nil
+                )
+                progress(cancelled)
+                return cancelled
+            }
+
+            let offset = processed
+            try withImmediateTransaction {
+                try executeUpdate(
+                    """
+                    INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
+                    SELECT content, summary, tags, NULL, id
+                    FROM chunks
+                    ORDER BY rowid ASC
+                    LIMIT ? OFFSET ?
+                    """,
+                    binds: { stmt in
+                        sqlite3_bind_int(stmt, 1, Int32(batchSize))
+                        sqlite3_bind_int(stmt, 2, Int32(offset))
+                    }
+                )
+            }
+
+            processed = min(processed + batchSize, total)
+            let running = TrigramMaintenanceProgress(
+                state: .running,
+                processed: processed,
+                total: total,
+                etaSeconds: Self.estimatedSecondsRemaining(
+                    startedAt: startedAt,
+                    processed: processed,
+                    total: total
+                )
+            )
+            progress(running)
+        }
+
+        try execute("ANALYZE chunks_fts_trigram", retries: 3)
+        let done = TrigramMaintenanceProgress(
+            state: .done,
+            processed: total,
+            total: total,
+            etaSeconds: 0
+        )
+        progress(done)
+        return done
+    }
+
+    private func clearTrigramFTSTableInBatches(batchSize: Int, shouldCancel: () -> Bool) throws {
+        while try countRows(in: "chunks_fts_trigram") > 0 {
+            if shouldCancel() {
+                return
+            }
+
+            try withImmediateTransaction {
+                try executeUpdate(
+                    """
+                    DELETE FROM chunks_fts_trigram
+                    WHERE rowid IN (
+                        SELECT rowid FROM chunks_fts_trigram LIMIT ?
+                    )
+                    """,
+                    binds: { stmt in
+                        sqlite3_bind_int(stmt, 1, Int32(batchSize))
+                    }
+                )
+            }
+        }
+    }
+
+    private static func estimatedSecondsRemaining(startedAt: Date, processed: Int, total: Int) -> Double? {
+        guard processed > 0, total > processed else { return nil }
+        let elapsed = Date().timeIntervalSince(startedAt)
+        let rate = Double(processed) / max(elapsed, 0.001)
+        return Double(total - processed) / rate
     }
 
     private func rebuildTrigramFTSTableIfNeeded() throws {

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -590,11 +590,17 @@ final class MCPRouter: @unchecked Sendable {
         guard let db = database else { throw ToolError.noDatabase }
         let batchSize = args["batch_size"] as? Int ?? 1_000
         let cancelRequested = args["cancel"] as? Bool ?? false
+        let maxReturnedEvents = 25
         var events: [BrainDatabase.TrigramMaintenanceProgress] = []
         let final = try db.triggerTrigramRebuild(
             batchSize: batchSize,
             shouldCancel: { cancelRequested },
-            progress: { event in events.append(event) }
+            progress: { event in
+                events.append(event)
+                if events.count > maxReturnedEvents {
+                    events.removeFirst(events.count - maxReturnedEvents)
+                }
+            }
         )
         let text = "brain_maintenance_rebuild_trigram: \(final.state.rawValue) \(final.processed)/\(final.total)"
         return ToolOutput(

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -206,6 +206,8 @@ final class MCPRouter: @unchecked Sendable {
             return try handleBrainUnsubscribe(arguments)
         case "brain_ack":
             return try handleBrainAck(arguments)
+        case "brain_maintenance_rebuild_trigram":
+            return try handleBrainMaintenanceRebuildTrigram(arguments)
         default:
             throw ToolError.unknownTool(name)
         }
@@ -582,6 +584,26 @@ final class MCPRouter: @unchecked Sendable {
         }
         let content = (chunk["content"] as? String ?? "").lowercased()
         return personalKeywords.contains(where: { content.contains($0) })
+    }
+
+    private func handleBrainMaintenanceRebuildTrigram(_ args: [String: Any]) throws -> ToolOutput {
+        guard let db = database else { throw ToolError.noDatabase }
+        let batchSize = args["batch_size"] as? Int ?? 1_000
+        let cancelRequested = args["cancel"] as? Bool ?? false
+        var events: [BrainDatabase.TrigramMaintenanceProgress] = []
+        let final = try db.triggerTrigramRebuild(
+            batchSize: batchSize,
+            shouldCancel: { cancelRequested },
+            progress: { event in events.append(event) }
+        )
+        let text = "brain_maintenance_rebuild_trigram: \(final.state.rawValue) \(final.processed)/\(final.total)"
+        return ToolOutput(
+            text: text,
+            metadata: [
+                "progress": final.metadata,
+                "events": events.map(\.metadata)
+            ]
+        )
     }
 
     /// Safe JSON encoding — never use string interpolation with user data.
@@ -981,6 +1003,18 @@ final class MCPRouter: @unchecked Sendable {
                 ] as [String: Any],
                 "required": ["agent_id", "seq"]
             ] as [String: Any])
+        ],
+        [
+            "name": "brain_maintenance_rebuild_trigram",
+            "description": "Operator-triggered maintenance command to rebuild the trigram FTS table in lock-aware batches.",
+            "annotations": MCPRouter.writeIdempotentAnnotations,
+            "inputSchema": [
+                "type": "object",
+                "properties": [
+                    "batch_size": ["type": "integer", "description": "Rows to backfill per write transaction (default: 1000)"],
+                    "cancel": ["type": "boolean", "description": "Return a cancelled state before starting work"],
+                ] as [String: Any]
+            ] as [String: Any]
         ],
     ]
 }

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -587,9 +587,25 @@ final class MCPRouter: @unchecked Sendable {
     }
 
     private func handleBrainMaintenanceRebuildTrigram(_ args: [String: Any]) throws -> ToolOutput {
+        let cancelRequested = args["cancel"] as? Bool ?? false
+        if cancelRequested {
+            let final = BrainDatabase.TrigramMaintenanceProgress(
+                state: .cancelled,
+                processed: 0,
+                total: 0,
+                etaSeconds: nil
+            )
+            return ToolOutput(
+                text: "brain_maintenance_rebuild_trigram: cancelled 0/0",
+                metadata: [
+                    "progress": final.metadata,
+                    "events": [final.metadata]
+                ]
+            )
+        }
+
         guard let db = database else { throw ToolError.noDatabase }
         let batchSize = args["batch_size"] as? Int ?? 1_000
-        let cancelRequested = args["cancel"] as? Bool ?? false
         let maxReturnedEvents = 25
         var events: [BrainDatabase.TrigramMaintenanceProgress] = []
         let final = try db.triggerTrigramRebuild(

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -270,6 +270,36 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 5)
     }
 
+    func testTriggerTrigramRebuildDoesNotDuplicateRowsWhenChunkUpdatesBetweenBatches() throws {
+        try seedTrigramMaintenanceRows(count: 4)
+        try sqliteExecWrite(path: tempDBPath, sql: "DELETE FROM chunks_fts_trigram")
+
+        var updatedDuringProgress = false
+        let final = try db.triggerTrigramRebuild(batchSize: 2, progress: { event in
+            guard event.state == .running, !updatedDuringProgress else { return }
+            updatedDuringProgress = true
+            try? sqliteExecWrite(
+                path: self.tempDBPath,
+                sql: """
+                    UPDATE chunks
+                    SET content = 'Updated not-yet-processed chunk during trigram maintenance'
+                    WHERE id = 'trigram-maintenance-3'
+                """
+            )
+        })
+
+        XCTAssertEqual(final.state, .done)
+        XCTAssertTrue(updatedDuringProgress)
+        XCTAssertEqual(
+            try sqliteCount(
+                path: tempDBPath,
+                sql: "SELECT COUNT(*) FROM chunks_fts_trigram WHERE chunk_id = 'trigram-maintenance-3'"
+            ),
+            1
+        )
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 4)
+    }
+
     func testUpsertSubscriptionRecoversMissingPubSubTables() throws {
         db.exec("DROP TABLE IF EXISTS brainbar_subscriptions")
         db.exec("DROP TABLE IF EXISTS brainbar_agents")
@@ -971,10 +1001,14 @@ private func sqliteExecWrite(path: String, sql: String) throws {
 }
 
 private func sqliteCount(path: String, table: String) throws -> Int {
+    try sqliteCount(path: path, sql: "SELECT COUNT(*) FROM \(table)")
+}
+
+private func sqliteCount(path: String, sql: String) throws -> Int {
     try withSQLiteConnection(path: path) { db in
         try scalarInt(
             db: db,
-            sql: "SELECT COUNT(*) FROM \(table)",
+            sql: sql,
             bind: { _ in }
         )
     }

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -197,6 +197,15 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(decision, .skipBackfill)
     }
 
+    func testTrigramMaintenanceBatchSizeIsClampedForExternalInput() {
+        XCTAssertEqual(BrainDatabase.normalizedTrigramMaintenanceBatchSize(0), 1)
+        XCTAssertEqual(BrainDatabase.normalizedTrigramMaintenanceBatchSize(42), 42)
+        XCTAssertEqual(
+            BrainDatabase.normalizedTrigramMaintenanceBatchSize(Int.max),
+            BrainDatabase.maximumTrigramMaintenanceBatchSize
+        )
+    }
+
     func testTriggerTrigramRebuildBackfillsInBatchesWithProgress() throws {
         try seedTrigramMaintenanceRows(count: 5)
         try sqliteExecWrite(path: tempDBPath, sql: "DELETE FROM chunks_fts_trigram")

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -233,38 +233,60 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(events.last?.state, .cancelled)
     }
 
+    func testTriggerTrigramRebuildCancellationPreservesUnprocessedLiveRows() throws {
+        try seedTrigramMaintenanceRows(count: 5)
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 5)
+
+        var events: [BrainDatabase.TrigramMaintenanceProgress] = []
+        let final = try db.triggerTrigramRebuild(
+            batchSize: 2,
+            shouldCancel: { !events.isEmpty },
+            progress: { event in events.append(event) }
+        )
+
+        XCTAssertEqual(final.state, .cancelled)
+        XCTAssertEqual(final.processed, 2)
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 5)
+    }
+
     func testTriggerTrigramRebuildAllowsWritersBetweenBatches() throws {
         try seedTrigramMaintenanceRows(count: 4)
         try sqliteExecWrite(path: tempDBPath, sql: "DELETE FROM chunks_fts_trigram")
 
         var insertedDuringProgress = false
+        var concurrentInsertError: Error?
         let final = try db.triggerTrigramRebuild(batchSize: 2, progress: { event in
             guard event.state == .running, !insertedDuringProgress else { return }
-            insertedDuringProgress = true
-            try? sqliteExecWrite(
-                path: self.tempDBPath,
-                sql: """
-                    INSERT INTO chunks (
-                        id, content, metadata, source_file, project, content_type, importance, conversation_id, char_count, tags, summary, preview_text
-                    ) VALUES (
-                        'trigram-concurrent-writer',
-                        'Concurrent writer should acquire the lock between trigram batches',
-                        '{}',
-                        'brainbar',
-                        'brainlayer',
-                        'assistant_text',
-                        5,
-                        'trigram-maintenance',
-                        67,
-                        '[]',
-                        '',
-                        'Concurrent writer should acquire the lock between trigram batches'
-                    )
-                """
-            )
+            do {
+                try sqliteExecWrite(
+                    path: self.tempDBPath,
+                    sql: """
+                        INSERT INTO chunks (
+                            id, content, metadata, source_file, project, content_type, importance, conversation_id, char_count, tags, summary, preview_text
+                        ) VALUES (
+                            'trigram-concurrent-writer',
+                            'Concurrent writer should acquire the lock between trigram batches',
+                            '{}',
+                            'brainbar',
+                            'brainlayer',
+                            'assistant_text',
+                            5,
+                            'trigram-maintenance',
+                            67,
+                            '[]',
+                            '',
+                            'Concurrent writer should acquire the lock between trigram batches'
+                        )
+                    """
+                )
+                insertedDuringProgress = true
+            } catch {
+                concurrentInsertError = error
+            }
         })
 
         XCTAssertEqual(final.state, .done)
+        XCTAssertNil(concurrentInsertError)
         XCTAssertTrue(insertedDuringProgress)
         XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks"), 5)
         XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 5)
@@ -275,20 +297,26 @@ final class DatabaseTests: XCTestCase {
         try sqliteExecWrite(path: tempDBPath, sql: "DELETE FROM chunks_fts_trigram")
 
         var updatedDuringProgress = false
+        var concurrentUpdateError: Error?
         let final = try db.triggerTrigramRebuild(batchSize: 2, progress: { event in
             guard event.state == .running, !updatedDuringProgress else { return }
-            updatedDuringProgress = true
-            try? sqliteExecWrite(
-                path: self.tempDBPath,
-                sql: """
-                    UPDATE chunks
-                    SET content = 'Updated not-yet-processed chunk during trigram maintenance'
-                    WHERE id = 'trigram-maintenance-3'
-                """
-            )
+            do {
+                try sqliteExecWrite(
+                    path: self.tempDBPath,
+                    sql: """
+                        UPDATE chunks
+                        SET content = 'Updated not-yet-processed chunk during trigram maintenance'
+                        WHERE id = 'trigram-maintenance-3'
+                    """
+                )
+                updatedDuringProgress = true
+            } catch {
+                concurrentUpdateError = error
+            }
         })
 
         XCTAssertEqual(final.state, .done)
+        XCTAssertNil(concurrentUpdateError)
         XCTAssertTrue(updatedDuringProgress)
         XCTAssertEqual(
             try sqliteCount(

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -197,6 +197,79 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(decision, .skipBackfill)
     }
 
+    func testTriggerTrigramRebuildBackfillsInBatchesWithProgress() throws {
+        try seedTrigramMaintenanceRows(count: 5)
+        try sqliteExecWrite(path: tempDBPath, sql: "DELETE FROM chunks_fts_trigram")
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 0)
+
+        var events: [BrainDatabase.TrigramMaintenanceProgress] = []
+        let final = try db.triggerTrigramRebuild(batchSize: 2, progress: { event in
+            events.append(event)
+        })
+
+        XCTAssertEqual(final.state, .done)
+        XCTAssertEqual(final.total, 5)
+        XCTAssertEqual(final.processed, 5)
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 5)
+        XCTAssertGreaterThanOrEqual(events.filter { $0.state == .running }.count, 2)
+        XCTAssertEqual(events.last?.state, .done)
+    }
+
+    func testTriggerTrigramRebuildHonorsCancellationBetweenBatches() throws {
+        try seedTrigramMaintenanceRows(count: 5)
+        try sqliteExecWrite(path: tempDBPath, sql: "DELETE FROM chunks_fts_trigram")
+
+        var events: [BrainDatabase.TrigramMaintenanceProgress] = []
+        let final = try db.triggerTrigramRebuild(
+            batchSize: 2,
+            shouldCancel: { !events.isEmpty },
+            progress: { event in events.append(event) }
+        )
+
+        XCTAssertEqual(final.state, .cancelled)
+        XCTAssertEqual(final.processed, 2)
+        XCTAssertEqual(final.total, 5)
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 2)
+        XCTAssertEqual(events.last?.state, .cancelled)
+    }
+
+    func testTriggerTrigramRebuildAllowsWritersBetweenBatches() throws {
+        try seedTrigramMaintenanceRows(count: 4)
+        try sqliteExecWrite(path: tempDBPath, sql: "DELETE FROM chunks_fts_trigram")
+
+        var insertedDuringProgress = false
+        let final = try db.triggerTrigramRebuild(batchSize: 2, progress: { event in
+            guard event.state == .running, !insertedDuringProgress else { return }
+            insertedDuringProgress = true
+            try? sqliteExecWrite(
+                path: self.tempDBPath,
+                sql: """
+                    INSERT INTO chunks (
+                        id, content, metadata, source_file, project, content_type, importance, conversation_id, char_count, tags, summary, preview_text
+                    ) VALUES (
+                        'trigram-concurrent-writer',
+                        'Concurrent writer should acquire the lock between trigram batches',
+                        '{}',
+                        'brainbar',
+                        'brainlayer',
+                        'assistant_text',
+                        5,
+                        'trigram-maintenance',
+                        67,
+                        '[]',
+                        '',
+                        'Concurrent writer should acquire the lock between trigram batches'
+                    )
+                """
+            )
+        })
+
+        XCTAssertEqual(final.state, .done)
+        XCTAssertTrue(insertedDuringProgress)
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks"), 5)
+        XCTAssertEqual(try sqliteCount(path: tempDBPath, table: "chunks_fts_trigram"), 5)
+    }
+
     func testUpsertSubscriptionRecoversMissingPubSubTables() throws {
         db.exec("DROP TABLE IF EXISTS brainbar_subscriptions")
         db.exec("DROP TABLE IF EXISTS brainbar_agents")
@@ -791,6 +864,19 @@ final class DatabaseTests: XCTestCase {
         let result = try db.digest(content: content)
         XCTAssertNotNil(result["chunks_created"])
     }
+
+    private func seedTrigramMaintenanceRows(count: Int) throws {
+        for index in 0..<count {
+            try db.insertChunk(
+                id: "trigram-maintenance-\(index)",
+                content: "Trigram maintenance fixture \(index)",
+                sessionId: "trigram-maintenance",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 5
+            )
+        }
+    }
 }
 
 private func sqliteMasterSQL(name: String, path: String) throws -> String {
@@ -881,6 +967,16 @@ private func sqliteExecWrite(path: String, sql: String) throws {
     let execRC = sqlite3_exec(db, sql, nil, nil, nil)
     guard execRC == SQLITE_OK else {
         throw NSError(domain: "DatabaseTests", code: Int(execRC))
+    }
+}
+
+private func sqliteCount(path: String, table: String) throws -> Int {
+    try withSQLiteConnection(path: path) { db in
+        try scalarInt(
+            db: db,
+            sql: "SELECT COUNT(*) FROM \(table)",
+            bind: { _ in }
+        )
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -294,6 +294,39 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(events.last?["state"] as? String, "done")
     }
 
+    func testBrainMaintenanceRebuildTrigramCancelReturnsBeforeSchemaWrites() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-maintenance-cancel-\(UUID().uuidString).db"
+        defer {
+            try? FileManager.default.removeItem(atPath: tempDB)
+            try? FileManager.default.removeItem(atPath: tempDB + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDB + "-shm")
+        }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try sqliteExec(path: tempDB, sql: "DROP TABLE IF EXISTS chunks_fts_trigram")
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 15,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_maintenance_rebuild_trigram",
+                "arguments": ["cancel": true]
+            ]
+        ])
+
+        let result = response["result"] as? [String: Any]
+        XCTAssertNotEqual(result?["isError"] as? Bool, true)
+        let progress = result?["progress"] as? [String: Any]
+        XCTAssertEqual(progress?["state"] as? String, "cancelled")
+        XCTAssertEqual(progress?["processed"] as? Int, 0)
+        XCTAssertEqual(progress?["total"] as? Int, 0)
+        XCTAssertFalse(try db.tableExists("chunks_fts_trigram"))
+    }
+
     func testToolsCallUnknownToolReturnsError() throws {
         let router = MCPRouter()
         let request: [String: Any] = [

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -265,8 +265,9 @@ final class MCPRouterTests: XCTestCase {
         }
         let db = BrainDatabase(path: tempDB)
         defer { db.close() }
-        try db.insertChunk(id: "mcp-trigram-1", content: "MCP trigram maintenance fixture one", sessionId: "mcp", project: "brainlayer", contentType: "assistant_text", importance: 5)
-        try db.insertChunk(id: "mcp-trigram-2", content: "MCP trigram maintenance fixture two", sessionId: "mcp", project: "brainlayer", contentType: "assistant_text", importance: 5)
+        for index in 0..<30 {
+            try db.insertChunk(id: "mcp-trigram-\(index)", content: "MCP trigram maintenance fixture \(index)", sessionId: "mcp", project: "brainlayer", contentType: "assistant_text", importance: 5)
+        }
         try sqliteExec(path: tempDB, sql: "DELETE FROM chunks_fts_trigram")
 
         let router = MCPRouter()
@@ -286,10 +287,11 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertNotEqual(result?["isError"] as? Bool, true)
         let progress = result?["progress"] as? [String: Any]
         XCTAssertEqual(progress?["state"] as? String, "done")
-        XCTAssertEqual(progress?["processed"] as? Int, 2)
-        XCTAssertEqual(progress?["total"] as? Int, 2)
+        XCTAssertEqual(progress?["processed"] as? Int, 30)
+        XCTAssertEqual(progress?["total"] as? Int, 30)
         let events = result?["events"] as? [[String: Any]] ?? []
-        XCTAssertGreaterThanOrEqual(events.count, 2)
+        XCTAssertLessThanOrEqual(events.count, 25)
+        XCTAssertEqual(events.last?["state"] as? String, "done")
     }
 
     func testToolsCallUnknownToolReturnsError() throws {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -127,14 +127,15 @@ final class MCPRouterTests: XCTestCase {
         let tools = result?["tools"] as? [[String: Any]]
 
         XCTAssertNotNil(tools)
-        XCTAssertEqual(tools?.count, 15, "Should have exactly 15 tools")
+        XCTAssertEqual(tools?.count, 16, "Should have exactly 16 tools")
 
         let toolNames = Set(tools?.compactMap { $0["name"] as? String } ?? [])
         let expected: Set<String> = [
             "brain_search", "brain_store", "brain_recall", "brain_entity",
             "brain_digest", "brain_update", "brain_expand", "brain_tags",
             "brain_subscribe", "brain_unsubscribe", "brain_ack",
-            "brain_get_person", "brain_supersede", "brain_archive", "brain_enrich"
+            "brain_get_person", "brain_supersede", "brain_archive", "brain_enrich",
+            "brain_maintenance_rebuild_trigram",
         ]
         XCTAssertEqual(toolNames, expected)
     }
@@ -190,6 +191,7 @@ final class MCPRouterTests: XCTestCase {
             "brain_subscribe": (false, false, false, false),
             "brain_unsubscribe": (false, false, true, false),
             "brain_ack": (false, false, true, false),
+            "brain_maintenance_rebuild_trigram": (false, false, true, false),
         ]
 
         XCTAssertEqual(toolsByName.count, expected.count)
@@ -252,6 +254,42 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertNil(response["error"], "brain_search should not return error")
         XCTAssertNotNil(response["result"], "brain_search should return result")
         XCTAssertEqual(response["id"] as? Int, 4)
+    }
+
+    func testBrainMaintenanceRebuildTrigramToolReturnsProgressMetadata() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-maintenance-\(UUID().uuidString).db"
+        defer {
+            try? FileManager.default.removeItem(atPath: tempDB)
+            try? FileManager.default.removeItem(atPath: tempDB + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDB + "-shm")
+        }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try db.insertChunk(id: "mcp-trigram-1", content: "MCP trigram maintenance fixture one", sessionId: "mcp", project: "brainlayer", contentType: "assistant_text", importance: 5)
+        try db.insertChunk(id: "mcp-trigram-2", content: "MCP trigram maintenance fixture two", sessionId: "mcp", project: "brainlayer", contentType: "assistant_text", importance: 5)
+        try sqliteExec(path: tempDB, sql: "DELETE FROM chunks_fts_trigram")
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 14,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_maintenance_rebuild_trigram",
+                "arguments": ["batch_size": 1]
+            ]
+        ])
+
+        let result = response["result"] as? [String: Any]
+        XCTAssertNotEqual(result?["isError"] as? Bool, true)
+        let progress = result?["progress"] as? [String: Any]
+        XCTAssertEqual(progress?["state"] as? String, "done")
+        XCTAssertEqual(progress?["processed"] as? Int, 2)
+        XCTAssertEqual(progress?["total"] as? Int, 2)
+        let events = result?["events"] as? [[String: Any]] ?? []
+        XCTAssertGreaterThanOrEqual(events.count, 2)
     }
 
     func testToolsCallUnknownToolReturnsError() throws {

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -91,7 +91,7 @@ final class SocketIntegrationTests: XCTestCase {
 
         let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]]
         XCTAssertNotNil(tools)
-        XCTAssertEqual(tools?.count, 15)
+        XCTAssertEqual(tools?.count, 16)
 
         let toolsByName = Dictionary(
             uniqueKeysWithValues: (tools ?? []).compactMap { tool -> (String, [String: Any])? in
@@ -116,6 +116,7 @@ final class SocketIntegrationTests: XCTestCase {
             "brain_subscribe": (false, false, false, false),
             "brain_unsubscribe": (false, false, true, false),
             "brain_ack": (false, false, true, false),
+            "brain_maintenance_rebuild_trigram": (false, false, true, false),
         ]
 
         for (name, taxonomy) in expected {
@@ -689,7 +690,7 @@ final class SocketIntegrationTests: XCTestCase {
 
         let toolsResponse = try JSONSerialization.jsonObject(with: Data(outputLines[1].utf8)) as? [String: Any]
         let tools = (toolsResponse?["result"] as? [String: Any])?["tools"] as? [[String: Any]]
-        XCTAssertEqual(tools?.count, 15)
+        XCTAssertEqual(tools?.count, 16)
     }
 
     // MARK: - C2: Socket path length validation


### PR DESCRIPTION
## Summary

@orcClaude Phase 2 / PR B for `docs.local/plans/2026-05-02-brainlayer-reliability-hardening/phase-2`.

Adds an explicit operator-triggered `brain_maintenance_rebuild_trigram` MCP command over the BrainBar Unix socket. This keeps Phase 1 startup safe by avoiding synchronous trigram backfill on cold boot, while giving operators a deliberate maintenance path to populate `chunks_fts_trigram` after boot.

## Implementation

- Adds `BrainDatabase.triggerTrigramRebuild(batchSize:shouldCancel:progress:)` with bounded `BEGIN IMMEDIATE` batches for both clearing existing trigram rows and backfilling from `chunks`.
- Exposes `brain_maintenance_rebuild_trigram` in `MCPRouter` with progress metadata and write-idempotent annotations.
- Adds trigram coverage to the dashboard Runtime & Details footer so the operator can see whether the trigram index is populated.
- Supports database-layer cancellation between batches; MCP cancellation is currently preflight-only because `tools/call` is synchronous JSON-RPC. A future async job/cancel-token router would be needed for live mid-run cancellation over MCP.

## Verification

- RED: targeted Swift test compile failed before `TrigramMaintenanceProgress` / `triggerTrigramRebuild` existed.
- GREEN: targeted Swift maintenance/router/socket tests passed.
- Full Swift: `swift test` passed 320 tests, 0 failures.
- Post-batched-clear targeted Swift: 8 tests passed, 0 failures.
- Pre-push gate before commit: `bash scripts/run_tests.sh` passed pytest, MCP registration, isolated eval/hook routing, Bun stale-index, and FTS determinism.
- Push hook repeated the same gate and passed: pytest `1811 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration `3 passed`; isolated eval/hook routing `32 passed`; Bun `1 pass`; `test_fts5_determinism.sh` PASS.

## Notes

The local pre-push gate reproducibly flips `.git/config` to `core.bare=true` after completion, making `git status` fail until `core.bare=false` is restored. That is documented in the Phase 2 findings as a harness/local-config issue, not part of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new DB maintenance path that deletes/reinserts `chunks_fts_trigram` rows in `BEGIN IMMEDIATE` batches; mistakes here could impact search correctness or cause lock contention during rebuilds.
> 
> **Overview**
> Adds a new MCP tool, `brain_maintenance_rebuild_trigram`, to explicitly rebuild the trigram FTS table on-demand and return structured progress (including recent progress events).
> 
> Implements `BrainDatabase.triggerTrigramRebuild` to rebuild `chunks_fts_trigram` incrementally in bounded, immediate-write batches with ETA estimation and optional cancellation between batches, and extends dashboard stats/UI to show trigram coverage and a maintenance progress bar.
> 
> Updates tests to cover batch-size clamping, batching/progress semantics, cancellation behavior, and MCP/socket tool registration + metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1a954e9083a7537e45ad794ceea25140ba53eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add operator-triggered `brain_maintenance_rebuild_trigram` MCP tool with lock-aware batching
> - Adds a new `brain_maintenance_rebuild_trigram` MCP tool in [`MCPRouter.swift`](https://github.com/EtanHey/brainlayer/pull/268/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f) that runs a batched trigram FTS rebuild with configurable `batch_size` (default 1000, capped at 10,000) and supports pre-flight cancellation via a `cancel` field.
> - Implements batched rebuild logic in [`BrainDatabase.swift`](https://github.com/EtanHey/brainlayer/pull/268/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc) that deletes and reinserts trigram rows per rowid interval, allowing concurrent writers between batches, and runs `ANALYZE` when done.
> - Adds `BrainDatabase.TrigramMaintenanceProgress` to carry structured progress state (running/done/cancelled/failed, processed count, ETA) back to the caller, accumulating up to 25 events per invocation.
> - Extends `DashboardStats` with `trigramIndexedChunkCount` and `trigramCoveragePercent`, and surfaces a progress bar and coverage string in the Brain Bar dashboard UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c1a954.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard diagnostics now display trigram maintenance progress with indexed chunk counts and coverage metrics
  * Users can trigger trigram index rebuild operations with progress updates and batch-based processing

* **Tests**
  * Added comprehensive test coverage for trigram maintenance operations including batch processing, cancellation handling, and concurrent database writes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->