### PR TITLE
fix(writer): single-writer pidfile mutex + retry/timeout/throttle hardening

### DIFF
--- a/hooks/brainlayer-prompt-search.py
+++ b/hooks/brainlayer-prompt-search.py
@@ -41,10 +41,9 @@ ENTITY_TOKEN_RE = re.compile(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*|[\u0590-\u05FF]+")
 _ENTITY_CACHE = None
 _ENTITY_CACHE_DB_PATH = None
 LOW_CONFIDENCE_FALLBACK_THRESHOLD = 0.30
-LOW_CONFIDENCE_FALLBACK_MESSAGE = (
-    "No high-confidence memories found. Use brain_search() for deeper retrieval."
-)
+LOW_CONFIDENCE_FALLBACK_MESSAGE = "No high-confidence memories found. Use brain_search() for deeper retrieval."
 _KG_ENTITY_CHUNKS_RELATION_TYPE_CACHE = {}
+AMBIGUOUS_SINGLE_TOKEN_ENTITY_TYPES = {"technology", "tool"}
 
 
 def get_session_context(conn, session_id: str, limit: int = 3) -> list[str]:
@@ -541,6 +540,8 @@ def _match_entity_spans(tokens, candidates_by_name, max_tokens, inject_types, se
             normalized = " ".join(token[1] for token in tokens[index : index + span])
             for candidate in candidates_by_name.get(normalized, []):
                 if candidate["entity_type"] not in inject_types or candidate["id"] in seen_ids:
+                    continue
+                if span == 1 and candidate["entity_type"] in AMBIGUOUS_SINGLE_TOKEN_ENTITY_TYPES:
                     continue
                 found = candidate
                 break

--- a/hooks/brainlayer-prompt-search.py
+++ b/hooks/brainlayer-prompt-search.py
@@ -773,7 +773,7 @@ def run_hybrid_search(prompt, db_path, keywords, limit):
     model = get_embedding_model()
     query_embedding = model.embed_query(prompt)
 
-    store = VectorStore(Path(db_path))
+    store = VectorStore(Path(db_path), readonly=True)
     try:
         semantic_limit = limit * 3
         if getattr(store, "_binary_index_available", False):

--- a/scripts/launchd/com.brainlayer.enrichment.plist
+++ b/scripts/launchd/com.brainlayer.enrichment.plist
@@ -53,7 +53,7 @@
     <key>RunAtLoad</key>
     <true/>
     <key>ThrottleInterval</key>
-    <integer>30</integer>
+    <integer>60</integer>
 
     <key>Nice</key>
     <integer>10</integer>

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -34,6 +34,13 @@ from .paths import get_db_path
 logger = logging.getLogger(__name__)
 
 
+def _drain_busy_timeout_ms() -> int:
+    try:
+        return int(os.environ.get("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000"))
+    except (TypeError, ValueError):
+        return 30000
+
+
 @dataclass
 class ApplyResult:
     chunk_id: str | None = None
@@ -63,7 +70,7 @@ def _log(path: Path, message: str) -> None:
 
 def _open_connection(db_path: Path) -> apsw.Connection:
     conn = apsw.Connection(str(db_path))
-    conn.setbusytimeout(int(os.environ.get("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000")))
+    conn.setbusytimeout(_drain_busy_timeout_ms())
     conn.enableloadextension(True)
     conn.loadextension(sqlite_vec.loadable_path())
     conn.enableloadextension(False)

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -33,13 +33,18 @@ from .paths import get_db_path
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_DRAIN_BUSY_TIMEOUT_MS = 30000
+_MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
+
 
 def _drain_busy_timeout_ms() -> int:
     try:
-        timeout_ms = int(os.environ.get("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000"))
+        timeout_ms = int(os.environ.get("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", str(_DEFAULT_DRAIN_BUSY_TIMEOUT_MS)))
     except (TypeError, ValueError):
-        return 30000
-    return timeout_ms if timeout_ms > 0 else 30000
+        return _DEFAULT_DRAIN_BUSY_TIMEOUT_MS
+    if timeout_ms <= 0 or timeout_ms > _MAX_APSW_BUSY_TIMEOUT_MS:
+        return _DEFAULT_DRAIN_BUSY_TIMEOUT_MS
+    return timeout_ms
 
 
 @dataclass

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -63,7 +63,7 @@ def _log(path: Path, message: str) -> None:
 
 def _open_connection(db_path: Path) -> apsw.Connection:
     conn = apsw.Connection(str(db_path))
-    conn.setbusytimeout(200)
+    conn.setbusytimeout(int(os.environ.get("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000")))
     conn.enableloadextension(True)
     conn.loadextension(sqlite_vec.loadable_path())
     conn.enableloadextension(False)

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -36,9 +36,10 @@ logger = logging.getLogger(__name__)
 
 def _drain_busy_timeout_ms() -> int:
     try:
-        return int(os.environ.get("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000"))
+        timeout_ms = int(os.environ.get("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000"))
     except (TypeError, ValueError):
         return 30000
+    return timeout_ms if timeout_ms > 0 else 30000
 
 
 @dataclass

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -64,6 +64,7 @@ _NOISE_CONTENT_PATTERNS = (
     "# session-restore",
 )
 _NOISE_RERANK_DEMOTION = 0.05
+_RECENCY_QUERY_TERMS = frozenset({"recent", "today", "current", "latest", "this week"})
 AUDIT_RECURSION_TAG_PATTERNS = (
     "{tag_expr} = 'audit'",
     "{tag_expr} = 'audit-recursion'",
@@ -1462,6 +1463,94 @@ class SearchMixin:
         _ingest_keyword_rows(fts_results, fts_ranks)
         _ingest_keyword_rows(trigram_fts_results, trigram_ranks)
 
+        recency_intent = any(term in query_text.lower() for term in _RECENCY_QUERY_TERMS)
+        if recency_intent and not date_from:
+            recent_extra = []
+            recent_params: list = []
+            if project_filter:
+                recent_extra.append("AND (project = ? OR project IS NULL)")
+                recent_params.append(project_filter)
+            if source_filter:
+                recent_extra.append("AND source = ?")
+                recent_params.append(source_filter)
+            if sender_filter:
+                recent_extra.append("AND sender = ?")
+                recent_params.append(sender_filter)
+            if language_filter:
+                recent_extra.append("AND language = ?")
+                recent_params.append(language_filter)
+            if tag_filter:
+                recent_extra.append("AND id IN (SELECT chunk_id FROM chunk_tags WHERE tag = ?)")
+                recent_params.append(tag_filter)
+            if intent_filter:
+                recent_extra.append("AND intent = ?")
+                recent_params.append(intent_filter)
+            if importance_min is not None:
+                recent_extra.append("AND importance >= ?")
+                recent_params.append(importance_min)
+            if source_filter_like:
+                recent_extra.append("AND source LIKE ?")
+                recent_params.append(source_filter_like)
+            if correction_category:
+                recent_extra.append("AND id IN (SELECT chunk_id FROM chunk_tags WHERE tag LIKE ?)")
+                recent_params.append(f"correction:{correction_category}%")
+            if not include_audit:
+                recent_extra.append(f"AND {self._audit_recursion_exclusion_sql('id', 'tags', 'content')}")
+            if not include_checkpoints:
+                checkpoint_clause = self._checkpoint_exclusion_clause()
+                if checkpoint_clause:
+                    recent_extra.append(f"AND {checkpoint_clause}")
+            if filter_meta_noise:
+                for pattern in META_NOISE_PATTERNS_CASEFOLDED:
+                    recent_extra.append("AND LOWER(content) NOT LIKE ?")
+                    recent_params.append(f"%{pattern}%")
+            if not include_archived:
+                recent_extra.append("AND superseded_by IS NULL")
+                recent_extra.append("AND aggregated_into IS NULL")
+                recent_extra.append("AND archived_at IS NULL")
+                recent_extra.append("AND COALESCE(archived, 0) = 0")
+                recent_extra.append("AND COALESCE(status, 'active') = 'active'")
+
+            recent_rows = list(
+                cursor.execute(
+                    f"""
+                    SELECT id, content, metadata, source_file, project,
+                           content_type, value_type, char_count,
+                           summary, tags, importance, intent,
+                           created_at, source, sender, language, decay_score
+                    FROM chunks
+                    WHERE created_at >= datetime('now', '-7 days') {" ".join(recent_extra)}
+                    ORDER BY created_at DESC
+                    LIMIT ?
+                    """,
+                    [*recent_params, min(candidate_fetch_count, 25)],
+                )
+            )
+            for i, row in enumerate(recent_rows):
+                chunk_id = row[0]
+                fts_ranks.setdefault(chunk_id, i)
+                keyword_data.setdefault(
+                    chunk_id,
+                    {
+                        "content": row[1],
+                        "metadata": json.loads(row[2]) if row[2] else {},
+                        "source_file": row[3],
+                        "project": row[4],
+                        "content_type": row[5],
+                        "value_type": row[6],
+                        "char_count": row[7],
+                        "summary": row[8],
+                        "tags": row[9],
+                        "importance": row[10],
+                        "intent": row[11],
+                        "created_at": row[12],
+                        "source": row[13],
+                        "sender": row[14],
+                        "language": row[15],
+                        "decay_score": row[16],
+                    },
+                )
+
         # 3. Reciprocal Rank Fusion — deduplicate by chunk_id
         # Build semantic rank map keyed by actual chunk_id
         semantic_by_id = {}
@@ -1575,6 +1664,8 @@ class SearchMixin:
                     age_days = max((now - dt).total_seconds() / 86400, 0)
                     recency = math.exp(-0.023 * age_days)  # ~0.5 at 30 days
                     boost *= 0.7 + 0.3 * recency  # range: 0.7x (old) to 1.0x (fresh)
+                    if recency_intent and age_days <= 7:
+                        boost *= 2.0
                 except (ValueError, TypeError):
                     pass
 

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -1479,12 +1479,18 @@ class SearchMixin:
             if language_filter:
                 recent_extra.append("AND language = ?")
                 recent_params.append(language_filter)
+            if entity_id:
+                recent_extra.append("AND id IN (SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = ?)")
+                recent_params.append(entity_id)
             if tag_filter:
                 recent_extra.append("AND id IN (SELECT chunk_id FROM chunk_tags WHERE tag = ?)")
                 recent_params.append(tag_filter)
             if intent_filter:
                 recent_extra.append("AND intent = ?")
                 recent_params.append(intent_filter)
+            if sentiment_filter:
+                recent_extra.append("AND sentiment_label = ?")
+                recent_params.append(sentiment_filter)
             if importance_min is not None:
                 recent_extra.append("AND importance >= ?")
                 recent_params.append(importance_min)

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -1486,6 +1486,9 @@ class SearchMixin:
             if language_filter:
                 recent_extra.append("AND language = ?")
                 recent_params.append(language_filter)
+            if content_type_filter:
+                recent_extra.append("AND content_type = ?")
+                recent_params.append(content_type_filter)
             if entity_id:
                 recent_extra.append("AND id IN (SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = ?)")
                 recent_params.append(entity_id)
@@ -1498,6 +1501,9 @@ class SearchMixin:
             if sentiment_filter:
                 recent_extra.append("AND sentiment_label = ?")
                 recent_params.append(sentiment_filter)
+            if date_to:
+                recent_extra.append("AND datetime(created_at) <= datetime(?)")
+                recent_params.append(date_to)
             if importance_min is not None:
                 recent_extra.append("AND importance >= ?")
                 recent_params.append(importance_min)
@@ -1524,9 +1530,7 @@ class SearchMixin:
                 recent_extra.append("AND COALESCE(archived, 0) = 0")
                 recent_extra.append("AND COALESCE(status, 'active') = 'active'")
 
-            recent_rows = list(
-                cursor.execute(
-                    f"""
+            recent_query = f"""
                     SELECT id, content, metadata, source_file, project,
                            content_type, value_type, char_count,
                            summary, tags, importance, intent,
@@ -1535,10 +1539,16 @@ class SearchMixin:
                     WHERE datetime(created_at) >= datetime('now', '-7 days') {" ".join(recent_extra)}
                     ORDER BY created_at DESC
                     LIMIT ?
-                    """,
-                    [*recent_params, min(candidate_fetch_count, 25)],
-                )
-            )
+                    """
+            recent_query_params = [*recent_params, min(candidate_fetch_count, 25)]
+            for attempt in range(3):
+                try:
+                    recent_rows = list(cursor.execute(recent_query, recent_query_params))
+                    break
+                except apsw.Error as exc:
+                    if not _is_sqlite_busy_error(exc) or attempt == 2:
+                        raise
+                    time.sleep(0.05 * (2**attempt))
             for i, row in enumerate(recent_rows):
                 chunk_id = row[0]
                 fts_ranks.setdefault(chunk_id, i)

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -1548,7 +1548,10 @@ class SearchMixin:
                     if not _is_sqlite_busy_error(exc) or attempt == 2:
                         raise
                     time.sleep(0.05 * (2**attempt))
-            for i, row in enumerate(recent_rows):
+            # Recency fallback supplements lexical search, so append ranks after
+            # existing FTS hits instead of tying the top exact match at rank 0.
+            recent_rank_offset = max(fts_ranks.values(), default=-1) + 1
+            for i, row in enumerate(recent_rows, start=recent_rank_offset):
                 chunk_id = row[0]
                 fts_ranks.setdefault(chunk_id, i)
                 keyword_data.setdefault(

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -65,6 +65,8 @@ _NOISE_CONTENT_PATTERNS = (
 )
 _NOISE_RERANK_DEMOTION = 0.05
 _RECENCY_QUERY_TERMS = frozenset({"recent", "today", "current", "latest", "this week"})
+_RECENCY_SINGLE_TERM_RE = re.compile(r"\b(?:current|latest|recent|today)\b", re.IGNORECASE)
+_RECENCY_THIS_WEEK_RE = re.compile(r"\bthis\s+week\b", re.IGNORECASE)
 AUDIT_RECURSION_TAG_PATTERNS = (
     "{tag_expr} = 'audit'",
     "{tag_expr} = 'audit-recursion'",
@@ -77,6 +79,11 @@ AUDIT_RECURSION_TAG_PATTERNS = (
 
 # Module-level LRU cache: {cache_key: (result, timestamp)}
 _hybrid_cache: "OrderedDict[tuple, tuple[dict, float]]" = OrderedDict()
+
+
+def _has_recency_intent(query_text: str) -> bool:
+    """Return true when recency words appear as terms, not substrings."""
+    return bool(_RECENCY_SINGLE_TERM_RE.search(query_text) or _RECENCY_THIS_WEEK_RE.search(query_text))
 
 
 def clear_hybrid_search_cache(store_key: Any = None) -> None:
@@ -1463,7 +1470,7 @@ class SearchMixin:
         _ingest_keyword_rows(fts_results, fts_ranks)
         _ingest_keyword_rows(trigram_fts_results, trigram_ranks)
 
-        recency_intent = any(term in query_text.lower() for term in _RECENCY_QUERY_TERMS)
+        recency_intent = _has_recency_intent(query_text)
         if recency_intent and not date_from:
             recent_extra = []
             recent_params: list = []

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -64,7 +64,6 @@ _NOISE_CONTENT_PATTERNS = (
     "# session-restore",
 )
 _NOISE_RERANK_DEMOTION = 0.05
-_RECENCY_QUERY_TERMS = frozenset({"recent", "today", "current", "latest", "this week"})
 _RECENCY_SINGLE_TERM_RE = re.compile(r"\b(?:current|latest|recent|today)\b", re.IGNORECASE)
 _RECENCY_THIS_WEEK_RE = re.compile(r"\bthis\s+week\b", re.IGNORECASE)
 AUDIT_RECURSION_TAG_PATTERNS = (

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -1532,7 +1532,7 @@ class SearchMixin:
                            summary, tags, importance, intent,
                            created_at, source, sender, language, decay_score
                     FROM chunks
-                    WHERE created_at >= datetime('now', '-7 days') {" ".join(recent_extra)}
+                    WHERE datetime(created_at) >= datetime('now', '-7 days') {" ".join(recent_extra)}
                     ORDER BY created_at DESC
                     LIMIT ?
                     """,

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -152,6 +152,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 self._PIDFILE_REFS[pidfile] += 1
                 self._writer_pidfile_acquired = True
                 self._writer_pidfile_path_value = pidfile
+                atexit.register(self._release_writer_pidfile)
                 return
 
         for attempt in range(2):

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -238,20 +238,18 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             self._writer_pidfile_acquired = False
             return
 
-        should_unlink = False
         with self._PIDFILE_REFS_LOCK:
             refs = self._PIDFILE_REFS.get(pidfile, 0)
             if refs <= 1:
+                if self._read_writer_pidfile(pidfile) == os.getpid():
+                    try:
+                        pidfile.unlink()
+                    except FileNotFoundError:
+                        pass
                 self._PIDFILE_REFS.pop(pidfile, None)
-                should_unlink = True
             else:
                 self._PIDFILE_REFS[pidfile] = refs - 1
 
-        if should_unlink and self._read_writer_pidfile(pidfile) == os.getpid():
-            try:
-                pidfile.unlink()
-            except FileNotFoundError:
-                pass
         self._writer_pidfile_acquired = False
 
     def _init_readonly_db(self) -> None:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -5,6 +5,8 @@ See search_repo.py, kg_repo.py, session_repo.py for the extracted methods.
 """
 
 import atexit
+import fcntl
+import hashlib
 import json
 import os
 import struct
@@ -136,7 +138,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
     def _writer_pidfile_path(self) -> Path:
         pidfile_dir = Path(os.environ.get("BRAINLAYER_WRITER_PIDFILE_DIR", "/tmp"))
-        return pidfile_dir / f"brainlayer-writer-{self.db_path.name}.pid"
+        path_hash = hashlib.sha256(str(self.db_path.resolve()).encode("utf-8")).hexdigest()[:16]
+        return pidfile_dir / f"brainlayer-writer-{path_hash}-{self.db_path.name}.pid"
 
     def _acquire_writer_pidfile(self) -> None:
         pidfile = self._writer_pidfile_path()
@@ -164,27 +167,50 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 atexit.register(self._release_writer_pidfile)
                 return
             except FileExistsError:
-                other_pid = self._read_writer_pidfile(pidfile)
-                if other_pid == pid:
-                    with self._PIDFILE_REFS_LOCK:
-                        self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
-                    self._writer_pidfile_acquired = True
-                    self._writer_pidfile_path_value = pidfile
-                    atexit.register(self._release_writer_pidfile)
+                if self._handle_existing_writer_pidfile(pidfile, pid):
                     return
-                if other_pid is not None and self._pid_is_alive(other_pid):
-                    raise WriterInUseError(f"another writer is using {self.db_path} (pid {other_pid})")
-                try:
-                    pidfile.unlink()
-                except FileNotFoundError:
-                    pass
                 if attempt == 1:
                     raise
+
+    def _handle_existing_writer_pidfile(self, pidfile: Path, pid: int) -> bool:
+        try:
+            fd = os.open(pidfile, os.O_RDONLY)
+        except FileNotFoundError:
+            return False
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            other_pid = self._read_writer_pidfile_fd(fd)
+            if other_pid == pid:
+                with self._PIDFILE_REFS_LOCK:
+                    self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
+                self._writer_pidfile_acquired = True
+                self._writer_pidfile_path_value = pidfile
+                atexit.register(self._release_writer_pidfile)
+                return True
+            if other_pid is not None and self._pid_is_alive(other_pid):
+                raise WriterInUseError(f"another writer is using {self.db_path} (pid {other_pid})")
+            try:
+                path_stat = pidfile.stat()
+            except FileNotFoundError:
+                return False
+            if os.path.samestat(os.fstat(fd), path_stat):
+                pidfile.unlink()
+            return False
+        finally:
+            os.close(fd)
 
     @staticmethod
     def _read_writer_pidfile(pidfile: Path) -> int | None:
         try:
             return int(pidfile.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _read_writer_pidfile_fd(fd: int) -> int | None:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            return int(os.read(fd, 64).decode("utf-8").strip())
         except (OSError, ValueError):
             return None
 

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -138,8 +138,9 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
     def _writer_pidfile_path(self) -> Path:
         pidfile_dir = Path(os.environ.get("BRAINLAYER_WRITER_PIDFILE_DIR", "/tmp"))
-        path_hash = hashlib.sha256(str(self.db_path.resolve()).encode("utf-8")).hexdigest()[:16]
-        return pidfile_dir / f"brainlayer-writer-{path_hash}-{self.db_path.name}.pid"
+        resolved_path = self.db_path.resolve()
+        path_hash = hashlib.sha256(str(resolved_path).encode("utf-8")).hexdigest()[:16]
+        return pidfile_dir / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
 
     def _acquire_writer_pidfile(self) -> None:
         pidfile = self._writer_pidfile_path()
@@ -194,7 +195,10 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             except FileNotFoundError:
                 return False
             if os.path.samestat(os.fstat(fd), path_stat):
-                pidfile.unlink()
+                try:
+                    pidfile.unlink()
+                except FileNotFoundError:
+                    pass
             return False
         finally:
             os.close(fd)

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -105,7 +105,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     """
 
     # Retry settings for DB init under contention (multiple MCP instances + enrichment)
-    _INIT_MAX_RETRIES = _int_env("BRAINLAYER_INIT_MAX_RETRIES", 10)
+    _INIT_MAX_RETRIES = max(_int_env("BRAINLAYER_INIT_MAX_RETRIES", 10), 1)
     _INIT_BASE_DELAY = 0.5  # seconds
     _INIT_MAX_DELAY = 30  # seconds
     _PIDFILE_REFS: dict[Path, int] = {}
@@ -295,7 +295,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         """
         last_err = None
         start = time.monotonic()
-        for attempt in range(self._INIT_MAX_RETRIES):
+        retry_budget = max(int(self._INIT_MAX_RETRIES), 1)
+        for attempt in range(retry_budget):
             try:
                 self._init_db()
                 return
@@ -306,7 +307,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
                 elapsed = time.monotonic() - start
                 print(
-                    f"  DB init BusyError (attempt {attempt + 1}/{self._INIT_MAX_RETRIES}), "
+                    f"  DB init BusyError (attempt {attempt + 1}/{retry_budget}), "
                     f"elapsed {elapsed:.1f}s, retrying in {delay:.1f}s...",
                     file=sys.stderr,
                 )

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -158,15 +158,18 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 if ref_pid is not None and ref_pid != pid:
                     self._PIDFILE_REFS.pop(pidfile, None)
                     self._PIDFILE_REF_PIDS.pop(pidfile, None)
-                elif self._read_writer_pidfile_owner(pidfile) == (pid, self._pid_start_time(pid)):
+                else:
+                    owner_pid, owner_start_time = self._read_writer_pidfile_owner(pidfile)
+                    if owner_pid != pid or not self._pidfile_owner_matches(owner_pid, owner_start_time):
+                        raise WriterInUseError(
+                            f"pidfile ref mismatch for {self.db_path}; refusing to clear active refs"
+                        )
                     self._PIDFILE_REFS[pidfile] += 1
                     self._PIDFILE_REF_PIDS[pidfile] = pid
                     self._writer_pidfile_acquired = True
                     self._writer_pidfile_path_value = pidfile
                     atexit.register(self._release_writer_pidfile)
                     return
-                else:
-                    raise WriterInUseError(f"pidfile ref mismatch for {self.db_path}; refusing to clear active refs")
 
         for attempt in range(2):
             try:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import struct
+import subprocess
 import threading
 import time
 from datetime import datetime, timezone
@@ -109,6 +110,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     _INIT_BASE_DELAY = 0.5  # seconds
     _INIT_MAX_DELAY = 30  # seconds
     _PIDFILE_REFS: dict[Path, int] = {}
+    _PIDFILE_REF_PIDS: dict[Path, int] = {}
     _PIDFILE_REFS_LOCK = threading.Lock()
 
     def __init__(self, db_path: Path, readonly: bool = False):
@@ -137,7 +139,10 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 raise
 
     def _writer_pidfile_path(self) -> Path:
-        pidfile_dir = Path(os.environ.get("BRAINLAYER_WRITER_PIDFILE_DIR", "/tmp"))
+        pidfile_dir = Path(os.environ.get("BRAINLAYER_WRITER_PIDFILE_DIR", "/tmp")).expanduser()
+        if not pidfile_dir.is_absolute():
+            pidfile_dir = Path("/tmp") / pidfile_dir
+        pidfile_dir = pidfile_dir.resolve()
         resolved_path = self.db_path.resolve()
         path_hash = hashlib.sha256(str(resolved_path).encode("utf-8")).hexdigest()[:16]
         return pidfile_dir / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
@@ -149,24 +154,31 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         with self._PIDFILE_REFS_LOCK:
             if self._PIDFILE_REFS.get(pidfile, 0) > 0:
-                if self._read_writer_pidfile(pidfile) == pid:
+                ref_pid = self._PIDFILE_REF_PIDS.get(pidfile)
+                if ref_pid is not None and ref_pid != pid:
+                    self._PIDFILE_REFS.pop(pidfile, None)
+                    self._PIDFILE_REF_PIDS.pop(pidfile, None)
+                elif self._read_writer_pidfile_owner(pidfile) == (pid, self._pid_start_time(pid)):
                     self._PIDFILE_REFS[pidfile] += 1
+                    self._PIDFILE_REF_PIDS[pidfile] = pid
                     self._writer_pidfile_acquired = True
                     self._writer_pidfile_path_value = pidfile
                     atexit.register(self._release_writer_pidfile)
                     return
-                self._PIDFILE_REFS.pop(pidfile, None)
+                else:
+                    raise WriterInUseError(f"pidfile ref mismatch for {self.db_path}; refusing to clear active refs")
 
         for attempt in range(2):
             try:
                 fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
                 try:
                     fcntl.flock(fd, fcntl.LOCK_EX)
-                    os.write(fd, f"{pid}\n".encode("utf-8"))
+                    os.write(fd, self._writer_pidfile_payload(pid))
                 finally:
                     os.close(fd)
                 with self._PIDFILE_REFS_LOCK:
                     self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
+                    self._PIDFILE_REF_PIDS[pidfile] = pid
                 self._writer_pidfile_acquired = True
                 self._writer_pidfile_path_value = pidfile
                 atexit.register(self._release_writer_pidfile)
@@ -184,15 +196,16 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             return False
         try:
             fcntl.flock(fd, fcntl.LOCK_EX)
-            other_pid = self._read_writer_pidfile_fd(fd)
-            if other_pid == pid:
+            other_pid, other_start_time = self._read_writer_pidfile_owner_fd(fd)
+            if other_pid == pid and self._pidfile_owner_matches(other_pid, other_start_time):
                 with self._PIDFILE_REFS_LOCK:
                     self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
+                    self._PIDFILE_REF_PIDS[pidfile] = pid
                 self._writer_pidfile_acquired = True
                 self._writer_pidfile_path_value = pidfile
                 atexit.register(self._release_writer_pidfile)
                 return True
-            if other_pid is not None and self._pid_is_alive(other_pid):
+            if other_pid is not None and self._pidfile_owner_matches(other_pid, other_start_time):
                 raise WriterInUseError(f"another writer is using {self.db_path} (pid {other_pid})")
             try:
                 path_stat = pidfile.stat()
@@ -209,18 +222,83 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
     @staticmethod
     def _read_writer_pidfile(pidfile: Path) -> int | None:
+        return VectorStore._read_writer_pidfile_owner(pidfile)[0]
+
+    @staticmethod
+    def _read_writer_pidfile_owner(pidfile: Path) -> tuple[int | None, str | None]:
         try:
-            return int(pidfile.read_text(encoding="utf-8").strip())
+            lines = pidfile.read_text(encoding="utf-8").splitlines()
+            if not lines:
+                return None, None
+            pid = int(lines[0].strip())
+            start_time = None
+            for line in lines[1:]:
+                if line.startswith("start_time="):
+                    start_time = line.removeprefix("start_time=").strip() or None
+                    break
+            return pid, start_time
         except (OSError, ValueError):
-            return None
+            return None, None
 
     @staticmethod
     def _read_writer_pidfile_fd(fd: int) -> int | None:
+        return VectorStore._read_writer_pidfile_owner_fd(fd)[0]
+
+    @staticmethod
+    def _read_writer_pidfile_owner_fd(fd: int) -> tuple[int | None, str | None]:
         try:
             os.lseek(fd, 0, os.SEEK_SET)
-            return int(os.read(fd, 64).decode("utf-8").strip())
+            lines = os.read(fd, 256).decode("utf-8").splitlines()
+            if not lines:
+                return None, None
+            pid = int(lines[0].strip())
+            start_time = None
+            for line in lines[1:]:
+                if line.startswith("start_time="):
+                    start_time = line.removeprefix("start_time=").strip() or None
+                    break
+            return pid, start_time
         except (OSError, ValueError):
+            return None, None
+
+    @staticmethod
+    def _writer_pidfile_payload(pid: int) -> bytes:
+        start_time = VectorStore._pid_start_time(pid)
+        if start_time:
+            return f"{pid}\nstart_time={start_time}\n".encode("utf-8")
+        return f"{pid}\n".encode("utf-8")
+
+    def _pidfile_owner_matches(self, pid: int, start_time: str | None) -> bool:
+        if not self._pid_is_alive(pid):
+            return False
+        if not start_time:
+            return True
+        current_start_time = self._pid_start_time(pid)
+        return current_start_time is None or current_start_time == start_time
+
+    @staticmethod
+    def _pid_start_time(pid: int) -> str | None:
+        try:
+            stat_path = Path("/proc") / str(pid) / "stat"
+            if stat_path.exists():
+                fields = stat_path.read_text(encoding="utf-8").split()
+                if len(fields) > 21:
+                    return fields[21]
+        except OSError:
+            pass
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "lstart=", "-p", str(pid)],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=1,
+            )
+        except (OSError, subprocess.SubprocessError):
             return None
+        if result.returncode != 0:
+            return None
+        return " ".join(result.stdout.split()) or None
 
     @staticmethod
     def _pid_is_alive(pid: int) -> bool:
@@ -250,6 +328,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     except FileNotFoundError:
                         pass
                 self._PIDFILE_REFS.pop(pidfile, None)
+                self._PIDFILE_REF_PIDS.pop(pidfile, None)
             else:
                 self._PIDFILE_REFS[pidfile] = refs - 1
 

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -149,16 +149,19 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         with self._PIDFILE_REFS_LOCK:
             if self._PIDFILE_REFS.get(pidfile, 0) > 0:
-                self._PIDFILE_REFS[pidfile] += 1
-                self._writer_pidfile_acquired = True
-                self._writer_pidfile_path_value = pidfile
-                atexit.register(self._release_writer_pidfile)
-                return
+                if self._read_writer_pidfile(pidfile) == pid:
+                    self._PIDFILE_REFS[pidfile] += 1
+                    self._writer_pidfile_acquired = True
+                    self._writer_pidfile_path_value = pidfile
+                    atexit.register(self._release_writer_pidfile)
+                    return
+                self._PIDFILE_REFS.pop(pidfile, None)
 
         for attempt in range(2):
             try:
                 fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
                 try:
+                    fcntl.flock(fd, fcntl.LOCK_EX)
                     os.write(fd, f"{pid}\n".encode("utf-8"))
                 finally:
                     os.close(fd)

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -2024,15 +2024,17 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
     def close(self) -> None:
         """Close database connections."""
-        # Close thread-local read connection if it exists
-        if hasattr(self, "_local"):
-            read_conn = getattr(self._local, "read_conn", None)
-            if read_conn is not None:
-                read_conn.close()
-                self._local.read_conn = None
-        if hasattr(self, "conn"):
-            self.conn.close()
-        self._release_writer_pidfile()
+        try:
+            # Close thread-local read connection if it exists
+            if hasattr(self, "_local"):
+                read_conn = getattr(self._local, "read_conn", None)
+                if read_conn is not None:
+                    read_conn.close()
+                    self._local.read_conn = None
+            if hasattr(self, "conn"):
+                self.conn.close()
+        finally:
+            self._release_writer_pidfile()
 
     def __enter__(self):
         return self

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -4,6 +4,7 @@ Thin facade: VectorStore inherits from focused mixin modules.
 See search_repo.py, kg_repo.py, session_repo.py for the extracted methods.
 """
 
+import atexit
 import json
 import os
 import struct
@@ -90,6 +91,10 @@ def _wal_autocheckpoint_pages() -> int:
     return max(_int_env("BRAINLAYER_WAL_AUTOCHECKPOINT", 10_000), 0)
 
 
+class WriterInUseError(RuntimeError):
+    """Raised when a live process already owns the writer pidfile."""
+
+
 class VectorStore(SearchMixin, KGMixin, SessionMixin):
     """SQLite-vec based vector store.
 
@@ -98,11 +103,15 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     """
 
     # Retry settings for DB init under contention (multiple MCP instances + enrichment)
-    _INIT_MAX_RETRIES = 5
+    _INIT_MAX_RETRIES = _int_env("BRAINLAYER_INIT_MAX_RETRIES", 10)
     _INIT_BASE_DELAY = 0.5  # seconds
+    _INIT_MAX_DELAY = 30  # seconds
+    _PIDFILE_REFS: dict[Path, int] = {}
+    _PIDFILE_REFS_LOCK = threading.Lock()
 
     def __init__(self, db_path: Path, readonly: bool = False):
         self.db_path = db_path
+        self._writer_pidfile_acquired = False
         if not readonly:
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._fts5_health_cache: dict[str, Any] = {}
@@ -118,7 +127,101 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         if self._readonly:
             self._init_readonly_db()
         else:
-            self._init_db_with_retry()
+            self._acquire_writer_pidfile()
+            try:
+                self._init_db_with_retry()
+            except Exception:
+                self._release_writer_pidfile()
+                raise
+
+    def _writer_pidfile_path(self) -> Path:
+        pidfile_dir = Path(os.environ.get("BRAINLAYER_WRITER_PIDFILE_DIR", "/tmp"))
+        return pidfile_dir / f"brainlayer-writer-{self.db_path.name}.pid"
+
+    def _acquire_writer_pidfile(self) -> None:
+        pidfile = self._writer_pidfile_path()
+        pidfile.parent.mkdir(parents=True, exist_ok=True)
+        pid = os.getpid()
+
+        with self._PIDFILE_REFS_LOCK:
+            if self._PIDFILE_REFS.get(pidfile, 0) > 0:
+                self._PIDFILE_REFS[pidfile] += 1
+                self._writer_pidfile_acquired = True
+                self._writer_pidfile_path_value = pidfile
+                return
+
+        for attempt in range(2):
+            try:
+                fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                try:
+                    os.write(fd, f"{pid}\n".encode("utf-8"))
+                finally:
+                    os.close(fd)
+                with self._PIDFILE_REFS_LOCK:
+                    self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
+                self._writer_pidfile_acquired = True
+                self._writer_pidfile_path_value = pidfile
+                atexit.register(self._release_writer_pidfile)
+                return
+            except FileExistsError:
+                other_pid = self._read_writer_pidfile(pidfile)
+                if other_pid == pid:
+                    with self._PIDFILE_REFS_LOCK:
+                        self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
+                    self._writer_pidfile_acquired = True
+                    self._writer_pidfile_path_value = pidfile
+                    atexit.register(self._release_writer_pidfile)
+                    return
+                if other_pid is not None and self._pid_is_alive(other_pid):
+                    raise WriterInUseError(f"another writer is using {self.db_path} (pid {other_pid})")
+                try:
+                    pidfile.unlink()
+                except FileNotFoundError:
+                    pass
+                if attempt == 1:
+                    raise
+
+    @staticmethod
+    def _read_writer_pidfile(pidfile: Path) -> int | None:
+        try:
+            return int(pidfile.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _pid_is_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    def _release_writer_pidfile(self) -> None:
+        if not self._writer_pidfile_acquired:
+            return
+
+        pidfile = getattr(self, "_writer_pidfile_path_value", None)
+        if pidfile is None:
+            self._writer_pidfile_acquired = False
+            return
+
+        should_unlink = False
+        with self._PIDFILE_REFS_LOCK:
+            refs = self._PIDFILE_REFS.get(pidfile, 0)
+            if refs <= 1:
+                self._PIDFILE_REFS.pop(pidfile, None)
+                should_unlink = True
+            else:
+                self._PIDFILE_REFS[pidfile] = refs - 1
+
+        if should_unlink and self._read_writer_pidfile(pidfile) == os.getpid():
+            try:
+                pidfile.unlink()
+            except FileNotFoundError:
+                pass
+        self._writer_pidfile_acquired = False
 
     def _init_readonly_db(self) -> None:
         """Open an existing DB in readonly mode without running migrations."""
@@ -164,21 +267,21 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         contend for write locks during DDL. Retry with exponential backoff
         instead of crashing on the first BusyError.
         """
-        import time
-
         last_err = None
+        start = time.monotonic()
         for attempt in range(self._INIT_MAX_RETRIES):
             try:
                 self._init_db()
                 return
             except apsw.BusyError as e:
                 last_err = e
-                delay = self._INIT_BASE_DELAY * (2**attempt)
+                delay = min(self._INIT_BASE_DELAY * (2**attempt), self._INIT_MAX_DELAY)
                 import sys
 
+                elapsed = time.monotonic() - start
                 print(
                     f"  DB init BusyError (attempt {attempt + 1}/{self._INIT_MAX_RETRIES}), "
-                    f"retrying in {delay:.1f}s...",
+                    f"elapsed {elapsed:.1f}s, retrying in {delay:.1f}s...",
                     file=sys.stderr,
                 )
                 time.sleep(delay)
@@ -1899,6 +2002,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 self._local.read_conn = None
         if hasattr(self, "conn"):
             self.conn.close()
+        self._release_writer_pidfile()
 
     def __enter__(self):
         return self

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -171,7 +171,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     atexit.register(self._release_writer_pidfile)
                     return
 
-        for attempt in range(2):
+        max_create_attempts = 4
+        for attempt in range(max_create_attempts):
             try:
                 fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
                 try:
@@ -189,8 +190,9 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             except FileExistsError:
                 if self._handle_existing_writer_pidfile(pidfile, pid):
                     return
-                if attempt == 1:
+                if attempt == max_create_attempts - 1:
                     raise
+                time.sleep(0.01 * (attempt + 1))
 
     def _handle_existing_writer_pidfile(self, pidfile: Path, pid: int) -> bool:
         try:

--- a/tests/test_adaptive_injection.py
+++ b/tests/test_adaptive_injection.py
@@ -155,6 +155,45 @@ class TestSearchFallback:
         assert used_hybrid is False
         assert [row["id"] for row in rows] == ["fts-best"]
 
+    def test_hybrid_search_opens_vector_store_readonly(self, prompt_search, monkeypatch, tmp_path):
+        opened = []
+
+        class FakeEmbeddingModel:
+            def embed_query(self, _prompt):
+                return [0.1, 0.2, 0.3]
+
+        class FakeCursor:
+            def execute(self, *_args, **_kwargs):
+                return []
+
+        class FakeVectorStore:
+            _binary_index_available = False
+
+            def __init__(self, path, readonly=False):
+                opened.append((Path(path), readonly))
+
+            def search(self, *, query_embedding, n_results):
+                assert query_embedding == [0.1, 0.2, 0.3]
+                assert n_results == 9
+                return {"ids": [[]], "metadatas": [[]], "documents": [[]]}
+
+            def _read_cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        import brainlayer.embeddings
+        import brainlayer.vector_store
+
+        monkeypatch.setattr(brainlayer.embeddings, "get_embedding_model", lambda: FakeEmbeddingModel())
+        monkeypatch.setattr(brainlayer.vector_store, "VectorStore", FakeVectorStore)
+
+        rows = prompt_search.run_hybrid_search("recent project notes", tmp_path / "brainlayer.db", ["recent"], 3)
+
+        assert rows == []
+        assert opened == [(tmp_path / "brainlayer.db", True)]
+
     def test_no_results_falls_back_to_low_confidence_message(self, prompt_search):
         message = prompt_search.build_low_confidence_fallback([])
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -345,7 +345,7 @@ class TestSessionsIntegration:
         from brainlayer.paths import DEFAULT_DB_PATH
         from brainlayer.vector_store import VectorStore
 
-        s = VectorStore(DEFAULT_DB_PATH)
+        s = VectorStore(DEFAULT_DB_PATH, readonly=True)
         yield s
         s.close()
 
@@ -390,7 +390,7 @@ class TestRecallFileIntegration:
         from brainlayer.paths import DEFAULT_DB_PATH
         from brainlayer.vector_store import VectorStore
 
-        s = VectorStore(DEFAULT_DB_PATH)
+        s = VectorStore(DEFAULT_DB_PATH, readonly=True)
         yield s
         s.close()
 

--- a/tests/test_eval_baselines.py
+++ b/tests/test_eval_baselines.py
@@ -65,7 +65,7 @@ def live_store():
     if not os.path.exists(db):
         pytest.skip(f"Live DB not found at {db}")
 
-    store = VectorStore(db)
+    store = VectorStore(db, readonly=True)
     yield store
     store.close()
 
@@ -686,7 +686,7 @@ def run_baseline() -> dict:
     from brainlayer.vector_store import VectorStore
 
     db = get_db_path()
-    store = VectorStore(db)
+    store = VectorStore(db, readonly=True)
     model = get_embedding_model()
 
     # All eval cases: (name, query, expected_snippets, top_n, project, tag)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -3,6 +3,7 @@
 import json
 import uuid
 
+import apsw
 import pytest
 
 from brainlayer._helpers import serialize_f32
@@ -44,6 +45,7 @@ def _insert_chunk(
     resolved_query: str | None = None,
     importance: float | None = None,
     created_at: str | None = "2026-04-05T00:00:00Z",
+    content_type: str = "assistant_text",
     project: str = "hybrid-test",
     sender: str | None = None,
     language: str | None = None,
@@ -54,12 +56,13 @@ def _insert_chunk(
         """INSERT INTO chunks (
             id, content, metadata, source_file, project, content_type,
             char_count, source, sender, language, summary, tags, resolved_query, importance, created_at
-        ) VALUES (?, ?, ?, 'test.jsonl', ?, 'assistant_text', ?, 'claude_code', ?, ?, ?, ?, ?, ?, ?)""",
+        ) VALUES (?, ?, ?, 'test.jsonl', ?, ?, ?, 'claude_code', ?, ?, ?, ?, ?, ?, ?)""",
         (
             chunk_id,
             content,
             json.dumps(metadata_obj) if metadata_obj is not None else "{}",
             project,
+            content_type,
             len(content),
             sender,
             language,
@@ -490,6 +493,39 @@ class TestHybridSearch:
         assert "recent-positive" in results["ids"][0]
         assert "recent-negative" not in results["ids"][0]
 
+    def test_recency_intent_fallback_preserves_content_type_filter(self, store, monkeypatch):
+        _insert_chunk(
+            store,
+            chunk_id="recent-ai-code",
+            content="fresh unrelated code notes",
+            embedding=_embed("fresh code"),
+            created_at="2999-01-01T00:00:00Z",
+            content_type="ai_code",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="recent-assistant",
+            content="fresh unrelated assistant notes",
+            embedding=_embed("fresh assistant"),
+            created_at="2999-01-01T00:00:00Z",
+            content_type="assistant_text",
+        )
+        monkeypatch.setattr(
+            store,
+            "search",
+            lambda **_kwargs: {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]},
+        )
+
+        results = store.hybrid_search(
+            query_embedding=_embed("latest work"),
+            query_text="latest work",
+            n_results=5,
+            content_type_filter="ai_code",
+        )
+
+        assert "recent-ai-code" in results["ids"][0]
+        assert "recent-assistant" not in results["ids"][0]
+
     def test_recency_intent_uses_term_boundaries(self):
         assert _has_recency_intent("latest work progress")
         assert _has_recency_intent("what changed this week")
@@ -518,6 +554,81 @@ class TestHybridSearch:
         )
 
         assert "stale-boundary" not in results["ids"][0]
+
+    def test_recency_intent_fallback_respects_date_to(self, store, monkeypatch):
+        cursor = store.conn.cursor()
+        before_date_to = cursor.execute("SELECT datetime('now', '-2 days')").fetchone()[0].replace(" ", "T") + "Z"
+        date_to = cursor.execute("SELECT datetime('now', '-1 days')").fetchone()[0].replace(" ", "T") + "Z"
+        after_date_to = cursor.execute("SELECT datetime('now')").fetchone()[0].replace(" ", "T") + "Z"
+        _insert_chunk(
+            store,
+            chunk_id="recent-before-date-to",
+            content="fresh before date_to payload",
+            embedding=_embed("fresh before date to"),
+            created_at=before_date_to,
+        )
+        _insert_chunk(
+            store,
+            chunk_id="recent-after-date-to",
+            content="fresh after date_to payload",
+            embedding=_embed("fresh after date to"),
+            created_at=after_date_to,
+        )
+        monkeypatch.setattr(
+            store,
+            "search",
+            lambda **_kwargs: {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]},
+        )
+
+        results = store.hybrid_search(
+            query_embedding=_embed("latest unrelated"),
+            query_text="latest unrelated",
+            n_results=5,
+            date_to=date_to,
+        )
+
+        assert "recent-before-date-to" in results["ids"][0]
+        assert "recent-after-date-to" not in results["ids"][0]
+
+    def test_recency_intent_fallback_retries_busy_query(self, store, monkeypatch):
+        _insert_chunk(
+            store,
+            chunk_id="recent-after-busy",
+            content="fresh after transient busy payload",
+            embedding=_embed("fresh busy"),
+            created_at="2999-01-01T00:00:00Z",
+        )
+        monkeypatch.setattr(
+            store,
+            "search",
+            lambda **_kwargs: {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]},
+        )
+        real_cursor = store.conn.cursor()
+
+        class BusyOnceCursor:
+            def __init__(self):
+                self.busy_count = 0
+
+            def execute(self, sql, params=()):
+                if "WHERE datetime(created_at) >= datetime('now', '-7 days')" in str(sql) and self.busy_count == 0:
+                    self.busy_count += 1
+                    raise apsw.BusyError("database is locked")
+                return real_cursor.execute(sql, params)
+
+        busy_cursor = BusyOnceCursor()
+        sleeps: list[float] = []
+        monkeypatch.setattr(store, "_read_cursor", lambda: busy_cursor)
+        monkeypatch.setattr("time.sleep", sleeps.append)
+
+        results = store.hybrid_search(
+            query_embedding=_embed("latest unrelated"),
+            query_text="latest unrelated",
+            n_results=5,
+        )
+
+        assert busy_cursor.busy_count == 1
+        assert sleeps == [0.05]
+        assert "recent-after-busy" in results["ids"][0]
 
     def test_mmr_rerank_dedupes_near_duplicates(self, store, monkeypatch):
         monkeypatch.setattr("brainlayer.search_repo._MMR_LAMBDA", 0.65)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -630,6 +630,43 @@ class TestHybridSearch:
         assert sleeps == [0.05]
         assert "recent-after-busy" in results["ids"][0]
 
+    def test_recency_intent_fallback_appends_ranks_after_fts_hits(self, store, monkeypatch):
+        _insert_chunk(
+            store,
+            chunk_id="exact-fts-hit",
+            content="latest arbitration mutex exact lexical match",
+            embedding=_embed("distant exact"),
+            created_at="2999-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="recent-only",
+            content="fresh unrelated operational note",
+            embedding=_embed("distant recent"),
+            created_at="2999-01-02T00:00:00Z",
+        )
+        monkeypatch.setattr(
+            store,
+            "search",
+            lambda **_kwargs: {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]},
+        )
+        monkeypatch.setattr(store, "_trigram_fts_available", False)
+        captured_scores: dict[str, float] = {}
+
+        def capture_scores(scored, *, n_results):
+            captured_scores.update({chunk_id: score for score, chunk_id, *_rest in scored})
+            return scored
+
+        monkeypatch.setattr(store, "_mmr_rerank_scored_results", capture_scores)
+
+        store.hybrid_search(
+            query_embedding=_embed("latest arbitration mutex"),
+            query_text="latest arbitration mutex",
+            n_results=5,
+        )
+
+        assert captured_scores["exact-fts-hit"] > captured_scores["recent-only"]
+
     def test_mmr_rerank_dedupes_near_duplicates(self, store, monkeypatch):
         monkeypatch.setattr("brainlayer.search_repo._MMR_LAMBDA", 0.65)
 

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -6,7 +6,7 @@ import uuid
 import pytest
 
 from brainlayer._helpers import serialize_f32
-from brainlayer.search_repo import _contains_precompact_or_quarantined_meta, _hybrid_cache
+from brainlayer.search_repo import _contains_precompact_or_quarantined_meta, _has_recency_intent, _hybrid_cache
 from brainlayer.vector_store import VectorStore
 
 
@@ -489,6 +489,12 @@ class TestHybridSearch:
 
         assert "recent-positive" in results["ids"][0]
         assert "recent-negative" not in results["ids"][0]
+
+    def test_recency_intent_uses_term_boundaries(self):
+        assert _has_recency_intent("latest work progress")
+        assert _has_recency_intent("what changed this week")
+        assert not _has_recency_intent("concurrent writer arbitration")
+        assert not _has_recency_intent("recurrent pattern analysis")
 
     def test_mmr_rerank_dedupes_near_duplicates(self, store, monkeypatch):
         monkeypatch.setattr("brainlayer.search_repo._MMR_LAMBDA", 0.65)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -431,6 +431,65 @@ class TestHybridSearch:
     def test_noise_demoter_does_not_treat_arbitrary_true_metadata_as_quarantine(self):
         assert not _contains_precompact_or_quarantined_meta({"feature_enabled": "true"}, "ordinary content")
 
+    def test_recency_intent_fallback_preserves_entity_filter(self, store):
+        store.upsert_entity("person-a", "person", "Person A")
+        store.upsert_entity("person-b", "person", "Person B")
+        _insert_chunk(
+            store,
+            chunk_id="recent-a",
+            content="fresh unrelated notes for person a",
+            embedding=_embed("fresh a"),
+            created_at="2999-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="recent-b",
+            content="fresh unrelated notes for person b",
+            embedding=_embed("fresh b"),
+            created_at="2999-01-01T00:00:00Z",
+        )
+        store.link_entity_chunk("person-a", "recent-a")
+        store.link_entity_chunk("person-b", "recent-b")
+
+        results = store.hybrid_search(
+            query_embedding=_embed("latest work"),
+            query_text="latest work",
+            n_results=5,
+            entity_id="person-a",
+        )
+
+        assert "recent-a" in results["ids"][0]
+        assert "recent-b" not in results["ids"][0]
+
+    def test_recency_intent_fallback_preserves_sentiment_filter(self, store):
+        _insert_chunk(
+            store,
+            chunk_id="recent-positive",
+            content="fresh unrelated positive notes",
+            embedding=_embed("fresh positive"),
+            created_at="2999-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="recent-negative",
+            content="fresh unrelated negative notes",
+            embedding=_embed("fresh negative"),
+            created_at="2999-01-01T00:00:00Z",
+        )
+        cursor = store.conn.cursor()
+        cursor.execute("UPDATE chunks SET sentiment_label = 'positive' WHERE id = 'recent-positive'")
+        cursor.execute("UPDATE chunks SET sentiment_label = 'negative' WHERE id = 'recent-negative'")
+
+        results = store.hybrid_search(
+            query_embedding=_embed("latest work"),
+            query_text="latest work",
+            n_results=5,
+            sentiment_filter="positive",
+        )
+
+        assert "recent-positive" in results["ids"][0]
+        assert "recent-negative" not in results["ids"][0]
+
     def test_mmr_rerank_dedupes_near_duplicates(self, store, monkeypatch):
         monkeypatch.setattr("brainlayer.search_repo._MMR_LAMBDA", 0.65)
 

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -496,6 +496,29 @@ class TestHybridSearch:
         assert not _has_recency_intent("concurrent writer arbitration")
         assert not _has_recency_intent("recurrent pattern analysis")
 
+    def test_recency_intent_fallback_compares_created_at_as_datetime(self, store, monkeypatch):
+        cutoff_date = store.conn.cursor().execute("SELECT date('now', '-7 days')").fetchone()[0]
+        _insert_chunk(
+            store,
+            chunk_id="stale-boundary",
+            content="stale boundary payload",
+            embedding=_embed("stale boundary"),
+            created_at=f"{cutoff_date}T00:00:00Z",
+        )
+        monkeypatch.setattr(
+            store,
+            "search",
+            lambda **_kwargs: {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]},
+        )
+
+        results = store.hybrid_search(
+            query_embedding=_embed("latest unrelated"),
+            query_text="latest unrelated",
+            n_results=5,
+        )
+
+        assert "stale-boundary" not in results["ids"][0]
+
     def test_mmr_rerank_dedupes_near_duplicates(self, store, monkeypatch):
         monkeypatch.setattr("brainlayer.search_repo._MMR_LAMBDA", 0.65)
 

--- a/tests/test_think_recall_integration.py
+++ b/tests/test_think_recall_integration.py
@@ -18,7 +18,7 @@ from brainlayer.vector_store import VectorStore
 @pytest.fixture(scope="module")
 def store():
     """Shared VectorStore for all tests in this module."""
-    s = VectorStore(DEFAULT_DB_PATH)
+    s = VectorStore(DEFAULT_DB_PATH, readonly=True)
     yield s
     s.close()
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -11,7 +11,7 @@ from brainlayer.vector_store import VectorStore
 @pytest.fixture(scope="module")
 def store():
     """Read-only connection to the production DB for integration tests."""
-    s = VectorStore(DEFAULT_DB_PATH)
+    s = VectorStore(DEFAULT_DB_PATH, readonly=True)
     yield s
     s.close()
 

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import plistlib
 import subprocess
@@ -11,7 +12,8 @@ from brainlayer.vector_store import VectorStore
 
 
 def _expected_pidfile(pidfile_dir: Path, db_path: Path) -> Path:
-    return pidfile_dir / f"brainlayer-writer-{db_path.name}.pid"
+    path_hash = hashlib.sha256(str(db_path.resolve()).encode("utf-8")).hexdigest()[:16]
+    return pidfile_dir / f"brainlayer-writer-{path_hash}-{db_path.name}.pid"
 
 
 def test_pidfile_created_on_rw_init(tmp_path, monkeypatch):
@@ -64,6 +66,40 @@ raise SystemExit("second writer unexpectedly acquired the pidfile")
         assert result.returncode == 0, result.stderr
         assert "WriterInUseError" in result.stdout
         assert f"another writer is using {db_path} (pid {os.getpid()})" in result.stdout
+    finally:
+        store.close()
+
+
+def test_pidfile_allows_different_directories_with_same_db_basename(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    first_db = tmp_path / "first" / "writer.db"
+    second_db = tmp_path / "second" / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    store = VectorStore(first_db)
+    try:
+        script = """
+from pathlib import Path
+from brainlayer.vector_store import VectorStore
+
+store = VectorStore(Path(__import__("os").environ["DB_PATH"]))
+store.close()
+"""
+        env = {
+            **os.environ,
+            "BRAINLAYER_WRITER_PIDFILE_DIR": str(pidfile_dir),
+            "DB_PATH": str(second_db),
+            "PYTHONPATH": f"{Path(__file__).resolve().parents[1] / 'src'}:{os.environ.get('PYTHONPATH', '')}",
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
     finally:
         store.close()
 
@@ -128,6 +164,17 @@ def test_init_retries_10_with_extended_backoff():
 
 def test_drain_busy_timeout_30s(tmp_path, monkeypatch):
     monkeypatch.setenv("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000")
+
+    conn = drain._open_connection(tmp_path / "drain.db")
+    try:
+        busy_timeout_ms = conn.cursor().execute("PRAGMA busy_timeout").fetchone()[0]
+        assert busy_timeout_ms >= 30000
+    finally:
+        conn.close()
+
+
+def test_drain_busy_timeout_invalid_env_falls_back_to_30s(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "not-an-int")
 
     conn = drain._open_connection(tmp_path / "drain.db")
     try:

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -264,6 +264,26 @@ def test_pidfile_removed_on_close(tmp_path, monkeypatch):
     assert not pidfile.exists()
 
 
+def test_close_releases_pidfile_when_connection_close_raises(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    store = VectorStore(db_path)
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+
+    class BrokenConnection:
+        def close(self):
+            raise RuntimeError("close failed")
+
+    store.conn = BrokenConnection()
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        store.close()
+
+    assert not pidfile.exists()
+
+
 def test_readonly_init_skips_pidfile(tmp_path, monkeypatch):
     pidfile_dir = tmp_path / "pidfiles"
     db_path = tmp_path / "writer.db"
@@ -282,7 +302,8 @@ def test_readonly_init_skips_pidfile(tmp_path, monkeypatch):
         reader.close()
 
 
-def test_init_retries_10_with_extended_backoff():
+def test_init_retries_10_with_extended_backoff(monkeypatch):
+    monkeypatch.setattr(VectorStore, "_INIT_MAX_RETRIES", 10)
     assert VectorStore._INIT_MAX_RETRIES == 10
     delays = [
         min(VectorStore._INIT_BASE_DELAY * (2**attempt), VectorStore._INIT_MAX_DELAY)

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -149,6 +149,22 @@ raise SystemExit("symlink writer unexpectedly acquired the pidfile")
         store.close()
 
 
+def test_same_process_pidfile_reuse_registers_atexit_release(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    registrations = []
+    monkeypatch.setattr("atexit.register", registrations.append)
+
+    first = VectorStore(db_path)
+    second = VectorStore(db_path)
+    try:
+        assert len(registrations) == 2
+    finally:
+        second.close()
+        first.close()
+
+
 def test_stale_pidfile_cleaned_up(tmp_path, monkeypatch):
     pidfile_dir = tmp_path / "pidfiles"
     db_path = tmp_path / "writer.db"

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -15,8 +15,9 @@ from brainlayer.vector_store import VectorStore
 
 
 def _expected_pidfile(pidfile_dir: Path, db_path: Path) -> Path:
-    path_hash = hashlib.sha256(str(db_path.resolve()).encode("utf-8")).hexdigest()[:16]
-    return pidfile_dir / f"brainlayer-writer-{path_hash}-{db_path.name}.pid"
+    resolved_path = db_path.resolve()
+    path_hash = hashlib.sha256(str(resolved_path).encode("utf-8")).hexdigest()[:16]
+    return pidfile_dir / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
 
 
 def test_pidfile_created_on_rw_init(tmp_path, monkeypatch):
@@ -107,6 +108,47 @@ store.close()
         store.close()
 
 
+def test_pidfile_blocks_symlink_alias_to_same_database(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    real_db = tmp_path / "real" / "writer.db"
+    symlink_db = tmp_path / "alias.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    store = VectorStore(real_db)
+    try:
+        symlink_db.symlink_to(real_db)
+        script = """
+from pathlib import Path
+from brainlayer.vector_store import VectorStore, WriterInUseError
+
+try:
+    VectorStore(Path(__import__("os").environ["DB_PATH"]))
+except WriterInUseError as exc:
+    print(type(exc).__name__)
+    print(str(exc))
+    raise SystemExit(0)
+raise SystemExit("symlink writer unexpectedly acquired the pidfile")
+"""
+        env = {
+            **os.environ,
+            "BRAINLAYER_WRITER_PIDFILE_DIR": str(pidfile_dir),
+            "DB_PATH": str(symlink_db),
+            "PYTHONPATH": f"{Path(__file__).resolve().parents[1] / 'src'}:{os.environ.get('PYTHONPATH', '')}",
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "WriterInUseError" in result.stdout
+    finally:
+        store.close()
+
+
 def test_stale_pidfile_cleaned_up(tmp_path, monkeypatch):
     pidfile_dir = tmp_path / "pidfiles"
     db_path = tmp_path / "writer.db"
@@ -121,6 +163,25 @@ def test_stale_pidfile_cleaned_up(tmp_path, monkeypatch):
         assert pidfile.read_text(encoding="utf-8").strip() == str(os.getpid())
     finally:
         store.close()
+
+
+def test_stale_pidfile_unlink_missing_race_is_ignored(tmp_path, monkeypatch):
+    pidfile = tmp_path / "writer.pid"
+    pidfile.write_text("999999", encoding="utf-8")
+    store = object.__new__(VectorStore)
+    store.db_path = tmp_path / "writer.db"
+    monkeypatch.setattr(store, "_pid_is_alive", lambda _pid: False)
+
+    original_unlink = Path.unlink
+
+    def unlink_race(path: Path, *args, **kwargs):
+        if path == pidfile:
+            raise FileNotFoundError
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", unlink_race)
+
+    assert store._handle_existing_writer_pidfile(pidfile, os.getpid()) is False
 
 
 def test_pidfile_removed_on_close(tmp_path, monkeypatch):

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -7,6 +7,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+import apsw
+import pytest
+
 from brainlayer import drain
 from brainlayer.vector_store import VectorStore
 
@@ -160,6 +163,27 @@ def test_init_retries_10_with_extended_backoff():
     ]
     assert delays == [0.5, 1, 2, 4, 8, 16, 30, 30, 30, 30]
     assert sum(delays) <= 600
+
+
+def test_init_retry_zero_budget_reraises_original_busy(monkeypatch):
+    store = object.__new__(VectorStore)
+    store._INIT_MAX_RETRIES = 0
+    store._INIT_BASE_DELAY = 0
+    store._INIT_MAX_DELAY = 0
+    calls = 0
+
+    def busy_init():
+        nonlocal calls
+        calls += 1
+        raise apsw.BusyError("locked")
+
+    monkeypatch.setattr(store, "_init_db", busy_init)
+    monkeypatch.setattr("time.sleep", lambda _delay: None)
+
+    with pytest.raises(apsw.BusyError, match="locked"):
+        store._init_db_with_retry()
+
+    assert calls == 1
 
 
 def test_drain_busy_timeout_30s(tmp_path, monkeypatch):

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import os
 import plistlib
@@ -12,7 +13,7 @@ import apsw
 import pytest
 
 from brainlayer import drain
-from brainlayer.vector_store import VectorStore
+from brainlayer.vector_store import VectorStore, WriterInUseError
 
 
 def _expected_pidfile(pidfile_dir: Path, db_path: Path) -> Path:
@@ -164,6 +165,56 @@ def test_same_process_pidfile_reuse_registers_atexit_release(tmp_path, monkeypat
     finally:
         second.close()
         first.close()
+
+
+def test_inherited_pidfile_ref_must_match_current_pid(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    pidfile.write_text("1\n", encoding="utf-8")
+    store = object.__new__(VectorStore)
+    store.db_path = db_path
+    store._writer_pidfile_acquired = False
+
+    with VectorStore._PIDFILE_REFS_LOCK:
+        VectorStore._PIDFILE_REFS[pidfile] = 1
+
+    try:
+        with pytest.raises(WriterInUseError, match="another writer is using"):
+            store._acquire_writer_pidfile()
+        assert not store._writer_pidfile_acquired
+    finally:
+        with VectorStore._PIDFILE_REFS_LOCK:
+            VectorStore._PIDFILE_REFS.pop(pidfile, None)
+
+
+def test_pidfile_create_locks_before_writing_pid(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    events: list[str] = []
+    original_flock = fcntl.flock
+    original_write = os.write
+
+    def record_flock(fd: int, operation: int) -> None:
+        if operation == fcntl.LOCK_EX:
+            events.append("flock")
+        original_flock(fd, operation)
+
+    def record_write(fd: int, data: bytes) -> int:
+        events.append("write")
+        return original_write(fd, data)
+
+    monkeypatch.setattr("fcntl.flock", record_flock)
+    monkeypatch.setattr("os.write", record_write)
+
+    store = VectorStore(db_path)
+    try:
+        assert events[:2] == ["flock", "write"]
+    finally:
+        store.close()
 
 
 def test_release_keeps_pidfile_ref_until_unlink_finishes(tmp_path, monkeypatch):
@@ -347,6 +398,17 @@ def test_drain_busy_timeout_30s(tmp_path, monkeypatch):
 
 def test_drain_busy_timeout_invalid_env_falls_back_to_30s(tmp_path, monkeypatch):
     monkeypatch.setenv("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "not-an-int")
+
+    conn = drain._open_connection(tmp_path / "drain.db")
+    try:
+        busy_timeout_ms = conn.cursor().execute("PRAGMA busy_timeout").fetchone()[0]
+        assert busy_timeout_ms >= 30000
+    finally:
+        conn.close()
+
+
+def test_drain_busy_timeout_non_positive_env_falls_back_to_30s(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "0")
 
     conn = drain._open_connection(tmp_path / "drain.db")
     try:

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -223,6 +223,34 @@ def test_pidfile_ref_mismatch_does_not_clear_existing_refs(tmp_path, monkeypatch
             VectorStore._PIDFILE_REF_PIDS.pop(pidfile, None)
 
 
+def test_same_process_reuse_accepts_pid_only_pidfile_when_owner_is_alive(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(VectorStore, "_pid_start_time", staticmethod(lambda _pid: "current-process-start"))
+    pidfile_dir.mkdir()
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    pidfile.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    store = object.__new__(VectorStore)
+    store.db_path = db_path
+    store._writer_pidfile_acquired = False
+
+    with VectorStore._PIDFILE_REFS_LOCK:
+        VectorStore._PIDFILE_REFS[pidfile] = 1
+        VectorStore._PIDFILE_REF_PIDS[pidfile] = os.getpid()
+
+    try:
+        store._acquire_writer_pidfile()
+        assert store._writer_pidfile_acquired
+        with VectorStore._PIDFILE_REFS_LOCK:
+            assert VectorStore._PIDFILE_REFS[pidfile] == 2
+    finally:
+        store._release_writer_pidfile()
+        with VectorStore._PIDFILE_REFS_LOCK:
+            VectorStore._PIDFILE_REFS.pop(pidfile, None)
+            VectorStore._PIDFILE_REF_PIDS.pop(pidfile, None)
+
+
 def test_pidfile_reused_pid_requires_matching_start_time(tmp_path, monkeypatch):
     pidfile_dir = tmp_path / "pidfiles"
     db_path = tmp_path / "writer.db"

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -5,6 +5,7 @@ import os
 import plistlib
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import apsw
@@ -163,6 +164,55 @@ def test_same_process_pidfile_reuse_registers_atexit_release(tmp_path, monkeypat
     finally:
         second.close()
         first.close()
+
+
+def test_release_keeps_pidfile_ref_until_unlink_finishes(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    first = VectorStore(db_path)
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    release_started = threading.Event()
+    opener_done = threading.Event()
+    opened: list[VectorStore] = []
+    errors: list[BaseException] = []
+    original_read = VectorStore._read_writer_pidfile
+
+    def delayed_pidfile_read(path: Path) -> int | None:
+        result = original_read(path)
+        if path == pidfile and not release_started.is_set():
+            release_started.set()
+            opener_done.wait(0.5)
+        return result
+
+    def open_second_writer() -> None:
+        release_started.wait(5)
+        try:
+            opened.append(VectorStore(db_path))
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+        finally:
+            opener_done.set()
+
+    monkeypatch.setattr(VectorStore, "_read_writer_pidfile", staticmethod(delayed_pidfile_read))
+    opener_thread = threading.Thread(target=open_second_writer)
+    release_thread = threading.Thread(target=first.close)
+
+    opener_thread.start()
+    release_thread.start()
+    release_thread.join(5)
+    opener_thread.join(5)
+
+    assert not release_thread.is_alive()
+    assert not opener_thread.is_alive()
+    assert not errors
+    assert opened
+    try:
+        assert pidfile.exists()
+        assert pidfile.read_text(encoding="utf-8").strip() == str(os.getpid())
+    finally:
+        opened[0].close()
 
 
 def test_stale_pidfile_cleaned_up(tmp_path, monkeypatch):

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+from brainlayer import drain
+from brainlayer.vector_store import VectorStore
+
+
+def _expected_pidfile(pidfile_dir: Path, db_path: Path) -> Path:
+    return pidfile_dir / f"brainlayer-writer-{db_path.name}.pid"
+
+
+def test_pidfile_created_on_rw_init(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    store = VectorStore(db_path)
+    try:
+        pidfile = _expected_pidfile(pidfile_dir, db_path)
+        assert pidfile.exists()
+        assert pidfile.read_text(encoding="utf-8").strip() == str(os.getpid())
+    finally:
+        store.close()
+
+
+def test_pidfile_blocks_second_writer(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    store = VectorStore(db_path)
+    try:
+        script = """
+from pathlib import Path
+from brainlayer.vector_store import VectorStore, WriterInUseError
+
+try:
+    VectorStore(Path(__import__("os").environ["DB_PATH"]))
+except WriterInUseError as exc:
+    print(type(exc).__name__)
+    print(str(exc))
+    raise SystemExit(0)
+raise SystemExit("second writer unexpectedly acquired the pidfile")
+"""
+        env = {
+            **os.environ,
+            "BRAINLAYER_WRITER_PIDFILE_DIR": str(pidfile_dir),
+            "DB_PATH": str(db_path),
+            "PYTHONPATH": f"{Path(__file__).resolve().parents[1] / 'src'}:{os.environ.get('PYTHONPATH', '')}",
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "WriterInUseError" in result.stdout
+        assert f"another writer is using {db_path} (pid {os.getpid()})" in result.stdout
+    finally:
+        store.close()
+
+
+def test_stale_pidfile_cleaned_up(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    pidfile.write_text("999999", encoding="utf-8")
+
+    store = VectorStore(db_path)
+    try:
+        assert pidfile.exists()
+        assert pidfile.read_text(encoding="utf-8").strip() == str(os.getpid())
+    finally:
+        store.close()
+
+
+def test_pidfile_removed_on_close(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    store = VectorStore(db_path)
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    assert pidfile.exists()
+
+    store.close()
+
+    assert not pidfile.exists()
+
+
+def test_readonly_init_skips_pidfile(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+
+    writer = VectorStore(db_path)
+    writer.close()
+
+    reader = VectorStore(db_path, readonly=True)
+    try:
+        pidfile = _expected_pidfile(pidfile_dir, db_path)
+        assert not pidfile.exists()
+        assert reader._writer_pidfile_acquired is False
+        assert not hasattr(reader, "_writer_pidfile_path_value")
+    finally:
+        reader.close()
+
+
+def test_init_retries_10_with_extended_backoff():
+    assert VectorStore._INIT_MAX_RETRIES == 10
+    delays = [
+        min(VectorStore._INIT_BASE_DELAY * (2**attempt), VectorStore._INIT_MAX_DELAY)
+        for attempt in range(VectorStore._INIT_MAX_RETRIES)
+    ]
+    assert delays == [0.5, 1, 2, 4, 8, 16, 30, 30, 30, 30]
+    assert sum(delays) <= 600
+
+
+def test_drain_busy_timeout_30s(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "30000")
+
+    conn = drain._open_connection(tmp_path / "drain.db")
+    try:
+        busy_timeout_ms = conn.cursor().execute("PRAGMA busy_timeout").fetchone()[0]
+        assert busy_timeout_ms >= 30000
+    finally:
+        conn.close()
+
+
+def test_enrichment_plist_throttle_interval_at_least_60s():
+    plist_path = Path(__file__).resolve().parents[1] / "scripts" / "launchd" / "com.brainlayer.enrichment.plist"
+    plist = plistlib.loads(plist_path.read_bytes())
+
+    assert plist["ThrottleInterval"] >= 60

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -546,6 +546,17 @@ def test_drain_busy_timeout_non_positive_env_falls_back_to_30s(tmp_path, monkeyp
         conn.close()
 
 
+def test_drain_busy_timeout_overflow_env_falls_back_to_30s(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "3000000000")
+
+    conn = drain._open_connection(tmp_path / "drain.db")
+    try:
+        busy_timeout_ms = conn.cursor().execute("PRAGMA busy_timeout").fetchone()[0]
+        assert busy_timeout_ms == 30000
+    finally:
+        conn.close()
+
+
 def test_enrichment_plist_throttle_interval_at_least_60s():
     plist_path = Path(__file__).resolve().parents[1] / "scripts" / "launchd" / "com.brainlayer.enrichment.plist"
     plist = plistlib.loads(plist_path.read_bytes())

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -313,6 +313,38 @@ def test_pidfile_create_locks_before_writing_pid(tmp_path, monkeypatch):
         store.close()
 
 
+def test_pidfile_acquire_retries_transient_file_exists_races(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    store = object.__new__(VectorStore)
+    store.db_path = db_path
+    store._writer_pidfile_acquired = False
+    original_open = os.open
+    create_attempts = 0
+
+    def flaky_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal create_attempts
+        if Path(path).name.startswith("brainlayer-writer-") and flags & os.O_CREAT:
+            create_attempts += 1
+            if create_attempts < 3:
+                raise FileExistsError(17, "File exists", str(path))
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("os.open", flaky_open)
+    monkeypatch.setattr(store, "_handle_existing_writer_pidfile", lambda _pidfile, _pid: False)
+
+    store._acquire_writer_pidfile()
+
+    try:
+        assert store._writer_pidfile_acquired
+        assert create_attempts == 3
+    finally:
+        store._release_writer_pidfile()
+
+
 def test_release_keeps_pidfile_ref_until_unlink_finishes(tmp_path, monkeypatch):
     pidfile_dir = tmp_path / "pidfiles"
     db_path = tmp_path / "writer.db"

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -22,6 +22,10 @@ def _expected_pidfile(pidfile_dir: Path, db_path: Path) -> Path:
     return pidfile_dir / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
 
 
+def _pidfile_pid(pidfile: Path) -> str:
+    return pidfile.read_text(encoding="utf-8").splitlines()[0].strip()
+
+
 def test_pidfile_created_on_rw_init(tmp_path, monkeypatch):
     pidfile_dir = tmp_path / "pidfiles"
     db_path = tmp_path / "writer.db"
@@ -31,7 +35,7 @@ def test_pidfile_created_on_rw_init(tmp_path, monkeypatch):
     try:
         pidfile = _expected_pidfile(pidfile_dir, db_path)
         assert pidfile.exists()
-        assert pidfile.read_text(encoding="utf-8").strip() == str(os.getpid())
+        assert _pidfile_pid(pidfile) == str(os.getpid())
     finally:
         store.close()
 
@@ -180,6 +184,7 @@ def test_inherited_pidfile_ref_must_match_current_pid(tmp_path, monkeypatch):
 
     with VectorStore._PIDFILE_REFS_LOCK:
         VectorStore._PIDFILE_REFS[pidfile] = 1
+        VectorStore._PIDFILE_REF_PIDS[pidfile] = 1
 
     try:
         with pytest.raises(WriterInUseError, match="another writer is using"):
@@ -188,6 +193,69 @@ def test_inherited_pidfile_ref_must_match_current_pid(tmp_path, monkeypatch):
     finally:
         with VectorStore._PIDFILE_REFS_LOCK:
             VectorStore._PIDFILE_REFS.pop(pidfile, None)
+            VectorStore._PIDFILE_REF_PIDS.pop(pidfile, None)
+
+
+def test_pidfile_ref_mismatch_does_not_clear_existing_refs(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    pidfile.write_text("999999\n", encoding="utf-8")
+    store = object.__new__(VectorStore)
+    store.db_path = db_path
+    store._writer_pidfile_acquired = False
+
+    with VectorStore._PIDFILE_REFS_LOCK:
+        VectorStore._PIDFILE_REFS[pidfile] = 2
+        VectorStore._PIDFILE_REF_PIDS[pidfile] = os.getpid()
+
+    try:
+        with pytest.raises(WriterInUseError, match="pidfile ref mismatch"):
+            store._acquire_writer_pidfile()
+        with VectorStore._PIDFILE_REFS_LOCK:
+            assert VectorStore._PIDFILE_REFS[pidfile] == 2
+        assert _pidfile_pid(pidfile) == "999999"
+    finally:
+        with VectorStore._PIDFILE_REFS_LOCK:
+            VectorStore._PIDFILE_REFS.pop(pidfile, None)
+            VectorStore._PIDFILE_REF_PIDS.pop(pidfile, None)
+
+
+def test_pidfile_reused_pid_requires_matching_start_time(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(
+        VectorStore,
+        "_pid_start_time",
+        staticmethod(lambda _pid: "current-process-start"),
+        raising=False,
+    )
+    pidfile_dir.mkdir()
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    pidfile.write_text(f"{os.getpid()}\nstart_time=previous-process-start\n", encoding="utf-8")
+
+    store = VectorStore(db_path)
+    try:
+        contents = pidfile.read_text(encoding="utf-8")
+        assert contents.startswith(f"{os.getpid()}\n")
+        assert "start_time=current-process-start" in contents
+    finally:
+        store.close()
+
+
+def test_relative_pidfile_dir_is_normalized_to_tmp(tmp_path, monkeypatch):
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", "brainlayer-relative-locks")
+    store = object.__new__(VectorStore)
+    store.db_path = db_path
+
+    pidfile = store._writer_pidfile_path()
+
+    assert pidfile.is_absolute()
+    assert pidfile.parent == (Path("/tmp") / "brainlayer-relative-locks").resolve()
 
 
 def test_pidfile_create_locks_before_writing_pid(tmp_path, monkeypatch):
@@ -261,7 +329,7 @@ def test_release_keeps_pidfile_ref_until_unlink_finishes(tmp_path, monkeypatch):
     assert opened
     try:
         assert pidfile.exists()
-        assert pidfile.read_text(encoding="utf-8").strip() == str(os.getpid())
+        assert _pidfile_pid(pidfile) == str(os.getpid())
     finally:
         opened[0].close()
 
@@ -277,7 +345,7 @@ def test_stale_pidfile_cleaned_up(tmp_path, monkeypatch):
     store = VectorStore(db_path)
     try:
         assert pidfile.exists()
-        assert pidfile.read_text(encoding="utf-8").strip() == str(os.getpid())
+        assert _pidfile_pid(pidfile) == str(os.getpid())
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary
- Add a pidfile-guarded single-writer mutex before writable `VectorStore` DB init; readonly opens do not touch the writer lock.
- Harden lock ownership for basename collisions, symlink aliases, forked/inherited refs, close/open races, PID reuse, relative pidfile dirs, and empty pidfile write races.
- Increase init retry budget, raise drain busy timeout, and raise enrichment LaunchAgent throttle.
- Keep prompt/live retrieval read-only under the new mutex and harden recency fallback filter parity/retry behavior.

## Writer Mutex Contract
- Default pidfile path: `/tmp/brainlayer-writer-${SHA256_RESOLVED_DB_PATH_16}-${RESOLVED_DB_BASENAME}.pid`.
- Override: `BRAINLAYER_WRITER_PIDFILE_DIR=/path/to/dir`; relative override values are normalized under `/tmp`.
- RW init uses `O_CREAT | O_EXCL`, takes an exclusive `flock` before writing, and records PID plus process start-time metadata.
- Existing live owner raises `WriterInUseError: another writer is using $DB_PATH (pid $PID)`.
- Dead, invalid, or PID-reused owners are reclaimed after verifying the opened pidfile is still the path target.
- Same-process writer opens are ref-counted; release keeps ownership until unlink completes and always runs from `close()`/`atexit`.

## Retry / Timeout / Throttle Math
- `_INIT_MAX_RETRIES`: `5 -> 10`, override `BRAINLAYER_INIT_MAX_RETRIES`, clamped to at least one attempt.
- Backoff sleeps: `0.5 + 1 + 2 + 4 + 8 + 16 + 30 + 30 + 30 + 30 = 151.5s` sleep budget.
- With APSW busy timeout at 30s per attempt, worst-case wall time remains under the 600s cap.
- Drain busy timeout: `200ms -> 30000ms`, override `BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS`; invalid, non-positive, or APSW-overflowing env falls back to 30000.
- Enrichment LaunchAgent `ThrottleInterval`: `30 -> 60` in `scripts/launchd/com.brainlayer.enrichment.plist`; installed user plist was also updated locally to 60.

## RED -> GREEN
- Initial required RED: `pytest tests/test_writer_pidfile_mutex.py` collected 7 required tests and all 7 failed before implementation.
- Initial plist RED: `test_enrichment_plist_throttle_interval_at_least_60s` failed against `ThrottleInterval=30` before restoring the template change.
- Review-fix REDs were added and watched fail before fixes for basename collisions, symlink aliases, stale unlink races, same-process atexit reuse, release ownership race, close failure release, inherited refs, locked-before-write creation, PID-reuse owner metadata, relative pidfile dir normalization, hook readonly opens, recency filter parity/date handling/busy retry, retry budget clamp, and drain timeout env validation.
- Latest focused GREEN: `pytest tests/test_writer_pidfile_mutex.py tests/test_adaptive_injection.py tests/test_hybrid_search.py tests/test_db_lock_resilience.py` -> 68 passed.

## Enrich-Rate Bench
Baseline supplied by PR-alpha prompt:
- Pre-PR-alpha post-T0, `2026-05-21T16:22:12Z`: 213 enrichments / 77 min = ~166/hr.

Fresh >=30 min live sample command:
```bash
PYTHONPATH=src python3 - <<'PY'
from datetime import datetime, timezone, timedelta
from brainlayer.paths import get_db_path
from brainlayer.vector_store import VectorStore
start = datetime.now(timezone.utc) - timedelta(minutes=30)
end = datetime.now(timezone.utc)
store = VectorStore(get_db_path(), readonly=True)
count = 0
try:
    for _, enriched_at in store.conn.cursor().execute(
        "SELECT id, enriched_at FROM chunks WHERE enriched_at IS NOT NULL AND enriched_at NOT LIKE 'skipped:%'"
    ):
        if not enriched_at:
            continue
        try:
            dt = datetime.fromisoformat(str(enriched_at).replace('Z', '+00:00'))
        except ValueError:
            continue
        if dt.tzinfo is None:
            dt = dt.replace(tzinfo=timezone.utc)
        if start <= dt <= end:
            count += 1
finally:
    store.close()
minutes = (end - start).total_seconds() / 60
print(start.isoformat(), end.isoformat(), count, f"{count / minutes * 60:.1f}/hr")
PY
```
Fresh sample observed during PR-alpha implementation:
- Window: `2026-05-21T18:03:20.907164+00:00` to `2026-05-21T18:33:20.907301+00:00`.
- Count: 207 enrichments / 30.0 min = 414.0/hr.

## Test Plan
- [x] `pytest tests/test_writer_pidfile_mutex.py tests/test_adaptive_injection.py tests/test_hybrid_search.py tests/test_db_lock_resilience.py` -> 68 passed.
- [x] `ruff check src/brainlayer/vector_store.py hooks/brainlayer-prompt-search.py src/brainlayer/search_repo.py tests/test_writer_pidfile_mutex.py tests/test_adaptive_injection.py` -> passed.
- [x] `ruff format --check src/brainlayer/vector_store.py hooks/brainlayer-prompt-search.py src/brainlayer/search_repo.py tests/test_writer_pidfile_mutex.py tests/test_adaptive_injection.py` -> 5 files already formatted.
- [x] `pytest tests/test_eval_baselines.py -m live` -> 34 passed, 5 xfailed, 2 xpassed.
- [x] Latest pre-push gate -> 2090 passed, 9 skipped, 75 deselected, 1 xfailed, 102 warnings; MCP registration 3 passed; isolated eval/hook routing 32 passed; Bun 1 passed; FTS determinism passed.
- [x] `cr review --plain` passed earlier on staged diff; a later local CLI attempt hung and was stopped, with hosted CodeRabbit running on the pushed commits.

## Notes
- Plain local `pytest` under system Python 3.13 was blocked earlier by optional dependency drift (`deepchecks` missing, `numba` incompatible with NumPy 2.4). The repo pre-push hook uses its Python 3.12 env and passed the configured gate.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add single-writer pidfile mutex and recency-intent search fallback to `VectorStore` and `hybrid_search`
> - Read-write `VectorStore` instances now acquire an exclusive pidfile lock on init; a second writer raises `WriterInUseError`. Same-process reuse is ref-counted and the lock is released on `close` even if connection teardown fails.
> - `hybrid_search` detects recency intent in query text and supplements FTS results with the most-recent matching chunks via a SQL fallback, retrying up to 3 times on SQLite busy errors with exponential backoff. Chunks ≤7 days old receive an extra 2.0× score boost when recency intent is detected.
> - The drain connection busy timeout is now configurable via `BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS` (default 30 s, was 200 ms).
> - Single-token entity matches for types `technology` and `tool` are skipped during entity span matching in the prompt-search hook.
> - The launchd enrichment job `ThrottleInterval` is raised from 30 s to 60 s.
> - Risk: any process that previously opened multiple read-write `VectorStore` instances concurrently will now fail with `WriterInUseError` unless re-entrant acquisition is detected correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c668da8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new cross-process single-writer gate for writable `VectorStore` opens and changes search fallback/ranking behavior; misconfiguration or unexpected multi-writer usage could now raise `WriterInUseError` or alter result ordering.
> 
> **Overview**
> **Adds a single-writer mutex for writable DB access.** Writable `VectorStore` initialization now acquires a pidfile-based lock (with PID/start-time validation, symlink-safe path hashing, ref-counting, and guaranteed release on `close()`/`atexit`) and raises `WriterInUseError` when another live writer owns the database.
> 
> **Hardens read paths and retrieval behavior under contention.** Hybrid prompt search and multiple integration tests now open `VectorStore(..., readonly=True)`; `VectorStore` init retry budget/backoff is increased and made configurable; `drain`’s APSW busy timeout is increased to 30s (env-configurable); the enrichment LaunchAgent throttle is raised to 60s.
> 
> **Improves search quality edge cases.** `hybrid_search` gains a “recency intent” fallback that supplements lexical candidates with the most recent 7 days (respecting existing filters and retrying on busy), plus an extra boost for ≤7-day results when recency words are present; prompt entity injection skips ambiguous single-token matches for `technology`/`tool` entity types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c668da8c0e4befdd1dbaa721564f8b2cd71a0e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Automatic recency prioritization: queries containing "current," "latest," "recent," "today," or "this week" now automatically retrieve results from the last 7 days with enhanced ranking when no explicit date range is specified.

* **Improvements**
  * Enhanced disambiguation for single-token entity type matching in search
  * Improved database concurrency protection and configurable connection timeout behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

