### PR TITLE
Make backup wrapper self-contained

### DIFF
--- a/scripts/launchd/backup-daily.sh
+++ b/scripts/launchd/backup-daily.sh
@@ -3,5 +3,10 @@ set -euo pipefail
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin"
 export PYTHONUNBUFFERED=1
+BRAINLAYER_DIR="${BRAINLAYER_DIR:-__BRAINLAYER_DIR__}"
+if [ "$BRAINLAYER_DIR" = "__BRAINLAYER_DIR__" ]; then
+    BRAINLAYER_DIR="$HOME/Gits/brainlayer"
+fi
+export PYTHONPATH="$BRAINLAYER_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "${BRAINLAYER_PYTHON:-python3}" -m brainlayer.backup_daily

--- a/scripts/launchd/backup-daily.sh
+++ b/scripts/launchd/backup-daily.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin"
 export PYTHONUNBUFFERED=1
-BRAINLAYER_DIR="${BRAINLAYER_DIR:-__BRAINLAYER_DIR__}"
-if [ "$BRAINLAYER_DIR" = "__BRAINLAYER_DIR__" ]; then
-    BRAINLAYER_DIR="$HOME/Gits/brainlayer"
-fi
+BRAINLAYER_DIR="${BRAINLAYER_DIR:-__BRAINLAYER_DIR_VALUE__}"
+case "$BRAINLAYER_DIR" in
+    __BRAINLAYER_DIR_*) BRAINLAYER_DIR="$HOME/Gits/brainlayer" ;;
+esac
 export PYTHONPATH="$BRAINLAYER_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "${BRAINLAYER_PYTHON:-python3}" -m brainlayer.backup_daily

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -106,7 +106,9 @@ install_backup_script() {
         return 1
     fi
 
-    cp "$src" "$dst"
+    sed \
+        -e "s|__BRAINLAYER_DIR__|$BRAINLAYER_DIR|g" \
+        "$src" > "$dst"
     chmod 755 "$dst"
     echo "Installed: $dst"
 }

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -100,14 +100,16 @@ install_plist() {
 install_backup_script() {
     local src="$SCRIPT_DIR/backup-daily.sh"
     local dst="$BRAINLAYER_LIB_DIR/backup-daily.sh"
+    local escaped_brainlayer_dir
 
     if [ ! -f "$src" ]; then
         echo "ERROR: $src not found"
         return 1
     fi
 
+    escaped_brainlayer_dir="$(printf '%s' "$BRAINLAYER_DIR" | sed 's/[\\&|]/\\&/g')"
     sed \
-        -e "s|__BRAINLAYER_DIR__|$BRAINLAYER_DIR|g" \
+        -e "s|__BRAINLAYER_DIR_VALUE__|$escaped_brainlayer_dir|g" \
         "$src" > "$dst"
     chmod 755 "$dst"
     echo "Installed: $dst"

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -100,16 +100,22 @@ def test_ensure_drive_folder_chain_creates_missing_folders():
 
 def test_launchd_installer_knows_backup_target():
     install_path = Path("scripts/launchd/install.sh")
+    wrapper_path = Path("scripts/launchd/backup-daily.sh")
     plist_path = Path("scripts/launchd/com.brainlayer.backup-daily.plist")
 
     assert install_path.is_file(), f"Installer not found at {install_path}; check test working directory"
+    assert wrapper_path.is_file(), f"Backup wrapper not found at {wrapper_path}; check launchd wrapper is committed"
     assert plist_path.is_file(), f"Backup plist not found at {plist_path}; check launchd template is committed"
 
     install = install_path.read_text()
+    wrapper = wrapper_path.read_text()
     plist = plist_path.read_text()
 
     assert "backup-daily" in install
     assert "install_backup_script" in install
+    assert "__BRAINLAYER_DIR__" in install
+    assert "PYTHONPATH" in wrapper
+    assert "__BRAINLAYER_DIR__" in wrapper
     assert "<string>com.brainlayer.backup-daily</string>" in plist
     assert "<integer>3</integer>" in plist
     assert "<integer>17</integer>" in plist

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -113,9 +113,10 @@ def test_launchd_installer_knows_backup_target():
 
     assert "backup-daily" in install
     assert "install_backup_script" in install
-    assert "__BRAINLAYER_DIR__" in install
+    assert "escaped_brainlayer_dir" in install
+    assert "__BRAINLAYER_DIR_VALUE__" in install
     assert "PYTHONPATH" in wrapper
-    assert "__BRAINLAYER_DIR__" in wrapper
+    assert "__BRAINLAYER_DIR_VALUE__" in wrapper
     assert "<string>com.brainlayer.backup-daily</string>" in plist
     assert "<integer>3</integer>" in plist
     assert "<integer>17</integer>" in plist


### PR DESCRIPTION
## Summary
- make `scripts/launchd/backup-daily.sh` set `PYTHONPATH` itself using installed BrainLayer repo path
- have launchd installer expand `__BRAINLAYER_DIR__` into the copied wrapper
- cover wrapper self-contained behavior in backup launchd test

## Why
Manual execution of `~/.local/lib/brainlayer/backup-daily.sh` failed after PR #280 because `PYTHONPATH` was only provided by the LaunchAgent plist. The wrapper needs to work both from launchd and direct manual restore/proof runs.

## Verification
- `python3 -m pytest tests/test_backup_daily.py -q` -> `4 passed`
- `bash -n scripts/launchd/backup-daily.sh scripts/launchd/install.sh` -> passed
- pre-push gate -> `1827 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration `3 passed`; eval/hook routing `32 passed`; Bun `1 pass`; regression shell pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change that only affects the launchd-installed daily backup wrapper and its install-time templating; main risk is mis-resolving `BRAINLAYER_DIR` or bad escaping causing backups to fail to run.
> 
> **Overview**
> Makes `backup-daily.sh` self-contained by resolving `BRAINLAYER_DIR` (env or install-time placeholder, with a fallback) and exporting `PYTHONPATH` to include `src` before running `brainlayer.backup_daily`.
> 
> Updates the launchd installer to generate the installed backup wrapper via `sed` substitution of `__BRAINLAYER_DIR_VALUE__` (with escaping) instead of copying verbatim, and extends `test_backup_daily.py` to assert the placeholder/substitution plumbing and wrapper `PYTHONPATH` setup are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4011a6408db3e21e559611e107ee2225258cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make backup wrapper self-contained by templating `BRAINLAYER_DIR` and `PYTHONPATH` at install time
> - [backup-daily.sh](https://github.com/EtanHey/brainlayer/pull/281/files#diff-42a62cc5ea2dc37c562db7cb0a293a1dc67d8aa2c4949bda415ceb979e01de8a) now contains a `__BRAINLAYER_DIR_VALUE__` placeholder and sets `PYTHONPATH` to include `$BRAINLAYER_DIR/src`, rather than relying on the environment at runtime.
> - [install.sh](https://github.com/EtanHey/brainlayer/pull/281/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756) substitutes the placeholder with the actual `BRAINLAYER_DIR` value (with special characters escaped) via `sed` when copying the script, instead of a verbatim `cp`.
> - Tests in [test_backup_daily.py](https://github.com/EtanHey/brainlayer/pull/281/files#diff-0301a5d845972c88681267a180201cacdc92ce8b76a363297e01acc211cb1141) verify the placeholder and `PYTHONPATH` are present in the wrapper and that the installer references the substitution logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b4011a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->