### PR TITLE
fix(test-harness): pre-push regression fixes (missing google dep, test isolation, worktree mutation)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ git config core.hooksPath .githooks
 
 The repo ships a pre-push regression gate in `.githooks/pre-push`. Set `core.hooksPath`
 once per clone so `git push` runs `scripts/run_tests.sh` before anything leaves your machine.
+The `dev` extra includes the Gemini SDK used by digest-time enrichment tests; keep it installed even if
+you do not set `GOOGLE_API_KEY` locally.
 
 ## Project Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ telemetry = [
 ]
 dev = [
     "deepchecks>=0.19.1",
+    "google-genai>=1.0.0",
     "numpy<2",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",

--- a/src/brainlayer/git_learning.py
+++ b/src/brainlayer/git_learning.py
@@ -24,6 +24,11 @@ MIGRATION_PATTERNS = [
 BREAKING_RE = re.compile(r"BREAKING CHANGE:", re.IGNORECASE)
 
 
+def _clean_git_env() -> dict[str, str]:
+    """Strip parent-repo Git hook variables before running Git in another repo."""
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
 @dataclass(frozen=True)
 class ParsedCommit:
     kind: str | None
@@ -217,6 +222,7 @@ def _iter_commits(repo: Path, since: str) -> list[dict[str, Any]]:
     hashes = subprocess.run(
         ["git", "log", "--no-merges", f"--since={_git_since_arg(since)}", "--format=%H"],
         cwd=repo,
+        env=_clean_git_env(),
         check=True,
         capture_output=True,
         text=True,
@@ -225,6 +231,7 @@ def _iter_commits(repo: Path, since: str) -> list[dict[str, Any]]:
         metadata = subprocess.run(
             ["git", "show", "-s", "--format=%an%x1f%at%x1f%s%x1f%b", commit_hash],
             cwd=repo,
+            env=_clean_git_env(),
             check=True,
             capture_output=True,
             text=True,
@@ -233,6 +240,7 @@ def _iter_commits(repo: Path, since: str) -> list[dict[str, Any]]:
         file_listing = subprocess.run(
             ["git", "show", "--pretty=format:", "--name-only", commit_hash],
             cwd=repo,
+            env=_clean_git_env(),
             check=True,
             capture_output=True,
             text=True,

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -8,14 +8,31 @@ import subprocess
 from pathlib import Path
 
 
+def _clean_git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
 def _git(repo: Path, *args: str) -> None:
     subprocess.run(
         ["git", *args],
         cwd=repo,
+        env=_clean_git_env(),
         check=True,
         capture_output=True,
         text=True,
     )
+
+
+def _git_stdout(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=_clean_git_env(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
 
 
 def _init_repo(repo: Path, branch: str = "main") -> None:
@@ -59,7 +76,7 @@ def _run_build_script(
     extra_args: list[str] | None = None,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    env = os.environ.copy()
+    env = _clean_git_env()
     env.pop("BRAINBAR_APP_DIR", None)
     env["HOME"] = str(home)
     env["BRAINBAR_CANONICAL_REPO_ROOT"] = str(canonical_root)
@@ -92,6 +109,34 @@ def test_build_app_allows_clean_canonical_repo_in_dry_run(tmp_path: Path) -> Non
     assert result.returncode == 0
     assert str(home / "Applications" / "BrainBar.app") in result.stdout
     assert "LaunchAgent: canonical install" in result.stdout
+
+
+def test_build_app_helpers_ignore_parent_git_hook_env(tmp_path: Path, monkeypatch) -> None:
+    parent_repo = tmp_path / "parent"
+    _init_repo(parent_repo)
+    _write_tracked_file(parent_repo, "README.md", "# parent repo\n")
+    _commit(parent_repo, "feat: parent commit")
+
+    monkeypatch.setenv("GIT_DIR", str(parent_repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(parent_repo))
+
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+    )
+
+    repo_subjects = _git_stdout(repo, "log", "--format=%s").splitlines()
+    parent_subjects = _git_stdout(parent_repo, "log", "--format=%s").splitlines()
+
+    assert result.returncode == 0
+    assert repo_subjects == ["chore: seed build script"]
+    assert parent_subjects == ["feat: parent commit"]
 
 
 def test_build_app_rejects_noncanonical_repo_without_force(tmp_path: Path) -> None:

--- a/tests/test_dev_dependencies.py
+++ b/tests/test_dev_dependencies.py
@@ -1,0 +1,12 @@
+"""Regression tests for dev-only dependencies used by the pre-push harness."""
+
+import tomllib
+from pathlib import Path
+
+
+def test_google_genai_listed_in_dev_extra() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    payload = tomllib.loads(pyproject_path.read_text())
+    dev_dependencies = payload["project"]["optional-dependencies"]["dev"]
+
+    assert any(dep.startswith("google-genai") for dep in dev_dependencies)

--- a/tests/test_git_learning.py
+++ b/tests/test_git_learning.py
@@ -1,6 +1,7 @@
 """Tests for Phase 3 git-based continual learning MVP."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -12,10 +13,15 @@ from brainlayer.vector_store import VectorStore
 runner = CliRunner()
 
 
+def _clean_git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
 def _git(repo: Path, *args: str) -> str:
     result = subprocess.run(
         ["git", *args],
         cwd=repo,
+        env=_clean_git_env(),
         check=True,
         capture_output=True,
         text=True,
@@ -86,6 +92,38 @@ def test_brain_learn_git_seeds_single_repo_without_duplicates(tmp_path, monkeypa
 
     second = runner.invoke(app, ["brain-learn", "--git", "--repos-config", str(config_path), "--since", "30d"])
     assert second.exit_code == 0, second.stdout
+
+    store = VectorStore(db_path)
+    cursor = store.conn.cursor()
+    count = cursor.execute("SELECT COUNT(*) FROM git_memories").fetchone()[0]
+    repos = {row[0] for row in cursor.execute("SELECT DISTINCT repo FROM git_memories")}
+
+    assert count == 2
+    assert repos == {repo.name}
+
+
+def test_brain_learn_git_ignores_parent_git_hook_env(tmp_path, monkeypatch):
+    from brainlayer.git_learning import ensure_repos_config
+
+    parent_repo = tmp_path / "parent"
+    _init_repo(parent_repo)
+    _commit_file(parent_repo, "README.md", "# parent\n", "feat: parent commit")
+
+    repo = tmp_path / "repo-one"
+    _init_repo(repo)
+    _commit_file(repo, "src/app.py", "print('one')\n", "feat: add app bootstrap")
+    _commit_file(repo, "src/app.py", "print('two')\n", "fix: handle startup failure")
+
+    db_path = tmp_path / "brainlayer.db"
+    config_path = tmp_path / "repos.json"
+    ensure_repos_config(config_path, default_repos=[str(repo)])
+
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("GIT_DIR", str(parent_repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(parent_repo))
+
+    result = runner.invoke(app, ["brain-learn", "--git", "--repos-config", str(config_path), "--since", "30d"])
+    assert result.exit_code == 0, result.stdout
 
     store = VectorStore(db_path)
     cursor = store.conn.cursor()


### PR DESCRIPTION
Summary
- add google-genai to the dev extra and pin it with a regression test so the pre-push harness always has the Gemini SDK it exercises
- sanitize inherited GIT_* variables in git-learning and BrainBar test helpers so hook-driven temp repos stay isolated from the outer worktree
- add regression coverage for parent hook env leakage in both git-learning and BrainBar harness tests

Verification
- controlled rollback: the new regressions fail when the harness fixes are removed, then pass again after restore
- uv run --extra dev pytest -q tests/test_dev_dependencies.py tests/test_git_learning.py tests/test_brainbar_build_app_guards.py tests/test_enrichment_controller.py tests/test_enrichment_entity_schema.py tests/test_smart_search_entity_dedup.py tests/test_entity_contracts.py
- bash scripts/run_tests.sh
- git push -u origin fix/pre-push-harness-stability (hook reran clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test harness isolation and dependency metadata, with small runtime impact confined to how `git` subprocesses are invoked during learning.
> 
> **Overview**
> **Pre-push/test harness reliability fixes.** Adds `google-genai` to the `dev` extra (and documents it) plus a regression test to ensure it stays listed.
> 
> **Git subprocess isolation.** Introduces `_clean_git_env()` and uses it when invoking `git` in `git_learning` and related tests/BrainBar build-script helpers, with new regression coverage proving parent-repo `GIT_DIR`/`GIT_WORK_TREE` leakage no longer mutates or reads the wrong repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11cc28a9cb6443b14f9e188584a56def0a38eaf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pre-push test regressions by stripping GIT_* env vars and adding google-genai dev dependency
> - Adds a `_clean_git_env()` helper in [`git_learning.py`](https://github.com/EtanHey/brainlayer/pull/269/files#diff-af09c67f0c05c956038eea5b53a31218b844a6f963343c970aabf26ce7594809) that strips all `GIT_*` variables before subprocess Git calls, preventing parent Git hook env vars (e.g. `GIT_DIR`, `GIT_WORK_TREE`) from leaking into child repo operations.
> - Applies the same env sanitization to test helpers in [`test_brainbar_build_app_guards.py`](https://github.com/EtanHey/brainlayer/pull/269/files#diff-55ab4f81b7c4728e3996f37748109685b4424032a223b6ffa23835b7c4de25b6) and [`test_git_learning.py`](https://github.com/EtanHey/brainlayer/pull/269/files#diff-d5119a154544e0784c27cb95c56f393cd2731b7634389b8b2d0d72273b08bb22), and adds regression tests to verify isolation.
> - Adds `google-genai>=1.0.0` to the `dev` extras in [`pyproject.toml`](https://github.com/EtanHey/brainlayer/pull/269/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) so digest-time enrichment tests have the dependency available without requiring `GOOGLE_API_KEY`.
> - Adds [`test_dev_dependencies.py`](https://github.com/EtanHey/brainlayer/pull/269/files#diff-423984c524064ddfcf1f74766c9109e3fb3815979963574f66d2c7d16a511b12) to fail CI if `google-genai` is ever dropped from the `dev` extra.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11cc28a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where parent-repository Git hooks could interfere with learning from git repositories.

* **Documentation**
  * Clarified the `dev` installation requirements for local development setup.

* **Tests**
  * Added regression tests to ensure Git environment isolation works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->