### PR TITLE
fix(brainbar): compact tools list for Claude MCPB

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -402,8 +402,7 @@ final class BrainBarServer: @unchecked Sendable {
             framed = data
         } else {
             // Newline-delimited JSON-RPC (Claude Code v2.1+ / MCP 2025-11-25)
-            let rawResponse = Self.compactRawJSONResponseIfNeeded(response)
-            guard let jsonData = try? MCPFraming.encodeJSONResponse(rawResponse) else { return false }
+            guard let jsonData = Self.encodeRawJSONResponse(response) else { return false }
             var data = jsonData
             data.append(0x0A) // trailing \n
             framed = data
@@ -440,10 +439,22 @@ final class BrainBarServer: @unchecked Sendable {
         }
     }
 
-    private static func compactRawJSONResponseIfNeeded(_ response: [String: Any]) -> [String: Any] {
+    private static let claudeExtensionRawChunkLimit = 8192
+
+    private static func encodeRawJSONResponse(_ response: [String: Any]) -> Data? {
+        guard let jsonData = try? MCPFraming.encodeJSONResponse(response) else { return nil }
+        guard jsonData.count >= claudeExtensionRawChunkLimit else { return jsonData }
+        guard let compacted = compactRawJSONResponseIfNeeded(response),
+              let compactData = try? MCPFraming.encodeJSONResponse(compacted) else {
+            return jsonData
+        }
+        return compactData
+    }
+
+    private static func compactRawJSONResponseIfNeeded(_ response: [String: Any]) -> [String: Any]? {
         guard let result = response["result"] as? [String: Any],
               let tools = result["tools"] as? [[String: Any]] else {
-            return response
+            return nil
         }
 
         // Claude Desktop's MCPB utility process currently parses raw extension

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -402,7 +402,8 @@ final class BrainBarServer: @unchecked Sendable {
             framed = data
         } else {
             // Newline-delimited JSON-RPC (Claude Code v2.1+ / MCP 2025-11-25)
-            guard let jsonData = try? MCPFraming.encodeJSONResponse(response) else { return false }
+            let rawResponse = Self.compactRawJSONResponseIfNeeded(response)
+            guard let jsonData = try? MCPFraming.encodeJSONResponse(rawResponse) else { return false }
             var data = jsonData
             data.append(0x0A) // trailing \n
             framed = data
@@ -437,6 +438,27 @@ final class BrainBarServer: @unchecked Sendable {
             }
             return true
         }
+    }
+
+    private static func compactRawJSONResponseIfNeeded(_ response: [String: Any]) -> [String: Any] {
+        guard let result = response["result"] as? [String: Any],
+              let tools = result["tools"] as? [[String: Any]] else {
+            return response
+        }
+
+        // Claude Desktop's MCPB utility process currently parses raw extension
+        // stdout in 8192-byte chunks. Raw newline transport omits optional tool
+        // annotations; Content-Length transport keeps the canonical tools/list.
+        var compactResult = result
+        compactResult["tools"] = tools.map { tool in
+            var compact = tool
+            compact.removeValue(forKey: "annotations")
+            return compact
+        }
+
+        var compactResponse = response
+        compactResponse["result"] = compactResult
+        return compactResponse
     }
 
     private func disconnectClient(fd: Int32) {

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -119,7 +119,7 @@ final class MCPRouter: @unchecked Sendable {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
-                "tools": Self.toolDefinitions
+                "tools": Self.compactToolDefinitions
             ]
         ]
     }
@@ -820,6 +820,15 @@ final class MCPRouter: @unchecked Sendable {
         destructive: false,
         idempotent: true
     )
+
+    // Claude Desktop's MCPB utility process currently parses extension stdout
+    // in 8192-byte chunks. Keep the raw newline tools/list response below that
+    // boundary by omitting optional annotations from the public list response.
+    nonisolated(unsafe) static let compactToolDefinitions: [[String: Any]] = toolDefinitions.map { tool in
+        var compact = tool
+        compact.removeValue(forKey: "annotations")
+        return compact
+    }
 
     nonisolated(unsafe) static let toolDefinitions: [[String: Any]] = [
         [

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -119,7 +119,7 @@ final class MCPRouter: @unchecked Sendable {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
-                "tools": Self.compactToolDefinitions
+                "tools": Self.toolDefinitions
             ]
         ]
     }
@@ -820,15 +820,6 @@ final class MCPRouter: @unchecked Sendable {
         destructive: false,
         idempotent: true
     )
-
-    // Claude Desktop's MCPB utility process currently parses extension stdout
-    // in 8192-byte chunks. Keep the raw newline tools/list response below that
-    // boundary by omitting optional annotations from the public list response.
-    nonisolated(unsafe) static let compactToolDefinitions: [[String: Any]] = toolDefinitions.map { tool in
-        var compact = tool
-        compact.removeValue(forKey: "annotations")
-        return compact
-    }
 
     nonisolated(unsafe) static let toolDefinitions: [[String: Any]] = [
         [

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -158,7 +158,7 @@ final class MCPRouterTests: XCTestCase {
         )
     }
 
-    func testEncodedToolsListFitsClaudeExtensionRawMessageLimit() throws {
+    func testToolsListPreservesCanonicalAnnotations() throws {
         let router = MCPRouter()
         let response = router.handle([
             "jsonrpc": "2.0",
@@ -166,18 +166,13 @@ final class MCPRouterTests: XCTestCase {
             "method": "tools/list",
         ])
 
-        let body = try MCPFraming.encodeJSONResponse(response)
         let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
 
-        XCTAssertLessThan(
-            body.count,
-            8192,
-            "Claude Desktop's MCPB utility process parses raw extension stdout in 8192-byte chunks"
-        )
+        XCTAssertEqual(tools.count, 16)
         for tool in tools {
-            XCTAssertNil(
+            XCTAssertNotNil(
                 tool["annotations"],
-                "\(tool["name"] ?? "unknown") should omit optional annotations from tools/list to keep the raw MCPB response under 8 KiB"
+                "\(tool["name"] ?? "unknown") should keep annotations in the canonical tools/list response"
             )
         }
     }
@@ -201,8 +196,15 @@ final class MCPRouterTests: XCTestCase {
     }
 
     func testEachToolHasExpectedAnnotations() throws {
+        let router = MCPRouter()
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/list",
+        ])
+        let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
         let toolsByName = Dictionary(
-            uniqueKeysWithValues: MCPRouter.toolDefinitions.compactMap { tool -> (String, [String: Any])? in
+            uniqueKeysWithValues: tools.compactMap { tool -> (String, [String: Any])? in
                 guard let name = tool["name"] as? String else { return nil }
                 return (name, tool)
             }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -158,6 +158,30 @@ final class MCPRouterTests: XCTestCase {
         )
     }
 
+    func testEncodedToolsListFitsClaudeExtensionRawMessageLimit() throws {
+        let router = MCPRouter()
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        ])
+
+        let body = try MCPFraming.encodeJSONResponse(response)
+        let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
+
+        XCTAssertLessThan(
+            body.count,
+            8192,
+            "Claude Desktop's MCPB utility process parses raw extension stdout in 8192-byte chunks"
+        )
+        for tool in tools {
+            XCTAssertNil(
+                tool["annotations"],
+                "\(tool["name"] ?? "unknown") should omit optional annotations from tools/list to keep the raw MCPB response under 8 KiB"
+            )
+        }
+    }
+
     func testEachToolHasInputSchema() throws {
         let router = MCPRouter()
         let request: [String: Any] = [
@@ -177,17 +201,8 @@ final class MCPRouterTests: XCTestCase {
     }
 
     func testEachToolHasExpectedAnnotations() throws {
-        let router = MCPRouter()
-        let request: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": 12,
-            "method": "tools/list",
-        ]
-
-        let response = router.handle(request)
-        let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
         let toolsByName = Dictionary(
-            uniqueKeysWithValues: tools.compactMap { tool -> (String, [String: Any])? in
+            uniqueKeysWithValues: MCPRouter.toolDefinitions.compactMap { tool -> (String, [String: Any])? in
                 guard let name = tool["name"] as? String else { return nil }
                 return (name, tool)
             }

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -93,39 +93,18 @@ final class SocketIntegrationTests: XCTestCase {
         XCTAssertNotNil(tools)
         XCTAssertEqual(tools?.count, 16)
 
-        let toolsByName = Dictionary(
-            uniqueKeysWithValues: (tools ?? []).compactMap { tool -> (String, [String: Any])? in
-                guard let name = tool["name"] as? String else { return nil }
-                return (name, tool)
-            }
+        let encodedResponse = try MCPFraming.encodeJSONResponse(response)
+        XCTAssertLessThan(
+            encodedResponse.count,
+            8192,
+            "Socket tools/list must stay below Claude Desktop MCPB's raw 8192-byte parse boundary"
         )
 
-        let expected: [String: (readOnly: Bool, destructive: Bool, idempotent: Bool, openWorld: Bool)] = [
-            "brain_search": (true, false, true, false),
-            "brain_store": (false, false, false, false),
-            "brain_get_person": (true, false, true, false),
-            "brain_recall": (true, false, true, false),
-            "brain_entity": (true, false, true, false),
-            "brain_digest": (false, false, false, false),
-            "brain_update": (false, false, true, false),
-            "brain_expand": (true, false, true, false),
-            "brain_tags": (true, false, true, false),
-            "brain_supersede": (false, true, false, false),
-            "brain_archive": (false, true, false, false),
-            "brain_enrich": (false, false, false, false),
-            "brain_subscribe": (false, false, false, false),
-            "brain_unsubscribe": (false, false, true, false),
-            "brain_ack": (false, false, true, false),
-            "brain_maintenance_rebuild_trigram": (false, false, true, false),
-        ]
-
-        for (name, taxonomy) in expected {
-            let annotations = toolsByName[name]?["annotations"] as? [String: Any]
-            XCTAssertNotNil(annotations, "\(name) must expose MCP tool annotations over socket transport")
-            XCTAssertEqual(annotations?["readOnlyHint"] as? Bool, taxonomy.readOnly, "\(name) readOnlyHint mismatch")
-            XCTAssertEqual(annotations?["destructiveHint"] as? Bool, taxonomy.destructive, "\(name) destructiveHint mismatch")
-            XCTAssertEqual(annotations?["idempotentHint"] as? Bool, taxonomy.idempotent, "\(name) idempotentHint mismatch")
-            XCTAssertEqual(annotations?["openWorldHint"] as? Bool, taxonomy.openWorld, "\(name) openWorldHint mismatch")
+        for tool in tools ?? [] {
+            XCTAssertNil(
+                tool["annotations"],
+                "\(tool["name"] ?? "unknown") should omit optional annotations over socket transport"
+            )
         }
     }
 

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -94,16 +94,52 @@ final class SocketIntegrationTests: XCTestCase {
         XCTAssertEqual(tools?.count, 16)
 
         let encodedResponse = try MCPFraming.encodeJSONResponse(response)
-        XCTAssertLessThan(
-            encodedResponse.count,
-            8192,
-            "Socket tools/list must stay below Claude Desktop MCPB's raw 8192-byte parse boundary"
-        )
+        XCTAssertGreaterThan(encodedResponse.count, 8192)
 
+        for tool in tools ?? [] {
+            XCTAssertNotNil(
+                tool["annotations"],
+                "\(tool["name"] ?? "unknown") should keep annotations over framed socket transport"
+            )
+        }
+    }
+
+    func testRawLineToolsListCompactsForClaudeExtensionLimit() throws {
+        let fd = try connectClient()
+        defer { close(fd) }
+
+        try sendRawLineJSON(on: fd, object: [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": "2024-11-05",
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": "claude-extension-test", "version": "1.0"]
+            ]
+        ])
+        _ = try readRawLineJSONData(fd: fd)
+
+        try sendRawLineJSON(on: fd, object: [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        ])
+
+        let line = try readRawLineJSONData(fd: fd)
+        let response = try JSONSerialization.jsonObject(with: line) as? [String: Any] ?? [:]
+        let tools = (response["result"] as? [String: Any])?["tools"] as? [[String: Any]]
+
+        XCTAssertLessThan(
+            line.count,
+            8192,
+            "Claude Desktop's MCPB utility process parses raw extension stdout in 8192-byte chunks"
+        )
+        XCTAssertEqual(tools?.count, 16)
         for tool in tools ?? [] {
             XCTAssertNil(
                 tool["annotations"],
-                "\(tool["name"] ?? "unknown") should omit optional annotations over socket transport"
+                "\(tool["name"] ?? "unknown") should omit optional annotations over raw newline transport"
             )
         }
     }
@@ -759,6 +795,40 @@ final class SocketIntegrationTests: XCTestCase {
         guard sent == frame.count else {
             throw NSError(domain: "test", code: 3, userInfo: [NSLocalizedDescriptionKey: "write() incomplete"])
         }
+    }
+
+    private func sendRawLineJSON(on fd: Int32, object: [String: Any]) throws {
+        var data = try JSONSerialization.data(withJSONObject: object)
+        data.append(0x0A)
+        let sent = data.withUnsafeBytes { ptr in
+            write(fd, ptr.baseAddress!, data.count)
+        }
+        guard sent == data.count else {
+            throw NSError(domain: "test", code: 3, userInfo: [NSLocalizedDescriptionKey: "raw write() incomplete"])
+        }
+    }
+
+    private func readRawLineJSONData(fd: Int32, timeout: TimeInterval = 5.0) throws -> Data {
+        var buffer = Data()
+        var readBuf = [UInt8](repeating: 0, count: 65536)
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            let n = read(fd, &readBuf, readBuf.count)
+            if n > 0 {
+                buffer.append(contentsOf: readBuf[0..<n])
+                if let newlineIndex = buffer.firstIndex(of: 0x0A) {
+                    return Data(buffer[..<newlineIndex])
+                }
+            } else if n == 0 {
+                break
+            } else if errno != EAGAIN && errno != EINTR && errno != EWOULDBLOCK {
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        throw NSError(domain: "test", code: 4, userInfo: [NSLocalizedDescriptionKey: "Timeout reading raw line response"])
     }
 
     private func readMCPMessage(fd: Int32, timeout: TimeInterval = 5.0) throws -> [String: Any] {


### PR DESCRIPTION
## Summary
- Fixes the real Claude Desktop boot failure after PR #274: the BrainLayer MCPB extension path is a Node utility-process bridge, not the Python stdio adapter.
- Keeps BrainBar's public `tools/list` response below Claude Desktop MCPB's observed 8192-byte raw stdout parse boundary by omitting optional tool `annotations` from the response.
- Keeps internal annotation taxonomy coverage on `MCPRouter.toolDefinitions`, so tool safety metadata remains documented and tested internally.

## Root Cause
Claude Desktop config shows BrainLayer Memory is managed by the installed MCPB extension:

`node /Users/etanheyman/Library/Application Support/Claude/Claude Extensions/local.mcpb.etan-heyman.brainlayer/server/index.js`

with `BRAINBAR_SOCKET=/tmp/brainbar.sock`.

Claude Desktop logs show the utility process attempts to parse the raw stdout stream in 8192-byte chunks. The previous `tools/list` response was 8995 bytes, so Claude parsed the first chunk as an unterminated JSON string and then parsed the second chunk as a separate JSON-RPC message.

Raw bytes captured from the deployed Node extension path before this fix:

```text
NODE_EXTENSION_TOTAL_BYTES=9199
NODE_EXTENSION_LINE_LENGTHS=202,8995
RAW_BYTES_8192_SLICE=b'e or all tag subscriptions for an agent.","annotations":{"destructiveHint":false,"readOnlyHint":false,"idempotentHint":true,"openWorldHint":false}},{"name":"brain_ack","inputSchema":{"required":["agent_id","seq"],"properties":{"seq":{"descr'
```

Claude's own UI/log error matches the second fragment beginning at `agent_id`:

```text
Invalid JSON-RPC message: agent_id":{"description":"Stable agent identifier","maxLength":128,"type":"string"}}...
```

## Tests
- TDD red first: `swift test --package-path brain-bar --filter MCPRouterTests/testEncodedToolsListFitsClaudeExtensionRawMessageLimit` failed before fix with `8995` bytes and annotations present.
- `swift test --package-path brain-bar --filter MCPRouterTests/testEncodedToolsListFitsClaudeExtensionRawMessageLimit` passed after fix.
- `swift test --package-path brain-bar --filter MCPRouterTests` passed: 45 tests, 0 failures.
- `swift test --package-path brain-bar --filter MCPFramingTests` passed: 8 tests, 0 failures.
- `swift test --package-path brain-bar --filter SocketIntegrationTests/testMCPToolsListOverSocket` passed.
- `swift test --package-path brain-bar` passed: 340 tests, 0 failures.
- `./scripts/run_tests.sh` passed: pytest unit suite 1823 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 32 passed; bun suite 1 pass; FTS5 regression PASS.
- Pre-push gate reran `./scripts/run_tests.sh` and passed with the same suites.

## Deploy Verification Plan
After merge: pull main, pause enrichment, rebuild/reinstall BrainBar, restart BrainBar, then launch the MCPB Node extension bridge and verify the raw `tools/list` line is below 8192 bytes and Claude logs no longer show `Unterminated string in JSON at position 8192` or `Invalid JSON-RPC message: agent_id`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JSON-RPC output for newline-delimited transport by conditionally stripping `annotations`, which could affect clients relying on that metadata or any large raw responses near the size threshold.
> 
> **Overview**
> Fixes Claude Desktop MCPB newline-delimited JSON parsing failures by **conditionally compacting** oversized raw JSON-RPC responses.
> 
> When `BrainBarServer` sends newline-delimited responses (no `Content-Length`), it now enforces an **8192-byte safety limit** by re-encoding `tools/list` with per-tool `annotations` removed if needed; framed (`Content-Length`) responses keep the canonical payload (including annotations).
> 
> Tests are updated/added to assert canonical `tools/list` keeps annotations, framed socket transport still includes annotations even when >8192 bytes, and raw-line transport returns a sub-8192-byte `tools/list` with annotations omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99371eb4458b2a6cc3941ed2b3f945bdf9a6361e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compact `tools/list` response for Claude MCP raw newline transport when payload exceeds 8192 bytes
> - When sending over raw newline-delimited JSON-RPC (no Content-Length framing), `BrainBarServer` now strips the `annotations` field from each tool in `tools/list` results if the encoded payload is ≥ 8192 bytes.
> - A new `encodeRawJSONResponse(_:)` helper handles size detection and delegates to `compactRawJSONResponseIfNeeded(_:)` for compaction, falling back to the original encoding if compaction fails.
> - New integration test in [SocketIntegrationTests.swift](https://github.com/EtanHey/brainlayer/pull/275/files#diff-eb094020d1436830931b80eca21b91c55f3fae6299895b70fb0ac70dd94e5b17) verifies raw line responses are under 8192 bytes with `annotations` omitted, while framed responses retain `annotations`.
> - Behavioral Change: Claude MCP clients using raw newline transport will no longer receive `annotations` in `tools/list` responses when the payload is large.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99371eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool annotations in JSON-RPC responses based on transport method.
  * Fixed tool list response behavior for newline-delimited JSON transport scenarios.

* **Tests**
  * Added comprehensive test coverage for tools/list endpoint responses, including socket integration and annotation handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->