### PR TITLE
feat: tune BrainLayer read path PRAGMAs and default MMR off

### DIFF
--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -34,6 +34,9 @@ _HYBRID_CACHE_MAX = 128  # max entries (LRU eviction)
 _MMR_CANDIDATE_LIMIT = 50
 try:
     _MMR_LAMBDA = float(os.environ.get("BRAINLAYER_MMR_LAMBDA", "1.0"))
+    if not math.isfinite(_MMR_LAMBDA):
+        raise ValueError
+    _MMR_LAMBDA = max(0.0, min(1.0, _MMR_LAMBDA))
 except (TypeError, ValueError):
     _MMR_LAMBDA = 1.0
 _FILTERED_KNN_MAX = 2000

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -32,7 +32,10 @@ from .ingest_guard import recursive_mcp_output_reason
 _HYBRID_CACHE_TTL = 60.0  # seconds
 _HYBRID_CACHE_MAX = 128  # max entries (LRU eviction)
 _MMR_CANDIDATE_LIMIT = 50
-_MMR_LAMBDA = 0.65
+try:
+    _MMR_LAMBDA = float(os.environ.get("BRAINLAYER_MMR_LAMBDA", "1.0"))
+except (TypeError, ValueError):
+    _MMR_LAMBDA = 1.0
 _FILTERED_KNN_MAX = 2000
 META_NOISE_PATTERNS = [
     "brain_search(",
@@ -477,6 +480,8 @@ class SearchMixin:
     ) -> List[tuple[float, str, str, Dict[str, Any], Any]]:
         """Diversify the top candidate pool with MMR while preserving overall recall."""
         if len(scored) < 2:
+            return scored
+        if _MMR_LAMBDA >= 1.0:
             return scored
 
         candidate_limit = min(len(scored), _MMR_CANDIDATE_LIMIT)

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -71,6 +71,25 @@ apsw.connection_hooks.insert(0, _set_busy_timeout_hook)
 apsw.bestpractice.apply(apsw.bestpractice.recommended)
 
 
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _read_mmap_bytes() -> int:
+    return max(_int_env("BRAINLAYER_READ_MMAP_BYTES", 30_000_000_000), 0)
+
+
+def _read_cache_size_kb() -> int:
+    return -abs(_int_env("BRAINLAYER_READ_CACHE_KB", 64_000))
+
+
+def _wal_autocheckpoint_pages() -> int:
+    return max(_int_env("BRAINLAYER_WAL_AUTOCHECKPOINT", 10_000), 0)
+
+
 class VectorStore(SearchMixin, KGMixin, SessionMixin):
     """SQLite-vec based vector store.
 
@@ -180,6 +199,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         # WAL mode is persistent on the DB file — set it every time
         cursor.execute("PRAGMA journal_mode = WAL")
+        cursor.execute(f"PRAGMA wal_autocheckpoint = {_wal_autocheckpoint_pages()}")
 
         # Create tables
         cursor.execute("""
@@ -1177,6 +1197,9 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             conn.loadextension(sqlite_vec.loadable_path())
             conn.enableloadextension(False)
             conn.setbusytimeout(30_000)
+            cursor = conn.cursor()
+            cursor.execute(f"PRAGMA mmap_size = {_read_mmap_bytes()}")
+            cursor.execute(f"PRAGMA cache_size = {_read_cache_size_kb()}")
             self._local.read_conn = conn
         return conn
 

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -431,7 +431,9 @@ class TestHybridSearch:
     def test_noise_demoter_does_not_treat_arbitrary_true_metadata_as_quarantine(self):
         assert not _contains_precompact_or_quarantined_meta({"feature_enabled": "true"}, "ordinary content")
 
-    def test_mmr_rerank_dedupes_near_duplicates(self, store):
+    def test_mmr_rerank_dedupes_near_duplicates(self, store, monkeypatch):
+        monkeypatch.setattr("brainlayer.search_repo._MMR_LAMBDA", 0.65)
+
         def embedding(primary: float, secondary: float = 0.0) -> list[float]:
             vector = [0.0] * 1024
             vector[0] = primary
@@ -487,7 +489,9 @@ class TestHybridSearch:
         assert "distinct-relevant" in ids[:2], ids
         assert set(ids[:2]) != {"dup-primary", "dup-secondary"}, ids
 
-    def test_mmr_rerank_keeps_nonvector_hits_in_original_score_slots(self, store):
+    def test_mmr_rerank_keeps_nonvector_hits_in_original_score_slots(self, store, monkeypatch):
+        monkeypatch.setattr("brainlayer.search_repo._MMR_LAMBDA", 0.65)
+
         def embedding(primary: float, secondary: float = 0.0) -> list[float]:
             vector = [0.0] * 1024
             vector[0] = primary

--- a/tests/test_mmr_default_off.py
+++ b/tests/test_mmr_default_off.py
@@ -1,0 +1,55 @@
+import importlib
+
+
+def _scored_candidates():
+    return [
+        (0.99, "a", "alpha", {}, 0.01),
+        (0.98, "b", "beta", {}, 0.02),
+        (0.97, "c", "gamma", {}, 0.03),
+    ]
+
+
+class _SpyStore:
+    def __init__(self):
+        self.embedding_load_calls = 0
+
+    def _load_chunk_embeddings(self, chunk_ids):
+        self.embedding_load_calls += 1
+        return {}
+
+
+def test_mmr_default_is_off_and_does_not_load_embeddings(monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_MMR_LAMBDA", raising=False)
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+    store = _SpyStore()
+    scored = _scored_candidates()
+
+    reranked = search_repo.SearchMixin._mmr_rerank_scored_results(store, scored, n_results=2)
+
+    assert search_repo._MMR_LAMBDA == 1.0
+    assert reranked == scored
+    assert store.embedding_load_calls == 0
+
+
+def test_mmr_env_override_reenables_embedding_load(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "0.65")
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+    store = _SpyStore()
+
+    search_repo.SearchMixin._mmr_rerank_scored_results(store, _scored_candidates(), n_results=2)
+
+    assert search_repo._MMR_LAMBDA == 0.65
+    assert store.embedding_load_calls == 1
+
+
+def test_invalid_mmr_env_override_falls_back_to_default_off(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "not-a-float")
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+
+    assert search_repo._MMR_LAMBDA == 1.0

--- a/tests/test_mmr_default_off.py
+++ b/tests/test_mmr_default_off.py
@@ -53,3 +53,26 @@ def test_invalid_mmr_env_override_falls_back_to_default_off(monkeypatch):
     search_repo = importlib.reload(search_repo)
 
     assert search_repo._MMR_LAMBDA == 1.0
+
+
+def test_nonfinite_mmr_env_override_falls_back_to_default_off(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "nan")
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+
+    assert search_repo._MMR_LAMBDA == 1.0
+
+
+def test_out_of_range_mmr_env_override_is_clamped(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "-0.25")
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+
+    assert search_repo._MMR_LAMBDA == 0.0
+
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "1.25")
+    search_repo = importlib.reload(search_repo)
+
+    assert search_repo._MMR_LAMBDA == 1.0

--- a/tests/test_vector_store_pragma_tuning.py
+++ b/tests/test_vector_store_pragma_tuning.py
@@ -1,0 +1,84 @@
+import pytest
+
+from brainlayer.vector_store import VectorStore
+
+
+def _pragma_value(conn, name: str) -> int:
+    row = conn.cursor().execute(f"PRAGMA {name}").fetchone()
+    return int(row[0])
+
+
+def test_read_connection_sets_mmap_size(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_READ_MMAP_BYTES", raising=False)
+    store = VectorStore(tmp_path / "pragma-read.db")
+    store.close()
+
+    reader = VectorStore(tmp_path / "pragma-read.db", readonly=True)
+    try:
+        mmap_size = _pragma_value(reader._get_read_conn(), "mmap_size")
+        if mmap_size == 0:
+            pytest.skip("SQLite build does not support mmap_size")
+        assert mmap_size > 0
+    finally:
+        reader.close()
+
+
+def test_read_connection_sets_private_cache_size(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_READ_CACHE_KB", raising=False)
+    store = VectorStore(tmp_path / "pragma-cache.db")
+    store.close()
+
+    reader = VectorStore(tmp_path / "pragma-cache.db", readonly=True)
+    try:
+        assert _pragma_value(reader._get_read_conn(), "cache_size") == -64000
+    finally:
+        reader.close()
+
+
+def test_writer_init_sets_wal_autocheckpoint(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_WAL_AUTOCHECKPOINT", raising=False)
+    store = VectorStore(tmp_path / "pragma-wal.db")
+    try:
+        assert _pragma_value(store.conn, "wal_autocheckpoint") == 10000
+    finally:
+        store.close()
+
+
+def test_pragma_env_overrides_apply_to_new_connections(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_WAL_AUTOCHECKPOINT", "2222")
+    monkeypatch.setenv("BRAINLAYER_READ_MMAP_BYTES", "0")
+    monkeypatch.setenv("BRAINLAYER_READ_CACHE_KB", "12345")
+
+    store = VectorStore(tmp_path / "pragma-overrides.db")
+    try:
+        assert _pragma_value(store.conn, "wal_autocheckpoint") == 2222
+    finally:
+        store.close()
+
+    reader = VectorStore(tmp_path / "pragma-overrides.db", readonly=True)
+    try:
+        conn = reader._get_read_conn()
+        assert _pragma_value(conn, "mmap_size") == 0
+        assert _pragma_value(conn, "cache_size") == -12345
+    finally:
+        reader.close()
+
+
+def test_invalid_pragma_env_values_fall_back_to_defaults(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_WAL_AUTOCHECKPOINT", "not-an-int")
+    monkeypatch.setenv("BRAINLAYER_READ_MMAP_BYTES", "not-an-int")
+    monkeypatch.setenv("BRAINLAYER_READ_CACHE_KB", "not-an-int")
+
+    store = VectorStore(tmp_path / "pragma-invalid-env.db")
+    try:
+        assert _pragma_value(store.conn, "wal_autocheckpoint") == 10000
+    finally:
+        store.close()
+
+    reader = VectorStore(tmp_path / "pragma-invalid-env.db", readonly=True)
+    try:
+        conn = reader._get_read_conn()
+        assert _pragma_value(conn, "mmap_size") > 0
+        assert _pragma_value(conn, "cache_size") == -64000
+    finally:
+        reader.close()


### PR DESCRIPTION
## Summary
- Adds production read-path PRAGMA tuning: read connections set `mmap_size=30000000000` and `cache_size=-64000`, with `BRAINLAYER_READ_MMAP_BYTES` and `BRAINLAYER_READ_CACHE_KB` overrides.
- Tunes WAL checkpoint cadence after writer WAL setup with `wal_autocheckpoint=10000`, with `BRAINLAYER_WAL_AUTOCHECKPOINT` override.
- Defaults MMR reranking off via `BRAINLAYER_MMR_LAMBDA=1.0`; lower values still opt into the existing MMR path. Triple RRF is preserved unchanged.
- Ships Phase 3 R4 α + γ only. No β. No signal-pause.

## R3 Stress-Test Evidence

| Path                       | median | p95     | max     |
|----------------------------|--------|---------|---------|
| baseline (Phase 1 only)    | 31.6ms | 4501ms  | 9831ms  |
| α (PRAGMA tuning)          | 36.0ms | 3141ms  | 8352ms  |
| γ (MMR off)                | 33.9ms | 2627ms  | 4354ms  |
| α + γ combined             | 33.0ms | 2384ms  | 2955ms  |
| α on LIVE DB (this PR)     | 61.0ms | 2505ms  | 8385ms  |

Headline from the read-path redesign: `brain_search` median `16930ms -> 33ms` (~510x), p95 `11337ms -> 2384ms` (~4.6x). Triple RRF remains unchanged.

## Phase 4 Future Work

The remaining 8s tail outliers and sqlite-vec brute-force KNN floor are Phase 4 future work. The likely durable fix is HNSW/vector-backend replacement after TechGym, not broadening this PR.

## Repro Commands

```bash
.venv/bin/python /tmp/phase3-r3-bench.py bench --mode baseline --db /tmp/readpath-r3-10gb.db --n 24 --writers 18 --rate 15 --duration 28 > /tmp/phase3-r3-baseline.json 2> /tmp/phase3-r3-baseline.stderr.log
.venv/bin/python /tmp/phase3-r3-bench.py bench --mode alpha --db /tmp/readpath-r3-10gb.db --n 24 --writers 18 --rate 15 --duration 28 > /tmp/phase3-r3-alpha.json 2> /tmp/phase3-r3-alpha.stderr.log
.venv/bin/python /tmp/phase3-r3-bench.py bench --mode gamma --db /tmp/readpath-r3-10gb.db --n 24 --writers 18 --rate 15 --duration 28 > /tmp/phase3-r3-gamma.json 2> /tmp/phase3-r3-gamma.stderr.log
.venv/bin/python /tmp/phase3-r3-bench.py bench --mode alpha-gamma --db /tmp/readpath-r3-10gb.db --n 24 --writers 18 --rate 15 --duration 28 > /tmp/phase3-r3-alpha-gamma.json 2> /tmp/phase3-r3-alpha-gamma.stderr.log
.venv/bin/python /tmp/phase3-r3-bench.py bench --mode live-alpha --db /Users/etanheyman/.local/share/brainlayer/brainlayer.db --n 20 --writers 0 --live > /tmp/phase3-r3-live-alpha.json 2> /tmp/phase3-r3-live-alpha.stderr.log
```

## Verification

- RED first: `.venv/bin/python -m pytest tests/test_vector_store_pragma_tuning.py tests/test_mmr_default_off.py -v` produced expected failures before implementation (`4 failed, 1 passed, 1 skipped`).
- RED invalid-env regressions: targeted invalid-env tests failed before the fallback parser fix.
- Target tests: `.venv/bin/python -m pytest tests/test_vector_store_pragma_tuning.py tests/test_mmr_default_off.py -v` -> `8 passed`.
- Wider affected tests: `.venv/bin/python -m pytest tests/test_hybrid_search.py tests/test_vector_store_pragma_tuning.py tests/test_mmr_default_off.py -v` -> `24 passed`.
- Lint/format: `.venv/bin/ruff check src tests` passed; `.venv/bin/ruff format --check src tests` passed.
- Pre-push gate passed: unit pytest (`2054 passed, 9 skipped, 75 deselected, 1 xfailed`), MCP registration (`3 passed`), isolated eval/hook routing (`32 passed`), bun stale-index suite (`1 pass`), FTS5 determinism shell regression passed.
- Live eval on `/tmp/readpath-r3-10gb.db` copy: `BRAINLAYER_DB=/tmp/readpath-r3-10gb.db .venv/bin/python -m pytest tests/test_eval_baselines.py -m live -v` -> `32 passed, 2 failed, 5 xfailed, 2 xpassed`; the two failures match the accepted pre-existing R4 prompt allowances: no recent-week chunks in the fixture copy and generic Python entity injection.
- Actual live eval against `~/.local/share/brainlayer/brainlayer.db` was blocked by active DB locks from enrichment/drain (`apsw.BusyError`).
- Full unmarked pytest also hit live/default DB lock errors and the known ranx/numba order-dependent eval issue; isolated `tests/test_eval_framework.py` passed (`11 passed`).

## Local Review

- `cr review --plain` after fixes reports only `.gemini/settings.json`, which is untracked and not included in this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes search ranking behavior (MMR reranking now disabled by default) and adjusts SQLite connection PRAGMAs, which can affect performance and operational characteristics across deployments.
> 
> **Overview**
> **Tunes BrainLayer’s SQLite read/write connection settings and makes MMR reranking opt-in.**
> 
> Read-only connections now set `PRAGMA mmap_size` and `PRAGMA cache_size`, and writer init sets `PRAGMA wal_autocheckpoint`; all three are configurable via `BRAINLAYER_READ_MMAP_BYTES`, `BRAINLAYER_READ_CACHE_KB`, and `BRAINLAYER_WAL_AUTOCHECKPOINT` with safe parsing/fallbacks.
> 
> Hybrid search MMR reranking is now **off by default** (`_MMR_LAMBDA=1.0`), configurable via `BRAINLAYER_MMR_LAMBDA`, and short-circuits to skip embedding loads when disabled; tests were added/updated to cover env overrides, clamping/invalid values, and PRAGMA application.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50389f500c107f2d4728d18571a6a50af87a8387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tune BrainLayer read path SQLite PRAGMAs and disable MMR reranking by default
> - Read-only connections in [`VectorStore._get_read_conn`](https://github.com/EtanHey/brainlayer/pull/305/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) now set `PRAGMA mmap_size` (default 30 GB) and `PRAGMA cache_size` (default -64000 KB); writer connections set `PRAGMA wal_autocheckpoint` (default 10000 pages). All values are overridable via environment variables.
> - `_MMR_LAMBDA` in [`search_repo.py`](https://github.com/EtanHey/brainlayer/pull/305/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) now defaults to `1.0` (MMR off), readable from `BRAINLAYER_MMR_LAMBDA`; invalid or non-finite values fall back to `1.0`.
> - `SearchMixin._mmr_rerank_scored_results` short-circuits and skips embedding loads when `_MMR_LAMBDA >= 1.0`.
> - Behavioral Change: MMR diversification is now off by default; existing deployments relying on MMR reranking must set `BRAINLAYER_MMR_LAMBDA` to a value below `1.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50389f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search result reranking is now disabled by default and can be configured via the `BRAINLAYER_MMR_LAMBDA` environment variable.
  * Database performance parameters are now configurable via environment variables (`BRAINLAYER_WAL_AUTOCHECKPOINT`, `BRAINLAYER_READ_MMAP_BYTES`, `BRAINLAYER_READ_CACHE_KB`).

* **Tests**
  * Added comprehensive test coverage for MMR configuration behavior and database pragma settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->