### PR TITLE
fix(brainbar): stabilize json-rpc envelope order

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -402,7 +402,7 @@ final class BrainBarServer: @unchecked Sendable {
             framed = data
         } else {
             // Newline-delimited JSON-RPC (Claude Code v2.1+ / MCP 2025-11-25)
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: response) else { return false }
+            guard let jsonData = try? MCPFraming.encodeJSONResponse(response) else { return false }
             var data = jsonData
             data.append(0x0A) // trailing \n
             framed = data

--- a/brain-bar/Sources/BrainBar/MCPFraming.swift
+++ b/brain-bar/Sources/BrainBar/MCPFraming.swift
@@ -113,14 +113,44 @@ struct MCPFraming: Sendable {
 
     /// Encode a JSON-RPC response with Content-Length framing.
     static func encode(_ response: [String: Any]) throws -> Data {
-        let jsonData = try JSONSerialization.data(withJSONObject: response)
+        let jsonData = try encodeJSONResponse(response)
         let header = "Content-Length: \(jsonData.count)\r\n\r\n"
         var frame = Data(header.utf8)
         frame.append(jsonData)
         return frame
     }
 
+    /// Encode JSON-RPC envelopes with a deterministic top-level key order.
+    ///
+    /// Claude Desktop currently rejects otherwise-valid JSON-RPC objects when
+    /// Foundation serializes `result` or `id` before `jsonrpc`.
+    static func encodeJSONResponse(_ response: [String: Any]) throws -> Data {
+        guard let jsonrpc = response["jsonrpc"],
+              let id = response["id"],
+              response["result"] != nil || response["error"] != nil else {
+            return try JSONSerialization.data(withJSONObject: response)
+        }
+
+        var data = Data("{\"jsonrpc\":".utf8)
+        data.append(try encodeJSONValue(jsonrpc))
+        data.append(Data(",\"id\":".utf8))
+        data.append(try encodeJSONValue(id))
+        if let result = response["result"] {
+            data.append(Data(",\"result\":".utf8))
+            data.append(try encodeJSONValue(result))
+        } else if let error = response["error"] {
+            data.append(Data(",\"error\":".utf8))
+            data.append(try encodeJSONValue(error))
+        }
+        data.append(0x7D) // }
+        return data
+    }
+
     // MARK: - Private
+
+    private static func encodeJSONValue(_ value: Any) throws -> Data {
+        try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed])
+    }
 
     private func parseContentLength(_ header: String) -> Int? {
         for line in header.split(separator: "\r\n") {

--- a/brain-bar/Tests/BrainBarTests/MCPFramingTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPFramingTests.swift
@@ -113,6 +113,27 @@ final class MCPFramingTests: XCTestCase {
         XCTAssertTrue(str.contains("protocolVersion"))
     }
 
+    func testEncodesJSONRPCEnvelopeWithJSONRPCFirst() throws {
+        let response: [String: Any] = [
+            "id": 2,
+            "jsonrpc": "2.0",
+            "result": [
+                "tools": [
+                    ["name": "brain_search"]
+                ]
+            ] as [String: Any]
+        ]
+
+        let framed = try MCPFraming.encode(response)
+        let frame = try XCTUnwrap(String(data: framed, encoding: .utf8))
+        let body = try XCTUnwrap(frame.components(separatedBy: "\r\n\r\n").last)
+
+        XCTAssertTrue(
+            body.hasPrefix(#"{"jsonrpc":"2.0","id":2,"result":"#),
+            "Claude Desktop expects the JSON-RPC envelope to serialize with jsonrpc first; got: \(body.prefix(80))"
+        )
+    }
+
     // MARK: - Empty body
 
     func testRejectsZeroContentLength() {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -140,6 +140,24 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(toolNames, expected)
     }
 
+    func testEncodedToolsListEnvelopeStartsWithJSONRPC() throws {
+        let router = MCPRouter()
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        ])
+
+        let framed = try MCPFraming.encode(response)
+        let frame = try XCTUnwrap(String(data: framed, encoding: .utf8))
+        let body = try XCTUnwrap(frame.components(separatedBy: "\r\n\r\n").last)
+
+        XCTAssertTrue(
+            body.hasPrefix(#"{"jsonrpc":"2.0","id":2,"result":"#),
+            "Claude Desktop expects jsonrpc to be the first envelope key for tools/list; got: \(body.prefix(80))"
+        )
+    }
+
     func testEachToolHasInputSchema() throws {
         let router = MCPRouter()
         let request: [String: Any] = [


### PR DESCRIPTION
## Summary
- Stabilizes BrainBar MCP JSON-RPC response encoding so top-level envelopes serialize with `jsonrpc` first, then `id`, then `result`/`error`.
- Routes the raw newline fallback through the same encoder as the Content-Length MCP path.
- Adds regression coverage for both direct framing and the real `tools/list` router response.

## Diagnosis
Claude Desktop rejected BrainBar on boot with `Invalid JSON-RPC message` even though the response was structurally valid JSON-RPC. Live framed socket probing against the installed BrainBar showed the Content-Length path emitted `{"id":2,"jsonrpc":"2.0","result":...}`. A release-mode TDD test reproduced Foundation dictionary serialization emitting non-MCP-like top-level ordering (`{"result":...,"id":2,"jsonrpc":"2.0"}`). Python/Node MCP servers emit `jsonrpc` first; this PR makes BrainBar match that stable envelope shape instead of relying on Swift dictionary serialization.

## Tests
- TDD red first: `swift test --package-path brain-bar -c release --filter MCPFramingTests/testEncodesJSONRPCEnvelopeWithJSONRPCFirst` failed before the fix with body `{"result":{"tools":[{"name":"brain_search"}]},"id":2,"jsonrpc":"2.0"}`.
- `swift test --package-path brain-bar -c release --filter MCPFramingTests/testEncodesJSONRPCEnvelopeWithJSONRPCFirst` passed after fix.
- `swift test --package-path brain-bar --filter MCPFramingTests` passed: 8 tests, 0 failures.
- `swift test --package-path brain-bar --filter MCPRouterTests/testEncodedToolsListEnvelopeStartsWithJSONRPC` passed.
- `swift test --package-path brain-bar` passed: 339 tests, 0 failures.
- `./scripts/run_tests.sh` passed: pytest unit suite 1823 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 32 passed; bun suite 1 pass; FTS5 regression PASS.
- Pre-push test gate reran `./scripts/run_tests.sh` and passed with the same suites.

## Deployment Plan
After merge, rebuild and reinstall BrainBar, restart it with enrichment paused, then smoke-test `/tmp/brainbar.sock` using `tools/list` to confirm the deployed response starts with `{"jsonrpc":"2.0","id":2,"result":...}`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JSON-RPC response serialization at the transport boundary (both Content-Length and newline-delimited modes), which could affect compatibility with existing clients if they relied on Foundation’s previous output shape.
> 
> **Overview**
> Ensures BrainBar’s MCP JSON-RPC responses serialize with a **deterministic envelope key order** (`jsonrpc`, then `id`, then `result`/`error`) to avoid client-side rejection caused by Foundation dictionary ordering.
> 
> Routes the newline-delimited JSON-RPC fallback through the same encoder as the Content-Length framing path, and adds regression tests covering both the framing encoder and a real `tools/list` router response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ac3a7c0d6df0d07ae0f209d5f8eaee23004f1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix JSON-RPC envelope key order in `MCPFraming` to be deterministic
> - Replaces `JSONSerialization`-based encoding with a new `MCPFraming.encodeJSONResponse` helper that explicitly orders top-level keys as `jsonrpc`, `id`, then `result`/`error`.
> - Applies to both Content-Length framed responses ([MCPFraming.swift](https://github.com/EtanHey/brainlayer/pull/274/files#diff-ef69d75525b915489c1a1acc192c6ff548ad8b9154aefdd43d4c5234941b1735)) and newline-delimited responses ([BrainBarServer.swift](https://github.com/EtanHey/brainlayer/pull/274/files#diff-4602849889150805f4b12b90f751f36f54c87a22076f044e0669a2276500e981)).
> - Falls back to Foundation serialization if required keys are missing.
> - Two new tests assert that encoded envelopes start with `jsonrpc` first in both framing modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45ac3a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced JSON-RPC response serialization to ensure deterministic and consistent formatting of protocol responses.

* **Tests**
  * Added tests verifying proper JSON-RPC response envelope structure and formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->