### PR TITLE
Fix BrainBar UI stats DB read-only mode

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -12,12 +12,14 @@ enum BrainBarAppSupport {
     static func makeStatsCollector(
         dbPath: String,
         targetPID: pid_t,
-        brainBusEvents: BrainBusEventSource? = BrainBusClient()
+        brainBusEvents: BrainBusEventSource? = BrainBusClient(),
+        databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) -> StatsCollector {
         StatsCollector(
             dbPath: dbPath,
             daemonMonitor: DaemonHealthMonitor(targetPID: targetPID),
-            brainBusEvents: brainBusEvents
+            brainBusEvents: brainBusEvents,
+            databaseOpenConfiguration: databaseOpenConfiguration
         )
     }
 
@@ -29,7 +31,8 @@ enum BrainBarAppSupport {
         makeStatsCollector(
             dbPath: dbPath,
             targetPID: 0,
-            brainBusEvents: brainBusEvents
+            brainBusEvents: brainBusEvents,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
         )
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -10,9 +10,11 @@ import SQLite3
 final class BrainDatabase: @unchecked Sendable {
     struct OpenConfiguration: Sendable, Equatable {
         let busyTimeoutMillis: Int32
+        let readOnly: Bool
 
-        init(busyTimeoutMillis: Int32 = 30_000) {
+        init(busyTimeoutMillis: Int32 = 30_000, readOnly: Bool = false) {
             self.busyTimeoutMillis = max(1, busyTimeoutMillis)
+            self.readOnly = readOnly
         }
     }
 
@@ -255,6 +257,12 @@ final class BrainDatabase: @unchecked Sendable {
             NSLog("[BrainBar] Connection opened, configuring...")
             try configureConnection(db)
             NSLog("[BrainBar] Connection configured, checking schema...")
+            if openConfiguration.readOnly {
+                NSLog("[BrainBar] Read-only connection - skipping schema migration checks")
+                lastOpenError = nil
+                isOpen = true
+                return
+            }
             // AIDEV-NOTE: Skip ensureSchema if chunks table already exists (Python creates all tables).
             // CREATE TABLE IF NOT EXISTS still acquires a RESERVED lock which blocks on watch agent.
             if (try? tableExists("chunks")) == true {
@@ -268,9 +276,19 @@ final class BrainDatabase: @unchecked Sendable {
             isOpen = true
             NSLog("[BrainBar] Database ready")
         } catch {
+            if let db {
+                sqlite3_close(db)
+                self.db = nil
+            }
+            isOpen = false
             lastOpenError = error
             NSLog("[BrainBar] Failed to open/configure database at %@: %@", path, String(describing: error))
         }
+    }
+
+    func reopenIfNeeded() {
+        guard !isOpen else { return }
+        openAndConfigure()
     }
 
     // tableExists defined at line ~237 (existing method)
@@ -467,6 +485,7 @@ final class BrainDatabase: @unchecked Sendable {
             sqlite3_close(db)
             self.db = nil
         }
+        isOpen = false
     }
 
     func vacuumInto(targetPath: String) throws -> Int64 {
@@ -1662,12 +1681,12 @@ final class BrainDatabase: @unchecked Sendable {
 
     private func openConnection(path: String) throws -> OpaquePointer {
         var handle: OpaquePointer?
-        // AIDEV-NOTE: READWRITE is needed for save/search. The async init in BrainBarApp.swift
-        // ensures this runs on a background queue so it doesn't block the menu item.
-        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        let flags = openConfiguration.readOnly
+            ? SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX
+            : SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
         let rc = sqlite3_open_v2(path, &handle, flags, nil)
         guard rc == SQLITE_OK, let handle else { throw DBError.open(path, rc) }
-        NSLog("[BrainBar] Database opened READWRITE")
+        NSLog("[BrainBar] Database opened %@", openConfiguration.readOnly ? "READONLY" : "READWRITE")
         return handle
     }
 
@@ -1675,6 +1694,12 @@ final class BrainDatabase: @unchecked Sendable {
         guard let handle else { throw DBError.notOpen }
         // AIDEV-NOTE: busy_timeout FIRST — 30s because watch agent holds locks during enrichment.
         try executeOnHandle(handle, sql: "PRAGMA busy_timeout = \(openConfiguration.busyTimeoutMillis)")
+        if openConfiguration.readOnly {
+            try executeOnHandle(handle, sql: "PRAGMA query_only = ON")
+            try executeOnHandle(handle, sql: "PRAGMA cache_size = -64000")
+            try executeOnHandle(handle, sql: "PRAGMA foreign_keys = ON")
+            return
+        }
         // AIDEV-NOTE: Skip journal_mode=WAL if already set — the PRAGMA itself needs a write lock
         // which blocks indefinitely when the watch agent is active. WAL is already set by Python.
         let currentMode = queryPragma(handle, name: "journal_mode")

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -38,9 +38,10 @@ final class StatsCollector: ObservableObject {
         dbPath: String,
         daemonMonitor: DaemonHealthMonitor,
         agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor(),
-        brainBusEvents: BrainBusEventSource? = nil
+        brainBusEvents: BrainBusEventSource? = nil,
+        databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) {
-        self.database = BrainDatabase(path: dbPath)
+        self.database = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
         self.daemonMonitor = daemonMonitor
         self.agentActivityMonitor = agentActivityMonitor
         self.brainBusEvents = brainBusEvents
@@ -94,6 +95,7 @@ final class StatsCollector: ObservableObject {
         agentActivity = agentActivityMonitor.sample()
 
         do {
+            database.reopenIfNeeded()
             let currentDataVersion = try database.dataVersion()
             if force || currentDataVersion != lastDataVersion {
                 stats = try database.dashboardStats(

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -256,6 +256,39 @@ final class DashboardTests: XCTestCase {
     }
 
     @MainActor
+    func testReadOnlyStatsCollectorReopensAfterDaemonCreatesDatabase() throws {
+        db.close()
+        try? FileManager.default.removeItem(atPath: tempDBPath)
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
+
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        collector.refresh(force: true)
+        XCTAssertEqual(collector.stats.chunkCount, 0)
+
+        let writer = BrainDatabase(path: tempDBPath)
+        defer { writer.close() }
+        try writer.insertChunk(
+            id: "dash-readonly-late-db",
+            content: "Daemon created the database after UI startup",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+
+        collector.refresh(force: true)
+
+        XCTAssertEqual(collector.stats.chunkCount, 1)
+    }
+
+    @MainActor
     func testStatsCollectorSubscribesToBrainBusWithoutPollingDelay() {
         let eventSource = RecordingBrainBusEventSource()
         let collector = StatsCollector(

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -93,6 +93,36 @@ final class DatabaseTests: XCTestCase {
         )
     }
 
+    func testReadOnlyOpenConfigurationAllowsDashboardReadsButRejectsWrites() throws {
+        try db.insertChunk(
+            id: "readonly-seed",
+            content: "Seed row for read-only dashboard stats",
+            sessionId: "readonly",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+
+        let reader = BrainDatabase(
+            path: tempDBPath,
+            openConfiguration: .init(readOnly: true)
+        )
+        defer { reader.close() }
+
+        let stats = try reader.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+        XCTAssertEqual(stats.chunkCount, 1)
+        XCTAssertThrowsError(
+            try reader.insertChunk(
+                id: "readonly-write",
+                content: "This write must not land from the UI process",
+                sessionId: "readonly",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 5
+            )
+        )
+    }
+
     func testInjectionEventsTableExists() throws {
         let exists = try db.tableExists("injection_events")
         XCTAssertTrue(exists, "injection_events table must exist")


### PR DESCRIPTION
## Summary
- Open the BrainBar UI stats database connection with SQLite READONLY flags and `PRAGMA query_only = ON`.
- Keep the daemon/server path as the sole read-write owner while preserving dashboard stats reads.
- Add regression coverage proving read-only dashboard stats can read existing rows and reject writes.

## Test plan
- [x] `swift test --package-path brain-bar --filter DatabaseTests/testReadOnlyOpenConfigurationAllowsDashboardReadsButRejectsWrites`
- [x] `pytest tests/test_brainbar_build_app_guards.py -q`
- [x] Live daemon/UI smoke: daemon opens temp DB READWRITE, UI opens same DB READONLY, killing UI leaves daemon MCP `initialize` healthy
- [x] `swift test --package-path brain-bar`
- [x] push hook: pytest unit suite, MCP registration, eval/hook routing, bun stale-index test, FTS5 regression shell

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQLite connection flags/PRAGMAs and schema-migration behavior, which could affect DB availability/locking if misconfigured, but is scoped to the UI stats reader path and covered by new tests.
> 
> **Overview**
> **Makes the BrainBar UI dashboard stats DB connection read-only** so the daemon remains the sole read-write owner.
> 
> Adds `readOnly` to `BrainDatabase.OpenConfiguration`, opening connections with `SQLITE_OPEN_READONLY` + `PRAGMA query_only=ON`, and skipping migration/schema checks and write-oriented PRAGMAs when in read-only mode.
> 
> Threads the configuration through `StatsCollector`/`makeStatsCollector`, sets `makeUIStatsCollector` to `readOnly: true`, adds `reopenIfNeeded()` to self-heal when the DB appears later, and adds regression tests verifying read-only reads succeed, writes fail, and the collector can reopen after the daemon creates the DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a05bc09f974704c719a3935d02fc62500688d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BrainBar UI stats collector to open the database in read-only mode
> - Adds `readOnly` support to `BrainDatabase.OpenConfiguration`, which sets SQLite `query_only` mode, adjusts cache size, and skips schema/migration checks on open.
> - Updates `BrainBarAppSupport.makeUIStatsCollector` to pass `OpenConfiguration(readOnly: true)` so the UI process never attempts writes to the stats DB.
> - Adds `BrainDatabase.reopenIfNeeded()` and calls it in `StatsCollector.refresh` so stats load once the DB becomes available after the daemon creates it.
> - Adds tests covering read-only dashboard reads, write rejection, and deferred DB availability scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a05bc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added read-only database access mode to enhance safety and prevent accidental data modifications
  * Dashboard statistics collector now uses read-only database configuration by default

* **Improvements**
  * Enhanced database configuration flexibility with parameterized open settings

* **Tests**
  * Added test coverage for read-only database operations and access patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->