### PR TITLE
Add kqueue parent-death watcher for Python sidecars

### DIFF
--- a/brain-bar/Scripts/brainbar_stdio_adapter.py
+++ b/brain-bar/Scripts/brainbar_stdio_adapter.py
@@ -19,6 +19,14 @@ def write_all(fd: int, data: bytes) -> None:
 
 
 def main() -> int:
+    try:
+        from brainlayer.parent_death import install_parent_death_watcher
+    except ModuleNotFoundError:
+        install_parent_death_watcher = None
+
+    if install_parent_death_watcher is not None:
+        install_parent_death_watcher()
+
     parser = argparse.ArgumentParser(description="Bridge stdio to BrainBar's Unix socket.")
     parser.add_argument(
         "--socket",

--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -187,6 +187,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    from brainlayer.parent_death import install_parent_death_watcher
+
+    install_parent_death_watcher()
+
     args = parse_args(argv)
     if args.db_path:
         os.environ["BRAINLAYER_DB"] = args.db_path

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -908,7 +908,10 @@ def enrich(
     try:
         from .. import cloud_backfill
         from ..enrichment_controller import enrich_realtime
+        from ..parent_death import install_parent_death_watcher
         from ..vector_store import VectorStore
+
+        install_parent_death_watcher()
 
         if mode not in ("realtime", "batch"):
             raise typer.BadParameter(f"Invalid mode: {mode}")
@@ -1639,9 +1642,12 @@ def watch(
     """
     import signal
 
+    from ..parent_death import install_parent_death_watcher
     from ..paths import get_db_path
     from ..watcher import JSONLWatcher
     from ..watcher_bridge import create_flush_callback
+
+    install_parent_death_watcher()
 
     db_path = get_db_path()
     offsets_path = db_path.parent / "offsets.json"

--- a/src/brainlayer/daemon.py
+++ b/src/brainlayer/daemon.py
@@ -1267,6 +1267,10 @@ def main():
     """Main daemon entry point."""
     import argparse
 
+    from brainlayer.parent_death import install_parent_death_watcher
+
+    install_parent_death_watcher()
+
     parser = argparse.ArgumentParser(description="BrainLayer daemon")
     parser.add_argument("--http", type=int, default=None, help="Also serve on HTTP port (e.g. --http 8787)")
     parser.add_argument("--host", type=str, default="127.0.0.1", help="HTTP bind address (default: 127.0.0.1)")

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -563,6 +563,10 @@ def run_daemon(interval: float, batch_size: int) -> None:
 
 
 def main() -> int:
+    from brainlayer.parent_death import install_parent_death_watcher
+
+    install_parent_death_watcher()
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--once", action="store_true")
     parser.add_argument("--interval", type=float, default=0.5)

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -1588,6 +1588,10 @@ def serve():
     Note: MCP uses stdin/stdout for communication, not network ports.
     This is designed for integration with Claude Code via mcpServers config.
     """
+    from brainlayer.parent_death import install_parent_death_watcher
+
+    install_parent_death_watcher()
+
     # Validate configuration at startup
     config_errors = validate_config()
     fatal = [e for e in config_errors if e["severity"] == "error"]

--- a/src/brainlayer/parent_death.py
+++ b/src/brainlayer/parent_death.py
@@ -1,0 +1,56 @@
+"""Parent-death watcher for BrainLayer Python sidecars on macOS/BSD."""
+
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import select
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+def install_parent_death_watcher() -> bool:
+    """Exit this process when its current parent exits.
+
+    macOS has no Linux-style PR_SET_PDEATHSIG. For BrainBar-spawned Python
+    sidecars, EVFILT_PROC/NOTE_EXIT gives us the same zero-polling behavior.
+    Returns False on platforms without kqueue or when already reparented.
+    """
+    if os.environ.get("BRAINLAYER_DISABLE_PARENT_DEATH_WATCH") == "1":
+        return False
+
+    kqueue_factory = getattr(select, "kqueue", None)
+    kevent_factory = getattr(select, "kevent", None)
+    if kqueue_factory is None or kevent_factory is None:
+        return False
+
+    parent_pid = os.getppid()
+    if parent_pid <= 1:
+        return False
+
+    try:
+        kq = kqueue_factory()
+        event = kevent_factory(
+            parent_pid,
+            filter=select.KQ_FILTER_PROC,
+            flags=select.KQ_EV_ADD,
+            fflags=select.KQ_NOTE_EXIT,
+        )
+        kq.control([event], 0, 0)
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            os._exit(0)
+        logger.debug("parent death watcher not installed for pid %s: %s", parent_pid, exc)
+        return False
+
+    def _wait_for_parent_exit() -> None:
+        try:
+            kq.control([], 1, None)
+        finally:
+            os._exit(0)
+
+    thread = threading.Thread(target=_wait_for_parent_exit, name="brainlayer-parent-death", daemon=True)
+    thread.start()
+    return True

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -1371,6 +1371,10 @@ def run_enrichment(
 if __name__ == "__main__":
     import argparse
 
+    from brainlayer.parent_death import install_parent_death_watcher
+
+    install_parent_death_watcher()
+
     parser = argparse.ArgumentParser(description="Enrich BrainLayer chunks with LLM metadata")
     parser.add_argument("--batch-size", type=int, default=50)
     parser.add_argument("--max", type=int, default=0, help="Max chunks to process (0=unlimited)")

--- a/tests/test_parent_death.py
+++ b/tests/test_parent_death.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import select
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_parent_death_watcher_noops_without_kqueue(monkeypatch):
+    from brainlayer import parent_death
+
+    monkeypatch.setattr(parent_death.select, "kqueue", None, raising=False)
+    assert parent_death.install_parent_death_watcher() is False
+
+
+def test_long_running_python_sidecar_entrypoints_install_parent_death_watcher():
+    entrypoints = {
+        "src/brainlayer/mcp/__init__.py",
+        "src/brainlayer/daemon.py",
+        "src/brainlayer/drain.py",
+        "src/brainlayer/pipeline/enrichment.py",
+        "src/brainlayer/brainbar_hybrid_helper.py",
+        "src/brainlayer/cli/__init__.py",
+        "brain-bar/Scripts/brainbar_stdio_adapter.py",
+    }
+
+    for relative in entrypoints:
+        text = (REPO_ROOT / relative).read_text()
+        assert "install_parent_death_watcher" in text, relative
+
+
+@pytest.mark.skipif(not hasattr(select, "kqueue"), reason="kqueue is only available on BSD/macOS")
+def test_parent_death_watcher_exits_when_parent_dies(tmp_path):
+    ready_path = tmp_path / "ready"
+    parent_script = tmp_path / "parent.py"
+    child_script = tmp_path / "child.py"
+
+    child_script.write_text(
+        textwrap.dedent(
+            """
+            import os
+            import sys
+            import time
+
+            from brainlayer.parent_death import install_parent_death_watcher
+
+            ready_path = sys.argv[1]
+            installed = install_parent_death_watcher()
+            if not installed:
+                raise SystemExit("watcher did not install")
+            with open(ready_path, "w", encoding="utf-8") as fh:
+                fh.write(str(os.getpid()))
+            while True:
+                time.sleep(0.1)
+            """
+        )
+    )
+    parent_script.write_text(
+        textwrap.dedent(
+            """
+            import os
+            import subprocess
+            import sys
+            import time
+
+            child = subprocess.Popen([sys.executable, sys.argv[1], sys.argv[2]])
+            deadline = time.monotonic() + 5
+            while not os.path.exists(sys.argv[2]):
+                if time.monotonic() > deadline:
+                    child.kill()
+                    raise SystemExit("child did not become ready")
+                time.sleep(0.01)
+            print(child.pid, flush=True)
+            """
+        )
+    )
+
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = f"{src_path}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    parent = subprocess.Popen(
+        [sys.executable, str(parent_script), str(child_script), str(ready_path)],
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert parent.stdout is not None
+    child_pid = int(parent.stdout.readline().strip())
+    assert parent.wait(timeout=5) == 0
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.02)
+    else:
+        os.kill(child_pid, signal.SIGKILL)
+        pytest.fail("child did not exit after parent death")


### PR DESCRIPTION
## Summary
- add a macOS/BSD kqueue NOTE_EXIT parent-death watcher for BrainLayer Python sidecars
- install it in BrainBar/MCP/daemon/watch/enrich/drain sidecar entry points
- add a real subprocess test that proves a child exits within 1s after its parent dies

## Verification
- PYTHONPATH=src pytest tests/test_parent_death.py tests/test_brainbar_hybrid_helper.py tests/test_cli_enrich.py tests/test_jsonl_watcher.py tests/test_daemon_kg.py tests/test_mcp_input_schema_limits.py tests/test_lifecycle.py -q
- ruff check src/ tests/ brain-bar/Scripts/brainbar_stdio_adapter.py
- ruff format --check src/ tests/ brain-bar/Scripts/brainbar_stdio_adapter.py
- swift test --filter SocketIntegrationTests (from brain-bar/)

## Notes
- The kqueue behavior is active only where Python exposes select.kqueue; other platforms no-op.
- `BRAINLAYER_DISABLE_PARENT_DEATH_WATCH=1` disables the watcher for emergency/debug runs.
- Full local pytest collection is blocked by local environment deps: missing deepchecks and NumPy 2.4 incompatible with numba/ranx.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes lifecycle/termination behavior for multiple persistent processes and uses a background `kqueue` thread with `os._exit`, which could surface platform-specific edge cases.
> 
> **Overview**
> Adds a new `brainlayer.parent_death.install_parent_death_watcher()` implementation using BSD/macOS `kqueue` `NOTE_EXIT` to terminate Python sidecar processes when their parent exits (with an env var escape hatch and no-op behavior on unsupported platforms).
> 
> Installs the watcher at startup across several long-running entry points (daemon, MCP stdio server, drain loop, enrichment pipeline runner, hybrid helper, CLI `enrich`/`watch`, and BrainBar’s `brainbar_stdio_adapter`).
> 
> Introduces `tests/test_parent_death.py`, including a subprocess-based integration test that verifies the child process exits shortly after its parent terminates, plus a unit test for the no-`kqueue` fallback and a check that entrypoints include the watcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf76d191529eb23c1c00f61facd3a3138c9a608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add kqueue parent-death watcher to Python sidecar processes
> - Adds [parent_death.py](https://github.com/EtanHey/brainlayer/pull/301/files#diff-53d14360ca0a06fc3016dc95b61df5497052b3a47688e27938df3a504a4a83f0) with `install_parent_death_watcher()`, which uses `kqueue`/`EVFILT_PROC` to monitor the parent PID and calls `os._exit(0)` in a daemon thread when the parent exits.
> - Installs the watcher at startup in all long-running entrypoints: daemon, drain, MCP stdio server, CLI `enrich` and `watch` commands, hybrid helper, enrichment pipeline, and the stdio adapter.
> - Can be disabled by setting `BRAINLAYER_DISABLE_PARENT_DEATH_WATCH`; no-ops silently on platforms without `select.kqueue` (i.e. non-BSD/macOS).
> - Adds tests covering the no-kqueue no-op path, a live parent-death integration test, and a coverage check that all entrypoints call `install_parent_death_watcher`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edf76d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->