### PR TITLE
PR-A: SQLite consolidation + atomic brick schema

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -300,7 +300,13 @@ final class BrainDatabase: @unchecked Sendable {
                     importance REAL DEFAULT 5,
                     intent TEXT,
                     enriched_at TEXT,
-                    created_at TEXT DEFAULT (datetime('now'))
+                    created_at TEXT DEFAULT (datetime('now')),
+                    aggregated_into TEXT,
+                    brick_id TEXT,
+                    source_uri TEXT,
+                    status TEXT DEFAULT 'active',
+                    ingested_at INTEGER,
+                    topic_cluster TEXT
                 )
             """)
         }
@@ -507,8 +513,12 @@ final class BrainDatabase: @unchecked Sendable {
     ) throws {
         guard let db else { throw DBError.notOpen }
         let sql = """
-            INSERT OR REPLACE INTO chunks (id, content, metadata, source_file, project, content_type, importance, conversation_id, char_count, tags, summary, preview_text)
-            VALUES (?, ?, '{}', 'brainbar', ?, ?, ?, ?, ?, ?, '', ?)
+            INSERT OR REPLACE INTO chunks (
+                id, content, metadata, source_file, project, content_type,
+                importance, conversation_id, char_count, tags, summary,
+                preview_text, brick_id, source_uri, status, ingested_at
+            )
+            VALUES (?, ?, '{}', 'brainbar', ?, ?, ?, ?, ?, ?, '', ?, ?, 'brainbar', 'active', CAST(strftime('%s', 'now') AS INTEGER))
         """
         try runWriteStatement(on: db, sql: sql, retries: 3) { stmt in
             bindText(id, to: stmt, index: 1)
@@ -520,6 +530,7 @@ final class BrainDatabase: @unchecked Sendable {
             sqlite3_bind_int(stmt, 7, Int32(content.count))
             bindText(tags, to: stmt, index: 8)
             bindText(Self.previewText(summary: "", content: content), to: stmt, index: 9)
+            bindText(id, to: stmt, index: 10)
         }
         try refreshSearchStatistics()
     }
@@ -626,7 +637,14 @@ final class BrainDatabase: @unchecked Sendable {
 
         var subscribedTags = subscribedTags
         let sourceFilter = normalizedSourceFilter(source)
-        var conditions = ["\(tableName) MATCH ?", "c.superseded_by IS NULL", "c.archived_at IS NULL"]
+        var conditions = [
+            "\(tableName) MATCH ?",
+            "c.superseded_by IS NULL",
+            "c.aggregated_into IS NULL",
+            "c.archived_at IS NULL",
+            "COALESCE(c.archived, 0) = 0",
+            "COALESCE(c.status, 'active') = 'active'"
+        ]
         if project != nil { conditions.append("c.project = ?") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
         if let explicitTag = tag {
@@ -920,7 +938,14 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         let sourceFilter = normalizedSourceFilter(source)
-        var conditions = ["chunks_fts MATCH ?", "c.superseded_by IS NULL", "c.archived_at IS NULL"]
+        var conditions = [
+            "chunks_fts MATCH ?",
+            "c.superseded_by IS NULL",
+            "c.aggregated_into IS NULL",
+            "c.archived_at IS NULL",
+            "COALESCE(c.archived, 0) = 0",
+            "COALESCE(c.status, 'active') = 'active'"
+        ]
         if project != nil { conditions.append("c.project = ?") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
         if let explicitTag = tag {
@@ -1821,7 +1846,14 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         let sourceFilter = normalizedSourceFilter(source)
-        var conditions = ["c.id = ?", "c.superseded_by IS NULL", "c.archived_at IS NULL"]
+        var conditions = [
+            "c.id = ?",
+            "c.superseded_by IS NULL",
+            "c.aggregated_into IS NULL",
+            "c.archived_at IS NULL",
+            "COALESCE(c.archived, 0) = 0",
+            "COALESCE(c.status, 'active') = 'active'"
+        ]
         if project != nil { conditions.append("c.project = ?") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
         if tag != nil { conditions.append("c.tags LIKE ?") }
@@ -1898,7 +1930,16 @@ final class BrainDatabase: @unchecked Sendable {
 
     private func ensureChunkColumns() throws {
         guard let db else { throw DBError.notOpen }
+        try execute("""
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                name TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            )
+        """)
         let existingColumns = try tableColumns(name: "chunks", on: db)
+        let atomicColumns = ["brick_id", "source_uri", "status", "ingested_at", "topic_cluster"]
+        let atomicMigrationApplied = try schemaMigrationApplied(name: "atomic_brick_chunks_v1", on: db)
+        let needsAtomicBackfill = atomicColumns.contains { !existingColumns.contains($0) } || !atomicMigrationApplied
         if !existingColumns.contains("summary") {
             try execute("ALTER TABLE chunks ADD COLUMN summary TEXT")
         }
@@ -1911,6 +1952,16 @@ final class BrainDatabase: @unchecked Sendable {
         if !existingColumns.contains("source") {
             try execute("ALTER TABLE chunks ADD COLUMN source TEXT DEFAULT 'claude_code'")
         }
+        if !existingColumns.contains("source_file") {
+            try execute("ALTER TABLE chunks ADD COLUMN source_file TEXT DEFAULT 'brainbar'")
+        }
+        if !existingColumns.contains("value_type") {
+            try execute("ALTER TABLE chunks ADD COLUMN value_type TEXT")
+        }
+        if !existingColumns.contains("created_at") {
+            try execute("ALTER TABLE chunks ADD COLUMN created_at TEXT")
+            try execute("UPDATE chunks SET created_at = datetime('now') WHERE created_at IS NULL")
+        }
         if !existingColumns.contains("enriched_at") {
             try execute("ALTER TABLE chunks ADD COLUMN enriched_at TEXT")
         }
@@ -1922,6 +1973,69 @@ final class BrainDatabase: @unchecked Sendable {
         }
         if !existingColumns.contains("archived_at") {
             try execute("ALTER TABLE chunks ADD COLUMN archived_at TEXT")
+        }
+        if !existingColumns.contains("aggregated_into") {
+            try execute("ALTER TABLE chunks ADD COLUMN aggregated_into TEXT")
+        }
+        if !existingColumns.contains("brick_id") {
+            try execute("ALTER TABLE chunks ADD COLUMN brick_id TEXT")
+        }
+        if !existingColumns.contains("source_uri") {
+            try execute("ALTER TABLE chunks ADD COLUMN source_uri TEXT")
+        }
+        if !existingColumns.contains("status") {
+            try execute("ALTER TABLE chunks ADD COLUMN status TEXT DEFAULT 'active'")
+        }
+        if !existingColumns.contains("ingested_at") {
+            try execute("ALTER TABLE chunks ADD COLUMN ingested_at INTEGER")
+        }
+        if !existingColumns.contains("topic_cluster") {
+            try execute("ALTER TABLE chunks ADD COLUMN topic_cluster TEXT")
+        }
+        if needsAtomicBackfill {
+            try execute("UPDATE chunks SET brick_id = id WHERE brick_id IS NULL")
+            if existingColumns.contains("source_file") {
+                try execute("UPDATE chunks SET source_uri = source_file WHERE source_uri IS NULL AND source_file IS NOT NULL")
+            } else {
+                try execute("UPDATE chunks SET source_uri = 'brainbar' WHERE source_uri IS NULL")
+            }
+            try execute("""
+                UPDATE chunks
+                SET ingested_at = COALESCE(
+                    CAST(strftime('%s', created_at) AS INTEGER),
+                    CAST(strftime('%s', 'now') AS INTEGER)
+                )
+                WHERE ingested_at IS NULL
+            """)
+            try execute("""
+                UPDATE chunks
+                SET status = CASE
+                    WHEN COALESCE(archived, 0) = 1
+                      OR value_type = 'ARCHIVED'
+                      OR archived_at IS NOT NULL
+                        THEN 'archived'
+                    WHEN superseded_by IS NOT NULL
+                      OR aggregated_into IS NOT NULL
+                        THEN 'superseded'
+                    ELSE 'active'
+                END
+                WHERE status IS NULL
+                   OR status NOT IN ('active', 'superseded', 'archived')
+                   OR (
+                        status = 'active'
+                        AND (
+                            COALESCE(archived, 0) = 1
+                            OR value_type = 'ARCHIVED'
+                            OR archived_at IS NOT NULL
+                            OR superseded_by IS NOT NULL
+                            OR aggregated_into IS NOT NULL
+                        )
+                    )
+            """)
+            try execute("""
+                INSERT OR REPLACE INTO schema_migrations(name, applied_at)
+                VALUES ('atomic_brick_chunks_v1', datetime('now'))
+            """)
         }
     }
 
@@ -2676,6 +2790,16 @@ final class BrainDatabase: @unchecked Sendable {
         return columns
     }
 
+    private func schemaMigrationApplied(name: String, on db: OpaquePointer) throws -> Bool {
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, "SELECT 1 FROM schema_migrations WHERE name = ? LIMIT 1", -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+
+        bindText(name, to: stmt, index: 1)
+        return sqlite3_step(stmt) == SQLITE_ROW
+    }
+
     private func sqliteMasterSQL(name: String, on db: OpaquePointer) throws -> String? {
         var stmt: OpaquePointer?
         let rc = sqlite3_prepare_v2(db, "SELECT sql FROM sqlite_master WHERE name = ?", -1, &stmt, nil)
@@ -3281,7 +3405,8 @@ final class BrainDatabase: @unchecked Sendable {
             """
             UPDATE chunks
             SET archived = 1,
-                archived_at = ?
+                archived_at = ?,
+                status = 'archived'
             WHERE id = ?
             """
         ) { stmt in
@@ -3297,7 +3422,7 @@ final class BrainDatabase: @unchecked Sendable {
             return false
         }
         try executeUpdate(
-            "UPDATE chunks SET superseded_by = ? WHERE id = ?"
+            "UPDATE chunks SET superseded_by = ?, status = 'superseded' WHERE id = ?"
         ) { stmt in
             bindText(newChunkID, to: stmt, index: 1)
             bindText(oldChunkID, to: stmt, index: 2)
@@ -3436,7 +3561,13 @@ final class BrainDatabase: @unchecked Sendable {
             ]
         }
 
-        var conditions = ["superseded_by IS NULL", "archived_at IS NULL"]
+        var conditions = [
+            "superseded_by IS NULL",
+            "aggregated_into IS NULL",
+            "archived_at IS NULL",
+            "COALESCE(archived, 0) = 0",
+            "COALESCE(status, 'active') = 'active'"
+        ]
         if chunkIDs == nil {
             conditions.append("enriched_at IS NULL")
             conditions.append("char_count >= 50")

--- a/src/brainlayer/decay_job.py
+++ b/src/brainlayer/decay_job.py
@@ -124,11 +124,23 @@ def run_decay_job(
                             WHEN (SELECT pinned FROM batch WHERE batch.rowid = chunks.rowid) = 1 THEN NULL
                             WHEN (SELECT new_decay_score FROM batch WHERE batch.rowid = chunks.rowid) < ? THEN ?
                             ELSE NULL
+                        END,
+                        status = CASE
+                            WHEN (SELECT new_decay_score FROM batch WHERE batch.rowid = chunks.rowid) < ? THEN 'archived'
+                            ELSE status
                         END
                     WHERE rowid IN (SELECT rowid FROM batch)
                     RETURNING rowid, decay_score, archived, pinned
                     """,
-                    (current_time, current_time, *batch_rowids, ARCHIVE_THRESHOLD, ARCHIVE_THRESHOLD, current_time),
+                    (
+                        current_time,
+                        current_time,
+                        *batch_rowids,
+                        ARCHIVE_THRESHOLD,
+                        ARCHIVE_THRESHOLD,
+                        current_time,
+                        ARCHIVE_THRESHOLD,
+                    ),
                 )
             )
         rows_processed += len(updated_rows)

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -217,7 +217,13 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     supersedes = event.get("supersedes") or metadata.get("supersedes")
     cols = _columns(conn, "chunks")
     if supersedes and "superseded_by" in cols:
-        conn.execute("UPDATE chunks SET superseded_by = ? WHERE id = ?", (stored_chunk_id, supersedes))
+        if "status" in cols:
+            conn.execute(
+                "UPDATE chunks SET superseded_by = ?, status = 'superseded' WHERE id = ?",
+                (stored_chunk_id, supersedes),
+            )
+        else:
+            conn.execute("UPDATE chunks SET superseded_by = ? WHERE id = ?", (stored_chunk_id, supersedes))
         for vector_table in ("chunk_vectors", "chunk_vectors_binary"):
             if conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?", (vector_table,)

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -201,6 +201,8 @@ def _exact_chunk_lookup_result(
     chunk = store.get_chunk(candidate)
     if not chunk:
         return None
+    if chunk.get("status") not in (None, "active"):
+        return None
     if any(chunk.get(field) is not None for field in ("superseded_by", "aggregated_into", "archived_at")):
         return _empty_exact_chunk_lookup_result(query)
     if not include_checkpoints and (

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -607,6 +607,8 @@ class SearchMixin:
                 where_clauses.append("c.superseded_by IS NULL")
                 where_clauses.append("c.aggregated_into IS NULL")
                 where_clauses.append("c.archived_at IS NULL")
+                where_clauses.append("COALESCE(c.archived, 0) = 0")
+                where_clauses.append("COALESCE(c.status, 'active') = 'active'")
 
             where_sql = ""
             if where_clauses:
@@ -703,6 +705,8 @@ class SearchMixin:
                 where_clauses.append("superseded_by IS NULL")
                 where_clauses.append("aggregated_into IS NULL")
                 where_clauses.append("archived_at IS NULL")
+                where_clauses.append("COALESCE(archived, 0) = 0")
+                where_clauses.append("COALESCE(status, 'active') = 'active'")
 
             params.append(n_results)
 
@@ -968,6 +972,8 @@ class SearchMixin:
             where_clauses.append("c.superseded_by IS NULL")
             where_clauses.append("c.aggregated_into IS NULL")
             where_clauses.append("c.archived_at IS NULL")
+            where_clauses.append("COALESCE(c.archived, 0) = 0")
+            where_clauses.append("COALESCE(c.status, 'active') = 'active'")
 
         where_sql = ""
         if where_clauses:
@@ -1295,6 +1301,8 @@ class SearchMixin:
                 fts_extra.append("AND c.superseded_by IS NULL")
                 fts_extra.append("AND c.aggregated_into IS NULL")
                 fts_extra.append("AND c.archived_at IS NULL")
+                fts_extra.append("AND COALESCE(c.archived, 0) = 0")
+                fts_extra.append("AND COALESCE(c.status, 'active') = 'active'")
 
             def _fetch_fts_rows(table_name: str) -> list[tuple]:
                 params = [fts_query, *fts_filter_params, candidate_fetch_count]

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -209,8 +209,23 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             )
         """)
 
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                name TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            )
+        """)
+        atomic_brick_migration_applied = (
+            cursor.execute("SELECT 1 FROM schema_migrations WHERE name = 'atomic_brick_chunks_v1'").fetchone()
+            is not None
+        )
+
         # Add columns if upgrading existing DB
         existing_cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+        atomic_brick_cols = {"brick_id", "source_uri", "status", "ingested_at", "topic_cluster"}
+        needs_atomic_brick_backfill = (
+            not atomic_brick_cols.issubset(existing_cols) or not atomic_brick_migration_applied
+        )
         for col, typ in [
             ("source", "TEXT"),
             ("sender", "TEXT"),
@@ -258,6 +273,14 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("simhash_band_1", "TEXT"),
             ("simhash_band_2", "TEXT"),
             ("simhash_band_3", "TEXT"),
+            # Atomic-brick compatibility columns. Embeddings remain in sqlite-vec
+            # virtual tables; these fields provide ledger/status metadata without
+            # duplicating vector blobs inside chunks.
+            ("brick_id", "TEXT"),
+            ("source_uri", "TEXT"),
+            ("status", "TEXT DEFAULT 'active'"),
+            ("ingested_at", "INTEGER"),
+            ("topic_cluster", "TEXT"),
         ]:
             if col not in existing_cols:
                 cursor.execute(f"ALTER TABLE chunks ADD COLUMN {col} {typ}")
@@ -318,6 +341,12 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             SET archived = 1
             WHERE value_type = 'ARCHIVED' AND COALESCE(archived, 0) = 0
         """)
+        if needs_atomic_brick_backfill:
+            self._backfill_atomic_brick_columns(cursor)
+            cursor.execute("""
+                INSERT OR REPLACE INTO schema_migrations(name, applied_at)
+                VALUES ('atomic_brick_chunks_v1', datetime('now'))
+            """)
 
         # Indexes for filtering
         for idx, col in [
@@ -333,8 +362,15 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("idx_chunks_content_type", "content_type"),
             ("idx_chunks_language", "language"),
             ("idx_chunks_chunk_origin", "chunk_origin"),
+            ("idx_chunks_source_uri", "source_uri"),
+            ("idx_chunks_status", "status"),
+            ("idx_chunks_ingested_at", "ingested_at"),
+            ("idx_chunks_topic_cluster", "topic_cluster"),
         ]:
             cursor.execute(f"CREATE INDEX IF NOT EXISTS {idx} ON chunks({col})")
+        cursor.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_brick_id ON chunks(brick_id) WHERE brick_id IS NOT NULL"
+        )
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_chunks_decay_score ON chunks(decay_score) WHERE archived = 0")
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_chunks_last_retrieved ON chunks(last_retrieved) WHERE archived = 0"
@@ -1049,6 +1085,52 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         # MCP tool calls (e.g., brain_search) hit the same VectorStore.
         self._local = threading.local()
 
+    def _backfill_atomic_brick_columns(self, cursor) -> None:
+        """Populate additive atomic-brick metadata from existing chunk fields."""
+        cursor.execute("""
+            UPDATE chunks
+            SET brick_id = id
+            WHERE brick_id IS NULL
+        """)
+        cursor.execute("""
+            UPDATE chunks
+            SET source_uri = source_file
+            WHERE source_uri IS NULL AND source_file IS NOT NULL
+        """)
+        cursor.execute("""
+            UPDATE chunks
+            SET ingested_at = COALESCE(
+                CAST(strftime('%s', created_at) AS INTEGER),
+                CAST(strftime('%s', 'now') AS INTEGER)
+            )
+            WHERE ingested_at IS NULL
+        """)
+        cursor.execute("""
+            UPDATE chunks
+            SET status = CASE
+                WHEN COALESCE(archived, 0) = 1
+                  OR value_type = 'ARCHIVED'
+                  OR archived_at IS NOT NULL
+                    THEN 'archived'
+                WHEN superseded_by IS NOT NULL
+                  OR aggregated_into IS NOT NULL
+                    THEN 'superseded'
+                ELSE 'active'
+            END
+            WHERE status IS NULL
+               OR status NOT IN ('active', 'superseded', 'archived')
+               OR (
+                    status = 'active'
+                    AND (
+                        COALESCE(archived, 0) = 1
+                        OR value_type = 'ARCHIVED'
+                        OR archived_at IS NOT NULL
+                        OR superseded_by IS NOT NULL
+                        OR aggregated_into IS NOT NULL
+                    )
+               )
+        """)
+
     def repair_fts(self, *, rebuild_trigram: bool = True) -> dict[str, int]:
         """Run explicit FTS repair work outside normal startup."""
         for attempt in range(5):
@@ -1443,8 +1525,9 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                          content_type, value_type, char_count, source, created_at,
                          conversation_id, position, sender, chunk_origin, tags, importance,
                          half_life_days, seen_count, last_seen_at, dedupe_hash, simhash,
-                         simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
+                         brick_id, source_uri, status, ingested_at, topic_cluster)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         ON CONFLICT(id) DO UPDATE SET
                             content = excluded.content,
                             metadata = excluded.metadata,
@@ -1469,6 +1552,15 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                             simhash_band_1 = excluded.simhash_band_1,
                             simhash_band_2 = excluded.simhash_band_2,
                             simhash_band_3 = excluded.simhash_band_3,
+                            brick_id = COALESCE(chunks.brick_id, excluded.brick_id),
+                            source_uri = COALESCE(excluded.source_uri, chunks.source_uri),
+                            status = CASE
+                                WHEN excluded.status IS NOT NULL AND excluded.status != 'active' THEN excluded.status
+                                WHEN chunks.status IS NULL THEN COALESCE(excluded.status, 'active')
+                                ELSE chunks.status
+                            END,
+                            ingested_at = COALESCE(chunks.ingested_at, excluded.ingested_at),
+                            topic_cluster = COALESCE(excluded.topic_cluster, chunks.topic_cluster),
                             chunk_origin = CASE
                                 WHEN excluded.content != chunks.content
                                     THEN COALESCE(excluded.chunk_origin, 'unknown')
@@ -1505,6 +1597,11 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                             dedupe_fields.bands[1],
                             dedupe_fields.bands[2],
                             dedupe_fields.bands[3],
+                            chunk.get("brick_id", chunk_id),
+                            chunk.get("source_uri") or chunk["source_file"],
+                            chunk.get("status", "active"),
+                            chunk.get("ingested_at") or int(time.time()),
+                            chunk.get("topic_cluster"),
                         ),
                     )
                     self._upsert_chunk_vector(cursor, chunk_id, embedding)
@@ -1609,7 +1706,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         now = datetime.now(timezone.utc).isoformat()
         cursor.execute(
-            "UPDATE chunks SET value_type = 'ARCHIVED', archived = 1, archived_at = ? WHERE id = ?",
+            "UPDATE chunks SET value_type = 'ARCHIVED', archived = 1, archived_at = ?, status = 'archived' WHERE id = ?",
             (now, chunk_id),
         )
         self._delete_chunk_vector(cursor, chunk_id)
@@ -1629,7 +1726,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         if not new_rows:
             return False
         cursor.execute(
-            "UPDATE chunks SET superseded_by = ? WHERE id = ?",
+            "UPDATE chunks SET superseded_by = ?, status = 'superseded' WHERE id = ?",
             (new_chunk_id, old_chunk_id),
         )
         self._delete_chunk_vector(cursor, old_chunk_id)
@@ -1639,19 +1736,55 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self._invalidate_filtered_count_caches()
         return True
 
-    def get_chunk(self, chunk_id: str) -> Optional[Dict[str, Any]]:
-        """Get a single chunk by ID."""
+    def get_chunk(self, chunk_id: str, *, include_archived: bool = False) -> Optional[Dict[str, Any]]:
+        """Get a single active chunk by ID.
+
+        Soft-deleted chunks are hidden by default: archived, superseded, aggregated,
+        or non-active status rows return None unless include_archived=True.
+        """
         read_conn = self._get_read_conn()
         cursor = read_conn.cursor()
         chunk_id = resolve_chunk_id(read_conn, chunk_id)
-        has_chunk_origin = getattr(self, "_has_chunk_origin", True)
-        chunk_origin_select = ", chunk_origin" if has_chunk_origin else ""
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+
+        def col_or_null(name: str, alias: str | None = None) -> str:
+            output = alias or name
+            if name in cols:
+                return name
+            return f"NULL AS {output}"
+
+        archived_expr = "COALESCE(archived, 0) AS archived" if "archived" in cols else "0 AS archived"
+        status_expr = "COALESCE(status, 'active') AS status" if "status" in cols else "'active' AS status"
+        chunk_origin_expr = (
+            "chunk_origin AS chunk_origin" if "chunk_origin" in cols else f"'{CHUNK_ORIGIN_UNKNOWN}' AS chunk_origin"
+        )
+        lifecycle_clauses = []
+        if not include_archived:
+            if "superseded_by" in cols:
+                lifecycle_clauses.append("superseded_by IS NULL")
+            if "aggregated_into" in cols:
+                lifecycle_clauses.append("aggregated_into IS NULL")
+            if "archived_at" in cols:
+                lifecycle_clauses.append("archived_at IS NULL")
+            if "archived" in cols:
+                lifecycle_clauses.append("COALESCE(archived, 0) = 0")
+            if "status" in cols:
+                lifecycle_clauses.append("COALESCE(status, 'active') = 'active'")
+        lifecycle_filter = "".join(f" AND {clause}" for clause in lifecycle_clauses)
         rows = list(
             cursor.execute(
                 f"""SELECT id, content, metadata, source_file, project, content_type,
-                      value_type, tags, importance, created_at, summary,
-                      superseded_by, aggregated_into, archived_at{chunk_origin_select}
-               FROM chunks WHERE id = ?""",
+                      {col_or_null("value_type")}, {col_or_null("tags")},
+                      {col_or_null("importance")}, {col_or_null("created_at")},
+                      {col_or_null("summary")},
+                      {col_or_null("superseded_by")}, {col_or_null("aggregated_into")},
+                      {col_or_null("archived_at")}, {archived_expr}, {status_expr},
+                      {col_or_null("brick_id")}, {col_or_null("source_uri")},
+                      {col_or_null("ingested_at")}, {col_or_null("topic_cluster")},
+                      {chunk_origin_expr}
+               FROM chunks WHERE id = ?
+               {lifecycle_filter}
+            """,
                 (chunk_id,),
             )
         )
@@ -1673,7 +1806,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             "superseded_by": r[11],
             "aggregated_into": r[12],
             "archived_at": r[13],
-            "chunk_origin": r[14] if has_chunk_origin else CHUNK_ORIGIN_UNKNOWN,
+            "archived": r[14],
+            "status": r[15],
+            "brick_id": r[16],
+            "source_uri": r[17],
+            "ingested_at": r[18],
+            "topic_cluster": r[19],
+            "chunk_origin": r[20],
         }
 
     def resolve_chunk_id(self, chunk_id: str) -> str:

--- a/tests/test_atomic_brick_schema.py
+++ b/tests/test_atomic_brick_schema.py
@@ -1,0 +1,411 @@
+"""Tests for PR-A atomic-brick-compatible schema migration."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import apsw
+import sqlite_vec
+
+from brainlayer._helpers import serialize_f32
+from brainlayer.vector_store import VectorStore
+
+
+def _connect_with_vec(db_path: Path) -> apsw.Connection:
+    conn = apsw.Connection(str(db_path))
+    conn.enableloadextension(True)
+    conn.loadextension(sqlite_vec.loadable_path())
+    conn.enableloadextension(False)
+    return conn
+
+
+def _create_legacy_db(db_path: Path, *, rows: int) -> None:
+    conn = _connect_with_vec(db_path)
+    cursor = conn.cursor()
+    cursor.execute("""
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            metadata TEXT NOT NULL,
+            source_file TEXT NOT NULL,
+            project TEXT,
+            content_type TEXT,
+            value_type TEXT,
+            char_count INTEGER,
+            created_at TEXT,
+            archived INTEGER DEFAULT 0,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived_at TEXT
+        )
+    """)
+    cursor.execute("""
+        CREATE VIRTUAL TABLE chunk_vectors USING vec0(
+            chunk_id TEXT PRIMARY KEY,
+            embedding FLOAT[1024]
+        )
+    """)
+    cursor.execute("""
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE chunk_tags (
+            chunk_id TEXT NOT NULL,
+            tag TEXT NOT NULL,
+            PRIMARY KEY (chunk_id, tag)
+        )
+    """)
+    for index in range(rows):
+        chunk_id = f"legacy-{index:05d}"
+        content = f"legacy content {index:05d}"
+        cursor.execute(
+            """
+            INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type,
+                value_type, char_count, created_at, archived, superseded_by,
+                aggregated_into, archived_at
+            ) VALUES (?, ?, '{}', ?, 'atomic-test', 'assistant_text',
+                      ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chunk_id,
+                content,
+                f"source-{index % 7}.jsonl",
+                "ARCHIVED" if index == 1 else "HIGH",
+                len(content),
+                f"2026-05-15T00:{index % 60:02d}:00Z",
+                1 if index == 1 else 0,
+                "legacy-00003" if index == 2 else None,
+                "aggregate-00001" if index == 4 else None,
+                "2026-05-15T01:00:00Z" if index == 1 else None,
+            ),
+        )
+        vector = [float(index % 17) + (dim / 100_000.0) for dim in range(1024)]
+        cursor.execute(
+            "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+            (chunk_id, serialize_f32(vector)),
+        )
+        cursor.execute(
+            """
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (?, NULL, NULL, NULL, NULL, NULL, ?)
+            """,
+            (content, chunk_id),
+        )
+        cursor.execute("INSERT INTO chunk_tags(chunk_id, tag) VALUES (?, ?)", (chunk_id, f"tag-{index % 3}"))
+    conn.close()
+
+
+def _checksum_rows(db_path: Path) -> tuple[str, int]:
+    conn = _connect_with_vec(db_path)
+    digest = hashlib.sha256()
+    count = 0
+    for chunk_id, content, embedding in conn.cursor().execute(
+        """
+        SELECT c.id, c.content, v.embedding
+        FROM chunks c
+        JOIN chunk_vectors v ON v.chunk_id = c.id
+        ORDER BY c.id
+        """
+    ):
+        digest.update(chunk_id.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(content.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(bytes(embedding))
+        digest.update(b"\n")
+        count += 1
+    conn.close()
+    return digest.hexdigest(), count
+
+
+def test_atomic_brick_columns_are_added_to_existing_chunks_schema(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path, rows=5)
+
+    store = VectorStore(db_path)
+    try:
+        cols = {row[1] for row in store.conn.cursor().execute("PRAGMA table_info(chunks)")}
+    finally:
+        store.close()
+
+    assert {"brick_id", "source_uri", "status", "ingested_at", "topic_cluster"}.issubset(cols)
+
+
+def test_atomic_brick_status_backfills_from_existing_lifecycle_fields(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path, rows=5)
+
+    store = VectorStore(db_path)
+    try:
+        rows = dict(store.conn.cursor().execute("SELECT id, status FROM chunks ORDER BY id"))
+    finally:
+        store.close()
+
+    assert rows["legacy-00000"] == "active"
+    assert rows["legacy-00001"] == "archived"
+    assert rows["legacy-00002"] == "superseded"
+    assert rows["legacy-00004"] == "superseded"
+
+
+def test_atomic_brick_migration_preserves_10k_content_and_vector_checksums(tmp_path):
+    db_path = tmp_path / "legacy-10k.db"
+    _create_legacy_db(db_path, rows=10_000)
+    before_hash, before_count = _checksum_rows(db_path)
+
+    store = VectorStore(db_path)
+    store.close()
+
+    after_hash, after_count = _checksum_rows(db_path)
+    assert before_count == after_count == 10_000
+    assert after_hash == before_hash
+
+
+def test_atomic_brick_migration_preserves_vectorless_rows_fts_and_tags(tmp_path):
+    db_path = tmp_path / "legacy-vectorless.db"
+    _create_legacy_db(db_path, rows=8)
+    conn = _connect_with_vec(db_path)
+    conn.cursor().execute("DELETE FROM chunk_vectors WHERE chunk_id IN ('legacy-00006', 'legacy-00007')")
+    before = (
+        conn.cursor()
+        .execute(
+            """
+        SELECT
+            (SELECT COUNT(*) FROM chunks),
+            (SELECT COUNT(*) FROM chunk_vectors),
+            (SELECT COUNT(*) FROM chunks_fts),
+            (SELECT COUNT(*) FROM chunk_tags)
+        """
+        )
+        .fetchone()
+    )
+    conn.close()
+
+    store = VectorStore(db_path)
+    try:
+        after = (
+            store.conn.cursor()
+            .execute(
+                """
+            SELECT
+                (SELECT COUNT(*) FROM chunks),
+                (SELECT COUNT(*) FROM chunk_vectors),
+                (SELECT COUNT(*) FROM chunks_fts),
+                (SELECT COUNT(*) FROM chunk_tags)
+            """
+            )
+            .fetchone()
+        )
+        rows = dict(
+            store.conn.cursor().execute(
+                """
+                SELECT c.id, COUNT(v.chunk_id)
+                FROM chunks c
+                LEFT JOIN chunk_vectors v ON v.chunk_id = c.id
+                WHERE c.id IN ('legacy-00006', 'legacy-00007')
+                GROUP BY c.id
+                """
+            )
+        )
+    finally:
+        store.close()
+
+    assert after == before
+    assert rows == {"legacy-00006": 0, "legacy-00007": 0}
+
+
+def test_atomic_brick_migration_recovers_from_partial_prior_run(tmp_path):
+    db_path = tmp_path / "partial.db"
+    _create_legacy_db(db_path, rows=5)
+    conn = _connect_with_vec(db_path)
+    conn.cursor().execute("ALTER TABLE chunks ADD COLUMN status TEXT DEFAULT 'active'")
+    conn.cursor().execute("UPDATE chunks SET status = 'active' WHERE id = 'legacy-00001'")
+    conn.close()
+
+    store = VectorStore(db_path)
+    try:
+        cols = {row[1] for row in store.conn.cursor().execute("PRAGMA table_info(chunks)")}
+        row = (
+            store.conn.cursor()
+            .execute("SELECT status, brick_id, source_uri, ingested_at FROM chunks WHERE id = 'legacy-00001'")
+            .fetchone()
+        )
+    finally:
+        store.close()
+
+    assert {"brick_id", "source_uri", "status", "ingested_at", "topic_cluster"}.issubset(cols)
+    assert row[0] == "archived"
+    assert row[1] == "legacy-00001"
+    assert row[2] == "source-1.jsonl"
+    assert isinstance(row[3], int)
+
+
+def test_atomic_brick_migration_recovers_when_columns_exist_without_marker(tmp_path):
+    db_path = tmp_path / "partial-all-columns.db"
+    _create_legacy_db(db_path, rows=5)
+    conn = _connect_with_vec(db_path)
+    cursor = conn.cursor()
+    for statement in [
+        "ALTER TABLE chunks ADD COLUMN brick_id TEXT",
+        "ALTER TABLE chunks ADD COLUMN source_uri TEXT",
+        "ALTER TABLE chunks ADD COLUMN status TEXT DEFAULT 'active'",
+        "ALTER TABLE chunks ADD COLUMN ingested_at INTEGER",
+        "ALTER TABLE chunks ADD COLUMN topic_cluster TEXT",
+    ]:
+        cursor.execute(statement)
+    cursor.execute("UPDATE chunks SET status = 'active' WHERE id = 'legacy-00001'")
+    conn.close()
+
+    store = VectorStore(db_path)
+    try:
+        row = (
+            store.conn.cursor()
+            .execute("SELECT status, brick_id, source_uri, ingested_at FROM chunks WHERE id = 'legacy-00001'")
+            .fetchone()
+        )
+        marker = (
+            store.conn.cursor()
+            .execute("SELECT applied_at FROM schema_migrations WHERE name = 'atomic_brick_chunks_v1'")
+            .fetchone()
+        )
+    finally:
+        store.close()
+
+    assert row[0] == "archived"
+    assert row[1] == "legacy-00001"
+    assert row[2] == "source-1.jsonl"
+    assert isinstance(row[3], int)
+    assert marker is not None
+
+
+def test_status_only_archived_rows_are_filtered_from_text_search(tmp_path):
+    db_path = tmp_path / "status-search.db"
+    store = VectorStore(db_path)
+    try:
+        store.upsert_chunks(
+            [
+                {
+                    "id": "status-active",
+                    "content": "UniqueStatusToken active memory",
+                    "metadata": {},
+                    "source_file": "test.jsonl",
+                    "project": "atomic-test",
+                    "content_type": "note",
+                    "value_type": "HIGH",
+                    "char_count": 31,
+                    "created_at": "2026-05-15T00:00:00Z",
+                },
+                {
+                    "id": "status-archived",
+                    "content": "UniqueStatusToken archived memory",
+                    "metadata": {},
+                    "source_file": "test.jsonl",
+                    "project": "atomic-test",
+                    "content_type": "note",
+                    "value_type": "HIGH",
+                    "char_count": 33,
+                    "created_at": "2026-05-15T00:01:00Z",
+                },
+            ],
+            [[0.01] * 1024, [0.02] * 1024],
+        )
+        store.conn.cursor().execute(
+            "UPDATE chunks SET status = 'archived', archived = 0, archived_at = NULL, superseded_by = NULL WHERE id = 'status-archived'"
+        )
+
+        active_results = store.search(query_text="UniqueStatusToken")
+        active_ids = active_results["ids"][0] if active_results["ids"] else []
+        historical_results = store.search(query_text="UniqueStatusToken", include_archived=True)
+        historical_ids = historical_results["ids"][0] if historical_results["ids"] else []
+    finally:
+        store.close()
+
+    assert "status-active" in active_ids
+    assert "status-archived" not in active_ids
+    assert {"status-active", "status-archived"}.issubset(set(historical_ids))
+
+
+def test_chunk_lifecycle_updates_status_without_deleting_personal_rows(tmp_path):
+    db_path = tmp_path / "lifecycle.db"
+    store = VectorStore(db_path)
+    try:
+        store.upsert_chunks(
+            [
+                {
+                    "id": "old",
+                    "content": "personal row should be retained",
+                    "metadata": {},
+                    "source_file": "test.jsonl",
+                    "project": "atomic-test",
+                    "content_type": "note",
+                    "value_type": "HIGH",
+                    "char_count": 31,
+                    "created_at": "2026-05-15T00:00:00Z",
+                },
+                {
+                    "id": "new",
+                    "content": "replacement row",
+                    "metadata": {},
+                    "source_file": "test.jsonl",
+                    "project": "atomic-test",
+                    "content_type": "note",
+                    "value_type": "HIGH",
+                    "char_count": 15,
+                    "created_at": "2026-05-15T00:01:00Z",
+                },
+            ],
+            [[0.01] * 1024, [0.02] * 1024],
+        )
+
+        assert store.supersede_chunk("old", "new") is True
+        row = store.conn.cursor().execute("SELECT status, superseded_by FROM chunks WHERE id = 'old'").fetchone()
+        assert row == ("superseded", "new")
+
+        assert store.archive_chunk("new") is True
+        row = (
+            store.conn.cursor().execute("SELECT status, archived, archived_at FROM chunks WHERE id = 'new'").fetchone()
+        )
+        assert row[0] == "archived"
+        assert row[1] == 1
+        assert row[2] is not None
+
+        retained = store.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE id IN ('old', 'new')").fetchone()[0]
+        assert retained == 2
+    finally:
+        store.close()
+
+
+def test_reupsert_does_not_resurrect_archived_status(tmp_path):
+    db_path = tmp_path / "status-resurrection.db"
+    store = VectorStore(db_path)
+    try:
+        chunk = {
+            "id": "personal-archive",
+            "content": "Personal archived row should stay archived",
+            "metadata": {},
+            "source_file": "test.jsonl",
+            "project": "atomic-test",
+            "content_type": "note",
+            "value_type": "HIGH",
+            "char_count": 42,
+            "created_at": "2026-05-15T00:00:00Z",
+        }
+        store.upsert_chunks([chunk], [[0.01] * 1024])
+        assert store.archive_chunk("personal-archive") is True
+
+        store.upsert_chunks([chunk], [[0.02] * 1024])
+
+        row = (
+            store.conn.cursor()
+            .execute("SELECT status, archived, archived_at FROM chunks WHERE id = 'personal-archive'")
+            .fetchone()
+        )
+    finally:
+        store.close()
+
+    assert row[0] == "archived"
+    assert row[1] == 1
+    assert row[2] is not None

--- a/tests/test_chunk_lifecycle.py
+++ b/tests/test_chunk_lifecycle.py
@@ -89,7 +89,7 @@ class TestSupersedeChunk:
         ok = store.supersede_chunk(old["id"], new["id"])
         assert ok is True
 
-        chunk = store.get_chunk(old["id"])
+        chunk = store.get_chunk(old["id"], include_archived=True)
         assert chunk["superseded_by"] == new["id"]
 
     def test_supersede_removes_from_vector_index(self, store, mock_embed):
@@ -134,7 +134,7 @@ class TestArchiveChunkLifecycle:
         result = _store_chunk(store, mock_embed, "To be archived")
         store.archive_chunk(result["id"])
 
-        chunk = store.get_chunk(result["id"])
+        chunk = store.get_chunk(result["id"], include_archived=True)
         assert chunk["archived_at"] is not None
         assert chunk["value_type"] == "ARCHIVED"
 
@@ -142,10 +142,18 @@ class TestArchiveChunkLifecycle:
         result = _store_chunk(store, mock_embed, "Archive me")
         store.archive_chunk(result["id"])
 
-        chunk = store.get_chunk(result["id"])
+        chunk = store.get_chunk(result["id"], include_archived=True)
         # Should parse as ISO 8601
         dt = datetime.fromisoformat(chunk["archived_at"])
         assert dt.year >= 2026
+
+    def test_get_chunk_excludes_archived_status_by_default(self, store, mock_embed):
+        result = _store_chunk(store, mock_embed, "Archived get_chunk hidden")
+        assert store.get_chunk(result["id"]) is not None
+
+        store.archive_chunk(result["id"])
+
+        assert store.get_chunk(result["id"]) is None
 
 
 # ── Search Filtering Tests ───────────────────────────────────────────────────
@@ -343,7 +351,7 @@ class TestStoreWithSupersedes:
         assert structured["superseded"] == old["id"]
 
         # Old chunk should be superseded
-        old_chunk = self.store.get_chunk(old["id"])
+        old_chunk = self.store.get_chunk(old["id"], include_archived=True)
         assert old_chunk["superseded_by"] is not None
 
     @pytest.mark.asyncio

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -212,11 +212,40 @@ def test_decay_job_updates_scores_and_archives_stale_chunks(store):
 
     stats = run_decay_job(store.db_path, now=1_800_000_000.0, dry_run=False, batch_size=100)
 
-    row = cursor.execute("SELECT decay_score, archived, archived_at FROM chunks WHERE id = 'archive-target'").fetchone()
+    row = cursor.execute(
+        "SELECT decay_score, archived, archived_at, status FROM chunks WHERE id = 'archive-target'"
+    ).fetchone()
     assert row[0] == pytest.approx(0.05)
     assert row[1] == 1
     assert float(row[2]) == 1_800_000_000.0
+    assert row[3] == "archived"
     assert stats["archived_rows"] >= 1
+
+
+def test_decay_job_preserves_superseded_status_for_non_archived_rows(store):
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type, char_count,
+            source, created_at, half_life_days, retrieval_count, decay_score,
+            superseded_by, status
+        ) VALUES (
+            'superseded-decay-target', 'already superseded', '{}', 'test.jsonl', 'decay-test',
+            'assistant_text', 18, 'claude_code', '2026-01-01T00:00:00Z', 36500.0, 0, 1.0,
+            'replacement', 'superseded'
+        )
+        """
+    )
+
+    from brainlayer.decay_job import run_decay_job
+
+    run_decay_job(store.db_path, now=1_800_000_000.0, dry_run=False, batch_size=100)
+
+    row = cursor.execute(
+        "SELECT archived, archived_at, superseded_by, status FROM chunks WHERE id = 'superseded-decay-target'"
+    ).fetchone()
+    assert row == (0, None, "replacement", "superseded")
 
 
 def test_backfill_seeds_half_life_and_pins_core_tags(tmp_path):

--- a/tests/test_search_exact_chunk_id.py
+++ b/tests/test_search_exact_chunk_id.py
@@ -127,6 +127,19 @@ def test_exact_chunk_lookup_defers_when_unhandled_filters_are_active():
     assert result is None
 
 
+def test_exact_chunk_lookup_skips_status_archived_chunks():
+    """Exact chunk lookup must also respect status-only soft deletes."""
+    mock_store = MagicMock()
+    mock_store.get_chunk.return_value = {
+        "id": "brainbar-status01",
+        "content": "Status archived chunk",
+        "project": "brainlayer",
+        "status": "archived",
+    }
+
+    assert _exact_chunk_lookup_result("brainbar-status01", mock_store, "compact") is None
+
+
 @pytest.mark.asyncio
 async def test_brain_search_chunk_id_context_routing_wins_over_exact_lookup():
     """Explicit chunk_id context expansion should run before exact-id short-circuiting."""


### PR DESCRIPTION
## Summary

PR-A for the BrainLayer overhaul. This adds the additive atomic-brick schema contract without replacing existing `chunks.id` or moving embeddings out of sqlite-vec.

## Changes

- Adds atomic-brick compatibility columns to `chunks`: `brick_id`, `source_uri`, `status`, `ingested_at`, `topic_cluster`.
- Adds idempotent migration/backfill with a `schema_migrations` marker so crash-after-ALTER reruns repair until completion.
- Keeps `chunk_vectors` and `chunk_vectors_binary` as external sqlite-vec tables; no vector blobs are duplicated into `chunks`.
- Updates archive/supersede writes and search filters to honor `status` alongside existing lifecycle fields.
- Updates BrainBar schema/open/search/enrichment paths for the same additive columns and status semantics.
- Adds legacy fixture coverage for sqlite-vec migration, vectorless rows, FTS/tag preservation, partial migration recovery, and 10K checksum fidelity.

## Verification

- RED observed before implementation: `pytest tests/test_atomic_brick_schema.py -q` failed on missing PR-A columns/status semantics.
- `pytest tests/test_atomic_brick_schema.py -q` -> 8 passed.
- `pytest tests/test_atomic_brick_schema.py tests/test_chunk_lifecycle.py tests/test_hybrid_search.py -q` -> 53 passed.
- `ruff check src/brainlayer/vector_store.py src/brainlayer/search_repo.py tests/test_atomic_brick_schema.py` -> passed.
- `python3 -m py_compile src/brainlayer/vector_store.py src/brainlayer/search_repo.py tests/test_atomic_brick_schema.py` -> passed.
- `git diff --check` -> passed.
- `swift test --package-path brain-bar --filter DatabaseTests` -> 72 tests passed.
- `./scripts/run_tests.sh` -> 1847 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 32 passed; bun stale-index test passed; FTS5 determinism regression passed.
- Pre-push hook reran `./scripts/run_tests.sh` and passed with the same gate.

## Notes

- Local `cr review --plain` was attempted twice and hung at setup with no findings; requesting CodeRabbit review on this PR.
- Do not merge until orc approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a schema migration/backfill on existing SQLite databases and changes default read/search behavior to hide non-`active` chunks unless explicitly included.
> 
> **Overview**
> **Adds atomic-brick chunk metadata + lifecycle status** by extending `chunks` with `brick_id`, `source_uri`, `ingested_at`, `topic_cluster`, `aggregated_into`, and a canonical `status` (`active`/`superseded`/`archived`). Both Swift (`BrainDatabase.swift`) and Python (`vector_store.py`) now run idempotent migrations with a `schema_migrations` marker and backfill these fields from existing lifecycle columns.
> 
> **Tightens default visibility rules**: search paths (FTS, trigram, vector/LIKE), exact chunk-id lookup, and enrichment selection now exclude aggregated/superseded/archived chunks *and* require `status='active'` (with `COALESCE` guards). Lifecycle writes (`archive_chunk`, `supersede_chunk`, decay job, drain supersedes) now also set `status`, and `VectorStore.get_chunk` gains `include_archived` to opt into returning non-active rows.
> 
> **Adds coverage** for migration correctness and safety (10k checksum preservation, vectorless rows/FTS/tags preserved, partial migration recovery) and updates existing lifecycle/decay/exact-lookup tests for the new `status` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c90b378d7575357b35dfe5d7dbc5543200020337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add atomic brick schema with `status` column and lifecycle-aware filtering to SQLite chunk stores
> - Adds new columns (`brick_id`, `source_uri`, `status`, `ingested_at`, `topic_cluster`) to the chunks table in both [vector_store.py](https://github.com/EtanHey/brainlayer/pull/284/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) and [BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/284/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc), with an idempotent migration tracked via a `schema_migrations` table.
> - Backfills `status` for existing rows by deriving it from existing lifecycle fields (`archived`, `archived_at`, `superseded_by`, `aggregated_into`), defaulting to `'active'`.
> - `archive_chunk` and `supersede_chunk` now set `status='archived'` and `status='superseded'` respectively, in addition to their existing field updates.
> - All search paths (KNN, FTS, exact lookup) now filter out non-active chunks by default via `COALESCE(status, 'active') = 'active'`, with `include_archived=True` to opt out.
> - Fixes a parameter mismatch in [decay_job.py](https://github.com/EtanHey/brainlayer/pull/284/files#diff-db466d3b233f0d618c8a24cd9ad03a6a34a89ab41d12098e888442b6990f40c1) where `ARCHIVE_THRESHOLD` was missing from the bound parameter tuple.
> - Behavioral Change: `get_chunk` now hides archived/superseded chunks by default; callers must pass `include_archived=True` to retrieve them. Tests in [test_chunk_lifecycle.py](https://github.com/EtanHey/brainlayer/pull/284/files#diff-f0d862887d6bd6249a8e2cd42a4d302a0709591597345bd3721414957733eb5f) are updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c90b378.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced content lifecycle tracking with improved state management for archived and inactive items.
  * Refined search filtering to automatically exclude archived content by default.

* **Bug Fixes**
  * Improved data integrity preservation during database schema updates.

* **Tests**
  * Added comprehensive test suite validating content state management, data preservation, and search filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/284)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->