### PR TITLE
feat(brainbar): humanize injections tab (item F-2)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4548,11 +4548,59 @@ final class BrainDatabase: @unchecked Sendable {
                 "chunk_ids": columnText(stmt, 4) as Any,
                 "token_count": Int(sqlite3_column_int(stmt, 5))
             ]
-            if let event = try? InjectionEvent(row: row) {
+            if var event = try? InjectionEvent(row: row) {
+                let details = (try? injectionChunkDetails(ids: event.chunkIDs)) ?? []
+                event = InjectionEvent(
+                    id: event.id,
+                    sessionID: event.sessionID,
+                    timestamp: event.timestamp,
+                    query: event.query,
+                    chunkIDs: event.chunkIDs,
+                    tokenCount: event.tokenCount,
+                    chunks: details
+                )
                 events.append(event)
             }
         }
         return events
+    }
+
+    private func injectionChunkDetails(ids: [String]) throws -> [InjectionChunk] {
+        guard let db else { throw DBError.notOpen }
+        let orderedIDs = ids.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        guard !orderedIDs.isEmpty else { return [] }
+
+        let placeholders = Array(repeating: "?", count: orderedIDs.count).joined(separator: ",")
+        let sql = """
+            SELECT id, content, summary, source, source_file, tags, content_type
+            FROM chunks
+            WHERE id IN (\(placeholders))
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw DBError.prepare(sqlite3_errcode(db))
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        for (offset, id) in orderedIDs.enumerated() {
+            bindText(id, to: stmt, index: Int32(offset + 1))
+        }
+
+        var detailsByID: [String: InjectionChunk] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let row: [String: Any] = [
+                "id": columnText(stmt, 0) as Any,
+                "content": columnText(stmt, 1) as Any,
+                "summary": columnText(stmt, 2) as Any,
+                "source": columnText(stmt, 3) as Any,
+                "source_file": columnText(stmt, 4) as Any,
+                "tags": columnText(stmt, 5) as Any,
+                "content_type": columnText(stmt, 6) as Any,
+            ]
+            let detail = InjectionChunk(row: row)
+            detailsByID[detail.id] = detail
+        }
+        return orderedIDs.compactMap { detailsByID[$0] }
     }
 
     // MARK: - brain_digest: rule-based entity extraction

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -300,7 +300,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
             self.chunkIDs = rawChunkIDs
         } else if let text = row["chunk_ids"] as? String,
                   let data = text.data(using: .utf8),
-                  let decoded = try JSONSerialization.jsonObject(with: data) as? [String] {
+                  let decoded = try? JSONSerialization.jsonObject(with: data) as? [String] {
             self.chunkIDs = decoded
         } else {
             self.chunkIDs = []

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -231,7 +231,10 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
     }
 
     func matches(typeFilter: InjectionTypeFilter) -> Bool {
-        allKinds.contains { typeFilter.contains($0) }
+        if chunks.isEmpty, !chunkIDs.isEmpty, typeFilter != .all {
+            return true
+        }
+        return allKinds.contains { typeFilter.contains($0) }
     }
 
     var displayTitle: String {
@@ -247,6 +250,10 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
 
     var modalTitle: String {
         primaryKind.modalTitle
+    }
+
+    func openingModalTitle(forChunkID chunkID: String) -> String {
+        chunks.first { $0.id == chunkID }?.kind.modalTitle ?? "Conversation"
     }
 
     var summaryLine: String {

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -1,5 +1,215 @@
 import Foundation
 
+struct InjectionChunk: Equatable, Sendable, Identifiable {
+    let id: String
+    let content: String
+    let summary: String
+    let source: String
+    let sourceFile: String
+    let tags: [String]
+    let contentType: String
+
+    var displayText: String {
+        let preferred = summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? content
+            : summary
+        return Self.elide(preferred, limit: 80)
+    }
+
+    var kind: InjectionKind {
+        InjectionKind.classify(source: source, sourceFile: sourceFile, tags: tags, content: content)
+    }
+
+    init(
+        id: String,
+        content: String,
+        summary: String,
+        source: String,
+        sourceFile: String,
+        tags: [String],
+        contentType: String
+    ) {
+        self.id = id
+        self.content = content
+        self.summary = summary
+        self.source = source
+        self.sourceFile = sourceFile
+        self.tags = tags
+        self.contentType = contentType
+    }
+
+    init(row: [String: Any]) {
+        id = row["id"] as? String ?? ""
+        content = row["content"] as? String ?? ""
+        summary = row["summary"] as? String ?? ""
+        source = row["source"] as? String ?? ""
+        sourceFile = row["source_file"] as? String ?? ""
+        contentType = row["content_type"] as? String ?? ""
+        tags = InjectionChunk.decodeTags(row["tags"])
+    }
+
+    static func elide(_ text: String, limit: Int) -> String {
+        let collapsed = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        guard collapsed.count > limit else { return collapsed }
+        return "\(collapsed.prefix(max(limit - 1, 1)))…"
+    }
+
+    private static func decodeTags(_ value: Any?) -> [String] {
+        if let tags = value as? [String] {
+            return tags
+        }
+        guard let text = value as? String,
+              let data = text.data(using: .utf8),
+              let decoded = try? JSONSerialization.jsonObject(with: data) as? [String] else {
+            return []
+        }
+        return decoded
+    }
+}
+
+enum InjectionKind: String, CaseIterable, Equatable, Sendable {
+    case memoryCheckpoint
+    case realtimeCapture
+    case storedMemory
+    case dailyDigest
+    case videoKnowledge
+    case chat
+    case toolSession
+    case quickCapture
+    case checkpoint
+    case other
+
+    var glyph: String {
+        switch self {
+        case .memoryCheckpoint: return "🧠"
+        case .realtimeCapture: return "💬"
+        case .storedMemory: return "📝"
+        case .dailyDigest: return "🌅"
+        case .videoKnowledge: return "🎬"
+        case .chat: return "📱"
+        case .toolSession: return "🛠"
+        case .quickCapture: return "⚡"
+        case .checkpoint: return "🏷"
+        case .other: return "📄"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .memoryCheckpoint: return "Memory Checkpoint"
+        case .realtimeCapture: return "Realtime Capture"
+        case .storedMemory: return "Stored Memory"
+        case .dailyDigest: return "Daily Digest"
+        case .videoKnowledge: return "Video Knowledge"
+        case .chat: return "Chat"
+        case .toolSession: return "Tool Session"
+        case .quickCapture: return "Quick Capture"
+        case .checkpoint: return "Checkpoint"
+        case .other: return "Other"
+        }
+    }
+
+    var modalTitle: String {
+        switch self {
+        case .memoryCheckpoint, .checkpoint:
+            return "Memory Checkpoint"
+        default:
+            return label
+        }
+    }
+
+    var paletteIndex: Int {
+        Self.allCases.firstIndex(of: self) ?? 0
+    }
+
+    static func classify(source: String, sourceFile: String, tags: [String], content: String) -> InjectionKind {
+        let normalizedSource = source.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedFile = sourceFile.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedTags = tags.map { $0.lowercased() }
+        let normalizedContent = content.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if normalizedTags.contains(where: { $0.contains("pr-merge") }) ||
+            normalizedContent.hasPrefix("[checkpoint]") {
+            return .checkpoint
+        }
+
+        if normalizedSource == "precompact-hook" || normalizedFile.hasPrefix("precompact:") {
+            return .memoryCheckpoint
+        }
+        if normalizedSource == "realtime_watcher" || normalizedSource == "claude_code" {
+            return .realtimeCapture
+        }
+        if normalizedSource == "mcp" || normalizedSource == "brain_store" {
+            return .storedMemory
+        }
+        if normalizedSource == "digest" {
+            return .dailyDigest
+        }
+        if normalizedSource == "youtube" {
+            return .videoKnowledge
+        }
+        if normalizedSource == "whatsapp" {
+            return .chat
+        }
+        if ["cursor", "codex_cli", "codex"].contains(normalizedSource) {
+            return .toolSession
+        }
+        if normalizedSource == "quick-capture" {
+            return .quickCapture
+        }
+        return .other
+    }
+}
+
+enum InjectionTypeFilter: String, CaseIterable, Equatable, Sendable {
+    case all
+    case memory
+    case stored
+    case realtime
+    case checkpoint
+    case video
+    case chat
+    case tool
+
+    var label: String {
+        switch self {
+        case .all: return "All"
+        case .memory: return "Memory"
+        case .stored: return "Stored"
+        case .realtime: return "Realtime"
+        case .checkpoint: return "Checkpoint"
+        case .video: return "Video"
+        case .chat: return "Chat"
+        case .tool: return "Tool"
+        }
+    }
+
+    func contains(_ kind: InjectionKind) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .memory:
+            return kind == .memoryCheckpoint || kind == .dailyDigest
+        case .stored:
+            return kind == .storedMemory || kind == .quickCapture
+        case .realtime:
+            return kind == .realtimeCapture
+        case .checkpoint:
+            return kind == .checkpoint || kind == .memoryCheckpoint
+        case .video:
+            return kind == .videoKnowledge
+        case .chat:
+            return kind == .chat
+        case .tool:
+            return kind == .toolSession
+        }
+    }
+}
+
 struct InjectionEvent: Equatable, Identifiable, Sendable {
     let id: Int64
     let sessionID: String
@@ -7,8 +217,37 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
     let query: String
     let chunkIDs: [String]
     let tokenCount: Int
+    let chunks: [InjectionChunk]
 
     var chunkCount: Int { chunkIDs.count }
+
+    var primaryKind: InjectionKind {
+        chunks.first?.kind ?? .other
+    }
+
+    var allKinds: [InjectionKind] {
+        let kinds = chunks.map(\.kind)
+        return kinds.isEmpty ? [.other] : kinds
+    }
+
+    func matches(typeFilter: InjectionTypeFilter) -> Bool {
+        allKinds.contains { typeFilter.contains($0) }
+    }
+
+    var displayTitle: String {
+        if let chunk = chunks.first, !chunk.displayText.isEmpty {
+            return chunk.displayText
+        }
+        return InjectionChunk.elide(query, limit: 80)
+    }
+
+    var triggeredByText: String {
+        "Triggered by: \(InjectionChunk.elide(query, limit: 96))"
+    }
+
+    var modalTitle: String {
+        primaryKind.modalTitle
+    }
 
     var summaryLine: String {
         "\(query) • \(chunkCount) chunks • \(tokenCount) tok"
@@ -20,7 +259,8 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         timestamp: String,
         query: String,
         chunkIDs: [String],
-        tokenCount: Int
+        tokenCount: Int,
+        chunks: [InjectionChunk] = []
     ) {
         self.id = id
         self.sessionID = sessionID
@@ -28,6 +268,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         self.query = query
         self.chunkIDs = chunkIDs
         self.tokenCount = tokenCount
+        self.chunks = chunks
     }
 
     init(row: [String: Any]) throws {
@@ -51,6 +292,12 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
             self.chunkIDs = decoded
         } else {
             self.chunkIDs = []
+        }
+
+        if let rawChunks = row["chunks"] as? [[String: Any]] {
+            chunks = rawChunks.map(InjectionChunk.init(row:))
+        } else {
+            chunks = []
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -221,8 +221,13 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
 
     var chunkCount: Int { chunkIDs.count }
 
+    var primaryChunk: InjectionChunk? {
+        guard let firstChunkID = chunkIDs.first else { return chunks.first }
+        return chunks.first { $0.id == firstChunkID }
+    }
+
     var primaryKind: InjectionKind {
-        chunks.first?.kind ?? .other
+        primaryChunk?.kind ?? .other
     }
 
     var allKinds: [InjectionKind] {
@@ -238,7 +243,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
     }
 
     var displayTitle: String {
-        if let chunk = chunks.first, !chunk.displayText.isEmpty {
+        if let chunk = primaryChunk, !chunk.displayText.isEmpty {
             return chunk.displayText
         }
         return InjectionChunk.elide(query, limit: 80)

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -143,7 +143,7 @@ enum InjectionKind: String, CaseIterable, Equatable, Sendable {
         if normalizedSource == "realtime_watcher" || normalizedSource == "claude_code" {
             return .realtimeCapture
         }
-        if normalizedSource == "mcp" || normalizedSource == "brain_store" {
+        if normalizedSource == "mcp" || normalizedSource == "brain_store" || normalizedSource == "manual" {
             return .storedMemory
         }
         if normalizedSource == "digest" {

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -66,6 +66,8 @@ struct InjectionFeedView: View {
     @State private var expandedEventIDs: Set<Int64> = []
     @State private var expandedBurstIDs: Set<String> = []
     @State private var selectedConversation: BrainDatabase.ExpandedConversation?
+    @State private var selectedConversationTitle = "Conversation"
+    @AppStorage("brainbar.injectionFeed.typeFilter") private var typeFilterRaw = InjectionTypeFilter.all.rawValue
 
     private let accentPalette: [Color] = [
         Color(red: 0.42, green: 0.62, blue: 0.98),
@@ -108,6 +110,7 @@ struct InjectionFeedView: View {
             if let conversation = selectedConversation {
                 ChunkConversationOverlay(
                     conversation: conversation,
+                    title: selectedConversationTitle,
                     onClose: { selectedConversation = nil }
                 )
             }
@@ -147,6 +150,29 @@ struct InjectionFeedView: View {
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.secondary)
                 }
+
+                filterChips
+            }
+        }
+    }
+
+    private var filterChips: some View {
+        let activeFilter = InjectionTypeFilter(rawValue: typeFilterRaw) ?? .all
+        return HStack(spacing: 6) {
+            ForEach(InjectionTypeFilter.allCases, id: \.rawValue) { filter in
+                Button {
+                    typeFilterRaw = filter.rawValue
+                } label: {
+                    Text(filter.label)
+                        .font(.system(size: 11, weight: .semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            Capsule()
+                                .fill(activeFilter == filter ? Color.accentColor.opacity(0.22) : Color.primary.opacity(0.06))
+                        )
+                }
+                .buttonStyle(.plain)
             }
         }
     }
@@ -230,18 +256,28 @@ struct InjectionFeedView: View {
             HStack(alignment: .top, spacing: 12) {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text("↻")
+                        let leadEvent = burst.events.first
+                        Text(leadEvent?.primaryKind.glyph ?? "📄")
                             .font(.system(size: 16, weight: .bold, design: .rounded))
                             .foregroundStyle(.blue)
                         Text(burst.summaryTitle)
                             .font(.system(size: 18, weight: .semibold, design: .rounded))
                             .lineLimit(2)
                     }
+                    if let leadEvent = burst.events.first {
+                        Text(leadEvent.triggeredByText)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
                     HStack(spacing: 8) {
                         chip(text: "Session: \(shortSessionID(burst.sessionID))", tint: .blue)
                         chip(text: relativeText(for: burst.endDate), tint: .neutral)
                         chip(text: "\(burst.queryCount) queries", tint: .neutral)
                         chip(text: "\(burst.tokenCount) tok", tint: .green)
+                        if let leadEvent = burst.events.first {
+                            chip(text: "\(leadEvent.primaryKind.glyph) \(leadEvent.primaryKind.label)", tint: .neutral)
+                        }
                     }
                 }
 
@@ -281,18 +317,30 @@ struct InjectionFeedView: View {
 
     private func collapsedChunkPreview(for burst: InjectionPresentation.Burst) -> some View {
         VStack(alignment: .leading, spacing: 7) {
-            ForEach(Array(burst.chunkPreviewIDs.enumerated()), id: \.offset) { _, chunkID in
-                Text(chunkPreviewText(chunkID))
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+            let previewChunks = Array(burst.events.flatMap(\.chunks).prefix(2))
+            if previewChunks.isEmpty {
+                ForEach(Array(burst.chunkPreviewIDs.enumerated()), id: \.offset) { _, chunkID in
+                    Text(chunkPreviewText(chunkID))
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            } else {
+                ForEach(previewChunks) { chunk in
+                    Text("\(chunk.kind.glyph) \(chunk.displayText)")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
             }
 
-            let remaining = burst.remainingChunkCount(after: burst.chunkPreviewIDs.count)
+            let visibleCount = previewChunks.isEmpty ? burst.chunkPreviewIDs.count : previewChunks.count
+            let remaining = burst.remainingChunkCount(after: visibleCount)
             if remaining > 0 {
                 Text("+\(remaining) more")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
                     .foregroundStyle(.secondary)
             }
         }
@@ -328,13 +376,25 @@ struct InjectionFeedView: View {
                     .frame(width: 48, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(event.query)
-                        .font(.system(size: 14, weight: .semibold))
-                        .lineLimit(3)
+                    HStack(spacing: 7) {
+                        Text(event.primaryKind.glyph)
+                        Text(event.primaryKind.label)
+                            .font(.system(size: 11, weight: .semibold))
+                        Text(event.displayTitle)
+                            .font(.system(size: 14, weight: .semibold))
+                            .lineLimit(2)
+                    }
+
+                    Text(event.triggeredByText)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
 
                     HStack(spacing: 10) {
+                        Text("Session \(shortSessionID(event.sessionID))")
                         Text("\(event.chunkCount) chunks")
                         Text("\(event.tokenCount) tok")
+                        Text("\(event.chunks.reduce(0) { $0 + $1.tags.count }) tags")
                         if !event.chunkIDs.isEmpty {
                             Button(expandedEventIDs.contains(event.id) ? "Hide hits" : "Show hits") {
                                 toggle(event.id)
@@ -357,6 +417,7 @@ struct InjectionFeedView: View {
 
                 Button {
                     if let firstChunk = event.chunkIDs.first {
+                        selectedConversationTitle = event.modalTitle
                         selectedConversation = try? store.expandedConversation(chunkID: firstChunk)
                     }
                 } label: {
@@ -374,12 +435,33 @@ struct InjectionFeedView: View {
     }
 
     private func chunkRibbon(for event: InjectionEvent) -> some View {
-        HStack(spacing: 4) {
-            ForEach(Array(event.chunkIDs.enumerated()), id: \.offset) { _, chunkID in
-                RoundedRectangle(cornerRadius: 999, style: .continuous)
-                    .fill(color(for: chunkID))
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 8)
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 8) {
+                ForEach(Array(Set(event.chunks.map(\.kind))).sorted(by: { $0.label < $1.label }), id: \.rawValue) { kind in
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(color(for: kind))
+                            .frame(width: 6, height: 6)
+                        Text(kind.label)
+                            .font(.system(size: 10, weight: .medium))
+                    }
+                }
+                if event.chunks.isEmpty {
+                    Text("Hit bars show retrieved chunk IDs; source metadata was unavailable.")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 4) {
+                ForEach(Array(event.chunkIDs.enumerated()), id: \.offset) { _, chunkID in
+                    let chunk = chunk(for: chunkID, event: event)
+                    RoundedRectangle(cornerRadius: 999, style: .continuous)
+                        .fill(color(for: chunk?.kind ?? .other))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 8)
+                        .help(hitHelpText(chunkID: chunkID, chunk: chunk))
+                }
             }
         }
         .padding(8)
@@ -393,13 +475,14 @@ struct InjectionFeedView: View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(event.chunkIDs, id: \.self) { chunkID in
                 Button {
+                    selectedConversationTitle = chunk(for: chunkID, event: event)?.kind.modalTitle ?? event.modalTitle
                     selectedConversation = try? store.expandedConversation(chunkID: chunkID)
                 } label: {
                     HStack(spacing: 8) {
                         Circle()
-                            .fill(color(for: chunkID))
+                            .fill(color(for: chunk(for: chunkID, event: event)?.kind ?? .other))
                             .frame(width: 8, height: 8)
-                        Text(chunkID)
+                        Text(chunkListTitle(chunkID: chunkID, event: event))
                             .font(.system(size: 10, weight: .medium, design: .monospaced))
                             .lineLimit(1)
                         Spacer()
@@ -524,8 +607,8 @@ struct InjectionFeedView: View {
             )
     }
 
-    private func color(for chunkID: String) -> Color {
-        let index = abs(chunkID.hashValue) % accentPalette.count
+    private func color(for kind: InjectionKind) -> Color {
+        let index = kind.paletteIndex % accentPalette.count
         return accentPalette[index]
     }
 
@@ -639,9 +722,28 @@ struct InjectionFeedView: View {
         InjectionPresentation.snapshot(
             events: presentationModel.events,
             filterText: filterText,
+            typeFilter: InjectionTypeFilter(rawValue: typeFilterRaw) ?? .all,
             now: now,
             bucketCount: 24
         )
+    }
+
+    private func chunk(for chunkID: String, event: InjectionEvent) -> InjectionChunk? {
+        event.chunks.first { $0.id == chunkID }
+    }
+
+    private func chunkListTitle(chunkID: String, event: InjectionEvent) -> String {
+        guard let chunk = chunk(for: chunkID, event: event), !chunk.displayText.isEmpty else {
+            return chunkID
+        }
+        return "\(chunk.kind.glyph) \(chunk.displayText)"
+    }
+
+    private func hitHelpText(chunkID: String, chunk: InjectionChunk?) -> String {
+        guard let chunk else {
+            return "Retrieved chunk \(chunkID)"
+        }
+        return "\(chunk.kind.label) · \(chunk.id) · \(chunk.displayText)"
     }
 }
 

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -317,7 +317,7 @@ struct InjectionFeedView: View {
 
     private func collapsedChunkPreview(for burst: InjectionPresentation.Burst) -> some View {
         VStack(alignment: .leading, spacing: 7) {
-            let previewChunks = Array(burst.events.flatMap(\.chunks).prefix(2))
+            let previewChunks = InjectionPresentation.previewChunks(for: burst.events, limit: 2)
             if previewChunks.isEmpty {
                 ForEach(Array(burst.chunkPreviewIDs.enumerated()), id: \.offset) { _, chunkID in
                     Text(chunkPreviewText(chunkID))
@@ -417,7 +417,7 @@ struct InjectionFeedView: View {
 
                 Button {
                     if let firstChunk = event.chunkIDs.first {
-                        selectedConversationTitle = event.modalTitle
+                        selectedConversationTitle = event.openingModalTitle(forChunkID: firstChunk)
                         selectedConversation = try? store.expandedConversation(chunkID: firstChunk)
                     }
                 } label: {

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -65,8 +65,7 @@ struct InjectionFeedView: View {
     @StateObject private var presentationModel = InjectionFeedPresentationModel()
     @State private var expandedEventIDs: Set<Int64> = []
     @State private var expandedBurstIDs: Set<String> = []
-    @State private var selectedConversation: BrainDatabase.ExpandedConversation?
-    @State private var selectedConversationTitle = "Conversation"
+    @State private var conversationSelection = InjectionConversationSelection()
     @AppStorage("brainbar.injectionFeed.typeFilter") private var typeFilterRaw = InjectionTypeFilter.all.rawValue
 
     private let accentPalette: [Color] = [
@@ -107,11 +106,11 @@ struct InjectionFeedView: View {
             .background(pageBackground)
         }
         .overlay {
-            if let conversation = selectedConversation {
+            if let conversation = conversationSelection.conversation {
                 ChunkConversationOverlay(
                     conversation: conversation,
-                    title: selectedConversationTitle,
-                    onClose: { selectedConversation = nil }
+                    title: conversationSelection.title,
+                    onClose: { conversationSelection.close() }
                 )
             }
         }
@@ -417,8 +416,12 @@ struct InjectionFeedView: View {
 
                 Button {
                     if let firstChunk = event.chunkIDs.first {
-                        selectedConversationTitle = event.openingModalTitle(forChunkID: firstChunk)
-                        selectedConversation = try? store.expandedConversation(chunkID: firstChunk)
+                        if let conversation = try? store.expandedConversation(chunkID: firstChunk) {
+                            conversationSelection.open(
+                                conversation,
+                                title: event.openingModalTitle(forChunkID: firstChunk)
+                            )
+                        }
                     }
                 } label: {
                     Text("Open")
@@ -475,8 +478,12 @@ struct InjectionFeedView: View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(event.chunkIDs, id: \.self) { chunkID in
                 Button {
-                    selectedConversationTitle = chunk(for: chunkID, event: event)?.kind.modalTitle ?? event.modalTitle
-                    selectedConversation = try? store.expandedConversation(chunkID: chunkID)
+                    if let conversation = try? store.expandedConversation(chunkID: chunkID) {
+                        conversationSelection.open(
+                            conversation,
+                            title: chunk(for: chunkID, event: event)?.kind.modalTitle ?? event.modalTitle
+                        )
+                    }
                 } label: {
                     HStack(spacing: 8) {
                         Circle()
@@ -744,6 +751,23 @@ struct InjectionFeedView: View {
             return "Retrieved chunk \(chunkID)"
         }
         return "\(chunk.kind.label) · \(chunk.id) · \(chunk.displayText)"
+    }
+}
+
+struct InjectionConversationSelection: Equatable {
+    static let defaultTitle = "Conversation"
+
+    var conversation: BrainDatabase.ExpandedConversation?
+    var title = defaultTitle
+
+    mutating func open(_ conversation: BrainDatabase.ExpandedConversation, title: String) {
+        self.conversation = conversation
+        self.title = title
+    }
+
+    mutating func close() {
+        conversation = nil
+        title = Self.defaultTitle
     }
 }
 

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -95,12 +95,13 @@ struct InjectionPresentation {
     static func snapshot(
         events: [InjectionEvent],
         filterText: String,
+        typeFilter: InjectionTypeFilter = .all,
         now: Date,
         windowMinutes: Int = 60,
         burstGapMinutes: Int = 60,
         bucketCount: Int = 12
     ) -> Snapshot {
-        let filteredEvents = filter(events: events, needle: filterText)
+        let filteredEvents = filter(events: events, needle: filterText, typeFilter: typeFilter)
         let parsedEvents = filteredEvents.compactMap { event in
             parseDate(event.timestamp).map { ParsedEvent(event: event, date: $0) }
         }
@@ -169,14 +170,23 @@ struct InjectionPresentation {
         let date: Date
     }
 
-    private static func filter(events: [InjectionEvent], needle: String) -> [InjectionEvent] {
+    private static func filter(
+        events: [InjectionEvent],
+        needle: String,
+        typeFilter: InjectionTypeFilter
+    ) -> [InjectionEvent] {
         let trimmed = needle.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return events }
+        let typedEvents = events.filter { event in
+            event.matches(typeFilter: typeFilter)
+        }
+        guard !trimmed.isEmpty else { return typedEvents }
         let lowered = trimmed.lowercased()
-        return events.filter { event in
+        return typedEvents.filter { event in
             event.sessionID.lowercased().contains(lowered) ||
                 event.query.lowercased().contains(lowered) ||
-                event.chunkIDs.joined(separator: " ").lowercased().contains(lowered)
+                event.chunkIDs.joined(separator: " ").lowercased().contains(lowered) ||
+                event.displayTitle.lowercased().contains(lowered) ||
+                event.chunks.map(\.source).joined(separator: " ").lowercased().contains(lowered)
         }
     }
 
@@ -321,7 +331,7 @@ struct InjectionPresentation {
     }
 
     private static func topicOrSource(for event: InjectionEvent) -> String {
-        let trimmed = event.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = event.displayTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "retrieval" : trimmed
     }
 

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -137,6 +137,19 @@ struct InjectionPresentation {
         )
     }
 
+    static func previewChunks(for events: [InjectionEvent], limit: Int) -> [InjectionChunk] {
+        guard limit > 0 else { return [] }
+        var seen = Set<String>()
+        var result: [InjectionChunk] = []
+        for chunk in events.flatMap(\.chunks) where seen.insert(chunk.id).inserted {
+            result.append(chunk)
+            if result.count == limit {
+                return result
+            }
+        }
+        return result
+    }
+
     static func parseDate(_ timestamp: String) -> Date? {
         if let date = fractionalISOFormatter().date(from: timestamp) {
             return date

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -344,7 +344,7 @@ struct InjectionPresentation {
     }
 
     private static func topicOrSource(for event: InjectionEvent) -> String {
-        let trimmed = event.displayTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = event.query.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "retrieval" : trimmed
     }
 

--- a/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
@@ -2,14 +2,17 @@ import SwiftUI
 
 struct ChunkConversationSheet: View {
     let conversation: BrainDatabase.ExpandedConversation
+    let title: String
     let onClose: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
 
     init(
         conversation: BrainDatabase.ExpandedConversation,
+        title: String = "Conversation",
         onClose: (() -> Void)? = nil
     ) {
         self.conversation = conversation
+        self.title = title
         self.onClose = onClose
     }
 
@@ -17,7 +20,7 @@ struct ChunkConversationSheet: View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Conversation")
+                    Text(title)
                         .font(.title3.bold())
                     Text(conversation.target.chunkID)
                         .font(.system(size: 11, weight: .medium, design: .monospaced))
@@ -93,7 +96,18 @@ struct ChunkConversationSheet: View {
 
 struct ChunkConversationOverlay: View {
     let conversation: BrainDatabase.ExpandedConversation
+    let title: String
     let onClose: () -> Void
+
+    init(
+        conversation: BrainDatabase.ExpandedConversation,
+        title: String = "Conversation",
+        onClose: @escaping () -> Void
+    ) {
+        self.conversation = conversation
+        self.title = title
+        self.onClose = onClose
+    }
 
     var body: some View {
         ZStack {
@@ -102,7 +116,7 @@ struct ChunkConversationOverlay: View {
                 .contentShape(Rectangle())
                 .onTapGesture(perform: onClose)
 
-            ChunkConversationSheet(conversation: conversation, onClose: onClose)
+            ChunkConversationSheet(conversation: conversation, title: title, onClose: onClose)
                 .background(
                     RoundedRectangle(cornerRadius: 24, style: .continuous)
                         .fill(Color(nsColor: .windowBackgroundColor))

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -651,6 +651,39 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(events.first?.tokenCount, 77)
     }
 
+    func testListInjectionEventsLoadsChunkDisplayMetadata() throws {
+        try db.insertChunk(
+            id: "chunk-human",
+            content: "This is the chunk content the card should title itself from.",
+            sessionId: "session-human",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6,
+            tags: "[\"pr-merge\"]"
+        )
+        db.exec("""
+            UPDATE chunks
+            SET summary = 'Human readable chunk summary',
+                source = 'mcp',
+                source_file = 'precompact:abc123'
+            WHERE id = 'chunk-human'
+        """)
+        try db.recordInjectionEvent(
+            sessionID: "session-human",
+            query: "source prompt should be only the trigger",
+            chunkIDs: ["chunk-human"],
+            tokenCount: 33,
+            timestamp: "2026-03-31T04:00:00.000Z"
+        )
+
+        let event = try XCTUnwrap(db.listInjectionEvents(limit: 1).first)
+
+        XCTAssertEqual(event.displayTitle, "Human readable chunk summary")
+        XCTAssertEqual(event.triggeredByText, "Triggered by: source prompt should be only the trigger")
+        XCTAssertEqual(event.chunks.first?.sourceFile, "precompact:abc123")
+        XCTAssertEqual(event.primaryKind.label, "Checkpoint")
+    }
+
     func testListInjectionEventsFiltersBySessionAndNewestFirst() throws {
         try db.recordInjectionEvent(
             sessionID: "session-a",

--- a/brain-bar/Tests/BrainBarTests/InjectionConversationSelectionTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionConversationSelectionTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import BrainBar
+
+final class InjectionConversationSelectionTests: XCTestCase {
+    func testCloseClearsConversationAndResetsTitle() {
+        var selection = InjectionConversationSelection()
+        let conversation = BrainDatabase.ExpandedConversation(
+            target: BrainDatabase.ConversationChunk(
+                chunkID: "chunk-1",
+                content: "Stored context",
+                contentType: "assistant_text",
+                importance: 8,
+                createdAt: "2026-05-27T00:00:00Z",
+                summary: "Stored context summary",
+                isTarget: true
+            ),
+            entries: []
+        )
+
+        selection.open(conversation, title: "Stored Memory")
+        selection.close()
+
+        XCTAssertNil(selection.conversation)
+        XCTAssertEqual(selection.title, InjectionConversationSelection.defaultTitle)
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
@@ -33,4 +33,142 @@ final class InjectionEventTests: XCTestCase {
         XCTAssertEqual(event.chunkIDs, ["chunk-a", "chunk-b"])
         XCTAssertEqual(event.tokenCount, 64)
     }
+
+    func testDisplayTitleUsesChunkSummaryBeforeSourcePrompt() {
+        let event = InjectionEvent(
+            id: 12,
+            sessionID: "session-abcdef",
+            timestamp: "2026-03-31T04:50:00.000Z",
+            query: "cron loop prompt with operational plumbing",
+            chunkIDs: ["chunk-1"],
+            tokenCount: 42,
+            chunks: [
+                InjectionChunk(
+                    id: "chunk-1",
+                    content: "The dashboard coverage bug comes from excluding terminal duplicate chunks.",
+                    summary: "Coverage bug excludes terminal duplicate chunks",
+                    source: "precompact-hook",
+                    sourceFile: "precompact:abc123",
+                    tags: ["pr-merge"],
+                    contentType: "memory"
+                )
+            ]
+        )
+
+        XCTAssertEqual(event.displayTitle, "Coverage bug excludes terminal duplicate chunks")
+        XCTAssertEqual(event.triggeredByText, "Triggered by: cron loop prompt with operational plumbing")
+        XCTAssertEqual(event.primaryKind.label, "Checkpoint")
+        XCTAssertEqual(event.primaryKind.glyph, "🏷")
+        XCTAssertEqual(event.modalTitle, "Memory Checkpoint")
+    }
+
+    func testKindClassificationCoversKnownSources() {
+        XCTAssertEqual(InjectionKind.classify(source: "precompact-hook", sourceFile: "", tags: [], content: "").label, "Memory Checkpoint")
+        XCTAssertEqual(InjectionKind.classify(source: "brain_store", sourceFile: "", tags: [], content: "").label, "Stored Memory")
+        XCTAssertEqual(InjectionKind.classify(source: "claude_code", sourceFile: "", tags: [], content: "").label, "Realtime Capture")
+        XCTAssertEqual(InjectionKind.classify(source: "youtube", sourceFile: "", tags: [], content: "").label, "Video Knowledge")
+        XCTAssertEqual(InjectionKind.classify(source: "codex_cli", sourceFile: "", tags: [], content: "").label, "Tool Session")
+        XCTAssertEqual(InjectionKind.classify(source: "mcp", sourceFile: "", tags: ["pr-merge"], content: "").label, "Checkpoint")
+        XCTAssertEqual(InjectionKind.classify(source: "", sourceFile: "", tags: [], content: "[CHECKPOINT] merged PR").label, "Checkpoint")
+    }
+
+    func testKindPaletteIndexUsesDeclarationOrder() {
+        XCTAssertEqual(InjectionKind.memoryCheckpoint.paletteIndex, 0)
+        XCTAssertEqual(InjectionKind.other.paletteIndex, InjectionKind.allCases.count - 1)
+    }
+
+    func testSnapshotFiltersByType() {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let timestamp = ISO8601DateFormatter().string(from: now.addingTimeInterval(-60))
+        let checkpoint = InjectionEvent(
+            id: 1,
+            sessionID: "s1",
+            timestamp: timestamp,
+            query: "checkpoint query",
+            chunkIDs: ["c1"],
+            tokenCount: 10,
+            chunks: [
+                InjectionChunk(
+                    id: "c1",
+                    content: "[CHECKPOINT] merged item",
+                    summary: "",
+                    source: "mcp",
+                    sourceFile: "",
+                    tags: ["pr-merge"],
+                    contentType: "memory"
+                )
+            ]
+        )
+        let realtime = InjectionEvent(
+            id: 2,
+            sessionID: "s2",
+            timestamp: timestamp,
+            query: "realtime query",
+            chunkIDs: ["c2"],
+            tokenCount: 10,
+            chunks: [
+                InjectionChunk(
+                    id: "c2",
+                    content: "Fresh Claude session capture",
+                    summary: "",
+                    source: "claude_code",
+                    sourceFile: "",
+                    tags: [],
+                    contentType: "user_message"
+                )
+            ]
+        )
+
+        let snapshot = InjectionPresentation.snapshot(
+            events: [checkpoint, realtime],
+            filterText: "",
+            typeFilter: .checkpoint,
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.filteredEvents.map(\.id), [1])
+        XCTAssertEqual(snapshot.summary.queryCount, 1)
+    }
+
+    func testSnapshotTypeFilterMatchesAnyRetrievedChunkKind() {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let timestamp = ISO8601DateFormatter().string(from: now.addingTimeInterval(-60))
+        let mixed = InjectionEvent(
+            id: 3,
+            sessionID: "s3",
+            timestamp: timestamp,
+            query: "mixed query",
+            chunkIDs: ["stored", "video"],
+            tokenCount: 10,
+            chunks: [
+                InjectionChunk(
+                    id: "stored",
+                    content: "Stored memory first",
+                    summary: "",
+                    source: "mcp",
+                    sourceFile: "",
+                    tags: [],
+                    contentType: "memory"
+                ),
+                InjectionChunk(
+                    id: "video",
+                    content: "Video knowledge second",
+                    summary: "",
+                    source: "youtube",
+                    sourceFile: "",
+                    tags: [],
+                    contentType: "media"
+                )
+            ]
+        )
+
+        let snapshot = InjectionPresentation.snapshot(
+            events: [mixed],
+            filterText: "",
+            typeFilter: .video,
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.filteredEvents.map(\.id), [3])
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
@@ -171,4 +171,44 @@ final class InjectionEventTests: XCTestCase {
 
         XCTAssertEqual(snapshot.filteredEvents.map(\.id), [3])
     }
+
+    func testTypeFilterKeepsUnloadedEventsWithChunkIDsVisible() {
+        let event = InjectionEvent(
+            id: 4,
+            sessionID: "s4",
+            timestamp: "2026-03-31T04:50:00.000Z",
+            query: "unloaded chunk metadata",
+            chunkIDs: ["missing-metadata"],
+            tokenCount: 10,
+            chunks: []
+        )
+
+        XCTAssertTrue(event.matches(typeFilter: .memory))
+        XCTAssertTrue(event.matches(typeFilter: .video))
+    }
+
+    func testOpeningModalTitleUsesOpenedChunkOrGenericFallback() {
+        let event = InjectionEvent(
+            id: 5,
+            sessionID: "s5",
+            timestamp: "2026-03-31T04:50:00.000Z",
+            query: "missing first chunk metadata",
+            chunkIDs: ["missing-first", "loaded-second"],
+            tokenCount: 10,
+            chunks: [
+                InjectionChunk(
+                    id: "loaded-second",
+                    content: "Video transcript hit",
+                    summary: "",
+                    source: "youtube",
+                    sourceFile: "",
+                    tags: [],
+                    contentType: "media"
+                )
+            ]
+        )
+
+        XCTAssertEqual(event.openingModalTitle(forChunkID: "missing-first"), "Conversation")
+        XCTAssertEqual(event.openingModalTitle(forChunkID: "loaded-second"), "Video Knowledge")
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
@@ -211,4 +211,29 @@ final class InjectionEventTests: XCTestCase {
         XCTAssertEqual(event.openingModalTitle(forChunkID: "missing-first"), "Conversation")
         XCTAssertEqual(event.openingModalTitle(forChunkID: "loaded-second"), "Video Knowledge")
     }
+
+    func testCardPrimaryContentDoesNotBorrowSecondChunkWhenLeadMetadataIsMissing() {
+        let event = InjectionEvent(
+            id: 6,
+            sessionID: "s6",
+            timestamp: "2026-03-31T04:50:00.000Z",
+            query: "lead chunk metadata missing",
+            chunkIDs: ["missing-first", "loaded-second"],
+            tokenCount: 10,
+            chunks: [
+                InjectionChunk(
+                    id: "loaded-second",
+                    content: "Second chunk content",
+                    summary: "Second chunk summary",
+                    source: "youtube",
+                    sourceFile: "",
+                    tags: [],
+                    contentType: "media"
+                )
+            ]
+        )
+
+        XCTAssertEqual(event.primaryKind, .other)
+        XCTAssertEqual(event.displayTitle, "lead chunk metadata missing")
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
@@ -88,6 +88,13 @@ final class InjectionEventTests: XCTestCase {
         XCTAssertEqual(InjectionKind.classify(source: "", sourceFile: "", tags: [], content: "[CHECKPOINT] merged PR").label, "Checkpoint")
     }
 
+    func testManualSourceClassifiesAsStoredMemory() {
+        let kind = InjectionKind.classify(source: "manual", sourceFile: "", tags: [], content: "")
+
+        XCTAssertEqual(kind, .storedMemory)
+        XCTAssertTrue(InjectionTypeFilter.stored.contains(kind))
+    }
+
     func testKindPaletteIndexUsesDeclarationOrder() {
         XCTAssertEqual(InjectionKind.memoryCheckpoint.paletteIndex, 0)
         XCTAssertEqual(InjectionKind.other.paletteIndex, InjectionKind.allCases.count - 1)

--- a/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
@@ -34,6 +34,22 @@ final class InjectionEventTests: XCTestCase {
         XCTAssertEqual(event.tokenCount, 64)
     }
 
+    func testMalformedChunkIDsJSONFallsBackToEmptyArray() throws {
+        let event = try InjectionEvent(
+            row: [
+                "id": 8,
+                "session_id": "sess-3",
+                "timestamp": "2026-03-31T04:50:00.000Z",
+                "query": "brainbar malformed chunk ids",
+                "chunk_ids": "[\"chunk-a\"",
+                "token_count": 32
+            ]
+        )
+
+        XCTAssertEqual(event.chunkIDs, [])
+        XCTAssertEqual(event.tokenCount, 32)
+    }
+
     func testDisplayTitleUsesChunkSummaryBeforeSourcePrompt() {
         let event = InjectionEvent(
             id: 12,

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -228,13 +228,47 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(initialSnapshot.bursts[0].id, updatedSnapshot.bursts[0].id)
     }
 
+    func testPreviewChunksDeduplicatesRepeatedChunkIDsAcrossBurstEvents() {
+        let events = [
+            makeEvent(
+                id: 1,
+                sessionID: "sess-a",
+                timestamp: "2026-04-18T09:58:00Z",
+                query: "auth refactor",
+                chunkIDs: ["shared", "unique-a"],
+                tokenCount: 10,
+                chunks: [
+                    makeChunk(id: "shared", content: "Shared hit"),
+                    makeChunk(id: "unique-a", content: "Unique hit A")
+                ]
+            ),
+            makeEvent(
+                id: 2,
+                sessionID: "sess-a",
+                timestamp: "2026-04-18T09:57:00Z",
+                query: "auth refactor",
+                chunkIDs: ["shared", "unique-b"],
+                tokenCount: 10,
+                chunks: [
+                    makeChunk(id: "shared", content: "Shared hit again"),
+                    makeChunk(id: "unique-b", content: "Unique hit B")
+                ]
+            )
+        ]
+
+        let preview = InjectionPresentation.previewChunks(for: events, limit: 3)
+
+        XCTAssertEqual(preview.map(\.id), ["shared", "unique-a", "unique-b"])
+    }
+
     private func makeEvent(
         id: Int64,
         sessionID: String,
         timestamp: String,
         query: String,
         chunkIDs: [String],
-        tokenCount: Int
+        tokenCount: Int,
+        chunks: [InjectionChunk] = []
     ) -> InjectionEvent {
         InjectionEvent(
             id: id,
@@ -242,7 +276,20 @@ final class InjectionPresentationTests: XCTestCase {
             timestamp: timestamp,
             query: query,
             chunkIDs: chunkIDs,
-            tokenCount: tokenCount
+            tokenCount: tokenCount,
+            chunks: chunks
+        )
+    }
+
+    private func makeChunk(id: String, content: String) -> InjectionChunk {
+        InjectionChunk(
+            id: id,
+            content: content,
+            summary: "",
+            source: "mcp",
+            sourceFile: "",
+            tags: [],
+            contentType: "memory"
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -113,6 +113,36 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.bursts.map(\.topicOrSource), ["auth refactor", "db migration"])
     }
 
+    func testBurstAggregationUsesTriggerQueryWhenChunkSummariesDiffer() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let events = [
+            makeEvent(
+                id: 1,
+                sessionID: "sess-a",
+                timestamp: "2026-04-18T09:59:00Z",
+                query: "auth refactor",
+                chunkIDs: ["chunk-1"],
+                tokenCount: 10,
+                chunks: [makeChunk(id: "chunk-1", content: "Auth service boundaries")]
+            ),
+            makeEvent(
+                id: 2,
+                sessionID: "sess-a",
+                timestamp: "2026-04-18T09:58:00Z",
+                query: "auth refactor",
+                chunkIDs: ["chunk-2"],
+                tokenCount: 10,
+                chunks: [makeChunk(id: "chunk-2", content: "Session token migration")]
+            ),
+        ]
+
+        let snapshot = InjectionPresentation.snapshot(events: events, filterText: "", now: now)
+
+        XCTAssertEqual(snapshot.bursts.count, 1)
+        XCTAssertEqual(snapshot.bursts[0].topicOrSource, "auth refactor")
+        XCTAssertEqual(snapshot.bursts[0].events.map(\.id), [1, 2])
+    }
+
     func testBurstAggregationSplitsSameSessionWhenEventsAreMoreThanSixtyMinutesApart() {
         let now = isoDate("2026-04-18T10:00:00Z")
         let events = [


### PR DESCRIPTION
## Summary

Implements Item F Fix 2 from `/tmp/codex-mandate-item-F.md`: humanize the BrainBar Injections tab so retrieval cards are based on retrieved chunk content instead of source-prompt plumbing.

## Changes

- Enriches `InjectionEvent` objects with chunk metadata from `chunks` during `listInjectionEvents`.
- Adds content-first injection titles from chunk `summary`/`content`, with query text demoted to `Triggered by:` subtitle.
- Adds source/type classification with glyphs and labels for checkpoints, realtime capture, stored memory, digests, video, chat, tool sessions, quick capture, and other chunks.
- Adds persisted type filter chips: All, Memory, Stored, Realtime, Checkpoint, Video, Chat, Tool.
- Adds source-type legend/tooltips for hit bars and human-readable expanded chunk rows.
- Lets the conversation modal title reflect the chunk type, e.g. Memory Checkpoint instead of always Conversation.

## Tests

- `swift test --package-path brain-bar --filter 'InjectionEventTests|DatabaseTests/testListInjectionEventsLoadsChunkDisplayMetadata'`
- `swift test --package-path brain-bar --filter 'InjectionPresentationTests|InjectionStoreTests|InjectionEventTests|DatabaseTests/testListInjectionEventsLoadsChunkDisplayMetadata'`
- `swift test --package-path brain-bar` — 478 tests, 0 failures
- `git diff --check`
- Local CodeRabbit: `cr review --plain --type uncommitted` — no findings
- Pre-push hook passed:
  - Python: 2186 passed, 9 skipped, 75 deselected, 1 xfailed
  - MCP tool registration: 3 passed
  - isolated eval/hook routing: 36 passed
  - bun stale index: 1 pass
  - `test_fts5_determinism.sh`: pass

## Visual Gate

Per Etan addendum, this PR still requires post-merge rebuild + relaunch + Computer Use screenshots of Dashboard, Injections, and Graph before `TASK_DONE_FIX_2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Each injection list now runs an extra chunks query per event (read-path cost), and classification/filter behavior affects what users see in a core BrainBar surface; changes are localized to UI/read models with broad test coverage.
> 
> **Overview**
> **Humanizes the BrainBar Injections tab** by loading retrieved **chunk rows** when listing injection events and driving cards from **summary/content** instead of raw query text, with the query shown as a **“Triggered by:”** line.
> 
> Adds **`InjectionChunk`**, **`InjectionKind`** (glyphs, labels, source-based classification), and **`InjectionTypeFilter`** with **persisted filter chips** (All, Memory, Stored, Realtime, etc.). **`InjectionPresentation.snapshot`** applies the type filter and extends text search to display titles and chunk sources; burst previews can show **deduplicated chunk previews** with kind glyphs.
> 
> **`InjectionFeedView`** updates burst/event rows, hit-bar **colors by kind** (not chunk-ID hash), legends/tooltips, and **`InjectionConversationSelection`** so **`ChunkConversationSheet` / overlay** use **chunk-type modal titles** instead of a fixed “Conversation”.
> 
> **`InjectionEvent` row parsing** no longer throws on malformed **`chunk_ids` JSON**—it falls back to an empty array. Events with chunk IDs but **missing loaded metadata** still pass non-`All` type filters so rows are not hidden incorrectly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca7b71b2d29cd26cba4ce1a4517e3b0c33dd2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Type-filter chips in the event feed (persisted) to filter injections by kind.
  * Enriched chunk display: summaries, sources, tags, and kind-based glyphs/labels.
  * Conversation sheets/overlays accept a custom title.

* **Bug Fixes**
  * Chunk previews and collapsed bursts show actual chunk content (not just IDs).
  * Event filtering/search respects type filter and chunk metadata.

* **Tests**
  * Added unit tests covering decoding, kind classification, presentation, and selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add semantic kind classification and type filtering to the BrainBar injections tab
> - Introduces `InjectionKind` (with glyphs, labels, and palette indices) and `InjectionTypeFilter` to classify injection events by source type (memory, stored, realtime, checkpoint, video, chat, tool)
> - `InjectionEvent` and `InjectionChunk` now carry chunk metadata (content, summary, source, tags) fetched from the database, enabling display-ready titles and kind classification in the UI
> - `InjectionFeedView` is reworked to show kind glyphs, display titles, 'Triggered by' query lines, and a persistent type-filter chip row; chunk ribbon colors are now stable per kind rather than hashed per chunk ID
> - `InjectionPresentation.snapshot` and `filter` accept a `typeFilter` to narrow results by type and match against display titles and chunk sources
> - Malformed `chunk_ids` JSON in `InjectionEvent` row initializer no longer throws — it silently falls back to an empty array
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dca7b71.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->