### PR TITLE
feat(brainbar): enrich_status column (dashboard truth A)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -320,6 +320,7 @@ final class BrainDatabase: @unchecked Sendable {
                     importance REAL DEFAULT 5,
                     intent TEXT,
                     enriched_at TEXT,
+                    enrich_status TEXT,
                     created_at TEXT DEFAULT (datetime('now')),
                     aggregated_into TEXT,
                     brick_id TEXT,
@@ -340,6 +341,10 @@ final class BrainDatabase: @unchecked Sendable {
         try execute("""
             CREATE INDEX IF NOT EXISTS idx_chunks_created_at
             ON chunks(created_at)
+        """)
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_chunks_enrich_status
+            ON chunks(enrich_status)
         """)
 
         try ensurePendingStoreQueueIndex()
@@ -477,6 +482,10 @@ final class BrainDatabase: @unchecked Sendable {
         """)
 
         try ensureChunkColumns()
+        try execute("""
+            CREATE INDEX IF NOT EXISTS idx_chunks_enrich_status
+            ON chunks(enrich_status)
+        """)
         try ensurePendingStoreQueueIndex()
         try ensureKGEntityColumns()
         try ensureKGRelationColumns()
@@ -1323,7 +1332,7 @@ final class BrainDatabase: @unchecked Sendable {
         let lastEvents = try dashboardLastEvents()
         let chunkCount = counts.chunkCount
         let enrichedChunkCount = counts.enrichedChunkCount
-        let pendingEnrichmentCount = max(0, chunkCount - enrichedChunkCount)
+        let pendingEnrichmentCount = counts.pendingEnrichmentCount
         let enrichmentPercent = chunkCount == 0 ? 0 : (Double(enrichedChunkCount) / Double(chunkCount)) * 100
         let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: liveWindowMinutes)
         let recentActivityBuckets = try recentActivityBuckets(
@@ -1395,12 +1404,13 @@ final class BrainDatabase: @unchecked Sendable {
         return Int(sqlite3_column_int(stmt, 0))
     }
 
-    private func dashboardCounts() throws -> (chunkCount: Int, enrichedChunkCount: Int) {
+    private func dashboardCounts() throws -> (chunkCount: Int, enrichedChunkCount: Int, pendingEnrichmentCount: Int) {
         guard let db else { throw DBError.notOpen }
         let sql = """
             SELECT
                 COUNT(*) AS chunk_count,
-                SUM(CASE WHEN enriched_at IS NOT NULL AND TRIM(enriched_at) != '' THEN 1 ELSE 0 END) AS enriched_count
+                SUM(CASE WHEN enrich_status = 'success' THEN 1 ELSE 0 END) AS enriched_count,
+                SUM(CASE WHEN enriched_at IS NULL AND enrich_status IS NULL THEN 1 ELSE 0 END) AS pending_enrichment_count
             FROM chunks
         """
         var stmt: OpaquePointer?
@@ -1410,7 +1420,8 @@ final class BrainDatabase: @unchecked Sendable {
         guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
         return (
             chunkCount: Int(sqlite3_column_int(stmt, 0)),
-            enrichedChunkCount: Int(sqlite3_column_int(stmt, 1))
+            enrichedChunkCount: Int(sqlite3_column_int(stmt, 1)),
+            pendingEnrichmentCount: Int(sqlite3_column_int(stmt, 2))
         )
     }
 
@@ -1420,14 +1431,16 @@ final class BrainDatabase: @unchecked Sendable {
         let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
         let sql = """
             SELECT
-                MAX(last_write_epoch),
-                MAX(last_enriched_epoch)
-            FROM (
-                SELECT
-                    \(createdAtEpochSQL) AS last_write_epoch,
-                    \(enrichedAtEpochSQL) AS last_enriched_epoch
-                FROM chunks
-            )
+                (SELECT MAX(last_write_epoch) FROM (
+                    SELECT \(createdAtEpochSQL) AS last_write_epoch
+                    FROM chunks
+                )),
+                (SELECT MAX(last_enriched_epoch) FROM (
+                    SELECT \(enrichedAtEpochSQL) AS last_enriched_epoch
+                    FROM chunks
+                    WHERE enriched_at IS NOT NULL
+                      AND enrich_status = 'success'
+                ))
         """
         var stmt: OpaquePointer?
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
@@ -1502,6 +1515,8 @@ final class BrainDatabase: @unchecked Sendable {
             FROM (
                 SELECT \(enrichedAtEpochSQL) AS enriched_epoch
                 FROM chunks
+                WHERE enriched_at IS NOT NULL
+                  AND enrich_status = 'success'
             )
             WHERE enriched_epoch IS NOT NULL
               AND enriched_epoch >= unixepoch('now', ?)
@@ -1543,6 +1558,8 @@ final class BrainDatabase: @unchecked Sendable {
             FROM (
                 SELECT \(enrichedAtEpochSQL) AS enriched_epoch
                 FROM chunks
+                WHERE enriched_at IS NOT NULL
+                  AND enrich_status = 'success'
             )
             WHERE enriched_epoch IS NOT NULL
               AND enriched_epoch >= unixepoch('now', ?)
@@ -2103,6 +2120,29 @@ final class BrainDatabase: @unchecked Sendable {
         if !existingColumns.contains("enriched_at") {
             try execute("ALTER TABLE chunks ADD COLUMN enriched_at TEXT")
         }
+        if !existingColumns.contains("enrich_status") {
+            try execute("ALTER TABLE chunks ADD COLUMN enrich_status TEXT")
+        }
+        try execute("""
+            UPDATE chunks
+            SET enriched_at = NULL
+            WHERE enriched_at IS NOT NULL
+              AND TRIM(enriched_at) = ''
+        """)
+        try execute("""
+            UPDATE chunks
+            SET enrich_status = 'success'
+            WHERE enriched_at IS NOT NULL
+              AND TRIM(enriched_at) != ''
+              AND enriched_at NOT LIKE 'skipped:%'
+              AND enrich_status IS NULL
+        """)
+        try execute("""
+            UPDATE chunks
+            SET enrich_status = NULLIF(TRIM(substr(enriched_at, length('skipped:') + 1)), ''),
+                enriched_at = NULL
+            WHERE enriched_at LIKE 'skipped:%'
+        """)
         if !existingColumns.contains("archived") {
             try execute("ALTER TABLE chunks ADD COLUMN archived INTEGER DEFAULT 0")
         }
@@ -3960,6 +4000,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     func enrichmentStats() throws -> EnrichmentStatsSummary {
         guard let db else { throw DBError.notOpen }
+        let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
 
         func queryInt(_ sql: String) throws -> Int {
             var stmt: OpaquePointer?
@@ -3973,10 +4014,19 @@ final class BrainDatabase: @unchecked Sendable {
 
         return EnrichmentStatsSummary(
             totalChunks: try queryInt("SELECT COUNT(*) FROM chunks"),
-            enriched: try queryInt("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NOT NULL"),
-            unenrichedEligible: try queryInt("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND char_count >= 50"),
-            skippedTooShort: try queryInt("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND char_count < 50"),
-            enrichedLast24Hours: try queryInt("SELECT COUNT(*) FROM chunks WHERE enriched_at > datetime('now', '-24 hours')")
+            enriched: try queryInt("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'success'"),
+            unenrichedEligible: try queryInt("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND enrich_status IS NULL AND char_count >= 50"),
+            skippedTooShort: try queryInt("SELECT COUNT(*) FROM chunks WHERE (enrich_status IS NOT NULL AND enrich_status != 'success') OR (enrich_status IS NULL AND enriched_at IS NULL AND char_count < 50)"),
+            enrichedLast24Hours: try queryInt("""
+                SELECT COUNT(*)
+                FROM (
+                    SELECT \(enrichedAtEpochSQL) AS enriched_epoch, enrich_status
+                    FROM chunks
+                )
+                WHERE enrich_status = 'success'
+                  AND enriched_epoch IS NOT NULL
+                  AND enriched_epoch >= unixepoch('now', '-24 hours')
+            """)
         )
     }
 
@@ -4007,6 +4057,7 @@ final class BrainDatabase: @unchecked Sendable {
         ]
         if chunkIDs == nil {
             conditions.append("enriched_at IS NULL")
+            conditions.append("enrich_status IS NULL")
             conditions.append("char_count >= 50")
         }
         if mode == "realtime", chunkIDs == nil {
@@ -4054,7 +4105,7 @@ final class BrainDatabase: @unchecked Sendable {
             let summary = Self.previewText(summary: nil, content: target.content)
             do {
                 try executeUpdate(
-                    "UPDATE chunks SET summary = ?, enriched_at = ? WHERE id = ?"
+                    "UPDATE chunks SET summary = ?, enriched_at = ?, enrich_status = 'success' WHERE id = ?"
                 ) { stmt in
                     bindText(summary, to: stmt, index: 1)
                     bindText(Self.timestamp(), to: stmt, index: 2)
@@ -4130,7 +4181,7 @@ final class BrainDatabase: @unchecked Sendable {
         let totalChunks = try queryInt("SELECT COUNT(*) FROM chunks")
         let totalEntities = try queryInt("SELECT COUNT(*) FROM kg_entities")
         let totalRelations = try queryInt("SELECT COUNT(*) FROM kg_relations")
-        let enrichedChunks = try queryInt("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NOT NULL")
+        let enrichedChunks = try queryInt("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'success'")
         let totalProjects = try queryInt("SELECT COUNT(DISTINCT project) FROM chunks")
         let projects = try queryStrings("SELECT DISTINCT project FROM chunks WHERE project IS NOT NULL AND project != '' ORDER BY project ASC LIMIT 12")
         let contentTypes = try queryStrings("SELECT DISTINCT content_type FROM chunks WHERE content_type IS NOT NULL AND content_type != '' ORDER BY content_type ASC")

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -37,7 +37,7 @@ final class DashboardTests: XCTestCase {
             contentType: "assistant_text",
             importance: 7
         )
-        db.exec("UPDATE chunks SET enriched_at = datetime('now') WHERE id = 'dash-2'")
+        db.exec("UPDATE chunks SET enriched_at = datetime('now'), enrich_status = 'success' WHERE id = 'dash-2'")
 
         let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
 
@@ -50,6 +50,45 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(stats.recentActivityBuckets.reduce(0, +), 2)
         XCTAssertGreaterThanOrEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
+    }
+
+    func testDashboardStatsIgnoresSkippedEnrichmentStatusStrings() throws {
+        try db.insertChunk(
+            id: "dash-success",
+            content: "Successfully enriched chunk",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        try db.insertChunk(
+            id: "dash-skipped",
+            content: "Legacy skipped duplicate marker",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        db.exec("""
+            UPDATE chunks
+            SET enriched_at = datetime('now', '-5 minutes'),
+                enrich_status = 'success'
+            WHERE id = 'dash-success'
+        """)
+        db.exec("""
+            UPDATE chunks
+            SET enriched_at = 'skipped:duplicate',
+                enrich_status = 'duplicate'
+            WHERE id = 'dash-skipped'
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.enrichedChunkCount, 1)
+        XCTAssertEqual(stats.pendingEnrichmentCount, 0)
+        XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
+        let lastEnrichedAt = try XCTUnwrap(stats.lastEnrichedAt)
+        XCTAssertLessThan(abs(lastEnrichedAt.timeIntervalSinceNow + 300), 10)
     }
 
     func testDashboardStatsReturnsZeroPercentForEmptyDatabase() throws {
@@ -142,7 +181,8 @@ final class DashboardTests: XCTestCase {
         db.exec("""
             UPDATE chunks
             SET created_at = datetime('now', '-45 minutes'),
-                enriched_at = datetime('now')
+                enriched_at = datetime('now'),
+                enrich_status = 'success'
             WHERE id = 'dash-enrichment-only'
         """)
 
@@ -164,7 +204,8 @@ final class DashboardTests: XCTestCase {
         )
         db.exec("""
             UPDATE chunks
-            SET enriched_at = datetime('now', '-6 minutes')
+            SET enriched_at = datetime('now', '-6 minutes'),
+                enrich_status = 'success'
             WHERE id = 'dash-stale-enrichment'
         """)
 
@@ -185,7 +226,8 @@ final class DashboardTests: XCTestCase {
         )
         db.exec("""
             UPDATE chunks
-            SET enriched_at = datetime('now', '-90 seconds')
+            SET enriched_at = datetime('now', '-90 seconds'),
+                enrich_status = 'success'
             WHERE id = 'dash-minute-stall'
         """)
 
@@ -207,7 +249,8 @@ final class DashboardTests: XCTestCase {
         db.exec("""
             UPDATE chunks
             SET created_at = datetime('now'),
-                enriched_at = datetime('now', '-90 seconds')
+                enriched_at = datetime('now', '-90 seconds'),
+                enrich_status = 'success'
             WHERE id = 'dash-explicit-times'
         """)
 

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -1166,6 +1166,48 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertNotNil(try chunkEnrichedAt(path: tempDB, id: "enrich-target"))
     }
 
+    func testBrainEnrichRealtimeSkipsTerminalEnrichStatusChunks() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-enrich-terminal-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        try db.insertChunk(
+            id: "enrich-pending",
+            content: "This chunk is long enough to qualify for enrichment and should be processed.",
+            sessionId: "s1",
+            project: "test",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        try db.insertChunk(
+            id: "enrich-duplicate",
+            content: "This duplicate terminal chunk is long enough but should not be processed again.",
+            sessionId: "s1",
+            project: "test",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        db.exec("UPDATE chunks SET enrich_status = 'duplicate' WHERE id = 'enrich-duplicate'")
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 28,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_enrich",
+                "arguments": ["mode": "realtime", "limit": 5] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let text = ((response["result"] as? [String: Any])?["content"] as? [[String: Any]])?.first?["text"] as? String ?? ""
+        XCTAssertTrue(text.contains("Attempted: 1"))
+        XCTAssertNotNil(try chunkEnrichedAt(path: tempDB, id: "enrich-pending"))
+        XCTAssertNil(try chunkEnrichedAt(path: tempDB, id: "enrich-duplicate"))
+    }
+
     func testBrainEnrichClampsNegativeLimit() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-enrich-limit-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }

--- a/migrations/004_enrich_status.sql
+++ b/migrations/004_enrich_status.sql
@@ -1,0 +1,22 @@
+-- Standalone SQL migration for pre-004 databases. Python and Swift startup
+-- migrators add this column through their own column-exists checks.
+ALTER TABLE chunks ADD COLUMN enrich_status TEXT;
+
+UPDATE chunks
+SET enriched_at = NULL
+WHERE enriched_at IS NOT NULL
+  AND TRIM(enriched_at) = '';
+
+UPDATE chunks
+SET enrich_status = 'success'
+WHERE enriched_at IS NOT NULL
+  AND TRIM(enriched_at) != ''
+  AND enriched_at NOT LIKE 'skipped:%'
+  AND enrich_status IS NULL;
+
+UPDATE chunks
+SET enrich_status = NULLIF(TRIM(SUBSTR(enriched_at, LENGTH('skipped:') + 1)), ''),
+    enriched_at = NULL
+WHERE enriched_at LIKE 'skipped:%';
+
+CREATE INDEX IF NOT EXISTS idx_chunks_enrich_status ON chunks(enrich_status);

--- a/src/brainlayer/cloud_backfill.py
+++ b/src/brainlayer/cloud_backfill.py
@@ -358,11 +358,13 @@ class ReadOnlyBackfillStore:
     def get_enrichment_stats(self) -> Dict[str, Any]:
         cursor = self._read_cursor()
         total = cursor.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
-        enriched = cursor.execute(
-            "SELECT COUNT(*) FROM chunks WHERE enriched_at IS NOT NULL AND enriched_at NOT LIKE 'skipped:%'"
+        enriched = cursor.execute("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'success'").fetchone()[0]
+        skipped = cursor.execute(
+            "SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL AND enrich_status != 'success'"
         ).fetchone()[0]
-        skipped = cursor.execute("SELECT COUNT(*) FROM chunks WHERE enriched_at LIKE 'skipped:%'").fetchone()[0]
-        remaining = cursor.execute("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL").fetchone()[0]
+        remaining = cursor.execute(
+            "SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND enrich_status IS NULL"
+        ).fetchone()[0]
         enrichable = total - skipped
         by_intent = cursor.execute(
             """

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -222,6 +222,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "source": event.get("source") or "manual",
             "created_at": now,
             "enriched_at": now,
+            "enrich_status": "success",
             "summary": content[:200],
             "tags": json.dumps(tags) if tags else None,
             "importance": float(event["importance"]) if event.get("importance") is not None else None,
@@ -388,6 +389,8 @@ def _apply_enrichment(conn: apsw.Connection, event: dict[str, Any]) -> None:
         updates["content_hash"] = event["content_hash"]
     if "enriched_at" in cols:
         updates["enriched_at"] = datetime.now(timezone.utc).isoformat()
+    if "enrich_status" in cols:
+        updates["enrich_status"] = "success"
     if not updates:
         return
     assignments = ", ".join(f"{col} = ?" for col in updates)

--- a/src/brainlayer/mcp/enrich_handler.py
+++ b/src/brainlayer/mcp/enrich_handler.py
@@ -88,21 +88,25 @@ async def _enrich_stats(store) -> CallToolResult:
         total = cursor.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
 
         # Enriched
-        enriched = cursor.execute("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NOT NULL").fetchone()[0]
+        enriched = cursor.execute("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'success'").fetchone()[0]
 
         # Unenriched (eligible — char_count >= 50)
         unenriched = cursor.execute(
-            "SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND char_count >= 50"
+            "SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND enrich_status IS NULL AND char_count >= 50"
         ).fetchone()[0]
 
-        # Skipped (too short)
+        # Skipped terminal statuses
         skipped = cursor.execute(
-            "SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND char_count < 50"
+            "SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL AND enrich_status != 'success'"
         ).fetchone()[0]
 
         # Recent enrichments (last 24h)
         recent = cursor.execute(
-            "SELECT COUNT(*) FROM chunks WHERE enriched_at > datetime('now', '-24 hours')"
+            """
+            SELECT COUNT(*) FROM chunks
+            WHERE datetime(enriched_at) > datetime('now', '-24 hours')
+              AND enrich_status = 'success'
+            """
         ).fetchone()[0]
 
         result = {

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -1163,7 +1163,7 @@ def enrich_batch(
 
 
 def mark_unenrichable(store: VectorStore) -> int:
-    """Tag chunks that are too short for their source as 'skipped:too_short'.
+    """Tag chunks that are too short for their source as enrich_status='too_short'.
 
     Uses source-aware thresholds: 15 chars for WhatsApp/Telegram, 50 for everything else.
     Returns the number of newly tagged chunks.
@@ -1172,8 +1172,9 @@ def mark_unenrichable(store: VectorStore) -> int:
     # Tag chunks below their source-specific threshold
     # WhatsApp/Telegram: 15 chars. Everything else: 50 chars.
     cursor.execute("""
-        UPDATE chunks SET enriched_at = 'skipped:too_short'
+        UPDATE chunks SET enrich_status = 'too_short', enriched_at = NULL
         WHERE enriched_at IS NULL
+        AND enrich_status IS NULL
         AND (
             (source IN ('whatsapp', 'telegram') AND char_count < 15)
             OR (source NOT IN ('whatsapp', 'telegram') AND char_count < 50)
@@ -1181,7 +1182,7 @@ def mark_unenrichable(store: VectorStore) -> int:
         )
     """)
     # apsw doesn't have rowcount, count via separate query
-    tagged = list(cursor.execute("SELECT COUNT(*) FROM chunks WHERE enriched_at = 'skipped:too_short'"))[0][0]
+    tagged = list(cursor.execute("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'too_short'"))[0][0]
     return tagged
 
 

--- a/src/brainlayer/session_repo.py
+++ b/src/brainlayer/session_repo.py
@@ -53,7 +53,7 @@ class SessionMixin:
 
         cursor = self._read_cursor()
         effective_min = max(min_content_length, source_aware_min_chars(source))
-        where = ["enriched_at IS NULL", "char_count >= ?"]
+        where = ["enriched_at IS NULL", "enrich_status IS NULL", "char_count >= ?"]
         params: list[Any] = [effective_min]
 
         if since_hours is not None:
@@ -128,8 +128,8 @@ class SessionMixin:
         """Update enrichment metadata for a chunk."""
         cursor = self.conn.cursor()
 
-        sets = ["enriched_at = ?"]
-        params: list = [datetime.now(timezone.utc).isoformat()]
+        sets = ["enriched_at = ?", "enrich_status = ?"]
+        params: list = [datetime.now(timezone.utc).isoformat(), "success"]
 
         if summary is not None:
             sets.append("summary = ?")
@@ -255,13 +255,13 @@ class SessionMixin:
         """Get enrichment progress statistics."""
         cursor = self._read_cursor()
         total = list(cursor.execute("SELECT COUNT(*) FROM chunks"))[0][0]
-        enriched = list(
-            cursor.execute(
-                "SELECT COUNT(*) FROM chunks WHERE enriched_at IS NOT NULL AND enriched_at NOT LIKE 'skipped:%'"
-            )
+        enriched = list(cursor.execute("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'success'"))[0][0]
+        skipped = list(
+            cursor.execute("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL AND enrich_status != 'success'")
         )[0][0]
-        skipped = list(cursor.execute("SELECT COUNT(*) FROM chunks WHERE enriched_at LIKE 'skipped:%'"))[0][0]
-        remaining = list(cursor.execute("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL"))[0][0]
+        remaining = list(
+            cursor.execute("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND enrich_status IS NULL")
+        )[0][0]
         enrichable = total - skipped
         by_intent = list(
             cursor.execute("""

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -224,11 +224,11 @@ def store_memory(
                         """
                         INSERT INTO chunks
                         (id, content, metadata, source_file, project, content_type,
-                         value_type, char_count, source, created_at, enriched_at,
+                         value_type, char_count, source, created_at, enriched_at, enrich_status,
                          summary, tags, importance, chunk_origin, seen_count, last_seen_at,
                          dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
                          ingested_at)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                                 CAST(strftime('%s', 'now') AS INTEGER))
                     """,
                         (
@@ -243,6 +243,7 @@ def store_memory(
                             "manual",
                             now,
                             now,
+                            "success",
                             content[:200],
                             tags_json,
                             float(importance) if importance is not None else None,

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -558,6 +558,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("importance", "REAL"),
             ("intent", "TEXT"),
             ("enriched_at", "TEXT"),
+            ("enrich_status", "TEXT"),
             ("enrichment_version", "TEXT DEFAULT '1.0'"),
             ("primary_symbols", "TEXT"),
             ("resolved_query", "TEXT"),
@@ -655,6 +656,54 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             self._checkpoint_wal_full(cursor)
             self._invalidate_filtered_count_caches()
 
+        enrich_status_migration_name = "2026_05_26_enrich_status_v1"
+        enrich_status_migration_done = cursor.execute(
+            "SELECT 1 FROM schema_migrations WHERE name = ?",
+            (enrich_status_migration_name,),
+        ).fetchone()
+        if enrich_status_migration_done is None:
+            cursor.execute(
+                """
+                UPDATE chunks
+                SET enriched_at = NULL
+                WHERE enriched_at IS NOT NULL
+                  AND TRIM(enriched_at) = ''
+                """
+            )
+            cursor.execute(
+                """
+                UPDATE chunks
+                SET enrich_status = 'success'
+                WHERE enriched_at IS NOT NULL
+                  AND TRIM(enriched_at) != ''
+                  AND enriched_at NOT LIKE 'skipped:%'
+                  AND enrich_status IS NULL
+                """
+            )
+            success_backfilled = self.conn.changes()
+            cursor.execute(
+                """
+                UPDATE chunks
+                SET enrich_status = NULLIF(TRIM(SUBSTR(enriched_at, LENGTH('skipped:') + 1)), ''),
+                    enriched_at = NULL
+                WHERE enriched_at LIKE 'skipped:%'
+                """
+            )
+            skipped_backfilled = self.conn.changes()
+            cursor.execute(
+                "INSERT OR IGNORE INTO schema_migrations (name, applied_at, details) VALUES (?, ?, ?)",
+                (
+                    enrich_status_migration_name,
+                    datetime.now(timezone.utc).isoformat(),
+                    json.dumps(
+                        {
+                            "success_backfilled": success_backfilled,
+                            "skipped_backfilled": skipped_backfilled,
+                        }
+                    ),
+                ),
+            )
+
         cursor.execute("""
             UPDATE chunks
             SET archived = 1
@@ -675,6 +724,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("idx_chunks_intent", "intent"),
             ("idx_chunks_importance", "importance"),
             ("idx_chunks_enriched", "enriched_at"),
+            ("idx_chunks_enrich_status", "enrich_status"),
             ("idx_chunks_created", "created_at"),
             ("idx_chunks_sentiment", "sentiment_label"),
             ("idx_chunks_project", "project"),

--- a/tests/test_enrichment_data_integrity.py
+++ b/tests/test_enrichment_data_integrity.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from brainlayer.pipeline.enrichment import mark_unenrichable
+from brainlayer.vector_store import VectorStore
+
+
+def test_enrich_status_migration_backfills_polluted_enriched_at_rows(tmp_path):
+    db_path = tmp_path / "legacy-polluted.db"
+    store = VectorStore(db_path)
+    store.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executemany(
+            "INSERT INTO chunks (id, content, metadata, source_file, char_count, summary, enriched_at) VALUES (?, ?, '{}', 'test.jsonl', ?, ?, ?)",
+            [
+                ("success", "success content", 120, "summary", "2026-05-26T10:00:00+00:00"),
+                ("duplicate", "duplicate content", 120, None, "skipped:duplicate"),
+                ("too-short", "tiny", 4, None, "skipped:too_short"),
+                ("blank", "blank content", 120, None, ""),
+                ("pending", "pending content", 120, None, None),
+            ],
+        )
+        conn.execute("UPDATE chunks SET enrich_status = NULL")
+        conn.execute("DELETE FROM schema_migrations WHERE name = '2026_05_26_enrich_status_v1'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    store = VectorStore(db_path)
+    try:
+        rows = {
+            row[0]: (row[1], row[2])
+            for row in store.conn.cursor().execute("SELECT id, enriched_at, enrich_status FROM chunks ORDER BY id")
+        }
+    finally:
+        store.close()
+
+    assert rows["success"] == ("2026-05-26T10:00:00+00:00", "success")
+    assert rows["duplicate"] == (None, "duplicate")
+    assert rows["too-short"] == (None, "too_short")
+    assert rows["blank"] == (None, None)
+    assert rows["pending"] == (None, None)
+
+
+def test_enriched_at_values_are_parseable_datetime_or_null_after_migration(tmp_path):
+    db_path = tmp_path / "datetime-integrity.db"
+    store = VectorStore(db_path)
+    store.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executemany(
+            "INSERT INTO chunks (id, content, metadata, source_file, enriched_at) VALUES (?, ?, '{}', 'test.jsonl', ?)",
+            [
+                ("polluted", "polluted content", "skipped:duplicate"),
+                ("valid", "valid content", "2026-05-26T10:00:00+00:00"),
+                ("blank", "blank content", ""),
+                ("pending", "pending content", None),
+            ],
+        )
+        conn.execute("UPDATE chunks SET enrich_status = NULL")
+        conn.execute("DELETE FROM schema_migrations WHERE name = '2026_05_26_enrich_status_v1'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    store = VectorStore(db_path)
+    try:
+        enriched_values = [row[0] for row in store.conn.cursor().execute("SELECT enriched_at FROM chunks")]
+    finally:
+        store.close()
+
+    for enriched_at in enriched_values:
+        if enriched_at is not None:
+            datetime.fromisoformat(enriched_at.replace("Z", "+00:00"))
+
+
+def test_mark_unenrichable_writes_status_not_enriched_at(tmp_path):
+    store = VectorStore(tmp_path / "unenrichable.db")
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type, char_count, source
+        ) VALUES (
+            'short', 'tiny', '{}', 'test.jsonl', 'brainlayer', 'assistant_text', 4, 'claude_code'
+        )
+        """
+    )
+
+    try:
+        tagged = mark_unenrichable(store)
+        row = cursor.execute("SELECT enriched_at, enrich_status FROM chunks WHERE id = 'short'").fetchone()
+    finally:
+        store.close()
+
+    assert tagged == 1
+    assert row == (None, "too_short")
+
+
+def test_update_enrichment_sets_success_status(tmp_path):
+    store = VectorStore(tmp_path / "success-status.db")
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type, char_count, source
+        ) VALUES (
+            'chunk-1', 'content that should be enriched', '{}', 'test.jsonl',
+            'brainlayer', 'assistant_text', 31, 'claude_code'
+        )
+        """
+    )
+
+    try:
+        store.update_enrichment("chunk-1", summary="summary")
+        enriched_at, enrich_status = cursor.execute(
+            "SELECT enriched_at, enrich_status FROM chunks WHERE id = 'chunk-1'"
+        ).fetchone()
+    finally:
+        store.close()
+
+    assert enrich_status == "success"
+    assert enriched_at is not None
+    datetime.fromisoformat(enriched_at.replace("Z", "+00:00"))
+
+
+def test_enrich_status_migration_sql_applies_cleanly(tmp_path):
+    database_path = tmp_path / "migration.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            enriched_at TEXT
+        )
+        """
+    )
+    connection.executemany(
+        "INSERT INTO chunks (id, enriched_at) VALUES (?, ?)",
+        [("dupe", "skipped:duplicate"), ("blank", "")],
+    )
+    migration_sql = (Path(__file__).parent.parent / "migrations/004_enrich_status.sql").read_text()
+
+    connection.executescript(migration_sql)
+
+    rows = dict(connection.execute("SELECT id, enriched_at FROM chunks ORDER BY id").fetchall())
+    row = connection.execute("SELECT enriched_at, enrich_status FROM chunks WHERE id = 'dupe'").fetchone()
+    assert row == (None, "duplicate")
+    assert rows["blank"] is None

--- a/tests/test_session_enrichment_candidates.py
+++ b/tests/test_session_enrichment_candidates.py
@@ -57,6 +57,17 @@ def test_get_enrichment_candidates_skips_already_enriched_chunks(tmp_path):
     assert [row["id"] for row in results] == ["c1"]
 
 
+def test_get_enrichment_candidates_skips_terminal_status_chunks(tmp_path):
+    store = VectorStore(tmp_path / "test.db")
+    _insert_chunk(store, "pending", "p" * 80)
+    _insert_chunk(store, "duplicate", "d" * 80)
+    store.conn.cursor().execute("UPDATE chunks SET enrich_status = 'duplicate' WHERE id = 'duplicate'")
+
+    results = store.get_enrichment_candidates(limit=10)
+
+    assert [row["id"] for row in results] == ["pending"]
+
+
 def test_get_enrichment_candidates_skips_short_chunks(tmp_path):
     store = VectorStore(tmp_path / "test.db")
     _insert_chunk(store, "short", "tiny")


### PR DESCRIPTION
## Summary
- Adds `chunks.enrich_status` plus Python, Swift, and standalone SQL migration/backfills so `enriched_at` is datetime-or-NULL data again.
- Stops skipped terminal states from being written into `enriched_at`; skipped rows now use status values like `duplicate` and `too_short`.
- Updates BrainBar dashboard/enrichment stats so success counts use `enrich_status='success'`, pending/eligible excludes terminal statuses, and last/recent enrichment remains timestamp-gated.

## Bug Evidence
- Live DB evidence from the mandate: `13268` rows had `enriched_at='skipped:duplicate'`.
- Live DB evidence from the mandate: `13268` rows matched `enriched_at LIKE 'skipped:%'`.
- Live DB evidence from the mandate: `MAX(enriched_at)=skipped:duplicate`, making dashboard recency false.
- Queue depth at task start: `7` in `/Users/etanheyman/.local/share/brainlayer/pending-stores.jsonl`.

## Research / Mandate References
- `/tmp/codex-mandate-brainbar-dashboard-truth.md`: Item A requires `enrich_status`, no status strings in `enriched_at`, migration cleanup, and BrainBar last-enrichment filtering on success timestamps.
- `docs.local/research/2026-05-24-brainbar-ui-claude-desktop-research.md` and `docs.local/audits/2026-05-24-brainbar-ui-research-audit.md`: dashboard telemetry must be trustworthy, not merely present.
- Google Drive R71 BrainBar UX results: BrainBar status text is product surface, so false dashboard state is a UX bug.
- Google Doc `1vEBaiP51EuK23kM0f1ak0edFj3CrDp23bH4razLD1ew`: BrainBar dashboard had degraded trust from dead/off-looking metrics and needs separated indexing/enrichment telemetry.

## Review Notes
- Local CodeRabbit CLI reviewed the staged diff multiple times and found migration/stat consistency issues; those were fixed.
- Final local CodeRabbit rerun hit the CLI review limit after fixes. The remaining SQLite `ADD COLUMN` idempotence concern is documented in `migrations/004_enrich_status.sql`: repo SQL migrations are standalone raw ALTER files, while Python/Swift startup migrators use column-exists checks.

## Test Plan
- RED first: `pytest tests/test_enrichment_data_integrity.py -q` failed before implementation.
- RED first: `swift test --package-path brain-bar --filter DashboardTests/testDashboardStatsIgnoresSkippedEnrichmentStatusStrings` failed before implementation.
- Focused Python: `pytest tests/test_enrichment_data_integrity.py tests/test_cloud_backfill.py tests/test_batch_reenrichment_setup.py tests/test_enrichment_controller.py -q` -> 98 passed.
- Focused Swift: `swift test --package-path brain-bar --filter DashboardTests` -> 26 tests, 0 failures.
- Full Python: `pytest -q` -> 2255 passed, 46 skipped, 5 xfailed, 328 warnings.
- Full Swift: `swift test --package-path brain-bar` -> 452 tests, 0 failures.
- Pre-push hook: 2185 selected Python tests passed, MCP registration 3 passed, isolated eval/hook routing 36 passed, bun test passed, FTS5 determinism shell regression passed.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared chunk schema and migration/backfill logic plus enrichment candidate selection across Python and BrainBar; incorrect migration or query drift could skew dashboard telemetry or re-queue skipped chunks, though coverage is extensive.
> 
> **Overview**
> Introduces **`enrich_status`** on `chunks` as the canonical enrichment outcome (`success`, terminal skips like `duplicate` / `too_short`, or `NULL` for pending), with startup/SQL migrations that backfill from existing rows and move legacy **`skipped:*`** strings out of **`enriched_at`** so that column stays datetime-or-NULL.
> 
> **Write paths** now set `enrich_status = 'success'` alongside real `enriched_at` values (store, drain, session updates, BrainBar backfill enrich), and **`mark_unenrichable`** writes terminal status without polluting `enriched_at`.
> 
> **Read paths** across Python (`session_repo`, MCP enrich stats, cloud backfill, vector store) and **BrainBar** (`dashboardCounts`, last/recent enrichment, `enrichChunks` candidate filters, `enrichmentStats`) count enriched rows via `enrich_status = 'success'`, exclude terminal statuses from pending/eligible queues, and gate recency metrics on successful enrichments only—replacing the old `chunkCount - enrichedCount` pending heuristic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 575c8cd0e94ed740993519192f35c0659bcfc595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `enrich_status` column to chunks table as the canonical enrichment state
> - Introduces an `enrich_status` TEXT column to the `chunks` table schema across Python ([vector_store.py](https://github.com/EtanHey/brainlayer/pull/330/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261), [session_repo.py](https://github.com/EtanHey/brainlayer/pull/330/files#diff-8869d9906ebb24eac961fec78a69eeaa3e285f2c046d3ed306f2d8c812fc58a7)) and Swift ([BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/330/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc)) layers, replacing sentinel values in `enriched_at` (e.g. `skipped:*` strings) with explicit status values (`success`, `too_short`).
> - Migration logic in [004_enrich_status.sql](https://github.com/EtanHey/brainlayer/pull/330/files#diff-6ded3118ce237c8a090fe77687028d9f8fcbc63bdf45d800ac86cd0a4dfbd606) and in-process startup migrations backfill existing rows: valid `enriched_at` timestamps become `enrich_status='success'`, `skipped:*` values move to `enrich_status`, and blank `enriched_at` values are nulled.
> - Enrichment candidate queries in [session_repo.py](https://github.com/EtanHey/brainlayer/pull/330/files#diff-8869d9906ebb24eac961fec78a69eeaa3e285f2c046d3ed306f2d8c812fc58a7), [BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/330/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc), and [enrich_handler.py](https://github.com/EtanHey/brainlayer/pull/330/files#diff-d09d0c3229cfb7979c1904caa615d51389679a6c0ca94b42a0bf04df10698b6a) now filter by `enrich_status IS NULL` to skip terminal-status chunks.
> - Dashboard and stats aggregators across all layers are updated to count enriched rows by `enrich_status='success'` and pending rows by `enrich_status IS NULL`.
> - Behavioral Change: chunks with any non-null `enrich_status` are permanently excluded from future enrichment runs; previously only `enriched_at` was checked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 575c8cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->