### PR TITLE
fix(brainbar): wire database + injection store on UI startup

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -62,17 +62,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let dbPath = BrainBarServer.defaultDBPath()
-        NSLog("[BrainBar] Starting UI shell; daemon owns %@", BrainBarServer.defaultSocketPath())
+        NSLog("[BrainBar] Starting UI shell; database at %@", dbPath)
         let collector = BrainBarAppSupport.makeUIStatsCollector(
             dbPath: dbPath,
             brainBusEvents: BrainBusClient()
         )
         self.collector = collector
-        runtime.install(
-            collector: collector,
-            injectionStore: nil,
-            database: nil
-        )
+        BrainBarAppSupport.wireRuntime(runtime, dbPath: dbPath, collector: collector)
 
         flushPendingBrainBarURLs()
 
@@ -82,7 +78,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         collector.start()
         configureQuickCaptureHotkey()
-        NSLog("[BrainBar] Socket ready; database will self-heal — launchMode=%@", String(describing: launchMode))
+        NSLog("[BrainBar] Runtime wired — launchMode=%@", String(describing: launchMode))
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
@@ -46,6 +46,44 @@ enum BrainBarAppSupport {
         )
     }
 
+    // AIDEV-NOTE: Wires the UI runtime's database + injection store after PR #312
+    // removed the FastAPI daemon. Pre-#312 the daemon owned the writer and the UI
+    // process consumed via socket; post-#312 each consumer opens SQLite directly.
+    // The UI runtime is opened READ-ONLY so the writer pidfile stays uncontended;
+    // InjectionStore opens its own writable connection internally for ack writes.
+    @MainActor
+    static func wireRuntime(
+        _ runtime: BrainBarRuntime,
+        dbPath: String,
+        collector: StatsCollector
+    ) {
+        let database = BrainDatabase(
+            path: dbPath,
+            openConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        if !database.isOpen {
+            NSLog(
+                "[BrainBar] Read-only database open failed at %@: %@",
+                dbPath,
+                String(describing: database.lastOpenError)
+            )
+        }
+
+        let injectionStore: InjectionStore?
+        do {
+            injectionStore = try InjectionStore(databasePath: dbPath)
+        } catch {
+            NSLog("[BrainBar] InjectionStore init failed: %@", String(describing: error))
+            injectionStore = nil
+        }
+
+        runtime.install(
+            collector: collector,
+            injectionStore: injectionStore,
+            database: database
+        )
+    }
+
     static func discoverDaemonPID() -> pid_t {
         for label in daemonLaunchdLabels {
             if let pid = launchctlPID(for: label) {

--- a/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
@@ -49,32 +49,47 @@ enum BrainBarAppSupport {
     // AIDEV-NOTE: Wires the UI runtime's database + injection store after PR #312
     // removed the FastAPI daemon. Pre-#312 the daemon owned the writer and the UI
     // process consumed via socket; post-#312 each consumer opens SQLite directly.
-    // The UI runtime is opened READ-ONLY so the writer pidfile stays uncontended;
-    // InjectionStore opens its own writable connection internally for ack writes.
+    //
+    // Order matters: InjectionStore opens its internal connection in default
+    // writable mode and creates the schema if the file doesn't exist (fresh
+    // install / cleared state). The UI runtime's read-only handle MUST open
+    // after that, otherwise on a missing DB the read-only open fails and the UI
+    // installs a permanently-closed handle that satisfies `database != nil` but
+    // breaks search/graph. If the read-only open still fails after
+    // bootstrapping, try `reopenIfNeeded()` once — in practice the DB at
+    // ~/.local/share/brainlayer/brainlayer.db is always present, but tests +
+    // fresh-install + cleared-state must work too.
+    //
+    // The UI runtime opens read-only so the writer pidfile stays uncontended
+    // with the Python enrich supervisor + drain. InjectionStore keeps its own
+    // writable connection for ack writes.
     @MainActor
     static func wireRuntime(
         _ runtime: BrainBarRuntime,
         dbPath: String,
         collector: StatsCollector
     ) {
-        let database = BrainDatabase(
-            path: dbPath,
-            openConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
-        )
-        if !database.isOpen {
-            NSLog(
-                "[BrainBar] Read-only database open failed at %@: %@",
-                dbPath,
-                String(describing: database.lastOpenError)
-            )
-        }
-
         let injectionStore: InjectionStore?
         do {
             injectionStore = try InjectionStore(databasePath: dbPath)
         } catch {
             NSLog("[BrainBar] InjectionStore init failed: %@", String(describing: error))
             injectionStore = nil
+        }
+
+        let database = BrainDatabase(
+            path: dbPath,
+            openConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        if !database.isOpen {
+            database.reopenIfNeeded()
+        }
+        if !database.isOpen {
+            NSLog(
+                "[BrainBar] Read-only database open failed at %@: %@",
+                dbPath,
+                String(describing: database.lastOpenError)
+            )
         }
 
         runtime.install(

--- a/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
@@ -50,4 +50,35 @@ final class BrainBarRuntimeWiringTests: XCTestCase {
         )
         XCTAssertNotNil(runtime.collector)
     }
+
+    func testWireRuntimeOpensReadonlyHandleEvenWhenDBFileMissing() {
+        // Fresh-install scenario: brainlayer.db doesn't exist yet. InjectionStore
+        // must create the file first; the read-only BrainDatabase must then open
+        // successfully. Otherwise the runtime installs a permanently-closed handle
+        // that satisfies `database != nil` but breaks search/graph downstream.
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: tempDBPath),
+            "Test precondition: DB file must NOT exist at start"
+        )
+
+        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
+        let collector = BrainBarAppSupport.makeStatsCollector(
+            dbPath: tempDBPath,
+            targetPID: ProcessInfo.processInfo.processIdentifier,
+            brainBusEvents: nil
+        )
+        defer { collector.stop() }
+
+        BrainBarAppSupport.wireRuntime(runtime, dbPath: tempDBPath, collector: collector)
+        defer { runtime.injectionStore?.stop() }
+
+        XCTAssertNotNil(runtime.database)
+        XCTAssertTrue(
+            runtime.database?.isOpen == true,
+            "Regression guard for Cursor Bugbot + ChatGPT-Codex flag (PR #314 review): "
+            + "on fresh install, wireRuntime must order InjectionStore (creates file) "
+            + "BEFORE the read-only BrainDatabase open — otherwise the runtime carries "
+            + "a closed handle and search/graph stay broken until app restart."
+        )
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import BrainBar
+
+@MainActor
+final class BrainBarRuntimeWiringTests: XCTestCase {
+    private var tempDBPath: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDBPath = NSTemporaryDirectory() + "brainbar-runtime-wiring-\(UUID().uuidString).db"
+    }
+
+    override func tearDown() async throws {
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: tempDBPath + suffix)
+        }
+        tempDBPath = nil
+        try await super.tearDown()
+    }
+
+    func testRuntimeStartsWithDatabaseAndInjectionStoreNil() {
+        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
+        XCTAssertNil(runtime.database)
+        XCTAssertNil(runtime.injectionStore)
+        XCTAssertNil(runtime.collector)
+    }
+
+    func testWireRuntimePopulatesDatabaseAndInjectionStore() {
+        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
+        let collector = BrainBarAppSupport.makeStatsCollector(
+            dbPath: tempDBPath,
+            targetPID: ProcessInfo.processInfo.processIdentifier,
+            brainBusEvents: nil
+        )
+        defer { collector.stop() }
+
+        BrainBarAppSupport.wireRuntime(runtime, dbPath: tempDBPath, collector: collector)
+        defer { runtime.injectionStore?.stop() }
+
+        XCTAssertNotNil(
+            runtime.database,
+            "Regression guard: BrainBarApp must not pass nil database to runtime.install — "
+            + "the UI gates 'Warming memory…' / QuickCaptureViewModel on database != nil. "
+            + "See PR #312 (FastAPI daemon removal) — UI process must open SQLite directly."
+        )
+        XCTAssertNotNil(
+            runtime.injectionStore,
+            "Regression guard: BrainBarApp must wire InjectionStore — "
+            + "the Injections tab placeholder shows when injectionStore == nil."
+        )
+        XCTAssertNotNil(runtime.collector)
+    }
+}


### PR DESCRIPTION
## Summary

- Wire `runtime.install()` with a real `BrainDatabase` (readonly) + `InjectionStore` so the BrainBar UI no longer sits forever on the "Warming memory…" / "Injections feed not wired" placeholders.
- Extract a testable `BrainBarAppSupport.wireRuntime(_:dbPath:collector:)` helper.
- Add `BrainBarRuntimeWiringTests` as a regression guard against re-introducing the nil-install pattern.

## Root cause

`brain-bar/Sources/BrainBar/BrainBarApp.swift:71-75` was calling:

```swift
runtime.install(
    collector: collector,
    injectionStore: nil,   // ← hardcoded
    database: nil          // ← hardcoded
)
```

`BrainBarRuntime.database` and `.injectionStore` are `@Published private(set)` and only mutable via `install()`. No other code path ever updated them, so they stayed nil for the app's lifetime. The UI gates on them:

- `BrainBarCommandBar.swift:69` — shows "Warming memory…" when `runtime.database == nil` (via `commandBarViewModel == nil`)
- `BrainBarWindowRootView.swift:120` — shows the "injection feed not wired" loading view when `runtime.injectionStore == nil`

## Regression history

- **fed97bb3 (PR #298)** — refactor split BrainBar daemon + UI; the UI process was supposed to consume the DB via the daemon's socket.
- **692839cc + e609d848 (PR #312, today)** — removed the FastAPI daemon entirely. The UI was left waiting for a daemon that no longer exists. This PR closes the loop by having the UI open SQLite directly.

The log comment `"Socket ready; database will self-heal"` referred to the now-removed daemon; updated to match reality.

## Why readonly for the UI runtime

The UI runtime's `BrainDatabase` only powers dashboard reads, search, and KG view — all read-only. Opening readonly keeps the writer pidfile uncontended with the Python enrich supervisor + drain. `InjectionStore` opens its own internal `BrainDatabase` connection (writable) for ack writes, so capture/ack paths keep working.

## Test plan

- [x] `swift test --filter BrainBarRuntimeWiringTests` — both new tests pass
- [x] `swift test` (full suite) — 380/380 tests pass, 0 failures
- [x] `swift build` — clean
- [ ] Manual: rebuild BrainBar.app, relaunch — command bar should show non-placeholder mode pills within ~1s of launch; Injections tab should populate (or show empty list) instead of the loading view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BrainBar UI startup to open SQLite directly and wire `BrainDatabase`/`InjectionStore`, which can affect launch behavior and database availability (especially on fresh installs or DB-open failures). Risk is moderate due to new initialization ordering and error handling around persistent storage.
> 
> **Overview**
> Fixes BrainBar’s UI startup wiring so the runtime is installed with a real read-only `BrainDatabase` and an `InjectionStore` instead of `nil`, unblocking the UI from staying in “Warming memory…” / “injections not wired” placeholder states.
> 
> Introduces `BrainBarAppSupport.wireRuntime(_:dbPath:collector:)` to centralize initialization (create `InjectionStore` first, then open the read-only DB with a reopen attempt and logging on failure) and updates `BrainBarApp` logging to reflect direct DB usage. Adds `BrainBarRuntimeWiringTests` to regress fresh-install/missing-DB behavior and ensure runtime fields are populated after wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d508f8383b8f00209b189a9a0984b3ff93a01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire database and injection store into BrainBar runtime on app startup
> - Previously, `applicationDidFinishLaunching` called `runtime.install` with `nil` for both the injection store and database; now it delegates to `BrainBarAppSupport.wireRuntime` to populate both.
> - `wireRuntime` in [BrainBarAppSupport.swift](https://github.com/EtanHey/brainlayer/pull/314/files#diff-b34b677756381fb9e0c95f0439bf5bebedb149757e49fdce0d116840899f155f) opens a read-only `BrainDatabase` (with a `reopenIfNeeded` retry on failure) and constructs an `InjectionStore`, then installs them into the runtime along with the collector.
> - Three tests are added in [BrainBarRuntimeWiringTests.swift](https://github.com/EtanHey/brainlayer/pull/314/files#diff-5a3ec4f47d5a8fca3c9eb3accf2a5078ceaa7553e6d59627726c3c0e3a6f7ec2) covering the nil baseline, successful wiring, and wiring when the DB file is missing.
> - Behavioral Change: the runtime now starts with a live database and injection store instead of nils; startup log messages have changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6d508f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->