### PR TITLE
Split BrainBar daemon and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ graph LR
     KG --> D
     E["JSONL conversations"] --> W["Real-time Watcher<br/>~1s latency"]
     W --> D
-    I["BrainBar<br/>macOS menu bar"] -->|Unix socket| B
+    I["BrainBar UI<br/>NSStatusItem + NSPopover"] -->|UDS /tmp/brainbar.sock| BB["BrainBarDaemon<br/>MCP + brain bus"]
+    BB -->|MCP socket protocol| B
 ```
 
 **Everything runs locally.** Cloud enrichment (Gemini/Groq) and Axiom telemetry are optional.
@@ -138,13 +139,22 @@ graph LR
 
 ## BrainBar — macOS Companion
 
-Optional native Swift menu bar app. Quick capture, live dashboard, knowledge graph viewer — all over a Unix socket. Auto-restarts after quit via LaunchAgent.
+Optional native Swift menu bar companion split into two launchd-managed processes:
+
+```mermaid
+flowchart LR
+    UI["BrainBar<br/>LSUIElement UI"] -->|"watch-brain-bus + commands<br/>/tmp/brainbar.sock"| D["BrainBarDaemon<br/>headless MCP server"]
+    D -->|"single writer queue + reads"| DB["SQLite WAL<br/>~/.local/share/brainlayer/brainlayer.db"]
+    D -->|"helper subprocess IPC"| H["Hybrid search helper"]
+```
+
+`BrainBarDaemon` owns the MCP server, `/tmp/brainbar.sock`, the single-writer path, the `watch-brain-bus` stream, and helper subprocess lifecycle. `BrainBar` owns only the `NSStatusItem`, transient `NSPopover`, SwiftUI surfaces, hotkey routing, and a reconnecting socket subscriber. Killing the UI does not stop the daemon socket.
 
 ```bash
 bash brain-bar/build-app.sh    # Build, sign, install LaunchAgent
 ```
 
-Requires the BrainLayer MCP server. The build script refuses non-canonical checkouts and dirty trees by default ([#265](https://github.com/EtanHey/brainlayer/pull/265)) and stamps each bundle with `GitCommit`, `GitDescribe`, and `BuildTimeUTC` in `Info.plist` ([#264](https://github.com/EtanHey/brainlayer/pull/264)) so a stale install is diagnosable in seconds.
+The build script builds both `BrainBar` and `BrainBarDaemon`, embeds both binaries in `BrainBar.app`, then installs `com.brainlayer.brainbar.plist` and `com.brainlayer.brainbar-daemon.plist` with `ProcessType=Interactive`. It refuses non-canonical checkouts and dirty trees by default ([#265](https://github.com/EtanHey/brainlayer/pull/265)) and stamps each bundle with `GitCommit`, `GitDescribe`, and `BuildTimeUTC` in `Info.plist` ([#264](https://github.com/EtanHey/brainlayer/pull/264)) so a stale install is diagnosable in seconds.
 
 ## Writer Arbitration
 

--- a/brain-bar/Package.swift
+++ b/brain-bar/Package.swift
@@ -6,6 +6,10 @@ let package = Package(
     platforms: [
         .macOS(.v14),
     ],
+    products: [
+        .executable(name: "BrainBar", targets: ["BrainBar"]),
+        .executable(name: "BrainBarDaemon", targets: ["BrainBarDaemon"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.5.0"),
     ],
@@ -16,6 +20,16 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Sources/BrainBar",
+            linkerSettings: [
+                .linkedLibrary("sqlite3"),
+            ]
+        ),
+        .executableTarget(
+            name: "BrainBarDaemon",
+            dependencies: [
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ],
+            path: "Sources/BrainBarDaemon",
             linkerSettings: [
                 .linkedLibrary("sqlite3"),
             ]

--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -20,6 +20,18 @@ enum BrainBarAppSupport {
             brainBusEvents: brainBusEvents
         )
     }
+
+    @MainActor
+    static func makeUIStatsCollector(
+        dbPath: String,
+        brainBusEvents: BrainBusEventSource? = BrainBusClient()
+    ) -> StatsCollector {
+        makeStatsCollector(
+            dbPath: dbPath,
+            targetPID: 0,
+            brainBusEvents: brainBusEvents
+        )
+    }
 }
 
 @MainActor
@@ -27,20 +39,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let runtime = BrainBarRuntime()
     private static let menuBarWindowAutosaveKey = "NSWindow Frame BrainBarMenuBarExtraWindow"
 
-    private var server: BrainBarServer?
     private var statusPopoverController: BrainBarStatusPopoverController?
     private var legacyStatusItem: NSStatusItem?
     private var legacyPopover: NSPopover?
     private var collector: StatsCollector?
-    private var injectionStore: InjectionStore?
-    private var quickCapturePanel: QuickCapturePanelController?
     private var searchPanel: SearchPanelController?
     private var dashboardPanel: BrainBarDashboardPanelController?
     private var quickCaptureHotkey: HotkeyManager?
     private weak var menuBarExtraWindow: NSWindow?
     private weak var discoveredMenuBarWindow: NSWindow?
     private var cancellables: Set<AnyCancellable> = []
-    private var sharedDatabase: BrainDatabase?
     private var pendingBrainBarURLs: [URL] = []
     private var hotkeyFileWatcher: DispatchSourceFileSystemObject?
     private var menuBarWindowObservers: [NSObjectProtocol] = []
@@ -85,44 +93,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let dbPath = BrainBarServer.defaultDBPath()
-        NSLog("[BrainBar] Starting server before database readiness at %@", dbPath)
-        let server = BrainBarServer(dbPath: dbPath)
-        server.onStartRejected = { reason in
-            NSLog("[BrainBar] Startup rejected: %@", reason)
-            Task { @MainActor in
-                NSApp.terminate(nil)
-            }
-        }
-        server.onDatabaseReady = { [weak self] database in
-            Task { @MainActor in
-                guard let self else { return }
-                self.sharedDatabase = database
-                self.configureQuickCapture(database: database)
-                self.runtime.install(
-                    collector: self.collector ?? BrainBarAppSupport.makeStatsCollector(
-                        dbPath: dbPath,
-                        targetPID: ProcessInfo.processInfo.processIdentifier,
-                        brainBusEvents: BrainBusClient()
-                    ),
-                    injectionStore: self.injectionStore,
-                    database: database
-                )
-                self.flushPendingBrainBarURLs()
-            }
-        }
-
-        let collector = BrainBarAppSupport.makeStatsCollector(
+        NSLog("[BrainBar] Starting UI shell; daemon owns %@", BrainBarServer.defaultSocketPath())
+        let collector = BrainBarAppSupport.makeUIStatsCollector(
             dbPath: dbPath,
-            targetPID: ProcessInfo.processInfo.processIdentifier,
             brainBusEvents: BrainBusClient()
         )
-        let injectionStore = try? InjectionStore(databasePath: dbPath)
-
-        self.server = server
         self.collector = collector
-        self.injectionStore = injectionStore
+        runtime.install(
+            collector: collector,
+            injectionStore: nil,
+            database: nil
+        )
 
-        server.start()
+        flushPendingBrainBarURLs()
 
         if launchMode == .legacyStatusItem {
             installLegacyMenuBarSurface(with: collector)
@@ -143,8 +126,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkeyFileWatcher?.cancel()
         quickCaptureHotkey?.stop()
         collector?.stop()
-        injectionStore?.stop()
-        server?.stop()
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -167,7 +148,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func showQuickCapturePanel() {
         guard launchMode == .menuBarWindow else {
-            quickCapturePanel?.toggle()
+            NSLog("[BrainBar] Quick capture requires the menu-bar command surface in UI-split mode")
             return
         }
 
@@ -827,16 +808,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func configureQuickCapture(database: BrainDatabase) {
-        guard launchMode == .legacyStatusItem else { return }
-        guard quickCapturePanel == nil else { return }
-        quickCapturePanel = QuickCapturePanelController(db: database)
-        if searchPanel == nil {
-            searchPanel = SearchPanelController(db: database)
-        }
-        flushPendingBrainBarURLs()
-    }
-
     private func ingestBrainBarURLs(_ urls: [URL]) {
         for url in urls {
             guard BrainBarURLAction.parse(url: url) != nil else { continue }
@@ -857,18 +828,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// URL actions are dispatched once the backing surface is ready. In
-    /// menuBarWindow mode the command bar is driven by `runtime.database` +
-    /// the MenuBarExtra window, so readiness means the database has been
-    /// installed into the runtime. In legacy mode the floating panel still
-    /// drives routing.
     private func isReadyToHandleBrainBarURL() -> Bool {
-        switch launchMode {
-        case .menuBarWindow:
-            return runtime.database != nil
-        case .legacyStatusItem:
-            return quickCapturePanel != nil
-        }
+        true
     }
 
     private func handleBrainBarURL(_ url: URL) {

--- a/brain-bar/Sources/BrainBar/BrainBarRuntime.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarRuntime.swift
@@ -26,7 +26,7 @@ final class BrainBarRuntime: ObservableObject {
     func install(
         collector: StatsCollector,
         injectionStore: InjectionStore?,
-        database: BrainDatabase
+        database: BrainDatabase?
     ) {
         self.collector = collector
         self.injectionStore = injectionStore

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1933,9 +1933,14 @@ final class BrainDatabase: @unchecked Sendable {
         try execute("""
             CREATE TABLE IF NOT EXISTS schema_migrations (
                 name TEXT PRIMARY KEY,
-                applied_at TEXT NOT NULL
+                applied_at TEXT NOT NULL,
+                details TEXT
             )
         """)
+        let schemaMigrationColumns = try tableColumns(name: "schema_migrations", on: db)
+        if !schemaMigrationColumns.contains("details") {
+            try execute("ALTER TABLE schema_migrations ADD COLUMN details TEXT")
+        }
         let existingColumns = try tableColumns(name: "chunks", on: db)
         let atomicColumns = ["brick_id", "source_uri", "status", "ingested_at", "topic_cluster"]
         let atomicMigrationApplied = try schemaMigrationApplied(name: "atomic_brick_chunks_v1", on: db)

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarCommandBar.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarCommandBar.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarCommandBar.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarDaemonMain.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarDaemonMain.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@main
+enum BrainBarDaemonMain {
+    static func main() {
+        let server = BrainBarServer()
+        server.onStartRejected = { reason in
+            NSLog("[BrainBarDaemon] Startup rejected: %@", reason)
+            Foundation.exit(1)
+        }
+        server.onDatabaseReady = { _ in
+            NSLog("[BrainBarDaemon] Database ready")
+        }
+        server.start()
+        NSLog("[BrainBarDaemon] Started on %@", BrainBarServer.defaultSocketPath())
+        RunLoop.main.run()
+    }
+}

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarDashboardPanelController.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarDashboardPanelController.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarInstanceLock.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarInstanceLock.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarInstanceLock.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarRuntime.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarRuntime.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarRuntime.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarServer.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarServer.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarStatusPopoverController.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarStatusPopoverController.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarStatusPopoverController.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarURLAction.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarURLAction.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarURLAction.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarWindowRootView.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarWindowRootView.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarWindowState.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarWindowState.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarWindowState.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBusClient.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBusClient.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBusClient.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainBusEvent.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBusEvent.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBusEvent.swift

--- a/brain-bar/Sources/BrainBarDaemon/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainDatabase.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainDatabase.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/AgentActivityMonitor.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/AgentActivityMonitor.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/BrainBarLivePulse.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/BrainBarLivePulse.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/BrainBarLivePulse.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/DaemonHealthMonitor.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/DaemonHealthMonitor.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/DaemonHealthMonitor.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/DashboardMetricFormatter.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/DashboardMetricFormatter.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/PipelineState.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/PipelineState.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/SparklineRenderer.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/SparklineRenderer.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/StatsCollector.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/StatsCollector.swift

--- a/brain-bar/Sources/BrainBarDaemon/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Dashboard/StatusPopoverView.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Dashboard/StatusPopoverView.swift

--- a/brain-bar/Sources/BrainBarDaemon/Formatters.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Formatters.swift
@@ -1,0 +1,1 @@
+../BrainBar/Formatters.swift

--- a/brain-bar/Sources/BrainBarDaemon/Formatting/TextFormatter.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Formatting/TextFormatter.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Formatting/TextFormatter.swift

--- a/brain-bar/Sources/BrainBarDaemon/HotkeyManager.swift
+++ b/brain-bar/Sources/BrainBarDaemon/HotkeyManager.swift
@@ -1,0 +1,1 @@
+../BrainBar/HotkeyManager.swift

--- a/brain-bar/Sources/BrainBarDaemon/HotkeyRouteStatus.swift
+++ b/brain-bar/Sources/BrainBarDaemon/HotkeyRouteStatus.swift
@@ -1,0 +1,1 @@
+../BrainBar/HotkeyRouteStatus.swift

--- a/brain-bar/Sources/BrainBarDaemon/HybridSearchHelperClient.swift
+++ b/brain-bar/Sources/BrainBarDaemon/HybridSearchHelperClient.swift
@@ -1,0 +1,1 @@
+../BrainBar/HybridSearchHelperClient.swift

--- a/brain-bar/Sources/BrainBarDaemon/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBarDaemon/InjectionEvent.swift
@@ -1,0 +1,1 @@
+../BrainBar/InjectionEvent.swift

--- a/brain-bar/Sources/BrainBarDaemon/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/InjectionFeedView.swift
@@ -1,0 +1,1 @@
+../BrainBar/InjectionFeedView.swift

--- a/brain-bar/Sources/BrainBarDaemon/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBarDaemon/InjectionPresentation.swift
@@ -1,0 +1,1 @@
+../BrainBar/InjectionPresentation.swift

--- a/brain-bar/Sources/BrainBarDaemon/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBarDaemon/InjectionStore.swift
@@ -1,0 +1,1 @@
+../BrainBar/InjectionStore.swift

--- a/brain-bar/Sources/BrainBarDaemon/InjectionSummaryView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/InjectionSummaryView.swift
@@ -1,0 +1,1 @@
+../BrainBar/InjectionSummaryView.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/EntityCache.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/EntityCache.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/EntityCache.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGAtlasLayout.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGAtlasLayout.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGAtlasLayout.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGAtlasPresentation.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGAtlasPresentation.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGCanvasView.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGCanvasView.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGEdge.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGEdge.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGEdge.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGEdgeView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGEdgeView.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGEdgeView.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGNode.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGNode.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGNode.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGNodeView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGNodeView.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGNodeView.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGSidebarView.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGSidebarView.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGSimulationController.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGSimulationController.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGSimulationController.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGViewModel.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGViewModel.swift

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/ScrollWheelZoomView.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/ScrollWheelZoomView.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/ScrollWheelZoomView.swift

--- a/brain-bar/Sources/BrainBarDaemon/MCPFraming.swift
+++ b/brain-bar/Sources/BrainBarDaemon/MCPFraming.swift
@@ -1,0 +1,1 @@
+../BrainBar/MCPFraming.swift

--- a/brain-bar/Sources/BrainBarDaemon/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBarDaemon/MCPRouter.swift
@@ -1,0 +1,1 @@
+../BrainBar/MCPRouter.swift

--- a/brain-bar/Sources/BrainBarDaemon/Models/DigestResult.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Models/DigestResult.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Models/DigestResult.swift

--- a/brain-bar/Sources/BrainBarDaemon/Models/EntityCard.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Models/EntityCard.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Models/EntityCard.swift

--- a/brain-bar/Sources/BrainBarDaemon/Models/KGSearchResult.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Models/KGSearchResult.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Models/KGSearchResult.swift

--- a/brain-bar/Sources/BrainBarDaemon/Models/SearchResult.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Models/SearchResult.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Models/SearchResult.swift

--- a/brain-bar/Sources/BrainBarDaemon/Models/StatsResult.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Models/StatsResult.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Models/StatsResult.swift

--- a/brain-bar/Sources/BrainBarDaemon/QuickCaptureController.swift
+++ b/brain-bar/Sources/BrainBarDaemon/QuickCaptureController.swift
@@ -1,0 +1,1 @@
+../BrainBar/QuickCaptureController.swift

--- a/brain-bar/Sources/BrainBarDaemon/QuickCapturePanel.swift
+++ b/brain-bar/Sources/BrainBarDaemon/QuickCapturePanel.swift
@@ -1,0 +1,1 @@
+../BrainBar/QuickCapturePanel.swift

--- a/brain-bar/Sources/BrainBarDaemon/QuickCapturePanelState.swift
+++ b/brain-bar/Sources/BrainBarDaemon/QuickCapturePanelState.swift
@@ -1,0 +1,1 @@
+../BrainBar/QuickCapturePanelState.swift

--- a/brain-bar/Sources/BrainBarDaemon/SearchFilters.swift
+++ b/brain-bar/Sources/BrainBarDaemon/SearchFilters.swift
@@ -1,0 +1,1 @@
+../BrainBar/SearchFilters.swift

--- a/brain-bar/Sources/BrainBarDaemon/SearchPanelController.swift
+++ b/brain-bar/Sources/BrainBarDaemon/SearchPanelController.swift
@@ -1,0 +1,1 @@
+../BrainBar/SearchPanelController.swift

--- a/brain-bar/Sources/BrainBarDaemon/SearchQueryActor.swift
+++ b/brain-bar/Sources/BrainBarDaemon/SearchQueryActor.swift
@@ -1,0 +1,1 @@
+../BrainBar/SearchQueryActor.swift

--- a/brain-bar/Sources/BrainBarDaemon/SearchViewModel.swift
+++ b/brain-bar/Sources/BrainBarDaemon/SearchViewModel.swift
@@ -1,0 +1,1 @@
+../BrainBar/SearchViewModel.swift

--- a/brain-bar/Sources/BrainBarDaemon/Views/Components/ChunkConversationSheet.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Views/Components/ChunkConversationSheet.swift
@@ -1,0 +1,1 @@
+../../../BrainBar/Views/Components/ChunkConversationSheet.swift

--- a/brain-bar/Sources/BrainBarDaemon/Views/Components/SearchResultCard.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Views/Components/SearchResultCard.swift
@@ -1,0 +1,1 @@
+../../../BrainBar/Views/Components/SearchResultCard.swift

--- a/brain-bar/Sources/BrainBarDaemon/Views/Components/SearchResultsList.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Views/Components/SearchResultsList.swift
@@ -1,0 +1,1 @@
+../../../BrainBar/Views/Components/SearchResultsList.swift

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -82,6 +82,17 @@ final class DatabaseTests: XCTestCase {
         XCTAssertTrue(exists, "brainbar_subscriptions table must exist")
     }
 
+    func testSchemaMigrationsTableIncludesDetailsForHybridHelperParity() throws {
+        let columns = try sqliteTableColumns(path: tempDBPath, table: "schema_migrations")
+
+        XCTAssertTrue(columns.contains("name"))
+        XCTAssertTrue(columns.contains("applied_at"))
+        XCTAssertTrue(
+            columns.contains("details"),
+            "Swift startup must keep schema_migrations compatible with the Phase D Python helper"
+        )
+    }
+
     func testInjectionEventsTableExists() throws {
         let exists = try db.tableExists("injection_events")
         XCTAssertTrue(exists, "injection_events table must exist")
@@ -1026,6 +1037,25 @@ private func sqliteQueryPlan(path: String, sql: String, binds: [String]) throws 
             }
         }
         return details
+    }
+}
+
+private func sqliteTableColumns(path: String, table: String) throws -> Set<String> {
+    try withSQLiteConnection(path: path) { db in
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, "PRAGMA table_info(\(table))", -1, &stmt, nil)
+        guard rc == SQLITE_OK else {
+            throw NSError(domain: "DatabaseTests", code: Int(rc))
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var columns = Set<String>()
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let text = sqlite3_column_text(stmt, 1) {
+                columns.insert(String(cString: text))
+            }
+        }
+        return columns
     }
 }
 

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -51,10 +51,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PACKAGE_DIR="$SCRIPT_DIR"
 BUNDLE_DIR="$SCRIPT_DIR/bundle"
 SIGN_IDENTITY="${BRAINBAR_CODESIGN_IDENTITY:-Apple Development: Etan Heyman (DXHB5E7P2D)}"
-PLIST_LABEL="com.brainlayer.brainbar"
-PLIST_FILENAME="$PLIST_LABEL.plist"
-PLIST_SRC="$BUNDLE_DIR/$PLIST_FILENAME"
-PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_FILENAME"
+UI_PLIST_LABEL="com.brainlayer.brainbar"
+DAEMON_PLIST_LABEL="com.brainlayer.brainbar-daemon"
+UI_PLIST_FILENAME="$UI_PLIST_LABEL.plist"
+DAEMON_PLIST_FILENAME="$DAEMON_PLIST_LABEL.plist"
+UI_PLIST_SRC="$BUNDLE_DIR/$UI_PLIST_FILENAME"
+DAEMON_PLIST_SRC="$BUNDLE_DIR/$DAEMON_PLIST_FILENAME"
+UI_PLIST_DST="$HOME/Library/LaunchAgents/$UI_PLIST_FILENAME"
+DAEMON_PLIST_DST="$HOME/Library/LaunchAgents/$DAEMON_PLIST_FILENAME"
 LAUNCH_DOMAIN="gui/$(id -u)"
 SOCKET_PATH="${BRAINBAR_SOCKET_PATH:-/tmp/brainbar.sock}"
 PLIST_BUDDY="/usr/libexec/PlistBuddy"
@@ -111,9 +115,10 @@ if [ "$DRY_RUN" -eq 1 ]; then
     echo "[build-app] Repo: $CURRENT_REPO_ROOT"
     echo "[build-app] App path: $APP_DIR"
     if [ "$DEV_BUNDLE_BUILD" -eq 1 ]; then
-        echo "[build-app] LaunchAgent: skipped for DEV worktree build"
+        echo "[build-app] LaunchAgents: skipped for DEV worktree build"
     else
-        echo "[build-app] LaunchAgent: canonical install to $PLIST_DST"
+        echo "[build-app] UI LaunchAgent: canonical install to $UI_PLIST_DST"
+        echo "[build-app] Daemon LaunchAgent: canonical install to $DAEMON_PLIST_DST"
     fi
     exit 0
 fi
@@ -170,15 +175,29 @@ stamp_info_plist() {
 }
 
 bootout_launchagent() {
-    launchctl bootout "$LAUNCH_DOMAIN/$PLIST_LABEL" 2>/dev/null || true
-    if [ -f "$PLIST_DST" ]; then
-        launchctl bootout "$LAUNCH_DOMAIN" "$PLIST_DST" 2>/dev/null || true
+    launchctl bootout "$LAUNCH_DOMAIN/$UI_PLIST_LABEL" 2>/dev/null || true
+    launchctl bootout "$LAUNCH_DOMAIN/$DAEMON_PLIST_LABEL" 2>/dev/null || true
+    if [ -f "$UI_PLIST_DST" ]; then
+        launchctl bootout "$LAUNCH_DOMAIN" "$UI_PLIST_DST" 2>/dev/null || true
+    fi
+    if [ -f "$DAEMON_PLIST_DST" ]; then
+        launchctl bootout "$LAUNCH_DOMAIN" "$DAEMON_PLIST_DST" 2>/dev/null || true
     fi
 }
 
 wait_for_brainbar_exit() {
     for _ in $(seq 1 100); do
         if ! pgrep -x BrainBar > /dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+wait_for_brainbar_daemon_exit() {
+    for _ in $(seq 1 100); do
+        if ! pgrep -x BrainBarDaemon > /dev/null 2>&1; then
             return 0
         fi
         sleep 0.2
@@ -199,9 +218,9 @@ wait_for_socket() {
 }
 
 if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then
-    # Stop LaunchAgent first so KeepAlive cannot race the rebuild and unlink the
+    # Stop LaunchAgents first so KeepAlive cannot race the rebuild and unlink the
     # freshly rebound socket from an older instance that is still terminating.
-    echo "[build-app] Stopping LaunchAgent..."
+    echo "[build-app] Stopping LaunchAgents..."
     bootout_launchagent
 
     # Kill any running BrainBar instances before installing.
@@ -214,19 +233,34 @@ if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then
             exit 1
         fi
     fi
+    if pgrep -x BrainBarDaemon > /dev/null 2>&1; then
+        echo "[build-app] Stopping running BrainBarDaemon instances..."
+        killall BrainBarDaemon 2>/dev/null || true
+        if ! wait_for_brainbar_daemon_exit; then
+            echo "[build-app] ERROR: BrainBarDaemon did not exit cleanly"
+            pgrep -fl BrainBarDaemon || true
+            exit 1
+        fi
+    fi
     rm -f "$SOCKET_PATH"
 else
     echo "[build-app] DEV worktree build: preserving canonical LaunchAgent and socket"
 fi
 
-echo "[build-app] Building BrainBar (release)..."
-swift build -c release --package-path "$PACKAGE_DIR"
+echo "[build-app] Building BrainBar and BrainBarDaemon (release)..."
+swift build -c release --package-path "$PACKAGE_DIR" --product BrainBar
+swift build -c release --package-path "$PACKAGE_DIR" --product BrainBarDaemon
 
 # Find the built binary
 BIN_DIR="$(swift build -c release --package-path "$PACKAGE_DIR" --show-bin-path)"
 BINARY="$BIN_DIR/BrainBar"
+DAEMON_BINARY="$BIN_DIR/BrainBarDaemon"
 if [ ! -f "$BINARY" ]; then
     echo "[build-app] ERROR: Binary not found at $BINARY"
+    exit 1
+fi
+if [ ! -f "$DAEMON_BINARY" ]; then
+    echo "[build-app] ERROR: Daemon binary not found at $DAEMON_BINARY"
     exit 1
 fi
 
@@ -242,6 +276,7 @@ mkdir -p "$APP_DIR/Contents/Resources"
 
 cp "$BUNDLE_DIR/Info.plist" "$APP_DIR/Contents/"
 cp "$BINARY" "$APP_DIR/Contents/MacOS/BrainBar"
+cp "$DAEMON_BINARY" "$APP_DIR/Contents/MacOS/BrainBarDaemon"
 
 COMMIT_SHA="$(git_commit)"
 DESCRIBE_REF="$(git_describe)"
@@ -266,19 +301,31 @@ fi
 # Register URL scheme with Launch Services (ensures brainbar:// works after rebuild)
 /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -R "$APP_DIR"
 
-# Install LaunchAgent (expands path to actual APP_DIR)
-if [ "$DEV_BUNDLE_BUILD" -eq 0 ] && [ -f "$PLIST_SRC" ]; then
-    echo "[build-app] Installing LaunchAgent to $PLIST_DST..."
-    bootout_launchagent
+install_launchagent() {
+    local source_plist="$1"
+    local target_plist="$2"
+    local label="$3"
+
+    echo "[build-app] Installing LaunchAgent to $target_plist..."
     TMP_PLIST="$(mktemp)"
     trap 'rm -f "$TMP_PLIST"' EXIT
-    sed "s|/Applications/BrainBar.app|$APP_DIR|g" "$PLIST_SRC" > "$TMP_PLIST"
+    sed "s|/Applications/BrainBar.app|$APP_DIR|g" "$source_plist" > "$TMP_PLIST"
     configure_launchagent_environment "$TMP_PLIST" "$CURRENT_REPO_ROOT"
-    mv "$TMP_PLIST" "$PLIST_DST"
+    mv "$TMP_PLIST" "$target_plist"
     trap - EXIT
-    launchctl bootstrap "$LAUNCH_DOMAIN" "$PLIST_DST"
-    launchctl kickstart -k "$LAUNCH_DOMAIN/$PLIST_LABEL"
-    echo "[build-app] LaunchAgent installed — BrainBar will auto-restart after quit"
+    launchctl bootstrap "$LAUNCH_DOMAIN" "$target_plist"
+    launchctl kickstart -k "$LAUNCH_DOMAIN/$label"
+}
+
+# Install LaunchAgents (expands path to actual APP_DIR)
+if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then
+    if [ -f "$DAEMON_PLIST_SRC" ]; then
+        install_launchagent "$DAEMON_PLIST_SRC" "$DAEMON_PLIST_DST" "$DAEMON_PLIST_LABEL"
+    fi
+    if [ -f "$UI_PLIST_SRC" ]; then
+        install_launchagent "$UI_PLIST_SRC" "$UI_PLIST_DST" "$UI_PLIST_LABEL"
+    fi
+    echo "[build-app] LaunchAgents installed — daemon and UI restart independently"
 fi
 
 if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then

--- a/brain-bar/bundle/com.brainlayer.brainbar-daemon.plist
+++ b/brain-bar/bundle/com.brainlayer.brainbar-daemon.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.brainlayer.brainbar-daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/BrainBar.app/Contents/MacOS/BrainBarDaemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/brainbar-daemon.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/brainbar-daemon.stderr.log</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -108,7 +108,8 @@ def test_build_app_allows_clean_canonical_repo_in_dry_run(tmp_path: Path) -> Non
 
     assert result.returncode == 0
     assert str(home / "Applications" / "BrainBar.app") in result.stdout
-    assert "LaunchAgent: canonical install" in result.stdout
+    assert "UI LaunchAgent: canonical install" in result.stdout
+    assert "Daemon LaunchAgent: canonical install" in result.stdout
 
 
 def test_build_app_helpers_ignore_parent_git_hook_env(tmp_path: Path, monkeypatch) -> None:
@@ -174,7 +175,7 @@ def test_build_app_routes_forced_noncanonical_repo_to_dev_bundle(tmp_path: Path)
 
     assert result.returncode == 0
     assert str(home / "Applications" / "BrainBar-DEV-feat-ui-guards.app") in result.stdout
-    assert "LaunchAgent: skipped for DEV worktree build" in result.stdout
+    assert "LaunchAgents: skipped for DEV worktree build" in result.stdout
 
 
 def test_build_app_rejects_dirty_canonical_repo_without_force(tmp_path: Path) -> None:
@@ -306,3 +307,22 @@ def test_build_app_rejects_untracked_dirty_repo_even_when_status_hides_untracked
     assert result.returncode != 0
     assert "dirty" in result.stderr.lower()
     assert "UNTRACKED.txt" in result.stderr
+
+
+def test_brainbar_daemon_launchagent_runs_interactive_daemon_binary() -> None:
+    plist = Path(__file__).resolve().parents[1] / "brain-bar" / "bundle" / "com.brainlayer.brainbar-daemon.plist"
+    content = plist.read_text()
+
+    assert "<string>com.brainlayer.brainbar-daemon</string>" in content
+    assert "<string>/Applications/BrainBar.app/Contents/MacOS/BrainBarDaemon</string>" in content
+    assert "<key>ProcessType</key>" in content
+    assert "<string>Interactive</string>" in content
+
+
+def test_brainbar_package_declares_separate_ui_and_daemon_products() -> None:
+    package = Path(__file__).resolve().parents[1] / "brain-bar" / "Package.swift"
+    content = package.read_text()
+
+    assert '.executable(name: "BrainBar", targets: ["BrainBar"])' in content
+    assert '.executable(name: "BrainBarDaemon", targets: ["BrainBarDaemon"])' in content
+    assert 'path: "Sources/BrainBarDaemon"' in content


### PR DESCRIPTION
## Summary

- Adds a separate `BrainBarDaemon` SwiftPM executable that owns the BrainBar MCP socket, brain bus, single-writer server path, and hybrid helper lifecycle.
- Keeps `BrainBar` as the LSUIElement UI process with `NSStatusItem`/`NSPopover` from item #6 and a reconnecting `BrainBusClient` subscriber from item #5.
- Updates `build-app.sh` to build both products, embed both binaries into `BrainBar.app`, and install two `ProcessType=Interactive` LaunchAgents.
- Aligns fresh Swift-created DBs with the Phase D Python helper by keeping `schema_migrations.details` present.
- Documents the two-process UDS topology in `README.md`.

## 30-second lecture demo

```bash
bash brain-bar/build-app.sh
launchctl print gui/$(id -u)/com.brainlayer.brainbar-daemon | head -40
launchctl print gui/$(id -u)/com.brainlayer.brainbar | head -40
pgrep -fl 'BrainBar|BrainBarDaemon'
kill -9 $(pgrep -x BrainBar)
python3 - <<'PY'
import json, socket
path = '/tmp/brainbar.sock'

def send(sock, payload):
    body = json.dumps(payload, separators=(',', ':')).encode()
    sock.sendall(f'Content-Length: {len(body)}\r\n\r\n'.encode() + body)

def recv(sock):
    data = b''
    while b'\r\n\r\n' not in data:
        data += sock.recv(1)
    header, body = data.split(b'\r\n\r\n', 1)
    length = int([line.split(':', 1)[1] for line in header.decode().split('\r\n') if line.lower().startswith('content-length:')][0])
    while len(body) < length:
        body += sock.recv(length - len(body))
    return json.loads(body[:length])

with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
    sock.connect(path)
    send(sock, {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"lecture-demo","version":"1"}}})
    print(recv(sock).get('result', {}).get('serverInfo'))
PY
launchctl kickstart -k gui/$(id -u)/com.brainlayer.brainbar
sleep 2
pgrep -fl 'BrainBar|BrainBarDaemon'
```

Expected: killing `BrainBar` does not remove `/tmp/brainbar.sock`; the daemon still answers MCP; kickstarting the UI relaunches the menu-bar process.

## Verification

- TDD red: `swift test --package-path brain-bar --filter DatabaseTests/testSchemaMigrationsTableIncludesDetailsForHybridHelperParity` failed before the Swift schema migration added `details`.
- `pytest tests/test_brainbar_build_app_guards.py -q` -> 13 passed.
- `swift build --package-path brain-bar --product BrainBar` -> passed.
- `swift build --package-path brain-bar --product BrainBarDaemon` -> passed.
- Isolated daemon smoke: launched `BrainBarDaemon` with temp `BRAINBAR_SOCKET_PATH` + `BRAINBAR_DB_PATH`; `initialize` succeeded and `tools/list` returned 16 tools over UDS.
- `swift test --package-path brain-bar` -> 363 passed.
- Pre-push gate -> pytest unit suite 2018 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook 32 passed; Bun 1 passed; FTS5 regression passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Splits BrainBar into two cooperating processes and updates launchd packaging/build scripts, which can impact startup/IPC reliability and deployment behavior. Also adjusts SQLite schema migration compatibility, which could affect fresh DB initialization if incorrect.
> 
> **Overview**
> BrainBar is split into two SwiftPM executables: **`BrainBarDaemon` now owns the MCP server and `/tmp/brainbar.sock`**, while **`BrainBar` becomes a UI-only menu bar shell** that no longer starts/stops the server or requires database readiness for URL handling.
> 
> The build and install flow is updated to build/embed both binaries into `BrainBar.app` and install **two** `ProcessType=Interactive` LaunchAgents (`com.brainlayer.brainbar` + `com.brainlayer.brainbar-daemon`), with new tests and a new daemon LaunchAgent plist.
> 
> SQLite startup migrations are tweaked to ensure `schema_migrations.details` exists (and is backfilled via `ALTER TABLE` when missing) to maintain compatibility with the hybrid helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983a1a353a97790f7f650387bbc2e6356a61a896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split BrainBar into separate UI and headless BrainBarDaemon processes
> - Introduces a new `BrainBarDaemon` executable ([BrainBarDaemonMain.swift](https://github.com/EtanHey/brainlayer/pull/298/files#diff-462f3fd8aad3480789eaa9a6493a8a4c598a94d2631bf33b268001571d92078d)) that owns the MCP server, Unix domain socket (`/tmp/brainbar.sock`), SQLite DB, and helper process lifecycle, running as a persistent launchd agent via [com.brainlayer.brainbar-daemon.plist](https://github.com/EtanHey/brainlayer/pull/298/files#diff-65ea85b1de4a9c8b7ae83be7e62eb8381511b068d2bc525e09375a5bf3951912).
> - The `BrainBar` UI app ([BrainBarApp.swift](https://github.com/EtanHey/brainlayer/pull/298/files#diff-9577de6dd76be378361fd90c956077766066b55e943853da8d80bd0d672a7ca4)) no longer starts or manages the server, database, or `InjectionStore`; it assumes the daemon is already running.
> - [Package.swift](https://github.com/EtanHey/brainlayer/pull/298/files#diff-b51d56888cdd363445419485ee9a5c99493cf63d44e6fc20c3b8e33e51b0ce46) declares both executables; [build-app.sh](https://github.com/EtanHey/brainlayer/pull/298/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb) builds, validates, and installs both binaries and their respective LaunchAgents.
> - Shared source files are symlinked into `Sources/BrainBarDaemon/` rather than duplicated.
> - `BrainDatabase.ensureChunkColumns` now adds a `details` column to `schema_migrations` if absent.
> - Behavioral Change: quick capture panel invocation in non-menu-bar-window mode now logs and returns instead of opening a panel; `isReadyToHandleBrainBarURL` always returns `true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 983a1a3. 7 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->