### PR TITLE
feat(brainbar): raise graph link cap (dashboard truth C)

### DIFF
--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -182,6 +182,8 @@ final class StatsCollector: ObservableObject {
                 return
             }
 
+            guard !Task.isCancelled else { return }
+
             await MainActor.run {
                 guard let self else { return }
                 self.pendingStatsRefreshTask = nil

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -138,9 +138,6 @@ final class StatsCollector: ObservableObject {
                 )
             }
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
-            if !force {
-                lastNonForcedStatsRefreshAt = snapshotTime
-            }
         }
     }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -71,6 +71,7 @@ final class StatsCollector: ObservableObject {
 
     func start() {
         guard !isRunning else { return }
+        resetRefreshTimingState()
         isRunning = true
         installDarwinObserver()
         refresh(force: true)
@@ -94,6 +95,7 @@ final class StatsCollector: ObservableObject {
             removeDarwinObserver()
         }
         isRunning = false
+        resetRefreshTimingState()
         database.close()
     }
 
@@ -167,6 +169,11 @@ final class StatsCollector: ObservableObject {
         }
         agentActivity = agentActivityMonitor.sample()
         lastAgentActivitySampleAt = now
+    }
+
+    private func resetRefreshTimingState() {
+        lastAgentActivitySampleAt = nil
+        lastNonForcedStatsRefreshAt = nil
     }
 
     fileprivate func handleDatabaseMutationNotification() {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -29,21 +29,29 @@ final class StatsCollector: ObservableObject {
     private let database: BrainDatabase
     private let daemonMonitor: DaemonHealthMonitor
     private let agentActivityMonitor: AgentActivityMonitor
+    private let agentActivitySampleInterval: TimeInterval
+    private let statsRefreshCoalesceInterval: TimeInterval
     private let brainBusEvents: BrainBusEventSource?
     private var brainBusTask: Task<Void, Never>?
     private var isRunning = false
+    private var lastAgentActivitySampleAt: Date?
+    private var lastNonForcedStatsRefreshAt: Date?
     private var pendingStoreQueueDepthSamples: [(date: Date, depth: Int)] = []
 
     init(
         dbPath: String,
         daemonMonitor: DaemonHealthMonitor,
         agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor(),
+        agentActivitySampleInterval: TimeInterval = 5,
+        statsRefreshCoalesceInterval: TimeInterval = 5,
         brainBusEvents: BrainBusEventSource? = nil,
         databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) {
         self.database = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
         self.daemonMonitor = daemonMonitor
         self.agentActivityMonitor = agentActivityMonitor
+        self.agentActivitySampleInterval = agentActivitySampleInterval
+        self.statsRefreshCoalesceInterval = statsRefreshCoalesceInterval
         self.brainBusEvents = brainBusEvents
         self.stats = DashboardStats(
             chunkCount: 0,
@@ -91,11 +99,17 @@ final class StatsCollector: ObservableObject {
 
     func refresh(force: Bool = false) {
         let nextDaemon = daemonMonitor.sample()
-        agentActivity = agentActivityMonitor.sample()
+        let snapshotTime = Date()
+        refreshAgentActivity(force: force, now: snapshotTime)
+
+        if !force, shouldCoalesceStatsRefresh(now: snapshotTime) {
+            daemon = nextDaemon
+            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            return
+        }
 
         do {
             database.reopenIfNeeded()
-            let snapshotTime = Date()
             let nextStats = try database.dashboardStats(
                 activityWindowMinutes: Self.defaultActivityWindowMinutes,
                 bucketCount: Self.defaultBucketCount
@@ -104,6 +118,9 @@ final class StatsCollector: ObservableObject {
             stats = nextStats.withPendingStoreFlushRate(queueFlushRate)
             daemon = nextDaemon
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            if !force {
+                lastNonForcedStatsRefreshAt = snapshotTime
+            }
         } catch {
             daemon = nextDaemon
             if force {
@@ -121,6 +138,9 @@ final class StatsCollector: ObservableObject {
                 )
             }
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            if !force {
+                lastNonForcedStatsRefreshAt = snapshotTime
+            }
         }
     }
 
@@ -139,6 +159,19 @@ final class StatsCollector: ObservableObject {
         return Double(drained)
     }
 
+    private func shouldCoalesceStatsRefresh(now: Date) -> Bool {
+        guard let lastNonForcedStatsRefreshAt else { return false }
+        return now.timeIntervalSince(lastNonForcedStatsRefreshAt) < statsRefreshCoalesceInterval
+    }
+
+    private func refreshAgentActivity(force: Bool, now: Date) {
+        if !force, let lastAgentActivitySampleAt, now.timeIntervalSince(lastAgentActivitySampleAt) < agentActivitySampleInterval {
+            return
+        }
+        agentActivity = agentActivityMonitor.sample()
+        lastAgentActivitySampleAt = now
+    }
+
     fileprivate func handleDatabaseMutationNotification() {
         refresh(force: false)
     }
@@ -147,7 +180,7 @@ final class StatsCollector: ObservableObject {
         switch event.type {
         case .healthTick:
             daemon = daemonMonitor.sample()
-            agentActivity = agentActivityMonitor.sample()
+            refreshAgentActivity(force: false, now: Date())
             state = PipelineState.derive(daemon: daemon, stats: stats)
         case .queueDepth, .enrichStatus, .lastChunkID, .dbBusy:
             refresh(force: false)

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -35,6 +35,7 @@ final class StatsCollector: ObservableObject {
     private var brainBusTask: Task<Void, Never>?
     private var pendingStatsRefreshTask: Task<Void, Never>?
     private var isRunning = false
+    private var isStopped = false
     private var lastAgentActivitySampleAt: Date?
     private var lastNonForcedStatsRefreshAt: Date?
     private var pendingStoreQueueDepthSamples: [(date: Date, depth: Int)] = []
@@ -73,6 +74,7 @@ final class StatsCollector: ObservableObject {
     func start() {
         guard !isRunning else { return }
         resetRefreshTimingState()
+        isStopped = false
         isRunning = true
         installDarwinObserver()
         refresh(force: true)
@@ -98,6 +100,7 @@ final class StatsCollector: ObservableObject {
             removeDarwinObserver()
         }
         isRunning = false
+        isStopped = true
         resetRefreshTimingState()
         database.close()
     }
@@ -185,7 +188,7 @@ final class StatsCollector: ObservableObject {
             guard !Task.isCancelled else { return }
 
             await MainActor.run {
-                guard let self else { return }
+                guard let self, !self.isStopped else { return }
                 self.pendingStatsRefreshTask = nil
                 self.refresh(force: false)
             }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -33,6 +33,7 @@ final class StatsCollector: ObservableObject {
     private let statsRefreshCoalesceInterval: TimeInterval
     private let brainBusEvents: BrainBusEventSource?
     private var brainBusTask: Task<Void, Never>?
+    private var pendingStatsRefreshTask: Task<Void, Never>?
     private var isRunning = false
     private var lastAgentActivitySampleAt: Date?
     private var lastNonForcedStatsRefreshAt: Date?
@@ -91,6 +92,8 @@ final class StatsCollector: ObservableObject {
     func stop() {
         brainBusTask?.cancel()
         brainBusTask = nil
+        pendingStatsRefreshTask?.cancel()
+        pendingStatsRefreshTask = nil
         if isRunning {
             removeDarwinObserver()
         }
@@ -104,11 +107,15 @@ final class StatsCollector: ObservableObject {
         let snapshotTime = Date()
         refreshAgentActivity(force: force, now: snapshotTime)
 
-        if !force, shouldCoalesceStatsRefresh(now: snapshotTime) {
+        if !force, let coalescedDelay = coalescedStatsRefreshDelay(now: snapshotTime) {
             daemon = nextDaemon
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            schedulePendingStatsRefresh(after: coalescedDelay)
             return
         }
+
+        pendingStatsRefreshTask?.cancel()
+        pendingStatsRefreshTask = nil
 
         do {
             database.reopenIfNeeded()
@@ -158,9 +165,29 @@ final class StatsCollector: ObservableObject {
         return Double(drained)
     }
 
-    private func shouldCoalesceStatsRefresh(now: Date) -> Bool {
-        guard let lastNonForcedStatsRefreshAt else { return false }
-        return now.timeIntervalSince(lastNonForcedStatsRefreshAt) < statsRefreshCoalesceInterval
+    private func coalescedStatsRefreshDelay(now: Date) -> TimeInterval? {
+        guard let lastNonForcedStatsRefreshAt else { return nil }
+        let elapsed = now.timeIntervalSince(lastNonForcedStatsRefreshAt)
+        guard elapsed < statsRefreshCoalesceInterval else { return nil }
+        return statsRefreshCoalesceInterval - elapsed
+    }
+
+    private func schedulePendingStatsRefresh(after delay: TimeInterval) {
+        guard pendingStatsRefreshTask == nil else { return }
+
+        pendingStatsRefreshTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(delay))
+            } catch {
+                return
+            }
+
+            await MainActor.run {
+                guard let self else { return }
+                self.pendingStatsRefreshTask = nil
+                self.refresh(force: false)
+            }
+        }
     }
 
     private func refreshAgentActivity(force: Bool, now: Date) {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
@@ -20,14 +20,18 @@ struct KGAtlasPresentation {
         nodes: [KGNode],
         edges: [KGEdge],
         selectedNodeId: String?,
-        minimumImportance: Double
+        minimumImportance: Double,
+        userDefaults: UserDefaults = .standard
     ) -> Snapshot {
         let visibleNodes = nodes.filter { node in
             node.importance >= minimumImportance || node.id == selectedNodeId
         }
 
         let visibleIDs = Set(visibleNodes.map(\.id))
-        let visibleEdges = edges.filter { visibleIDs.contains($0.sourceId) && visibleIDs.contains($0.targetId) }
+        let visibleEdges = virtualizedVisibleEdges(
+            from: edges.filter { visibleIDs.contains($0.sourceId) && visibleIDs.contains($0.targetId) },
+            maxLinksPerNode: maxLinksPerNode(from: userDefaults)
+        )
 
         let grouped = Dictionary(grouping: visibleNodes, by: \.entityType)
         let regions: [Region] = orderedEntityTypes.compactMap { entityType in
@@ -80,4 +84,34 @@ struct KGAtlasPresentation {
         "topic",
         "decision",
     ]
+
+    private static let maxLinksPerNodeKey = "brainBar.maxLinksPerNode"
+    private static let defaultMaxLinksPerNode = 50
+
+    private static func maxLinksPerNode(from userDefaults: UserDefaults) -> Int {
+        let configuredValue = userDefaults.integer(forKey: maxLinksPerNodeKey)
+        return configuredValue > 0 ? configuredValue : defaultMaxLinksPerNode
+    }
+
+    private static func virtualizedVisibleEdges(
+        from edges: [KGEdge],
+        maxLinksPerNode: Int
+    ) -> [KGEdge] {
+        var linkCountsByNode: [String: Int] = [:]
+        var visibleEdges: [KGEdge] = []
+
+        for edge in edges {
+            let sourceCount = linkCountsByNode[edge.sourceId, default: 0]
+            let targetCount = linkCountsByNode[edge.targetId, default: 0]
+            guard sourceCount < maxLinksPerNode, targetCount < maxLinksPerNode else {
+                continue
+            }
+
+            visibleEdges.append(edge)
+            linkCountsByNode[edge.sourceId] = sourceCount + 1
+            linkCountsByNode[edge.targetId] = targetCount + 1
+        }
+
+        return visibleEdges
+    }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
@@ -30,7 +30,8 @@ struct KGAtlasPresentation {
         let visibleIDs = Set(visibleNodes.map(\.id))
         let visibleEdges = virtualizedVisibleEdges(
             from: edges.filter { visibleIDs.contains($0.sourceId) && visibleIDs.contains($0.targetId) },
-            maxLinksPerNode: maxLinksPerNode(from: userDefaults)
+            maxLinksPerNode: maxLinksPerNode(from: userDefaults),
+            selectedNodeId: selectedNodeId
         )
 
         let grouped = Dictionary(grouping: visibleNodes, by: \.entityType)
@@ -95,12 +96,14 @@ struct KGAtlasPresentation {
 
     private static func virtualizedVisibleEdges(
         from edges: [KGEdge],
-        maxLinksPerNode: Int
+        maxLinksPerNode: Int,
+        selectedNodeId: String?
     ) -> [KGEdge] {
         var linkCountsByNode: [String: Int] = [:]
         var visibleEdges: [KGEdge] = []
+        let orderedEdges = prioritizedEdges(edges, selectedNodeId: selectedNodeId)
 
-        for edge in edges {
+        for edge in orderedEdges {
             let sourceCount = linkCountsByNode[edge.sourceId, default: 0]
             let targetCount = linkCountsByNode[edge.targetId, default: 0]
             guard sourceCount < maxLinksPerNode, targetCount < maxLinksPerNode else {
@@ -113,5 +116,12 @@ struct KGAtlasPresentation {
         }
 
         return visibleEdges
+    }
+
+    private static func prioritizedEdges(_ edges: [KGEdge], selectedNodeId: String?) -> [KGEdge] {
+        guard let selectedNodeId else { return edges }
+        let incidentEdges = edges.filter { $0.sourceId == selectedNodeId || $0.targetId == selectedNodeId }
+        let remainingEdges = edges.filter { $0.sourceId != selectedNodeId && $0.targetId != selectedNodeId }
+        return incidentEdges + remainingEdges
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
@@ -27,13 +27,6 @@ struct KGAtlasPresentation {
             node.importance >= minimumImportance || node.id == selectedNodeId
         }
 
-        let visibleIDs = Set(visibleNodes.map(\.id))
-        let visibleEdges = virtualizedVisibleEdges(
-            from: edges.filter { visibleIDs.contains($0.sourceId) && visibleIDs.contains($0.targetId) },
-            maxLinksPerNode: maxLinksPerNode(from: userDefaults),
-            selectedNodeId: selectedNodeId
-        )
-
         let grouped = Dictionary(grouping: visibleNodes, by: \.entityType)
         let regions: [Region] = orderedEntityTypes.compactMap { entityType in
             guard let values = grouped[entityType], !values.isEmpty else { return nil }
@@ -48,6 +41,13 @@ struct KGAtlasPresentation {
                 }
             )
         }
+        let renderableNodes = regions.flatMap { $0.nodes }
+        let renderableIDs = Set(renderableNodes.map(\.id))
+        let visibleEdges = virtualizedVisibleEdges(
+            from: edges.filter { renderableIDs.contains($0.sourceId) && renderableIDs.contains($0.targetId) },
+            maxLinksPerNode: maxLinksPerNode(from: userDefaults),
+            selectedNodeId: selectedNodeId
+        )
 
         let selectedRegion = regions.first { region in
             region.nodes.contains { $0.id == selectedNodeId }
@@ -55,7 +55,7 @@ struct KGAtlasPresentation {
 
         return Snapshot(
             regions: regions,
-            visibleNodes: regions.flatMap { $0.nodes },
+            visibleNodes: renderableNodes,
             visibleEdges: visibleEdges,
             selectedRegion: selectedRegion
         )

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -466,7 +466,7 @@ final class DashboardTests: XCTestCase {
     }
 
     @MainActor
-    func testStatsCollectorCoalescesRapidMutationStatsRefreshes() throws {
+    func testStatsCollectorCoalescesRapidMutationStatsRefreshes() async throws {
         let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("pending-stores-coalesce-\(UUID().uuidString).jsonl")
         let restoreQueuePath = setDashboardPendingStoreQueuePath(queuePath)
@@ -479,7 +479,7 @@ final class DashboardTests: XCTestCase {
         let collector = StatsCollector(
             dbPath: tempDBPath,
             daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
-            statsRefreshCoalesceInterval: 60
+            statsRefreshCoalesceInterval: 0.05
         )
         defer { collector.stop() }
 
@@ -494,6 +494,9 @@ final class DashboardTests: XCTestCase {
         collector.refresh(force: false)
 
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 2)
+
+        try await Task.sleep(for: .milliseconds(120))
+        XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 1)
     }
 
     @MainActor

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -446,6 +446,56 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(collector.stats.pendingStoreFlushRatePerMinute, 2)
     }
 
+    @MainActor
+    func testStatsCollectorDoesNotResampleAgentActivityOnEveryMutationRefresh() throws {
+        let sampleCounter = AgentActivitySampleCounter()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            agentActivityMonitor: AgentActivityMonitor(snapshotProvider: {
+                sampleCounter.snapshot()
+            })
+        )
+        defer { collector.stop() }
+
+        collector.refresh(force: true)
+        collector.refresh(force: false)
+        collector.refresh(force: false)
+
+        XCTAssertEqual(sampleCounter.count, 1)
+    }
+
+    @MainActor
+    func testStatsCollectorCoalescesRapidMutationStatsRefreshes() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("pending-stores-coalesce-\(UUID().uuidString).jsonl")
+        let restoreQueuePath = setDashboardPendingStoreQueuePath(queuePath)
+        defer {
+            restoreQueuePath()
+            try? FileManager.default.removeItem(at: queuePath)
+        }
+
+        try writeDashboardPendingStoreQueue(count: 3, to: queuePath)
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 60
+        )
+        defer { collector.stop() }
+
+        collector.refresh(force: true)
+        XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 3)
+
+        try writeDashboardPendingStoreQueue(count: 2, to: queuePath)
+        collector.refresh(force: false)
+        XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 2)
+
+        try writeDashboardPendingStoreQueue(count: 1, to: queuePath)
+        collector.refresh(force: false)
+
+        XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 2)
+    }
+
     func test_DaemonHealthMonitor_returns_non_nil_when_PID_provided() throws {
         let monitor = DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
 
@@ -656,6 +706,22 @@ private final class RecordingBrainBusEventSource: BrainBusEventSource, @unchecke
             requests += 1
         }
         return AsyncStream { _ in }
+    }
+}
+
+private final class AgentActivitySampleCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var samples = 0
+
+    var count: Int {
+        lock.withLock { samples }
+    }
+
+    func snapshot() -> String {
+        lock.withLock {
+            samples += 1
+        }
+        return ""
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -496,6 +496,46 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 2)
     }
 
+    @MainActor
+    func testStatsCollectorRetriesAfterFailedNonForcedRefresh() throws {
+        let brokenPath = NSTemporaryDirectory() + "brainbar-dashboard-broken-\(UUID().uuidString).db"
+        try FileManager.default.createDirectory(
+            atPath: brokenPath,
+            withIntermediateDirectories: false
+        )
+        defer {
+            try? FileManager.default.removeItem(atPath: brokenPath)
+            try? FileManager.default.removeItem(atPath: brokenPath + "-wal")
+            try? FileManager.default.removeItem(atPath: brokenPath + "-shm")
+        }
+
+        let collector = StatsCollector(
+            dbPath: brokenPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 60
+        )
+        defer { collector.stop() }
+
+        collector.refresh(force: false)
+        XCTAssertEqual(collector.stats.chunkCount, 0)
+
+        try FileManager.default.removeItem(atPath: brokenPath)
+        let repairedDB = BrainDatabase(path: brokenPath)
+        try repairedDB.insertChunk(
+            id: "recovered-dashboard",
+            content: "Recovered dashboard refresh",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        repairedDB.close()
+
+        collector.refresh(force: false)
+
+        XCTAssertEqual(collector.stats.chunkCount, 1)
+    }
+
     func test_DaemonHealthMonitor_returns_non_nil_when_PID_provided() throws {
         let monitor = DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -753,6 +753,8 @@ private final class AgentActivitySampleCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var samples = 0
 
+    deinit {}
+
     var count: Int {
         lock.withLock { samples }
     }

--- a/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
@@ -117,6 +117,34 @@ final class KGAtlasPresentationTests: XCTestCase {
         })
     }
 
+    func testSnapshotCapsLinksAfterRemovingHiddenEntityTypes() {
+        testUserDefaults.set(2, forKey: maxLinksKey)
+        let nodes = [
+            KGNode(id: "hub", name: "Hub", entityType: "person", importance: 10, position: .zero),
+            KGNode(id: "hidden-1", name: "Hidden 1", entityType: "library", importance: 5, position: .zero),
+            KGNode(id: "hidden-2", name: "Hidden 2", entityType: "library", importance: 5, position: .zero),
+            KGNode(id: "project-1", name: "Project 1", entityType: "project", importance: 5, position: .zero),
+            KGNode(id: "project-2", name: "Project 2", entityType: "project", importance: 5, position: .zero),
+        ]
+        let edges = [
+            KGEdge(sourceId: "hub", targetId: "hidden-1", relationType: "uses"),
+            KGEdge(sourceId: "hub", targetId: "hidden-2", relationType: "uses"),
+            KGEdge(sourceId: "hub", targetId: "project-1", relationType: "owns"),
+            KGEdge(sourceId: "hub", targetId: "project-2", relationType: "owns"),
+        ]
+
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: edges,
+            selectedNodeId: nil,
+            minimumImportance: 0,
+            userDefaults: testUserDefaults
+        )
+
+        XCTAssertEqual(snapshot.visibleNodes.map(\.id), ["hub", "project-1", "project-2"])
+        XCTAssertEqual(snapshot.visibleEdges.map(\.targetId), ["project-1", "project-2"])
+    }
+
     private func makeHubGraph(edgeCount: Int) -> (nodes: [KGNode], edges: [KGEdge]) {
         let hub = KGNode(
             id: "hub",

--- a/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
@@ -3,9 +3,19 @@ import XCTest
 
 final class KGAtlasPresentationTests: XCTestCase {
     private let maxLinksKey = "brainBar.maxLinksPerNode"
+    private var userDefaultsSuiteName: String!
+    private var testUserDefaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        userDefaultsSuiteName = "KGAtlasPresentationTests-\(UUID().uuidString)"
+        testUserDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
+    }
 
     override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: maxLinksKey)
+        testUserDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+        testUserDefaults = nil
+        userDefaultsSuiteName = nil
         super.tearDown()
     }
 
@@ -24,7 +34,8 @@ final class KGAtlasPresentationTests: XCTestCase {
             nodes: nodes,
             edges: edges,
             selectedNodeId: nil,
-            minimumImportance: 0
+            minimumImportance: 0,
+            userDefaults: testUserDefaults
         )
 
         XCTAssertEqual(snapshot.regions.map { $0.title }, ["People", "Projects", "Tools"])
@@ -48,7 +59,8 @@ final class KGAtlasPresentationTests: XCTestCase {
             nodes: nodes,
             edges: edges,
             selectedNodeId: "a1",
-            minimumImportance: 5
+            minimumImportance: 5,
+            userDefaults: testUserDefaults
         )
 
         XCTAssertEqual(snapshot.visibleNodes.map { $0.id }, ["p1", "t1", "a1"])
@@ -57,14 +69,14 @@ final class KGAtlasPresentationTests: XCTestCase {
     }
 
     func testSnapshotVirtualizesHubLinksAtDefaultFiftyVisibleRelations() {
-        UserDefaults.standard.removeObject(forKey: maxLinksKey)
         let graph = makeHubGraph(edgeCount: 60)
 
         let snapshot = KGAtlasPresentation.snapshot(
             nodes: graph.nodes,
             edges: graph.edges,
             selectedNodeId: nil,
-            minimumImportance: 0
+            minimumImportance: 0,
+            userDefaults: testUserDefaults
         )
 
         XCTAssertEqual(snapshot.visibleEdges.count, 50)
@@ -73,14 +85,15 @@ final class KGAtlasPresentationTests: XCTestCase {
     }
 
     func testSnapshotUsesConfiguredMaxLinksPerNode() {
-        UserDefaults.standard.set(12, forKey: maxLinksKey)
+        testUserDefaults.set(12, forKey: maxLinksKey)
         let graph = makeHubGraph(edgeCount: 30)
 
         let snapshot = KGAtlasPresentation.snapshot(
             nodes: graph.nodes,
             edges: graph.edges,
             selectedNodeId: nil,
-            minimumImportance: 0
+            minimumImportance: 0,
+            userDefaults: testUserDefaults
         )
 
         XCTAssertEqual(snapshot.visibleEdges.count, 12)
@@ -94,7 +107,8 @@ final class KGAtlasPresentationTests: XCTestCase {
             nodes: graph.nodes,
             edges: graph.edges,
             selectedNodeId: "leaf-60",
-            minimumImportance: 0
+            minimumImportance: 0,
+            userDefaults: testUserDefaults
         )
 
         XCTAssertEqual(snapshot.visibleEdges.count, 50)

--- a/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
@@ -87,6 +87,22 @@ final class KGAtlasPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.visibleEdges.last?.targetId, "leaf-12")
     }
 
+    func testSnapshotKeepsSelectedNodeIncidentEdgeInsideLinkCap() {
+        let graph = makeHubGraph(edgeCount: 60)
+
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: graph.nodes,
+            edges: graph.edges,
+            selectedNodeId: "leaf-60",
+            minimumImportance: 0
+        )
+
+        XCTAssertEqual(snapshot.visibleEdges.count, 50)
+        XCTAssertTrue(snapshot.visibleEdges.contains { edge in
+            edge.sourceId == "hub" && edge.targetId == "leaf-60"
+        })
+    }
+
     private func makeHubGraph(edgeCount: Int) -> (nodes: [KGNode], edges: [KGEdge]) {
         let hub = KGNode(
             id: "hub",

--- a/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
@@ -2,6 +2,13 @@ import XCTest
 @testable import BrainBar
 
 final class KGAtlasPresentationTests: XCTestCase {
+    private let maxLinksKey = "brainBar.maxLinksPerNode"
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: maxLinksKey)
+        super.tearDown()
+    }
+
     func testSnapshotBuildsDeterministicRegions() {
         let nodes = [
             KGNode(id: "p1", name: "Etan Heyman", entityType: "person", importance: 9, position: .zero),
@@ -47,5 +54,60 @@ final class KGAtlasPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.visibleNodes.map { $0.id }, ["p1", "t1", "a1"])
         XCTAssertEqual(snapshot.visibleEdges.map { $0.id }, ["p1-uses-a1", "a1-calls-t1"])
         XCTAssertEqual(snapshot.selectedRegion?.title, "Agents")
+    }
+
+    func testSnapshotVirtualizesHubLinksAtDefaultFiftyVisibleRelations() {
+        UserDefaults.standard.removeObject(forKey: maxLinksKey)
+        let graph = makeHubGraph(edgeCount: 60)
+
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: graph.nodes,
+            edges: graph.edges,
+            selectedNodeId: nil,
+            minimumImportance: 0
+        )
+
+        XCTAssertEqual(snapshot.visibleEdges.count, 50)
+        XCTAssertEqual(snapshot.visibleEdges.first?.targetId, "leaf-1")
+        XCTAssertEqual(snapshot.visibleEdges.last?.targetId, "leaf-50")
+    }
+
+    func testSnapshotUsesConfiguredMaxLinksPerNode() {
+        UserDefaults.standard.set(12, forKey: maxLinksKey)
+        let graph = makeHubGraph(edgeCount: 30)
+
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: graph.nodes,
+            edges: graph.edges,
+            selectedNodeId: nil,
+            minimumImportance: 0
+        )
+
+        XCTAssertEqual(snapshot.visibleEdges.count, 12)
+        XCTAssertEqual(snapshot.visibleEdges.last?.targetId, "leaf-12")
+    }
+
+    private func makeHubGraph(edgeCount: Int) -> (nodes: [KGNode], edges: [KGEdge]) {
+        let hub = KGNode(
+            id: "hub",
+            name: "Etan Heyman",
+            entityType: "person",
+            importance: 10,
+            position: .zero
+        )
+        let leaves = (1...edgeCount).map { index in
+            KGNode(
+                id: "leaf-\(index)",
+                name: "Project \(index)",
+                entityType: "project",
+                importance: 5,
+                position: .zero
+            )
+        }
+        let edges = (1...edgeCount).map { index in
+            KGEdge(sourceId: "hub", targetId: "leaf-\(index)", relationType: "owns")
+        }
+
+        return ([hub] + leaves, edges)
     }
 }


### PR DESCRIPTION
## Summary
- Raise the BrainBar Atlas graph per-node visible edge cap from the observed 10-link behavior to a configurable default of 50 via `UserDefaults` key `brainBar.maxLinksPerNode`.
- Keep the full KG edge set intact in the view model and apply the cap only in `KGAtlasPresentation.visibleEdges`, so rendering is bounded without throwing away graph data.
- Add an urgent dashboard openability fix discovered while validating BrainBar locally: coalesce non-forced dashboard stats refreshes and throttle agent-process sampling so DB notification storms do not peg the menu-bar UI.

## Research / mandate
- Mandate: `/tmp/codex-mandate-brainbar-dashboard-truth.md` Item C requires graph cap 10 -> 50, virtualization, and `UserDefaults.brainBar.maxLinksPerNode` default 50.
- Research audit notes graph scaling risk and recommends explicit graph caps / LOD rather than unbounded dense rendering: `docs.local/research/2026-05-24-brainbar-ui-claude-desktop-research.md` and `docs.local/audits/2026-05-24-brainbar-ui-research-audit.md`.
- The dashboard openability fix is included because local validation found BrainBar already running with a responsive socket, but the UI process was starved by repeated `StatsCollector.refresh` work after Item B notification paths.

## TDD / verification
- RED: `swift test --package-path brain-bar --filter KGAtlasPresentationTests` initially failed because a 60-link hub still exposed 60 visible relations and a configured 12 cap still exposed 30.
- GREEN: `swift test --package-path brain-bar --filter KGAtlasPresentationTests`
- RED: `DashboardTests/testStatsCollectorDoesNotResampleAgentActivityOnEveryMutationRefresh` initially failed with 3 agent samples instead of 1.
- GREEN focused: `DashboardTests/testStatsCollectorCoalescesRapidMutationStatsRefreshes`, `DashboardTests/testStatsCollectorDoesNotResampleAgentActivityOnEveryMutationRefresh`, `DashboardTests/testStatsCollectorRefreshesAfterDatabaseWriteNotification`
- Full Swift: `swift test --package-path brain-bar` -> 462 tests, 0 failures.
- Full Python: `pytest -q` -> 2256 passed, 46 skipped, 5 xfailed.
- Pre-push gate: pytest unit suite -> 2186 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration -> 3 passed; eval/hook routing -> 36 passed; Bun stale-index test -> 1 passed; regression shell `test_fts5_determinism.sh` passed.
- `git diff --check` passed.
- CodeRabbit local pre-commit review: no findings.
- Local app validation: `brain-bar/build-app.sh --force-dirty` installed `~/Applications/BrainBar.app`; `/tmp/brainbar.sock` responded to initialize; fresh post-fix `sample` no longer showed `StatsCollector`, `AgentActivityMonitor`, or dashboard SQLite stacks; BrainBar UI/daemon were at 0% CPU in `ps`.

## Notes
This PR has two commits intentionally: Item C graph cap, then the dashboard refresh-storm hotfix. I kept them separate to preserve the mandate item boundary while addressing the immediate "can't open BrainBar" regression found during validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live dashboard update latency (up to ~5s coalesce) and which graph edges render, though underlying data is preserved; core paths are UI/presentation with broad test coverage.
> 
> **Overview**
> **Atlas graph rendering** now limits how many edges each node can show in the presentation snapshot, default **50** via `UserDefaults` key `brainBar.maxLinksPerNode`. Edges are chosen after filtering to region-renderable nodes; incident edges to the **selected node** are prioritized so they stay within the cap. Full graph data in the view model is unchanged—only `visibleEdges` is bounded.
> 
> **Dashboard `StatsCollector`** adds throttling so DB mutation storms do not peg the menu-bar UI: non-forced stats refreshes within a **5s** window are deferred to a single scheduled refresh, and **agent activity** is sampled at most once per **5s** unless forced. `start`/`stop` reset timing state and cancel pending refresh tasks.
> 
> Tests cover link virtualization, coalesced refreshes, agent sampling, and recovery after a failed non-forced DB read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 813b0c4d454b63dbb8502529ad0f90c014e254d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise graph link cap and coalesce stats refreshes in BrainBar dashboard
> - Adds per-node edge virtualization to `KGAtlasPresentation.snapshot`, capping visible links at 50 by default (configurable via `UserDefaults` key `brainBar.maxLinksPerNode`) and prioritizing edges incident to the selected node.
> - Adds coalesced stats refreshes to `StatsCollector`: rapid non-forced refreshes update daemon/state immediately but defer the full stats refresh until a configurable coalesce interval elapses.
> - Throttles agent activity sampling in `StatsCollector` to a configurable interval, avoiding redundant samples on every mutation refresh.
> - Behavioral Change: non-forced stats refreshes no longer update all stats immediately; callers will observe a delay in stats updates during rapid refresh bursts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 918e6ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Knowledge graph visualization now supports configurable limits on visible links per node (default: 50 links).

* **Performance**
  * Stats collection now coalesces rapid refresh requests to reduce unnecessary full refreshes.

* **Tests**
  * Added test coverage for stats refresh behavior and knowledge graph link virtualization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->