### PR TITLE
Promote raw entities into KG aliases

### DIFF
--- a/scripts/backfill_kg_promotion.py
+++ b/scripts/backfill_kg_promotion.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Backfill KG identities from chunks.raw_entities_json."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from brainlayer.kg_promotion import main  # noqa: I001
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -594,6 +594,14 @@ def _apply_enrichment(store, chunk: dict[str, Any], enrichment: dict[str, Any]) 
             "UPDATE chunks SET raw_entities_json = ? WHERE id = ?",
             (json.dumps(entities), chunk["id"]),
         )
+        try:
+            from .kg_promotion import promote_chunk_raw_entities
+            from .vector_store import VectorStore
+
+            if isinstance(store, VectorStore):
+                promote_chunk_raw_entities(store, chunk["id"])
+        except Exception:
+            logger.debug("raw entity KG promotion skipped for %s", chunk["id"], exc_info=True)
     # Set content_hash after enrichment so dedup works next time
     content = chunk.get("content", "")
     if content:

--- a/src/brainlayer/kg_promotion.py
+++ b/src/brainlayer/kg_promotion.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sqlite3
+import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from .vector_store import VectorStore
 
@@ -19,7 +22,8 @@ class _ReadOnlyPromotionStore:
     """Small read-only adapter for dry-runs against a live BrainLayer DB."""
 
     def __init__(self, db_path: Path):
-        self.conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        db_uri_path = quote(str(db_path), safe="/:")
+        self.conn = sqlite3.connect(f"file:{db_uri_path}?mode=ro", uri=True)
 
     def _read_cursor(self) -> sqlite3.Cursor:
         return self.conn.cursor()
@@ -47,6 +51,13 @@ class PromotionCandidate:
 
 def _slugify(value: str) -> str:
     return _SLUG_TOKEN_RE.sub("-", value.casefold()).strip("-")
+
+
+def _entity_slug(value: str) -> str:
+    slug = _slugify(value)
+    if slug:
+        return slug
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()[:16]
 
 
 def _canonical_from_identity_tag(tag: str) -> str:
@@ -167,16 +178,18 @@ def _collect_candidates(rows: list[dict[str, Any]], entity_type: str) -> list[Pr
             raw_surface_entries.append((chunk_id, surface))
 
         for tag in identity_tags:
+            canonical_name = _canonical_from_identity_tag(tag)
+            matching_surfaces = {surface for surface in surfaces if _surface_matches_identity(canonical_name, surface)}
             candidate = by_identity_tag.setdefault(
                 tag,
                 PromotionCandidate(
-                    canonical_name=_canonical_from_identity_tag(tag),
+                    canonical_name=canonical_name,
                     entity_type=entity_type,
                     reason="identity_tag",
                 ),
             )
             candidate.chunk_ids.add(chunk_id)
-            candidate.surfaces.update(surfaces)
+            candidate.surfaces.update(matching_surfaces)
             candidate.identity_tags.add(tag)
 
         if not raw_entities:
@@ -219,18 +232,43 @@ def _surface_matches_identity(canonical_name: str, surface: str) -> bool:
         return False
     normalized_surface = _SLUG_TOKEN_RE.sub("", surface_folded).replace("h", "")
     normalized_family = _SLUG_TOKEN_RE.sub("", family).replace("h", "")
-    return normalized_family in normalized_surface or len(surface.split()) == 1
+    return normalized_family in normalized_surface
+
+
+def _empty_stats(chunks_scanned: int = 0) -> dict[str, int]:
+    return {
+        "chunks_scanned": chunks_scanned,
+        "candidates": 0,
+        "entities_promoted": 0,
+        "aliases_created": 0,
+        "chunks_linked": 0,
+    }
+
+
+def _retry_busy(fn, *, attempts: int = 5, base_delay: float = 0.05) -> dict[str, int]:
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except Exception as exc:
+            message = str(exc).casefold()
+            if "busy" not in message and "locked" not in message:
+                raise
+            if attempt == attempts - 1:
+                raise
+            time.sleep(base_delay * (2**attempt))
+    raise RuntimeError("unreachable busy retry state")
 
 
 def _promote_candidate(store: VectorStore, candidate: PromotionCandidate, *, dry_run: bool = False) -> dict[str, int]:
     stats = {"entities_promoted": 0, "aliases_created": 0, "chunks_linked": 0}
     if dry_run:
+        aliases = {surface for surface in candidate.surfaces if surface != candidate.canonical_name}
         stats["entities_promoted"] = 1
-        stats["aliases_created"] = len(candidate.surfaces | candidate.identity_tags)
+        stats["aliases_created"] = len(aliases | candidate.identity_tags)
         stats["chunks_linked"] = len(candidate.chunk_ids)
         return stats
 
-    entity_id = f"promoted-{candidate.entity_type}-{_slugify(candidate.canonical_name)}"
+    entity_id = f"promoted-{candidate.entity_type}-{_entity_slug(candidate.canonical_name)}"
     existing = store.get_entity_by_name(candidate.entity_type, candidate.canonical_name)
     if existing:
         entity_id = existing["id"]
@@ -240,7 +278,7 @@ def _promote_candidate(store: VectorStore, candidate: PromotionCandidate, *, dry
             candidate.entity_type,
             candidate.canonical_name,
             metadata={"source": "raw_entities_json_promotion", "reason": candidate.reason},
-            canonical_name=_slugify(candidate.canonical_name).replace("-", "_"),
+            canonical_name=_entity_slug(candidate.canonical_name).replace("-", "_"),
             confidence=0.9,
             importance=0.7,
         )
@@ -292,7 +330,7 @@ def promote_raw_entity_identities(
         "chunks_linked": 0,
     }
     for candidate in candidates:
-        stats = _promote_candidate(store, candidate, dry_run=dry_run)
+        stats = _retry_busy(lambda candidate=candidate: _promote_candidate(store, candidate, dry_run=dry_run))
         for key in ("entities_promoted", "aliases_created", "chunks_linked"):
             totals[key] += stats[key]
     return totals
@@ -309,17 +347,11 @@ def promote_chunk_raw_entities(
     cursor = store._read_cursor()
     row = cursor.execute("SELECT tags FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
     if row is None:
-        return {
-            "chunks_scanned": 0,
-            "candidates": 0,
-            "entities_promoted": 0,
-            "aliases_created": 0,
-            "chunks_linked": 0,
-        }
+        return _empty_stats()
 
     identity_tags = [tag for tag in _load_tags(row[0]) if _IDENTITY_TAG_RE.fullmatch(tag)]
     if not identity_tags:
-        return promote_raw_entity_identities(store, entity_type=entity_type, limit=500, dry_run=dry_run)
+        return _empty_stats(chunks_scanned=1)
 
     placeholders = ", ".join("?" for _ in identity_tags)
     rows = list(
@@ -327,16 +359,29 @@ def promote_chunk_raw_entities(
             f"""
             SELECT c.id, c.raw_entities_json, c.tags
             FROM chunks c
-            JOIN chunk_tags ct ON c.id = ct.chunk_id
-            WHERE ct.tag IN ({placeholders})
+            WHERE (
+                c.id IN (
+                    SELECT chunk_id FROM chunk_tags WHERE tag IN ({placeholders})
+                )
+                OR (c.raw_entities_json IS NOT NULL AND c.raw_entities_json != '')
+            )
+              AND COALESCE(c.status, 'active') = 'active'
+              AND c.superseded_by IS NULL
+              AND c.aggregated_into IS NULL
+              AND c.archived_at IS NULL
             """,
             identity_tags,
         )
     )
-    candidates = _collect_candidates(
-        [{"chunk_id": item[0], "raw_entities_json": item[1], "tags": item[2]} for item in rows],
-        entity_type=entity_type,
-    )
+    identity_tag_set = set(identity_tags)
+    candidates = [
+        candidate
+        for candidate in _collect_candidates(
+            [{"chunk_id": item[0], "raw_entities_json": item[1], "tags": item[2]} for item in rows],
+            entity_type=entity_type,
+        )
+        if candidate.reason == "identity_tag" and candidate.identity_tags & identity_tag_set
+    ]
     totals = {
         "chunks_scanned": len(rows),
         "candidates": len(candidates),
@@ -345,7 +390,7 @@ def promote_chunk_raw_entities(
         "chunks_linked": 0,
     }
     for candidate in candidates:
-        stats = _promote_candidate(store, candidate, dry_run=dry_run)
+        stats = _retry_busy(lambda candidate=candidate: _promote_candidate(store, candidate, dry_run=dry_run))
         for key in ("entities_promoted", "aliases_created", "chunks_linked"):
             totals[key] += stats[key]
     return totals

--- a/src/brainlayer/kg_promotion.py
+++ b/src/brainlayer/kg_promotion.py
@@ -27,6 +27,7 @@ class _ReadOnlyPromotionStore:
     def close(self) -> None:
         self.conn.close()
 
+
 _IDENTITY_TAG_RE = re.compile(r"^[a-z][a-z0-9-]+-[a-z][a-z0-9-]+-identification$")
 _SLUG_TOKEN_RE = re.compile(r"[^a-z0-9]+")
 _KNOWN_GIVEN_NAME_ALIASES = {
@@ -245,17 +246,13 @@ def _promote_candidate(store: VectorStore, candidate: PromotionCandidate, *, dry
         )
         stats["entities_promoted"] = 1
 
-    before_aliases = {
-        (row["alias"].casefold(), row["alias_type"]) for row in store.get_entity_aliases(entity_id)
-    }
+    before_aliases = {(row["alias"].casefold(), row["alias_type"]) for row in store.get_entity_aliases(entity_id)}
     for surface in sorted(candidate.surfaces):
         if surface != candidate.canonical_name:
             store.add_entity_alias(surface, entity_id, alias_type="raw_surface")
     for tag in sorted(candidate.identity_tags):
         store.add_entity_alias(tag, entity_id, alias_type="identity_tag")
-    after_aliases = {
-        (row["alias"].casefold(), row["alias_type"]) for row in store.get_entity_aliases(entity_id)
-    }
+    after_aliases = {(row["alias"].casefold(), row["alias_type"]) for row in store.get_entity_aliases(entity_id)}
     stats["aliases_created"] = len(after_aliases - before_aliases)
 
     cursor = store.conn.cursor()
@@ -360,7 +357,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Backfill KG promotion from chunks.raw_entities_json")
     parser.add_argument("--db-path", type=Path, default=get_db_path())
     parser.add_argument("--limit", type=int, default=None)
-    parser.add_argument("--dry-run", action="store_true", help="Preview promotions without writing. This is the default.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Preview promotions without writing. This is the default."
+    )
     parser.add_argument("--apply", action="store_true", help="Write promotions. Default is dry-run.")
     args = parser.parse_args()
 

--- a/src/brainlayer/kg_promotion.py
+++ b/src/brainlayer/kg_promotion.py
@@ -1,0 +1,379 @@
+"""Deterministic KG promotion from staged raw entity enrichment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .vector_store import VectorStore
+
+
+class _ReadOnlyPromotionStore:
+    """Small read-only adapter for dry-runs against a live BrainLayer DB."""
+
+    def __init__(self, db_path: Path):
+        self.conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+
+    def _read_cursor(self) -> sqlite3.Cursor:
+        return self.conn.cursor()
+
+    def close(self) -> None:
+        self.conn.close()
+
+_IDENTITY_TAG_RE = re.compile(r"^[a-z][a-z0-9-]+-[a-z][a-z0-9-]+-identification$")
+_SLUG_TOKEN_RE = re.compile(r"[^a-z0-9]+")
+_KNOWN_GIVEN_NAME_ALIASES = {
+    "michal": {"מיכל"},
+}
+
+
+@dataclass
+class PromotionCandidate:
+    canonical_name: str
+    entity_type: str
+    reason: str
+    chunk_ids: set[str] = field(default_factory=set)
+    surfaces: set[str] = field(default_factory=set)
+    identity_tags: set[str] = field(default_factory=set)
+
+
+def _slugify(value: str) -> str:
+    return _SLUG_TOKEN_RE.sub("-", value.casefold()).strip("-")
+
+
+def _canonical_from_identity_tag(tag: str) -> str:
+    base = tag[: -len("-identification")]
+    return " ".join(part.capitalize() for part in base.split("-") if part)
+
+
+def _load_raw_entities(raw_json: Any) -> list[dict[str, Any]]:
+    if not raw_json:
+        return []
+    if isinstance(raw_json, list):
+        decoded = raw_json
+    else:
+        try:
+            decoded = json.loads(raw_json)
+        except (json.JSONDecodeError, TypeError):
+            return []
+    if not isinstance(decoded, list):
+        return []
+    return [item for item in decoded if isinstance(item, dict)]
+
+
+def _load_tags(tags_json: Any) -> list[str]:
+    if not tags_json:
+        return []
+    if isinstance(tags_json, list):
+        decoded = tags_json
+    else:
+        try:
+            decoded = json.loads(tags_json)
+        except (json.JSONDecodeError, TypeError):
+            decoded = [tags_json]
+    if not isinstance(decoded, list):
+        return []
+    return [str(tag).strip() for tag in decoded if str(tag).strip()]
+
+
+def _raw_entity_name(entity: dict[str, Any]) -> str:
+    name = entity.get("name") or entity.get("text")
+    return str(name).strip() if name else ""
+
+
+def _raw_entity_type(entity: dict[str, Any]) -> str:
+    entity_type = entity.get("type") or entity.get("entity_type")
+    return str(entity_type).strip().casefold() if entity_type else ""
+
+
+def _valid_surface(surface: str) -> bool:
+    if not surface:
+        return False
+    folded = surface.casefold()
+    if "person_" in folded or "[person" in folded:
+        return False
+    return True
+
+
+def _select_canonical_surface(surfaces: set[str]) -> str:
+    latin = [surface for surface in surfaces if surface and surface.isascii() and " " in surface]
+    if latin:
+        return max(latin, key=lambda value: (len(value), value))
+    spaced = [surface for surface in surfaces if " " in surface]
+    if spaced:
+        return max(spaced, key=lambda value: (len(value), value))
+    return max(surfaces, key=lambda value: (len(value), value))
+
+
+def _matching_rows(store: Any, limit: int | None = None) -> list[dict[str, Any]]:
+    cursor = store._read_cursor()
+    params: list[Any] = []
+    limit_sql = ""
+    if limit is not None:
+        limit_sql = " LIMIT ?"
+        params.append(int(limit))
+
+    rows = list(
+        cursor.execute(
+            f"""
+            SELECT c.id, c.raw_entities_json, c.tags
+            FROM chunks c
+            WHERE (
+                (c.raw_entities_json IS NOT NULL AND c.raw_entities_json != '')
+                OR c.id IN (
+                    SELECT chunk_id FROM chunk_tags WHERE tag GLOB '*-identification'
+                )
+            )
+              AND COALESCE(c.status, 'active') = 'active'
+              AND c.superseded_by IS NULL
+              AND c.aggregated_into IS NULL
+              AND c.archived_at IS NULL
+            ORDER BY c.created_at DESC, c.id
+            {limit_sql}
+            """,
+            params,
+        )
+    )
+    return [{"chunk_id": row[0], "raw_entities_json": row[1], "tags": row[2]} for row in rows]
+
+
+def _collect_candidates(rows: list[dict[str, Any]], entity_type: str) -> list[PromotionCandidate]:
+    by_identity_tag: dict[str, PromotionCandidate] = {}
+    by_surface_key: dict[str, PromotionCandidate] = defaultdict(
+        lambda: PromotionCandidate(canonical_name="", entity_type=entity_type, reason="stable_raw_entity")
+    )
+    raw_surface_entries: list[tuple[str, str]] = []
+
+    for row in rows:
+        chunk_id = row["chunk_id"]
+        tags = _load_tags(row.get("tags"))
+        identity_tags = [tag for tag in tags if _IDENTITY_TAG_RE.fullmatch(tag)]
+        raw_entities = [
+            entity
+            for entity in _load_raw_entities(row.get("raw_entities_json"))
+            if _raw_entity_type(entity) == entity_type
+        ]
+
+        surfaces = {surface for entity in raw_entities if _valid_surface(surface := _raw_entity_name(entity))}
+        for surface in surfaces:
+            raw_surface_entries.append((chunk_id, surface))
+
+        for tag in identity_tags:
+            candidate = by_identity_tag.setdefault(
+                tag,
+                PromotionCandidate(
+                    canonical_name=_canonical_from_identity_tag(tag),
+                    entity_type=entity_type,
+                    reason="identity_tag",
+                ),
+            )
+            candidate.chunk_ids.add(chunk_id)
+            candidate.surfaces.update(surfaces)
+            candidate.identity_tags.add(tag)
+
+        if not raw_entities:
+            continue
+
+        for surface in surfaces:
+            key = f"{entity_type}:{surface.casefold()}"
+            candidate = by_surface_key[key]
+            candidate.chunk_ids.add(chunk_id)
+            candidate.surfaces.add(surface)
+
+    candidates: list[PromotionCandidate] = []
+    for candidate in by_identity_tag.values():
+        for chunk_id, surface in raw_surface_entries:
+            if _surface_matches_identity(candidate.canonical_name, surface):
+                candidate.chunk_ids.add(chunk_id)
+                candidate.surfaces.add(surface)
+        if len(candidate.chunk_ids) >= 2:
+            candidate.surfaces.add(candidate.canonical_name)
+            candidates.append(candidate)
+
+    for candidate in by_surface_key.values():
+        if len(candidate.chunk_ids) >= 3 and candidate.surfaces:
+            candidate.canonical_name = _select_canonical_surface(candidate.surfaces)
+            candidates.append(candidate)
+
+    return candidates
+
+
+def _surface_matches_identity(canonical_name: str, surface: str) -> bool:
+    canonical_parts = [part.casefold() for part in canonical_name.split() if part]
+    if len(canonical_parts) < 2:
+        return False
+    surface_folded = surface.casefold()
+    given = canonical_parts[0]
+    family = canonical_parts[-1]
+    if surface_folded in _KNOWN_GIVEN_NAME_ALIASES.get(given, set()):
+        return True
+    if given not in surface_folded:
+        return False
+    normalized_surface = _SLUG_TOKEN_RE.sub("", surface_folded).replace("h", "")
+    normalized_family = _SLUG_TOKEN_RE.sub("", family).replace("h", "")
+    return normalized_family in normalized_surface or len(surface.split()) == 1
+
+
+def _promote_candidate(store: VectorStore, candidate: PromotionCandidate, *, dry_run: bool = False) -> dict[str, int]:
+    stats = {"entities_promoted": 0, "aliases_created": 0, "chunks_linked": 0}
+    if dry_run:
+        stats["entities_promoted"] = 1
+        stats["aliases_created"] = len(candidate.surfaces | candidate.identity_tags)
+        stats["chunks_linked"] = len(candidate.chunk_ids)
+        return stats
+
+    entity_id = f"promoted-{candidate.entity_type}-{_slugify(candidate.canonical_name)}"
+    existing = store.get_entity_by_name(candidate.entity_type, candidate.canonical_name)
+    if existing:
+        entity_id = existing["id"]
+    else:
+        entity_id = store.upsert_entity(
+            entity_id,
+            candidate.entity_type,
+            candidate.canonical_name,
+            metadata={"source": "raw_entities_json_promotion", "reason": candidate.reason},
+            canonical_name=_slugify(candidate.canonical_name).replace("-", "_"),
+            confidence=0.9,
+            importance=0.7,
+        )
+        stats["entities_promoted"] = 1
+
+    before_aliases = {
+        (row["alias"].casefold(), row["alias_type"]) for row in store.get_entity_aliases(entity_id)
+    }
+    for surface in sorted(candidate.surfaces):
+        if surface != candidate.canonical_name:
+            store.add_entity_alias(surface, entity_id, alias_type="raw_surface")
+    for tag in sorted(candidate.identity_tags):
+        store.add_entity_alias(tag, entity_id, alias_type="identity_tag")
+    after_aliases = {
+        (row["alias"].casefold(), row["alias_type"]) for row in store.get_entity_aliases(entity_id)
+    }
+    stats["aliases_created"] = len(after_aliases - before_aliases)
+
+    cursor = store.conn.cursor()
+    for chunk_id in sorted(candidate.chunk_ids):
+        before = cursor.execute(
+            "SELECT 1 FROM kg_entity_chunks WHERE entity_id = ? AND chunk_id = ?",
+            (entity_id, chunk_id),
+        ).fetchone()
+        store.link_entity_chunk(
+            entity_id=entity_id,
+            chunk_id=chunk_id,
+            relevance=0.95 if candidate.reason == "identity_tag" else 0.8,
+            context=f"raw_entities_json promotion: {candidate.reason}",
+            mention_type="explicit" if candidate.reason == "identity_tag" else "inferred",
+        )
+        if before is None:
+            stats["chunks_linked"] += 1
+
+    return stats
+
+
+def promote_raw_entity_identities(
+    store: VectorStore,
+    *,
+    entity_type: str = "person",
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Promote high-signal staged raw entities into canonical KG identities."""
+    rows = _matching_rows(store, limit=limit)
+    candidates = _collect_candidates(rows, entity_type=entity_type)
+    totals = {
+        "chunks_scanned": len(rows),
+        "candidates": len(candidates),
+        "entities_promoted": 0,
+        "aliases_created": 0,
+        "chunks_linked": 0,
+    }
+    for candidate in candidates:
+        stats = _promote_candidate(store, candidate, dry_run=dry_run)
+        for key in ("entities_promoted", "aliases_created", "chunks_linked"):
+            totals[key] += stats[key]
+    return totals
+
+
+def promote_chunk_raw_entities(
+    store: VectorStore,
+    chunk_id: str,
+    *,
+    entity_type: str = "person",
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Promote identities relevant to one chunk after realtime enrichment."""
+    cursor = store._read_cursor()
+    row = cursor.execute("SELECT tags FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+    if row is None:
+        return {
+            "chunks_scanned": 0,
+            "candidates": 0,
+            "entities_promoted": 0,
+            "aliases_created": 0,
+            "chunks_linked": 0,
+        }
+
+    identity_tags = [tag for tag in _load_tags(row[0]) if _IDENTITY_TAG_RE.fullmatch(tag)]
+    if not identity_tags:
+        return promote_raw_entity_identities(store, entity_type=entity_type, limit=500, dry_run=dry_run)
+
+    placeholders = ", ".join("?" for _ in identity_tags)
+    rows = list(
+        cursor.execute(
+            f"""
+            SELECT c.id, c.raw_entities_json, c.tags
+            FROM chunks c
+            JOIN chunk_tags ct ON c.id = ct.chunk_id
+            WHERE ct.tag IN ({placeholders})
+            """,
+            identity_tags,
+        )
+    )
+    candidates = _collect_candidates(
+        [{"chunk_id": item[0], "raw_entities_json": item[1], "tags": item[2]} for item in rows],
+        entity_type=entity_type,
+    )
+    totals = {
+        "chunks_scanned": len(rows),
+        "candidates": len(candidates),
+        "entities_promoted": 0,
+        "aliases_created": 0,
+        "chunks_linked": 0,
+    }
+    for candidate in candidates:
+        stats = _promote_candidate(store, candidate, dry_run=dry_run)
+        for key in ("entities_promoted", "aliases_created", "chunks_linked"):
+            totals[key] += stats[key]
+    return totals
+
+
+def main() -> None:
+    from .paths import get_db_path
+
+    parser = argparse.ArgumentParser(description="Backfill KG promotion from chunks.raw_entities_json")
+    parser.add_argument("--db-path", type=Path, default=get_db_path())
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--dry-run", action="store_true", help="Preview promotions without writing. This is the default.")
+    parser.add_argument("--apply", action="store_true", help="Write promotions. Default is dry-run.")
+    args = parser.parse_args()
+
+    dry_run = not args.apply
+    store = _ReadOnlyPromotionStore(args.db_path) if dry_run else VectorStore(args.db_path)
+    try:
+        stats = promote_raw_entity_identities(store, limit=args.limit, dry_run=dry_run)
+        stats["mode"] = "apply" if args.apply else "dry-run"
+        stats["timestamp"] = datetime.now(timezone.utc).isoformat()
+        print(json.dumps(stats, ensure_ascii=False, indent=2))
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -245,6 +245,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("resolved_query", "TEXT"),
             ("key_facts", "TEXT"),
             ("resolved_queries", "TEXT"),
+            ("raw_entities_json", "TEXT"),
             ("epistemic_level", "TEXT"),
             ("version_scope", "TEXT"),
             ("debt_impact", "TEXT"),

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -926,6 +926,54 @@ def test_apply_enrichment_persists_raw_entities():
     assert row == (json.dumps(entities),)
 
 
+def test_apply_enrichment_triggers_raw_entity_promotion(tmp_path):
+    from brainlayer.enrichment_controller import _apply_enrichment
+    from brainlayer.vector_store import VectorStore
+
+    store = VectorStore(tmp_path / "apply-promotion.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        cursor = store.conn.cursor()
+        cursor.execute(
+            """INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type,
+                char_count, source, raw_entities_json, tags
+            ) VALUES (?, ?, '{}', 'test.jsonl', 'brainlayer', 'assistant_text',
+                      ?, 'test', ?, ?)""",
+            (
+                "existing",
+                "Michal Hershkovits coached Etan.",
+                len("Michal Hershkovits coached Etan."),
+                json.dumps([{"name": "Michal Hershkovits", "type": "person", "relation": "coach"}]),
+                json.dumps([tag]),
+            ),
+        )
+        cursor.execute("INSERT OR IGNORE INTO chunk_tags (chunk_id, tag) VALUES (?, ?)", ("existing", tag))
+        cursor.execute(
+            """INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type,
+                char_count, source, tags
+            ) VALUES (?, ?, '{}', 'test.jsonl', 'brainlayer', 'assistant_text',
+                      ?, 'test', ?)""",
+            ("new", "היי מיכל", len("היי מיכל"), json.dumps([tag])),
+        )
+        cursor.execute("INSERT OR IGNORE INTO chunk_tags (chunk_id, tag) VALUES (?, ?)", ("new", tag))
+
+        _apply_enrichment(
+            store,
+            _candidate("new", "היי מיכל"),
+            {"summary": "s", "entities": [{"name": "מיכל", "type": "person", "relation": "recipient"}]},
+        )
+
+        entity = store.resolve_entity("Michal Hershkovits")
+        assert entity is not None
+        hebrew_entity = store.resolve_entity("מיכל")
+        assert hebrew_entity is not None
+        assert hebrew_entity["id"] == entity["id"]
+    finally:
+        store.close()
+
+
 # ── Telemetry tests ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_kg_promotion.py
+++ b/tests/test_kg_promotion.py
@@ -74,6 +74,81 @@ def test_promotes_identification_tagged_person_surfaces_to_canonical_entity(tmp_
         store.close()
 
 
+def test_identity_tag_does_not_alias_co_mentioned_people(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-co-mentioned.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        _insert_chunk(
+            store,
+            chunk_id="chunk-co-mentioned",
+            content="Michal Hershkovits coached Etan Hey for the speakers workshop.",
+            raw_entities=[
+                {"name": "Michal Hershkovits", "type": "person", "relation": "coach"},
+                {"name": "Etan Hey", "type": "person", "relation": "student"},
+            ],
+            tags=[tag],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="chunk-he",
+            content="היי מיכל, אשמח להשתתף בסדנא",
+            raw_entities=[{"name": "מיכל", "type": "person", "relation": "recipient"}],
+            tags=[tag],
+        )
+
+        promote_raw_entity_identities(store, entity_type="person")
+
+        entity = store.resolve_entity("Michal Hershkovits")
+        assert entity is not None
+        aliases = {row["alias"] for row in store.get_entity_aliases(entity["id"])}
+        assert "Etan Hey" not in aliases
+        assert store.resolve_entity("Etan Hey") is None
+    finally:
+        store.close()
+
+
+def test_identity_tag_does_not_match_untagged_bare_given_name(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-given-name.db")
+    try:
+        tag = "john-smith-identification"
+        _insert_chunk(
+            store,
+            chunk_id="identity",
+            content="John Smith is the account owner.",
+            raw_entities=[{"name": "John Smith", "type": "person", "relation": "owner"}],
+            tags=[tag],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="identity-tag-only",
+            content="Follow-up about John Smith.",
+            raw_entities=[],
+            tags=[tag],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="untagged-john",
+            content="John asked a separate unrelated question.",
+            raw_entities=[{"name": "John", "type": "person", "relation": "speaker"}],
+            tags=["inbox"],
+        )
+
+        promote_raw_entity_identities(store, entity_type="person")
+
+        entity = store.resolve_entity("John Smith")
+        assert entity is not None
+        aliases = {row["alias"] for row in store.get_entity_aliases(entity["id"])}
+        linked = {row["chunk_id"] for row in store.get_entity_chunks(entity["id"], limit=10, include_audit=True)}
+        assert "John" not in aliases
+        assert "untagged-john" not in linked
+    finally:
+        store.close()
+
+
 def test_promoted_alias_resolves_through_entity_lookup_for_person(tmp_path):
     from brainlayer.kg_promotion import promote_raw_entity_identities
 
@@ -204,6 +279,161 @@ def test_identity_tag_can_promote_matching_raw_surfaces_from_other_chunks(tmp_pa
         assert hebrew_entity is not None
         assert hebrew_entity["id"] == entity["id"]
         assert stats["entities_promoted"] == 1
+    finally:
+        store.close()
+
+
+def test_chunk_promotion_includes_untagged_matching_raw_surfaces(tmp_path):
+    from brainlayer.kg_promotion import promote_chunk_raw_entities
+
+    store = VectorStore(tmp_path / "kg-promotion-chunk-shape.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        _insert_chunk(
+            store,
+            chunk_id="identity-tag-only",
+            content="Michal Hershkovits is the speakers workshop coach.",
+            raw_entities=[],
+            tags=[tag],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="raw-spelling-drift",
+            content="Slide example uses Michal Herskovits as the search target.",
+            raw_entities=[{"name": "Michal Herskovits", "type": "person", "relation": "search target"}],
+            tags=["presentation-dev"],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="raw-hebrew",
+            content="היי מיכל, אשמח להשתתף בסדנא",
+            raw_entities=[{"name": "מיכל", "type": "person", "relation": "recipient"}],
+            tags=["hebrew"],
+        )
+
+        stats = promote_chunk_raw_entities(store, "identity-tag-only", entity_type="person")
+
+        entity = store.resolve_entity("Michal Hershkovits")
+        assert entity is not None
+        spelling_drift_entity = store.resolve_entity("Michal Herskovits")
+        assert spelling_drift_entity is not None
+        assert spelling_drift_entity["id"] == entity["id"]
+        hebrew_entity = store.resolve_entity("מיכל")
+        assert hebrew_entity is not None
+        assert hebrew_entity["id"] == entity["id"]
+        assert stats["entities_promoted"] == 1
+    finally:
+        store.close()
+
+
+def test_chunk_promotion_without_identity_tag_is_noop(tmp_path):
+    from brainlayer.kg_promotion import promote_chunk_raw_entities
+
+    store = VectorStore(tmp_path / "kg-promotion-no-tag.db")
+    try:
+        for index in range(3):
+            _insert_chunk(
+                store,
+                chunk_id=f"chunk-{index}",
+                content=f"Ofir Levi appeared in planning note {index}.",
+                raw_entities=[{"name": "Ofir Levi", "type": "person", "relation": "participant"}],
+                tags=["planning"],
+            )
+
+        stats = promote_chunk_raw_entities(store, "chunk-0", entity_type="person")
+
+        assert stats == {
+            "chunks_scanned": 1,
+            "candidates": 0,
+            "entities_promoted": 0,
+            "aliases_created": 0,
+            "chunks_linked": 0,
+        }
+        assert store.resolve_entity("Ofir Levi") is None
+    finally:
+        store.close()
+
+
+def test_chunk_promotion_excludes_archived_identity_tag_chunks(tmp_path):
+    from brainlayer.kg_promotion import promote_chunk_raw_entities
+
+    store = VectorStore(tmp_path / "kg-promotion-archived.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        _insert_chunk(
+            store,
+            chunk_id="active",
+            content="Michal Hershkovits is the speakers workshop coach.",
+            raw_entities=[{"name": "Michal Hershkovits", "type": "person", "relation": "coach"}],
+            tags=[tag],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="archived",
+            content="היי מיכל, archived note",
+            raw_entities=[{"name": "מיכל", "type": "person", "relation": "recipient"}],
+            tags=[tag],
+        )
+        store.conn.cursor().execute("UPDATE chunks SET archived_at = '2026-05-18T00:00:00Z' WHERE id = 'archived'")
+
+        stats = promote_chunk_raw_entities(store, "active", entity_type="person")
+
+        entity = store.resolve_entity("Michal Hershkovits")
+        assert entity is None
+        assert stats["entities_promoted"] == 0
+        assert stats["chunks_scanned"] == 1
+    finally:
+        store.close()
+
+
+def test_non_latin_promoted_entity_id_uses_hash_fallback(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-non-latin.db")
+    try:
+        for index in range(3):
+            _insert_chunk(
+                store,
+                chunk_id=f"chunk-{index}",
+                content=f"משה לוי appeared in planning note {index}.",
+                raw_entities=[{"name": "משה לוי", "type": "person", "relation": "participant"}],
+                tags=["planning"],
+            )
+
+        promote_raw_entity_identities(store, entity_type="person")
+
+        entity = store.resolve_entity("משה לוי")
+        assert entity is not None
+        assert entity["id"].startswith("promoted-person-")
+        assert entity["id"] != "promoted-person-"
+    finally:
+        store.close()
+
+
+def test_dry_run_alias_count_excludes_canonical_name(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-dry-run.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        _insert_chunk(
+            store,
+            chunk_id="chunk-en",
+            content="Michal Hershkovits coached Etan.",
+            raw_entities=[{"name": "Michal Hershkovits", "type": "person", "relation": "coach"}],
+            tags=[tag],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="chunk-he",
+            content="היי מיכל",
+            raw_entities=[{"name": "מיכל", "type": "person", "relation": "recipient"}],
+            tags=[tag],
+        )
+
+        stats = promote_raw_entity_identities(store, entity_type="person", dry_run=True)
+
+        assert stats["aliases_created"] == 2
     finally:
         store.close()
 

--- a/tests/test_kg_promotion.py
+++ b/tests/test_kg_promotion.py
@@ -1,0 +1,237 @@
+import json
+
+from brainlayer.pipeline.digest import entity_lookup
+from brainlayer.vector_store import VectorStore
+
+
+def _insert_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    content: str,
+    raw_entities: list[dict],
+    tags: list[str],
+) -> None:
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, raw_entities_json, tags
+        ) VALUES (?, ?, '{}', 'kg-promotion-test.jsonl', 'brainlayer',
+                  'assistant_text', ?, 'test', ?, ?)""",
+        (chunk_id, content, len(content), json.dumps(raw_entities), json.dumps(tags)),
+    )
+    cursor.executemany(
+        "INSERT OR IGNORE INTO chunk_tags (chunk_id, tag) VALUES (?, ?)",
+        [(chunk_id, tag) for tag in tags],
+    )
+
+
+def test_promotes_identification_tagged_person_surfaces_to_canonical_entity(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        _insert_chunk(
+            store,
+            chunk_id="chunk-en",
+            content="Michal Hershkovits coached Etan for the speakers workshop.",
+            raw_entities=[
+                {"name": "Michal Hershkovits", "type": "person", "relation": "coach"},
+                {"name": "TechGym Speakers Workshop", "type": "concept", "relation": "context"},
+            ],
+            tags=[tag, "workshop-coaching"],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="chunk-he",
+            content="היי מיכל, אשמח להשתתף בסדנא",
+            raw_entities=[{"name": "מיכל", "type": "person", "relation": "recipient"}],
+            tags=[tag, "hebrew"],
+        )
+
+        stats = promote_raw_entity_identities(store, entity_type="person")
+
+        entity = store.resolve_entity("Michal Hershkovits")
+        assert entity is not None
+        assert entity["entity_type"] == "person"
+        assert entity["name"] == "Michal Hershkovits"
+        hebrew_entity = store.resolve_entity("מיכל")
+        assert hebrew_entity is not None
+        assert hebrew_entity["id"] == entity["id"]
+
+        aliases = {(row["alias"], row["alias_type"]) for row in store.get_entity_aliases(entity["id"])}
+        assert ("מיכל", "raw_surface") in aliases
+        assert ("michal-hershkovits-identification", "identity_tag") in aliases
+
+        linked = {row["chunk_id"] for row in store.get_entity_chunks(entity["id"], limit=10, include_audit=True)}
+        assert linked == {"chunk-en", "chunk-he"}
+        assert stats["entities_promoted"] == 1
+        assert stats["aliases_created"] >= 2
+        assert stats["chunks_linked"] == 2
+    finally:
+        store.close()
+
+
+def test_promoted_alias_resolves_through_entity_lookup_for_person(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-lookup.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        _insert_chunk(
+            store,
+            chunk_id="chunk-en",
+            content="Michal Hershkovits coached Etan for the speakers workshop.",
+            raw_entities=[{"name": "Michal Hershkovits", "type": "person", "relation": "coach"}],
+            tags=[tag],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="chunk-he",
+            content="היי מיכל, אשמח להשתתף בסדנא",
+            raw_entities=[{"name": "מיכל", "type": "person", "relation": "recipient"}],
+            tags=[tag],
+        )
+
+        promote_raw_entity_identities(store, entity_type="person")
+
+        by_full_name = entity_lookup(
+            query="Michal Hershkovits",
+            store=store,
+            embed_fn=lambda _: [0.0] * 1024,
+            entity_type="person",
+        )
+        by_hebrew_alias = entity_lookup(
+            query="מיכל",
+            store=store,
+            embed_fn=lambda _: [0.0] * 1024,
+            entity_type="person",
+        )
+
+        assert by_full_name is not None
+        assert by_hebrew_alias is not None
+        assert by_hebrew_alias["id"] == by_full_name["id"]
+        assert by_hebrew_alias["name"] == "Michal Hershkovits"
+    finally:
+        store.close()
+
+
+def test_skips_single_mention_person_without_identity_tag(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-skip.db")
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="chunk-one",
+            content="A one-off mention of Dana should not become a KG person.",
+            raw_entities=[{"name": "Dana", "type": "person", "relation": "mentioned"}],
+            tags=["casual-note"],
+        )
+
+        stats = promote_raw_entity_identities(store, entity_type="person")
+
+        assert store.resolve_entity("Dana") is None
+        assert stats["entities_promoted"] == 0
+        assert stats["chunks_linked"] == 0
+    finally:
+        store.close()
+
+
+def test_promotes_stable_person_surface_seen_in_three_chunks(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-stable.db")
+    try:
+        for index in range(3):
+            _insert_chunk(
+                store,
+                chunk_id=f"chunk-{index}",
+                content=f"Ofir Levi appeared in planning note {index}.",
+                raw_entities=[{"name": "Ofir Levi", "type": "person", "relation": "participant"}],
+                tags=["planning"],
+            )
+
+        stats = promote_raw_entity_identities(store, entity_type="person")
+
+        entity = store.resolve_entity("Ofir Levi")
+        assert entity is not None
+        assert entity["name"] == "Ofir Levi"
+        assert stats["entities_promoted"] == 1
+        assert stats["chunks_linked"] == 3
+    finally:
+        store.close()
+
+
+def test_identity_tag_can_promote_matching_raw_surfaces_from_other_chunks(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-real-shape.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        _insert_chunk(
+            store,
+            chunk_id="identity-tag-only",
+            content="Can't find Michal Hershkovits anywhere, but she is the speakers workshop coach.",
+            raw_entities=[],
+            tags=[tag, "workshop-coaching"],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="raw-spelling-drift",
+            content="Slide example uses Michal Herskovits as the search target.",
+            raw_entities=[{"name": "Michal Herskovits", "type": "person", "relation": "search target"}],
+            tags=["presentation-dev"],
+        )
+        _insert_chunk(
+            store,
+            chunk_id="raw-hebrew",
+            content="היי מיכל, אשמח להשתתף בסדנא",
+            raw_entities=[{"name": "מיכל", "type": "person", "relation": "recipient"}],
+            tags=["hebrew"],
+        )
+
+        stats = promote_raw_entity_identities(store, entity_type="person")
+
+        entity = store.resolve_entity("Michal Hershkovits")
+        assert entity is not None
+        spelling_drift_entity = store.resolve_entity("Michal Herskovits")
+        assert spelling_drift_entity is not None
+        assert spelling_drift_entity["id"] == entity["id"]
+        hebrew_entity = store.resolve_entity("מיכל")
+        assert hebrew_entity is not None
+        assert hebrew_entity["id"] == entity["id"]
+        assert stats["entities_promoted"] == 1
+    finally:
+        store.close()
+
+
+def test_raw_entity_promotion_is_idempotent(tmp_path):
+    from brainlayer.kg_promotion import promote_raw_entity_identities
+
+    store = VectorStore(tmp_path / "kg-promotion-idempotent.db")
+    try:
+        tag = "michal-hershkovits-identification"
+        for chunk_id, surface in (("chunk-en", "Michal Hershkovits"), ("chunk-he", "מיכל")):
+            _insert_chunk(
+                store,
+                chunk_id=chunk_id,
+                content=f"{surface} workshop context",
+                raw_entities=[{"name": surface, "type": "person", "relation": "participant"}],
+                tags=[tag],
+            )
+
+        first = promote_raw_entity_identities(store, entity_type="person")
+        second = promote_raw_entity_identities(store, entity_type="person")
+        entity = store.resolve_entity("Michal Hershkovits")
+
+        assert first["entities_promoted"] == 1
+        assert first["chunks_linked"] == 2
+        assert second["entities_promoted"] == 0
+        assert second["aliases_created"] == 0
+        assert second["chunks_linked"] == 0
+        assert len(store.get_entity_chunks(entity["id"], limit=10, include_audit=True)) == 2
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- add deterministic KG promotion from staged `chunks.raw_entities_json` into `kg_entities`, `kg_entity_aliases`, and `kg_entity_chunks`
- wire realtime enrichment to trigger promotion after raw entity staging
- add bounded backfill CLI with read-only dry-run mode for live DB previews
- cover Michal Hershkovits English/Hebrew alias resolution and stable 3-chunk raw person promotion

## Verification
- `pytest tests/test_kg_promotion.py -q`
- `pytest tests/test_enrichment_controller.py::test_apply_enrichment_triggers_raw_entity_promotion tests/test_enrichment_controller.py::test_apply_enrichment_persists_raw_entities tests/test_enrichment_controller.py::test_apply_enrichment_calls_update_enrichment_with_all_fields -q`
- `pytest tests/test_hebrew_alias.py tests/test_entity_dedup.py tests/test_search_alias_expansion.py -q`
- `pytest tests/test_kg_promotion.py tests/test_enrichment_controller.py tests/test_hebrew_alias.py tests/test_entity_dedup.py tests/test_search_alias_expansion.py tests/test_entity_contracts.py -q`
- `python3 -m ruff check src/brainlayer/kg_promotion.py scripts/backfill_kg_promotion.py src/brainlayer/enrichment_controller.py src/brainlayer/vector_store.py tests/test_kg_promotion.py tests/test_enrichment_controller.py`
- `python3 scripts/backfill_kg_promotion.py --dry-run --limit 1000` -> 1000 chunks scanned, 17 candidates, 23 aliases previewed, 124 chunk links previewed
- push hook gate passed on second normal run: 2003 selected pytest tests, MCP registration tests, isolated eval/hook tests, Bun test, FTS determinism shell test

## Notes
- First push-hook run had one timing-only failure in `test_digest_under_2_seconds` at 2.11s; isolated rerun passed and the second full push hook passed without bypassing hooks.
- Full `pytest -q` under system Python is still not representative on this machine: it fails collection on missing `deepchecks` and a `numba`/NumPy 2.4 mismatch. The project venv hook gate has the expected dependencies and passed.

## Backfill after merge
1. `python3 scripts/backfill_kg_promotion.py --dry-run --limit 100`
2. `python3 scripts/backfill_kg_promotion.py --apply`
3. Verify `brain_get_person("Michal Hershkovits")`, `brain_entity("Michal Hershkovits")`, and `brain_entity("מיכל")` resolve to the promoted person.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new KG write-paths (entity upserts, alias creation, chunk linking) and triggers them synchronously during enrichment, which can impact correctness and latency under DB contention despite being best-effort wrapped in a catch-all.
> 
> **Overview**
> Adds a deterministic “KG promotion” pipeline that scans `chunks.raw_entities_json` and `*-identification` tags to *upsert canonical `kg_entities`*, create `kg_entity_aliases`, and link evidence via `kg_entity_chunks` (including idempotency and busy/locked retries).
> 
> Wires `_apply_enrichment` to persist `raw_entities_json` and then best-effort call `promote_chunk_raw_entities` for `VectorStore` instances, and extends the `chunks` schema to include a `raw_entities_json` staging column.
> 
> Introduces a `scripts/backfill_kg_promotion.py` CLI for bounded backfills with default read-only `--dry-run` mode, and adds extensive tests covering identity-tag promotion, stable 3-mention promotion, multilingual/spelling-drift aliasing, chunk-scoped promotion behavior, and idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc08e06744ae07d579d955153fec5c3ab6a1fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Promote raw entities from chunk enrichment into KG aliases
> - Adds [kg_promotion.py](https://github.com/EtanHey/brainlayer/pull/292/files#diff-2270f302b2435f6ce6487997e486cc2f5e7c8d2e08a790d09e154a7cc5ee2f10) with logic to collect `PromotionCandidate` instances from `raw_entities_json` staging data and upsert them as KG entities, aliases, and chunk links.
> - `promote_chunk_raw_entities` triggers per-chunk promotion in real time from `_apply_enrichment` in [enrichment_controller.py](https://github.com/EtanHey/brainlayer/pull/292/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb); failures are caught and logged at debug (non-fatal).
> - `promote_raw_entity_identities` supports bulk backfill via a CLI in [scripts/backfill_kg_promotion.py](https://github.com/EtanHey/brainlayer/pull/292/files#diff-55a8e7cc28b1ba1db31df9b6c29126d6838006fe5208437e0a2495bbb37d245f), with optional dry-run and row limit flags.
> - Adds a `raw_entities_json` TEXT column to the `chunks` table in [vector_store.py](https://github.com/EtanHey/brainlayer/pull/292/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) to stage raw entity data for promotion.
> - Risk: existing databases will need migration to add the `raw_entities_json` column.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fc08e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic knowledge graph entity promotion: Raw entities are now promoted to canonical KG entries based on identification tags, enabling improved entity resolution and multilingual alias support for enhanced knowledge graph discoverability.

* **Tests**
  * Added comprehensive test coverage for entity promotion workflows, including multilingual alias resolution, cross-chunk linking, and idempotency validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->