### PR TITLE
feat(brainbar): render KG expiration with inline pill (Linear-archived treatment)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -400,6 +400,7 @@ final class BrainDatabase: @unchecked Sendable {
                 UNIQUE(source_id, target_id, relation_type)
             )
         """)
+        try ensureKGRelationColumns()
 
         try execute("""
             CREATE TABLE IF NOT EXISTS kg_entity_chunks (
@@ -476,6 +477,7 @@ final class BrainDatabase: @unchecked Sendable {
         try ensureChunkColumns()
         try ensurePendingStoreQueueIndex()
         try ensureKGEntityColumns()
+        try ensureKGRelationColumns()
         try ensureKGEntityAliasTable()
         try rebuildTrigramFTSTableIfNeeded()
     }
@@ -2113,6 +2115,12 @@ final class BrainDatabase: @unchecked Sendable {
         if !existingColumns.contains("importance") {
             try execute("ALTER TABLE kg_entities ADD COLUMN importance REAL DEFAULT 0.5")
         }
+        if !existingColumns.contains("valid_until") {
+            try execute("ALTER TABLE kg_entities ADD COLUMN valid_until TEXT")
+        }
+        if !existingColumns.contains("expired_at") {
+            try execute("ALTER TABLE kg_entities ADD COLUMN expired_at TEXT")
+        }
     }
 
     private func ensureKGEntityTable() throws {
@@ -2127,6 +2135,37 @@ final class BrainDatabase: @unchecked Sendable {
                 created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 UNIQUE(entity_type, name)
+            )
+        """)
+    }
+
+    private func ensureKGRelationColumns() throws {
+        guard let db else { throw DBError.notOpen }
+        try ensureKGRelationTable()
+        let existingColumns = try tableColumns(name: "kg_relations", on: db)
+        if !existingColumns.contains("valid_from") {
+            try execute("ALTER TABLE kg_relations ADD COLUMN valid_from TEXT")
+        }
+        if !existingColumns.contains("valid_until") {
+            try execute("ALTER TABLE kg_relations ADD COLUMN valid_until TEXT")
+        }
+        if !existingColumns.contains("expired_at") {
+            try execute("ALTER TABLE kg_relations ADD COLUMN expired_at TEXT")
+        }
+        try execute("CREATE INDEX IF NOT EXISTS idx_kg_relations_validity ON kg_relations(valid_from, valid_until)")
+        try execute("CREATE INDEX IF NOT EXISTS idx_kg_relations_expired ON kg_relations(expired_at)")
+    }
+
+    private func ensureKGRelationTable() throws {
+        try execute("""
+            CREATE TABLE IF NOT EXISTS kg_relations (
+                id TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                relation_type TEXT NOT NULL,
+                properties TEXT DEFAULT '{}',
+                created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                UNIQUE(source_id, target_id, relation_type)
             )
         """)
     }
@@ -3199,15 +3238,17 @@ final class BrainDatabase: @unchecked Sendable {
         // Get typed relations for found entity (excludes co_occurs_with noise)
         if let entityId, result != nil {
             let relSQL = """
-                SELECT r.relation_type, e.name, 'outgoing' AS direction
-                FROM kg_relations_typed r
+                SELECT r.relation_type, e.name, 'outgoing' AS direction, r.valid_until, r.expired_at
+                FROM kg_relations r
                 LEFT JOIN kg_entities e ON e.id = r.target_id
                 WHERE r.source_id = ?
+                  AND r.relation_type != 'co_occurs_with'
                 UNION ALL
-                SELECT r.relation_type, e.name, 'incoming' AS direction
-                FROM kg_relations_typed r
+                SELECT r.relation_type, e.name, 'incoming' AS direction, r.valid_until, r.expired_at
+                FROM kg_relations r
                 LEFT JOIN kg_entities e ON e.id = r.source_id
                 WHERE r.target_id = ?
+                  AND r.relation_type != 'co_occurs_with'
                 ORDER BY 1
                 LIMIT 20
             """
@@ -3223,7 +3264,9 @@ final class BrainDatabase: @unchecked Sendable {
                     relations.append([
                         "relation_type": columnText(relStmt, 0) as Any,
                         "target_name": targetName as Any,
-                        "direction": direction as Any
+                        "direction": direction as Any,
+                        "valid_until": columnText(relStmt, 3) as Any,
+                        "expired_at": columnText(relStmt, 4) as Any
                     ])
                 }
                 result?["relations"] = relations
@@ -3312,6 +3355,24 @@ final class BrainDatabase: @unchecked Sendable {
         let sourceId: String
         let targetId: String
         let relationType: String
+        let validUntil: Date?
+        let expiredAt: Date?
+
+        init(
+            id: String,
+            sourceId: String,
+            targetId: String,
+            relationType: String,
+            validUntil: Date? = nil,
+            expiredAt: Date? = nil
+        ) {
+            self.id = id
+            self.sourceId = sourceId
+            self.targetId = targetId
+            self.relationType = relationType
+            self.validUntil = validUntil
+            self.expiredAt = expiredAt
+        }
     }
 
     struct KGChunkRow: Equatable, Sendable {
@@ -3375,7 +3436,7 @@ final class BrainDatabase: @unchecked Sendable {
         // Exclude co_occurs_with — these are auto-generated from text proximity
         // and produce noisy, often incorrect edges in the graph view.
         let sql = """
-            SELECT id, source_id, target_id, relation_type
+            SELECT id, source_id, target_id, relation_type, valid_until, expired_at
             FROM kg_relations
             WHERE relation_type != 'co_occurs_with'
             ORDER BY id
@@ -3394,7 +3455,9 @@ final class BrainDatabase: @unchecked Sendable {
                 id: columnText(stmt, 0) ?? "",
                 sourceId: columnText(stmt, 1) ?? "",
                 targetId: columnText(stmt, 2) ?? "",
-                relationType: columnText(stmt, 3) ?? ""
+                relationType: columnText(stmt, 3) ?? "",
+                validUntil: KGTemporalDate.parse(columnText(stmt, 4)),
+                expiredAt: KGTemporalDate.parse(columnText(stmt, 5))
             ))
         }
         return rows

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3237,14 +3237,17 @@ final class BrainDatabase: @unchecked Sendable {
 
         // Get typed relations for found entity (excludes co_occurs_with noise)
         if let entityId, result != nil {
+            let expirationSelects = try kgRelationExpirationSelects(alias: "r")
             let relSQL = """
-                SELECT r.relation_type, e.name, 'outgoing' AS direction, r.valid_until, r.expired_at
+                SELECT r.relation_type, e.name, 'outgoing' AS direction,
+                       \(expirationSelects.validUntil), \(expirationSelects.expiredAt)
                 FROM kg_relations r
                 LEFT JOIN kg_entities e ON e.id = r.target_id
                 WHERE r.source_id = ?
                   AND r.relation_type != 'co_occurs_with'
                 UNION ALL
-                SELECT r.relation_type, e.name, 'incoming' AS direction, r.valid_until, r.expired_at
+                SELECT r.relation_type, e.name, 'incoming' AS direction,
+                       \(expirationSelects.validUntil), \(expirationSelects.expiredAt)
                 FROM kg_relations r
                 LEFT JOIN kg_entities e ON e.id = r.source_id
                 WHERE r.target_id = ?
@@ -3433,10 +3436,12 @@ final class BrainDatabase: @unchecked Sendable {
 
     func fetchKGRelations(limit: Int = 5_000) throws -> [KGRelationRow] {
         guard let db else { throw DBError.notOpen }
+        let expirationSelects = try kgRelationExpirationSelects(alias: "kg_relations")
         // Exclude co_occurs_with — these are auto-generated from text proximity
         // and produce noisy, often incorrect edges in the graph view.
         let sql = """
-            SELECT id, source_id, target_id, relation_type, valid_until, expired_at
+            SELECT id, source_id, target_id, relation_type,
+                   \(expirationSelects.validUntil), \(expirationSelects.expiredAt)
             FROM kg_relations
             WHERE relation_type != 'co_occurs_with'
             ORDER BY id
@@ -3461,6 +3466,18 @@ final class BrainDatabase: @unchecked Sendable {
             ))
         }
         return rows
+    }
+
+    private func kgRelationExpirationSelects(alias: String) throws -> (validUntil: String, expiredAt: String) {
+        guard let db else { throw DBError.notOpen }
+        let columns = try tableColumns(name: "kg_relations", on: db)
+        let validUntil = columns.contains("valid_until")
+            ? "\(alias).valid_until AS valid_until"
+            : "NULL AS valid_until"
+        let expiredAt = columns.contains("expired_at")
+            ? "\(alias).expired_at AS expired_at"
+            : "NULL AS expired_at"
+        return (validUntil, expiredAt)
     }
 
     func linkEntityChunk(entityId: String, chunkId: String, relevance: Double = 1.0) throws {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGRelationPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGRelationPresentation.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct KGRelationPresentation: Equatable {
+    struct Expiration: Equatable {
+        let date: Date
+        let label: String
+    }
+
+    let expirationPill: Expiration?
+
+    init(relation: EntityCard.Relation) {
+        if let expiredAt = relation.expiredAt {
+            expirationPill = Expiration(date: expiredAt, label: "expired")
+        } else if let validUntil = relation.validUntil {
+            expirationPill = Expiration(date: validUntil, label: "until")
+        } else {
+            expirationPill = nil
+        }
+    }
+
+    var isDimmed: Bool {
+        expirationPill?.label == "expired"
+    }
+}

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGRelationPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGRelationPresentation.swift
@@ -8,9 +8,11 @@ struct KGRelationPresentation: Equatable {
 
     let expirationPill: Expiration?
 
-    init(relation: EntityCard.Relation) {
+    init(relation: EntityCard.Relation, now: Date = Date()) {
         if let expiredAt = relation.expiredAt {
             expirationPill = Expiration(date: expiredAt, label: "expired")
+        } else if let validUntil = relation.validUntil, validUntil < now {
+            expirationPill = Expiration(date: validUntil, label: "expired")
         } else if let validUntil = relation.validUntil {
             expirationPill = Expiration(date: validUntil, label: "until")
         } else {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -105,22 +105,29 @@ struct KGSidebarView: View {
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(Array(relations.enumerated()), id: \.offset) { _, relation in
+                    let presentation = KGRelationPresentation(relation: relation)
                     HStack(alignment: .top, spacing: 10) {
                         Text(relation.direction == "incoming" ? "←" : "→")
                             .font(.system(size: 13, weight: .bold, design: .rounded))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
                             .frame(width: 14)
 
                         VStack(alignment: .leading, spacing: 4) {
-                            Text(relation.targetName)
-                                .font(.system(size: 13, weight: .semibold))
+                            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                Text(relation.targetName)
+                                    .font(.system(size: 13, weight: .semibold))
+                                if let expiration = presentation.expirationPill {
+                                    ExpirationPill(date: expiration.date, label: expiration.label)
+                                }
+                            }
                             Text(relation.relationType.replacingOccurrences(of: "_", with: " "))
                                 .font(.system(size: 11, weight: .medium, design: .monospaced))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
                         }
 
                         Spacer()
                     }
+                    .foregroundStyle(presentation.isDimmed ? .tertiary : .primary)
                     .padding(12)
                     .background(
                         RoundedRectangle(cornerRadius: 14, style: .continuous)

--- a/brain-bar/Sources/BrainBar/Models/EntityCard.swift
+++ b/brain-bar/Sources/BrainBar/Models/EntityCard.swift
@@ -5,11 +5,21 @@ struct EntityCard: Equatable {
         let relationType: String
         let targetName: String
         let direction: String  // "outgoing" or "incoming"
+        let validUntil: Date?
+        let expiredAt: Date?
 
-        init(relationType: String, targetName: String, direction: String = "outgoing") {
+        init(
+            relationType: String,
+            targetName: String,
+            direction: String = "outgoing",
+            validUntil: Date? = nil,
+            expiredAt: Date? = nil
+        ) {
             self.relationType = relationType
             self.targetName = targetName
             self.direction = direction
+            self.validUntil = validUntil
+            self.expiredAt = expiredAt
         }
 
         var displayText: String {
@@ -85,7 +95,9 @@ struct EntityCard: Equatable {
                 Relation(
                     relationType: $0["relation_type"] as? String ?? "related_to",
                     targetName: ($0["target_name"] as? String) ?? (($0["name"] as? String) ?? (($0["target"] as? [String: Any])?["name"] as? String ?? "")),
-                    direction: $0["direction"] as? String ?? "outgoing"
+                    direction: $0["direction"] as? String ?? "outgoing",
+                    validUntil: KGTemporalDate.parse($0["valid_until"] ?? $0["validUntil"]),
+                    expiredAt: KGTemporalDate.parse($0["expired_at"] ?? $0["expiredAt"])
                 )
             }
         memories = []

--- a/brain-bar/Sources/BrainBar/Models/KGTemporalDate.swift
+++ b/brain-bar/Sources/BrainBar/Models/KGTemporalDate.swift
@@ -8,13 +8,13 @@ enum KGTemporalDate {
         guard let text = raw as? String, !text.isEmpty else {
             return nil
         }
+        if let date = pythonMicrosecondISOFormatter().date(from: text) {
+            return date
+        }
         if let date = fractionalISOFormatter().date(from: text) {
             return date
         }
         if let date = plainISOFormatter().date(from: text) {
-            return date
-        }
-        if let date = microsecondISOFormatter().date(from: text) {
             return date
         }
         return sqliteTimestampFormatter().date(from: text)
@@ -32,7 +32,7 @@ enum KGTemporalDate {
         return formatter
     }
 
-    private static func microsecondISOFormatter() -> DateFormatter {
+    private static func pythonMicrosecondISOFormatter() -> DateFormatter {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)

--- a/brain-bar/Sources/BrainBar/Models/KGTemporalDate.swift
+++ b/brain-bar/Sources/BrainBar/Models/KGTemporalDate.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum KGTemporalDate {
+    static func parse(_ raw: Any?) -> Date? {
+        if let date = raw as? Date {
+            return date
+        }
+        guard let text = raw as? String, !text.isEmpty else {
+            return nil
+        }
+        if let date = fractionalISOFormatter().date(from: text) {
+            return date
+        }
+        if let date = plainISOFormatter().date(from: text) {
+            return date
+        }
+        if let date = microsecondISOFormatter().date(from: text) {
+            return date
+        }
+        return sqliteTimestampFormatter().date(from: text)
+    }
+
+    private static func fractionalISOFormatter() -> ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }
+
+    private static func plainISOFormatter() -> ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }
+
+    private static func microsecondISOFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX"
+        return formatter
+    }
+
+    private static func sqliteTimestampFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }
+}

--- a/brain-bar/Sources/BrainBar/Views/ExpirationPill.swift
+++ b/brain-bar/Sources/BrainBar/Views/ExpirationPill.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ExpirationPill: View {
+    let date: Date
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 9, weight: .medium))
+            Text(Self.displayText(date: date, label: label))
+                .font(.system(size: 11, weight: .medium))
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(Capsule().fill(Color.secondary.opacity(0.12)))
+    }
+
+    nonisolated static func displayText(date: Date, label: String) -> String {
+        "\(label) \(formattedDate(date))"
+    }
+
+    nonisolated static func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: date)
+    }
+}

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGRelationPresentation.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGRelationPresentation.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGRelationPresentation.swift

--- a/brain-bar/Sources/BrainBarDaemon/Models/KGTemporalDate.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Models/KGTemporalDate.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Models/KGTemporalDate.swift

--- a/brain-bar/Sources/BrainBarDaemon/Views/ExpirationPill.swift
+++ b/brain-bar/Sources/BrainBarDaemon/Views/ExpirationPill.swift
@@ -1,0 +1,1 @@
+../../BrainBar/Views/ExpirationPill.swift

--- a/brain-bar/Tests/BrainBarTests/KGExpirationRenderingTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGExpirationRenderingTests.swift
@@ -26,6 +26,31 @@ final class KGExpirationRenderingTests: XCTestCase {
         XCTAssertNotNil(relation.expiredAt)
     }
 
+    func testEntityCardRelationDecodesPythonMicrosecondExpirationTimestamp() throws {
+        let payload: [String: Any] = [
+            "entity_id": "person-etan",
+            "name": "Etan",
+            "entity_type": "person",
+            "relations": [
+                [
+                    "relation_type": "cto_of",
+                    "target_name": "Domica",
+                    "direction": "outgoing",
+                    "expired_at": "2026-05-24T12:34:56.123456Z",
+                ]
+            ],
+        ]
+
+        let card = EntityCard(lookupPayload: payload)
+        let relation = try XCTUnwrap(card.relations.first)
+        let now = try XCTUnwrap(KGTemporalDate.parse("2026-05-25T00:00:00Z"))
+        let presentation = KGRelationPresentation(relation: relation, now: now)
+
+        XCTAssertNotNil(relation.expiredAt)
+        XCTAssertTrue(presentation.isDimmed)
+        XCTAssertEqual(presentation.expirationPill?.label, "expired")
+    }
+
     func testExpirationPillFormatsDateForInlineRendering() throws {
         let date = try XCTUnwrap(KGTemporalDate.parse("2026-05-24T00:00:00Z"))
 

--- a/brain-bar/Tests/BrainBarTests/KGExpirationRenderingTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGExpirationRenderingTests.swift
@@ -36,6 +36,7 @@ final class KGExpirationRenderingTests: XCTestCase {
     func testRelationPresentationDimsExpiredAndPillsButKeepsLiveRelationsVisible() throws {
         let expiredAt = try XCTUnwrap(KGTemporalDate.parse("2026-05-24T00:00:00Z"))
         let validUntil = try XCTUnwrap(KGTemporalDate.parse("2026-06-01T00:00:00Z"))
+        let now = try XCTUnwrap(KGTemporalDate.parse("2026-05-25T00:00:00Z"))
         let expired = EntityCard.Relation(
             relationType: "cto_of",
             targetName: "Domica",
@@ -51,11 +52,27 @@ final class KGExpirationRenderingTests: XCTestCase {
             validUntil: validUntil
         )
 
-        XCTAssertTrue(KGRelationPresentation(relation: expired).isDimmed)
-        XCTAssertEqual(KGRelationPresentation(relation: expired).expirationPill?.label, "expired")
-        XCTAssertFalse(KGRelationPresentation(relation: live).isDimmed)
-        XCTAssertNil(KGRelationPresentation(relation: live).expirationPill)
-        XCTAssertFalse(KGRelationPresentation(relation: forwardDated).isDimmed)
-        XCTAssertEqual(KGRelationPresentation(relation: forwardDated).expirationPill?.label, "until")
+        XCTAssertTrue(KGRelationPresentation(relation: expired, now: now).isDimmed)
+        XCTAssertEqual(KGRelationPresentation(relation: expired, now: now).expirationPill?.label, "expired")
+        XCTAssertFalse(KGRelationPresentation(relation: live, now: now).isDimmed)
+        XCTAssertNil(KGRelationPresentation(relation: live, now: now).expirationPill)
+        XCTAssertFalse(KGRelationPresentation(relation: forwardDated, now: now).isDimmed)
+        XCTAssertEqual(KGRelationPresentation(relation: forwardDated, now: now).expirationPill?.label, "until")
+    }
+
+    func testRelationPresentationDimsPastValidUntilAsExpiredWhenExpiredAtIsMissing() throws {
+        let validUntil = try XCTUnwrap(KGTemporalDate.parse("2026-05-24T00:00:00Z"))
+        let now = try XCTUnwrap(KGTemporalDate.parse("2026-05-25T00:00:00Z"))
+        let relation = EntityCard.Relation(
+            relationType: "cto_of",
+            targetName: "Domica",
+            validUntil: validUntil
+        )
+
+        let presentation = KGRelationPresentation(relation: relation, now: now)
+
+        XCTAssertTrue(presentation.isDimmed)
+        XCTAssertEqual(presentation.expirationPill?.label, "expired")
+        XCTAssertEqual(presentation.expirationPill?.date, validUntil)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/KGExpirationRenderingTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGExpirationRenderingTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import BrainBar
+
+final class KGExpirationRenderingTests: XCTestCase {
+    func testEntityCardRelationDecodesExpirationDatesFromLookupPayload() throws {
+        let payload: [String: Any] = [
+            "entity_id": "person-etan",
+            "name": "Etan",
+            "entity_type": "person",
+            "relations": [
+                [
+                    "relation_type": "cto_of",
+                    "target_name": "Domica",
+                    "direction": "outgoing",
+                    "valid_until": "2026-05-24T00:00:00Z",
+                    "expired_at": "2026-05-24T00:00:00Z",
+                ]
+            ],
+        ]
+
+        let card = EntityCard(lookupPayload: payload)
+        let relation = try XCTUnwrap(card.relations.first)
+
+        XCTAssertEqual(relation.targetName, "Domica")
+        XCTAssertNotNil(relation.validUntil)
+        XCTAssertNotNil(relation.expiredAt)
+    }
+
+    func testExpirationPillFormatsDateForInlineRendering() throws {
+        let date = try XCTUnwrap(KGTemporalDate.parse("2026-05-24T00:00:00Z"))
+
+        XCTAssertEqual(ExpirationPill.formattedDate(date), "May 24, 2026")
+        XCTAssertEqual(ExpirationPill.displayText(date: date, label: "expired"), "expired May 24, 2026")
+    }
+
+    func testRelationPresentationDimsExpiredAndPillsButKeepsLiveRelationsVisible() throws {
+        let expiredAt = try XCTUnwrap(KGTemporalDate.parse("2026-05-24T00:00:00Z"))
+        let validUntil = try XCTUnwrap(KGTemporalDate.parse("2026-06-01T00:00:00Z"))
+        let expired = EntityCard.Relation(
+            relationType: "cto_of",
+            targetName: "Domica",
+            expiredAt: expiredAt
+        )
+        let live = EntityCard.Relation(
+            relationType: "builds",
+            targetName: "BrainLayer"
+        )
+        let forwardDated = EntityCard.Relation(
+            relationType: "collaborates_with",
+            targetName: "Cursor",
+            validUntil: validUntil
+        )
+
+        XCTAssertTrue(KGRelationPresentation(relation: expired).isDimmed)
+        XCTAssertEqual(KGRelationPresentation(relation: expired).expirationPill?.label, "expired")
+        XCTAssertFalse(KGRelationPresentation(relation: live).isDimmed)
+        XCTAssertNil(KGRelationPresentation(relation: live).expirationPill)
+        XCTAssertFalse(KGRelationPresentation(relation: forwardDated).isDimmed)
+        XCTAssertEqual(KGRelationPresentation(relation: forwardDated).expirationPill?.label, "until")
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -218,6 +218,26 @@ final class KGDatabaseTests: XCTestCase {
         XCTAssertNotNil(relation.validUntil)
     }
 
+    func testReadOnlyLegacyKGRelationSchemaDoesNotRequireExpirationColumns() throws {
+        db.close()
+        try? FileManager.default.removeItem(atPath: tempDBPath)
+        try createLegacyKGDatabaseWithoutRelationExpirationColumns(path: tempDBPath)
+
+        let reader = BrainDatabase(path: tempDBPath, openConfiguration: .init(readOnly: true))
+        defer { reader.close() }
+
+        let relations = try reader.fetchKGRelations()
+        let payload = try XCTUnwrap(reader.lookupEntity(query: "Etan"))
+        let card = EntityCard(lookupPayload: payload)
+
+        XCTAssertEqual(relations.count, 1)
+        XCTAssertNil(relations.first?.validUntil)
+        XCTAssertNil(relations.first?.expiredAt)
+        XCTAssertEqual(card.relations.first?.targetName, "Domica")
+        XCTAssertNil(card.relations.first?.validUntil)
+        XCTAssertNil(card.relations.first?.expiredAt)
+    }
+
     // MARK: - linkEntityChunk + fetchEntityChunks
 
     func testLinkEntityChunkAndFetch() throws {
@@ -262,6 +282,50 @@ final class KGDatabaseTests: XCTestCase {
         try db.insertEntity(id: "e1", type: "person", name: "Lonely")
         let chunks = try db.fetchEntityChunks(entityId: "e1")
         XCTAssertTrue(chunks.isEmpty)
+    }
+}
+
+private func createLegacyKGDatabaseWithoutRelationExpirationColumns(path: String) throws {
+    var handle: OpaquePointer?
+    let openRC = sqlite3_open_v2(
+        path,
+        &handle,
+        SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+        nil
+    )
+    guard openRC == SQLITE_OK, let handle else {
+        throw NSError(domain: "KnowledgeGraphTests", code: Int(openRC))
+    }
+    defer { sqlite3_close(handle) }
+
+    let sql = """
+        CREATE TABLE kg_entities (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            metadata TEXT DEFAULT '{}',
+            description TEXT,
+            importance REAL DEFAULT 0.5
+        );
+        CREATE TABLE kg_relations (
+            id TEXT PRIMARY KEY,
+            source_id TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            relation_type TEXT NOT NULL,
+            properties TEXT DEFAULT '{}',
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(source_id, target_id, relation_type)
+        );
+        INSERT INTO kg_entities (id, entity_type, name, metadata, description)
+        VALUES
+            ('person-etan', 'person', 'Etan', '{}', NULL),
+            ('company-domica', 'company', 'Domica', '{}', NULL);
+        INSERT INTO kg_relations (id, source_id, target_id, relation_type)
+        VALUES ('person-etan-cto_of-company-domica', 'person-etan', 'company-domica', 'cto_of');
+    """
+    let execRC = sqlite3_exec(handle, sql, nil, nil, nil)
+    guard execRC == SQLITE_OK else {
+        throw NSError(domain: "KnowledgeGraphTests", code: Int(execRC))
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -107,6 +107,42 @@ final class KGDatabaseTests: XCTestCase {
         XCTAssertEqual(relations.first?.relationType, "builds")
     }
 
+    func testFetchKGRelationsSurfacesExpirationMetadataWithoutFilteringExpiredRelations() throws {
+        try db.insertEntity(id: "person-etan", type: "person", name: "Etan")
+        try db.insertEntity(id: "company-domica", type: "company", name: "Domica")
+        try db.insertEntity(id: "project-brainlayer", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "person-etan", targetId: "company-domica", relationType: "cto_of")
+        try db.insertRelation(sourceId: "person-etan", targetId: "project-brainlayer", relationType: "builds")
+
+        guard let handle = db.dbHandle else {
+            XCTFail("Expected database handle")
+            return
+        }
+
+        XCTAssertEqual(
+            sqlite3_exec(
+                handle,
+                """
+                UPDATE kg_relations
+                SET expired_at = '2026-05-24T00:00:00Z',
+                    valid_until = '2026-05-24T00:00:00Z'
+                WHERE source_id = 'person-etan' AND target_id = 'company-domica'
+                """,
+                nil,
+                nil,
+                nil
+            ),
+            SQLITE_OK
+        )
+
+        let relations = try db.fetchKGRelations()
+
+        XCTAssertEqual(relations.count, 2, "Expired relations remain first-class graph context")
+        let expired = try XCTUnwrap(relations.first { $0.targetId == "company-domica" })
+        XCTAssertNotNil(expired.expiredAt)
+        XCTAssertNotNil(expired.validUntil)
+    }
+
     func testFetchKGRelationsMultiple() throws {
         try db.insertEntity(id: "a", type: "person", name: "A")
         try db.insertEntity(id: "b", type: "project", name: "B")
@@ -145,6 +181,41 @@ final class KGDatabaseTests: XCTestCase {
     func testFetchKGRelationsEmptyDB() throws {
         let relations = try db.fetchKGRelations()
         XCTAssertTrue(relations.isEmpty)
+    }
+
+    func testLookupEntityPayloadIncludesRelationExpirationMetadata() throws {
+        try db.insertEntity(id: "person-etan", type: "person", name: "Etan")
+        try db.insertEntity(id: "company-domica", type: "company", name: "Domica")
+        try db.insertRelation(sourceId: "person-etan", targetId: "company-domica", relationType: "cto_of")
+
+        guard let handle = db.dbHandle else {
+            XCTFail("Expected database handle")
+            return
+        }
+
+        XCTAssertEqual(
+            sqlite3_exec(
+                handle,
+                """
+                UPDATE kg_relations
+                SET expired_at = '2026-05-24T00:00:00Z',
+                    valid_until = '2026-05-24T00:00:00Z'
+                WHERE source_id = 'person-etan' AND target_id = 'company-domica'
+                """,
+                nil,
+                nil,
+                nil
+            ),
+            SQLITE_OK
+        )
+
+        let payload = try XCTUnwrap(db.lookupEntity(query: "Etan"))
+        let card = EntityCard(lookupPayload: payload)
+        let relation = try XCTUnwrap(card.relations.first)
+
+        XCTAssertEqual(relation.targetName, "Domica")
+        XCTAssertNotNil(relation.expiredAt)
+        XCTAssertNotNil(relation.validUntil)
     }
 
     // MARK: - linkEntityChunk + fetchEntityChunks


### PR DESCRIPTION
## Summary
- Surface `valid_until` and `expired_at` from BrainBar KG relation queries into `EntityCard.Relation`.
- Add `ExpirationPill` plus sidebar presentation logic: expired relations stay visible, are dimmed, and show an inline `expired` pill; forward-dated relations show an `until` pill.
- Keep expired KG relations in graph/sidebar context instead of filtering them.

## Test plan
- [x] TDD red: new Swift tests initially failed on missing expiration fields/helpers.
- [x] `swift test --filter 'KGExpirationRenderingTests|KGDatabaseTests/testFetchKGRelationsSurfacesExpirationMetadataWithoutFilteringExpiredRelations|KGDatabaseTests/testLookupEntityPayloadIncludesRelationExpirationMetadata'`
- [x] `swift test` (399 tests, 0 failures)
- [x] pre-push BrainLayer gate (2128 selected pytest tests + MCP registration + isolated eval/hook routing + bun + shell regression)
- [ ] Full local `pytest` had live-DB environmental failures unrelated to this Swift UI diff: active writer pidfile owned by realtime supervisor pid 64630, and canonical DB `created_at` coverage at 95.5% vs test's 99% live-data assertion.

Co-Authored-By: Codex <codex@openai.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render KG relation expiration as inline pill in brain-bar sidebar
> - Adds `validUntil` and `expiredAt` fields to `EntityCard.Relation` and `KGRelationRow`, parsed via the new `KGTemporalDate` utility that handles ISO8601, Python microsecond, and SQLite timestamp formats.
> - Introduces `KGRelationPresentation` to compute display state: expired relations are visually dimmed in the sidebar and show an `ExpirationPill` (e.g. "expired May 24, 2026") next to the target name.
> - Adds `valid_until` and `expired_at` columns (plus validity indexes) to `kg_relations` and `kg_entities` via conditional `ALTER TABLE` migrations; a `kgRelationExpirationSelects` helper falls back to `NULL` selects on legacy schemas so read-only access remains unaffected.
> - Behavioral Change: `fetchKGRelations` now returns expired relations rather than filtering them out; callers are responsible for presentation-layer dimming.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 246d074.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and additive DB migrations with backward-compatible reads; no auth or write-path behavior changes beyond schema ensure on open.
> 
> **Overview**
> Adds **temporal metadata** for knowledge-graph relations end-to-end: SQLite migrations add `valid_from`, `valid_until`, and `expired_at` on `kg_relations` (plus entity expiration columns), with indexes and **legacy-safe** queries that emit NULL when columns are missing.
> 
> **`lookupEntity`** and **`fetchKGRelations`** now return `valid_until` / `expired_at`; **`EntityCard.Relation`** and **`KGRelationRow`** carry optional dates parsed via new **`KGTemporalDate`**. Expired relations are **not filtered out**—they stay in graph/sidebar context.
> 
> The KG sidebar uses **`KGRelationPresentation`** and **`ExpirationPill`**: expired rows are **dimmed** with an `expired` pill; future **`valid_until`** shows an `until` pill. BrainBarDaemon reuses the same Swift sources via symlinks. Tests cover decoding, presentation rules, DB payloads, and read-only legacy schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246d074918fcfad13455ba9cc3bb1f665f852d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->