### PR TITLE
feat(brainbar): add sparkline hover tooltips

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -567,6 +567,7 @@ private struct BrainBarFlowLaneCard: View {
             BrainBarHeroSparkline(
                 values: lane.values,
                 accentColor: lane.accentColor,
+                activityWindowMinutes: lane.activityWindowMinutes,
                 pulseRevision: pulseRevision
             )
             .frame(height: chartHeight)
@@ -1055,6 +1056,7 @@ private struct BrainBarFlowStatusPill: View {
 private struct BrainBarHeroSparkline: View {
     let values: [Int]
     let accentColor: NSColor
+    let activityWindowMinutes: Int
     let pulseRevision: Int
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -1076,7 +1078,8 @@ private struct BrainBarHeroSparkline: View {
                 SparklineChart(
                     presentation: SparklineChartPresentation(
                         label: "Recent activity sparkline",
-                        values: values
+                        values: values,
+                        activityWindowMinutes: activityWindowMinutes
                     ),
                     accentColor: accentColor,
                     compact: SparklineRenderer.isCompact(size: renderSize)

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -182,6 +182,7 @@ struct DashboardFlowLane: Sendable, Equatable {
     let status: DashboardFlowLaneStatus
     let statusText: String
     let windowLabel: String
+    let activityWindowMinutes: Int
     let rateText: String
     let volumeText: String
     let lastEventText: String
@@ -311,6 +312,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
                 status: ingressStatus,
                 statusText: ingressStatus == .live ? "Ingress live now" : (ingressStatus == .recent ? "Recent writes in \(windowLabel.lowercased())" : "No recent writes"),
                 windowLabel: windowLabel,
+                activityWindowMinutes: stats.activityWindowMinutes,
                 rateText: DashboardMetricFormatter.rateString(
                     totalEvents: stats.recentWriteCount,
                     activityWindowMinutes: stats.activityWindowMinutes
@@ -361,6 +363,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
                 status: enrichmentStatus,
                 statusText: enrichmentStatusText,
                 windowLabel: windowLabel,
+                activityWindowMinutes: stats.activityWindowMinutes,
                 rateText: DashboardMetricFormatter.rateString(
                     totalEvents: stats.recentEnrichmentCount,
                     activityWindowMinutes: stats.activityWindowMinutes

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -13,15 +13,18 @@ struct SparklineChartPoint: Identifiable, Equatable, Sendable {
 struct SparklineChartPresentation: Equatable, Sendable {
     let label: String
     let values: [Int]
+    let activityWindowMinutes: Int
     let latestBucketName: String
 
     init(
         label: String,
         values: [Int],
+        activityWindowMinutes: Int = 30,
         latestBucketName: String = "latest bucket count"
     ) {
         self.label = label
         self.values = values
+        self.activityWindowMinutes = activityWindowMinutes
         self.latestBucketName = latestBucketName
     }
 
@@ -41,6 +44,23 @@ struct SparklineChartPresentation: Equatable, Sendable {
 
     var maxValue: Int {
         max(values.max() ?? 0, 1)
+    }
+
+    func bucketLabel(for bucket: Int) -> String {
+        guard !values.isEmpty else { return "no bucket" }
+        let clampedBucket = min(max(bucket, 0), values.count - 1)
+        let bucketWidth = max(1, Int(ceil(Double(activityWindowMinutes) / Double(values.count))))
+        let newerMinutesAgo = max(values.count - 1 - clampedBucket, 0) * bucketWidth
+        let olderMinutesAgo = min(newerMinutesAgo + bucketWidth, activityWindowMinutes)
+
+        if newerMinutesAgo == 0 {
+            return "last \(olderMinutesAgo)m"
+        }
+        return "\(olderMinutesAgo)-\(newerMinutesAgo)m ago"
+    }
+
+    func tooltipText(for point: SparklineChartPoint) -> String {
+        "\(bucketLabel(for: point.bucket)): \(point.value)"
     }
 
     private var trendDescription: String {
@@ -66,6 +86,8 @@ struct SparklineChart: View {
     let presentation: SparklineChartPresentation
     let accentColor: NSColor
     let compact: Bool
+    @State private var hoveredPoint: SparklineChartPoint?
+    @State private var hoverLocation: CGPoint?
 
     init(
         presentation: SparklineChartPresentation,
@@ -103,9 +125,83 @@ struct SparklineChart: View {
                 .background(Color.clear)
                 .padding(compact ? 2 : 10)
         }
+        .chartOverlay { chartProxy in
+            GeometryReader { geometry in
+                if let plotAnchor = chartProxy.plotFrame {
+                    let plotFrame = geometry[plotAnchor]
+
+                    Rectangle()
+                        .fill(.clear)
+                        .contentShape(Rectangle())
+                        .onContinuousHover { phase in
+                            switch phase {
+                            case .active(let location):
+                                hoveredPoint = nearestPoint(
+                                    to: location,
+                                    plotFrame: plotFrame,
+                                    chartProxy: chartProxy
+                                )
+                                hoverLocation = location
+                            case .ended:
+                                hoveredPoint = nil
+                                hoverLocation = nil
+                            }
+                        }
+
+                    if let hoveredPoint,
+                       let hoverLocation,
+                       !compact {
+                        sparklineTooltip(for: hoveredPoint)
+                            .position(tooltipPosition(near: hoverLocation, in: geometry.size))
+                            .allowsHitTesting(false)
+                    }
+                }
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(presentation.accessibilityLabel))
         .accessibilityValue(Text(presentation.accessibilityValue))
+    }
+
+    private func nearestPoint(
+        to location: CGPoint,
+        plotFrame: CGRect,
+        chartProxy: ChartProxy
+    ) -> SparklineChartPoint? {
+        guard !presentation.points.isEmpty,
+              plotFrame.contains(location) else {
+            return nil
+        }
+
+        let plotX = location.x - plotFrame.minX
+        guard let bucket: Double = chartProxy.value(atX: plotX, as: Double.self) else {
+            return nil
+        }
+        let index = min(max(Int(bucket.rounded()), 0), presentation.points.count - 1)
+        return presentation.points[index]
+    }
+
+    private func tooltipPosition(near location: CGPoint, in size: CGSize) -> CGPoint {
+        let x = min(max(location.x, 58), max(size.width - 58, 58))
+        let y = max(location.y - 28, 16)
+        return CGPoint(x: x, y: y)
+    }
+
+    @ViewBuilder
+    private func sparklineTooltip(for point: SparklineChartPoint) -> some View {
+        Text(presentation.tooltipText(for: point))
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: true)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(nsColor: accentColor).opacity(0.35), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.14), radius: 8, y: 3)
     }
 }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -49,18 +49,35 @@ struct SparklineChartPresentation: Equatable, Sendable {
     func bucketLabel(for bucket: Int) -> String {
         guard !values.isEmpty else { return "no bucket" }
         let clampedBucket = min(max(bucket, 0), values.count - 1)
-        let bucketWidth = max(1, Int(ceil(Double(activityWindowMinutes) / Double(values.count))))
-        let newerMinutesAgo = max(values.count - 1 - clampedBucket, 0) * bucketWidth
-        let olderMinutesAgo = min(newerMinutesAgo + bucketWidth, activityWindowMinutes)
+        let totalSeconds = max(activityWindowMinutes * 60, 1)
+        let bucketWidthSeconds = max(1, Double(totalSeconds) / Double(values.count))
+        let bucketStart = Double(clampedBucket) * bucketWidthSeconds
+        let bucketEnd = min(Double(clampedBucket + 1) * bucketWidthSeconds, Double(totalSeconds))
+        let olderSecondsAgo = max(0, Int(round(Double(totalSeconds) - bucketStart)))
+        let newerSecondsAgo = max(0, Int(round(Double(totalSeconds) - bucketEnd)))
 
-        if newerMinutesAgo == 0 {
-            return "last \(olderMinutesAgo)m"
+        if newerSecondsAgo == 0 {
+            return "last \(Self.durationLabel(seconds: olderSecondsAgo))"
         }
-        return "\(olderMinutesAgo)-\(newerMinutesAgo)m ago"
+        return "\(Self.durationLabel(seconds: olderSecondsAgo))-\(Self.durationLabel(seconds: newerSecondsAgo)) ago"
     }
 
-    func tooltipText(for point: SparklineChartPoint) -> String {
-        "\(bucketLabel(for: point.bucket)): \(point.value)"
+    func tooltipText(forBucket bucket: Int) -> String {
+        let clampedBucket = min(max(bucket, 0), max(values.count - 1, 0))
+        let value = values.indices.contains(clampedBucket) ? values[clampedBucket] : 0
+        return "\(bucketLabel(for: clampedBucket)): \(value)"
+    }
+
+    private static func durationLabel(seconds: Int) -> String {
+        let minutes = seconds / 60
+        let remainingSeconds = seconds % 60
+        if remainingSeconds == 0 {
+            return "\(minutes)m"
+        }
+        if minutes == 0 {
+            return "\(remainingSeconds)s"
+        }
+        return "\(minutes)m \(remainingSeconds)s"
     }
 
     private var trendDescription: String {
@@ -86,7 +103,7 @@ struct SparklineChart: View {
     let presentation: SparklineChartPresentation
     let accentColor: NSColor
     let compact: Bool
-    @State private var hoveredPoint: SparklineChartPoint?
+    @State private var hoveredBucket: Int?
     @State private var hoverLocation: CGPoint?
 
     init(
@@ -136,22 +153,22 @@ struct SparklineChart: View {
                         .onContinuousHover { phase in
                             switch phase {
                             case .active(let location):
-                                hoveredPoint = nearestPoint(
+                                hoveredBucket = nearestBucket(
                                     to: location,
                                     plotFrame: plotFrame,
                                     chartProxy: chartProxy
                                 )
                                 hoverLocation = location
                             case .ended:
-                                hoveredPoint = nil
+                                hoveredBucket = nil
                                 hoverLocation = nil
                             }
                         }
 
-                    if let hoveredPoint,
+                    if let hoveredBucket,
                        let hoverLocation,
                        !compact {
-                        sparklineTooltip(for: hoveredPoint)
+                        sparklineTooltip(forBucket: hoveredBucket)
                             .position(tooltipPosition(near: hoverLocation, in: geometry.size))
                             .allowsHitTesting(false)
                     }
@@ -163,11 +180,11 @@ struct SparklineChart: View {
         .accessibilityValue(Text(presentation.accessibilityValue))
     }
 
-    private func nearestPoint(
+    private func nearestBucket(
         to location: CGPoint,
         plotFrame: CGRect,
         chartProxy: ChartProxy
-    ) -> SparklineChartPoint? {
+    ) -> Int? {
         guard !presentation.points.isEmpty,
               plotFrame.contains(location) else {
             return nil
@@ -177,8 +194,7 @@ struct SparklineChart: View {
         guard let bucket: Double = chartProxy.value(atX: plotX, as: Double.self) else {
             return nil
         }
-        let index = min(max(Int(bucket.rounded()), 0), presentation.points.count - 1)
-        return presentation.points[index]
+        return min(max(Int(bucket.rounded()), 0), presentation.points.count - 1)
     }
 
     private func tooltipPosition(near location: CGPoint, in size: CGSize) -> CGPoint {
@@ -188,8 +204,8 @@ struct SparklineChart: View {
     }
 
     @ViewBuilder
-    private func sparklineTooltip(for point: SparklineChartPoint) -> some View {
-        Text(presentation.tooltipText(for: point))
+    private func sparklineTooltip(forBucket bucket: Int) -> some View {
+        Text(presentation.tooltipText(forBucket: bucket))
             .font(.system(size: 11, weight: .semibold))
             .foregroundStyle(.primary)
             .lineLimit(1)

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -370,7 +370,8 @@ final class StatusPopoverView: NSViewController {
         sparklineChartView.rootView = SparklineChart(
             presentation: SparklineChartPresentation(
                 label: "Recent activity sparkline",
-                values: summary.enrichment.values
+                values: summary.enrichment.values,
+                activityWindowMinutes: summary.enrichment.activityWindowMinutes
             ),
             accentColor: collector.state.color
         )

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -138,9 +138,20 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(presentation.points.map(\.value), [0, 2, 5, 3])
         XCTAssertEqual(presentation.accessibilityLabel, "Recent activity sparkline")
         XCTAssertEqual(presentation.accessibilityValue, "latest bucket count 3, trending down")
-        XCTAssertEqual(presentation.bucketLabel(for: 0), "20-15m ago")
+        XCTAssertEqual(presentation.bucketLabel(for: 0), "20m-15m ago")
         XCTAssertEqual(presentation.bucketLabel(for: 3), "last 5m")
-        XCTAssertEqual(presentation.tooltipText(for: presentation.points[2]), "10-5m ago: 5")
+        XCTAssertEqual(presentation.tooltipText(forBucket: 2), "10m-5m ago: 5")
+    }
+
+    func testSparklineChartPresentationLabelsPartialMinuteBucketsLikeDatabase() {
+        let presentation = SparklineChartPresentation(
+            label: "Recent activity sparkline",
+            values: Array(repeating: 0, count: 12),
+            activityWindowMinutes: 31
+        )
+
+        XCTAssertEqual(presentation.bucketLabel(for: 0), "31m-28m 25s ago")
+        XCTAssertEqual(presentation.bucketLabel(for: 11), "last 2m 35s")
     }
 
     func testSparklineRendererCompactClassificationMatchesEndpointAndChartPadding() {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -130,13 +130,17 @@ final class DashboardTests: XCTestCase {
     func testSparklineChartPresentationCarriesBucketsAndVoiceOverMetadata() {
         let presentation = SparklineChartPresentation(
             label: "Recent activity sparkline",
-            values: [0, 2, 5, 3]
+            values: [0, 2, 5, 3],
+            activityWindowMinutes: 20
         )
 
         XCTAssertEqual(presentation.points.map(\.bucket), [0, 1, 2, 3])
         XCTAssertEqual(presentation.points.map(\.value), [0, 2, 5, 3])
         XCTAssertEqual(presentation.accessibilityLabel, "Recent activity sparkline")
         XCTAssertEqual(presentation.accessibilityValue, "latest bucket count 3, trending down")
+        XCTAssertEqual(presentation.bucketLabel(for: 0), "20-15m ago")
+        XCTAssertEqual(presentation.bucketLabel(for: 3), "last 5m")
+        XCTAssertEqual(presentation.tooltipText(for: presentation.points[2]), "10-5m ago: 5")
     }
 
     func testSparklineRendererCompactClassificationMatchesEndpointAndChartPadding() {


### PR DESCRIPTION
## Summary
- Add Swift Charts hover overlay for BrainBar sparklines using chartOverlay and ChartProxy.
- Show floating tooltip text with exact bucket label and count.
- Carry dashboard activity window metadata into flow-lane sparklines so labels match the live dashboard window.

## Mandate / Evidence
- Implements Item E from /tmp/codex-mandate-brainbar-dashboard-truth.md.
- Related research: Brain Drive/BrainBar Design Audit - April 2026/R1-brainbar-ux-research.md and BrainBar UX Dashboard Research doc id 1vEBaiP51EuK23kM0f1ak0edFj3CrDp23bH4razLD1ew.
- This completes the dashboard truth work after Items A-D: exact chart buckets reduce ambiguity in the live dashboard during the Wed demo.

## Test Plan
- Red/green: swift test --package-path brain-bar --filter DashboardTests/testSparklineChartPresentationCarriesBucketsAndVoiceOverMetadata
- swift test --package-path brain-bar --filter DashboardTests
- swift test --package-path brain-bar
- git diff --check
- cr review --plain
- pre-push scripts/run_tests.sh gate: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard sparkline labeling and tooltip presentation only; no data pipeline or persistence changes.
> 
> **Overview**
> Refines **sparkline hover tooltips** so bucket time ranges match how the dashboard divides the activity window across buckets, including uneven splits (e.g. 31 minutes into 12 buckets).
> 
> **`SparklineChartPresentation`** now computes bucket boundaries in **seconds** (window × 60 ÷ bucket count) instead of rounding to whole minutes per bucket. Labels use a new **`durationLabel(seconds:)`** helper so ranges can show minutes only, seconds only, or mixed values (e.g. `31m-28m 25s ago`, `last 2m 35s`). **`tooltipText(forBucket:)`** takes a bucket index and reads the count from `values` rather than a chart point struct.
> 
> **`SparklineChart`** hover state tracks a **bucket index** (`hoveredBucket`) end-to-end; **`nearestBucket`** returns that index for the tooltip overlay.
> 
> Tests update expectations for the new label format and add **`testSparklineChartPresentationLabelsPartialMinuteBucketsLikeDatabase`** for the partial-minute case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63afc1aca7a000f83596cbe1c5d637a29fed1796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hover tooltips to BrainBar sparkline charts
> - Adds interactive hover tooltips to `SparklineChart` (non-compact mode) showing the time range and value for the bucket nearest the pointer, tracked via a chart overlay.
> - Extends `SparklineChartPresentation` with `activityWindowMinutes`, `bucketLabel(for:)`, and `tooltipText(forBucket:)` to compute human-readable time-range labels per bucket.
> - Threads `activityWindowMinutes` from `DashboardFlowLane` through `BrainBarHeroSparkline` and `StatusPopoverView` so tooltips reflect the actual configured activity window.
> - Adds tests for bucket label and tooltip text behavior, including a partial-minute case for a 31-minute window over 12 buckets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63afc1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->