### PR TITLE
feat: add BrainLayer queue merge utility

### DIFF
--- a/scripts/merge_queue.py
+++ b/scripts/merge_queue.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Union an AirDrop'd BrainLayer queue directory into the live queue.
+
+Invocation:
+  python3 scripts/merge_queue.py ~/Downloads/queue
+  python3 scripts/merge_queue.py ~/Downloads/queue --dry-run
+  python3 scripts/merge_queue.py ~/Downloads/queue --dest ~/.brainlayer/queue
+
+After a real merge, kick the drain LaunchAgent:
+  launchctl kickstart -k gui/$(id -u)/com.brainlayer.drain
+
+This script is append-only. It never mirrors, deletes, or overwrites queue files.
+Byte-identical JSONL files are skipped so re-runs are no-ops.
+Same-name/different-content files are copied under a deterministic -merge-<hash>
+name so both queue events survive for the drain daemon.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from brainlayer.queue_io import get_queue_dir  # noqa: E402
+from brainlayer.queue_merge import merge_queue_dirs  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Union an AirDrop'd BrainLayer queue into the live queue.")
+    parser.add_argument("source", type=Path, help="AirDrop'd queue directory, for example ~/Downloads/queue")
+    parser.add_argument("--dest", type=Path, default=None, help="Destination queue dir (default: ~/.brainlayer/queue)")
+    parser.add_argument("--dry-run", action="store_true", help="List planned actions without writing files")
+    args = parser.parse_args()
+
+    dest = args.dest.expanduser() if args.dest else get_queue_dir()
+    result = merge_queue_dirs(args.source, dest, dry_run=args.dry_run)
+    mode = "DRY-RUN" if args.dry_run else "MERGED"
+    print(f"{mode}: source={args.source.expanduser()} dest={dest}")
+    for name in result.copied:
+        print(f"copy {name}")
+    for name in result.collisions:
+        print(f"collision-renamed {name}")
+    for name in result.skipped_exact:
+        print(f"skip-exact {name}")
+    for name in result.skipped_non_jsonl:
+        print(f"skip-non-jsonl {name}")
+    print(
+        "summary "
+        f"copied={len(result.copied)} "
+        f"collisions={len(result.collisions)} "
+        f"skipped_exact={len(result.skipped_exact)} "
+        f"skipped_non_jsonl={len(result.skipped_non_jsonl)}"
+    )
+    if not args.dry_run and result.copied:
+        print("next: launchctl kickstart -k gui/$(id -u)/com.brainlayer.drain")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_queue.py
+++ b/scripts/merge_queue.py
@@ -43,8 +43,8 @@ def main() -> int:
     print(f"{mode}: source={args.source.expanduser()} dest={dest}")
     for name in result.copied:
         print(f"copy {name}")
-    for name in result.collisions:
-        print(f"collision-renamed {name}")
+    for old_name, new_name in result.collision_renames:
+        print(f"collision-renamed {old_name} -> {new_name}")
     for name in result.skipped_exact:
         print(f"skip-exact {name}")
     for name in result.skipped_non_jsonl:

--- a/src/brainlayer/queue_merge.py
+++ b/src/brainlayer/queue_merge.py
@@ -14,6 +14,7 @@ class QueueMergeResult:
     skipped_exact: list[str] = field(default_factory=list)
     skipped_non_jsonl: list[str] = field(default_factory=list)
     collisions: list[str] = field(default_factory=list)
+    collision_renames: list[tuple[str, str]] = field(default_factory=list)
 
     @property
     def total_actions(self) -> int:
@@ -30,7 +31,11 @@ def _read_existing_hashes(queue_dir: Path) -> dict[str, str]:
         return hashes
     for path in sorted(queue_dir.glob("*.jsonl")):
         if path.is_file():
-            hashes[_sha256(path.read_bytes())] = path.name
+            try:
+                hashes[_sha256(path.read_bytes())] = path.name
+            except FileNotFoundError:
+                # The drain daemon may consume files while an operator is preparing a merge.
+                continue
     return hashes
 
 
@@ -85,10 +90,11 @@ def merge_queue_dirs(source_dir: Path, dest_dir: Path, *, dry_run: bool = False)
         if target_path.exists():
             result.collisions.append(source_path.name)
             target_path = _collision_target(dest_dir, source_path.name, content_hash, content)
+            result.collision_renames.append((source_path.name, target_path.name))
 
         result.copied.append(target_path.name)
+        existing_hashes[content_hash] = target_path.name
         if not dry_run:
             _copy_atomic(source_path, target_path)
-            existing_hashes[content_hash] = target_path.name
 
     return result

--- a/src/brainlayer/queue_merge.py
+++ b/src/brainlayer/queue_merge.py
@@ -1,0 +1,94 @@
+"""Merge append-only BrainLayer queue directories safely."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class QueueMergeResult:
+    copied: list[str] = field(default_factory=list)
+    skipped_exact: list[str] = field(default_factory=list)
+    skipped_non_jsonl: list[str] = field(default_factory=list)
+    collisions: list[str] = field(default_factory=list)
+
+    @property
+    def total_actions(self) -> int:
+        return len(self.copied) + len(self.skipped_exact) + len(self.skipped_non_jsonl)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_existing_hashes(queue_dir: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    if not queue_dir.exists():
+        return hashes
+    for path in sorted(queue_dir.glob("*.jsonl")):
+        if path.is_file():
+            hashes[_sha256(path.read_bytes())] = path.name
+    return hashes
+
+
+def _collision_target(dest_dir: Path, source_name: str, content_hash: str, content: bytes) -> Path:
+    source_path = Path(source_name)
+    stem = source_path.stem
+    suffix = source_path.suffix
+    target = dest_dir / f"{stem}-merge-{content_hash[:12]}{suffix}"
+    if not target.exists() or target.read_bytes() == content:
+        return target
+    counter = 1
+    while True:
+        candidate = dest_dir / f"{stem}-merge-{content_hash[:12]}-{counter}{suffix}"
+        if not candidate.exists() or candidate.read_bytes() == content:
+            return candidate
+        counter += 1
+
+
+def _copy_atomic(source: Path, target: Path) -> None:
+    tmp = target.with_name(f".{target.name}.tmp")
+    shutil.copyfile(source, tmp)
+    tmp.replace(target)
+
+
+def merge_queue_dirs(source_dir: Path, dest_dir: Path, *, dry_run: bool = False) -> QueueMergeResult:
+    """Union ``source_dir`` into ``dest_dir`` without deleting or overwriting queue files."""
+    source_dir = source_dir.expanduser()
+    dest_dir = dest_dir.expanduser()
+    if not source_dir.is_dir():
+        raise NotADirectoryError(source_dir)
+    if source_dir.resolve() == dest_dir.resolve():
+        raise ValueError("source and destination queue directories must be different")
+
+    result = QueueMergeResult()
+    existing_hashes = _read_existing_hashes(dest_dir)
+
+    if not dry_run:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+    for source_path in sorted(path for path in source_dir.iterdir() if path.is_file()):
+        if source_path.suffix != ".jsonl":
+            result.skipped_non_jsonl.append(source_path.name)
+            continue
+
+        content = source_path.read_bytes()
+        content_hash = _sha256(content)
+        if content_hash in existing_hashes:
+            result.skipped_exact.append(source_path.name)
+            continue
+
+        target_path = dest_dir / source_path.name
+        if target_path.exists():
+            result.collisions.append(source_path.name)
+            target_path = _collision_target(dest_dir, source_path.name, content_hash, content)
+
+        result.copied.append(target_path.name)
+        if not dry_run:
+            _copy_atomic(source_path, target_path)
+            existing_hashes[content_hash] = target_path.name
+
+    return result

--- a/tests/test_queue_merge.py
+++ b/tests/test_queue_merge.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 
 def _write_event(path: Path, content: str) -> None:
     path.write_text(json.dumps({"kind": "store_memory", "content": content}) + "\n", encoding="utf-8")
@@ -53,8 +55,10 @@ def test_queue_merge_renames_filename_collision_without_overwriting(tmp_path):
     result = merge_queue_dirs(source, dest)
 
     assert result.collisions == ["same.jsonl"]
+    assert len(result.collision_renames) == 1
     assert len(result.copied) == 1
     merged_name = result.copied[0]
+    assert result.collision_renames == [("same.jsonl", merged_name)]
     assert merged_name.startswith("same-merge-")
     assert merged_name.endswith(".jsonl")
     assert (dest / "same.jsonl").read_text(encoding="utf-8").endswith('"m4 content"}\n')
@@ -76,3 +80,74 @@ def test_queue_merge_ignores_non_jsonl_files(tmp_path):
     assert result.copied == ["event.jsonl"]
     assert result.skipped_non_jsonl == ["README.txt"]
     assert not (dest / "README.txt").exists()
+
+
+def test_queue_merge_raises_on_nonexistent_source(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    with pytest.raises(NotADirectoryError):
+        merge_queue_dirs(tmp_path / "missing", tmp_path / "dest")
+
+
+def test_queue_merge_raises_when_source_equals_dest(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+
+    with pytest.raises(ValueError, match="must be different"):
+        merge_queue_dirs(queue_dir, queue_dir)
+
+
+def test_queue_merge_creates_dest_if_missing(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    source = tmp_path / "airdrop-queue"
+    dest = tmp_path / "live-queue"
+    source.mkdir()
+    _write_event(source / "m1-1.jsonl", "from m1")
+
+    result = merge_queue_dirs(source, dest)
+
+    assert result.copied == ["m1-1.jsonl"]
+    assert (dest / "m1-1.jsonl").exists()
+
+
+def test_queue_merge_deduplicates_same_content_across_filenames(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    source = tmp_path / "airdrop-queue"
+    dest = tmp_path / "live-queue"
+    source.mkdir()
+    dest.mkdir()
+    _write_event(source / "a.jsonl", "same content")
+    _write_event(source / "b.jsonl", "same content")
+
+    result = merge_queue_dirs(source, dest)
+
+    assert result.copied == ["a.jsonl"]
+    assert result.skipped_exact == ["b.jsonl"]
+    assert len(list(dest.glob("*.jsonl"))) == 1
+
+
+def test_queue_merge_skips_destination_file_deleted_by_drain(tmp_path, monkeypatch):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    source = tmp_path / "airdrop-queue"
+    dest = tmp_path / "live-queue"
+    source.mkdir()
+    dest.mkdir()
+    _write_event(source / "m1-1.jsonl", "from m1")
+    _write_event(dest / "vanished.jsonl", "drain deletes this during hash scan")
+    original_read_bytes = Path.read_bytes
+
+    def flaky_read_bytes(path: Path) -> bytes:
+        if path.name == "vanished.jsonl":
+            raise FileNotFoundError(path)
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", flaky_read_bytes)
+
+    result = merge_queue_dirs(source, dest)
+
+    assert result.copied == ["m1-1.jsonl"]

--- a/tests/test_queue_merge.py
+++ b/tests/test_queue_merge.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+
+def _write_event(path: Path, content: str) -> None:
+    path.write_text(json.dumps({"kind": "store_memory", "content": content}) + "\n", encoding="utf-8")
+
+
+def test_queue_merge_dry_run_lists_copies_without_writing(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    source = tmp_path / "airdrop-queue"
+    dest = tmp_path / "live-queue"
+    source.mkdir()
+    dest.mkdir()
+    _write_event(source / "m1-1.jsonl", "from m1")
+
+    result = merge_queue_dirs(source, dest, dry_run=True)
+
+    assert result.copied == ["m1-1.jsonl"]
+    assert result.skipped_exact == []
+    assert not (dest / "m1-1.jsonl").exists()
+
+
+def test_queue_merge_is_idempotent_and_skips_exact_content(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    source = tmp_path / "airdrop-queue"
+    dest = tmp_path / "live-queue"
+    source.mkdir()
+    dest.mkdir()
+    _write_event(source / "m1-1.jsonl", "from m1")
+
+    first = merge_queue_dirs(source, dest)
+    second = merge_queue_dirs(source, dest)
+
+    assert first.copied == ["m1-1.jsonl"]
+    assert second.copied == []
+    assert second.skipped_exact == ["m1-1.jsonl"]
+    assert len(list(dest.glob("*.jsonl"))) == 1
+
+
+def test_queue_merge_renames_filename_collision_without_overwriting(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    source = tmp_path / "airdrop-queue"
+    dest = tmp_path / "live-queue"
+    source.mkdir()
+    dest.mkdir()
+    _write_event(source / "same.jsonl", "m1 content")
+    _write_event(dest / "same.jsonl", "m4 content")
+
+    result = merge_queue_dirs(source, dest)
+
+    assert result.collisions == ["same.jsonl"]
+    assert len(result.copied) == 1
+    merged_name = result.copied[0]
+    assert merged_name.startswith("same-merge-")
+    assert merged_name.endswith(".jsonl")
+    assert (dest / "same.jsonl").read_text(encoding="utf-8").endswith('"m4 content"}\n')
+    assert (dest / merged_name).read_text(encoding="utf-8").endswith('"m1 content"}\n')
+
+
+def test_queue_merge_ignores_non_jsonl_files(tmp_path):
+    from brainlayer.queue_merge import merge_queue_dirs
+
+    source = tmp_path / "airdrop-queue"
+    dest = tmp_path / "live-queue"
+    source.mkdir()
+    dest.mkdir()
+    (source / "README.txt").write_text("not a queue event", encoding="utf-8")
+    _write_event(source / "event.jsonl", "from m1")
+
+    result = merge_queue_dirs(source, dest)
+
+    assert result.copied == ["event.jsonl"]
+    assert result.skipped_non_jsonl == ["README.txt"]
+    assert not (dest / "README.txt").exists()


### PR DESCRIPTION
## Summary
- Adds `scripts/merge_queue.py` to union an AirDrop'd M1 Pro BrainLayer queue directory into the live M4 Max `~/.brainlayer/queue/` without mirroring, deleting, or overwriting.
- Adds testable `brainlayer.queue_merge.merge_queue_dirs()` logic with byte-hash idempotency, exact-content skip reporting, and same-filename/different-content collision renames.
- Covers dry-run behavior, idempotent re-runs, filename collisions, and non-JSONL skips with fixture tests.

## Operator Usage
```bash
python3 scripts/merge_queue.py ~/Downloads/queue --dry-run
python3 scripts/merge_queue.py ~/Downloads/queue
launchctl kickstart -k gui/$(id -u)/com.brainlayer.drain
```

This PR does not run the actual M1→M4 queue merge; Etan has not AirDropped the source queue yet.

## Test Plan
- [x] RED: `pytest tests/test_queue_merge.py -q` failed with `ModuleNotFoundError` before implementation.
- [x] GREEN: `pytest tests/test_queue_merge.py -q` → 4 passed.
- [x] `ruff check src/brainlayer/queue_merge.py scripts/merge_queue.py tests/test_queue_merge.py` → all checks passed.
- [x] Manual CLI smoke with temp dirs using `python3 scripts/merge_queue.py` verified dry-run, first merge, and idempotent second run.
- [x] `./scripts/run_tests.sh` → BrainLayer test gate passed: 1843 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 32 passed; bun 1 passed; regression shell passed.
- [x] Pre-push hook reran `./scripts/run_tests.sh` and passed again with the same gate.

## Notes
- Local `cr review --plain` was attempted before commit but hung after setup for ~5 minutes and was killed; PR review bots are requested below.
- Waiting for orc approval before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new filesystem merge logic for the write-arbitration queue; while append-only and well-tested, mistakes could duplicate events or affect drain behavior during a live merge.
> 
> **Overview**
> Adds an operator-facing CLI (`scripts/merge_queue.py`) to merge an AirDrop’d queue directory into the live BrainLayer queue, supporting `--dry-run`/`--dest` and printing per-file actions plus a post-merge `launchctl` hint.
> 
> Implements `brainlayer.queue_merge.merge_queue_dirs()` to **append-only** copy `.jsonl` events with SHA-256 deduping (skip byte-identical content across reruns or different filenames), deterministic collision renames (`-merge-<hash>`), and atomic temp-then-rename writes; non-`.jsonl` files are ignored and destination-file races during hash scanning are tolerated. Adds pytest coverage for dry-run, idempotency, collisions, non-JSONL skips, missing/equal dirs, dest creation, cross-filename dedupe, and drain-race handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d89b1e38e663e6142937e5efd18dccee5ed8f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `merge_queue_dirs` utility to safely merge AirDrop'd queue directories into the live queue
> - Adds [`src/brainlayer/queue_merge.py`](https://github.com/EtanHey/brainlayer/pull/283/files#diff-0ccdf55abe11b5bb6e5bd5f17ddd09843a88e1b8472f8c863276a85f30faa611) with `merge_queue_dirs`, which unions a source queue directory into a destination, copying only `.jsonl` files and skipping exact duplicates by SHA-256 content hash.
> - Filename collisions (same name, different content) are resolved by renaming with a deterministic `-merge-<hash>` suffix; no files are overwritten or deleted.
> - Adds [`scripts/merge_queue.py`](https://github.com/EtanHey/brainlayer/pull/283/files#diff-cc4a8fd29befa76b60152f88e057a064e2e721a69028b265cec11f573cdeaaec) as a CLI entrypoint with `--dry-run` support, printing a per-file action summary and a `launchctl kickstart` hint after a live merge.
> - Full test coverage in [`tests/test_queue_merge.py`](https://github.com/EtanHey/brainlayer/pull/283/files#diff-ba3ddde2eaee440730951fe5a5e9c1b8692b6dbd1de7f09af60abef36bb08279) covers idempotency, deduplication, collision renaming, missing source/dest handling, and dry-run behaviour.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d89b1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->