### PR TITLE
fix(site): replace invalid &check; entity with ✓ in comparison component

### DIFF
--- a/site/components/comparison.tsx
+++ b/site/components/comparison.tsx
@@ -67,7 +67,7 @@ export function Comparison() {
                   className="flex items-start gap-3 text-[15px] leading-relaxed text-text"
                 >
                   <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent/10 text-accent text-xs font-bold">
-                    &check;
+                    ✓
                   </span>
                   <span>{item}</span>
                 </li>


### PR DESCRIPTION

<img width="957" height="361" alt="image" src="https://github.com/user-attachments/assets/2ad6c044-a8db-4a03-9d36-672ea40747e3" />


&check; is not a valid HTML entity in JSX; use the Unicode checkmark character instead.

https://claude.ai/code/session_01M3FNUCYhhNrVx6rF8qayQH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace invalid `✓` entity with `✓` in `Comparison` component
> The `✓` HTML entity is not a standard named HTML entity and renders incorrectly in some browsers. Replaces it with the literal Unicode character `✓` in [comparison.tsx](https://github.com/EtanHey/brainlayer/pull/278/files#diff-09bfb467bf237be5dcde40db53146b694f8e46a84220a4c4f4115df93ef2b2ef).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41c5efd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated status icon display in the comparison section to use a checkmark symbol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->