### PR TITLE
feat(brainbar): async KG graph load + bounded relations

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -2,6 +2,10 @@ import AppKit
 import Combine
 import SwiftUI
 
+enum BrainBarPlaceholderCopy {
+    static let injectionFeedNotWired = "Injection feed not yet wired in this build."
+}
+
 struct BrainBarWindowRootView: View {
     @ObservedObject var runtime: BrainBarRuntime
     private let managesWindowFrame: Bool
@@ -113,7 +117,7 @@ struct BrainBarWindowRootView: View {
         if let store = runtime.injectionStore {
             BrainBarInjectionTab(store: store)
         } else {
-            BrainBarLoadingView(title: "Injections", subtitle: "Injection store unavailable.")
+            BrainBarLoadingView(title: "Injections", subtitle: BrainBarPlaceholderCopy.injectionFeedNotWired)
         }
     }
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3386,7 +3386,7 @@ final class BrainDatabase: @unchecked Sendable {
             throw DBError.prepare(sqlite3_errcode(db))
         }
         defer { sqlite3_finalize(stmt) }
-        sqlite3_bind_int(stmt, 1, Int32(max(0, limit)))
+        sqlite3_bind_int64(stmt, 1, Int64(max(0, limit)))
 
         var rows: [KGRelationRow] = []
         while sqlite3_step(stmt) == SQLITE_ROW {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3299,7 +3299,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     // MARK: - Knowledge Graph bulk queries
 
-    struct KGEntityRow: Equatable {
+    struct KGEntityRow: Equatable, Sendable {
         let id: String
         let name: String
         let entityType: String
@@ -3307,21 +3307,21 @@ final class BrainDatabase: @unchecked Sendable {
         let importance: Double
     }
 
-    struct KGRelationRow: Equatable {
+    struct KGRelationRow: Equatable, Sendable {
         let id: String
         let sourceId: String
         let targetId: String
         let relationType: String
     }
 
-    struct KGChunkRow: Equatable {
+    struct KGChunkRow: Equatable, Sendable {
         let chunkID: String
         let snippet: String
         let importance: Int
         let relevance: Double
     }
 
-    struct EnrichmentStatsSummary: Equatable {
+    struct EnrichmentStatsSummary: Equatable, Sendable {
         let totalChunks: Int
         let enriched: Int
         let unenrichedEligible: Int
@@ -3370,16 +3370,23 @@ final class BrainDatabase: @unchecked Sendable {
         return rows
     }
 
-    func fetchKGRelations() throws -> [KGRelationRow] {
+    func fetchKGRelations(limit: Int = 5_000) throws -> [KGRelationRow] {
         guard let db else { throw DBError.notOpen }
         // Exclude co_occurs_with — these are auto-generated from text proximity
         // and produce noisy, often incorrect edges in the graph view.
-        let sql = "SELECT id, source_id, target_id, relation_type FROM kg_relations WHERE relation_type != 'co_occurs_with'"
+        let sql = """
+            SELECT id, source_id, target_id, relation_type
+            FROM kg_relations
+            WHERE relation_type != 'co_occurs_with'
+            ORDER BY id
+            LIMIT ?
+        """
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             throw DBError.prepare(sqlite3_errcode(db))
         }
         defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int(stmt, 1, Int32(max(0, limit)))
 
         var rows: [KGRelationRow] = []
         while sqlite3_step(stmt) == SQLITE_ROW {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -287,7 +287,7 @@ final class StatusPopoverView: NSViewController {
         if let hosting = injectionHosting { return hosting.view }
 
         guard let store = injectionStore else {
-            return makePlaceholder("Injection store unavailable")
+            return makePlaceholder(BrainBarPlaceholderCopy.injectionFeedNotWired)
         }
 
         store.start()

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -55,10 +55,11 @@ struct KGCanvasView: View {
             }
             .onAppear {
                 setCanvas(size: geo.size)
-                if !hasLoadedGraph {
-                    viewModel.loadGraph()
-                    hasLoadedGraph = true
-                }
+            }
+            .task {
+                guard !hasLoadedGraph else { return }
+                await viewModel.loadGraph()
+                hasLoadedGraph = true
             }
             .onChange(of: geo.size) { _, newSize in
                 setCanvas(size: newSize)

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -58,8 +58,9 @@ struct KGCanvasView: View {
             }
             .task {
                 guard !hasLoadedGraph else { return }
-                await viewModel.loadGraph()
-                hasLoadedGraph = true
+                if await viewModel.loadGraph() {
+                    hasLoadedGraph = true
+                }
             }
             .onChange(of: geo.size) { _, newSize in
                 setCanvas(size: newSize)

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGEdge.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGEdge.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct KGEdge: Identifiable, Equatable {
+struct KGEdge: Identifiable, Equatable, Sendable {
     let sourceId: String
     let targetId: String
     let relationType: String

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGNode.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGNode.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct KGNode: Identifiable, Equatable {
+struct KGNode: Identifiable, Equatable, Sendable {
     let id: String
     let name: String
     let entityType: String

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -4,6 +4,7 @@ import SwiftUI
 final class KGViewModel: ObservableObject {
     @Published var nodes: [KGNode] = []
     @Published var edges: [KGEdge] = []
+    @Published var isLoading = false
     @Published var selectedNodeId: String?
     @Published var selectedEntity: EntityCard?
     @Published var selectedEntityChunks: [BrainDatabase.KGChunkRow] = []
@@ -27,43 +28,72 @@ final class KGViewModel: ObservableObject {
 
     // MARK: - Data Loading
 
-    func loadGraph() {
+    func loadGraph() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
         do {
-            let entityRows = try database.fetchKGEntities()
-            let relationRows = try database.fetchKGRelations()
-
-            let entityIds = Set(entityRows.map(\.id))
-
-            let seededNodes = entityRows.map { row in
-                KGNode(
-                    id: row.id,
-                    name: row.name,
-                    entityType: row.entityType,
-                    importance: row.importance
-                )
-            }
-            nodes = KGAtlasLayout.seededNodes(
-                seededNodes,
-                canvasSize: CGSize(
-                    width: max(canvasCenter.x * 2, 640),
-                    height: max(canvasCenter.y * 2, 480)
-                )
-            )
-
-            // Only include edges where both endpoints exist
-            edges = relationRows.compactMap { row in
-                guard entityIds.contains(row.sourceId), entityIds.contains(row.targetId) else {
-                    return nil
-                }
-                return KGEdge(
-                    sourceId: row.sourceId,
-                    targetId: row.targetId,
-                    relationType: row.relationType
-                )
-            }
+            let graph = try await Self.fetchGraphRows(database: database)
+            applyGraph(entityRows: graph.entities, relationRows: graph.relations)
         } catch {
             nodes = []
             edges = []
+        }
+    }
+
+    private struct GraphRows: Sendable {
+        let entities: [BrainDatabase.KGEntityRow]
+        let relations: [BrainDatabase.KGRelationRow]
+    }
+
+    private nonisolated static func fetchGraphRows(database: BrainDatabase) async throws -> GraphRows {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    continuation.resume(returning: GraphRows(
+                        entities: try database.fetchKGEntities(),
+                        relations: try database.fetchKGRelations(limit: 5_000)
+                    ))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func applyGraph(
+        entityRows: [BrainDatabase.KGEntityRow],
+        relationRows: [BrainDatabase.KGRelationRow]
+    ) {
+        let entityIds = Set(entityRows.map(\.id))
+
+        let seededNodes = entityRows.map { row in
+            KGNode(
+                id: row.id,
+                name: row.name,
+                entityType: row.entityType,
+                importance: row.importance
+            )
+        }
+        nodes = KGAtlasLayout.seededNodes(
+            seededNodes,
+            canvasSize: CGSize(
+                width: max(canvasCenter.x * 2, 640),
+                height: max(canvasCenter.y * 2, 480)
+            )
+        )
+
+        // Only include edges where both endpoints exist
+        edges = relationRows.compactMap { row in
+            guard entityIds.contains(row.sourceId), entityIds.contains(row.targetId) else {
+                return nil
+            }
+            return KGEdge(
+                sourceId: row.sourceId,
+                targetId: row.targetId,
+                relationType: row.relationType
+            )
         }
     }
 

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -28,17 +28,20 @@ final class KGViewModel: ObservableObject {
 
     // MARK: - Data Loading
 
-    func loadGraph() async {
-        guard !isLoading else { return }
+    @discardableResult
+    func loadGraph() async -> Bool {
+        guard !isLoading else { return false }
         isLoading = true
         defer { isLoading = false }
 
         do {
             let graph = try await Self.fetchGraphRows(database: database)
             applyGraph(entityRows: graph.entities, relationRows: graph.relations)
+            return true
         } catch {
             nodes = []
             edges = []
+            return false
         }
     }
 

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -130,6 +130,18 @@ final class KGDatabaseTests: XCTestCase {
         XCTAssertEqual(relations.count, 2)
     }
 
+    func testFetchKGRelationsHandlesOversizedLimit() throws {
+        try db.insertEntity(id: "root", type: "project", name: "Root")
+        for index in 0..<5 {
+            try db.insertEntity(id: "e-\(index)", type: "person", name: "Entity \(index)")
+            try db.insertRelation(sourceId: "e-\(index)", targetId: "root", relationType: "builds")
+        }
+
+        let relations = try db.fetchKGRelations(limit: Int.max)
+
+        XCTAssertEqual(relations.count, 5)
+    }
+
     func testFetchKGRelationsEmptyDB() throws {
         let relations = try db.fetchKGRelations()
         XCTAssertTrue(relations.isEmpty)
@@ -274,8 +286,8 @@ final class KGViewModelTests: XCTestCase {
 
         await vm.loadGraph()
 
-        XCTAssertTrue(mainActorRanDuringLoad, "loadGraph should suspend off the MainActor while database work runs")
         await marker.value
+        XCTAssertTrue(mainActorRanDuringLoad, "loadGraph should suspend off the MainActor while database work runs")
     }
 
     func testLoadGraphEmptyDB() async throws {
@@ -366,6 +378,8 @@ final class KGViewModelTests: XCTestCase {
 }
 
 final class BrainBarInjectionsPlaceholderTests: XCTestCase {
+    deinit {}
+
     func testInjectionsTabShowsClearMessageWhenStoreNil() {
         let subtitle = BrainBarPlaceholderCopy.injectionFeedNotWired
 

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -118,6 +118,18 @@ final class KGDatabaseTests: XCTestCase {
         XCTAssertEqual(relations.count, 2)
     }
 
+    func testFetchKGRelationsRespectsLimit() throws {
+        try db.insertEntity(id: "root", type: "project", name: "Root")
+        for index in 0..<5 {
+            try db.insertEntity(id: "e-\(index)", type: "person", name: "Entity \(index)")
+            try db.insertRelation(sourceId: "e-\(index)", targetId: "root", relationType: "builds")
+        }
+
+        let relations = try db.fetchKGRelations(limit: 2)
+
+        XCTAssertEqual(relations.count, 2)
+    }
+
     func testFetchKGRelationsEmptyDB() throws {
         let relations = try db.fetchKGRelations()
         XCTAssertTrue(relations.isEmpty)
@@ -237,32 +249,49 @@ final class KGViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func testLoadGraphPopulatesNodesAndEdges() throws {
+    func testLoadGraphPopulatesNodesAndEdges() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
         try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
 
         let vm = KGViewModel(database: db)
-        vm.loadGraph()
+        await vm.loadGraph()
 
         XCTAssertEqual(vm.nodes.count, 2)
         XCTAssertEqual(vm.edges.count, 1)
     }
 
-    func testLoadGraphEmptyDB() throws {
+    func testLoadGraphKeepsMainActorAvailableWhileLoading() async throws {
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+
         let vm = KGViewModel(database: db)
-        vm.loadGraph()
+        var mainActorRanDuringLoad = false
+        let marker = Task { @MainActor in
+            mainActorRanDuringLoad = true
+        }
+
+        await vm.loadGraph()
+
+        XCTAssertTrue(mainActorRanDuringLoad, "loadGraph should suspend off the MainActor while database work runs")
+        await marker.value
+    }
+
+    func testLoadGraphEmptyDB() async throws {
+        let vm = KGViewModel(database: db)
+        await vm.loadGraph()
 
         XCTAssertTrue(vm.nodes.isEmpty)
         XCTAssertTrue(vm.edges.isEmpty)
     }
 
-    func testSelectNodeUpdatesSelectedEntity() throws {
+    func testSelectNodeUpdatesSelectedEntity() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
         try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
         let vm = KGViewModel(database: db)
-        vm.loadGraph()
+        await vm.loadGraph()
 
         vm.selectNode(id: "a")
         XCTAssertEqual(vm.selectedNodeId, "a")
@@ -270,12 +299,12 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertEqual(vm.selectedEntity?.name, "Alice")
     }
 
-    func testSelectNodeNilDeselects() throws {
+    func testSelectNodeNilDeselects() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
         try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
         let vm = KGViewModel(database: db)
-        vm.loadGraph()
+        await vm.loadGraph()
 
         vm.selectNode(id: "a")
         vm.selectNode(id: nil)
@@ -283,13 +312,13 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertNil(vm.selectedEntity)
     }
 
-    func testForceTickMovesNodes() throws {
+    func testForceTickMovesNodes() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
         try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
 
         let vm = KGViewModel(database: db)
-        vm.loadGraph()
+        await vm.loadGraph()
 
         let positionsBefore = vm.nodes.map(\.position)
         vm.tick() // one simulation step
@@ -300,12 +329,12 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertTrue(moved, "Force tick should move at least one node")
     }
 
-    func testNodeHitTestFindsCorrectNode() throws {
+    func testNodeHitTestFindsCorrectNode() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
         try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
         let vm = KGViewModel(database: db)
-        vm.loadGraph()
+        await vm.loadGraph()
 
         // Place node at known position
         vm.nodes[0].position = CGPoint(x: 100, y: 100)
@@ -317,7 +346,7 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertNil(miss)
     }
 
-    func testSelectedEntityChunksPopulated() throws {
+    func testSelectedEntityChunksPopulated() async throws {
         try db.insertEntity(id: "e1", type: "person", name: "Alice")
         try db.insertEntity(id: "e2", type: "project", name: "BrainLayer")
         try db.insertRelation(sourceId: "e1", targetId: "e2", relationType: "builds")
@@ -328,11 +357,20 @@ final class KGViewModelTests: XCTestCase {
         try db.linkEntityChunk(entityId: "e1", chunkId: "c1", relevance: 0.9)
 
         let vm = KGViewModel(database: db)
-        vm.loadGraph()
+        await vm.loadGraph()
         vm.selectNode(id: "e1")
 
         XCTAssertFalse(vm.selectedEntityChunks.isEmpty)
         XCTAssertTrue(vm.selectedEntityChunks.first?.snippet.contains("Alice") ?? false)
+    }
+}
+
+final class BrainBarInjectionsPlaceholderTests: XCTestCase {
+    func testInjectionsTabShowsClearMessageWhenStoreNil() {
+        let subtitle = BrainBarPlaceholderCopy.injectionFeedNotWired
+
+        XCTAssertEqual(subtitle, "Injection feed not yet wired in this build.")
+        XCTAssertFalse(subtitle.localizedCaseInsensitiveContains("unavailable"))
     }
 }
 


### PR DESCRIPTION
## Summary
- Move BrainBar KG graph loading off the MainActor and apply the graph on the main actor after background DB fetches complete.
- Add `BrainDatabase.fetchKGRelations(limit:)` with a default 5,000-row cap so Graph tab relation loads are bounded.
- Replace the ambiguous Injections placeholder with shared copy: "Injection feed not yet wired in this build."

## Plan / Coordination
- Phase 1 from `/Users/etanheyman/Gits/orchestrator/docs.local/plans/2026-05-20-brainlayer-responsiveness/phase-1-injections-graph-perf/README.md`.
- Status and decisions logged in `/Users/etanheyman/Gits/orchestrator/collab/2026-05-20-brainlayer-responsiveness.md`.
- Merge requirement: do not squash; use rebase merge or merge commit.

## Measured Evidence
All timing values below are from commands run on 2026-05-20; they are not inferred.

| Measurement | Before | After | Notes |
| --- | ---: | ---: | --- |
| Live canonical DB graph fetch p50 | 3.76 ms | 3.73 ms | `~/.local/share/brainlayer/brainlayer.db`; semantic relation rows were only 75, so the cap is neutral here. |
| Live canonical DB graph fetch p95 | 3.82 ms | 3.91 ms | Same live DB run; relation rows stayed 75 -> 75. |
| Synthetic 12k-relation stress fixture graph fetch p50 | 8.04 ms | 5.54 ms | Temp DB with 12,000 semantic relations; after path reads 5,000 relations. |
| Synthetic 12k-relation stress fixture graph fetch p95 | 8.51 ms | 5.62 ms | Temp DB with 12,000 semantic relations; after path reads 5,000 relations. |
| BrainBar MCP `initialize` after rebuild | n/a | 3.7 ms | Bounded smoke call against `/tmp/brainbar.sock`. |

## Tests
- RED: new focused test initially failed to compile because `fetchKGRelations(limit:)` did not exist, confirming the cap API was missing.
- PASS: `swift test --package-path brain-bar --filter 'KGDatabaseTests/testFetchKGRelationsRespectsLimit|KGViewModelTests/testLoadGraphKeepsMainActorAvailableWhileLoading|BrainBarInjectionsPlaceholderTests/testInjectionsTabShowsClearMessageWhenStoreNil'` -> 3 tests, 0 failures.
- PASS: `swift test --package-path brain-bar` -> 373 tests, 0 failures.
- PASS: `bash brain-bar/build-app.sh --force-dirty` installed `/Users/etanheyman/Applications/BrainBar.app`; restarted BrainBarDaemon PID 59327 and BrainBar PID 59384.
- PASS from pre-push gate: pytest unit suite -> 2032 passed, 9 skipped, 75 deselected, 1 xfailed; MCP tool registration -> 3 passed; isolated eval/hook routing -> 32 passed; Bun stale-index fixture -> 1 passed; shell `test_fts5_determinism.sh` passed.
- Known non-blocking environment failure: full `.venv/bin/python -m pytest` reported 6 failed, 2063 passed, 10 skipped, 8 xfailed, 62 errors. Errors were dominated by live production DB lock (`apsw.BusyError`) and eval/ranx/numba environment errors; details logged in the phase findings file.

## Review Requests
After opening this PR I will request `@codex review`, `@cursor`, `@bugbot`, and CodeRabbit/Greptile review per BrainLayer PR workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves knowledge-graph loading onto background threads and changes database query behavior by introducing a default relation limit, which could affect graph completeness and has concurrency/main-thread correctness risk.
> 
> **Overview**
> **Improves Graph tab responsiveness** by making `KGViewModel.loadGraph` async, guarding against concurrent loads (`isLoading`), and doing database reads on a background queue before applying nodes/edges on the main actor; `KGCanvasView` now triggers loading via `.task` instead of `onAppear`.
> 
> **Bounds knowledge-graph relation fetches** by adding `BrainDatabase.fetchKGRelations(limit:)` (default 5,000) with deterministic ordering, and updates tests accordingly; several KG model/row structs add `Sendable` to support the new concurrency usage.
> 
> **Clarifies Injections placeholders** by centralizing the “Injection feed not yet wired in this build.” copy and reusing it in both the window and status popover, with a small test asserting the messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c4a4e3abf04a5955e9c079485de03124656622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load KG graph asynchronously and cap relation fetches at 5,000 rows
> - `KGViewModel.loadGraph` is now async and returns a `Bool`; database fetches run off the `MainActor` via a nonisolated helper, and a new `isLoading` guard prevents concurrent loads.
> - `BrainDatabase.fetchKGRelations` now accepts a `limit` parameter (default 5,000), adds `ORDER BY id LIMIT ?`, and clamps negative values to zero.
> - `KGCanvasView` switches from a synchronous `onAppear` call to a `.task` modifier; `hasLoadedGraph` is only set to `true` on a successful load.
> - `KGNode`, `KGEdge`, and several `BrainDatabase` row types gain `Sendable` conformance to support cross-actor data transfer.
> - Injection placeholder copy is centralized in a new `BrainBarPlaceholderCopy` enum, replacing hardcoded strings in `BrainBarWindowRootView` and `StatusPopoverView`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0c4a4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicator for the knowledge graph display during data fetch operations.

* **Improvements**
  * Converted knowledge graph loading to asynchronous operations for improved UI responsiveness and responsiveness while loading large datasets.
  * Optimized relation data fetching with result limits for better performance.

* **Tests**
  * Enhanced test coverage for graph relation limiting and main-thread responsiveness during loading operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->