### PR TITLE
feat(search): hybrid pre-warm + command-bar debounce + preview_text overlay

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3444,7 +3444,7 @@ final class BrainDatabase: @unchecked Sendable {
     func getChunk(id: String) throws -> [String: Any]? {
         guard let db else { throw DBError.notOpen }
         let sql = """
-            SELECT id, content, content_type, source, summary, created_at, archived_at, superseded_by
+            SELECT id, content, content_type, source, summary, created_at, archived_at, superseded_by, tags
             FROM chunks
             WHERE id = ?
             LIMIT 1
@@ -3465,6 +3465,7 @@ final class BrainDatabase: @unchecked Sendable {
             "created_at": columnText(stmt, 5) as Any,
             "archived_at": columnText(stmt, 6) as Any,
             "superseded_by": columnText(stmt, 7) as Any,
+            "tags": columnText(stmt, 8) as Any,
         ]
     }
 

--- a/brain-bar/Sources/BrainBar/QuickCaptureController.swift
+++ b/brain-bar/Sources/BrainBar/QuickCaptureController.swift
@@ -60,12 +60,73 @@ enum QuickCaptureController {
             return SearchResult(count: 0, formatted: "", results: [])
         }
 
-        let results = try db.search(query: trimmed, limit: limit)
+        var candidateResultsByID: [String: [String: Any]] = [:]
+        var candidateOrder: [String] = []
+        let candidates = try db.searchCandidates(query: trimmed, limit: limit)
+        for candidate in candidates {
+            candidateOrder.append(candidate.id)
+            candidateResultsByID[candidate.id] = try searchResult(from: candidate, db: db)
+        }
+
+        var seenChunkIDs = Set<String>()
+        var results: [[String: Any]] = []
+        let fallbackRows = try db.search(query: trimmed, limit: limit)
+        for row in fallbackRows {
+            guard let chunkID = row["chunk_id"] as? String else { continue }
+            guard seenChunkIDs.insert(chunkID).inserted else { continue }
+            if let candidateResult = candidateResultsByID[chunkID] {
+                results.append(candidateResult)
+            } else {
+                results.append(searchResult(from: row))
+            }
+            if results.count >= limit { break }
+        }
+        for chunkID in candidateOrder {
+            guard seenChunkIDs.insert(chunkID).inserted else { continue }
+            guard let candidateResult = candidateResultsByID[chunkID] else { continue }
+            results.append(candidateResult)
+            if results.count >= limit { break }
+        }
         let formatted = Formatters.formatSearchResults(
             query: trimmed,
             results: results,
             total: results.count
         )
         return SearchResult(count: results.count, formatted: formatted, results: results)
+    }
+
+    private static func searchResult(from candidate: SearchQueryCandidate, db: BrainDatabase) throws -> [String: Any] {
+        let chunk = try db.getChunk(id: candidate.id)
+        let fullContent = (chunk?["content"] as? String) ?? candidate.previewText
+        return [
+            "chunk_id": candidate.id,
+            "content": candidate.previewText,
+            "full_content": fullContent,
+            "created_at": candidate.date,
+            "project": candidate.project,
+            "content_type": chunk?["content_type"] as Any,
+            "importance": candidate.importance,
+            "summary": chunk?["summary"] as Any,
+            "tags": chunk?["tags"] as Any,
+            "source": chunk?["source"] as Any,
+            "score": candidate.lexicalScore,
+        ]
+    }
+
+    private static func searchResult(from row: [String: Any]) -> [String: Any] {
+        let previewText = (row["preview_text"] as? String) ?? (row["content"] as? String) ?? "Untitled result"
+        return [
+            "chunk_id": row["chunk_id"] as Any,
+            "content": previewText,
+            "full_content": (row["content"] as? String) ?? previewText,
+            "created_at": row["created_at"] as Any,
+            "project": row["project"] as Any,
+            "content_type": row["content_type"] as Any,
+            "importance": row["importance"] as Any,
+            "summary": row["summary"] as Any,
+            "tags": row["tags"] as Any,
+            "source": row["source"] as Any,
+            "score": row["score"] as Any,
+        ]
     }
 }

--- a/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
+++ b/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
@@ -5,6 +5,8 @@ protocol QuickCaptureClipboard {
     func copy(_ string: String)
 }
 
+typealias QuickCaptureSearch = @MainActor (_ query: String, _ limit: Int) throws -> QuickCaptureController.SearchResult
+
 struct SystemQuickCaptureClipboard: QuickCaptureClipboard {
     func copy(_ string: String) {
         let pasteboard = NSPasteboard.general
@@ -55,13 +57,14 @@ struct QuickCaptureSearchRow: Identifiable, Equatable {
     static func fromSearchResult(_ result: [String: Any]) -> QuickCaptureSearchRow? {
         let rawID = (result["chunk_id"] as? String) ?? UUID().uuidString
         let title = (result["content"] as? String) ?? "Untitled result"
+        let fullContent = (result["full_content"] as? String) ?? title
         let createdAt = (result["created_at"] as? String) ?? "unknown time"
         let importance = formattedImportance(result["importance"])
 
         return QuickCaptureSearchRow(
             id: rawID,
             title: title,
-            content: title,
+            content: fullContent,
             metadata: "\(importance) • \(createdAt)"
         )
     }
@@ -103,8 +106,11 @@ final class QuickCaptureViewModel: ObservableObject {
     private let db: BrainDatabase
     private let panelState: QuickCapturePanelState
     private let clipboard: QuickCaptureClipboard
+    private let search: QuickCaptureSearch
     private var copyResetTask: Task<Void, Never>?
     private var feedbackResetTask: Task<Void, Never>?
+    private let searchDebounceDelay: Duration
+    var _pendingSearchTask: Task<Void, Never>?
     /// Exposed for test awaiting — set when an async store is in flight.
     var _pendingStoreTask: Task<Void, Never>?
     /// Feedback state clears back to `.idle` after this delay on success.
@@ -115,13 +121,26 @@ final class QuickCaptureViewModel: ObservableObject {
         db: BrainDatabase,
         panelState: QuickCapturePanelState,
         clipboard: QuickCaptureClipboard = SystemQuickCaptureClipboard(),
-        feedbackAutoClearDelay: Duration = .milliseconds(2000)
+        feedbackAutoClearDelay: Duration = .milliseconds(2000),
+        searchDebounceDelay: Duration = .milliseconds(250),
+        search: QuickCaptureSearch? = nil
     ) {
         self.db = db
         self.panelState = panelState
         self.clipboard = clipboard
+        self.search = search ?? { [db] query, limit in
+            try QuickCaptureController.search(db: db, query: query, limit: limit)
+        }
         self.feedbackAutoClearDelay = feedbackAutoClearDelay
+        self.searchDebounceDelay = searchDebounceDelay
         mode = panelState.mode
+    }
+
+    deinit {
+        copyResetTask?.cancel()
+        feedbackResetTask?.cancel()
+        _pendingSearchTask?.cancel()
+        _pendingStoreTask?.cancel()
     }
 
     /// Called when the user clicks outside the overlay. Preserves `inputText`
@@ -188,6 +207,7 @@ final class QuickCaptureViewModel: ObservableObject {
         copiedResultID = nil
         isSearchOverlayDismissed = false
         if newMode == .capture {
+            _pendingSearchTask?.cancel()
             results = []
             selectedResultIndex = nil
         } else if !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -240,11 +260,19 @@ final class QuickCaptureViewModel: ObservableObject {
     func handleInputChange(_ newValue: String) {
         if inputText != newValue {
             inputText = newValue
+            if mode == .search {
+                results = []
+                selectedResultIndex = nil
+                copiedResultID = nil
+            }
         }
         isSearchOverlayDismissed = false
 
-        guard mode == .search else { return }
-        submitSearch()
+        guard mode == .search else {
+            _pendingSearchTask?.cancel()
+            return
+        }
+        scheduleDebouncedSearch()
     }
 
     func handleInputReturn(modifiers: NSEvent.ModifierFlags) {
@@ -299,6 +327,7 @@ final class QuickCaptureViewModel: ObservableObject {
 
     func dismiss() {
         panelState.dismiss()
+        _pendingSearchTask?.cancel()
         mode = panelState.mode
         inputText = ""
         results = []
@@ -341,13 +370,24 @@ final class QuickCaptureViewModel: ObservableObject {
         }
     }
 
-    private func submitSearch() {
+    private func scheduleDebouncedSearch() {
+        let query = inputText
+        _pendingSearchTask?.cancel()
+        _pendingSearchTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: searchDebounceDelay)
+            guard !Task.isCancelled, query == inputText else { return }
+            submitSearch(query: query, cancelPending: false)
+        }
+    }
+
+    private func submitSearch(query: String? = nil, cancelPending: Bool = true) {
+        if cancelPending {
+            _pendingSearchTask?.cancel()
+        }
+        let query = query ?? inputText
         do {
-            let searchResult = try QuickCaptureController.search(
-                db: db,
-                query: inputText,
-                limit: 8
-            )
+            let searchResult = try search(query, 8)
             results = searchResult.results.compactMap(QuickCaptureSearchRow.fromSearchResult)
             selectedResultIndex = results.isEmpty ? nil : 0
             copiedResultID = nil

--- a/brain-bar/Tests/BrainBarTests/QuickCapturePanelTests.swift
+++ b/brain-bar/Tests/BrainBarTests/QuickCapturePanelTests.swift
@@ -80,28 +80,174 @@ final class QuickCapturePanelTests: XCTestCase {
         XCTAssertEqual(model.selectedResultID, "search-1", "Search should preselect the first result for keyboard navigation")
     }
 
-    func testHandleInputChangeRunsSearchImmediatelyInSearchMode() throws {
+    func testHandleInputChangeDebouncesSearchByAtLeast200Milliseconds() async throws {
         let (db, path) = try makeDatabase(name: "live-search")
         defer { cleanupDatabase(db, path: path) }
-        try db.insertChunk(
-            id: "live-1",
-            content: "BrainBar live search should query while typing",
-            sessionId: "s1",
-            project: "brainlayer",
-            contentType: "assistant_text",
-            importance: 6
-        )
 
         let panelState = QuickCapturePanelState()
         panelState.switchMode(.search)
-        let model = QuickCaptureViewModel(db: db, panelState: panelState)
+        var searchCallTimes: [Date] = []
+        let model = QuickCaptureViewModel(
+            db: db,
+            panelState: panelState,
+            searchDebounceDelay: .milliseconds(250),
+            search: { _, _ in
+                searchCallTimes.append(Date())
+                return QuickCaptureController.SearchResult(count: 0, formatted: "", results: [])
+            }
+        )
 
+        let startedAt = Date()
         model.handleInputChange("live search")
+        try await Task.sleep(for: .milliseconds(200))
 
         XCTAssertEqual(model.inputText, "live search")
-        XCTAssertEqual(model.results.map(\.id), ["live-1"])
-        XCTAssertEqual(model.selectedResultID, "live-1")
+        XCTAssertTrue(model.results.isEmpty)
+        XCTAssertEqual(searchCallTimes.count, 0)
+
+        try await Task.sleep(for: .milliseconds(120))
+        await model._pendingSearchTask?.value
+
+        XCTAssertEqual(searchCallTimes.count, 1)
+        XCTAssertGreaterThanOrEqual(searchCallTimes[0].timeIntervalSince(startedAt), 0.2)
         XCTAssertTrue(model.feedback.isIdle)
+    }
+
+    func testRapidInputChangesOnlyRunLatestDebouncedSearch() async throws {
+        let (db, path) = try makeDatabase(name: "live-search-coalesce")
+        defer { cleanupDatabase(db, path: path) }
+
+        let panelState = QuickCapturePanelState()
+        panelState.switchMode(.search)
+        var searchedQueries: [String] = []
+        let model = QuickCaptureViewModel(
+            db: db,
+            panelState: panelState,
+            searchDebounceDelay: .milliseconds(250),
+            search: { query, _ in
+                searchedQueries.append(query)
+                return QuickCaptureController.SearchResult(
+                    count: 1,
+                    formatted: "",
+                    results: [["chunk_id": "latest", "content": query, "created_at": "now", "importance": 5]]
+                )
+            }
+        )
+
+        model.handleInputChange("l")
+        try await Task.sleep(for: .milliseconds(100))
+        model.handleInputChange("li")
+        try await Task.sleep(for: .milliseconds(100))
+        model.handleInputChange("live")
+        try await Task.sleep(for: .milliseconds(300))
+        await model._pendingSearchTask?.value
+
+        XCTAssertEqual(searchedQueries, ["live"])
+        XCTAssertEqual(model.results.map(\.title), ["live"])
+    }
+
+    func testExplicitSubmitCancelsPendingDebouncedSearch() async throws {
+        let (db, path) = try makeDatabase(name: "submit-cancels-debounce")
+        defer { cleanupDatabase(db, path: path) }
+
+        let panelState = QuickCapturePanelState()
+        panelState.switchMode(.search)
+        var searchedQueries: [String] = []
+        let model = QuickCaptureViewModel(
+            db: db,
+            panelState: panelState,
+            searchDebounceDelay: .milliseconds(50),
+            search: { query, _ in
+                searchedQueries.append(query)
+                return QuickCaptureController.SearchResult(
+                    count: 1,
+                    formatted: "",
+                    results: [["chunk_id": "submitted", "content": query, "created_at": "now", "importance": 5]]
+                )
+            }
+        )
+
+        model.handleInputChange("submit now")
+        model.handleInputReturn(modifiers: [])
+        try await Task.sleep(for: .milliseconds(80))
+        await model._pendingSearchTask?.value
+
+        XCTAssertEqual(searchedQueries, ["submit now"])
+        XCTAssertEqual(model.results.map(\.title), ["submit now"])
+    }
+
+    func testInputChangeClearsStaleResultsBeforeDebouncedSearchCompletes() throws {
+        let (db, path) = try makeDatabase(name: "live-search-stale-results")
+        defer { cleanupDatabase(db, path: path) }
+        try db.insertChunk(
+            id: "old-result",
+            content: "Old query result should not remain selectable",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        try db.insertChunk(
+            id: "new-result",
+            content: "New query result should replace stale rows",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+
+        let clipboard = TestClipboard()
+        let panelState = QuickCapturePanelState()
+        panelState.switchMode(.search)
+        let model = QuickCaptureViewModel(db: db, panelState: panelState, clipboard: clipboard)
+        model.inputText = "old query"
+        model.submit()
+        XCTAssertEqual(model.selectedResultID, "old-result")
+
+        model.handleInputChange("new query")
+
+        XCTAssertTrue(model.results.isEmpty)
+        XCTAssertNil(model.selectedResultID)
+
+        model.handleInputReturn(modifiers: [])
+
+        XCTAssertTrue(clipboard.copiedStrings.isEmpty)
+        XCTAssertEqual(model.selectedResultID, "new-result")
+    }
+
+    func testEnterCopiesFullContentWhenSearchRowDisplaysPreview() throws {
+        let (db, path) = try makeDatabase(name: "copy-full-content-from-preview-row")
+        defer { cleanupDatabase(db, path: path) }
+
+        let clipboard = TestClipboard()
+        let panelState = QuickCapturePanelState()
+        panelState.switchMode(.search)
+        let model = QuickCaptureViewModel(
+            db: db,
+            panelState: panelState,
+            clipboard: clipboard,
+            search: { _, _ in
+                QuickCaptureController.SearchResult(
+                    count: 1,
+                    formatted: "",
+                    results: [[
+                        "chunk_id": "full-copy-1",
+                        "content": "Short overlay preview",
+                        "full_content": "Full stored chunk content that should be copied",
+                        "created_at": "now",
+                        "importance": 5,
+                    ]]
+                )
+            }
+        )
+        model.inputText = "overlay preview"
+        model.submit()
+
+        XCTAssertEqual(model.results.first?.title, "Short overlay preview")
+
+        model.submit()
+
+        XCTAssertEqual(clipboard.copiedStrings, ["Full stored chunk content that should be copied"])
     }
 
     func testTabTogglesBetweenCaptureAndSearchModes() throws {
@@ -344,7 +490,8 @@ final class QuickCapturePanelTests: XCTestCase {
         let panelState = QuickCapturePanelState()
         panelState.switchMode(.search)
         let model = QuickCaptureViewModel(db: db, panelState: panelState)
-        model.handleInputChange("dismiss test")
+        model.inputText = "dismiss test"
+        model.submit()
 
         XCTAssertFalse(model.isSearchOverlayDismissed)
         XCTAssertGreaterThan(model.results.count, 0)
@@ -377,7 +524,8 @@ final class QuickCapturePanelTests: XCTestCase {
         let panelState = QuickCapturePanelState()
         panelState.switchMode(.search)
         let model = QuickCaptureViewModel(db: db, panelState: panelState)
-        model.handleInputChange("tests")
+        model.inputText = "tests"
+        model.submit()
         XCTAssertGreaterThan(model.results.count, 0, "Initial search must populate results")
 
         // Leave search mode → results get cleared (existing contract).
@@ -591,7 +739,8 @@ final class QuickCapturePanelTests: XCTestCase {
         panelState.switchMode(.search)
         let clipboard = TestClipboard()
         let model = QuickCaptureViewModel(db: db, panelState: panelState, clipboard: clipboard)
-        model.handleInputChange("copy this exact")
+        model.inputText = "copy this exact"
+        model.submit()
 
         model.copyResultToClipboard(id: "copy-1")
 
@@ -616,7 +765,8 @@ final class QuickCapturePanelTests: XCTestCase {
         let panelState = QuickCapturePanelState()
         panelState.switchMode(.search)
         let model = QuickCaptureViewModel(db: db, panelState: panelState, clipboard: TestClipboard())
-        model.handleInputChange("highlight this row")
+        model.inputText = "highlight this row"
+        model.submit()
 
         model.copyResultToClipboard(id: "copy-visual-1")
 

--- a/brain-bar/Tests/BrainBarTests/QuickCaptureTests.swift
+++ b/brain-bar/Tests/BrainBarTests/QuickCaptureTests.swift
@@ -4,6 +4,7 @@
 // hotkey manager configuration, and panel state management.
 
 import XCTest
+import SQLite3
 @testable import BrainBar
 
 final class QuickCaptureTests: XCTestCase {
@@ -76,6 +77,119 @@ final class QuickCaptureTests: XCTestCase {
         XCTAssertFalse(results.formatted.isEmpty, "Should return formatted text")
         XCTAssertTrue(results.formatted.contains("\u{250c}"), "Should have box-drawing header")
         XCTAssertGreaterThan(results.count, 0, "Should find at least one result")
+    }
+
+    func testSearchOverlayResultsUsePreviewTextNotFullContent() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-search-preview-\(UUID().uuidString).db"
+        defer {
+            try? FileManager.default.removeItem(atPath: tempDB)
+            try? FileManager.default.removeItem(atPath: tempDB + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDB + "-shm")
+        }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        let fullContent = "BrainBar overlay preview sentinel term should not load this full content column"
+        let previewText = "Short preview from preview_text"
+        try db.insertChunk(
+            id: "preview-overlay-1",
+            content: fullContent,
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        try updatePreviewText(path: tempDB, chunkID: "preview-overlay-1", previewText: previewText)
+
+        let results = try QuickCaptureController.search(db: db, query: "sentinel", limit: 5)
+
+        XCTAssertEqual(results.results.first?["chunk_id"] as? String, "preview-overlay-1")
+        XCTAssertEqual(results.results.first?["content"] as? String, previewText)
+        XCTAssertFalse(results.formatted.contains(fullContent))
+        XCTAssertTrue(results.formatted.contains(previewText))
+    }
+
+    func testSearchKeepsExactChunkIDFallback() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-search-exact-id-\(UUID().uuidString).db"
+        defer {
+            try? FileManager.default.removeItem(atPath: tempDB)
+            try? FileManager.default.removeItem(atPath: tempDB + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDB + "-shm")
+        }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        try db.insertChunk(
+            id: "exact-id-lookup-1",
+            content: "Chunk content does not mention its identifier",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+
+        let results = try QuickCaptureController.search(db: db, query: "exact-id-lookup-1", limit: 5)
+
+        XCTAssertEqual(results.results.first?["chunk_id"] as? String, "exact-id-lookup-1")
+    }
+
+    func testSearchKeepsExactChunkIDFallbackWhenCandidatesFillLimit() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-search-exact-id-limit-\(UUID().uuidString).db"
+        defer {
+            try? FileManager.default.removeItem(atPath: tempDB)
+            try? FileManager.default.removeItem(atPath: tempDB + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDB + "-shm")
+        }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        try db.insertChunk(
+            id: "candidate-hit-1",
+            content: "exact-id-priority-1 appears only in this candidate text",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        try db.insertChunk(
+            id: "exact-id-priority-1",
+            content: "Chunk content does not mention its identifier",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+
+        let results = try QuickCaptureController.search(db: db, query: "exact-id-priority-1", limit: 1)
+
+        XCTAssertEqual(results.results.first?["chunk_id"] as? String, "exact-id-priority-1")
+    }
+
+    func testSearchPreservesTagsInMappedResults() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-search-tags-\(UUID().uuidString).db"
+        defer {
+            try? FileManager.default.removeItem(atPath: tempDB)
+            try? FileManager.default.removeItem(atPath: tempDB + "-wal")
+            try? FileManager.default.removeItem(atPath: tempDB + "-shm")
+        }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        try db.insertChunk(
+            id: "tagged-result-1",
+            content: "Tagged result should keep tag metadata",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7,
+            tags: "[\"phase-2-4\", \"search-perf\"]"
+        )
+
+        let results = try QuickCaptureController.search(db: db, query: "tagged metadata", limit: 5)
+
+        XCTAssertEqual(results.results.first?["chunk_id"] as? String, "tagged-result-1")
+        XCTAssertEqual(results.results.first?["tags"] as? String, "[\"phase-2-4\", \"search-perf\"]")
+        XCTAssertTrue(results.formatted.contains("phase-2-4"))
     }
 
     func testSearchEmptyQueryReturnsEmpty() throws {
@@ -269,5 +383,29 @@ final class QuickCaptureTests: XCTestCase {
     func testBrainBarURLRejectsOtherSchemes() {
         let url = URL(string: "https://example.com")!
         XCTAssertNil(BrainBarURLAction.parse(url: url))
+    }
+}
+
+private func updatePreviewText(path: String, chunkID: String, previewText: String) throws {
+    var sqlite: OpaquePointer?
+    let rc = sqlite3_open_v2(path, &sqlite, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil)
+    guard rc == SQLITE_OK, let sqlite else {
+        throw NSError(domain: "QuickCaptureTests", code: Int(rc))
+    }
+    defer { sqlite3_close(sqlite) }
+
+    var stmt: OpaquePointer?
+    let prepareRC = sqlite3_prepare_v2(sqlite, "UPDATE chunks SET preview_text = ? WHERE id = ?", -1, &stmt, nil)
+    guard prepareRC == SQLITE_OK, let stmt else {
+        throw NSError(domain: "QuickCaptureTests", code: Int(prepareRC))
+    }
+    defer { sqlite3_finalize(stmt) }
+
+    let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    sqlite3_bind_text(stmt, 1, previewText, -1, transient)
+    sqlite3_bind_text(stmt, 2, chunkID, -1, transient)
+    let stepRC = sqlite3_step(stmt)
+    guard stepRC == SQLITE_DONE else {
+        throw NSError(domain: "QuickCaptureTests", code: Int(stepRC))
     }
 }

--- a/brain-bar/Tests/BrainBarTests/StabilityFixTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StabilityFixTests.swift
@@ -127,7 +127,7 @@ final class EnterKeySearchTests: XCTestCase {
         // Switch to search mode and populate results
         vm.setMode(.search)
         vm.inputText = "React"
-        vm.handleInputChange("React")
+        vm.submit()
 
         // Verify we have results and no selection yet is OK — submit should select first
         guard !vm.results.isEmpty else {

--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -10,15 +10,20 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import os
 import signal
 import socket
+import sqlite3
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
 _ACCEPT_TIMEOUT_SECONDS = 0.25
 _CONNECTION_TIMEOUT_SECONDS = 5.0
+_WARMUP_RETRY_DELAYS_SECONDS = (0.05, 0.1)
+_LOGGER = logging.getLogger(__name__)
 
 
 def _json_safe(value: Any) -> Any:
@@ -43,9 +48,28 @@ class HybridSearchHelper:
         os.environ["BRAINLAYER_DB"] = os.fspath(self.db_path)
         from brainlayer.mcp._shared import _get_embedding_model, _get_search_vector_store
 
-        _get_search_vector_store()
+        store = _get_search_vector_store()
         model = _get_embedding_model()
-        model.embed_query("brainbar hybrid helper warmup")
+        warmup_query = "brainbar hybrid helper warmup"
+        query_embedding = model.embed_query(warmup_query)
+        for attempt in range(len(_WARMUP_RETRY_DELAYS_SECONDS) + 1):
+            try:
+                store.hybrid_search(
+                    query_embedding=query_embedding,
+                    query_text=warmup_query,
+                    n_results=5,
+                )
+                return
+            except sqlite3.OperationalError as exc:
+                if "database is locked" not in str(exc).lower():
+                    _LOGGER.warning("BrainBar hybrid warmup skipped after SQLite error: %s", exc)
+                    return
+                if attempt >= len(_WARMUP_RETRY_DELAYS_SECONDS):
+                    _LOGGER.warning("BrainBar hybrid warmup skipped after repeated SQLite busy errors")
+                    return
+                delay = _WARMUP_RETRY_DELAYS_SECONDS[attempt]
+                _LOGGER.warning("BrainBar hybrid warmup hit SQLite busy; retrying in %.2fs", delay)
+                time.sleep(delay)
 
     def serve_forever(self) -> None:
         if self.socket_path.exists():

--- a/tests/test_brainbar_hybrid_helper.py
+++ b/tests/test_brainbar_hybrid_helper.py
@@ -1,7 +1,67 @@
+import sqlite3
+
 import pytest
 from mcp.types import TextContent
 
 from brainlayer.brainbar_hybrid_helper import HybridSearchHelper
+
+
+def test_warm_preloads_embedding_then_hybrid_search(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeModel:
+        def embed_query(self, text):
+            calls.append(("embed_query", text))
+            return [0.1, 0.2, 0.3]
+
+    class FakeStore:
+        def hybrid_search(self, **kwargs):
+            calls.append(("hybrid_search", kwargs))
+            return [{"chunk_id": "warm-1"}]
+
+    monkeypatch.setattr("brainlayer.mcp._shared._get_embedding_model", lambda: FakeModel())
+    monkeypatch.setattr("brainlayer.mcp._shared._get_search_vector_store", lambda: FakeStore())
+
+    helper = HybridSearchHelper(socket_path=tmp_path / "helper.sock", db_path=tmp_path / "test.db")
+    helper.warm()
+
+    assert calls == [
+        ("embed_query", "brainbar hybrid helper warmup"),
+        (
+            "hybrid_search",
+            {
+                "query_embedding": [0.1, 0.2, 0.3],
+                "query_text": "brainbar hybrid helper warmup",
+                "n_results": 5,
+            },
+        ),
+    ]
+
+
+def test_warm_retries_locked_hybrid_search_and_continues(monkeypatch, tmp_path):
+    calls = []
+    sleeps = []
+
+    class FakeModel:
+        def embed_query(self, text):
+            return [0.1, 0.2, 0.3]
+
+    class FakeStore:
+        def hybrid_search(self, **kwargs):
+            calls.append(kwargs)
+            if len(calls) < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return [{"chunk_id": "warm-1"}]
+
+    monkeypatch.setattr("brainlayer.mcp._shared._get_embedding_model", lambda: FakeModel())
+    monkeypatch.setattr("brainlayer.mcp._shared._get_search_vector_store", lambda: FakeStore())
+    monkeypatch.setattr("brainlayer.brainbar_hybrid_helper.time.sleep", lambda delay: sleeps.append(delay))
+
+    helper = HybridSearchHelper(socket_path=tmp_path / "helper.sock", db_path=tmp_path / "test.db")
+    helper.warm()
+
+    assert len(calls) == 3
+    assert sleeps == [0.05, 0.1]
 
 
 def test_helper_routes_brain_search_to_python_mcp_with_source_all_default(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Extend BrainBar hybrid helper warmup to run a dummy hybrid search after embedding warmup so the binary vector index is preloaded.
- Add a 250ms debounce to command-bar search input while keeping explicit submit immediate.
- Route command-bar overlay search through searchCandidates and preview_text instead of full content.

## Test Plan
- uv run pytest tests/test_brainbar_hybrid_helper.py -q
- swift test --filter 'QuickCapturePanelTests/testHandleInputChangeDebouncesSearchByAtLeast200Milliseconds|QuickCapturePanelTests/testRapidInputChangesOnlyRunLatestDebouncedSearch|QuickCaptureTests/testSearchOverlayResultsUsePreviewTextNotFullContent'\n- uv run ruff check src/ tests/\n- uv run ruff format --check src/ tests/\n- uv run pytest tests/ -v --tb=short -m "not integration and not live" -x --ignore=tests/test_eval_framework.py --ignore=tests/test_follow_up_rewrite.py --ignore=tests/test_prompt_classification.py\n- uv run pytest tests/test_eval_framework.py tests/test_follow_up_rewrite.py tests/test_prompt_classification.py -v --tb=short -x\n- uv run pytest tests/test_think_recall_integration.py::TestMCPToolCount -v --tb=short\n\nNo squash merge; use rebase merge per Phase 2.4-A mandate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Search ordering and copy semantics changed for the command bar; hybrid warmup adds concurrent SQLite access at startup with retry-only handling for lock errors.
> 
> **Overview**
> Improves BrainBar quick-capture search UX and startup latency by changing **what** gets queried, **when** searches run, and **what** gets copied.
> 
> **Command bar search** no longer fires on every keystroke: `QuickCaptureViewModel` debounces input by **250ms** (default), cancels pending tasks on dismiss/mode switch, and clears result rows immediately when the query changes so stale hits are not selectable. Explicit submit still runs search right away and cancels any pending debounced task. Search is injectable for tests.
> 
> **Search payload shape** changes in `QuickCaptureController.search`: it builds results from `searchCandidates` (preview_text–leaning FTS path) merged with legacy `db.search` rows (deduped by `chunk_id`, with exact-ID fallback preserved). Display `content` is the **preview**; **`full_content`** holds the stored chunk text. Candidate rows enrich via `getChunk`, which now also returns **`tags`**. The overlay list title stays short; row `content` used for copy/Enter is **`full_content`**, not the preview.
> 
> **Python hybrid helper warmup** (`HybridSearchHelper.warm`) now embeds a dummy query and runs a real **`hybrid_search`** to prime the vector index, with short retries when SQLite reports **database is locked**.
> 
> Tests cover debounce timing, coalescing, stale-result clearing, preview vs full copy, exact chunk ID fallback, and warmup/retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ce586ec037e69fb2892094d59a0233527c062b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hybrid search pre-warming, debounced command-bar search, and preview_text overlay
> - `HybridSearchHelper.warm` in [brainbar_hybrid_helper.py](https://github.com/EtanHey/brainlayer/pull/320/files#diff-d3d5162fd8f713352fe31ea2b66de6014b80c7e9af406132cdd41d99375a7b21) now pre-runs a hybrid search on startup, with retry logic (two attempts) for transient SQLite `database is locked` errors.
> - `QuickCaptureViewModel` in [QuickCapturePanel.swift](https://github.com/EtanHey/brainlayer/pull/320/files#diff-59b5101e9347008e291127bbbd129683c991d1829ddd09698350701d67b6b49c) debounces live search by 250ms (configurable), coalescing rapid keystrokes and clearing stale results immediately on input change.
> - Search results now carry a separate `content` (preview text) and `full_content` field; the command bar displays the preview while downstream copy/actions use full content.
> - `QuickCaptureController.search` in [QuickCaptureController.swift](https://github.com/EtanHey/brainlayer/pull/320/files#diff-98d3084c49763ee1565d63fa3075da798e6a922a6fd429ccc3ef4f289ee24edb) merges candidate-based matches with fallback rows, deduplicates by chunk ID, preserves candidate order, and includes `tags` in all result maps.
> - Behavioral Change: explicit search submissions now cancel any pending debounced search by default; pending tasks are also cancelled on `dismiss` and `deinit` to prevent stale updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8ce586.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debounced search with configurable delay—search executes after the user stops typing (250ms default).
  * Search results now display preview text instead of full content for better readability.

* **Improvements**
  * Enhanced search task management with proper cancellation and cleanup.
  * Improved hybrid search warmup performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->