### PR TITLE
feat(build): auto-clean stale BrainBar DEV bundles on canonical build

### DIFF
--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -90,9 +90,7 @@ sanitize_branch_name() {
 }
 
 dev_bundle_apps_dir() {
-    local app_parent
-    app_parent="$(dirname "$APP_DIR")"
-    printf '%s\n' "$app_parent"
+    printf '%s\n' "$HOME/Applications"
 }
 
 branch_is_checked_out_anywhere() {

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -156,7 +156,7 @@ safe_branch_ref_exists() {
 
 bundle_mtime_epoch() {
     local bundle="$1"
-    stat -f %m "$bundle" 2>/dev/null || stat -c %Y "$bundle"
+    stat -c %Y "$bundle" 2>/dev/null || stat -f %m "$bundle"
 }
 
 dev_bundle_age_days() {

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -62,6 +62,7 @@ DAEMON_PLIST_DST="$HOME/Library/LaunchAgents/$DAEMON_PLIST_FILENAME"
 LAUNCH_DOMAIN="gui/$(id -u)"
 SOCKET_PATH="${BRAINBAR_SOCKET_PATH:-/tmp/brainbar.sock}"
 PLIST_BUDDY="${BRAINBAR_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
+LSREGISTER="${BRAINBAR_LSREGISTER:-/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister}"
 CANONICAL_REPO_ROOT="${BRAINBAR_CANONICAL_REPO_ROOT:-$HOME/Gits/brainlayer}"
 BRAINLAYER_LOG_DIR="$HOME/Library/Logs/brainlayer"
 
@@ -198,6 +199,10 @@ cleanup_stale_dev_bundles() {
     local apps_dir
     apps_dir="$(dev_bundle_apps_dir)"
     local stale_days="${BRAINBAR_DEV_STALE_DAYS:-14}"
+    if ! [[ "$stale_days" =~ ^[0-9]+$ ]]; then
+        echo "[build-app] WARNING: invalid BRAINBAR_DEV_STALE_DAYS='$stale_days', using 14" >&2
+        stale_days=14
+    fi
     local bundle
     local found=0
 
@@ -470,7 +475,7 @@ if ! codesign -dv --verbose=4 "$APP_DIR" 2>&1 | grep -F "Authority=$SIGN_IDENTIT
 fi
 
 # Register URL scheme with Launch Services (ensures brainbar:// works after rebuild)
-/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -R "$APP_DIR"
+"$LSREGISTER" -R "$APP_DIR"
 
 install_launchagent() {
     local source_plist="$1"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -61,7 +61,7 @@ UI_PLIST_DST="$HOME/Library/LaunchAgents/$UI_PLIST_FILENAME"
 DAEMON_PLIST_DST="$HOME/Library/LaunchAgents/$DAEMON_PLIST_FILENAME"
 LAUNCH_DOMAIN="gui/$(id -u)"
 SOCKET_PATH="${BRAINBAR_SOCKET_PATH:-/tmp/brainbar.sock}"
-PLIST_BUDDY="/usr/libexec/PlistBuddy"
+PLIST_BUDDY="${BRAINBAR_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
 CANONICAL_REPO_ROOT="${BRAINBAR_CANONICAL_REPO_ROOT:-$HOME/Gits/brainlayer}"
 BRAINLAYER_LOG_DIR="$HOME/Library/Logs/brainlayer"
 

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -96,6 +96,7 @@ dev_bundle_apps_dir() {
 
 safe_branch_is_checked_out_anywhere() {
     local safe_branch="$1"
+    local bundle_sha="${2:-}"
     local detached_sha=""
     case "$safe_branch" in
         detached-*)
@@ -105,12 +106,14 @@ safe_branch_is_checked_out_anywhere() {
 
     local line
     local head_sha=""
+    local has_branch=0
     while IFS= read -r line || [ -n "$line" ]; do
         case "$line" in
             HEAD\ *)
                 head_sha="${line#HEAD }"
                 ;;
             branch\ refs/heads/*)
+                has_branch=1
                 local branch
                 branch="${line#branch refs/heads/}"
                 if [ "$(sanitize_branch_name "$branch")" = "$safe_branch" ]; then
@@ -118,15 +121,22 @@ safe_branch_is_checked_out_anywhere() {
                 fi
                 ;;
             "")
-                if [ -n "$detached_sha" ] && [ "${head_sha#$detached_sha}" != "$head_sha" ]; then
+                if [ -n "$detached_sha" ] && [ "${head_sha#"$detached_sha"}" != "$head_sha" ]; then
+                    return 0
+                fi
+                if [ "$has_branch" -eq 0 ] && [ -n "$bundle_sha" ] && [ "$head_sha" = "$bundle_sha" ]; then
                     return 0
                 fi
                 head_sha=""
+                has_branch=0
                 ;;
         esac
     done < <(git -C "$CURRENT_REPO_ROOT" worktree list --porcelain)
 
-    if [ -n "$detached_sha" ] && [ "${head_sha#$detached_sha}" != "$head_sha" ]; then
+    if [ -n "$detached_sha" ] && [ "${head_sha#"$detached_sha"}" != "$head_sha" ]; then
+        return 0
+    fi
+    if [ "$has_branch" -eq 0 ] && [ -n "$bundle_sha" ] && [ "$head_sha" = "$bundle_sha" ]; then
         return 0
     fi
     return 1
@@ -222,8 +232,8 @@ cleanup_stale_dev_bundles() {
         local is_stale=0
         local reason=""
 
-        if safe_branch_is_checked_out_anywhere "$safe_branch"; then
-            reason="bundle branch token '$safe_branch' is checked out in a worktree"
+        if safe_branch_is_checked_out_anywhere "$safe_branch" "$sha"; then
+            reason="bundle branch token '$safe_branch' or SHA is checked out in a worktree"
         elif [ -n "$sha" ] && git -C "$CURRENT_REPO_ROOT" merge-base --is-ancestor "$sha" origin/main 2>/dev/null; then
             is_stale=1
             reason="bundle SHA $sha is in origin/main"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -93,18 +93,75 @@ dev_bundle_apps_dir() {
     printf '%s\n' "$HOME/Applications"
 }
 
-branch_is_checked_out_anywhere() {
-    local branch="$1"
-    git -C "$CURRENT_REPO_ROOT" worktree list --porcelain |
-        awk -v branch_ref="refs/heads/$branch" '
-            $1 == "branch" && $2 == branch_ref { found = 1 }
-            END { exit found ? 0 : 1 }
-        '
+safe_branch_is_checked_out_anywhere() {
+    local safe_branch="$1"
+    local detached_sha=""
+    case "$safe_branch" in
+        detached-*)
+            detached_sha="${safe_branch#detached-}"
+            ;;
+    esac
+
+    local line
+    local head_sha=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            HEAD\ *)
+                head_sha="${line#HEAD }"
+                ;;
+            branch\ refs/heads/*)
+                local branch
+                branch="${line#branch refs/heads/}"
+                if [ "$(sanitize_branch_name "$branch")" = "$safe_branch" ]; then
+                    return 0
+                fi
+                ;;
+            "")
+                if [ -n "$detached_sha" ] && [ "${head_sha#$detached_sha}" != "$head_sha" ]; then
+                    return 0
+                fi
+                head_sha=""
+                ;;
+        esac
+    done < <(git -C "$CURRENT_REPO_ROOT" worktree list --porcelain)
+
+    if [ -n "$detached_sha" ] && [ "${head_sha#$detached_sha}" != "$head_sha" ]; then
+        return 0
+    fi
+    return 1
+}
+
+safe_branch_ref_exists() {
+    local safe_branch="$1"
+    local ref
+    while IFS= read -r ref; do
+        local branch
+        case "$ref" in
+            refs/heads/*)
+                branch="${ref#refs/heads/}"
+                ;;
+            refs/remotes/origin/*)
+                branch="${ref#refs/remotes/origin/}"
+                ;;
+            *)
+                continue
+                ;;
+        esac
+        if [ "$(sanitize_branch_name "$branch")" = "$safe_branch" ]; then
+            return 0
+        fi
+    done < <(git -C "$CURRENT_REPO_ROOT" for-each-ref --format='%(refname)' refs/heads refs/remotes/origin 2>/dev/null)
+    return 1
+}
+
+bundle_mtime_epoch() {
+    local bundle="$1"
+    stat -f %m "$bundle" 2>/dev/null || stat -c %Y "$bundle"
 }
 
 dev_bundle_age_days() {
     local bundle="$1"
-    echo $(( ($(date +%s) - $(stat -f %m "$bundle")) / 86400 ))
+    echo $(( ($(date +%s) - $(bundle_mtime_epoch "$bundle")) / 86400 ))
 }
 
 read_bundle_git_commit() {
@@ -137,12 +194,6 @@ resolve_dev_bundle_branch() {
     printf '%s\n' "$safe_branch"
 }
 
-branch_ref_exists() {
-    local branch="$1"
-    git -C "$CURRENT_REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch" ||
-        git -C "$CURRENT_REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/$branch"
-}
-
 cleanup_stale_dev_bundles() {
     local apps_dir
     apps_dir="$(dev_bundle_apps_dir)"
@@ -166,12 +217,12 @@ cleanup_stale_dev_bundles() {
         local is_stale=0
         local reason=""
 
-        if branch_is_checked_out_anywhere "$branch"; then
-            reason="branch '$branch' is checked out in a worktree"
+        if safe_branch_is_checked_out_anywhere "$safe_branch"; then
+            reason="bundle branch token '$safe_branch' is checked out in a worktree"
         elif [ -n "$sha" ] && git -C "$CURRENT_REPO_ROOT" merge-base --is-ancestor "$sha" origin/main 2>/dev/null; then
             is_stale=1
             reason="bundle SHA $sha is in origin/main"
-        elif ! branch_ref_exists "$branch"; then
+        elif ! safe_branch_ref_exists "$safe_branch"; then
             is_stale=1
             reason="branch '$branch' not found locally or upstream"
         else
@@ -224,7 +275,7 @@ if [ -n "$DIRTY_STATUS" ] && [ "$FORCE_DIRTY" -ne 1 ]; then
     exit 1
 fi
 
-if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then
+if [ "$DEV_BUNDLE_BUILD" -eq 0 ] && [ "$DRY_RUN" -eq 1 ]; then
     cleanup_stale_dev_bundles
 fi
 
@@ -360,6 +411,7 @@ if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then
             exit 1
         fi
     fi
+    cleanup_stale_dev_bundles
     rm -f "$SOCKET_PATH"
 else
     echo "[build-app] DEV worktree build: preserving canonical LaunchAgent and socket"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -116,15 +116,31 @@ resolve_dev_bundle_branch() {
     local safe_branch="$1"
     local ref
     while IFS= read -r ref; do
-        local branch="$ref"
-        branch="${branch#origin/}"
+        local branch
+        case "$ref" in
+            refs/heads/*)
+                branch="${ref#refs/heads/}"
+                ;;
+            refs/remotes/origin/*)
+                branch="${ref#refs/remotes/origin/}"
+                ;;
+            *)
+                continue
+                ;;
+        esac
         if [ "$(sanitize_branch_name "$branch")" = "$safe_branch" ]; then
             printf '%s\n' "$branch"
             return 0
         fi
-    done < <(git -C "$CURRENT_REPO_ROOT" for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin 2>/dev/null)
+    done < <(git -C "$CURRENT_REPO_ROOT" for-each-ref --format='%(refname)' refs/heads refs/remotes/origin 2>/dev/null)
 
     printf '%s\n' "$safe_branch"
+}
+
+branch_ref_exists() {
+    local branch="$1"
+    git -C "$CURRENT_REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch" ||
+        git -C "$CURRENT_REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/$branch"
 }
 
 cleanup_stale_dev_bundles() {
@@ -150,15 +166,14 @@ cleanup_stale_dev_bundles() {
         local is_stale=0
         local reason=""
 
-        if [ -n "$sha" ] && git -C "$CURRENT_REPO_ROOT" merge-base --is-ancestor "$sha" origin/main 2>/dev/null; then
+        if branch_is_checked_out_anywhere "$branch"; then
+            reason="branch '$branch' is checked out in a worktree"
+        elif [ -n "$sha" ] && git -C "$CURRENT_REPO_ROOT" merge-base --is-ancestor "$sha" origin/main 2>/dev/null; then
             is_stale=1
             reason="bundle SHA $sha is in origin/main"
-        elif ! git -C "$CURRENT_REPO_ROOT" rev-parse --verify "origin/$branch" >/dev/null 2>&1 &&
-             ! git -C "$CURRENT_REPO_ROOT" rev-parse --verify "$branch" >/dev/null 2>&1; then
+        elif ! branch_ref_exists "$branch"; then
             is_stale=1
             reason="branch '$branch' not found locally or upstream"
-        elif branch_is_checked_out_anywhere "$branch"; then
-            reason="branch '$branch' is checked out in a worktree"
         else
             local age_days
             age_days="$(dev_bundle_age_days "$bundle")"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -89,6 +89,106 @@ sanitize_branch_name() {
     printf '%s' "$1" | sed 's#[[:space:]/]#-#g; s/[^A-Za-z0-9._-]/-/g'
 }
 
+dev_bundle_apps_dir() {
+    local app_parent
+    app_parent="$(dirname "$APP_DIR")"
+    printf '%s\n' "$app_parent"
+}
+
+branch_is_checked_out_anywhere() {
+    local branch="$1"
+    git -C "$CURRENT_REPO_ROOT" worktree list --porcelain |
+        awk -v branch_ref="refs/heads/$branch" '
+            $1 == "branch" && $2 == branch_ref { found = 1 }
+            END { exit found ? 0 : 1 }
+        '
+}
+
+dev_bundle_age_days() {
+    local bundle="$1"
+    echo $(( ($(date +%s) - $(stat -f %m "$bundle")) / 86400 ))
+}
+
+read_bundle_git_commit() {
+    local bundle="$1"
+    "$PLIST_BUDDY" -c "Print :GitCommit" "$bundle/Contents/Info.plist" 2>/dev/null || true
+}
+
+resolve_dev_bundle_branch() {
+    local safe_branch="$1"
+    local ref
+    while IFS= read -r ref; do
+        local branch="$ref"
+        branch="${branch#origin/}"
+        if [ "$(sanitize_branch_name "$branch")" = "$safe_branch" ]; then
+            printf '%s\n' "$branch"
+            return 0
+        fi
+    done < <(git -C "$CURRENT_REPO_ROOT" for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin 2>/dev/null)
+
+    printf '%s\n' "$safe_branch"
+}
+
+cleanup_stale_dev_bundles() {
+    local apps_dir
+    apps_dir="$(dev_bundle_apps_dir)"
+    local stale_days="${BRAINBAR_DEV_STALE_DAYS:-14}"
+    local bundle
+    local found=0
+
+    for bundle in "$apps_dir"/BrainBar-DEV-*.app; do
+        [ -d "$bundle" ] || continue
+        found=1
+
+        local name
+        name="$(basename "$bundle")"
+        local safe_branch
+        safe_branch="${name#BrainBar-DEV-}"
+        safe_branch="${safe_branch%.app}"
+        local branch
+        branch="$(resolve_dev_bundle_branch "$safe_branch")"
+        local sha
+        sha="$(read_bundle_git_commit "$bundle")"
+        local is_stale=0
+        local reason=""
+
+        if [ -n "$sha" ] && git -C "$CURRENT_REPO_ROOT" merge-base --is-ancestor "$sha" origin/main 2>/dev/null; then
+            is_stale=1
+            reason="bundle SHA $sha is in origin/main"
+        elif ! git -C "$CURRENT_REPO_ROOT" rev-parse --verify "origin/$branch" >/dev/null 2>&1 &&
+             ! git -C "$CURRENT_REPO_ROOT" rev-parse --verify "$branch" >/dev/null 2>&1; then
+            is_stale=1
+            reason="branch '$branch' not found locally or upstream"
+        elif branch_is_checked_out_anywhere "$branch"; then
+            reason="branch '$branch' is checked out in a worktree"
+        else
+            local age_days
+            age_days="$(dev_bundle_age_days "$bundle")"
+            if [ "$age_days" -gt "$stale_days" ]; then
+                is_stale=1
+                reason="bundle age $age_days days exceeds threshold $stale_days"
+            else
+                reason="bundle age $age_days days is within threshold $stale_days"
+            fi
+        fi
+
+        if [ "$DRY_RUN" -eq 1 ]; then
+            if [ "$is_stale" -eq 1 ]; then
+                echo "[build-app] Dry run: would clean stale DEV bundle: $name ($reason)"
+            else
+                echo "[build-app] Keeping DEV bundle: $name ($reason)"
+            fi
+        elif [ "$is_stale" -eq 1 ]; then
+            echo "[build-app] Cleaning stale DEV bundle: $name ($reason)"
+            rm -rf "$bundle"
+        fi
+    done
+
+    if [ "$DRY_RUN" -eq 1 ] && [ "$found" -eq 0 ]; then
+        echo "[build-app] Dry run: no DEV bundles found under $apps_dir"
+    fi
+}
+
 if [ "$CURRENT_REPO_ROOT" != "$CANONICAL_REPO_ROOT" ] && [ "$FORCE_WORKTREE_BUILD" -ne 1 ]; then
     echo "[build-app] ERROR: refusing non-canonical build from $CURRENT_REPO_ROOT" >&2
     echo "[build-app] Re-run with --force-worktree-build to install a DEV bundle instead of ~/Applications/BrainBar.app" >&2
@@ -109,6 +209,10 @@ if [ -n "$DIRTY_STATUS" ] && [ "$FORCE_DIRTY" -ne 1 ]; then
     echo "[build-app] Re-run with --force-dirty once these changes are explicitly reviewed:" >&2
     printf '%s\n' "$DIRTY_STATUS" >&2
     exit 1
+fi
+
+if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then
+    cleanup_stale_dev_bundles
 fi
 
 if [ "$DRY_RUN" -eq 1 ]; then

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -212,9 +212,10 @@ fi
 exit 0
 """
     )
+    (tool_dir / "lsregister").write_text("#!/usr/bin/env bash\nexit 0\n")
     (tool_dir / "pgrep").write_text("#!/usr/bin/env bash\nexit 1\n")
     (tool_dir / "killall").write_text("#!/usr/bin/env bash\nexit 0\n")
-    for tool in ("swift", "codesign", "plistbuddy", "launchctl", "pgrep", "killall"):
+    for tool in ("swift", "codesign", "plistbuddy", "launchctl", "lsregister", "pgrep", "killall"):
         os.chmod(tool_dir / tool, 0o755)
     return tool_dir, bin_dir
 
@@ -273,6 +274,7 @@ def test_canonical_build_removes_only_stale_dev_bundles(tmp_path: Path) -> None:
             "BRAINBAR_CODESIGN_IDENTITY": "Test Identity",
             "BRAINBAR_DEV_STALE_DAYS": "1",
             "BRAINBAR_FAKE_BIN_DIR": str(bin_dir),
+            "BRAINBAR_LSREGISTER": str(tool_dir / "lsregister"),
             "BRAINBAR_PLIST_BUDDY": str(tool_dir / "plistbuddy"),
             "BRAINBAR_SOCKET_PATH": f"/tmp/brainbar-test-{os.getpid()}.sock",
             "BRAINBAR_SOCKET_WAIT_ATTEMPTS": "1",
@@ -463,6 +465,30 @@ exit 1
     )
 
     assert result.returncode == 0, result.stderr
+    assert "would clean stale DEV bundle: BrainBar-DEV-feat-old-dev.app" in result.stdout
+    assert bundle.exists()
+
+
+def test_canonical_dev_cleanup_invalid_stale_days_falls_back_to_default(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    _git(repo, "branch", "feat/old-dev")
+    bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-old-dev.app")
+    old_mtime = 0
+    os.utime(bundle, (old_mtime, old_mtime))
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={"BRAINBAR_DEV_STALE_DAYS": "not-a-number"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "invalid BRAINBAR_DEV_STALE_DAYS='not-a-number', using 14" in result.stderr
     assert "would clean stale DEV bundle: BrainBar-DEV-feat-old-dev.app" in result.stdout
     assert bundle.exists()
 

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -409,6 +409,35 @@ def test_canonical_dev_cleanup_preserves_detached_worktree_bundle(tmp_path: Path
     assert bundle.exists()
 
 
+def test_canonical_dev_cleanup_preserves_branch_bundle_for_detached_worktree_head(
+    tmp_path: Path,
+) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    remote = tmp_path / "origin.git"
+    _git(remote.parent, "init", "--bare", remote.name)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    main_sha = _git_stdout(repo, "rev-parse", "HEAD")
+    _git(repo, "branch", "feat/detached-active")
+    worktree = tmp_path / "detached-active-worktree"
+    _git(repo, "worktree", "add", "--detach", str(worktree), "HEAD")
+    bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-detached-active.app", main_sha)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Keeping DEV bundle: BrainBar-DEV-feat-detached-active.app" in result.stdout
+    assert bundle.exists()
+
+
 def test_canonical_dev_cleanup_preserves_checked_out_sanitized_branch_collision(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -172,6 +172,21 @@ fi
 exit 0
 """
     )
+    (tool_dir / "plistbuddy").write_text(
+        """#!/usr/bin/env bash
+if [[ "$2" == "Print :GitCommit" && -f "$3" ]]; then
+  awk '
+    found { gsub(/^[[:space:]]*<string>|<\\/string>[[:space:]]*$/, ""); print; exit }
+    /<key>GitCommit<\\/key>/ { found=1 }
+  ' "$3"
+  exit 0
+fi
+if [[ "$2" == Print* ]]; then
+  exit 1
+fi
+exit 0
+"""
+    )
     (tool_dir / "launchctl").write_text(
         """#!/usr/bin/env bash
 if [[ "$1" == "kickstart" && -n "${BRAINBAR_SOCKET_PATH:-}" && ! -S "$BRAINBAR_SOCKET_PATH" ]]; then
@@ -199,7 +214,7 @@ exit 0
     )
     (tool_dir / "pgrep").write_text("#!/usr/bin/env bash\nexit 1\n")
     (tool_dir / "killall").write_text("#!/usr/bin/env bash\nexit 0\n")
-    for tool in ("swift", "codesign", "launchctl", "pgrep", "killall"):
+    for tool in ("swift", "codesign", "plistbuddy", "launchctl", "pgrep", "killall"):
         os.chmod(tool_dir / tool, 0o755)
     return tool_dir, bin_dir
 
@@ -258,6 +273,7 @@ def test_canonical_build_removes_only_stale_dev_bundles(tmp_path: Path) -> None:
             "BRAINBAR_CODESIGN_IDENTITY": "Test Identity",
             "BRAINBAR_DEV_STALE_DAYS": "1",
             "BRAINBAR_FAKE_BIN_DIR": str(bin_dir),
+            "BRAINBAR_PLIST_BUDDY": str(tool_dir / "plistbuddy"),
             "BRAINBAR_SOCKET_PATH": f"/tmp/brainbar-test-{os.getpid()}.sock",
             "BRAINBAR_SOCKET_WAIT_ATTEMPTS": "1",
             "PATH": f"{tool_dir}{os.pathsep}{os.environ['PATH']}",

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -190,12 +190,15 @@ exit 0
     (tool_dir / "launchctl").write_text(
         """#!/usr/bin/env bash
 if [[ "$1" == "kickstart" && -n "${BRAINBAR_SOCKET_PATH:-}" && ! -S "$BRAINBAR_SOCKET_PATH" ]]; then
-  python3 - "$BRAINBAR_SOCKET_PATH" <<'PY' >/dev/null 2>&1 &
+  ready_file="${BRAINBAR_SOCKET_PATH}.ready"
+  rm -f "$ready_file"
+  python3 - "$BRAINBAR_SOCKET_PATH" "$ready_file" <<'PY' >/dev/null 2>&1 &
 import os
 import socket
 import sys
 
 path = sys.argv[1]
+ready_file = sys.argv[2]
 try:
     os.unlink(path)
 except FileNotFoundError:
@@ -203,10 +206,17 @@ except FileNotFoundError:
 server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 server.bind(path)
 server.listen(1)
+with open(ready_file, "w"):
+    pass
 conn, _ = server.accept()
 conn.close()
 server.close()
 PY
+  for _ in {1..50}; do
+    [[ -S "$BRAINBAR_SOCKET_PATH" ]] && break
+    sleep 0.02
+  done
+  rm -f "$ready_file"
   disown
 fi
 exit 0

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -359,6 +359,58 @@ def test_canonical_dev_cleanup_preserves_local_branch_named_origin_prefix(tmp_pa
     assert bundle.exists()
 
 
+def test_canonical_dev_cleanup_preserves_detached_worktree_bundle(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    detached_sha = _git_stdout(repo, "rev-parse", "--short", "HEAD")
+    worktree = tmp_path / "detached-worktree"
+    _git(repo, "worktree", "add", "--detach", str(worktree), "HEAD")
+    bundle = _create_fake_bundle(apps_dir, f"BrainBar-DEV-detached-{detached_sha}.app")
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"Keeping DEV bundle: BrainBar-DEV-detached-{detached_sha}.app" in result.stdout
+    assert bundle.exists()
+
+
+def test_canonical_dev_cleanup_preserves_checked_out_sanitized_branch_collision(
+    tmp_path: Path,
+) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    remote = tmp_path / "origin.git"
+    _git(remote.parent, "init", "--bare", remote.name)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    main_sha = _git_stdout(repo, "rev-parse", "HEAD")
+    _git(repo, "branch", "feat-z-collision")
+    _git(repo, "branch", "feat/z/collision")
+    worktree = tmp_path / "collision-worktree"
+    _git(repo, "worktree", "add", str(worktree), "feat/z/collision")
+    bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-z-collision.app", main_sha)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Keeping DEV bundle: BrainBar-DEV-feat-z-collision.app" in result.stdout
+    assert bundle.exists()
+
+
 def test_build_app_helpers_ignore_parent_git_hook_env(tmp_path: Path, monkeypatch) -> None:
     parent_repo = tmp_path / "parent"
     _init_repo(parent_repo)

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -411,6 +411,46 @@ def test_canonical_dev_cleanup_preserves_checked_out_sanitized_branch_collision(
     assert bundle.exists()
 
 
+def test_canonical_dev_cleanup_reads_gnu_stat_mtime(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    _git(repo, "branch", "feat/old-dev")
+    bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-old-dev.app")
+    fake_stat_dir = tmp_path / "fake-gnu-stat"
+    fake_stat_dir.mkdir()
+    (fake_stat_dir / "stat").write_text(
+        """#!/usr/bin/env bash
+if [[ "$1" == "-c" && "$2" == "%Y" ]]; then
+  printf '0\n'
+  exit 0
+fi
+if [[ "$1" == "-f" ]]; then
+  printf '  File: "%s"\n' "$3"
+  exit 0
+fi
+exit 1
+"""
+    )
+    os.chmod(fake_stat_dir / "stat", 0o755)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            "BRAINBAR_DEV_STALE_DAYS": "1",
+            "PATH": f"{fake_stat_dir}{os.pathsep}{os.environ['PATH']}",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "would clean stale DEV bundle: BrainBar-DEV-feat-old-dev.app" in result.stdout
+    assert bundle.exists()
+
+
 def test_build_app_helpers_ignore_parent_git_hook_env(tmp_path: Path, monkeypatch) -> None:
     parent_repo = tmp_path / "parent"
     _init_repo(parent_repo)

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -73,6 +73,7 @@ def _run_build_script(
     *,
     canonical_root: Path,
     home: Path,
+    dry_run: bool = True,
     extra_args: list[str] | None = None,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
@@ -82,7 +83,9 @@ def _run_build_script(
     env["BRAINBAR_CANONICAL_REPO_ROOT"] = str(canonical_root)
     if extra_env:
         env.update(extra_env)
-    cmd = ["bash", str(script), "--dry-run"]
+    cmd = ["bash", str(script)]
+    if dry_run:
+        cmd.append("--dry-run")
     if extra_args:
         cmd.extend(extra_args)
     return subprocess.run(
@@ -92,6 +95,113 @@ def _run_build_script(
         text=True,
         env=env,
     )
+
+
+def _create_fake_bundle(apps_dir: Path, name: str, git_commit: str | None = None) -> Path:
+    bundle = apps_dir / name
+    contents = bundle / "Contents"
+    contents.mkdir(parents=True, exist_ok=True)
+    git_commit_xml = ""
+    if git_commit is not None:
+        git_commit_xml = f"""
+    <key>GitCommit</key>
+    <string>{git_commit}</string>"""
+    (contents / "Info.plist").write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>{git_commit_xml}
+</dict>
+</plist>
+"""
+    )
+    return bundle
+
+
+def _prepare_bundle_inputs(repo: Path) -> None:
+    bundle_dir = repo / "brain-bar" / "bundle"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "Info.plist").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>
+"""
+    )
+    for label in ("com.brainlayer.brainbar", "com.brainlayer.brainbar-daemon"):
+        (bundle_dir / f"{label}.plist").write_text(
+            """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>
+"""
+        )
+    _git(repo, "add", "brain-bar/bundle")
+    _commit(repo, "test: add bundle inputs")
+
+
+def _prepare_fake_build_tools(tmp_path: Path) -> tuple[Path, Path]:
+    tool_dir = tmp_path / "fake-tools"
+    bin_dir = tmp_path / "fake-swift-bin"
+    tool_dir.mkdir()
+    bin_dir.mkdir()
+    (bin_dir / "BrainBar").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (bin_dir / "BrainBarDaemon").write_text("#!/usr/bin/env bash\nexit 0\n")
+    os.chmod(bin_dir / "BrainBar", 0o755)
+    os.chmod(bin_dir / "BrainBarDaemon", 0o755)
+    (tool_dir / "swift").write_text(
+        """#!/usr/bin/env bash
+if [[ "$*" == *"--show-bin-path"* ]]; then
+  printf '%s\n' "$BRAINBAR_FAKE_BIN_DIR"
+fi
+exit 0
+"""
+    )
+    (tool_dir / "codesign").write_text(
+        """#!/usr/bin/env bash
+if [[ "$*" == *"-dv"* ]]; then
+  printf 'Authority=%s\n' "$BRAINBAR_CODESIGN_IDENTITY"
+fi
+exit 0
+"""
+    )
+    (tool_dir / "launchctl").write_text(
+        """#!/usr/bin/env bash
+if [[ "$1" == "kickstart" && -n "${BRAINBAR_SOCKET_PATH:-}" && ! -S "$BRAINBAR_SOCKET_PATH" ]]; then
+  python3 - "$BRAINBAR_SOCKET_PATH" <<'PY' >/dev/null 2>&1 &
+import os
+import socket
+import sys
+
+path = sys.argv[1]
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(path)
+server.listen(1)
+conn, _ = server.accept()
+conn.close()
+server.close()
+PY
+  disown
+fi
+exit 0
+"""
+    )
+    (tool_dir / "pgrep").write_text("#!/usr/bin/env bash\nexit 1\n")
+    (tool_dir / "killall").write_text("#!/usr/bin/env bash\nexit 0\n")
+    for tool in ("swift", "codesign", "launchctl", "pgrep", "killall"):
+        os.chmod(tool_dir / tool, 0o755)
+    return tool_dir, bin_dir
 
 
 def test_build_app_allows_clean_canonical_repo_in_dry_run(tmp_path: Path) -> None:
@@ -110,6 +220,85 @@ def test_build_app_allows_clean_canonical_repo_in_dry_run(tmp_path: Path) -> Non
     assert str(home / "Applications" / "BrainBar.app") in result.stdout
     assert "UI LaunchAgent: canonical install" in result.stdout
     assert "Daemon LaunchAgent: canonical install" in result.stdout
+
+
+def test_canonical_build_removes_only_stale_dev_bundles(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    remote = tmp_path / "origin.git"
+    _git(remote.parent, "init", "--bare", remote.name)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    main_sha = _git_stdout(repo, "rev-parse", "HEAD")
+    _git(repo, "branch", "feat/active-dev")
+    worktree = tmp_path / "active-worktree"
+    _git(repo, "worktree", "add", str(worktree), "feat/active-dev")
+
+    merged_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-merged.app", main_sha)
+    missing_branch_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-missing.app")
+    active_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-active-dev.app")
+    _prepare_bundle_inputs(repo)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        dry_run=False,
+        extra_env={
+            "BRAINBAR_CODESIGN_IDENTITY": "Test Identity",
+            "BRAINBAR_FAKE_BIN_DIR": str(bin_dir),
+            "BRAINBAR_SOCKET_PATH": f"/tmp/brainbar-test-{os.getpid()}.sock",
+            "BRAINBAR_SOCKET_WAIT_ATTEMPTS": "1",
+            "PATH": f"{tool_dir}{os.pathsep}{os.environ['PATH']}",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Cleaning stale DEV bundle: BrainBar-DEV-feat-merged.app" in result.stdout
+    assert "Cleaning stale DEV bundle: BrainBar-DEV-feat-missing.app" in result.stdout
+    assert not merged_bundle.exists()
+    assert not missing_branch_bundle.exists()
+    assert active_bundle.exists()
+
+
+def test_canonical_dry_run_lists_dev_bundle_cleanup_without_removing(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    remote = tmp_path / "origin.git"
+    _git(remote.parent, "init", "--bare", remote.name)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    main_sha = _git_stdout(repo, "rev-parse", "HEAD")
+    _git(repo, "branch", "feat/active-dev")
+    worktree = tmp_path / "active-worktree"
+    _git(repo, "worktree", "add", str(worktree), "feat/active-dev")
+
+    bundles = [
+        _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-merged.app", main_sha),
+        _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-missing.app"),
+        _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-active-dev.app"),
+    ]
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    for bundle in bundles:
+        assert bundle.name in result.stdout
+        assert bundle.exists()
+    assert "would clean stale DEV bundle" in result.stdout
+    assert "Keeping DEV bundle: BrainBar-DEV-feat-active-dev.app" in result.stdout
 
 
 def test_build_app_helpers_ignore_parent_git_hook_env(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -301,6 +301,34 @@ def test_canonical_dry_run_lists_dev_bundle_cleanup_without_removing(tmp_path: P
     assert "Keeping DEV bundle: BrainBar-DEV-feat-active-dev.app" in result.stdout
 
 
+def test_canonical_dev_cleanup_scans_home_applications_when_app_dir_is_overridden(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    custom_app_dir = tmp_path / "custom" / "BrainBar-Custom.app"
+    remote = tmp_path / "origin.git"
+    _git(remote.parent, "init", "--bare", remote.name)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    main_sha = _git_stdout(repo, "rev-parse", "HEAD")
+    bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-merged.app", main_sha)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={"BRAINBAR_APP_DIR": str(custom_app_dir)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert str(custom_app_dir) in result.stdout
+    assert bundle.name in result.stdout
+    assert "would clean stale DEV bundle" in result.stdout
+    assert bundle.exists()
+
+
 def test_build_app_helpers_ignore_parent_git_hook_env(tmp_path: Path, monkeypatch) -> None:
     parent_repo = tmp_path / "parent"
     _init_repo(parent_repo)

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -234,12 +234,17 @@ def test_canonical_build_removes_only_stale_dev_bundles(tmp_path: Path) -> None:
     _git(repo, "push", "-u", "origin", "main")
     main_sha = _git_stdout(repo, "rev-parse", "HEAD")
     _git(repo, "branch", "feat/active-dev")
+    _git(repo, "branch", "feat/old-dev")
+    _git(repo, "tag", "feat-missing")
     worktree = tmp_path / "active-worktree"
     _git(repo, "worktree", "add", str(worktree), "feat/active-dev")
 
     merged_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-merged.app", main_sha)
     missing_branch_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-missing.app")
-    active_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-active-dev.app")
+    active_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-active-dev.app", main_sha)
+    old_age_bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-feat-old-dev.app")
+    old_mtime = 0
+    os.utime(old_age_bundle, (old_mtime, old_mtime))
     _prepare_bundle_inputs(repo)
     tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
 
@@ -251,6 +256,7 @@ def test_canonical_build_removes_only_stale_dev_bundles(tmp_path: Path) -> None:
         dry_run=False,
         extra_env={
             "BRAINBAR_CODESIGN_IDENTITY": "Test Identity",
+            "BRAINBAR_DEV_STALE_DAYS": "1",
             "BRAINBAR_FAKE_BIN_DIR": str(bin_dir),
             "BRAINBAR_SOCKET_PATH": f"/tmp/brainbar-test-{os.getpid()}.sock",
             "BRAINBAR_SOCKET_WAIT_ATTEMPTS": "1",
@@ -261,8 +267,10 @@ def test_canonical_build_removes_only_stale_dev_bundles(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "Cleaning stale DEV bundle: BrainBar-DEV-feat-merged.app" in result.stdout
     assert "Cleaning stale DEV bundle: BrainBar-DEV-feat-missing.app" in result.stdout
+    assert "Cleaning stale DEV bundle: BrainBar-DEV-feat-old-dev.app" in result.stdout
     assert not merged_bundle.exists()
     assert not missing_branch_bundle.exists()
+    assert not old_age_bundle.exists()
     assert active_bundle.exists()
 
 
@@ -295,9 +303,9 @@ def test_canonical_dry_run_lists_dev_bundle_cleanup_without_removing(tmp_path: P
 
     assert result.returncode == 0, result.stderr
     for bundle in bundles:
-        assert bundle.name in result.stdout
         assert bundle.exists()
-    assert "would clean stale DEV bundle" in result.stdout
+    assert "would clean stale DEV bundle: BrainBar-DEV-feat-merged.app" in result.stdout
+    assert "would clean stale DEV bundle: BrainBar-DEV-feat-missing.app" in result.stdout
     assert "Keeping DEV bundle: BrainBar-DEV-feat-active-dev.app" in result.stdout
 
 
@@ -326,6 +334,28 @@ def test_canonical_dev_cleanup_scans_home_applications_when_app_dir_is_overridde
     assert str(custom_app_dir) in result.stdout
     assert bundle.name in result.stdout
     assert "would clean stale DEV bundle" in result.stdout
+    assert bundle.exists()
+
+
+def test_canonical_dev_cleanup_preserves_local_branch_named_origin_prefix(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    apps_dir = home / "Applications"
+    apps_dir.mkdir(parents=True)
+    _git(repo, "branch", "origin/active-dev")
+    worktree = tmp_path / "origin-active-worktree"
+    _git(repo, "worktree", "add", str(worktree), "origin/active-dev")
+    bundle = _create_fake_bundle(apps_dir, "BrainBar-DEV-origin-active-dev.app")
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Keeping DEV bundle: BrainBar-DEV-origin-active-dev.app" in result.stdout
     assert bundle.exists()
 
 


### PR DESCRIPTION
## Summary
- Auto-clean stale `BrainBar-DEV-*.app` bundles at the start of canonical BrainBar builds, addressing Etan's 2026-05-25 flag about the orphan May 21 DEV bundle left after PR #307 merged.
- Treat a DEV bundle as stale when its stamped `GitCommit` is reachable from `origin/main`, when its branch no longer exists locally or on `origin`, or when it is older than `BRAINBAR_DEV_STALE_DAYS` and not checked out in any worktree.
- Keep DEV worktree builds isolated: cleanup only runs for canonical builds, and checked-out DEV branches are preserved.
- Extend `--dry-run` so it reports which DEV bundles would be cleaned or kept without removing anything.

## Test plan
- [x] TDD red: new BrainBar build guard tests failed before implementation because stale DEV cleanup was absent.
- [x] `pytest tests/test_brainbar_build_app_guards.py -q`
- [x] `pytest`
- [x] `bash -n brain-bar/build-app.sh`
- [x] `git diff --check`
- [x] pre-push BrainLayer test gate: pytest unit suite, MCP registration, isolated eval/hook routing, Bun test, FTS5 regression

Co-Authored-By: OpenAI Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes directories under ~/Applications during canonical builds; logic is git/worktree-dependent but preserves checked-out and in-use bundles, with dry-run to preview changes.
> 
> **Overview**
> Canonical **BrainBar** builds now **prune stale `BrainBar-DEV-*.app` bundles** under `$HOME/Applications` before install (and report candidates under `--dry-run`), so orphaned worktree apps do not accumulate after merges.
> 
> **`cleanup_stale_dev_bundles`** in `build-app.sh` removes a DEV bundle when its branch is **not** checked out in any worktree and it is **merged into `origin/main`**, its branch is **missing** locally/upstream, or it is **older than `BRAINBAR_DEV_STALE_DAYS`** (default 14). Bundles tied to active/detached worktrees, sanitized branch-name collisions, and similar “still in use” cases are **kept**. **`PlistBuddy`** and **`lsregister`** paths are overridable via **`BRAINBAR_PLIST_BUDDY`** / **`BRAINBAR_LSREGISTER`**. DEV worktree builds still skip this cleanup.
> 
> **`test_brainbar_build_app_guards.py`** adds integration coverage for real deletion vs dry-run, `BRAINBAR_APP_DIR` override (cleanup still scans `~/Applications`), and edge cases (detached HEAD, `origin/`-prefixed branch names, invalid stale-days).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cdc0a64cdda31147c12a10d2c7075d6bd22b684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-clean stale BrainBar DEV bundles on canonical builds
> - Adds `cleanup_stale_dev_bundles` to [brain-bar/build-app.sh](https://github.com/EtanHey/brainlayer/pull/328/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb), which scans `$HOME/Applications` for `BrainBar-DEV-*.app` bundles and removes ones deemed stale.
> - A bundle is stale if its `GitCommit` is an ancestor of `origin/main`, its branch no longer exists locally or on origin, or its age exceeds `BRAINBAR_DEV_STALE_DAYS` (default 14 days). Bundles tied to an active worktree or checked-out branch are preserved.
> - Cleanup runs automatically on canonical (non-DEV) builds after stopping LaunchAgents; dry-run mode reports intended actions without deleting.
> - Makes `PlistBuddy` and `lsregister` paths configurable via `BRAINBAR_PLIST_BUDDY` and an `LSREGISTER` variable instead of hardcoded paths.
> - Adds integration tests covering stale/active bundle detection, detached HEAD worktrees, sanitized branch collisions, GNU/BSD stat fallback, and invalid `BRAINBAR_DEV_STALE_DAYS` handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cdc0a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build script now prunes stale development app bundles during canonical builds, reporting candidates in dry-run mode and deleting stale bundles in normal mode. Staleness considers checkout state, branch/commit relationships and bundle age (default 14 days); active or referenced bundles are preserved. App search directory can be overridden.
  * Build script accepts configurable paths for PlistBuddy and lsregister and uses the configurable lsregister for URL-scheme registration.

* **Tests**
  * Added tests covering deletion, dry-run reporting, app-dir override, detached worktrees, branch-name collisions, mtime probing, and stale-days fallback; test harness supports dry-run flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->