### PR TITLE
feat(enrich): bound enrichment write pressure

### DIFF
--- a/scripts/launchd/com.brainlayer.enrichment.plist
+++ b/scripts/launchd/com.brainlayer.enrichment.plist
@@ -41,7 +41,9 @@
         <key>BRAINLAYER_ENRICH_RATE</key>
         <string>15</string>
         <key>BRAINLAYER_ENRICH_CONCURRENCY</key>
-        <string>18</string>
+        <string>4</string>
+        <key>BRAINLAYER_MAX_COMMIT_BATCH</key>
+        <string>25</string>
         <key>BRAINLAYER_GEMINI_SERVICE_TIER</key>
         <string>flex</string>
         <key>GOOGLE_API_KEY</key>

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -246,8 +246,12 @@ class _EnrichmentWriteBatcher:
         if self._pending and self._last_flush is not None:
             elapsed = now - self._last_flush
             if elapsed >= self.max_interval_seconds:
-                # Flush overdue writes before appending the next result so drain gets smaller DB lock windows.
-                self.flush()
+                try:
+                    # Flush overdue writes before appending the next result so drain gets smaller DB lock windows.
+                    self.flush()
+                except Exception:
+                    self._pending.append((chunk, enrichment))
+                    raise
                 now = time.monotonic()
         if not self._pending:
             self._last_flush = now
@@ -262,6 +266,27 @@ class _EnrichmentWriteBatcher:
         _enqueue_enrichment_write_batch(pending)
         self._pending = []
         self._last_flush = None
+
+    def pending_items(self) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+        return list(self._pending)
+
+
+def _flush_enrichment_batcher(
+    write_batcher: _EnrichmentWriteBatcher,
+    result: EnrichmentResult,
+    mode: str,
+) -> None:
+    try:
+        write_batcher.flush()
+    except Exception as exc:
+        pending = write_batcher.pending_items()
+        if not pending:
+            raise
+        result.failed += len(pending)
+        for chunk, _ in pending:
+            chunk_id = chunk.get("id")
+            result.errors.append(f"{chunk_id}: {exc}")
+            _emit_enrichment_error(mode, str(chunk_id), str(exc))
 
 
 def _meta_research_enrichment(chunk: dict[str, Any]) -> dict[str, Any]:
@@ -968,7 +993,7 @@ def enrich_realtime(
                     result.enriched += 1
         finally:
             if write_batcher is not None:
-                write_batcher.flush()
+                _flush_enrichment_batcher(write_batcher, result, "realtime")
 
         duration_ms = (time.monotonic() - start_time) * 1000
         _emit_enrichment_complete(result, duration_ms)
@@ -1071,7 +1096,7 @@ def enrich_batch(
                     _emit_enrichment_error("batch", chunk["id"], str(exc))
         finally:
             if write_batcher is not None:
-                write_batcher.flush()
+                _flush_enrichment_batcher(write_batcher, result, "batch")
 
         duration_ms = (time.monotonic() - start_time) * 1000
         _emit_enrichment_complete(result, duration_ms)

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -43,6 +43,14 @@ def _bounded_nonnegative_float(value: Any, default: float) -> float:
     return max(0.0, parsed)
 
 
+def _bounded_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return max(1, default)
+    return max(1, parsed)
+
+
 # Auto-enrichment on brain_store: set to "0" or "false" to disable
 AUTO_ENRICH_ENABLED = os.environ.get("BRAINLAYER_AUTO_ENRICH", "1").lower() not in ("0", "false", "no")
 
@@ -54,7 +62,7 @@ RATE_LIMITS = {
     "batch": float(os.environ.get("BRAINLAYER_BATCH_RATE", "0")),  # no limit (async)
 }
 ENRICH_CONCURRENCY = int(os.environ.get("BRAINLAYER_ENRICH_CONCURRENCY", "10"))
-MAX_COMMIT_BATCH = int(os.environ.get("BRAINLAYER_MAX_COMMIT_BATCH", "25"))
+MAX_COMMIT_BATCH = _bounded_positive_int(os.environ.get("BRAINLAYER_MAX_COMMIT_BATCH"), 25)
 MAX_COMMIT_INTERVAL_SECONDS = (
     _bounded_nonnegative_float(os.environ.get("BRAINLAYER_MAX_COMMIT_INTERVAL_MS"), DEFAULT_MAX_COMMIT_INTERVAL_MS)
     / 1000.0
@@ -181,14 +189,6 @@ def _submit_write(store, name: str, callback) -> Any:
 
 def _arbitrated_writes_enabled() -> bool:
     return os.environ.get("BRAINLAYER_ARBITRATED") == "1"
-
-
-def _bounded_positive_int(value: Any, default: int) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return max(1, default)
-    return max(1, parsed)
 
 
 def _current_max_commit_batch() -> int:

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -44,6 +44,8 @@ RATE_LIMITS = {
     "batch": float(os.environ.get("BRAINLAYER_BATCH_RATE", "0")),  # no limit (async)
 }
 ENRICH_CONCURRENCY = int(os.environ.get("BRAINLAYER_ENRICH_CONCURRENCY", "10"))
+MAX_COMMIT_BATCH = int(os.environ.get("BRAINLAYER_MAX_COMMIT_BATCH", "25"))
+MAX_COMMIT_INTERVAL_SECONDS = float(os.environ.get("BRAINLAYER_MAX_COMMIT_INTERVAL_MS", "250")) / 1000.0
 WRITE_QUEUE_MAXSIZE = int(os.environ.get("BRAINLAYER_WRITE_QUEUE_MAXSIZE", "1000"))
 RATE_LIMIT_BURST = int(os.environ.get("BRAINLAYER_ENRICH_BURST", "10"))
 
@@ -168,33 +170,94 @@ def _arbitrated_writes_enabled() -> bool:
     return os.environ.get("BRAINLAYER_ARBITRATED") == "1"
 
 
-def _enqueue_enrichment_write(chunk: dict[str, Any], enrichment: dict[str, Any]) -> None:
-    from .queue_io import enqueue_enrichment_update
-
-    content = chunk.get("content", "")
+def _bounded_positive_int(value: Any, default: int) -> int:
     try:
-        enqueue_enrichment_update(
-            chunk_id=chunk["id"],
-            enrichment=enrichment,
-            content_hash=_content_hash(content) if content else None,
-            entities=enrichment.get("entities", []),
-        )
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return max(1, default)
+    return max(1, parsed)
+
+
+def _current_max_commit_batch() -> int:
+    return _bounded_positive_int(os.environ.get("BRAINLAYER_MAX_COMMIT_BATCH"), MAX_COMMIT_BATCH)
+
+
+def _enrichment_update_payload(chunk: dict[str, Any], enrichment: dict[str, Any]) -> dict[str, Any]:
+    content = chunk.get("content", "")
+    return {
+        "chunk_id": chunk["id"],
+        "enrichment": enrichment,
+        "content_hash": _content_hash(content) if content else None,
+        "entities": enrichment.get("entities", []),
+    }
+
+
+def _enqueue_enrichment_write(chunk: dict[str, Any], enrichment: dict[str, Any]) -> None:
+    from .queue_io import enqueue_enrichment_updates
+
+    try:
+        enqueue_enrichment_updates([_enrichment_update_payload(chunk, enrichment)])
     except Exception:
         logger.exception("Failed to enqueue enrichment update for chunk %s", chunk.get("id"))
         raise
 
 
-def _enqueue_meta_research_write(chunk: dict[str, Any]) -> None:
+def _enqueue_enrichment_write_batch(items: list[tuple[dict[str, Any], dict[str, Any]]]) -> None:
+    if not items:
+        return
+
+    from .queue_io import enqueue_enrichment_updates
+
+    try:
+        enqueue_enrichment_updates([_enrichment_update_payload(chunk, enrichment) for chunk, enrichment in items])
+    except Exception:
+        chunk_ids = ",".join(str(chunk.get("id")) for chunk, _ in items)
+        logger.exception("Failed to enqueue enrichment update batch for chunks %s", chunk_ids)
+        raise
+
+
+class _EnrichmentWriteBatcher:
+    def __init__(
+        self,
+        *,
+        max_batch: int | None = None,
+        max_interval_seconds: float = MAX_COMMIT_INTERVAL_SECONDS,
+    ) -> None:
+        self.max_batch = max(1, max_batch if max_batch is not None else _current_max_commit_batch())
+        self.max_interval_seconds = max(0.0, max_interval_seconds)
+        self._pending: list[tuple[dict[str, Any], dict[str, Any]]] = []
+        self._last_flush: float | None = None
+
+    def enqueue(self, chunk: dict[str, Any], enrichment: dict[str, Any]) -> None:
+        now = time.monotonic()
+        if not self._pending:
+            self._last_flush = now
+        self._pending.append((chunk, enrichment))
+        elapsed = now - self._last_flush if self._last_flush is not None else 0.0
+        if len(self._pending) >= self.max_batch or (len(self._pending) > 1 and elapsed >= self.max_interval_seconds):
+            self.flush()
+
+    def flush(self) -> None:
+        if not self._pending:
+            return
+        pending = self._pending
+        self._pending = []
+        self._last_flush = None
+        _enqueue_enrichment_write_batch(pending)
+
+
+def _meta_research_enrichment(chunk: dict[str, Any]) -> dict[str, Any]:
     tags = _normalize_chunk_tags(chunk.get("tags"))
     if "meta-research" not in tags:
         tags.append("meta-research")
-    _enqueue_enrichment_write(
-        chunk,
-        {
-            "summary": None,
-            "tags": tags,
-        },
-    )
+    return {
+        "summary": None,
+        "tags": tags,
+    }
+
+
+def _enqueue_meta_research_write(chunk: dict[str, Any]) -> None:
+    _enqueue_enrichment_write(chunk, _meta_research_enrichment(chunk))
 
 
 def _ensure_enrichment_columns(store) -> None:
@@ -833,56 +896,61 @@ def enrich_realtime(
         sanitizer = Sanitizer.from_env()
         config = _build_gemini_config()
         rate_limiter = _get_store_rate_limiter(store, rate_per_second=rate_per_second)
+        write_batcher = _EnrichmentWriteBatcher() if _arbitrated_writes_enabled() else None
 
         def is_duplicate(content: str) -> bool:
             return _is_duplicate_content(store, content)
 
-        with ThreadPoolExecutor(max_workers=ENRICH_CONCURRENCY) as executor:
-            futures = []
-            for chunk in candidates:
-                futures.append(
-                    executor.submit(
-                        _enrich_single_chunk,
-                        client,
-                        GEMINI_REALTIME_MODEL,
-                        config,
-                        chunk,
-                        sanitizer,
-                        is_duplicate=is_duplicate,
-                        rate_limiter=rate_limiter,
-                        max_retries=max_retries,
+        try:
+            with ThreadPoolExecutor(max_workers=ENRICH_CONCURRENCY) as executor:
+                futures = []
+                for chunk in candidates:
+                    futures.append(
+                        executor.submit(
+                            _enrich_single_chunk,
+                            client,
+                            GEMINI_REALTIME_MODEL,
+                            config,
+                            chunk,
+                            sanitizer,
+                            is_duplicate=is_duplicate,
+                            rate_limiter=rate_limiter,
+                            max_retries=max_retries,
+                        )
                     )
-                )
 
-            for future in as_completed(futures):
-                chunk, status, data = future.result()
-                if status == "skip":
-                    result.skipped += 1
-                    continue
-                if status == "meta":
-                    if _arbitrated_writes_enabled():
-                        _enqueue_meta_research_write(chunk)
+                for future in as_completed(futures):
+                    chunk, status, data = future.result()
+                    if status == "skip":
+                        result.skipped += 1
+                        continue
+                    if status == "meta":
+                        if write_batcher is not None:
+                            write_batcher.enqueue(chunk, _meta_research_enrichment(chunk))
+                        else:
+                            _submit_write(
+                                store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk)
+                            )
+                        result.skipped += 1
+                        continue
+                    if status == "error":
+                        result.failed += 1
+                        result.errors.append(f"{chunk['id']}: {data}")
+                        _emit_enrichment_error("realtime", chunk["id"], str(data))
+                        continue
+
+                    if write_batcher is not None:
+                        write_batcher.enqueue(chunk, data)
                     else:
                         _submit_write(
-                            store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk)
+                            store,
+                            f"apply-enrichment:{chunk['id']}",
+                            lambda chunk=chunk, data=data: _apply_enrichment(store, chunk, data),
                         )
-                    result.skipped += 1
-                    continue
-                if status == "error":
-                    result.failed += 1
-                    result.errors.append(f"{chunk['id']}: {data}")
-                    _emit_enrichment_error("realtime", chunk["id"], str(data))
-                    continue
-
-                if _arbitrated_writes_enabled():
-                    _enqueue_enrichment_write(chunk, data)
-                else:
-                    _submit_write(
-                        store,
-                        f"apply-enrichment:{chunk['id']}",
-                        lambda chunk=chunk, data=data: _apply_enrichment(store, chunk, data),
-                    )
-                result.enriched += 1
+                    result.enriched += 1
+        finally:
+            if write_batcher is not None:
+                write_batcher.flush()
 
         duration_ms = (time.monotonic() - start_time) * 1000
         _emit_enrichment_complete(result, duration_ms)
@@ -929,58 +997,63 @@ def enrich_batch(
         sanitizer = Sanitizer.from_env()
         config = _build_gemini_config()
         rate_limiter = _get_store_rate_limiter(store, rate_per_second=RATE_LIMITS["batch"])
+        write_batcher = _EnrichmentWriteBatcher() if _arbitrated_writes_enabled() else None
 
-        for chunk in candidates:
-            if is_meta_research(chunk.get("content", "")):
-                if _arbitrated_writes_enabled():
-                    _enqueue_meta_research_write(chunk)
-                else:
-                    _submit_write(
-                        store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk)
-                    )
-                result.skipped += 1
-                continue
-            if _is_duplicate_content(store, chunk.get("content", "")):
-                result.skipped += 1
-                continue
-
-            try:
-                prompt, _sanitize_result = build_external_prompt(chunk, sanitizer)
-            except Exception as exc:
-                result.failed += 1
-                result.errors.append(f"{chunk['id']}: prompt_build_error: {exc}")
-                continue
-
-            try:
-                response = _retry_with_backoff(
-                    lambda: _generate_content_with_rate_limit(
-                        client,
-                        GEMINI_REALTIME_MODEL,
-                        prompt,
-                        config,
-                        rate_limiter,
-                    ),
-                    max_retries=max_retries,
-                )
-                enrichment = parse_enrichment(response.text)
-                if not enrichment:
-                    result.failed += 1
-                    result.errors.append(f"{chunk['id']}: invalid_enrichment")
-                    _emit_enrichment_error("batch", chunk["id"], "invalid_enrichment")
+        try:
+            for chunk in candidates:
+                if is_meta_research(chunk.get("content", "")):
+                    if write_batcher is not None:
+                        write_batcher.enqueue(chunk, _meta_research_enrichment(chunk))
+                    else:
+                        _submit_write(
+                            store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk)
+                        )
+                    result.skipped += 1
                     continue
-                if _arbitrated_writes_enabled():
-                    _enqueue_enrichment_write(chunk, enrichment)
-                else:
-                    _submit_write(
-                        store,
-                        f"apply-enrichment:{chunk['id']}",
-                        lambda chunk=chunk, enrichment=enrichment: _apply_enrichment(store, chunk, enrichment),
+                if _is_duplicate_content(store, chunk.get("content", "")):
+                    result.skipped += 1
+                    continue
+
+                try:
+                    prompt, _sanitize_result = build_external_prompt(chunk, sanitizer)
+                except Exception as exc:
+                    result.failed += 1
+                    result.errors.append(f"{chunk['id']}: prompt_build_error: {exc}")
+                    continue
+
+                try:
+                    response = _retry_with_backoff(
+                        lambda: _generate_content_with_rate_limit(
+                            client,
+                            GEMINI_REALTIME_MODEL,
+                            prompt,
+                            config,
+                            rate_limiter,
+                        ),
+                        max_retries=max_retries,
                     )
-                result.enriched += 1
-            except Exception as exc:
-                result.failed += 1
-                result.errors.append(f"{chunk['id']}: {exc}")
-                _emit_enrichment_error("batch", chunk["id"], str(exc))
+                    enrichment = parse_enrichment(response.text)
+                    if not enrichment:
+                        result.failed += 1
+                        result.errors.append(f"{chunk['id']}: invalid_enrichment")
+                        _emit_enrichment_error("batch", chunk["id"], "invalid_enrichment")
+                        continue
+                    if write_batcher is not None:
+                        write_batcher.enqueue(chunk, enrichment)
+                    else:
+                        _submit_write(
+                            store,
+                            f"apply-enrichment:{chunk['id']}",
+                            lambda chunk=chunk, enrichment=enrichment: _apply_enrichment(store, chunk, enrichment),
+                        )
+                    result.enriched += 1
+                except Exception as exc:
+                    result.failed += 1
+                    result.errors.append(f"{chunk['id']}: {exc}")
+                    _emit_enrichment_error("batch", chunk["id"], str(exc))
+        finally:
+            if write_batcher is not None:
+                write_batcher.flush()
 
         duration_ms = (time.monotonic() - start_time) * 1000
         _emit_enrichment_complete(result, duration_ms)

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -32,6 +32,16 @@ from .pipeline.write_queue import WriteQueue
 logger = logging.getLogger(__name__)
 
 GEMINI_REALTIME_MODEL = os.environ.get("BRAINLAYER_GEMINI_REALTIME_MODEL", "gemini-2.5-flash-lite")
+DEFAULT_MAX_COMMIT_INTERVAL_MS = 250.0
+
+
+def _bounded_nonnegative_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return max(0.0, default)
+    return max(0.0, parsed)
+
 
 # Auto-enrichment on brain_store: set to "0" or "false" to disable
 AUTO_ENRICH_ENABLED = os.environ.get("BRAINLAYER_AUTO_ENRICH", "1").lower() not in ("0", "false", "no")
@@ -45,7 +55,10 @@ RATE_LIMITS = {
 }
 ENRICH_CONCURRENCY = int(os.environ.get("BRAINLAYER_ENRICH_CONCURRENCY", "10"))
 MAX_COMMIT_BATCH = int(os.environ.get("BRAINLAYER_MAX_COMMIT_BATCH", "25"))
-MAX_COMMIT_INTERVAL_SECONDS = float(os.environ.get("BRAINLAYER_MAX_COMMIT_INTERVAL_MS", "250")) / 1000.0
+MAX_COMMIT_INTERVAL_SECONDS = (
+    _bounded_nonnegative_float(os.environ.get("BRAINLAYER_MAX_COMMIT_INTERVAL_MS"), DEFAULT_MAX_COMMIT_INTERVAL_MS)
+    / 1000.0
+)
 WRITE_QUEUE_MAXSIZE = int(os.environ.get("BRAINLAYER_WRITE_QUEUE_MAXSIZE", "1000"))
 RATE_LIMIT_BURST = int(os.environ.get("BRAINLAYER_ENRICH_BURST", "10"))
 
@@ -230,11 +243,16 @@ class _EnrichmentWriteBatcher:
 
     def enqueue(self, chunk: dict[str, Any], enrichment: dict[str, Any]) -> None:
         now = time.monotonic()
+        if self._pending and self._last_flush is not None:
+            elapsed = now - self._last_flush
+            if elapsed >= self.max_interval_seconds:
+                # Flush overdue writes before appending the next result so drain gets smaller DB lock windows.
+                self.flush()
+                now = time.monotonic()
         if not self._pending:
             self._last_flush = now
         self._pending.append((chunk, enrichment))
-        elapsed = now - self._last_flush if self._last_flush is not None else 0.0
-        if len(self._pending) >= self.max_batch or (len(self._pending) > 1 and elapsed >= self.max_interval_seconds):
+        if len(self._pending) >= self.max_batch:
             self.flush()
 
     def flush(self) -> None:

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -259,9 +259,9 @@ class _EnrichmentWriteBatcher:
         if not self._pending:
             return
         pending = self._pending
+        _enqueue_enrichment_write_batch(pending)
         self._pending = []
         self._last_flush = None
-        _enqueue_enrichment_write_batch(pending)
 
 
 def _meta_research_enrichment(chunk: dict[str, Any]) -> dict[str, Any]:

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -238,10 +238,10 @@ class _EnrichmentWriteBatcher:
     ) -> None:
         self.max_batch = max(1, max_batch if max_batch is not None else _current_max_commit_batch())
         self.max_interval_seconds = max(0.0, max_interval_seconds)
-        self._pending: list[tuple[dict[str, Any], dict[str, Any]]] = []
+        self._pending: list[tuple[dict[str, Any], dict[str, Any], str | None]] = []
         self._last_flush: float | None = None
 
-    def enqueue(self, chunk: dict[str, Any], enrichment: dict[str, Any]) -> None:
+    def enqueue(self, chunk: dict[str, Any], enrichment: dict[str, Any], *, counted_as: str | None = None) -> None:
         now = time.monotonic()
         if self._pending and self._last_flush is not None:
             elapsed = now - self._last_flush
@@ -249,25 +249,27 @@ class _EnrichmentWriteBatcher:
                 try:
                     # Flush overdue writes before appending the next result so drain gets smaller DB lock windows.
                     self.flush()
+                    now = time.monotonic()
                 except Exception:
-                    self._pending.append((chunk, enrichment))
-                    raise
-                now = time.monotonic()
+                    logger.exception("Deferred overdue enrichment batch flush; retaining pending writes")
         if not self._pending:
             self._last_flush = now
-        self._pending.append((chunk, enrichment))
+        self._pending.append((chunk, enrichment, counted_as))
         if len(self._pending) >= self.max_batch:
-            self.flush()
+            try:
+                self.flush()
+            except Exception:
+                logger.exception("Deferred full enrichment batch flush; retaining pending writes")
 
     def flush(self) -> None:
         if not self._pending:
             return
         pending = self._pending
-        _enqueue_enrichment_write_batch(pending)
+        _enqueue_enrichment_write_batch([(chunk, enrichment) for chunk, enrichment, _ in pending])
         self._pending = []
         self._last_flush = None
 
-    def pending_items(self) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    def pending_items(self) -> list[tuple[dict[str, Any], dict[str, Any], str | None]]:
         return list(self._pending)
 
 
@@ -283,7 +285,11 @@ def _flush_enrichment_batcher(
         if not pending:
             raise
         result.failed += len(pending)
-        for chunk, _ in pending:
+        for chunk, _, counted_as in pending:
+            if counted_as == "enriched" and result.enriched > 0:
+                result.enriched -= 1
+            elif counted_as == "skipped" and result.skipped > 0:
+                result.skipped -= 1
             chunk_id = chunk.get("id")
             result.errors.append(f"{chunk_id}: {exc}")
             _emit_enrichment_error(mode, str(chunk_id), str(exc))
@@ -969,7 +975,7 @@ def enrich_realtime(
                         continue
                     if status == "meta":
                         if write_batcher is not None:
-                            write_batcher.enqueue(chunk, _meta_research_enrichment(chunk))
+                            write_batcher.enqueue(chunk, _meta_research_enrichment(chunk), counted_as="skipped")
                         else:
                             _submit_write(
                                 store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk)
@@ -983,7 +989,7 @@ def enrich_realtime(
                         continue
 
                     if write_batcher is not None:
-                        write_batcher.enqueue(chunk, data)
+                        write_batcher.enqueue(chunk, data, counted_as="enriched")
                     else:
                         _submit_write(
                             store,
@@ -1046,7 +1052,7 @@ def enrich_batch(
             for chunk in candidates:
                 if is_meta_research(chunk.get("content", "")):
                     if write_batcher is not None:
-                        write_batcher.enqueue(chunk, _meta_research_enrichment(chunk))
+                        write_batcher.enqueue(chunk, _meta_research_enrichment(chunk), counted_as="skipped")
                     else:
                         _submit_write(
                             store, f"mark-meta:{chunk['id']}", lambda chunk=chunk: _mark_meta_research(store, chunk)
@@ -1082,7 +1088,7 @@ def enrich_batch(
                         _emit_enrichment_error("batch", chunk["id"], "invalid_enrichment")
                         continue
                     if write_batcher is not None:
-                        write_batcher.enqueue(chunk, enrichment)
+                        write_batcher.enqueue(chunk, enrichment, counted_as="enriched")
                     else:
                         _submit_write(
                             store,

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -22,22 +22,36 @@ def get_queue_dir() -> Path:
     return Path.home() / ".brainlayer" / "queue"
 
 
-def enqueue_jsonl(event: dict[str, Any], *, source: str, queue_dir: Path | None = None) -> Path:
-    """Atomically append a write intent as a one-line JSONL file."""
+def enqueue_jsonl_batch(events: list[dict[str, Any]], *, source: str, queue_dir: Path | None = None) -> Path:
+    """Atomically append one or more write intents as a JSONL file."""
+    if not events:
+        raise ValueError("enqueue_jsonl_batch requires at least one event")
     resolved_dir = queue_dir or get_queue_dir()
     resolved_dir.mkdir(parents=True, exist_ok=True)
     now_ms = int(time.time() * 1000)
+    queued_at = time.time()
     safe_source = _safe_source_name(source)
-    event = {
-        **event,
-        "source": source,
-        "queued_at": time.time(),
-    }
+    lines = [
+        json.dumps(
+            {
+                **event,
+                "source": source,
+                "queued_at": queued_at,
+            },
+            ensure_ascii=True,
+        )
+        for event in events
+    ]
     final_path = resolved_dir / f"{safe_source}-{now_ms}-{uuid.uuid4().hex}.jsonl"
     tmp_path = final_path.with_suffix(".tmp")
-    tmp_path.write_text(json.dumps(event, ensure_ascii=True) + "\n", encoding="utf-8")
+    tmp_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     tmp_path.replace(final_path)
     return final_path
+
+
+def enqueue_jsonl(event: dict[str, Any], *, source: str, queue_dir: Path | None = None) -> Path:
+    """Atomically append a write intent as a one-line JSONL file."""
+    return enqueue_jsonl_batch([event], source=source, queue_dir=queue_dir)
 
 
 def enqueue_store(
@@ -142,14 +156,32 @@ def enqueue_enrichment_update(
     entities: list[Any] | None = None,
     queue_dir: Path | None = None,
 ) -> Path:
-    return enqueue_jsonl(
-        {
-            "kind": "enrichment_update",
-            "chunk_id": chunk_id,
-            "enrichment": enrichment,
-            "content_hash": content_hash,
-            "entities": entities,
-        },
-        source="enrichment",
+    return enqueue_enrichment_updates(
+        [
+            {
+                "chunk_id": chunk_id,
+                "enrichment": enrichment,
+                "content_hash": content_hash,
+                "entities": entities,
+            }
+        ],
         queue_dir=queue_dir,
     )
+
+
+def enqueue_enrichment_updates(
+    updates: list[dict[str, Any]],
+    *,
+    queue_dir: Path | None = None,
+) -> Path:
+    events = [
+        {
+            "kind": "enrichment_update",
+            "chunk_id": update["chunk_id"],
+            "enrichment": update["enrichment"],
+            "content_hash": update.get("content_hash"),
+            "entities": update.get("entities"),
+        }
+        for update in updates
+    ]
+    return enqueue_jsonl_batch(events, source="enrichment", queue_dir=queue_dir)

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -128,3 +128,23 @@ def test_invalid_commit_interval_env_does_not_crash_import():
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "0.25"
+
+
+def test_invalid_commit_batch_env_does_not_crash_import():
+    env = os.environ.copy()
+    env["BRAINLAYER_MAX_COMMIT_BATCH"] = "not-a-number"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from brainlayer import enrichment_controller as c; print(c.MAX_COMMIT_BATCH)",
+        ],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "25"

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -102,7 +102,7 @@ def test_enrichment_batcher_retains_pending_items_when_flush_fails(monkeypatch):
     with pytest.raises(RuntimeError, match="queue unavailable"):
         batcher.flush()
 
-    assert [chunk["id"] for chunk, _ in batcher._pending] == ["c0"]
+    assert [chunk["id"] for chunk, _, _ in batcher._pending] == ["c0"]
 
     batcher.flush()
 
@@ -124,10 +124,9 @@ def test_enrichment_batcher_retains_current_item_when_overdue_flush_fails(monkey
     batcher = controller._EnrichmentWriteBatcher(max_batch=25, max_interval_seconds=0.1)
     batcher.enqueue(_candidate("c0"), {"summary": "s0", "tags": []})
 
-    with pytest.raises(RuntimeError, match="queue unavailable"):
-        batcher.enqueue(_candidate("c1"), {"summary": "s1", "tags": []})
+    batcher.enqueue(_candidate("c1"), {"summary": "s1", "tags": []})
 
-    assert [chunk["id"] for chunk, _ in batcher._pending] == ["c0", "c1"]
+    assert [chunk["id"] for chunk, _, _ in batcher._pending] == ["c0", "c1"]
 
 
 def test_enrich_batch_reports_final_flush_failure_without_crashing(monkeypatch):
@@ -164,7 +163,7 @@ def test_enrich_batch_reports_final_flush_failure_without_crashing(monkeypatch):
 
     result = controller.enrich_batch(store, limit=1)
 
-    assert result.enriched == 1
+    assert result.enriched == 0
     assert result.failed == 1
     assert result.errors == ["c0: queue unavailable"]
     assert errors == [("batch", "c0", "queue unavailable")]

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -1,4 +1,7 @@
 import json
+import os
+import subprocess
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -54,3 +57,43 @@ def test_enrich_batch_batches_arbitrated_enrichment_writes(monkeypatch, tmp_path
     assert result.enriched == 5
     assert sorted(line_counts, reverse=True) == [2, 2, 1]
     assert sorted(queued_chunk_ids) == ["c0", "c1", "c2", "c3", "c4"]
+
+
+def test_enrichment_batcher_flushes_overdue_single_pending_item(monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    flushed_batches = []
+    ticks = iter([10.0, 10.2, 10.2])
+    monkeypatch.setattr(controller.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(controller, "_enqueue_enrichment_write_batch", lambda items: flushed_batches.append(items))
+
+    batcher = controller._EnrichmentWriteBatcher(max_batch=25, max_interval_seconds=0.1)
+
+    batcher.enqueue(_candidate("c0"), {"summary": "s0", "tags": []})
+    batcher.enqueue(_candidate("c1"), {"summary": "s1", "tags": []})
+
+    assert [[chunk["id"] for chunk, _ in batch] for batch in flushed_batches] == [["c0"]]
+
+    batcher.flush()
+
+    assert [[chunk["id"] for chunk, _ in batch] for batch in flushed_batches] == [["c0"], ["c1"]]
+
+
+def test_invalid_commit_interval_env_does_not_crash_import():
+    env = os.environ.copy()
+    env["BRAINLAYER_MAX_COMMIT_INTERVAL_MS"] = "not-a-number"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from brainlayer import enrichment_controller as c; print(c.MAX_COMMIT_INTERVAL_SECONDS)",
+        ],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0.25"

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -5,6 +5,8 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def _candidate(chunk_id: str) -> dict:
     return {
@@ -77,6 +79,35 @@ def test_enrichment_batcher_flushes_overdue_single_pending_item(monkeypatch):
     batcher.flush()
 
     assert [[chunk["id"] for chunk, _ in batch] for batch in flushed_batches] == [["c0"], ["c1"]]
+
+
+def test_enrichment_batcher_retains_pending_items_when_flush_fails(monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    flushed_batches = []
+    attempts = 0
+
+    def flaky_enqueue(items):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("queue unavailable")
+        flushed_batches.append(items)
+
+    monkeypatch.setattr(controller, "_enqueue_enrichment_write_batch", flaky_enqueue)
+
+    batcher = controller._EnrichmentWriteBatcher(max_batch=25, max_interval_seconds=10)
+    batcher.enqueue(_candidate("c0"), {"summary": "s0", "tags": []})
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        batcher.flush()
+
+    assert [chunk["id"] for chunk, _ in batcher._pending] == ["c0"]
+
+    batcher.flush()
+
+    assert batcher._pending == []
+    assert [[chunk["id"] for chunk, _ in batch] for batch in flushed_batches] == [["c0"]]
 
 
 def test_invalid_commit_interval_env_does_not_crash_import():

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -1,0 +1,56 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _candidate(chunk_id: str) -> dict:
+    return {
+        "id": chunk_id,
+        "content": f"content for {chunk_id}",
+        "project": "brainlayer",
+        "content_type": "assistant_text",
+        "source": "claude_code",
+    }
+
+
+def test_enrich_batch_batches_arbitrated_enrichment_writes(monkeypatch, tmp_path):
+    from brainlayer import enrichment_controller as controller
+    from brainlayer import queue_io
+
+    queue_dir = tmp_path / "queue"
+    store = MagicMock()
+    store.get_enrichment_candidates.return_value = [_candidate(f"c{i}") for i in range(5)]
+
+    monkeypatch.setenv("BRAINLAYER_ARBITRATED", "1")
+    monkeypatch.setenv("BRAINLAYER_MAX_COMMIT_BATCH", "2")
+    monkeypatch.setattr(controller, "MAX_COMMIT_BATCH", 2, raising=False)
+    monkeypatch.setattr(queue_io, "get_queue_dir", lambda: queue_dir)
+    monkeypatch.setattr(controller, "_ensure_enrichment_columns", lambda store: None)
+    monkeypatch.setattr(controller, "_is_duplicate_content", lambda store, content: False)
+    monkeypatch.setattr(controller, "build_external_prompt", lambda chunk, sanitizer: ("prompt", SimpleNamespace()))
+    monkeypatch.setattr(controller, "parse_enrichment", lambda text: {"summary": text, "tags": ["python"]})
+    monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
+    monkeypatch.setattr(controller, "_get_gemini_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(controller, "_emit_enrichment_start", lambda *args, **kwargs: True)
+    monkeypatch.setattr(controller, "_emit_enrichment_complete", lambda *args, **kwargs: True)
+    monkeypatch.setattr(controller, "_emit_enrichment_error", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        controller,
+        "_generate_content_with_rate_limit",
+        lambda client, model, prompt, config, rate_limiter: SimpleNamespace(text="summary"),
+    )
+
+    result = controller.enrich_batch(store, limit=5)
+
+    files = sorted(queue_dir.glob("enrichment-*.jsonl"))
+    line_counts = [len(path.read_text(encoding="utf-8").splitlines()) for path in files]
+    queued_chunk_ids = [
+        json.loads(line)["chunk_id"]
+        for path in files
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert result.enriched == 5
+    assert sorted(line_counts, reverse=True) == [2, 2, 1]
+    assert sorted(queued_chunk_ids) == ["c0", "c1", "c2", "c3", "c4"]

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -110,6 +110,67 @@ def test_enrichment_batcher_retains_pending_items_when_flush_fails(monkeypatch):
     assert [[chunk["id"] for chunk, _ in batch] for batch in flushed_batches] == [["c0"]]
 
 
+def test_enrichment_batcher_retains_current_item_when_overdue_flush_fails(monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    ticks = iter([10.0, 10.2])
+
+    def fail_enqueue(items):
+        raise RuntimeError("queue unavailable")
+
+    monkeypatch.setattr(controller.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(controller, "_enqueue_enrichment_write_batch", fail_enqueue)
+
+    batcher = controller._EnrichmentWriteBatcher(max_batch=25, max_interval_seconds=0.1)
+    batcher.enqueue(_candidate("c0"), {"summary": "s0", "tags": []})
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        batcher.enqueue(_candidate("c1"), {"summary": "s1", "tags": []})
+
+    assert [chunk["id"] for chunk, _ in batcher._pending] == ["c0", "c1"]
+
+
+def test_enrich_batch_reports_final_flush_failure_without_crashing(monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    store = MagicMock()
+    store.get_enrichment_candidates.return_value = [_candidate("c0")]
+    errors = []
+    completed = []
+
+    monkeypatch.setenv("BRAINLAYER_ARBITRATED", "1")
+    monkeypatch.setattr(controller, "MAX_COMMIT_BATCH", 25, raising=False)
+    monkeypatch.setattr(controller, "_ensure_enrichment_columns", lambda store: None)
+    monkeypatch.setattr(controller, "_is_duplicate_content", lambda store, content: False)
+    monkeypatch.setattr(controller, "build_external_prompt", lambda chunk, sanitizer: ("prompt", SimpleNamespace()))
+    monkeypatch.setattr(controller, "parse_enrichment", lambda text: {"summary": text, "tags": ["python"]})
+    monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
+    monkeypatch.setattr(controller, "_get_gemini_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(controller, "_emit_enrichment_start", lambda *args, **kwargs: True)
+    monkeypatch.setattr(controller, "_emit_enrichment_complete", lambda result, duration_ms: completed.append(result))
+    monkeypatch.setattr(
+        controller, "_emit_enrichment_error", lambda mode, chunk_id, error: errors.append((mode, chunk_id, error))
+    )
+    monkeypatch.setattr(
+        controller,
+        "_generate_content_with_rate_limit",
+        lambda client, model, prompt, config, rate_limiter: SimpleNamespace(text="summary"),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_enqueue_enrichment_write_batch",
+        lambda items: (_ for _ in ()).throw(RuntimeError("queue unavailable")),
+    )
+
+    result = controller.enrich_batch(store, limit=1)
+
+    assert result.enriched == 1
+    assert result.failed == 1
+    assert result.errors == ["c0: queue unavailable"]
+    assert errors == [("batch", "c0", "queue unavailable")]
+    assert completed == [result]
+
+
 def test_invalid_commit_interval_env_does_not_crash_import():
     env = os.environ.copy()
     env["BRAINLAYER_MAX_COMMIT_INTERVAL_MS"] = "not-a-number"

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -1244,7 +1244,8 @@ def test_enrichment_plist_matches_validated_flex_realtime_profile():
     assert plist["StandardOutPath"] == "__HOME__/Library/Logs/brainlayer/enrichment.out.log"
     assert plist["StandardErrorPath"] == "__HOME__/Library/Logs/brainlayer/enrichment.err.log"
     assert env["BRAINLAYER_ENRICH_RATE"] == "15"
-    assert env["BRAINLAYER_ENRICH_CONCURRENCY"] == "18"
+    assert env["BRAINLAYER_ENRICH_CONCURRENCY"] == "4"
+    assert env["BRAINLAYER_MAX_COMMIT_BATCH"] == "25"
     assert env["BRAINLAYER_GEMINI_SERVICE_TIER"] == "flex"
 
 


### PR DESCRIPTION
## Summary

Implements Phase 2 candidate (4): reduce enrichment write pressure by bounding realtime enrichment concurrency and batching arbitrated enrichment-update queue writes.

- sets the LaunchAgent enrichment profile to `BRAINLAYER_ENRICH_CONCURRENCY=4`
- adds `BRAINLAYER_MAX_COMMIT_BATCH=25` as the bounded commit/queue batch knob
- batches arbitrated enrichment-update JSONL writes up to the configured cap, with a short flush interval so writes do not sit indefinitely
- adds RED/GREEN regressions proving bounded queue batches, overdue single-item flush behavior, failed-flush retry retention, invalid env hardening, final flush failure reporting, and counter rollback on persistent flush failure

Important caveat: this candidate improved drain/queue movement modestly, but it did **not** meet the `<2s` `brain_search` responsiveness pass condition in the first live after-window. Candidate (2), signal-pause IPC, remains the documented fallback/follow-up.

## Before/After Evidence

All numbers below are from local artifacts captured during Phase 2. I am not extrapolating beyond observed output.

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Queue depth avg over 10 min | 18710.6 files | 18378.5 files | -332.1 files |
| Queue depth start -> end | 18819 -> 18594 | 18500 -> 18226 | net drain improved from -22.5/min to -27.4/min |
| Drain stdout throughput | 0 new stdout lines | 252 files / 10 min = 25.2/min | +25.2/min by stdout |
| `brain_recall` p50 | 2.6ms | 2.4ms | -0.2ms |
| `brain_recall` p95 | 30.4ms | 93.5ms | +63.1ms |
| `brain_tags` median | 1631.9ms | 1649.0ms | +17.1ms |
| `brain_search` median | 16930.5ms (n=5) | 16903.3ms (n=2 completed; 3 later iterations timed out/errored) | -27.2ms on completed calls; pass condition not met |

`/tmp/brainbar_bench.py` did not emit p95 for `brain_tags` or `brain_search`; it emitted min/median/max for those sections. The after `brain_search` section only had 2 completed calls, then timed out/errored.

Source artifacts:

- before queue depth: `/tmp/brainlayer-phase2-before-20260520-231631/q-depth-before.log`
- before bench: `/tmp/brainlayer-phase2-before-20260520-231631/bench-before.log`
- before drain snapshots: `/tmp/brainlayer-phase2-before-20260520-231631/drain-before-wc.txt`, `drain-after-wc.txt`, `drain-before-tail-start.log`, `drain-before-tail-end.log`
- after queue depth: `/tmp/brainlayer-phase2-after-20260520-233053/q-depth-after.log`
- after bench: `/tmp/brainlayer-phase2-after-20260520-233053/bench-after.log`
- after drain snapshots: `/tmp/brainlayer-phase2-after-20260520-233053/drain-before-wc.txt`, `drain-after-wc.txt`, `drain-tail-start.log`, `drain-tail-end.log`

Bench caveat: `/tmp/brainbar_bench.py` emitted valid latency sections in both runs, then exited nonzero at its stale final load footer because it still runs `ps -p 13093` and that PID no longer exists.

Live applied profile before after-window:

- ran `scripts/launchd/install.sh enrichment`
- verified LaunchAgent env: `BRAINLAYER_ENRICH_CONCURRENCY=4`, `BRAINLAYER_MAX_COMMIT_BATCH=25`
- sampled recent `~/.brainlayer/queue/enrichment-*.jsonl` files from the new code: max `3` JSONL lines/file, below configured cap `25`

## TDD / Review Evidence

RED:

- `.venv/bin/python -m pytest tests/test_enrichment_bounded_commit.py -v`
- failed as intended before implementation: expected queue file line counts `[2, 2, 1]`, actual `[1, 1, 1, 1, 1]`

Focused final:

- `.venv/bin/python -m pytest tests/test_enrichment_bounded_commit.py -v`
- `7 passed in 6.71s`

Relevant suite final:

- `.venv/bin/python -m pytest tests/test_enrichment_bounded_commit.py tests/test_enrichment_controller.py tests/test_concurrent_enrichment.py tests/test_write_queue.py tests/test_arbitration.py -q`
- `118 passed in 16.06s`

Lint/format final:

- `.venv/bin/python -m ruff check src/brainlayer/enrichment_controller.py tests/test_enrichment_bounded_commit.py`
- `All checks passed!`
- `.venv/bin/python -m ruff format --check src/brainlayer/enrichment_controller.py tests/test_enrichment_bounded_commit.py`
- `2 files already formatted`

Full local/pre-push gate after final review fix:

- `git push` pre-push hook ran the BrainLayer gate
- unit suite: `2039 passed, 9 skipped, 75 deselected, 1 xfailed, 102 warnings in 142.29s`
- MCP registration: `3 passed`
- isolated eval/hook routing: `32 passed`
- Bun stale index: `1 pass`
- FTS5 determinism shell regression: `PASS`

Test count note: this PR adds seven bounded-batch/review-hardening regressions; the observed full unit gate on this branch is `2039 passed`.

## Review Fixes

- CodeRabbit: invalid commit-interval env no longer crashes import; single pending item can flush on elapsed interval.
- Cursor Bugbot: failed flushes retain pending items until queue batch write succeeds.
- Cursor Bugbot/Codex: invalid `BRAINLAYER_MAX_COMMIT_BATCH` now falls back to `25` instead of crashing import.
- Cursor Bugbot/Codex: overdue pre-append flush failure retains pending writes; final batcher flush failure is reported on `EnrichmentResult` instead of escaping and skipping completion.
- Cursor Bugbot/Macroscope: final persistent flush failure reverses pending enriched/skipped credit before marking those writes failed, avoiding over-counting.

## Merge Policy

Per Etan's 2026-05-20 ban: **NO SQUASH**. Use `gh pr merge --rebase` only.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound enrichment write pressure by batching commits in `enrich_realtime` and `enrich_batch`
> - Introduces `_EnrichmentWriteBatcher` in [`enrichment_controller.py`](https://github.com/EtanHey/brainlayer/pull/303/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb) that buffers enrichment writes and flushes when a batch reaches `MAX_COMMIT_BATCH` items (default 25) or `MAX_COMMIT_INTERVAL_SECONDS` elapses (default 250ms).
> - Adds `enqueue_enrichment_updates` and `enqueue_jsonl_batch` to [`queue_io.py`](https://github.com/EtanHey/brainlayer/pull/303/files#diff-2867bea29e6832d2011b2e5f6e00fa8212abf0e059278a6cb08fda52bdae2de6) to write multiple enrichment events atomically in a single JSONL file.
> - Both `enrich_realtime` and `enrich_batch` use the batcher when arbitrated writes are enabled; flush failures are reported per chunk without aborting the run.
> - Reduces enrichment concurrency from 18 to 4 in the launchd plist and sets `BRAINLAYER_MAX_COMMIT_BATCH=25` in the process environment.
> - Behavioral Change: single enrichment writes now go through the batch API path; final flush errors adjust result counters and emit per-chunk errors rather than raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c4e602.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->