### PR TITLE
fix(vector_store): sweep stale writer pidfiles on acquire + cleanup on exit

### DIFF
--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -6,9 +6,11 @@ See search_repo.py, kg_repo.py, session_repo.py for the extracted methods.
 
 import atexit
 import fcntl
+import glob
 import hashlib
 import json
 import os
+import stat
 import struct
 import subprocess
 import threading
@@ -112,6 +114,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     _PIDFILE_REFS: dict[Path, int] = {}
     _PIDFILE_REF_PIDS: dict[Path, int] = {}
     _PIDFILE_REFS_LOCK = threading.Lock()
+    _PIDFILE_ACQUIRE_LOCK = threading.Lock()
 
     def __init__(self, db_path: Path, readonly: bool = False):
         self.db_path = db_path
@@ -150,54 +153,91 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     def _acquire_writer_pidfile(self) -> None:
         pidfile = self._writer_pidfile_path()
         pidfile.parent.mkdir(parents=True, exist_ok=True)
-        pid = os.getpid()
+        with self._PIDFILE_ACQUIRE_LOCK:
+            self._reclaim_stale_writer_pidfiles(pidfile)
+            pid = os.getpid()
 
-        with self._PIDFILE_REFS_LOCK:
-            if self._PIDFILE_REFS.get(pidfile, 0) > 0:
-                ref_pid = self._PIDFILE_REF_PIDS.get(pidfile)
-                if ref_pid is not None and ref_pid != pid:
-                    self._PIDFILE_REFS.pop(pidfile, None)
-                    self._PIDFILE_REF_PIDS.pop(pidfile, None)
-                else:
-                    owner_pid, owner_start_time = self._read_writer_pidfile_owner(pidfile)
-                    if owner_pid != pid or not self._pidfile_owner_matches(owner_pid, owner_start_time):
-                        raise WriterInUseError(
-                            f"pidfile ref mismatch for {self.db_path}; refusing to clear active refs"
-                        )
-                    self._PIDFILE_REFS[pidfile] += 1
-                    self._PIDFILE_REF_PIDS[pidfile] = pid
+            with self._PIDFILE_REFS_LOCK:
+                if self._PIDFILE_REFS.get(pidfile, 0) > 0:
+                    ref_pid = self._PIDFILE_REF_PIDS.get(pidfile)
+                    if ref_pid is not None and ref_pid != pid:
+                        self._PIDFILE_REFS.pop(pidfile, None)
+                        self._PIDFILE_REF_PIDS.pop(pidfile, None)
+                    else:
+                        owner_pid, owner_start_time = self._read_writer_pidfile_owner(pidfile)
+                        if owner_pid != pid or not self._pidfile_owner_matches(owner_pid, owner_start_time):
+                            raise WriterInUseError(
+                                f"pidfile ref mismatch for {self.db_path}; refusing to clear active refs"
+                            )
+                        self._PIDFILE_REFS[pidfile] += 1
+                        self._PIDFILE_REF_PIDS[pidfile] = pid
+                        self._writer_pidfile_acquired = True
+                        self._writer_pidfile_path_value = pidfile
+                        atexit.register(self._release_writer_pidfile)
+                        return
+
+            max_create_attempts = 4
+            for attempt in range(max_create_attempts):
+                try:
+                    fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                    try:
+                        fcntl.flock(fd, fcntl.LOCK_EX)
+                        os.write(fd, self._writer_pidfile_payload(pid))
+                    finally:
+                        os.close(fd)
+                    with self._PIDFILE_REFS_LOCK:
+                        self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
+                        self._PIDFILE_REF_PIDS[pidfile] = pid
                     self._writer_pidfile_acquired = True
                     self._writer_pidfile_path_value = pidfile
                     atexit.register(self._release_writer_pidfile)
                     return
+                except FileExistsError:
+                    if self._handle_existing_writer_pidfile(pidfile, pid):
+                        return
+                    if attempt == max_create_attempts - 1:
+                        raise
+                    time.sleep(0.01 * (attempt + 1))
 
-        max_create_attempts = 4
-        for attempt in range(max_create_attempts):
-            try:
-                fd = os.open(pidfile, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-                try:
-                    fcntl.flock(fd, fcntl.LOCK_EX)
-                    os.write(fd, self._writer_pidfile_payload(pid))
-                finally:
-                    os.close(fd)
-                with self._PIDFILE_REFS_LOCK:
-                    self._PIDFILE_REFS[pidfile] = self._PIDFILE_REFS.get(pidfile, 0) + 1
-                    self._PIDFILE_REF_PIDS[pidfile] = pid
-                self._writer_pidfile_acquired = True
-                self._writer_pidfile_path_value = pidfile
-                atexit.register(self._release_writer_pidfile)
+    def _reclaim_stale_writer_pidfiles(self, pidfile: Path) -> None:
+        # Legacy pidfiles do not record the database path. Sweep sibling hashes
+        # for the same DB basename, then use db_path metadata when it exists.
+        pattern = f"brainlayer-writer-*-{glob.escape(self.db_path.resolve().name)}.pid"
+        for candidate in pidfile.parent.glob(pattern):
+            self._reclaim_stale_writer_pidfile(candidate)
+
+    def _reclaim_stale_writer_pidfile(self, pidfile: Path) -> None:
+        with self._PIDFILE_REFS_LOCK:
+            if self._PIDFILE_REFS.get(pidfile, 0) > 0:
                 return
-            except FileExistsError:
-                if self._handle_existing_writer_pidfile(pidfile, pid):
-                    return
-                if attempt == max_create_attempts - 1:
-                    raise
-                time.sleep(0.01 * (attempt + 1))
+        fd = self._open_writer_pidfile_readonly(pidfile)
+        if fd is None:
+            return
+        try:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return
+            owner_pid, owner_start_time, owner_db_path = self._read_writer_pidfile_record_fd(fd)
+            if owner_db_path is not None and not self._pidfile_db_path_matches(owner_db_path):
+                return
+            if owner_pid is not None and self._pidfile_owner_matches(owner_pid, owner_start_time):
+                return
+            try:
+                path_stat = pidfile.stat()
+            except FileNotFoundError:
+                return
+            if os.path.samestat(os.fstat(fd), path_stat):
+                try:
+                    pidfile.unlink()
+                except FileNotFoundError:
+                    pass
+        finally:
+            os.close(fd)
 
     def _handle_existing_writer_pidfile(self, pidfile: Path, pid: int) -> bool:
-        try:
-            fd = os.open(pidfile, os.O_RDONLY)
-        except FileNotFoundError:
+        fd = self._open_writer_pidfile_readonly(pidfile)
+        if fd is None:
             return False
         try:
             fcntl.flock(fd, fcntl.LOCK_EX)
@@ -226,21 +266,38 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             os.close(fd)
 
     @staticmethod
+    def _open_writer_pidfile_readonly(pidfile: Path) -> int | None:
+        try:
+            candidate_stat = pidfile.lstat()
+        except OSError:
+            return None
+        if not stat.S_ISREG(candidate_stat.st_mode):
+            return None
+
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(pidfile, flags)
+        except OSError:
+            return None
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                os.close(fd)
+                return None
+        except OSError:
+            os.close(fd)
+            return None
+        return fd
+
+    @staticmethod
     def _read_writer_pidfile(pidfile: Path) -> int | None:
         return VectorStore._read_writer_pidfile_owner(pidfile)[0]
 
     @staticmethod
     def _read_writer_pidfile_owner(pidfile: Path) -> tuple[int | None, str | None]:
         try:
-            lines = pidfile.read_text(encoding="utf-8").splitlines()
-            if not lines:
-                return None, None
-            pid = int(lines[0].strip())
-            start_time = None
-            for line in lines[1:]:
-                if line.startswith("start_time="):
-                    start_time = line.removeprefix("start_time=").strip() or None
-                    break
+            pid, start_time, _db_path = VectorStore._parse_writer_pidfile_lines(
+                pidfile.read_text(encoding="utf-8").splitlines()
+            )
             return pid, start_time
         except (OSError, ValueError):
             return None, None
@@ -251,27 +308,41 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
     @staticmethod
     def _read_writer_pidfile_owner_fd(fd: int) -> tuple[int | None, str | None]:
-        try:
-            os.lseek(fd, 0, os.SEEK_SET)
-            lines = os.read(fd, 256).decode("utf-8").splitlines()
-            if not lines:
-                return None, None
-            pid = int(lines[0].strip())
-            start_time = None
-            for line in lines[1:]:
-                if line.startswith("start_time="):
-                    start_time = line.removeprefix("start_time=").strip() or None
-                    break
-            return pid, start_time
-        except (OSError, ValueError):
-            return None, None
+        pid, start_time, _db_path = VectorStore._read_writer_pidfile_record_fd(fd)
+        return pid, start_time
 
     @staticmethod
-    def _writer_pidfile_payload(pid: int) -> bytes:
+    def _read_writer_pidfile_record_fd(fd: int) -> tuple[int | None, str | None, str | None]:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            return VectorStore._parse_writer_pidfile_lines(os.read(fd, 512).decode("utf-8").splitlines())
+        except (OSError, ValueError):
+            return None, None, None
+
+    @staticmethod
+    def _parse_writer_pidfile_lines(lines: list[str]) -> tuple[int | None, str | None, str | None]:
+        if not lines:
+            return None, None, None
+        pid = int(lines[0].strip())
+        start_time = None
+        db_path = None
+        for line in lines[1:]:
+            key, separator, value = line.strip().partition("=")
+            if not separator:
+                continue
+            if key == "start_time":
+                start_time = value.strip() or None
+            elif key == "db_path":
+                db_path = value.strip() or None
+        return pid, start_time, db_path
+
+    def _writer_pidfile_payload(self, pid: int) -> bytes:
         start_time = VectorStore._pid_start_time(pid)
+        lines = [str(pid)]
         if start_time:
-            return f"{pid}\nstart_time={start_time}\n".encode("utf-8")
-        return f"{pid}\n".encode("utf-8")
+            lines.append(f"start_time={start_time}")
+        lines.append(f"db_path={self.db_path.resolve()}")
+        return ("\n".join(lines) + "\n").encode("utf-8")
 
     def _pidfile_owner_matches(self, pid: int, start_time: str | None) -> bool:
         if not self._pid_is_alive(pid):
@@ -280,6 +351,12 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             return True
         current_start_time = self._pid_start_time(pid)
         return current_start_time is None or current_start_time == start_time
+
+    def _pidfile_db_path_matches(self, db_path: str) -> bool:
+        try:
+            return Path(db_path).expanduser().resolve() == self.db_path.resolve()
+        except (OSError, RuntimeError, ValueError):
+            return False
 
     @staticmethod
     def _pid_start_time(pid: int) -> str | None:

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -22,6 +22,11 @@ def _expected_pidfile(pidfile_dir: Path, db_path: Path) -> Path:
     return pidfile_dir / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
 
 
+def _sibling_pidfile(pidfile_dir: Path, db_path: Path, suffix: str) -> Path:
+    resolved_path = db_path.resolve()
+    return pidfile_dir / f"brainlayer-writer-{suffix}-{resolved_path.name}.pid"
+
+
 def _pidfile_pid(pidfile: Path) -> str:
     return pidfile.read_text(encoding="utf-8").splitlines()[0].strip()
 
@@ -410,6 +415,129 @@ def test_stale_pidfile_cleaned_up(tmp_path, monkeypatch):
         store.close()
 
 
+def test_acquire_sweeps_all_stale_pidfiles_before_live_conflict(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    live_pid = 424242
+    live_pidfile = _expected_pidfile(pidfile_dir, db_path)
+    live_pidfile.write_text(f"{live_pid}\n", encoding="utf-8")
+    stale_pidfiles = [
+        _sibling_pidfile(pidfile_dir, db_path, "stale-one"),
+        _sibling_pidfile(pidfile_dir, db_path, "stale-two"),
+        _sibling_pidfile(pidfile_dir, db_path, "stale-three"),
+    ]
+    for stale_pidfile in stale_pidfiles:
+        stale_pidfile.write_text("999999\n", encoding="utf-8")
+
+    monkeypatch.setattr(VectorStore, "_pid_is_alive", staticmethod(lambda pid: pid == live_pid))
+
+    with pytest.raises(WriterInUseError, match=f"another writer is using {db_path} \\(pid {live_pid}\\)"):
+        VectorStore(db_path)
+
+    assert live_pidfile.exists()
+    assert _pidfile_pid(live_pidfile) == str(live_pid)
+    assert all(not stale_pidfile.exists() for stale_pidfile in stale_pidfiles)
+
+
+def test_reclaim_skips_stale_pidfile_for_different_recorded_db_path(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    other_db_path = tmp_path / "other" / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    other_pidfile = _sibling_pidfile(pidfile_dir, db_path, "other-db")
+    other_pidfile.write_text(f"999999\ndb_path={other_db_path.resolve()}\n", encoding="utf-8")
+
+    store = VectorStore(db_path)
+    try:
+        assert other_pidfile.exists()
+    finally:
+        store.close()
+
+
+def test_reclaim_skips_malformed_recorded_db_path_without_blocking_open(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    malformed_pidfile = _sibling_pidfile(pidfile_dir, db_path, "malformed-db-path")
+    malformed_pidfile.write_text("999999\ndb_path=bad\x00path\n", encoding="utf-8")
+
+    store = VectorStore(db_path)
+    try:
+        assert malformed_pidfile.exists()
+    finally:
+        store.close()
+
+
+def test_reclaim_escapes_db_basename_glob_metacharacters(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer[abc].db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    stale_pidfile = _sibling_pidfile(pidfile_dir, db_path, "stale")
+    stale_pidfile.write_text("999999\n", encoding="utf-8")
+
+    store = VectorStore(db_path)
+    try:
+        assert not stale_pidfile.exists()
+    finally:
+        store.close()
+
+
+def test_reclaim_skips_unreadable_sibling_pidfile_without_blocking_open(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    unreadable_pidfile = _sibling_pidfile(pidfile_dir, db_path, "unreadable")
+    unreadable_pidfile.write_text("999999\n", encoding="utf-8")
+    original_open = os.open
+
+    def unreadable_open(path, flags, mode=0o777, *, dir_fd=None):
+        if dir_fd is None and Path(path) == unreadable_pidfile and flags & os.O_ACCMODE == os.O_RDONLY:
+            raise PermissionError(13, "Permission denied", str(path))
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("os.open", unreadable_open)
+
+    store = VectorStore(db_path)
+    try:
+        assert unreadable_pidfile.exists()
+    finally:
+        store.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX fifos")
+def test_reclaim_skips_fifo_sibling_pidfile_without_opening(tmp_path, monkeypatch):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    pidfile_dir.mkdir()
+    fifo_pidfile = _sibling_pidfile(pidfile_dir, db_path, "fifo")
+    os.mkfifo(fifo_pidfile)
+    original_open = os.open
+
+    def no_fifo_open(path, flags, mode=0o777, *, dir_fd=None):
+        if dir_fd is None and Path(path) == fifo_pidfile:
+            raise AssertionError("fifo pidfile candidates must be skipped before open")
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("os.open", no_fifo_open)
+
+    store = VectorStore(db_path)
+    try:
+        assert fifo_pidfile.exists()
+    finally:
+        store.close()
+
+
 def test_stale_pidfile_unlink_missing_race_is_ignored(tmp_path, monkeypatch):
     pidfile = tmp_path / "writer.pid"
     pidfile.write_text("999999", encoding="utf-8")
@@ -440,6 +568,35 @@ def test_pidfile_removed_on_close(tmp_path, monkeypatch):
 
     store.close()
 
+    assert not pidfile.exists()
+
+
+def test_pidfile_removed_by_atexit_without_explicit_close(tmp_path):
+    pidfile_dir = tmp_path / "pidfiles"
+    db_path = tmp_path / "writer.db"
+    pidfile = _expected_pidfile(pidfile_dir, db_path)
+    script = """
+from pathlib import Path
+from brainlayer.vector_store import VectorStore
+
+VectorStore(Path(__import__("os").environ["DB_PATH"]))
+"""
+    env = {
+        **os.environ,
+        "BRAINLAYER_WRITER_PIDFILE_DIR": str(pidfile_dir),
+        "DB_PATH": str(db_path),
+        "PYTHONPATH": f"{Path(__file__).resolve().parents[1] / 'src'}:{os.environ.get('PYTHONPATH', '')}",
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
     assert not pidfile.exists()
 
 


### PR DESCRIPTION
## Summary
- Implements Phase 2.4-L from `/tmp/codex-mandate-phase-2-4-L-stale-pidfile-reclaim.md`: writer pidfile acquire now sweeps all sibling pidfiles for the DB basename before deciding whether a live writer blocks acquisition.
- Addresses the reported 7-pidfile incident (`1` live enrichment supervisor pidfile plus `6` stale pidfiles) by reclaiming dead owners across sibling hashes while preserving live owners and same-basename pidfiles that record a different `db_path`.
- Adds graceful-exit cleanup coverage via the existing `atexit.register(self._release_writer_pidfile)` path and a subprocess regression test that verifies pidfiles disappear even without explicit `close()`.
- Hardens review-found edges: literal glob metacharacters in DB basenames are escaped, unreadable and non-regular sibling pidfiles are skipped, malformed recorded `db_path` values do not abort acquisition, and same-process acquires are serialized so a sweep cannot remove an in-flight local pidfile.
- Fix 3 / hourly launchd sweep was not added because Fix 1 + Fix 2 now cover recurrence at acquire time and clean process exit without adding a second maintenance surface.

## Test plan
- [x] TDD red: new stale-sibling sweep and reviewer-edge tests failed before implementation.
- [x] `pytest tests/test_writer_pidfile_mutex.py` -> `32 passed`
- [x] `pytest tests/test_writer_pidfile_mutex.py tests/test_db_lock_resilience.py::TestVectorStoreInitRetry::test_concurrent_vectorstore_init` -> `33 passed`
- [x] `python3 -m compileall -q src/brainlayer/vector_store.py`
- [x] `git diff --check`
- [x] Full local `pytest` on Python 3.13 -> `2229 passed, 46 skipped, 5 xfailed, 328 warnings`
- [x] Pre-push Python 3.12 unit gate -> `2159 passed, 9 skipped, 75 deselected, 1 xfailed, 102 warnings`
- [x] Pre-push MCP registration -> `3 passed`
- [x] Pre-push isolated eval and hook routing -> `36 passed`
- [x] Pre-push Bun stale-index suite -> `1 pass`
- [x] Pre-push regression shell `test_fts5_determinism.sh` -> `PASS`

## Review gate
- AP_BL_7 target: 2+ green from CodeRabbit, Codex, Macroscope-Correctness.
- Cursor Bugbot is informational only per mandate.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale writer pidfile sweeping on acquire and register atexit cleanup on exit in `VectorStore`
> - Before acquiring the writer pidfile, `VectorStore._acquire_writer_pidfile` now scans and removes stale sibling pidfiles matching the DB basename via `_reclaim_stale_writer_pidfiles`.
> - Reclamation uses non-blocking `flock`, lstat/type checks, and samestat verification to safely unlink only dead-owner pidfiles that match the current DB path, skipping non-regular files (e.g. FIFOs) and symlinks.
> - Pidfile payloads now include a `db_path` field; reclamation uses this to skip pidfiles belonging to a different database.
> - Acquisition is serialized within a process via a new class-level `_PIDFILE_ACQUIRE_LOCK` mutex, and atexit cleanup is registered on first successful acquire.
> - Behavioral Change: processes that exit without calling `close()` will now have their pidfile removed via atexit, and stale pidfiles from prior crashed processes are cleaned up on the next acquire.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a55c7d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->