### PR TITLE
feat: tag PreCompact checkpoints

### DIFF
--- a/src/brainlayer/_helpers.py
+++ b/src/brainlayer/_helpers.py
@@ -4,6 +4,8 @@ import json
 import struct
 from typing import Any, List, Optional
 
+import apsw
+
 _SOURCE_MIN_CHARS = {
     "whatsapp": 15,
     "telegram": 15,
@@ -63,6 +65,14 @@ def _escape_fts5_query(query: str, *, match_mode: str = "auto") -> str:
         # Space-separated terms in FTS5 are implicit AND.
         joiner = " "
     return joiner.join(terms)
+
+
+def _is_sqlite_busy_error(exc: BaseException) -> bool:
+    """Return True for APSW busy/locked errors, including wrapped messages."""
+    if isinstance(exc, (apsw.BusyError, apsw.LockedError)):
+        return True
+    message = str(exc).casefold()
+    return "database is locked" in message or "database table is locked" in message or "database is busy" in message
 
 
 def serialize_f32(vector: List[float]) -> bytes:

--- a/src/brainlayer/chunk_origin.py
+++ b/src/brainlayer/chunk_origin.py
@@ -1,0 +1,54 @@
+"""Chunk-origin classification helpers."""
+
+from __future__ import annotations
+
+CHUNK_ORIGIN_USER_EXPLICIT = "user_explicit"
+CHUNK_ORIGIN_AGENT_EXPLICIT = "agent_explicit"
+CHUNK_ORIGIN_AUTO_SUMMARY = "auto_summary"
+CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT = "precompact_checkpoint"
+CHUNK_ORIGIN_UNKNOWN = "unknown"
+
+VALID_CHUNK_ORIGINS = frozenset(
+    {
+        CHUNK_ORIGIN_USER_EXPLICIT,
+        CHUNK_ORIGIN_AGENT_EXPLICIT,
+        CHUNK_ORIGIN_AUTO_SUMMARY,
+        CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        CHUNK_ORIGIN_UNKNOWN,
+    }
+)
+
+_DIRECT_PRECOMPACT_PREFIXES = (
+    "[precompact checkpoint]",
+    "# precompact checkpoint",
+    "session-restore",
+    "# session-restore",
+)
+_WRAPPED_PRECOMPACT_MARKERS = (
+    'content="[precompact checkpoint]',
+    "content='[precompact checkpoint]",
+    '"content": "[precompact checkpoint]',
+    "'content': '[precompact checkpoint]",
+)
+
+
+def is_precompact_checkpoint_content(content: str | None) -> bool:
+    """Return True when content is a stored PreCompact checkpoint or its write prompt."""
+    if not content:
+        return False
+
+    stripped = content.lstrip().casefold()
+    if stripped.startswith(_DIRECT_PRECOMPACT_PREFIXES):
+        return True
+
+    prefix = stripped[:1024]
+    return any(marker in prefix for marker in _WRAPPED_PRECOMPACT_MARKERS)
+
+
+def detect_chunk_origin(content: str | None, explicit_origin: str | None = None) -> str:
+    """Classify the origin enum for a chunk."""
+    if explicit_origin in VALID_CHUNK_ORIGINS and explicit_origin != CHUNK_ORIGIN_UNKNOWN:
+        return explicit_origin
+    if is_precompact_checkpoint_content(content):
+        return CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+    return CHUNK_ORIGIN_UNKNOWN

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -19,6 +19,7 @@ import apsw
 import sqlite_vec
 
 from ._helpers import serialize_f32
+from .chunk_origin import detect_chunk_origin
 from .paths import get_db_path
 
 logger = logging.getLogger(__name__)
@@ -137,6 +138,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "summary": content[:200],
             "tags": json.dumps(tags) if tags else None,
             "importance": float(event["importance"]) if event.get("importance") is not None else None,
+            "chunk_origin": detect_chunk_origin(content, event.get("chunk_origin")),
         },
     )
     supersedes = event.get("supersedes") or metadata.get("supersedes")
@@ -190,6 +192,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> None:
             "conversation_id": event.get("conversation_id"),
             "sender": event.get("sender"),
             "tags": json.dumps(tags) if tags else None,
+            "chunk_origin": detect_chunk_origin(content, event.get("chunk_origin")),
         },
     )
 
@@ -227,6 +230,7 @@ def _apply_hook(conn: apsw.Connection, event: dict[str, Any]) -> None:
             "created_at": datetime.fromtimestamp(timestamp, timezone.utc).isoformat(),
             "conversation_id": session_id,
             "importance": 5,
+            "chunk_origin": detect_chunk_origin(content, event.get("chunk_origin")),
         },
     )
 

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -981,6 +981,7 @@ class KGMixin:
         query: str,
         relation_type: Optional[str] = None,
         limit: int = 20,
+        include_checkpoints: bool = False,
     ) -> List[Dict[str, Any]]:
         """Structured KG fact retrieval. Excludes co_occurs_with noise."""
         results: List[Dict[str, Any]] = []
@@ -989,14 +990,28 @@ class KGMixin:
         if entity:
             cursor = self._read_cursor()
 
+            checkpoint_join = ""
+            checkpoint_filter = ""
+            checkpoint_params: list[str] = []
+            if not include_checkpoints and getattr(self, "_has_chunk_origin", True):
+                checkpoint_join = "LEFT JOIN chunks source_chunk ON r.source_chunk_id = source_chunk.id"
+                checkpoint_filter = """
+                          AND (
+                              r.source_chunk_id IS NULL
+                              OR source_chunk.id IS NULL
+                              OR COALESCE(source_chunk.chunk_origin, 'unknown') != ?
+                          )
+                """
+                checkpoint_params.append("precompact_checkpoint")
+
             if relation_type:
                 type_filter_src = "AND r.relation_type = ?"
                 type_filter_tgt = "AND r.relation_type = ?"
-                params = [entity["id"], relation_type, entity["id"], relation_type, limit]
+                params = [entity["id"], relation_type, entity["id"], relation_type, *checkpoint_params, limit]
             else:
                 type_filter_src = "AND r.relation_type != 'co_occurs_with'"
                 type_filter_tgt = "AND r.relation_type != 'co_occurs_with'"
-                params = [entity["id"], entity["id"], limit]
+                params = [entity["id"], entity["id"], *checkpoint_params, limit]
 
             rows = list(
                 cursor.execute(
@@ -1009,8 +1024,10 @@ class KGMixin:
                     FROM kg_current_facts r
                     JOIN kg_entities se ON r.source_id = se.id
                     JOIN kg_entities te ON r.target_id = te.id
-                    WHERE (r.source_id = ? {type_filter_src})
-                       OR (r.target_id = ? {type_filter_tgt})
+                    {checkpoint_join}
+                    WHERE ((r.source_id = ? {type_filter_src})
+                       OR (r.target_id = ? {type_filter_tgt}))
+                    {checkpoint_filter}
                     ORDER BY r.importance DESC, r.confidence DESC
                     LIMIT ?
                     """,
@@ -1070,6 +1087,7 @@ class KGMixin:
             query=search_term,
             relation_type=relation_type,
             limit=n_results,
+            include_checkpoints=bool(kwargs.get("include_checkpoints", False)),
         )
 
         scored_facts = []

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -41,6 +41,7 @@ from .entity_handler import _brain_entity as _brain_entity
 from .entity_handler import _brain_get_person
 from .search_handler import (
     _brain_recall,
+    _brain_resume,
     _brain_search,
     _context,
     _current_context,
@@ -505,6 +506,11 @@ async def list_tools() -> list[Tool]:
                             "type": "string",
                             "description": "Filter by correction type tag (e.g. 'correction:preference', 'correction:factual', 'correction:naming'). Matches chunks tagged with the given correction category.",
                         },
+                        "include_checkpoints": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Include PreCompact checkpoint chunks in search results. Defaults to false; use brain_resume for explicit session recovery.",
+                        },
                         "detail": {
                             "type": "string",
                             "enum": ["compact", "full"],
@@ -513,6 +519,31 @@ async def list_tools() -> list[Tool]:
                         },
                     },
                     "required": ["query"],
+                }
+            ),
+        ),
+        Tool(
+            name="brain_resume",
+            title="Resume From PreCompact Checkpoint",
+            description="""Return recent PreCompact checkpoint chunks for session recovery. Use when: an agent asks what it was working on after compaction or needs explicit session-restore state. Don't use for normal topical search; brain_search excludes checkpoints by default to avoid checkpoint pollution. session_id narrows to one session when known, and lookback_days defaults to 7.""",
+            annotations=_READ_ONLY,
+            inputSchema=_bounded_input_schema(
+                {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "Optional session ID to resume.",
+                        },
+                        "lookback_days": {
+                            "type": "integer",
+                            "default": 7,
+                            "minimum": 1,
+                            "maximum": 90,
+                            "description": "How many days back to search checkpoints.",
+                        },
+                    },
+                    "required": [],
                 }
             ),
         ),
@@ -791,6 +822,11 @@ async def list_tools() -> list[Tool]:
                             "enum": ["compact", "full"],
                             "default": "compact",
                             "description": "Result detail level (mode=search). 'compact': snippet + metadata. 'full': complete content.",
+                        },
+                        "include_checkpoints": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Include PreCompact checkpoint chunks in mode=search results. Defaults to false; use brain_resume for explicit session recovery.",
                         },
                     },
                 }
@@ -1218,6 +1254,15 @@ async def call_tool(name: str, arguments: dict[str, Any]):
                 detail=arguments.get("detail", "compact"),
                 source_filter=resolved_source_filter,
                 correction_category=arguments.get("correction_category"),
+                include_checkpoints=arguments.get("include_checkpoints", False),
+            )
+        )
+
+    elif name == "brain_resume":
+        return await _with_timeout(
+            _brain_resume(
+                session_id=arguments.get("session_id"),
+                lookback_days=arguments.get("lookback_days", 7),
             )
         )
 
@@ -1297,6 +1342,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
                 max_results=arguments.get("max_results", 10),
                 detail=arguments.get("detail", "compact"),
                 entity_type=arguments.get("entity_type"),
+                include_checkpoints=arguments.get("include_checkpoints", False),
             )
         )
 

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -3,12 +3,14 @@
 import asyncio
 import json
 import re
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import apsw
 from mcp.types import TextContent
 
-from .._helpers import _escape_fts5_query
+from .._helpers import _escape_fts5_query, _is_sqlite_busy_error
+from ..chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
 from ..lexical_defense import _normalize_surface, load_lexical_defense_dictionary
 
 # Retry settings for DB lock resilience on reads
@@ -35,6 +37,10 @@ from ._shared import (
 )
 
 _CHUNK_ID_QUERY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:-[A-Za-z0-9_]+)+$")
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _quote_fts_phrase(value: str) -> str:
@@ -163,6 +169,7 @@ def _exact_chunk_lookup_result(
     sentiment: str | None = None,
     source_filter: str | None = None,
     correction_category: str | None = None,
+    include_checkpoints: bool = False,
 ) -> tuple[list[TextContent], dict] | None:
     """Return an exact chunk hit for chunk-id shaped queries, or None on miss."""
     candidate = query.strip()
@@ -174,6 +181,9 @@ def _exact_chunk_lookup_result(
         return None
     if any(chunk.get(field) is not None for field in ("superseded_by", "aggregated_into", "archived_at")):
         return None
+    if not include_checkpoints and chunk.get("chunk_origin") == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT:
+        empty = {"query": query, "total": 0, "results": []}
+        return ([TextContent(type="text", text="No results found.")], empty)
     if any(value is not None for value in (source, intent, sentiment, source_filter, correction_category)):
         return None
     if project is not None:
@@ -313,7 +323,7 @@ def _detect_entities(query: str, store: Any) -> list[dict]:
         return []
 
 
-def _kg_facts_sql(store: Any, entity_name: str) -> list[dict]:
+def _kg_facts_sql(store: Any, entity_name: str, *, include_checkpoints: bool = False) -> list[dict]:
     """Pure SQL KG fact lookup — no embeddings, no vector search.
 
     Returns typed relations for an entity, excluding co_occurs_with noise.
@@ -333,20 +343,36 @@ def _kg_facts_sql(store: Any, entity_name: str) -> list[dict]:
 
         entity_id = row[0][0]
 
+        checkpoint_join = ""
+        checkpoint_filter = ""
+        params: list[Any] = [entity_id, entity_id]
+        if not include_checkpoints and getattr(store, "_has_chunk_origin", True):
+            checkpoint_join = "LEFT JOIN chunks source_chunk ON r.source_chunk_id = source_chunk.id"
+            checkpoint_filter = """
+                     AND (
+                         r.source_chunk_id IS NULL
+                         OR source_chunk.id IS NULL
+                         OR COALESCE(source_chunk.chunk_origin, 'unknown') != ?
+                     )
+            """
+            params.append(CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT)
+
         # Get all semantic relations (exclude co_occurs_with)
         facts_raw = list(
             cursor.execute(
-                """SELECT r.relation_type, r.properties, r.confidence,
+                f"""SELECT r.relation_type, r.properties, r.confidence,
                           se.name as source_name, se.entity_type as source_type,
                           te.name as target_name, te.entity_type as target_type
                    FROM kg_relations r
                    JOIN kg_entities se ON r.source_id = se.id
                    JOIN kg_entities te ON r.target_id = te.id
+                   {checkpoint_join}
                    WHERE (r.source_id = ? OR r.target_id = ?)
                      AND r.relation_type != 'co_occurs_with'
+                     {checkpoint_filter}
                    ORDER BY r.confidence DESC
                    LIMIT 20""",
-                (entity_id, entity_id),
+                params,
             )
         )
 
@@ -397,6 +423,7 @@ async def _brain_search(
     detail: str = "compact",
     source_filter: str | None = None,
     correction_category: str | None = None,
+    include_checkpoints: bool = False,
 ):
     """Unified search dispatcher -- routes to the right internal handler."""
 
@@ -432,9 +459,15 @@ async def _brain_search(
             detail=detail,
             source_filter_like=source_filter,
             correction_category=correction_category,
+            include_checkpoints=include_checkpoints,
         )
 
     if chunk_id is not None:
+        store = _get_vector_store()
+        chunk = store.get_chunk(chunk_id)
+        if not include_checkpoints and chunk and chunk.get("chunk_origin") == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT:
+            empty = {"query": query, "total": 0, "results": []}
+            return ([TextContent(type="text", text="No results found.")], empty)
         return await _context(chunk_id=chunk_id, before=before, after=after)
 
     if file_path is not None and _query_has_regression_signal(query):
@@ -480,6 +513,7 @@ async def _brain_search(
             detail=detail,
             source_filter=source_filter,
             correction_category=correction_category,
+            include_checkpoints=include_checkpoints,
         )
 
     if _query_signals_current_context(query):
@@ -518,6 +552,7 @@ async def _brain_search(
         sentiment=sentiment,
         source_filter=source_filter,
         correction_category=correction_category,
+        include_checkpoints=include_checkpoints,
     )
     if exact_chunk_hit is not None:
         return exact_chunk_hit
@@ -546,7 +581,7 @@ async def _brain_search(
         entity_name = detected_entities[0]["name"]
 
         # Path 1: Pure SQL KG facts (no embedding model needed, always runs)
-        fact_items = _kg_facts_sql(store, entity_name)
+        fact_items = _kg_facts_sql(store, entity_name, include_checkpoints=include_checkpoints)
 
         # Path 2: Try full hybrid search (embedding + vector + KG)
         structured_results = []
@@ -563,6 +598,7 @@ async def _brain_search(
                 n_results=num_results,
                 entity_name=entity_name,
                 project_filter=normalized_project,
+                include_checkpoints=include_checkpoints,
             )
             chunk_results = kg_results.get("chunks", {})
 
@@ -634,7 +670,106 @@ async def _brain_search(
         fts_query_override=fts_query_override,
         source_filter_like=source_filter,
         correction_category=correction_category,
+        include_checkpoints=include_checkpoints,
     )
+
+
+def _escape_like_pattern(value: str) -> str:
+    """Escape user text for a literal SQLite LIKE pattern."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+async def _execute_resume_query_with_retry(store: Any, query: str, params: list[Any]) -> list:
+    for attempt in range(_RETRY_MAX_ATTEMPTS):
+        try:
+            return list(store._read_cursor().execute(query, params))
+        except apsw.Error as exc:
+            if not _is_sqlite_busy_error(exc) or attempt == _RETRY_MAX_ATTEMPTS - 1:
+                raise
+            await asyncio.sleep(_retry_delay * (2**attempt))
+    return []
+
+
+async def _brain_resume(session_id: str | None = None, lookback_days: int = 7):
+    """Return recent PreCompact checkpoints without polluting default search."""
+    try:
+        try:
+            days = int(lookback_days)
+        except (TypeError, ValueError):
+            days = 7
+        days = max(1, min(days, 90))
+
+        now = datetime.fromisoformat(_utcnow_iso().replace("Z", "+00:00"))
+        cutoff = (now - timedelta(days=days)).isoformat()
+
+        where_clauses = [
+            "COALESCE(chunk_origin, 'unknown') = ?",
+            "(created_at IS NULL OR created_at >= ?)",
+            "superseded_by IS NULL",
+            "aggregated_into IS NULL",
+            "archived_at IS NULL",
+        ]
+        params: list[Any] = [CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, cutoff]
+        if session_id:
+            where_clauses.append("(conversation_id = ? OR content LIKE ? ESCAPE '\\' OR metadata LIKE ? ESCAPE '\\')")
+            session_like = f"%{_escape_like_pattern(session_id)}%"
+            params.extend([session_id, session_like, session_like])
+        params.append(20)
+
+        store = _get_vector_store()
+        if not getattr(store, "_has_chunk_origin", True):
+            structured = {"session_id": session_id, "lookback_days": days, "total": 0, "results": []}
+            return ([TextContent(type="text", text="No PreCompact checkpoints found.")], structured)
+
+        rows = await _execute_resume_query_with_retry(
+            store,
+            f"""
+                SELECT id, content, source_file, project, content_type, created_at,
+                       source, conversation_id, summary, importance
+                FROM chunks
+                WHERE {" AND ".join(where_clauses)}
+                ORDER BY COALESCE(created_at, '') DESC
+                LIMIT ?
+                """,
+            params,
+        )
+
+        structured_results = [
+            {
+                "chunk_id": row[0],
+                "content": row[1],
+                "source_file": row[2],
+                "project": _normalize_project_name(row[3]) or row[3] or "unknown",
+                "content_type": row[4],
+                "date": row[5][:10] if row[5] else None,
+                "source": row[6],
+                "session_id": row[7],
+                "summary": row[8],
+                "importance": row[9],
+            }
+            for row in rows
+        ]
+        structured = {
+            "session_id": session_id,
+            "lookback_days": days,
+            "total": len(structured_results),
+            "results": structured_results,
+        }
+        if not structured_results:
+            return ([TextContent(type="text", text="No PreCompact checkpoints found.")], structured)
+
+        output_parts = [f"## PreCompact Checkpoints ({len(structured_results)})"]
+        for index, item in enumerate(structured_results, start=1):
+            header = f"\n### Checkpoint {index}: {item['chunk_id']}"
+            if item.get("date"):
+                header += f" | {item['date']}"
+            if item.get("session_id"):
+                header += f" | session: {item['session_id']}"
+            output_parts.append(header)
+            output_parts.append(item["content"])
+        return ([TextContent(type="text", text="\n".join(output_parts))], structured)
+    except Exception as exc:
+        return _error_result(f"Resume error: {exc}")
 
 
 def _infer_recall_mode(arguments: dict) -> str:
@@ -732,6 +867,7 @@ async def _brain_recall(
     # --- T3 filter additions ---
     source_filter: str | None = None,
     correction_category: str | None = None,
+    include_checkpoints: bool = False,
 ):
     """Unified recall dispatcher -- routes to session/context/search/entity handlers.
 
@@ -789,6 +925,7 @@ async def _brain_recall(
             detail=detail,
             source_filter=source_filter,
             correction_category=correction_category,
+            include_checkpoints=include_checkpoints,
         )
 
     if resolved_mode == "entity":
@@ -849,6 +986,7 @@ async def _search(
     # --- T3 filter additions ---
     source_filter_like: str | None = None,
     correction_category: str | None = None,
+    include_checkpoints: bool = False,
 ):
     """Execute a hybrid search query (semantic + keyword via RRF). Retries on BusyError."""
     try:
@@ -909,6 +1047,7 @@ async def _search(
                     entity_id=entity_id,
                     source_filter_like=source_filter_like,
                     correction_category=correction_category,
+                    include_checkpoints=include_checkpoints,
                 )
                 break
             except Exception as e:

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -83,6 +83,7 @@ def enqueue_watcher_chunk(
     conversation_id: str,
     sender: str | None = None,
     tags: list[str] | None = None,
+    chunk_origin: str | None = None,
     queue_dir: Path | None = None,
 ) -> Path:
     return enqueue_jsonl(
@@ -99,6 +100,7 @@ def enqueue_watcher_chunk(
             "conversation_id": conversation_id,
             "sender": sender,
             "tags": tags,
+            "chunk_origin": chunk_origin,
         },
         source="watcher",
         queue_dir=queue_dir,

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -14,7 +14,8 @@ from typing import Any, Dict, List, Optional
 import apsw
 import numpy as np
 
-from ._helpers import _escape_fts5_query, serialize_f32
+from ._helpers import _escape_fts5_query, _is_sqlite_busy_error, serialize_f32
+from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
 
 # ── hybrid_search result cache ───────────────────────────────────────────────
 # Caches identical (store, query_text, filters) → results for 60s.
@@ -82,6 +83,7 @@ def _hybrid_cache_key(
     entity_id: Optional[str],
     k: int,
     include_archived: bool = False,
+    include_checkpoints: bool = False,
 ) -> tuple:
     return (
         store_key,
@@ -102,6 +104,7 @@ def _hybrid_cache_key(
         entity_id,
         k,
         include_archived,
+        include_checkpoints,
     )
 
 
@@ -119,6 +122,64 @@ def _contains_meta_noise(content: Optional[str]) -> bool:
 
 class SearchMixin:
     """Search and query methods, mixed into VectorStore."""
+
+    def _checkpoint_exclusion_clause(self, table_alias: str | None = None) -> str | None:
+        if not getattr(self, "_has_chunk_origin", True):
+            return None
+        column = f"{table_alias}.chunk_origin" if table_alias else "chunk_origin"
+        return f"COALESCE({column}, 'unknown') != 'precompact_checkpoint'"
+
+    def _checkpoint_cache_data_version(self) -> int | None:
+        for attempt in range(3):
+            try:
+                row = self._read_cursor().execute("PRAGMA data_version").fetchone()
+                return int(row[0]) if row else None
+            except (apsw.Error, TypeError, IndexError, ValueError) as exc:
+                if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
+                    return None
+                time.sleep(0.05 * (2**attempt))
+        return None
+
+    def _checkpoint_filtered_knn_k(self, n_results: int, include_checkpoints: bool) -> int:
+        if include_checkpoints or not getattr(self, "_has_chunk_origin", True):
+            return n_results
+
+        cached_count = getattr(self, "_checkpoint_count_cache", None)
+        current_data_version = self._checkpoint_cache_data_version()
+        cached_data_version = getattr(self, "_checkpoint_count_cache_data_version", None)
+        if cached_count is not None and (current_data_version is None or cached_data_version == current_data_version):
+            checkpoint_count = cached_count
+        else:
+            checkpoint_count = 0
+            for attempt in range(3):
+                try:
+                    checkpoint_count = int(
+                        self._read_cursor()
+                        .execute(
+                            "SELECT COUNT(*) FROM chunks WHERE chunk_origin = ?",
+                            (CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,),
+                        )
+                        .fetchone()[0]
+                        or 0
+                    )
+                    setattr(self, "_checkpoint_count_cache", checkpoint_count)
+                    setattr(self, "_checkpoint_count_cache_data_version", current_data_version)
+                    break
+                except (apsw.Error, TypeError, IndexError) as exc:
+                    if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
+                        checkpoint_count = 0
+                        break
+                    time.sleep(0.05 * (2**attempt))
+
+        if checkpoint_count <= 0:
+            return n_results
+        return n_results + checkpoint_count
+
+    def _effective_knn_k(self, n_results: int, needs_overfetch: bool, include_checkpoints: bool) -> int:
+        effective_k = n_results
+        if needs_overfetch:
+            effective_k = max(effective_k, min(n_results * 10, 1000))
+        return self._checkpoint_filtered_knn_k(effective_k, include_checkpoints)
 
     def _load_chunk_embeddings(self, chunk_ids: List[str]) -> Dict[str, np.ndarray]:
         """Fetch float embeddings for the provided chunk IDs."""
@@ -292,6 +353,7 @@ class SearchMixin:
         sentiment_filter: Optional[str] = None,
         entity_id: Optional[str] = None,
         include_archived: bool = False,
+        include_checkpoints: bool = False,
         source_filter_like: Optional[str] = None,
         correction_category: Optional[str] = None,
     ) -> Dict[str, List]:
@@ -355,6 +417,10 @@ class SearchMixin:
             if correction_category:
                 where_clauses.append("c.id IN (SELECT chunk_id FROM chunk_tags WHERE tag LIKE ?)")
                 filter_params.append(f"correction:{correction_category}%")
+            if not include_checkpoints:
+                checkpoint_clause = self._checkpoint_exclusion_clause("c")
+                if checkpoint_clause:
+                    where_clauses.append(checkpoint_clause)
             if not include_archived:
                 where_clauses.append("c.superseded_by IS NULL")
                 where_clauses.append("c.aggregated_into IS NULL")
@@ -374,7 +440,7 @@ class SearchMixin:
                 or source_filter_like
                 or correction_category
             )
-            effective_k = min(n_results * 10, 1000) if needs_overfetch else n_results
+            effective_k = self._effective_knn_k(n_results, bool(needs_overfetch), include_checkpoints)
             params = [query_bytes, effective_k] + filter_params
             query = f"""
                 SELECT c.id, c.content, c.metadata, c.source_file, c.project,
@@ -389,6 +455,7 @@ class SearchMixin:
             """
 
             results = list(cursor.execute(query, params))
+            results = results[:n_results]
 
         elif query_text is not None:
             # Text search using LIKE
@@ -434,6 +501,10 @@ class SearchMixin:
             if correction_category:
                 where_clauses.append("id IN (SELECT chunk_id FROM chunk_tags WHERE tag LIKE ?)")
                 params.append(f"correction:{correction_category}%")
+            if not include_checkpoints:
+                checkpoint_clause = self._checkpoint_exclusion_clause()
+                if checkpoint_clause:
+                    where_clauses.append(checkpoint_clause)
             if not include_archived:
                 where_clauses.append("superseded_by IS NULL")
                 where_clauses.append("aggregated_into IS NULL")
@@ -639,6 +710,7 @@ class SearchMixin:
         sentiment_filter: Optional[str] = None,
         entity_id: Optional[str] = None,
         include_archived: bool = False,
+        include_checkpoints: bool = False,
         source_filter_like: Optional[str] = None,
         correction_category: Optional[str] = None,
     ) -> Dict[str, List]:
@@ -691,6 +763,10 @@ class SearchMixin:
         if correction_category:
             where_clauses.append("c.id IN (SELECT chunk_id FROM chunk_tags WHERE tag LIKE ?)")
             filter_params.append(f"correction:{correction_category}%")
+        if not include_checkpoints:
+            checkpoint_clause = self._checkpoint_exclusion_clause("c")
+            if checkpoint_clause:
+                where_clauses.append(checkpoint_clause)
         if not include_archived:
             where_clauses.append("c.superseded_by IS NULL")
             where_clauses.append("c.aggregated_into IS NULL")
@@ -703,7 +779,7 @@ class SearchMixin:
         needs_overfetch = (
             entity_id or (source_filter and source_filter != "claude_code") or source_filter_like or correction_category
         )
-        effective_k = min(n_results * 10, 1000) if needs_overfetch else n_results
+        effective_k = self._effective_knn_k(n_results, bool(needs_overfetch), include_checkpoints)
         params = [query_bytes, effective_k] + filter_params
         results = list(
             cursor.execute(
@@ -721,6 +797,7 @@ class SearchMixin:
                 params,
             )
         )
+        results = results[:n_results]
 
         ids = []
         documents = []
@@ -841,6 +918,7 @@ class SearchMixin:
         entity_id: Optional[str] = None,
         k: int = 60,
         include_archived: bool = False,
+        include_checkpoints: bool = False,
         kg_boost: bool = False,
         source_filter_like: Optional[str] = None,
         correction_category: Optional[str] = None,
@@ -878,6 +956,7 @@ class SearchMixin:
             entity_id,
             k,
             include_archived,
+            include_checkpoints,
         ) + (fts_query_override, kg_boost, source_filter_like, correction_category, filter_meta_noise)
         now = time.monotonic()
         if cache_key in _hybrid_cache:
@@ -910,6 +989,7 @@ class SearchMixin:
                 sentiment_filter=sentiment_filter,
                 entity_id=entity_id,
                 include_archived=include_archived,
+                include_checkpoints=include_checkpoints,
                 source_filter_like=source_filter_like,
                 correction_category=correction_category,
             )
@@ -931,6 +1011,7 @@ class SearchMixin:
                 sentiment_filter=sentiment_filter,
                 entity_id=entity_id,
                 include_archived=include_archived,
+                include_checkpoints=include_checkpoints,
                 source_filter_like=source_filter_like,
                 correction_category=correction_category,
             )
@@ -993,6 +1074,10 @@ class SearchMixin:
             if correction_category:
                 fts_extra.append("AND c.id IN (SELECT chunk_id FROM chunk_tags WHERE tag LIKE ?)")
                 fts_filter_params.append(f"correction:{correction_category}%")
+            if not include_checkpoints:
+                checkpoint_clause = self._checkpoint_exclusion_clause("c")
+                if checkpoint_clause:
+                    fts_extra.append(f"AND {checkpoint_clause}")
             if filter_meta_noise:
                 for pattern in META_NOISE_PATTERNS_CASEFOLDED:
                     fts_extra.append("AND LOWER(c.content) NOT LIKE ?")

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -36,6 +36,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
+from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, detect_chunk_origin
 from .pipeline.classify import looks_like_system_prompt
 from .vector_store import VectorStore
 
@@ -143,13 +144,14 @@ def store_memory(
 
     # Insert into chunks table
     cursor = store.conn.cursor()
+    chunk_origin = detect_chunk_origin(content)
     cursor.execute(
         """
         INSERT INTO chunks
         (id, content, metadata, source_file, project, content_type,
          value_type, char_count, source, created_at, enriched_at,
-         summary, tags, importance)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         summary, tags, importance, chunk_origin)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """,
         (
             chunk_id,
@@ -166,6 +168,7 @@ def store_memory(
             content[:200],  # summary = first 200 chars
             json.dumps(tags) if tags else None,
             float(importance) if importance is not None else None,
+            chunk_origin,
         ),
     )
 
@@ -189,6 +192,8 @@ def store_memory(
     from .search_repo import clear_hybrid_search_cache
 
     clear_hybrid_search_cache(getattr(store, "db_path", None))
+    if chunk_origin == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT:
+        store._invalidate_checkpoint_count_cache()
 
     return {
         "id": chunk_id,

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -8,6 +8,7 @@ import json
 import os
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -32,6 +33,11 @@ from ._helpers import (
 )
 from ._helpers import (
     source_aware_min_chars as source_aware_min_chars,
+)
+from .chunk_origin import (
+    CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    CHUNK_ORIGIN_UNKNOWN,
+    detect_chunk_origin,
 )
 from .kg_repo import KGMixin
 from .search_repo import SearchMixin
@@ -74,6 +80,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self._retrieval_strengthening_query_count = 0
         self._retrieval_strengthening_flush_threshold = 100
         self._retrieval_strengthening_lock = threading.Lock()
+        self._checkpoint_count_cache: int | None = None
+        self._checkpoint_count_cache_data_version: int | None = None
         self._readonly = self.db_path.exists() and not os.access(self.db_path, os.W_OK)
         if self._readonly:
             self._init_readonly_db()
@@ -92,9 +100,21 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         existing_tables = {
             row[0] for row in cursor.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")
         }
+        chunk_columns = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+        self._has_chunk_origin = "chunk_origin" in chunk_columns
         self._binary_index_available = "chunk_vectors_binary" in existing_tables
         self._trigram_fts_available = "chunks_fts_trigram" in existing_tables
         self._local = threading.local()
+
+    def _invalidate_checkpoint_count_cache(self) -> None:
+        self._checkpoint_count_cache = None
+        self._checkpoint_count_cache_data_version = None
+
+    def _checkpoint_wal_full(self, cursor) -> None:
+        try:
+            cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        except apsw.Error:
+            pass
 
     def _init_db_with_retry(self) -> None:
         """Initialize DB with retry on BusyError.
@@ -155,7 +175,16 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 language TEXT,
                 conversation_id TEXT,
                 position INTEGER,
-                context_summary TEXT
+                context_summary TEXT,
+                chunk_origin TEXT DEFAULT 'unknown'
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                name TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL,
+                details TEXT
             )
         """)
 
@@ -198,9 +227,60 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("superseded_by", "TEXT"),
             ("aggregated_into", "TEXT"),
             ("archived_at", "TEXT"),
+            ("chunk_origin", "TEXT DEFAULT 'unknown'"),
         ]:
             if col not in existing_cols:
                 cursor.execute(f"ALTER TABLE chunks ADD COLUMN {col} {typ}")
+        self._has_chunk_origin = True
+
+        migration_name = "2026_05_16_fm6_chunk_origin"
+        migration_done = cursor.execute(
+            "SELECT 1 FROM schema_migrations WHERE name = ?",
+            (migration_name,),
+        ).fetchone()
+        if migration_done is None:
+            self._checkpoint_wal_full(cursor)
+            cursor.execute(
+                """
+                UPDATE chunks
+                SET chunk_origin = ?
+                WHERE COALESCE(chunk_origin, ?) != ?
+                  AND (
+                    LOWER(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)))
+                        LIKE '[precompact checkpoint]%'
+                    OR LOWER(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)))
+                        LIKE '# precompact checkpoint%'
+                    OR LOWER(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)))
+                        LIKE 'session-restore%'
+                    OR LOWER(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)))
+                        LIKE '# session-restore%'
+                    OR LOWER(SUBSTR(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)), 1, 1024))
+                        LIKE '%content="[precompact checkpoint]%'
+                    OR LOWER(SUBSTR(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)), 1, 1024))
+                        LIKE '%content=''[precompact checkpoint]%'
+                    OR LOWER(SUBSTR(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)), 1, 1024))
+                        LIKE '%"content": "[precompact checkpoint]%'
+                    OR LOWER(SUBSTR(LTRIM(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)), 1, 1024))
+                        LIKE '%''content'': ''[precompact checkpoint]%'
+                  )
+                """,
+                (
+                    CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+                    CHUNK_ORIGIN_UNKNOWN,
+                    CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+                ),
+            )
+            backfilled = self.conn.changes()
+            cursor.execute(
+                "INSERT OR IGNORE INTO schema_migrations (name, applied_at, details) VALUES (?, ?, ?)",
+                (
+                    migration_name,
+                    datetime.now(timezone.utc).isoformat(),
+                    json.dumps({"backfilled_precompact_checkpoints": backfilled}),
+                ),
+            )
+            self._checkpoint_wal_full(cursor)
+            self._invalidate_checkpoint_count_cache()
 
         cursor.execute("""
             UPDATE chunks
@@ -221,6 +301,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("idx_chunks_project", "project"),
             ("idx_chunks_content_type", "content_type"),
             ("idx_chunks_language", "language"),
+            ("idx_chunks_chunk_origin", "chunk_origin"),
         ]:
             cursor.execute(f"CREATE INDEX IF NOT EXISTS {idx} ON chunks({col})")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_chunks_decay_score ON chunks(decay_score) WHERE archived = 0")
@@ -1246,8 +1327,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 INSERT INTO chunks
                 (id, content, metadata, source_file, project,
                  content_type, value_type, char_count, source, created_at,
-                 conversation_id, position, sender)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 conversation_id, position, sender, chunk_origin)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     content = excluded.content,
                     metadata = excluded.metadata,
@@ -1260,7 +1341,16 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     created_at = COALESCE(chunks.created_at, excluded.created_at),
                     conversation_id = COALESCE(excluded.conversation_id, chunks.conversation_id),
                     position = COALESCE(excluded.position, chunks.position),
-                    sender = COALESCE(excluded.sender, chunks.sender)
+                    sender = COALESCE(excluded.sender, chunks.sender),
+                    chunk_origin = CASE
+                        WHEN excluded.content != chunks.content
+                            THEN COALESCE(excluded.chunk_origin, 'unknown')
+                        WHEN excluded.chunk_origin IS NOT NULL AND excluded.chunk_origin != 'unknown'
+                            THEN excluded.chunk_origin
+                        WHEN chunks.chunk_origin IS NULL
+                            THEN COALESCE(excluded.chunk_origin, 'unknown')
+                        ELSE chunks.chunk_origin
+                    END
             """,
                 (
                     chunk_id,
@@ -1276,6 +1366,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     chunk.get("conversation_id"),
                     chunk.get("position"),
                     chunk.get("sender"),
+                    detect_chunk_origin(chunk.get("content"), chunk.get("chunk_origin")),
                 ),
             )
 
@@ -1284,6 +1375,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         from .search_repo import clear_hybrid_search_cache
 
         clear_hybrid_search_cache(getattr(self, "db_path", None))
+        self._invalidate_checkpoint_count_cache()
 
         return len(chunks)
 
@@ -1303,8 +1395,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         if content is not None:
             cursor.execute(
-                "UPDATE chunks SET content = ?, char_count = ?, summary = ? WHERE id = ?",
-                (content, len(content), content[:200], chunk_id),
+                "UPDATE chunks SET content = ?, char_count = ?, summary = ?, chunk_origin = ? WHERE id = ?",
+                (content, len(content), content[:200], detect_chunk_origin(content), chunk_id),
             )
         if tags is not None:
             cursor.execute(
@@ -1321,6 +1413,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         from .search_repo import clear_hybrid_search_cache
 
         clear_hybrid_search_cache(getattr(self, "db_path", None))
+        self._invalidate_checkpoint_count_cache()
         return True
 
     def archive_chunk(self, chunk_id: str) -> bool:
@@ -1364,11 +1457,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     def get_chunk(self, chunk_id: str) -> Optional[Dict[str, Any]]:
         """Get a single chunk by ID."""
         cursor = self.conn.cursor()
+        has_chunk_origin = getattr(self, "_has_chunk_origin", True)
+        chunk_origin_select = ", chunk_origin" if has_chunk_origin else ""
         rows = list(
             cursor.execute(
-                """SELECT id, content, metadata, source_file, project, content_type,
+                f"""SELECT id, content, metadata, source_file, project, content_type,
                       value_type, tags, importance, created_at, summary,
-                      superseded_by, aggregated_into, archived_at
+                      superseded_by, aggregated_into, archived_at{chunk_origin_select}
                FROM chunks WHERE id = ?""",
                 (chunk_id,),
             )
@@ -1391,6 +1486,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             "superseded_by": r[11],
             "aggregated_into": r[12],
             "archived_at": r[13],
+            "chunk_origin": r[14] if has_chunk_origin else CHUNK_ORIGIN_UNKNOWN,
         }
 
     # ── Chunk events audit ─────────────────────────────────────────────

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .chunk_origin import detect_chunk_origin
 from .paths import get_db_path
 from .pipeline.chunk import chunk_content
 from .pipeline.classify import classify_content
@@ -268,6 +269,7 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                     correction_tags = build_correction_tags(clean_content)
                     if correction_tags:
                         tags = json.dumps(correction_tags)
+                chunk_origin = detect_chunk_origin(clean_content)
 
                 try:
                     if arbitrated:
@@ -283,6 +285,7 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                             conversation_id=conversation_id,
                             sender=chunk.metadata.get("sender"),
                             tags=json.loads(tags) if tags else None,
+                            chunk_origin=chunk_origin,
                         )
                         inserted += 1
                     else:
@@ -291,8 +294,8 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                             """INSERT OR IGNORE INTO chunks
                                (id, content, metadata, source_file, project,
                                 content_type, value_type, char_count, source,
-                                created_at, conversation_id, sender, tags)
-                               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                                created_at, conversation_id, sender, tags, chunk_origin)
+                               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                             (
                                 chunk_id,
                                 clean_content,
@@ -307,6 +310,7 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                                 conversation_id,
                                 chunk.metadata.get("sender"),
                                 tags,
+                                chunk_origin,
                             ),
                         )
                         if store.conn.changes() > 0:

--- a/tests/test_db_lock_resilience.py
+++ b/tests/test_db_lock_resilience.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 import apsw
 import pytest
 
+from brainlayer._helpers import _is_sqlite_busy_error
 from brainlayer.vector_store import VectorStore
+
+
+def test_sqlite_busy_helper_treats_locked_error_as_busy():
+    assert _is_sqlite_busy_error(apsw.LockedError("database table is locked")) is True
 
 
 class TestVectorStoreInitRetry:

--- a/tests/test_precompact_chunk_origin.py
+++ b/tests/test_precompact_chunk_origin.py
@@ -1,0 +1,853 @@
+"""Tests for PreCompact checkpoint tagging and retrieval."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import apsw
+
+from brainlayer._helpers import serialize_f32
+from brainlayer.chunk_origin import (
+    CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    CHUNK_ORIGIN_UNKNOWN,
+    detect_chunk_origin,
+)
+from brainlayer.drain import _apply_watcher
+from brainlayer.mcp.search_handler import _brain_resume, _kg_facts_sql
+from brainlayer.search_repo import _hybrid_cache
+from brainlayer.store import store_memory
+from brainlayer.vector_store import VectorStore
+from brainlayer.watcher_bridge import create_flush_callback
+
+
+def _embed(seed: str) -> list[float]:
+    base = (sum(ord(char) for char in seed) % 97) / 1000.0
+    return [base + (index / 10000.0) for index in range(1024)]
+
+
+def _insert_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    content: str,
+    embedding: list[float] | None = None,
+    chunk_origin: str | None = None,
+    created_at: str = "2026-05-16T10:00:00+00:00",
+    conversation_id: str = "session-a",
+) -> None:
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, created_at, conversation_id, chunk_origin
+        ) VALUES (?, ?, '{}', 'test.jsonl', 'brainlayer', 'assistant_text', ?, 'claude_code', ?, ?, ?)""",
+        (chunk_id, content, len(content), created_at, conversation_id, chunk_origin),
+    )
+    cursor.execute(
+        "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+        (chunk_id, serialize_f32(embedding or _embed(content))),
+    )
+
+
+def test_detect_chunk_origin_matches_direct_and_watcher_checkpoint_forms():
+    assert detect_chunk_origin("[PreCompact checkpoint]\ntimestamp: 2026-05-16") == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+    assert detect_chunk_origin("# PreCompact Checkpoint\nsession_id: abc") == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+    assert (
+        detect_chunk_origin('Call mcp__brainlayer__brain_store exactly once with content="[PreCompact checkpoint]\\n"')
+        == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+    )
+    assert detect_chunk_origin("Enabled Claude Code PreCompact checkpoint storage in ~/.claude") == CHUNK_ORIGIN_UNKNOWN
+
+
+def test_detect_chunk_origin_auto_detects_when_explicit_origin_is_unknown():
+    assert (
+        detect_chunk_origin("[PreCompact checkpoint]\ntimestamp: 2026-05-16", CHUNK_ORIGIN_UNKNOWN)
+        == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+    )
+    assert detect_chunk_origin("normal assistant memory", CHUNK_ORIGIN_UNKNOWN) == CHUNK_ORIGIN_UNKNOWN
+
+
+def test_vector_store_migration_adds_chunk_origin_and_backfills_legacy_rows(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    conn = apsw.Connection(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            metadata TEXT NOT NULL,
+            source_file TEXT NOT NULL,
+            project TEXT,
+            content_type TEXT,
+            value_type TEXT,
+            char_count INTEGER,
+            source TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO chunks (id, content, metadata, source_file, source) VALUES (?, ?, '{}', 'watcher.jsonl', ?)",
+        ("direct", "[PreCompact checkpoint]\ntimestamp: 2026-05-16", "mcp"),
+    )
+    conn.execute(
+        "INSERT INTO chunks (id, content, metadata, source_file, source) VALUES (?, ?, '{}', 'watcher.jsonl', ?)",
+        ("leading-whitespace", "\t\n[PreCompact checkpoint]\ntimestamp: 2026-05-16", "mcp"),
+    )
+    conn.execute(
+        "INSERT INTO chunks (id, content, metadata, source_file, source) VALUES (?, ?, '{}', 'watcher.jsonl', ?)",
+        (
+            "wrapped",
+            'Call mcp__brainlayer__brain_store exactly once with content="[PreCompact checkpoint]\\ntimestamp"',
+            "realtime_watcher",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO chunks (id, content, metadata, source_file, source) VALUES (?, ?, '{}', 'watcher.jsonl', ?)",
+        (
+            "wrapped-leading-whitespace",
+            (" \n\t" * 400)
+            + 'Call mcp__brainlayer__brain_store exactly once with content="[PreCompact checkpoint]\\ntimestamp"',
+            "realtime_watcher",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO chunks (id, content, metadata, source_file, source) VALUES (?, ?, '{}', 'manual.md', ?)",
+        ("manual", "Enabled Claude Code PreCompact checkpoint storage in ~/.claude", "manual"),
+    )
+    conn.close()
+
+    store = VectorStore(db_path)
+    rows = dict(store.conn.cursor().execute("SELECT id, chunk_origin FROM chunks"))
+    migration = (
+        store.conn.cursor()
+        .execute("SELECT details FROM schema_migrations WHERE name = '2026_05_16_fm6_chunk_origin'")
+        .fetchone()
+    )
+    store.close()
+
+    assert rows == {
+        "direct": CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        "leading-whitespace": CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        "wrapped": CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        "wrapped-leading-whitespace": CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        "manual": CHUNK_ORIGIN_UNKNOWN,
+    }
+    assert migration is not None
+    assert json.loads(migration[0])["backfilled_precompact_checkpoints"] == 4
+
+
+def test_upsert_chunks_tags_precompact_origin(tmp_path):
+    store = VectorStore(tmp_path / "upsert.db")
+    store.upsert_chunks(
+        [
+            {
+                "id": "checkpoint-upsert",
+                "content": "[PreCompact checkpoint]\ntimestamp: 2026-05-16",
+                "metadata": {},
+                "source_file": "mcp",
+                "project": "brainlayer",
+                "content_type": "assistant_text",
+                "char_count": 45,
+                "source": "mcp",
+                "created_at": "2026-05-16T10:00:00+00:00",
+            }
+        ],
+        [_embed("checkpoint-upsert")],
+    )
+
+    row = store.conn.cursor().execute("SELECT chunk_origin FROM chunks WHERE id = 'checkpoint-upsert'").fetchone()
+    store.close()
+
+    assert row == (CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,)
+
+
+def test_upsert_chunks_recomputes_origin_when_stable_chunk_content_changes(tmp_path):
+    store = VectorStore(tmp_path / "upsert-recompute.db")
+    store.upsert_chunks(
+        [
+            {
+                "id": "stable-source-file-0",
+                "content": "[PreCompact checkpoint]\nold compacted state",
+                "metadata": {},
+                "source_file": "session.jsonl",
+                "project": "brainlayer",
+                "content_type": "assistant_text",
+                "char_count": 41,
+                "source": "mcp",
+                "created_at": "2026-05-16T10:00:00+00:00",
+            }
+        ],
+        [_embed("old checkpoint")],
+    )
+    store.upsert_chunks(
+        [
+            {
+                "id": "stable-source-file-0",
+                "content": "normal assistant memory after source file was reprocessed",
+                "metadata": {},
+                "source_file": "session.jsonl",
+                "project": "brainlayer",
+                "content_type": "assistant_text",
+                "char_count": 55,
+                "source": "mcp",
+                "created_at": "2026-05-16T10:05:00+00:00",
+            }
+        ],
+        [_embed("normal reprocessed content")],
+    )
+
+    row = store.conn.cursor().execute("SELECT chunk_origin FROM chunks WHERE id = 'stable-source-file-0'").fetchone()
+    store.close()
+
+    assert row == (CHUNK_ORIGIN_UNKNOWN,)
+
+
+def test_update_chunk_recomputes_origin_when_content_changes(tmp_path):
+    store = VectorStore(tmp_path / "update-origin.db")
+    _insert_chunk(
+        store,
+        chunk_id="updated-checkpoint",
+        content="normal assistant memory",
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+
+    updated = store.update_chunk("updated-checkpoint", content="[PreCompact checkpoint]\nrestored task state")
+
+    row = store.conn.cursor().execute("SELECT chunk_origin FROM chunks WHERE id = 'updated-checkpoint'").fetchone()
+    store.close()
+
+    assert updated is True
+    assert row == (CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,)
+
+
+def test_watcher_and_drain_tag_precompact_origin(tmp_path, monkeypatch):
+    db_path = tmp_path / "watcher.db"
+    source_file = tmp_path / "session.jsonl"
+    source_file.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-05-16T10:00:00+00:00",
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": 'Call mcp__brainlayer__brain_store exactly once with content="[PreCompact checkpoint]\\ntimestamp: 2026-05-16"',
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("BRAINLAYER_WRITER_ARBITRATION", raising=False)
+
+    flush = create_flush_callback(db_path)
+    flush([json.loads(source_file.read_text(encoding="utf-8")) | {"_source_file": str(source_file)}])
+    store = VectorStore(db_path)
+    row = store.conn.cursor().execute("SELECT chunk_origin FROM chunks WHERE source = 'realtime_watcher'").fetchone()
+
+    _apply_watcher(
+        store.conn,
+        {
+            "chunk_id": "queued-checkpoint",
+            "content": "[PreCompact checkpoint]\ntimestamp: 2026-05-16",
+            "metadata": {},
+            "source_file": "queue.jsonl",
+            "created_at": "2026-05-16T10:00:00+00:00",
+        },
+    )
+    queued = store.conn.cursor().execute("SELECT chunk_origin FROM chunks WHERE id = 'queued-checkpoint'").fetchone()
+    store.close()
+
+    assert row == (CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,)
+    assert queued == (CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,)
+
+
+def test_search_excludes_checkpoints_by_default_and_can_include_them(tmp_path):
+    _hybrid_cache.clear()
+    store = VectorStore(tmp_path / "search.db")
+    _insert_chunk(
+        store,
+        chunk_id="checkpoint",
+        content="Recoverable focus token alpha beta",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    )
+    _insert_chunk(
+        store,
+        chunk_id="normal",
+        content="Recoverable focus token alpha beta",
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+    store.build_binary_index()
+
+    text_default = store.search(query_text="Recoverable focus token", n_results=10)
+    text_with_checkpoints = store.search(query_text="Recoverable focus token", n_results=10, include_checkpoints=True)
+    hybrid_default = store.hybrid_search(
+        query_embedding=_embed("Recoverable focus token"),
+        query_text="Recoverable focus token",
+        n_results=10,
+    )
+    hybrid_with_checkpoints = store.hybrid_search(
+        query_embedding=_embed("Recoverable focus token"),
+        query_text="Recoverable focus token",
+        n_results=10,
+        include_checkpoints=True,
+    )
+    store.close()
+
+    assert text_default["ids"][0] == ["normal"]
+    assert set(text_with_checkpoints["ids"][0]) == {"checkpoint", "normal"}
+    assert "checkpoint" not in hybrid_default["ids"][0]
+    assert {"checkpoint", "normal"}.issubset(set(hybrid_with_checkpoints["ids"][0]))
+
+
+def test_vector_search_overfetches_when_checkpoint_filter_discards_nearest_neighbors(tmp_path):
+    store = VectorStore(tmp_path / "vector-overfetch.db")
+    query_embedding = [0.0] * 1024
+    for index in range(5):
+        _insert_chunk(
+            store,
+            chunk_id=f"checkpoint-{index}",
+            content=f"[PreCompact checkpoint]\nnoise {index}",
+            embedding=query_embedding,
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+    _insert_chunk(
+        store,
+        chunk_id="normal-just-outside-knn-window",
+        content="normal memory just outside the checkpoint nearest-neighbor window",
+        embedding=[0.001] + ([0.0] * 1023),
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+
+    results = store.search(query_embedding=query_embedding, n_results=2)
+    store.close()
+
+    assert results["ids"][0] == ["normal-just-outside-knn-window"]
+
+
+def test_vector_search_does_not_starve_normal_results_after_many_checkpoints(tmp_path):
+    store = VectorStore(tmp_path / "vector-many-checkpoints.db")
+    query_embedding = [0.0] * 1024
+    for index in range(1001):
+        _insert_chunk(
+            store,
+            chunk_id=f"checkpoint-{index}",
+            content=f"[PreCompact checkpoint]\nnoise {index}",
+            embedding=query_embedding,
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+    _insert_chunk(
+        store,
+        chunk_id="normal-after-many-checkpoints",
+        content="normal memory after many checkpoint nearest neighbors",
+        embedding=[0.001] + ([0.0] * 1023),
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+
+    results = store.search(query_embedding=query_embedding, n_results=1)
+    store.close()
+
+    assert results["ids"][0] == ["normal-after-many-checkpoints"]
+
+
+def test_vector_search_does_not_overfetch_for_checkpoint_filter_when_no_checkpoints_exist(tmp_path, monkeypatch):
+    store = VectorStore(tmp_path / "vector-no-checkpoint-overfetch.db")
+    query_embedding = [0.0] * 1024
+    for index in range(5):
+        _insert_chunk(
+            store,
+            chunk_id=f"normal-{index}",
+            content=f"normal memory {index}",
+            embedding=[index / 1000.0] + ([0.0] * 1023),
+            chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+        )
+
+    captured_k = []
+    real_read_cursor = store._read_cursor
+
+    class CapturingCursor:
+        def __init__(self, cursor):
+            self.cursor = cursor
+
+        def execute(self, sql, params=None):
+            if "FROM chunk_vectors v" in sql and params:
+                captured_k.append(params[1])
+            return self.cursor.execute(sql, params)
+
+    monkeypatch.setattr(store, "_read_cursor", lambda: CapturingCursor(real_read_cursor()))
+
+    store.search(query_embedding=query_embedding, n_results=2)
+    store.close()
+
+    assert captured_k == [2]
+
+
+def test_store_memory_checkpoint_invalidates_checkpoint_count_cache(tmp_path):
+    store = VectorStore(tmp_path / "store-memory-cache.db")
+    query_embedding = [0.0] * 1024
+    _insert_chunk(
+        store,
+        chunk_id="normal-after-checkpoint",
+        content="normal memory reachable after checkpoint overfetch",
+        embedding=[0.001] + ([0.0] * 1023),
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+    assert store.search(query_embedding=query_embedding, n_results=1)["ids"][0] == ["normal-after-checkpoint"]
+    assert store._checkpoint_count_cache == 0
+
+    store_memory(
+        store=store,
+        embed_fn=lambda _content: query_embedding,
+        content="[PreCompact checkpoint]\nmanual recovery state",
+        memory_type="note",
+        project="brainlayer",
+    )
+
+    results = store.search(query_embedding=query_embedding, n_results=1)
+    store.close()
+
+    assert results["ids"][0] == ["normal-after-checkpoint"]
+
+
+def test_external_checkpoint_write_invalidates_cached_checkpoint_count(tmp_path):
+    db_path = tmp_path / "external-checkpoint-cache.db"
+    reader = VectorStore(db_path)
+    writer = VectorStore(db_path)
+    query_embedding = [0.0] * 1024
+    try:
+        _insert_chunk(
+            reader,
+            chunk_id="normal-after-external-checkpoint",
+            content="normal memory reachable after external checkpoint",
+            embedding=[0.001] + ([0.0] * 1023),
+            chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+        )
+        assert reader.search(query_embedding=query_embedding, n_results=1)["ids"][0] == [
+            "normal-after-external-checkpoint"
+        ]
+        assert reader._checkpoint_count_cache == 0
+
+        _insert_chunk(
+            writer,
+            chunk_id="external-checkpoint",
+            content="[PreCompact checkpoint]\nexternal writer state",
+            embedding=query_embedding,
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+
+        results = reader.search(query_embedding=query_embedding, n_results=1)
+    finally:
+        reader.close()
+        writer.close()
+
+    assert results["ids"][0] == ["normal-after-external-checkpoint"]
+
+
+def test_checkpoint_overfetch_composes_with_entity_filter_overfetch(tmp_path):
+    store = VectorStore(tmp_path / "checkpoint-entity-overfetch.db")
+    query_embedding = [0.0] * 1024
+    try:
+        for index in range(5):
+            _insert_chunk(
+                store,
+                chunk_id=f"checkpoint-near-{index}",
+                content=f"[PreCompact checkpoint]\nnear checkpoint {index}",
+                embedding=[index / 10000.0] + ([0.0] * 1023),
+                chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+            )
+        for index in range(5):
+            _insert_chunk(
+                store,
+                chunk_id=f"normal-unlinked-{index}",
+                content=f"normal unlinked memory {index}",
+                embedding=[0.01 + (index / 10000.0)] + ([0.0] * 1023),
+                chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+            )
+        _insert_chunk(
+            store,
+            chunk_id="normal-linked-target",
+            content="normal entity-linked memory after checkpoint and entity filtering",
+            embedding=[0.02] + ([0.0] * 1023),
+            chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+        )
+        store.upsert_entity("entity-target", "project", "Target Project")
+        store.conn.cursor().execute(
+            "INSERT INTO kg_entity_chunks (entity_id, chunk_id, relevance) VALUES (?, ?, ?)",
+            ("entity-target", "normal-linked-target", 0.95),
+        )
+
+        results = store.search(query_embedding=query_embedding, n_results=1, entity_id="entity-target")
+    finally:
+        store.close()
+
+    assert results["ids"][0] == ["normal-linked-target"]
+
+
+def test_vector_search_caps_results_after_checkpoint_overfetch(tmp_path):
+    store = VectorStore(tmp_path / "vector-result-cap.db")
+    query_embedding = [0.0] * 1024
+    for index in range(5):
+        _insert_chunk(
+            store,
+            chunk_id=f"normal-near-{index}",
+            content=f"normal nearby memory {index}",
+            embedding=[index / 10000.0] + ([0.0] * 1023),
+            chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+        )
+        _insert_chunk(
+            store,
+            chunk_id=f"checkpoint-far-{index}",
+            content=f"[PreCompact checkpoint]\nfar checkpoint {index}",
+            embedding=[1.0 + index] + ([0.0] * 1023),
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+
+    results = store.search(query_embedding=query_embedding, n_results=2)
+    store.close()
+
+    assert results["ids"][0] == ["normal-near-0", "normal-near-1"]
+
+
+def test_readonly_legacy_db_without_chunk_origin_searches_as_unknown(tmp_path):
+    db_path = tmp_path / "legacy-readonly.db"
+    store = VectorStore(db_path)
+    _insert_chunk(
+        store,
+        chunk_id="legacy-normal",
+        content="legacy searchable memory",
+        embedding=_embed("legacy searchable memory"),
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+    store.close()
+
+    conn = apsw.Connection(str(db_path))
+    conn.execute("DROP INDEX IF EXISTS idx_chunks_chunk_origin")
+    conn.execute("ALTER TABLE chunks DROP COLUMN chunk_origin")
+    conn.close()
+    readonly_store = None
+    os.chmod(db_path, 0o444)
+    try:
+        readonly_store = VectorStore(db_path)
+        text_results = readonly_store.search(query_text="legacy searchable", n_results=1)
+        vector_results = readonly_store.search(query_embedding=_embed("legacy searchable memory"), n_results=1)
+        legacy_chunk = readonly_store.get_chunk("legacy-normal")
+    finally:
+        if readonly_store is not None:
+            readonly_store.close()
+        os.chmod(db_path, 0o644)
+
+    assert text_results["ids"][0] == ["legacy-normal"]
+    assert vector_results["ids"][0] == ["legacy-normal"]
+    assert legacy_chunk is not None
+    assert legacy_chunk["chunk_origin"] == CHUNK_ORIGIN_UNKNOWN
+
+
+def test_brain_resume_returns_empty_on_readonly_legacy_db_without_chunk_origin(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy-resume-readonly.db"
+    store = VectorStore(db_path)
+    _insert_chunk(
+        store,
+        chunk_id="legacy-checkpoint",
+        content="[PreCompact checkpoint]\nlegacy state",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    )
+    store.close()
+
+    conn = apsw.Connection(str(db_path))
+    conn.execute("DROP INDEX IF EXISTS idx_chunks_chunk_origin")
+    conn.execute("ALTER TABLE chunks DROP COLUMN chunk_origin")
+    conn.close()
+    readonly_store = None
+    os.chmod(db_path, 0o444)
+    try:
+        readonly_store = VectorStore(db_path)
+        monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: readonly_store)
+        monkeypatch.setattr("brainlayer.mcp.search_handler._utcnow_iso", lambda: "2026-05-16T12:00:00+00:00")
+
+        content, structured = asyncio.run(_brain_resume())
+    finally:
+        if readonly_store is not None:
+            readonly_store.close()
+        os.chmod(db_path, 0o644)
+
+    assert structured == {"session_id": None, "lookback_days": 7, "total": 0, "results": []}
+    assert content[0].text == "No PreCompact checkpoints found."
+
+
+def test_kg_sql_facts_excludes_checkpoint_sourced_relations_by_default(tmp_path):
+    store = VectorStore(tmp_path / "kg-sql-facts.db")
+    _insert_chunk(
+        store,
+        chunk_id="checkpoint-fact-chunk",
+        content="[PreCompact checkpoint]\nEtan builds checkpoint-only project",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    )
+    _insert_chunk(
+        store,
+        chunk_id="normal-fact-chunk",
+        content="Etan builds durable project",
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+    store.upsert_entity("person-etan", "person", "Etan")
+    store.upsert_entity("project-checkpoint", "project", "Checkpoint Project")
+    store.upsert_entity("project-normal", "project", "Normal Project")
+    store.add_relation(
+        "rel-checkpoint",
+        "person-etan",
+        "project-checkpoint",
+        "builds",
+        properties={"description": "checkpoint-only fact"},
+        source_chunk_id="checkpoint-fact-chunk",
+    )
+    store.add_relation(
+        "rel-normal",
+        "person-etan",
+        "project-normal",
+        "maintains",
+        properties={"description": "normal fact"},
+        source_chunk_id="normal-fact-chunk",
+    )
+
+    default_facts = _kg_facts_sql(store, "Etan")
+    checkpoint_facts = _kg_facts_sql(store, "Etan", include_checkpoints=True)
+    store.close()
+
+    assert {fact["target"] for fact in default_facts} == {"Normal Project"}
+    assert {fact["target"] for fact in checkpoint_facts} == {"Checkpoint Project", "Normal Project"}
+
+
+def test_kg_hybrid_search_facts_excludes_checkpoint_sourced_relations_by_default(tmp_path):
+    store = VectorStore(tmp_path / "kg-hybrid-facts.db")
+    _insert_chunk(
+        store,
+        chunk_id="checkpoint-fact-chunk",
+        content="[PreCompact checkpoint]\nEtan builds checkpoint-only project",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    )
+    _insert_chunk(
+        store,
+        chunk_id="normal-fact-chunk",
+        content="Etan builds durable project",
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+    store.upsert_entity("person-etan", "person", "Etan")
+    store.upsert_entity("project-checkpoint", "project", "Checkpoint Project")
+    store.upsert_entity("project-normal", "project", "Normal Project")
+    store.add_relation(
+        "rel-checkpoint",
+        "person-etan",
+        "project-checkpoint",
+        "builds",
+        fact="checkpoint-only fact",
+        source_chunk_id="checkpoint-fact-chunk",
+    )
+    store.add_relation(
+        "rel-normal",
+        "person-etan",
+        "project-normal",
+        "maintains",
+        fact="normal fact",
+        source_chunk_id="normal-fact-chunk",
+    )
+
+    default_results = store.kg_hybrid_search(
+        query_embedding=_embed("Etan"),
+        query_text="Etan",
+        n_results=10,
+        entity_name="Etan",
+    )
+    checkpoint_results = store.kg_hybrid_search(
+        query_embedding=_embed("Etan"),
+        query_text="Etan",
+        n_results=10,
+        entity_name="Etan",
+        include_checkpoints=True,
+    )
+    store.close()
+
+    assert {fact["target_entity"]["name"] for fact in default_results["facts"]} == {"Normal Project"}
+    assert {fact["target_entity"]["name"] for fact in checkpoint_results["facts"]} == {
+        "Checkpoint Project",
+        "Normal Project",
+    }
+
+
+def test_binary_search_overfetches_when_checkpoint_filter_discards_nearest_neighbors(tmp_path):
+    store = VectorStore(tmp_path / "binary-overfetch.db")
+    query_embedding = [1.0] + ([0.0] * 1023)
+    for index in range(5):
+        _insert_chunk(
+            store,
+            chunk_id=f"checkpoint-{index}",
+            content=f"[PreCompact checkpoint]\nnoise {index}",
+            embedding=query_embedding,
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+    _insert_chunk(
+        store,
+        chunk_id="normal-just-outside-binary-window",
+        content="normal binary memory just outside the checkpoint nearest-neighbor window",
+        embedding=query_embedding,
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+    )
+    store.build_binary_index()
+
+    results = store._binary_search(query_embedding=query_embedding, n_results=2)
+    store.close()
+
+    assert results["ids"][0] == ["normal-just-outside-binary-window"]
+
+
+def test_brain_resume_returns_recent_checkpoint_partition(tmp_path, monkeypatch):
+    store = VectorStore(tmp_path / "resume.db")
+    _insert_chunk(
+        store,
+        chunk_id="recent-checkpoint",
+        content="[PreCompact checkpoint]\nsession_id: session-a\nCurrent task: PR A",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        created_at="2026-05-16T10:00:00+00:00",
+        conversation_id="session-a",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="normal-note",
+        content="Current task: PR A",
+        chunk_origin=CHUNK_ORIGIN_UNKNOWN,
+        created_at="2026-05-16T10:00:00+00:00",
+        conversation_id="session-a",
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._utcnow_iso", lambda: "2026-05-16T12:00:00+00:00")
+
+    content, structured = asyncio.run(_brain_resume(session_id="session-a", lookback_days=7))
+    store.close()
+
+    assert structured["total"] == 1
+    assert structured["results"][0]["chunk_id"] == "recent-checkpoint"
+    assert "PR A" in content[0].text
+
+
+def test_brain_resume_excludes_archived_checkpoints(tmp_path, monkeypatch):
+    store = VectorStore(tmp_path / "resume-lifecycle.db")
+    _insert_chunk(
+        store,
+        chunk_id="active-checkpoint",
+        content="[PreCompact checkpoint]\nCurrent task: active",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        created_at="2026-05-16T10:00:00+00:00",
+        conversation_id="session-a",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="archived-checkpoint",
+        content="[PreCompact checkpoint]\nCurrent task: archived",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        created_at="2026-05-16T11:00:00+00:00",
+        conversation_id="session-a",
+    )
+    store.conn.cursor().execute(
+        "UPDATE chunks SET archived_at = '2026-05-16T11:30:00+00:00' WHERE id = 'archived-checkpoint'"
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._utcnow_iso", lambda: "2026-05-16T12:00:00+00:00")
+
+    _content, structured = asyncio.run(_brain_resume(session_id="session-a", lookback_days=7))
+    store.close()
+
+    assert structured["total"] == 1
+    assert structured["results"][0]["chunk_id"] == "active-checkpoint"
+
+
+def test_brain_resume_retries_busy_read_once(tmp_path, monkeypatch):
+    class BusyOnceCursor:
+        def __init__(self):
+            self.calls = 0
+
+        def execute(self, _sql, _params):
+            self.calls += 1
+            if self.calls == 1:
+                raise apsw.BusyError("database is locked")
+            return []
+
+    class BusyOnceStore:
+        def __init__(self):
+            self.cursor = BusyOnceCursor()
+
+        def _read_cursor(self):
+            return self.cursor
+
+    store = BusyOnceStore()
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._utcnow_iso", lambda: "2026-05-16T12:00:00+00:00")
+    monkeypatch.setattr("brainlayer.mcp.search_handler.asyncio.sleep", fake_sleep)
+
+    content, structured = asyncio.run(_brain_resume())
+
+    assert structured["total"] == 0
+    assert content[0].text == "No PreCompact checkpoints found."
+    assert store.cursor.calls == 2
+    assert sleep_calls == [0.1]
+
+
+def test_brain_resume_error_path_preserves_mcp_error_result(monkeypatch):
+    class BrokenStore:
+        def _read_cursor(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: BrokenStore())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._utcnow_iso", lambda: "2026-05-16T12:00:00+00:00")
+
+    result = asyncio.run(_brain_resume())
+
+    assert result.isError is True
+    assert result.content[0].text == "Resume error: boom"
+
+
+def test_brain_resume_escapes_session_id_like_wildcards(tmp_path, monkeypatch):
+    store = VectorStore(tmp_path / "resume-like-escape.db")
+    _insert_chunk(
+        store,
+        chunk_id="literal-session",
+        content="[PreCompact checkpoint]\nsession_id: abc_def\nCurrent task: literal",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        created_at="2026-05-16T10:00:00+00:00",
+        conversation_id="other-literal",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="wildcard-false-positive",
+        content="[PreCompact checkpoint]\nsession_id: abcXdef\nCurrent task: false positive",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        created_at="2026-05-16T10:00:00+00:00",
+        conversation_id="other-false-positive",
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._utcnow_iso", lambda: "2026-05-16T12:00:00+00:00")
+
+    _content, structured = asyncio.run(_brain_resume(session_id="abc_def", lookback_days=7))
+    store.close()
+
+    assert structured["total"] == 1
+    assert structured["results"][0]["chunk_id"] == "literal-session"
+
+
+def test_brain_resume_store_creation_error_preserves_mcp_error_result(monkeypatch):
+    def raise_store_error():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", raise_store_error)
+
+    result = asyncio.run(_brain_resume())
+
+    assert result.isError is True
+    assert result.content[0].text == "Resume error: boom"

--- a/tests/test_search_exact_chunk_id.py
+++ b/tests/test_search_exact_chunk_id.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from brainlayer.chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
 from brainlayer.mcp.search_handler import _brain_search, _exact_chunk_lookup_result
 
 
@@ -65,6 +66,34 @@ async def test_brain_search_exact_chunk_id_defaults_missing_project_to_unknown()
         _, structured = await _brain_search(query=chunk_id, detail="compact")
 
     assert structured["results"][0]["project"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_brain_search_exact_checkpoint_chunk_id_returns_empty_without_fallback():
+    """Default exact chunk-id lookup must not leak checkpoint chunks via fallback search."""
+    chunk_id = "brainbar-checkpt01"
+    mock_store = MagicMock()
+    mock_store.get_chunk.return_value = {
+        "id": chunk_id,
+        "content": "[PreCompact checkpoint]\nCurrent task: hidden from default search",
+        "source_file": "watcher.jsonl",
+        "project": "brainlayer",
+        "content_type": "assistant_text",
+        "created_at": "2026-05-16T09:15:00Z",
+        "chunk_origin": CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    }
+
+    with (
+        patch("brainlayer.mcp.search_handler._get_vector_store", return_value=mock_store),
+        patch(
+            "brainlayer.mcp.search_handler._search",
+            new=AsyncMock(side_effect=AssertionError("excluded checkpoint chunk-id query should not fall back")),
+        ),
+    ):
+        content, structured = await _brain_search(query=chunk_id, detail="compact")
+
+    assert content[0].text == "No results found."
+    assert structured == {"query": chunk_id, "total": 0, "results": []}
 
 
 def test_exact_chunk_lookup_skips_lifecycle_managed_chunks():

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -73,6 +73,25 @@ class TestNewFilterParamsPassthrough:
         call_kwargs = mock_search.call_args[1]
         assert call_kwargs.get("correction_category") is None
         assert call_kwargs.get("source_filter") is None
+        assert call_kwargs.get("include_checkpoints") is False
+
+    def test_include_checkpoints_passes_through(self):
+        """include_checkpoints reaches _brain_search from _brain_recall."""
+        with patch(
+            "brainlayer.mcp.search_handler._brain_search",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ) as mock_search:
+            asyncio.run(
+                _brain_recall(
+                    mode="search",
+                    query="resume checkpoint",
+                    include_checkpoints=True,
+                )
+            )
+
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["include_checkpoints"] is True
 
 
 # ── _brain_search -> _search delegation ──────────────────────────────────────
@@ -180,6 +199,78 @@ class TestBrainSearchToSearch:
         mock_detect.assert_not_called()
         mock_search.assert_called_once()
 
+    def test_include_checkpoints_reaches_search(self):
+        """include_checkpoints flows from _brain_search to _search."""
+        with (
+            patch(
+                "brainlayer.mcp.search_handler._get_vector_store",
+                return_value=MagicMock(count=MagicMock(return_value=100)),
+            ),
+            patch(
+                "brainlayer.mcp.search_handler._get_embedding_model",
+                return_value=MagicMock(embed_query=MagicMock(return_value=[0.1] * 1024)),
+            ),
+            patch(
+                "brainlayer.mcp.search_handler._search",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ) as mock_search,
+            patch(
+                "brainlayer.mcp.search_handler._normalize_project_name",
+                return_value=None,
+            ),
+        ):
+            asyncio.run(
+                _brain_search(
+                    query="resume checkpoint",
+                    include_checkpoints=True,
+                )
+            )
+
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["include_checkpoints"] is True
+
+    def test_include_checkpoints_does_not_skip_entity_routing(self):
+        """include_checkpoints widens checkpoint visibility but keeps entity-aware routing active."""
+        store = MagicMock(count=MagicMock(return_value=100))
+        store.kg_hybrid_search.return_value = {
+            "chunks": {
+                "ids": [["chunk-1"]],
+                "documents": [["entity checkpoint context"]],
+                "metadatas": [[{"project": "brainlayer", "source_file": "test", "created_at": "2026-05-16"}]],
+                "distances": [[0.1]],
+            }
+        }
+        with (
+            patch("brainlayer.mcp.search_handler._get_vector_store", return_value=store),
+            patch(
+                "brainlayer.mcp.search_handler._get_embedding_model",
+                return_value=MagicMock(embed_query=MagicMock(return_value=[0.1] * 1024)),
+            ),
+            patch(
+                "brainlayer.mcp.search_handler._detect_entities",
+                return_value=[{"id": "e1", "name": "Etan", "entity_type": "person"}],
+            ) as mock_detect,
+            patch("brainlayer.mcp.search_handler._kg_facts_sql", return_value=[]),
+            patch(
+                "brainlayer.mcp.search_handler._search",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ) as mock_search,
+            patch("brainlayer.mcp.search_handler._normalize_project_name", return_value=None),
+        ):
+            asyncio.run(
+                _brain_search(
+                    query="Etan checkpoint context",
+                    include_checkpoints=True,
+                )
+            )
+
+        mock_detect.assert_called_once_with("Etan checkpoint context", store)
+        store.kg_hybrid_search.assert_called_once()
+        assert store.kg_hybrid_search.call_args[1]["include_checkpoints"] is True
+        mock_search.assert_not_awaited()
+
 
 # ── Input schema validation ──────────────────────────────────────────────────
 
@@ -202,6 +293,7 @@ class TestInputSchemaPresence:
         assert "content_type_filter" in props
         assert "source_filter" in props
         assert "correction_category" in props
+        assert "include_checkpoints" in props
 
     def test_sentiment_filter_enum_values(self):
         """sentiment_filter has the standardized enum values."""
@@ -353,3 +445,39 @@ class TestAliasResolution:
 
         call_kwargs = mock_recall.call_args[1]
         assert call_kwargs["source_filter"] == "%youtube%"
+
+    def test_include_checkpoints_passes_from_call_tool(self):
+        """include_checkpoints is forwarded from call_tool to _brain_recall."""
+        from brainlayer.mcp import call_tool
+
+        with patch(
+            "brainlayer.mcp._brain_recall",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ) as mock_recall:
+            asyncio.run(
+                call_tool(
+                    "brain_search",
+                    {
+                        "query": "resume checkpoint",
+                        "include_checkpoints": True,
+                    },
+                )
+            )
+
+        call_kwargs = mock_recall.call_args[1]
+        assert call_kwargs["include_checkpoints"] is True
+
+
+class TestBrainResumeSchema:
+    """Verify the explicit checkpoint resume tool is exposed."""
+
+    def test_brain_resume_tool_schema(self):
+        from brainlayer.mcp import list_tools
+
+        tools = asyncio.run(list_tools())
+        brain_resume = next(tool for tool in tools if tool.name == "brain_resume")
+        props = brain_resume.inputSchema["properties"]
+
+        assert props["session_id"]["type"] == "string"
+        assert props["lookback_days"]["type"] == "integer"

--- a/tests/test_think_recall_integration.py
+++ b/tests/test_think_recall_integration.py
@@ -246,13 +246,13 @@ class TestMCPToolCount:
     """Verify MCP server has correct tool count."""
 
     def test_tool_count(self):
-        """MCP server should have 12 tools: search, store, recall, digest, entity, get_person, update, expand, tags, supersede, archive, enrich."""
+        """MCP server should have 13 tools including explicit checkpoint resume."""
         import asyncio
 
         from brainlayer.mcp import list_tools
 
         tools = asyncio.run(list_tools())
-        assert len(tools) == 12
+        assert len(tools) == 13
 
     def test_consolidated_tools_registered(self):
         """brain_search, brain_store, brain_recall are registered."""

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,4 +1,4 @@
-"""Tests for B6: ToolAnnotations on all 12 MCP tools + B7: agent_id scoping on brain_store."""
+"""Tests for B6: ToolAnnotations on all MCP tools + B7: agent_id scoping on brain_store."""
 
 import asyncio
 
@@ -11,6 +11,7 @@ EXPECTED_TOOLS = [
     "brain_search",
     "brain_store",
     "brain_recall",
+    "brain_resume",
     "brain_digest",
     "brain_entity",
     "brain_expand",
@@ -26,6 +27,7 @@ EXPECTED_TOOLS = [
 READ_ONLY_TOOLS = {
     "brain_search",
     "brain_recall",
+    "brain_resume",
     "brain_entity",
     "brain_expand",
     "brain_tags",
@@ -46,6 +48,7 @@ WRITE_TOOLS = {
 IDEMPOTENT_TOOLS = {
     "brain_search",
     "brain_recall",
+    "brain_resume",
     "brain_entity",
     "brain_expand",
     "brain_tags",
@@ -68,8 +71,8 @@ class TestToolAnnotationsPresent:
 
         return asyncio.run(list_tools())
 
-    def test_all_12_tools_have_annotations(self):
-        """Every one of the 12 tools must have a non-None annotations field."""
+    def test_all_tools_have_annotations(self):
+        """Every expected tool must have a non-None annotations field."""
         tools = self._get_tools()
         tool_map = {t.name: t for t in tools}
         for name in EXPECTED_TOOLS:


### PR DESCRIPTION
## Summary
- add `chunk_origin` tagging for PreCompact checkpoints without repurposing the overloaded `source` column
- backfill existing checkpoint-shaped rows during VectorStore schema init and log the migration count in `schema_migrations`
- exclude checkpoint chunks from default search, add `include_checkpoints`, and expose `brain_resume(session_id=None, lookback_days=7)` for explicit recovery

## Verification
- `pytest tests/test_precompact_chunk_origin.py tests/test_search_filter_params.py tests/test_think_recall_integration.py::TestMCPToolCount -q` → 29 passed
- `pytest tests/test_precompact_chunk_origin.py tests/test_search_filter_params.py tests/test_hybrid_search.py tests/test_watcher_bridge.py tests/test_chunk_lifecycle.py tests/test_3tool_aliases.py -q` → 135 passed
- `./scripts/run_tests.sh` → 1860 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated pytest 32 passed; bun 1 pass; regression shell passed
- pre-push hook reran `./scripts/run_tests.sh` with the same passing counts
- snapshot backfill on `/tmp/brainlayer-fm6-precompact-snapshot.db` → 51 checkpoint rows tagged, 0 manual checkpoint-storage note false positives
- touched-file `ruff check` and `ruff format --check` passed

## Notes
- Whole-repo `ruff check` / `ruff format --check` still report pre-existing script lint/format debt outside this PR; touched files are clean.
- `cr review --plain` could not start locally because the CLI is not connected to the repository's CodeRabbit organization; requesting CodeRabbit on the PR instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a schema migration/backfill (`chunks.chunk_origin`) and changes default search/KG retrieval behavior to exclude checkpoint content, which could affect existing workflows and query results; adds additional retry/overfetch logic around SQLite reads that may impact performance under load.
> 
> **Overview**
> Adds first-class `chunk_origin` classification (new `chunks.chunk_origin` column + `chunk_origin.py` detection helpers) and tags incoming data across ingestion paths (store, watcher/queue drain, upserts, chunk updates), including a one-time backfill migration recorded in `schema_migrations`.
> 
> Changes default retrieval to **exclude** `precompact_checkpoint` chunks across hybrid/text/vector search, exact chunk-id lookups, and KG fact queries unless `include_checkpoints=true`, with KNN overfetch/caching tweaks to avoid starving results when checkpoints are filtered.
> 
> Exposes an explicit `brain_resume` MCP tool to fetch recent PreCompact checkpoints (optionally filtered by `session_id`, with lock-resilient retries) and wires the new parameter/tool through MCP schemas and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c758a1dd6ed5517a52983b9ef2f868dea66c332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PreCompact checkpoint tagging, filtering, and `brain_resume` tool to VectorStore search
> - Introduces a `chunk_origin` column to the `chunks` table with a backfill migration that detects and tags existing PreCompact checkpoint content using content-marker heuristics in [`chunk_origin.py`](https://github.com/EtanHey/brainlayer/pull/285/files#diff-08baa51d09137d24a69627a4cb8e994e994260293471bb8c6246165674734083).
> - All write paths ([`store.py`](https://github.com/EtanHey/brainlayer/pull/285/files#diff-3f4ff41bcf437c9376f0c0bc397eca30e1b05c0d75d4e95ef1579366d7c4c707), [`vector_store.py`](https://github.com/EtanHey/brainlayer/pull/285/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261), [`drain.py`](https://github.com/EtanHey/brainlayer/pull/285/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c), [`watcher_bridge.py`](https://github.com/EtanHey/brainlayer/pull/285/files#diff-9c9df603fa7a5ecf5cdb0da9ab4077d520d812083da4b052847100f2874f60c9)) now compute and persist `chunk_origin` on insert or update.
> - Vector, binary, and hybrid KNN searches exclude `precompact_checkpoint` chunks by default, overfetching to compensate and truncating to the requested result count; an `include_checkpoints` flag opts back in.
> - Adds a new `brain_resume` MCP tool in [`search_handler.py`](https://github.com/EtanHey/brainlayer/pull/285/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) that queries recent PreCompact checkpoints filtered by `lookback_days` and optional `session_id`, with retry logic on SQLite busy/locked errors.
> - KG fact queries and exact chunk-id lookups also respect the checkpoint exclusion by default.
> - Risk: existing databases undergo a one-time backfill migration on first open; checkpoint count caching (keyed on `PRAGMA data_version`) adds reads on each KNN query when no cached value exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c758a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic chunk-origin tagging and persistence, plus a one-time migration/backfill to populate origin data
  * Search controls: new include_checkpoints flag (defaults to exclude) and overfetch logic so exclusions don’t starve results
  * New brain_resume tool to return recent session checkpoint content
  * Queue and ingestion now propagate chunk-origin metadata

* **Tests**
  * Extensive end-to-end coverage for detection, storage, migration, search filtering/overfetch, resume, and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->