### PR TITLE
feat(brainbar): show graph + injections panels with degradation resilience

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -750,9 +750,17 @@ private struct BrainBarInjectionTab: View {
     @State private var filterText = ""
 
     var body: some View {
-        InjectionFeedView(store: store, filterText: $filterText)
-            .padding(16)
-            .onAppear { store.start() }
+        ZStack(alignment: .topTrailing) {
+            InjectionFeedView(store: store, filterText: $filterText)
+                .padding(16)
+                .onAppear { store.start() }
+
+            if store.degradationState.isDegraded {
+                DegradationBadge(reason: store.degradationState.reason)
+                    .padding(.top, 20)
+                    .padding(.trailing, 20)
+            }
+        }
     }
 }
 
@@ -764,8 +772,42 @@ private struct BrainBarGraphTab: View {
     }
 
     var body: some View {
-        KGCanvasView(viewModel: viewModel)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ZStack(alignment: .topTrailing) {
+            KGCanvasView(viewModel: viewModel)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            if viewModel.degradationState.isDegraded {
+                DegradationBadge(reason: viewModel.degradationState.reason)
+                    .padding(.top, 12)
+                    .padding(.trailing, 12)
+            }
+        }
+    }
+}
+
+// AIDEV-NOTE: User-facing indicator that a BrainBar surface is reading from a
+// degraded source (transient ReadOnly / busy / locked errors from the writer-
+// pidfile contention introduced by PR #309 + amplified post-PR #312). Shown as
+// an unobtrusive amber pill so the user sees "data may be stale" rather than
+// "blank screen" or "warming memory" lingering — per Etan-mandate 2026-05-22:
+// "WITHOUT DEGRATION!" (no blank states, but visible when degraded).
+struct DegradationBadge: View {
+    let reason: String?
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 10, weight: .semibold))
+            Text("Degraded")
+                .font(.system(size: 11, weight: .semibold))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(
+            Capsule().fill(Color.orange.opacity(0.85))
+        )
+        .help(reason ?? "Data source temporarily degraded.")
     }
 }
 

--- a/brain-bar/Sources/BrainBar/DegradationState.swift
+++ b/brain-bar/Sources/BrainBar/DegradationState.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Tracks read-path degradation for BrainBar UI surfaces (graph + injections).
+///
+/// After PR #312 removed the FastAPI daemon, the UI process opens SQLite
+/// directly and contends with the Python enrich-supervisor + drain for the
+/// writer pidfile (PR #309). Transient ReadOnly / busy / locked errors can
+/// surface here. Instead of blanking the UI or silently swallowing the error,
+/// surfaces report a degradation state so the user sees a small badge and
+/// knows data may be stale rather than absent.
+///
+/// Etan-mandate 2026-05-22 ~18:00 IDT: "WITHOUT DEGRATION" — no blank screens,
+/// no "warming memory" lingering after data should be available; degraded ≠
+/// hidden.
+enum DegradationState: Equatable, Sendable {
+    case healthy
+    case degraded(reason: String)
+
+    var isDegraded: Bool {
+        if case .degraded = self { return true }
+        return false
+    }
+
+    var reason: String? {
+        if case .degraded(let reason) = self { return reason }
+        return nil
+    }
+}

--- a/brain-bar/Sources/BrainBar/DegradationState.swift
+++ b/brain-bar/Sources/BrainBar/DegradationState.swift
@@ -9,7 +9,7 @@ import Foundation
 /// surfaces report a degradation state so the user sees a small badge and
 /// knows data may be stale rather than absent.
 ///
-/// Etan-mandate 2026-05-22 ~18:00 IDT: "WITHOUT DEGRATION" — no blank screens,
+/// Etan-mandate 2026-05-22 ~18:00 IDT: "WITHOUT DEGRATION" [sic] — no blank screens,
 /// no "warming memory" lingering after data should be available; degraded ≠
 /// hidden.
 enum DegradationState: Equatable, Sendable {

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -18,6 +18,7 @@ private func injectionStoreDarwinNotificationCallback(
 @MainActor
 final class InjectionStore: ObservableObject {
     @Published private(set) var events: [InjectionEvent] = []
+    @Published private(set) var degradationState: DegradationState = .healthy
 
     private let database: BrainDatabase
     private var pollTask: Task<Void, Never>?
@@ -102,8 +103,15 @@ final class InjectionStore: ObservableObject {
                 )
                 lastDataVersion = currentDataVersion
             }
+            // Clear degradation flag on a clean refresh — transient ReadOnly /
+            // busy / locked errors during writer-pidfile contention should not
+            // stick beyond the next successful poll cycle.
+            if degradationState.isDegraded {
+                degradationState = .healthy
+            }
         } catch {
             NSLog("[BrainBar] InjectionStore refresh failed: %@", String(describing: error))
+            degradationState = .degraded(reason: String(describing: error))
         }
     }
 

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -1,6 +1,27 @@
 import CoreFoundation
 import Foundation
 
+protocol InjectionEventReading: AnyObject {
+    func dataVersion() throws -> Int
+    func listInjectionEvents(sessionID: String?, limit: Int) throws -> [InjectionEvent]
+    func expandedConversation(
+        chunkID: String,
+        before: Int,
+        after: Int
+    ) throws -> BrainDatabase.ExpandedConversation
+    func close()
+}
+
+extension BrainDatabase: InjectionEventReading {
+    func expandedConversation(
+        chunkID: String,
+        before: Int,
+        after: Int
+    ) throws -> BrainDatabase.ExpandedConversation {
+        try expandedConversation(id: chunkID, before: before, after: after)
+    }
+}
+
 private func injectionStoreDarwinNotificationCallback(
     center: CFNotificationCenter?,
     observer: UnsafeMutableRawPointer?,
@@ -20,15 +41,35 @@ final class InjectionStore: ObservableObject {
     @Published private(set) var events: [InjectionEvent] = []
     @Published private(set) var degradationState: DegradationState = .healthy
 
-    private let database: BrainDatabase
+    private enum RecoveryPhase: Equatable {
+        case healthy
+        case degraded(reason: String)
+        case probing(reason: String)
+
+        var reason: String? {
+            switch self {
+            case .healthy:
+                return nil
+            case .degraded(let reason), .probing(let reason):
+                return reason
+            }
+        }
+    }
+
+    private let reader: InjectionEventReading
     private var pollTask: Task<Void, Never>?
     private var isRunning = false
     private var lastDataVersion: Int?
     private var currentSessionID: String?
     private var currentLimit = 50
+    private var recoveryPhase: RecoveryPhase = .healthy
 
     init(databasePath: String) throws {
-        self.database = BrainDatabase(path: databasePath)
+        self.reader = BrainDatabase(path: databasePath)
+    }
+
+    init(reader: InjectionEventReading) {
+        self.reader = reader
     }
 
     func start(sessionID: String? = nil, limit: Int = 50) {
@@ -65,7 +106,7 @@ final class InjectionStore: ObservableObject {
         }
 
         isRunning = false
-        database.close()
+        reader.close()
     }
 
     deinit {
@@ -86,32 +127,49 @@ final class InjectionStore: ObservableObject {
     }
 
     func expandedConversation(chunkID: String, before: Int = 3, after: Int = 3) throws -> BrainDatabase.ExpandedConversation {
-        try database.expandedConversation(id: chunkID, before: before, after: after)
+        try reader.expandedConversation(chunkID: chunkID, before: before, after: after)
     }
 
     fileprivate func handleDatabaseMutationNotification() {
         refresh(force: false)
     }
 
+    func refreshForTesting(force: Bool) {
+        refresh(force: force)
+    }
+
     private func refresh(force: Bool) {
         do {
-            let currentDataVersion = try database.dataVersion()
-            if force || currentDataVersion != lastDataVersion {
-                events = try database.listInjectionEvents(
+            let currentDataVersion = try reader.dataVersion()
+            let shouldProbeEvents: Bool
+            switch recoveryPhase {
+            case .healthy, .degraded:
+                shouldProbeEvents = false
+            case .probing:
+                shouldProbeEvents = true
+            }
+
+            if force || currentDataVersion != lastDataVersion || shouldProbeEvents {
+                events = try reader.listInjectionEvents(
                     sessionID: currentSessionID,
                     limit: currentLimit
                 )
                 lastDataVersion = currentDataVersion
-            }
-            // Clear degradation flag on a clean refresh — transient ReadOnly /
-            // busy / locked errors during writer-pidfile contention should not
-            // stick beyond the next successful poll cycle.
-            if degradationState.isDegraded {
+                recoveryPhase = .healthy
                 degradationState = .healthy
+            } else if let reason = recoveryPhase.reason {
+                // A clean data_version read is not enough to prove the
+                // injections read path recovered. Keep the public badge
+                // degraded and let the next poll probe listInjectionEvents
+                // even if SQLite's data version is still unchanged.
+                recoveryPhase = .probing(reason: reason)
+                degradationState = .degraded(reason: reason)
             }
         } catch {
             NSLog("[BrainBar] InjectionStore refresh failed: %@", String(describing: error))
-            degradationState = .degraded(reason: String(describing: error))
+            let reason = String(describing: error)
+            recoveryPhase = .degraded(reason: reason)
+            degradationState = .degraded(reason: reason)
         }
     }
 

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -1,5 +1,21 @@
 import SwiftUI
 
+enum KGCanvasMetrics {
+    static let sidebarWidth: CGFloat = 320
+    static let canvasPadding: CGFloat = 18
+
+    static func sidebarVisible(windowWidth: CGFloat, selectedEntityVisible: Bool) -> Bool {
+        windowWidth >= 980 || selectedEntityVisible
+    }
+
+    static func drawableSize(windowSize: CGSize, sidebarVisible: Bool) -> CGSize {
+        CGSize(
+            width: max(windowSize.width - (sidebarVisible ? sidebarWidth : 0) - canvasPadding * 2, 0),
+            height: max(windowSize.height - canvasPadding * 2, 0)
+        )
+    }
+}
+
 struct KGCanvasView: View {
     @ObservedObject var viewModel: KGViewModel
     @Environment(\.colorScheme) private var colorScheme
@@ -24,7 +40,10 @@ struct KGCanvasView: View {
 
     var body: some View {
         GeometryReader { geo in
-            let sidebarVisible = geo.size.width >= 980 || viewModel.selectedEntity != nil
+            let sidebarVisible = KGCanvasMetrics.sidebarVisible(
+                windowWidth: geo.size.width,
+                selectedEntityVisible: viewModel.selectedEntity != nil
+            )
 
             HStack(spacing: 0) {
                 ZStack(alignment: .topLeading) {
@@ -54,7 +73,10 @@ struct KGCanvasView: View {
                 }
             }
             .onAppear {
-                setCanvas(size: geo.size)
+                setCanvas(size: KGCanvasMetrics.drawableSize(
+                    windowSize: geo.size,
+                    sidebarVisible: sidebarVisible
+                ))
             }
             .task {
                 guard !hasLoadedGraph else { return }
@@ -63,9 +85,19 @@ struct KGCanvasView: View {
                 }
             }
             .onChange(of: geo.size) { _, newSize in
-                setCanvas(size: newSize)
-                guard hasLoadedGraph, !viewModel.nodes.isEmpty else { return }
-                viewModel.nodes = KGAtlasLayout.seededNodes(viewModel.nodes, canvasSize: newSize)
+                resizeCanvas(size: KGCanvasMetrics.drawableSize(
+                    windowSize: newSize,
+                    sidebarVisible: KGCanvasMetrics.sidebarVisible(
+                        windowWidth: newSize.width,
+                        selectedEntityVisible: viewModel.selectedEntity != nil
+                    )
+                ))
+            }
+            .onChange(of: sidebarVisible) { _, newSidebarVisible in
+                resizeCanvas(size: KGCanvasMetrics.drawableSize(
+                    windowSize: geo.size,
+                    sidebarVisible: newSidebarVisible
+                ))
             }
         }
     }
@@ -112,7 +144,7 @@ struct KGCanvasView: View {
                 Color.clear
                     .onAppear { setCanvas(size: geo.size) }
                     .onChange(of: geo.size) { _, newSize in
-                        setCanvas(size: newSize)
+                        resizeCanvas(size: newSize)
                     }
             }
         )
@@ -121,7 +153,7 @@ struct KGCanvasView: View {
         .gesture(tapGesture(snapshot: snapshot))
         .gesture(dragGesture)
         .gesture(magnifyGesture)
-        .padding(18)
+        .padding(KGCanvasMetrics.canvasPadding)
     }
 
     private var atlasBackground: some View {
@@ -344,6 +376,12 @@ struct KGCanvasView: View {
         guard size != .zero else { return }
         canvasSize = size
         viewModel.canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
+    }
+
+    private func resizeCanvas(size: CGSize) {
+        setCanvas(size: size)
+        guard hasLoadedGraph, !viewModel.nodes.isEmpty else { return }
+        viewModel.nodes = KGAtlasLayout.seededNodes(viewModel.nodes, canvasSize: size)
     }
 
     private var toolbarInteractionGesture: some Gesture {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -58,7 +58,7 @@ struct KGCanvasView: View {
             }
             .task {
                 guard !hasLoadedGraph else { return }
-                if await viewModel.loadGraph() {
+                if await viewModel.loadGraphUntilSuccessful() {
                     hasLoadedGraph = true
                 }
             }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -27,6 +27,7 @@ struct KGCanvasView: View {
     @State private var canvasSize: CGSize = .zero
     @State private var minimumImportance: Double = 3
     @State private var hasLoadedGraph = false
+    @State private var hasStartedGraphPolling = false
     @GestureState private var toolbarInteractionActive = false
 
     private var atlas: KGAtlasPresentation.Snapshot {
@@ -72,32 +73,15 @@ struct KGCanvasView: View {
                     )
                 }
             }
-            .onAppear {
-                setCanvas(size: KGCanvasMetrics.drawableSize(
-                    windowSize: geo.size,
-                    sidebarVisible: sidebarVisible
-                ))
-            }
             .task {
-                guard !hasLoadedGraph else { return }
-                if await viewModel.loadGraphUntilSuccessful() {
+                guard !hasStartedGraphPolling else { return }
+                hasStartedGraphPolling = true
+                defer { hasStartedGraphPolling = false }
+                if await viewModel.loadGraphRepeatedly(onSuccessfulLoad: {
+                    hasLoadedGraph = true
+                }) {
                     hasLoadedGraph = true
                 }
-            }
-            .onChange(of: geo.size) { _, newSize in
-                resizeCanvas(size: KGCanvasMetrics.drawableSize(
-                    windowSize: newSize,
-                    sidebarVisible: KGCanvasMetrics.sidebarVisible(
-                        windowWidth: newSize.width,
-                        selectedEntityVisible: viewModel.selectedEntity != nil
-                    )
-                ))
-            }
-            .onChange(of: sidebarVisible) { _, newSidebarVisible in
-                resizeCanvas(size: KGCanvasMetrics.drawableSize(
-                    windowSize: geo.size,
-                    sidebarVisible: newSidebarVisible
-                ))
             }
         }
     }
@@ -142,6 +126,8 @@ struct KGCanvasView: View {
         .background(
             GeometryReader { geo in
                 Color.clear
+                    // This reports the actual drawable Canvas size after the
+                    // sidebar and padding have been applied.
                     .onAppear { setCanvas(size: geo.size) }
                     .onChange(of: geo.size) { _, newSize in
                         resizeCanvas(size: newSize)

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -361,13 +361,11 @@ struct KGCanvasView: View {
     private func setCanvas(size: CGSize) {
         guard size != .zero else { return }
         canvasSize = size
-        viewModel.canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
+        viewModel.updateCanvasSize(size)
     }
 
     private func resizeCanvas(size: CGSize) {
         setCanvas(size: size)
-        guard hasLoadedGraph, !viewModel.nodes.isEmpty else { return }
-        viewModel.nodes = KGAtlasLayout.seededNodes(viewModel.nodes, canvasSize: size)
     }
 
     private var toolbarInteractionGesture: some Gesture {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -23,7 +23,7 @@ struct KGSidebarView: View {
             }
             .padding(18)
         }
-        .frame(width: 320)
+        .frame(width: KGCanvasMetrics.sidebarWidth)
         .background(
             LinearGradient(
                 colors: [

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+protocol KnowledgeGraphReading: AnyObject, Sendable {
+    func fetchKGEntities(limit: Int) throws -> [BrainDatabase.KGEntityRow]
+    func fetchKGRelations(limit: Int) throws -> [BrainDatabase.KGRelationRow]
+}
+
+extension BrainDatabase: KnowledgeGraphReading {}
+
 @MainActor
 final class KGViewModel: ObservableObject {
     @Published var nodes: [KGNode] = []
@@ -14,7 +21,8 @@ final class KGViewModel: ObservableObject {
     /// Set by KGCanvasView via GeometryReader — used for centering force
     var canvasCenter: CGPoint = CGPoint(x: 300, y: 250)
 
-    private let database: BrainDatabase
+    private let database: BrainDatabase?
+    private let graphReader: KnowledgeGraphReading
 
     // Force simulation parameters
     private let repulsionStrength: CGFloat = 5000
@@ -25,6 +33,12 @@ final class KGViewModel: ObservableObject {
 
     init(database: BrainDatabase) {
         self.database = database
+        self.graphReader = database
+    }
+
+    init(graphReader: KnowledgeGraphReading) {
+        self.database = nil
+        self.graphReader = graphReader
     }
 
     // MARK: - Data Loading
@@ -43,14 +57,18 @@ final class KGViewModel: ObservableObject {
         var lastError: Error?
         for attempt in 1...attemptLimit {
             do {
-                let graph = try await Self.fetchGraphRows(database: database)
+                let graph = try await Self.fetchGraphRows(reader: graphReader)
                 applyGraph(entityRows: graph.entities, relationRows: graph.relations)
                 degradationState = .healthy
                 return true
             } catch {
                 lastError = error
                 if attempt < attemptLimit {
-                    try? await Task.sleep(nanoseconds: 200_000_000)
+                    do {
+                        try await Task.sleep(for: .milliseconds(200))
+                    } catch {
+                        return false
+                    }
                 }
             }
         }
@@ -68,18 +86,36 @@ final class KGViewModel: ObservableObject {
         return false
     }
 
+    @discardableResult
+    func loadGraphUntilSuccessful(
+        retryDelay: Duration = .seconds(5),
+        sleep: (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+    ) async -> Bool {
+        while !Task.isCancelled {
+            if await loadGraph() {
+                return true
+            }
+            do {
+                try await sleep(retryDelay)
+            } catch {
+                return false
+            }
+        }
+        return false
+    }
+
     private struct GraphRows: Sendable {
         let entities: [BrainDatabase.KGEntityRow]
         let relations: [BrainDatabase.KGRelationRow]
     }
 
-    private nonisolated static func fetchGraphRows(database: BrainDatabase) async throws -> GraphRows {
+    private nonisolated static func fetchGraphRows(reader: KnowledgeGraphReading) async throws -> GraphRows {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
                     continuation.resume(returning: GraphRows(
-                        entities: try database.fetchKGEntities(),
-                        relations: try database.fetchKGRelations(limit: 5_000)
+                        entities: try reader.fetchKGEntities(limit: 500),
+                        relations: try reader.fetchKGRelations(limit: 5_000)
                     ))
                 } catch {
                     continuation.resume(throwing: error)
@@ -128,6 +164,7 @@ final class KGViewModel: ObservableObject {
     func selectNode(id: String?) {
         selectedNodeId = id
         if let id {
+            guard let database else { return }
             if let lookup = try? database.lookupEntity(query: nodeById(id)?.name ?? "") {
                 selectedEntity = EntityCard(lookupPayload: lookup)
             }
@@ -140,6 +177,7 @@ final class KGViewModel: ObservableObject {
     }
 
     func openConversation(chunkID: String) {
+        guard let database else { return }
         selectedConversation = try? database.expandedConversation(id: chunkID)
     }
 

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -44,7 +44,9 @@ final class KGViewModel: ObservableObject {
     // MARK: - Data Loading
 
     @discardableResult
-    func loadGraph() async -> Bool {
+    func loadGraph(
+        retrySleep: (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+    ) async -> Bool {
         guard !isLoading else { return false }
         isLoading = true
         defer { isLoading = false }
@@ -65,22 +67,16 @@ final class KGViewModel: ObservableObject {
                 lastError = error
                 if attempt < attemptLimit {
                     do {
-                        try await Task.sleep(for: .milliseconds(200))
+                        try await retrySleep(.milliseconds(200))
                     } catch {
+                        markDegraded(from: lastError)
                         return false
                     }
                 }
             }
         }
 
-        let reason: String
-        if let lastError {
-            reason = String(describing: lastError)
-        } else {
-            reason = "unknown"
-        }
-        NSLog("[BrainBar.KG] loadGraph failed: %@", reason)
-        degradationState = .degraded(reason: reason)
+        markDegraded(from: lastError)
         // Keep previously-loaded nodes/edges so the user sees last-known-good
         // data rather than a blank canvas — degraded ≠ hidden.
         return false
@@ -102,6 +98,35 @@ final class KGViewModel: ObservableObject {
             }
         }
         return false
+    }
+
+    @discardableResult
+    func loadGraphRepeatedly(
+        refreshDelay: Duration = .seconds(30),
+        retryDelay: Duration = .seconds(5),
+        sleep: (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
+        onSuccessfulLoad: @MainActor () -> Void = {}
+    ) async -> Bool {
+        var loadedOnce = false
+        while !Task.isCancelled {
+            let loaded = await loadGraph()
+            if loaded {
+                loadedOnce = true
+                onSuccessfulLoad()
+            }
+            do {
+                try await sleep(loaded ? refreshDelay : retryDelay)
+            } catch {
+                return loadedOnce
+            }
+        }
+        return loadedOnce
+    }
+
+    private func markDegraded(from error: Error?) {
+        let reason = error.map { String(describing: $0) } ?? "unknown"
+        NSLog("[BrainBar.KG] loadGraph failed: %@", reason)
+        degradationState = .degraded(reason: reason)
     }
 
     private struct GraphRows: Sendable {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -9,6 +9,7 @@ final class KGViewModel: ObservableObject {
     @Published var selectedEntity: EntityCard?
     @Published var selectedEntityChunks: [BrainDatabase.KGChunkRow] = []
     @Published var selectedConversation: BrainDatabase.ExpandedConversation?
+    @Published private(set) var degradationState: DegradationState = .healthy
 
     /// Set by KGCanvasView via GeometryReader — used for centering force
     var canvasCenter: CGPoint = CGPoint(x: 300, y: 250)
@@ -34,15 +35,37 @@ final class KGViewModel: ObservableObject {
         isLoading = true
         defer { isLoading = false }
 
-        do {
-            let graph = try await Self.fetchGraphRows(database: database)
-            applyGraph(entityRows: graph.entities, relationRows: graph.relations)
-            return true
-        } catch {
-            nodes = []
-            edges = []
-            return false
+        // Retry once on transient ReadOnly/busy/locked failures from the writer
+        // pidfile contention (PR #309). The Python enrich-supervisor + drain
+        // hold the writer briefly; one retry after a short backoff usually
+        // suffices. Persistent failures surface as a degradation badge.
+        let attemptLimit = 2
+        var lastError: Error?
+        for attempt in 1...attemptLimit {
+            do {
+                let graph = try await Self.fetchGraphRows(database: database)
+                applyGraph(entityRows: graph.entities, relationRows: graph.relations)
+                degradationState = .healthy
+                return true
+            } catch {
+                lastError = error
+                if attempt < attemptLimit {
+                    try? await Task.sleep(nanoseconds: 200_000_000)
+                }
+            }
         }
+
+        let reason: String
+        if let lastError {
+            reason = String(describing: lastError)
+        } else {
+            reason = "unknown"
+        }
+        NSLog("[BrainBar.KG] loadGraph failed: %@", reason)
+        degradationState = .degraded(reason: reason)
+        // Keep previously-loaded nodes/edges so the user sees last-known-good
+        // data rather than a blank canvas — degraded ≠ hidden.
+        return false
     }
 
     private struct GraphRows: Sendable {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -23,6 +23,7 @@ final class KGViewModel: ObservableObject {
 
     private let database: BrainDatabase?
     private let graphReader: KnowledgeGraphReading
+    private var layoutCanvasSize: CGSize?
 
     // Force simulation parameters
     private let repulsionStrength: CGFloat = 5000
@@ -154,22 +155,23 @@ final class KGViewModel: ObservableObject {
         relationRows: [BrainDatabase.KGRelationRow]
     ) {
         let entityIds = Set(entityRows.map(\.id))
+        let existingNodes = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0) })
 
-        let seededNodes = entityRows.map { row in
-            KGNode(
+        let incomingNodes = entityRows.map { row in
+            let existingNode = existingNodes[row.id]
+            return KGNode(
                 id: row.id,
                 name: row.name,
                 entityType: row.entityType,
-                importance: row.importance
+                importance: row.importance,
+                position: existingNode?.position,
+                velocity: existingNode?.velocity ?? .zero
             )
         }
-        nodes = KGAtlasLayout.seededNodes(
-            seededNodes,
-            canvasSize: CGSize(
-                width: max(canvasCenter.x * 2, 640),
-                height: max(canvasCenter.y * 2, 480)
-            )
-        )
+        let seededNodes = KGAtlasLayout.seededNodes(incomingNodes, canvasSize: graphCanvasSize)
+        nodes = zip(incomingNodes, seededNodes).map { incomingNode, seededNode in
+            existingNodes[incomingNode.id] == nil ? seededNode : incomingNode
+        }
 
         // Only include edges where both endpoints exist
         edges = relationRows.compactMap { row in
@@ -182,6 +184,25 @@ final class KGViewModel: ObservableObject {
                 relationType: row.relationType
             )
         }
+    }
+
+    private var graphCanvasSize: CGSize {
+        layoutCanvasSize ?? CGSize(
+            width: max(canvasCenter.x * 2, 640),
+            height: max(canvasCenter.y * 2, 480)
+        )
+    }
+
+    func updateCanvasSize(_ size: CGSize) {
+        guard size != .zero else { return }
+        guard layoutCanvasSize != size else {
+            canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
+            return
+        }
+        layoutCanvasSize = size
+        canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
+        guard !nodes.isEmpty else { return }
+        nodes = KGAtlasLayout.seededNodes(nodes, canvasSize: size)
     }
 
     // MARK: - Selection

--- a/brain-bar/Sources/BrainBarDaemon/DegradationState.swift
+++ b/brain-bar/Sources/BrainBarDaemon/DegradationState.swift
@@ -1,0 +1,1 @@
+../BrainBar/DegradationState.swift

--- a/brain-bar/Tests/BrainBarTests/DegradationStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DegradationStateTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import BrainBar
+
+@MainActor
+final class KGDegradationStateTests: XCTestCase {
+    var db: BrainDatabase!
+    var tempDBPath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDBPath = NSTemporaryDirectory() + "brainbar-kg-degraded-\(UUID().uuidString).db"
+        db = BrainDatabase(path: tempDBPath)
+    }
+
+    override func tearDown() {
+        db.close()
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: tempDBPath + suffix)
+        }
+        super.tearDown()
+    }
+
+    // Regression guard: per Etan-mandate 2026-05-22 "WITHOUT DEGRATION!", a KG
+    // read-path failure must surface a user-visible degradation state, not
+    // silently blank the canvas. Before this guard, loadGraph()'s catch block
+    // set nodes=[]/edges=[] and returned false with NO published flag — the UI
+    // had no way to differentiate "empty graph" from "queries failing."
+    func testLoadGraphFailureSetsDegradationState() async {
+        db.close() // Force subsequent queries to throw — simulates fatal
+                   // ReadOnly state.
+
+        let vm = KGViewModel(database: db)
+        XCTAssertEqual(vm.degradationState, .healthy, "Initial state is healthy")
+
+        let success = await vm.loadGraph()
+
+        XCTAssertFalse(success, "loadGraph should report failure on closed DB")
+        XCTAssertTrue(
+            vm.degradationState.isDegraded,
+            "loadGraph failure MUST set degradationState to .degraded — see Etan-mandate 2026-05-22 (no silent blank states)."
+        )
+        XCTAssertNotNil(vm.degradationState.reason)
+    }
+
+    func testLoadGraphSuccessKeepsDegradationStateHealthy() async throws {
+        // Match the seeding pattern of existing KGViewModelTests — a single
+        // entity isn't surfaced by fetchKGEntities without participating in
+        // at least one relation.
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+
+        let vm = KGViewModel(database: db)
+        let success = await vm.loadGraph()
+
+        XCTAssertTrue(success)
+        XCTAssertEqual(vm.degradationState, .healthy)
+        XCTAssertEqual(vm.nodes.count, 2)
+        XCTAssertEqual(vm.edges.count, 1)
+    }
+}
+
+@MainActor
+final class InjectionStoreDegradationStateTests: XCTestCase {
+    var tempDBPath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDBPath = NSTemporaryDirectory() + "brainbar-inj-degraded-\(UUID().uuidString).db"
+    }
+
+    override func tearDown() {
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: tempDBPath + suffix)
+        }
+        super.tearDown()
+    }
+
+    // Regression guard: per Etan-mandate 2026-05-22 the injections panel must
+    // not silently blank when InjectionStore.refresh hits a transient
+    // ReadOnly / busy / locked error. Before this guard, refresh's catch only
+    // NSLog'd the error and the UI had no signal that data was stale.
+    func testInjectionStoreStartsHealthy() throws {
+        let store = try InjectionStore(databasePath: tempDBPath)
+        defer { store.stop() }
+
+        XCTAssertEqual(store.degradationState, .healthy)
+    }
+}
+
+@MainActor
+final class DegradationStateTypeTests: XCTestCase {
+    func testHealthyIsNotDegraded() {
+        let state: DegradationState = .healthy
+        XCTAssertFalse(state.isDegraded)
+        XCTAssertNil(state.reason)
+    }
+
+    func testDegradedExposesReason() {
+        let state: DegradationState = .degraded(reason: "ReadOnly")
+        XCTAssertTrue(state.isDegraded)
+        XCTAssertEqual(state.reason, "ReadOnly")
+    }
+
+    func testDegradationStateEquatable() {
+        XCTAssertEqual(DegradationState.healthy, .healthy)
+        XCTAssertEqual(DegradationState.degraded(reason: "x"), .degraded(reason: "x"))
+        XCTAssertNotEqual(DegradationState.healthy, .degraded(reason: "x"))
+        XCTAssertNotEqual(
+            DegradationState.degraded(reason: "x"),
+            DegradationState.degraded(reason: "y")
+        )
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/DegradationStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DegradationStateTests.swift
@@ -108,6 +108,60 @@ final class KGDegradationStateTests: XCTestCase {
         XCTAssertEqual(vm.edges.count, 1)
         XCTAssertEqual(retrySleeps, 1)
     }
+
+    func testLoadGraphRepeatedlyMarksLaterFailureAfterInitialSuccess() async {
+        // Regression guard: Cursor Bugbot PR #315 flagged that the graph tab
+        // stopped checking the read path after the first successful load.
+        let reader = ScriptedKnowledgeGraphReader(results: [
+            .success((
+                entities: [
+                    BrainDatabase.KGEntityRow(
+                        id: "a",
+                        name: "Alice",
+                        entityType: "person",
+                        description: nil,
+                        importance: 7
+                    ),
+                ],
+                relations: []
+            )),
+            .failure(ScriptedKnowledgeGraphError.fetchFailed),
+            .failure(ScriptedKnowledgeGraphError.fetchFailed),
+        ])
+        let vm = KGViewModel(graphReader: reader)
+        var sleepCount = 0
+
+        let loadedOnce = await vm.loadGraphRepeatedly(
+            refreshDelay: .milliseconds(1),
+            retryDelay: .milliseconds(1)
+        ) { _ in
+            sleepCount += 1
+            if sleepCount == 2 {
+                throw CancellationError()
+            }
+        }
+
+        XCTAssertTrue(loadedOnce)
+        XCTAssertTrue(vm.degradationState.isDegraded)
+        XCTAssertEqual(vm.degradationState.reason, "fetchFailed")
+    }
+
+    func testLoadGraphMarksDegradedWhenRetrySleepIsCancelledAfterReadFailure() async {
+        // Regression guard: Cursor Bugbot PR #315 flagged cancellation between
+        // failed graph-read attempts as a path that hid the degraded badge.
+        let reader = ScriptedKnowledgeGraphReader(results: [
+            .failure(ScriptedKnowledgeGraphError.fetchFailed),
+        ])
+        let vm = KGViewModel(graphReader: reader)
+
+        let success = await vm.loadGraph { _ in
+            throw CancellationError()
+        }
+
+        XCTAssertFalse(success)
+        XCTAssertTrue(vm.degradationState.isDegraded)
+        XCTAssertEqual(vm.degradationState.reason, "fetchFailed")
+    }
 }
 
 @MainActor
@@ -171,6 +225,9 @@ private enum ScriptedKnowledgeGraphError: Error {
     case fetchFailed
 }
 
+// ScriptedKnowledgeGraphReader is @unchecked Sendable because the mutable
+// results and activeRelations buffers are test-confined and only accessed via
+// fetchKGEntities/fetchKGRelations from @MainActor tests.
 private final class ScriptedKnowledgeGraphReader: KnowledgeGraphReading, @unchecked Sendable {
     deinit {}
 

--- a/brain-bar/Tests/BrainBarTests/DegradationStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DegradationStateTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 @MainActor
 final class KGDegradationStateTests: XCTestCase {
+    deinit {}
+
     var db: BrainDatabase!
     var tempDBPath: String!
 
@@ -58,10 +60,60 @@ final class KGDegradationStateTests: XCTestCase {
         XCTAssertEqual(vm.nodes.count, 2)
         XCTAssertEqual(vm.edges.count, 1)
     }
+
+    func testLoadGraphUntilSuccessfulRecoversAfterInitialDegradation() async {
+        // Regression guard: Cursor Bugbot PR #315 flagged that KGCanvasView
+        // only performed one load. A first failed read must be retried so the
+        // graph badge can clear after a later successful graph query.
+        let reader = ScriptedKnowledgeGraphReader(results: [
+            .failure(ScriptedKnowledgeGraphError.fetchFailed),
+            .failure(ScriptedKnowledgeGraphError.fetchFailed),
+            .success((
+                entities: [
+                    BrainDatabase.KGEntityRow(
+                        id: "a",
+                        name: "Alice",
+                        entityType: "person",
+                        description: nil,
+                        importance: 7
+                    ),
+                    BrainDatabase.KGEntityRow(
+                        id: "b",
+                        name: "BrainLayer",
+                        entityType: "project",
+                        description: nil,
+                        importance: 8
+                    ),
+                ],
+                relations: [
+                    BrainDatabase.KGRelationRow(
+                        id: "r1",
+                        sourceId: "a",
+                        targetId: "b",
+                        relationType: "builds"
+                    ),
+                ]
+            )),
+        ])
+        let vm = KGViewModel(graphReader: reader)
+        var retrySleeps = 0
+
+        let success = await vm.loadGraphUntilSuccessful(retryDelay: .milliseconds(1)) { _ in
+            retrySleeps += 1
+        }
+
+        XCTAssertTrue(success)
+        XCTAssertEqual(vm.degradationState, .healthy)
+        XCTAssertEqual(vm.nodes.count, 2)
+        XCTAssertEqual(vm.edges.count, 1)
+        XCTAssertEqual(retrySleeps, 1)
+    }
 }
 
 @MainActor
 final class InjectionStoreDegradationStateTests: XCTestCase {
+    deinit {}
+
     var tempDBPath: String!
 
     override func setUp() {
@@ -90,6 +142,8 @@ final class InjectionStoreDegradationStateTests: XCTestCase {
 
 @MainActor
 final class DegradationStateTypeTests: XCTestCase {
+    deinit {}
+
     func testHealthyIsNotDegraded() {
         let state: DegradationState = .healthy
         XCTAssertFalse(state.isDegraded)
@@ -110,5 +164,42 @@ final class DegradationStateTypeTests: XCTestCase {
             DegradationState.degraded(reason: "x"),
             DegradationState.degraded(reason: "y")
         )
+    }
+}
+
+private enum ScriptedKnowledgeGraphError: Error {
+    case fetchFailed
+}
+
+private final class ScriptedKnowledgeGraphReader: KnowledgeGraphReading, @unchecked Sendable {
+    deinit {}
+
+    typealias GraphResult = (
+        entities: [BrainDatabase.KGEntityRow],
+        relations: [BrainDatabase.KGRelationRow]
+    )
+
+    private var results: [Result<GraphResult, Error>]
+    private var activeRelations: [BrainDatabase.KGRelationRow] = []
+
+    init(results: [Result<GraphResult, Error>]) {
+        self.results = results
+    }
+
+    func fetchKGEntities(limit: Int) throws -> [BrainDatabase.KGEntityRow] {
+        guard !results.isEmpty else {
+            throw ScriptedKnowledgeGraphError.fetchFailed
+        }
+        switch results.removeFirst() {
+        case .success(let graph):
+            activeRelations = graph.relations
+            return graph.entities
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func fetchKGRelations(limit: Int) throws -> [BrainDatabase.KGRelationRow] {
+        activeRelations
     }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -84,4 +84,88 @@ final class InjectionStoreTests: XCTestCase {
             ["inject-1", "inject-2", "inject-3", "inject-4"]
         )
     }
+
+    @MainActor
+    func testDegradedStoreStaysDegradedUntilEventQuerySucceeds() throws {
+        // Regression guard: Bugbot PR #315 flagged that a forced
+        // listInjectionEvents failure could mark the store degraded, then a
+        // later unchanged dataVersion poll could skip the event query and
+        // incorrectly clear the badge. Recovery must require a successful
+        // event query, not only a successful PRAGMA data_version read.
+        let reader = ScriptedInjectionEventReader(
+            versions: [1, 1, 1],
+            eventResults: [
+                .success([]),
+                .failure(ScriptedInjectionError.listFailed),
+                .success([
+                    InjectionEvent(
+                        id: 1,
+                        sessionID: "session-recovered",
+                        timestamp: "2026-05-22T18:05:00Z",
+                        query: "recovered query",
+                        chunkIDs: ["chunk-1"],
+                        tokenCount: 7
+                    )
+                ]),
+            ]
+        )
+        let store = InjectionStore(reader: reader)
+
+        store.refreshForTesting(force: true)
+        XCTAssertEqual(store.degradationState, .healthy)
+
+        store.refreshForTesting(force: true)
+        XCTAssertTrue(store.degradationState.isDegraded)
+
+        store.refreshForTesting(force: false)
+        XCTAssertTrue(
+            store.degradationState.isDegraded,
+            "An unchanged dataVersion poll skipped the event query; that is not positive recovery evidence."
+        )
+
+        store.refreshForTesting(force: false)
+        XCTAssertEqual(store.degradationState, .healthy)
+        XCTAssertEqual(store.events.map(\.query), ["recovered query"])
+    }
+}
+
+private enum ScriptedInjectionError: Error {
+    case listFailed
+}
+
+private final class ScriptedInjectionEventReader: InjectionEventReading {
+    var versions: [Int]
+    var eventResults: [Result<[InjectionEvent], Error>]
+
+    init(versions: [Int], eventResults: [Result<[InjectionEvent], Error>]) {
+        self.versions = versions
+        self.eventResults = eventResults
+    }
+
+    func dataVersion() throws -> Int {
+        if versions.count > 1 {
+            return versions.removeFirst()
+        }
+        return versions.first ?? 1
+    }
+
+    func listInjectionEvents(sessionID: String?, limit: Int) throws -> [InjectionEvent] {
+        guard !eventResults.isEmpty else { return [] }
+        switch eventResults.removeFirst() {
+        case .success(let events):
+            return events
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func expandedConversation(
+        chunkID: String,
+        before: Int,
+        after: Int
+    ) throws -> BrainDatabase.ExpandedConversation {
+        throw ScriptedInjectionError.listFailed
+    }
+
+    func close() {}
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -131,9 +131,12 @@ final class InjectionStoreTests: XCTestCase {
 
 private enum ScriptedInjectionError: Error {
     case listFailed
+    case unexpectedListCall
 }
 
 private final class ScriptedInjectionEventReader: InjectionEventReading {
+    deinit {}
+
     var versions: [Int]
     var eventResults: [Result<[InjectionEvent], Error>]
 
@@ -150,7 +153,9 @@ private final class ScriptedInjectionEventReader: InjectionEventReading {
     }
 
     func listInjectionEvents(sessionID: String?, limit: Int) throws -> [InjectionEvent] {
-        guard !eventResults.isEmpty else { return [] }
+        guard !eventResults.isEmpty else {
+            throw ScriptedInjectionError.unexpectedListCall
+        }
         switch eventResults.removeFirst() {
         case .success(let events):
             return events

--- a/brain-bar/Tests/BrainBarTests/KGAtlasLayoutTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasLayoutTests.swift
@@ -2,6 +2,20 @@ import XCTest
 @testable import BrainBar
 
 final class KGAtlasLayoutTests: XCTestCase {
+    deinit {}
+
+    func testCanvasMetricsSubtractSidebarAndCanvasPadding() {
+        // Regression guard: Macroscope PR #315 flagged that resizing used the
+        // outer window size, which placed graph nodes behind the visible sidebar.
+        let size = KGCanvasMetrics.drawableSize(
+            windowSize: CGSize(width: 1_200, height: 800),
+            sidebarVisible: true
+        )
+
+        XCTAssertEqual(size.width, 844)
+        XCTAssertEqual(size.height, 764)
+    }
+
     func testSeededNodesPlaceEntityTypesIntoStableRegions() {
         let nodes = [
             KGNode(id: "p1", name: "Etan Heyman", entityType: "person", importance: 9, position: .zero),

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -273,6 +273,53 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertEqual(vm.edges.count, 1)
     }
 
+    func testLoadGraphRefreshPreservesExistingLayoutForStableNodes() async throws {
+        // Regression guard: Cursor Bugbot PR #315 flagged repeated graph refresh
+        // resetting node positions and discarding in-progress force layout state.
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+
+        let vm = KGViewModel(database: db)
+        await vm.loadGraph()
+        vm.nodes[0].position = CGPoint(x: 123, y: 234)
+        vm.nodes[0].velocity = CGVector(dx: 5, dy: 7)
+        vm.nodes[1].position = CGPoint(x: 456, y: 345)
+        vm.nodes[1].velocity = CGVector(dx: -3, dy: 2)
+
+        await vm.loadGraph()
+
+        let nodeA = try XCTUnwrap(vm.nodes.first { $0.id == "a" })
+        let nodeB = try XCTUnwrap(vm.nodes.first { $0.id == "b" })
+        XCTAssertEqual(nodeA.position, CGPoint(x: 123, y: 234))
+        XCTAssertEqual(nodeA.velocity, CGVector(dx: 5, dy: 7))
+        XCTAssertEqual(nodeB.position, CGPoint(x: 456, y: 345))
+        XCTAssertEqual(nodeB.velocity, CGVector(dx: -3, dy: 2))
+    }
+
+    func testUpdateCanvasSizeReseedsLoadedGraphFromActualDrawableSize() async throws {
+        // Regression guard: Cursor Bugbot PR #315 flagged a race where data can
+        // load before the inner Canvas reports its real size, leaving nodes
+        // seeded against the default center until a later size change.
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+
+        let vm = KGViewModel(database: db)
+        await vm.loadGraph()
+        let defaultPositions = Dictionary(uniqueKeysWithValues: vm.nodes.map { ($0.id, $0.position) })
+
+        vm.updateCanvasSize(CGSize(width: 1_200, height: 800))
+
+        XCTAssertEqual(vm.canvasCenter, CGPoint(x: 600, y: 400))
+        let nodeA = try XCTUnwrap(vm.nodes.first { $0.id == "a" })
+        let nodeB = try XCTUnwrap(vm.nodes.first { $0.id == "b" })
+        XCTAssertNotEqual(nodeA.position, defaultPositions["a"])
+        XCTAssertNotEqual(nodeB.position, defaultPositions["b"])
+        XCTAssertEqual(nodeA.position, CGPoint(x: 264, y: 192))
+        XCTAssertEqual(nodeB.position, CGPoint(x: 600, y: 192))
+    }
+
     func testLoadGraphKeepsMainActorAvailableWhileLoading() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")


### PR DESCRIPTION
## Summary

Etan TOP PRIORITY ("IMPROVE BRAINBAR AND MAKE IT SHOW GRAPH AND INJESTIONS ALREADY, WITHOUT DEGRATION!").

Commit `c25dc760` (Etan-authored) adds graph + injections UI surfaces with degradation resilience — the BrainBar UI now shows the KG graph view + injections panel without getting stuck on partial/degraded daemon state.

## Diff

6 files changed, +229 / -13:
- `brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift` (+52/-1) — graph + injections panel wiring
- `brain-bar/Sources/BrainBar/DegradationState.swift` (NEW, +28) — degradation state model
- `brain-bar/Sources/BrainBar/InjectionStore.swift` (+8) — degradation hooks
- `brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift` (+39/-3) — graph view-model degradation handling
- `brain-bar/Sources/BrainBarDaemon/DegradationState.swift` (+1) — daemon-side mirror
- `brain-bar/Tests/BrainBarTests/DegradationStateTests.swift` (NEW, +114) — regression test suite

## Test plan

- [x] BrainBarTests/DegradationStateTests.swift — 114 lines of regression coverage
- [ ] CI: test (3.11/3.12/3.13), lint, CodeRabbit, Cursor Bugbot, Macroscope - Correctness Check

## Provenance

Branch was prepared by brainlayerCodex worker spawned via cmux MCP earlier in this session. Codex pushed the commit before its surface was lost in a cmux topology shift; no PR was opened by codex. PR created here by orc gen-6 per A1 Row 1 (Etan-authored + autonomous-mode declared).

## Related

- PR #314 (warming-memory wireRuntime fix, merged at 14:32Z) — predecessor for runtime install
- Issue 1b investigation (`docs.local/audits/2026-05-22-issue-1b-fts5-kg-investigation.md`) — identified KG forward-only as the real "degradation without recovery" root cause; this PR addresses UI-side resilience, KG-ingest-side fix remains separate follow-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live data-refresh logic for the knowledge graph and injection feed, adding retry/polling and new state transitions that could impact UI update frequency and error recovery behavior.
> 
> **Overview**
> Adds a shared `DegradationState` model and a small `DegradationBadge` UI indicator, and wires the badge into both the Graph and Injections tabs so users see when data may be stale instead of the surface blanking.
> 
> Makes the Graph tab resilient to transient SQLite read failures by retrying loads, continuously polling via `loadGraphRepeatedly`, and keeping last-known `nodes`/`edges` while degraded; also stabilizes layout on refresh/resize by preserving node positions/velocities and reseeding based on the *actual drawable canvas size* (`KGCanvasMetrics`).
> 
> Updates `InjectionStore` to publish `degradationState` and to only clear degraded status after a successful `listInjectionEvents` read (not just `dataVersion`), with added test coverage for the new degradation and recovery behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06b74d9077fce149535cd1697f5368f70aa205e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show degradation badges on graph and injection panels in BrainBar with recovery resilience
> - Adds a `DegradationBadge` overlay (orange pill with exclamation icon) to both the graph and injection tabs in BrainBar, shown when the respective view model or store reports a degraded state.
> - Introduces a `DegradationState` enum (`healthy` / `degraded(reason:)`) shared across BrainBar and BrainBarDaemon via a symlink.
> - `InjectionStore` now publishes `degradationState` and stays degraded until an event query succeeds — a clean `dataVersion` read alone no longer clears the badge.
> - `KGViewModel` retries graph loads once on failure, preserves existing node positions/velocities across reloads, and polls repeatedly via `loadGraphRepeatedly`; node seeding uses the actual drawable canvas size via `KGCanvasMetrics`.
> - Adds tests covering degradation state semantics, recovery sequences, node position preservation, and canvas metrics calculations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b06b74d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added visual degradation badge to indicate system health status in graph and injection views

**Improvements**
* Features now gracefully handle transient read issues while maintaining last valid state and automatic recovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->