### PR TITLE
fix(brainbar): title injection bursts from chunk content

### DIFF
--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -36,8 +36,12 @@ struct InjectionPresentation {
         var tokenCount: Int { events.reduce(0) { $0 + $1.tokenCount } }
 
         var summaryTitle: String {
+            if let chunkTitle = InjectionPresentation.previewChunks(for: events, limit: 1).first?.displayText,
+               !chunkTitle.isEmpty {
+                return chunkTitle
+            }
             let chunkNoun = chunkCount == 1 ? "chunk" : "chunks"
-            return "\(chunkCount) \(chunkNoun) injected from \"\(topicOrSource)\""
+            return "\(chunkCount) \(chunkNoun) injected"
         }
 
         var chunkPreviewIDs: [String] {

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -80,10 +80,33 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.bursts.count, 1)
         XCTAssertEqual(snapshot.bursts[0].sessionID, "brain-c7a8")
         XCTAssertEqual(snapshot.bursts[0].topicOrSource, "auth refactor")
-        XCTAssertEqual(snapshot.bursts[0].summaryTitle, "5 chunks injected from \"auth refactor\"")
+        XCTAssertEqual(snapshot.bursts[0].summaryTitle, "5 chunks injected")
         XCTAssertEqual(snapshot.bursts[0].events.map(\.id), [1, 2, 3, 4, 5])
         XCTAssertEqual(snapshot.bursts[0].chunkPreviewIDs, ["chunk-1", "chunk-2"])
         XCTAssertEqual(snapshot.bursts[0].remainingChunkCount(after: 2), 3)
+    }
+
+    func testBurstSummaryTitleUsesChunkContentInsteadOfSourcePrompt() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let event = makeEvent(
+            id: 1,
+            sessionID: "sess-a",
+            timestamp: "2026-04-18T09:58:00Z",
+            query: "[orc gen-7 s:1 — researchLead monitor v2 — prompts-deliverable workflow]",
+            chunkIDs: ["chunk-1"],
+            tokenCount: 10,
+            chunks: [
+                makeChunk(id: "chunk-1", content: "Coverage moved to terminal-status semantics after the dashboard fix")
+            ]
+        )
+
+        let snapshot = InjectionPresentation.snapshot(events: [event], filterText: "", now: now)
+
+        XCTAssertEqual(
+            snapshot.bursts[0].summaryTitle,
+            "Coverage moved to terminal-status semantics after the dashboard fix"
+        )
+        XCTAssertEqual(snapshot.bursts[0].topicOrSource, event.query)
     }
 
     func testBurstAggregationSplitsDifferentSessions() {


### PR DESCRIPTION
## Summary
- make injection burst card titles use the first retrieved chunk summary/content
- keep source prompts as grouping keys and Triggered by subtitles only
- add regression coverage for the visual failure caught after rebuilding PR #336

## Verification
- red: swift test --package-path brain-bar --filter InjectionPresentationTests/testBurstSummaryTitleUsesChunkContentInsteadOfSourcePrompt
- swift test --package-path brain-bar --filter 'InjectionConversationSelectionTests|InjectionEventTests|InjectionPresentationTests|DatabaseTests/testListInjectionEventsLoadsChunkDisplayMetadata'
- swift test --package-path brain-bar
- pre-push gate: Python pytest suite, MCP registration, isolated eval/hook routing, bun, FTS regression

Follow-up to Item F Fix 2 visual verification; PR #336 exposed that burst titles could still display source prompt text in live BrainBar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in BrainBar injection burst titles; grouping and data paths are unchanged.
> 
> **Overview**
> **Injection burst card titles** now show the first retrieved chunk’s summary/content (via existing `previewChunks` / `displayText`) instead of repeating the source/trigger prompt. When no chunk text is available, the fallback is shortened to **“N chunk(s) injected”** without quoting `topicOrSource`.
> 
> Burst **grouping** still keys on session + query (`topicOrSource`); only the visible title string changed. A regression test covers the case where the query is a long orchestrator-style prompt but chunk content should drive the title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48177f18751ae0ec4c545f1c4d277f7ee8a525ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Burst.summaryTitle` to show first chunk's display text instead of source/prompt
> - `Burst.summaryTitle` in [InjectionPresentation.swift](https://github.com/EtanHey/brainlayer/pull/337/files#diff-122482b429312571e0f6b54d0c5380a75296ed791e7303eecde2bfa2909b1423) now returns the first preview chunk's `displayText` when it is non-empty.
> - The fallback (when no chunk text is available) drops the source/prompt and returns `'N chunk(s) injected'` instead of `'N chunk(s) injected from "<source>"'`.
> - Behavioral Change: burst titles in the brain bar will show chunk content rather than the source/prompt label when chunk text is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48177f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->