### PR TITLE
fix(brainbar): throttle injection feed to stop UI CPU runaway loop

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -746,21 +746,13 @@ struct BrainBarDashboardLayout {
 }
 
 private struct BrainBarInjectionTab: View {
-    @ObservedObject var store: InjectionStore
+    let store: InjectionStore
     @State private var filterText = ""
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            InjectionFeedView(store: store, filterText: $filterText)
-                .padding(16)
-                .onAppear { store.start() }
-
-            if store.degradationState.isDegraded {
-                DegradationBadge(reason: store.degradationState.reason)
-                    .padding(.top, 20)
-                    .padding(.trailing, 20)
-            }
-        }
+        InjectionFeedView(store: store, filterText: $filterText)
+            .padding(16)
+            .onAppear { store.start() }
     }
 }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -437,7 +437,7 @@ final class StatusPopoverView: NSViewController {
 // MARK: - SwiftUI Tab Wrappers
 
 struct PopoverInjectionTab: View {
-    @ObservedObject var store: InjectionStore
+    let store: InjectionStore
     @State private var filterText = ""
 
     var body: some View {

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -1,9 +1,68 @@
+import Combine
 import SwiftUI
+
+struct InjectionFeedPresentationState: Equatable {
+    let events: [InjectionEvent]
+    let degradationState: DegradationState
+
+    static let empty = InjectionFeedPresentationState(
+        events: [],
+        degradationState: .healthy
+    )
+}
+
+@MainActor
+final class InjectionFeedPresentationModel: ObservableObject {
+    @Published private(set) var state: InjectionFeedPresentationState = .empty
+
+    var events: [InjectionEvent] { state.events }
+    var degradationState: DegradationState { state.degradationState }
+
+    private let throttleInterval: RunLoop.SchedulerTimeType.Stride
+    private var cancellables: Set<AnyCancellable> = []
+    private weak var boundStore: InjectionStore?
+
+    init(throttleInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(500)) {
+        self.throttleInterval = throttleInterval
+    }
+
+    func bind(to store: InjectionStore) {
+        guard boundStore !== store else { return }
+
+        boundStore = store
+        cancellables.removeAll()
+        let currentState = InjectionFeedPresentationState(
+            events: store.events,
+            degradationState: store.degradationState
+        )
+        if state != currentState {
+            state = currentState
+        }
+
+        Publishers.CombineLatest(store.$events, store.$degradationState)
+            .map { events, degradationState in
+                InjectionFeedPresentationState(
+                    events: events,
+                    degradationState: degradationState
+                )
+            }
+            .dropFirst()
+            .removeDuplicates()
+            .throttle(for: throttleInterval, scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] state in
+                Task { @MainActor [weak self] in
+                    self?.state = state
+                }
+            }
+            .store(in: &cancellables)
+    }
+}
 
 struct InjectionFeedView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @ObservedObject var store: InjectionStore
+    let store: InjectionStore
     @Binding var filterText: String
+    @StateObject private var presentationModel = InjectionFeedPresentationModel()
     @State private var expandedEventIDs: Set<Int64> = []
     @State private var expandedBurstIDs: Set<String> = []
     @State private var selectedConversation: BrainDatabase.ExpandedConversation?
@@ -52,6 +111,16 @@ struct InjectionFeedView: View {
                     onClose: { selectedConversation = nil }
                 )
             }
+        }
+        .overlay(alignment: .topTrailing) {
+            if presentationModel.degradationState.isDegraded {
+                DegradationBadge(reason: presentationModel.degradationState.reason)
+                    .padding(.top, 20)
+                    .padding(.trailing, 20)
+            }
+        }
+        .onAppear {
+            presentationModel.bind(to: store)
         }
     }
 
@@ -568,7 +637,7 @@ struct InjectionFeedView: View {
 
     private func makePresentation(now: Date = Date()) -> InjectionPresentation.Snapshot {
         InjectionPresentation.snapshot(
-            events: store.events,
+            events: presentationModel.events,
             filterText: filterText,
             now: now,
             bucketCount: 24

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -1,9 +1,11 @@
 import XCTest
+import Combine
 @testable import BrainBar
 
 final class InjectionStoreTests: XCTestCase {
     private var tempDBPath: String!
     private var db: BrainDatabase!
+    private var cancellables: Set<AnyCancellable> = []
 
     override func setUp() {
         super.setUp()
@@ -12,6 +14,7 @@ final class InjectionStoreTests: XCTestCase {
     }
 
     override func tearDown() {
+        cancellables.removeAll()
         db.close()
         try? FileManager.default.removeItem(atPath: tempDBPath)
         try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
@@ -127,6 +130,62 @@ final class InjectionStoreTests: XCTestCase {
         XCTAssertEqual(store.degradationState, .healthy)
         XCTAssertEqual(store.events.map(\.query), ["recovered query"])
     }
+
+    @MainActor
+    func testInjectionFeedPresentationModelThrottlesRapidEventBursts() async throws {
+        let reader = ScriptedInjectionEventReader(
+            versions: [1, 2, 3],
+            eventResults: [
+                .success([makeEvent(id: 1, query: "burst one")]),
+                .success([makeEvent(id: 2, query: "burst two")]),
+                .success([makeEvent(id: 3, query: "burst three")]),
+            ]
+        )
+        let store = InjectionStore(reader: reader)
+        let model = InjectionFeedPresentationModel(throttleInterval: .milliseconds(100))
+        var publishedStates: [InjectionFeedPresentationState] = []
+
+        model.$state
+            .dropFirst()
+            .sink { state in
+                publishedStates.append(state)
+            }
+            .store(in: &cancellables)
+
+        model.bind(to: store)
+        store.refreshForTesting(force: true)
+        store.refreshForTesting(force: true)
+        store.refreshForTesting(force: true)
+
+        try await Task.sleep(for: .milliseconds(180))
+
+        XCTAssertLessThanOrEqual(
+            publishedStates.count,
+            2,
+            "A rapid store burst should be coalesced before invalidating SwiftUI."
+        )
+        XCTAssertEqual(model.events.map(\.id), [3])
+        XCTAssertEqual(model.state.events.map(\.id), [3])
+        XCTAssertEqual(model.state.degradationState, .healthy)
+    }
+
+    @MainActor
+    func testInjectionFeedPresentationModelSeedsCurrentStoreStateImmediately() throws {
+        let reader = ScriptedInjectionEventReader(
+            versions: [1],
+            eventResults: [
+                .success([makeEvent(id: 42, query: "already loaded")]),
+            ]
+        )
+        let store = InjectionStore(reader: reader)
+        store.refreshForTesting(force: true)
+
+        let model = InjectionFeedPresentationModel(throttleInterval: .milliseconds(500))
+        model.bind(to: store)
+
+        XCTAssertEqual(model.state.events.map(\.id), [42])
+        XCTAssertEqual(model.state.degradationState, .healthy)
+    }
 }
 
 private enum ScriptedInjectionError: Error {
@@ -173,4 +232,15 @@ private final class ScriptedInjectionEventReader: InjectionEventReading {
     }
 
     func close() {}
+}
+
+private func makeEvent(id: Int64, query: String) -> InjectionEvent {
+    InjectionEvent(
+        id: id,
+        sessionID: "session-\(id)",
+        timestamp: "2026-05-25T19:00:00Z",
+        query: query,
+        chunkIDs: ["chunk-\(id)"],
+        tokenCount: 7
+    )
 }


### PR DESCRIPTION
## Summary
- Bisected the BrainBar UI CPU runaway to PR #322 (`feat(brainbar): burst-aggregate injections + 60-min ribbon`), merge commit `272427699f890f03323e5e4f9529665145e53ce1`.
- Added a Combine throttling boundary between `InjectionStore.events` and the SwiftUI injection feed presentation model: `.throttle(for: .milliseconds(500), scheduler: RunLoop.main, latest: true)`.
- Removed direct `@ObservedObject` subscriptions from the injection feed wrappers so raw store bursts no longer invalidate the full SwiftUI feed on every store publish.
- Added a regression test that simulates a rapid injection event burst and asserts the presentation model coalesces updates before publishing into SwiftUI.

## Mandate / evidence
- Mandate: `/tmp/codex-mandate-phase-2-4-K-cpu-regression.md`.
- BL-LEAD `sample(1)` finding from mandate: main UI thread and `com.brainlayer.brainbar.brain-bus-client` were both saturated, with multiple additional threads pegged during the runaway.
- User/BL-LEAD reported live BrainBar UI CPU: 98% CPU per phase handoff; mandate also notes 64-65% sustained across fresh PIDs.

## Bisect result
- Reverted PR #322 on scratch branch `bisect/no-322` via commit `5a18b8b3`.
- Installed/relaunched that build and measured BrainBar UI PID `25037` after 60s:
  - `0.0%, 0.0%, 0.0%, 0.0%, 0.0%` across five 5s-spaced `ps` samples.
- Result: PR #322 confirmed as regression source; PR #319 and #321 were not reverted after #322 cleared the symptom.

## Fix verification
- Hotfix build installed/relaunched from this branch and measured BrainBar UI PID `31665` after 60s:
  - `0.0%, 0.0%, 0.0%, 0.0%, 0.0%` across five 5s-spaced `ps` samples.

## Test plan
- [x] RED: `swift test --package-path brain-bar --filter InjectionStoreTests/testInjectionFeedPresentationModelThrottlesRapidEventBursts` failed before implementation because `InjectionFeedPresentationModel` did not exist.
- [x] GREEN: `swift test --package-path brain-bar --filter InjectionStoreTests/testInjectionFeedPresentationModelThrottlesRapidEventBursts` passed: 1 test, 0 failures.
- [x] `swift test --package-path brain-bar` passed: 450 tests, 0 failures.
- [x] `pytest` passed: 2222 passed, 46 skipped, 5 xfailed.
- [x] Pre-push BrainLayer test gate passed: 2152 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 36 passed; Bun 1 passed; FTS5 regression shell passed.

## Review gate
- Refined AP_BL_7 required: 2+ green from CodeRabbit, Codex, Macroscope-Correctness. Cursor Bugbot informational only.
- Local `cr review --plain` was attempted pre-commit but CodeRabbit CLI returned `Review limit reached`; requesting CodeRabbit via PR comment below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance fix with localized SwiftUI/Combine wiring and regression tests; no auth, data, or backend behavior changes.
> 
> **Overview**
> Fixes a BrainBar UI CPU runaway tied to rapid `InjectionStore` publishes by inserting a throttled presentation layer before SwiftUI redraws the injection feed.
> 
> Adds **`InjectionFeedPresentationModel`**, which combines `events` and `degradationState`, deduplicates updates, and applies a **500ms main-run-loop throttle** before publishing. **`InjectionFeedView`** binds to that model via `@StateObject` instead of observing the store directly, and builds its snapshot from the throttled events. Injection tab wrappers (`BrainBarInjectionTab`, `PopoverInjectionTab`) now pass the store as a plain `let` rather than `@ObservedObject`.
> 
> The **degradation badge** moves from the tab wrappers into **`InjectionFeedView`**, driven by the presentation model’s degradation state.
> 
> Regression tests assert that rapid store refreshes coalesce to at most two published state updates and that binding seeds the current store state immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344871805baf58f055f684540ccb9a1d373df8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Throttle `InjectionFeedView` state updates to fix CPU runaway loop in BrainBar
> - Introduces `InjectionFeedPresentationModel`, a `@MainActor` `ObservableObject` that combines store events and degradation state into a throttled, deduplicated stream before publishing to the UI.
> - `InjectionFeedView` now owns a `@StateObject` presentation model and binds to the store on appear, seeding current state immediately to avoid a blank initial render.
> - `BrainBarInjectionTab` and `PopoverInjectionTab` drop `@ObservedObject` in favor of plain `let` properties; observation is now handled entirely within `InjectionFeedView`.
> - The `DegradationBadge` overlay moves into `InjectionFeedView` and is driven by the presentation model's throttled state.
> - Adds two `@MainActor` tests in `InjectionStoreTests` covering throttle coalescing and immediate state seeding on bind.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3448718. 3 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Feed view now efficiently handles rapid event updates with optimized rendering, improving responsiveness and reducing unnecessary UI refreshes.

* **Tests**
  * Added test coverage for feed event handling under high-frequency update scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->