### PR TITLE
fix(daemon): fall back to readonly when writer pidfile is held

### DIFF
--- a/src/brainlayer/daemon.py
+++ b/src/brainlayer/daemon.py
@@ -20,7 +20,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
 from .embeddings import get_embedding_model
-from .vector_store import VectorStore
+from .vector_store import VectorStore, WriterInUseError
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +80,23 @@ async def lifespan(app: FastAPI):
     # Startup
     logger.info("Starting brainlayer daemon...")
 
-    vector_store = VectorStore(DEFAULT_DB_PATH)
-    logger.info(f"Loaded vector store: {vector_store.count()} chunks")
+    # Try RW first (some endpoints write: /digest, /store, /entity PATCH, /backlog/items POST/PATCH/DELETE).
+    # If another live writer holds the pidfile mutex (added in PR #309), gracefully fall back to readonly.
+    # In readonly mode, read endpoints (search/stats/context/dashboard) still work; write endpoints
+    # will return 500 on the SQL layer until the operator restarts the daemon when no writer is active.
+    # This prevents the entire FastAPI daemon from failing to start just because enrich is running.
+    try:
+        vector_store = VectorStore(DEFAULT_DB_PATH)
+        logger.info(f"Loaded vector store (READ-WRITE): {vector_store.count()} chunks")
+    except WriterInUseError as exc:
+        logger.warning(
+            "Another writer holds the pidfile mutex (%s); falling back to READONLY mode. "
+            "Search/stats/context endpoints work; write endpoints (/digest, /store, /entity PATCH, "
+            "/backlog/items POST/PATCH/DELETE) will return 500 until daemon is restarted with no live writer.",
+            exc,
+        )
+        vector_store = VectorStore(DEFAULT_DB_PATH, readonly=True)
+        logger.info(f"Loaded vector store (READONLY fallback): {vector_store.count()} chunks")
 
     embedding_model = get_embedding_model()
     logger.info(f"Loaded embedding model: {embedding_model.model_name}")


### PR DESCRIPTION
## Why

PR #309 (single-writer pidfile mutex) inadvertently broke `brainlayer-daemon` (FastAPI). At startup, daemon.py:83 opens `VectorStore(DEFAULT_DB_PATH)` in RW mode, but the new pidfile mutex raises `WriterInUseError` if any other writer (enrich supervisor, drain, etc.) holds the lock — which is normal production state.

**Symptom**: `brainlayer search` CLI hangs ~17-36 min, `brainlayer stats` hangs, `/tmp/brainlayer.sock` never appears.

**Discovered during** Phase 4a eval baseline.json generation tonight — the runner needed `brainlayer search` to work.

## Fix

Catch `WriterInUseError` in the lifespan handler and fall back to readonly mode. Log a clear warning explaining what works and what doesn't.

## Smoke-test evidence (empirical)

Direct lifespan invocation while enrich supervisor PID 14909 holds the pidfile:

```
$ PYTHONPATH=src python -c "import asyncio; from brainlayer.daemon import lifespan, app; asyncio.run((lambda: (yield from lifespan(app).__aenter__()))())"
Another writer holds the pidfile mutex (another writer is using /Users/etanheyman/.local/share/brainlayer/brainlayer.db (pid 14909)); falling back to READONLY mode. Search/stats/context endpoints work; write endpoints (/digest, /store, /entity PATCH, /backlog/items POST/PATCH/DELETE) will return 500 until daemon is restarted with no live writer.
LIFESPAN OK
```

## Test plan

- [x] Smoke-tested locally against production state (enrich supervisor alive)
- [ ] Brainlayer search CLI works after this PR (would need merge + restart to verify)
- [ ] Dashboard search endpoints work in readonly mode
- [ ] Future PR: move write endpoints (/digest, /store, /entity PATCH, /backlog/items) to arbitrated queue path so daemon can serve them regardless of writer state

## Sequencing

Independent of Phase 4a/4b. Ships standalone as a small bugfix.

🤖 Generated with Claude Code by orcClaude-successor s:42

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon startup behavior to continue running in a degraded (readonly) mode when a writer lock is held; this can surface as 500s on write endpoints until restart. Risk is limited to initialization/control flow and logging, with no schema or query logic changes.
> 
> **Overview**
> Fixes `brainlayer-daemon` startup failures introduced by the single-writer pidfile mutex by catching `WriterInUseError` during `VectorStore` initialization.
> 
> On lock contention, the daemon now **falls back to `VectorStore(..., readonly=True)`** and logs a clear warning that read endpoints (search/stats/context/dashboard) remain available while write endpoints (e.g. `POST /digest`, `POST /store`, `PATCH /entity`, backlog mutations) will fail until restarted without another active writer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6383adf6fd18b78add63270f422d405f0c313058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to readonly `VectorStore` when writer pidfile is held on daemon startup
> In [daemon.py](https://github.com/EtanHey/brainlayer/pull/311/files#diff-2eaf6ca230151eadc6c56d569db8ba5a0c1b66dfd459b416faa7beb6289fa97b), the `lifespan` startup now wraps `VectorStore` initialization in a try/except. If `WriterInUseError` is raised, the daemon logs a warning and re-opens the store with `readonly=True` instead of failing. Behavioral Change: the daemon can now start successfully when another process holds the writer lock, but will serve read-only traffic in that state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6383adf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon startup is now more resilient. When another writer instance is active, the daemon gracefully falls back to read-only mode, allowing read operations to continue while write operations remain unavailable until the conflict is resolved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->