### PR TITLE
feat(mcp): warm-route brain_search through brainbar-hybrid-helper socket

### DIFF
--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -187,6 +187,7 @@ class HybridSearchHelper:
             "importance_min": arguments.get("importance_min"),
             "num_results": int(arguments.get("num_results") or 5),
             "detail": str(arguments.get("detail") or "compact"),
+            "allow_helper_route": False,
         }
         if search_profile.enabled() or query_id is not None:
             search_kwargs["profile_query_id"] = query_id

--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -163,13 +163,16 @@ class HybridSearchHelper:
         if not isinstance(arguments, dict):
             raise ValueError("arguments must be an object")
 
-        text, structured = asyncio.run(self._search(arguments))
+        text, structured, is_error = asyncio.run(self._search(arguments))
         metadata: dict[str, Any] = {}
         if structured is not None:
             metadata["structuredContent"] = structured
-        return {"ok": True, "text": text, "metadata": metadata}
+        response: dict[str, Any] = {"ok": True, "text": text, "metadata": metadata}
+        if is_error:
+            response["isError"] = True
+        return response
 
-    async def _search(self, arguments: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+    async def _search(self, arguments: dict[str, Any]) -> tuple[str, dict[str, Any] | None, bool]:
         from brainlayer.mcp.search_handler import _brain_search
 
         query_id = str(arguments.get("_profile_query_id") or "") or None
@@ -186,6 +189,7 @@ class HybridSearchHelper:
             "tag": arguments.get("tag"),
             "importance_min": arguments.get("importance_min"),
             "num_results": int(arguments.get("num_results") or 5),
+            "max_results": int(arguments.get("max_results") or 10),
             "detail": str(arguments.get("detail") or "compact"),
             "allow_helper_route": False,
         }
@@ -197,10 +201,10 @@ class HybridSearchHelper:
 
         if isinstance(result, tuple):
             content, structured = result
-            return self._content_text(content), structured if isinstance(structured, dict) else None
+            return self._content_text(content), structured if isinstance(structured, dict) else None, False
         if hasattr(result, "content"):
-            return self._content_text(result.content), None
-        return self._content_text(result), None
+            return self._content_text(result.content), None, bool(getattr(result, "isError", False))
+        return self._content_text(result), None, False
 
     @staticmethod
     def _content_text(content: Any) -> str:

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -606,20 +606,24 @@ async def _brain_search(
         profile_query_id = search_profile.new_query_id()
     profile_started = search_profile.now()
     try:
-        if allow_helper_route and _helper_route_enabled() and _should_try_helper_route(
-            query,
-            file_path=file_path,
-            chunk_id=chunk_id,
-            content_type=content_type,
-            intent=intent,
-            date_from=date_from,
-            date_to=date_to,
-            sentiment=sentiment,
-            entity_id=entity_id,
-            source_filter=source_filter,
-            correction_category=correction_category,
-            include_checkpoints=include_checkpoints,
-            include_audit=include_audit,
+        if (
+            allow_helper_route
+            and _helper_route_enabled()
+            and _should_try_helper_route(
+                query,
+                file_path=file_path,
+                chunk_id=chunk_id,
+                content_type=content_type,
+                intent=intent,
+                date_from=date_from,
+                date_to=date_to,
+                sentiment=sentiment,
+                entity_id=entity_id,
+                source_filter=source_filter,
+                correction_category=correction_category,
+                include_checkpoints=include_checkpoints,
+                include_audit=include_audit,
+            )
         ):
             for sock_path in _warm_helper_socket_candidates():
                 helper_started = time.perf_counter()

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -63,16 +63,19 @@ def _helper_route_enabled() -> bool:
     return os.environ.get("BRAINLAYER_MCP_USE_HELPER") == "1" or _helper_sentinel_path().exists()
 
 
-def _find_warm_helper_socket() -> str | None:
+def _warm_helper_socket_candidates() -> list[str]:
     candidates: list[tuple[float, str]] = []
     for path in glob.glob(_HELPER_SOCKET_GLOB):
         try:
             candidates.append((os.path.getmtime(path), path))
         except OSError:
             continue
-    if not candidates:
-        return None
-    return max(candidates)[1]
+    return [path for _mtime, path in sorted(candidates, reverse=True)]
+
+
+def _find_warm_helper_socket() -> str | None:
+    candidates = _warm_helper_socket_candidates()
+    return candidates[0] if candidates else None
 
 
 def _forward_to_helper(sock_path: str, query: str, **kwargs) -> dict[str, Any]:
@@ -618,8 +621,7 @@ async def _brain_search(
             include_checkpoints=include_checkpoints,
             include_audit=include_audit,
         ):
-            sock_path = _find_warm_helper_socket()
-            if sock_path:
+            for sock_path in _warm_helper_socket_candidates():
                 helper_started = time.perf_counter()
                 try:
                     helper_project = _resolve_helper_project(project, entity_id=entity_id, source=source)
@@ -642,7 +644,7 @@ async def _brain_search(
                     latency_ms = (time.perf_counter() - helper_started) * 1000
                     return _helper_response_to_search_result(response, latency_ms)
                 except Exception as exc:
-                    logger.debug("Warm helper route failed; falling back to cold path: %s", exc)
+                    logger.debug("Warm helper route failed for %s: %s", sock_path, exc)
         return await _brain_search_dispatch(
             query=query,
             project=project,

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -132,9 +132,23 @@ def _should_try_helper_route(
     return True
 
 
+def _resolve_helper_project(project: str | None, *, entity_id: str | None, source: str | None) -> str | None:
+    if project is not None or entity_id is not None or source in ("youtube", "whatsapp", "telegram", "all"):
+        return project
+    try:
+        from ..scoping import resolve_project_scope
+
+        return resolve_project_scope()
+    except Exception:
+        logger.debug("Project auto-scope failed for warm helper route, proceeding without scope")
+        return project
+
+
 def _helper_response_to_search_result(response: dict[str, Any], latency_ms: float):
     if not response.get("ok"):
         raise RuntimeError(str(response.get("error") or "helper returned ok=false"))
+    if response.get("isError"):
+        return _error_result(str(response.get("text") or "Helper search failed"))
     metadata = response.get("metadata") if isinstance(response.get("metadata"), dict) else {}
     structured = metadata.get("structuredContent") if isinstance(metadata.get("structuredContent"), dict) else {}
     structured = dict(structured)
@@ -608,17 +622,19 @@ async def _brain_search(
             if sock_path:
                 helper_started = time.perf_counter()
                 try:
+                    helper_project = _resolve_helper_project(project, entity_id=entity_id, source=source)
                     loop = asyncio.get_running_loop()
                     response = await loop.run_in_executor(
                         None,
                         lambda: _forward_to_helper(
                             sock_path,
                             query,
-                            project=project,
+                            project=helper_project,
                             source=source,
                             tag=tag,
                             importance_min=importance_min,
                             num_results=num_results,
+                            max_results=max_results,
                             detail=detail,
                             _profile_query_id=profile_query_id,
                         ),

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -1,11 +1,15 @@
 """Search and recall MCP handlers."""
 
 import asyncio
+import glob
 import json
 import os
 import platform
 import re
+import socket
+import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 import apsw
@@ -23,6 +27,8 @@ _retry_delay = 0.1  # base delay in seconds (exposed for test patching)
 _VALID_SEARCH_DETAILS = frozenset({"compact", "full"})
 _MAX_PUBLIC_NUM_RESULTS = 100
 _MIN_PUBLIC_NUM_RESULTS = 1
+_HELPER_SOCKET_GLOB = "/tmp/brainbar-hybrid-*.sock"
+_HELPER_SOCKET_TIMEOUT_SECONDS = 2.0
 
 from ._format import format_kg_search, format_recalled_context, format_search_results, format_stats
 from ._shared import (
@@ -47,6 +53,95 @@ from ._shared import (
 def _get_vector_store():
     """Compatibility hook for tests; search handlers use the readonly store by default."""
     return _get_search_vector_store()
+
+
+def _helper_sentinel_path() -> Path:
+    return Path("~/.local/share/brainlayer/use-helper-socket").expanduser()
+
+
+def _helper_route_enabled() -> bool:
+    return os.environ.get("BRAINLAYER_MCP_USE_HELPER") == "1" or _helper_sentinel_path().exists()
+
+
+def _find_warm_helper_socket() -> str | None:
+    candidates: list[tuple[float, str]] = []
+    for path in glob.glob(_HELPER_SOCKET_GLOB):
+        try:
+            candidates.append((os.path.getmtime(path), path))
+        except OSError:
+            continue
+    if not candidates:
+        return None
+    return max(candidates)[1]
+
+
+def _forward_to_helper(sock_path: str, query: str, **kwargs) -> dict[str, Any]:
+    arguments = {"query": query, **{key: value for key, value in kwargs.items() if value is not None}}
+    request = {"method": "brain_search", "arguments": arguments}
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(_HELPER_SOCKET_TIMEOUT_SECONDS)
+        client.connect(sock_path)
+        client.sendall(json.dumps(request).encode("utf-8") + b"\n")
+        buffer = b""
+        while b"\n" not in buffer:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            buffer += chunk
+    if not buffer:
+        raise ValueError("empty helper response")
+    return json.loads(buffer.split(b"\n", 1)[0].decode("utf-8"))
+
+
+def _should_try_helper_route(
+    query: str,
+    *,
+    file_path: str | None,
+    chunk_id: str | None,
+    content_type: str | None,
+    intent: str | None,
+    date_from: str | None,
+    date_to: str | None,
+    sentiment: str | None,
+    entity_id: str | None,
+    source_filter: str | None,
+    correction_category: str | None,
+    include_checkpoints: bool,
+    include_audit: bool,
+) -> bool:
+    if any(
+        value is not None
+        for value in (
+            file_path,
+            chunk_id,
+            content_type,
+            intent,
+            date_from,
+            date_to,
+            sentiment,
+            entity_id,
+            source_filter,
+            correction_category,
+        )
+    ):
+        return False
+    if include_checkpoints or include_audit:
+        return False
+    if _extract_file_path(query):
+        return False
+    return True
+
+
+def _helper_response_to_search_result(response: dict[str, Any], latency_ms: float):
+    if not response.get("ok"):
+        raise RuntimeError(str(response.get("error") or "helper returned ok=false"))
+    metadata = response.get("metadata") if isinstance(response.get("metadata"), dict) else {}
+    structured = metadata.get("structuredContent") if isinstance(metadata.get("structuredContent"), dict) else {}
+    structured = dict(structured)
+    structured["via_helper"] = True
+    structured["helper_latency_ms"] = round(latency_ms, 3)
+    text = str(response.get("text") or "")
+    return ([TextContent(type="text", text=text)], structured)
 
 
 _CHUNK_ID_QUERY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:-[A-Za-z0-9_]+)+$")
@@ -487,12 +582,51 @@ async def _brain_search(
     include_audit: bool = False,
     profile_query_id: str | None = None,
     profile_scope: str = "search.mcp",
+    allow_helper_route: bool = True,
 ):
     """Unified search dispatcher -- routes to the right internal handler."""
     if search_profile.enabled() and profile_query_id is None:
         profile_query_id = search_profile.new_query_id()
     profile_started = search_profile.now()
     try:
+        if allow_helper_route and _helper_route_enabled() and _should_try_helper_route(
+            query,
+            file_path=file_path,
+            chunk_id=chunk_id,
+            content_type=content_type,
+            intent=intent,
+            date_from=date_from,
+            date_to=date_to,
+            sentiment=sentiment,
+            entity_id=entity_id,
+            source_filter=source_filter,
+            correction_category=correction_category,
+            include_checkpoints=include_checkpoints,
+            include_audit=include_audit,
+        ):
+            sock_path = _find_warm_helper_socket()
+            if sock_path:
+                helper_started = time.perf_counter()
+                try:
+                    loop = asyncio.get_running_loop()
+                    response = await loop.run_in_executor(
+                        None,
+                        lambda: _forward_to_helper(
+                            sock_path,
+                            query,
+                            project=project,
+                            source=source,
+                            tag=tag,
+                            importance_min=importance_min,
+                            num_results=num_results,
+                            detail=detail,
+                            _profile_query_id=profile_query_id,
+                        ),
+                    )
+                    latency_ms = (time.perf_counter() - helper_started) * 1000
+                    return _helper_response_to_search_result(response, latency_ms)
+                except Exception as exc:
+                    logger.debug("Warm helper route failed; falling back to cold path: %s", exc)
         return await _brain_search_dispatch(
             query=query,
             project=project,

--- a/tests/test_brainbar_hybrid_helper.py
+++ b/tests/test_brainbar_hybrid_helper.py
@@ -110,6 +110,7 @@ def test_helper_routes_brain_search_to_python_mcp_with_source_all_default(monkey
             "importance_min": 8,
             "num_results": 3,
             "detail": "compact",
+            "allow_helper_route": False,
         }
     ]
 

--- a/tests/test_brainbar_hybrid_helper.py
+++ b/tests/test_brainbar_hybrid_helper.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 import pytest
-from mcp.types import TextContent
+from mcp.types import CallToolResult, TextContent
 
 from brainlayer.brainbar_hybrid_helper import HybridSearchHelper
 
@@ -109,10 +109,28 @@ def test_helper_routes_brain_search_to_python_mcp_with_source_all_default(monkey
             "tag": "speakers-workshop",
             "importance_min": 8,
             "num_results": 3,
+            "max_results": 10,
             "detail": "compact",
             "allow_helper_route": False,
         }
     ]
+
+
+def test_helper_preserves_brain_search_mcp_error(monkeypatch, tmp_path):
+    async def fake_brain_search(**_kwargs):
+        return CallToolResult(content=[TextContent(type="text", text="Invalid detail='verbose'")], isError=True)
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search", fake_brain_search)
+
+    helper = HybridSearchHelper(socket_path=tmp_path / "helper.sock", db_path=tmp_path / "test.db")
+    response = helper._handle_request({"method": "brain_search", "arguments": {"query": "x"}})
+
+    assert response == {
+        "ok": True,
+        "text": "Invalid detail='verbose'",
+        "metadata": {},
+        "isError": True,
+    }
 
 
 def test_content_text_extracts_single_dict_text():

--- a/tests/test_mcp_warm_route.py
+++ b/tests/test_mcp_warm_route.py
@@ -143,10 +143,81 @@ async def test_brain_search_uses_helper_path_when_enabled_with_valid_socket(monk
                 "tag": "demo",
                 "importance_min": 8,
                 "num_results": 3,
+                "max_results": 10,
                 "detail": "compact",
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_brain_search_helper_path_forwards_max_results(monkeypatch):
+    calls = []
+
+    def fake_forward(_sock_path, query, **kwargs):
+        calls.append({"query": query, **kwargs})
+        return {
+            "ok": True,
+            "text": "warm helper result",
+            "metadata": {"structuredContent": {"query": query, "total": 0, "results": []}},
+        }
+
+    async def cold_dispatch(**_kwargs):
+        raise AssertionError("cold path should not be called when helper succeeds")
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._forward_to_helper", fake_forward)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    await _brain_search(query="recall previous warm route decisions", project="brainlayer", max_results=17)
+
+    assert calls[0]["max_results"] == 17
+
+
+@pytest.mark.asyncio
+async def test_brain_search_helper_path_resolves_implicit_project_before_forwarding(monkeypatch):
+    calls = []
+
+    def fake_forward(_sock_path, query, **kwargs):
+        calls.append({"query": query, **kwargs})
+        return {
+            "ok": True,
+            "text": "warm helper result",
+            "metadata": {"structuredContent": {"query": query, "total": 0, "results": []}},
+        }
+
+    async def cold_dispatch(**_kwargs):
+        raise AssertionError("cold path should not be called when helper succeeds")
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "brainlayer")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._forward_to_helper", fake_forward)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    await _brain_search(query="warm route implicit scope")
+
+    assert calls[0]["project"] == "brainlayer"
+
+
+@pytest.mark.asyncio
+async def test_brain_search_helper_path_preserves_helper_mcp_error(monkeypatch):
+    async def cold_dispatch(**_kwargs):
+        raise AssertionError("cold path should not be called when helper returns MCP error")
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr(
+        "brainlayer.mcp.search_handler._forward_to_helper",
+        lambda *_args, **_kwargs: {"ok": True, "text": "Invalid detail='verbose'", "isError": True},
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    result = await _brain_search(query="invalid helper response")
+
+    assert result.isError is True
+    assert result.content[0].text == "Invalid detail='verbose'"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_warm_route.py
+++ b/tests/test_mcp_warm_route.py
@@ -38,6 +38,45 @@ def test_find_warm_helper_socket_skips_disappearing_socket(monkeypatch):
     assert _find_warm_helper_socket() == "/tmp/brainbar-hybrid-new.sock"
 
 
+@pytest.mark.asyncio
+async def test_brain_search_retries_older_helper_socket_when_newest_is_stale(monkeypatch, tmp_path):
+    suffix = uuid.uuid4().hex[:8]
+    live_sock = Path(f"/tmp/bl-live-{os.getpid()}-{suffix}.sock")
+    stale_sock = Path(f"/tmp/bl-stale-{os.getpid()}-{suffix}.sock")
+    stale_sock.touch()
+    received, thread = _serve_one_json_line(
+        live_sock,
+        {
+            "ok": True,
+            "text": "older live helper result",
+            "metadata": {"structuredContent": {"query": "retry live helper", "total": 0, "results": []}},
+        },
+    )
+
+    def fake_getmtime(path):
+        return {str(stale_sock): 3.0, str(live_sock): 1.0}[path]
+
+    async def cold_dispatch(**_kwargs):
+        raise AssertionError("cold path should not be called when an older helper socket is live")
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr(
+        "brainlayer.mcp.search_handler.glob.glob",
+        lambda _pattern: [str(live_sock), str(stale_sock)],
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler.os.path.getmtime", fake_getmtime)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    content, structured = await _brain_search(query="retry live helper", project="brainlayer")
+
+    thread.join(1)
+    stale_sock.unlink(missing_ok=True)
+    live_sock.unlink(missing_ok=True)
+    assert content == [TextContent(type="text", text="older live helper result")]
+    assert structured["via_helper"] is True
+    assert received[0]["arguments"]["query"] == "retry live helper"
+
+
 async def _cold_result(**kwargs):
     return (
         [TextContent(type="text", text=f"cold result for {kwargs['query']}")],
@@ -81,7 +120,7 @@ async def test_brain_search_uses_cold_path_when_helper_route_disabled(monkeypatc
 
     monkeypatch.delenv("BRAINLAYER_MCP_USE_HELPER", raising=False)
     monkeypatch.setattr("brainlayer.mcp.search_handler._helper_sentinel_path", lambda: tmp_path / "missing")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: ["/tmp/helper.sock"])
     monkeypatch.setattr("brainlayer.mcp.search_handler._forward_to_helper", helper_should_not_be_called)
     monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
 
@@ -114,7 +153,7 @@ async def test_brain_search_uses_helper_path_when_enabled_with_valid_socket(monk
         raise AssertionError("cold path should not be called when helper succeeds")
 
     monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: str(sock_path))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: [str(sock_path)])
     monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
 
     content, structured = await _brain_search(
@@ -166,7 +205,7 @@ async def test_brain_search_helper_path_forwards_max_results(monkeypatch):
         raise AssertionError("cold path should not be called when helper succeeds")
 
     monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: ["/tmp/helper.sock"])
     monkeypatch.setattr("brainlayer.mcp.search_handler._forward_to_helper", fake_forward)
     monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
 
@@ -192,7 +231,7 @@ async def test_brain_search_helper_path_resolves_implicit_project_before_forward
 
     monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
     monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "brainlayer")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: ["/tmp/helper.sock"])
     monkeypatch.setattr("brainlayer.mcp.search_handler._forward_to_helper", fake_forward)
     monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
 
@@ -207,7 +246,7 @@ async def test_brain_search_helper_path_preserves_helper_mcp_error(monkeypatch):
         raise AssertionError("cold path should not be called when helper returns MCP error")
 
     monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: ["/tmp/helper.sock"])
     monkeypatch.setattr(
         "brainlayer.mcp.search_handler._forward_to_helper",
         lambda *_args, **_kwargs: {"ok": True, "text": "Invalid detail='verbose'", "isError": True},
@@ -239,7 +278,7 @@ async def test_brain_search_uses_helper_path_when_sentinel_file_exists(monkeypat
 
     monkeypatch.delenv("BRAINLAYER_MCP_USE_HELPER", raising=False)
     monkeypatch.setattr("brainlayer.mcp.search_handler._helper_sentinel_path", lambda: sentinel)
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: str(sock_path))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: [str(sock_path)])
     monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
 
     content, structured = await _brain_search(query="sentinel route", project="brainlayer")
@@ -259,7 +298,7 @@ async def test_brain_search_falls_back_when_helper_enabled_but_socket_missing(mo
         return await _cold_result(**kwargs)
 
     monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: [])
     monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
 
     content, structured = await _brain_search(query="missing helper socket", project="brainlayer")
@@ -278,7 +317,7 @@ async def test_brain_search_falls_back_when_helper_raises(monkeypatch):
         return await _cold_result(**kwargs)
 
     monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: ["/tmp/helper.sock"])
     monkeypatch.setattr(
         "brainlayer.mcp.search_handler._forward_to_helper",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("helper timed out")),
@@ -308,7 +347,7 @@ async def test_brain_search_helper_path_returns_under_100ms_with_mock_helper(mon
         raise AssertionError("cold path should not be called during latency-budget helper test")
 
     monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
-    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: str(sock_path))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._warm_helper_socket_candidates", lambda: [str(sock_path)])
     monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
 
     started = time.perf_counter()

--- a/tests/test_mcp_warm_route.py
+++ b/tests/test_mcp_warm_route.py
@@ -1,0 +1,251 @@
+import json
+import os
+import socket
+import threading
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from mcp.types import TextContent
+
+from brainlayer.mcp.search_handler import _brain_search
+
+
+def test_find_warm_helper_socket_skips_disappearing_socket(monkeypatch):
+    mtimes = {
+        "/tmp/brainbar-hybrid-old.sock": 1.0,
+        "/tmp/brainbar-hybrid-new.sock": 3.0,
+    }
+
+    def fake_getmtime(path):
+        if path == "/tmp/brainbar-hybrid-gone.sock":
+            raise FileNotFoundError(path)
+        return mtimes[path]
+
+    monkeypatch.setattr(
+        "brainlayer.mcp.search_handler.glob.glob",
+        lambda _pattern: [
+            "/tmp/brainbar-hybrid-old.sock",
+            "/tmp/brainbar-hybrid-gone.sock",
+            "/tmp/brainbar-hybrid-new.sock",
+        ],
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler.os.path.getmtime", fake_getmtime)
+
+    from brainlayer.mcp.search_handler import _find_warm_helper_socket
+
+    assert _find_warm_helper_socket() == "/tmp/brainbar-hybrid-new.sock"
+
+
+async def _cold_result(**kwargs):
+    return (
+        [TextContent(type="text", text=f"cold result for {kwargs['query']}")],
+        {"query": kwargs["query"], "total": 0, "results": [], "path": "cold"},
+    )
+
+
+def _serve_one_json_line(sock_path: Path, response: dict):
+    ready = threading.Event()
+    received = []
+
+    def run():
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            server.bind(str(sock_path))
+            server.listen(1)
+            ready.set()
+            conn, _ = server.accept()
+            with conn:
+                data = b""
+                while b"\n" not in data:
+                    data += conn.recv(65536)
+                received.append(json.loads(data.split(b"\n", 1)[0].decode("utf-8")))
+                conn.sendall(json.dumps(response).encode("utf-8") + b"\n")
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    assert ready.wait(1)
+    return received, thread
+
+
+@pytest.mark.asyncio
+async def test_brain_search_uses_cold_path_when_helper_route_disabled(monkeypatch, tmp_path):
+    calls = []
+
+    async def cold_dispatch(**kwargs):
+        calls.append(kwargs)
+        return await _cold_result(**kwargs)
+
+    def helper_should_not_be_called(*_args, **_kwargs):
+        raise AssertionError("helper should not be called when opt-in is disabled")
+
+    monkeypatch.delenv("BRAINLAYER_MCP_USE_HELPER", raising=False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_sentinel_path", lambda: tmp_path / "missing")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._forward_to_helper", helper_should_not_be_called)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    content, structured = await _brain_search(query="warm route disabled", project="brainlayer")
+
+    assert content[0].text == "cold result for warm route disabled"
+    assert structured["path"] == "cold"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_brain_search_uses_helper_path_when_enabled_with_valid_socket(monkeypatch, tmp_path):
+    sock_path = Path(f"/tmp/bl-warm-{os.getpid()}-{uuid.uuid4().hex[:8]}.sock")
+    received, thread = _serve_one_json_line(
+        sock_path,
+        {
+            "ok": True,
+            "text": "warm helper result",
+            "metadata": {
+                "structuredContent": {
+                    "query": "warm route enabled",
+                    "total": 1,
+                    "results": [{"chunk_id": "warm-1"}],
+                }
+            },
+        },
+    )
+
+    async def cold_dispatch(**_kwargs):
+        raise AssertionError("cold path should not be called when helper succeeds")
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: str(sock_path))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    content, structured = await _brain_search(
+        query="warm route enabled",
+        project="brainlayer",
+        source="all",
+        tag="demo",
+        importance_min=8,
+        num_results=3,
+        detail="compact",
+    )
+
+    thread.join(1)
+    sock_path.unlink(missing_ok=True)
+    assert content == [TextContent(type="text", text="warm helper result")]
+    assert structured["results"] == [{"chunk_id": "warm-1"}]
+    assert structured["via_helper"] is True
+    assert isinstance(structured["helper_latency_ms"], float)
+    assert received == [
+        {
+            "method": "brain_search",
+            "arguments": {
+                "query": "warm route enabled",
+                "project": "brainlayer",
+                "source": "all",
+                "tag": "demo",
+                "importance_min": 8,
+                "num_results": 3,
+                "detail": "compact",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_brain_search_uses_helper_path_when_sentinel_file_exists(monkeypatch, tmp_path):
+    sock_path = Path(f"/tmp/bl-warm-{os.getpid()}-{uuid.uuid4().hex[:8]}.sock")
+    sentinel = tmp_path / "use-helper-socket"
+    sentinel.touch()
+    _received, thread = _serve_one_json_line(
+        sock_path,
+        {
+            "ok": True,
+            "text": "sentinel helper result",
+            "metadata": {"structuredContent": {"query": "sentinel route", "total": 0, "results": []}},
+        },
+    )
+
+    async def cold_dispatch(**_kwargs):
+        raise AssertionError("cold path should not be called when sentinel route succeeds")
+
+    monkeypatch.delenv("BRAINLAYER_MCP_USE_HELPER", raising=False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_sentinel_path", lambda: sentinel)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: str(sock_path))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    content, structured = await _brain_search(query="sentinel route", project="brainlayer")
+
+    thread.join(1)
+    sock_path.unlink(missing_ok=True)
+    assert content == [TextContent(type="text", text="sentinel helper result")]
+    assert structured["via_helper"] is True
+
+
+@pytest.mark.asyncio
+async def test_brain_search_falls_back_when_helper_enabled_but_socket_missing(monkeypatch):
+    calls = []
+
+    async def cold_dispatch(**kwargs):
+        calls.append(kwargs)
+        return await _cold_result(**kwargs)
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    content, structured = await _brain_search(query="missing helper socket", project="brainlayer")
+
+    assert content[0].text == "cold result for missing helper socket"
+    assert structured["path"] == "cold"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_brain_search_falls_back_when_helper_raises(monkeypatch):
+    calls = []
+
+    async def cold_dispatch(**kwargs):
+        calls.append(kwargs)
+        return await _cold_result(**kwargs)
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: "/tmp/helper.sock")
+    monkeypatch.setattr(
+        "brainlayer.mcp.search_handler._forward_to_helper",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("helper timed out")),
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    content, structured = await _brain_search(query="helper timeout fallback", project="brainlayer")
+
+    assert content[0].text == "cold result for helper timeout fallback"
+    assert structured["path"] == "cold"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_brain_search_helper_path_returns_under_100ms_with_mock_helper(monkeypatch, tmp_path):
+    sock_path = Path(f"/tmp/bl-warm-{os.getpid()}-{uuid.uuid4().hex[:8]}.sock")
+    _received, thread = _serve_one_json_line(
+        sock_path,
+        {
+            "ok": True,
+            "text": "fast warm helper result",
+            "metadata": {"structuredContent": {"query": "fast helper", "total": 0, "results": []}},
+        },
+    )
+
+    async def cold_dispatch(**_kwargs):
+        raise AssertionError("cold path should not be called during latency-budget helper test")
+
+    monkeypatch.setenv("BRAINLAYER_MCP_USE_HELPER", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._find_warm_helper_socket", lambda: str(sock_path))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search_dispatch", cold_dispatch)
+
+    started = time.perf_counter()
+    _content, structured = await _brain_search(query="fast helper", project="brainlayer")
+    elapsed_ms = (time.perf_counter() - started) * 1000
+
+    thread.join(1)
+    sock_path.unlink(missing_ok=True)
+    assert elapsed_ms < 100
+    assert structured["via_helper"] is True
+    assert structured["helper_latency_ms"] < 100


### PR DESCRIPTION
## Summary
- Implements the Phase 2.X mandate from `/tmp/codex-mandate-warm-mcp-helper-route.md`: opt-in MCP `brain_search` warm-routing through the existing `brainbar-hybrid-helper` Unix socket.
- Activation is default-off via `BRAINLAYER_MCP_USE_HELPER=1` or `~/.local/share/brainlayer/use-helper-socket`; missing/unreachable/slow helper sockets transparently fall back to the existing cold path.
- Adds `via_helper: true` and `helper_latency_ms` to structured response metadata when the helper path is used.
- Keeps helper-originated searches from recursively routing back into the helper socket with `allow_helper_route=False`.

## Context
- Mandate cites existing measurements: `brainbar-hybrid-helper` socket roundtrip ~0.2ms and cold `brainlayer search` CLI first invocation around 15-20s / 17s.
- This PR only changes Python MCP/search helper routing. It does not touch `brain_store`, `brain_entity`, `brain_digest`, or BrainBar Swift.

## Test plan
- [x] TDD red run: `pytest tests/test_mcp_warm_route.py` failed before implementation because warm-route helpers did not exist.
- [x] `pytest tests/test_mcp_warm_route.py tests/test_brainbar_hybrid_helper.py`
- [x] `pytest tests/test_search_profile.py tests/test_search_filter_params.py tests/test_search_routing.py tests/test_search_quality.py tests/test_mcp_warm_route.py tests/test_brainbar_hybrid_helper.py`
- [x] `ruff check src/brainlayer/mcp/search_handler.py src/brainlayer/brainbar_hybrid_helper.py tests/test_mcp_warm_route.py tests/test_brainbar_hybrid_helper.py`
- [x] Real MCP stdio client gate via `brainlayer-mcp` with `BRAINLAYER_MCP_USE_HELPER=1`: response included `via_helper: true` and `helper_latency_ms: 0.273`.
- [x] Full local `pytest`: `2245 passed, 46 skipped, 5 xfailed, 328 warnings in 214.90s`.
- [x] Push hook gate: `2175 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration `3 passed`; isolated eval/hook routing `36 passed`; bun stale-index test `1 pass`; regression shell `test_fts5_determinism.sh` passed.
- [x] CodeRabbit pre-commit review: first pass found socket TOCTOU + blocking async I/O; fixed both. Second pass: no findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core search dispatch and adds a second execution path; behavior diverges for helper-eligible vs filtered queries, though failures fall back to the cold path.
> 
> **Overview**
> Adds an **opt-in fast path** for MCP `brain_search`: when `BRAINLAYER_MCP_USE_HELPER=1` or a sentinel file exists, eligible queries are forwarded over a Unix socket to a warm `brainbar-hybrid-helper` instead of the cold `_brain_search_dispatch` path. Successful helper responses gain **`via_helper`** and **`helper_latency_ms`** in structured metadata; missing sockets, connect failures, and timeouts **fall back** to the existing cold dispatcher.
> 
> Routing is limited to **simple broad searches**—any advanced filter (file path, chunk ID, dates, entity, checkpoints/audit, etc.) or a file path embedded in the query skips the helper. The helper process calls `_brain_search` with **`allow_helper_route=False`** and forwards **`max_results`**, avoiding recursive routing. **`isError`** from MCP-style helper responses is propagated through the socket protocol and back to MCP clients.
> 
> New coverage in `tests/test_mcp_warm_route.py` and updates to `tests/test_brainbar_hybrid_helper.py` exercise enable/disable, sentinel activation, socket retry order, fallback, error preservation, and latency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd165b16c073a4f350db541ad69653c32daa7c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `brain_search` through a local brainbar-hybrid-helper Unix socket when opted in
> - Adds a warm-route path in [`mcp/search_handler.py`](https://github.com/EtanHey/brainlayer/pull/329/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0): when `BRAINLAYER_MCP_USE_HELPER=1` or a sentinel file exists, eligible `brain_search` calls are forwarded over a Unix domain socket to the most-recently-modified helper process instead of the in-process dispatcher.
> - Routing is restricted to simple queries — requests with advanced filters (file path, date range, intent, sentiment, etc.) or embedded file paths bypass the helper path entirely.
> - [`brainbar_hybrid_helper.py`](https://github.com/EtanHey/brainlayer/pull/329/files#diff-d3d5162fd8f713352fe31ea2b66de6014b80c7e9af406132cdd41d99375a7b21) is updated to pass `allow_helper_route=False` when calling `_brain_search` (preventing re-routing loops) and to forward `max_results`; MCP `isError` state is now propagated back through the socket response.
> - Structured results returned via the helper include `via_helper: true` and `helper_latency_ms` metadata; the socket timeout is 2 seconds with per-candidate fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd165b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search requests can now be routed through an optional helper service when available, with automatic fallback to standard processing if unavailable.
  * Added latency tracking and helper service status indicators in search results for transparency.

* **Tests**
  * Comprehensive test coverage added for helper service routing, including fallback scenarios and performance validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->