### PR TITLE
feat(enrich): long-lived supervisor replaces respawn-init storm

### DIFF
--- a/scripts/launchd/com.brainlayer.enrichment.plist
+++ b/scripts/launchd/com.brainlayer.enrichment.plist
@@ -6,13 +6,15 @@
     <string>com.brainlayer.enrichment</string>
 
     <!-- Realtime Gemini enrichment LaunchAgent.
-         Runs a supervised shell loop so the one-shot enrich command stays continuous. -->
+         Runs one long-lived supervisor; launchd restarts only on process crash. -->
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/zsh</string>
-        <string>-lc</string>
-        <string>cd "__BRAINLAYER_DIR__" || exit 1; while true; do "__BRAINLAYER_BIN__" enrich --mode realtime --limit 200000 --since-hours 87600; sleep 5; done</string>
+        <string>__BRAINLAYER_BIN__</string>
+        <string>enrich</string>
+        <string>--mode</string>
+        <string>realtime</string>
+        <string>--supervisor</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -903,11 +903,17 @@ def enrich(
         help="Batch mode Gemini model override",
     ),
     stats_only: bool = typer.Option(False, "--stats", help="Show progress and exit"),
+    supervisor: bool = typer.Option(False, "--supervisor", help="Run realtime enrichment as a long-lived supervisor"),
 ) -> None:
     """Enrich chunks via Gemini-backed realtime or batch modes."""
     try:
         from .. import cloud_backfill
-        from ..enrichment_controller import enrich_realtime
+        from ..enrichment_controller import (
+            DEFAULT_ENRICH_SUPERVISOR_LIMIT,
+            DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS,
+            enrich_realtime,
+            run_enrich_supervisor,
+        )
         from ..parent_death import install_parent_death_watcher
         from ..vector_store import VectorStore
 
@@ -935,6 +941,39 @@ def enrich(
             return
 
         if mode == "realtime":
+            if supervisor:
+                import signal
+                import threading
+
+                stop_event = threading.Event()
+
+                def handle_signal(signum, frame):
+                    rprint("\n[bold yellow]Stopping enrich supervisor...[/]")
+                    stop_event.set()
+
+                previous_sigterm = signal.getsignal(signal.SIGTERM)
+                previous_sigint = signal.getsignal(signal.SIGINT)
+                signal.signal(signal.SIGTERM, handle_signal)
+                signal.signal(signal.SIGINT, handle_signal)
+                try:
+                    result = run_enrich_supervisor(
+                        db_path,
+                        limit=limit or DEFAULT_ENRICH_SUPERVISOR_LIMIT,
+                        since_hours=since_hours
+                        if since_hours != DEFAULT_REALTIME_ENRICH_SINCE_HOURS
+                        else DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS,
+                        stop_event=stop_event,
+                    )
+                finally:
+                    signal.signal(signal.SIGTERM, previous_sigterm)
+                    signal.signal(signal.SIGINT, previous_sigint)
+                console.print(
+                    f"[bold green]Done![/] mode={result.mode} cycles={result.cycles} "
+                    f"attempted={result.attempted} enriched={result.enriched} "
+                    f"skipped={result.skipped} failed={result.failed}"
+                )
+                raise typer.Exit(result.exit_code)
+
             store = VectorStore(db_path)
             try:
                 result = enrich_realtime(store, limit=limit or 25, since_hours=since_hours)
@@ -978,6 +1017,8 @@ def enrich(
             return
 
         raise typer.BadParameter(f"Invalid batch phase: {phase}")
+    except typer.Exit:
+        raise
     except Exception as e:
         rprint(f"[bold red]Error:[/] {e}")
         raise typer.Exit(1)

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -889,8 +889,8 @@ def enrich(
         "-n",
         help="Realtime: max chunks to process. Batch submit/run: optional sample size; defaults to all.",
     ),
-    since_hours: int = typer.Option(
-        DEFAULT_REALTIME_ENRICH_SINCE_HOURS,
+    since_hours: Optional[int] = typer.Option(
+        None,
         "--since-hours",
         help=(
             f"Realtime mode: only enrich chunks from the last N hours. Default: {DEFAULT_REALTIME_ENRICH_SINCE_HOURS}h"
@@ -959,9 +959,7 @@ def enrich(
                     result = run_enrich_supervisor(
                         db_path,
                         limit=limit or DEFAULT_ENRICH_SUPERVISOR_LIMIT,
-                        since_hours=since_hours
-                        if since_hours != DEFAULT_REALTIME_ENRICH_SINCE_HOURS
-                        else DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS,
+                        since_hours=since_hours if since_hours is not None else DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS,
                         stop_event=stop_event,
                     )
                 finally:
@@ -976,7 +974,11 @@ def enrich(
 
             store = VectorStore(db_path)
             try:
-                result = enrich_realtime(store, limit=limit or 25, since_hours=since_hours)
+                result = enrich_realtime(
+                    store,
+                    limit=limit or 25,
+                    since_hours=since_hours if since_hours is not None else DEFAULT_REALTIME_ENRICH_SINCE_HOURS,
+                )
                 console.print(
                     f"[bold green]Done![/] mode={result.mode} attempted={result.attempted} "
                     f"enriched={result.enriched} skipped={result.skipped} failed={result.failed}"

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -114,6 +114,7 @@ class EnrichmentSupervisorResult:
     enriched: int = 0
     skipped: int = 0
     failed: int = 0
+    failed_cycles: int = 0
     errors: list[str] = field(default_factory=list)
     exit_code: int = 0
 
@@ -174,10 +175,12 @@ def run_enrich_supervisor(
                 result = enrich_fn(store, limit=limit, since_hours=since_hours)
             except Exception as exc:  # noqa: BLE001
                 stats.cycles += 1
-                stats.failed += 1
+                stats.failed_cycles += 1
                 error = f"supervisor: {exc}"
                 stats.errors.append(error)
                 logger.exception("Enrich supervisor cycle failed; continuing")
+                if max_cycles is None or stats.cycles < max_cycles:
+                    _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
                 continue
 
             stats.cycles += 1

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 
 GEMINI_REALTIME_MODEL = os.environ.get("BRAINLAYER_GEMINI_REALTIME_MODEL", "gemini-2.5-flash-lite")
 DEFAULT_MAX_COMMIT_INTERVAL_MS = 250.0
+DEFAULT_ENRICH_SUPERVISOR_LIMIT = 200_000
+DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS = 87_600
+DEFAULT_ENRICH_IDLE_POLL_SECONDS = 30.0
 
 
 def _bounded_nonnegative_float(value: Any, default: float) -> float:
@@ -101,6 +104,95 @@ class EnrichmentResult:
     skipped: int
     failed: int
     errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EnrichmentSupervisorResult:
+    mode: str = "supervisor"
+    cycles: int = 0
+    attempted: int = 0
+    enriched: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+    exit_code: int = 0
+
+
+def _current_idle_poll_seconds() -> float:
+    return _bounded_nonnegative_float(
+        os.environ.get("BRAINLAYER_ENRICH_IDLE_POLL_SECONDS"),
+        DEFAULT_ENRICH_IDLE_POLL_SECONDS,
+    )
+
+
+def _sleep_or_wait_for_stop(stop_event: threading.Event | None, seconds: float, sleep_fn) -> None:
+    if seconds <= 0:
+        return
+    if stop_event is not None and sleep_fn is time.sleep:
+        stop_event.wait(seconds)
+        return
+    sleep_fn(seconds)
+
+
+def run_enrich_supervisor(
+    db_path: Path | str,
+    *,
+    limit: int = DEFAULT_ENRICH_SUPERVISOR_LIMIT,
+    since_hours: int = DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS,
+    idle_poll_seconds: float | None = None,
+    max_cycles: int | None = None,
+    stop_event: threading.Event | None = None,
+    vector_store_cls=None,
+    enrich_fn=None,
+    sleep_fn=time.sleep,
+) -> EnrichmentSupervisorResult:
+    """Run realtime enrichment as a long-lived supervisor around one VectorStore.
+
+    PR-alpha's writer pidfile mutex is acquired by the writable VectorStore
+    constructor. Keeping that store alive here keeps the pidfile for the whole
+    supervisor lifetime instead of reacquiring it on every launchd respawn.
+    """
+    from .vector_store import VectorStore
+
+    if vector_store_cls is None:
+        vector_store_cls = VectorStore
+    if enrich_fn is None:
+        enrich_fn = enrich_realtime
+    if idle_poll_seconds is None:
+        idle_poll_seconds = _current_idle_poll_seconds()
+
+    db_path = Path(db_path)
+    stats = EnrichmentSupervisorResult()
+    store = vector_store_cls(db_path)
+    logger.info("VectorStore initialized for enrich supervisor: %s", db_path)
+    try:
+        while stop_event is None or not stop_event.is_set():
+            if max_cycles is not None and stats.cycles >= max_cycles:
+                break
+
+            try:
+                result = enrich_fn(store, limit=limit, since_hours=since_hours)
+            except Exception as exc:  # noqa: BLE001
+                stats.cycles += 1
+                stats.failed += 1
+                error = f"supervisor: {exc}"
+                stats.errors.append(error)
+                logger.exception("Enrich supervisor cycle failed; continuing")
+                continue
+
+            stats.cycles += 1
+            stats.attempted += result.attempted
+            stats.enriched += result.enriched
+            stats.skipped += result.skipped
+            stats.failed += result.failed
+            stats.errors.extend(result.errors)
+
+            if result.attempted == 0 and (max_cycles is None or stats.cycles < max_cycles):
+                logger.info("Enrich supervisor queue empty; sleeping %.1fs", idle_poll_seconds)
+                _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
+    finally:
+        store.close()
+    return stats
 
 
 def _load_cloud_backfill_module():

--- a/tests/test_cli_enrich.py
+++ b/tests/test_cli_enrich.py
@@ -1,5 +1,7 @@
 """Tests for brainlayer enrichment and maintenance CLI routing."""
 
+import os
+import signal
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -26,6 +28,64 @@ def test_cli_enrich_mode_realtime_routes_to_controller(monkeypatch):
     assert result.exit_code == 0
     assert called["limit"] == 9
     assert called["since_hours"] == 12
+
+
+def test_cli_enrich_supervisor_routes_to_controller(monkeypatch):
+    monkeypatch.setattr("brainlayer.cli.get_db_path", lambda: "/tmp/test.db")
+    called = {}
+
+    def fake_supervisor(db_path, limit=0, since_hours=0, stop_event=None):
+        called.update({"db_path": str(db_path), "limit": limit, "since_hours": since_hours, "stop_event": stop_event})
+        return SimpleNamespace(
+            mode="supervisor",
+            cycles=2,
+            attempted=3,
+            enriched=2,
+            skipped=1,
+            failed=0,
+            errors=[],
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("brainlayer.enrichment_controller.run_enrich_supervisor", fake_supervisor)
+
+    result = runner.invoke(app, ["enrich", "--mode", "realtime", "--supervisor"])
+
+    assert result.exit_code == 0
+    assert called["db_path"] == "/tmp/test.db"
+    assert called["limit"] == 200000
+    assert called["since_hours"] == 87600
+    assert called["stop_event"] is not None
+    assert "mode=supervisor" in result.stdout
+    assert "cycles=2" in result.stdout
+
+
+def test_cli_enrich_supervisor_handles_sigterm_gracefully(monkeypatch):
+    monkeypatch.setattr("brainlayer.cli.get_db_path", lambda: "/tmp/test.db")
+    called = {}
+
+    def fake_supervisor(db_path, stop_event=None, **kwargs):
+        os.kill(os.getpid(), signal.SIGTERM)
+        called["stop_event_set"] = stop_event.is_set()
+        return SimpleNamespace(
+            mode="supervisor",
+            cycles=1,
+            attempted=1,
+            enriched=1,
+            skipped=0,
+            failed=0,
+            errors=[],
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("brainlayer.enrichment_controller.run_enrich_supervisor", fake_supervisor)
+
+    result = runner.invoke(app, ["enrich", "--mode", "realtime", "--supervisor"])
+
+    assert result.exit_code == 0
+    assert called["stop_event_set"] is True
+    assert "Stopping enrich supervisor" in result.stdout
+    assert "mode=supervisor" in result.stdout
 
 
 def test_cli_enrich_mode_batch_submit_routes_to_cloud_backfill(monkeypatch):

--- a/tests/test_cli_enrich.py
+++ b/tests/test_cli_enrich.py
@@ -60,6 +60,31 @@ def test_cli_enrich_supervisor_routes_to_controller(monkeypatch):
     assert "cycles=2" in result.stdout
 
 
+def test_cli_enrich_supervisor_preserves_explicit_since_hours(monkeypatch):
+    monkeypatch.setattr("brainlayer.cli.get_db_path", lambda: "/tmp/test.db")
+    called = {}
+
+    def fake_supervisor(db_path, limit=0, since_hours=0, stop_event=None):
+        called.update({"limit": limit, "since_hours": since_hours})
+        return SimpleNamespace(
+            mode="supervisor",
+            cycles=1,
+            attempted=0,
+            enriched=0,
+            skipped=0,
+            failed=0,
+            errors=[],
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("brainlayer.enrichment_controller.run_enrich_supervisor", fake_supervisor)
+
+    result = runner.invoke(app, ["enrich", "--mode", "realtime", "--supervisor", "--since-hours", "8760"])
+
+    assert result.exit_code == 0
+    assert called == {"limit": 200000, "since_hours": 8760}
+
+
 def test_cli_enrich_supervisor_handles_sigterm_gracefully(monkeypatch):
     monkeypatch.setattr("brainlayer.cli.get_db_path", lambda: "/tmp/test.db")
     called = {}

--- a/tests/test_enrich_supervisor.py
+++ b/tests/test_enrich_supervisor.py
@@ -84,9 +84,39 @@ def test_supervisor_logs_gemini_error_and_continues(tmp_path, caplog):
 
     assert calls == 2
     assert result.enriched == 1
-    assert result.failed == 1
+    assert result.failed == 0
+    assert result.failed_cycles == 1
     assert result.errors == ["supervisor: gemini 503"]
     assert "Enrich supervisor cycle failed; continuing" in caplog.text
+
+
+def test_supervisor_backs_off_between_persistent_cycle_errors(tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            self.db_path = db_path
+
+        def close(self):
+            pass
+
+    sleeps = []
+
+    def failing_enrich(store, **kwargs):
+        raise RuntimeError("gemini still down")
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        max_cycles=3,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=failing_enrich,
+        sleep_fn=sleeps.append,
+    )
+
+    assert result.cycles == 3
+    assert result.failed == 0
+    assert result.failed_cycles == 3
+    assert sleeps == [30.0, 30.0]
 
 
 def test_supervisor_graceful_shutdown_closes_store_after_inflight_cycle(tmp_path):

--- a/tests/test_enrich_supervisor.py
+++ b/tests/test_enrich_supervisor.py
@@ -1,0 +1,213 @@
+import logging
+import plistlib
+from pathlib import Path
+
+import pytest
+
+
+def _result(*, attempted: int, enriched: int = 0, skipped: int = 0, failed: int = 0, errors=None):
+    from brainlayer.enrichment_controller import EnrichmentResult
+
+    return EnrichmentResult(
+        mode="realtime",
+        attempted=attempted,
+        enriched=enriched,
+        skipped=skipped,
+        failed=failed,
+        errors=list(errors or []),
+    )
+
+
+def test_supervisor_reuses_one_vector_store_across_cycles(tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    init_paths = []
+    enrich_calls = []
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            init_paths.append(db_path)
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    def fake_enrich(store, **kwargs):
+        enrich_calls.append((store, kwargs))
+        return _result(attempted=1, enriched=1)
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        limit=7,
+        since_hours=12,
+        max_cycles=3,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=fake_enrich,
+        sleep_fn=lambda seconds: None,
+    )
+
+    assert init_paths == [tmp_path / "brainlayer.db"]
+    assert len({id(call[0]) for call in enrich_calls}) == 1
+    assert len(enrich_calls) == 3
+    assert all(call[1]["limit"] == 7 and call[1]["since_hours"] == 12 for call in enrich_calls)
+    assert result.cycles == 3
+    assert result.enriched == 3
+
+
+def test_supervisor_logs_gemini_error_and_continues(tmp_path, caplog):
+    from brainlayer import enrichment_controller as controller
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            self.db_path = db_path
+
+        def close(self):
+            pass
+
+    calls = 0
+
+    def flaky_enrich(store, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("gemini 503")
+        return _result(attempted=1, enriched=1)
+
+    with caplog.at_level(logging.ERROR, logger="brainlayer.enrichment_controller"):
+        result = controller.run_enrich_supervisor(
+            tmp_path / "brainlayer.db",
+            max_cycles=2,
+            vector_store_cls=FakeVectorStore,
+            enrich_fn=flaky_enrich,
+            sleep_fn=lambda seconds: None,
+        )
+
+    assert calls == 2
+    assert result.enriched == 1
+    assert result.failed == 1
+    assert result.errors == ["supervisor: gemini 503"]
+    assert "Enrich supervisor cycle failed; continuing" in caplog.text
+
+
+def test_supervisor_graceful_shutdown_closes_store_after_inflight_cycle(tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    events = []
+    stop_event = controller.threading.Event()
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            events.append("init")
+
+        def close(self):
+            events.append("close")
+
+    def stopping_enrich(store, **kwargs):
+        events.append("enrich-start")
+        stop_event.set()
+        events.append("enrich-finish")
+        return _result(attempted=1, enriched=1)
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        stop_event=stop_event,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=stopping_enrich,
+        sleep_fn=lambda seconds: None,
+    )
+
+    assert events == ["init", "enrich-start", "enrich-finish", "close"]
+    assert result.exit_code == 0
+    assert result.cycles == 1
+
+
+def test_supervisor_propagates_writer_in_use_from_vector_store(tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    class WriterInUseError(RuntimeError):
+        pass
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            raise WriterInUseError("another writer is using brainlayer.db (pid 123)")
+
+    with pytest.raises(WriterInUseError, match="another writer is using"):
+        controller.run_enrich_supervisor(
+            tmp_path / "brainlayer.db",
+            vector_store_cls=FakeVectorStore,
+            enrich_fn=lambda store, **kwargs: _result(attempted=0),
+            sleep_fn=lambda seconds: None,
+        )
+
+
+def test_supervisor_sleeps_when_queue_empty_and_polls_again(tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            pass
+
+        def close(self):
+            pass
+
+    sleeps = []
+    calls = 0
+
+    def empty_then_work(store, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _result(attempted=0)
+        return _result(attempted=1, enriched=1)
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        max_cycles=2,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=empty_then_work,
+        sleep_fn=sleeps.append,
+    )
+
+    assert calls == 2
+    assert sleeps == [30.0]
+    assert result.cycles == 2
+    assert result.enriched == 1
+
+
+def test_supervisor_logs_single_vectorstore_initialized_line(tmp_path, caplog):
+    from brainlayer import enrichment_controller as controller
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            pass
+
+        def close(self):
+            pass
+
+    with caplog.at_level(logging.INFO, logger="brainlayer.enrichment_controller"):
+        controller.run_enrich_supervisor(
+            tmp_path / "brainlayer.db",
+            max_cycles=3,
+            vector_store_cls=FakeVectorStore,
+            enrich_fn=lambda store, **kwargs: _result(attempted=1, enriched=1),
+            sleep_fn=lambda seconds: None,
+        )
+
+    init_lines = [
+        record for record in caplog.records if "VectorStore initialized for enrich supervisor" in record.message
+    ]
+    assert len(init_lines) == 1
+
+
+def test_enrichment_launchagent_runs_supervisor_not_shell_respawn_loop():
+    plist_path = Path("scripts/launchd/com.brainlayer.enrichment.plist")
+    plist = plistlib.loads(plist_path.read_bytes())
+
+    args = plist["ProgramArguments"]
+
+    assert args == ["__BRAINLAYER_BIN__", "enrich", "--mode", "realtime", "--supervisor"]
+    assert "--limit" not in args
+    assert "--since-hours" not in args
+    assert "while true" not in " ".join(args)
+    assert plist["KeepAlive"] is True
+    assert plist["ProcessType"] == "Background"

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -1227,13 +1227,10 @@ def test_enrichment_plist_invokes_cli_enrich_entrypoint():
     plist = _load_enrichment_plist()
 
     args = plist["ProgramArguments"]
-    assert args[:2] == ["/bin/zsh", "-lc"]
-    command = args[2]
-    assert "__BRAINLAYER_BIN__" in command
-    assert "while true" in command
-    assert "enrich --mode realtime" in command
-    assert "--limit 200000" in command
-    assert "--since-hours 87600" in command
+    assert args == ["__BRAINLAYER_BIN__", "enrich", "--mode", "realtime", "--supervisor"]
+    assert "while true" not in " ".join(args)
+    assert "--limit" not in args
+    assert "--since-hours" not in args
 
 
 def test_enrichment_plist_matches_validated_flex_realtime_profile():


### PR DESCRIPTION
## Status

DRAFT: PR-alpha (`fix/single-writer-arbitration-option-a`) is not merged or visible on GitHub yet. This PR intentionally stays draft until it can be rebased on the pidfile mutex base and the real single-instance path can be validated.

## Summary

- Added `run_enrich_supervisor()` as a long-lived realtime enrichment loop around one writable `VectorStore(db_path)`.
- Added `brainlayer enrich --mode realtime --supervisor` with SIGTERM/SIGINT stop-event handling.
- Replaced the LaunchAgent shell `while true` respawn loop with a direct supervisor invocation.
- Added supervisor lifecycle, error survival, idle polling, shutdown, log, CLI, and plist regression tests.

## Architecture

```text
launchd KeepAlive
  -> brainlayer enrich --mode realtime --supervisor
      -> VectorStore(db_path) once
          -> PR-alpha pidfile mutex once, after rebase
      -> loop until SIGTERM/SIGINT
          -> enrich_realtime(store, limit=200000, since_hours=87600)
              -> existing bounded Gemini worker pool
              -> existing bounded enrichment write batcher
          -> if queue empty: sleep BRAINLAYER_ENRICH_IDLE_POLL_SECONDS, default 30s
          -> if transient cycle error: log and continue
      -> close VectorStore, releasing PR-alpha pidfile mutex
```

## Single-init proof

Focused test: `pytest tests/test_enrich_supervisor.py::test_supervisor_logs_single_vectorstore_initialized_line -q`

Relevant assertion: `caplog` records exactly one `VectorStore initialized for enrich supervisor` line across three supervisor cycles.

## Error survival proof

Focused test: `pytest tests/test_enrich_supervisor.py::test_supervisor_logs_gemini_error_and_continues -q`

This injects `RuntimeError("gemini 503")` on cycle 1 and asserts cycle 2 still enriches successfully, with `failed == 1` and `enriched == 1`.

## SIGTERM graceful-shutdown proof

Focused test: `pytest tests/test_cli_enrich.py::test_cli_enrich_supervisor_handles_sigterm_gracefully -q`

This sends a real `SIGTERM` to the process while the CLI handler is installed, asserts the supervisor stop event is set, and exits with code 0.

## Before/after enrich rate

- Baseline from dispatch prompt: 213 enrichments / 77 min = ~166/hr.
- Draft PR after-rate: pending. Must be sampled for >=30 min after PR-alpha is merged, this branch is rebased, the LaunchAgent is installed/restarted, and the supervisor is running against the production queue.
- Target: >=1500/hr sustained per prompt.

## Reproducible bench commands

```bash
# Verify supervisor tests
pytest tests/test_enrich_supervisor.py tests/test_cli_enrich.py -q

# Verify launchd template shape
pytest tests/test_enrichment_controller.py::test_enrichment_plist_invokes_cli_enrich_entrypoint \
  tests/test_enrich_supervisor.py::test_enrichment_launchagent_runs_supervisor_not_shell_respawn_loop -q

# Full repo gate used by pre-push
PYTHONPATH=/Users/etanheyman/Gits/brainlayer-pr-beta/src /Users/etanheyman/Gits/brainlayer-pr-beta/.venv/bin/pytest
ruff check src tests
ruff format --check src tests

# Post-merge rate sample sketch, run for >=30 min after deploying plist
brainlayer enrich --stats
# record enriched count and timestamp, wait >=30m, run again, compute delta/hour
brainlayer enrich --stats
```

## Test plan

- RED first: `pytest tests/test_enrich_supervisor.py -q` initially failed 6/6 on missing `run_enrich_supervisor`.
- RED CLI: `pytest tests/test_cli_enrich.py::test_cli_enrich_supervisor_routes_to_controller -q` initially failed on unknown `--supervisor`.
- RED plist: `pytest tests/test_enrich_supervisor.py::test_enrichment_launchagent_runs_supervisor_not_shell_respawn_loop -q` initially failed on `/bin/zsh -lc while true` args.
- Focused final: `pytest tests/test_enrich_supervisor.py tests/test_cli_enrich.py tests/test_enrichment_controller.py::test_enrichment_plist_invokes_cli_enrich_entrypoint -q` -> 18 passed.
- `ruff check src tests` -> passed.
- `ruff format --check src tests` -> passed.
- Pre-push gate -> 2067 passed / 9 skipped / 75 deselected / 1 xfailed, MCP registration 3 passed, isolated eval/hook routing 32 passed, bun 1 passed, FTS5 shell regression passed.

## Known dependency

The actual pidfile single-instance enforcement remains owned by PR-alpha. Until that merges, this PR proves constructor-error propagation with a `WriterInUseError`-shaped fake and keeps the PR draft.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace shell-loop respawn with a long-lived `run_enrich_supervisor` loop in the enrichment LaunchAgent
> - Adds `run_enrich_supervisor` to [enrichment_controller.py](https://github.com/EtanHey/brainlayer/pull/306/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb): a persistent loop that reuses a single `VectorStore`, sleeps when the queue is idle, continues on per-cycle errors, and returns an `EnrichmentSupervisorResult` with aggregated stats.
> - Adds `--supervisor` flag to the `enrich` CLI command; when used with `--mode realtime`, the CLI runs the supervisor loop, installs SIGTERM/SIGINT handlers for graceful shutdown, and exits with the supervisor's exit code.
> - Updates the [LaunchAgent plist](https://github.com/EtanHey/brainlayer/pull/306/files#diff-0aae57a309147ea4d1c82c7d669b582cfe5dfa28918361636f35341ce9c936b5) to invoke `__BRAINLAYER_BIN__ enrich --mode realtime --supervisor` directly, delegating restart-on-crash to launchd instead of a `while true` shell loop.
> - Idle poll interval is tunable via `BRAINLAYER_ENRICH_IDLE_POLL_SECONDS` environment variable, defaulting to 30 seconds.
> - Behavioral Change: the enrichment process is now a single long-running binary managed by launchd rather than a zsh subprocess; crashes surface to launchd immediately rather than being silently restarted by the shell loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7a89948. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a supervisor mode to run continuous realtime enrichment as a long-lived background service with configurable limits, lookback window, and idle polling.
  * CLI gains a --supervisor option and improved graceful SIGTERM/SIGINT shutdown with propagated exit codes.
  * LaunchAgent updated to directly run the enrichment supervisor as a background process (no shell respawn loop).

* **Tests**
  * New and extended tests covering supervisor control flow, signal handling, retries/backoff, observability, and LaunchAgent arguments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how realtime enrichment runs under `launchd` by introducing a long-lived supervisor loop with signal handling and new defaults, which could impact background job stability and throughput if misconfigured. Test coverage is added, but behavior changes are operationally significant.
> 
> **Overview**
> Switches realtime enrichment from a `launchd`-driven shell `while true` respawn loop to a first-class `--supervisor` mode that keeps a single `VectorStore` open and repeatedly runs realtime enrichment, sleeping when idle and continuing past per-cycle errors.
> 
> Updates `brainlayer enrich` to support `--supervisor` (with SIGTERM/SIGINT graceful shutdown and explicit `since_hours` defaulting behavior), adds supervisor defaults/tuning (`BRAINLAYER_ENRICH_IDLE_POLL_SECONDS`) in `enrichment_controller`, and revises the enrichment LaunchAgent plist to invoke the supervisor directly; adds regression tests covering CLI routing, supervisor lifecycle/error handling, and plist shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96848f4979d8596da89321852c65d3c5d36b81d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->