### PR TITLE
Add daily BrainLayer DB backups

### DIFF
--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -1,0 +1,112 @@
+# BrainLayer Backup Strategy
+
+Status: implemented for daily database snapshots.
+
+## Decision
+
+Use SQLite's online backup API, gzip the resulting snapshot, and upload it directly to Google Drive using the existing `~/.config/google-drive-mcp` OAuth credentials.
+
+Target folder:
+
+`Brain Drive/06_ARCHIVE/backups/brainlayer-db/YYYY-MM-DD.db.gz`
+
+Schedule:
+
+Daily at 03:17 local time via `com.brainlayer.backup-daily`.
+
+Retention:
+
+Keep the latest 30 daily snapshots plus the latest snapshot for each of the latest 12 months.
+
+## Why This Approach
+
+The database runs in WAL mode and has active writers from BrainBar, enrichment, watch, and maintenance jobs. Copying `brainlayer.db` directly can miss WAL contents or capture an inconsistent file pair. SQLite's online backup API reads through SQLite itself, so the backup is a consistent snapshot without stopping the live services.
+
+Direct Google Drive API upload is used because the post-repair machine no longer has Google Drive Desktop mounted at the old CloudStorage path. Historical DriveFS logs show the previous path was:
+
+`~/Library/CloudStorage/GoogleDrive-etanface@gmail.com/My Drive/Brain Drive`
+
+That mount is not present after repair, and `/Applications/Google Drive.app` is also absent. The API path avoids depending on that local mount.
+
+## Implementation
+
+Repo files:
+
+- `src/brainlayer/backup_daily.py`: creates the SQLite backup, gzips it, uploads it to Drive, and prunes retention.
+- `scripts/launchd/backup-daily.sh`: launchd wrapper installed to `~/.local/lib/brainlayer/backup-daily.sh`.
+- `scripts/launchd/com.brainlayer.backup-daily.plist`: LaunchAgent template.
+- `scripts/launchd/install.sh backup`: installs the wrapper and LaunchAgent.
+
+Local logs:
+
+- `~/.local/share/brainlayer/logs/backup-daily.log`
+- `~/.local/share/brainlayer/logs/backup-daily.err`
+
+Manual run:
+
+```bash
+PYTHONPATH=~/Gits/brainlayer/src python3 -m brainlayer.backup_daily
+```
+
+## Restore Drill
+
+1. Pick the newest good snapshot from Google Drive:
+
+   `Brain Drive/06_ARCHIVE/backups/brainlayer-db/YYYY-MM-DD.db.gz`
+
+2. Download it to a local scratch path, for example:
+
+   `/tmp/brainlayer-restore/YYYY-MM-DD.db.gz`
+
+3. Decompress and verify integrity:
+
+   ```bash
+   mkdir -p /tmp/brainlayer-restore
+   gunzip -c /tmp/brainlayer-restore/YYYY-MM-DD.db.gz > /tmp/brainlayer-restore/brainlayer.db
+   sqlite3 /tmp/brainlayer-restore/brainlayer.db 'PRAGMA integrity_check; SELECT count(*) FROM chunks;'
+   ```
+
+4. Stop writers before replacing the live DB:
+
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/com.brainlayer.brainbar.plist 2>/dev/null || true
+   launchctl unload ~/Library/LaunchAgents/com.brainlayer.enrichment.plist 2>/dev/null || true
+   launchctl unload ~/Library/LaunchAgents/com.brainlayer.watch.plist 2>/dev/null || true
+   launchctl unload ~/Library/LaunchAgents/com.brainlayer.decay.plist 2>/dev/null || true
+   ```
+
+5. Preserve the corrupted DB and install the restored copy:
+
+   ```bash
+   ts="$(date +%Y%m%d-%H%M%S)"
+   mkdir -p ~/.local/share/brainlayer/corrupt-$ts
+   mv ~/.local/share/brainlayer/brainlayer.db* ~/.local/share/brainlayer/corrupt-$ts/
+   cp /tmp/brainlayer-restore/brainlayer.db ~/.local/share/brainlayer/brainlayer.db
+   ```
+
+6. Re-enable services:
+
+   ```bash
+   launchctl load ~/Library/LaunchAgents/com.brainlayer.brainbar.plist
+   launchctl load ~/Library/LaunchAgents/com.brainlayer.enrichment.plist
+   launchctl load ~/Library/LaunchAgents/com.brainlayer.watch.plist
+   launchctl load ~/Library/LaunchAgents/com.brainlayer.decay.plist
+   ```
+
+7. Confirm the DB is usable:
+
+   ```bash
+   sqlite3 ~/.local/share/brainlayer/brainlayer.db 'PRAGMA integrity_check; SELECT count(*) FROM chunks;'
+   brainlayer wal-checkpoint --mode TRUNCATE
+   ```
+
+## Monthly Drill
+
+Once per month:
+
+1. Download the newest snapshot from Drive.
+2. Restore it into `/tmp/brainlayer-restore`.
+3. Run `PRAGMA integrity_check` and `SELECT count(*) FROM chunks`.
+4. Record the snapshot date, chunk count, and command output in the maintenance log.
+
+Do not replace the live DB during a drill unless the live DB is actually corrupted.

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -84,9 +84,15 @@ PYTHONPATH=~/Gits/brainlayer/src python3 -m brainlayer.backup_daily
    ```bash
    ts="$(date +%Y%m%d-%H%M%S)"
    mkdir -p ~/.local/share/brainlayer/corrupt-$ts
+   ls -lh ~/.local/share/brainlayer/brainlayer.db ~/.local/share/brainlayer/brainlayer.db-wal ~/.local/share/brainlayer/brainlayer.db-shm 2>/dev/null || true
    mv ~/.local/share/brainlayer/brainlayer.db* ~/.local/share/brainlayer/corrupt-$ts/
+   ls -lh ~/.local/share/brainlayer/corrupt-$ts/
    cp /tmp/brainlayer-restore/brainlayer.db ~/.local/share/brainlayer/brainlayer.db
    ```
+
+   The `brainlayer.db*` move preserves the main database plus SQLite auxiliary files: `brainlayer.db`,
+   `brainlayer.db-wal`, and `brainlayer.db-shm`. Verify the `ls` output before and after the move; the
+   wildcard will also move any other similarly named files in that directory.
 
 6. Verify the restored DB before re-enabling services:
 

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -10,6 +10,10 @@ Target folder:
 
 `Brain Drive/06_ARCHIVE/backups/brainlayer-db/YYYY-MM-DD.db.gz`
 
+Encryption posture:
+
+Backups are encrypted in transit by HTTPS and at rest by Google Drive. The database can contain user messages, code snippets, file paths, and agent memory, so client-side encryption should be added before upload if the threat model requires protection from the Drive account/provider layer. Recommended upgrade path: encrypt the gzip with `age` or GPG using a key stored in 1Password, then upload `YYYY-MM-DD.db.gz.age` and document the recovery key location.
+
 Schedule:
 
 Daily at 03:17 local time via `com.brainlayer.backup-daily`.
@@ -84,7 +88,13 @@ PYTHONPATH=~/Gits/brainlayer/src python3 -m brainlayer.backup_daily
    cp /tmp/brainlayer-restore/brainlayer.db ~/.local/share/brainlayer/brainlayer.db
    ```
 
-6. Re-enable services:
+6. Verify the restored DB before re-enabling services:
+
+   ```bash
+   sqlite3 ~/.local/share/brainlayer/brainlayer.db 'PRAGMA integrity_check; SELECT count(*) FROM chunks;'
+   ```
+
+7. Re-enable services:
 
    ```bash
    launchctl load ~/Library/LaunchAgents/com.brainlayer.brainbar.plist
@@ -93,10 +103,9 @@ PYTHONPATH=~/Gits/brainlayer/src python3 -m brainlayer.backup_daily
    launchctl load ~/Library/LaunchAgents/com.brainlayer.decay.plist
    ```
 
-7. Confirm the DB is usable:
+8. Run a post-restore WAL checkpoint:
 
    ```bash
-   sqlite3 ~/.local/share/brainlayer/brainlayer.db 'PRAGMA integrity_check; SELECT count(*) FROM chunks;'
    brainlayer wal-checkpoint --mode TRUNCATE
    ```
 

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -12,7 +12,7 @@ Target folder:
 
 Encryption posture:
 
-Backups are encrypted in transit by HTTPS and at rest by Google Drive. The database can contain user messages, code snippets, file paths, and agent memory, so client-side encryption should be added before upload if the threat model requires protection from the Drive account/provider layer. Recommended upgrade path: encrypt the gzip with `age` or GPG using a key stored in 1Password, then upload `YYYY-MM-DD.db.gz.age` and document the recovery key location.
+Backups are encrypted in transit by HTTPS and at rest by Google's infrastructure. Google holds the provider-side encryption keys. The database can contain user messages, code snippets, file paths, and agent memory, so client-side encryption should be added before upload if the threat model requires protection from the Drive account/provider layer. Recommended upgrade path: encrypt the gzip with `age` or GPG using a key stored in 1Password, then upload `YYYY-MM-DD.db.gz.age` and document the recovery key location.
 
 Schedule:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "scikit-learn>=1.0.0",  # K-means for cluster-based sampling
     "spacy>=3.7,<4.0",  # NER for PII sanitization (en_core_web_sm model)
     "requests>=2.28.0",  # HTTP calls to Ollama for enrichment
+    "google-api-python-client>=2.0.0",  # Daily DB backup upload to Google Drive
+    "google-auth>=2.0.0",  # OAuth refresh for Google Drive backups
     "ranx>=0.3.20",  # IR evaluation metrics + significance testing
     "abydos>=0.5.0",  # Beider-Morse phonetic matching for cross-script entity aliases
 ]

--- a/scripts/launchd/backup-daily.sh
+++ b/scripts/launchd/backup-daily.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin"
+export PYTHONUNBUFFERED=1
+
+exec "${BRAINLAYER_PYTHON:-python3}" -m brainlayer.backup_daily

--- a/scripts/launchd/com.brainlayer.backup-daily.plist
+++ b/scripts/launchd/com.brainlayer.backup-daily.plist
@@ -5,6 +5,9 @@
     <key>Label</key>
     <string>com.brainlayer.backup-daily</string>
 
+    <!-- __HOME__ and __BRAINLAYER_DIR__ are expanded by scripts/launchd/install.sh
+         before this template is copied into ~/Library/LaunchAgents. -->
+
     <key>ProgramArguments</key>
     <array>
         <string>__HOME__/.local/lib/brainlayer/backup-daily.sh</string>
@@ -27,7 +30,7 @@
     <dict>
         <key>PYTHONPATH</key>
         <string>__BRAINLAYER_DIR__/src</string>
-        <key>BRAINLAYER_BACKUP_DRIVE_PATH</key>
+        <key>BRAINLAYER_BACKUP_DRIVE_FOLDER</key>
         <string>Brain Drive/06_ARCHIVE/backups/brainlayer-db</string>
     </dict>
 

--- a/scripts/launchd/com.brainlayer.backup-daily.plist
+++ b/scripts/launchd/com.brainlayer.backup-daily.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.brainlayer.backup-daily</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/.local/lib/brainlayer/backup-daily.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>17</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.local/share/brainlayer/logs/backup-daily.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.local/share/brainlayer/logs/backup-daily.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONPATH</key>
+        <string>__BRAINLAYER_DIR__/src</string>
+        <key>BRAINLAYER_BACKUP_DRIVE_PATH</key>
+        <string>Brain Drive/06_ARCHIVE/backups/brainlayer-db</string>
+    </dict>
+
+    <key>Nice</key>
+    <integer>15</integer>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -9,6 +9,7 @@
 #   ./scripts/launchd/install.sh load enrichment
 #   ./scripts/launchd/install.sh unload enrichment
 #   ./scripts/launchd/install.sh checkpoint   # Install WAL checkpoint only
+#   ./scripts/launchd/install.sh backup       # Install daily DB backup only
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
 set -euo pipefail
 
@@ -16,6 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LAUNCH_DIR="$HOME/Library/LaunchAgents"
 LOG_DIR="$HOME/Library/Logs"
 BRAINLAYER_LOG_DIR="$HOME/.local/share/brainlayer/logs"
+BRAINLAYER_LIB_DIR="$HOME/.local/lib/brainlayer"
 BRAINLAYER_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BRAINLAYER_BIN="${BRAINLAYER_BIN:-$(which brainlayer 2>/dev/null || echo "$HOME/.local/bin/brainlayer")}"
 GOOGLE_API_KEY="${GOOGLE_API_KEY:-}"
@@ -27,7 +29,7 @@ if [ ! -x "$BRAINLAYER_BIN" ]; then
     exit 1
 fi
 
-mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$BRAINLAYER_LOG_DIR"
+mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
 
 resolve_google_api_key() {
     if [ -n "${GOOGLE_API_KEY:-}" ]; then
@@ -95,6 +97,20 @@ install_plist() {
     load_plist "$name"
 }
 
+install_backup_script() {
+    local src="$SCRIPT_DIR/backup-daily.sh"
+    local dst="$BRAINLAYER_LIB_DIR/backup-daily.sh"
+
+    if [ ! -f "$src" ]; then
+        echo "ERROR: $src not found"
+        return 1
+    fi
+
+    cp "$src" "$dst"
+    chmod 755 "$dst"
+    echo "Installed: $dst"
+}
+
 remove_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
@@ -127,11 +143,17 @@ case "${1:-all}" in
     checkpoint)
         install_plist wal-checkpoint
         ;;
+    backup)
+        install_backup_script
+        install_plist backup-daily
+        ;;
     all)
         install_plist index
         install_plist enrichment
         install_plist decay
         install_plist wal-checkpoint
+        install_backup_script
+        install_plist backup-daily
         # Remove old enrich plist if present
         remove_plist enrich 2>/dev/null || true
         ;;
@@ -141,9 +163,11 @@ case "${1:-all}" in
         remove_plist enrichment 2>/dev/null || true
         remove_plist decay 2>/dev/null || true
         remove_plist wal-checkpoint
+        remove_plist backup-daily 2>/dev/null || true
+        rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
         ;;
     *)
-        echo "Usage: $0 [index|enrich|enrichment|decay|load [name]|unload [name]|checkpoint|all|remove]"
+        echo "Usage: $0 [index|enrich|enrichment|decay|load [name]|unload [name]|checkpoint|backup|all|remove]"
         exit 1
         ;;
 esac

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import datetime as dt
 import fcntl
 import gzip
-import http.client
 import json
 import os
 import shutil
@@ -116,6 +115,8 @@ def get_drive_credentials(token_path: Path = DEFAULT_TOKEN_PATH, client_path: Pa
         parsed_expiry = dt.datetime.fromisoformat(expiry.replace("Z", "+00:00")) if expiry else None
         if parsed_expiry and parsed_expiry.tzinfo:
             parsed_expiry = parsed_expiry.astimezone(dt.UTC).replace(tzinfo=None)
+        elif parsed_expiry:
+            parsed_expiry = parsed_expiry.replace(tzinfo=None)
 
         creds = Credentials(
             token=token_data.get("access_token"),
@@ -127,6 +128,7 @@ def get_drive_credentials(token_path: Path = DEFAULT_TOKEN_PATH, client_path: Pa
             expiry=parsed_expiry,
         )
 
+        # google-auth Credentials.expired compares against a naive UTC helper, so keep expiry comparisons naive UTC.
         refresh_before = dt.datetime.now(dt.UTC).replace(tzinfo=None) + dt.timedelta(hours=2)
         if creds.expired or not creds.valid or (creds.expiry and creds.expiry < refresh_before):
             creds.refresh(Request())
@@ -177,47 +179,6 @@ def ensure_drive_folder_chain(service: Any, folder_parts: list[str]) -> str:
     if parent_id is None:
         raise ValueError("folder_parts must not be empty")
     return parent_id
-
-
-def _execute_resumable_upload(request: Any, max_attempts: int = 30) -> dict[str, Any]:
-    import httplib2
-    from google.auth.exceptions import TransportError
-    from googleapiclient.errors import HttpError
-
-    response = None
-    attempt = 0
-    while response is None:
-        try:
-            _, response = request.next_chunk()
-            attempt = 0
-        except HttpError as exc:
-            if exc.resp.status not in {429, 500, 502, 503, 504}:
-                raise
-            attempt += 1
-            if attempt >= max_attempts:
-                raise
-            sleep_seconds = min(60, 2**attempt)
-            print(f"drive upload retry {attempt}/{max_attempts - 1}: {exc}; sleeping {sleep_seconds}s", flush=True)
-            time.sleep(sleep_seconds)
-        except (TransportError, http.client.HTTPException, httplib2.HttpLib2Error, OSError, TimeoutError) as exc:
-            attempt += 1
-            if attempt >= max_attempts:
-                raise
-            sleep_seconds = min(60, 2**attempt)
-            print(f"drive upload retry {attempt}/{max_attempts - 1}: {exc}; sleeping {sleep_seconds}s", flush=True)
-            time.sleep(sleep_seconds)
-    return response
-
-
-def upload_file_to_drive(service: Any, file_path: Path, folder_parts: list[str] = DEFAULT_FOLDER_PARTS) -> dict[str, Any]:
-    from googleapiclient.http import MediaFileUpload
-
-    file_path = Path(file_path)
-    folder_id = ensure_drive_folder_chain(service, folder_parts)
-    media = MediaFileUpload(str(file_path), mimetype="application/gzip", chunksize=1024 * 1024, resumable=True)
-    metadata = {"name": file_path.name, "parents": [folder_id]}
-    request = service.files().create(body=metadata, media_body=media, fields="id,name", supportsAllDrives=True)
-    return _execute_resumable_upload(request)
 
 
 def upload_file_to_drive_raw(
@@ -377,6 +338,7 @@ def main() -> int:
     try:
         result = run_backup(
             staging_dir=Path(os.environ.get("BRAINLAYER_BACKUP_STAGING_DIR", str(DEFAULT_STAGING_DIR))),
+            # Prefer BRAINLAYER_BACKUP_DRIVE_FOLDER; BRAINLAYER_BACKUP_DRIVE_PATH is a legacy alias before DEFAULT_FOLDER_PARTS.
             folder_parts=os.environ.get(
                 "BRAINLAYER_BACKUP_DRIVE_FOLDER",
                 os.environ.get("BRAINLAYER_BACKUP_DRIVE_PATH", "/".join(DEFAULT_FOLDER_PARTS)),

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -8,6 +8,7 @@ snapshot without stopping BrainBar or the enrichment jobs.
 from __future__ import annotations
 
 import datetime as dt
+import fcntl
 import gzip
 import http.client
 import json
@@ -16,6 +17,7 @@ import shutil
 import sqlite3
 import tempfile
 import time
+import traceback
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +34,7 @@ DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
 
 
 def _today() -> str:
-    return dt.date.today().isoformat()
+    return dt.datetime.now(dt.UTC).date().isoformat()
 
 
 def _escape_drive_query_value(value: str) -> str:
@@ -49,6 +51,13 @@ def create_sqlite_backup_gzip(db_path: Path, output_dir: Path, date_stamp: str |
         raise FileNotFoundError(f"BrainLayer database not found: {db_path}")
 
     output_dir.mkdir(parents=True, exist_ok=True)
+    required_bytes = (db_path.stat().st_size * 2) + (512 * 1024 * 1024)
+    free_bytes = shutil.disk_usage(output_dir).free
+    if free_bytes < required_bytes:
+        raise RuntimeError(
+            f"Insufficient free space for backup in {output_dir}: "
+            f"{free_bytes} bytes free, {required_bytes} bytes required"
+        )
     final_gz = output_dir / f"{date_stamp}.db.gz"
 
     with tempfile.TemporaryDirectory(prefix="brainlayer-backup-", dir=output_dir) as tmp:
@@ -57,7 +66,7 @@ def create_sqlite_backup_gzip(db_path: Path, output_dir: Path, date_stamp: str |
         target = sqlite3.connect(raw_snapshot)
         try:
             source.backup(target, pages=10_000, sleep=0.1)
-            target.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            target.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             integrity = target.execute("PRAGMA integrity_check").fetchone()
             if not integrity or integrity[0] != "ok":
                 raise RuntimeError(f"Backup integrity check failed: {integrity!r}")
@@ -73,6 +82,15 @@ def create_sqlite_backup_gzip(db_path: Path, output_dir: Path, date_stamp: str |
     return final_gz
 
 
+def _atomic_write_text(path: Path, content: str) -> None:
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temp_path.write_text(content)
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 def get_drive_credentials(token_path: Path = DEFAULT_TOKEN_PATH, client_path: Path = DEFAULT_CLIENT_PATH):
     """Load and refresh Google Drive OAuth credentials from the existing MCP auth files."""
     from google.auth.transport.requests import Request
@@ -85,33 +103,36 @@ def get_drive_credentials(token_path: Path = DEFAULT_TOKEN_PATH, client_path: Pa
     if not client_path.exists():
         raise FileNotFoundError(f"Google OAuth client file not found: {client_path}")
 
-    token_data = json.loads(token_path.read_text())
-    client_data = json.loads(client_path.read_text())["installed"]
+    lock_path = token_path.with_suffix(token_path.suffix + ".lock")
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        token_data = json.loads(token_path.read_text())
+        client_data = json.loads(client_path.read_text())["installed"]
 
-    expiry = token_data.get("expiry")
-    if not expiry and token_data.get("expiry_date"):
-        expiry = dt.datetime.fromtimestamp(int(token_data["expiry_date"]) / 1000, tz=dt.UTC).isoformat()
+        expiry = token_data.get("expiry")
+        if not expiry and token_data.get("expiry_date"):
+            expiry = dt.datetime.fromtimestamp(int(token_data["expiry_date"]) / 1000, tz=dt.UTC).isoformat()
 
-    parsed_expiry = dt.datetime.fromisoformat(expiry.replace("Z", "+00:00")) if expiry else None
-    if parsed_expiry and parsed_expiry.tzinfo:
-        parsed_expiry = parsed_expiry.astimezone(dt.UTC).replace(tzinfo=None)
+        parsed_expiry = dt.datetime.fromisoformat(expiry.replace("Z", "+00:00")) if expiry else None
+        if parsed_expiry and parsed_expiry.tzinfo:
+            parsed_expiry = parsed_expiry.astimezone(dt.UTC).replace(tzinfo=None)
 
-    creds = Credentials(
-        token=token_data.get("access_token"),
-        refresh_token=token_data.get("refresh_token"),
-        token_uri=client_data["token_uri"],
-        client_id=client_data["client_id"],
-        client_secret=client_data["client_secret"],
-        scopes=token_data.get("scope", " ".join(DRIVE_SCOPES)).split(),
-        expiry=parsed_expiry,
-    )
+        creds = Credentials(
+            token=token_data.get("access_token"),
+            refresh_token=token_data.get("refresh_token"),
+            token_uri=client_data["token_uri"],
+            client_id=client_data["client_id"],
+            client_secret=client_data["client_secret"],
+            scopes=token_data.get("scope", " ".join(DRIVE_SCOPES)).split(),
+            expiry=parsed_expiry,
+        )
 
-    refresh_before = dt.datetime.now(dt.UTC).replace(tzinfo=None) + dt.timedelta(hours=2)
-    if creds.expired or not creds.valid or (creds.expiry and creds.expiry < refresh_before):
-        creds.refresh(Request())
-        token_data["access_token"] = creds.token
-        token_data["expiry"] = creds.expiry.isoformat() if creds.expiry else None
-        token_path.write_text(json.dumps(token_data, indent=2, sort_keys=True) + "\n")
+        refresh_before = dt.datetime.now(dt.UTC).replace(tzinfo=None) + dt.timedelta(hours=2)
+        if creds.expired or not creds.valid or (creds.expiry and creds.expiry < refresh_before):
+            creds.refresh(Request())
+            token_data["access_token"] = creds.token
+            token_data["expiry"] = creds.expiry.isoformat() if creds.expiry else None
+            _atomic_write_text(token_path, json.dumps(token_data, indent=2, sort_keys=True) + "\n")
 
     return creds
 
@@ -228,7 +249,10 @@ def upload_file_to_drive_raw(
     with file_path.open("rb") as handle:
         while sent < total:
             handle.seek(sent)
-            chunk = handle.read(min(chunk_size, total - sent))
+            expected = min(chunk_size, total - sent)
+            chunk = handle.read(expected)
+            if len(chunk) != expected:
+                raise RuntimeError(f"Backup file changed during upload: expected {expected} bytes, got {len(chunk)}")
             start = sent
             end = sent + len(chunk) - 1
             headers = {
@@ -247,6 +271,7 @@ def upload_file_to_drive_raw(
                             sent = int(uploaded_range.rsplit("-", 1)[1]) + 1
                         else:
                             sent = end + 1
+                        print(f"drive upload progress: {sent}/{total} bytes", flush=True)
                         break
                     if response.status_code in {429, 500, 502, 503, 504}:
                         raise RuntimeError(f"retryable HTTP {response.status_code}: {response.text[:200]}")
@@ -358,7 +383,7 @@ def main() -> int:
             ).split("/"),
         )
     except Exception as exc:
-        print(f"brainlayer backup failed: {exc}", flush=True)
+        print(f"brainlayer backup failed: {exc}\n{traceback.format_exc()}", flush=True)
         return 1
     print(json.dumps(result, sort_keys=True), flush=True)
     return 0

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -106,7 +106,7 @@ def get_drive_credentials(token_path: Path = DEFAULT_TOKEN_PATH, client_path: Pa
         expiry=parsed_expiry,
     )
 
-    refresh_before = dt.datetime.utcnow() + dt.timedelta(hours=2)
+    refresh_before = dt.datetime.now(dt.UTC).replace(tzinfo=None) + dt.timedelta(hours=2)
     if creds.expired or not creds.valid or (creds.expiry and creds.expiry < refresh_before):
         creds.refresh(Request())
         token_data["access_token"] = creds.token
@@ -243,7 +243,10 @@ def upload_file_to_drive_raw(
                         return response.json()
                     if response.status_code == 308:
                         uploaded_range = response.headers.get("Range")
-                        sent = int(uploaded_range.rsplit("-", 1)[1]) + 1 if uploaded_range else end + 1
+                        if uploaded_range and "-" in uploaded_range:
+                            sent = int(uploaded_range.rsplit("-", 1)[1]) + 1
+                        else:
+                            sent = end + 1
                         break
                     if response.status_code in {429, 500, 502, 503, 504}:
                         raise RuntimeError(f"retryable HTTP {response.status_code}: {response.text[:200]}")
@@ -274,19 +277,27 @@ def _parse_snapshot_date(name: str) -> dt.date | None:
 def prune_drive_backups(service: Any, folder_parts: list[str] = DEFAULT_FOLDER_PARTS) -> list[str]:
     """Keep 30 latest daily snapshots plus latest snapshot for each of 12 months."""
     folder_id = ensure_drive_folder_chain(service, folder_parts)
-    result = (
-        service.files()
-        .list(
-            q=f"'{folder_id}' in parents and trashed = false",
-            spaces="drive",
-            fields="files(id,name)",
-            pageSize=1000,
-            supportsAllDrives=True,
+    files: list[dict[str, str]] = []
+    page_token = None
+    while True:
+        result = (
+            service.files()
+            .list(
+                q=f"'{folder_id}' in parents and trashed = false",
+                spaces="drive",
+                fields="nextPageToken,files(id,name)",
+                pageSize=1000,
+                pageToken=page_token,
+                supportsAllDrives=True,
+            )
+            .execute()
         )
-        .execute()
-    )
+        files.extend(result.get("files", []))
+        page_token = result.get("nextPageToken")
+        if not page_token:
+            break
     dated = []
-    for item in result.get("files", []):
+    for item in files:
         parsed = _parse_snapshot_date(item.get("name", ""))
         if parsed:
             dated.append((parsed, item))
@@ -341,7 +352,10 @@ def main() -> int:
     try:
         result = run_backup(
             staging_dir=Path(os.environ.get("BRAINLAYER_BACKUP_STAGING_DIR", str(DEFAULT_STAGING_DIR))),
-            folder_parts=os.environ.get("BRAINLAYER_BACKUP_DRIVE_PATH", "/".join(DEFAULT_FOLDER_PARTS)).split("/"),
+            folder_parts=os.environ.get(
+                "BRAINLAYER_BACKUP_DRIVE_FOLDER",
+                os.environ.get("BRAINLAYER_BACKUP_DRIVE_PATH", "/".join(DEFAULT_FOLDER_PARTS)),
+            ).split("/"),
         )
     except Exception as exc:
         print(f"brainlayer backup failed: {exc}", flush=True)

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -1,0 +1,354 @@
+"""Daily BrainLayer database backups.
+
+The backup path intentionally uses SQLite's online backup API instead of copying
+the database file directly, so live WAL writes are folded into a consistent
+snapshot without stopping BrainBar or the enrichment jobs.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import gzip
+import http.client
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from .paths import get_db_path
+
+DEFAULT_TOKEN_PATH = Path.home() / ".config" / "google-drive-mcp" / "tokens.json"
+DEFAULT_CLIENT_PATH = Path.home() / ".config" / "google-drive-mcp" / "gcp-oauth.keys.json"
+DEFAULT_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"]
+DEFAULT_STAGING_DIR = Path.home() / ".local" / "share" / "brainlayer" / "backups"
+DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
+DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+
+def _today() -> str:
+    return dt.date.today().isoformat()
+
+
+def _escape_drive_query_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def create_sqlite_backup_gzip(db_path: Path, output_dir: Path, date_stamp: str | None = None) -> Path:
+    """Create a restorable `.db.gz` snapshot using SQLite's online backup API."""
+    db_path = Path(db_path).expanduser()
+    output_dir = Path(output_dir).expanduser()
+    date_stamp = date_stamp or _today()
+
+    if not db_path.exists():
+        raise FileNotFoundError(f"BrainLayer database not found: {db_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_gz = output_dir / f"{date_stamp}.db.gz"
+
+    with tempfile.TemporaryDirectory(prefix="brainlayer-backup-", dir=output_dir) as tmp:
+        raw_snapshot = Path(tmp) / f"{date_stamp}.db"
+        source = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=60)
+        target = sqlite3.connect(raw_snapshot)
+        try:
+            source.backup(target, pages=10_000, sleep=0.1)
+            target.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            integrity = target.execute("PRAGMA integrity_check").fetchone()
+            if not integrity or integrity[0] != "ok":
+                raise RuntimeError(f"Backup integrity check failed: {integrity!r}")
+        finally:
+            target.close()
+            source.close()
+
+        temp_gz = Path(tmp) / final_gz.name
+        with raw_snapshot.open("rb") as src, gzip.open(temp_gz, "wb", compresslevel=6) as dst:
+            shutil.copyfileobj(src, dst, length=1024 * 1024)
+        shutil.move(str(temp_gz), final_gz)
+
+    return final_gz
+
+
+def get_drive_credentials(token_path: Path = DEFAULT_TOKEN_PATH, client_path: Path = DEFAULT_CLIENT_PATH):
+    """Load and refresh Google Drive OAuth credentials from the existing MCP auth files."""
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+
+    token_path = Path(token_path).expanduser()
+    client_path = Path(client_path).expanduser()
+    if not token_path.exists():
+        raise FileNotFoundError(f"Google Drive token file not found: {token_path}")
+    if not client_path.exists():
+        raise FileNotFoundError(f"Google OAuth client file not found: {client_path}")
+
+    token_data = json.loads(token_path.read_text())
+    client_data = json.loads(client_path.read_text())["installed"]
+
+    expiry = token_data.get("expiry")
+    if not expiry and token_data.get("expiry_date"):
+        expiry = dt.datetime.fromtimestamp(int(token_data["expiry_date"]) / 1000, tz=dt.UTC).isoformat()
+
+    parsed_expiry = dt.datetime.fromisoformat(expiry.replace("Z", "+00:00")) if expiry else None
+    if parsed_expiry and parsed_expiry.tzinfo:
+        parsed_expiry = parsed_expiry.astimezone(dt.UTC).replace(tzinfo=None)
+
+    creds = Credentials(
+        token=token_data.get("access_token"),
+        refresh_token=token_data.get("refresh_token"),
+        token_uri=client_data["token_uri"],
+        client_id=client_data["client_id"],
+        client_secret=client_data["client_secret"],
+        scopes=token_data.get("scope", " ".join(DRIVE_SCOPES)).split(),
+        expiry=parsed_expiry,
+    )
+
+    refresh_before = dt.datetime.utcnow() + dt.timedelta(hours=2)
+    if creds.expired or not creds.valid or (creds.expiry and creds.expiry < refresh_before):
+        creds.refresh(Request())
+        token_data["access_token"] = creds.token
+        token_data["expiry"] = creds.expiry.isoformat() if creds.expiry else None
+        token_path.write_text(json.dumps(token_data, indent=2, sort_keys=True) + "\n")
+
+    return creds
+
+
+def build_drive_service(token_path: Path = DEFAULT_TOKEN_PATH, client_path: Path = DEFAULT_CLIENT_PATH):
+    from googleapiclient.discovery import build
+
+    return build("drive", "v3", credentials=get_drive_credentials(token_path, client_path))
+
+
+def ensure_drive_folder(service: Any, name: str, parent_id: str | None = None) -> str:
+    escaped = _escape_drive_query_value(name)
+    clauses = [
+        f"name = '{escaped}'",
+        f"mimeType = '{DRIVE_FOLDER_MIME}'",
+        "trashed = false",
+    ]
+    if parent_id:
+        clauses.append(f"'{parent_id}' in parents")
+    query = " and ".join(clauses)
+
+    result = (
+        service.files()
+        .list(q=query, spaces="drive", fields="files(id,name)", pageSize=10, supportsAllDrives=True)
+        .execute()
+    )
+    files = result.get("files", [])
+    if files:
+        return files[0]["id"]
+
+    metadata: dict[str, Any] = {"name": name, "mimeType": DRIVE_FOLDER_MIME}
+    if parent_id:
+        metadata["parents"] = [parent_id]
+    created = service.files().create(body=metadata, fields="id", supportsAllDrives=True).execute()
+    return created["id"]
+
+
+def ensure_drive_folder_chain(service: Any, folder_parts: list[str]) -> str:
+    parent_id = None
+    for part in folder_parts:
+        parent_id = ensure_drive_folder(service, part, parent_id)
+    if parent_id is None:
+        raise ValueError("folder_parts must not be empty")
+    return parent_id
+
+
+def _execute_resumable_upload(request: Any, max_attempts: int = 30) -> dict[str, Any]:
+    import httplib2
+    from google.auth.exceptions import TransportError
+    from googleapiclient.errors import HttpError
+
+    response = None
+    attempt = 0
+    while response is None:
+        try:
+            _, response = request.next_chunk()
+            attempt = 0
+        except HttpError as exc:
+            if exc.resp.status not in {429, 500, 502, 503, 504}:
+                raise
+            attempt += 1
+            if attempt >= max_attempts:
+                raise
+            sleep_seconds = min(60, 2**attempt)
+            print(f"drive upload retry {attempt}/{max_attempts - 1}: {exc}; sleeping {sleep_seconds}s", flush=True)
+            time.sleep(sleep_seconds)
+        except (TransportError, http.client.HTTPException, httplib2.HttpLib2Error, OSError, TimeoutError) as exc:
+            attempt += 1
+            if attempt >= max_attempts:
+                raise
+            sleep_seconds = min(60, 2**attempt)
+            print(f"drive upload retry {attempt}/{max_attempts - 1}: {exc}; sleeping {sleep_seconds}s", flush=True)
+            time.sleep(sleep_seconds)
+    return response
+
+
+def upload_file_to_drive(service: Any, file_path: Path, folder_parts: list[str] = DEFAULT_FOLDER_PARTS) -> dict[str, Any]:
+    from googleapiclient.http import MediaFileUpload
+
+    file_path = Path(file_path)
+    folder_id = ensure_drive_folder_chain(service, folder_parts)
+    media = MediaFileUpload(str(file_path), mimetype="application/gzip", chunksize=1024 * 1024, resumable=True)
+    metadata = {"name": file_path.name, "parents": [folder_id]}
+    request = service.files().create(body=metadata, media_body=media, fields="id,name", supportsAllDrives=True)
+    return _execute_resumable_upload(request)
+
+
+def upload_file_to_drive_raw(
+    file_path: Path,
+    folder_id: str,
+    credentials: Any,
+    chunk_size: int = 8 * 1024 * 1024,
+    max_attempts: int = 30,
+) -> dict[str, Any]:
+    """Upload large backups with Drive's raw resumable protocol."""
+    file_path = Path(file_path)
+    total = file_path.stat().st_size
+    metadata = {"name": file_path.name, "parents": [folder_id]}
+    init = requests.post(
+        "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable&supportsAllDrives=true&fields=id,name,size",
+        headers={
+            "Authorization": f"Bearer {credentials.token}",
+            "Content-Type": "application/json; charset=UTF-8",
+            "X-Upload-Content-Type": "application/gzip",
+            "X-Upload-Content-Length": str(total),
+        },
+        data=json.dumps(metadata),
+        timeout=60,
+    )
+    init.raise_for_status()
+    upload_url = init.headers["Location"]
+
+    sent = 0
+    with file_path.open("rb") as handle:
+        while sent < total:
+            handle.seek(sent)
+            chunk = handle.read(min(chunk_size, total - sent))
+            start = sent
+            end = sent + len(chunk) - 1
+            headers = {
+                "Authorization": f"Bearer {credentials.token}",
+                "Content-Length": str(len(chunk)),
+                "Content-Range": f"bytes {start}-{end}/{total}",
+            }
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    response = requests.put(upload_url, headers=headers, data=chunk, timeout=120)
+                    if response.status_code in {200, 201}:
+                        return response.json()
+                    if response.status_code == 308:
+                        uploaded_range = response.headers.get("Range")
+                        sent = int(uploaded_range.rsplit("-", 1)[1]) + 1 if uploaded_range else end + 1
+                        break
+                    if response.status_code in {429, 500, 502, 503, 504}:
+                        raise RuntimeError(f"retryable HTTP {response.status_code}: {response.text[:200]}")
+                    response.raise_for_status()
+                except Exception as exc:
+                    if attempt >= max_attempts:
+                        raise
+                    sleep_seconds = min(60, 2 ** min(attempt, 6))
+                    print(
+                        f"drive upload retry chunk={start}-{end} attempt={attempt}/{max_attempts}: {exc}; "
+                        f"sleeping {sleep_seconds}s",
+                        flush=True,
+                    )
+                    time.sleep(sleep_seconds)
+
+    raise RuntimeError("Drive upload ended without final response")
+
+
+def _parse_snapshot_date(name: str) -> dt.date | None:
+    if not name.endswith(".db.gz"):
+        return None
+    try:
+        return dt.date.fromisoformat(name[:10])
+    except ValueError:
+        return None
+
+
+def prune_drive_backups(service: Any, folder_parts: list[str] = DEFAULT_FOLDER_PARTS) -> list[str]:
+    """Keep 30 latest daily snapshots plus latest snapshot for each of 12 months."""
+    folder_id = ensure_drive_folder_chain(service, folder_parts)
+    result = (
+        service.files()
+        .list(
+            q=f"'{folder_id}' in parents and trashed = false",
+            spaces="drive",
+            fields="files(id,name)",
+            pageSize=1000,
+            supportsAllDrives=True,
+        )
+        .execute()
+    )
+    dated = []
+    for item in result.get("files", []):
+        parsed = _parse_snapshot_date(item.get("name", ""))
+        if parsed:
+            dated.append((parsed, item))
+
+    dated.sort(key=lambda pair: pair[0], reverse=True)
+    keep_ids = {item["id"] for _, item in dated[:30]}
+
+    months_seen: set[tuple[int, int]] = set()
+    for snapshot_date, item in dated:
+        month = (snapshot_date.year, snapshot_date.month)
+        if month in months_seen:
+            continue
+        if len(months_seen) >= 12:
+            continue
+        months_seen.add(month)
+        keep_ids.add(item["id"])
+
+    deleted: list[str] = []
+    for _, item in dated:
+        if item["id"] in keep_ids:
+            continue
+        service.files().delete(fileId=item["id"], supportsAllDrives=True).execute()
+        deleted.append(item["name"])
+    return deleted
+
+
+def run_backup(
+    db_path: Path | None = None,
+    staging_dir: Path = DEFAULT_STAGING_DIR,
+    folder_parts: list[str] = DEFAULT_FOLDER_PARTS,
+    date_stamp: str | None = None,
+    upload: bool = True,
+) -> dict[str, Any]:
+    snapshot = create_sqlite_backup_gzip(db_path or get_db_path(), staging_dir, date_stamp=date_stamp)
+    result: dict[str, Any] = {
+        "db": str(db_path or get_db_path()),
+        "snapshot": str(snapshot),
+        "bytes": snapshot.stat().st_size,
+        "uploaded": False,
+    }
+    if upload:
+        credentials = get_drive_credentials()
+        service = build_drive_service()
+        folder_id = ensure_drive_folder_chain(service, folder_parts)
+        uploaded = upload_file_to_drive_raw(snapshot, folder_id, credentials)
+        deleted = prune_drive_backups(service, folder_parts=folder_parts)
+        result.update({"uploaded": True, "drive_file": uploaded, "retention_deleted": deleted})
+    return result
+
+
+def main() -> int:
+    try:
+        result = run_backup(
+            staging_dir=Path(os.environ.get("BRAINLAYER_BACKUP_STAGING_DIR", str(DEFAULT_STAGING_DIR))),
+            folder_parts=os.environ.get("BRAINLAYER_BACKUP_DRIVE_PATH", "/".join(DEFAULT_FOLDER_PARTS)).split("/"),
+        )
+    except Exception as exc:
+        print(f"brainlayer backup failed: {exc}", flush=True)
+        return 1
+    print(json.dumps(result, sort_keys=True), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -2,6 +2,8 @@ import gzip
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 
 def test_create_snapshot_gzip_is_restorable(tmp_path):
     from brainlayer.backup_daily import create_sqlite_backup_gzip
@@ -31,6 +33,24 @@ def test_create_snapshot_gzip_is_restorable(tmp_path):
         assert restored_conn.execute("SELECT content FROM chunks WHERE id = 'c1'").fetchone()[0] == "hello"
     finally:
         restored_conn.close()
+
+
+def test_create_snapshot_rejects_low_disk_space(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    source = tmp_path / "brainlayer.db"
+    conn = sqlite3.connect(source)
+    conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, content TEXT)")
+    conn.commit()
+    conn.close()
+
+    class LowDisk:
+        free = 1
+
+    monkeypatch.setattr(backup_daily.shutil, "disk_usage", lambda _path: LowDisk())
+
+    with pytest.raises(RuntimeError, match="Insufficient free space"):
+        backup_daily.create_sqlite_backup_gzip(source, tmp_path / "out", date_stamp="2026-05-13")
 
 
 def test_upload_to_drive_creates_missing_folder_chain(tmp_path):

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -1,0 +1,98 @@
+import gzip
+import sqlite3
+from pathlib import Path
+
+
+def test_create_snapshot_gzip_is_restorable(tmp_path):
+    from brainlayer.backup_daily import create_sqlite_backup_gzip
+
+    source = tmp_path / "brainlayer.db"
+    conn = sqlite3.connect(source)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, content TEXT)")
+    conn.execute("INSERT INTO chunks VALUES ('c1', 'hello')")
+    conn.commit()
+    conn.close()
+
+    out_dir = tmp_path / "out"
+    snapshot = create_sqlite_backup_gzip(source, out_dir, date_stamp="2026-05-13")
+
+    assert snapshot == out_dir / "2026-05-13.db.gz"
+    assert snapshot.exists()
+
+    restored = tmp_path / "restored.db"
+    with gzip.open(snapshot, "rb") as src, restored.open("wb") as dst:
+        dst.write(src.read())
+
+    restored_conn = sqlite3.connect(restored)
+    try:
+        assert restored_conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert restored_conn.execute("SELECT content FROM chunks WHERE id = 'c1'").fetchone()[0] == "hello"
+    finally:
+        restored_conn.close()
+
+
+def test_upload_to_drive_creates_missing_folder_chain(tmp_path):
+    from brainlayer.backup_daily import upload_file_to_drive
+
+    class FakeExecute:
+        def __init__(self, value):
+            self.value = value
+
+        def execute(self):
+            return self.value
+
+        def next_chunk(self):
+            return None, self.value
+
+    class FakeFiles:
+        def __init__(self):
+            self.created = []
+
+        def list(self, **kwargs):
+            query = kwargs["q"]
+            if "name = 'Brain Drive'" in query:
+                return FakeExecute({"files": [{"id": "brain-drive"}]})
+            return FakeExecute({"files": []})
+
+        def create(self, body, media_body=None, fields=None, **kwargs):  # noqa: ARG002
+            if media_body is None:
+                folder_id = f"folder-{body['name']}"
+                self.created.append((body["name"], body["parents"][0]))
+                return FakeExecute({"id": folder_id})
+            self.created.append((body["name"], body["parents"][0], "file"))
+            return FakeExecute({"id": "backup-file", "name": body["name"]})
+
+    class FakeService:
+        def __init__(self):
+            self._files = FakeFiles()
+
+        def files(self):
+            return self._files
+
+    gz = tmp_path / "2026-05-13.db.gz"
+    gz.write_bytes(b"backup")
+    service = FakeService()
+
+    result = upload_file_to_drive(
+        service,
+        gz,
+        folder_parts=["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"],
+    )
+
+    assert result == {"id": "backup-file", "name": "2026-05-13.db.gz"}
+    assert ("06_ARCHIVE", "brain-drive") in service.files().created
+    assert ("backups", "folder-06_ARCHIVE") in service.files().created
+    assert ("brainlayer-db", "folder-backups") in service.files().created
+    assert ("2026-05-13.db.gz", "folder-brainlayer-db", "file") in service.files().created
+
+
+def test_launchd_installer_knows_backup_target():
+    install = Path("scripts/launchd/install.sh").read_text()
+    plist = Path("scripts/launchd/com.brainlayer.backup-daily.plist").read_text()
+
+    assert "backup-daily" in install
+    assert "install_backup_script" in install
+    assert "<string>com.brainlayer.backup-daily</string>" in plist
+    assert "<integer>3</integer>" in plist
+    assert "<integer>17</integer>" in plist

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -53,8 +53,8 @@ def test_create_snapshot_rejects_low_disk_space(tmp_path, monkeypatch):
         backup_daily.create_sqlite_backup_gzip(source, tmp_path / "out", date_stamp="2026-05-13")
 
 
-def test_upload_to_drive_creates_missing_folder_chain(tmp_path):
-    from brainlayer.backup_daily import upload_file_to_drive
+def test_ensure_drive_folder_chain_creates_missing_folders():
+    from brainlayer.backup_daily import ensure_drive_folder_chain
 
     class FakeExecute:
         def __init__(self, value):
@@ -62,9 +62,6 @@ def test_upload_to_drive_creates_missing_folder_chain(tmp_path):
 
         def execute(self):
             return self.value
-
-        def next_chunk(self):
-            return None, self.value
 
     class FakeFiles:
         def __init__(self):
@@ -76,13 +73,10 @@ def test_upload_to_drive_creates_missing_folder_chain(tmp_path):
                 return FakeExecute({"files": [{"id": "brain-drive"}]})
             return FakeExecute({"files": []})
 
-        def create(self, body, media_body=None, fields=None, **kwargs):  # noqa: ARG002
-            if media_body is None:
-                folder_id = f"folder-{body['name']}"
-                self.created.append((body["name"], body["parents"][0]))
-                return FakeExecute({"id": folder_id})
-            self.created.append((body["name"], body["parents"][0], "file"))
-            return FakeExecute({"id": "backup-file", "name": body["name"]})
+        def create(self, body, fields=None, **kwargs):  # noqa: ARG002
+            folder_id = f"folder-{body['name']}"
+            self.created.append((body["name"], body["parents"][0]))
+            return FakeExecute({"id": folder_id})
 
     class FakeService:
         def __init__(self):
@@ -91,21 +85,17 @@ def test_upload_to_drive_creates_missing_folder_chain(tmp_path):
         def files(self):
             return self._files
 
-    gz = tmp_path / "2026-05-13.db.gz"
-    gz.write_bytes(b"backup")
     service = FakeService()
 
-    result = upload_file_to_drive(
+    result = ensure_drive_folder_chain(
         service,
-        gz,
-        folder_parts=["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"],
+        ["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"],
     )
 
-    assert result == {"id": "backup-file", "name": "2026-05-13.db.gz"}
+    assert result == "folder-brainlayer-db"
     assert ("06_ARCHIVE", "brain-drive") in service.files().created
     assert ("backups", "folder-06_ARCHIVE") in service.files().created
     assert ("brainlayer-db", "folder-backups") in service.files().created
-    assert ("2026-05-13.db.gz", "folder-brainlayer-db", "file") in service.files().created
 
 
 def test_launchd_installer_knows_backup_target():

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -8,7 +8,8 @@ def test_create_snapshot_gzip_is_restorable(tmp_path):
 
     source = tmp_path / "brainlayer.db"
     conn = sqlite3.connect(source)
-    conn.execute("PRAGMA journal_mode=WAL")
+    journal_mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+    assert journal_mode.upper() == "WAL"
     conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, content TEXT)")
     conn.execute("INSERT INTO chunks VALUES ('c1', 'hello')")
     conn.commit()
@@ -88,8 +89,14 @@ def test_upload_to_drive_creates_missing_folder_chain(tmp_path):
 
 
 def test_launchd_installer_knows_backup_target():
-    install = Path("scripts/launchd/install.sh").read_text()
-    plist = Path("scripts/launchd/com.brainlayer.backup-daily.plist").read_text()
+    install_path = Path("scripts/launchd/install.sh")
+    plist_path = Path("scripts/launchd/com.brainlayer.backup-daily.plist")
+
+    assert install_path.is_file(), f"Installer not found at {install_path}; check test working directory"
+    assert plist_path.is_file(), f"Backup plist not found at {plist_path}; check launchd template is committed"
+
+    install = install_path.read_text()
+    plist = plist_path.read_text()
 
     assert "backup-daily" in install
     assert "install_backup_script" in install


### PR DESCRIPTION
## Summary
- add a daily SQLite online backup job for `~/.local/share/brainlayer/brainlayer.db`
- gzip snapshots and upload them to Google Drive: `Brain Drive/06_ARCHIVE/backups/brainlayer-db/YYYY-MM-DD.db.gz`
- install via launchd at 03:17 local time with 30 daily + 12 monthly retention pruning
- document restore and monthly restore drill in `docs/backup-strategy.md`

## Verification
- `python3 -m pytest tests/test_backup_daily.py tests/test_wal_checkpoint_module.py tests/test_cli_enrich.py::test_cli_wal_checkpoint_routes_to_helper -q` -> `7 passed`
- `plutil -lint scripts/launchd/com.brainlayer.backup-daily.plist` -> OK
- `python3 -m compileall -q src/brainlayer/backup_daily.py` -> OK
- pre-push gate -> `1826 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration `3 passed`; eval/hook routing `32 passed`; Bun `1 pass`; regression shell pass
- first production snapshot uploaded to Drive: `2026-05-13.db.gz`, Drive file id `1tnAhWnmfpjG6Kn4peHTCGAptD0mrY8HF`, size `5243572021`
- restore verification from gzip -> `PRAGMA integrity_check` returned `ok`; `SELECT count(*) FROM chunks` returned `361029`

## Notes
- Google Drive Desktop was not mounted on this repaired Mac, so the implementation uses the existing Google Drive OAuth token from `~/.config/google-drive-mcp` and uploads via Drive API.
- Backups are HTTPS/in-Drive encrypted but not client-side encrypted; the doc calls out `age`/GPG as a recommended future hardening step if provider-layer protection is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new automated data-backup logic plus Google Drive OAuth/token handling and remote deletion for retention; mistakes could impact backup reliability or unintentionally delete snapshots.
> 
> **Overview**
> Implements an automated daily backup flow that creates a consistent SQLite snapshot via the online backup API, gzips it, uploads it to Google Drive using existing `~/.config/google-drive-mcp` OAuth credentials, and applies retention (30 daily + 12 monthly) via remote pruning.
> 
> Adds a `launchd` LaunchAgent (`com.brainlayer.backup-daily`) and installer support (new `backup` target plus wrapper script install) to run at **03:17** with logs under `~/.local/share/brainlayer/logs`.
> 
> Updates `pyproject.toml` with Google Drive client/auth deps, adds tests covering snapshot restoration, low-disk-space rejection, Drive folder creation logic, and installer/plist wiring, and documents restore/drill procedures in `docs/backup-strategy.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edea74e33dfd815f6432f247860507f096f37174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily automated database backups to Google Drive with gzip compression.
  * Implemented automatic backup retention policy: 30 most recent daily snapshots plus latest monthly backups for 12 months.

* **Documentation**
  * Added comprehensive backup and restore strategy guide with detailed recovery procedures and monthly drill checklist.

* **Tests**
  * Added integration tests for backup creation, Drive upload, and installer configuration verification.

* **Chores**
  * Added Google Drive API dependencies to support backup uploads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/280)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add daily BrainLayer SQLite backups with Google Drive upload and retention
> - Adds [`backup_daily.py`](https://github.com/EtanHey/brainlayer/pull/280/files#diff-7478d7f165ea261a3912ebf2e9fb51ab469e9e8d211be7aa70cc123b4c9b97b8) which takes an online SQLite snapshot via the backup API, gzips it, uploads to Google Drive using resumable chunked transfer with retries, and prunes old backups (keeps 30 daily + 1 per month for 12 months).
> - Schedules the backup via a macOS launchd [`LaunchAgent plist`](https://github.com/EtanHey/brainlayer/pull/280/files#diff-17aa774d0414e162683cabfa143047e110b70495ae8663d3c4c18c7d9496fb2c) that runs daily at 03:17 with Nice level 15.
> - Extends [`install.sh`](https://github.com/EtanHey/brainlayer/pull/280/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756) with a `backup` subcommand to deploy the wrapper script and plist; `remove` also cleans them up.
> - OAuth credentials are loaded from existing local MCP config paths and refreshed automatically when expired or within 2 hours of expiry.
> - Risk: first-run requires pre-existing OAuth token files in the expected config paths; no automatic OAuth flow is included.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 99cc4e1. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->