### PR TITLE
fix(brainbar): coverage counts terminal statuses (item F-1)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1445,10 +1445,11 @@ final class BrainDatabase: @unchecked Sendable {
 
     private func dashboardCounts() throws -> (chunkCount: Int, enrichedChunkCount: Int, pendingEnrichmentCount: Int) {
         guard let db else { throw DBError.notOpen }
+        // Pending enrichment is represented by NULL; any persisted status is terminal coverage.
         let sql = """
             SELECT
                 COUNT(*) AS chunk_count,
-                SUM(CASE WHEN enrich_status = 'success' THEN 1 ELSE 0 END) AS enriched_count,
+                SUM(CASE WHEN enrich_status IS NOT NULL THEN 1 ELSE 0 END) AS enriched_count,
                 SUM(CASE WHEN enriched_at IS NULL AND enrich_status IS NULL THEN 1 ELSE 0 END) AS pending_enrichment_count
             FROM chunks
         """
@@ -4274,6 +4275,7 @@ final class BrainDatabase: @unchecked Sendable {
     func enrichmentStats() throws -> EnrichmentStatsSummary {
         guard let db else { throw DBError.notOpen }
         let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
+        let terminalCoveragePredicate = "enrich_status IS NOT NULL"
 
         func queryInt(_ sql: String) throws -> Int {
             var stmt: OpaquePointer?
@@ -4287,9 +4289,9 @@ final class BrainDatabase: @unchecked Sendable {
 
         return EnrichmentStatsSummary(
             totalChunks: try queryInt("SELECT COUNT(*) FROM chunks"),
-            enriched: try queryInt("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'success'"),
+            enriched: try queryInt("SELECT COUNT(*) FROM chunks WHERE \(terminalCoveragePredicate)"),
             unenrichedEligible: try queryInt("SELECT COUNT(*) FROM chunks WHERE enriched_at IS NULL AND enrich_status IS NULL AND char_count >= 50"),
-            skippedTooShort: try queryInt("SELECT COUNT(*) FROM chunks WHERE (enrich_status IS NOT NULL AND enrich_status != 'success') OR (enrich_status IS NULL AND enriched_at IS NULL AND char_count < 50)"),
+            skippedTooShort: try queryInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NULL AND enriched_at IS NULL AND char_count < 50"),
             enrichedLast24Hours: try queryInt("""
                 SELECT COUNT(*)
                 FROM (
@@ -4454,7 +4456,8 @@ final class BrainDatabase: @unchecked Sendable {
         let totalChunks = try queryInt("SELECT COUNT(*) FROM chunks")
         let totalEntities = try queryInt("SELECT COUNT(*) FROM kg_entities")
         let totalRelations = try queryInt("SELECT COUNT(*) FROM kg_relations")
-        let enrichedChunks = try queryInt("SELECT COUNT(*) FROM chunks WHERE enrich_status = 'success'")
+        // Pending enrichment is represented by NULL; any persisted status is terminal coverage.
+        let enrichedChunks = try queryInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL")
         let totalProjects = try queryInt("SELECT COUNT(DISTINCT project) FROM chunks")
         let projects = try queryStrings("SELECT DISTINCT project FROM chunks WHERE project IS NOT NULL AND project != '' ORDER BY project ASC LIMIT 12")
         let contentTypes = try queryStrings("SELECT DISTINCT content_type FROM chunks WHERE content_type IS NOT NULL AND content_type != '' ORDER BY content_type ASC")

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -52,7 +52,7 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
     }
 
-    func testDashboardStatsIgnoresSkippedEnrichmentStatusStrings() throws {
+    func testDashboardStatsCountsTerminalEnrichmentStatusesAsCovered() throws {
         try db.insertChunk(
             id: "dash-success",
             content: "Successfully enriched chunk",
@@ -62,8 +62,16 @@ final class DashboardTests: XCTestCase {
             importance: 7
         )
         try db.insertChunk(
-            id: "dash-skipped",
-            content: "Legacy skipped duplicate marker",
+            id: "dash-duplicate",
+            content: "Terminal duplicate marker",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        try db.insertChunk(
+            id: "dash-noise",
+            content: "Terminal noise marker",
             sessionId: "dashboard",
             project: "brainlayer",
             contentType: "assistant_text",
@@ -79,13 +87,20 @@ final class DashboardTests: XCTestCase {
             UPDATE chunks
             SET enriched_at = 'skipped:duplicate',
                 enrich_status = 'duplicate'
-            WHERE id = 'dash-skipped'
+            WHERE id = 'dash-duplicate'
+        """)
+        db.exec("""
+            UPDATE chunks
+            SET enriched_at = NULL,
+                enrich_status = 'noise'
+            WHERE id = 'dash-noise'
         """)
 
         let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
 
-        XCTAssertEqual(stats.enrichedChunkCount, 1)
+        XCTAssertEqual(stats.enrichedChunkCount, 3)
         XCTAssertEqual(stats.pendingEnrichmentCount, 0)
+        XCTAssertEqual(stats.enrichmentPercent, 100.0, accuracy: 0.001)
         XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
         let lastEnrichedAt = try XCTUnwrap(stats.lastEnrichedAt)
         XCTAssertLessThan(abs(lastEnrichedAt.timeIntervalSinceNow + 300), 10)
@@ -100,6 +115,56 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.enrichmentPercent, 0.0, accuracy: 0.001)
         XCTAssertEqual(stats.recentActivityBuckets, [0, 0, 0, 0])
         XCTAssertEqual(stats.recentEnrichmentBuckets, [0, 0, 0, 0])
+    }
+
+    func testEnrichmentStatsCountsAnyTerminalStatusAsCovered() throws {
+        try db.insertChunk(
+            id: "stats-success",
+            content: "Successfully enriched stats chunk",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        try db.insertChunk(
+            id: "stats-duplicate",
+            content: "Duplicate terminal stats chunk",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        try db.insertChunk(
+            id: "stats-noise",
+            content: "Noise terminal stats chunk",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        try db.insertChunk(
+            id: "stats-pending",
+            content: "Pending eligible stats chunk with enough text to meet the eligibility threshold",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        db.exec("UPDATE chunks SET enriched_at = datetime('now'), enrich_status = 'success' WHERE id = 'stats-success'")
+        db.exec("UPDATE chunks SET enriched_at = 'skipped:duplicate', enrich_status = 'duplicate' WHERE id = 'stats-duplicate'")
+        db.exec("UPDATE chunks SET enriched_at = NULL, enrich_status = 'noise' WHERE id = 'stats-noise'")
+
+        let summary = try db.enrichmentStats()
+
+        XCTAssertEqual(summary.totalChunks, 4)
+        XCTAssertEqual(summary.enriched, 3)
+        XCTAssertEqual(summary.unenrichedEligible, 1)
+        XCTAssertEqual(summary.skippedTooShort, 0)
+        XCTAssertEqual(
+            summary.totalChunks,
+            summary.enriched + summary.unenrichedEligible + summary.skippedTooShort
+        )
+        XCTAssertEqual(summary.enrichedPercentText, "75.0%")
     }
 
     func testDashboardStatsReadsPendingStoreQueueDepthAndOldestEntry() throws {

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -977,6 +977,22 @@ final class DatabaseTests: XCTestCase {
         XCTAssertGreaterThan(total, 0)
     }
 
+    func testRecallStatsCoverageCountsAnyTerminalStatusAsEnriched() throws {
+        try db.insertChunk(id: "rc-success", content: "Recall stats success", sessionId: "s1", project: "test", contentType: "assistant_text", importance: 5)
+        try db.insertChunk(id: "rc-duplicate", content: "Recall stats duplicate", sessionId: "s1", project: "test", contentType: "assistant_text", importance: 5)
+        try db.insertChunk(id: "rc-noise", content: "Recall stats noise", sessionId: "s1", project: "test", contentType: "assistant_text", importance: 5)
+        try db.insertChunk(id: "rc-pending", content: "Recall stats pending", sessionId: "s1", project: "test", contentType: "assistant_text", importance: 5)
+        db.exec("UPDATE chunks SET enrich_status = 'success' WHERE id = 'rc-success'")
+        db.exec("UPDATE chunks SET enrich_status = 'duplicate' WHERE id = 'rc-duplicate'")
+        db.exec("UPDATE chunks SET enrich_status = 'noise' WHERE id = 'rc-noise'")
+
+        let stats = try db.recallStats()
+
+        XCTAssertEqual(stats["total_chunks"] as? Int, 4)
+        XCTAssertEqual(stats["enriched_chunks"] as? Int, 3)
+        XCTAssertEqual(stats["enrichment_pct"] as? Double, 75.0)
+    }
+
     // MARK: - brain_digest (rule-based entity extraction)
 
     func testDigestExtractsEntities() throws {


### PR DESCRIPTION
## Summary
- Implements Item F Fix 1 from `/tmp/codex-mandate-item-F.md`.
- Changes coverage numerators from `enrich_status = 'success'` to `enrich_status IS NOT NULL` so terminal statuses like `duplicate`, `noise`, and future terminal outcomes count as covered.
- Applies the same coverage semantics to dashboard counts, enrichment stats, and recall stats coverage output.
- Leaves recent enrichment activity/rate queries success-only, since those measure successful enrichment events rather than terminal coverage.

## Diagnosis cited
- Demo dashboard was stuck at 88% because `duplicate` rows were terminal but excluded from the numerator.
- Mandate math: `337,573 / 383,333 = 88.06%`; counting terminal statuses gives `350,841 / 383,333 = 91.52%` immediately.
- Pending enrichment remains represented by `enrich_status IS NULL`; non-NULL statuses are terminal coverage.

## TDD / Test plan
- RED: `DashboardTests/testDashboardStatsCountsTerminalEnrichmentStatusesAsCovered` failed at 1 enriched / 33.33%.
- RED: `DashboardTests/testEnrichmentStatsCountsAnyTerminalStatusAsCovered` failed at 1 enriched / 25.0%.
- RED: `DatabaseTests/testRecallStatsCoverageCountsAnyTerminalStatusAsEnriched` failed at 1 enriched / 25.0%.
- GREEN: all three targeted tests pass.
- `swift test --package-path brain-bar`: 474 tests, 0 failures.
- `git diff --check`: passed.
- Pre-push gate: Python 2186 passed, 9 skipped, 75 deselected, 1 xfailed; MCP tool registration 3 passed; isolated eval/hook routing 36 passed; bun stale index 1 pass; regression shell passed.

## Review note
- Local CodeRabbit pre-commit review raised a concern that `IS NOT NULL` could count a future persisted `pending` status. I investigated and found pending enrichment is represented as NULL in this codebase; `/tmp/codex-mandate-item-F.md` explicitly requests `IS NOT NULL` to include future terminal statuses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only SQL and metric semantics in BrainBar stats; no auth or write-path changes. Main risk is dashboard percentages shifting upward for duplicate/noise rows, which is intentional.
> 
> **Overview**
> **Enrichment coverage** in `BrainDatabase` now treats any non-null `enrich_status` as covered (terminal outcomes like `duplicate` and `noise`), with **NULL** still meaning pending. Dashboard totals, `enrichmentStats`, and `recallStats` numerators use `enrich_status IS NOT NULL` instead of `enrich_status = 'success'`.
> 
> `skippedTooShort` in `enrichmentStats` is narrowed to chunks that are still pending and below the char threshold, so terminal statuses are no longer folded into that bucket.
> 
> **Recent enrichment activity** (last enriched time, sparkline buckets, rate, last-24h count) still filters **`success` only**, so live pipeline metrics stay tied to successful enrichments.
> 
> Tests were updated/added in `DashboardTests` and `DatabaseTests` to lock in terminal-status coverage and the split between coverage vs success-only activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c3e53887f07fb06c0a64bfe2ee7677d94abbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix coverage counts in BrainBar to include all terminal enrichment statuses
> - Updates `enrich_status IS NOT NULL` as the predicate for coverage in `BrainDatabase.enrichmentStats` and `BrainDatabase.recallStats`, replacing the previous `enrich_status = 'success'` check.
> - Chunks with terminal statuses like `duplicate` or `noise` are now counted as covered, alongside `success`.
> - `skippedTooShort` now only counts chunks where both `enrich_status` and `enriched_at` are NULL and `char_count < 50`.
> - Behavioral Change: `enriched_chunks`, `enrichedChunkCount`, and derived percentages will be higher for databases containing non-`success` terminal statuses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28c3e53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Updated enrichment coverage metrics to count all terminal enrichment states as covered, not only successful ones. Dashboard and report statistics now reflect this broader calculation for enrichment completion percentages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->