### PR TITLE
feat(readpath): bootstrap search stores readonly

### DIFF
--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -41,9 +41,9 @@ class HybridSearchHelper:
 
     def warm(self) -> None:
         os.environ["BRAINLAYER_DB"] = os.fspath(self.db_path)
-        from brainlayer.mcp._shared import _get_embedding_model, _get_vector_store
+        from brainlayer.mcp._shared import _get_embedding_model, _get_search_vector_store
 
-        _get_vector_store()
+        _get_search_vector_store()
         model = _get_embedding_model()
         model.embed_query("brainbar hybrid helper warmup")
 

--- a/src/brainlayer/mcp/_shared.py
+++ b/src/brainlayer/mcp/_shared.py
@@ -37,10 +37,10 @@ def _get_search_vector_store():
     if _search_vector_store is None:
         with _search_store_lock:
             if _search_vector_store is None:
-                from ..paths import DEFAULT_DB_PATH
+                from ..paths import get_db_path
                 from ..vector_store import VectorStore
 
-                _search_vector_store = VectorStore(DEFAULT_DB_PATH, readonly=True)
+                _search_vector_store = VectorStore(get_db_path(), readonly=True)
     return _search_vector_store
 
 

--- a/src/brainlayer/mcp/_shared.py
+++ b/src/brainlayer/mcp/_shared.py
@@ -5,6 +5,7 @@ import os
 import re
 import threading
 
+import apsw
 from mcp.types import CallToolResult, TextContent
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,45 @@ _store_lock = threading.Lock()
 _search_store_lock = threading.Lock()
 _model_lock = threading.Lock()
 
+_SEARCH_REQUIRED_TABLES = {"chunks", "chunk_vectors"}
+_SEARCH_REQUIRED_CHUNK_COLUMNS = {
+    "archived",
+    "chunk_origin",
+    "resolved_queries",
+    "status",
+    "summary",
+}
+
+
+def _search_store_needs_bootstrap(db_path) -> bool:
+    """Return true when readonly search would skip required first-run migrations."""
+    if not db_path.exists():
+        return True
+
+    conn = None
+    try:
+        conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+        cursor = conn.cursor()
+        tables = {row[0] for row in cursor.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")}
+        if not _SEARCH_REQUIRED_TABLES.issubset(tables):
+            return True
+
+        chunk_columns = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+        return not _SEARCH_REQUIRED_CHUNK_COLUMNS.issubset(chunk_columns)
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def _bootstrap_search_store(db_path) -> None:
+    if not _search_store_needs_bootstrap(db_path):
+        return
+
+    from ..vector_store import VectorStore
+
+    bootstrap_store = VectorStore(db_path)
+    bootstrap_store.close()
+
 
 def _get_vector_store():
     """Get or initialize the global VectorStore (thread-safe)."""
@@ -24,10 +64,10 @@ def _get_vector_store():
     if _vector_store is None:
         with _store_lock:
             if _vector_store is None:
-                from ..paths import DEFAULT_DB_PATH
+                from ..paths import get_db_path
                 from ..vector_store import VectorStore
 
-                _vector_store = VectorStore(DEFAULT_DB_PATH)
+                _vector_store = VectorStore(get_db_path())
     return _vector_store
 
 
@@ -40,7 +80,9 @@ def _get_search_vector_store():
                 from ..paths import get_db_path
                 from ..vector_store import VectorStore
 
-                _search_vector_store = VectorStore(get_db_path(), readonly=True)
+                db_path = get_db_path()
+                _bootstrap_search_store(db_path)
+                _search_vector_store = VectorStore(db_path, readonly=True)
     return _search_vector_store
 
 

--- a/src/brainlayer/mcp/_shared.py
+++ b/src/brainlayer/mcp/_shared.py
@@ -11,8 +11,10 @@ logger = logging.getLogger(__name__)
 
 # Lazy-loaded globals with thread-safe initialization
 _vector_store = None
+_search_vector_store = None
 _embedding_model = None
 _store_lock = threading.Lock()
+_search_store_lock = threading.Lock()
 _model_lock = threading.Lock()
 
 
@@ -27,6 +29,19 @@ def _get_vector_store():
 
                 _vector_store = VectorStore(DEFAULT_DB_PATH)
     return _vector_store
+
+
+def _get_search_vector_store():
+    """Get or initialize the read-only VectorStore for search-only handlers."""
+    global _search_vector_store
+    if _search_vector_store is None:
+        with _search_store_lock:
+            if _search_vector_store is None:
+                from ..paths import DEFAULT_DB_PATH
+                from ..vector_store import VectorStore
+
+                _search_vector_store = VectorStore(DEFAULT_DB_PATH, readonly=True)
+    return _search_vector_store
 
 
 def _get_embedding_model():

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -27,7 +27,6 @@ from ._shared import (
     _error_result,
     _extract_file_path,
     _get_embedding_model,
-    _get_vector_store,
     _memory_to_dict,
     _normalize_project_name,
     _query_has_regression_signal,
@@ -35,6 +34,9 @@ from ._shared import (
     _query_signals_recall,
     _query_signals_think,
     logger,
+)
+from ._shared import (
+    _get_search_vector_store as _get_vector_store,
 )
 
 _CHUNK_ID_QUERY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:-[A-Za-z0-9_]+)+$")

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -27,6 +27,7 @@ from ._shared import (
     _error_result,
     _extract_file_path,
     _get_embedding_model,
+    _get_search_vector_store,
     _memory_to_dict,
     _normalize_project_name,
     _query_has_regression_signal,
@@ -36,8 +37,14 @@ from ._shared import (
     logger,
 )
 from ._shared import (
-    _get_search_vector_store as _get_vector_store,
+    _get_vector_store as _get_rw_vector_store,
 )
+
+
+def _get_vector_store():
+    """Compatibility hook for tests; search handlers use the readonly store by default."""
+    return _get_search_vector_store()
+
 
 _CHUNK_ID_QUERY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:-[A-Za-z0-9_]+)+$")
 
@@ -1258,7 +1265,7 @@ async def _search(
 async def _stats():
     """Get knowledge base statistics."""
     try:
-        store = _get_vector_store()
+        store = _get_rw_vector_store()
         stats = store.get_stats()
         fts5_health = store.check_fts5_health()
         structured = {

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -84,7 +84,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
     def __init__(self, db_path: Path, readonly: bool = False):
         self.db_path = db_path
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        if not readonly:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._fts5_health_cache: dict[str, Any] = {}
         self._retrieval_strengthening_pending: dict[str, dict[str, float]] = {}
         self._retrieval_strengthening_query_count = 0

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -82,7 +82,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     _INIT_MAX_RETRIES = 5
     _INIT_BASE_DELAY = 0.5  # seconds
 
-    def __init__(self, db_path: Path):
+    def __init__(self, db_path: Path, readonly: bool = False):
         self.db_path = db_path
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._fts5_health_cache: dict[str, Any] = {}
@@ -94,7 +94,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self._checkpoint_count_cache_data_version: int | None = None
         self._audit_recursion_count_cache: int | None = None
         self._audit_recursion_count_cache_data_version: int | None = None
-        self._readonly = self.db_path.exists() and not os.access(self.db_path, os.W_OK)
+        self._readonly = readonly or (self.db_path.exists() and not os.access(self.db_path, os.W_OK))
         if self._readonly:
             self._init_readonly_db()
         else:

--- a/tests/test_vector_store_readonly.py
+++ b/tests/test_vector_store_readonly.py
@@ -2,14 +2,22 @@ import apsw
 import pytest
 
 from brainlayer._helpers import serialize_f32
+from brainlayer.mcp import _shared
 from brainlayer.search_repo import _hybrid_cache
 from brainlayer.vector_store import VectorStore
 
 
 @pytest.fixture(autouse=True)
 def clear_hybrid_cache():
+    _shared._search_vector_store = None
+    _shared._vector_store = None
     _hybrid_cache.clear()
     yield
+    for store in (_shared._search_vector_store, _shared._vector_store):
+        if store is not None:
+            store.close()
+    _shared._search_vector_store = None
+    _shared._vector_store = None
     _hybrid_cache.clear()
 
 
@@ -139,3 +147,75 @@ def test_readonly_busyerror_resilience(tmp_path, monkeypatch):
     finally:
         writer_cursor.execute("ROLLBACK")
         writer_conn.close()
+
+
+def test_explicit_readonly_does_not_create_parent_directory(tmp_path, monkeypatch):
+    db_path = tmp_path / "missing-parent" / "readonly.db"
+
+    def fake_init_readonly(self):
+        self._local = None
+
+    monkeypatch.setattr(VectorStore, "_init_readonly_db", fake_init_readonly)
+
+    VectorStore(db_path, readonly=True)
+
+    assert not db_path.parent.exists()
+
+
+def test_search_vector_store_bootstraps_missing_db_then_reopens_readonly(tmp_path, monkeypatch):
+    db_path = tmp_path / "fresh" / "brainlayer.db"
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+
+    store = _shared._get_search_vector_store()
+    try:
+        assert db_path.exists()
+        assert store._readonly is True
+        assert store.count() == 0
+        with pytest.raises(apsw.ReadOnlyError):
+            store.conn.cursor().execute(
+                "INSERT INTO chunks (id, content, metadata, source_file) VALUES ('x', 'x', '{}', 'x')"
+            )
+    finally:
+        store.close()
+        _shared._search_vector_store = None
+
+
+def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_path, monkeypatch):
+    db_path = tmp_path / "stale.db"
+    conn = apsw.Connection(str(db_path))
+    conn.cursor().execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            metadata TEXT NOT NULL,
+            source_file TEXT NOT NULL,
+            project TEXT,
+            content_type TEXT,
+            value_type TEXT,
+            char_count INTEGER,
+            source TEXT,
+            sender TEXT,
+            language TEXT,
+            conversation_id TEXT,
+            position INTEGER,
+            context_summary TEXT,
+            chunk_origin TEXT DEFAULT 'unknown'
+        )
+        """
+    )
+    conn.close()
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+
+    store = _shared._get_search_vector_store()
+    try:
+        columns = {row[1] for row in store.conn.cursor().execute("PRAGMA table_info(chunks)")}
+        assert {"status", "archived", "summary", "resolved_queries", "chunk_origin"}.issubset(columns)
+        assert store._readonly is True
+        with pytest.raises(apsw.ReadOnlyError):
+            store.conn.cursor().execute(
+                "INSERT INTO chunks (id, content, metadata, source_file) VALUES ('x', 'x', '{}', 'x')"
+            )
+    finally:
+        store.close()
+        _shared._search_vector_store = None

--- a/tests/test_vector_store_readonly.py
+++ b/tests/test_vector_store_readonly.py
@@ -1,0 +1,141 @@
+import apsw
+import pytest
+
+from brainlayer._helpers import serialize_f32
+from brainlayer.search_repo import _hybrid_cache
+from brainlayer.vector_store import VectorStore
+
+
+@pytest.fixture(autouse=True)
+def clear_hybrid_cache():
+    _hybrid_cache.clear()
+    yield
+    _hybrid_cache.clear()
+
+
+def _embed(text: str) -> list[float]:
+    seed = (sum(ord(c) for c in text[:40]) % 97) / 1000.0
+    return [seed + (i / 10000.0) for i in range(1024)]
+
+
+def _create_vector_db(db_path):
+    store = VectorStore(db_path)
+    store.close()
+
+
+def _insert_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    content: str,
+    embedding: list[float],
+):
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, decay_score, half_life_days, retrieval_count, created_at
+        ) VALUES (?, ?, '{}', 'readonly.jsonl', 'readonly', 'assistant_text', ?, 'claude_code', 1.0, 30.0, 0, '2026-04-05T00:00:00Z')""",
+        (chunk_id, content, len(content)),
+    )
+    cursor.execute(
+        "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+        (chunk_id, serialize_f32(embedding)),
+    )
+
+
+def test_open_readonly_skips_init_retry(tmp_path, monkeypatch):
+    db_path = tmp_path / "readonly.db"
+    _create_vector_db(db_path)
+
+    init_retry_calls = []
+
+    def fail_init_retry(self):
+        init_retry_calls.append(self.db_path)
+        raise AssertionError("_init_db_with_retry should not run for readonly stores")
+
+    monkeypatch.setattr(VectorStore, "_init_db_with_retry", fail_init_retry)
+
+    store = VectorStore(db_path, readonly=True)
+    try:
+        assert store._readonly is True
+        assert init_retry_calls == []
+    finally:
+        store.close()
+
+
+def test_readonly_rejects_writes(tmp_path):
+    db_path = tmp_path / "readonly.db"
+    _create_vector_db(db_path)
+
+    store = VectorStore(db_path, readonly=True)
+    try:
+        with pytest.raises(apsw.ReadOnlyError):
+            store.conn.cursor().execute(
+                "INSERT INTO chunks (id, content, metadata, source_file) VALUES ('x', 'x', '{}', 'x')"
+            )
+    finally:
+        store.close()
+
+
+def test_readonly_skips_strengthening(tmp_path):
+    db_path = tmp_path / "readonly.db"
+    query_embedding = _embed("readonly strengthening")
+
+    writer = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            writer,
+            chunk_id="target",
+            content="readonly strengthening result",
+            embedding=query_embedding,
+        )
+    finally:
+        writer.close()
+
+    store = VectorStore(db_path, readonly=True)
+    try:
+        store._retrieval_strengthening_flush_threshold = 1
+        results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="readonly strengthening",
+            n_results=1,
+        )
+        assert results["ids"][0] == ["target"]
+    finally:
+        store.close()
+
+    inspector = VectorStore(db_path)
+    try:
+        row = (
+            inspector.conn.cursor()
+            .execute("SELECT retrieval_count, last_retrieved FROM chunks WHERE id = 'target'")
+            .fetchone()
+        )
+        assert row == (0, None)
+    finally:
+        inspector.close()
+
+
+def test_readonly_busyerror_resilience(tmp_path, monkeypatch):
+    db_path = tmp_path / "readonly.db"
+    _create_vector_db(db_path)
+
+    def fail_init_retry(self):
+        raise AssertionError("_init_db_with_retry should not run while opening readonly under write contention")
+
+    monkeypatch.setattr(VectorStore, "_init_db_with_retry", fail_init_retry)
+
+    writer_conn = apsw.Connection(str(db_path))
+    writer_cursor = writer_conn.cursor()
+    writer_cursor.execute("BEGIN IMMEDIATE")
+    try:
+        store = VectorStore(db_path, readonly=True)
+        try:
+            assert store._readonly is True
+            assert store.conn.cursor().execute("SELECT COUNT(*) FROM sqlite_master").fetchone()[0] > 0
+        finally:
+            store.close()
+    finally:
+        writer_cursor.execute("ROLLBACK")
+        writer_conn.close()


### PR DESCRIPTION
## Summary
- Add explicit `VectorStore(..., readonly=True)` bootstrap that uses `_init_readonly_db()` and sets `_readonly=True`.
- Route MCP search handlers and BrainBar hybrid helper warmup through a separate cached read-only search store, leaving write handlers on the existing read-write store.
- Add read-only bootstrap regression tests for retry bypass, write rejection, strengthening skip, and writer-contention initialization.

## R3 before/after evidence
- Repro artifacts: `/tmp/readpath-r3/20260521-020313-r3-aggregate.json`, `/tmp/readpath-r3/20260521-020313-r3-summary.txt`.
- Cold-open under write load: baseline median `1834.354ms`, p95 `2831.598ms`; candidate readonly median `2.362ms`, p95 `2.446ms`.
- `brain_search` under write load: baseline median `21.084ms`, p95 `12559.992ms`; candidate readonly median `22.271ms`, p95 `10588.061ms`.
- Phase 1 targets the init backoff path; long p95 tails remain sqlite-vec/checkpoint contention for later phases.

## Test count delta
- New readonly bootstrap test file: `0 -> 4` tests.

## Verification
- RED: `pytest tests/test_vector_store_readonly.py` failed `4/4` before implementation with `VectorStore.__init__() got an unexpected keyword argument 'readonly'`.
- GREEN focused: `pytest tests/test_vector_store_readonly.py tests/test_brainbar_hybrid_helper.py tests/test_search_exact_chunk_id.py tests/test_search_filter_params.py` passed `42/42`.
- Ruff scoped: `ruff check src tests` passed; `ruff format --check src tests` passed.
- Pre-push repo gate passed: pytest unit suite `2043 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration `3 passed`; isolated eval/hook routing `32 passed`; bun stale-index test `1 passed`; FTS5 shell regression passed.

## Notes
- Local system-Python `pytest` is not authoritative in this checkout: it failed collection due missing `deepchecks` and NumPy 2.4 vs numba. The repo pre-push gate uses `.venv` and passed.
- R3 design prose is internally stale: `DESIGN.md` ends with `VERDICT FAIL`, while collab dispatch marks R3 PASS. Raw R3 aggregate confirms the Phase 1 cold-open win above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new read-only search `VectorStore` path with schema bootstrapping logic; mistakes could lead to missing migrations or runtime failures in search/stats under contention.
> 
> **Overview**
> Search flows now default to a dedicated cached **read-only** `VectorStore` to avoid startup/migration lock contention, while keeping write-capable operations on the existing read-write store.
> 
> This adds `_get_search_vector_store()` with a bootstrap check that runs one-time migrations in RW mode when the DB is missing or schema is stale, updates BrainBar hybrid helper warmup and MCP `search_handler` to use the RO store (with `_stats` explicitly using RW), and extends `VectorStore` with an explicit `readonly` constructor flag. A new `test_vector_store_readonly.py` suite covers RO init behavior, write rejection, strengthening-skip, and opening under writer contention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 113ab16c50dcc1b1de03451d022f14b32a04117c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector store now supports read-only initialization mode, enabling optimized search operations with enhanced reliability.
  * Search functionality now uses a dedicated, read-only vector store instance for improved performance.

* **Tests**
  * Added comprehensive test suite validating read-only vector store behavior across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bootstrap search stores in read-only mode for the readpath
> - Adds `_get_search_vector_store` in [_shared.py](https://github.com/EtanHey/brainlayer/pull/304/files#diff-8d50696b7d699becb60051866c0f5ad08fb051abf31b0ba06846824756994879) that returns a read-only `VectorStore`, bootstrapping the DB schema if missing or stale before opening with `readonly=True`.
> - Adds a `readonly` parameter to `VectorStore.__init__` in [vector_store.py](https://github.com/EtanHey/brainlayer/pull/304/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261); when set, directory creation is skipped and initialization uses the read-only path instead of `_init_db_with_retry`.
> - Redirects search handler code paths in [search_handler.py](https://github.com/EtanHey/brainlayer/pull/304/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) to use the read-only store by default; the stats endpoint retains the read-write store.
> - Updates `HybridSearchHelper.warm` in [brainbar_hybrid_helper.py](https://github.com/EtanHey/brainlayer/pull/304/files#diff-c85489aba31fa1d5281e047454fd19b9bc81038f1a1d67505020bb97543bb622) to warm against the search (read-only) store.
> - Risk: search endpoints now operate on a read-only connection; any path that unexpectedly requires a write will raise `apsw.ReadOnlyError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 113ab16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->