### PR TITLE
refactor: use NSStatusItem popover shell

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -7,6 +7,19 @@ enum BrainBarAppSupport {
     static func hotkeyPermissionFailureMessage(permissions: HotkeyPermissionStatus) -> String {
         "BrainBar could not start the fallback hotkey listener. Enable \(permissions.missingPermissionsMessage) in System Settings. The CGEventTap fallback requires both Input Monitoring and Accessibility."
     }
+
+    @MainActor
+    static func makeStatsCollector(
+        dbPath: String,
+        targetPID: pid_t,
+        brainBusEvents: BrainBusEventSource? = BrainBusClient()
+    ) -> StatsCollector {
+        StatsCollector(
+            dbPath: dbPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: targetPID),
+            brainBusEvents: brainBusEvents
+        )
+    }
 }
 
 @MainActor
@@ -15,6 +28,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let menuBarWindowAutosaveKey = "NSWindow Frame BrainBarMenuBarExtraWindow"
 
     private var server: BrainBarServer?
+    private var statusPopoverController: BrainBarStatusPopoverController?
     private var legacyStatusItem: NSStatusItem?
     private var legacyPopover: NSPopover?
     private var collector: StatsCollector?
@@ -47,11 +61,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         startHotkeyFileWatcher()
 
-        if launchMode == .menuBarWindow {
-            UserDefaults.standard.removeObject(forKey: Self.menuBarWindowAutosaveKey)
-            dashboardPanel = BrainBarDashboardPanelController(runtime: runtime)
-        }
-
         let runningInstances = NSRunningApplication.runningApplications(
             withBundleIdentifier: Bundle.main.bundleIdentifier ?? "com.brainlayer.BrainBar"
         )
@@ -69,7 +78,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.configureQuickCaptureHotkey()
         }
 
-        if launchMode == .legacyStatusItem {
+        if launchMode == .menuBarWindow {
+            statusPopoverController = BrainBarStatusPopoverController(runtime: runtime)
+        } else if launchMode == .legacyStatusItem {
             createLegacyStatusItem()
         }
 
@@ -88,9 +99,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.sharedDatabase = database
                 self.configureQuickCapture(database: database)
                 self.runtime.install(
-                    collector: self.collector ?? StatsCollector(
+                    collector: self.collector ?? BrainBarAppSupport.makeStatsCollector(
                         dbPath: dbPath,
-                        daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+                        targetPID: ProcessInfo.processInfo.processIdentifier,
                         brainBusEvents: BrainBusClient()
                     ),
                     injectionStore: self.injectionStore,
@@ -100,9 +111,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        let collector = StatsCollector(
+        let collector = BrainBarAppSupport.makeStatsCollector(
             dbPath: dbPath,
-            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            targetPID: ProcessInfo.processInfo.processIdentifier,
             brainBusEvents: BrainBusClient()
         )
         let injectionStore = try? InjectionStore(databasePath: dbPath)
@@ -125,6 +136,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         menuBarWindowObservers.forEach(NotificationCenter.default.removeObserver)
         menuBarWindowObservers.removeAll()
+        statusPopoverController?.stop()
+        statusPopoverController = nil
         menuBarWindowSyncTask?.cancel()
         menuBarWindowSyncTask = nil
         hotkeyFileWatcher?.cancel()
@@ -149,7 +162,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         runtime.presentQuickAction(.search)
-        showMenuBarWindow(nil)
+        statusPopoverController?.show(nil)
     }
 
     func showQuickCapturePanel() {
@@ -159,7 +172,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         runtime.presentQuickAction(.capture)
-        showMenuBarWindow(nil)
+        statusPopoverController?.show(nil)
     }
 
     private func configureRuntimeCallbacks() {
@@ -238,6 +251,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        if launchMode == .menuBarWindow, let statusPopoverController {
+            statusPopoverController.toggle(sender)
+            return
+        }
+
         if let dashboardPanel {
             dashboardPanel.toggle()
             return
@@ -286,10 +304,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        if let statusPopoverController {
+            statusPopoverController.show(nil)
+            return
+        }
+
         dashboardPanel?.show()
     }
 
     private func showMenuBarWindow(_ sender: Any?) {
+        if launchMode == .menuBarWindow, let statusPopoverController {
+            statusPopoverController.show(sender)
+            return
+        }
+
         if launchMode == .menuBarWindow, let dashboardPanel {
             dashboardPanel.show()
             return
@@ -861,26 +889,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct BrainBarApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    private let launchMode = BrainBarLaunchMode.resolve()
 
     var body: some Scene {
-        MenuBarExtra(isInserted: .constant(launchMode == .menuBarWindow)) {
-            Button("Open Dashboard") {
-                appDelegate.showDashboardPanel()
-            }
-
-            Button("Search BrainLayer") {
-                appDelegate.showSearchPanel()
-            }
-
-            Button("Capture Note") {
-                appDelegate.showQuickCapturePanel()
-            }
-        } label: {
-            BrainBarMenuBarLabel(runtime: appDelegate.runtime)
-        }
-        .menuBarExtraStyle(.menu)
-
         Settings {
             EmptyView()
         }
@@ -899,30 +909,6 @@ struct BrainBarApp: App {
                     appDelegate.showQuickCapturePanel()
                 }
             }
-        }
-    }
-}
-
-private struct BrainBarMenuBarLabel: View {
-    @ObservedObject var runtime: BrainBarRuntime
-
-    var body: some View {
-        if let collector = runtime.collector {
-            let livePresentation = BrainBarLivePresentation.derive(stats: collector.stats)
-            HStack(spacing: 6) {
-                Image(systemName: "brain")
-                Image(
-                    nsImage: SparklineRenderer.render(
-                        state: collector.state,
-                        values: collector.stats.recentEnrichmentBuckets,
-                        size: NSSize(width: 22, height: 12),
-                        accentColor: livePresentation.accentColor
-                    )
-                )
-                .interpolation(.high)
-            }
-        } else {
-            Image(systemName: "brain")
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
@@ -1,0 +1,104 @@
+import AppKit
+import Combine
+import SwiftUI
+
+@MainActor
+final class BrainBarStatusPopoverController: NSObject {
+    static let contentSize = NSSize(width: 900, height: 640)
+
+    let statusItemForTesting: NSStatusItem
+    let popoverForTesting: NSPopover
+
+    private let runtime: BrainBarRuntime
+    private var runtimeCancellables: Set<AnyCancellable> = []
+    private var collectorCancellables: Set<AnyCancellable> = []
+
+    init(runtime: BrainBarRuntime) {
+        self.runtime = runtime
+        statusItemForTesting = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        popoverForTesting = NSPopover()
+        super.init()
+
+        configureStatusItem()
+        prewarmPopover()
+        bindRuntime()
+    }
+
+    func toggle(_ sender: Any?) {
+        if popoverForTesting.isShown {
+            popoverForTesting.performClose(sender)
+        } else {
+            show(sender)
+        }
+    }
+
+    func show(_ sender: Any?) {
+        guard let button = statusItemForTesting.button else { return }
+        popoverForTesting.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        popoverForTesting.contentViewController?.view.window?.makeKey()
+    }
+
+    func close(_ sender: Any?) {
+        popoverForTesting.performClose(sender)
+    }
+
+    func stop() {
+        close(nil)
+        NSStatusBar.system.removeStatusItem(statusItemForTesting)
+    }
+
+    private func configureStatusItem() {
+        guard let button = statusItemForTesting.button else { return }
+        button.image = NSImage(systemSymbolName: "brain", accessibilityDescription: "BrainBar")
+        button.target = self
+        button.action = #selector(toggleFromStatusItem(_:))
+        button.toolTip = "BrainBar"
+    }
+
+    private func prewarmPopover() {
+        popoverForTesting.behavior = .transient
+        popoverForTesting.contentSize = Self.contentSize
+
+        let hosting = NSHostingController(
+            rootView: BrainBarWindowRootView(runtime: runtime, managesWindowFrame: false)
+                .frame(width: Self.contentSize.width, height: Self.contentSize.height)
+        )
+        _ = hosting.view
+        popoverForTesting.contentViewController = hosting
+    }
+
+    private func bindRuntime() {
+        runtime.$collector
+            .receive(on: RunLoop.main)
+            .sink { [weak self] collector in
+                self?.bindCollector(collector)
+            }
+            .store(in: &runtimeCancellables)
+    }
+
+    private func bindCollector(_ collector: StatsCollector?) {
+        collectorCancellables.removeAll()
+        guard let collector else { return }
+
+        Publishers.CombineLatest(collector.$stats, collector.$state)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] stats, state in
+                self?.renderStatusIcon(stats: stats, state: state)
+            }
+            .store(in: &collectorCancellables)
+    }
+
+    private func renderStatusIcon(stats: BrainDatabase.DashboardStats, state: PipelineState) {
+        let livePresentation = BrainBarLivePresentation.derive(stats: stats)
+        statusItemForTesting.button?.image = SparklineRenderer.render(
+            state: state,
+            values: stats.recentEnrichmentBuckets,
+            size: NSSize(width: 22, height: 12),
+            accentColor: livePresentation.accentColor
+        )
+    }
+
+    @objc private func toggleFromStatusItem(_ sender: Any?) {
+        toggle(sender)
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
@@ -1,0 +1,53 @@
+import AppKit
+import XCTest
+@testable import BrainBar
+
+@MainActor
+final class BrainBarStatusPopoverControllerTests: XCTestCase {
+    func testControllerPrewarmsVariableLengthStatusItemPopover() {
+        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
+        let controller = BrainBarStatusPopoverController(runtime: runtime)
+        defer { controller.stop() }
+
+        XCTAssertEqual(controller.statusItemForTesting.length, NSStatusItem.variableLength)
+        XCTAssertEqual(controller.popoverForTesting.behavior, NSPopover.Behavior.transient)
+        XCTAssertNotNil(controller.popoverForTesting.contentViewController)
+        XCTAssertTrue(controller.popoverForTesting.contentViewController?.isViewLoaded == true)
+    }
+
+    func testAppSupportCollectorFactoryWiresBrainBusEvents() {
+        let tempDBPath = NSTemporaryDirectory() + "brainbar-status-popover-\(UUID().uuidString).db"
+        let eventSource = RecordingBrainBusEventSource()
+        let collector = BrainBarAppSupport.makeStatsCollector(
+            dbPath: tempDBPath,
+            targetPID: ProcessInfo.processInfo.processIdentifier,
+            brainBusEvents: eventSource
+        )
+        defer {
+            collector.stop()
+            try? FileManager.default.removeItem(atPath: tempDBPath)
+            try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
+        }
+
+        collector.start()
+
+        XCTAssertEqual(eventSource.streamRequestCount, 1)
+    }
+}
+
+private final class RecordingBrainBusEventSource: BrainBusEventSource, @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests = 0
+
+    var streamRequestCount: Int {
+        lock.withLock { requests }
+    }
+
+    func events() -> AsyncStream<BrainBusEvent> {
+        lock.withLock {
+            requests += 1
+        }
+        return AsyncStream { _ in }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the active SwiftUI `MenuBarExtra` shell with a prewarmed AppKit `NSStatusItem` + transient `NSPopover` wrapper.
- Keep the existing SwiftUI BrainBar content tree by hosting `BrainBarWindowRootView` inside `NSHostingController`; no dashboard/content rewrite.
- Route dashboard/search/capture requests through the prewarmed popover and keep `StatsCollector` wired to `BrainBusClient` from item #5.

## Stacking
Stacked on Phase D IPC foundation / Lane B item #5 via `fix/brainbar-hybrid-parity`. This assumes PR #295's `watch-brain-bus` push path is present.

## Responsiveness Notes
- Popover and hosting controller are instantiated at app launch, before first click.
- Status item uses `NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)`.
- First-click work is limited to `popover.show(...)` against already-loaded content.
- I ran a lightweight simulated-load check with 10 `yes` workers around the prewarm XCTest. It passed, but this is not a real pointer-click p95 measurement; a human stage-demo click test is still the right final proof.

## No UI Polling
- No `MenuBarExtra` scene remains in `BrainBarApp`.
- This PR does not add timers or polling loops.
- The app collector factory explicitly injects `BrainBusClient()` so dashboard state remains push-driven over `watch-brain-bus`.

## Test Plan
- TDD RED: `swift test --package-path brain-bar --filter BrainBarStatusPopoverControllerTests` initially failed because `BrainBarStatusPopoverController` and `BrainBarAppSupport.makeStatsCollector` did not exist.
- Focused GREEN: `swift test --package-path brain-bar --filter BrainBarStatusPopoverControllerTests` -> 2 tests passed.
- Simulated CPU load: 10 `yes >/dev/null` workers + `swift test --package-path brain-bar --filter BrainBarStatusPopoverControllerTests/testControllerPrewarmsVariableLengthStatusItemPopover` -> passed.
- Full Swift suite: `swift test --package-path brain-bar` -> 362 tests passed, 0 failures.
- Pre-push BrainLayer gate: pytest unit suite 2016 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 32 passed; bun stale index 1 passed; FTS5 determinism shell regression PASS.

## Review Caveat
Local `cr review --plain` could not start because CodeRabbit CLI was rate-limited externally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the primary menu bar UI surface and toggle/show routing, which could affect app visibility/interaction and lifecycle cleanup despite largely reusing existing SwiftUI content.
> 
> **Overview**
> Replaces the SwiftUI `MenuBarExtra`-based menu bar shell with an AppKit `NSStatusItem` + transient `NSPopover` wrapper that is *prewarmed at launch* and hosts the existing `BrainBarWindowRootView`.
> 
> Updates `AppDelegate` to create/stop the new `BrainBarStatusPopoverController` in `.menuBarWindow` mode and route toggle/search/capture/dashboard actions through it, and factors `StatsCollector` construction into `BrainBarAppSupport.makeStatsCollector` to allow injection/testing while keeping `BrainBusClient` wired.
> 
> Adds focused XCTest coverage to verify popover prewarming/configuration and that the collector factory requests the BrainBus event stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740e90c1b8420cb3c2ca3d22548b54d065f4f68c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace SwiftUI MenuBarExtra with NSStatusItem popover shell in BrainBar
> - Replaces the SwiftUI `MenuBarExtra` scene with an imperative `BrainBarStatusPopoverController` that manages an `NSStatusItem` and a transient `NSPopover` hosting `BrainBarWindowRootView`.
> - In `.menuBarWindow` launch mode, `AppDelegate` now creates a `BrainBarStatusPopoverController` on launch; quick actions (search, capture, dashboard) route to its `show`/`toggle` APIs instead of focusing a menu bar window.
> - The status item button displays a live-updating sparkline image driven by `BrainBarRuntime.$collector` stats.
> - Adds a `BrainBarAppSupport.makeStatsCollector` factory and tests verifying popover prewarming and single-subscription behavior of the event stream.
> - Behavioral Change: the SwiftUI `MenuBarExtra` scene and `BrainBarMenuBarLabel` view are removed; menu bar integration is now fully imperative.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 740e90c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->