### PR TITLE
fix(mcp): brain_store queue fallback returns real chunk_id

### DIFF
--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -133,7 +133,7 @@ def format_recalled_context(query: str, chunks: list[dict]) -> str:
 def format_store_result(chunk_id: str, superseded: str | None = None, queued: bool = False) -> str:
     """Format store confirmation as a clean one-liner."""
     if queued:
-        return "\u2502 \u23f3 Memory queued (DB busy) \u2500 will flush on next successful store."
+        return f"\u2502 \u23f3 Memory queued (DB busy) \u2192 {chunk_id} \u2500 will flush on next successful store."
 
     parts = [f"\u2714 Stored \u2192 {chunk_id}"]
     if superseded:

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -449,7 +449,7 @@ def _flush_pending_stores(store, embed_fn) -> int:
     for line in lines:
         try:
             item = json.loads(line)
-            store_memory(
+            result = store_memory(
                 store=store,
                 embed_fn=embed_fn,
                 content=item["content"],
@@ -469,6 +469,8 @@ def _flush_pending_stores(store, embed_fn) -> int:
                 line_number=item.get("line_number"),
                 chunk_id=item.get("chunk_id"),
             )
+            if item.get("supersedes"):
+                store.supersede_chunk(item["supersedes"], result["id"])
             flushed += 1
         except Exception as e:
             logger.warning("Failed to flush pending store item: %s", e)
@@ -653,6 +655,7 @@ async def _store(
                     "file_path": file_path,
                     "function_name": function_name,
                     "line_number": line_number,
+                    "supersedes": supersedes,
                 }
             )
             structured = {"chunk_id": queued_chunk_id, "queued": True, "related": []}

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -467,6 +467,7 @@ def _flush_pending_stores(store, embed_fn) -> int:
                 file_path=item.get("file_path"),
                 function_name=item.get("function_name"),
                 line_number=item.get("line_number"),
+                chunk_id=item.get("chunk_id"),
             )
             flushed += 1
         except Exception as e:

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -470,7 +470,10 @@ def _flush_pending_stores(store, embed_fn) -> int:
                 chunk_id=item.get("chunk_id"),
             )
             if item.get("supersedes"):
-                store.supersede_chunk(item["supersedes"], result["id"])
+                if not store.supersede_chunk(item["supersedes"], result["id"]):
+                    raise RuntimeError(
+                        f"failed to supersede queued chunk {item['supersedes']} with {result['id']}"
+                    )
             flushed += 1
         except Exception as e:
             logger.warning("Failed to flush pending store item: %s", e)

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import threading
+import uuid
 
 import apsw
 from mcp.types import CallToolResult, TextContent
@@ -23,6 +24,10 @@ from ._shared import (
 _RETRY_MAX_ATTEMPTS = 4
 _retry_delay = 0.15  # base delay in seconds (exposed for test patching)
 _QUEUE_MAX_SIZE = 100
+
+
+def _new_manual_chunk_id() -> str:
+    return f"manual-{uuid.uuid4().hex[:16]}"
 
 
 async def _brain_digest(
@@ -514,8 +519,10 @@ async def _store(
             reject_recursive_mcp_output(content)
             if looks_like_system_prompt(content):
                 raise ValueError("system prompt content is not stored in BrainLayer")
+            queued_chunk_id = _new_manual_chunk_id()
             _queue_store(
                 {
+                    "chunk_id": queued_chunk_id,
                     "content": content,
                     "memory_type": memory_type,
                     "project": _normalize_project_name(project),
@@ -535,8 +542,8 @@ async def _store(
                 }
             )
             clear_hybrid_search_cache()
-            structured = {"chunk_id": "queued", "related": []}
-            return ([TextContent(type="text", text=format_store_result("queued", queued=True))], structured)
+            structured = {"chunk_id": queued_chunk_id, "queued": True, "related": []}
+            return ([TextContent(type="text", text=format_store_result(queued_chunk_id, queued=True))], structured)
 
         from ..store import embed_pending_chunks, store_memory
 
@@ -626,8 +633,10 @@ async def _store(
         return _error_result(f"Validation error: {str(e)}")
     except Exception as e:
         if "locked" in str(e).lower() or "busy" in str(e).lower():
+            queued_chunk_id = _new_manual_chunk_id()
             _queue_store(
                 {
+                    "chunk_id": queued_chunk_id,
                     "content": content,
                     "memory_type": memory_type,
                     "project": _normalize_project_name(project),
@@ -645,8 +654,8 @@ async def _store(
                     "line_number": line_number,
                 }
             )
-            structured = {"chunk_id": "queued", "related": []}
-            formatted = format_store_result("queued", queued=True)
+            structured = {"chunk_id": queued_chunk_id, "queued": True, "related": []}
+            formatted = format_store_result(queued_chunk_id, queued=True)
             return (
                 [TextContent(type="text", text=formatted)],
                 structured,

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -471,9 +471,7 @@ def _flush_pending_stores(store, embed_fn) -> int:
             )
             if item.get("supersedes"):
                 if not store.supersede_chunk(item["supersedes"], result["id"]):
-                    raise RuntimeError(
-                        f"failed to supersede queued chunk {item['supersedes']} with {result['id']}"
-                    )
+                    raise RuntimeError(f"failed to supersede queued chunk {item['supersedes']} with {result['id']}")
             flushed += 1
         except Exception as e:
             logger.warning("Failed to flush pending store item: %s", e)

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -40,7 +40,7 @@ from typing import Any, Callable, Dict, List, Optional
 import apsw
 
 from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, detect_chunk_origin
-from .dedupe import find_duplicate, merge_duplicate_chunk
+from .dedupe import find_duplicate, merge_duplicate_chunk, merge_existing_chunk_content, merge_existing_chunk_seen
 from .ingest_guard import reject_recursive_mcp_output
 from .pipeline.classify import looks_like_system_prompt
 from .vector_store import VectorStore
@@ -155,6 +155,14 @@ def store_memory(
     incoming_chunk_id = chunk_id
     stored_chunk_id = chunk_id
     pending_reembed: tuple[str, str] | None = None
+    incoming = {
+        "id": incoming_chunk_id,
+        "content": content,
+        "tags": tags_json,
+        "importance": float(importance) if importance is not None else None,
+        "created_at": now,
+        "last_seen_at": now,
+    }
     for attempt in range(5):
         cursor = store.conn.cursor()
         transaction_started = False
@@ -162,31 +170,15 @@ def store_memory(
             cursor.execute("BEGIN IMMEDIATE")
             transaction_started = True
             pending_reembed = None
-            duplicate, dedupe_fields = find_duplicate(
-                store.conn,
-                chunk_id=incoming_chunk_id,
-                content=content,
-                created_at=now,
-                project=project,
-                content_type=memory_type,
-            )
-            if duplicate is not None:
-                content_changed = merge_duplicate_chunk(
-                    store.conn,
-                    canonical_id=duplicate.canonical_chunk_id,
-                    duplicate_id=incoming_chunk_id,
-                    incoming={
-                        "id": incoming_chunk_id,
-                        "content": content,
-                        "tags": tags_json,
-                        "importance": float(importance) if importance is not None else None,
-                        "created_at": now,
-                        "last_seen_at": now,
-                    },
-                    mechanism=duplicate.mechanism,
-                    hamming_distance_value=duplicate.hamming_distance,
-                )
-                stored_chunk_id = duplicate.canonical_chunk_id
+            if cursor.execute("SELECT 1 FROM chunks WHERE id = ?", (incoming_chunk_id,)).fetchone():
+                stored_chunk_id = incoming_chunk_id
+                content_changed = False
+                if not merge_existing_chunk_seen(store.conn, chunk_id=incoming_chunk_id, incoming=incoming):
+                    content_changed = merge_existing_chunk_content(
+                        store.conn,
+                        chunk_id=incoming_chunk_id,
+                        incoming=incoming,
+                    )
                 if embedding is not None:
                     if content_changed:
                         merged_row = cursor.execute(
@@ -198,46 +190,75 @@ def store_memory(
                     elif not store._chunk_vector_exists(cursor, stored_chunk_id):
                         store._upsert_chunk_vector(cursor, stored_chunk_id, embedding)
             else:
-                stored_chunk_id = incoming_chunk_id
-                cursor.execute(
-                    """
-                    INSERT INTO chunks
-                    (id, content, metadata, source_file, project, content_type,
-                     value_type, char_count, source, created_at, enriched_at,
-                     summary, tags, importance, chunk_origin, seen_count, last_seen_at,
-                     dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
-                     ingested_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                            CAST(strftime('%s', 'now') AS INTEGER))
-                """,
-                    (
-                        incoming_chunk_id,
-                        content,
-                        json.dumps(meta),
-                        "brainlayer-store",
-                        project,
-                        memory_type,
-                        "HIGH",
-                        len(content),
-                        "manual",
-                        now,
-                        now,
-                        content[:200],
-                        tags_json,
-                        float(importance) if importance is not None else None,
-                        chunk_origin,
-                        1,
-                        now,
-                        dedupe_fields.dedupe_hash,
-                        dedupe_fields.simhash,
-                        dedupe_fields.bands[0],
-                        dedupe_fields.bands[1],
-                        dedupe_fields.bands[2],
-                        dedupe_fields.bands[3],
-                    ),
+                duplicate, dedupe_fields = find_duplicate(
+                    store.conn,
+                    chunk_id=incoming_chunk_id,
+                    content=content,
+                    created_at=now,
+                    project=project,
+                    content_type=memory_type,
                 )
-                if embedding is not None:
-                    store._upsert_chunk_vector(cursor, stored_chunk_id, embedding)
+                if duplicate is not None:
+                    content_changed = merge_duplicate_chunk(
+                        store.conn,
+                        canonical_id=duplicate.canonical_chunk_id,
+                        duplicate_id=incoming_chunk_id,
+                        incoming=incoming,
+                        mechanism=duplicate.mechanism,
+                        hamming_distance_value=duplicate.hamming_distance,
+                    )
+                    stored_chunk_id = duplicate.canonical_chunk_id
+                    if embedding is not None:
+                        if content_changed:
+                            merged_row = cursor.execute(
+                                "SELECT content FROM chunks WHERE id = ?",
+                                (stored_chunk_id,),
+                            ).fetchone()
+                            if merged_row:
+                                pending_reembed = (stored_chunk_id, str(merged_row[0]))
+                        elif not store._chunk_vector_exists(cursor, stored_chunk_id):
+                            store._upsert_chunk_vector(cursor, stored_chunk_id, embedding)
+                else:
+                    stored_chunk_id = incoming_chunk_id
+                    cursor.execute(
+                        """
+                        INSERT INTO chunks
+                        (id, content, metadata, source_file, project, content_type,
+                         value_type, char_count, source, created_at, enriched_at,
+                         summary, tags, importance, chunk_origin, seen_count, last_seen_at,
+                         dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
+                         ingested_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                                CAST(strftime('%s', 'now') AS INTEGER))
+                    """,
+                        (
+                            incoming_chunk_id,
+                            content,
+                            json.dumps(meta),
+                            "brainlayer-store",
+                            project,
+                            memory_type,
+                            "HIGH",
+                            len(content),
+                            "manual",
+                            now,
+                            now,
+                            content[:200],
+                            tags_json,
+                            float(importance) if importance is not None else None,
+                            chunk_origin,
+                            1,
+                            now,
+                            dedupe_fields.dedupe_hash,
+                            dedupe_fields.simhash,
+                            dedupe_fields.bands[0],
+                            dedupe_fields.bands[1],
+                            dedupe_fields.bands[2],
+                            dedupe_fields.bands[3],
+                        ),
+                    )
+                    if embedding is not None:
+                        store._upsert_chunk_vector(cursor, stored_chunk_id, embedding)
 
             if entity_id:
                 entity = store.get_entity(entity_id)

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -68,6 +68,7 @@ def store_memory(
     file_path: Optional[str] = None,
     function_name: Optional[str] = None,
     line_number: Optional[int] = None,
+    chunk_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Persistently store a memory into BrainLayer.
 
@@ -93,6 +94,7 @@ def store_memory(
         file_path: Optional code file reference. Only for type=issue.
         function_name: Optional function reference. Only for type=issue.
         line_number: Optional line number reference. Only for type=issue.
+        chunk_id: Optional caller-supplied chunk ID for durable queued writes.
 
     Returns:
         Dict with 'id' (chunk ID) and 'related' (list of similar existing memories).
@@ -116,7 +118,7 @@ def store_memory(
         importance = max(1, min(10, importance))
 
     # Generate chunk ID and timestamps
-    chunk_id = f"manual-{uuid.uuid4().hex[:16]}"
+    chunk_id = chunk_id or f"manual-{uuid.uuid4().hex[:16]}"
     now = datetime.now(timezone.utc).isoformat()
 
     # Embed at write time (if embed_fn provided), otherwise defer

--- a/tests/test_brainstore.py
+++ b/tests/test_brainstore.py
@@ -344,6 +344,53 @@ class TestStoreMemory:
         assert row == (2,)
         assert link == (first["id"],)
 
+    def test_supplied_chunk_id_retry_is_idempotent(self, store, mock_embed):
+        """Retrying a queued write with the promised chunk ID should not violate the primary key."""
+        from brainlayer.store import store_memory
+
+        chunk_id = "manual-queuedretry01"
+        content = "Queued brain_store retry must reuse the promised chunk id"
+
+        first = store_memory(
+            store=store,
+            embed_fn=mock_embed,
+            content=content,
+            memory_type="learning",
+            project="brainlayer",
+            tags=["first"],
+            importance=4,
+            chunk_id=chunk_id,
+        )
+        second = store_memory(
+            store=store,
+            embed_fn=mock_embed,
+            content=content,
+            memory_type="learning",
+            project="brainlayer",
+            tags=["second"],
+            importance=9,
+            chunk_id=chunk_id,
+        )
+
+        row = (
+            store.conn.cursor()
+            .execute("SELECT seen_count, importance, tags FROM chunks WHERE id = ?", (chunk_id,))
+            .fetchone()
+        )
+        audit = (
+            store.conn.cursor()
+            .execute(
+                "SELECT chunk_id_dropped, chunk_id_kept, mechanism FROM dedupe_audit WHERE chunk_id_kept = ?",
+                (chunk_id,),
+            )
+            .fetchone()
+        )
+
+        assert first["id"] == chunk_id
+        assert second["id"] == chunk_id
+        assert row == (2, 9.0, '["first", "second"]')
+        assert audit == (chunk_id, chunk_id, "sha256_same_id")
+
     def test_changed_duplicate_embedding_runs_after_write_transaction(self, store):
         """Merged-content embedding should not hold the write transaction open."""
         from brainlayer.store import store_memory

--- a/tests/test_mcp_format.py
+++ b/tests/test_mcp_format.py
@@ -172,8 +172,9 @@ class TestFormatStoreResult:
         assert "superseded" in result
 
     def test_queued(self):
-        result = format_store_result("ignored", queued=True)
+        result = format_store_result("manual-test123", queued=True)
         assert "queued" in result.lower() or "\u23f3" in result
+        assert "manual-test123" in result
         assert "DB busy" in result or "busy" in result.lower()
 
 

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -38,6 +38,32 @@ async def test_busy_queue_fallback_returns_queued_chunk_id(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_busy_queue_fallback_preserves_supersedes(tmp_path):
+    """DB-busy fallback queues supersedes so the deferred write keeps lifecycle intent."""
+    from brainlayer.mcp.store_handler import _store
+
+    queue_dir = tmp_path / "queue"
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store"),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+        patch("brainlayer.store.store_memory", side_effect=apsw.BusyError("locked")),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        await _store(
+            content="replacement memory",
+            memory_type="note",
+            project="test",
+            supersedes="manual-old1234",
+        )
+
+    queued_files = list(queue_dir.glob("mcp-*.jsonl"))
+    assert len(queued_files) == 1
+    queued_event = json.loads(queued_files[0].read_text())
+    assert queued_event["supersedes"] == "manual-old1234"
+
+
+@pytest.mark.asyncio
 async def test_arbitrated_queue_fallback_returns_queued_chunk_id(tmp_path, monkeypatch):
     """Arbitrated fallback also reports the queued event's real chunk ID."""
     from brainlayer.mcp.store_handler import _store

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -1,0 +1,60 @@
+"""Tests for MCP store handler responses."""
+
+import json
+from unittest.mock import patch
+
+import apsw
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_busy_queue_fallback_returns_queued_chunk_id(tmp_path):
+    """DB-busy fallback returns the durable queue chunk ID, not a sentinel."""
+    from brainlayer.mcp.store_handler import _store
+
+    queue_dir = tmp_path / "queue"
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store"),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+        patch("brainlayer.store.store_memory", side_effect=apsw.BusyError("locked")),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        texts, structured = await _store(
+            content="test memory",
+            memory_type="note",
+            project="test",
+        )
+
+    queued_files = list(queue_dir.glob("mcp-*.jsonl"))
+    assert len(queued_files) == 1
+    queued_event = json.loads(queued_files[0].read_text())
+    expected_chunk_id = queued_event["chunk_id"]
+
+    assert expected_chunk_id != "queued"
+    assert structured["chunk_id"] == expected_chunk_id
+    assert structured["queued"] is True
+    assert any(expected_chunk_id in item.text for item in texts)
+
+
+@pytest.mark.asyncio
+async def test_arbitrated_queue_fallback_returns_queued_chunk_id(tmp_path, monkeypatch):
+    """Arbitrated fallback also reports the queued event's real chunk ID."""
+    from brainlayer.mcp.store_handler import _store
+
+    monkeypatch.setenv("BRAINLAYER_ARBITRATED", "1")
+    with (
+        patch("brainlayer.queue_io.get_queue_dir", return_value=tmp_path),
+        patch("brainlayer.search_repo.clear_hybrid_search_cache"),
+    ):
+        texts, structured = await _store(content="arbitrated queued memory", memory_type="note", project="test")
+
+    queued_files = list(tmp_path.glob("mcp-*.jsonl"))
+    assert len(queued_files) == 1
+    queued_event = json.loads(queued_files[0].read_text())
+    expected_chunk_id = queued_event["chunk_id"]
+
+    assert expected_chunk_id != "queued"
+    assert structured["chunk_id"] == expected_chunk_id
+    assert structured["queued"] is True
+    assert any(expected_chunk_id in item.text for item in texts)

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -172,6 +172,31 @@ class TestFlushPendingStores:
         assert flushed == 1
         assert not pending_path.exists()  # File deleted after full flush
 
+    def test_flush_preserves_legacy_pending_chunk_id(self, tmp_path):
+        """Legacy pending-stores flush must persist the caller-visible queued ID."""
+        pending_path = tmp_path / "pending-stores.jsonl"
+        pending_path.write_text(
+            json.dumps(
+                {
+                    "chunk_id": "manual-promised1234",
+                    "content": "queued item",
+                    "memory_type": "note",
+                }
+            )
+            + "\n"
+        )
+
+        with patch(
+            "brainlayer.mcp.store_handler._get_pending_store_path",
+            return_value=pending_path,
+        ):
+            with patch("brainlayer.store.store_memory") as mock_store_memory:
+                mock_store_memory.return_value = {"id": "manual-promised1234", "related": []}
+                flushed = _flush_pending_stores(MagicMock(), MagicMock())
+
+        assert flushed == 1
+        assert mock_store_memory.call_args.kwargs["chunk_id"] == "manual-promised1234"
+
     def test_flush_keeps_failed_items(self, tmp_path):
         """Items that fail to flush are kept in the queue."""
         pending_path = tmp_path / "pending-stores.jsonl"

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -247,7 +247,8 @@ class TestStoreRetryOnLock:
 
         # Should return queued response, not error
         texts, structured = result
-        assert structured["chunk_id"] == "queued"
+        assert structured["chunk_id"].startswith("manual-")
+        assert structured["queued"] is True
         assert any("queued" in t.text.lower() for t in texts)
 
         # Should have written to the unified queue
@@ -255,6 +256,7 @@ class TestStoreRetryOnLock:
         assert len(files) == 1
         item = json.loads(files[0].read_text().strip())
         assert item["kind"] == "store_memory"
+        assert item["chunk_id"] == structured["chunk_id"]
         assert item["content"] == "test memory"
 
     @pytest.mark.asyncio
@@ -282,7 +284,8 @@ class TestStoreRetryOnLock:
         ):
             texts, structured = await _store(content="queued cache invalidation", memory_type="note", project="test")
 
-        assert structured["chunk_id"] == "queued"
+        assert structured["chunk_id"].startswith("manual-")
+        assert structured["queued"] is True
         assert any("queued" in item.text.lower() for item in texts)
         clear_cache.assert_called_once_with()
 

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -197,6 +197,33 @@ class TestFlushPendingStores:
         assert flushed == 1
         assert mock_store_memory.call_args.kwargs["chunk_id"] == "manual-promised1234"
 
+    def test_flush_preserves_legacy_pending_supersedes(self, tmp_path):
+        """Legacy pending-stores flush must apply queued supersedes metadata."""
+        pending_path = tmp_path / "pending-stores.jsonl"
+        pending_path.write_text(
+            json.dumps(
+                {
+                    "chunk_id": "manual-new1234",
+                    "content": "replacement item",
+                    "memory_type": "note",
+                    "supersedes": "manual-old1234",
+                }
+            )
+            + "\n"
+        )
+
+        mock_store = MagicMock()
+        with patch(
+            "brainlayer.mcp.store_handler._get_pending_store_path",
+            return_value=pending_path,
+        ):
+            with patch("brainlayer.store.store_memory") as mock_store_memory:
+                mock_store_memory.return_value = {"id": "manual-new1234", "related": []}
+                flushed = _flush_pending_stores(mock_store, MagicMock())
+
+        assert flushed == 1
+        mock_store.supersede_chunk.assert_called_once_with("manual-old1234", "manual-new1234")
+
     def test_flush_keeps_failed_items(self, tmp_path):
         """Items that fail to flush are kept in the queue."""
         pending_path = tmp_path / "pending-stores.jsonl"

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -224,6 +224,37 @@ class TestFlushPendingStores:
         assert flushed == 1
         mock_store.supersede_chunk.assert_called_once_with("manual-old1234", "manual-new1234")
 
+    def test_flush_keeps_item_when_legacy_supersedes_fails(self, tmp_path):
+        """A failed queued supersedes transition must not drop the pending store item."""
+        pending_path = tmp_path / "pending-stores.jsonl"
+        pending_path.write_text(
+            json.dumps(
+                {
+                    "chunk_id": "manual-new1234",
+                    "content": "replacement item",
+                    "memory_type": "note",
+                    "supersedes": "manual-old1234",
+                }
+            )
+            + "\n"
+        )
+
+        mock_store = MagicMock()
+        mock_store.supersede_chunk.return_value = False
+        with patch(
+            "brainlayer.mcp.store_handler._get_pending_store_path",
+            return_value=pending_path,
+        ):
+            with patch("brainlayer.store.store_memory") as mock_store_memory:
+                mock_store_memory.return_value = {"id": "manual-new1234", "related": []}
+                flushed = _flush_pending_stores(mock_store, MagicMock())
+
+        assert flushed == 0
+        remaining = pending_path.read_text().strip().splitlines()
+        assert len(remaining) == 1
+        assert json.loads(remaining[0])["chunk_id"] == "manual-new1234"
+        mock_store.supersede_chunk.assert_called_once_with("manual-old1234", "manual-new1234")
+
     def test_flush_keeps_failed_items(self, tmp_path):
         """Items that fail to flush are kept in the queue."""
         pending_path = tmp_path / "pending-stores.jsonl"


### PR DESCRIPTION
## Summary
- Generate a real `manual-*` chunk ID before `brain_store` queue fallback writes.
- Return that ID in structured output with `queued: true` instead of overloading `chunk_id` with the literal `queued`.
- Include the queued chunk ID in `format_store_result(..., queued=True)` text output.
- Update old queue tests and add direct store handler regression coverage for both DB-busy and arbitrated queue fallback paths.

## Test plan
- [x] TDD red: `pytest tests/test_store_handler.py` failed on literal `queued` structured IDs before implementation.
- [x] Focused: `pytest tests/test_store_handler.py tests/test_write_queue.py tests/test_mcp_format.py tests/test_auto_enrich.py` -> 83 passed.
- [x] Full local: `pytest` -> 2211 passed, 46 skipped, 5 xfailed, 328 warnings.
- [x] MCP runtime gate: fresh cmux Claude client called BrainLayer MCP `brain_search` and `brain_store`; result `MCP_RUNTIME_VERIFIED` (search returned 1 result, store accepted and queued due live DB busy).
- [x] Pre-push gate: pytest unit suite -> 2141 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration -> 3 passed; isolated eval/hook routing -> 36 passed; bun -> 1 pass; FTS5 determinism shell regression -> pass.
- [x] CodeRabbit pre-commit review: 3 findings, all on pre-existing untracked local files not included in this PR (`.gemini/settings.json`, transcript file); no staged PR-file findings.

## Notes
- This PR intentionally keeps queued status as a separate `queued: true` field for callers that need to distinguish queued writes without losing the real chunk ID.
- Merge mode requested by mandate: no squash; use rebase/admin when checks and reviews are satisfied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write-path queue semantics and idempotent store behavior under DB contention; incorrect flush/supersede handling could strand or duplicate memories, though coverage is strong.
> 
> **Overview**
> **`brain_store` queue paths now return a stable `manual-*` chunk ID** instead of the literal `"queued"`, with **`queued: true`** in structured output so callers can tell the write is deferred while still referencing the promised ID.
> 
> When arbitration or DB lock forces queueing, **`_store`** pre-generates that ID via **`_new_manual_chunk_id`**, persists it on the queue payload, and **`format_store_result(..., queued=True)`** includes the ID in the user-facing message. The DB-busy exception path also queues **`supersedes`** (previously dropped).
> 
> **`store_memory`** accepts an optional **`chunk_id`**; if that ID already exists, it merges seen/content (and embeddings) instead of inserting again, so flush/retry of queued writes is idempotent. **`_flush_pending_stores`** forwards queued **`chunk_id`**, applies **`supersedes`** after a successful store, and **retains** the pending line if supersede fails.
> 
> Tests cover handler fallbacks, flush behavior, formatting, and supplied-ID retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4c7a1dd6873841a1ebe120a57dd7ea058bc1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `brain_store` queue fallback to return a real durable `chunk_id`
> - When a store is queued (DB busy or arbitrated path), a durable `chunk_id` is now generated via a new `_new_manual_chunk_id` helper (`manual-{16hex}`) and included in both the JSONL queue payload and the structured response.
> - `store_memory` in [store.py](https://github.com/EtanHey/brainlayer/pull/324/files#diff-3f4ff41bcf437c9376f0c0bc397eca30e1b05c0d75d4e95ef1579366d7c4c707) accepts an optional `chunk_id` parameter, enabling idempotent retries: if the ID already exists, it updates seen metadata and merges content instead of inserting a duplicate.
> - `_flush_pending_stores` in [store_handler.py](https://github.com/EtanHey/brainlayer/pull/324/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263) now passes the queued `chunk_id` through to `store_memory` and applies any deferred `supersedes` transition; a failed supersede keeps the item in the queue.
> - The queued confirmation message in [_format.py](https://github.com/EtanHey/brainlayer/pull/324/files#diff-620f1b58e5c06f4a3deffae64c1f9ae5a2889d8ae71386fe2251340fb17c6644) now includes the specific `chunk_id` instead of generic text.
> - Behavioral Change: callers that previously received a generic queued response now receive a structured response with `{'chunk_id': ..., 'queued': True}`; `supersedes` on busy-path stores is deferred rather than dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a4c7a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storage queue operations now return deterministic chunk identifiers instead of generic placeholders, enabling better tracking and idempotency of queued write requests.

* **Bug Fixes**
  * Improved chunk deduplication and merging logic to better handle duplicate submissions and preserve chunk identity across retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->