### PR TITLE
feat(ingest): reject rt-agent qid judge notes (Class B)

### DIFF
--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -14,9 +14,9 @@ DEFAULT_DB_PATH = Path.home() / ".local/share/brainlayer/brainlayer.db"
 DEFAULT_LOG_DIR = Path.home() / ".brainlayer-p0-counter"
 
 P0_SQL = """
-SELECT date(created_at) AS day, COUNT(*) AS new_audit_chunks
+SELECT date(datetime(created_at)) AS day, COUNT(*) AS new_audit_chunks
 FROM chunks
-WHERE created_at > '2026-05-16T16:56:00+03:00'
+WHERE datetime(created_at) > datetime('2026-05-16T16:56:00+03:00')
   AND (content GLOB '┌─brain_search:*'
        OR content GLOB '┌─brain_*:*'
        OR content GLOB '┌─ brain_search:*'

--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -19,6 +19,8 @@ FROM chunks
 WHERE created_at > '2026-05-16T16:56:00+03:00'
   AND (content GLOB '┌─brain_search:*'
        OR content GLOB '┌─brain_*:*'
+       OR content GLOB '┌─ brain_search:*'
+       OR content GLOB '┌─ brain_*:*'
        OR content GLOB '*"jsonrpc"*"2.0"*'
        OR content GLOB '*MCP BrainLayer Memory: Invalid JSON-RPC*')
 GROUP BY day
@@ -39,10 +41,7 @@ def run_count(db_path: Path) -> list[dict[str, object]]:
     try:
         conn.execute("PRAGMA query_only=true")
         conn.execute("PRAGMA busy_timeout=5000")
-        return [
-            {"day": day, "new_audit_chunks": int(count)}
-            for day, count in conn.execute(P0_SQL).fetchall()
-        ]
+        return [{"day": day, "new_audit_chunks": int(count)} for day, count in conn.execute(P0_SQL).fetchall()]
     finally:
         conn.close()
 

--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -9,8 +9,9 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
+from brainlayer.paths import get_db_path
+
 SINCE = "2026-05-16T16:56:00+03:00"
-DEFAULT_DB_PATH = Path.home() / ".local/share/brainlayer/brainlayer.db"
 DEFAULT_LOG_DIR = Path.home() / ".brainlayer-p0-counter"
 
 P0_SQL = """
@@ -29,7 +30,7 @@ ORDER BY day;
 
 
 def _db_path() -> Path:
-    return Path(os.environ.get("BRAINLAYER_DB", DEFAULT_DB_PATH)).expanduser()
+    return get_db_path().expanduser()
 
 
 def _log_dir() -> Path:

--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Daily P0 audit-recursion counter for the post-PR287 longitudinal window."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+SINCE = "2026-05-16T16:56:00+03:00"
+DEFAULT_DB_PATH = Path.home() / ".local/share/brainlayer/brainlayer.db"
+DEFAULT_LOG_DIR = Path.home() / ".brainlayer-p0-counter"
+
+P0_SQL = """
+SELECT date(created_at) AS day, COUNT(*) AS new_audit_chunks
+FROM chunks
+WHERE created_at > '2026-05-16T16:56:00+03:00'
+  AND (content GLOB '┌─brain_search:*'
+       OR content GLOB '┌─brain_*:*'
+       OR content GLOB '*"jsonrpc"*"2.0"*'
+       OR content GLOB '*MCP BrainLayer Memory: Invalid JSON-RPC*')
+GROUP BY day
+ORDER BY day;
+""".strip()
+
+
+def _db_path() -> Path:
+    return Path(os.environ.get("BRAINLAYER_DB", DEFAULT_DB_PATH)).expanduser()
+
+
+def _log_dir() -> Path:
+    return Path(os.environ.get("BRAINLAYER_P0_COUNTER_DIR", DEFAULT_LOG_DIR)).expanduser()
+
+
+def run_count(db_path: Path) -> list[dict[str, object]]:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+    try:
+        conn.execute("PRAGMA query_only=true")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return [
+            {"day": day, "new_audit_chunks": int(count)}
+            for day, count in conn.execute(P0_SQL).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def build_payload(db_path: Path) -> dict[str, object]:
+    rows = run_count(db_path)
+    total = sum(int(row["new_audit_chunks"]) for row in rows)
+    now = datetime.now(timezone.utc)
+    elapsed_days = max(0, (now.date() - datetime.fromisoformat(SINCE).date()).days)
+    verdict_ready = elapsed_days >= 7
+    structural_fix = verdict_ready and total == 0
+    return {
+        "generated_at": now.isoformat(),
+        "since": SINCE,
+        "db_path": str(db_path),
+        "sql": P0_SQL,
+        "rows": rows,
+        "total_new_audit_chunks": total,
+        "elapsed_days": elapsed_days,
+        "verdict_ready": verdict_ready,
+        "structural_fix_p_lt_0_001": structural_fix,
+        "brain_store_verdict_content": (
+            "P0 longitudinal counter verdict: 0 audit-recursion chunks across 7 days "
+            "since 2026-05-16T16:56:00+03:00; structural fix p<0.001 per R51."
+            if structural_fix
+            else None
+        ),
+    }
+
+
+def main() -> int:
+    db_path = _db_path()
+    if not db_path.exists():
+        raise SystemExit(f"BrainLayer DB not found: {db_path}")
+
+    log_dir = _log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    payload = build_payload(db_path)
+    output_path = log_dir / f"{datetime.now().date().isoformat()}.json"
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"output_path": str(output_path), **payload}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -16,7 +16,7 @@ DEFAULT_LOG_DIR = Path.home() / ".brainlayer-p0-counter"
 P0_SQL = """
 SELECT date(datetime(created_at)) AS day, COUNT(*) AS new_audit_chunks
 FROM chunks
-WHERE datetime(created_at) > datetime('2026-05-16T16:56:00+03:00')
+WHERE datetime(created_at) > datetime(?)
   AND (content GLOB '┌─brain_search:*'
        OR content GLOB '┌─brain_*:*'
        OR content GLOB '┌─ brain_search:*'
@@ -36,12 +36,14 @@ def _log_dir() -> Path:
     return Path(os.environ.get("BRAINLAYER_P0_COUNTER_DIR", DEFAULT_LOG_DIR)).expanduser()
 
 
-def run_count(db_path: Path) -> list[dict[str, object]]:
+def run_count(db_path: Path, since: str = SINCE) -> list[dict[str, object]]:
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
     try:
         conn.execute("PRAGMA query_only=true")
         conn.execute("PRAGMA busy_timeout=5000")
-        return [{"day": day, "new_audit_chunks": int(count)} for day, count in conn.execute(P0_SQL).fetchall()]
+        return [
+            {"day": day, "new_audit_chunks": int(count)} for day, count in conn.execute(P0_SQL, (since,)).fetchall()
+        ]
     finally:
         conn.close()
 
@@ -58,14 +60,15 @@ def build_payload(db_path: Path) -> dict[str, object]:
         "since": SINCE,
         "db_path": str(db_path),
         "sql": P0_SQL,
+        "sql_params": [SINCE],
         "rows": rows,
         "total_new_audit_chunks": total,
         "elapsed_days": elapsed_days,
         "verdict_ready": verdict_ready,
         "structural_fix_p_lt_0_001": structural_fix,
         "brain_store_verdict_content": (
-            "P0 longitudinal counter verdict: 0 audit-recursion chunks across 7 days "
-            "since 2026-05-16T16:56:00+03:00; structural fix p<0.001 per R51."
+            f"P0 longitudinal counter verdict: 0 audit-recursion chunks across 7 days "
+            f"since {SINCE}; structural fix p<0.001 per R51."
             if structural_fix
             else None
         ),

--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -15,8 +15,14 @@ SINCE = "2026-05-16T16:56:00+03:00"
 DEFAULT_LOG_DIR = Path.home() / ".brainlayer-p0-counter"
 
 P0_SQL = """
+WITH normalized AS (
+    SELECT
+        created_at,
+        ltrim(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)) AS content
+    FROM chunks
+)
 SELECT date(datetime(created_at)) AS day, COUNT(*) AS new_audit_chunks
-FROM chunks
+FROM normalized
 WHERE datetime(created_at) > datetime(?)
   AND (content GLOB '┌─brain_search:*'
        OR content GLOB '┌─brain_*:*'

--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -48,11 +48,15 @@ def run_count(db_path: Path, since: str = SINCE) -> list[dict[str, object]]:
         conn.close()
 
 
-def build_payload(db_path: Path) -> dict[str, object]:
+def build_payload(db_path: Path, now: datetime | None = None) -> dict[str, object]:
     rows = run_count(db_path)
     total = sum(int(row["new_audit_chunks"]) for row in rows)
-    now = datetime.now(timezone.utc)
-    elapsed_days = max(0, (now.date() - datetime.fromisoformat(SINCE).date()).days)
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    since = datetime.fromisoformat(SINCE)
+    elapsed_seconds = max(0.0, (now - since).total_seconds())
+    elapsed_days = int(elapsed_seconds // 86400)
     verdict_ready = elapsed_days >= 7
     structural_fix = verdict_ready and total == 0
     return {

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -160,7 +160,12 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     if not content:
         logger.warning("Skipping malformed store event with empty content")
         return ApplyResult()
-    recursive_reason = recursive_mcp_output_reason(content)
+    chunk_id = event.get("chunk_id") or f"manual-{uuid.uuid4().hex[:16]}"
+    recursive_reason = recursive_mcp_output_reason(
+        content,
+        chunk_id=chunk_id,
+        source_file=event.get("source_file"),
+    )
     if recursive_reason:
         logger.warning("Skipping recursive MCP store event: %s", recursive_reason)
         return ApplyResult()
@@ -171,7 +176,6 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         metadata.update(raw_metadata)
     elif raw_metadata:
         logger.warning("Skipping non-object store metadata for chunk_id=%s", event.get("chunk_id"))
-    chunk_id = event.get("chunk_id") or f"manual-{uuid.uuid4().hex[:16]}"
     tags = event.get("tags")
     existing = conn.execute("SELECT content FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
     if existing:
@@ -244,7 +248,8 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> None:
     if not content:
         logger.warning("Skipping malformed watcher event with empty content")
         return
-    recursive_reason = recursive_mcp_output_reason(content)
+    source_file = event.get("source_file") or "realtime-watcher"
+    recursive_reason = recursive_mcp_output_reason(content, chunk_id=chunk_id, source_file=source_file)
     if recursive_reason:
         logger.warning("Skipping recursive MCP watcher event: %s", recursive_reason)
         return
@@ -255,7 +260,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> None:
             "id": chunk_id,
             "content": content,
             "metadata": json.dumps(event.get("metadata") or {}),
-            "source_file": event.get("source_file") or "realtime-watcher",
+            "source_file": source_file,
             "project": event.get("project"),
             "content_type": event.get("content_type") or "assistant_text",
             "value_type": event.get("value_type") or "HIGH",
@@ -279,13 +284,14 @@ def _apply_hook(conn: apsw.Connection, event: dict[str, Any]) -> None:
     if not content:
         logger.warning("Skipping malformed hook event with empty content")
         return
-    recursive_reason = recursive_mcp_output_reason(content)
-    if recursive_reason:
-        logger.warning("Skipping recursive MCP hook event: %s", recursive_reason)
-        return
     content_hash = event.get("content_hash") or hashlib.sha256(content.encode()).hexdigest()[:16]
     session_id = event.get("session_id") or "unknown"
     chunk_id = event.get("chunk_id") or f"rt-{str(session_id)[:8]}-{content_hash}"
+    source_file = event.get("source_file") or "realtime-hook"
+    recursive_reason = recursive_mcp_output_reason(content, chunk_id=chunk_id, source_file=source_file)
+    if recursive_reason:
+        logger.warning("Skipping recursive MCP hook event: %s", recursive_reason)
+        return
     ts_raw = event.get("timestamp")
     try:
         timestamp = float(ts_raw) if ts_raw is not None else time.time()
@@ -298,7 +304,7 @@ def _apply_hook(conn: apsw.Connection, event: dict[str, Any]) -> None:
             "id": chunk_id,
             "content": content,
             "metadata": json.dumps({"session_id": session_id, "content_hash": content_hash}),
-            "source_file": "realtime-hook",
+            "source_file": source_file,
             "project": event.get("project"),
             "content_type": "assistant_text",
             "value_type": "HIGH",

--- a/src/brainlayer/ingest_guard.py
+++ b/src/brainlayer/ingest_guard.py
@@ -11,9 +11,37 @@ _BRAINLAYER_BOX_PREFIX_RE = re.compile(
     r"^┌─\s*(?:brain_[a-z_]+|entity(?:\s+search)?):",
     re.IGNORECASE,
 )
+_RT_AGENT_CHUNK_ID_RE = re.compile(r"^rt-agent-a[0-9a-f]+-[0-9a-f]+$", re.IGNORECASE)
+_RT_AGENT_SOURCE_FILE_RE = re.compile(r"/subagents/agent-a[0-9a-f]+\.jsonl$", re.IGNORECASE)
+_JUDGE_NOTE_MARKERS = (
+    "judge_agent_name",
+    "failure_modes_observed",
+    "judge_reasoning",
+    "grade distribution",
+    "fm11",
+)
 
 
-def recursive_mcp_output_reason(content: str | None) -> str | None:
+def _looks_like_rt_agent_judge_notes(content: str, chunk_id: str | None = None, source_file: str | None = None) -> bool:
+    folded = content.casefold()
+    has_qid = bool(re.search(r"\bqid\s*=", folded))
+    has_judge_marker = any(marker in folded for marker in _JUDGE_NOTE_MARKERS)
+    if has_qid and has_judge_marker:
+        return True
+
+    has_rt_agent_context = bool(
+        (chunk_id and _RT_AGENT_CHUNK_ID_RE.match(chunk_id))
+        or (source_file and _RT_AGENT_SOURCE_FILE_RE.search(source_file))
+    )
+    return has_rt_agent_context and has_judge_marker
+
+
+def recursive_mcp_output_reason(
+    content: str | None,
+    *,
+    chunk_id: str | None = None,
+    source_file: str | None = None,
+) -> str | None:
     """Return a reason when content is BrainLayer MCP output being re-ingested."""
     if not content:
         return None
@@ -29,12 +57,19 @@ def recursive_mcp_output_reason(content: str | None) -> str | None:
         return "invalid_jsonrpc_mcp_output"
     if _JSONRPC_MESSAGE_RE.search(stripped):
         return "jsonrpc_message"
+    if _looks_like_rt_agent_judge_notes(stripped, chunk_id=chunk_id, source_file=source_file):
+        return "rt-agent judge notes"
 
     return None
 
 
-def reject_recursive_mcp_output(content: str | None) -> None:
+def reject_recursive_mcp_output(
+    content: str | None,
+    *,
+    chunk_id: str | None = None,
+    source_file: str | None = None,
+) -> None:
     """Raise ValueError when content is recursive BrainLayer MCP output."""
-    reason = recursive_mcp_output_reason(content)
+    reason = recursive_mcp_output_reason(content, chunk_id=chunk_id, source_file=source_file)
     if reason:
         raise ValueError(f"recursive MCP output is not stored in BrainLayer: {reason}")

--- a/src/brainlayer/ingest_guard.py
+++ b/src/brainlayer/ingest_guard.py
@@ -11,7 +11,7 @@ _BRAINLAYER_BOX_PREFIX_RE = re.compile(
     r"^┌─\s*(?:brain_[a-z_]+|entity(?:\s+search)?):",
     re.IGNORECASE,
 )
-_RT_AGENT_CHUNK_ID_RE = re.compile(r"^rt-agent-a[0-9a-f]+-[0-9a-f]+$", re.IGNORECASE)
+_RT_AGENT_CHUNK_ID_RE = re.compile(r"^rt-agent-a[0-9a-f]+-[A-Za-z0-9_-]+$", re.IGNORECASE)
 _RT_AGENT_SOURCE_FILE_RE = re.compile(r"/subagents/agent-a[0-9a-f]+\.jsonl$", re.IGNORECASE)
 _JUDGE_NOTE_MARKERS = (
     "judge_agent_name",

--- a/src/brainlayer/ingest_guard.py
+++ b/src/brainlayer/ingest_guard.py
@@ -13,11 +13,14 @@ _BRAINLAYER_BOX_PREFIX_RE = re.compile(
 )
 _RT_AGENT_CHUNK_ID_RE = re.compile(r"^rt-agent-a[0-9a-f]+-[A-Za-z0-9_-]+$", re.IGNORECASE)
 _RT_AGENT_SOURCE_FILE_RE = re.compile(r"/subagents/agent-a[0-9a-f]+\.jsonl$", re.IGNORECASE)
-_JUDGE_NOTE_MARKERS = (
+_STRONG_JUDGE_NOTE_MARKERS = (
     "judge_agent_name",
     "failure_modes_observed",
     "judge_reasoning",
     "grade distribution",
+)
+_QID_JUDGE_NOTE_MARKERS = (
+    *_STRONG_JUDGE_NOTE_MARKERS,
     "fm11",
 )
 
@@ -25,15 +28,16 @@ _JUDGE_NOTE_MARKERS = (
 def _looks_like_rt_agent_judge_notes(content: str, chunk_id: str | None = None, source_file: str | None = None) -> bool:
     folded = content.casefold()
     has_qid = bool(re.search(r"\bqid\s*=", folded))
-    has_judge_marker = any(marker in folded for marker in _JUDGE_NOTE_MARKERS)
-    if has_qid and has_judge_marker:
+    if has_qid and any(marker in folded for marker in _QID_JUDGE_NOTE_MARKERS):
         return True
 
+    chunk_id_s = chunk_id if isinstance(chunk_id, str) else None
+    source_file_s = source_file if isinstance(source_file, str) else None
     has_rt_agent_context = bool(
-        (chunk_id and _RT_AGENT_CHUNK_ID_RE.match(chunk_id))
-        or (source_file and _RT_AGENT_SOURCE_FILE_RE.search(source_file))
+        (chunk_id_s and _RT_AGENT_CHUNK_ID_RE.match(chunk_id_s))
+        or (source_file_s and _RT_AGENT_SOURCE_FILE_RE.search(source_file_s))
     )
-    return has_rt_agent_context and has_judge_marker
+    return has_rt_agent_context and any(marker in folded for marker in _STRONG_JUDGE_NOTE_MARKERS)
 
 
 def recursive_mcp_output_reason(

--- a/src/brainlayer/ingest_guard.py
+++ b/src/brainlayer/ingest_guard.py
@@ -27,9 +27,6 @@ _QID_JUDGE_NOTE_MARKERS = (
 
 def _looks_like_rt_agent_judge_notes(content: str, chunk_id: str | None = None, source_file: str | None = None) -> bool:
     folded = content.casefold()
-    has_qid = bool(re.search(r"\bqid\s*=", folded))
-    if has_qid and any(marker in folded for marker in _QID_JUDGE_NOTE_MARKERS):
-        return True
 
     chunk_id_s = chunk_id if isinstance(chunk_id, str) else None
     source_file_s = source_file if isinstance(source_file, str) else None
@@ -37,7 +34,13 @@ def _looks_like_rt_agent_judge_notes(content: str, chunk_id: str | None = None, 
         (chunk_id_s and _RT_AGENT_CHUNK_ID_RE.match(chunk_id_s))
         or (source_file_s and _RT_AGENT_SOURCE_FILE_RE.search(source_file_s))
     )
-    return has_rt_agent_context and any(marker in folded for marker in _STRONG_JUDGE_NOTE_MARKERS)
+    has_qid = bool(re.search(r"\bqid\s*=", folded))
+    has_strong_judge_marker = any(marker in folded for marker in _STRONG_JUDGE_NOTE_MARKERS)
+    if has_qid and has_strong_judge_marker:
+        return True
+    if has_rt_agent_context and has_qid and any(marker in folded for marker in _QID_JUDGE_NOTE_MARKERS):
+        return True
+    return has_rt_agent_context and has_strong_judge_marker
 
 
 def recursive_mcp_output_reason(

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -127,7 +127,7 @@ def enqueue_hook_chunk(
             "content_hash": content_hash,
             "project": project,
             "source_file": source_file,
-            "timestamp": timestamp or time.time(),
+            "timestamp": timestamp if timestamp is not None else time.time(),
         },
         source="hook",
         queue_dir=queue_dir,

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -111,8 +111,10 @@ def enqueue_hook_chunk(
     *,
     session_id: str,
     content: str,
+    chunk_id: str | None = None,
     content_hash: str | None = None,
     project: str | None = None,
+    source_file: str | None = None,
     timestamp: float | None = None,
     queue_dir: Path | None = None,
 ) -> Path:
@@ -120,9 +122,11 @@ def enqueue_hook_chunk(
         {
             "kind": "hook_chunk",
             "session_id": session_id,
+            "chunk_id": chunk_id,
             "content": content,
             "content_hash": content_hash,
             "project": project,
+            "source_file": source_file,
             "timestamp": timestamp or time.time(),
         },
         source="hook",

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -1367,7 +1367,11 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         rejected_error: ValueError | None = None
         for chunk, embedding in zip(chunks, embeddings):
             try:
-                reject_recursive_mcp_output(chunk.get("content"))
+                reject_recursive_mcp_output(
+                    chunk.get("content"),
+                    chunk_id=chunk.get("id"),
+                    source_file=chunk.get("source_file"),
+                )
             except ValueError as exc:
                 rejected_error = rejected_error or exc
                 continue
@@ -1540,7 +1544,12 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             return False
 
         if content is not None:
-            reject_recursive_mcp_output(content)
+            existing_source_file = cursor.execute("SELECT source_file FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+            reject_recursive_mcp_output(
+                content,
+                chunk_id=chunk_id,
+                source_file=existing_source_file[0] if existing_source_file else None,
+            )
             created_at_row = cursor.execute("SELECT created_at FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
             dedupe_fields = compute_dedupe_fields(content, created_at_row[0] if created_at_row else None)
             cursor.execute(

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -110,7 +110,7 @@ def _extract_raw_text(entry: dict) -> str:
     return ""
 
 
-def should_skip_entry(entry: dict) -> str | None:
+def should_skip_entry(entry: dict, *, source_file: str | None = None) -> str | None:
     """Pre-classify filter. Returns skip reason or None to keep.
 
     This runs BEFORE classify_content to reject obvious noise early.
@@ -128,7 +128,8 @@ def should_skip_entry(entry: dict) -> str | None:
     if len(raw_text.strip()) < MIN_RAW_CONTENT_LENGTH:
         return "too_short"
 
-    if recursive_mcp_output_reason(raw_text):
+    resolved_source_file = source_file or entry.get("_source_file")
+    if recursive_mcp_output_reason(raw_text, source_file=resolved_source_file):
         return "recursive_mcp_output"
 
     # Skip if content is mostly system-reminder injection
@@ -139,14 +140,19 @@ def should_skip_entry(entry: dict) -> str | None:
     return None
 
 
-def should_skip_chunk_content(content: str) -> str | None:
+def should_skip_chunk_content(
+    content: str,
+    *,
+    chunk_id: str | None = None,
+    source_file: str | None = None,
+) -> str | None:
     """Post-chunk filter. Returns skip reason or None to keep."""
     # Strip system-reminders from the final content
     cleaned = _strip_system_reminders(content)
     if len(cleaned.strip()) < MIN_RAW_CONTENT_LENGTH:
         return "system_reminder_residue"
 
-    if recursive_mcp_output_reason(cleaned):
+    if recursive_mcp_output_reason(cleaned, chunk_id=chunk_id, source_file=source_file):
         return "recursive_mcp_output"
 
     # Skip pure file deletion diffs
@@ -234,7 +240,7 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
             project = _extract_project_from_source(source_file)
 
             # Layer 1: Pre-classify filter
-            skip_reason = should_skip_entry(entry)
+            skip_reason = should_skip_entry(entry, source_file=source_file)
             if skip_reason:
                 skipped += 1
                 continue
@@ -258,16 +264,16 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                 continue
 
             for chunk in chunks:
-                # Layer 4: Post-chunk content filter
                 clean_content = _strip_system_reminders(chunk.content)
-                skip_reason = should_skip_chunk_content(clean_content)
-                if skip_reason:
-                    skipped += 1
-                    continue
-
                 content_hash = normalized_exact_hash(clean_content)[:16]
                 file_stem = Path(source_file).stem
                 chunk_id = f"rt-{file_stem[:8]}-{content_hash}"
+
+                # Layer 4: Post-chunk content filter
+                skip_reason = should_skip_chunk_content(clean_content, chunk_id=chunk_id, source_file=source_file)
+                if skip_reason:
+                    skipped += 1
+                    continue
 
                 created_at = entry.get("timestamp")
                 if not created_at:

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -14,11 +14,11 @@ JSONRPC_RECURSION_CONTENT = (
 )
 
 RT_AGENT_A7_JUDGE_NOTES_CONTENT = (
-    'Key observations:\n'
+    "Key observations:\n"
     '- **qid=20 "Etan TechGym title abstract sent WhatsApp Sagit content"**: '
     "Pair 49 contains Sagit context but says pre-draft.\n"
     '- **qid=22 "two-sentence hook opener"**: Both pairs are FM6 PreCompact pollution.\n'
-    'Final JSONL fields: judge_agent_name, failure_modes_observed, judge_reasoning.'
+    "Final JSONL fields: judge_agent_name, failure_modes_observed, judge_reasoning."
 )
 
 

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -6,7 +6,7 @@ from brainlayer.drain import drain_once
 from brainlayer.queue_io import enqueue_hook_chunk, enqueue_store, enqueue_watcher_chunk
 from brainlayer.store import store_memory
 from brainlayer.vector_store import VectorStore
-from brainlayer.watcher_bridge import should_skip_chunk_content, should_skip_entry
+from brainlayer.watcher_bridge import create_flush_callback, should_skip_chunk_content, should_skip_entry
 
 JSONRPC_RECURSION_CONTENT = (
     'MCP BrainLayer Memory: Invalid JSON-RPC message: {"jsonrpc":"2.0","id":24,'
@@ -61,6 +61,50 @@ def test_watcher_preclassify_rejects_rt_agent_qid_judge_notes():
 
 def test_watcher_postchunk_rejects_rt_agent_qid_judge_notes():
     assert should_skip_chunk_content(RT_AGENT_A7_JUDGE_NOTES_CONTENT) == "recursive_mcp_output"
+
+
+def test_watcher_preclassify_rejects_rt_agent_context_only_judge_notes_from_subagent_source():
+    entry = _make_entry(RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT)
+    entry["_source_file"] = (
+        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+        "session/subagents/agent-a7823570938b54ccd.jsonl"
+    )
+
+    assert should_skip_entry(entry) == "recursive_mcp_output"
+
+
+def test_watcher_postchunk_rejects_rt_agent_context_only_judge_notes_from_source_context():
+    source_file = (
+        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+        "session/subagents/agent-a7823570938b54ccd.jsonl"
+    )
+
+    assert (
+        should_skip_chunk_content(
+            RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
+            chunk_id="ordinary-watcher-id",
+            source_file=source_file,
+        )
+        == "recursive_mcp_output"
+    )
+
+
+def test_non_arbitrated_watcher_drops_rt_agent_context_only_judge_notes(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_ARBITRATED", raising=False)
+    db_path = tmp_path / "watcher-direct-rt-agent-guard.db"
+    flush = create_flush_callback(db_path)
+    entry = _make_entry(RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT)
+    entry["_source_file"] = (
+        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+        "session/subagents/agent-a7823570938b54ccd.jsonl"
+    )
+
+    flush([entry])
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT id, content FROM chunks").fetchall()
+
+    assert rows == []
 
 
 def test_direct_store_rejects_recursive_mcp_output(tmp_path):

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -28,6 +28,18 @@ RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT = (
     "judge_reasoning=These are benchmark comparison notes, not durable user memory."
 )
 
+RT_AGENT_FM11_ANALYSIS_CONTENT = (
+    "Investigate FM11 retrieval failure mode and summarize why recall missed a valid workshop memory."
+)
+
+RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE = (
+    "/Users/test-user/.claude/projects/-Users-test-user-Gits-orchestrator/"
+    "session/subagents/agent-a7823570938b54ccd.jsonl"
+)
+RT_AGENT_VOICELAYER_SUBAGENT_SOURCE_FILE = (
+    "/Users/test-user/.claude/projects/-Users-test-user-Gits-voicelayer/session/subagents/agent-a7c933d4439ab60b3.jsonl"
+)
+
 
 def _make_entry(text: str) -> dict:
     return {
@@ -65,25 +77,17 @@ def test_watcher_postchunk_rejects_rt_agent_qid_judge_notes():
 
 def test_watcher_preclassify_rejects_rt_agent_context_only_judge_notes_from_subagent_source():
     entry = _make_entry(RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT)
-    entry["_source_file"] = (
-        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-        "session/subagents/agent-a7823570938b54ccd.jsonl"
-    )
+    entry["_source_file"] = RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE
 
     assert should_skip_entry(entry) == "recursive_mcp_output"
 
 
 def test_watcher_postchunk_rejects_rt_agent_context_only_judge_notes_from_source_context():
-    source_file = (
-        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-        "session/subagents/agent-a7823570938b54ccd.jsonl"
-    )
-
     assert (
         should_skip_chunk_content(
             RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
             chunk_id="ordinary-watcher-id",
-            source_file=source_file,
+            source_file=RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
         )
         == "recursive_mcp_output"
     )
@@ -94,10 +98,7 @@ def test_non_arbitrated_watcher_drops_rt_agent_context_only_judge_notes(tmp_path
     db_path = tmp_path / "watcher-direct-rt-agent-guard.db"
     flush = create_flush_callback(db_path)
     entry = _make_entry(RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT)
-    entry["_source_file"] = (
-        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-        "session/subagents/agent-a7823570938b54ccd.jsonl"
-    )
+    entry["_source_file"] = RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE
 
     flush([entry])
 
@@ -105,6 +106,28 @@ def test_non_arbitrated_watcher_drops_rt_agent_context_only_judge_notes(tmp_path
         rows = conn.execute("SELECT id, content FROM chunks").fetchall()
 
     assert rows == []
+
+
+def test_rt_agent_fm11_analysis_without_judge_fields_is_allowed():
+    assert (
+        should_skip_chunk_content(
+            RT_AGENT_FM11_ANALYSIS_CONTENT,
+            chunk_id="rt-agent-a7-fm11analysis",
+            source_file=RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
+        )
+        is None
+    )
+
+
+def test_rt_agent_guard_ignores_non_string_context_values():
+    assert (
+        should_skip_chunk_content(
+            RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
+            chunk_id=7,
+            source_file={"path": RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE},
+        )
+        is None
+    )
 
 
 def test_direct_store_rejects_recursive_mcp_output(tmp_path):
@@ -161,10 +184,7 @@ def test_vector_upsert_rejects_rt_agent_a7_qid_judge_notes(tmp_path):
                         "id": "rt-agent-a7-deadbeefcafefeed",
                         "content": RT_AGENT_A7_JUDGE_NOTES_CONTENT,
                         "metadata": {},
-                        "source_file": (
-                            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-                            "session/subagents/agent-a7823570938b54ccd.jsonl"
-                        ),
+                        "source_file": RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
                         "project": "brainlayer",
                         "content_type": "assistant_text",
                         "char_count": len(RT_AGENT_A7_JUDGE_NOTES_CONTENT),
@@ -183,10 +203,7 @@ def test_vector_upsert_rejects_rt_agent_context_only_judge_notes(tmp_path):
                         "id": "rt-agent-a7-contextonly",
                         "content": RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
                         "metadata": {},
-                        "source_file": (
-                            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-                            "session/subagents/agent-a7823570938b54ccd.jsonl"
-                        ),
+                        "source_file": RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
                         "project": "brainlayer",
                         "content_type": "assistant_text",
                         "char_count": len(RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT),
@@ -204,10 +221,7 @@ def test_vector_upsert_allows_non_judge_rt_agent_chunk(tmp_path):
                     "id": "rt-agent-a7-feedfacecafebeef",
                     "content": "Explore the landing page animation and summarize the CSS keyframe structure.",
                     "metadata": {},
-                    "source_file": (
-                        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-voicelayer/"
-                        "session/subagents/agent-a7c933d4439ab60b3.jsonl"
-                    ),
+                    "source_file": RT_AGENT_VOICELAYER_SUBAGENT_SOURCE_FILE,
                     "project": "brainlayer",
                     "content_type": "assistant_text",
                     "char_count": 75,
@@ -282,10 +296,7 @@ def test_update_chunk_rejects_rt_agent_qid_judge_notes(tmp_path):
                     "id": "rt-agent-a7-update-target",
                     "content": "ordinary rt-agent memory before attempted judge-note update",
                     "metadata": {},
-                    "source_file": (
-                        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-                        "session/subagents/agent-a7823570938b54ccd.jsonl"
-                    ),
+                    "source_file": RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
                     "project": "brainlayer",
                     "content_type": "assistant_text",
                     "char_count": 57,
@@ -362,10 +373,7 @@ def test_drain_drops_rt_agent_qid_judge_note_events(tmp_path, monkeypatch):
         chunk_id="rt-agent-a7-drainwatcher",
         content=RT_AGENT_A7_JUDGE_NOTES_CONTENT,
         metadata={},
-        source_file=(
-            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-            "session/subagents/agent-a7823570938b54ccd.jsonl"
-        ),
+        source_file=RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
         project="brainlayer",
         content_type="assistant_text",
         value_type="HIGH",
@@ -408,10 +416,7 @@ def test_drain_passes_rt_agent_context_to_judge_note_guard(tmp_path, monkeypatch
         chunk_id="ordinary-drainwatcher-id",
         content=RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
         metadata={},
-        source_file=(
-            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-            "session/subagents/agent-a7823570938b54ccd.jsonl"
-        ),
+        source_file=RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
         project="brainlayer",
         content_type="assistant_text",
         value_type="HIGH",
@@ -425,10 +430,7 @@ def test_drain_passes_rt_agent_context_to_judge_note_guard(tmp_path, monkeypatch
         chunk_id="rt-agent-a7-drainhook",
         content=RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
         project="brainlayer",
-        source_file=(
-            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
-            "session/subagents/agent-a7823570938b54ccd.jsonl"
-        ),
+        source_file=RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE,
         queue_dir=queue_dir,
     )
 

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -21,6 +21,13 @@ RT_AGENT_A7_JUDGE_NOTES_CONTENT = (
     "Final JSONL fields: judge_agent_name, failure_modes_observed, judge_reasoning."
 )
 
+RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT = (
+    "Final judge pass summary:\n"
+    "judge_agent_name=rt-eval-a7\n"
+    "failure_modes_observed=[FM6, FM11]\n"
+    "judge_reasoning=These are benchmark comparison notes, not durable user memory."
+)
+
 
 def _make_entry(text: str) -> dict:
     return {
@@ -117,6 +124,28 @@ def test_vector_upsert_rejects_rt_agent_a7_qid_judge_notes(tmp_path):
                         "project": "brainlayer",
                         "content_type": "assistant_text",
                         "char_count": len(RT_AGENT_A7_JUDGE_NOTES_CONTENT),
+                    }
+                ],
+                [[0.1] * 1024],
+            )
+
+
+def test_vector_upsert_rejects_rt_agent_context_only_judge_notes(tmp_path):
+    with VectorStore(tmp_path / "upsert-rt-agent-context-guard.db") as store:
+        with pytest.raises(ValueError, match="rt-agent judge notes"):
+            store.upsert_chunks(
+                [
+                    {
+                        "id": "rt-agent-a7-contextonly",
+                        "content": RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
+                        "metadata": {},
+                        "source_file": (
+                            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+                            "session/subagents/agent-a7823570938b54ccd.jsonl"
+                        ),
+                        "project": "brainlayer",
+                        "content_type": "assistant_text",
+                        "char_count": len(RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT),
                     }
                 ],
                 [[0.1] * 1024],
@@ -305,6 +334,57 @@ def test_drain_drops_rt_agent_qid_judge_note_events(tmp_path, monkeypatch):
         session_id="33abe108-session",
         content=RT_AGENT_A7_JUDGE_NOTES_CONTENT,
         project="brainlayer",
+        queue_dir=queue_dir,
+    )
+
+    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10, log_path=tmp_path / "drain.log")
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT id, content FROM chunks").fetchall()
+
+    assert drained == 3
+    assert rows == []
+    assert not list(queue_dir.glob("*.jsonl"))
+
+
+def test_drain_passes_rt_agent_context_to_judge_note_guard(tmp_path, monkeypatch):
+    db_path = tmp_path / "drain-rt-agent-context-guard.db"
+    queue_dir = tmp_path / "queue"
+    VectorStore(db_path).close()
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    enqueue_store(
+        chunk_id="rt-agent-a7-drainstore",
+        content=RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
+        project="brainlayer",
+        tags=["correction:factual", "auto-detected"],
+        queue_dir=queue_dir,
+    )
+    enqueue_watcher_chunk(
+        chunk_id="ordinary-drainwatcher-id",
+        content=RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
+        metadata={},
+        source_file=(
+            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+            "session/subagents/agent-a7823570938b54ccd.jsonl"
+        ),
+        project="brainlayer",
+        content_type="assistant_text",
+        value_type="HIGH",
+        created_at="2026-05-16T12:00:00Z",
+        conversation_id="session",
+        tags=["correction:factual", "auto-detected"],
+        queue_dir=queue_dir,
+    )
+    enqueue_hook_chunk(
+        session_id="33abe108-session",
+        chunk_id="rt-agent-a7-drainhook",
+        content=RT_AGENT_CONTEXT_ONLY_JUDGE_NOTES_CONTENT,
+        project="brainlayer",
+        source_file=(
+            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+            "session/subagents/agent-a7823570938b54ccd.jsonl"
+        ),
         queue_dir=queue_dir,
     )
 

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -13,6 +13,14 @@ JSONRPC_RECURSION_CONTENT = (
     '"result":{"content":[{"type":"text","text":"recursive output"}]}}'
 )
 
+RT_AGENT_A7_JUDGE_NOTES_CONTENT = (
+    'Key observations:\n'
+    '- **qid=20 "Etan TechGym title abstract sent WhatsApp Sagit content"**: '
+    "Pair 49 contains Sagit context but says pre-draft.\n"
+    '- **qid=22 "two-sentence hook opener"**: Both pairs are FM6 PreCompact pollution.\n'
+    'Final JSONL fields: judge_agent_name, failure_modes_observed, judge_reasoning.'
+)
+
 
 def _make_entry(text: str) -> dict:
     return {
@@ -38,6 +46,16 @@ def test_watcher_postchunk_rejects_jsonrpc_mcp_memory_output():
     assert should_skip_chunk_content(JSONRPC_RECURSION_CONTENT) == "recursive_mcp_output"
 
 
+def test_watcher_preclassify_rejects_rt_agent_qid_judge_notes():
+    entry = _make_entry(RT_AGENT_A7_JUDGE_NOTES_CONTENT)
+
+    assert should_skip_entry(entry) == "recursive_mcp_output"
+
+
+def test_watcher_postchunk_rejects_rt_agent_qid_judge_notes():
+    assert should_skip_chunk_content(RT_AGENT_A7_JUDGE_NOTES_CONTENT) == "recursive_mcp_output"
+
+
 def test_direct_store_rejects_recursive_mcp_output(tmp_path):
     with VectorStore(tmp_path / "store-guard.db") as store:
         with pytest.raises(ValueError, match="recursive MCP output"):
@@ -45,6 +63,19 @@ def test_direct_store_rejects_recursive_mcp_output(tmp_path):
                 store=store,
                 embed_fn=None,
                 content=JSONRPC_RECURSION_CONTENT,
+                memory_type="note",
+                project="brainlayer",
+                tags=["correction:factual", "auto-detected"],
+            )
+
+
+def test_direct_store_rejects_rt_agent_qid_judge_notes(tmp_path):
+    with VectorStore(tmp_path / "store-rt-agent-guard.db") as store:
+        with pytest.raises(ValueError, match="rt-agent judge notes"):
+            store_memory(
+                store=store,
+                embed_fn=None,
+                content=RT_AGENT_A7_JUDGE_NOTES_CONTENT,
                 memory_type="note",
                 project="brainlayer",
                 tags=["correction:factual", "auto-detected"],
@@ -68,6 +99,52 @@ def test_vector_upsert_rejects_recursive_mcp_output(tmp_path):
                 ],
                 [[0.1] * 1024],
             )
+
+
+def test_vector_upsert_rejects_rt_agent_a7_qid_judge_notes(tmp_path):
+    with VectorStore(tmp_path / "upsert-rt-agent-guard.db") as store:
+        with pytest.raises(ValueError, match="rt-agent judge notes"):
+            store.upsert_chunks(
+                [
+                    {
+                        "id": "rt-agent-a7-deadbeefcafefeed",
+                        "content": RT_AGENT_A7_JUDGE_NOTES_CONTENT,
+                        "metadata": {},
+                        "source_file": (
+                            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+                            "session/subagents/agent-a7823570938b54ccd.jsonl"
+                        ),
+                        "project": "brainlayer",
+                        "content_type": "assistant_text",
+                        "char_count": len(RT_AGENT_A7_JUDGE_NOTES_CONTENT),
+                    }
+                ],
+                [[0.1] * 1024],
+            )
+
+
+def test_vector_upsert_allows_non_judge_rt_agent_chunk(tmp_path):
+    with VectorStore(tmp_path / "upsert-rt-agent-allowed.db") as store:
+        count = store.upsert_chunks(
+            [
+                {
+                    "id": "rt-agent-a7-feedfacecafebeef",
+                    "content": "Explore the landing page animation and summarize the CSS keyframe structure.",
+                    "metadata": {},
+                    "source_file": (
+                        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-voicelayer/"
+                        "session/subagents/agent-a7c933d4439ab60b3.jsonl"
+                    ),
+                    "project": "brainlayer",
+                    "content_type": "assistant_text",
+                    "char_count": 75,
+                }
+            ],
+            [[0.1] * 1024],
+        )
+
+        assert count == 1
+        assert store.get_chunk("rt-agent-a7-feedfacecafebeef") is not None
 
 
 def test_vector_upsert_skips_recursive_mcp_output_without_rolling_back_valid_siblings(tmp_path):
@@ -124,6 +201,34 @@ def test_update_chunk_rejects_recursive_mcp_output(tmp_path):
         assert store.get_chunk("safe-update-target")["content"] == "ordinary memory before attempted recursive update"
 
 
+def test_update_chunk_rejects_rt_agent_qid_judge_notes(tmp_path):
+    with VectorStore(tmp_path / "update-rt-agent-guard.db") as store:
+        store.upsert_chunks(
+            [
+                {
+                    "id": "rt-agent-a7-update-target",
+                    "content": "ordinary rt-agent memory before attempted judge-note update",
+                    "metadata": {},
+                    "source_file": (
+                        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+                        "session/subagents/agent-a7823570938b54ccd.jsonl"
+                    ),
+                    "project": "brainlayer",
+                    "content_type": "assistant_text",
+                    "char_count": 57,
+                }
+            ],
+            [[0.2] * 1024],
+        )
+
+        with pytest.raises(ValueError, match="rt-agent judge notes"):
+            store.update_chunk("rt-agent-a7-update-target", content=RT_AGENT_A7_JUDGE_NOTES_CONTENT)
+
+        assert store.get_chunk("rt-agent-a7-update-target")["content"] == (
+            "ordinary rt-agent memory before attempted judge-note update"
+        )
+
+
 def test_drain_drops_recursive_mcp_output_events(tmp_path, monkeypatch):
     db_path = tmp_path / "drain-guard.db"
     queue_dir = tmp_path / "queue"
@@ -153,6 +258,52 @@ def test_drain_drops_recursive_mcp_output_events(tmp_path, monkeypatch):
     enqueue_hook_chunk(
         session_id="33abe108-session",
         content="MCP BrainLayer Memory: Invalid JSON-RPC message: recursive hook output",
+        project="brainlayer",
+        queue_dir=queue_dir,
+    )
+
+    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10, log_path=tmp_path / "drain.log")
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT id, content FROM chunks").fetchall()
+
+    assert drained == 3
+    assert rows == []
+    assert not list(queue_dir.glob("*.jsonl"))
+
+
+def test_drain_drops_rt_agent_qid_judge_note_events(tmp_path, monkeypatch):
+    db_path = tmp_path / "drain-rt-agent-guard.db"
+    queue_dir = tmp_path / "queue"
+    VectorStore(db_path).close()
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    enqueue_store(
+        chunk_id="queued-store-rt-agent",
+        content=RT_AGENT_A7_JUDGE_NOTES_CONTENT,
+        project="brainlayer",
+        tags=["correction:factual", "auto-detected"],
+        queue_dir=queue_dir,
+    )
+    enqueue_watcher_chunk(
+        chunk_id="rt-agent-a7-drainwatcher",
+        content=RT_AGENT_A7_JUDGE_NOTES_CONTENT,
+        metadata={},
+        source_file=(
+            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-orchestrator/"
+            "session/subagents/agent-a7823570938b54ccd.jsonl"
+        ),
+        project="brainlayer",
+        content_type="assistant_text",
+        value_type="HIGH",
+        created_at="2026-05-16T12:00:00Z",
+        conversation_id="session",
+        tags=["correction:factual", "auto-detected"],
+        queue_dir=queue_dir,
+    )
+    enqueue_hook_chunk(
+        session_id="33abe108-session",
+        content=RT_AGENT_A7_JUDGE_NOTES_CONTENT,
         project="brainlayer",
         queue_dir=queue_dir,
     )

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -32,6 +32,10 @@ RT_AGENT_FM11_ANALYSIS_CONTENT = (
     "Investigate FM11 retrieval failure mode and summarize why recall missed a valid workshop memory."
 )
 
+ORDINARY_QID_FM11_NOTE_CONTENT = (
+    "qid=20 shows an FM11 retrieval miss. Keep this durable diagnostic note because it is not an rt-agent judge note."
+)
+
 RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE = (
     "/Users/test-user/.claude/projects/-Users-test-user-Gits-orchestrator/"
     "session/subagents/agent-a7823570938b54ccd.jsonl"
@@ -117,6 +121,10 @@ def test_rt_agent_fm11_analysis_without_judge_fields_is_allowed():
         )
         is None
     )
+
+
+def test_qid_fm11_note_without_rt_agent_context_is_allowed():
+    assert should_skip_chunk_content(ORDINARY_QID_FM11_NOTE_CONTENT) is None
 
 
 def test_rt_agent_guard_ignores_non_string_context_values():

--- a/tests/test_p0_longitudinal_count.py
+++ b/tests/test_p0_longitudinal_count.py
@@ -42,3 +42,18 @@ def test_p0_counter_counts_spaced_brain_search_box(tmp_path):
     rows = counter.run_count(db_path)
 
     assert rows == [{"day": "2026-05-16", "new_audit_chunks": 1}]
+
+
+def test_p0_counter_cutoff_uses_since_parameter(tmp_path):
+    counter = _load_counter_module()
+    db_path = tmp_path / "counter.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+        conn.execute(
+            "INSERT INTO chunks (created_at, content) VALUES (?, ?)",
+            ("2026-05-16T14:00:00+00:00", 'MCP BrainLayer Memory: Invalid JSON-RPC message: {"jsonrpc":"2.0"}'),
+        )
+
+    rows = counter.run_count(db_path, since="2026-05-16T14:30:00+00:00")
+
+    assert rows == []

--- a/tests/test_p0_longitudinal_count.py
+++ b/tests/test_p0_longitudinal_count.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -57,3 +58,31 @@ def test_p0_counter_cutoff_uses_since_parameter(tmp_path):
     rows = counter.run_count(db_path, since="2026-05-16T14:30:00+00:00")
 
     assert rows == []
+
+
+def test_p0_counter_verdict_waits_for_full_168_hours(tmp_path):
+    counter = _load_counter_module()
+    db_path = tmp_path / "counter.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+
+    since_utc = datetime.fromisoformat(counter.SINCE).astimezone(timezone.utc)
+    payload = counter.build_payload(db_path, now=since_utc + timedelta(days=7, seconds=-1))
+
+    assert payload["elapsed_days"] == 6
+    assert payload["verdict_ready"] is False
+    assert payload["brain_store_verdict_content"] is None
+
+
+def test_p0_counter_verdict_ready_after_full_168_hours(tmp_path):
+    counter = _load_counter_module()
+    db_path = tmp_path / "counter.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+
+    since_utc = datetime.fromisoformat(counter.SINCE).astimezone(timezone.utc)
+    payload = counter.build_payload(db_path, now=since_utc + timedelta(days=7))
+
+    assert payload["elapsed_days"] == 7
+    assert payload["verdict_ready"] is True
+    assert payload["structural_fix_p_lt_0_001"] is True

--- a/tests/test_p0_longitudinal_count.py
+++ b/tests/test_p0_longitudinal_count.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+
+def _load_counter_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "p0_longitudinal_count.py"
+    spec = importlib.util.spec_from_file_location("p0_longitudinal_count", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_p0_counter_normalizes_created_at_offsets(tmp_path):
+    counter = _load_counter_module()
+    db_path = tmp_path / "counter.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+        conn.execute(
+            "INSERT INTO chunks (created_at, content) VALUES (?, ?)",
+            ("2026-05-16T14:00:00+00:00", 'MCP BrainLayer Memory: Invalid JSON-RPC message: {"jsonrpc":"2.0"}'),
+        )
+
+    rows = counter.run_count(db_path)
+
+    assert rows == [{"day": "2026-05-16", "new_audit_chunks": 1}]
+
+
+def test_p0_counter_counts_spaced_brain_search_box(tmp_path):
+    counter = _load_counter_module()
+    db_path = tmp_path / "counter.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+        conn.execute(
+            "INSERT INTO chunks (created_at, content) VALUES (?, ?)",
+            ("2026-05-16T14:00:00+00:00", '┌─ brain_search: "audit recursion" ─ 1 result'),
+        )
+
+    rows = counter.run_count(db_path)
+
+    assert rows == [{"day": "2026-05-16", "new_audit_chunks": 1}]

--- a/tests/test_p0_longitudinal_count.py
+++ b/tests/test_p0_longitudinal_count.py
@@ -45,6 +45,21 @@ def test_p0_counter_counts_spaced_brain_search_box(tmp_path):
     assert rows == [{"day": "2026-05-16", "new_audit_chunks": 1}]
 
 
+def test_p0_counter_counts_leading_whitespace_brain_search_box(tmp_path):
+    counter = _load_counter_module()
+    db_path = tmp_path / "counter.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+        conn.execute(
+            "INSERT INTO chunks (created_at, content) VALUES (?, ?)",
+            ("2026-05-16T14:00:00+00:00", '\n  ┌─ brain_search: "audit recursion" ─ 1 result'),
+        )
+
+    rows = counter.run_count(db_path)
+
+    assert rows == [{"day": "2026-05-16", "new_audit_chunks": 1}]
+
+
 def test_p0_counter_cutoff_uses_since_parameter(tmp_path):
     counter = _load_counter_module()
     db_path = tmp_path / "counter.db"

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -17,6 +17,7 @@ from brainlayer.mcp.store_handler import (
     _flush_pending_stores,
     _queue_store,
 )
+from brainlayer.queue_io import enqueue_hook_chunk
 
 # ---------------------------------------------------------------------------
 # _queue_store / _flush_pending_stores unit tests
@@ -58,6 +59,18 @@ class TestQueueStore:
                 _queue_store({"content": f"item-{i}", "memory_type": "note"})
 
         assert len(list(tmp_path.glob("mcp-*.jsonl"))) == 105
+
+    def test_enqueue_hook_chunk_preserves_zero_timestamp(self, tmp_path):
+        path = enqueue_hook_chunk(
+            session_id="session-zero",
+            content="hook memory with explicit epoch timestamp",
+            timestamp=0.0,
+            queue_dir=tmp_path,
+        )
+
+        item = json.loads(path.read_text())
+
+        assert item["timestamp"] == 0.0
 
 
 class TestSingleWriterQueue:


### PR DESCRIPTION
## Summary
- Add an ingest guard signature for rt-agent qid judge-note chunks, including rt-agent-a7-style chunk IDs and nested subagent source files.
- Pass chunk ID and source file context into vector upsert/update guard calls so Class B notes are rejected before persistence.
- Add the R51 P0 longitudinal counter script for the 7-day audit-recursion window.

## Test plan
- `pytest tests/test_ingest_guard.py::test_vector_upsert_rejects_rt_agent_a7_qid_judge_notes -q` (red first, then green)
- `pytest tests/test_ingest_guard.py -q`
- `ruff check src/brainlayer/ingest_guard.py src/brainlayer/vector_store.py tests/test_ingest_guard.py scripts/p0_longitudinal_count.py`
- `pytest tests/test_ingest_guard.py tests/test_audit_recursion_filter.py tests/test_write_queue.py -q`
- `python3 -m py_compile scripts/p0_longitudinal_count.py src/brainlayer/ingest_guard.py src/brainlayer/vector_store.py`
- `scripts/run_tests.sh`

## Notes
- Bundles Mission B script with the Class B guard PR because the script is small and related to the same R51 mitigation sequence.
- Local LaunchAgent installed at `~/Library/LaunchAgents/com.brainlayer.p0-counter.plist`; it is intentionally outside this repo.
- First local counter run wrote `~/.brainlayer-p0-counter/2026-05-16.json` and found 5 matching post-window audit chunks, so the 7-day zero verdict is not yet established.
- CodeRabbit CLI pre-commit review was attempted but could not connect this repository to a CodeRabbit organization.
- Mission C audit doc was written outside this PR at `~/Gits/orchestrator/docs.local/audits/2026-05-17-paraphrase-diagnostic-class-q5.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens ingest filtering across multiple write paths (watcher/hook/store/upsert/update), which could drop legitimate content if the new rt-agent judge-note heuristics misfire. Adds a new DB-querying script that reads production data but is read-only and self-contained.
> 
> **Overview**
> **Prevents rt-agent “judge notes” from being persisted as durable memory.** `recursive_mcp_output_reason`/`reject_recursive_mcp_output` now accept `chunk_id` and `source_file` context and add a new heuristic to classify rt-agent QID/judge-note content as recursive output.
> 
> This context is propagated through the ingest surface area (`drain.py`, `watcher_bridge.py`, `vector_store.py`), and `enqueue_hook_chunk` now carries optional `chunk_id`/`source_file` and preserves an explicit `timestamp=0.0`. Adds `scripts/p0_longitudinal_count.py` plus tests to count daily post-window audit-recursion chunks and emit a 7-day “structural fix” verdict JSON report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25ee279bfb0e78ce38b417f3d6732fb1fac271e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject rt-agent qid judge notes from ingestion across drain, watcher, and vector store paths
> - Adds `_looks_like_rt_agent_judge_notes` in [`ingest_guard.py`](https://github.com/EtanHey/brainlayer/pull/288/files#diff-ba85783a8c497e844d2d51a0847749c025b3fe9ed22f6277f0aaae82cb0127ef) to detect rt-agent judge notes by checking for qid markers, strong judge fields, and rt-agent chunk ID/source file patterns.
> - Extends `recursive_mcp_output_reason` and `reject_recursive_mcp_output` to accept `chunk_id` and `source_file` context, so the recursion guard can now classify and reject rt-agent judge notes.
> - Propagates this context through [`drain.py`](https://github.com/EtanHey/brainlayer/pull/288/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c), [`watcher_bridge.py`](https://github.com/EtanHey/brainlayer/pull/288/files#diff-9c9df603fa7a5ecf5cdb0da9ab4077d520d812083da4b052847100f2874f60c9), and [`vector_store.py`](https://github.com/EtanHey/brainlayer/pull/288/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) so all ingest paths reject matching content before insertion.
> - Adds a [`p0_longitudinal_count.py`](https://github.com/EtanHey/brainlayer/pull/288/files#diff-bfdc28799884ac63656c3682ea3b1a62db6c5941479dd4a24848c901c3615b2b) CLI script that queries the BrainLayer DB for daily audit-recursion counts since a fixed timestamp and writes a JSON report.
> - Risk: any content matching the rt-agent judge note heuristics will be silently dropped with a warning rather than ingested, which is a new behavioral gate across store, watcher, hook, and upsert paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e25ee27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RT-agent judge notes are now detected and filtered to prevent unwanted storage.
  * Added longitudinal counting tool for monitoring audit records.

* **Improvements**
  * Enhanced recursion and noise detection with richer contextual information for improved content filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->