### PR TITLE
docs: add 2026-05-17 phase-5 ship wave to Recent Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Requires the BrainLayer MCP server. The build script refuses non-canonical check
 
 Background producers run with `BRAINLAYER_ARBITRATED=1` and append writes to `~/.brainlayer/queue/`; `com.brainlayer.drain.plist` drains that queue every 500ms as the single writer. Trigram FTS maintenance is explicit via `brainlayer repair-fts` and the weekly `com.brainlayer.repair-fts.plist`, not synchronous startup work. See [docs/arbitration.md](docs/arbitration.md).
 
-## Recent Hardening (2026-04-15 → 2026-05-02)
+## Recent Hardening (2026-04-15 → 2026-05-17)
 
 Two-week stability sprint behind the next presentation. Every line below traces to a merged PR.
 
@@ -186,7 +186,10 @@ Two-week stability sprint behind the next presentation. Every line below traces 
 - KG atlas presentation (importance-based altitude filtering, region backdrops, deterministic seeding) and `AgentActivityMonitor` for live CLI presence on the dashboard.
 - Pub/sub plane on `/tmp/brainbar.sock` is explicitly preserved (`brain_subscribe`, `brain_unsubscribe`, `notifications/claude/channel`) — only search/store handlers move to the Python MCP path.
 
-
+**Phase 5 ship wave (2026-05-17)** — ingest hygiene + KG regression fix
+- **Diagnostic + PreCompact noise rejection at ingest** ([#289](https://github.com/EtanHey/brainlayer/pull/289)) — `recursive_mcp_output_reason` now detects BrainLayer-MCP-unavailable diagnostics and PreCompact checkpoint payloads, rejecting them at the watcher / drain / store ingestion heads so tooling failures do not become durable memory. The hybrid reranker *demotes* (not removes) any chunk tagged with precompact/quarantine signals so explicit `include_checkpoints` callers still see them. Pre-push gate: `1995 passed, 9 skipped, 75 deselected, 1 xfailed`. A dry-run-first `scripts/quarantine_noise.py` is available for back-filling existing infra noise — live DB mutation requires explicit `--apply`.
+- **Persist digest LLM entities** ([#290](https://github.com/EtanHey/brainlayer/pull/290)) — fixes a KG persistence regression where `brain_digest` silently skipped Gemini entity extraction because `process_chunk` passed `use_llm=llm_caller is not None` and the MCP/CLI path never sets `llm_caller`. Non-seed person entities were never materialized into `kg_entities` / `kg_entity_chunks`. The 2026-04-06 entity-recall recurrence root-caused to this code path. RED-first regression test (`test_digest_content_persists_llm_people_entities_for_lookup`) now guards the fix.
+- **Enrichment LaunchAgent recovered** — `com.brainlayer.enrichment` was silently unloaded since 2026-05-15 11:50 IDT (no entity extraction running). Bootstrapped back on 2026-05-17 against the 56K-chunk backfill; throttled by Gemini 503s on flex tier but actively draining (verified via `launchctl list | grep enrichment` returning a live PID).
 
 ## Data Sources
 


### PR DESCRIPTION
## Summary

Extends the Recent Hardening window from 2026-05-02 to 2026-05-17 and adds a "Phase 5 ship wave (2026-05-17)" subsection to the README covering this week's two ingest/KG merges and the enrichment LaunchAgent recovery.

### Changes
- `README.md` (+5 / −2) — section-header date range bump + new bullet group.

### What gets called out

- **PR #289 — reject MCP-unavailable diagnostics + PreCompact checkpoint noise at the watcher / drain / store ingest heads.** Hybrid reranker now *demotes* (not removes) any chunk with precompact/quarantine signals so explicit `include_checkpoints` callers still see them. Pre-push gate at merge time: `1995 passed, 9 skipped, 75 deselected, 1 xfailed`. Optional `scripts/quarantine_noise.py` is dry-run-by-default; live DB mutation requires explicit `--apply`.
- **PR #290 — fix KG persistence regression** in `process_chunk` where `use_llm=llm_caller is not None` silently disabled Gemini entity extraction on the MCP/CLI digest path. Non-seed person entities were never materialized into `kg_entities`. This was the second recurrence of the same 2026-04-06 root cause; new RED-first regression test (`test_digest_content_persists_llm_people_entities_for_lookup`) now guards it.
- **Enrichment LaunchAgent recovered** — `com.brainlayer.enrichment` was silently unloaded since 2026-05-15 11:50 IDT (no entity extraction running). Bootstrapped back on 2026-05-17 against the 56K-chunk backfill; throttled by Gemini 503s on flex tier but actively draining (verified via `launchctl list | grep enrichment` returning a live PID).

### Test plan

- [x] Docs-only change; no Python / Swift code affected.
- [x] Pre-push test gate ran on push (the full \`scripts/run_tests.sh\` regression suite must pass before any push to \`main\`-tracking branches).
- [x] Every PR number cited resolves to a merged PR on `EtanHey/brainlayer`.

### Companion docs PRs in the same maintenance wave
- golems #413 — "Recent skill updates" section in golems/README + docsite
- etanheyman.com #100 — May-17 narrative in journey.md + skills page (already merged 2026-05-18)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: README-only documentation updates with no runtime/code changes.
> 
> **Overview**
> Extends the `Recent Hardening` date range in `README.md` to `2026-05-17` and adds a new **Phase 5 ship wave (2026-05-17)** subsection.
> 
> The new subsection documents recent ingest noise rejection work, a KG entity persistence regression fix, and recovery of the enrichment LaunchAgent, with links to the merged PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 890d8b9cdbd07f80166d08607ff95e446ff7cf2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Phase 5 ship wave (2026-05-17) entry to Recent Hardening docs
> Updates [README.md](https://github.com/EtanHey/brainlayer/pull/291/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to extend the Recent Hardening date range to 2026-05-17 and adds a new Phase 5 section covering three items: diagnostic/PreCompact noise rejection at ingest, a fix for persisting digest LLM entities, and recovery of the enrichment LaunchAgent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 890d8b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->