### PR TITLE
feat(ingest): reject diagnostic + PreCompact noise + reranker demote

### DIFF
--- a/scripts/quarantine_noise.py
+++ b/scripts/quarantine_noise.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Quarantine noisy F-infra and PreCompact chunks.
+
+Usage:
+    python3 scripts/quarantine_noise.py
+    python3 scripts/quarantine_noise.py --limit 100
+    python3 scripts/quarantine_noise.py --apply
+    python3 scripts/quarantine_noise.py --apply --limit 100 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from brainlayer.chunk_origin import is_precompact_checkpoint_content
+from brainlayer.paths import get_db_path
+
+NOISE_TAG = "quarantined/noise"
+CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT = "precompact_checkpoint"
+PRECOMPACT_ID_PREFIXES = ("c89", "0cb", "d3f", "493", "303", "362", "8f1", "037", "3c8", "16b", "dec", "ce2")
+F_INFRA_NOISE_PREFIXES = (
+    "brainlayer mcp not connected",
+    "brainlayer mcp is down",
+    "done. summary:  brainlayer mcp not connected",
+    "done. summary: brainlayer mcp not connected",
+)
+
+
+def _to_bool(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _normalize_headline(content: str | None) -> str:
+    """Normalize a chunk to a best-effort leading-line comparable form."""
+    if not content:
+        return ""
+
+    text = content.strip()
+    if not text:
+        return ""
+
+    text = re.sub(r"(?i)^assistant:\s*", "", text)
+
+    normalized = []
+    for line in text.replace("\r", "\n").splitlines():
+        normalized.append(line.strip())
+    text = " ".join(part for part in normalized if part)
+
+    # Strip leading wrapper chars used by diagnostic formatting.
+    text = re.sub(r"^\W+", "", text)
+    text = text.lstrip(" \t*`>-•_")
+    text = text.replace("**", "")
+    text = text.lower()
+    return text
+
+
+def is_f_infra_root_content(content: str | None) -> bool:
+    """Return True for F-infra diagnostic chatter candidates."""
+    normalized = _normalize_headline(content)
+    if not normalized:
+        return False
+    # Root diagnostics tend to start near the beginning.
+    return any(normalized.startswith(prefix) for prefix in F_INFRA_NOISE_PREFIXES)
+
+
+def _chunk_id_has_prefix(chunk_id: str | None, prefixes: tuple[str, ...]) -> bool:
+    if not chunk_id:
+        return False
+    return any(chunk_id.startswith(f"brainbar-{prefix}") for prefix in prefixes)
+
+
+def _parse_tags(raw: str | None) -> list[str] | None:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        parsed = raw
+    else:
+        if not raw:
+            return []
+        if not isinstance(raw, str):
+            return None
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(parsed, list):
+        return None
+    tags: list[str] = []
+    for item in parsed:
+        if isinstance(item, str):
+            tag = item.strip()
+            if tag:
+                tags.append(tag)
+    return tags
+
+
+def _tags_indicate_precompact(raw: str | None) -> bool:
+    tags = _parse_tags(raw)
+    if tags is None:
+        return False
+    checkpoint_tags = {
+        "pre-compact",
+        "precompact",
+        "precompact-checkpoint",
+        "precompact_checkpoint",
+        "pre-compact-checkpoint",
+    }
+    return any(tag.strip().lower() in checkpoint_tags for tag in tags)
+
+
+def _normalize_and_append_tag(existing: list[str], tag: str) -> tuple[list[str], bool]:
+    """Append tag if missing (case-insensitive), preserving existing order."""
+    lowered = {t.lower() for t in existing}
+    if tag.lower() in lowered:
+        return existing, False
+    return existing + [tag], True
+
+
+def is_precompact_candidate(
+    content: str | None,
+    chunk_origin: str | None,
+    tags: str | None,
+    chunk_id: str | None = None,
+) -> bool:
+    if is_precompact_checkpoint_content(content):
+        return True
+    if (chunk_origin or "").strip().lower() == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT:
+        return True
+    if _chunk_id_has_prefix(chunk_id, PRECOMPACT_ID_PREFIXES):
+        return True
+    return _tags_indicate_precompact(tags)
+
+
+def _connect(db_path: Path, apply: bool) -> sqlite3.Connection:
+    if apply:
+        conn = sqlite3.connect(db_path)
+    else:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    if apply:
+        conn.execute("PRAGMA journal_mode = WAL")
+    return conn
+
+
+def _table_columns(conn: sqlite3.Connection) -> set[str]:
+    return {row["name"] for row in conn.execute("PRAGMA table_info(chunks)").fetchall()}
+
+
+def _fetch_candidates(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    columns = _table_columns(conn)
+    has_chunk_origin = "chunk_origin" in columns
+
+    where_parts = [
+        "content IS NOT NULL",
+        "(LOWER(content) LIKE :infra_phrase)",
+    ]
+    params: dict[str, str] = {"infra_phrase": "%brainlayer mcp not connected%"}
+
+    if has_chunk_origin:
+        where_parts.append("chunk_origin = :chunk_origin_precompact")
+        params["chunk_origin_precompact"] = CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+
+    where_parts.extend(
+        [
+            "(LOWER(content) LIKE :precompact_content)",
+            "(COALESCE(tags, '') LIKE :precompact_tag)",
+            "(LOWER(content) LIKE :precompact_wrapped)",
+        ]
+    )
+    params.update(
+        {
+            "precompact_content": "%[precompact checkpoint]%",
+            "precompact_tag": "%precompact%",
+            "precompact_wrapped": "%content=\"[precompact checkpoint]%",
+        }
+    )
+    precompact_id_like_clauses = [
+        "id LIKE :precompact_id_like_" + re.sub(r"[^a-z0-9]", "", prefix)
+        for prefix in PRECOMPACT_ID_PREFIXES
+    ]
+    params.update({
+        f"precompact_id_like_{re.sub(r'[^a-z0-9]', '', prefix)}": f"brainbar-{prefix}%"
+        for prefix in PRECOMPACT_ID_PREFIXES
+    })
+    where_parts.append(f"({' OR '.join(precompact_id_like_clauses)})")
+
+    select_parts = [
+        "id",
+        "content",
+        "tags",
+        "project",
+        "source",
+        "source_file",
+        "created_at",
+        "importance",
+        "archived",
+        "status",
+        "archived_at",
+    ]
+    if has_chunk_origin:
+        select_parts.append("chunk_origin")
+    else:
+        select_parts.append("NULL AS chunk_origin")
+
+    sql = f"""
+        SELECT {", ".join(select_parts)}
+        FROM chunks
+        WHERE (
+            {" OR ".join(where_parts)}
+        )
+        ORDER BY COALESCE(created_at, ''), id
+    """
+
+    return list(conn.execute(sql, params))
+
+
+def _candidate_map(rows: list[sqlite3.Row]) -> dict[str, dict[str, Any]]:
+    candidates: dict[str, dict[str, Any]] = {}
+
+    for row in rows:
+        row_content = (row["content"] or "").strip()
+        content_preview = row_content.replace("\n", " ")
+        if len(content_preview) > 140:
+            content_preview = content_preview[:140] + "…"
+
+        reasons = []
+        if is_f_infra_root_content(row["content"]):
+            reasons.append("f_infra_root")
+        if is_precompact_candidate(row["content"], row["chunk_origin"], row["tags"], row["id"]):
+            reasons.append("precompact")
+        if not reasons:
+            continue
+
+        existing = candidates.setdefault(row["id"], {})
+        existing.setdefault("id", row["id"])
+        existing.setdefault("project", row["project"])
+        existing.setdefault("source", row["source"])
+        existing.setdefault("source_file", row["source_file"])
+        existing.setdefault("created_at", row["created_at"])
+        existing.setdefault("tags", row["tags"])
+        existing.setdefault("chunk_origin", row["chunk_origin"])
+        existing.setdefault("importance", row["importance"])
+        existing.setdefault("archived", _to_bool(row["archived"]))
+        existing.setdefault("status", row["status"])
+        existing.setdefault("archived_at", row["archived_at"])
+        existing.setdefault("content_preview", content_preview)
+        reasons_set = set(existing.get("reasons", []))
+        reasons_set.update(reasons)
+        existing["reasons"] = sorted(reasons_set)
+        candidates[row["id"]] = existing
+
+    return candidates
+
+
+def _summarize_rows(rows: list[dict[str, Any]]) -> dict[str, int | float]:
+    return {
+        "total": len(rows),
+        "f_infra_root": sum("f_infra_root" in row["reasons"] for row in rows),
+        "precompact": sum("precompact" in row["reasons"] for row in rows),
+        "already_archived": sum(bool(_to_bool(row["archived"])) for row in rows),
+        "taggable": sum(_parse_tags(row["tags"]) is not None for row in rows),
+    }
+
+
+def _human_preview(rows: list[dict[str, Any]]) -> str:
+    lines = []
+    for row in rows[:50]:
+        lines.append(
+            "  - {id} [{project}] source={source} created={created_at} reasons={reasons} tags={tags_added}".format(
+                id=row["id"],
+                project=row.get("project"),
+                source=row.get("source"),
+                created_at=row.get("created_at"),
+                reasons=",".join(row["reasons"]),
+                tags_added="yes" if row.get("tag_added") else "no",
+            )
+        )
+        preview = row.get("content_preview")
+        if preview:
+            lines.append(f"    {preview}")
+    if not lines:
+        return "  (none)"
+    return "\n".join(lines)
+
+
+def _apply_quarantine(conn: sqlite3.Connection, rows: list[dict[str, Any]]) -> dict[str, int | bool]:
+    if not rows:
+        return {"updated": 0, "tags_added": 0}
+
+    now = datetime.now(timezone.utc).isoformat()
+    base_stmt = """
+        UPDATE chunks
+           SET importance = ?,
+               archived = ?,
+               archived_at = ?,
+               status = ?
+         WHERE id = ?
+    """
+    tag_stmt = "UPDATE chunks SET tags = ? WHERE id = ?"
+    updated = 0
+    tags_added = 0
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute("BEGIN IMMEDIATE")
+        for row in rows:
+            cursor.execute(base_stmt, (0, 1, now, "archived", row["id"]))
+            updated += 1
+            parsed = _parse_tags(row["tags"])
+            if parsed is None:
+                row["tag_added"] = False
+                row["tag_error"] = "malformed_tags"
+                continue
+            merged, changed = _normalize_and_append_tag(parsed, NOISE_TAG)
+            if changed:
+                cursor.execute(tag_stmt, (json.dumps(merged, ensure_ascii=False), row["id"]))
+                row["tag_added"] = True
+                tags_added += 1
+            else:
+                row["tag_added"] = False
+            row["tags"] = json.dumps(merged, ensure_ascii=False)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    return {"updated": updated, "tags_added": tags_added}
+
+
+def _build_output(candidates: list[dict[str, Any]], dry_run: bool, stats: dict[str, int | float], result: dict[str, int | bool]) -> dict[str, Any]:
+    return {
+        "mode": "dry_run" if dry_run else "apply",
+        "candidates": candidates,
+        "summary": stats,
+        "applied": result["updated"],
+        "tags_added": result["tags_added"],
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dry-run and quarantine noise chunks in the BrainLayer DB.")
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=get_db_path(),
+        help="Path to BrainLayer sqlite DB (default: ~/.local/share/brainlayer/brainlayer.db)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply quarantines. Without this flag, the script only reports matches.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional max number of rows to process.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON summary for automation.",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.limit is not None and args.limit <= 0:
+        raise ValueError("--limit must be positive.")
+
+    conn = _connect(args.db, apply=args.apply)
+    try:
+        prefetch = _fetch_candidates(conn)
+        candidates = list(_candidate_map(prefetch).values())
+        candidate_rows = candidates[: args.limit] if args.limit is not None else candidates
+        summary = _summarize_rows(candidate_rows)
+
+        if not candidate_rows:
+            if args.json:
+                print(json.dumps(
+                    _build_output(
+                        candidates=[],
+                        dry_run=not args.apply,
+                        stats=summary,
+                        result={"updated": 0, "tags_added": 0},
+                    ),
+                    indent=2,
+                ))
+            else:
+                print("No candidates found.")
+            return 0
+
+        if args.apply:
+            result = _apply_quarantine(conn, candidate_rows)
+            if args.json:
+                print(json.dumps(_build_output(candidate_rows, dry_run=False, stats=summary, result=result), indent=2))
+            else:
+                print(f"Quarantined {result['updated']} chunks.")
+                print(f"Tag updates applied: {result['tags_added']}")
+                print(_human_preview(candidate_rows))
+            return 0
+
+        result = {"updated": 0, "tags_added": 0}
+        if args.json:
+            print(json.dumps(_build_output(candidate_rows, dry_run=True, stats=summary, result=result), indent=2))
+            return 0
+
+        print(f"Candidates: {summary['total']}")
+        print(f"  - f-infra root: {summary['f_infra_root']}")
+        print(f"  - precompact: {summary['precompact']}")
+        print(f"  - already_archived: {summary['already_archived']}")
+        print("Dry-run mode: add --apply to write changes.\n")
+        print(_human_preview(candidate_rows))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -165,6 +165,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         content,
         chunk_id=chunk_id,
         source_file=event.get("source_file"),
+        reject_precompact=True,
     )
     if recursive_reason:
         logger.warning("Skipping recursive MCP store event: %s", recursive_reason)
@@ -255,7 +256,12 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> None:
         logger.warning("Skipping malformed watcher event with empty content")
         return
     source_file = event.get("source_file") or "realtime-watcher"
-    recursive_reason = recursive_mcp_output_reason(content, chunk_id=chunk_id, source_file=source_file)
+    recursive_reason = recursive_mcp_output_reason(
+        content,
+        chunk_id=chunk_id,
+        source_file=source_file,
+        reject_precompact=True,
+    )
     if recursive_reason:
         logger.warning("Skipping recursive MCP watcher event: %s", recursive_reason)
         return
@@ -294,7 +300,12 @@ def _apply_hook(conn: apsw.Connection, event: dict[str, Any]) -> None:
     session_id = event.get("session_id") or "unknown"
     chunk_id = event.get("chunk_id") or f"rt-{str(session_id)[:8]}-{content_hash}"
     source_file = event.get("source_file") or "realtime-hook"
-    recursive_reason = recursive_mcp_output_reason(content, chunk_id=chunk_id, source_file=source_file)
+    recursive_reason = recursive_mcp_output_reason(
+        content,
+        chunk_id=chunk_id,
+        source_file=source_file,
+        reject_precompact=True,
+    )
     if recursive_reason:
         logger.warning("Skipping recursive MCP hook event: %s", recursive_reason)
         return

--- a/src/brainlayer/ingest_guard.py
+++ b/src/brainlayer/ingest_guard.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import re
 
+from .chunk_origin import is_precompact_checkpoint_content
+
 _JSONRPC_MESSAGE_RE = re.compile(r'"jsonrpc"\s*:\s*"2\.0"', re.IGNORECASE)
 _INVALID_JSONRPC_MARKER = "mcp brainlayer memory: invalid json-rpc message"
 _BRAIN_SEARCH_BOX_PREFIX = "┌─ brain_search:"
@@ -23,6 +25,18 @@ _QID_JUDGE_NOTE_MARKERS = (
     *_STRONG_JUDGE_NOTE_MARKERS,
     "fm11",
 )
+_F_INFRA_NOISE_PREFIXES = (
+    "brainlayer mcp not connected",
+    "brainlayer mcp is down",
+    "brainlayer mcp tools are not callable",
+    "brainlayer unavailable",
+    "mcp__brainlayer__brain_search is not available",
+    "i can't call `brain_search` or `brain_store` directly",
+    "i cannot brain_store",
+    'toolsearch found zero matches for "mcp brain"',
+)
+_F_INFRA_MAX_PREFIX_CHARS = 500
+_ASSISTANT_PREFIX_RE = re.compile(r"^assistant\s*:\s*", re.IGNORECASE)
 
 
 def _looks_like_rt_agent_judge_notes(content: str, chunk_id: str | None = None, source_file: str | None = None) -> bool:
@@ -43,11 +57,27 @@ def _looks_like_rt_agent_judge_notes(content: str, chunk_id: str | None = None, 
     return has_rt_agent_context and has_strong_judge_marker
 
 
+def _looks_like_brainlayer_infra_noise(content: str) -> bool:
+    if not content:
+        return False
+
+    stripped = content.lstrip()
+    stripped = _ASSISTANT_PREFIX_RE.sub("", stripped, count=1)
+    stripped = re.sub(r"^[^A-Za-z0-9]+", "", stripped)
+    stripped = stripped[:_F_INFRA_MAX_PREFIX_CHARS].casefold()
+
+    return any(
+        re.match(rf"^(?:{re.escape(prefix)})(?:$|[^a-z0-9])", stripped)
+        for prefix in _F_INFRA_NOISE_PREFIXES
+    )
+
+
 def recursive_mcp_output_reason(
     content: str | None,
     *,
     chunk_id: str | None = None,
     source_file: str | None = None,
+    reject_precompact: bool = False,
 ) -> str | None:
     """Return a reason when content is BrainLayer MCP output being re-ingested."""
     if not content:
@@ -62,6 +92,10 @@ def recursive_mcp_output_reason(
     folded = stripped.casefold()
     if _INVALID_JSONRPC_MARKER in folded:
         return "invalid_jsonrpc_mcp_output"
+    if _looks_like_brainlayer_infra_noise(stripped):
+        return "brainlayer_mcp_unavailable_diagnostic"
+    if reject_precompact and is_precompact_checkpoint_content(stripped):
+        return "precompact_checkpoint_noise"
     if _JSONRPC_MESSAGE_RE.search(stripped):
         return "jsonrpc_message"
     if _looks_like_rt_agent_judge_notes(stripped, chunk_id=chunk_id, source_file=source_file):
@@ -75,8 +109,14 @@ def reject_recursive_mcp_output(
     *,
     chunk_id: str | None = None,
     source_file: str | None = None,
+    reject_precompact: bool = False,
 ) -> None:
     """Raise ValueError when content is recursive BrainLayer MCP output."""
-    reason = recursive_mcp_output_reason(content, chunk_id=chunk_id, source_file=source_file)
+    reason = recursive_mcp_output_reason(
+        content,
+        chunk_id=chunk_id,
+        source_file=source_file,
+        reject_precompact=reject_precompact,
+    )
     if reason:
         raise ValueError(f"recursive MCP output is not stored in BrainLayer: {reason}")

--- a/src/brainlayer/ingest_guard.py
+++ b/src/brainlayer/ingest_guard.py
@@ -66,10 +66,7 @@ def _looks_like_brainlayer_infra_noise(content: str) -> bool:
     stripped = re.sub(r"^[^A-Za-z0-9]+", "", stripped)
     stripped = stripped[:_F_INFRA_MAX_PREFIX_CHARS].casefold()
 
-    return any(
-        re.match(rf"^(?:{re.escape(prefix)})(?:$|[^a-z0-9])", stripped)
-        for prefix in _F_INFRA_NOISE_PREFIXES
-    )
+    return any(re.match(rf"^(?:{re.escape(prefix)})(?:$|[^a-z0-9])", stripped) for prefix in _F_INFRA_NOISE_PREFIXES)
 
 
 def recursive_mcp_output_reason(

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import math
 import os
+import re
 import struct
 import time
 from collections import OrderedDict
@@ -42,6 +43,21 @@ META_NOISE_PATTERNS = [
     "Grounding Results — Prompt",
 ]
 META_NOISE_PATTERNS_CASEFOLDED = [pattern.casefold() for pattern in META_NOISE_PATTERNS]
+_ALNUM_ONLY_RE = re.compile(r"[^a-z0-9]+")
+_PRECOMPACT_TAG_MARKERS = frozenset(
+    {
+        "precompact",
+        "precompactcheckpoint",
+    }
+)
+_QUARANTINE_TAG_MARKERS = frozenset({"quarantine", "quarantined"})
+_NOISE_CONTENT_PATTERNS = (
+    "[precompact checkpoint]",
+    "# precompact checkpoint",
+    "session-restore",
+    "# session-restore",
+)
+_NOISE_RERANK_DEMOTION = 0.05
 AUDIT_RECURSION_TAG_PATTERNS = (
     "{tag_expr} = 'audit'",
     "{tag_expr} = 'audit-recursion'",
@@ -132,6 +148,84 @@ def _contains_meta_noise(content: Optional[str]) -> bool:
         return False
     content_folded = content.casefold()
     return any(pattern in content_folded for pattern in META_NOISE_PATTERNS_CASEFOLDED)
+
+
+def _is_noise_tag(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    normalized = _ALNUM_ONLY_RE.sub("", value.casefold())
+    return (
+        normalized in _PRECOMPACT_TAG_MARKERS
+        or normalized in _QUARANTINE_TAG_MARKERS
+    )
+
+
+def _contains_precompact_or_quarantined_meta(
+    meta: dict[str, Any],
+    content: str | None = None,
+    *,
+    include_checkpoints: bool = False,
+) -> bool:
+    if meta is None:
+        return False
+
+    has_precompact_signal = is_precompact_checkpoint_content(content)
+    has_quarantine_signal = False
+
+    tags = meta.get("tags", [])
+    if isinstance(tags, list):
+        for tag in tags:
+            if _is_noise_tag(tag):
+                normalized = _ALNUM_ONLY_RE.sub("", tag.casefold())
+                if normalized in _QUARANTINE_TAG_MARKERS:
+                    has_quarantine_signal = True
+                else:
+                    has_precompact_signal = True
+    elif isinstance(tags, str):
+        try:
+            parsed = json.loads(tags)
+        except (json.JSONDecodeError, TypeError):
+            parsed = []
+        if isinstance(parsed, list):
+            for tag in parsed:
+                if _is_noise_tag(tag):
+                    normalized = _ALNUM_ONLY_RE.sub("", tag.casefold())
+                    if normalized in _QUARANTINE_TAG_MARKERS:
+                        has_quarantine_signal = True
+                    else:
+                        has_precompact_signal = True
+
+    for key in ("quarantine", "quarantined", "is_quarantine", "is_quarantined"):
+        value = meta.get(key)
+        if isinstance(value, bool):
+            if value:
+                has_quarantine_signal = True
+        elif isinstance(value, (int, float)):
+            if bool(value):
+                has_quarantine_signal = True
+        elif isinstance(value, str):
+            if value.casefold() in {"true", "1", "yes", "quarantine", "quarantined"}:
+                has_quarantine_signal = True
+
+    for key, value in meta.items():
+        if isinstance(key, str) and _is_noise_tag(key):
+            normalized = _ALNUM_ONLY_RE.sub("", key.casefold())
+            if normalized in _QUARANTINE_TAG_MARKERS:
+                has_quarantine_signal = True
+            else:
+                has_precompact_signal = True
+        if isinstance(value, str) and _is_noise_tag(value):
+            normalized = _ALNUM_ONLY_RE.sub("", value.casefold())
+            if normalized in _QUARANTINE_TAG_MARKERS:
+                has_quarantine_signal = True
+            else:
+                has_precompact_signal = True
+
+    normalized_content = content.casefold() if content else ""
+    if any(pattern in normalized_content for pattern in _NOISE_CONTENT_PATTERNS):
+        has_precompact_signal = True
+
+    return has_quarantine_signal or (has_precompact_signal and not include_checkpoints)
 
 
 def _audit_recursion_tag_predicate(tag_expr: str) -> str:
@@ -1518,6 +1612,12 @@ class SearchMixin:
                             scored[i] = (score * KG_BOOST_FACTOR, cid, doc, meta, dist)
             except Exception:
                 pass  # KG tables may not exist in all DBs
+
+        # Penalize literal pre-compact or quarantined signals after all positive boosts.
+        # This keeps them discoverable but deprioritizes them in normal ranking.
+        for i, (score, cid, doc, meta, dist) in enumerate(scored):
+            if _contains_precompact_or_quarantined_meta(meta, doc, include_checkpoints=include_checkpoints):
+                scored[i] = (score * _NOISE_RERANK_DEMOTION, cid, doc, meta, dist)
 
         # Sort by boosted RRF score descending
         scored.sort(key=lambda x: x[0], reverse=True)

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -154,10 +154,7 @@ def _is_noise_tag(value: Any) -> bool:
     if not isinstance(value, str):
         return False
     normalized = _ALNUM_ONLY_RE.sub("", value.casefold())
-    return (
-        normalized in _PRECOMPACT_TAG_MARKERS
-        or normalized in _QUARANTINE_TAG_MARKERS
-    )
+    return normalized in _PRECOMPACT_TAG_MARKERS or normalized in _QUARANTINE_TAG_MARKERS
 
 
 def _contains_precompact_or_quarantined_meta(

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -129,7 +129,7 @@ def should_skip_entry(entry: dict, *, source_file: str | None = None) -> str | N
         return "too_short"
 
     resolved_source_file = source_file or entry.get("_source_file")
-    if recursive_mcp_output_reason(raw_text, source_file=resolved_source_file):
+    if recursive_mcp_output_reason(raw_text, source_file=resolved_source_file, reject_precompact=True):
         return "recursive_mcp_output"
 
     # Skip if content is mostly system-reminder injection
@@ -152,7 +152,7 @@ def should_skip_chunk_content(
     if len(cleaned.strip()) < MIN_RAW_CONTENT_LENGTH:
         return "system_reminder_residue"
 
-    if recursive_mcp_output_reason(cleaned, chunk_id=chunk_id, source_file=source_file):
+    if recursive_mcp_output_reason(cleaned, chunk_id=chunk_id, source_file=source_file, reject_precompact=True):
         return "recursive_mcp_output"
 
     # Skip pure file deletion diffs

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -6,7 +6,7 @@ import uuid
 import pytest
 
 from brainlayer._helpers import serialize_f32
-from brainlayer.search_repo import _hybrid_cache
+from brainlayer.search_repo import _contains_precompact_or_quarantined_meta, _hybrid_cache
 from brainlayer.vector_store import VectorStore
 
 
@@ -38,6 +38,7 @@ def _insert_chunk(
     chunk_id: str,
     content: str,
     embedding: list[float],
+    metadata_obj: dict | None = None,
     summary: str | None = None,
     tags: list[str] | None = None,
     resolved_query: str | None = None,
@@ -53,10 +54,11 @@ def _insert_chunk(
         """INSERT INTO chunks (
             id, content, metadata, source_file, project, content_type,
             char_count, source, sender, language, summary, tags, resolved_query, importance, created_at
-        ) VALUES (?, ?, '{}', 'test.jsonl', ?, 'assistant_text', ?, 'claude_code', ?, ?, ?, ?, ?, ?, ?)""",
+        ) VALUES (?, ?, ?, 'test.jsonl', ?, 'assistant_text', ?, 'claude_code', ?, ?, ?, ?, ?, ?, ?)""",
         (
             chunk_id,
             content,
+            json.dumps(metadata_obj) if metadata_obj is not None else "{}",
             project,
             len(content),
             sender,
@@ -347,6 +349,87 @@ class TestHybridSearch:
 
         assert "meta-noise-upper" not in filtered["ids"][0]
         assert "real-hit-lower" in filtered["ids"][0]
+
+    def test_hybrid_search_demotes_precompact_and_quarantined_tagged_chunks(self, store):
+        query_embedding = _embed("noise-aware rerank control")
+
+        _insert_chunk(
+            store,
+            chunk_id="precompact-noise",
+            content="noise-aware rerank control with direct match",
+            embedding=query_embedding,
+            tags=["precompact-checkpoint"],
+            created_at="2026-05-16T00:00:00Z",
+            importance=1.0,
+        )
+        _insert_chunk(
+            store,
+            chunk_id="quarantined-noise",
+            content="noise-aware rerank control with direct match",
+            embedding=query_embedding,
+            tags=["quarantined"],
+            created_at="2026-05-16T00:00:00Z",
+            importance=1.0,
+        )
+        _insert_chunk(
+            store,
+            chunk_id="clean-hit",
+            content="noise-aware rerank control semantic anchor phrase",
+            embedding=[value + 0.0002 for value in query_embedding],
+            created_at="2026-05-17T00:00:00Z",
+            importance=10.0,
+        )
+        store.build_binary_index()
+
+        results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="noise-aware rerank control",
+            n_results=3,
+            include_archived=False,
+        )
+
+        ids = results["ids"][0]
+        assert ids[0] == "clean-hit", ids
+        assert set(ids[1:]) == {"precompact-noise", "quarantined-noise"}, ids
+
+    def test_hybrid_search_demotes_chunks_with_quarantine_metadata(self, store):
+        query_embedding = _embed("metadata noise rerank")
+        clean_content = "metadata noise rerank control anchor"
+        noisy_content = "metadata noise rerank control anchor"
+
+        _insert_chunk(
+            store,
+            chunk_id="meta-hit",
+            content=clean_content,
+            embedding=[value + 0.00002 for value in query_embedding],
+            created_at="2026-05-17T00:00:00Z",
+            importance=10.0,
+        )
+        _insert_chunk(
+            store,
+            chunk_id="meta-flag-noise",
+            content=noisy_content,
+            embedding=query_embedding,
+            created_at="2026-05-16T00:00:00Z",
+            importance=10.0,
+            metadata_obj={"quarantine": True},
+            tags=["search"],
+        )
+        store.build_binary_index()
+
+        results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="metadata noise rerank",
+            n_results=2,
+            include_archived=False,
+        )
+
+        ids = results["ids"][0]
+        assert ids[0] == "meta-hit", ids
+        assert ids[1] == "meta-flag-noise", ids
+
+    def test_noise_demoter_does_not_treat_arbitrary_true_metadata_as_quarantine(self):
+        assert not _contains_precompact_or_quarantined_meta({"feature_enabled": "true"}, "ordinary content")
 
     def test_mmr_rerank_dedupes_near_duplicates(self, store):
         def embedding(primary: float, secondary: float = 0.0) -> list[float]:

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -55,8 +55,7 @@ F_INFRA_ALLOWED_REPORT = (
 )
 PRECOMPACT_NOISE_HEADING = "# PreCompact Checkpoint — abc123\nCurrent task: resume active work."
 PRECOMPACT_NOISE_WRAPPED = (
-    "Call mcp__brainlayer__brain_store exactly once with content=\"[PreCompact checkpoint]\\n"
-    "timestamp: 2026-05-17\"\n"
+    'Call mcp__brainlayer__brain_store exactly once with content="[PreCompact checkpoint]\\ntimestamp: 2026-05-17"\n'
 )
 
 
@@ -145,7 +144,9 @@ def test_drain_passes_brainlayer_mcp_diagnostic_reported_later(tmp_path, monkeyp
         tags=["correction:factual", "auto-detected"],
         queue_dir=queue_dir,
     )
-    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain-report-later.log")
+    drained = drain_once(
+        db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain-report-later.log"
+    )
 
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute("SELECT id, content FROM chunks").fetchall()

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -43,6 +43,21 @@ RT_AGENT_ORCHESTRATOR_SUBAGENT_SOURCE_FILE = (
 RT_AGENT_VOICELAYER_SUBAGENT_SOURCE_FILE = (
     "/Users/test-user/.claude/projects/-Users-test-user-Gits-voicelayer/session/subagents/agent-a7c933d4439ab60b3.jsonl"
 )
+F_INFRA_NOISE_DIAGNOSTIC = (
+    "🚨 **BrainLayer MCP not connected.** I can't call `brain_search` or `brain_store` directly. "
+    "The hook injected some memories at boot."
+)
+F_INFRA_NOISE_UPPERCASE = "Assistant: 🚨🚨🚨 **BRAINLAYER MCP NOT CONNECTED** — retrying in 5 minutes."
+F_INFRA_NOISE_TOOLSEARCH = 'ToolSearch found zero matches for "mcp brain".'
+F_INFRA_ALLOWED_REPORT = (
+    "In our migration notes, we discuss that BrainLayer MCP not connected and why fallback tooling failed, "
+    "but this is not a startup boot diagnostic."
+)
+PRECOMPACT_NOISE_HEADING = "# PreCompact Checkpoint — abc123\nCurrent task: resume active work."
+PRECOMPACT_NOISE_WRAPPED = (
+    "Call mcp__brainlayer__brain_store exactly once with content=\"[PreCompact checkpoint]\\n"
+    "timestamp: 2026-05-17\"\n"
+)
 
 
 def _make_entry(text: str) -> dict:
@@ -75,8 +90,81 @@ def test_watcher_preclassify_rejects_rt_agent_qid_judge_notes():
     assert should_skip_entry(entry) == "recursive_mcp_output"
 
 
+def test_watcher_preclassify_rejects_brainlayer_mcp_unavailable_diagnostic():
+    entry = _make_entry(F_INFRA_NOISE_DIAGNOSTIC)
+
+    assert should_skip_entry(entry) == "recursive_mcp_output"
+
+
+def test_watcher_preclassify_rejects_brainlayer_mcp_unavailable_diagnostic_uppercase_with_assistant_prefix():
+    entry = _make_entry(F_INFRA_NOISE_UPPERCASE)
+
+    assert should_skip_entry(entry) == "recursive_mcp_output"
+
+
+def test_watcher_preclassify_rejects_toolsearch_match_diagnostic():
+    entry = _make_entry(F_INFRA_NOISE_TOOLSEARCH)
+
+    assert should_skip_entry(entry) == "recursive_mcp_output"
+
+
+def test_watcher_preclassify_allows_late_brainlayer_mcp_phrase_in_report():
+    entry = _make_entry(F_INFRA_ALLOWED_REPORT)
+
+    assert should_skip_entry(entry) is None
+
+
 def test_watcher_postchunk_rejects_rt_agent_qid_judge_notes():
     assert should_skip_chunk_content(RT_AGENT_A7_JUDGE_NOTES_CONTENT) == "recursive_mcp_output"
+
+
+def test_watcher_postchunk_rejects_brainlayer_mcp_unavailable_diagnostic():
+    assert should_skip_chunk_content(F_INFRA_NOISE_DIAGNOSTIC) == "recursive_mcp_output"
+
+
+def test_watcher_postchunk_rejects_precompact_checkpoint_heading():
+    assert should_skip_chunk_content(PRECOMPACT_NOISE_HEADING) == "recursive_mcp_output"
+
+
+def test_watcher_preclassify_rejects_precompact_checkpoint_wrapped_metadata():
+    entry = _make_entry(PRECOMPACT_NOISE_WRAPPED)
+
+    assert should_skip_entry(entry) == "recursive_mcp_output"
+
+
+def test_drain_passes_brainlayer_mcp_diagnostic_reported_later(tmp_path, monkeypatch):
+    db_path = tmp_path / "drain-report-later-guard.db"
+    queue_dir = tmp_path / "queue"
+    VectorStore(db_path).close()
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    enqueue_store(
+        chunk_id="queued-store-report-later",
+        content=F_INFRA_ALLOWED_REPORT,
+        project="brainlayer",
+        tags=["correction:factual", "auto-detected"],
+        queue_dir=queue_dir,
+    )
+    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain-report-later.log")
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT id, content FROM chunks").fetchall()
+
+    assert drained == 1
+    assert rows[0][0] == "queued-store-report-later"
+
+
+def test_direct_store_rejects_brainlayer_mcp_not_connected_diagnostic(tmp_path):
+    with VectorStore(tmp_path / "store-brainlayer-infra-guard.db") as store:
+        with pytest.raises(ValueError, match="brainlayer_mcp_unavailable_diagnostic"):
+            store_memory(
+                store=store,
+                embed_fn=None,
+                content=F_INFRA_NOISE_DIAGNOSTIC,
+                memory_type="note",
+                project="brainlayer",
+                tags=["correction:factual", "auto-detected"],
+            )
 
 
 def test_watcher_preclassify_rejects_rt_agent_context_only_judge_notes_from_subagent_source():

--- a/tests/test_precompact_chunk_origin.py
+++ b/tests/test_precompact_chunk_origin.py
@@ -255,7 +255,7 @@ def test_update_chunk_recomputes_dedupe_fingerprints_when_content_changes(tmp_pa
     assert row == (expected.dedupe_hash, expected.simhash, *expected.bands)
 
 
-def test_watcher_and_drain_tag_precompact_origin(tmp_path, monkeypatch):
+def test_watcher_and_drain_reject_precompact_checkpoint_noise(tmp_path, monkeypatch):
     db_path = tmp_path / "watcher.db"
     source_file = tmp_path / "session.jsonl"
     source_file.write_text(
@@ -296,8 +296,8 @@ def test_watcher_and_drain_tag_precompact_origin(tmp_path, monkeypatch):
     queued = store.conn.cursor().execute("SELECT chunk_origin FROM chunks WHERE id = 'queued-checkpoint'").fetchone()
     store.close()
 
-    assert row == (CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,)
-    assert queued == (CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,)
+    assert row is None
+    assert queued is None
 
 
 def test_search_excludes_checkpoints_by_default_and_can_include_them(tmp_path):

--- a/tests/test_quarantine_noise.py
+++ b/tests/test_quarantine_noise.py
@@ -24,11 +24,11 @@ def test_precompact_detection():
     """PreCompact chunks are recognized by content and checkpoint tags."""
     assert is_precompact_candidate("# PreCompact Checkpoint\nsession now.", None, None)
     assert is_precompact_candidate("normal text", "precompact_checkpoint", '["tag:one"]')
-    assert is_precompact_candidate("normal text", None, '[\"precompact\", \"session\"]')
-    assert is_precompact_candidate("normal text", None, '[\"pre-compact\", \"session-checkpoint\"]')
+    assert is_precompact_candidate("normal text", None, '["precompact", "session"]')
+    assert is_precompact_candidate("normal text", None, '["pre-compact", "session-checkpoint"]')
     assert is_precompact_candidate("normal text", None, None, "brainbar-c89abcd")
-    assert not is_precompact_candidate("normal text", None, '[\"precompact-hook\"]')
-    assert not is_precompact_candidate("normal text", None, '[\"session-checkpoint\"]')
+    assert not is_precompact_candidate("normal text", None, '["precompact-hook"]')
+    assert not is_precompact_candidate("normal text", None, '["session-checkpoint"]')
     assert not is_precompact_candidate("normal text", None, None)
 
 
@@ -102,7 +102,7 @@ def test_dry_run_does_not_mutate_db(tmp_path: Path):
             {
                 "id": "pre-a",
                 "content": "# PreCompact Checkpoint\\nsession",
-                "tags": "[\"precompact\"]",
+                "tags": '["precompact"]',
                 "chunk_origin": "precompact_checkpoint",
                 "project": "brainlayer",
                 "source": "mcp",
@@ -128,8 +128,7 @@ def test_dry_run_does_not_mutate_db(tmp_path: Path):
 
     with sqlite3.connect(db_path) as check:
         rows = {
-            row[0]: row[1:]
-            for row in check.execute("SELECT id, importance, archived, status, archived_at FROM chunks")
+            row[0]: row[1:] for row in check.execute("SELECT id, importance, archived, status, archived_at FROM chunks")
         }
     assert rows["rt-root"] == (8.0, 0, "active", None)
     assert rows["pre-a"] == (9.0, 0, "active", None)
@@ -144,7 +143,7 @@ def test_apply_updates_only_quarantine_fields_and_tag(tmp_path: Path):
             {
                 "id": "pre-valid",
                 "content": "normal [PreCompact checkpoint]\nnote",
-                "tags": "[\"keep-me\"]",
+                "tags": '["keep-me"]',
                 "chunk_origin": "precompact_checkpoint",
                 "project": "brainlayer",
                 "source": "mcp",

--- a/tests/test_quarantine_noise.py
+++ b/tests/test_quarantine_noise.py
@@ -1,0 +1,199 @@
+"""Tests for the noise-quarantine script."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from scripts.quarantine_noise import is_f_infra_root_content, is_precompact_candidate, run
+
+
+def test_infra_root_normalization():
+    """Root diagnostics are recognized when they appear at the content head."""
+    assert is_f_infra_root_content("BrainLayer MCP not connected right now.")
+    assert is_f_infra_root_content("🚨 **BrainLayer MCP NOT CONNECTED** I'll continue.")
+    assert is_f_infra_root_content("⚠️ BrainLayer MCP not connected — can't call tools.")
+    assert is_f_infra_root_content("Assistant: BrainLayer MCP is down.")
+    assert not is_f_infra_root_content("Some background; BrainLayer MCP not connected")
+
+
+def test_precompact_detection():
+    """PreCompact chunks are recognized by content and checkpoint tags."""
+    assert is_precompact_candidate("# PreCompact Checkpoint\nsession now.", None, None)
+    assert is_precompact_candidate("normal text", "precompact_checkpoint", '["tag:one"]')
+    assert is_precompact_candidate("normal text", None, '[\"precompact\", \"session\"]')
+    assert is_precompact_candidate("normal text", None, '[\"pre-compact\", \"session-checkpoint\"]')
+    assert is_precompact_candidate("normal text", None, None, "brainbar-c89abcd")
+    assert not is_precompact_candidate("normal text", None, '[\"precompact-hook\"]')
+    assert not is_precompact_candidate("normal text", None, '[\"session-checkpoint\"]')
+    assert not is_precompact_candidate("normal text", None, None)
+
+
+def _make_db(db_path: Path, rows: list[dict[str, object]]) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            tags TEXT,
+            chunk_origin TEXT,
+            project TEXT,
+            source TEXT,
+            source_file TEXT,
+            created_at TEXT,
+            importance REAL,
+            archived INTEGER,
+            status TEXT,
+            archived_at TEXT
+        )
+        """
+    )
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO chunks (
+                id, content, tags, chunk_origin, project, source, source_file,
+                created_at, importance, archived, status, archived_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row["id"],
+                row["content"],
+                row["tags"],
+                row["chunk_origin"],
+                row["project"],
+                row["source"],
+                row["source_file"],
+                row["created_at"],
+                row["importance"],
+                row["archived"],
+                row["status"],
+                row["archived_at"],
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_dry_run_does_not_mutate_db(tmp_path: Path):
+    """Dry-run mode reports candidates without writing fields."""
+    db_path = tmp_path / "dry.db"
+    _make_db(
+        db_path,
+        [
+            {
+                "id": "rt-root",
+                "content": "BrainLayer MCP not connected right now.",
+                "tags": None,
+                "chunk_origin": None,
+                "project": "brainlayer",
+                "source": "realtime",
+                "source_file": "a.jsonl",
+                "created_at": "2026-05-17T00:00:00Z",
+                "importance": 8.0,
+                "archived": 0,
+                "status": "active",
+                "archived_at": None,
+            },
+            {
+                "id": "pre-a",
+                "content": "# PreCompact Checkpoint\\nsession",
+                "tags": "[\"precompact\"]",
+                "chunk_origin": "precompact_checkpoint",
+                "project": "brainlayer",
+                "source": "mcp",
+                "source_file": "b.jsonl",
+                "created_at": "2026-05-17T00:01:00Z",
+                "importance": 9.0,
+                "archived": 0,
+                "status": "active",
+                "archived_at": None,
+            },
+        ],
+    )
+
+    out = StringIO()
+    with redirect_stdout(out):
+        code = run(["--db", str(db_path), "--json"])
+    assert code == 0
+    payload = json.loads(out.getvalue())
+    assert payload["mode"] == "dry_run"
+    assert payload["applied"] == 0
+    assert payload["summary"]["total"] == 2
+    assert set(row["id"] for row in payload["candidates"]) == {"rt-root", "pre-a"}
+
+    with sqlite3.connect(db_path) as check:
+        rows = {
+            row[0]: row[1:]
+            for row in check.execute("SELECT id, importance, archived, status, archived_at FROM chunks")
+        }
+    assert rows["rt-root"] == (8.0, 0, "active", None)
+    assert rows["pre-a"] == (9.0, 0, "active", None)
+
+
+def test_apply_updates_only_quarantine_fields_and_tag(tmp_path: Path):
+    """Apply mode sets archive lifecycle fields and keeps existing tags intact."""
+    db_path = tmp_path / "apply.db"
+    _make_db(
+        db_path,
+        [
+            {
+                "id": "pre-valid",
+                "content": "normal [PreCompact checkpoint]\nnote",
+                "tags": "[\"keep-me\"]",
+                "chunk_origin": "precompact_checkpoint",
+                "project": "brainlayer",
+                "source": "mcp",
+                "source_file": "b.jsonl",
+                "created_at": "2026-05-17T00:00:00Z",
+                "importance": 5.0,
+                "archived": 0,
+                "status": "active",
+                "archived_at": None,
+            },
+            {
+                "id": "rt-root",
+                "content": "BrainLayer MCP not connected right now.",
+                "tags": "not-json",
+                "chunk_origin": None,
+                "project": "brainlayer",
+                "source": "realtime",
+                "source_file": "a.jsonl",
+                "created_at": "2026-05-17T01:00:00Z",
+                "importance": 7.0,
+                "archived": 1,
+                "status": "archived",
+                "archived_at": "2026-01-01T00:00:00Z",
+            },
+        ],
+    )
+
+    out = StringIO()
+    with redirect_stdout(out):
+        code = run(["--db", str(db_path), "--apply"])
+    assert code == 0
+    assert "Tag updates applied" in out.getvalue()
+
+    with sqlite3.connect(db_path) as check:
+        row_a = check.execute(
+            "SELECT importance, archived, status, archived_at, tags FROM chunks WHERE id = 'pre-valid'"
+        ).fetchone()
+        row_b = check.execute(
+            "SELECT importance, archived, status, archived_at, tags FROM chunks WHERE id = 'rt-root'"
+        ).fetchone()
+
+    assert row_a[0] == 0
+    assert row_a[1] == 1
+    assert row_a[2] == "archived"
+    assert row_a[4] is not None
+    assert "quarantined/noise" in row_a[4]
+    assert "keep-me" in row_a[4]
+
+    assert row_b[0] == 0
+    assert row_b[1] == 1
+    assert row_b[2] == "archived"
+    assert row_b[4] == "not-json"


### PR DESCRIPTION
## Summary
- Reject BrainLayer MCP unavailable diagnostics at ingest head so boot/tooling failures do not become durable memory.
- Reject PreCompact checkpoint noise from watcher/drain ingestion while preserving explicit checkpoint APIs used by brain_resume.
- Add a dry-run-first quarantine script for existing F-infra and PreCompact candidates; live DB mutation requires explicit --apply and was not run.
- Demote pre-compact/quarantined chunks in hybrid reranking for default search, while preserving explicit include_checkpoints behavior.

## Safety
- `scripts/quarantine_noise.py` defaults to read-only dry-run.
- No live DB quarantine was applied.
- Existing .gemini/ and .worktrees/ untracked files were left untouched.

## Test Plan
- `ruff check src/brainlayer/ingest_guard.py src/brainlayer/drain.py src/brainlayer/watcher_bridge.py src/brainlayer/search_repo.py scripts/quarantine_noise.py tests/test_ingest_guard.py tests/test_hybrid_search.py tests/test_quarantine_noise.py tests/test_precompact_chunk_origin.py`
- `pytest -q tests/test_ingest_guard.py tests/test_quarantine_noise.py tests/test_hybrid_search.py tests/test_precompact_chunk_origin.py tests/test_hybrid_search_decay.py tests/test_audit_search_quality.py tests/test_search_exact_chunk_id.py`
- Pre-push gate: `1995 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration 3 passed; isolated eval/hook routing 32 passed; Bun suite 1 passed; regression shell `test_fts5_determinism.sh` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingestion filtering across watcher/drain/store paths and adjusts hybrid search reranking, which can affect what content is stored and what results surface. Also introduces an optional DB-mutating quarantine script (guarded by `--apply`) that could archive data if misused.
> 
> **Overview**
> Prevents two new classes of “noise” from becoming durable memory by extending `recursive_mcp_output_reason` to detect BrainLayer MCP unavailability diagnostics and (optionally) PreCompact checkpoint content, and updating watcher/drain ingestion paths to reject them.
> 
> Adds a new `scripts/quarantine_noise.py` tool to scan for existing infra/PreCompact candidates and, when explicitly run with `--apply`, archive them and append a `quarantined/noise` tag.
> 
> Updates `hybrid_search` reranking to *demote* (not remove) results with precompact/quarantine signals (via tags/metadata/content), while preserving `include_checkpoints` behavior; tests are expanded/adjusted to cover the new guards and demotion logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a208b46cd02f12b2e9d8dd0c89300fa06f1e979c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject precompact checkpoint and F-infra diagnostic noise during ingest and demote in reranker
> - Extends `recursive_mcp_output_reason` in [ingest_guard.py](https://github.com/EtanHey/brainlayer/pull/289/files#diff-ba85783a8c497e844d2d51a0847749c025b3fe9ed22f6277f0aaae82cb0127ef) to detect F-infra MCP unavailable diagnostics and precompact checkpoint content, causing them to be rejected at ingest time across drain, watcher bridge, and store handlers.
> - Adds score demotion in `SearchMixin.hybrid_search` in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/289/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) for chunks with precompact or quarantine signals in metadata/tags, keeping them discoverable but deprioritized.
> - Adds [scripts/quarantine_noise.py](https://github.com/EtanHey/brainlayer/pull/289/files#diff-797ee6eabdbe8e279d79d8fc60d3809b6aca54c9badb4b50f86aab96b5b211b7), a CLI tool to dry-run or apply quarantine on existing noise chunks in the BrainLayer SQLite DB, updating archived fields and appending a `quarantined/noise` tag.
> - Behavioral Change: chunks previously stored with `chunk_origin=precompact_checkpoint` are now rejected at ingest; existing tests updated to reflect `chunk_origin=None` for these rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a208b46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->