### PR TITLE
feat(brainbar): burst-aggregate injections + 60-min ribbon

### DIFF
--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -374,7 +374,7 @@ struct InjectionFeedView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     railMetric(label: "Average", value: averageTokenText(snapshot: snapshot))
                     railMetric(label: "Peak event", value: peakTokenText(snapshot: snapshot))
-                    railMetric(label: "Burst count", value: "\(snapshot.bursts.count)")
+                    railMetric(label: "Burst count", value: "\(snapshot.summary.burstCount)")
                 }
             }
 

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -184,9 +184,15 @@ struct InjectionFeedView: View {
                     Text("retrieved chunks")
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.secondary)
-                    Text(isExpanded ? "Collapse" : "Expand")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.blue)
+                    Button {
+                        toggleBurst(burst.id)
+                    } label: {
+                        Text(isExpanded ? "Collapse" : "Expand")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.blue)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(isExpanded ? "Collapse burst" : "Expand burst")
                 }
             }
 
@@ -202,10 +208,6 @@ struct InjectionFeedView: View {
         }
         .padding(18)
         .background(cardBackground)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            toggleBurst(burst.id)
-        }
     }
 
     private func collapsedChunkPreview(for burst: InjectionPresentation.Burst) -> some View {

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 
 struct InjectionFeedView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject var store: InjectionStore
     @Binding var filterText: String
     @State private var expandedEventIDs: Set<Int64> = []
+    @State private var expandedBurstIDs: Set<String> = []
     @State private var selectedConversation: BrainDatabase.ExpandedConversation?
 
     private let accentPalette: [Color] = [
@@ -24,7 +26,7 @@ struct InjectionFeedView: View {
                     header(snapshot: snapshot)
                     overviewStrip(snapshot: snapshot)
 
-                    if snapshot.filteredEvents.isEmpty {
+                    if snapshot.bursts.isEmpty {
                         emptyState
                     } else if wideLayout {
                         HStack(alignment: .top, spacing: 16) {
@@ -139,22 +141,36 @@ struct InjectionFeedView: View {
     }
 
     private func feedColumn(snapshot: InjectionPresentation.Snapshot) -> some View {
-        VStack(alignment: .leading, spacing: 16) {
-            ForEach(snapshot.bursts) { burst in
-                burstCard(burst)
+        LazyVStack(alignment: .leading, spacing: 16, pinnedViews: [.sectionHeaders]) {
+            ForEach(snapshot.burstSections) { section in
+                Section {
+                    ForEach(section.bursts) { burst in
+                        burstCard(burst)
+                    }
+                } header: {
+                    ribbonHeader(section.bucket)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func burstCard(_ burst: InjectionPresentation.Burst) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        let isExpanded = expandedBurstIDs.contains(burst.id)
+        return VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 12) {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(InjectionPresentation.burstRangeText(start: burst.startDate, end: burst.endDate))
-                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("↻")
+                            .font(.system(size: 16, weight: .bold, design: .rounded))
+                            .foregroundStyle(.blue)
+                        Text(burst.summaryTitle)
+                            .font(.system(size: 18, weight: .semibold, design: .rounded))
+                            .lineLimit(2)
+                    }
                     HStack(spacing: 8) {
-                        chip(text: burst.sessionID, tint: .blue)
+                        chip(text: "Session: \(shortSessionID(burst.sessionID))", tint: .blue)
+                        chip(text: relativeText(for: burst.endDate), tint: .neutral)
                         chip(text: "\(burst.queryCount) queries", tint: .neutral)
                         chip(text: "\(burst.tokenCount) tok", tint: .green)
                     }
@@ -168,17 +184,68 @@ struct InjectionFeedView: View {
                     Text("retrieved chunks")
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.secondary)
+                    Text(isExpanded ? "Collapse" : "Expand")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.blue)
                 }
             }
 
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(burst.events) { event in
-                    eventRow(event)
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(burst.events) { event in
+                        eventRow(event)
+                    }
                 }
+            } else {
+                collapsedChunkPreview(for: burst)
             }
         }
         .padding(18)
         .background(cardBackground)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            toggleBurst(burst.id)
+        }
+    }
+
+    private func collapsedChunkPreview(for burst: InjectionPresentation.Burst) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            ForEach(Array(burst.chunkPreviewIDs.enumerated()), id: \.offset) { _, chunkID in
+                Text(chunkPreviewText(chunkID))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            let remaining = burst.remainingChunkCount(after: burst.chunkPreviewIDs.count)
+            if remaining > 0 {
+                Text("+\(remaining) more")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.primary.opacity(0.045))
+        )
+    }
+
+    private func ribbonHeader(_ bucket: InjectionPresentation.RibbonBucket) -> some View {
+        HStack(spacing: 10) {
+            Text(bucket.title)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Rectangle()
+                .fill(Color.primary.opacity(0.08))
+                .frame(height: 1)
+        }
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial)
     }
 
     private func eventRow(_ event: InjectionEvent) -> some View {
@@ -453,6 +520,48 @@ struct InjectionFeedView: View {
         } else {
             expandedEventIDs.insert(eventID)
         }
+    }
+
+    private func toggleBurst(_ burstID: String) {
+        let update = {
+            if expandedBurstIDs.contains(burstID) {
+                expandedBurstIDs.remove(burstID)
+            } else {
+                expandedBurstIDs.insert(burstID)
+            }
+        }
+
+        if reduceMotion {
+            update()
+        } else {
+            withAnimation(.easeInOut(duration: 0.16), update)
+        }
+    }
+
+    private func shortSessionID(_ sessionID: String) -> String {
+        guard sessionID.count > 12 else { return sessionID }
+        let prefix = sessionID.prefix(10)
+        return "\(prefix)…"
+    }
+
+    private func relativeText(for date: Date) -> String {
+        let seconds = max(Date().timeIntervalSince(date), 0)
+        if seconds < 60 {
+            return "just now"
+        }
+        if seconds < 60 * 60 {
+            return "\(Int(seconds / 60))m ago"
+        }
+        if seconds < 24 * 60 * 60 {
+            return "\(Int(seconds / 3600))h ago"
+        }
+        return "\(Int(seconds / 86_400))d ago"
+    }
+
+    private func chunkPreviewText(_ chunkID: String) -> String {
+        let limit = 80
+        guard chunkID.count > limit else { return chunkID }
+        return "\(chunkID.prefix(limit - 1))…"
     }
 
     private func makePresentation(now: Date = Date()) -> InjectionPresentation.Snapshot {

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -104,10 +104,10 @@ struct InjectionPresentation {
             parseDate(event.timestamp).map { ParsedEvent(event: event, date: $0) }
         }
         .sorted { $0.date > $1.date }
+        let presentEvents = parsedEvents.filter { $0.date <= now }
 
         let windowStart = now.addingTimeInterval(-Double(windowMinutes) * 60.0)
-        let windowEvents = parsedEvents.filter { $0.date > windowStart && $0.date <= now }
-        let burstEvents = parsedEvents.filter { $0.date <= now }
+        let windowEvents = presentEvents.filter { $0.date > windowStart }
 
         let summary = Summary(
             queryCount: windowEvents.count,
@@ -115,10 +115,10 @@ struct InjectionPresentation {
             tokenCount: windowEvents.reduce(0) { $0 + $1.event.tokenCount },
             activeSessionCount: Set(windowEvents.map(\.event.sessionID)).count
         )
-        let bursts = makeBursts(from: burstEvents, burstGapMinutes: burstGapMinutes)
+        let bursts = makeBursts(from: presentEvents, burstGapMinutes: burstGapMinutes)
 
         return Snapshot(
-            filteredEvents: filteredEvents,
+            filteredEvents: presentEvents.map(\.event),
             windowEvents: windowEvents.map(\.event),
             summary: summary,
             bursts: bursts,
@@ -187,6 +187,7 @@ struct InjectionPresentation {
         var currentEvents = [first]
         var newest = first.date
         var oldest = first.date
+        var previousDate = first.date
 
         func flush() {
             bursts.append(
@@ -202,12 +203,13 @@ struct InjectionPresentation {
 
         for parsed in events.dropFirst() {
             let topicOrSource = topicOrSource(for: parsed.event)
-            let gap = newest.timeIntervalSince(parsed.date)
+            let gap = previousDate.timeIntervalSince(parsed.date)
             if parsed.event.sessionID == currentSessionID,
                topicOrSource == currentTopicOrSource,
                gap < maxGap {
                 currentEvents.append(parsed)
                 oldest = parsed.date
+                previousDate = parsed.date
             } else {
                 flush()
                 currentSessionID = parsed.event.sessionID
@@ -215,6 +217,7 @@ struct InjectionPresentation {
                 currentEvents = [parsed]
                 newest = parsed.date
                 oldest = parsed.date
+                previousDate = parsed.date
             }
         }
 

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -16,6 +16,7 @@ struct InjectionPresentation {
         let chunkCount: Int
         let tokenCount: Int
         let activeSessionCount: Int
+        let burstCount: Int
     }
 
     struct Burst: Equatable, Identifiable {
@@ -108,12 +109,14 @@ struct InjectionPresentation {
 
         let windowStart = now.addingTimeInterval(-Double(windowMinutes) * 60.0)
         let windowEvents = presentEvents.filter { $0.date > windowStart }
+        let windowBursts = makeBursts(from: windowEvents, burstGapMinutes: burstGapMinutes)
 
         let summary = Summary(
             queryCount: windowEvents.count,
             chunkCount: windowEvents.reduce(0) { $0 + $1.event.chunkCount },
             tokenCount: windowEvents.reduce(0) { $0 + $1.event.tokenCount },
-            activeSessionCount: Set(windowEvents.map(\.event.sessionID)).count
+            activeSessionCount: Set(windowEvents.map(\.event.sessionID)).count,
+            burstCount: windowBursts.count
         )
         let bursts = makeBursts(from: presentEvents, burstGapMinutes: burstGapMinutes)
 

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -27,7 +27,7 @@ struct InjectionPresentation {
         let events: [InjectionEvent]
 
         var id: String {
-            "\(groupKey)|\(endDate.timeIntervalSince1970)"
+            "\(groupKey)|\(events.last?.id ?? 0)"
         }
 
         var groupKey: String { "\(sessionID)\u{001F}\(topicOrSource)" }

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -107,6 +107,7 @@ struct InjectionPresentation {
 
         let windowStart = now.addingTimeInterval(-Double(windowMinutes) * 60.0)
         let windowEvents = parsedEvents.filter { $0.date > windowStart && $0.date <= now }
+        let burstEvents = parsedEvents.filter { $0.date <= now }
 
         let summary = Summary(
             queryCount: windowEvents.count,
@@ -114,7 +115,7 @@ struct InjectionPresentation {
             tokenCount: windowEvents.reduce(0) { $0 + $1.event.tokenCount },
             activeSessionCount: Set(windowEvents.map(\.event.sessionID)).count
         )
-        let bursts = makeBursts(from: parsedEvents, burstGapMinutes: burstGapMinutes)
+        let bursts = makeBursts(from: burstEvents, burstGapMinutes: burstGapMinutes)
 
         return Snapshot(
             filteredEvents: filteredEvents,

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -6,6 +6,7 @@ struct InjectionPresentation {
         let windowEvents: [InjectionEvent]
         let summary: Summary
         let bursts: [Burst]
+        let burstSections: [BurstSection]
         let ribbonBuckets: [Int]
         let sessions: [SessionSummary]
     }
@@ -19,17 +20,65 @@ struct InjectionPresentation {
 
     struct Burst: Equatable, Identifiable {
         let sessionID: String
+        let topicOrSource: String
         let startDate: Date
         let endDate: Date
         let events: [InjectionEvent]
 
         var id: String {
-            "\(sessionID)|\(endDate.timeIntervalSince1970)"
+            "\(groupKey)|\(endDate.timeIntervalSince1970)"
         }
 
+        var groupKey: String { "\(sessionID)\u{001F}\(topicOrSource)" }
         var queryCount: Int { events.count }
         var chunkCount: Int { events.reduce(0) { $0 + $1.chunkCount } }
         var tokenCount: Int { events.reduce(0) { $0 + $1.tokenCount } }
+
+        var summaryTitle: String {
+            let chunkNoun = chunkCount == 1 ? "chunk" : "chunks"
+            return "\(chunkCount) \(chunkNoun) injected from \"\(topicOrSource)\""
+        }
+
+        var chunkPreviewIDs: [String] {
+            Array(events.flatMap(\.chunkIDs).prefix(2))
+        }
+
+        func remainingChunkCount(after visibleCount: Int) -> Int {
+            max(chunkCount - visibleCount, 0)
+        }
+    }
+
+    struct BurstSection: Equatable, Identifiable {
+        let bucket: RibbonBucket
+        let bursts: [Burst]
+
+        var id: String { bucket.rawValue }
+    }
+
+    enum RibbonBucket: String, Equatable {
+        case lastSixtyMinutes
+        case oneToTwoHoursAgo
+        case twoToSixHoursAgo
+        case todayEarlier
+        case yesterday
+        case older
+
+        var title: String {
+            switch self {
+            case .lastSixtyMinutes:
+                return "Last 60 min"
+            case .oneToTwoHoursAgo:
+                return "1-2h ago"
+            case .twoToSixHoursAgo:
+                return "2-6h ago"
+            case .todayEarlier:
+                return "Today earlier"
+            case .yesterday:
+                return "Yesterday"
+            case .older:
+                return "Older"
+            }
+        }
     }
 
     struct SessionSummary: Equatable, Identifiable {
@@ -47,7 +96,7 @@ struct InjectionPresentation {
         filterText: String,
         now: Date,
         windowMinutes: Int = 60,
-        burstGapMinutes: Int = 8,
+        burstGapMinutes: Int = 60,
         bucketCount: Int = 12
     ) -> Snapshot {
         let filteredEvents = filter(events: events, needle: filterText)
@@ -57,7 +106,7 @@ struct InjectionPresentation {
         .sorted { $0.date > $1.date }
 
         let windowStart = now.addingTimeInterval(-Double(windowMinutes) * 60.0)
-        let windowEvents = parsedEvents.filter { $0.date >= windowStart && $0.date <= now }
+        let windowEvents = parsedEvents.filter { $0.date > windowStart && $0.date <= now }
 
         let summary = Summary(
             queryCount: windowEvents.count,
@@ -65,12 +114,14 @@ struct InjectionPresentation {
             tokenCount: windowEvents.reduce(0) { $0 + $1.event.tokenCount },
             activeSessionCount: Set(windowEvents.map(\.event.sessionID)).count
         )
+        let bursts = makeBursts(from: parsedEvents, burstGapMinutes: burstGapMinutes)
 
         return Snapshot(
             filteredEvents: filteredEvents,
             windowEvents: windowEvents.map(\.event),
             summary: summary,
-            bursts: makeBursts(from: windowEvents, burstGapMinutes: burstGapMinutes),
+            bursts: bursts,
+            burstSections: makeBurstSections(from: bursts, now: now),
             ribbonBuckets: makeRibbonBuckets(
                 from: windowEvents,
                 windowStart: windowStart,
@@ -131,6 +182,7 @@ struct InjectionPresentation {
         let maxGap = Double(max(burstGapMinutes, 1)) * 60.0
         var bursts: [Burst] = []
         var currentSessionID = first.event.sessionID
+        var currentTopicOrSource = topicOrSource(for: first.event)
         var currentEvents = [first]
         var newest = first.date
         var oldest = first.date
@@ -139,6 +191,7 @@ struct InjectionPresentation {
             bursts.append(
                 Burst(
                     sessionID: currentSessionID,
+                    topicOrSource: currentTopicOrSource,
                     startDate: oldest,
                     endDate: newest,
                     events: currentEvents.map(\.event)
@@ -147,13 +200,17 @@ struct InjectionPresentation {
         }
 
         for parsed in events.dropFirst() {
-            let gap = oldest.timeIntervalSince(parsed.date)
-            if parsed.event.sessionID == currentSessionID, gap <= maxGap {
+            let topicOrSource = topicOrSource(for: parsed.event)
+            let gap = newest.timeIntervalSince(parsed.date)
+            if parsed.event.sessionID == currentSessionID,
+               topicOrSource == currentTopicOrSource,
+               gap < maxGap {
                 currentEvents.append(parsed)
                 oldest = parsed.date
             } else {
                 flush()
                 currentSessionID = parsed.event.sessionID
+                currentTopicOrSource = topicOrSource
                 currentEvents = [parsed]
                 newest = parsed.date
                 oldest = parsed.date
@@ -162,6 +219,58 @@ struct InjectionPresentation {
 
         flush()
         return bursts
+    }
+
+    private static func makeBurstSections(from bursts: [Burst], now: Date) -> [BurstSection] {
+        var sections: [BurstSection] = []
+        var currentBucket: RibbonBucket?
+        var currentBursts: [Burst] = []
+
+        func flush() {
+            guard let currentBucket, !currentBursts.isEmpty else { return }
+            sections.append(BurstSection(bucket: currentBucket, bursts: currentBursts))
+        }
+
+        for burst in bursts {
+            let bucket = ribbonBucket(for: burst.endDate, now: now)
+            if currentBucket == nil || currentBucket == bucket {
+                currentBucket = bucket
+                currentBursts.append(burst)
+            } else {
+                flush()
+                currentBucket = bucket
+                currentBursts = [burst]
+            }
+        }
+
+        flush()
+        return sections
+    }
+
+    static func ribbonBucket(for date: Date, now: Date, calendar: Calendar = .current) -> RibbonBucket {
+        let age = now.timeIntervalSince(date)
+        if age < 60.0 * 60.0 {
+            return .lastSixtyMinutes
+        }
+        if age < 2.0 * 60.0 * 60.0 {
+            return .oneToTwoHoursAgo
+        }
+        if age < 6.0 * 60.0 * 60.0 {
+            return .twoToSixHoursAgo
+        }
+        if calendar.isDate(date, inSameDayAs: now) {
+            return .todayEarlier
+        }
+        if let yesterday = calendar.date(byAdding: .day, value: -1, to: now),
+           calendar.isDate(date, inSameDayAs: yesterday) {
+            return .yesterday
+        }
+        return .older
+    }
+
+    private static func topicOrSource(for event: InjectionEvent) -> String {
+        let trimmed = event.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "retrieval" : trimmed
     }
 
     private static func makeRibbonBuckets(

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -239,19 +239,64 @@ struct InjectionPresentation {
         }
 
         for burst in bursts {
-            let bucket = ribbonBucket(for: burst.endDate, now: now)
-            if currentBucket == nil || currentBucket == bucket {
-                currentBucket = bucket
-                currentBursts.append(burst)
-            } else {
-                flush()
-                currentBucket = bucket
-                currentBursts = [burst]
+            for sectionBurst in makeSectionBursts(from: burst, now: now) {
+                let bucket = ribbonBucket(for: sectionBurst.endDate, now: now)
+                if currentBucket == nil || currentBucket == bucket {
+                    currentBucket = bucket
+                    currentBursts.append(sectionBurst)
+                } else {
+                    flush()
+                    currentBucket = bucket
+                    currentBursts = [sectionBurst]
+                }
             }
         }
 
         flush()
         return sections
+    }
+
+    private static func makeSectionBursts(from burst: Burst, now: Date) -> [Burst] {
+        let parsedEvents = burst.events.compactMap { event in
+            parseDate(event.timestamp).map { ParsedEvent(event: event, date: $0) }
+        }
+        .sorted { $0.date > $1.date }
+        guard let first = parsedEvents.first else { return [burst] }
+
+        var sectionBursts: [Burst] = []
+        var currentBucket = ribbonBucket(for: first.date, now: now)
+        var currentEvents = [first]
+        var newest = first.date
+        var oldest = first.date
+
+        func flush() {
+            sectionBursts.append(
+                Burst(
+                    sessionID: burst.sessionID,
+                    topicOrSource: burst.topicOrSource,
+                    startDate: oldest,
+                    endDate: newest,
+                    events: currentEvents.map(\.event)
+                )
+            )
+        }
+
+        for parsed in parsedEvents.dropFirst() {
+            let bucket = ribbonBucket(for: parsed.date, now: now)
+            if currentBucket == bucket {
+                currentEvents.append(parsed)
+                oldest = parsed.date
+            } else {
+                flush()
+                currentBucket = bucket
+                currentEvents = [parsed]
+                newest = parsed.date
+                oldest = parsed.date
+            }
+        }
+
+        flush()
+        return sectionBursts
     }
 
     static func ribbonBucket(for date: Date, now: Date, calendar: Calendar = .current) -> RibbonBucket {

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -193,6 +193,25 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.summary.burstCount, 1)
     }
 
+    func testBurstIDStaysStableWhenNewerEventAppendsToSameBurst() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let initialEvents = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:58:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:57:00Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10),
+        ]
+        let updatedEvents = [
+            makeEvent(id: 3, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-3"], tokenCount: 10),
+        ] + initialEvents
+
+        let initialSnapshot = InjectionPresentation.snapshot(events: initialEvents, filterText: "", now: now)
+        let updatedSnapshot = InjectionPresentation.snapshot(events: updatedEvents, filterText: "", now: now)
+
+        XCTAssertEqual(initialSnapshot.bursts.count, 1)
+        XCTAssertEqual(updatedSnapshot.bursts.count, 1)
+        XCTAssertEqual(updatedSnapshot.bursts[0].events.map(\.id), [3, 1, 2])
+        XCTAssertEqual(initialSnapshot.bursts[0].id, updatedSnapshot.bursts[0].id)
+    }
+
     private func makeEvent(
         id: Int64,
         sessionID: String,

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -140,6 +140,22 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.bursts[0].events.map(\.id), [1, 2, 3])
     }
 
+    func testBurstSectionsSplitSpanningBurstAtRibbonBucketBoundaries() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:01:00Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10),
+            makeEvent(id: 3, sessionID: "sess-a", timestamp: "2026-04-18T08:02:00Z", query: "auth refactor", chunkIDs: ["chunk-3"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 1)
+        XCTAssertEqual(snapshot.bursts[0].events.map(\.id), [1, 2, 3])
+        XCTAssertEqual(snapshot.burstSections.map(\.bucket), [.lastSixtyMinutes, .oneToTwoHoursAgo])
+        XCTAssertEqual(snapshot.burstSections.map { $0.bursts.flatMap { $0.events.map(\.id) } }, [[1, 2], [3]])
+    }
+
     func testRibbonBucketBoundaryTreatsExactlySixtyMinutesAsOlderBucket() {
         let now = isoDate("2026-04-18T10:00:00Z")
         let events = [

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -24,6 +24,7 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.summary.chunkCount, 7)
         XCTAssertEqual(snapshot.summary.tokenCount, 231)
         XCTAssertEqual(snapshot.summary.activeSessionCount, 2)
+        XCTAssertEqual(snapshot.summary.burstCount, 3)
         XCTAssertEqual(snapshot.bursts.count, 3)
         XCTAssertEqual(snapshot.bursts[0].sessionID, "sess-a")
         XCTAssertEqual(snapshot.bursts[0].events.map { $0.id }, [1, 2])
@@ -177,6 +178,19 @@ final class InjectionPresentationTests: XCTestCase {
 
         XCTAssertTrue(snapshot.filteredEvents.isEmpty)
         XCTAssertTrue(snapshot.bursts.isEmpty)
+    }
+
+    func testSummaryBurstCountUsesLastHourWindowOnly() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-b", timestamp: "2026-04-18T07:59:00Z", query: "older migration", chunkIDs: ["chunk-2"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 2)
+        XCTAssertEqual(snapshot.summary.burstCount, 1)
     }
 
     private func makeEvent(

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -125,6 +125,20 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.bursts.map { $0.events.map(\.id) }, [[1], [2]])
     }
 
+    func testBurstAggregationChainsConsecutiveEventsUnderSixtyMinutesApart() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T10:00:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:01:00Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10),
+            makeEvent(id: 3, sessionID: "sess-a", timestamp: "2026-04-18T08:02:00Z", query: "auth refactor", chunkIDs: ["chunk-3"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 1)
+        XCTAssertEqual(snapshot.bursts[0].events.map(\.id), [1, 2, 3])
+    }
+
     func testRibbonBucketBoundaryTreatsExactlySixtyMinutesAsOlderBucket() {
         let now = isoDate("2026-04-18T10:00:00Z")
         let events = [
@@ -147,10 +161,22 @@ final class InjectionPresentationTests: XCTestCase {
 
         let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
 
-        XCTAssertEqual(snapshot.filteredEvents.map(\.id), [1, 2])
+        XCTAssertEqual(snapshot.filteredEvents.map(\.id), [2])
         XCTAssertEqual(snapshot.windowEvents.map(\.id), [2])
         XCTAssertEqual(snapshot.bursts.map { $0.events.map(\.id) }, [[2]])
         XCTAssertEqual(snapshot.burstSections.map(\.bucket), [.lastSixtyMinutes])
+    }
+
+    func testFilterCountExcludesFutureDatedMatches() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T10:01:00Z", query: "future skew", chunkIDs: ["chunk-1"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "future", now: now)
+
+        XCTAssertTrue(snapshot.filteredEvents.isEmpty)
+        XCTAssertTrue(snapshot.bursts.isEmpty)
     }
 
     private func makeEvent(

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -99,6 +99,19 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.bursts.map(\.sessionID), ["sess-a", "sess-b", "sess-a"])
     }
 
+    func testBurstAggregationSplitsSameSessionWhenTopicChanges() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:58:00Z", query: "db migration", chunkIDs: ["chunk-2"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 2)
+        XCTAssertEqual(snapshot.bursts.map(\.topicOrSource), ["auth refactor", "db migration"])
+    }
+
     func testBurstAggregationSplitsSameSessionWhenEventsAreMoreThanSixtyMinutesApart() {
         let now = isoDate("2026-04-18T10:00:00Z")
         let events = [
@@ -123,6 +136,21 @@ final class InjectionPresentationTests: XCTestCase {
 
         XCTAssertEqual(snapshot.summary.queryCount, 1)
         XCTAssertEqual(snapshot.burstSections.map(\.bucket), [.lastSixtyMinutes, .oneToTwoHoursAgo])
+    }
+
+    func testBurstAggregationExcludesFutureDatedEvents() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T10:01:00Z", query: "future skew", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.filteredEvents.map(\.id), [1, 2])
+        XCTAssertEqual(snapshot.windowEvents.map(\.id), [2])
+        XCTAssertEqual(snapshot.bursts.map { $0.events.map(\.id) }, [[2]])
+        XCTAssertEqual(snapshot.burstSections.map(\.bucket), [.lastSixtyMinutes])
     }
 
     private func makeEvent(

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -6,7 +6,7 @@ final class InjectionPresentationTests: XCTestCase {
         let now = isoDate("2026-04-18T10:00:00Z")
         let events = [
             makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:58:00Z", query: "latest cc release", chunkIDs: ["chunk-1", "chunk-2"], tokenCount: 48),
-            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:55:00Z", query: "extract transcript", chunkIDs: ["chunk-3"], tokenCount: 52),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:55:00Z", query: "latest cc release", chunkIDs: ["chunk-3"], tokenCount: 52),
             makeEvent(id: 3, sessionID: "sess-a", timestamp: "2026-04-18T09:40:00Z", query: "why is ffmpeg stuck", chunkIDs: ["chunk-4", "chunk-5", "chunk-6"], tokenCount: 91),
             makeEvent(id: 4, sessionID: "sess-b", timestamp: "2026-04-18T09:38:00Z", query: "brainbar graph empty", chunkIDs: ["chunk-7"], tokenCount: 40),
         ]
@@ -61,6 +61,70 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(chunkSnapshot.filteredEvents.map { $0.id }, [2])
     }
 
+    func testBurstAggregationGroupsFiveEventsFromOneSessionAndTopicInsideFiveMinutes() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = (0..<5).map { offset in
+            makeEvent(
+                id: Int64(offset + 1),
+                sessionID: "brain-c7a8",
+                timestamp: isoTimestamp(now.addingTimeInterval(-Double(offset) * 60.0)),
+                query: "auth refactor",
+                chunkIDs: ["chunk-\(offset + 1)"],
+                tokenCount: 10
+            )
+        }
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 1)
+        XCTAssertEqual(snapshot.bursts[0].sessionID, "brain-c7a8")
+        XCTAssertEqual(snapshot.bursts[0].topicOrSource, "auth refactor")
+        XCTAssertEqual(snapshot.bursts[0].summaryTitle, "5 chunks injected from \"auth refactor\"")
+        XCTAssertEqual(snapshot.bursts[0].events.map(\.id), [1, 2, 3, 4, 5])
+        XCTAssertEqual(snapshot.bursts[0].chunkPreviewIDs, ["chunk-1", "chunk-2"])
+        XCTAssertEqual(snapshot.bursts[0].remainingChunkCount(after: 2), 3)
+    }
+
+    func testBurstAggregationSplitsDifferentSessions() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-b", timestamp: "2026-04-18T09:58:00Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10),
+            makeEvent(id: 3, sessionID: "sess-a", timestamp: "2026-04-18T09:57:00Z", query: "auth refactor", chunkIDs: ["chunk-3"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 3)
+        XCTAssertEqual(snapshot.bursts.map(\.sessionID), ["sess-a", "sess-b", "sess-a"])
+    }
+
+    func testBurstAggregationSplitsSameSessionWhenEventsAreMoreThanSixtyMinutesApart() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T08:58:59Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 2)
+        XCTAssertEqual(snapshot.bursts.map { $0.events.map(\.id) }, [[1], [2]])
+    }
+
+    func testRibbonBucketBoundaryTreatsExactlySixtyMinutesAsOlderBucket() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:00:01Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10),
+            makeEvent(id: 2, sessionID: "sess-b", timestamp: "2026-04-18T09:00:00Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.summary.queryCount, 1)
+        XCTAssertEqual(snapshot.burstSections.map(\.bucket), [.lastSixtyMinutes, .oneToTwoHoursAgo])
+    }
+
     private func makeEvent(
         id: Int64,
         sessionID: String,
@@ -83,5 +147,11 @@ final class InjectionPresentationTests: XCTestCase {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: text)!
+    }
+
+    private func isoTimestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
     }
 }


### PR DESCRIPTION
## Summary
- Replace Injections feed rendering with burst cards grouped by session/topic in a strict 60-minute window.
- Add sticky relative time-ribbon sections: Last 60 min, 1-2h ago, 2-6h ago, Today earlier, Yesterday, Older.
- Add collapsed chunk previews with +N more and reduce-motion-gated inline expansion.

## Test plan
- [x] TDD red: new InjectionPresentationTests failed before implementation for missing burst/ribbon API.
- [x] swift test --package-path brain-bar --filter InjectionPresentationTests (6 tests, 0 failures)
- [x] swift test --package-path brain-bar (435 tests, 0 failures)
- [x] pytest (2200 passed, 46 skipped, 5 xfailed)
- [x] pre-push BrainLayer gate: 2130 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook 36 passed; bun 1 passed; regression shell passed
- [x] cr review --plain --type uncommitted --dir brain-bar (No findings)

## Notes
- No squash merge. Merge path should be rebase/admin per mandate once required CI and reviewers are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and read-only presentation logic in BrainBar with behavior covered by new unit tests; no auth, persistence, or backend changes.
> 
> **Overview**
> **Redesigns the Injections feed** around **burst cards** (session + query/topic clusters) instead of a flat event list, with **sticky time-ribbon section headers** (Last 60 min through Older).
> 
> **Presentation layer (`InjectionPresentation`)** now groups bursts by **session, topic/query, and a 60-minute inter-event gap** (default gap raised from 8 minutes). Bursts can **split across ribbon buckets** for sectioning; **`summary.burstCount`** counts only the last-hour window while the full **`bursts`** list covers all non-future events. **`filteredEvents`** drops future-dated timestamps; burst **IDs** anchor on the oldest event in the group for stable expand/collapse.
> 
> **UI (`InjectionFeedView`)** shows collapsible bursts with **summary titles**, truncated session IDs, relative times, and **collapsed chunk previews** (+N more); expand/collapse respects **`accessibilityReduceMotion`**. Empty state keys off **`bursts`** rather than raw filtered events.
> 
> **Tests** add broad coverage for aggregation rules, ribbon boundaries, future-event exclusion, and summary window scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3da7e191df8ab0675aedaeefef9a0a75ced0f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add burst-aggregate grouping and 60-minute ribbon sections to injection feed
> - Bursts in [InjectionFeedView.swift](https://github.com/EtanHey/brainlayer/pull/322/files#diff-6332189fd07a82bbf0d03eba69489afb10493291f2ed71f888c418002b6e54f2) are now grouped into time-bucketed sections (last 60 min, 1–2h ago, today, yesterday, older) with sticky ribbon headers.
> - Each burst card is collapsible, showing a `summaryTitle`, abbreviated session ID, relative time chip, and a compact chunk ID preview when collapsed.
> - [InjectionPresentation.swift](https://github.com/EtanHey/brainlayer/pull/322/files#diff-122482b429312571e0f6b54d0c5380a75296ed791e7303eecde2bfa2909b1423) chains consecutive events into bursts when the adjacent gap is under 60 minutes and the session ID and topic/source match; bursts spanning bucket boundaries are split.
> - Future-dated events are now excluded from all snapshot computations (filtered events, window events, bursts, and sections).
> - The side-rail burst count now reflects only the last-hour window via `summary.burstCount`.
> - Expand/collapse animation respects the system Reduce Motion accessibility setting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b3da7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events are now grouped into "bursts" (related event clusters) with expandable/collapsible sections
  * Feed displays burst section headers for improved organization
  * Burst summaries show topic/source and relative timestamps
  * Reduced-motion accessibility support for burst animations

* **Bug Fixes**
  * Fixed empty state detection in the feed
  * Improved burst gap calculation (now 60 minutes instead of 8)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->