### PR TITLE
feat(brainbar): queue status truth (dashboard truth B)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -81,6 +81,9 @@ final class BrainDatabase: @unchecked Sendable {
         let lastWriteAt: Date?
         let lastEnrichedAt: Date?
         let trigramIndexedChunkCount: Int
+        let pendingStoreQueueDepth: Int
+        let pendingStoreOldestQueuedAt: Date?
+        let pendingStoreFlushRatePerMinute: Double
 
         init(
             chunkCount: Int,
@@ -96,7 +99,10 @@ final class BrainDatabase: @unchecked Sendable {
             liveWindowMinutes: Int = 1,
             lastWriteAt: Date? = nil,
             lastEnrichedAt: Date? = nil,
-            trigramIndexedChunkCount: Int = 0
+            trigramIndexedChunkCount: Int = 0,
+            pendingStoreQueueDepth: Int = 0,
+            pendingStoreOldestQueuedAt: Date? = nil,
+            pendingStoreFlushRatePerMinute: Double = 0
         ) {
             self.chunkCount = chunkCount
             self.enrichedChunkCount = enrichedChunkCount
@@ -112,6 +118,9 @@ final class BrainDatabase: @unchecked Sendable {
             self.lastWriteAt = lastWriteAt
             self.lastEnrichedAt = lastEnrichedAt
             self.trigramIndexedChunkCount = trigramIndexedChunkCount
+            self.pendingStoreQueueDepth = pendingStoreQueueDepth
+            self.pendingStoreOldestQueuedAt = pendingStoreOldestQueuedAt
+            self.pendingStoreFlushRatePerMinute = pendingStoreFlushRatePerMinute
         }
 
         var recentWriteCount: Int {
@@ -145,6 +154,33 @@ final class BrainDatabase: @unchecked Sendable {
             guard chunkCount > 0 else { return 100 }
             return (Double(trigramIndexedChunkCount) / Double(chunkCount)) * 100
         }
+
+        func withPendingStoreFlushRate(_ rate: Double) -> DashboardStats {
+            DashboardStats(
+                chunkCount: chunkCount,
+                enrichedChunkCount: enrichedChunkCount,
+                pendingEnrichmentCount: pendingEnrichmentCount,
+                enrichmentPercent: enrichmentPercent,
+                enrichmentRatePerMinute: enrichmentRatePerMinute,
+                databaseSizeBytes: databaseSizeBytes,
+                recentActivityBuckets: recentActivityBuckets,
+                recentEnrichmentBuckets: recentEnrichmentBuckets,
+                activityWindowMinutes: activityWindowMinutes,
+                bucketCount: bucketCount,
+                liveWindowMinutes: liveWindowMinutes,
+                lastWriteAt: lastWriteAt,
+                lastEnrichedAt: lastEnrichedAt,
+                trigramIndexedChunkCount: trigramIndexedChunkCount,
+                pendingStoreQueueDepth: pendingStoreQueueDepth,
+                pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
+                pendingStoreFlushRatePerMinute: rate
+            )
+        }
+    }
+
+    struct PendingStoreQueueSnapshot: Sendable, Equatable {
+        let depth: Int
+        let oldestQueuedAt: Date?
     }
 
     struct SubscriberRecord: Sendable {
@@ -1343,6 +1379,7 @@ final class BrainDatabase: @unchecked Sendable {
             activityWindowMinutes: activityWindowMinutes,
             bucketCount: bucketCount
         )
+        let pendingStoreQueue = pendingStoreQueueSnapshot()
 
         return DashboardStats(
             chunkCount: chunkCount,
@@ -1358,7 +1395,9 @@ final class BrainDatabase: @unchecked Sendable {
             liveWindowMinutes: liveWindowMinutes,
             lastWriteAt: lastEvents.lastWriteAt,
             lastEnrichedAt: lastEvents.lastEnrichedAt,
-            trigramIndexedChunkCount: (try? countRows(in: "chunks_fts_trigram")) ?? 0
+            trigramIndexedChunkCount: (try? countRows(in: "chunks_fts_trigram")) ?? 0,
+            pendingStoreQueueDepth: pendingStoreQueue.depth,
+            pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt
         )
     }
 
@@ -2705,6 +2744,40 @@ final class BrainDatabase: @unchecked Sendable {
         try? Data(contentsOf: path)
     }
 
+    func pendingStoreQueueSnapshot() -> PendingStoreQueueSnapshot {
+        let path = pendingStorePath()
+        Self.pendingStoreFileLock.lock()
+        defer { Self.pendingStoreFileLock.unlock() }
+
+        do {
+            return try Self.withPendingStoreProcessLock(for: path) {
+                guard FileManager.default.fileExists(atPath: path.path),
+                      let data = readPendingStoreData(at: path) else {
+                    return PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil)
+                }
+
+                let lines = Self.pendingStoreLines(from: data)
+                guard !lines.isEmpty else {
+                    return PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil)
+                }
+
+                let decoder = JSONDecoder()
+                let oldest = lines.compactMap { line -> Date? in
+                    guard let item = try? decoder.decode(PendingStoreItem.self, from: line),
+                          let queuedAt = item.queuedAt else {
+                        return nil
+                    }
+                    return Self.parsePendingStoreQueuedAt(queuedAt)
+                }.min()
+
+                return PendingStoreQueueSnapshot(depth: lines.count, oldestQueuedAt: oldest)
+            }
+        } catch {
+            NSLog("[BrainBar] Failed to inspect pending stores queue: %@", String(describing: error))
+            return PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil)
+        }
+    }
+
     private static func pendingStoreLines(from data: Data) -> [Data] {
         var lines: [Data] = []
         var start = data.startIndex
@@ -2729,6 +2802,22 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         return lines
+    }
+
+    private static func parsePendingStoreQueuedAt(_ rawValue: String) -> Date? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let date = ISO8601DateFormatter().date(from: trimmed) {
+            return date
+        }
+        if let epoch = TimeInterval(trimmed) {
+            return Date(timeIntervalSince1970: epoch)
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.date(from: trimmed)
     }
 
     private static func pendingStoreMaxLines() -> Int {

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -144,6 +144,39 @@ enum DashboardQueueStatus: String, Sendable, Equatable {
     }
 }
 
+enum DashboardStoreQueueHealth: String, Sendable, Equatable {
+    case empty
+    case activeDraining
+    case backlogAccumulating
+    case writerStuck
+
+    var label: String {
+        switch self {
+        case .empty:
+            return "empty"
+        case .activeDraining:
+            return "active draining"
+        case .backlogAccumulating:
+            return "backlog accumulating"
+        case .writerStuck:
+            return "writer stuck - investigate"
+        }
+    }
+
+    var color: NSColor {
+        switch self {
+        case .empty:
+            return .secondaryLabelColor
+        case .activeDraining:
+            return .systemGreen
+        case .backlogAccumulating:
+            return .systemYellow
+        case .writerStuck:
+            return .systemRed
+        }
+    }
+}
+
 struct DashboardFlowLane: Sendable, Equatable {
     let name: String
     let status: DashboardFlowLaneStatus
@@ -159,6 +192,14 @@ struct DashboardFlowLane: Sendable, Equatable {
 struct DashboardQueueSummary: Sendable, Equatable {
     let status: DashboardQueueStatus
     let backlogCount: Int
+    let storeHealth: DashboardStoreQueueHealth
+    let storeHealthText: String
+    let storeDepth: Int
+    let storeOldestAgeSeconds: Int?
+    let storeFlushRatePerMinute: Double
+    let storeDepthText: String
+    let storeOldestAgeText: String
+    let storeFlushRateText: String
     let title: String
     let detail: String
 }
@@ -183,6 +224,8 @@ struct DashboardFlowSummary: Sendable, Equatable {
         let writesLive = stats.eventIsLive(stats.lastWriteAt, now: now)
         let enrichmentsLive = stats.eventIsLive(stats.lastEnrichedAt, now: now)
         let backlogCount = stats.pendingEnrichmentCount
+        let storeOldestAgeSeconds = stats.pendingStoreOldestQueuedAt.map { max(0, Int(now.timeIntervalSince($0).rounded())) }
+        let storeHealth = storeQueueHealth(depth: stats.pendingStoreQueueDepth, oldestAgeSeconds: storeOldestAgeSeconds)
 
         let ingressStatus: DashboardFlowLaneStatus
         if writesLive {
@@ -287,10 +330,28 @@ struct DashboardFlowSummary: Sendable, Equatable {
             queue: DashboardQueueSummary(
                 status: queueStatus,
                 backlogCount: backlogCount,
-                title: queueTitle(status: queueStatus, backlogCount: backlogCount),
+                storeHealth: storeHealth,
+                storeHealthText: storeHealth.label,
+                storeDepth: stats.pendingStoreQueueDepth,
+                storeOldestAgeSeconds: storeOldestAgeSeconds,
+                storeFlushRatePerMinute: stats.pendingStoreFlushRatePerMinute,
+                storeDepthText: storeDepthText(stats.pendingStoreQueueDepth),
+                storeOldestAgeText: storeOldestAgeText(storeOldestAgeSeconds),
+                storeFlushRateText: DashboardMetricFormatter.speedString(
+                    ratePerMinute: stats.pendingStoreFlushRatePerMinute
+                ),
+                title: queueTitle(
+                    status: queueStatus,
+                    backlogCount: backlogCount,
+                    storeHealth: storeHealth
+                ),
                 detail: queueDetail(
                     status: queueStatus,
                     backlogCount: backlogCount,
+                    storeHealth: storeHealth,
+                    storeDepth: stats.pendingStoreQueueDepth,
+                    storeOldestAgeSeconds: storeOldestAgeSeconds,
+                    storeFlushRatePerMinute: stats.pendingStoreFlushRatePerMinute,
                     stats: stats,
                     windowLabel: windowLabel
                 )
@@ -319,7 +380,39 @@ struct DashboardFlowSummary: Sendable, Equatable {
         )
     }
 
-    private static func queueTitle(status: DashboardQueueStatus, backlogCount: Int) -> String {
+    private static func storeQueueHealth(depth: Int, oldestAgeSeconds: Int?) -> DashboardStoreQueueHealth {
+        guard depth > 0 else { return .empty }
+        let oldest = oldestAgeSeconds ?? 0
+        if depth >= 500 || oldest >= 300 {
+            return .writerStuck
+        }
+        if depth >= 50 || oldest >= 30 {
+            return .backlogAccumulating
+        }
+        return .activeDraining
+    }
+
+    private static func storeDepthText(_ depth: Int) -> String {
+        depth == 1 ? "1 queued" : "\(depth) queued"
+    }
+
+    private static func storeOldestAgeText(_ oldestAgeSeconds: Int?) -> String {
+        guard let seconds = oldestAgeSeconds else { return "oldest unknown" }
+        if seconds < 60 {
+            return "oldest \(seconds)s"
+        }
+        let minutes = Int((Double(seconds) / 60.0).rounded())
+        return "oldest \(minutes)m"
+    }
+
+    private static func queueTitle(
+        status: DashboardQueueStatus,
+        backlogCount: Int,
+        storeHealth: DashboardStoreQueueHealth
+    ) -> String {
+        if storeHealth != .empty {
+            return "Queue \(storeHealth.label)"
+        }
         switch status {
         case .empty:
             return "Queue empty"
@@ -339,9 +432,20 @@ struct DashboardFlowSummary: Sendable, Equatable {
     private static func queueDetail(
         status: DashboardQueueStatus,
         backlogCount: Int,
+        storeHealth: DashboardStoreQueueHealth,
+        storeDepth: Int,
+        storeOldestAgeSeconds: Int?,
+        storeFlushRatePerMinute: Double,
         stats: DashboardStats,
         windowLabel: String
     ) -> String {
+        if storeHealth != .empty {
+            let depth = storeDepthText(storeDepth)
+            let oldest = storeOldestAgeText(storeOldestAgeSeconds)
+            let rate = DashboardMetricFormatter.speedString(ratePerMinute: storeFlushRatePerMinute)
+            return "\(depth), \(oldest), draining \(rate) over 60s."
+        }
+
         switch status {
         case .empty:
             return "No chunks are waiting for enrichment."

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -32,7 +32,7 @@ final class StatsCollector: ObservableObject {
     private let brainBusEvents: BrainBusEventSource?
     private var brainBusTask: Task<Void, Never>?
     private var isRunning = false
-    private var lastDataVersion: Int?
+    private var pendingStoreQueueDepthSamples: [(date: Date, depth: Int)] = []
 
     init(
         dbPath: String,
@@ -95,14 +95,13 @@ final class StatsCollector: ObservableObject {
 
         do {
             database.reopenIfNeeded()
-            let currentDataVersion = try database.dataVersion()
-            if force || currentDataVersion != lastDataVersion {
-                stats = try database.dashboardStats(
-                    activityWindowMinutes: Self.defaultActivityWindowMinutes,
-                    bucketCount: Self.defaultBucketCount
-                )
-                lastDataVersion = currentDataVersion
-            }
+            let snapshotTime = Date()
+            let nextStats = try database.dashboardStats(
+                activityWindowMinutes: Self.defaultActivityWindowMinutes,
+                bucketCount: Self.defaultBucketCount
+            )
+            let queueFlushRate = recordPendingStoreQueueDepth(nextStats.pendingStoreQueueDepth, now: snapshotTime)
+            stats = nextStats.withPendingStoreFlushRate(queueFlushRate)
             daemon = nextDaemon
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
         } catch {
@@ -123,6 +122,21 @@ final class StatsCollector: ObservableObject {
             }
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
         }
+    }
+
+    private func recordPendingStoreQueueDepth(_ depth: Int, now: Date) -> Double {
+        pendingStoreQueueDepthSamples.append((date: now, depth: depth))
+        let windowStart = now.addingTimeInterval(-60)
+        pendingStoreQueueDepthSamples.removeAll { $0.date < windowStart }
+
+        guard pendingStoreQueueDepthSamples.count > 1 else { return 0 }
+
+        let drained = zip(pendingStoreQueueDepthSamples, pendingStoreQueueDepthSamples.dropFirst())
+            .reduce(0) { total, pair in
+                let decrease = max(0, pair.0.depth - pair.1.depth)
+                return total + decrease
+            }
+        return Double(drained)
     }
 
     fileprivate func handleDatabaseMutationNotification() {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -48,11 +48,11 @@ final class StatusPopoverView: NSViewController {
     private let databaseSizeLabel = NSTextField(labelWithString: "")
     private let chunkMetric = MetricTileView(title: "Chunks", accentColor: .systemBlue)
     private let enrichedMetric = MetricTileView(title: "Enriched", accentColor: .systemGreen)
-    private let pendingMetric = MetricTileView(title: "Backlog", accentColor: .systemOrange)
+    private let pendingMetric = MetricTileView(title: "Queue", accentColor: .systemOrange)
     private let rateMetric = MetricTileView(title: "Speed", accentColor: .systemPink)
     private let indexingIndicator = PipelineIndicatorBadgeView(name: "Indexing")
     private let enrichingIndicator = PipelineIndicatorBadgeView(name: "Enriching")
-    private let activityLabel = NSTextField(labelWithString: "Enrichment Throughput")
+    private let activityLabel = NSTextField(labelWithString: "Queue Health")
     private let activityDetailLabel = NSTextField(labelWithString: "")
     private let enrichmentLabel = NSTextField(labelWithString: "")
     private let sparklineChartView = NSHostingView(
@@ -362,11 +362,11 @@ final class StatusPopoverView: NSViewController {
 
         chunkMetric.value = "\(collector.stats.chunkCount)"
         enrichedMetric.value = "\(collector.stats.enrichedChunkCount)"
-        pendingMetric.value = "\(collector.stats.pendingEnrichmentCount)"
+        pendingMetric.value = "\(collector.stats.pendingStoreQueueDepth)"
         rateMetric.value = DashboardMetricFormatter.speedString(ratePerMinute: collector.stats.enrichmentRatePerMinute)
 
         enrichmentLabel.stringValue = "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched"
-        activityDetailLabel.stringValue = enrichmentActivitySummary(collector.stats)
+        activityDetailLabel.stringValue = queueActivitySummary(summary.queue)
         sparklineChartView.rootView = SparklineChart(
             presentation: SparklineChartPresentation(
                 label: "Recent activity sparkline",
@@ -402,12 +402,8 @@ final class StatusPopoverView: NSViewController {
         ByteCountFormatter.string(fromByteCount: value, countStyle: .file)
     }
 
-    private func enrichmentActivitySummary(_ stats: DashboardStats) -> String {
-        let recentCompletions = stats.recentEnrichmentBuckets.reduce(0, +)
-        if recentCompletions == 0 {
-            return "No completions in \(DashboardMetricFormatter.windowLabel(minutes: stats.activityWindowMinutes).lowercased())"
-        }
-        return "\(recentCompletions) completions in \(DashboardMetricFormatter.windowLabel(minutes: stats.activityWindowMinutes).lowercased())"
+    private func queueActivitySummary(_ queue: DashboardQueueSummary) -> String {
+        "\(queue.storeHealthText): \(queue.storeDepthText), \(queue.storeOldestAgeText), \(queue.storeFlushRateText)"
     }
 
     private func verticalStack(_ views: [NSView]) -> NSStackView {

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -173,6 +173,78 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(summary.enrichment.lastEventText, "2m ago")
     }
 
+    func testDashboardQueueSummaryReportsActiveDrainingForSmallFreshStoreQueue() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 120,
+            pendingEnrichmentCount: 0,
+            enrichmentPercent: 100,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0],
+            pendingStoreQueueDepth: 6,
+            pendingStoreOldestQueuedAt: now.addingTimeInterval(-2),
+            pendingStoreFlushRatePerMinute: 60
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+
+        XCTAssertEqual(summary.queue.storeHealth, .activeDraining)
+        XCTAssertEqual(summary.queue.storeHealthText, "active draining")
+        XCTAssertEqual(summary.queue.storeDepthText, "6 queued")
+        XCTAssertEqual(summary.queue.storeOldestAgeText, "oldest 2s")
+        XCTAssertEqual(summary.queue.storeFlushRateText, "60/min")
+        XCTAssertEqual(summary.queue.title, "Queue active draining")
+    }
+
+    func testDashboardQueueSummaryEscalatesToBacklogAccumulatingByDepthOrAge() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 120,
+            pendingEnrichmentCount: 0,
+            enrichmentPercent: 100,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0],
+            pendingStoreQueueDepth: 50,
+            pendingStoreOldestQueuedAt: now.addingTimeInterval(-12),
+            pendingStoreFlushRatePerMinute: 5
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+
+        XCTAssertEqual(summary.queue.storeHealth, .backlogAccumulating)
+        XCTAssertEqual(summary.queue.storeHealthText, "backlog accumulating")
+        XCTAssertEqual(summary.queue.title, "Queue backlog accumulating")
+    }
+
+    func testDashboardQueueSummaryEscalatesToWriterStuckByDepthOrAge() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 120,
+            pendingEnrichmentCount: 0,
+            enrichmentPercent: 100,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0],
+            pendingStoreQueueDepth: 7,
+            pendingStoreOldestQueuedAt: now.addingTimeInterval(-300),
+            pendingStoreFlushRatePerMinute: 0
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+
+        XCTAssertEqual(summary.queue.storeHealth, .writerStuck)
+        XCTAssertEqual(summary.queue.storeHealthText, "writer stuck - investigate")
+        XCTAssertEqual(summary.queue.title, "Queue writer stuck - investigate")
+    }
+
     func testIncomingRelationDisplayPutsEntityNameBeforeRelationVerb() {
         let relation = EntityCard.Relation(
             relationType: "coaches",

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -102,6 +102,31 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.recentEnrichmentBuckets, [0, 0, 0, 0])
     }
 
+    func testDashboardStatsReadsPendingStoreQueueDepthAndOldestEntry() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("pending-stores-dashboard-\(UUID().uuidString).jsonl")
+        let restoreQueuePath = setDashboardPendingStoreQueuePath(queuePath)
+        defer {
+            restoreQueuePath()
+            try? FileManager.default.removeItem(at: queuePath)
+        }
+
+        let older = ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: 1_000))
+        let newer = ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: 1_060))
+        let payload = """
+        {"content":"old queued item","tags":["queue"],"importance":5,"source":"mcp","queued_at":"\(older)"}
+        {"content":"new queued item","tags":["queue"],"importance":5,"source":"mcp","queued_at":"\(newer)"}
+
+        """
+        try payload.write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 15, bucketCount: 4)
+
+        XCTAssertEqual(stats.pendingStoreQueueDepth, 2)
+        XCTAssertEqual(stats.pendingStoreOldestQueuedAt, Date(timeIntervalSince1970: 1_000))
+        XCTAssertEqual(stats.pendingStoreFlushRatePerMinute, 0)
+    }
+
     func testSparklineChartPresentationCarriesBucketsAndVoiceOverMetadata() {
         let presentation = SparklineChartPresentation(
             label: "Recent activity sparkline",
@@ -392,6 +417,35 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(collector.stats.chunkCount, 1)
     }
 
+    @MainActor
+    func testStatsCollectorComputesPendingStoreFlushRateFromDepthDrops() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("pending-stores-collector-\(UUID().uuidString).jsonl")
+        let restoreQueuePath = setDashboardPendingStoreQueuePath(queuePath)
+        defer {
+            restoreQueuePath()
+            try? FileManager.default.removeItem(at: queuePath)
+        }
+
+        try writeDashboardPendingStoreQueue(count: 3, to: queuePath)
+
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
+        )
+        defer { collector.stop() }
+
+        collector.refresh(force: true)
+        XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 3)
+        XCTAssertEqual(collector.stats.pendingStoreFlushRatePerMinute, 0)
+
+        try writeDashboardPendingStoreQueue(count: 1, to: queuePath)
+        collector.refresh(force: true)
+
+        XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 1)
+        XCTAssertEqual(collector.stats.pendingStoreFlushRatePerMinute, 2)
+    }
+
     func test_DaemonHealthMonitor_returns_non_nil_when_PID_provided() throws {
         let monitor = DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
 
@@ -603,4 +657,26 @@ private final class RecordingBrainBusEventSource: BrainBusEventSource, @unchecke
         }
         return AsyncStream { _ in }
     }
+}
+
+private func setDashboardPendingStoreQueuePath(_ path: URL) -> () -> Void {
+    let previous = ProcessInfo.processInfo.environment["BRAINBAR_PENDING_STORES_PATH"]
+    setenv("BRAINBAR_PENDING_STORES_PATH", path.path, 1)
+    return {
+        if let previous {
+            setenv("BRAINBAR_PENDING_STORES_PATH", previous, 1)
+        } else {
+            unsetenv("BRAINBAR_PENDING_STORES_PATH")
+        }
+    }
+}
+
+private func writeDashboardPendingStoreQueue(count: Int, to path: URL) throws {
+    let queuedAt = ISO8601DateFormatter().string(from: Date())
+    let lines = (0..<count).map { index in
+        """
+        {"content":"queued item \(index)","tags":["queue"],"importance":5,"source":"mcp","queued_at":"\(queuedAt)"}
+        """
+    }
+    try lines.joined(separator: "\n").appending("\n").write(to: path, atomically: true, encoding: .utf8)
 }


### PR DESCRIPTION
## Summary

Implements Item B from `/tmp/codex-mandate-brainbar-dashboard-truth.md`: BrainBar now reports the pending-store queue as operational telemetry instead of a vague queued/backlog hint.

Changes:
- Reads `pending-stores.jsonl` into dashboard stats: depth, oldest queued entry timestamp.
- Tracks 60-second drain rate in `StatsCollector` from queue depth drops.
- Adds explicit health thresholds:
  - depth < 50 and oldest < 30s: green `active draining`
  - depth >= 50 or oldest >= 30s: yellow `backlog accumulating`
  - depth >= 500 or oldest >= 5m: red `writer stuck - investigate`
- Updates the status popover queue surface to show queue depth, oldest age, and flush rate.

## Evidence / Research

Mandate: `/tmp/codex-mandate-brainbar-dashboard-truth.md`, Item B.

Research cited from the dashboard-truth packet:
- `Brain Drive/03_RESEARCH/Active/orchestrator/R71-brainbar-ux-results.md`
- `BrainBar UX Dashboard Research` Google Doc `1vEBaiP51EuK23kM0f1ak0edFj3CrDp23bH4razLD1ew`
- Local audit context: `docs.local/research/2026-05-24-brainbar-ui-claude-desktop-research.md` and `docs.local/audits/2026-05-24-brainbar-ui-research-audit.md`

Bug evidence at time of work:
- `~/.local/share/brainlayer/pending-stores.jsonl` depth: 11
- Parseable `queued_at` entries: 11
- Oldest entry: `2026-05-26T12:01:13+00:00`
- Oldest age measured during work: 9356 seconds
- Under the new rules, this correctly surfaces as red `writer stuck - investigate`.

## TDD / Validation

Red first:
- `swift test --package-path brain-bar --filter 'BrainBarUXLogicTests/testDashboardQueueSummary|DashboardTests/testDashboardStatsReadsPendingStoreQueueDepthAndOldestEntry'`
- Failed on missing queue telemetry fields and health model before implementation.

Green:
- `swift test --package-path brain-bar --filter 'BrainBarUXLogicTests/testDashboardQueueSummary|DashboardTests/testDashboardStatsReadsPendingStoreQueueDepthAndOldestEntry|DashboardTests/testStatsCollectorComputesPendingStoreFlushRateFromDepthDrops'` -> 5 tests passed
- `swift test --package-path brain-bar` -> 458 tests passed
- `pytest -q` -> 2256 passed, 46 skipped, 5 xfailed
- `git diff --check` -> passed
- pre-push gate -> passed:
  - pytest unit suite: 2186 passed, 9 skipped, 75 deselected, 1 xfailed
  - MCP tool registration: 3 passed
  - isolated eval/hook routing: 36 passed
  - bun stale index test: passed
  - FTS5 determinism regression: passed

## Review Gate

AP_BL_7 requested: 2+ green reviews from CodeRabbit / Codex / Macroscope-Correctness; Cursor optional. No squash. Merge mode after green gate: `gh pr merge --rebase --admin`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches write-path queue inspection and changes refresh cadence (no longer gated on SQLite data_version), which could add I/O on busy dashboards but stays read-only on the queue file with existing locking.
> 
> **Overview**
> BrainBar’s dashboard now surfaces **pending-store** (`pending-stores.jsonl`) health instead of treating enrichment backlog as the only “queue” signal.
> 
> **Data layer:** `DashboardStats` gains queue depth, oldest `queued_at`, and flush rate; `BrainDatabase.pendingStoreQueueSnapshot()` reads the JSONL under the same file lock as flush. **`StatsCollector`** always refreshes stats (drops `data_version` gating), samples depth over 60s, and derives flush rate from depth drops.
> 
> **UI / flow model:** New `DashboardStoreQueueHealth` tiers (active draining → backlog accumulating → writer stuck) from depth/age thresholds; queue titles and details prefer store health when the file queue is non-empty. The status popover **Queue** tile shows store depth; **Queue Health** shows depth, oldest age, and drain rate.
> 
> Tests cover snapshot parsing, health escalation, and flush-rate sampling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1bbc1970b77c954341934c94a2d3d28bbe37378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pending store queue depth, age, and flush rate to the brain-bar dashboard
> - `BrainDatabase.dashboardStats` now reads the pending store queue file to report queue depth and oldest queued-at timestamp via a new `pendingStoreQueueSnapshot()` method that supports ISO8601, epoch, and `yyyy-MM-dd HH:mm:ss` timestamp formats.
> - `StatsCollector` tracks depth samples over a 60-second sliding window to compute a flush rate (items drained per minute), always sampling regardless of `data_version`.
> - A new `DashboardStoreQueueHealth` enum classifies queue state as `empty`, `activeDraining`, `backlogAccumulating`, or `writerStuck` based on depth and age thresholds (≥50 items or ≥30s → accumulating; ≥500 or ≥300s → stuck).
> - The status popover renames the 'Backlog' tile to 'Queue' and shows queue health, depth, oldest age, and flush rate in the detail line.
> - Behavioral Change: `StatsCollector.refresh` no longer gates stat sampling on a `data_version` change, so database reads happen on every refresh cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1bbc19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->