### PR TITLE
Normalize BrainLayer launchd plist hygiene

### DIFF
--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -59,6 +59,7 @@ LAUNCH_DOMAIN="gui/$(id -u)"
 SOCKET_PATH="${BRAINBAR_SOCKET_PATH:-/tmp/brainbar.sock}"
 PLIST_BUDDY="/usr/libexec/PlistBuddy"
 CANONICAL_REPO_ROOT="${BRAINBAR_CANONICAL_REPO_ROOT:-$HOME/Gits/brainlayer}"
+BRAINLAYER_LOG_DIR="$HOME/Library/Logs/brainlayer"
 
 if [ -d "$CANONICAL_REPO_ROOT" ]; then
     CANONICAL_REPO_ROOT="$(cd "$CANONICAL_REPO_ROOT" && pwd -P)"
@@ -222,6 +223,7 @@ fi
 echo "[build-app] Creating .app bundle at $APP_DIR..."
 mkdir -p "$APP_DIR/Contents/MacOS"
 mkdir -p "$APP_DIR/Contents/Resources"
+mkdir -p "$BRAINLAYER_LOG_DIR"
 
 cp "$BUNDLE_DIR/Info.plist" "$APP_DIR/Contents/"
 cp "$BINARY" "$APP_DIR/Contents/MacOS/BrainBar"
@@ -253,7 +255,10 @@ fi
 if [ "$DEV_BUNDLE_BUILD" -eq 0 ] && [ -f "$PLIST_SRC" ]; then
     echo "[build-app] Installing LaunchAgent to $PLIST_DST..."
     bootout_launchagent
-    sed "s|/Applications/BrainBar.app|$APP_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
+    sed \
+        -e "s|/Applications/BrainBar.app|$APP_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        "$PLIST_SRC" > "$PLIST_DST"
     launchctl bootstrap "$LAUNCH_DOMAIN" "$PLIST_DST"
     launchctl kickstart -k "$LAUNCH_DOMAIN/$PLIST_LABEL"
     echo "[build-app] LaunchAgent installed — BrainBar will auto-restart after quit"

--- a/brain-bar/bundle/com.brainlayer.brainbar.plist
+++ b/brain-bar/bundle/com.brainlayer.brainbar.plist
@@ -8,16 +8,30 @@
     <array>
         <string>/Applications/BrainBar.app/Contents/MacOS/BrainBar</string>
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/tmp/brainbar.stdout.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/brainbar.out.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/brainbar.stderr.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/brainbar.err.log</string>
     <key>ProcessType</key>
     <string>Interactive</string>
+    <key>ExitTimeOut</key>
+    <integer>30</integer>
+    <key>LowPriorityIO</key>
+    <false/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
     <key>ThrottleInterval</key>
     <integer>10</integer>
 </dict>

--- a/launchd/com.brainlayer.watch.plist
+++ b/launchd/com.brainlayer.watch.plist
@@ -18,14 +18,14 @@
     </array>
 
     <key>StandardOutPath</key>
-    <string>/Users/etanheyman/.local/share/brainlayer/logs/watch.log</string>
+    <string>/Users/etanheyman/Library/Logs/brainlayer/watch.out.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/etanheyman/.local/share/brainlayer/logs/watch.err</string>
+    <string>/Users/etanheyman/Library/Logs/brainlayer/watch.err.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/Users/etanheyman/.local/bin</string>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/etanheyman/.local/bin</string>
         <key>PYTHONUNBUFFERED</key>
         <string>1</string>
         <key>AXIOM_TOKEN</key>
@@ -46,5 +46,14 @@
 
     <key>ProcessType</key>
     <string>Background</string>
+    <key>ExitTimeOut</key>
+    <integer>30</integer>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.brainlayer.backup-daily.plist
+++ b/scripts/launchd/com.brainlayer.backup-daily.plist
@@ -22,12 +22,14 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/backup-daily.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/backup-daily.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/backup-daily.err</string>
+    <string>__HOME__/Library/Logs/brainlayer/backup-daily.err.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
         <key>PYTHONPATH</key>
         <string>__BRAINLAYER_DIR__/src</string>
         <key>BRAINLAYER_BACKUP_DRIVE_FOLDER</key>
@@ -42,5 +44,12 @@
 
     <key>ProcessType</key>
     <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.brainlayer.decay.plist
+++ b/scripts/launchd/com.brainlayer.decay.plist
@@ -24,14 +24,31 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/decay.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/decay.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/decay.err</string>
+    <string>__HOME__/Library/Logs/brainlayer/decay.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
 
     <key>Nice</key>
     <integer>15</integer>
 
     <key>ProcessType</key>
     <string>Background</string>
+    <key>ExitTimeOut</key>
+    <integer>120</integer>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.brainlayer.drain.plist
+++ b/scripts/launchd/com.brainlayer.drain.plist
@@ -9,25 +9,48 @@
     <array>
         <string>__PYTHON_BIN__</string>
         <string>__REPO_ROOT__/scripts/drain_daemon.py</string>
-        <string>--interval</string>
-        <string>0.5</string>
+        <string>--once</string>
+        <string>--batch-size</string>
+        <string>250</string>
     </array>
 
-    <key>StandardOutPath</key>
-    <string>__HOME__/.brainlayer/logs/drain.log</string>
-    <key>StandardErrorPath</key>
-    <string>__HOME__/.brainlayer/logs/drain.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+        <key>PYTHONPATH</key>
+        <string>__REPO_ROOT__/src</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
 
-    <key>KeepAlive</key>
-    <true/>
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/brainlayer/drain.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/brainlayer/drain.err.log</string>
+
+    <key>WatchPaths</key>
+    <array>
+        <string>__HOME__/.brainlayer/queue</string>
+    </array>
+    <key>QueueDirectories</key>
+    <array>
+        <string>__HOME__/.brainlayer/queue</string>
+    </array>
     <key>RunAtLoad</key>
     <true/>
-    <key>ThrottleInterval</key>
-    <integer>5</integer>
     <key>Nice</key>
     <integer>10</integer>
     <key>ProcessType</key>
-    <string>Background</string>
+    <string>Adaptive</string>
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>
-

--- a/scripts/launchd/com.brainlayer.enrichment.plist
+++ b/scripts/launchd/com.brainlayer.enrichment.plist
@@ -22,14 +22,14 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/Library/Logs/brainlayer-enrichment.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/enrichment.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/Library/Logs/brainlayer-enrichment.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/enrichment.err.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin</string>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
         <key>PYTHONUNBUFFERED</key>
         <string>1</string>
         <key>PYTHONPATH</key>
@@ -50,11 +50,22 @@
 
     <key>RunAtLoad</key>
     <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
 
     <key>Nice</key>
     <integer>10</integer>
 
     <key>ProcessType</key>
     <string>Background</string>
+    <key>ExitTimeOut</key>
+    <integer>120</integer>
+    <key>LowPriorityIO</key>
+    <false/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.brainlayer.index.plist
+++ b/scripts/launchd/com.brainlayer.index.plist
@@ -15,14 +15,14 @@
     <integer>1800</integer>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/index.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/index.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/index.err</string>
+    <string>__HOME__/Library/Logs/brainlayer/index.err.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin</string>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
         <key>PYTHONUNBUFFERED</key>
         <string>1</string>
     </dict>
@@ -32,5 +32,16 @@
 
     <key>Nice</key>
     <integer>10</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ExitTimeOut</key>
+    <integer>120</integer>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.brainlayer.repair-fts.plist
+++ b/scripts/launchd/com.brainlayer.repair-fts.plist
@@ -23,13 +23,30 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/repair-fts.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/repair-fts.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/repair-fts.err</string>
+    <string>__HOME__/Library/Logs/brainlayer/repair-fts.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
 
     <key>Nice</key>
     <integer>15</integer>
     <key>ProcessType</key>
     <string>Background</string>
+    <key>ExitTimeOut</key>
+    <integer>120</integer>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.brainlayer.wal-checkpoint.plist
+++ b/scripts/launchd/com.brainlayer.wal-checkpoint.plist
@@ -25,14 +25,31 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/wal-checkpoint.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/wal-checkpoint.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/wal-checkpoint.err</string>
+    <string>__HOME__/Library/Logs/brainlayer/wal-checkpoint.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
 
     <key>Nice</key>
     <integer>15</integer>
 
     <key>ProcessType</key>
     <string>Background</string>
+    <key>ExitTimeOut</key>
+    <integer>120</integer>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.brainlayer.watch.plist
+++ b/scripts/launchd/com.brainlayer.watch.plist
@@ -20,7 +20,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin</string>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
         <key>PYTHONUNBUFFERED</key>
         <string>1</string>
         <key>PYTHONPATH</key>
@@ -30,9 +30,9 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/watch.log</string>
+    <string>__HOME__/Library/Logs/brainlayer/watch.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.local/share/brainlayer/logs/watch.err</string>
+    <string>__HOME__/Library/Logs/brainlayer/watch.err.log</string>
 
     <key>KeepAlive</key>
     <true/>
@@ -44,5 +44,14 @@
     <integer>10</integer>
     <key>ProcessType</key>
     <string>Background</string>
+    <key>ExitTimeOut</key>
+    <integer>30</integer>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
 </dict>
 </plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -39,7 +39,7 @@ if [ ! -x "$BRAINLAYER_BIN" ]; then
     exit 1
 fi
 
-mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
+mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$LOG_DIR/brainlayer" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
 mkdir -p "$HOME/.brainlayer/logs" "$HOME/.brainlayer/queue"
 
 resolve_google_api_key() {

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -1241,7 +1241,8 @@ def test_enrichment_plist_matches_validated_flex_realtime_profile():
     env = plist["EnvironmentVariables"]
 
     assert plist["Nice"] == 10
-    assert plist["StandardOutPath"] == "__HOME__/Library/Logs/brainlayer-enrichment.log"
+    assert plist["StandardOutPath"] == "__HOME__/Library/Logs/brainlayer/enrichment.out.log"
+    assert plist["StandardErrorPath"] == "__HOME__/Library/Logs/brainlayer/enrichment.err.log"
     assert env["BRAINLAYER_ENRICH_RATE"] == "15"
     assert env["BRAINLAYER_ENRICH_CONCURRENCY"] == "18"
     assert env["BRAINLAYER_GEMINI_SERVICE_TIER"] == "flex"

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import plistlib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOG_ROOT = "__HOME__/Library/Logs/brainlayer/"
+RENDERED_LOG_ROOT = "/Users/etanheyman/Library/Logs/brainlayer/"
+REQUIRED_PATH_PARTS = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+
+
+def _load(path: str) -> dict:
+    with (REPO_ROOT / path).open("rb") as handle:
+        return plistlib.load(handle)
+
+
+def _assert_common_hygiene(plist: dict) -> None:
+    env = plist.get("EnvironmentVariables")
+    assert isinstance(env, dict)
+    path_dirs = [os.path.normpath(part) for part in env.get("PATH", "").split(os.pathsep) if part]
+    for part in REQUIRED_PATH_PARTS:
+        assert os.path.normpath(part) in path_dirs
+
+    assert plist["StandardOutPath"].startswith((LOG_ROOT, RENDERED_LOG_ROOT))
+    assert plist["StandardErrorPath"].startswith((LOG_ROOT, RENDERED_LOG_ROOT))
+
+    limits = plist.get("SoftResourceLimits")
+    assert isinstance(limits, dict)
+    assert limits.get("NumberOfFiles", 0) >= 4096
+    assert "ProcessType" in plist
+    assert "ExitTimeOut" in plist
+
+
+def test_active_daemon_launchd_hygiene_matrix():
+    cases = {
+        "brain-bar/bundle/com.brainlayer.brainbar.plist": {
+            "ProcessType": "Interactive",
+            "ExitTimeOut": 30,
+            "LowPriorityIO": False,
+            "KeepAlive": True,
+        },
+        "scripts/launchd/com.brainlayer.enrichment.plist": {
+            "ProcessType": "Background",
+            "ExitTimeOut": 120,
+            "LowPriorityIO": False,
+            "KeepAlive": True,
+        },
+        "scripts/launchd/com.brainlayer.watch.plist": {
+            "ProcessType": "Background",
+            "ExitTimeOut": 30,
+            "LowPriorityIO": True,
+            "KeepAlive": True,
+        },
+        "launchd/com.brainlayer.watch.plist": {
+            "ProcessType": "Background",
+            "ExitTimeOut": 30,
+            "LowPriorityIO": True,
+            "KeepAlive": True,
+        },
+        "scripts/launchd/com.brainlayer.drain.plist": {
+            "ProcessType": "Adaptive",
+            "ExitTimeOut": 60,
+            "LowPriorityIO": True,
+        },
+        "scripts/launchd/com.brainlayer.backup-daily.plist": {
+            "ProcessType": "Background",
+            "ExitTimeOut": 300,
+            "LowPriorityIO": True,
+        },
+    }
+
+    for path, expected in cases.items():
+        plist = _load(path)
+        _assert_common_hygiene(plist)
+        for key, value in expected.items():
+            assert plist.get(key) == value, path
+
+    drain = _load("scripts/launchd/com.brainlayer.drain.plist")
+    assert "KeepAlive" not in drain
+    assert drain["WatchPaths"] == ["__HOME__/.brainlayer/queue"]
+    assert drain["QueueDirectories"] == ["__HOME__/.brainlayer/queue"]
+    assert "--once" in drain["ProgramArguments"]
+
+    backup = _load("scripts/launchd/com.brainlayer.backup-daily.plist")
+    assert "KeepAlive" not in backup
+    assert "StartCalendarInterval" in backup
+
+
+def test_all_script_launchd_plists_have_common_hygiene():
+    for path in sorted((REPO_ROOT / "scripts/launchd").glob("com.brainlayer.*.plist")):
+        _assert_common_hygiene(plistlib.loads(path.read_bytes()))


### PR DESCRIPTION
## Summary
- Normalize BrainLayer launchd templates across ProcessType, triggers, ExitTimeOut, LowPriorityIO, log locations, PATH, and SoftResourceLimits.
- Convert `com.brainlayer.drain` from perpetual KeepAlive daemon to event-driven `WatchPaths` + `--once` with `ProcessType=Adaptive`.
- Update BrainBar/install helpers so generated installed plists create/use `~/Library/Logs/brainlayer/`.

## Before / After
| Daemon | Before | After |
|---|---|---|
| BrainBar | `Interactive`, `KeepAlive=true`, `/tmp` logs, no ExitTimeOut/FD limit | `Interactive`, `KeepAlive=true`, `ExitTimeOut=30`, `LowPriorityIO=false`, `~/Library/Logs/brainlayer/*`, `NumberOfFiles=4096` |
| enrichment_controller | `Background`, `KeepAlive=true`, mixed log path, no ExitTimeOut/FD limit | `Background`, `KeepAlive=true` + `ThrottleInterval=30`, `ExitTimeOut=120`, `LowPriorityIO=false`, common logs/PATH/FD limit |
| watch | `Background`, `KeepAlive=true`, old local-share logs, no ExitTimeOut/FD limit | `Background`, `KeepAlive=true`, `ExitTimeOut=30`, `LowPriorityIO=true`, common logs/PATH/FD limit |
| drain | `Background`, perpetual `KeepAlive=true`, `--interval 0.5`, `.brainlayer/logs` | `Adaptive`, `WatchPaths=~/.brainlayer/queue`, `--once`, `ExitTimeOut=60`, `LowPriorityIO=true`, common logs/PATH/FD limit |
| backup_daily | `Background`, `StartCalendarInterval`, no LowPriorityIO/FD limit/PATH | `Background`, `StartCalendarInterval`, `ExitTimeOut=300`, `LowPriorityIO=true`, common logs/PATH/FD limit |
| scheduled maintenance | mixed/no ProcessType, old local-share logs, no common PATH/FD limit | `Background`, calendar/interval triggers preserved, `ExitTimeOut=120`, `LowPriorityIO=true`, common logs/PATH/FD limit |

## Installed copy verification
- Rendered and reloaded installed LaunchAgents for BrainBar, backup, decay, drain, enrichment, WAL checkpoint, and watch.
- `launchctl list | rg 'brainlayer'` showed BrainBar, enrichment, and watch running; backup/decay/drain/WAL loaded but not perpetually running.
- `launchctl print` showed BrainBar as interactive, watch/enrichment as background, drain as adaptive with watch path, backup as calendar-triggered with `keepalive = 0`.

## Tests
- `PYTHONPATH=src pytest tests/test_backup_daily.py tests/test_launchd_hygiene.py -q`
- `ruff check src/ tests/ && ruff format --check src/ tests/`
- `for f in brain-bar/bundle/com.brainlayer.brainbar.plist launchd/com.brainlayer.watch.plist scripts/launchd/com.brainlayer.*.plist; do plutil -lint "$f" || exit 1; done`
- Installed plist lint for `~/Library/LaunchAgents/com.brainlayer.{brainbar,backup-daily,decay,drain,enrichment,wal-checkpoint,watch}.plist`

## Notes
- CodeRabbit CLI first pass found one minor test issue; fixed exact PATH component matching. Second pass was rate-limited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes launchd job behavior (notably converting `com.brainlayer.drain` from a KeepAlive polling daemon to an event-driven `WatchPaths` + `--once` job), which can affect indexing/enrichment throughput and latency.
> 
> **Overview**
> Standardizes BrainLayer launchd plists to a consistent “hygiene” baseline: logs move to `~/Library/Logs/brainlayer/`, `PATH` is made explicit (including `/usr/sbin` + `/sbin`), and common `ExitTimeOut` + `SoftResourceLimits.NumberOfFiles=4096`/`LowPriorityIO` settings are added across agents.
> 
> Updates installation helpers (`brain-bar/build-app.sh`, `scripts/launchd/install.sh`) to create the new log directory and to render `__HOME__` placeholders when installing plists. **Behaviorally**, `com.brainlayer.drain` is switched from a perpetual `KeepAlive` polling loop to an event-driven, one-shot run triggered by queue directory changes (`WatchPaths`/`QueueDirectories`, `ProcessType=Adaptive`, `--once --batch-size 250`).
> 
> Adds/updates tests to lock these plist conventions in place, including a new `test_launchd_hygiene.py` matrix that asserts required PATH components, log destinations, resource limits, and per-daemon expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f28fd685e1ef73cc079749f15aa324919d0c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize launchd plist hygiene across all BrainLayer daemons
> - Redirects stdout/stderr for all daemons from `/tmp` to `~/Library/Logs/brainlayer/` using `__HOME__` placeholders, expanded at install time via `sed` in [build-app.sh](https://github.com/EtanHey/brainlayer/pull/297/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb) and [install.sh](https://github.com/EtanHey/brainlayer/pull/297/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756)
> - Adds consistent `EnvironmentVariables` with an expanded `PATH` (including `/usr/sbin` and `/sbin`) across all plists; Python daemons also get `PYTHONUNBUFFERED=1`
> - Sets `SoftResourceLimits.NumberOfFiles=4096` and per-daemon `ExitTimeOut` values (30s, 60s, or 120s) on all jobs
> - Changes the `drain` daemon from persistent (`KeepAlive`) to event-driven, triggered by `WatchPaths`/`QueueDirectories` on `~/.brainlayer/queue`, running one batch of 250 per invocation with `ProcessType=Adaptive`
> - Adds [test_launchd_hygiene.py](https://github.com/EtanHey/brainlayer/pull/297/files#diff-288210b4160b1253fe79745f55be532bc29857ea99361693e48dfbf4edae5e4a) to validate PATH, log paths, resource limits, and per-daemon settings
> - Behavioral Change: `drain` no longer runs continuously; it fires on queue activity and at load, processing a fixed batch size of 250
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90f28fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->