### PR TITLE
fix: persist digest LLM entities

### DIFF
--- a/src/brainlayer/pipeline/batch_extraction.py
+++ b/src/brainlayer/pipeline/batch_extraction.py
@@ -84,7 +84,7 @@ def process_chunk(
         text,
         seed_entities,
         llm_caller=llm_caller,
-        use_llm=llm_caller is not None,
+        use_llm=True,
     )
     result.chunk_id = chunk_id
 

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -128,6 +128,45 @@ def test_digest_content_extracts_entities(tmp_path):
     assert any("Etan" in n for n in entity_names) or any("Dor" in n for n in entity_names)
 
 
+def test_digest_content_persists_llm_people_entities_for_lookup(tmp_path, monkeypatch):
+    """brain_digest persists LLM-extracted people so brain_entity can find them."""
+    from brainlayer.pipeline.digest import digest_content, entity_lookup
+
+    def fake_extraction(prompt):  # noqa: ARG001
+        return """
+        {
+          "entities": [
+            {"text": "Katya Taershmidt", "type": "person", "description": "Operations lead"},
+            {"text": "Rotem Maimon", "type": "person", "description": "Product strategist"},
+            {"text": "Israel Davidson", "type": "person", "description": "Engineering advisor"}
+          ],
+          "relations": []
+        }
+        """
+
+    monkeypatch.setattr("brainlayer.enrichment_controller.call_gemini_for_extraction", fake_extraction)
+
+    store = VectorStore(tmp_path / "test.db")
+    content = (
+        "PEOPLE-ROLES: Katya Taershmidt owns operations, Rotem Maimon handles product strategy, "
+        "and Israel Davidson advises engineering."
+    )
+
+    result = digest_content(
+        content=content,
+        store=store,
+        embed_fn=_dummy_embed,
+        project="kg-regression",
+        faceted_enrich_fn=lambda **kw: {"status": "skipped"},
+    )
+
+    assert result["stats"]["entities_found"] >= 3
+    found = entity_lookup("Katya Taershmidt", store, _dummy_embed, entity_type="person")
+    assert found is not None
+    assert found["name"] == "Katya Taershmidt"
+    assert found["evidence"]
+
+
 def test_digest_content_applies_sentiment(tmp_path):
     """digest_content includes sentiment analysis."""
     from brainlayer.pipeline.digest import digest_content


### PR DESCRIPTION
## Summary
- Re-enable LLM entity extraction in the `brain_digest` batch extraction wrapper.
- Add a regression test that digests PEOPLE-ROLES-style content and verifies `entity_lookup` can find a newly extracted person with evidence.

## Root Cause
`src/brainlayer/pipeline/batch_extraction.py:87` passed `use_llm=llm_caller is not None` into `extract_entities_combined()`. The normal MCP/CLI `brain_digest` path does not pass an explicit test `llm_caller`, so default Gemini extraction was silently disabled and non-seed people were never materialized into `kg_entities` / `kg_entity_chunks`.

## Test Plan
- RED first: `pytest -q tests/test_phase3_digest.py::test_digest_content_persists_llm_people_entities_for_lookup` failed with `entities_found == 0` before the fix.
- `pytest -q tests/test_phase3_digest.py::test_digest_content_persists_llm_people_entities_for_lookup`
- `GOOGLE_API_KEY= GEMINI_API_KEY= pytest -q tests/test_phase3_digest.py tests/test_digest_pipeline_v2.py tests/test_mcp_digest_modes.py tests/test_kg_extraction.py tests/test_kg_rebuild.py tests/test_kg_relations.py tests/test_entity_extraction.py tests/test_entity_contracts.py tests/test_daemon_kg` -> 185 passed, 6 skipped.
- Pre-push test gate passed: 1980 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 32 passed; bun 1 passed; FTS5 determinism shell passed.

## Notes
A system-Python full `pytest -q` outside the repo venv failed during collection due unrelated local dependency state: missing `deepchecks`, plus `numba` rejecting NumPy 2.4 through `ranx`. The repo pre-push gate uses `.venv` and passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes digest/batch extraction behavior to always run LLM-based entity extraction, which can increase external LLM calls/cost and introduce new failure modes if credentials/rate limits are misconfigured.
> 
> **Overview**
> Fixes `brain_digest` entity persistence by forcing `process_chunk` to call `extract_entities_combined(..., use_llm=True)` even when no explicit `llm_caller` is passed.
> 
> Adds a regression test that stubs Gemini extraction, digests PEOPLE-ROLES content, and asserts newly LLM-extracted `person` entities are stored with evidence and retrievable via `entity_lookup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b61cb1bc71d5a8fc6a0860a44870b5c9ecbdabe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `process_chunk` to persist LLM-extracted entities during digest
> Sets `use_llm=True` unconditionally in [`process_chunk`](https://github.com/EtanHey/brainlayer/pull/290/files#diff-30a10d7cce0a8a4e5335e0b9668779170a089b8696671f1602c78d848a1d6dc8) when calling `extract_entities_combined`, fixing a bug where LLM-extracted entities were not persisted during digest. Previously, `use_llm` was only set when `llm_caller` was not `None`, but the condition did not work as intended. A new test verifies that `digest_content` persists `person` entities from LLM extraction so they are retrievable via `entity_lookup`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b61cb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Entity extraction has been significantly enhanced to consistently utilize advanced processing capabilities, providing improved accuracy and reliability in identifying relevant entities across all projects and datasets. Extracted entities are now reliably persisted and remain accessible for subsequent lookup and reference operations, delivering better overall quality in entity recognition and more robust knowledge graph management functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->