### PR TITLE
fix(mcp): defer vector-store init past signal-routing branches in _brain_search

### DIFF
--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -437,27 +437,6 @@ async def _brain_search(
     if chunk_id is not None:
         return await _context(chunk_id=chunk_id, before=before, after=after)
 
-    store = _get_vector_store()
-    exact_chunk_hit = _exact_chunk_lookup_result(
-        query,
-        store,
-        detail,
-        project=project,
-        content_type=content_type,
-        tag=tag,
-        importance_min=importance_min,
-        date_from=date_from,
-        date_to=date_to,
-        source=source,
-        intent=intent,
-        sentiment=sentiment,
-        source_filter=source_filter,
-        correction_category=correction_category,
-    )
-    if exact_chunk_hit is not None:
-        return exact_chunk_hit
-    fts_query_override = _expanded_fts_query(query, store)
-
     if file_path is not None and _query_has_regression_signal(query):
         regression_result = await _regression(file_path=file_path, project=project)
         recall_result = await _recall(file_path=file_path, project=project, max_results=max_results)
@@ -522,6 +501,27 @@ async def _brain_search(
 
     if _query_signals_recall(query):
         return await _recall(topic=query, project=project, max_results=max_results)
+
+    store = _get_vector_store()
+    exact_chunk_hit = _exact_chunk_lookup_result(
+        query,
+        store,
+        detail,
+        project=project,
+        content_type=content_type,
+        tag=tag,
+        importance_min=importance_min,
+        date_from=date_from,
+        date_to=date_to,
+        source=source,
+        intent=intent,
+        sentiment=sentiment,
+        source_filter=source_filter,
+        correction_category=correction_category,
+    )
+    if exact_chunk_hit is not None:
+        return exact_chunk_hit
+    fts_query_override = _expanded_fts_query(query, store)
 
     # Entity-aware routing: detect known entity names in query.
     # Path 1: Pure SQL KG lookup (no embeddings, always works).


### PR DESCRIPTION
## Summary
- Defers the DB-backed vector-store initialization in `_brain_search()` until after current-context, think, and recall signal-routing branches have had a chance to return.
- Closes the test-isolation root cause shared by PR #268 and PR #241: `tests/test_phase6_critical.py::TestSearchRouting` was hitting the canonical DB before mocked routing handlers, which also overlaps the test_post_commit_hook ordering bug family.

## Test plan
- Red first: `uv run pytest -vv tests/test_phase6_critical.py -k "current_context_signal or think_signal or recall_signal"` failed with `apsw.BusyError: database is locked` before the fix.
- Green: `uv run pytest -vv tests/test_phase6_critical.py -k "current_context_signal or think_signal or recall_signal"` passed.
- Green: `uv run pytest -vv tests/test_phase6_critical.py` passed with 14 tests.
- Bonus isolation check: booted out `com.brainlayer.enrichment`, reran the three routing tests, confirmed they still passed, then bootstrapped enrichment again.
- Pre-push gate passed: pytest unit suite, MCP registration tests, isolated eval/hook tests, Bun stale-index test, and `test_fts5_determinism.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk reorder of `_brain_search` control flow; main impact is avoiding early vector-store/DB access, which could subtly change precedence only if a query both matches a routing signal and looks like a chunk id.
> 
> **Overview**
> Defers `_get_vector_store()` initialization (and the dependent exact chunk-id lookup / FTS query expansion) in `_brain_search` until after early-return routing branches like `current_context`, `think`, `recall`, and file/regression handlers.
> 
> This reduces unintended DB/vector-store access during signal-routed queries (improving test isolation and avoiding lock contention) while keeping the same downstream search behavior for non-routed queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af5a57fce1bcc0f8568c9cde615f2a9ed897cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer vector-store init in `_brain_search` until after signal-routing early returns
> - Previously, `_get_vector_store()`, `_exact_chunk_lookup_result()`, and `_expanded_fts_query()` were called before the regression, think, and recall routing checks in [search_handler.py](https://github.com/EtanHey/brainlayer/pull/272/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0).
> - These calls are now deferred until after those early-return branches, so signal-routed queries no longer hit the vector store unnecessarily.
> - Behavioral Change: queries that match both an exact chunk and a regression/think/recall signal now follow the signal route instead of returning the exact chunk hit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2af5a57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->