### PR TITLE
feat(brainbar): reduce-motion gate + Swift Charts sparklines

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -1086,7 +1086,8 @@ private struct BrainBarHeroSparkline: View {
                         label: "Recent activity sparkline",
                         values: values
                     ),
-                    accentColor: accentColor
+                    accentColor: accentColor,
+                    compact: SparklineRenderer.isCompact(size: renderSize)
                 )
                 .frame(width: proxy.size.width, height: proxy.size.height)
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -1065,6 +1065,7 @@ private struct BrainBarHeroSparkline: View {
     let accentColor: NSColor
     let pulseRevision: Int
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var ringScale: CGFloat = 0.8
     @State private var ringOpacity = 0.0
 
@@ -1074,24 +1075,22 @@ private struct BrainBarHeroSparkline: View {
                 width: max(proxy.size.width.rounded(.up), 1),
                 height: max(proxy.size.height.rounded(.up), 1)
             )
-            let image = SparklineRenderer.render(
-                state: .idle,
-                values: values,
-                size: renderSize,
-                accentColor: accentColor
-            )
             let endpoint = SparklineRenderer.endpoint(
                 values: values,
                 size: renderSize
             )
 
             ZStack(alignment: .topLeading) {
-                Image(nsImage: image)
-                    .interpolation(.high)
-                    .resizable()
-                    .frame(width: proxy.size.width, height: proxy.size.height)
+                SparklineChart(
+                    presentation: SparklineChartPresentation(
+                        label: "Recent activity sparkline",
+                        values: values
+                    ),
+                    accentColor: accentColor
+                )
+                .frame(width: proxy.size.width, height: proxy.size.height)
 
-                if let endpoint {
+                if let endpoint, !reduceMotion {
                     let point = CGPoint(
                         x: endpoint.x,
                         y: proxy.size.height - endpoint.y
@@ -1121,6 +1120,11 @@ private struct BrainBarHeroSparkline: View {
     }
 
     private func triggerPulse() {
+        guard !reduceMotion else {
+            ringScale = 1
+            ringOpacity = 0
+            return
+        }
         ringScale = 0.8
         ringOpacity = 0.7
         withAnimation(.easeOut(duration: 0.75)) {

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -44,13 +44,18 @@ struct SparklineChartPresentation: Equatable, Sendable {
     }
 
     private var trendDescription: String {
-        guard let first = values.first, let last = values.last else {
+        guard let last = values.last else {
             return "no trend"
         }
-        if last > first {
+        guard values.count > 1 else {
+            return "steady"
+        }
+
+        let previous = values[values.count - 2]
+        if last > previous {
             return "trending up"
         }
-        if last < first {
+        if last < previous {
             return "trending down"
         }
         return "steady"
@@ -105,13 +110,19 @@ struct SparklineChart: View {
 }
 
 enum SparklineRenderer {
+    static func isCompact(size: NSSize) -> Bool {
+        let width = max(size.width.rounded(.up), 1)
+        let height = max(size.height.rounded(.up), 1)
+        return height <= 20 || width <= 52
+    }
+
     static func endpoint(
         values: [Int],
         size: NSSize = NSSize(width: 44, height: 18)
     ) -> CGPoint? {
         let width = max(Int(size.width.rounded(.up)), 1)
         let height = max(Int(size.height.rounded(.up)), 1)
-        let isCompact = height <= 20 || width <= 52
+        let isCompact = isCompact(size: size)
 
         guard values.count > 1 else { return nil }
 
@@ -149,7 +160,7 @@ enum SparklineRenderer {
                 values: values
             ),
             accentColor: accentColor ?? state.color,
-            compact: height <= 20 || width <= 52
+            compact: isCompact(size: size)
         )
         .frame(width: width, height: height)
 

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -1,6 +1,108 @@
 import AppKit
-import CoreGraphics
+import Charts
 import Foundation
+import SwiftUI
+
+struct SparklineChartPoint: Identifiable, Equatable, Sendable {
+    let bucket: Int
+    let value: Int
+
+    var id: Int { bucket }
+}
+
+struct SparklineChartPresentation: Equatable, Sendable {
+    let label: String
+    let values: [Int]
+    let latestBucketName: String
+
+    init(
+        label: String,
+        values: [Int],
+        latestBucketName: String = "latest bucket count"
+    ) {
+        self.label = label
+        self.values = values
+        self.latestBucketName = latestBucketName
+    }
+
+    var points: [SparklineChartPoint] {
+        values.enumerated().map { index, value in
+            SparklineChartPoint(bucket: index, value: value)
+        }
+    }
+
+    var accessibilityLabel: String {
+        label
+    }
+
+    var accessibilityValue: String {
+        "\(latestBucketName) \(values.last ?? 0), \(trendDescription)"
+    }
+
+    var maxValue: Int {
+        max(values.max() ?? 0, 1)
+    }
+
+    private var trendDescription: String {
+        guard let first = values.first, let last = values.last else {
+            return "no trend"
+        }
+        if last > first {
+            return "trending up"
+        }
+        if last < first {
+            return "trending down"
+        }
+        return "steady"
+    }
+}
+
+struct SparklineChart: View {
+    let presentation: SparklineChartPresentation
+    let accentColor: NSColor
+    let compact: Bool
+
+    init(
+        presentation: SparklineChartPresentation,
+        accentColor: NSColor,
+        compact: Bool = false
+    ) {
+        self.presentation = presentation
+        self.accentColor = accentColor
+        self.compact = compact
+    }
+
+    var body: some View {
+        Chart(presentation.points) { point in
+            if !compact {
+                AreaMark(
+                    x: .value("Bucket", point.bucket),
+                    y: .value("Count", point.value)
+                )
+                .foregroundStyle(Color(nsColor: accentColor).opacity(0.10))
+            }
+
+            LineMark(
+                x: .value("Bucket", point.bucket),
+                y: .value("Count", point.value)
+            )
+            .interpolationMethod(.catmullRom)
+            .foregroundStyle(Color(nsColor: accentColor).opacity(0.85))
+            .lineStyle(StrokeStyle(lineWidth: compact ? 1.6 : 2, lineCap: .round, lineJoin: .round))
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartYScale(domain: 0...presentation.maxValue)
+        .chartPlotStyle { plotArea in
+            plotArea
+                .background(Color.clear)
+                .padding(compact ? 2 : 10)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(presentation.accessibilityLabel))
+        .accessibilityValue(Text(presentation.accessibilityValue))
+    }
+}
 
 enum SparklineRenderer {
     static func endpoint(
@@ -32,107 +134,31 @@ enum SparklineRenderer {
         )
     }
 
+    @MainActor
     static func render(
         state: PipelineState,
         values: [Int],
         size: NSSize = NSSize(width: 44, height: 18),
         accentColor: NSColor? = nil
     ) -> NSImage {
-        let width = max(Int(size.width.rounded(.up)), 1)
-        let height = max(Int(size.height.rounded(.up)), 1)
-        let isCompact = height <= 20 || width <= 52
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let lineColor = accentColor ?? state.color
-
-        guard let context = CGContext(
-            data: nil,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: 0,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
-            return NSImage(size: size)
-        }
-
-        let rect = CGRect(origin: .zero, size: CGSize(width: width, height: height))
-        context.setFillColor(NSColor.clear.cgColor)
-        context.fill(rect)
-
-        context.setAllowsAntialiasing(true)
-        context.setShouldAntialias(true)
-
-        guard values.count > 1 else {
-            return image(from: context, size: size)
-        }
-
-        let maxValue = max(values.max() ?? 0, 1)
-        let horizontalInset: CGFloat = isCompact ? 2 : 10
-        let verticalInset: CGFloat = isCompact ? 2 : 10
-        let chartRect = CGRect(
-            x: horizontalInset,
-            y: verticalInset,
-            width: max(CGFloat(width) - (horizontalInset * 2), 1),
-            height: max(CGFloat(height) - (verticalInset * 2), 1)
+        let width = max(size.width.rounded(.up), 1)
+        let height = max(size.height.rounded(.up), 1)
+        let chart = SparklineChart(
+            presentation: SparklineChartPresentation(
+                label: "Recent activity sparkline",
+                values: values
+            ),
+            accentColor: accentColor ?? state.color,
+            compact: height <= 20 || width <= 52
         )
-        let step = chartRect.width / CGFloat(max(values.count - 1, 1))
-        let path = CGMutablePath()
-        var points: [CGPoint] = []
+        .frame(width: width, height: height)
 
-        if !isCompact {
-            context.setStrokeColor(NSColor.separatorColor.withAlphaComponent(0.55).cgColor)
-            context.setLineWidth(1)
-            for fraction in [0.25, 0.5, 0.75] {
-                let y = chartRect.minY + chartRect.height * CGFloat(fraction)
-                context.move(to: CGPoint(x: chartRect.minX, y: y))
-                context.addLine(to: CGPoint(x: chartRect.maxX, y: y))
-            }
-            context.strokePath()
+        let renderer = ImageRenderer(content: chart)
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
+        if let image = renderer.nsImage {
+            image.isTemplate = false
+            return image
         }
-
-        for (index, value) in values.enumerated() {
-            let x = chartRect.minX + CGFloat(index) * step
-            let normalized = CGFloat(value) / CGFloat(maxValue)
-            let y = chartRect.minY + normalized * chartRect.height
-            let point = CGPoint(x: x, y: y)
-            points.append(point)
-            if index == 0 {
-                path.move(to: point)
-            } else {
-                path.addLine(to: point)
-            }
-        }
-
-        if !isCompact, let first = points.first, let last = points.last {
-            let fill = CGMutablePath()
-            fill.move(to: CGPoint(x: first.x, y: chartRect.minY))
-            for point in points {
-                fill.addLine(to: point)
-            }
-            fill.addLine(to: CGPoint(x: last.x, y: chartRect.minY))
-            fill.closeSubpath()
-            context.addPath(fill)
-            context.setFillColor(lineColor.withAlphaComponent(0.10).cgColor)
-            context.fillPath()
-        }
-
-        context.addPath(path)
-        context.setStrokeColor(lineColor.withAlphaComponent(0.85).cgColor)
-        context.setLineWidth(isCompact ? 1.6 : 2)
-        context.setLineCap(.round)
-        context.setLineJoin(.round)
-        context.strokePath()
-
-        return image(from: context, size: size)
-    }
-
-    private static func image(from context: CGContext, size: NSSize) -> NSImage {
-        guard let cgImage = context.makeImage() else {
-            return NSImage(size: size)
-        }
-        let image = NSImage(cgImage: cgImage, size: size)
-        image.isTemplate = false
-        return image
+        return NSImage(size: NSSize(width: width, height: height))
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -55,7 +55,15 @@ final class StatusPopoverView: NSViewController {
     private let activityLabel = NSTextField(labelWithString: "Enrichment Throughput")
     private let activityDetailLabel = NSTextField(labelWithString: "")
     private let enrichmentLabel = NSTextField(labelWithString: "")
-    private let sparklineImageView = NSImageView(frame: .zero)
+    private let sparklineChartView = NSHostingView(
+        rootView: SparklineChart(
+            presentation: SparklineChartPresentation(
+                label: "Recent activity sparkline",
+                values: []
+            ),
+            accentColor: .systemBlue
+        )
+    )
     private let daemonLabel = NSTextField(labelWithString: "")
     private let hotkeyLabel = NSTextField(labelWithString: "")
     private let headerPanel = SurfacePanelView(cornerRadius: 14)
@@ -199,10 +207,9 @@ final class StatusPopoverView: NSViewController {
         hotkeyLabel.maximumNumberOfLines = 2
         hotkeyLabel.lineBreakMode = .byWordWrapping
 
-        sparklineImageView.imageScaling = .scaleAxesIndependently
-        sparklineImageView.wantsLayer = true
-        sparklineImageView.layer?.cornerRadius = 4
-        sparklineImageView.layer?.backgroundColor = NSColor.clear.cgColor
+        sparklineChartView.wantsLayer = true
+        sparklineChartView.layer?.cornerRadius = 4
+        sparklineChartView.layer?.backgroundColor = NSColor.clear.cgColor
     }
 
     private func makeDashboardContent() -> NSView {
@@ -251,7 +258,7 @@ final class StatusPopoverView: NSViewController {
         activityHeader.orientation = .horizontal
         activityHeader.alignment = .centerY
 
-        let activityStack = NSStackView(views: [activityHeader, sparklineImageView])
+        let activityStack = NSStackView(views: [activityHeader, sparklineChartView])
         activityStack.orientation = .vertical
         activityStack.spacing = 10
         let activityCard = activityPanel.wrap(
@@ -259,7 +266,7 @@ final class StatusPopoverView: NSViewController {
             edgeInsets: NSEdgeInsets(top: 14, left: 14, bottom: 14, right: 14)
         )
 
-        sparklineImageView.translatesAutoresizingMaskIntoConstraints = false
+        sparklineChartView.translatesAutoresizingMaskIntoConstraints = false
         hotkeyLabel.isHidden = hotkeyStatus == nil
 
         for row in [headerCard, activityCard] as [NSView] {
@@ -274,7 +281,7 @@ final class StatusPopoverView: NSViewController {
         content.edgeInsets = NSEdgeInsets(top: 8, left: 14, bottom: 14, right: 14)
 
         NSLayoutConstraint.activate([
-            sparklineImageView.heightAnchor.constraint(equalToConstant: 188),
+            sparklineChartView.heightAnchor.constraint(equalToConstant: 188),
         ])
 
         dashboardContent = content
@@ -360,10 +367,12 @@ final class StatusPopoverView: NSViewController {
 
         enrichmentLabel.stringValue = "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched"
         activityDetailLabel.stringValue = enrichmentActivitySummary(collector.stats)
-        sparklineImageView.image = SparklineRenderer.render(
-            state: collector.state,
-            values: summary.enrichment.values,
-            size: NSSize(width: 500, height: 188)
+        sparklineChartView.rootView = SparklineChart(
+            presentation: SparklineChartPresentation(
+                label: "Recent activity sparkline",
+                values: summary.enrichment.values
+            ),
+            accentColor: collector.state.color
         )
 
         if let daemon = collector.daemon {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -19,6 +19,7 @@ enum KGCanvasMetrics {
 struct KGCanvasView: View {
     @ObservedObject var viewModel: KGViewModel
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var offset: CGSize = .zero
     @State private var lastDragOffset: CGSize = .zero
@@ -90,8 +91,16 @@ struct KGCanvasView: View {
                 defer { hasStartedGraphPolling = false }
                 if await viewModel.loadGraphRepeatedly(onSuccessfulLoad: {
                     hasLoadedGraph = true
+                    if reduceMotion {
+                        _ = viewModel.tick(reduceMotionEnabled: true)
+                    }
                 }) {
                     hasLoadedGraph = true
+                }
+            }
+            .onChange(of: reduceMotion) { _, enabled in
+                if enabled {
+                    _ = viewModel.tick(reduceMotionEnabled: true)
                 }
             }
         }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -357,8 +357,12 @@ final class KGViewModel: ObservableObject {
 
     // MARK: - Force-Directed Layout
 
-    func tick() -> CGFloat {
+    func tick(reduceMotionEnabled: Bool = false) -> CGFloat {
         guard nodes.count > 1 else { return 0 }
+        if reduceMotionEnabled {
+            freezeLayout()
+            return 0
+        }
 
         var forces = Array(repeating: CGVector.zero, count: nodes.count)
         let center = canvasCenter
@@ -418,6 +422,12 @@ final class KGViewModel: ObservableObject {
     }
 
     // MARK: - Helpers
+
+    private func freezeLayout() {
+        for index in nodes.indices {
+            nodes[index].velocity = .zero
+        }
+    }
 
     private func nodeById(_ id: String) -> KGNode? {
         nodes.first { $0.id == id }

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -72,7 +72,13 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(presentation.points.map(\.bucket), [0, 1, 2, 3])
         XCTAssertEqual(presentation.points.map(\.value), [0, 2, 5, 3])
         XCTAssertEqual(presentation.accessibilityLabel, "Recent activity sparkline")
-        XCTAssertEqual(presentation.accessibilityValue, "latest bucket count 3, trending up")
+        XCTAssertEqual(presentation.accessibilityValue, "latest bucket count 3, trending down")
+    }
+
+    func testSparklineRendererCompactClassificationMatchesEndpointAndChartPadding() {
+        XCTAssertTrue(SparklineRenderer.isCompact(size: NSSize(width: 52, height: 116)))
+        XCTAssertTrue(SparklineRenderer.isCompact(size: NSSize(width: 300, height: 20)))
+        XCTAssertFalse(SparklineRenderer.isCompact(size: NSSize(width: 53, height: 21)))
     }
 
     func testDashboardStatsCountsRecentISO8601Timestamps() throws {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -63,6 +63,18 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.recentEnrichmentBuckets, [0, 0, 0, 0])
     }
 
+    func testSparklineChartPresentationCarriesBucketsAndVoiceOverMetadata() {
+        let presentation = SparklineChartPresentation(
+            label: "Recent activity sparkline",
+            values: [0, 2, 5, 3]
+        )
+
+        XCTAssertEqual(presentation.points.map(\.bucket), [0, 1, 2, 3])
+        XCTAssertEqual(presentation.points.map(\.value), [0, 2, 5, 3])
+        XCTAssertEqual(presentation.accessibilityLabel, "Recent activity sparkline")
+        XCTAssertEqual(presentation.accessibilityValue, "latest bucket count 3, trending up")
+    }
+
     func testDashboardStatsCountsRecentISO8601Timestamps() throws {
         try db.insertChunk(
             id: "dash-iso",

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -871,6 +871,24 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertTrue(moved, "Force tick should move at least one node")
     }
 
+    func testReduceMotionTickFreezesLayoutAndReportsZeroEnergy() async throws {
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+
+        let vm = KGViewModel(database: db)
+        await vm.loadGraph()
+        vm.nodes[0].velocity = CGVector(dx: 10, dy: 3)
+        vm.nodes[1].velocity = CGVector(dx: -4, dy: -7)
+
+        let positionsBefore = vm.nodes.map(\.position)
+        let energy = vm.tick(reduceMotionEnabled: true)
+
+        XCTAssertEqual(energy, 0, "Reduce Motion should make force layout report settled energy")
+        XCTAssertEqual(vm.nodes.map(\.position), positionsBefore, "Reduce Motion should freeze node positions")
+        XCTAssertTrue(vm.nodes.allSatisfy { $0.velocity == .zero }, "Reduce Motion should zero any residual velocity")
+    }
+
     func testNodeHitTestFindsCorrectNode() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")


### PR DESCRIPTION
## Summary
- Gate BrainBar knowledge-graph force layout and hero sparkline pulse behavior on Reduce Motion.
- Replace the custom CoreGraphics sparkline drawing path with Swift Charts-backed chart views, preserving compact menu-bar rendering through `ImageRenderer`.
- Add VoiceOver label/value/trend metadata and bucket presentation tests for sparklines.

## Test plan
- [x] TDD RED: targeted Swift tests failed for missing reduce-motion/chart presentation APIs.
- [x] `swift test --package-path brain-bar --filter 'KGViewModelTests/testReduceMotionTickFreezesLayoutAndReportsZeroEnergy|DashboardTests/testSparklineChartPresentationCarriesBucketsAndVoiceOverMetadata'`
- [x] `swift test --package-path brain-bar` (430 tests)
- [x] `pytest` (2200 passed, 46 skipped, 5 xfailed)
- [x] pre-push BrainLayer test gate (pytest unit suite, MCP registration, isolated eval/hook routing, bun, regression shell)

## Notes
- Initial `pytest` exposed local canonical DB `created_at` coverage drift unrelated to this Swift diff. I unloaded only `com.brainlayer.enrichment`, ran `scripts/backfill-created-at.py`, reloaded enrichment, and reran the suite green.

Co-Authored-By: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dashboard and graph UI rendering and animation paths with a new Charts dependency and ImageRenderer snapshot path; changes are localized and covered by new unit tests, with no auth or data-layer impact.
> 
> **Overview**
> Replaces hand-drawn CoreGraphics sparklines with a shared **Swift Charts** `SparklineChart` view (line/area marks, catmullRom interpolation). **Menu bar** icons still use `SparklineRenderer.render`, which now snapshots that view via `ImageRenderer` instead of drawing paths directly; **gridlines are dropped** in the new chart style.
> 
> The **main window hero** and **status popover** dashboard now embed the live chart (popover moves from `NSImageView` to `NSHostingView`). Charts get **VoiceOver** label/value/trend strings through `SparklineChartPresentation`.
> 
> **Reduce Motion** suppresses the hero endpoint pulse ring and skips its animation. On the knowledge graph, `KGViewModel.tick(reduceMotionEnabled:)` **zeros velocities and stops layout motion** when the setting is on, including after graph load and when the preference toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8d701d05f144b909c67a33cefe046ca1541a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Swift Charts sparklines and reduce-motion gating to BrainBar
> - Replaces CoreGraphics/`NSImage`-based sparkline rendering with a `SparklineChart` SwiftUI view backed by Swift Charts, with area fill in non-compact mode and VoiceOver accessibility support via `SparklineChartPresentation`.
> - Updates `StatusPopoverView` to host `SparklineChart` in an `NSHostingView` and `BrainBarHeroSparkline` to embed the chart directly, removing all `ImageRenderer`/CoreGraphics paths.
> - Gates the pulsing endpoint ring and `triggerPulse` animation in `BrainBarHeroSparkline` behind `accessibilityReduceMotion`, skipping animation and hiding the ring when Reduce Motion is enabled.
> - Stabilizes the knowledge graph force layout in `KGViewModel.tick` when `reduceMotionEnabled: true` by zeroing node velocities and returning zero kinetic energy immediately.
> - Adds unit tests for `SparklineChartPresentation` accessibility metadata, `SparklineRenderer.isCompact` thresholds, and the reduce-motion tick freeze behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d8d701.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility support for reduced motion across dashboard and knowledge graph visualizations, improving experience for users with motion sensitivity.

* **Improvements**
  * Enhanced sparkline chart rendering with improved visual quality and accessibility metadata.

* **Tests**
  * Added unit tests for sparkline chart accessibility and reduced motion behavior verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->