### PR TITLE
fix: expose KG degrade observability

### DIFF
--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -688,18 +688,17 @@ async def _brain_search(
         def _emit_kg_degrade(reason: str) -> None:
             if not os.environ.get("AXIOM_TOKEN"):
                 return
+            event = {
+                "_type": "kg_degraded",
+                "reason": reason,
+                "entity": entity_name,
+                "query_preview": query[:200],
+                "timestamp": _utcnow_iso(),
+                "mcp_host": platform.node(),
+            }
             try:
-                telemetry.emit(
-                    "brainlayer-search-degrade",
-                    {
-                        "_type": "kg_degraded",
-                        "reason": reason,
-                        "entity": entity_name,
-                        "query_preview": query[:200],
-                        "timestamp": _utcnow_iso(),
-                        "mcp_host": platform.node(),
-                    },
-                )
+                loop = asyncio.get_running_loop()
+                loop.run_in_executor(None, telemetry.emit, "brainlayer-search-degrade", event)
             except Exception:
                 pass
 

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import os
+import platform
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -9,6 +11,7 @@ from typing import Any
 import apsw
 from mcp.types import TextContent
 
+from .. import telemetry
 from .._helpers import _escape_fts5_query, _is_sqlite_busy_error
 from ..chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_checkpoint_content
 from ..lexical_defense import _normalize_surface, load_lexical_defense_dictionary
@@ -680,6 +683,26 @@ async def _brain_search(
         # Path 2: Try full hybrid search (embedding + vector + KG)
         structured_results = []
         kg_degraded = False
+        kg_degrade_reason = None
+
+        def _emit_kg_degrade(reason: str) -> None:
+            if not os.environ.get("AXIOM_TOKEN"):
+                return
+            try:
+                telemetry.emit(
+                    "brainlayer-search-degrade",
+                    {
+                        "_type": "kg_degraded",
+                        "reason": reason,
+                        "entity": entity_name,
+                        "query_preview": query[:200],
+                        "timestamp": _utcnow_iso(),
+                        "mcp_host": platform.node(),
+                    },
+                )
+            except Exception:
+                pass
+
         try:
             normalized_project = _normalize_project_name(project)
             loop = asyncio.get_running_loop()
@@ -727,11 +750,30 @@ async def _brain_search(
                         }
                     structured_results.append(item)
         except (RuntimeError, OSError, MemoryError) as e:
-            logger.warning("KG hybrid search failed (embedding/model issue), using SQL-only: %s", e)
+            reason = "embedding_or_model"
+            logger.warning(
+                "KG hybrid search degraded: reason=%s entity=%s query=%r err=%s",
+                reason,
+                entity_name,
+                query,
+                e,
+            )
             kg_degraded = True
+            kg_degrade_reason = reason
+            _emit_kg_degrade(reason)
         except Exception as e:
-            logger.warning("KG hybrid search failed unexpectedly: %s", e, exc_info=True)
+            reason = e.__class__.__name__
+            logger.warning(
+                "KG hybrid search degraded (unexpected): reason=%s entity=%s query=%r err=%s",
+                reason,
+                entity_name,
+                query,
+                e,
+                exc_info=True,
+            )
             kg_degraded = True
+            kg_degrade_reason = reason
+            _emit_kg_degrade(reason)
 
         # If we have KG facts OR chunk results, return them
         if fact_items or structured_results:
@@ -744,10 +786,19 @@ async def _brain_search(
             }
             if kg_degraded:
                 structured["kg_degraded"] = True
+                structured["kg_degrade_reason"] = kg_degrade_reason
             formatted_text = format_kg_search(entity_name, structured_results, fact_items, query)
             if kg_degraded:
-                formatted_text += "\n⚠ KG search degraded — showing SQL-only results"
+                formatted_text += f"\n⚠ KG search degraded — reason={kg_degrade_reason} — showing SQL-only results"
             return ([TextContent(type="text", text=formatted_text)], structured)
+
+        if kg_degraded:
+            logger.warning(
+                "KG degrade hidden by fall-through: reason=%s entity=%s query=%r",
+                kg_degrade_reason,
+                entity_name,
+                query,
+            )
 
     return await _search(
         query=query,

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from brainlayer.mcp.search_handler import _brain_recall, _brain_search
@@ -314,6 +315,105 @@ class TestBrainSearchToSearch:
         mock_search.assert_not_awaited()
         assert structured["entity"] == "Etan"
         assert structured["facts"] == fact_items
+
+
+class TestKgDegradeObservability:
+    """KG hybrid degrade paths should be visible in structured output and logs."""
+
+    def _run_entity_search_with_degraded_hybrid(
+        self,
+        *,
+        fact_items=None,
+        search_fallback=None,
+    ):
+        store = MagicMock(count=MagicMock(return_value=100))
+        store.kg_hybrid_search.side_effect = RuntimeError("embedding backend unavailable")
+        fact_items = [] if fact_items is None else fact_items
+        search_fallback = (
+            ([MagicMock(type="text", text="fallback")], {"query": "Etan BrainLayer context", "total": 0})
+            if search_fallback is None
+            else search_fallback
+        )
+
+        with (
+            patch("brainlayer.mcp.search_handler._get_vector_store", return_value=store),
+            patch(
+                "brainlayer.mcp.search_handler._get_embedding_model",
+                return_value=MagicMock(embed_query=MagicMock(return_value=[0.1] * 1024)),
+            ),
+            patch(
+                "brainlayer.mcp.search_handler._detect_entities",
+                return_value=[{"id": "e1", "name": "Etan", "entity_type": "person"}],
+            ),
+            patch("brainlayer.mcp.search_handler._kg_facts_sql", return_value=fact_items),
+            patch(
+                "brainlayer.mcp.search_handler._search",
+                new_callable=AsyncMock,
+                return_value=search_fallback,
+            ) as mock_search,
+            patch("brainlayer.mcp.search_handler._normalize_project_name", return_value=None),
+        ):
+            result = asyncio.run(_brain_search(query="Etan BrainLayer context"))
+
+        return result, store, mock_search
+
+    def test_kg_degrade_emits_structured_reason(self):
+        """Runtime hybrid failures expose a stable reason in structuredContent."""
+        _content, structured = self._run_entity_search_with_degraded_hybrid(
+            fact_items=[{"source": "Etan", "relation": "works_on", "target": "BrainLayer"}]
+        )[0]
+
+        assert structured["kg_degraded"] is True
+        assert structured["kg_degrade_reason"] == "embedding_or_model"
+
+    def test_kg_degrade_emits_log_line(self, caplog):
+        """Every degrade log includes reason, entity, and query for operators."""
+        caplog.set_level(logging.WARNING, logger="brainlayer.mcp._shared")
+
+        self._run_entity_search_with_degraded_hybrid(
+            fact_items=[{"source": "Etan", "relation": "works_on", "target": "BrainLayer"}]
+        )
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "KG hybrid search degraded" in message
+            and "reason=embedding_or_model" in message
+            and "entity=Etan" in message
+            and "query='Etan BrainLayer context'" in message
+            for message in messages
+        )
+
+    def test_kg_degrade_fall_through_logs(self, caplog):
+        """Hybrid degrade is logged even when empty KG output falls back to normal search."""
+        caplog.set_level(logging.WARNING, logger="brainlayer.mcp._shared")
+
+        _result, _store, mock_search = self._run_entity_search_with_degraded_hybrid(fact_items=[])
+
+        mock_search.assert_awaited_once()
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "KG degrade hidden by fall-through" in message
+            and "reason=embedding_or_model" in message
+            and "entity=Etan" in message
+            for message in messages
+        )
+
+    def test_kg_degrade_axiom_emit_attempted(self, monkeypatch):
+        """Axiom degrade telemetry is attempted when AXIOM_TOKEN is configured."""
+        monkeypatch.setenv("AXIOM_TOKEN", "test-token")
+
+        with patch("brainlayer.telemetry.emit", return_value=True) as emit:
+            self._run_entity_search_with_degraded_hybrid(
+                fact_items=[{"source": "Etan", "relation": "works_on", "target": "BrainLayer"}]
+            )
+
+        emit.assert_called_once()
+        dataset, event = emit.call_args.args
+        assert dataset == "brainlayer-search-degrade"
+        assert event["_type"] == "kg_degraded"
+        assert event["reason"] == "embedding_or_model"
+        assert event["entity"] == "Etan"
+        assert event["query_preview"] == "Etan BrainLayer context"
 
 
 # ── Input schema validation ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds structured `kg_degrade_reason` to KG-degraded `brain_search` responses in `src/brainlayer/mcp/search_handler.py:683` and `src/brainlayer/mcp/search_handler.py:786`.
- Replaces ambiguous KG hybrid failure warnings with logs that include `reason`, `entity`, and `query` at `src/brainlayer/mcp/search_handler.py:751` and `src/brainlayer/mcp/search_handler.py:763`.
- Emits gated Axiom telemetry to `brainlayer-search-degrade` when `AXIOM_TOKEN` is set at `src/brainlayer/mcp/search_handler.py:687`.
- Logs the hidden-degrade fall-through path at `src/brainlayer/mcp/search_handler.py:794`.
- Adds TDD coverage in `tests/test_search_filter_params.py:317` for structured reason, log content, fall-through logging, and Axiom emission.

## Source Audit
Cross-reference: `docs.local/audits/2026-05-21-brainlayer-kg-degrade-gate.md`

## Before / After Response Example
Before structuredContent:
```json
{
  "query": "Etan BrainLayer context",
  "entity": "Etan",
  "total": 0,
  "results": [],
  "facts": [{"source": "Etan", "relation": "works_on", "target": "BrainLayer"}],
  "kg_degraded": true
}
```
Before footer:
```text
⚠ KG search degraded — showing SQL-only results
```

After structuredContent:
```json
{
  "query": "Etan BrainLayer context",
  "entity": "Etan",
  "total": 0,
  "results": [],
  "facts": [{"source": "Etan", "relation": "works_on", "target": "BrainLayer"}],
  "kg_degraded": true,
  "kg_degrade_reason": "embedding_or_model"
}
```
After footer:
```text
⚠ KG search degraded — reason=embedding_or_model — showing SQL-only results
```

## TDD Evidence
RED command before production change:
```bash
pytest tests/test_search_filter_params.py::TestKgDegradeObservability -q
```
Observed: `4 failed`; failures were `KeyError: 'kg_degrade_reason'`, missing enriched degrade log, missing fall-through log, and `telemetry.emit` called 0 times.

GREEN command:
```bash
pytest tests/test_search_filter_params.py::TestKgDegradeObservability -q
```
Output:
```text
....                                                                     [100%]
4 passed in 0.26s
```

Log proof command:
```bash
pytest tests/test_search_filter_params.py::TestKgDegradeObservability -q -o log_cli=true --log-cli-level=WARNING
```
Output excerpt:
```text
WARNING  brainlayer.mcp._shared:search_handler.py:753 KG hybrid search degraded: reason=embedding_or_model entity=Etan query='Etan BrainLayer context' err=embedding backend unavailable
WARNING  brainlayer.mcp._shared:search_handler.py:795 KG degrade hidden by fall-through: reason=embedding_or_model entity=Etan query='Etan BrainLayer context'
============================== 4 passed in 0.36s ===============================
```

## Verification
```bash
ruff check src/brainlayer/mcp/search_handler.py tests/test_search_filter_params.py
```
Output: `All checks passed!`

```bash
pytest tests/test_search_filter_params.py -q
```
Output: `26 passed in 0.26s`

Pre-push BrainLayer gate output:
```text
= 2060 passed, 9 skipped, 75 deselected, 1 xfailed, 102 warnings in 259.23s (0:04:19) =
PASS: pytest unit suite
============================== 3 passed in 0.91s ===============================
PASS: pytest MCP tool registration
======================== 32 passed, 5 warnings in 8.94s ========================
PASS: pytest isolated eval and hook routing
bun test: 1 pass, 0 fail
PASS: regression shell test_fts5_determinism.sh
BrainLayer test gate passed.
```

Local direct `pytest` under system Python 3.13 was also attempted and blocked by local environment/live DB issues: missing `deepchecks`, NumPy 2.4 incompatible with `numba`, and production DB `apsw.BusyError` locks. The repo-managed pre-push gate above ran under Python 3.12 and passed.

## Review Notes
- CodeRabbit CLI pre-commit review found one valid critical issue: `os.uname()` is not cross-platform. This PR fixes it with `platform.node()`.
- A second CodeRabbit CLI run was attempted but hit the free/limited CLI review quota.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds metadata/logging and optional Axiom telemetry around existing KG hybrid-search failure paths, with only a small backward-compatible extension to structured search responses.
> 
> **Overview**
> **KG hybrid-search degradation is now explicit and attributable.** When entity-aware `kg_hybrid_search` fails, `_brain_search` records a stable `kg_degrade_reason` (or exception class) alongside `kg_degraded`, and includes the reason in the user-facing footer.
> 
> **Operational visibility is improved.** Warnings now log `reason`, `entity`, and `query`, an extra warning covers the silent fall-through to normal `_search`, and (when `AXIOM_TOKEN` is set) a gated `brainlayer-search-degrade` telemetry event is emitted asynchronously.
> 
> **Tests added.** New `TestKgDegradeObservability` coverage asserts structured output, log contents, fall-through logging, and telemetry emission behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8cf329877ffb2b0a4b9083a846d1acdf854a721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose KG degrade observability with telemetry, structured output, and warning logs in `_brain_search`
> - When KG hybrid search degrades, `_brain_search` now logs a warning with a stable reason string, entity, and query for easier debugging.
> - Adds `kg_degraded=True` and `kg_degrade_reason` to the structured return value and appends the reason to the human-formatted text output.
> - When `AXIOM_TOKEN` is set, emits a telemetry event to the `brainlayer-search-degrade` dataset via a background executor with type, reason, entity, query preview, UTC timestamp, and host node.
> - Logs a dedicated warning when a KG degrade is masked by fallback to general search (no facts and no structured results).
> - New `TestKgDegradeObservability` test class in [test_search_filter_params.py](https://github.com/EtanHey/brainlayer/pull/308/files#diff-f1047640f374072c51262647b577137b5a46c7fa852266ddd9b516eceffdc5c6) covers structured output, log content, fall-through warning, and telemetry emission.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8cf329.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->