### PR TITLE
feat: stream BrainBar brain bus events

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -90,7 +90,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.runtime.install(
                     collector: self.collector ?? StatsCollector(
                         dbPath: dbPath,
-                        daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
+                        daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+                        brainBusEvents: BrainBusClient()
                     ),
                     injectionStore: self.injectionStore,
                     database: database
@@ -101,7 +102,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let collector = StatsCollector(
             dbPath: dbPath,
-            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            brainBusEvents: BrainBusClient()
         )
         let injectionStore = try? InjectionStore(databasePath: dbPath)
 

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -101,6 +101,8 @@ final class BrainBarServer: @unchecked Sendable {
     private var hybridSearchHelperClient: HybridSearchHelperClient?
     private let providedHybridSearchClient: HybridSearchClientProtocol?
     private let enableHybridSearchHelper: Bool
+    private let brainBus = BrainBusEventHub()
+    private var brainBusQueueDepthEstimate = 0
     private var databaseRetryWorkItem: DispatchWorkItem?
     private var lastDatabaseRetryDelayMillis: UInt64?
     private var databaseOpenInProgress = false
@@ -108,8 +110,9 @@ final class BrainBarServer: @unchecked Sendable {
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
     var onStartRejected: (@Sendable (String) -> Void)?
     /// Maximum EAGAIN retries before disconnecting a stalled client.
-    /// Each retry sleeps 1ms, so 10 retries = 10ms max blocking the serial queue.
-    static let maxWriteRetries = 10
+    /// Each retry sleeps 1ms; 50 retries keeps false-positive disconnects
+    /// below the UI budget while still bounding serial-queue stalls.
+    static let maxWriteRetries = 50
     private let debugLogPath = "/tmp/brainbar-debug.log"
 
     private func debugLog(_ msg: String) {
@@ -138,6 +141,7 @@ final class BrainBarServer: @unchecked Sendable {
         var usesContentLengthFraming: Bool = true
         var agentID: String?
         var subscribedTags: Set<String> = []
+        var brainBusSubscriptionID: BrainBusEventHub.SubscriptionID?
     }
 
     init(
@@ -338,6 +342,9 @@ final class BrainBarServer: @unchecked Sendable {
             database = db
             router.setDatabase(db)
             onDatabaseReady?(db)
+            brainBus.publish(.dbBusy(false))
+            brainBus.publish(.queueDepth(brainBusQueueDepthEstimate))
+            brainBus.publish(.enrichStatus("idle"))
             NSLog("[BrainBar] Database ready (%@)", dbPath)
             return
         }
@@ -346,6 +353,7 @@ final class BrainBarServer: @unchecked Sendable {
             db.close()
         }
         NSLog("[BrainBar] ⚠️ DATABASE FAILED TO OPEN — tools/call will return errors (%@)", dbPath)
+        brainBus.publish(.dbBusy(true))
         scheduleDatabaseRetry(lastError: db.lastOpenError)
     }
 
@@ -417,6 +425,7 @@ final class BrainBarServer: @unchecked Sendable {
         if !messages.isEmpty {
             state.usesContentLengthFraming = state.framing.lastExtractUsedContentLength
         }
+        clients[fd] = state
         debugLog("EXTRACTED \(messages.count) messages from fd=\(fd) (framing=\(state.usesContentLengthFraming ? "content-length" : "newline-json"), buffer remaining: \(state.framing.bufferCount) bytes)")
         for msg in messages {
             let method = msg["method"] as? String ?? "<no method>"
@@ -454,11 +463,16 @@ final class BrainBarServer: @unchecked Sendable {
                 if toolCall.name == "brain_store", !isToolError(response) {
                     publishStoredChunks(response: response, arguments: toolCall.arguments)
                 }
+                if toolCall.name == "brain_enrich", !isToolError(response) {
+                    brainBus.publish(.enrichStatus("running"))
+                }
                 return response
             }
         }
         if let method = request["method"] as? String {
             switch method {
+            case "watch-brain-bus":
+                return handleWatchBrainBus(fd: fd)
             default:
                 break
             }
@@ -511,6 +525,74 @@ final class BrainBarServer: @unchecked Sendable {
         }
     }
 
+    private func writeFramedData(fd: Int32, data: Data) -> Bool {
+        data.withUnsafeBytes { ptr in
+            var totalWritten = 0
+            var eagainRetries = 0
+            while totalWritten < data.count {
+                let n = write(fd, ptr.baseAddress!.advanced(by: totalWritten), data.count - totalWritten)
+                if n < 0 {
+                    if errno == EAGAIN || errno == EWOULDBLOCK {
+                        eagainRetries += 1
+                        if eagainRetries > Self.maxWriteRetries {
+                            return false
+                        }
+                        usleep(1000)
+                        continue
+                    }
+                    return false
+                }
+                if n == 0 {
+                    return false
+                }
+                totalWritten += n
+                eagainRetries = 0
+            }
+            return true
+        }
+    }
+
+    private func handleWatchBrainBus(fd: Int32) -> [String: Any] {
+        guard var client = clients[fd] else { return [:] }
+        if let existing = client.brainBusSubscriptionID {
+            brainBus.unsubscribe(existing)
+        }
+
+        let useContentLength = client.usesContentLengthFraming
+        let subscription = brainBus.subscribe { [weak self] event in
+            guard let self else { return false }
+            guard let response = self.brainBusNotification(event: event) else { return true }
+            let framed: Data
+            do {
+                if useContentLength {
+                    framed = try MCPFraming.encode(response)
+                } else {
+                    var data = try MCPFraming.encodeJSONResponse(response)
+                    data.append(0x0A)
+                    framed = data
+                }
+            } catch {
+                return true
+            }
+
+            let delivered = self.writeFramedData(fd: fd, data: framed)
+            if !delivered {
+                self.queue.async { [weak self] in
+                    self?.disconnectClient(fd: fd)
+                }
+            }
+            return delivered
+        }
+
+        client.brainBusSubscriptionID = subscription
+        clients[fd] = client
+        brainBus.publish(.dbBusy(database == nil))
+        brainBus.publish(.queueDepth(brainBusQueueDepthEstimate))
+        brainBus.publish(.enrichStatus("idle"))
+        brainBus.publish(.healthTick(openConnections: clients.count))
+        return [:]
+    }
+
     private static let claudeExtensionRawChunkLimit = 8192
 
     private static func encodeRawJSONResponse(_ response: [String: Any]) -> Data? {
@@ -545,6 +627,9 @@ final class BrainBarServer: @unchecked Sendable {
     }
 
     private func disconnectClient(fd: Int32) {
+        if let subscriptionID = clients[fd]?.brainBusSubscriptionID {
+            brainBus.unsubscribe(subscriptionID)
+        }
         if let agentID = clients[fd]?.agentID {
             try? database?.markSubscriberDisconnected(agentID: agentID)
         }
@@ -761,6 +846,9 @@ final class BrainBarServer: @unchecked Sendable {
     }
 
     private func publishStoredChunk(stored: StoreResultPayload, content: String, tags: [String], importance: Int) {
+        brainBusQueueDepthEstimate += 1
+        brainBus.publish(.queueDepth(brainBusQueueDepthEstimate))
+        brainBus.publish(.lastChunkID(stored.chunkID))
         guard !tags.isEmpty else { return }
         let tagSet = Set(tags)
         for (clientFD, client) in Array(clients) {
@@ -857,5 +945,14 @@ final class BrainBarServer: @unchecked Sendable {
             return nil
         }
         return object
+    }
+
+    private func brainBusNotification(event: BrainBusEvent) -> [String: Any]? {
+        guard let params = jsonObject(event) else { return nil }
+        return [
+            "jsonrpc": "2.0",
+            "method": "notifications/brain-bus",
+            "params": params
+        ]
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBusClient.swift
+++ b/brain-bar/Sources/BrainBar/BrainBusClient.swift
@@ -1,0 +1,170 @@
+import Darwin
+import Foundation
+
+protocol BrainBusEventSource: Sendable {
+    func events() -> AsyncStream<BrainBusEvent>
+}
+
+final class BrainBusClient: BrainBusEventSource, @unchecked Sendable {
+    private let socketPath: String
+    private let reconnectDelay: TimeInterval
+    private let queue = DispatchQueue(label: "com.brainlayer.brainbar.brain-bus-client")
+
+    init(socketPath: String = BrainBarServer.defaultSocketPath(), reconnectDelay: TimeInterval = 1.0) {
+        self.socketPath = socketPath
+        self.reconnectDelay = reconnectDelay
+    }
+
+    func events() -> AsyncStream<BrainBusEvent> {
+        AsyncStream { continuation in
+            let run = BrainBusClientRun(
+                socketPath: socketPath,
+                reconnectDelay: reconnectDelay,
+                continuation: continuation
+            )
+            continuation.onTermination = { @Sendable _ in
+                run.cancel()
+            }
+            queue.async {
+                run.start()
+            }
+        }
+    }
+}
+
+private final class BrainBusClientRun: @unchecked Sendable {
+    private let socketPath: String
+    private let reconnectDelay: TimeInterval
+    private let continuation: AsyncStream<BrainBusEvent>.Continuation
+    private let lock = NSLock()
+    private var cancelled = false
+    private var currentFD: Int32 = -1
+
+    init(
+        socketPath: String,
+        reconnectDelay: TimeInterval,
+        continuation: AsyncStream<BrainBusEvent>.Continuation
+    ) {
+        self.socketPath = socketPath
+        self.reconnectDelay = reconnectDelay
+        self.continuation = continuation
+    }
+
+    func start() {
+        while !isCancelled {
+            autoreleasepool {
+                if let fd = try? connect() {
+                    setCurrentFD(fd)
+                    sendWatchCommand(fd: fd)
+                    readEvents(fd: fd)
+                    close(fd)
+                    setCurrentFD(-1)
+                }
+            }
+            if !isCancelled {
+                Thread.sleep(forTimeInterval: reconnectDelay)
+            }
+        }
+        continuation.finish()
+    }
+
+    func cancel() {
+        let fd: Int32 = lock.withLock {
+            cancelled = true
+            return currentFD
+        }
+        if fd >= 0 {
+            shutdown(fd, SHUT_RDWR)
+        }
+    }
+
+    private var isCancelled: Bool {
+        lock.withLock { cancelled }
+    }
+
+    private func setCurrentFD(_ fd: Int32) {
+        lock.withLock {
+            currentFD = fd
+        }
+    }
+
+    private func connect() throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw BrainBusClientError.socket(errno) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString
+        guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
+            close(fd)
+            throw BrainBusClientError.socketPathTooLong(socketPath)
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { dest in
+                pathBytes.withUnsafeBufferPointer { src in
+                    _ = memcpy(dest, src.baseAddress!, src.count)
+                }
+            }
+        }
+
+        let result = withUnsafePointer(to: &addr) { addrPtr in
+            addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                Darwin.connect(fd, ptr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard result == 0 else {
+            let code = errno
+            close(fd)
+            throw BrainBusClientError.connect(code)
+        }
+        return fd
+    }
+
+    private func sendWatchCommand(fd: Int32) {
+        let request: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "watch-brain-bus",
+        ]
+        guard var data = try? JSONSerialization.data(withJSONObject: request) else { return }
+        data.append(0x0A)
+        data.withUnsafeBytes { ptr in
+            _ = write(fd, ptr.baseAddress!, data.count)
+        }
+    }
+
+    private func readEvents(fd: Int32) {
+        var buffer = Data()
+        var readBuffer = [UInt8](repeating: 0, count: 8192)
+        while !isCancelled {
+            let count = read(fd, &readBuffer, readBuffer.count)
+            if count > 0 {
+                buffer.append(contentsOf: readBuffer[0..<count])
+                drainLines(from: &buffer)
+            } else {
+                break
+            }
+        }
+    }
+
+    private func drainLines(from buffer: inout Data) {
+        while let newlineIndex = buffer.firstIndex(of: 0x0A) {
+            let line = Data(buffer[..<newlineIndex])
+            buffer.removeSubrange(buffer.startIndex...newlineIndex)
+            guard !line.isEmpty,
+                  let message = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  let params = message["params"] as? [String: Any],
+                  let eventData = try? JSONSerialization.data(withJSONObject: params),
+                  let event = try? JSONDecoder().decode(BrainBusEvent.self, from: eventData) else {
+                continue
+            }
+            continuation.yield(event)
+        }
+    }
+}
+
+private enum BrainBusClientError: Error {
+    case socket(Int32)
+    case connect(Int32)
+    case socketPathTooLong(String)
+}

--- a/brain-bar/Sources/BrainBar/BrainBusEvent.swift
+++ b/brain-bar/Sources/BrainBar/BrainBusEvent.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+enum BrainBusEventType: String, Codable, Equatable, Sendable {
+    case queueDepth = "queue_depth"
+    case enrichStatus = "enrich_status"
+    case lastChunkID = "last_chunk_id"
+    case dbBusy = "db_busy"
+    case healthTick = "health_tick"
+}
+
+struct BrainBusEvent: Codable, Equatable, Sendable {
+    let type: BrainBusEventType
+    let sequence: Int
+    let generatedAt: Date
+    let queueDepth: Int?
+    let enrichStatus: String?
+    let lastChunkID: String?
+    let dbBusy: Bool?
+    let openConnections: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case sequence
+        case generatedAt = "generated_at"
+        case queueDepth = "queue_depth"
+        case enrichStatus = "enrich_status"
+        case lastChunkID = "last_chunk_id"
+        case dbBusy = "db_busy"
+        case openConnections = "open_connections"
+    }
+
+    static func queueDepth(_ depth: Int) -> BrainBusEvent {
+        BrainBusEvent(type: .queueDepth, queueDepth: depth)
+    }
+
+    static func enrichStatus(_ status: String) -> BrainBusEvent {
+        BrainBusEvent(type: .enrichStatus, enrichStatus: status)
+    }
+
+    static func lastChunkID(_ chunkID: String) -> BrainBusEvent {
+        BrainBusEvent(type: .lastChunkID, lastChunkID: chunkID)
+    }
+
+    static func dbBusy(_ busy: Bool) -> BrainBusEvent {
+        BrainBusEvent(type: .dbBusy, dbBusy: busy)
+    }
+
+    static func healthTick(openConnections: Int) -> BrainBusEvent {
+        BrainBusEvent(type: .healthTick, openConnections: openConnections)
+    }
+
+    func withSequence(_ sequence: Int, generatedAt: Date = Date()) -> BrainBusEvent {
+        BrainBusEvent(
+            type: type,
+            sequence: sequence,
+            generatedAt: generatedAt,
+            queueDepth: queueDepth,
+            enrichStatus: enrichStatus,
+            lastChunkID: lastChunkID,
+            dbBusy: dbBusy,
+            openConnections: openConnections
+        )
+    }
+
+    private init(
+        type: BrainBusEventType,
+        sequence: Int = 0,
+        generatedAt: Date = Date(),
+        queueDepth: Int? = nil,
+        enrichStatus: String? = nil,
+        lastChunkID: String? = nil,
+        dbBusy: Bool? = nil,
+        openConnections: Int? = nil
+    ) {
+        self.type = type
+        self.sequence = sequence
+        self.generatedAt = generatedAt
+        self.queueDepth = queueDepth
+        self.enrichStatus = enrichStatus
+        self.lastChunkID = lastChunkID
+        self.dbBusy = dbBusy
+        self.openConnections = openConnections
+    }
+}
+
+final class BrainBusEventHub: @unchecked Sendable {
+    typealias SubscriptionID = UUID
+    typealias EventWriter = @Sendable (BrainBusEvent) -> Bool
+
+    private struct Subscriber {
+        let writer: EventWriter
+        let drainQueue: DispatchQueue
+        var buffer: [BrainBusEvent] = []
+        var isDraining = false
+    }
+
+    private let queue = DispatchQueue(label: "com.brainlayer.brainbar.brain-bus")
+    private let bufferCapacity: Int
+    private var nextSequence = 0
+    private var subscribers: [SubscriptionID: Subscriber] = [:]
+    private var heartbeatTimer: DispatchSourceTimer?
+
+    init(bufferCapacity: Int = 64, heartbeatInterval: TimeInterval? = 5) {
+        self.bufferCapacity = max(1, bufferCapacity)
+        if let heartbeatInterval {
+            let timer = DispatchSource.makeTimerSource(queue: queue)
+            timer.schedule(deadline: .now() + heartbeatInterval, repeating: heartbeatInterval, leeway: .milliseconds(100))
+            timer.setEventHandler { [weak self] in
+                self?.publishOnQueue(.healthTick(openConnections: self?.subscribers.count ?? 0))
+            }
+            timer.resume()
+            heartbeatTimer = timer
+        }
+    }
+
+    deinit {
+        heartbeatTimer?.cancel()
+    }
+
+    func subscribe(_ writer: @escaping EventWriter) -> SubscriptionID {
+        let id = UUID()
+        queue.sync {
+            subscribers[id] = Subscriber(
+                writer: writer,
+                drainQueue: DispatchQueue(label: "com.brainlayer.brainbar.brain-bus.subscriber.\(id.uuidString)")
+            )
+        }
+        return id
+    }
+
+    func unsubscribe(_ id: SubscriptionID) {
+        queue.async {
+            self.subscribers.removeValue(forKey: id)
+        }
+    }
+
+    func publish(_ event: BrainBusEvent) {
+        queue.async {
+            self.publishOnQueue(event)
+        }
+    }
+
+    private func publishOnQueue(_ event: BrainBusEvent) {
+        nextSequence += 1
+        let sequenced = event.withSequence(nextSequence)
+        for id in subscribers.keys {
+            enqueue(sequenced, for: id)
+        }
+    }
+
+    private func enqueue(_ event: BrainBusEvent, for id: SubscriptionID) {
+        guard var subscriber = subscribers[id] else { return }
+        if subscriber.buffer.count >= bufferCapacity {
+            subscriber.buffer.removeFirst()
+        }
+        subscriber.buffer.append(event)
+        let shouldStartDrain = !subscriber.isDraining
+        if shouldStartDrain {
+            subscriber.isDraining = true
+        }
+        subscribers[id] = subscriber
+        if shouldStartDrain {
+            drainNext(for: id)
+        }
+    }
+
+    private func drainNext(for id: SubscriptionID) {
+        guard var subscriber = subscribers[id] else { return }
+        guard !subscriber.buffer.isEmpty else {
+            subscriber.isDraining = false
+            subscribers[id] = subscriber
+            return
+        }
+        let event = subscriber.buffer.removeFirst()
+        let writer = subscriber.writer
+        let drainQueue = subscriber.drainQueue
+        subscribers[id] = subscriber
+
+        drainQueue.async { [weak self] in
+            let keepOpen = writer(event)
+            self?.queue.async { [weak self] in
+                guard keepOpen else {
+                    self?.subscribers.removeValue(forKey: id)
+                    return
+                }
+                self?.drainNext(for: id)
+            }
+        }
+    }
+}

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -29,18 +29,21 @@ final class StatsCollector: ObservableObject {
     private let database: BrainDatabase
     private let daemonMonitor: DaemonHealthMonitor
     private let agentActivityMonitor: AgentActivityMonitor
-    private var pollTask: Task<Void, Never>?
+    private let brainBusEvents: BrainBusEventSource?
+    private var brainBusTask: Task<Void, Never>?
     private var isRunning = false
     private var lastDataVersion: Int?
 
     init(
         dbPath: String,
         daemonMonitor: DaemonHealthMonitor,
-        agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor()
+        agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor(),
+        brainBusEvents: BrainBusEventSource? = nil
     ) {
         self.database = BrainDatabase(path: dbPath)
         self.daemonMonitor = daemonMonitor
         self.agentActivityMonitor = agentActivityMonitor
+        self.brainBusEvents = brainBusEvents
         self.stats = DashboardStats(
             chunkCount: 0,
             enrichedChunkCount: 0,
@@ -61,19 +64,24 @@ final class StatsCollector: ObservableObject {
         guard !isRunning else { return }
         isRunning = true
         installDarwinObserver()
-        refresh(force: true)
-        pollTask = Task { [weak self] in
-            while let self, !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
-                guard !Task.isCancelled else { break }
-                self.pollForChanges()
+        if let brainBusEvents {
+            let eventStream = brainBusEvents.events()
+            brainBusTask = Task { [weak self] in
+                for await event in eventStream {
+                    guard !Task.isCancelled else { break }
+                    await MainActor.run {
+                        self?.handleBrainBusEvent(event)
+                    }
+                }
             }
+        } else {
+            refresh(force: true)
         }
     }
 
     func stop() {
-        pollTask?.cancel()
-        pollTask = nil
+        brainBusTask?.cancel()
+        brainBusTask = nil
         if isRunning {
             removeDarwinObserver()
         }
@@ -120,8 +128,15 @@ final class StatsCollector: ObservableObject {
         refresh(force: false)
     }
 
-    private func pollForChanges() {
-        refresh(force: false)
+    private func handleBrainBusEvent(_ event: BrainBusEvent) {
+        switch event.type {
+        case .healthTick:
+            daemon = daemonMonitor.sample()
+            agentActivity = agentActivityMonitor.sample()
+            state = PipelineState.derive(daemon: daemon, stats: stats)
+        case .queueDepth, .enrichStatus, .lastChunkID, .dbBusy:
+            refresh(force: false)
+        }
     }
 
     private func installDarwinObserver() {

--- a/brain-bar/Tests/BrainBarTests/BrainBusEventHubTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBusEventHubTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import BrainBar
+
+final class BrainBusEventHubTests: XCTestCase {
+    func testSubscribeReceivesThreeStateChangesInOrderWithinLatencyBudget() throws {
+        let hub = BrainBusEventHub(bufferCapacity: 8, heartbeatInterval: nil)
+        let received = LockedBrainBusEvents()
+        let allReceived = XCTestExpectation(description: "received three brain bus events")
+
+        let subscription = hub.subscribe { event in
+            received.append(event)
+            if received.count == 3 {
+                allReceived.fulfill()
+            }
+            return true
+        }
+        defer { hub.unsubscribe(subscription) }
+
+        let startedAt = DispatchTime.now()
+        hub.publish(.queueDepth(2))
+        hub.publish(.enrichStatus("running"))
+        hub.publish(.lastChunkID("chunk-3"))
+
+        wait(for: [allReceived], timeout: 1.0)
+        let elapsedMillis = Double(DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000
+
+        XCTAssertLessThan(elapsedMillis, 50)
+        XCTAssertEqual(received.snapshot().map(\.type), [.queueDepth, .enrichStatus, .lastChunkID])
+    }
+
+    func testBackpressureDropsOldestEventsWithoutStallingPublisher() throws {
+        let hub = BrainBusEventHub(bufferCapacity: 3, heartbeatInterval: nil)
+        let received = LockedBrainBusEvents()
+        let sawLatest = XCTestExpectation(description: "slow subscriber eventually receives latest event")
+
+        let subscription = hub.subscribe { event in
+            Thread.sleep(forTimeInterval: 0.02)
+            received.append(event)
+            if event.sequence == 20 {
+                sawLatest.fulfill()
+            }
+            return true
+        }
+        defer { hub.unsubscribe(subscription) }
+
+        let startedAt = DispatchTime.now()
+        for index in 1...20 {
+            hub.publish(.healthTick(openConnections: index))
+        }
+        let publishElapsedMillis = Double(DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000
+
+        XCTAssertLessThan(publishElapsedMillis, 20)
+        wait(for: [sawLatest], timeout: 1.0)
+
+        let delivered = received.snapshot()
+        XCTAssertLessThan(delivered.count, 20)
+        XCTAssertEqual(delivered.last?.sequence, 20)
+    }
+}
+
+private final class LockedBrainBusEvents: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [BrainBusEvent] = []
+
+    var count: Int {
+        lock.withLock { events.count }
+    }
+
+    func append(_ event: BrainBusEvent) {
+        lock.withLock {
+            events.append(event)
+        }
+    }
+
+    func snapshot() -> [BrainBusEvent] {
+        lock.withLock { events }
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -255,6 +255,24 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(collector.stats.chunkCount, 1)
     }
 
+    @MainActor
+    func testStatsCollectorSubscribesToBrainBusWithoutPollingDelay() {
+        let eventSource = RecordingBrainBusEventSource()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            brainBusEvents: eventSource
+        )
+        defer { collector.stop() }
+
+        let startedAt = DispatchTime.now()
+        collector.start()
+        let elapsedMillis = Double(DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000
+
+        XCTAssertEqual(eventSource.streamRequestCount, 1)
+        XCTAssertLessThan(elapsedMillis, 100)
+    }
+
     func testPipelineStateTreatsMissingDaemonSnapshotAsDegraded() {
         let stats = DashboardStats(
             chunkCount: 10,
@@ -385,5 +403,21 @@ final class DashboardTests: XCTestCase {
         XCTAssertFalse(viewController.isViewLoaded)
         _ = viewController.view
         XCTAssertTrue(viewController.isViewLoaded)
+    }
+}
+
+private final class RecordingBrainBusEventSource: BrainBusEventSource, @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests = 0
+
+    var streamRequestCount: Int {
+        lock.withLock { requests }
+    }
+
+    func events() -> AsyncStream<BrainBusEvent> {
+        lock.withLock {
+            requests += 1
+        }
+        return AsyncStream { _ in }
     }
 }

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -151,6 +151,38 @@ final class SocketIntegrationTests: XCTestCase {
         }
     }
 
+    func testWatchBrainBusStreamsStoreEventsOverRawUnixSocket() throws {
+        let watchFD = try connectClient()
+        defer { close(watchFD) }
+
+        try sendRawLineJSON(on: watchFD, object: [
+            "jsonrpc": "2.0",
+            "id": 50,
+            "method": "watch-brain-bus",
+        ])
+        _ = try readBrainBusEvent(fd: watchFD, matching: "health_tick")
+
+        let storeResponse = try sendMCPRequest([
+            "jsonrpc": "2.0",
+            "id": 51,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Brain bus stream integration",
+                    "tags": ["agent-message"]
+                ] as [String: Any]
+            ]
+        ])
+        XCTAssertNil(storeResponse["error"])
+
+        let event = try readBrainBusEvent(fd: watchFD, matching: "last_chunk_id")
+        XCTAssertEqual(event["method"] as? String, "notifications/brain-bus")
+        let params = try XCTUnwrap(event["params"] as? [String: Any])
+        XCTAssertEqual(params["type"] as? String, "last_chunk_id")
+        XCTAssertFalse((params["last_chunk_id"] as? String ?? "").isEmpty)
+    }
+
     // MARK: - MCP tools/call brain_search over socket
 
     func testMCPBrainSearchOverSocket() throws {
@@ -887,6 +919,35 @@ final class SocketIntegrationTests: XCTestCase {
         }
 
         throw NSError(domain: "test", code: 4, userInfo: [NSLocalizedDescriptionKey: "Timeout reading raw line response"])
+    }
+
+    private func readBrainBusEvent(fd: Int32, matching type: String, timeout: TimeInterval = 5.0) throws -> [String: Any] {
+        let deadline = Date().addingTimeInterval(timeout)
+        var buffer = Data()
+        var readBuf = [UInt8](repeating: 0, count: 65536)
+        while Date() < deadline {
+            while let newlineIndex = buffer.firstIndex(of: 0x0A) {
+                let line = Data(buffer[..<newlineIndex])
+                buffer.removeSubrange(buffer.startIndex...newlineIndex)
+                guard !line.isEmpty else { continue }
+                let message = try JSONSerialization.jsonObject(with: line) as? [String: Any] ?? [:]
+                let params = message["params"] as? [String: Any]
+                if params?["type"] as? String == type {
+                    return message
+                }
+            }
+
+            let n = read(fd, &readBuf, readBuf.count)
+            if n > 0 {
+                buffer.append(contentsOf: readBuf[0..<n])
+            } else if n == 0 {
+                break
+            } else if errno != EAGAIN && errno != EINTR && errno != EWOULDBLOCK {
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        throw NSError(domain: "test", code: 6, userInfo: [NSLocalizedDescriptionKey: "Timeout reading brain bus event \(type)"])
     }
 
     private func readMCPMessage(fd: Int32, timeout: TimeInterval = 5.0) throws -> [String: Any] {


### PR DESCRIPTION
## Summary
- Add a `watch-brain-bus` IPC method on the existing BrainBar Unix socket, streaming newline-delimited JSON notifications for queue depth, enrichment status, last stored chunk, DB busy state, and health ticks.
- Replace the dashboard's one-second polling loop with a push-driven `BrainBusClient` subscription; Darwin DB notifications remain a fallback path.
- Add a bounded per-subscriber event hub so slow UI clients cannot block producers.

## Stacking
This PR is stacked on Phase D IPC foundation PR #293 (`fix/brainbar-hybrid-parity`) and follows its helper-subprocess IPC conventions: one existing UDS, long-lived raw JSON watch connection, existing Content-Length framing preserved for framed callers.

## Before / After
Before: `StatsCollector.start()` created a `pollTask`, slept for one second in a loop, and refreshed dashboard state directly.

After: `StatsCollector` subscribes to `BrainBusClient` over `/tmp/brainbar.sock`; dashboard state changes are driven by pushed `watch-brain-bus` events, with no UI polling loop.

## Tailscale Safesocket Pattern
- Reuses the existing local Unix socket rather than opening a second listener.
- Nonblocking accept/write path remains in place.
- Watch subscribers get bounded buffers and are disconnected cleanly on socket close.
- Slow subscribers drop old events instead of back-pressuring store/enrich paths.

## Test Plan
- TDD RED/GREEN for `BrainBusEventHubTests`, `SocketIntegrationTests/testWatchBrainBusStreamsStoreEventsOverRawUnixSocket`, and `DashboardTests/testStatsCollectorSubscribesToBrainBusWithoutPollingDelay`.
- Clean staged temp worktree: `swift test --package-path brain-bar` -> 360 tests passed.
- Push hook full gate passed on second run: pytest unit suite 2017 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 32 passed; bun stale index 1 pass; FTS5 determinism shell regression PASS.

## Notes
The first push hook run hit `tests/test_arbitration.py::test_drain_daemon_serializes_three_concurrent_producers`; the single test passed immediately on rerun and the full hook passed on the second push attempt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new long-lived socket subscription path and buffered event fanout, which affects IPC framing/write behavior and could impact client stability or server queueing under load.
> 
> **Overview**
> Adds a new `watch-brain-bus` JSON-RPC method on the BrainBar Unix socket that streams `notifications/brain-bus` events (DB busy, queue depth, enrich status, last stored chunk ID, and periodic health ticks) to subscribed clients, with per-subscriber buffering/backpressure via the new `BrainBusEventHub`.
> 
> Updates the dashboard `StatsCollector` to consume these pushed events via a new `BrainBusClient` (replacing the 1s polling loop when available) and wires this client into app startup. Socket write handling is tweaked (higher EAGAIN retry cap + shared write helper), and new unit/integration tests cover hub ordering/backpressure, dashboard subscription, and end-to-end brain bus streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65df049fb7735aadb8cd8258014e4f306297c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream real-time brain bus events from BrainBar server to dashboard clients
> - Adds a `watch-brain-bus` JSON-RPC method to [BrainBarServer.swift](https://github.com/EtanHey/brainlayer/pull/295/files#diff-4602849889150805f4b12b90f751f36f54c87a22076f044e0669a2276500e981) that pushes `notifications/brain-bus` events (`db_busy`, `queue_depth`, `enrich_status`, `last_chunk_id`, `health_tick`) over the existing UNIX socket connection.
> - Introduces [BrainBusEvent.swift](https://github.com/EtanHey/brainlayer/pull/295/files#diff-a5f1261f1cff84873119eec4255447b55cfb15bc6ea8ad21cfb6dcd6ab38a18f) with `BrainBusEventHub` for sequenced, backpressure-aware fan-out to multiple subscribers, and [BrainBusClient.swift](https://github.com/EtanHey/brainlayer/pull/295/files#diff-99499487dbfda7a3467a6f490154b4f600237df00719f2e0731c855a88b587b5) as the client-side consumer that reconnects on disconnect.
> - Replaces the 1-second polling loop in [StatsCollector.swift](https://github.com/EtanHey/brainlayer/pull/295/files#diff-a4209e66a51bd173f8a6c459869edaac5781fd9448f010f9972815f52a42f70e) with a push-driven event listener when a `BrainBusEventSource` is provided.
> - Increases socket write `maxWriteRetries` from 10 to 50 to reduce disconnects under transient EAGAIN conditions.
> - Behavioral Change: `StatsCollector` no longer polls on a fixed interval when wired to a `BrainBusClient`; dashboard updates are now event-driven.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b65df04. 5 files reviewed, 9 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->