### PR TITLE
fix(cli): bootstrap partial sqlite schema before readonly

### DIFF
--- a/src/brainlayer/cli_new.py
+++ b/src/brainlayer/cli_new.py
@@ -1,7 +1,9 @@
 """CLI commands backed by direct readonly SQLite access."""
 
+import sqlite3
 import time
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator
 
 import typer
@@ -26,12 +28,35 @@ def _readonly_store() -> Iterator[VectorStore]:
         store.close()
 
 
-def _ensure_readonly_db_ready(db_path) -> None:
-    if db_path.exists():
+def _ensure_readonly_db_ready(db_path: Path) -> None:
+    if _has_readonly_schema(db_path):
         return
 
     bootstrap_store = VectorStore(db_path)
-    bootstrap_store.close()
+    try:
+        pass
+    finally:
+        bootstrap_store.close()
+
+
+def _has_readonly_schema(db_path: Path) -> bool:
+    if not db_path.exists():
+        return False
+
+    required_tables = {"chunks", "schema_migrations", "chunk_vectors", "chunks_fts"}
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            rows = conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')").fetchall()
+            existing_tables = {row[0] for row in rows}
+            if not required_tables.issubset(existing_tables):
+                return False
+            chunk_columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)").fetchall()}
+            return {"id", "content", "metadata", "source_file"}.issubset(chunk_columns)
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
 
 
 def get_embedding_model():

--- a/src/brainlayer/dashboard/app.py
+++ b/src/brainlayer/dashboard/app.py
@@ -7,6 +7,7 @@ from rich.layout import Layout
 from rich.panel import Panel
 from rich.text import Text
 
+from ..cli_new import _ensure_readonly_db_ready
 from ..paths import get_db_path
 from ..vector_store import VectorStore
 from .search import HybridSearchEngine
@@ -27,11 +28,14 @@ class DashboardApp:
         """Initialize database connection using sqlite-vec."""
         try:
             db_path = get_db_path()
-            if not db_path.exists():
-                bootstrap_store = VectorStore(db_path)
-                bootstrap_store.close()
+            _ensure_readonly_db_ready(db_path)
             self.vector_store = VectorStore(db_path, readonly=True)
-            self.stats = self.vector_store.get_stats()
+            try:
+                self.stats = self.vector_store.get_stats()
+            except Exception:
+                self.vector_store.close()
+                self.vector_store = None
+                raise
         except Exception as e:
             self.console.print(f"[red]Database error: {e}[/]")
             self.stats = {"total_chunks": 0, "projects": [], "content_types": []}

--- a/tests/test_cli_direct_sqlite.py
+++ b/tests/test_cli_direct_sqlite.py
@@ -84,12 +84,36 @@ def test_cli_stats_bootstraps_missing_db_before_readonly(tmp_path: Path) -> None
     assert _daemon_pids() == []
 
 
+def test_cli_stats_bootstraps_empty_existing_db_before_readonly(tmp_path: Path) -> None:
+    db_path = tmp_path / "brainlayer.db"
+    db_path.touch()
+
+    env = os.environ.copy()
+    env["BRAINLAYER_DB"] = str(db_path)
+    env["PATH"] = str(tmp_path)
+    env["PYTHONPATH"] = f"{REPO_ROOT / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
+
+    result = subprocess.run(
+        [sys.executable, "-c", "from brainlayer.cli import app; app()", "stats"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Total Chunks" in result.stdout
+    assert _daemon_pids() == []
+
+
 def test_cli_search_opens_vectorstore_readonly_directly(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     import brainlayer.cli_new as cli_new
     from brainlayer.cli import app
 
     db_path = tmp_path / "brainlayer.db"
-    db_path.touch()
+    _seed_empty_db(db_path)
     calls: list[tuple[Path, bool]] = []
 
     class SpyStore:
@@ -121,7 +145,7 @@ def test_cli_stats_p95_under_200ms_with_direct_readonly_store(monkeypatch: pytes
     from brainlayer.cli import app
 
     db_path = tmp_path / "brainlayer.db"
-    db_path.touch()
+    _seed_empty_db(db_path)
     calls: list[tuple[Path, bool]] = []
 
     class FastStatsStore:


### PR DESCRIPTION
## Summary

Follow-up to PR #312 (FastAPI daemon removal).

Net-new commit `8ac5b653` authored by Etan at 14:43:49 IDT 2026-05-22 on top of `e609d848`. Adds bootstrap of partial sqlite schema before readonly reads — addresses a P1 edge case found by the codex worker (s:12 / `socket-direct-codex-v2`) immediately after the daemon-removal merge: CLI hit `no such table: chunks` when opening a brand-new or partially-populated DB in readonly mode.

## Diff

3 files changed, +62 / -9:
- `src/brainlayer/cli_new.py` (+31 / -3)
- `src/brainlayer/dashboard/app.py` (+12 / -4)
- `tests/test_cli_direct_sqlite.py` (+28 / -2)

## Test plan

- [x] `pytest tests/test_cli_direct_sqlite.py -q` → 7 passed (3.20s)
- [x] `pytest tests/test_cli_direct_sqlite.py tests/test_parent_death.py tests/test_dashboard.py -q` → 14 passed (10.64s)
- [x] `ruff check src tests` → clean (264 files formatted)
- [ ] CI: test (3.11, 3.12, 3.13), lint, CodeRabbit, Cursor Bugbot, Macroscope Correctness Check

## Provenance note

Branch was prepared by codex worker s:12 (TDD red-green: failed red on `no such table: chunks` → fixed bootstrap helper → green). Codex backend lost stream connection before push could complete autonomously. Shipped by orc gen-6 per autonomous-mode policy + A1 (Etan-as-PR-author signal).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how CLI/dashboard decide when to open the SQLite DB in readonly mode and adds direct schema probing via `sqlite3`, which could affect startup behavior on corrupted/edge-case DB files.
> 
> **Overview**
> Fixes an edge case where the CLI/dashboard could open an *existing but uninitialized/partial* SQLite file in readonly mode and fail with missing-table errors.
> 
> Adds a `_has_readonly_schema` probe and updates `_ensure_readonly_db_ready` to bootstrap the DB schema (via a temporary writable `VectorStore`) whenever the required tables/columns aren’t present, then re-opens the store readonly; the dashboard now uses the same bootstrap path and closes the readonly store if `get_stats()` fails. Tests are extended to cover the “empty file already exists” bootstrap case and adjust other readonly-store tests to seed a minimal schema instead of touching an empty file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac5b65304762aca484b010c759cb7ac42681c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced database validation to verify schema integrity and completeness, not just file presence
  * Improved database initialization with automatic bootstrapping when needed
  * Strengthened error handling for database setup failures in the dashboard

* **Bug Fixes**
  * Stats command now properly handles edge cases with empty database files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CLI bootstrap of partial SQLite schema before opening in read-only mode
> - Adds `_has_readonly_schema` helper in [cli_new.py](https://github.com/EtanHey/brainlayer/pull/313/files#diff-519f84373784b47cbaaf435c9a025a096d630573ed44f30024d2d1151c414a67) that validates required tables and columns exist in a SQLite DB before treating it as ready for read-only access.
> - Updates `_ensure_readonly_db_ready` to call this helper instead of just checking file existence; if the schema is missing, it bootstraps the DB via `VectorStore` before proceeding.
> - Updates `DashboardApp.setup_database` in [app.py](https://github.com/EtanHey/brainlayer/pull/313/files#diff-adafbb4789f8aef13040e225fcc7993f25a3a1a362e2bd8a0ea6d1cbb8bf8080) to use the shared `_ensure_readonly_db_ready` logic, and closes/clears the store if `get_stats` raises.
> - Adds a test covering the bootstrap-on-empty-file path; updates existing tests to seed the DB properly instead of just touching the file.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8ac5b65. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->