### PR TITLE
feat(kg): expire stale entity/relation facts via reconciliation pass

### DIFF
--- a/src/brainlayer/eval/benchmark.py
+++ b/src/brainlayer/eval/benchmark.py
@@ -290,7 +290,7 @@ class SearchBenchmark:
         return name, int(cutoff_text) if sep else None
 
     def _mean_query_score(self, run_dict: dict[str, dict[str, Any]], score_fn: Callable[[str], float]) -> float:
-        query_ids = sorted(set(self.qrels) | set(run_dict))
+        query_ids = sorted(self.qrels)
         if not query_ids:
             return 0.0
         return sum(score_fn(query_id) for query_id in query_ids) / len(query_ids)

--- a/src/brainlayer/eval/benchmark.py
+++ b/src/brainlayer/eval/benchmark.py
@@ -305,11 +305,11 @@ class SearchBenchmark:
     def _ndcg(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
         ranked = self._ranked_docs(run, cutoff)
         gains = self.qrels.get(query_id, {})
-        dcg = sum((2 ** gains.get(doc_id, 0) - 1) / math.log2(rank + 2) for rank, doc_id in enumerate(ranked))
+        dcg = sum(gains.get(doc_id, 0) / math.log2(rank + 2) for rank, doc_id in enumerate(ranked))
         ideal_grades = sorted((grade for grade in gains.values() if grade > 0), reverse=True)
         if cutoff is not None:
             ideal_grades = ideal_grades[:cutoff]
-        idcg = sum((2**grade - 1) / math.log2(rank + 2) for rank, grade in enumerate(ideal_grades))
+        idcg = sum(grade / math.log2(rank + 2) for rank, grade in enumerate(ideal_grades))
         return dcg / idcg if idcg else 0.0
 
     def _recall(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
@@ -330,7 +330,8 @@ class SearchBenchmark:
                 continue
             hits += 1
             precision_sum += hits / rank
-        return precision_sum / len(relevant)
+        denominator = min(len(relevant), cutoff) if cutoff is not None else len(relevant)
+        return precision_sum / denominator
 
     def _reciprocal_rank(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
         relevant = set(self._relevant_docs(query_id))

--- a/src/brainlayer/eval/benchmark.py
+++ b/src/brainlayer/eval/benchmark.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import sqlite3
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable
 
 os.environ.setdefault("NUMBA_DISABLE_JIT", "1")
 os.environ.setdefault("IR_DATASETS_HOME", "/tmp/ir_datasets")
@@ -18,6 +19,7 @@ from brainlayer._helpers import _escape_fts5_query
 
 DEFAULT_RUN_METRICS = ["ndcg@10", "recall@20", "map@10", "mrr"]
 DEFAULT_COMPARE_METRICS = ["ndcg@10", "recall@20"]
+_RANX_RUN_FALLBACK_PATCHED = False
 MINED_FRUSTRATION_QUERY_SUITE: list[tuple[str, str]] = [
     (
         "frustration_001",
@@ -160,19 +162,59 @@ class ReadOnlyBenchmarkStore:
         self.close()
 
 
+def _patch_ranx_run_fallback() -> None:
+    global _RANX_RUN_FALLBACK_PATCHED
+    if _RANX_RUN_FALLBACK_PATCHED:
+        return
+
+    def _init(self, name: str | None = None, run: dict[str, dict[str, Any]] | None = None, **_kwargs):
+        self.name = name
+        self.run = run or {}
+
+    def _to_dict(self):
+        return self.run
+
+    def _keys(self):
+        return self.run.keys()
+
+    def _getitem(self, key: str):
+        return self.run[key]
+
+    Run.__init__ = _init
+    Run.to_dict = _to_dict
+    Run.keys = _keys
+    Run.__getitem__ = _getitem
+    _RANX_RUN_FALLBACK_PATCHED = True
+
+
+def _run_from_dict(run_dict: dict[str, dict[str, float]]) -> Run:
+    try:
+        return Run(run=run_dict)
+    except Exception:
+        _patch_ranx_run_fallback()
+        return Run(run=run_dict)
+
+
 class SearchBenchmark:
     """Benchmarks search pipelines against graded relevance judgments."""
 
     def __init__(self, qrels_path: str):
         self.qrels_path = Path(qrels_path)
         self.qrels = self._load_qrels(self.qrels_path)
-        self.ranx_qrels = Qrels.from_dict(self.qrels)
+        self.ranx_qrels = self._build_ranx_qrels()
 
     def _load_qrels(self, qrels_path: Path) -> dict[str, dict[str, int]]:
         payload = json.loads(qrels_path.read_text())
         if not isinstance(payload, dict):
             raise ValueError("Qrels JSON must be a dict of query_id -> {doc_id: grade}")
         return payload
+
+    def _build_ranx_qrels(self) -> Qrels | None:
+        try:
+            return Qrels.from_dict(self.qrels)
+        except Exception:
+            _patch_ranx_run_fallback()
+            return None
 
     def queries_in_qrels(self, queries: Iterable[tuple[str, str]]) -> list[tuple[str, str]]:
         return [query for query in queries if query[0] in self.qrels and query[1].strip()]
@@ -186,27 +228,116 @@ class SearchBenchmark:
         for query_id, query_text in queries:
             results = pipeline_fn(query_text)
             run_dict[query_id] = {chunk_id: float(score) for chunk_id, score in results}
-        return Run(run=run_dict)
+        return _run_from_dict(run_dict)
 
     def evaluate_pipeline(self, run: Run, metrics: list[str] | None = None) -> dict[str, float]:
         metric_list = metrics or DEFAULT_RUN_METRICS
-        scores = evaluate(self.ranx_qrels, run, metric_list, make_comparable=True)
-        if isinstance(scores, dict):
-            return scores
-        if len(metric_list) == 1:
-            return {metric_list[0]: float(scores)}
-        raise TypeError(f"Unexpected Ranx evaluate() result type: {type(scores)!r}")
+        if self.ranx_qrels is not None:
+            try:
+                scores = evaluate(self.ranx_qrels, run, metric_list, make_comparable=True)
+                if isinstance(scores, dict):
+                    return scores
+                if len(metric_list) == 1:
+                    return {metric_list[0]: float(scores)}
+                raise TypeError(f"Unexpected Ranx evaluate() result type: {type(scores)!r}")
+            except Exception:
+                pass
+        return self._evaluate_without_ranx(run.to_dict(), metric_list)
 
     def compare_pipelines(self, runs: dict[str, Run], metrics: list[str] | None = None) -> str:
-        named_runs = [Run(name=name, run=run.to_dict()) for name, run in runs.items()]
-        report = compare(
-            self.ranx_qrels,
-            runs=named_runs,
-            metrics=metrics or DEFAULT_COMPARE_METRICS,
-            max_p=0.05,
-            rounding_digits=4,
-        )
-        return str(report)
+        metric_list = metrics or DEFAULT_COMPARE_METRICS
+        if self.ranx_qrels is not None:
+            try:
+                named_runs = [Run(name=name, run=run.to_dict()) for name, run in runs.items()]
+                report = compare(
+                    self.ranx_qrels,
+                    runs=named_runs,
+                    metrics=metric_list,
+                    max_p=0.05,
+                    rounding_digits=4,
+                )
+                return str(report)
+            except Exception:
+                pass
+        lines = []
+        for name, run in runs.items():
+            scores = self._evaluate_without_ranx(run.to_dict(), metric_list)
+            metrics_text = ", ".join(f"{metric}={score:.4f}" for metric, score in scores.items())
+            lines.append(f"{name}: {metrics_text}")
+        return "\n".join(lines)
+
+    def _evaluate_without_ranx(self, run_dict: dict[str, dict[str, Any]], metrics: list[str]) -> dict[str, float]:
+        return {metric: self._manual_metric(run_dict, metric) for metric in metrics}
+
+    def _manual_metric(self, run_dict: dict[str, dict[str, Any]], metric: str) -> float:
+        name, cutoff = self._parse_metric(metric)
+        if name == "ndcg":
+            return self._mean_query_score(run_dict, lambda qid: self._ndcg(run_dict.get(qid, {}), qid, cutoff))
+        if name == "recall":
+            return self._mean_query_score(run_dict, lambda qid: self._recall(run_dict.get(qid, {}), qid, cutoff))
+        if name == "map":
+            return self._mean_query_score(
+                run_dict, lambda qid: self._average_precision(run_dict.get(qid, {}), qid, cutoff)
+            )
+        if name == "mrr":
+            return self._mean_query_score(
+                run_dict, lambda qid: self._reciprocal_rank(run_dict.get(qid, {}), qid, cutoff)
+            )
+        raise ValueError(f"Unsupported metric without ranx: {metric}")
+
+    def _parse_metric(self, metric: str) -> tuple[str, int | None]:
+        name, sep, cutoff_text = metric.partition("@")
+        return name, int(cutoff_text) if sep else None
+
+    def _mean_query_score(self, run_dict: dict[str, dict[str, Any]], score_fn: Callable[[str], float]) -> float:
+        query_ids = sorted(set(self.qrels) | set(run_dict))
+        if not query_ids:
+            return 0.0
+        return sum(score_fn(query_id) for query_id in query_ids) / len(query_ids)
+
+    def _ranked_docs(self, run: dict[str, Any], cutoff: int | None) -> list[str]:
+        ranked = [doc_id for doc_id, _score in sorted(run.items(), key=lambda item: float(item[1]), reverse=True)]
+        return ranked[:cutoff] if cutoff is not None else ranked
+
+    def _relevant_docs(self, query_id: str) -> dict[str, int]:
+        return {doc_id: grade for doc_id, grade in self.qrels.get(query_id, {}).items() if grade > 0}
+
+    def _ndcg(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
+        ranked = self._ranked_docs(run, cutoff)
+        gains = self.qrels.get(query_id, {})
+        dcg = sum((2 ** gains.get(doc_id, 0) - 1) / math.log2(rank + 2) for rank, doc_id in enumerate(ranked))
+        ideal_grades = sorted((grade for grade in gains.values() if grade > 0), reverse=True)
+        if cutoff is not None:
+            ideal_grades = ideal_grades[:cutoff]
+        idcg = sum((2**grade - 1) / math.log2(rank + 2) for rank, grade in enumerate(ideal_grades))
+        return dcg / idcg if idcg else 0.0
+
+    def _recall(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
+        relevant = self._relevant_docs(query_id)
+        if not relevant:
+            return 0.0
+        retrieved = set(self._ranked_docs(run, cutoff))
+        return len(retrieved & set(relevant)) / len(relevant)
+
+    def _average_precision(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
+        relevant = set(self._relevant_docs(query_id))
+        if not relevant:
+            return 0.0
+        hits = 0
+        precision_sum = 0.0
+        for rank, doc_id in enumerate(self._ranked_docs(run, cutoff), start=1):
+            if doc_id not in relevant:
+                continue
+            hits += 1
+            precision_sum += hits / rank
+        return precision_sum / len(relevant)
+
+    def _reciprocal_rank(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
+        relevant = set(self._relevant_docs(query_id))
+        for rank, doc_id in enumerate(self._ranked_docs(run, cutoff), start=1):
+            if doc_id in relevant:
+                return 1 / rank
+        return 0.0
 
 
 def pipeline_fts5_only(store, query: str, n_results: int = 20) -> list[tuple[str, float]]:

--- a/src/brainlayer/eval/benchmark.py
+++ b/src/brainlayer/eval/benchmark.py
@@ -287,7 +287,12 @@ class SearchBenchmark:
 
     def _parse_metric(self, metric: str) -> tuple[str, int | None]:
         name, sep, cutoff_text = metric.partition("@")
-        return name, int(cutoff_text) if sep else None
+        if not sep:
+            return name, None
+        cutoff = int(cutoff_text)
+        if cutoff <= 0:
+            raise ValueError(f"Metric cutoff must be > 0: {metric}")
+        return name, cutoff
 
     def _mean_query_score(self, run_dict: dict[str, dict[str, Any]], score_fn: Callable[[str], float]) -> float:
         query_ids = sorted(self.qrels)
@@ -330,8 +335,7 @@ class SearchBenchmark:
                 continue
             hits += 1
             precision_sum += hits / rank
-        denominator = min(len(relevant), cutoff) if cutoff is not None else len(relevant)
-        return precision_sum / denominator
+        return precision_sum / len(relevant)
 
     def _reciprocal_rank(self, run: dict[str, Any], query_id: str, cutoff: int | None) -> float:
         relevant = set(self._relevant_docs(query_id))

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -26,8 +26,9 @@ class KGMixin:
             "importance": row[9],
             "valid_from": row[10],
             "valid_until": row[11],
-            "group_id": row[12],
-            "parent_id": row[13] if len(row) > 13 else None,
+            "expired_at": row[12] if len(row) > 12 else None,
+            "group_id": row[13] if len(row) > 13 else None,
+            "parent_id": row[14] if len(row) > 14 else None,
         }
 
     def _fetch_entities_by_lower_name(self, name: str, entity_type: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -35,7 +36,7 @@ class KGMixin:
         base_query = """
             SELECT id, entity_type, name, metadata, created_at, updated_at,
                    canonical_name, description, confidence, importance,
-                   valid_from, valid_until, group_id, parent_id
+                   valid_from, valid_until, expired_at, group_id, parent_id
             FROM kg_entities
             WHERE LOWER(name) = LOWER(?)
         """
@@ -177,6 +178,7 @@ class KGMixin:
                     importance = COALESCE(?, importance),
                     valid_from = COALESCE(?, valid_from),
                     valid_until = COALESCE(?, valid_until),
+                    expired_at = NULL,
                     group_id = COALESCE(?, group_id),
                     parent_id = COALESCE(?, parent_id),
                     updated_at = ?
@@ -222,6 +224,7 @@ class KGMixin:
                 importance = excluded.importance,
                 valid_from = COALESCE(excluded.valid_from, kg_entities.valid_from),
                 valid_until = COALESCE(excluded.valid_until, kg_entities.valid_until),
+                expired_at = NULL,
                 group_id = COALESCE(excluded.group_id, kg_entities.group_id),
                 parent_id = COALESCE(excluded.parent_id, kg_entities.parent_id),
                 updated_at = excluded.updated_at
@@ -292,6 +295,7 @@ class KGMixin:
                 importance = COALESCE(excluded.importance, kg_relations.importance),
                 valid_from = COALESCE(excluded.valid_from, kg_relations.valid_from),
                 valid_until = COALESCE(excluded.valid_until, kg_relations.valid_until),
+                expired_at = NULL,
                 source_chunk_id = COALESCE(excluded.source_chunk_id, kg_relations.source_chunk_id)
             """,
             (
@@ -350,7 +354,7 @@ class KGMixin:
             cursor.execute(
                 """SELECT id, entity_type, name, metadata, created_at, updated_at,
                           canonical_name, description, confidence, importance,
-                          valid_from, valid_until, group_id, parent_id
+                          valid_from, valid_until, expired_at, group_id, parent_id
                    FROM kg_entities WHERE id = ?""",
                 (entity_id,),
             )
@@ -951,7 +955,7 @@ class KGMixin:
             cursor.execute(
                 """SELECT id, entity_type, name, metadata, created_at, updated_at,
                           canonical_name, description, confidence, importance,
-                          valid_from, valid_until, group_id
+                          valid_from, valid_until, expired_at, group_id
                    FROM kg_entities WHERE LOWER(canonical_name) = LOWER(?)""",
                 (name_or_alias,),
             )
@@ -971,7 +975,8 @@ class KGMixin:
                 "importance": row[9],
                 "valid_from": row[10],
                 "valid_until": row[11],
-                "group_id": row[12],
+                "expired_at": row[12],
+                "group_id": row[13],
             }
 
         # 4. Stored phonetic alias fallback

--- a/src/brainlayer/mcp/_shared.py
+++ b/src/brainlayer/mcp/_shared.py
@@ -26,6 +26,8 @@ _SEARCH_REQUIRED_CHUNK_COLUMNS = {
     "status",
     "summary",
 }
+_SEARCH_REQUIRED_KG_ENTITY_COLUMNS = {"valid_until", "expired_at"}
+_SEARCH_REQUIRED_KG_RELATION_COLUMNS = {"valid_from", "valid_until", "expired_at"}
 
 
 def _search_store_needs_bootstrap(db_path) -> bool:
@@ -42,7 +44,18 @@ def _search_store_needs_bootstrap(db_path) -> bool:
             return True
 
         chunk_columns = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
-        return not _SEARCH_REQUIRED_CHUNK_COLUMNS.issubset(chunk_columns)
+        if not _SEARCH_REQUIRED_CHUNK_COLUMNS.issubset(chunk_columns):
+            return True
+
+        if {"kg_entities", "kg_relations"}.issubset(tables):
+            entity_columns = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entities)")}
+            relation_columns = {row[1] for row in cursor.execute("PRAGMA table_info(kg_relations)")}
+            if not _SEARCH_REQUIRED_KG_ENTITY_COLUMNS.issubset(entity_columns):
+                return True
+            if not _SEARCH_REQUIRED_KG_RELATION_COLUMNS.issubset(relation_columns):
+                return True
+
+        return False
     finally:
         if conn is not None:
             conn.close()

--- a/src/brainlayer/mcp/_shared.py
+++ b/src/brainlayer/mcp/_shared.py
@@ -47,7 +47,10 @@ def _search_store_needs_bootstrap(db_path) -> bool:
         if not _SEARCH_REQUIRED_CHUNK_COLUMNS.issubset(chunk_columns):
             return True
 
-        if {"kg_entities", "kg_relations"}.issubset(tables):
+        kg_tables = {"kg_entities", "kg_relations"}
+        if kg_tables & tables:
+            if not kg_tables.issubset(tables):
+                return True
             entity_columns = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entities)")}
             relation_columns = {row[1] for row in cursor.execute("PRAGMA table_info(kg_relations)")}
             if not _SEARCH_REQUIRED_KG_ENTITY_COLUMNS.issubset(entity_columns):

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -424,8 +424,8 @@ def _kg_facts_sql(
                    WHERE (r.source_id = ? OR r.target_id = ?)
                      AND r.relation_type != 'co_occurs_with'
                      AND r.expired_at IS NULL
-                     AND (r.valid_from IS NULL OR r.valid_from <= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-                     AND (r.valid_until IS NULL OR r.valid_until >= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                     AND (r.valid_from IS NULL OR julianday(r.valid_from) <= julianday('now'))
+                     AND (r.valid_until IS NULL OR julianday(r.valid_until) >= julianday('now'))
                      AND (se.expired_at IS NULL)
                      AND (te.expired_at IS NULL)
                      {checkpoint_filter}

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -423,6 +423,11 @@ def _kg_facts_sql(
                    {source_chunk_join}
                    WHERE (r.source_id = ? OR r.target_id = ?)
                      AND r.relation_type != 'co_occurs_with'
+                     AND r.expired_at IS NULL
+                     AND (r.valid_from IS NULL OR r.valid_from <= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                     AND (r.valid_until IS NULL OR r.valid_until >= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                     AND (se.expired_at IS NULL)
+                     AND (te.expired_at IS NULL)
                      {checkpoint_filter}
                      {audit_filter}
                    ORDER BY r.confidence DESC

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -602,10 +602,11 @@ def _add_dependency_relation(
             if existing[2] is not None and not dry_run:
                 conn.execute(
                     """UPDATE kg_relations
-                       SET valid_from = COALESCE(valid_from, ?),
+                       SET properties = ?,
+                           valid_from = COALESCE(valid_from, ?),
                            valid_until = ?, expired_at = NULL
                        WHERE id = ?""",
-                    (observed_at, valid_until, existing[0]),
+                    (_code_intelligence_properties(existing[1]), observed_at, valid_until, existing[0]),
                 )
             return target_id
         if not dry_run:

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -8,7 +8,6 @@ Usage:
     python -m brainlayer.pipeline.code_intelligence [--base-dir ~/Gits] [--dry-run]
 """
 
-import fcntl
 import hashlib
 import json
 import logging
@@ -22,6 +21,11 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised via monkeypatch on Unix CI
+    fcntl = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +211,8 @@ def _code_intelligence_writer_lock(db_path: str | Path, dry_run: bool):
         try:
             fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
             try:
-                fcntl.flock(fd, fcntl.LOCK_EX)
+                if fcntl is not None:
+                    fcntl.flock(fd, fcntl.LOCK_EX)
                 os.write(fd, _pidfile_payload(pid))
             finally:
                 os.close(fd)

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -8,11 +8,17 @@ Usage:
     python -m brainlayer.pipeline.code_intelligence [--base-dir ~/Gits] [--dry-run]
 """
 
+import fcntl
+import hashlib
 import json
 import logging
+import os
 import re
 import sqlite3
+import subprocess
+import time
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -22,6 +28,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_BASE_DIR = Path.home() / "Gits"
 OBSERVATION_VALIDITY_DAYS = 30
 CODE_INTELLIGENCE_SOURCE = "code_intelligence"
+SQLITE_BUSY_TIMEOUT_MS = 30_000
 NOTABLE_DEPENDENCIES = {
     # Frameworks & runtimes
     "react",
@@ -60,36 +67,184 @@ NOTABLE_DEPENDENCIES = {
 
 
 def _timestamp(dt: datetime) -> str:
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return f"{dt:%Y-%m-%dT%H:%M:%S}.{dt.microsecond // 1000:03d}Z"
+
+
+def _load_relation_properties(properties: str | None) -> dict[str, Any]:
+    if not properties:
+        return {}
+    try:
+        loaded = json.loads(properties)
+    except (TypeError, ValueError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
 
 
 def _is_code_intelligence_relation(properties: str | None) -> bool:
-    if not properties:
-        return False
+    loaded = _load_relation_properties(properties)
+    source = loaded.get("source")
+    sources = loaded.get("sources")
+    return (
+        source == CODE_INTELLIGENCE_SOURCE
+        or (isinstance(source, list) and CODE_INTELLIGENCE_SOURCE in source)
+        or (isinstance(sources, list) and CODE_INTELLIGENCE_SOURCE in sources)
+    )
+
+
+def _code_intelligence_properties(properties: str | None = None) -> str:
+    loaded = _load_relation_properties(properties)
+    source = loaded.get("source")
+    sources = loaded.get("sources")
+    if source is None and sources is None:
+        loaded["source"] = CODE_INTELLIGENCE_SOURCE
+    elif isinstance(source, list):
+        if CODE_INTELLIGENCE_SOURCE not in source:
+            loaded["source"] = [*source, CODE_INTELLIGENCE_SOURCE]
+    elif source != CODE_INTELLIGENCE_SOURCE:
+        existing_sources = sources if isinstance(sources, list) else []
+        loaded["sources"] = [*dict.fromkeys([*existing_sources, source, CODE_INTELLIGENCE_SOURCE])]
+    return json.dumps(loaded, sort_keys=True)
+
+
+def _writer_pidfile_path(db_path: str | Path) -> Path:
+    pidfile_dir = Path(os.environ.get("BRAINLAYER_WRITER_PIDFILE_DIR", "/tmp")).expanduser()
+    if not pidfile_dir.is_absolute():
+        pidfile_dir = Path("/tmp") / pidfile_dir
+    resolved_path = Path(db_path).expanduser().resolve()
+    path_hash = hashlib.sha256(str(resolved_path).encode("utf-8")).hexdigest()[:16]
+    return pidfile_dir.resolve() / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
+
+
+def _pid_start_time(pid: int) -> str | None:
     try:
-        return json.loads(properties).get("source") == CODE_INTELLIGENCE_SOURCE
-    except (TypeError, ValueError):
+        stat_path = Path("/proc") / str(pid) / "stat"
+        if stat_path.exists():
+            fields = stat_path.read_text(encoding="utf-8").split()
+            if len(fields) > 21:
+                return fields[21]
+    except OSError:
+        pass
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=1,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return " ".join(result.stdout.split()) or None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
         return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _pidfile_payload(pid: int) -> bytes:
+    start_time = _pid_start_time(pid)
+    if start_time:
+        return f"{pid}\nstart_time={start_time}\n".encode("utf-8")
+    return f"{pid}\n".encode("utf-8")
+
+
+def _read_pidfile_owner(pidfile: Path) -> tuple[int | None, str | None]:
+    try:
+        lines = pidfile.read_text(encoding="utf-8").splitlines()
+        if not lines:
+            return None, None
+        pid = int(lines[0].strip())
+        start_time = None
+        for line in lines[1:]:
+            if line.startswith("start_time="):
+                start_time = line.removeprefix("start_time=").strip() or None
+                break
+        return pid, start_time
+    except (OSError, ValueError):
+        return None, None
+
+
+def _pidfile_owner_matches(pid: int, start_time: str | None) -> bool:
+    if not _pid_is_alive(pid):
+        return False
+    if not start_time:
+        return True
+    current_start_time = _pid_start_time(pid)
+    return current_start_time is None or current_start_time == start_time
+
+
+@contextmanager
+def _code_intelligence_writer_lock(db_path: str | Path, dry_run: bool):
+    if dry_run:
+        yield
+        return
+
+    pidfile = _writer_pidfile_path(db_path)
+    pidfile.parent.mkdir(parents=True, exist_ok=True)
+    pid = os.getpid()
+    acquired = False
+
+    for attempt in range(4):
+        try:
+            fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                os.write(fd, _pidfile_payload(pid))
+            finally:
+                os.close(fd)
+            acquired = True
+            break
+        except FileExistsError:
+            owner_pid, owner_start_time = _read_pidfile_owner(pidfile)
+            if owner_pid == pid and _pidfile_owner_matches(owner_pid, owner_start_time):
+                yield
+                return
+            if owner_pid is not None and _pidfile_owner_matches(owner_pid, owner_start_time):
+                raise RuntimeError(f"another writer is using {db_path} (pid {owner_pid})")
+            try:
+                pidfile.unlink()
+            except FileNotFoundError:
+                pass
+            time.sleep(0.01 * (attempt + 1))
+
+    if not acquired:
+        raise RuntimeError(f"could not acquire writer pidfile for {db_path}")
+
+    try:
+        yield
+    finally:
+        if _read_pidfile_owner(pidfile)[0] == pid:
+            try:
+                pidfile.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def _ensure_reconciliation_schema(conn: sqlite3.Connection) -> None:
     """Apply the KG validity columns needed by code-intelligence reconciliation."""
     entity_cols = {row[1] for row in conn.execute("PRAGMA table_info(kg_entities)")}
-    for col, definition in [
-        ("valid_until", "TEXT"),
-        ("expired_at", "TEXT"),
-    ]:
-        if col not in entity_cols:
-            conn.execute(f"ALTER TABLE kg_entities ADD COLUMN {col} {definition}")
+    if "valid_until" not in entity_cols:
+        conn.execute("ALTER TABLE kg_entities ADD COLUMN valid_until TEXT")
+    if "expired_at" not in entity_cols:
+        conn.execute("ALTER TABLE kg_entities ADD COLUMN expired_at TEXT")
 
     relation_cols = {row[1] for row in conn.execute("PRAGMA table_info(kg_relations)")}
-    for col, definition in [
-        ("valid_from", "TEXT"),
-        ("valid_until", "TEXT"),
-        ("expired_at", "TEXT"),
-    ]:
-        if col not in relation_cols:
-            conn.execute(f"ALTER TABLE kg_relations ADD COLUMN {col} {definition}")
+    if "valid_from" not in relation_cols:
+        conn.execute("ALTER TABLE kg_relations ADD COLUMN valid_from TEXT")
+    if "valid_until" not in relation_cols:
+        conn.execute("ALTER TABLE kg_relations ADD COLUMN valid_until TEXT")
+    if "expired_at" not in relation_cols:
+        conn.execute("ALTER TABLE kg_relations ADD COLUMN expired_at TEXT")
 
     conn.execute("CREATE INDEX IF NOT EXISTS idx_kg_entities_expired ON kg_entities(expired_at)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_kg_relations_expired ON kg_relations(expired_at)")
@@ -266,11 +421,6 @@ def enrich_projects(
             "dep_entities_expired": 0,
         }
 
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode = WAL")
-    if not dry_run:
-        _ensure_reconciliation_schema(conn)
-
     observed_dt = datetime.now(timezone.utc)
     observed_at = _timestamp(observed_dt)
     valid_until = _timestamp(observed_dt + timedelta(days=OBSERVATION_VALIDITY_DAYS))
@@ -285,14 +435,23 @@ def enrich_projects(
         "dep_entities_expired": 0,
     }
 
-    try:
-        for project in projects:
-            _upsert_project(conn, project, stats, dry_run, observed_at, valid_until)
-
+    with _code_intelligence_writer_lock(db_path, dry_run):
+        conn = sqlite3.connect(db_path, timeout=SQLITE_BUSY_TIMEOUT_MS / 1000)
+        conn.execute("PRAGMA busy_timeout = 30000")
+        conn.execute("PRAGMA journal_mode = WAL")
         if not dry_run:
-            conn.commit()
-    finally:
-        conn.close()
+            conn.execute("PRAGMA wal_checkpoint(FULL)")
+            _ensure_reconciliation_schema(conn)
+
+        try:
+            for project in projects:
+                _upsert_project(conn, project, stats, dry_run, observed_at, valid_until)
+
+            if not dry_run:
+                conn.commit()
+                conn.execute("PRAGMA wal_checkpoint(FULL)")
+        finally:
+            conn.close()
 
     return stats
 
@@ -425,12 +584,12 @@ def _add_dependency_relation(
                    SET properties = ?, confidence = 0.99, valid_from = COALESCE(valid_from, ?),
                        valid_until = ?, expired_at = NULL
                    WHERE id = ?""",
-                (json.dumps({"source": CODE_INTELLIGENCE_SOURCE}), observed_at, valid_until, existing[0]),
+                (_code_intelligence_properties(existing[1]), observed_at, valid_until, existing[0]),
             )
         return target_id
 
     rel_id = f"rel-{uuid.uuid4().hex[:12]}"
-    props = json.dumps({"source": CODE_INTELLIGENCE_SOURCE})
+    props = _code_intelligence_properties()
 
     if not dry_run:
         conn.execute(

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -412,11 +412,13 @@ def _add_dependency_relation(
 
     # Check if relation already exists
     existing = conn.execute(
-        "SELECT id FROM kg_relations WHERE source_id = ? AND target_id = ? AND relation_type = 'depends_on'",
+        "SELECT id, properties FROM kg_relations WHERE source_id = ? AND target_id = ? AND relation_type = 'depends_on'",
         (source_id, target_id),
     ).fetchone()
 
     if existing:
+        if not _is_code_intelligence_relation(existing[1]):
+            return target_id
         if not dry_run:
             conn.execute(
                 """UPDATE kg_relations
@@ -476,18 +478,17 @@ def _expire_stale_dependency_relations(
             stats["relations_expired"] += 1
 
     for target_id in stale_target_ids:
-        active_rows = conn.execute(
+        active_depends_on = conn.execute(
             """
-            SELECT properties
-            FROM kg_relations
+            SELECT 1
+            FROM kg_current_facts
             WHERE target_id = ?
               AND relation_type = 'depends_on'
-              AND expired_at IS NULL
+            LIMIT 1
             """,
             (target_id,),
-        ).fetchall()
-        has_active_code_fact = any(_is_code_intelligence_relation(properties) for (properties,) in active_rows)
-        if has_active_code_fact:
+        ).fetchone()
+        if active_depends_on:
             continue
         result = conn.execute(
             """

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -206,9 +206,6 @@ def _code_intelligence_writer_lock(db_path: str | Path, dry_run: bool):
             break
         except FileExistsError:
             owner_pid, owner_start_time = _read_pidfile_owner(pidfile)
-            if owner_pid == pid and _pidfile_owner_matches(owner_pid, owner_start_time):
-                yield
-                return
             if owner_pid is not None and _pidfile_owner_matches(owner_pid, owner_start_time):
                 raise RuntimeError(f"another writer is using {db_path} (pid {owner_pid})")
             try:

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -13,12 +13,95 @@ import logging
 import re
 import sqlite3
 import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_DIR = Path.home() / "Gits"
+OBSERVATION_VALIDITY_DAYS = 30
+CODE_INTELLIGENCE_SOURCE = "code_intelligence"
+NOTABLE_DEPENDENCIES = {
+    # Frameworks & runtimes
+    "react",
+    "react-dom",
+    "react-native",
+    "next",
+    "express",
+    "fastify",
+    "convex",
+    "expo",
+    "electron",
+    # AI/ML
+    "@anthropic-ai/sdk",
+    "@modelcontextprotocol/sdk",
+    "openai",
+    "langchain",
+    "sentence-transformers",
+    "onnxruntime-node",
+    # Databases
+    "apsw",
+    "sqlite-vec",
+    "prisma",
+    "@prisma/client",
+    "drizzle-orm",
+    # Infra
+    "fastapi",
+    "uvicorn",
+    "@axiomhq/js",
+    # Python notable
+    "pyyaml",
+    "typer",
+    "rich",
+    "textual",
+    "mcp",
+}
+
+
+def _timestamp(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _is_code_intelligence_relation(properties: str | None) -> bool:
+    if not properties:
+        return False
+    try:
+        return json.loads(properties).get("source") == CODE_INTELLIGENCE_SOURCE
+    except (TypeError, ValueError):
+        return False
+
+
+def _ensure_reconciliation_schema(conn: sqlite3.Connection) -> None:
+    """Apply the KG validity columns needed by code-intelligence reconciliation."""
+    entity_cols = {row[1] for row in conn.execute("PRAGMA table_info(kg_entities)")}
+    for col, definition in [
+        ("valid_until", "TEXT"),
+        ("expired_at", "TEXT"),
+    ]:
+        if col not in entity_cols:
+            conn.execute(f"ALTER TABLE kg_entities ADD COLUMN {col} {definition}")
+
+    relation_cols = {row[1] for row in conn.execute("PRAGMA table_info(kg_relations)")}
+    for col, definition in [
+        ("valid_from", "TEXT"),
+        ("valid_until", "TEXT"),
+        ("expired_at", "TEXT"),
+    ]:
+        if col not in relation_cols:
+            conn.execute(f"ALTER TABLE kg_relations ADD COLUMN {col} {definition}")
+
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_kg_entities_expired ON kg_entities(expired_at)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_kg_relations_expired ON kg_relations(expired_at)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_kg_relations_validity ON kg_relations(valid_from, valid_until)")
+    conn.execute("DROP VIEW IF EXISTS kg_current_facts")
+    conn.execute("""
+        CREATE VIEW IF NOT EXISTS kg_current_facts AS
+        SELECT * FROM kg_relations
+        WHERE (valid_from IS NULL OR valid_from <= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+          AND (valid_until IS NULL OR valid_until >= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+          AND expired_at IS NULL
+    """)
 
 
 def scan_projects(base_dir: Path) -> list[dict[str, Any]]:
@@ -179,10 +262,18 @@ def enrich_projects(
             "entities_updated": 0,
             "relations_added": 0,
             "dep_entities_created": 0,
+            "relations_expired": 0,
+            "dep_entities_expired": 0,
         }
 
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode = WAL")
+    if not dry_run:
+        _ensure_reconciliation_schema(conn)
+
+    observed_dt = datetime.now(timezone.utc)
+    observed_at = _timestamp(observed_dt)
+    valid_until = _timestamp(observed_dt + timedelta(days=OBSERVATION_VALIDITY_DAYS))
 
     stats = {
         "projects_scanned": len(projects),
@@ -190,11 +281,13 @@ def enrich_projects(
         "entities_updated": 0,
         "relations_added": 0,
         "dep_entities_created": 0,
+        "relations_expired": 0,
+        "dep_entities_expired": 0,
     }
 
     try:
         for project in projects:
-            _upsert_project(conn, project, stats, dry_run)
+            _upsert_project(conn, project, stats, dry_run, observed_at, valid_until)
 
         if not dry_run:
             conn.commit()
@@ -209,6 +302,8 @@ def _upsert_project(
     project: dict[str, Any],
     stats: dict[str, int],
     dry_run: bool,
+    observed_at: str,
+    valid_until: str,
 ) -> None:
     """Create or update a project entity with its metadata and relations."""
     name = project["name"]
@@ -241,9 +336,10 @@ def _upsert_project(
             conn.execute(
                 """UPDATE kg_entities
                    SET description = ?, metadata = ?, importance = ?,
+                       valid_until = ?, expired_at = NULL,
                        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
                    WHERE id = ?""",
-                (description, metadata_json, importance, entity_id),
+                (description, metadata_json, importance, valid_until, entity_id),
             )
         stats["entities_updated"] += 1
         logger.info("Updated project: %s (id=%s)", name, entity_id)
@@ -251,16 +347,22 @@ def _upsert_project(
         entity_id = f"proj-{uuid.uuid4().hex[:12]}"
         if not dry_run:
             conn.execute(
-                """INSERT INTO kg_entities (id, entity_type, name, description, metadata, importance, created_at, updated_at)
-                   VALUES (?, 'project', ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now'))""",
-                (entity_id, name, description, metadata_json, importance),
+                """INSERT INTO kg_entities
+                   (id, entity_type, name, description, metadata, importance, valid_until, expired_at, created_at, updated_at)
+                   VALUES (?, 'project', ?, ?, ?, ?, ?, NULL, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now'))""",
+                (entity_id, name, description, metadata_json, importance, valid_until),
             )
         stats["entities_created"] += 1
         logger.info("Created project: %s (id=%s)", name, entity_id)
 
     # Add depends_on relations for key dependencies
+    observed_targets: set[str] = set()
     for dep_name in project.get("dependencies", []):
-        _add_dependency_relation(conn, entity_id, name, dep_name, stats, dry_run)
+        target_id = _add_dependency_relation(conn, entity_id, name, dep_name, stats, dry_run, observed_at, valid_until)
+        if target_id is not None:
+            observed_targets.add(target_id)
+
+    _expire_stale_dependency_relations(conn, entity_id, observed_targets, stats, dry_run, observed_at)
 
 
 def _add_dependency_relation(
@@ -270,51 +372,16 @@ def _add_dependency_relation(
     dep_name: str,
     stats: dict[str, int],
     dry_run: bool,
-) -> None:
+    observed_at: str,
+    valid_until: str,
+) -> str | None:
     """Add a depends_on relation from project to dependency.
 
     Creates the dependency as a 'library' entity if it doesn't exist.
     Only creates relations for notable dependencies (frameworks, SDKs, key tools).
     """
-    # Only track notable dependencies to avoid noise
-    notable_patterns = {
-        # Frameworks & runtimes
-        "react",
-        "react-dom",
-        "react-native",
-        "next",
-        "express",
-        "fastify",
-        "convex",
-        "expo",
-        "electron",
-        # AI/ML
-        "@anthropic-ai/sdk",
-        "@modelcontextprotocol/sdk",
-        "openai",
-        "langchain",
-        "sentence-transformers",
-        "onnxruntime-node",
-        # Databases
-        "apsw",
-        "sqlite-vec",
-        "prisma",
-        "@prisma/client",
-        "drizzle-orm",
-        # Infra
-        "fastapi",
-        "uvicorn",
-        "@axiomhq/js",
-        # Python notable
-        "pyyaml",
-        "typer",
-        "rich",
-        "textual",
-        "mcp",
-    }
-
-    if dep_name not in notable_patterns:
-        return
+    if dep_name not in NOTABLE_DEPENDENCIES:
+        return None
 
     # Find or create the dependency entity
     target_row = conn.execute(
@@ -326,13 +393,22 @@ def _add_dependency_relation(
         target_id = f"lib-{uuid.uuid4().hex[:12]}"
         if not dry_run:
             conn.execute(
-                """INSERT INTO kg_entities (id, entity_type, name, importance, created_at, updated_at)
-                   VALUES (?, 'library', ?, 3.0, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now'))""",
-                (target_id, dep_name),
+                """INSERT INTO kg_entities
+                   (id, entity_type, name, importance, valid_until, expired_at, created_at, updated_at)
+                   VALUES (?, 'library', ?, 3.0, ?, NULL, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now'))""",
+                (target_id, dep_name, valid_until),
             )
         stats["dep_entities_created"] += 1
     else:
         target_id = target_row[0]
+        if not dry_run:
+            conn.execute(
+                """UPDATE kg_entities
+                   SET valid_until = ?, expired_at = NULL,
+                       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                   WHERE id = ?""",
+                (valid_until, target_id),
+            )
 
     # Check if relation already exists
     existing = conn.execute(
@@ -341,20 +417,88 @@ def _add_dependency_relation(
     ).fetchone()
 
     if existing:
-        return
+        if not dry_run:
+            conn.execute(
+                """UPDATE kg_relations
+                   SET properties = ?, confidence = 0.99, valid_from = COALESCE(valid_from, ?),
+                       valid_until = ?, expired_at = NULL
+                   WHERE id = ?""",
+                (json.dumps({"source": CODE_INTELLIGENCE_SOURCE}), observed_at, valid_until, existing[0]),
+            )
+        return target_id
 
     rel_id = f"rel-{uuid.uuid4().hex[:12]}"
-    props = json.dumps({"source": "code_intelligence"})
+    props = json.dumps({"source": CODE_INTELLIGENCE_SOURCE})
 
     if not dry_run:
         conn.execute(
             """INSERT OR IGNORE INTO kg_relations
-               (id, source_id, target_id, relation_type, properties, confidence, created_at)
-               VALUES (?, ?, ?, 'depends_on', ?, 0.99, strftime('%Y-%m-%dT%H:%M:%fZ','now'))""",
-            (rel_id, source_id, target_id, props),
+               (id, source_id, target_id, relation_type, properties, confidence, valid_from, valid_until, expired_at, created_at)
+               VALUES (?, ?, ?, 'depends_on', ?, 0.99, ?, ?, NULL, strftime('%Y-%m-%dT%H:%M:%fZ','now'))""",
+            (rel_id, source_id, target_id, props, observed_at, valid_until),
         )
     stats["relations_added"] += 1
     logger.info("Added relation: %s --depends_on--> %s", source_name, dep_name)
+    return target_id
+
+
+def _expire_stale_dependency_relations(
+    conn: sqlite3.Connection,
+    source_id: str,
+    observed_targets: set[str],
+    stats: dict[str, int],
+    dry_run: bool,
+    observed_at: str,
+) -> None:
+    """Expire code_intelligence depends_on facts absent from the current project scan."""
+    if dry_run:
+        return
+
+    stale_target_ids: set[str] = set()
+    rows = conn.execute(
+        """
+        SELECT id, target_id, properties, expired_at
+        FROM kg_relations
+        WHERE source_id = ? AND relation_type = 'depends_on'
+        """,
+        (source_id,),
+    ).fetchall()
+
+    for rel_id, target_id, properties, expired_at in rows:
+        if target_id in observed_targets or not _is_code_intelligence_relation(properties):
+            continue
+        stale_target_ids.add(target_id)
+        if expired_at is None:
+            conn.execute(
+                "UPDATE kg_relations SET valid_until = ?, expired_at = ? WHERE id = ?",
+                (observed_at, observed_at, rel_id),
+            )
+            stats["relations_expired"] += 1
+
+    for target_id in stale_target_ids:
+        active_rows = conn.execute(
+            """
+            SELECT properties
+            FROM kg_relations
+            WHERE target_id = ?
+              AND relation_type = 'depends_on'
+              AND expired_at IS NULL
+            """,
+            (target_id,),
+        ).fetchall()
+        has_active_code_fact = any(_is_code_intelligence_relation(properties) for (properties,) in active_rows)
+        if has_active_code_fact:
+            continue
+        result = conn.execute(
+            """
+            UPDATE kg_entities
+            SET valid_until = ?, expired_at = COALESCE(expired_at, ?),
+                updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+            WHERE id = ? AND entity_type = 'library'
+            """,
+            (observed_at, observed_at, target_id),
+        )
+        stats["dep_entities_expired"] += result.rowcount
 
 
 if __name__ == "__main__":

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -104,7 +104,9 @@ def _code_intelligence_properties(properties: str | None = None) -> str:
             loaded["source"] = [*source, CODE_INTELLIGENCE_SOURCE]
     elif source != CODE_INTELLIGENCE_SOURCE:
         existing_sources = sources if isinstance(sources, list) else []
-        loaded["sources"] = [*dict.fromkeys([*existing_sources, source, CODE_INTELLIGENCE_SOURCE])]
+        loaded["sources"] = [
+            item for item in dict.fromkeys([*existing_sources, source, CODE_INTELLIGENCE_SOURCE]) if item is not None
+        ]
     return json.dumps(loaded, sort_keys=True)
 
 
@@ -117,13 +119,20 @@ def _writer_pidfile_path(db_path: str | Path) -> Path:
     return pidfile_dir.resolve() / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
 
 
+def _linux_proc_stat_start_time(stat_text: str) -> str | None:
+    end_comm = stat_text.rfind(")")
+    if end_comm == -1:
+        fields = stat_text.split()
+        return fields[21] if len(fields) > 21 else None
+    fields_after_comm = stat_text[end_comm + 2 :].split()
+    return fields_after_comm[19] if len(fields_after_comm) > 19 else None
+
+
 def _pid_start_time(pid: int) -> str | None:
     try:
         stat_path = Path("/proc") / str(pid) / "stat"
         if stat_path.exists():
-            fields = stat_path.read_text(encoding="utf-8").split()
-            if len(fields) > 21:
-                return fields[21]
+            return _linux_proc_stat_start_time(stat_path.read_text(encoding="utf-8"))
     except OSError:
         pass
     try:
@@ -206,7 +215,10 @@ def _code_intelligence_writer_lock(db_path: str | Path, dry_run: bool):
             break
         except FileExistsError:
             owner_pid, owner_start_time = _read_pidfile_owner(pidfile)
-            if owner_pid is not None and _pidfile_owner_matches(owner_pid, owner_start_time):
+            if owner_pid is None:
+                time.sleep(0.01 * (attempt + 1))
+                continue
+            if _pidfile_owner_matches(owner_pid, owner_start_time):
                 raise RuntimeError(f"another writer is using {db_path} (pid {owner_pid})")
             try:
                 pidfile.unlink()
@@ -220,7 +232,9 @@ def _code_intelligence_writer_lock(db_path: str | Path, dry_run: bool):
     try:
         yield
     finally:
-        if _read_pidfile_owner(pidfile)[0] == pid:
+        owner_pid, owner_start_time = _read_pidfile_owner(pidfile)
+        current_start_time = _pid_start_time(pid)
+        if owner_pid == pid and (owner_start_time is None or owner_start_time == current_start_time):
             try:
                 pidfile.unlink()
             except FileNotFoundError:
@@ -250,8 +264,8 @@ def _ensure_reconciliation_schema(conn: sqlite3.Connection) -> None:
     conn.execute("""
         CREATE VIEW IF NOT EXISTS kg_current_facts AS
         SELECT * FROM kg_relations
-        WHERE (valid_from IS NULL OR valid_from <= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-          AND (valid_until IS NULL OR valid_until >= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+        WHERE (valid_from IS NULL OR julianday(valid_from) <= julianday('now'))
+          AND (valid_until IS NULL OR julianday(valid_until) >= julianday('now'))
           AND expired_at IS NULL
     """)
 
@@ -634,17 +648,17 @@ def _expire_stale_dependency_relations(
             stats["relations_expired"] += 1
 
     for target_id in stale_target_ids:
-        active_depends_on = conn.execute(
+        active_fact = conn.execute(
             """
             SELECT 1
             FROM kg_current_facts
-            WHERE target_id = ?
-              AND relation_type = 'depends_on'
+            WHERE source_id = ?
+               OR target_id = ?
             LIMIT 1
             """,
-            (target_id,),
+            (target_id, target_id),
         ).fetchone()
-        if active_depends_on:
+        if active_fact:
             continue
         result = conn.execute(
             """

--- a/src/brainlayer/pipeline/code_intelligence.py
+++ b/src/brainlayer/pipeline/code_intelligence.py
@@ -586,13 +586,27 @@ def _add_dependency_relation(
             )
 
     # Check if relation already exists
+    relation_cols = {row[1] for row in conn.execute("PRAGMA table_info(kg_relations)")}
+    expired_column = "expired_at" if "expired_at" in relation_cols else "NULL AS expired_at"
     existing = conn.execute(
-        "SELECT id, properties FROM kg_relations WHERE source_id = ? AND target_id = ? AND relation_type = 'depends_on'",
+        """
+        SELECT id, properties, {expired_column}
+        FROM kg_relations
+        WHERE source_id = ? AND target_id = ? AND relation_type = 'depends_on'
+        """.format(expired_column=expired_column),
         (source_id, target_id),
     ).fetchone()
 
     if existing:
         if not _is_code_intelligence_relation(existing[1]):
+            if existing[2] is not None and not dry_run:
+                conn.execute(
+                    """UPDATE kg_relations
+                       SET valid_from = COALESCE(valid_from, ?),
+                           valid_until = ?, expired_at = NULL
+                       WHERE id = ?""",
+                    (observed_at, valid_until, existing[0]),
+                )
             return target_id
         if not dry_run:
             conn.execute(

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -1189,6 +1189,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("importance", "REAL DEFAULT 0.5"),
             ("valid_from", "TEXT"),
             ("valid_until", "TEXT"),
+            ("expired_at", "TEXT"),
             ("group_id", "TEXT"),
         ]:
             if col not in kg_entity_cols:
@@ -1198,6 +1199,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             "CREATE INDEX IF NOT EXISTS idx_kg_entities_canonical ON kg_entities(canonical_name, entity_type)"
         )
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_kg_entities_valid ON kg_entities(valid_from, valid_until)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_kg_entities_expired ON kg_entities(expired_at)")
 
         for col, default in [
             ("fact", "TEXT"),
@@ -1211,6 +1213,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 cursor.execute(f"ALTER TABLE kg_relations ADD COLUMN {col} {default}")
 
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_kg_relations_validity ON kg_relations(valid_from, valid_until)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_kg_relations_expired ON kg_relations(expired_at)")
 
         ec_cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_chunks)")}
         if "mention_type" not in ec_cols:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -1310,8 +1310,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         cursor.execute("""
             CREATE VIEW IF NOT EXISTS kg_current_facts AS
             SELECT * FROM kg_relations
-            WHERE (valid_from IS NULL OR valid_from <= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-              AND (valid_until IS NULL OR valid_until >= strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            WHERE (valid_from IS NULL OR julianday(valid_from) <= julianday('now'))
+              AND (valid_until IS NULL OR julianday(valid_until) >= julianday('now'))
               AND expired_at IS NULL
         """)
 

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -731,6 +731,19 @@ dependencies = [
 
         assert pidfile.exists()
 
+    def test_writer_lock_allows_missing_fcntl(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """regression-guard: importing code-intelligence on non-Unix hosts must not require fcntl."""
+        from brainlayer.pipeline import code_intelligence
+
+        monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "locks"))
+        monkeypatch.setattr(code_intelligence, "fcntl", None)
+        db_path = tmp_path / "portable.db"
+
+        with code_intelligence._code_intelligence_writer_lock(db_path, dry_run=False):
+            assert code_intelligence._writer_pidfile_path(db_path).exists()
+
+        assert not code_intelligence._writer_pidfile_path(db_path).exists()
+
     def test_code_intelligence_properties_do_not_write_none_sources(self) -> None:
         """regression-guard: source merge must not persist null provenance values."""
         from brainlayer.pipeline.code_intelligence import _code_intelligence_properties

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -418,9 +418,10 @@ dependencies = [
 
     def test_reconcile_preserves_non_code_intelligence_dependency_owner(self, tmp_repos: Path, tmp_db: str) -> None:
         """regression-guard: code scanner must not take ownership of non-scanner relations."""
-        from brainlayer.pipeline.code_intelligence import enrich_projects
+        from brainlayer.pipeline.code_intelligence import _ensure_reconciliation_schema, enrich_projects
 
         conn = sqlite3.connect(tmp_db)
+        _ensure_reconciliation_schema(conn)
         conn.execute(
             "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('proj-manual', 'project', 'brainlayer', '{}')"
         )
@@ -460,6 +461,65 @@ dependencies = [
         assert row is not None
         assert json.loads(row[0]) == {"source": "manual"}
         assert row[1] is None
+
+    def test_observed_manual_dependency_is_reactivated_without_taking_ownership(
+        self, tmp_repos: Path, tmp_db: str
+    ) -> None:
+        """regression-guard: live scan evidence must revive an expired manual edge without changing provenance."""
+        from brainlayer.pipeline.code_intelligence import _ensure_reconciliation_schema, enrich_projects
+
+        conn = sqlite3.connect(tmp_db)
+        _ensure_reconciliation_schema(conn)
+        conn.execute(
+            "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('proj-manual', 'project', 'brainlayer', '{}')"
+        )
+        conn.execute(
+            """
+            INSERT INTO kg_entities
+                (id, entity_type, name, metadata, valid_until, expired_at)
+            VALUES
+                ('lib-manual', 'library', 'fastapi', '{}',
+                 '2026-01-01T00:00:00.000000Z', '2026-01-01T00:00:00.000000Z')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO kg_relations
+                (id, source_id, target_id, relation_type, properties, confidence, valid_until, expired_at)
+            VALUES
+                ('rel-manual', 'proj-manual', 'lib-manual', 'depends_on', '{"source":"manual"}', 0.8,
+                 '2026-01-01T00:00:00.000000Z', '2026-01-01T00:00:00.000000Z')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute(
+            """
+            SELECT properties, valid_until, expired_at
+            FROM kg_relations
+            WHERE id = 'rel-manual'
+            """
+        ).fetchone()
+        active_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM kg_current_facts
+            WHERE source_id = 'proj-manual'
+              AND target_id = 'lib-manual'
+              AND relation_type = 'depends_on'
+            """
+        ).fetchone()[0]
+        conn.close()
+
+        assert row is not None
+        assert json.loads(row[0]) == {"source": "manual"}
+        assert row[1] != "2026-01-01T00:00:00.000000Z"
+        assert row[2] is None
+        assert active_count == 1
 
     def test_library_entity_not_expired_when_other_depends_on_remains(self, tmp_repos: Path, tmp_db: str) -> None:
         """regression-guard: expiring one source fact must not hide another active depends_on fact."""

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -3,7 +3,7 @@
 import json
 import os
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -528,6 +528,61 @@ dependencies = [
         assert entity_expired_at is None
         assert manual_active_count == 1
 
+    def test_library_entity_not_expired_when_other_active_relation_remains(self, tmp_repos: Path, tmp_db: str) -> None:
+        """regression-guard: expiring one scanner fact must not hide other active KG facts."""
+        from brainlayer.pipeline.code_intelligence import enrich_projects
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        fastapi_id = conn.execute(
+            "SELECT id FROM kg_entities WHERE entity_type = 'library' AND name = 'fastapi'"
+        ).fetchone()[0]
+        conn.execute(
+            "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('tool-api', 'tool', 'api-check', '{}')"
+        )
+        conn.execute(
+            """
+            INSERT INTO kg_relations (id, source_id, target_id, relation_type, properties, confidence)
+            VALUES ('rel-tool-fastapi', 'tool-api', ?, 'uses_tool', '{"source":"manual"}', 0.8)
+            """,
+            (fastapi_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        (tmp_repos / "brainlayer" / "pyproject.toml").write_text(
+            """
+[project]
+name = "brainlayer"
+version = "1.0.0"
+description = "Memory for AI agents"
+dependencies = [
+    "apsw>=3.45.0",
+    "typer>=0.9.0",
+    "rich>=13.0",
+]
+"""
+        )
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        entity_expired_at = conn.execute("SELECT expired_at FROM kg_entities WHERE id = ?", (fastapi_id,)).fetchone()[0]
+        active_tool_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM kg_current_facts
+            WHERE source_id = 'tool-api'
+              AND target_id = ?
+              AND relation_type = 'uses_tool'
+            """,
+            (fastapi_id,),
+        ).fetchone()[0]
+        conn.close()
+
+        assert entity_expired_at is None
+        assert active_tool_count == 1
+
     def test_timestamp_precision_matches_sqlite_current_fact_view(self) -> None:
         """regression-guard: Python validity timestamps must sort with SQLite strftime('%f') values."""
         from brainlayer.pipeline.code_intelligence import _timestamp
@@ -535,6 +590,38 @@ dependencies = [
         observed = datetime(2026, 5, 23, 10, 0, 45, 123456, tzinfo=timezone.utc)
 
         assert _timestamp(observed) == "2026-05-23T10:00:45.123Z"
+
+    def test_current_facts_view_uses_timestamp_aware_validity(self, tmp_db: str) -> None:
+        """regression-guard: valid_from offsets must not be compared as raw strings."""
+        from brainlayer.pipeline.code_intelligence import _ensure_reconciliation_schema
+
+        offset = timezone(timedelta(hours=1))
+        valid_from = (
+            (datetime.now(timezone.utc) - timedelta(seconds=1)).astimezone(offset).isoformat(timespec="milliseconds")
+        )
+        valid_until = (
+            (datetime.now(timezone.utc) + timedelta(days=1)).astimezone(offset).isoformat(timespec="milliseconds")
+        )
+
+        conn = sqlite3.connect(tmp_db)
+        _ensure_reconciliation_schema(conn)
+        conn.execute(
+            "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('proj-a', 'project', 'a', '{}')"
+        )
+        conn.execute("INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('lib-b', 'library', 'b', '{}')")
+        conn.execute(
+            """
+            INSERT INTO kg_relations
+                (id, source_id, target_id, relation_type, properties, confidence, valid_from, valid_until, expired_at)
+            VALUES ('rel-offset', 'proj-a', 'lib-b', 'depends_on', '{}', 0.9, ?, ?, NULL)
+            """,
+            (valid_from, valid_until),
+        )
+
+        count = conn.execute("SELECT COUNT(*) FROM kg_current_facts WHERE id = 'rel-offset'").fetchone()[0]
+        conn.close()
+
+        assert count == 1
 
     def test_refresh_preserves_code_intelligence_relation_metadata(self, tmp_repos: Path, tmp_db: str) -> None:
         """regression-guard: refreshing scanner-owned facts must not clobber extra provenance metadata."""
@@ -629,3 +716,51 @@ dependencies = [
                 pass
 
         assert pidfile.exists()
+
+    def test_writer_lock_cleanup_checks_pid_start_time(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """regression-guard: cleanup must not unlink a pidfile for a reused PID owner."""
+        from brainlayer.pipeline import code_intelligence
+
+        monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "locks"))
+        monkeypatch.setattr(code_intelligence, "_pid_start_time", lambda pid: "owner-start")
+        db_path = tmp_path / "cleanup.db"
+        pidfile = code_intelligence._writer_pidfile_path(db_path)
+
+        with code_intelligence._code_intelligence_writer_lock(db_path, dry_run=False):
+            pidfile.write_text(f"{os.getpid()}\nstart_time=reused-start\n")
+
+        assert pidfile.exists()
+
+    def test_code_intelligence_properties_do_not_write_none_sources(self) -> None:
+        """regression-guard: source merge must not persist null provenance values."""
+        from brainlayer.pipeline.code_intelligence import _code_intelligence_properties
+
+        properties = json.loads(_code_intelligence_properties('{"sources":["manual"]}'))
+
+        assert properties["sources"] == ["manual", "code_intelligence"]
+
+    def test_writer_lock_preserves_unreadable_pidfile_race(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """regression-guard: empty pidfiles may be in-flight writers and must not be unlinked immediately."""
+        from brainlayer.pipeline.code_intelligence import _code_intelligence_writer_lock, _writer_pidfile_path
+
+        monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "locks"))
+        db_path = tmp_path / "race.db"
+        pidfile = _writer_pidfile_path(db_path)
+        pidfile.parent.mkdir(parents=True)
+        pidfile.write_text("")
+
+        with pytest.raises(RuntimeError, match="could not acquire writer pidfile"):
+            with _code_intelligence_writer_lock(db_path, dry_run=False):
+                pass
+
+        assert pidfile.exists()
+
+    def test_linux_proc_stat_start_time_handles_process_names_with_spaces(self) -> None:
+        """regression-guard: /proc pid stat parsing must account for spaces inside process names."""
+        from brainlayer.pipeline.code_intelligence import _linux_proc_stat_start_time
+
+        stat_text = "1234 (python worker) S " + " ".join(str(idx) for idx in range(3, 21)) + " 987654 0"
+
+        assert _linux_proc_stat_start_time(stat_text) == "987654"

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -315,3 +315,101 @@ class TestEnrichProjects:
         conn.close()
         # Should be exactly the number from first run, not doubled
         assert count > 0
+
+    def test_reconcile_removed_dependency_expires_relation(self, tmp_repos: Path, tmp_db: str) -> None:
+        """regression-guard: removed code_intelligence dependencies are expired, not left current."""
+        from brainlayer.pipeline.code_intelligence import enrich_projects
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        (tmp_repos / "brainlayer" / "pyproject.toml").write_text(
+            """
+[project]
+name = "brainlayer"
+version = "1.0.0"
+description = "Memory for AI agents"
+dependencies = [
+    "apsw>=3.45.0",
+    "typer>=0.9.0",
+    "rich>=13.0",
+]
+"""
+        )
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute(
+            """
+            SELECT r.expired_at
+            FROM kg_relations r
+            JOIN kg_entities src ON r.source_id = src.id
+            JOIN kg_entities tgt ON r.target_id = tgt.id
+            WHERE src.name = 'brainlayer'
+              AND tgt.name = 'fastapi'
+              AND r.relation_type = 'depends_on'
+            """
+        ).fetchone()
+        active_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM kg_current_facts r
+            JOIN kg_entities src ON r.source_id = src.id
+            JOIN kg_entities tgt ON r.target_id = tgt.id
+            WHERE src.name = 'brainlayer'
+              AND tgt.name = 'fastapi'
+              AND r.relation_type = 'depends_on'
+            """
+        ).fetchone()[0]
+        conn.close()
+
+        assert row is not None
+        assert row[0] is not None
+        assert active_count == 0
+
+    def test_reobserved_dependency_refreshes_valid_until_without_expiring(self, tmp_repos: Path, tmp_db: str) -> None:
+        """regression-guard: positive re-observation revives the fact and extends validity."""
+        from brainlayer.pipeline.code_intelligence import enrich_projects
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        conn.execute(
+            """
+            UPDATE kg_relations
+            SET valid_until = '2026-01-01T00:00:00.000000Z',
+                expired_at = '2026-01-01T00:00:00.000000Z'
+            WHERE id IN (
+                SELECT r.id
+                FROM kg_relations r
+                JOIN kg_entities src ON r.source_id = src.id
+                JOIN kg_entities tgt ON r.target_id = tgt.id
+                WHERE src.name = 'brainlayer'
+                  AND tgt.name = 'fastapi'
+                  AND r.relation_type = 'depends_on'
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute(
+            """
+            SELECT r.valid_until, r.expired_at
+            FROM kg_relations r
+            JOIN kg_entities src ON r.source_id = src.id
+            JOIN kg_entities tgt ON r.target_id = tgt.id
+            WHERE src.name = 'brainlayer'
+              AND tgt.name = 'fastapi'
+              AND r.relation_type = 'depends_on'
+            """
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] is not None
+        assert row[0] != "2026-01-01T00:00:00.000000Z"
+        assert row[1] is None

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -413,3 +413,115 @@ dependencies = [
         assert row[0] is not None
         assert row[0] != "2026-01-01T00:00:00.000000Z"
         assert row[1] is None
+
+    def test_reconcile_preserves_non_code_intelligence_dependency_owner(self, tmp_repos: Path, tmp_db: str) -> None:
+        """regression-guard: code scanner must not take ownership of non-scanner relations."""
+        from brainlayer.pipeline.code_intelligence import enrich_projects
+
+        conn = sqlite3.connect(tmp_db)
+        conn.execute(
+            "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('proj-manual', 'project', 'brainlayer', '{}')"
+        )
+        conn.execute(
+            "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('lib-manual', 'library', 'fastapi', '{}')"
+        )
+        conn.execute(
+            """
+            INSERT INTO kg_relations (id, source_id, target_id, relation_type, properties, confidence)
+            VALUES ('rel-manual', 'proj-manual', 'lib-manual', 'depends_on', '{"source":"manual"}', 0.8)
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        (tmp_repos / "brainlayer" / "pyproject.toml").write_text(
+            """
+[project]
+name = "brainlayer"
+version = "1.0.0"
+description = "Memory for AI agents"
+dependencies = [
+    "apsw>=3.45.0",
+    "typer>=0.9.0",
+    "rich>=13.0",
+]
+"""
+        )
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute("SELECT properties, expired_at FROM kg_relations WHERE id = 'rel-manual'").fetchone()
+        conn.close()
+
+        assert row is not None
+        assert json.loads(row[0]) == {"source": "manual"}
+        assert row[1] is None
+
+    def test_library_entity_not_expired_when_other_depends_on_remains(self, tmp_repos: Path, tmp_db: str) -> None:
+        """regression-guard: expiring one source fact must not hide another active depends_on fact."""
+        from brainlayer.pipeline.code_intelligence import enrich_projects
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        fastapi_id = conn.execute(
+            "SELECT id FROM kg_entities WHERE entity_type = 'library' AND name = 'fastapi'"
+        ).fetchone()[0]
+        conn.execute(
+            "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES ('proj-other', 'project', 'other', '{}')"
+        )
+        conn.execute(
+            """
+            INSERT INTO kg_relations (id, source_id, target_id, relation_type, properties, confidence)
+            VALUES ('rel-other', 'proj-other', ?, 'depends_on', '{"source":"manual"}', 0.8)
+            """,
+            (fastapi_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        (tmp_repos / "brainlayer" / "pyproject.toml").write_text(
+            """
+[project]
+name = "brainlayer"
+version = "1.0.0"
+description = "Memory for AI agents"
+dependencies = [
+    "apsw>=3.45.0",
+    "typer>=0.9.0",
+    "rich>=13.0",
+]
+"""
+        )
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        relation_expired_at, entity_expired_at = conn.execute(
+            """
+            SELECT r.expired_at, lib.expired_at
+            FROM kg_relations r
+            JOIN kg_entities src ON r.source_id = src.id
+            JOIN kg_entities lib ON r.target_id = lib.id
+            WHERE src.name = 'brainlayer'
+              AND lib.name = 'fastapi'
+              AND r.relation_type = 'depends_on'
+            """
+        ).fetchone()
+        manual_active_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM kg_current_facts r
+            JOIN kg_entities src ON r.source_id = src.id
+            JOIN kg_entities lib ON r.target_id = lib.id
+            WHERE src.name = 'other'
+              AND lib.name = 'fastapi'
+              AND r.relation_type = 'depends_on'
+            """
+        ).fetchone()[0]
+        conn.close()
+
+        assert relation_expired_at is not None
+        assert entity_expired_at is None
+        assert manual_active_count == 1

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -516,10 +516,43 @@ dependencies = [
         conn.close()
 
         assert row is not None
-        assert json.loads(row[0]) == {"source": "manual"}
+        properties = json.loads(row[0])
+        assert properties["source"] == "manual"
+        assert properties["sources"] == ["manual", "code_intelligence"]
         assert row[1] != "2026-01-01T00:00:00.000000Z"
         assert row[2] is None
         assert active_count == 1
+
+        (tmp_repos / "brainlayer" / "pyproject.toml").write_text(
+            """
+[project]
+name = "brainlayer"
+version = "1.0.0"
+description = "Memory for AI agents"
+dependencies = [
+    "apsw>=3.45.0",
+    "typer>=0.9.0",
+    "rich>=13.0",
+]
+"""
+        )
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        expired_at = conn.execute("SELECT expired_at FROM kg_relations WHERE id = 'rel-manual'").fetchone()[0]
+        active_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM kg_current_facts
+            WHERE source_id = 'proj-manual'
+              AND target_id = 'lib-manual'
+              AND relation_type = 'depends_on'
+            """
+        ).fetchone()[0]
+        conn.close()
+
+        assert expired_at is not None
+        assert active_count == 0
 
     def test_library_entity_not_expired_when_other_depends_on_remains(self, tmp_repos: Path, tmp_db: str) -> None:
         """regression-guard: expiring one source fact must not hide another active depends_on fact."""

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -525,3 +526,85 @@ dependencies = [
         assert relation_expired_at is not None
         assert entity_expired_at is None
         assert manual_active_count == 1
+
+    def test_timestamp_precision_matches_sqlite_current_fact_view(self) -> None:
+        """regression-guard: Python validity timestamps must sort with SQLite strftime('%f') values."""
+        from brainlayer.pipeline.code_intelligence import _timestamp
+
+        observed = datetime(2026, 5, 23, 10, 0, 45, 123456, tzinfo=timezone.utc)
+
+        assert _timestamp(observed) == "2026-05-23T10:00:45.123Z"
+
+    def test_refresh_preserves_code_intelligence_relation_metadata(self, tmp_repos: Path, tmp_db: str) -> None:
+        """regression-guard: refreshing scanner-owned facts must not clobber extra provenance metadata."""
+        from brainlayer.pipeline.code_intelligence import enrich_projects
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        conn.execute(
+            """
+            UPDATE kg_relations
+            SET properties = '{"source":"code_intelligence","evidence":"manual-note"}'
+            WHERE id IN (
+                SELECT r.id
+                FROM kg_relations r
+                JOIN kg_entities src ON r.source_id = src.id
+                JOIN kg_entities tgt ON r.target_id = tgt.id
+                WHERE src.name = 'brainlayer'
+                  AND tgt.name = 'fastapi'
+                  AND r.relation_type = 'depends_on'
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute(
+            """
+            SELECT r.properties
+            FROM kg_relations r
+            JOIN kg_entities src ON r.source_id = src.id
+            JOIN kg_entities tgt ON r.target_id = tgt.id
+            WHERE src.name = 'brainlayer'
+              AND tgt.name = 'fastapi'
+              AND r.relation_type = 'depends_on'
+            """
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert json.loads(row[0])["evidence"] == "manual-note"
+
+    def test_reconcile_checkpoints_wal_around_bulk_writes(
+        self, tmp_repos: Path, tmp_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """regression-guard: KG reconciliation bulk writes checkpoint WAL before and after the pass."""
+        from brainlayer.pipeline import code_intelligence
+
+        real_connect = sqlite3.connect
+        executed_sql: list[str] = []
+
+        class RecordingConnection:
+            def __init__(self, conn: sqlite3.Connection) -> None:
+                self._conn = conn
+
+            def execute(self, sql: str, *args, **kwargs):
+                executed_sql.append(sql)
+                return self._conn.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name: str):
+                return getattr(self._conn, name)
+
+        def recording_connect(*args, **kwargs):
+            return RecordingConnection(real_connect(*args, **kwargs))
+
+        monkeypatch.setattr(code_intelligence.sqlite3, "connect", recording_connect)
+
+        code_intelligence.enrich_projects(db_path=tmp_db, base_dir=tmp_repos)
+
+        checkpoint_count = sum(1 for sql in executed_sql if "PRAGMA wal_checkpoint(FULL)" in sql)
+        assert checkpoint_count >= 2

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -1,6 +1,7 @@
 """Tests for code_intelligence.py — project entity extraction from repo metadata."""
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -608,3 +609,23 @@ dependencies = [
 
         checkpoint_count = sum(1 for sql in executed_sql if "PRAGMA wal_checkpoint(FULL)" in sql)
         assert checkpoint_count >= 2
+
+    def test_writer_lock_rejects_existing_same_pid_owner(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """regression-guard: code-intelligence must not bypass another writer owned by this PID."""
+        from brainlayer.pipeline.code_intelligence import (
+            _code_intelligence_writer_lock,
+            _pidfile_payload,
+            _writer_pidfile_path,
+        )
+
+        monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "locks"))
+        db_path = tmp_path / "same-pid.db"
+        pidfile = _writer_pidfile_path(db_path)
+        pidfile.parent.mkdir(parents=True)
+        pidfile.write_bytes(_pidfile_payload(os.getpid()))
+
+        with pytest.raises(RuntimeError, match="another writer is using"):
+            with _code_intelligence_writer_lock(db_path, dry_run=False):
+                pass
+
+        assert pidfile.exists()

--- a/tests/test_eval_framework.py
+++ b/tests/test_eval_framework.py
@@ -87,6 +87,21 @@ def test_benchmark_evaluates_with_mismatched_query_ids(qrels_file: Path):
     assert 0.0 <= scores["ndcg@10"] <= 1.0
 
 
+def test_manual_fallback_averages_only_qrels_queries(qrels_file: Path):
+    """regression-guard: manual fallback should match Ranx's qrels-query averaging."""
+    from brainlayer.eval.benchmark import SearchBenchmark
+
+    benchmark = SearchBenchmark(str(qrels_file))
+    run_dict = {
+        "q1": {"doc-a": 4.0},
+        "q-extra": {"doc-z": 9.0},
+    }
+
+    scores = benchmark._evaluate_without_ranx(run_dict, ["recall@10"])
+
+    assert scores["recall@10"] == pytest.approx(0.25)
+
+
 def test_benchmark_compares(qrels_file: Path):
     from brainlayer.eval.benchmark import DEFAULT_QUERY_SUITE, SearchBenchmark
 

--- a/tests/test_eval_framework.py
+++ b/tests/test_eval_framework.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import math
 import os
 from pathlib import Path
 
@@ -100,6 +101,34 @@ def test_manual_fallback_averages_only_qrels_queries(qrels_file: Path):
     scores = benchmark._evaluate_without_ranx(run_dict, ["recall@10"])
 
     assert scores["recall@10"] == pytest.approx(0.25)
+
+
+def test_manual_fallback_map_at_k_uses_cutoff_relevant_count(tmp_path: Path):
+    """regression-guard: perfect top-k AP should be 1.0 even when more relevant docs exist."""
+    from brainlayer.eval.benchmark import SearchBenchmark
+
+    qrels_path = tmp_path / "qrels.json"
+    qrels_path.write_text(json.dumps({"q1": {f"doc-{idx}": 1 for idx in range(20)}}))
+    benchmark = SearchBenchmark(str(qrels_path))
+    run_dict = {"q1": {f"doc-{idx}": 20 - idx for idx in range(10)}}
+
+    scores = benchmark._evaluate_without_ranx(run_dict, ["map@10"])
+
+    assert scores["map@10"] == pytest.approx(1.0)
+
+
+def test_manual_fallback_ndcg_uses_linear_gain(qrels_file: Path):
+    """regression-guard: ndcg fallback must match ranx ndcg's linear-gain semantics."""
+    from brainlayer.eval.benchmark import SearchBenchmark
+
+    benchmark = SearchBenchmark(str(qrels_file))
+    run_dict = {"q1": {"doc-b": 2.0, "doc-a": 1.0}}
+
+    scores = benchmark._evaluate_without_ranx(run_dict, ["ndcg@10"])
+
+    expected_q1 = (1 / math.log2(2) + 3 / math.log2(3)) / (3 / math.log2(2) + 1 / math.log2(3))
+    expected = (expected_q1 + 0.0) / 2
+    assert scores["ndcg@10"] == pytest.approx(expected)
 
 
 def test_benchmark_compares(qrels_file: Path):

--- a/tests/test_eval_framework.py
+++ b/tests/test_eval_framework.py
@@ -103,8 +103,8 @@ def test_manual_fallback_averages_only_qrels_queries(qrels_file: Path):
     assert scores["recall@10"] == pytest.approx(0.25)
 
 
-def test_manual_fallback_map_at_k_uses_cutoff_relevant_count(tmp_path: Path):
-    """regression-guard: perfect top-k AP should be 1.0 even when more relevant docs exist."""
+def test_manual_fallback_map_at_k_uses_full_relevant_count(tmp_path: Path):
+    """regression-guard: map@k fallback must match ranx full-relevance denominator semantics."""
     from brainlayer.eval.benchmark import SearchBenchmark
 
     qrels_path = tmp_path / "qrels.json"
@@ -114,7 +114,17 @@ def test_manual_fallback_map_at_k_uses_cutoff_relevant_count(tmp_path: Path):
 
     scores = benchmark._evaluate_without_ranx(run_dict, ["map@10"])
 
-    assert scores["map@10"] == pytest.approx(1.0)
+    assert scores["map@10"] == pytest.approx(0.5)
+
+
+def test_manual_fallback_rejects_non_positive_metric_cutoff(qrels_file: Path):
+    """regression-guard: metric cutoffs must fail clearly before AP denominator math."""
+    from brainlayer.eval.benchmark import SearchBenchmark
+
+    benchmark = SearchBenchmark(str(qrels_file))
+
+    with pytest.raises(ValueError, match="Metric cutoff must be > 0"):
+        benchmark._evaluate_without_ranx({"q1": {"doc-a": 1.0}}, ["map@0"])
 
 
 def test_manual_fallback_ndcg_uses_linear_gain(qrels_file: Path):

--- a/tests/test_kg_schema.py
+++ b/tests/test_kg_schema.py
@@ -12,6 +12,8 @@ Tests cover:
 9. YouTube source filter bug fix (project auto-scope skip for non-claude_code sources)
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from brainlayer.vector_store import VectorStore
@@ -134,6 +136,29 @@ class TestKGTableCreation:
         relation_indexes = {row[1] for row in cursor.execute("PRAGMA index_list(kg_relations)")}
         assert "idx_kg_entities_expired" in entity_indexes
         assert "idx_kg_relations_expired" in relation_indexes
+
+    def test_current_facts_view_uses_timestamp_aware_validity(self, store):
+        """regression-guard: VectorStore must recreate kg_current_facts with timestamp-aware checks."""
+        store.upsert_entity("proj-a", "project", "a")
+        store.upsert_entity("lib-b", "library", "b")
+        store.add_relation("rel-offset", "proj-a", "lib-b", "depends_on", confidence=0.9)
+        offset = timezone(timedelta(hours=1))
+        valid_from = (
+            (datetime.now(timezone.utc) - timedelta(seconds=1)).astimezone(offset).isoformat(timespec="milliseconds")
+        )
+        valid_until = (
+            (datetime.now(timezone.utc) + timedelta(days=1)).astimezone(offset).isoformat(timespec="milliseconds")
+        )
+        store.conn.cursor().execute(
+            "UPDATE kg_relations SET valid_from = ?, valid_until = ? WHERE id = 'rel-offset'",
+            (valid_from, valid_until),
+        )
+
+        count = (
+            store._read_cursor().execute("SELECT COUNT(*) FROM kg_current_facts WHERE id = 'rel-offset'").fetchone()[0]
+        )
+
+        assert count == 1
 
 
 # ── Entity CRUD Tests ────────────────────────────────────────

--- a/tests/test_kg_schema.py
+++ b/tests/test_kg_schema.py
@@ -88,6 +88,7 @@ class TestKGTableCreation:
             "importance",
             "valid_from",
             "valid_until",
+            "expired_at",
             "group_id",
             "parent_id",
             "entity_subtype",
@@ -125,6 +126,14 @@ class TestKGTableCreation:
         cursor = store._read_cursor()
         cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
         assert "source_project_id" in cols
+
+    def test_expired_at_indexes_exist(self, store):
+        """regression-guard: stateful reconciliation needs efficient current-fact filtering."""
+        cursor = store._read_cursor()
+        entity_indexes = {row[1] for row in cursor.execute("PRAGMA index_list(kg_entities)")}
+        relation_indexes = {row[1] for row in cursor.execute("PRAGMA index_list(kg_relations)")}
+        assert "idx_kg_entities_expired" in entity_indexes
+        assert "idx_kg_relations_expired" in relation_indexes
 
 
 # ── Entity CRUD Tests ────────────────────────────────────────

--- a/tests/test_kg_standard.py
+++ b/tests/test_kg_standard.py
@@ -160,6 +160,7 @@ class TestKGStandardColumns:
             "importance",
             "valid_from",
             "valid_until",
+            "expired_at",
             "group_id",
         ):
             assert col in cols, f"Missing column: {col}"
@@ -226,6 +227,7 @@ class TestEntityStandardCRUD:
         assert entity["description"] is None
         assert entity["valid_from"] is None
         assert entity["valid_until"] is None
+        assert entity["expired_at"] is None
         assert entity["group_id"] is None
 
     def test_backward_compat_metadata_still_works(self, store):

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -11,6 +11,7 @@ Covers:
 
 import asyncio
 import logging
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from brainlayer.mcp.search_handler import _brain_recall, _brain_search
@@ -40,6 +41,43 @@ def test_kg_facts_sql_excludes_expired_relations(tmp_path):
         store.soft_close_relation("rel-fastapi")
 
         assert _kg_facts_sql(store, "brainlayer") == []
+    finally:
+        store.close()
+
+
+def test_kg_facts_sql_uses_timestamp_aware_validity(tmp_path):
+    """regression-guard: brain_search KG SQL must not lexicographically compare offset timestamps."""
+    from brainlayer.mcp.search_handler import _kg_facts_sql
+    from brainlayer.vector_store import VectorStore
+
+    store = VectorStore(tmp_path / "kg.db")
+    try:
+        store.upsert_entity("proj-brainlayer", "project", "brainlayer")
+        store.upsert_entity("lib-fastapi", "library", "fastapi")
+        store.add_relation(
+            "rel-fastapi",
+            "proj-brainlayer",
+            "lib-fastapi",
+            "depends_on",
+            properties={"source": "code_intelligence"},
+            confidence=0.99,
+        )
+        offset = timezone(timedelta(hours=1))
+        valid_from = (
+            (datetime.now(timezone.utc) - timedelta(seconds=1)).astimezone(offset).isoformat(timespec="milliseconds")
+        )
+        valid_until = (
+            (datetime.now(timezone.utc) + timedelta(days=1)).astimezone(offset).isoformat(timespec="milliseconds")
+        )
+        store.conn.cursor().execute(
+            "UPDATE kg_relations SET valid_from = ?, valid_until = ? WHERE id = 'rel-fastapi'",
+            (valid_from, valid_until),
+        )
+
+        facts = _kg_facts_sql(store, "brainlayer")
+
+        assert len(facts) == 1
+        assert facts[0]["relation"] == "depends_on"
     finally:
         store.close()
 

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -33,6 +33,10 @@ def test_kg_facts_sql_excludes_expired_relations(tmp_path):
             properties={"source": "code_intelligence"},
             confidence=0.99,
         )
+        facts_before = _kg_facts_sql(store, "brainlayer")
+        assert len(facts_before) == 1
+        assert facts_before[0]["relation"] == "depends_on"
+
         store.soft_close_relation("rel-fastapi")
 
         assert _kg_facts_sql(store, "brainlayer") == []

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -15,6 +15,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from brainlayer.mcp.search_handler import _brain_recall, _brain_search
 
+
+def test_kg_facts_sql_excludes_expired_relations(tmp_path):
+    """regression-guard: brain_search's SQL KG path must not return stale facts."""
+    from brainlayer.mcp.search_handler import _kg_facts_sql
+    from brainlayer.vector_store import VectorStore
+
+    store = VectorStore(tmp_path / "kg.db")
+    try:
+        store.upsert_entity("proj-brainlayer", "project", "brainlayer")
+        store.upsert_entity("lib-fastapi", "library", "fastapi")
+        store.add_relation(
+            "rel-fastapi",
+            "proj-brainlayer",
+            "lib-fastapi",
+            "depends_on",
+            properties={"source": "code_intelligence"},
+            confidence=0.99,
+        )
+        store.soft_close_relation("rel-fastapi")
+
+        assert _kg_facts_sql(store, "brainlayer") == []
+    finally:
+        store.close()
+
+
 # ── New filter params passthrough ────────────────────────────────────────────
 
 

--- a/tests/test_vector_store_readonly.py
+++ b/tests/test_vector_store_readonly.py
@@ -219,3 +219,18 @@ def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_p
     finally:
         store.close()
         _shared._search_vector_store = None
+
+
+def test_search_store_bootstrap_required_for_partial_kg_schema(tmp_path):
+    """regression-guard: readonly search must bootstrap when only one KG table exists."""
+    db_path = tmp_path / "partial-kg.db"
+    store = VectorStore(db_path)
+    store.close()
+
+    conn = apsw.Connection(str(db_path))
+    try:
+        conn.cursor().execute("DROP TABLE kg_relations")
+    finally:
+        conn.close()
+
+    assert _shared._search_store_needs_bootstrap(db_path) is True


### PR DESCRIPTION
## Mandate

Implements the user mandate for **PHASE 1 — KG STATEFUL RECONCILIATION** on branch `feat/kg-stateful-reconciliation`, following the Etan-mandate 2026-05-22 plan and `/pr-loop` invariant.

Source citations:
- Phase scope states the forward-only KG bug and stale `brainlayer depends_on fastapi` example: `docs.local/plans/2026-05-22-brainlayer-actually-works/phase-1-kg-stateful/scope.md:8-17`.
- Phase scope requires reconciliation, no deletes, default search filtering, schema columns, indexes, and tests: `docs.local/plans/2026-05-22-brainlayer-actually-works/phase-1-kg-stateful/scope.md:21-32`, `:48-58`.
- Issue 1b audit maps KG ingest to `code_intelligence.py` and confirms `brainlayer -> fastapi depends_on` persisted without validity state: `/Users/etanheyman/Gits/orchestrator/docs.local/audits/2026-05-22-issue-1b-fts5-kg-investigation.md:7-17`.
- Collab invariants require TDD, full `/pr-loop`, all 7 checks green, no squash, and brain_store on merge: `docs.local/plans/2026-05-22-brainlayer-actually-works/collab.md:38-47`.

## Implementation

- Adds idempotent KG validity schema support for `kg_entities.expired_at`, existing/required validity columns, and expired indexes in `src/brainlayer/vector_store.py:1184-1216`.
- Adds code-intelligence schema guard for lightweight DBs and `kg_current_facts` view compatibility in `src/brainlayer/pipeline/code_intelligence.py:75-104`.
- Writes observation validity on each code-intelligence scan and tracks observed dependency targets in `src/brainlayer/pipeline/code_intelligence.py:239-365`.
- Re-observation refreshes `valid_until` and clears `expired_at`; missing code-intelligence `depends_on` facts are soft-expired without deletes in `src/brainlayer/pipeline/code_intelligence.py:368-501`.
- Re-adding entities/relations through KG repo revives soft-expired facts by clearing `expired_at` in `src/brainlayer/kg_repo.py:168-230`, `:282-299`.
- `brain_search` SQL KG fallback now excludes expired relations/entities and invalid validity windows by default in `src/brainlayer/mcp/search_handler.py:420-430`.
- Readonly search bootstrap now detects stale KG validity schemas before opening readonly in `src/brainlayer/mcp/_shared.py:29-56`.
- Hardened eval benchmark fallback for Ranx/Numba order-sensitive failures encountered during the local CI-equivalent test gate in `src/brainlayer/eval/benchmark.py:165-267`.

## Regression Tests

- Removed dependency expires and disappears from current facts: `tests/test_code_intelligence.py:319-368`.
- Re-observed dependency refreshes `valid_until` and remains unexpired: `tests/test_code_intelligence.py:370-415`.
- `brain_search` SQL KG path excludes expired relations: `tests/test_search_filter_params.py:19-40`.
- Schema/index guards cover `expired_at` on entities and expired indexes: `tests/test_kg_schema.py:74-135`, `tests/test_kg_standard.py:153-228`.

## Acceptance

- [x] Ingest `(brainlayer, depends_on, fastapi)`, remove fastapi, rerun reconcile, and assert `expired_at != NULL` plus exclusion from `kg_current_facts`.
- [x] Re-observation updates `valid_until` and clears/does not set `expired_at`.
- [x] No deletes; stale facts retain audit trail through soft expiry.
- [x] `brain_search` default SQL KG query excludes expired facts.
- [x] Existing KG tests pass locally.
- [x] Local CI-equivalent gate passed before push.

## Validation

- RED first: targeted new tests failed on missing `expired_at`/`valid_until`, missing expired indexes, and `_kg_facts_sql` returning a soft-closed relation.
- GREEN focused: `.venv/bin/pytest tests/test_code_intelligence.py tests/test_kg_schema.py tests/test_kg_standard.py tests/test_search_filter_params.py -q` → `131 passed`.
- Lint/format: `.venv/bin/ruff check src/ tests/ && .venv/bin/ruff format --check src/ tests/` → passed.
- CI-equivalent local: `.venv/bin/pytest tests/ -m "not integration and not live" -x` → `2139 passed, 9 skipped, 75 deselected, 1 xfailed`.
- Pre-push hook: passed unit pytest, MCP registration pytest, isolated eval/hook routing pytest, bun test, and FTS5 determinism shell regression.

## Review Requests

@codex review
@cursor review
@bugbot review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches KG reconciliation update logic for existing relations, which could affect provenance metadata and whether edges are considered current/expired across scans.
> 
> **Overview**
> Ensures `enrich_projects` updates `kg_relations.properties` when a previously expired, non-`code_intelligence` `depends_on` relation is re-observed, merging provenance so the edge can be revived without taking ownership.
> 
> Updates the regression test to assert the merged `sources` provenance and adds coverage that the revived manual edge is later soft-expired and removed from `kg_current_facts` when the dependency disappears again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1f6ba3d1af42a92d3bf3976191ac339f8f6f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expire stale entity and relation facts via reconciliation pass in code intelligence
> - Adds `valid_from`, `valid_until`, and `expired_at` columns to `kg_entities` and `kg_relations`, with indexes and a rebuilt `kg_current_facts` view using julianday-based timestamp comparisons in [vector_store.py](https://github.com/EtanHey/brainlayer/pull/316/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) and [code_intelligence.py](https://github.com/EtanHey/brainlayer/pull/316/files#diff-d8281deda9bd79765332450d125473216c76860ea16f5954f1c0f68f35654f30).
> - During `enrich_projects`, dependency relations not observed in the current scan are marked expired; library entities with no remaining active facts are also expired via `_expire_stale_dependency_relations`.
> - Entities and relations that are re-observed have their `valid_until` refreshed and `expired_at` cleared, preserving provenance and avoiding duplicates.
> - A pidfile-backed single-writer lock (with PID + start-time validation and `fcntl` fallback) prevents concurrent enrichment runs from corrupting the KG.
> - Bootstrap for readonly search now triggers when KG tables are partially present or missing the required validity/expiry columns.
> - Risk: Existing deployments will have the schema migrated on first run; entities and relations without validity windows will not appear in `kg_current_facts` until re-observed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d1f6ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validity/expiration tracking and timestamp-aware view logic so search and KG queries ignore outdated facts; schema upgrades applied where needed.
  * Improved dependency reconciliation with observation/validity windows to refresh or expire scanner-owned relations.

* **Bug Fixes**
  * Made evaluation resilient to external library failures with a guarded fallback and manual metric computation.
  * Search-store bootstrap now detects partial KG schemas and triggers repair.

* **Performance**
  * Added indexes to speed expiration-aware filtering.

* **Tests**
  * Expanded regression coverage for reconciliation, expiry, evaluation fallbacks, locking, and timestamp handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->