### PR TITLE
perf(brainbar): refresh dashboard without blocking startup

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
@@ -46,19 +46,14 @@ enum BrainBarAppSupport {
         )
     }
 
-    // AIDEV-NOTE: Wires the UI runtime's database + injection store after PR #312
+    // AIDEV-NOTE: Wires the UI runtime's database after PR #312
     // removed the FastAPI daemon. Pre-#312 the daemon owned the writer and the UI
     // process consumed via socket; post-#312 each consumer opens SQLite directly.
     //
-    // Order matters: InjectionStore opens its internal connection in default
-    // writable mode and creates the schema if the file doesn't exist (fresh
-    // install / cleared state). The UI runtime's read-only handle MUST open
-    // after that, otherwise on a missing DB the read-only open fails and the UI
-    // installs a permanently-closed handle that satisfies `database != nil` but
-    // breaks search/graph. If the read-only open still fails after
-    // bootstrapping, try `reopenIfNeeded()` once — in practice the DB at
-    // ~/.local/share/brainlayer/brainlayer.db is always present, but tests +
-    // fresh-install + cleared-state must work too.
+    // The heavy InjectionStore is intentionally lazy: Dashboard startup should
+    // not open an extra writable SQLite handle just because the Injections tab
+    // exists. On a missing DB, bootstrap the schema once before installing the
+    // read-only handle so fresh installs still work.
     //
     // The UI runtime opens read-only so the writer pidfile stays uncontended
     // with the Python enrich supervisor + drain. InjectionStore keeps its own
@@ -69,19 +64,16 @@ enum BrainBarAppSupport {
         dbPath: String,
         collector: StatsCollector
     ) {
-        let injectionStore: InjectionStore?
-        do {
-            injectionStore = try InjectionStore(databasePath: dbPath)
-        } catch {
-            NSLog("[BrainBar] InjectionStore init failed: %@", String(describing: error))
-            injectionStore = nil
-        }
-
         let database = BrainDatabase(
             path: dbPath,
             openConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
         )
         if !database.isOpen {
+            database.reopenIfNeeded()
+        }
+        if !database.isOpen, !FileManager.default.fileExists(atPath: dbPath) {
+            let bootstrapDatabase = BrainDatabase(path: dbPath)
+            bootstrapDatabase.close()
             database.reopenIfNeeded()
         }
         if !database.isOpen {
@@ -94,8 +86,16 @@ enum BrainBarAppSupport {
 
         runtime.install(
             collector: collector,
-            injectionStore: injectionStore,
-            database: database
+            injectionStore: nil,
+            database: database,
+            injectionStoreFactory: {
+                do {
+                    return try InjectionStore(databasePath: dbPath)
+                } catch {
+                    NSLog("[BrainBar] InjectionStore init failed: %@", String(describing: error))
+                    return nil
+                }
+            }
         )
     }
 

--- a/brain-bar/Sources/BrainBar/BrainBarRuntime.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarRuntime.swift
@@ -11,6 +11,8 @@ final class BrainBarRuntime: ObservableObject {
     @Published private(set) var database: BrainDatabase?
     @Published private(set) var requestedQuickAction: BrainBarQuickAction?
 
+    private var injectionStoreFactory: (() -> InjectionStore?)?
+
     var onToggleRequested: (() -> Void)?
     var onSearchRequested: (() -> Void)?
     var onQuickCaptureRequested: (() -> Void)?
@@ -26,11 +28,18 @@ final class BrainBarRuntime: ObservableObject {
     func install(
         collector: StatsCollector,
         injectionStore: InjectionStore?,
-        database: BrainDatabase?
+        database: BrainDatabase?,
+        injectionStoreFactory: (() -> InjectionStore?)? = nil
     ) {
         self.collector = collector
         self.injectionStore = injectionStore
         self.database = database
+        self.injectionStoreFactory = injectionStoreFactory
+    }
+
+    func ensureInjectionStore() {
+        guard injectionStore == nil else { return }
+        injectionStore = injectionStoreFactory?()
     }
 
     func handleToggleRequest() {

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -28,6 +28,7 @@ struct BrainBarWindowRootView: View {
         VStack(spacing: 0) {
             BrainBarWindowHeader(
                 selectedTab: $selectedTab,
+                collector: runtime.collector,
                 hotkeyStatus: runtime.hotkeyStatus.statusLine,
                 commandBarViewModel: commandBarViewModel
             )
@@ -147,8 +148,9 @@ struct BrainBarWindowRootView: View {
     private func activate(tab: BrainBarTab) {
         switch tab {
         case .dashboard:
-            break
+            runtime.collector?.requestRefresh(force: true, trigger: .tabSwitch)
         case .injections:
+            runtime.ensureInjectionStore()
             hasActivatedInjectionsTab = true
         case .graph:
             hasActivatedGraphTab = true
@@ -182,6 +184,7 @@ private extension View {
 private struct BrainBarWindowHeader: View {
     @Binding var selectedTab: BrainBarTab
 
+    let collector: StatsCollector?
     let hotkeyStatus: String
     let commandBarViewModel: QuickCaptureViewModel?
 
@@ -203,7 +206,26 @@ private struct BrainBarWindowHeader: View {
                 .frame(maxWidth: 280)
                 .labelsHidden()
 
-                Spacer(minLength: 16)
+                if let collector {
+                    Button {
+                        collector.manualRefresh()
+                    } label: {
+                        Label("Refresh now", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .keyboardShortcut("r", modifiers: .command)
+                    .disabled(collector.isManualRefreshInProgress)
+                    .help("Refresh dashboard now")
+
+                    if collector.isManualRefreshInProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(width: 16, height: 16)
+                    }
+                }
+
+                Spacer(minLength: 12)
 
                 Text(hotkeyStatus)
                     .font(.system(size: 11, weight: .medium))
@@ -243,6 +265,7 @@ private struct BrainBarDashboardView: View {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: layout.sectionSpacing) {
                     overviewCard(layout: layout)
+                    freshnessLine
                     chartCards(layout: layout)
                     agentPresenceStrip(layout: layout)
                     if layout.usesQueueRail {
@@ -351,6 +374,29 @@ private struct BrainBarDashboardView: View {
             .fixedSize(horizontal: false, vertical: true)
     }
 
+    private var freshnessLine: some View {
+        HStack(spacing: 8) {
+            Image(systemName: collector.isRefreshing ? "arrow.triangle.2.circlepath" : "clock")
+                .font(.system(size: 11, weight: .semibold))
+            Text("Data fetched at: \(dataFetchedText)")
+                .font(.system(size: 11, weight: .semibold))
+                .monospacedDigit()
+            if collector.isRefreshing {
+                Text("Refreshing...")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 4)
+    }
+
+    private var dataFetchedText: String {
+        guard let lastDataFetchedAt = collector.lastDataFetchedAt else { return "not yet" }
+        return DashboardMetricFormatter.absoluteTimeString(lastDataFetchedAt)
+    }
+
     private var overviewBadgeRow: some View {
         Group {
             BrainBarHeroBadge(text: flowSummary.windowLabel)
@@ -395,6 +441,7 @@ private struct BrainBarDashboardView: View {
             pulseRevision: writePulseRevision,
             compact: layout.compactCards,
             chartHeight: layout.sparklineHeight,
+            fetchedAt: collector.lastDataFetchedAt ?? Date(),
             emphasize: true
         )
     }
@@ -405,6 +452,7 @@ private struct BrainBarDashboardView: View {
             pulseRevision: enrichmentPulseRevision,
             compact: layout.compactCards,
             chartHeight: layout.sparklineHeight,
+            fetchedAt: collector.lastDataFetchedAt ?? Date(),
             emphasize: true
         )
     }
@@ -545,6 +593,7 @@ private struct BrainBarFlowLaneCard: View {
     let pulseRevision: Int
     let compact: Bool
     let chartHeight: CGFloat
+    let fetchedAt: Date
     let emphasize: Bool
 
     var body: some View {
@@ -568,6 +617,7 @@ private struct BrainBarFlowLaneCard: View {
                 values: lane.values,
                 accentColor: lane.accentColor,
                 activityWindowMinutes: lane.activityWindowMinutes,
+                fetchedAt: fetchedAt,
                 pulseRevision: pulseRevision
             )
             .frame(height: chartHeight)
@@ -1057,11 +1107,8 @@ private struct BrainBarHeroSparkline: View {
     let values: [Int]
     let accentColor: NSColor
     let activityWindowMinutes: Int
+    let fetchedAt: Date
     let pulseRevision: Int
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var ringScale: CGFloat = 0.8
-    @State private var ringOpacity = 0.0
 
     var body: some View {
         GeometryReader { proxy in
@@ -1069,63 +1116,18 @@ private struct BrainBarHeroSparkline: View {
                 width: max(proxy.size.width.rounded(.up), 1),
                 height: max(proxy.size.height.rounded(.up), 1)
             )
-            let endpoint = SparklineRenderer.endpoint(
-                values: values,
-                size: renderSize
+
+            SparklineChart(
+                presentation: SparklineChartPresentation(
+                    label: "Recent activity sparkline",
+                    values: values,
+                    activityWindowMinutes: activityWindowMinutes,
+                    fetchedAt: fetchedAt
+                ),
+                accentColor: accentColor,
+                compact: SparklineRenderer.isCompact(size: renderSize)
             )
-
-            ZStack(alignment: .topLeading) {
-                SparklineChart(
-                    presentation: SparklineChartPresentation(
-                        label: "Recent activity sparkline",
-                        values: values,
-                        activityWindowMinutes: activityWindowMinutes
-                    ),
-                    accentColor: accentColor,
-                    compact: SparklineRenderer.isCompact(size: renderSize)
-                )
-                .frame(width: proxy.size.width, height: proxy.size.height)
-
-                if let endpoint, !reduceMotion {
-                    let point = CGPoint(
-                        x: endpoint.x,
-                        y: proxy.size.height - endpoint.y
-                    )
-
-                    Circle()
-                        .stroke(Color(nsColor: accentColor).opacity(0.45), lineWidth: 2)
-                        .frame(width: 26, height: 26)
-                        .scaleEffect(ringScale)
-                        .opacity(ringOpacity)
-                        .position(point)
-
-                    Circle()
-                        .fill(Color(nsColor: accentColor))
-                        .frame(width: 9, height: 9)
-                        .shadow(color: Color(nsColor: accentColor).opacity(0.65), radius: 6)
-                        .position(point)
-                }
-            }
-        }
-        .onAppear {
-            triggerPulse()
-        }
-        .onChange(of: pulseRevision) { _, _ in
-            triggerPulse()
-        }
-    }
-
-    private func triggerPulse() {
-        guard !reduceMotion else {
-            ringScale = 1
-            ringOpacity = 0
-            return
-        }
-        ringScale = 0.8
-        ringOpacity = 0.7
-        withAnimation(.easeOut(duration: 0.75)) {
-            ringScale = 1.75
-            ringOpacity = 0
+            .frame(width: proxy.size.width, height: proxy.size.height)
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -207,22 +207,7 @@ private struct BrainBarWindowHeader: View {
                 .labelsHidden()
 
                 if let collector {
-                    Button {
-                        collector.manualRefresh()
-                    } label: {
-                        Label("Refresh now", systemImage: "arrow.clockwise")
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .keyboardShortcut("r", modifiers: .command)
-                    .disabled(collector.isManualRefreshInProgress)
-                    .help("Refresh dashboard now")
-
-                    if collector.isManualRefreshInProgress {
-                        ProgressView()
-                            .controlSize(.small)
-                            .frame(width: 16, height: 16)
-                    }
+                    BrainBarHeaderRefreshControls(collector: collector)
                 }
 
                 Spacer(minLength: 12)
@@ -241,6 +226,33 @@ private struct BrainBarWindowHeader: View {
         .padding(.bottom, 12)
         .background(.regularMaterial)
         .background(WindowDragHandle())
+    }
+}
+
+private struct BrainBarHeaderRefreshControls: View {
+    @ObservedObject private var collector: StatsCollector
+
+    init(collector: StatsCollector) {
+        self.collector = collector
+    }
+
+    var body: some View {
+        Button {
+            collector.manualRefresh()
+        } label: {
+            Label("Refresh now", systemImage: "arrow.clockwise")
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .keyboardShortcut("r", modifiers: .command)
+        .disabled(collector.isManualRefreshInProgress)
+        .help("Refresh dashboard now")
+
+        if collector.isManualRefreshInProgress {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 16, height: 16)
+        }
     }
 }
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1347,58 +1347,60 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func dashboardStats(activityWindowMinutes: Int = 30, bucketCount: Int = 12) throws -> DashboardStats {
-        let liveWindowMinutes = 1
-        guard bucketCount > 0 else {
+        try withReadTransaction {
+            let liveWindowMinutes = 1
+            guard bucketCount > 0 else {
+                return DashboardStats(
+                    chunkCount: 0,
+                    enrichedChunkCount: 0,
+                    pendingEnrichmentCount: 0,
+                    enrichmentPercent: 0,
+                    enrichmentRatePerMinute: 0,
+                    databaseSizeBytes: databaseSizeBytes(),
+                    recentActivityBuckets: [],
+                    recentEnrichmentBuckets: [],
+                    activityWindowMinutes: activityWindowMinutes,
+                    bucketCount: bucketCount,
+                    liveWindowMinutes: liveWindowMinutes
+                )
+            }
+
+            let counts = try dashboardCounts()
+            let lastEvents = try dashboardLastEvents()
+            let chunkCount = counts.chunkCount
+            let enrichedChunkCount = counts.enrichedChunkCount
+            let pendingEnrichmentCount = counts.pendingEnrichmentCount
+            let enrichmentPercent = chunkCount == 0 ? 0 : (Double(enrichedChunkCount) / Double(chunkCount)) * 100
+            let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: liveWindowMinutes)
+            let recentActivityBuckets = try recentActivityBuckets(
+                activityWindowMinutes: activityWindowMinutes,
+                bucketCount: bucketCount
+            )
+            let recentEnrichmentBuckets = try recentEnrichmentBuckets(
+                activityWindowMinutes: activityWindowMinutes,
+                bucketCount: bucketCount
+            )
+            let pendingStoreQueue = pendingStoreQueueSnapshot()
+
             return DashboardStats(
-                chunkCount: 0,
-                enrichedChunkCount: 0,
-                pendingEnrichmentCount: 0,
-                enrichmentPercent: 0,
-                enrichmentRatePerMinute: 0,
+                chunkCount: chunkCount,
+                enrichedChunkCount: enrichedChunkCount,
+                pendingEnrichmentCount: pendingEnrichmentCount,
+                enrichmentPercent: enrichmentPercent,
+                enrichmentRatePerMinute: enrichmentRatePerMinute,
                 databaseSizeBytes: databaseSizeBytes(),
-                recentActivityBuckets: [],
-                recentEnrichmentBuckets: [],
+                recentActivityBuckets: recentActivityBuckets,
+                recentEnrichmentBuckets: recentEnrichmentBuckets,
                 activityWindowMinutes: activityWindowMinutes,
                 bucketCount: bucketCount,
-                liveWindowMinutes: liveWindowMinutes
+                liveWindowMinutes: liveWindowMinutes,
+                lastWriteAt: lastEvents.lastWriteAt,
+                lastEnrichedAt: lastEvents.lastEnrichedAt,
+                trigramIndexedChunkCount: (try? countRows(in: "chunks_fts_trigram")) ?? 0,
+                pendingStoreQueueDepth: pendingStoreQueue.depth,
+                pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt
             )
         }
-
-        let counts = try dashboardCounts()
-        let lastEvents = try dashboardLastEvents()
-        let chunkCount = counts.chunkCount
-        let enrichedChunkCount = counts.enrichedChunkCount
-        let pendingEnrichmentCount = counts.pendingEnrichmentCount
-        let enrichmentPercent = chunkCount == 0 ? 0 : (Double(enrichedChunkCount) / Double(chunkCount)) * 100
-        let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: liveWindowMinutes)
-        let recentActivityBuckets = try recentActivityBuckets(
-            activityWindowMinutes: activityWindowMinutes,
-            bucketCount: bucketCount
-        )
-        let recentEnrichmentBuckets = try recentEnrichmentBuckets(
-            activityWindowMinutes: activityWindowMinutes,
-            bucketCount: bucketCount
-        )
-        let pendingStoreQueue = pendingStoreQueueSnapshot()
-
-        return DashboardStats(
-            chunkCount: chunkCount,
-            enrichedChunkCount: enrichedChunkCount,
-            pendingEnrichmentCount: pendingEnrichmentCount,
-            enrichmentPercent: enrichmentPercent,
-            enrichmentRatePerMinute: enrichmentRatePerMinute,
-            databaseSizeBytes: databaseSizeBytes(),
-            recentActivityBuckets: recentActivityBuckets,
-            recentEnrichmentBuckets: recentEnrichmentBuckets,
-            activityWindowMinutes: activityWindowMinutes,
-            bucketCount: bucketCount,
-            liveWindowMinutes: liveWindowMinutes,
-            lastWriteAt: lastEvents.lastWriteAt,
-            lastEnrichedAt: lastEvents.lastEnrichedAt,
-            trigramIndexedChunkCount: (try? countRows(in: "chunks_fts_trigram")) ?? 0,
-            pendingStoreQueueDepth: pendingStoreQueue.depth,
-            pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt
-        )
     }
 
     func dataVersion() throws -> Int {
@@ -1444,140 +1446,81 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func dashboardCounts() throws -> (chunkCount: Int, enrichedChunkCount: Int, pendingEnrichmentCount: Int) {
-        guard let db else { throw DBError.notOpen }
-        // Pending enrichment is represented by NULL; any persisted status is terminal coverage.
-        let sql = """
-            SELECT
-                COUNT(*) AS chunk_count,
-                SUM(CASE WHEN enrich_status IS NOT NULL THEN 1 ELSE 0 END) AS enriched_count,
-                SUM(CASE WHEN enriched_at IS NULL AND enrich_status IS NULL THEN 1 ELSE 0 END) AS pending_enrichment_count
-            FROM chunks
-        """
-        var stmt: OpaquePointer?
-        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
-        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
-        defer { sqlite3_finalize(stmt) }
-        guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
         return (
-            chunkCount: Int(sqlite3_column_int(stmt, 0)),
-            enrichedChunkCount: Int(sqlite3_column_int(stmt, 1)),
-            pendingEnrichmentCount: Int(sqlite3_column_int(stmt, 2))
+            chunkCount: try scalarInt("SELECT COUNT(*) FROM chunks"),
+            enrichedChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL"),
+            pendingEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NULL AND enriched_at IS NULL")
         )
     }
 
     private func dashboardLastEvents() throws -> (lastWriteAt: Date?, lastEnrichedAt: Date?) {
-        guard let db else { throw DBError.notOpen }
-        let createdAtEpochSQL = Self.normalizedUnixEpochSQL(for: "created_at")
-        let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
-        let sql = """
-            SELECT
-                (SELECT MAX(last_write_epoch) FROM (
-                    SELECT \(createdAtEpochSQL) AS last_write_epoch
-                    FROM chunks
-                )),
-                (SELECT MAX(last_enriched_epoch) FROM (
-                    SELECT \(enrichedAtEpochSQL) AS last_enriched_epoch
-                    FROM chunks
-                    WHERE enriched_at IS NOT NULL
-                      AND enrich_status = 'success'
-                ))
-        """
-        var stmt: OpaquePointer?
-        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
-        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
-        defer { sqlite3_finalize(stmt) }
-        guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
-
-        let lastWriteAt = sqlite3_column_type(stmt, 0) == SQLITE_NULL
-            ? nil
-            : Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 0)))
-        let lastEnrichedAt = sqlite3_column_type(stmt, 1) == SQLITE_NULL
-            ? nil
-            : Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 1)))
+        let recentWindowStart = Date().addingTimeInterval(-Self.dashboardLatestEventLookbackSeconds)
+        let lastWriteAt = try latestIndexedTimestampEpoch(
+            column: "created_at",
+            whereClause: nil,
+            since: recentWindowStart
+        )
+        let lastEnrichedAt = try latestIndexedTimestampEpoch(
+            column: "enriched_at",
+            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            since: recentWindowStart
+        )
         return (lastWriteAt: lastWriteAt, lastEnrichedAt: lastEnrichedAt)
     }
 
     private func recentActivityBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
         guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
-        guard let db else { throw DBError.notOpen }
 
-        let bucketWidthSeconds = max(1, Double(activityWindowMinutes * 60) / Double(bucketCount))
-        let windowStart = Date().addingTimeInterval(Double(-activityWindowMinutes * 60))
-        let createdAtEpochSQL = Self.normalizedUnixEpochSQL(for: "created_at")
-
-        var stmt: OpaquePointer?
-        let sql = """
-            SELECT created_epoch
-            FROM (
-                SELECT \(createdAtEpochSQL) AS created_epoch
-                FROM chunks
-            )
-            WHERE created_epoch IS NOT NULL
-              AND created_epoch >= unixepoch('now', ?)
-            ORDER BY created_epoch ASC
-        """
-        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
-        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
-        defer { sqlite3_finalize(stmt) }
-        bindText("-\(activityWindowMinutes) minutes", to: stmt, index: 1)
-
-        var buckets = Array(repeating: 0, count: bucketCount)
-
-        while sqlite3_step(stmt) == SQLITE_ROW {
-            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else {
-                continue
-            }
-            let createdAt = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 0)))
-
-            let offset = createdAt.timeIntervalSince(windowStart)
-            if offset < 0 { continue }
-            if offset > Double(activityWindowMinutes * 60) { continue }
-
-            let rawIndex = Int(offset / bucketWidthSeconds)
-            let clampedIndex = min(max(rawIndex, 0), bucketCount - 1)
-            buckets[clampedIndex] += 1
-        }
-
-        return buckets
+        return try indexedTimestampBuckets(
+            column: "created_at",
+            whereClause: nil,
+            activityWindowMinutes: activityWindowMinutes,
+            bucketCount: bucketCount
+        )
     }
 
     private func recentEnrichmentBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
         guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
-        guard let db else { throw DBError.notOpen }
 
-        let bucketWidthSeconds = max(1, Double(activityWindowMinutes * 60) / Double(bucketCount))
-        let windowStart = Date().addingTimeInterval(Double(-activityWindowMinutes * 60))
-        let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
+        return try indexedTimestampBuckets(
+            column: "enriched_at",
+            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            activityWindowMinutes: activityWindowMinutes,
+            bucketCount: bucketCount
+        )
+    }
 
-        var stmt: OpaquePointer?
-        let sql = """
-            SELECT enriched_epoch
-            FROM (
-                SELECT \(enrichedAtEpochSQL) AS enriched_epoch
-                FROM chunks
-                WHERE enriched_at IS NOT NULL
-                  AND enrich_status = 'success'
-            )
-            WHERE enriched_epoch IS NOT NULL
-              AND enriched_epoch >= unixepoch('now', ?)
-            ORDER BY enriched_epoch ASC
-        """
-        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
-        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
-        defer { sqlite3_finalize(stmt) }
-        bindText("-\(activityWindowMinutes) minutes", to: stmt, index: 1)
+    private func recentEnrichmentRatePerMinute(windowMinutes: Int) throws -> Double {
+        guard windowMinutes > 0 else { return 0 }
+        let count = Double(try indexedTimestampEpochs(
+            column: "enriched_at",
+            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            since: Date().addingTimeInterval(Double(-windowMinutes * 60))
+        ).count)
+        return count / Double(windowMinutes)
+    }
 
+    private func indexedTimestampBuckets(
+        column: String,
+        whereClause: String?,
+        activityWindowMinutes: Int,
+        bucketCount: Int
+    ) throws -> [Int] {
+        let windowDuration = Double(activityWindowMinutes * 60)
+        let bucketWidthSeconds = max(1, windowDuration / Double(bucketCount))
+        let windowStart = Date().addingTimeInterval(-windowDuration)
+        let epochs = try indexedTimestampEpochs(
+            column: column,
+            whereClause: whereClause,
+            since: windowStart
+        )
         var buckets = Array(repeating: 0, count: bucketCount)
 
-        while sqlite3_step(stmt) == SQLITE_ROW {
-            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else {
-                continue
-            }
-            let enrichedAt = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 0)))
-
-            let offset = enrichedAt.timeIntervalSince(windowStart)
+        for epoch in epochs {
+            let eventDate = Date(timeIntervalSince1970: TimeInterval(epoch))
+            let offset = eventDate.timeIntervalSince(windowStart)
             if offset < 0 { continue }
-            if offset > Double(activityWindowMinutes * 60) { continue }
+            if offset > windowDuration { continue }
 
             let rawIndex = Int(offset / bucketWidthSeconds)
             let clampedIndex = min(max(rawIndex, 0), bucketCount - 1)
@@ -1587,31 +1530,86 @@ final class BrainDatabase: @unchecked Sendable {
         return buckets
     }
 
-    private func recentEnrichmentRatePerMinute(windowMinutes: Int) throws -> Double {
-        guard windowMinutes > 0 else { return 0 }
+    private func indexedTimestampEpochs(
+        column: String,
+        whereClause: String?,
+        since cutoffDate: Date
+    ) throws -> [Int64] {
         guard let db else { throw DBError.notOpen }
-        let enrichedAtEpochSQL = Self.normalizedUnixEpochSQL(for: "enriched_at")
+        let epochSQL = Self.normalizedUnixEpochSQL(for: column)
+        let indexLowerBound = cutoffDate.addingTimeInterval(-Self.dashboardTimestampIndexLookbackPaddingSeconds)
+        let cutoffText = Self.dashboardTimestampIndexCutoffFormatter.string(from: indexLowerBound)
+        var predicates = ["\(column) IS NOT NULL", "\(column) >= ?"]
+        if let whereClause {
+            predicates.append(whereClause)
+        }
+        let sql = """
+            SELECT \(epochSQL) AS event_epoch
+            FROM chunks
+            WHERE \(predicates.joined(separator: " AND "))
+            ORDER BY \(column) ASC
+        """
 
         var stmt: OpaquePointer?
-        let sql = """
-            SELECT COUNT(*)
-            FROM (
-                SELECT \(enrichedAtEpochSQL) AS enriched_epoch
-                FROM chunks
-                WHERE enriched_at IS NOT NULL
-                  AND enrich_status = 'success'
-            )
-            WHERE enriched_epoch IS NOT NULL
-              AND enriched_epoch >= unixepoch('now', ?)
-        """
         let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
         defer { sqlite3_finalize(stmt) }
-        bindText("-\(windowMinutes) minutes", to: stmt, index: 1)
+        bindText(cutoffText, to: stmt, index: 1)
 
-        guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
-        let count = Double(sqlite3_column_int(stmt, 0))
-        return count / Double(windowMinutes)
+        let cutoffEpoch = Int64(cutoffDate.timeIntervalSince1970)
+        var epochs: [Int64] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else { continue }
+            let epoch = sqlite3_column_int64(stmt, 0)
+            guard epoch >= cutoffEpoch else { continue }
+            epochs.append(epoch)
+        }
+        return epochs
+    }
+
+    private func latestIndexedTimestampEpoch(
+        column: String,
+        whereClause: String?,
+        since cutoffDate: Date
+    ) throws -> Date? {
+        let recentEpoch = try indexedTimestampEpochs(
+            column: column,
+            whereClause: whereClause,
+            since: cutoffDate
+        ).max()
+        if let recentEpoch {
+            return Date(timeIntervalSince1970: TimeInterval(recentEpoch))
+        }
+
+        guard let db else { throw DBError.notOpen }
+        let epochSQL = Self.normalizedUnixEpochSQL(for: column)
+        var predicates = ["\(column) IS NOT NULL", "TRIM(\(column)) != ''"]
+        if let whereClause {
+            predicates.append(whereClause)
+        }
+        let sql = """
+            SELECT \(epochSQL) AS event_epoch
+            FROM chunks
+            WHERE \(predicates.joined(separator: " AND "))
+            ORDER BY \(column) DESC
+            LIMIT 1000
+        """
+
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+
+        var latestEpoch: Int64?
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else { continue }
+            let epoch = sqlite3_column_int64(stmt, 0)
+            if latestEpoch.map({ epoch > $0 }) ?? true {
+                latestEpoch = epoch
+            }
+        }
+
+        return latestEpoch.map { Date(timeIntervalSince1970: TimeInterval($0)) }
     }
 
     private static func normalizedUnixEpochSQL(for column: String) -> String {
@@ -1625,6 +1623,17 @@ final class BrainDatabase: @unchecked Sendable {
         END
         """
     }
+
+    private static let dashboardTimestampIndexCutoffFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+
+    private static let dashboardLatestEventLookbackSeconds: TimeInterval = 30 * 24 * 60 * 60
+    private static let dashboardTimestampIndexLookbackPaddingSeconds: TimeInterval = 24 * 60 * 60
 
     private func databaseSizeBytes() -> Int64 {
         let candidates = [path, "\(path)-wal", "\(path)-shm"]

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1347,7 +1347,8 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func dashboardStats(activityWindowMinutes: Int = 30, bucketCount: Int = 12) throws -> DashboardStats {
-        try withReadTransaction {
+        let pendingStoreQueue = pendingStoreQueueSnapshot()
+        return try withReadTransaction {
             let liveWindowMinutes = 1
             let now = Date()
             guard bucketCount > 0 else {
@@ -1383,7 +1384,6 @@ final class BrainDatabase: @unchecked Sendable {
                 bucketCount: bucketCount,
                 now: now
             )
-            let pendingStoreQueue = pendingStoreQueueSnapshot()
 
             return DashboardStats(
                 chunkCount: chunkCount,
@@ -1594,11 +1594,13 @@ final class BrainDatabase: @unchecked Sendable {
             predicates.append(whereClause)
         }
         let sql = """
-            SELECT \(epochSQL) AS event_epoch
-            FROM chunks
-            WHERE \(predicates.joined(separator: " AND "))
-            ORDER BY \(column) DESC
-            LIMIT 1000
+            SELECT MAX(event_epoch)
+            FROM (
+                SELECT \(epochSQL) AS event_epoch
+                FROM chunks
+                WHERE \(predicates.joined(separator: " AND "))
+            )
+            WHERE event_epoch IS NOT NULL
         """
 
         var stmt: OpaquePointer?
@@ -1606,16 +1608,11 @@ final class BrainDatabase: @unchecked Sendable {
         guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
         defer { sqlite3_finalize(stmt) }
 
-        var latestEpoch: Int64?
-        while sqlite3_step(stmt) == SQLITE_ROW {
-            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else { continue }
-            let epoch = sqlite3_column_int64(stmt, 0)
-            if latestEpoch.map({ epoch > $0 }) ?? true {
-                latestEpoch = epoch
-            }
+        guard sqlite3_step(stmt) == SQLITE_ROW, sqlite3_column_type(stmt, 0) != SQLITE_NULL else {
+            return nil
         }
 
-        return latestEpoch.map { Date(timeIntervalSince1970: TimeInterval($0)) }
+        return Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(stmt, 0)))
     }
 
     private func latestIndexedEpochSince(

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1349,6 +1349,7 @@ final class BrainDatabase: @unchecked Sendable {
     func dashboardStats(activityWindowMinutes: Int = 30, bucketCount: Int = 12) throws -> DashboardStats {
         try withReadTransaction {
             let liveWindowMinutes = 1
+            let now = Date()
             guard bucketCount > 0 else {
                 return DashboardStats(
                     chunkCount: 0,
@@ -1366,19 +1367,21 @@ final class BrainDatabase: @unchecked Sendable {
             }
 
             let counts = try dashboardCounts()
-            let lastEvents = try dashboardLastEvents()
+            let lastEvents = try dashboardLastEvents(now: now)
             let chunkCount = counts.chunkCount
             let enrichedChunkCount = counts.enrichedChunkCount
             let pendingEnrichmentCount = counts.pendingEnrichmentCount
             let enrichmentPercent = chunkCount == 0 ? 0 : (Double(enrichedChunkCount) / Double(chunkCount)) * 100
-            let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: liveWindowMinutes)
+            let enrichmentRatePerMinute = try recentEnrichmentRatePerMinute(windowMinutes: liveWindowMinutes, now: now)
             let recentActivityBuckets = try recentActivityBuckets(
                 activityWindowMinutes: activityWindowMinutes,
-                bucketCount: bucketCount
+                bucketCount: bucketCount,
+                now: now
             )
             let recentEnrichmentBuckets = try recentEnrichmentBuckets(
                 activityWindowMinutes: activityWindowMinutes,
-                bucketCount: bucketCount
+                bucketCount: bucketCount,
+                now: now
             )
             let pendingStoreQueue = pendingStoreQueueSnapshot()
 
@@ -1453,8 +1456,8 @@ final class BrainDatabase: @unchecked Sendable {
         )
     }
 
-    private func dashboardLastEvents() throws -> (lastWriteAt: Date?, lastEnrichedAt: Date?) {
-        let recentWindowStart = Date().addingTimeInterval(-Self.dashboardLatestEventLookbackSeconds)
+    private func dashboardLastEvents(now: Date) throws -> (lastWriteAt: Date?, lastEnrichedAt: Date?) {
+        let recentWindowStart = now.addingTimeInterval(-Self.dashboardLatestEventLookbackSeconds)
         let lastWriteAt = try latestIndexedTimestampEpoch(
             column: "created_at",
             whereClause: nil,
@@ -1468,34 +1471,36 @@ final class BrainDatabase: @unchecked Sendable {
         return (lastWriteAt: lastWriteAt, lastEnrichedAt: lastEnrichedAt)
     }
 
-    private func recentActivityBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
+    private func recentActivityBuckets(activityWindowMinutes: Int, bucketCount: Int, now: Date) throws -> [Int] {
         guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
 
         return try indexedTimestampBuckets(
             column: "created_at",
             whereClause: nil,
             activityWindowMinutes: activityWindowMinutes,
-            bucketCount: bucketCount
+            bucketCount: bucketCount,
+            now: now
         )
     }
 
-    private func recentEnrichmentBuckets(activityWindowMinutes: Int, bucketCount: Int) throws -> [Int] {
+    private func recentEnrichmentBuckets(activityWindowMinutes: Int, bucketCount: Int, now: Date) throws -> [Int] {
         guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
 
         return try indexedTimestampBuckets(
             column: "enriched_at",
             whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
             activityWindowMinutes: activityWindowMinutes,
-            bucketCount: bucketCount
+            bucketCount: bucketCount,
+            now: now
         )
     }
 
-    private func recentEnrichmentRatePerMinute(windowMinutes: Int) throws -> Double {
+    private func recentEnrichmentRatePerMinute(windowMinutes: Int, now: Date) throws -> Double {
         guard windowMinutes > 0 else { return 0 }
         let count = Double(try indexedTimestampEpochs(
             column: "enriched_at",
             whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
-            since: Date().addingTimeInterval(Double(-windowMinutes * 60))
+            since: now.addingTimeInterval(Double(-windowMinutes * 60))
         ).count)
         return count / Double(windowMinutes)
     }
@@ -1504,11 +1509,12 @@ final class BrainDatabase: @unchecked Sendable {
         column: String,
         whereClause: String?,
         activityWindowMinutes: Int,
-        bucketCount: Int
+        bucketCount: Int,
+        now: Date
     ) throws -> [Int] {
         let windowDuration = Double(activityWindowMinutes * 60)
         let bucketWidthSeconds = max(1, windowDuration / Double(bucketCount))
-        let windowStart = Date().addingTimeInterval(-windowDuration)
+        let windowStart = now.addingTimeInterval(-windowDuration)
         let epochs = try indexedTimestampEpochs(
             column: column,
             whereClause: whereClause,
@@ -1572,11 +1578,11 @@ final class BrainDatabase: @unchecked Sendable {
         whereClause: String?,
         since cutoffDate: Date
     ) throws -> Date? {
-        let recentEpoch = try indexedTimestampEpochs(
+        let recentEpoch = try latestIndexedEpochSince(
             column: column,
             whereClause: whereClause,
             since: cutoffDate
-        ).max()
+        )
         if let recentEpoch {
             return Date(timeIntervalSince1970: TimeInterval(recentEpoch))
         }
@@ -1610,6 +1616,40 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         return latestEpoch.map { Date(timeIntervalSince1970: TimeInterval($0)) }
+    }
+
+    private func latestIndexedEpochSince(
+        column: String,
+        whereClause: String?,
+        since cutoffDate: Date
+    ) throws -> Int64? {
+        guard let db else { throw DBError.notOpen }
+        let epochSQL = Self.normalizedUnixEpochSQL(for: column)
+        let indexLowerBound = cutoffDate.addingTimeInterval(-Self.dashboardTimestampIndexLookbackPaddingSeconds)
+        let cutoffText = Self.dashboardTimestampIndexCutoffFormatter.string(from: indexLowerBound)
+        var predicates = ["\(column) IS NOT NULL", "\(column) >= ?"]
+        if let whereClause {
+            predicates.append(whereClause)
+        }
+        let sql = """
+            SELECT MAX(\(epochSQL)) AS event_epoch
+            FROM chunks
+            WHERE \(predicates.joined(separator: " AND "))
+        """
+
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+        bindText(cutoffText, to: stmt, index: 1)
+
+        let stepRc = sqlite3_step(stmt)
+        guard stepRc == SQLITE_ROW else { throw DBError.step(stepRc) }
+        guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else { return nil }
+
+        let epoch = sqlite3_column_int64(stmt, 0)
+        let cutoffEpoch = Int64(cutoffDate.timeIntervalSince1970)
+        return epoch >= cutoffEpoch ? epoch : nil
     }
 
     private static func normalizedUnixEpochSQL(for column: String) -> String {

--- a/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
@@ -88,11 +88,11 @@ enum DashboardMetricFormatter {
             return "Just now"
         }
         if secondsAgo < 3600 {
-            let minutesAgo = Int((secondsAgo / 60).rounded(.up))
+            let minutesAgo = Int((secondsAgo / 60).rounded(.towardZero))
             return "\(minutesAgo)m ago"
         }
 
-        let hoursAgo = Int((secondsAgo / 3600).rounded(.up))
+        let hoursAgo = Int((secondsAgo / 3600).rounded(.towardZero))
         return "\(hoursAgo)h ago"
     }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
@@ -1,6 +1,18 @@
 import Foundation
 
 enum DashboardMetricFormatter {
+    private static let absoluteTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    private static let shortAbsoluteTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
     static func speedString(ratePerMinute: Double) -> String {
         liveBadgeString(ratePerMinute: ratePerMinute)
     }
@@ -65,6 +77,12 @@ enum DashboardMetricFormatter {
             return "\(shortWindowLabel(minutes: activityWindowMinutes))+"
         }
 
+        let absolute = absoluteTimeFormatter.string(from: lastEventAt)
+        let relative = relativeEventString(lastEventAt: lastEventAt, now: now)
+        return "\(absolute) (\(relative))"
+    }
+
+    static func relativeEventString(lastEventAt: Date, now: Date = Date()) -> String {
         let secondsAgo = max(now.timeIntervalSince(lastEventAt), 0)
         if secondsAgo < 60 {
             return "Just now"
@@ -76,6 +94,14 @@ enum DashboardMetricFormatter {
 
         let hoursAgo = Int((secondsAgo / 3600).rounded(.up))
         return "\(hoursAgo)h ago"
+    }
+
+    static func absoluteTimeString(_ date: Date) -> String {
+        absoluteTimeFormatter.string(from: date)
+    }
+
+    static func shortAbsoluteTimeString(_ date: Date) -> String {
+        shortAbsoluteTimeFormatter.string(from: date)
     }
 
     static func windowLabel(minutes: Int) -> String {

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -15,23 +15,30 @@ struct SparklineChartPresentation: Equatable, Sendable {
     let values: [Int]
     let activityWindowMinutes: Int
     let latestBucketName: String
+    let fetchedAt: Date
 
     init(
         label: String,
         values: [Int],
         activityWindowMinutes: Int = 30,
-        latestBucketName: String = "latest bucket count"
+        latestBucketName: String = "latest bucket count",
+        fetchedAt: Date = Date()
     ) {
         self.label = label
         self.values = values
         self.activityWindowMinutes = activityWindowMinutes
         self.latestBucketName = latestBucketName
+        self.fetchedAt = fetchedAt
     }
 
     var points: [SparklineChartPoint] {
         values.enumerated().map { index, value in
             SparklineChartPoint(bucket: index, value: value)
         }
+    }
+
+    var latestPoint: SparklineChartPoint? {
+        points.last
     }
 
     var accessibilityLabel: String {
@@ -47,6 +54,13 @@ struct SparklineChartPresentation: Equatable, Sendable {
     }
 
     func bucketLabel(for bucket: Int) -> String {
+        guard !values.isEmpty else { return "no bucket" }
+        let clampedBucket = min(max(bucket, 0), values.count - 1)
+        let range = bucketRange(for: clampedBucket)
+        return "\(DashboardMetricFormatter.shortAbsoluteTimeString(range.start))-\(DashboardMetricFormatter.shortAbsoluteTimeString(range.end))"
+    }
+
+    func relativeBucketLabel(for bucket: Int) -> String {
         guard !values.isEmpty else { return "no bucket" }
         let clampedBucket = min(max(bucket, 0), values.count - 1)
         let totalSeconds = max(activityWindowMinutes * 60, 1)
@@ -65,7 +79,17 @@ struct SparklineChartPresentation: Equatable, Sendable {
     func tooltipText(forBucket bucket: Int) -> String {
         let clampedBucket = min(max(bucket, 0), max(values.count - 1, 0))
         let value = values.indices.contains(clampedBucket) ? values[clampedBucket] : 0
-        return "\(bucketLabel(for: clampedBucket)): \(value)"
+        return "\(bucketLabel(for: clampedBucket)) (\(relativeBucketLabel(for: clampedBucket))): \(value)"
+    }
+
+    private func bucketRange(for bucket: Int) -> (start: Date, end: Date) {
+        let totalSeconds = max(activityWindowMinutes * 60, 1)
+        let bucketWidthSeconds = max(1, Double(totalSeconds) / Double(max(values.count, 1)))
+        let bucketStart = Double(bucket) * bucketWidthSeconds
+        let bucketEnd = min(Double(bucket + 1) * bucketWidthSeconds, Double(totalSeconds))
+        let start = fetchedAt.addingTimeInterval(-(Double(totalSeconds) - bucketStart))
+        let end = fetchedAt.addingTimeInterval(-(Double(totalSeconds) - bucketEnd))
+        return (start, end)
     }
 
     private static func durationLabel(seconds: Int) -> String {
@@ -117,62 +141,89 @@ struct SparklineChart: View {
     }
 
     var body: some View {
-        Chart(presentation.points) { point in
-            if !compact {
-                AreaMark(
+        VStack(spacing: 2) {
+            Chart(presentation.points) { point in
+                if !compact {
+                    AreaMark(
+                        x: .value("Bucket", point.bucket),
+                        y: .value("Count", point.value)
+                    )
+                    .foregroundStyle(Color(nsColor: accentColor).opacity(0.10))
+                }
+
+                LineMark(
                     x: .value("Bucket", point.bucket),
                     y: .value("Count", point.value)
                 )
-                .foregroundStyle(Color(nsColor: accentColor).opacity(0.10))
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(Color(nsColor: accentColor).opacity(0.85))
+                .lineStyle(StrokeStyle(lineWidth: compact ? 1.6 : 2, lineCap: .round, lineJoin: .round))
+
+                if point == presentation.latestPoint {
+                    PointMark(
+                        x: .value("Bucket", point.bucket),
+                        y: .value("Count", point.value)
+                    )
+                    .foregroundStyle(Color(nsColor: accentColor))
+                    .symbolSize(compact ? 18 : 42)
+                }
             }
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            .chartYScale(domain: 0...presentation.maxValue)
+            .chartPlotStyle { plotArea in
+                plotArea
+                    .background(Color.clear)
+                    .padding(compact ? 2 : 10)
+            }
+            .chartOverlay { chartProxy in
+                GeometryReader { geometry in
+                    if let plotAnchor = chartProxy.plotFrame {
+                        let plotFrame = geometry[plotAnchor]
 
-            LineMark(
-                x: .value("Bucket", point.bucket),
-                y: .value("Count", point.value)
-            )
-            .interpolationMethod(.catmullRom)
-            .foregroundStyle(Color(nsColor: accentColor).opacity(0.85))
-            .lineStyle(StrokeStyle(lineWidth: compact ? 1.6 : 2, lineCap: .round, lineJoin: .round))
-        }
-        .chartXAxis(.hidden)
-        .chartYAxis(.hidden)
-        .chartYScale(domain: 0...presentation.maxValue)
-        .chartPlotStyle { plotArea in
-            plotArea
-                .background(Color.clear)
-                .padding(compact ? 2 : 10)
-        }
-        .chartOverlay { chartProxy in
-            GeometryReader { geometry in
-                if let plotAnchor = chartProxy.plotFrame {
-                    let plotFrame = geometry[plotAnchor]
-
-                    Rectangle()
-                        .fill(.clear)
-                        .contentShape(Rectangle())
-                        .onContinuousHover { phase in
-                            switch phase {
-                            case .active(let location):
-                                hoveredBucket = nearestBucket(
-                                    to: location,
-                                    plotFrame: plotFrame,
-                                    chartProxy: chartProxy
-                                )
-                                hoverLocation = location
-                            case .ended:
-                                hoveredBucket = nil
-                                hoverLocation = nil
+                        Rectangle()
+                            .fill(.clear)
+                            .contentShape(Rectangle())
+                            .onContinuousHover { phase in
+                                switch phase {
+                                case .active(let location):
+                                    hoveredBucket = nearestBucket(
+                                        to: location,
+                                        plotFrame: plotFrame,
+                                        chartProxy: chartProxy
+                                    )
+                                    hoverLocation = location
+                                case .ended:
+                                    hoveredBucket = nil
+                                    hoverLocation = nil
+                                }
                             }
-                        }
 
-                    if let hoveredBucket,
-                       let hoverLocation,
-                       !compact {
-                        sparklineTooltip(forBucket: hoveredBucket)
-                            .position(tooltipPosition(near: hoverLocation, in: geometry.size))
-                            .allowsHitTesting(false)
+                        if let hoveredBucket,
+                           let hoverLocation,
+                           !compact {
+                            sparklineTooltip(forBucket: hoveredBucket)
+                                .position(tooltipPosition(near: hoverLocation, in: geometry.size))
+                                .allowsHitTesting(false)
+                        }
                     }
                 }
+            }
+
+            if !compact {
+                HStack {
+                    ForEach(xAxisBuckets, id: \.self) { bucket in
+                        Text(presentation.bucketLabel(for: bucket))
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                        if bucket != xAxisBuckets.last {
+                            Spacer(minLength: 8)
+                        }
+                    }
+                }
+                .frame(height: 12)
+                .padding(.horizontal, 16)
             }
         }
         .accessibilityElement(children: .combine)
@@ -195,6 +246,13 @@ struct SparklineChart: View {
             return nil
         }
         return min(max(Int(bucket.rounded()), 0), presentation.points.count - 1)
+    }
+
+    private var xAxisBuckets: [Int] {
+        guard !presentation.values.isEmpty else { return [] }
+        let last = presentation.values.count - 1
+        if last <= 0 { return [0] }
+        return Array(Set([0, last / 2, last])).sorted()
     }
 
     private func tooltipPosition(near location: CGPoint, in size: CGSize) -> CGPoint {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -25,15 +25,24 @@ final class StatsCollector: ObservableObject {
     @Published private(set) var daemon: DaemonHealthSnapshot?
     @Published private(set) var agentActivity: AgentActivitySnapshot
     @Published private(set) var state: PipelineState
+    @Published private(set) var isRefreshing = false
+    @Published private(set) var isManualRefreshInProgress = false
+    @Published private(set) var lastDataFetchedAt: Date?
 
+    private let dbPath: String
+    private let databaseOpenConfiguration: BrainDatabase.OpenConfiguration
     private let database: BrainDatabase
     private let daemonMonitor: DaemonHealthMonitor
     private let agentActivityMonitor: AgentActivityMonitor
     private let agentActivitySampleInterval: TimeInterval
     private let statsRefreshCoalesceInterval: TimeInterval
+    private let autoRefreshInterval: TimeInterval
     private let brainBusEvents: BrainBusEventSource?
     private var brainBusTask: Task<Void, Never>?
+    private var autoRefreshTask: Task<Void, Never>?
     private var pendingStatsRefreshTask: Task<Void, Never>?
+    private var dashboardRefreshTask: Task<Void, Never>?
+    private var dashboardRefreshGeneration = 0
     private var isRunning = false
     private var isStopped = false
     private var lastAgentActivitySampleAt: Date?
@@ -46,14 +55,18 @@ final class StatsCollector: ObservableObject {
         agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor(),
         agentActivitySampleInterval: TimeInterval = 5,
         statsRefreshCoalesceInterval: TimeInterval = 5,
+        autoRefreshInterval: TimeInterval = 30,
         brainBusEvents: BrainBusEventSource? = nil,
         databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) {
+        self.dbPath = dbPath
+        self.databaseOpenConfiguration = databaseOpenConfiguration
         self.database = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
         self.daemonMonitor = daemonMonitor
         self.agentActivityMonitor = agentActivityMonitor
         self.agentActivitySampleInterval = agentActivitySampleInterval
         self.statsRefreshCoalesceInterval = statsRefreshCoalesceInterval
+        self.autoRefreshInterval = autoRefreshInterval
         self.brainBusEvents = brainBusEvents
         self.stats = DashboardStats(
             chunkCount: 0,
@@ -77,7 +90,8 @@ final class StatsCollector: ObservableObject {
         isStopped = false
         isRunning = true
         installDarwinObserver()
-        refresh(force: true)
+        requestRefresh(force: true)
+        startAutoRefreshLoop()
         if let brainBusEvents {
             let eventStream = brainBusEvents.events()
             brainBusTask = Task { [weak self] in
@@ -94,8 +108,14 @@ final class StatsCollector: ObservableObject {
     func stop() {
         brainBusTask?.cancel()
         brainBusTask = nil
+        autoRefreshTask?.cancel()
+        autoRefreshTask = nil
+        dashboardRefreshTask?.cancel()
+        dashboardRefreshTask = nil
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
+        isRefreshing = false
+        isManualRefreshInProgress = false
         if isRunning {
             removeDarwinObserver()
         }
@@ -106,6 +126,17 @@ final class StatsCollector: ObservableObject {
     }
 
     func refresh(force: Bool = false) {
+        refresh(force: force, trigger: .auto)
+    }
+
+    func manualRefresh() {
+        NSLog("[BrainBar] manual refresh requested at %@", ISO8601DateFormatter().string(from: Date()))
+        pendingStatsRefreshTask?.cancel()
+        pendingStatsRefreshTask = nil
+        requestRefresh(force: true, trigger: .manual)
+    }
+
+    func requestRefresh(force: Bool = false, trigger: DashboardRefreshTrigger = .auto) {
         let nextDaemon = daemonMonitor.sample()
         let snapshotTime = Date()
         refreshAgentActivity(force: force, now: snapshotTime)
@@ -114,6 +145,109 @@ final class StatsCollector: ObservableObject {
             daemon = nextDaemon
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
             schedulePendingStatsRefresh(after: coalescedDelay)
+            return
+        }
+
+        if dashboardRefreshTask != nil, trigger != .manual {
+            daemon = nextDaemon
+            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            if !force {
+                schedulePendingStatsRefresh(after: statsRefreshCoalesceInterval)
+            }
+            return
+        }
+
+        pendingStatsRefreshTask?.cancel()
+        pendingStatsRefreshTask = nil
+        dashboardRefreshTask?.cancel()
+        dashboardRefreshGeneration += 1
+        let generation = dashboardRefreshGeneration
+        let dbPath = self.dbPath
+        let openConfiguration = self.databaseOpenConfiguration
+        let activityWindowMinutes = Self.defaultActivityWindowMinutes
+        let bucketCount = Self.defaultBucketCount
+        let startStats = stats
+        let startUnix = snapshotTime.timeIntervalSince1970
+        isRefreshing = true
+        if trigger == .manual {
+            isManualRefreshInProgress = true
+        }
+        daemon = nextDaemon
+        state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+        logDashboardRefresh(
+            timestamp: snapshotTime,
+            startUnix: startUnix,
+            endUnix: nil,
+            rows: startStats.chunkCount,
+            writes5m: startStats.recentActivityBuckets.suffix(1).reduce(0, +),
+            enrich5m: startStats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
+            trigger: trigger
+        )
+
+        dashboardRefreshTask = Task.detached(priority: .utility) { [weak self] in
+            let result: Result<DashboardStats, Error> = Result {
+                let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: openConfiguration)
+                defer { backgroundDatabase.close() }
+                backgroundDatabase.reopenIfNeeded()
+                return try backgroundDatabase.dashboardStats(
+                    activityWindowMinutes: activityWindowMinutes,
+                    bucketCount: bucketCount
+                )
+            }
+
+            await MainActor.run {
+                guard let self, !self.isStopped, generation == self.dashboardRefreshGeneration else { return }
+                self.finishRequestedRefresh(
+                    result: result,
+                    daemon: nextDaemon,
+                    snapshotTime: snapshotTime,
+                    startUnix: startUnix,
+                    force: force,
+                    trigger: trigger
+                )
+            }
+        }
+    }
+
+    func refresh(force: Bool = false, trigger: DashboardRefreshTrigger) {
+        let nextDaemon = daemonMonitor.sample()
+        let snapshotTime = Date()
+        let startUnix = snapshotTime.timeIntervalSince1970
+        isRefreshing = true
+        if trigger == .manual {
+            isManualRefreshInProgress = true
+        }
+        logDashboardRefresh(
+            timestamp: snapshotTime,
+            startUnix: startUnix,
+            endUnix: nil,
+            rows: stats.chunkCount,
+            writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
+            enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
+            trigger: trigger
+        )
+        defer { isRefreshing = false }
+        defer {
+            if trigger == .manual {
+                isManualRefreshInProgress = false
+            }
+        }
+
+        refreshAgentActivity(force: force, now: snapshotTime)
+
+        if !force, let coalescedDelay = coalescedStatsRefreshDelay(now: snapshotTime) {
+            daemon = nextDaemon
+            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            schedulePendingStatsRefresh(after: coalescedDelay)
+            logDashboardRefresh(
+                timestamp: snapshotTime,
+                startUnix: startUnix,
+                endUnix: Date().timeIntervalSince1970,
+                rows: stats.chunkCount,
+                writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
+                enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
+                trigger: trigger
+            )
             return
         }
 
@@ -130,6 +264,7 @@ final class StatsCollector: ObservableObject {
             stats = nextStats.withPendingStoreFlushRate(queueFlushRate)
             daemon = nextDaemon
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            lastDataFetchedAt = Date()
             if !force {
                 lastNonForcedStatsRefreshAt = snapshotTime
             }
@@ -151,6 +286,69 @@ final class StatsCollector: ObservableObject {
             }
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
         }
+
+        logDashboardRefresh(
+            timestamp: snapshotTime,
+            startUnix: startUnix,
+            endUnix: Date().timeIntervalSince1970,
+            rows: stats.chunkCount,
+            writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
+            enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
+            trigger: trigger
+        )
+    }
+
+    private func finishRequestedRefresh(
+        result: Result<DashboardStats, Error>,
+        daemon nextDaemon: DaemonHealthSnapshot?,
+        snapshotTime: Date,
+        startUnix: TimeInterval,
+        force: Bool,
+        trigger: DashboardRefreshTrigger
+    ) {
+        switch result {
+        case .success(let nextStats):
+            let queueFlushRate = recordPendingStoreQueueDepth(nextStats.pendingStoreQueueDepth, now: snapshotTime)
+            stats = nextStats.withPendingStoreFlushRate(queueFlushRate)
+            daemon = nextDaemon
+            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            lastDataFetchedAt = Date()
+            if !force {
+                lastNonForcedStatsRefreshAt = snapshotTime
+            }
+        case .failure:
+            daemon = nextDaemon
+            if force {
+                stats = DashboardStats(
+                    chunkCount: 0,
+                    enrichedChunkCount: 0,
+                    pendingEnrichmentCount: 0,
+                    enrichmentPercent: 0,
+                    enrichmentRatePerMinute: 0,
+                    databaseSizeBytes: 0,
+                    recentActivityBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
+                    recentEnrichmentBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
+                    activityWindowMinutes: Self.defaultActivityWindowMinutes,
+                    bucketCount: Self.defaultBucketCount
+                )
+            }
+            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+        }
+
+        isRefreshing = false
+        if trigger == .manual {
+            isManualRefreshInProgress = false
+        }
+        dashboardRefreshTask = nil
+        logDashboardRefresh(
+            timestamp: snapshotTime,
+            startUnix: startUnix,
+            endUnix: Date().timeIntervalSince1970,
+            rows: stats.chunkCount,
+            writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
+            enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
+            trigger: trigger
+        )
     }
 
     private func recordPendingStoreQueueDepth(_ depth: Int, now: Date) -> Double {
@@ -190,7 +388,29 @@ final class StatsCollector: ObservableObject {
             await MainActor.run {
                 guard let self, !self.isStopped else { return }
                 self.pendingStatsRefreshTask = nil
-                self.refresh(force: false)
+                self.requestRefresh(force: false, trigger: .auto)
+            }
+        }
+    }
+
+    private func startAutoRefreshLoop() {
+        autoRefreshTask?.cancel()
+        let interval = autoRefreshInterval
+        autoRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(interval))
+                } catch {
+                    break
+                }
+
+                guard !Task.isCancelled else { break }
+                await MainActor.run {
+                    guard let self, !self.isStopped else { return }
+                    self.pendingStatsRefreshTask?.cancel()
+                    self.pendingStatsRefreshTask = nil
+                    self.requestRefresh(force: false, trigger: .auto)
+                }
             }
         }
     }
@@ -209,7 +429,7 @@ final class StatsCollector: ObservableObject {
     }
 
     fileprivate func handleDatabaseMutationNotification() {
-        refresh(force: false)
+        requestRefresh(force: false, trigger: .auto)
     }
 
     private func handleBrainBusEvent(_ event: BrainBusEvent) {
@@ -219,8 +439,30 @@ final class StatsCollector: ObservableObject {
             refreshAgentActivity(force: false, now: Date())
             state = PipelineState.derive(daemon: daemon, stats: stats)
         case .queueDepth, .enrichStatus, .lastChunkID, .dbBusy:
-            refresh(force: false)
+            requestRefresh(force: false, trigger: .auto)
         }
+    }
+
+    private func logDashboardRefresh(
+        timestamp: Date,
+        startUnix: TimeInterval,
+        endUnix: TimeInterval?,
+        rows: Int,
+        writes5m: Int,
+        enrich5m: Int,
+        trigger: DashboardRefreshTrigger
+    ) {
+        let endText = endUnix.map { String(format: "%.3f", $0) } ?? "ongoing"
+        NSLog(
+            "[BrainBar] dashboard refresh: %@ start=%.3f end=%@ rows=%d writes_5m=%d enrich_5m=%d trigger=%@",
+            ISO8601DateFormatter().string(from: timestamp),
+            startUnix,
+            endText,
+            rows,
+            writes5m,
+            enrich5m,
+            trigger.rawValue
+        )
     }
 
     private func installDarwinObserver() {
@@ -244,4 +486,10 @@ final class StatsCollector: ObservableObject {
             nil
         )
     }
+}
+
+enum DashboardRefreshTrigger: String {
+    case auto
+    case manual
+    case tabSwitch = "tab_switch"
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -31,7 +31,6 @@ final class StatsCollector: ObservableObject {
 
     private let dbPath: String
     private let databaseOpenConfiguration: BrainDatabase.OpenConfiguration
-    private let database: BrainDatabase
     private let daemonMonitor: DaemonHealthMonitor
     private let agentActivityMonitor: AgentActivityMonitor
     private let agentActivitySampleInterval: TimeInterval
@@ -61,7 +60,6 @@ final class StatsCollector: ObservableObject {
     ) {
         self.dbPath = dbPath
         self.databaseOpenConfiguration = databaseOpenConfiguration
-        self.database = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
         self.daemonMonitor = daemonMonitor
         self.agentActivityMonitor = agentActivityMonitor
         self.agentActivitySampleInterval = agentActivitySampleInterval
@@ -122,7 +120,6 @@ final class StatsCollector: ObservableObject {
         isRunning = false
         isStopped = true
         resetRefreshTimingState()
-        database.close()
     }
 
     func refresh(force: Bool = false) {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -213,6 +213,7 @@ final class StatsCollector: ObservableObject {
         let nextDaemon = daemonMonitor.sample()
         let snapshotTime = Date()
         let startUnix = snapshotTime.timeIntervalSince1970
+        cancelInFlightDashboardRefresh()
         isRefreshing = true
         if trigger == .manual {
             isManualRefreshInProgress = true
@@ -349,6 +350,14 @@ final class StatsCollector: ObservableObject {
             enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
             trigger: trigger
         )
+    }
+
+    private func cancelInFlightDashboardRefresh() {
+        guard dashboardRefreshTask != nil else { return }
+        dashboardRefreshTask?.cancel()
+        dashboardRefreshTask = nil
+        dashboardRefreshGeneration += 1
+        isManualRefreshInProgress = false
     }
 
     private func recordPendingStoreQueueDepth(_ depth: Int, now: Date) -> Double {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -126,7 +126,7 @@ final class StatsCollector: ObservableObject {
     }
 
     func refresh(force: Bool = false) {
-        refresh(force: force, trigger: .auto)
+        requestRefresh(force: force, trigger: .auto)
     }
 
     func manualRefresh() {
@@ -210,93 +210,7 @@ final class StatsCollector: ObservableObject {
     }
 
     func refresh(force: Bool = false, trigger: DashboardRefreshTrigger) {
-        let nextDaemon = daemonMonitor.sample()
-        let snapshotTime = Date()
-        let startUnix = snapshotTime.timeIntervalSince1970
-        cancelInFlightDashboardRefresh()
-        isRefreshing = true
-        if trigger == .manual {
-            isManualRefreshInProgress = true
-        }
-        logDashboardRefresh(
-            timestamp: snapshotTime,
-            startUnix: startUnix,
-            endUnix: nil,
-            rows: stats.chunkCount,
-            writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
-            enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
-            trigger: trigger
-        )
-        defer { isRefreshing = false }
-        defer {
-            if trigger == .manual {
-                isManualRefreshInProgress = false
-            }
-        }
-
-        refreshAgentActivity(force: force, now: snapshotTime)
-
-        if !force, let coalescedDelay = coalescedStatsRefreshDelay(now: snapshotTime) {
-            daemon = nextDaemon
-            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
-            schedulePendingStatsRefresh(after: coalescedDelay)
-            logDashboardRefresh(
-                timestamp: snapshotTime,
-                startUnix: startUnix,
-                endUnix: Date().timeIntervalSince1970,
-                rows: stats.chunkCount,
-                writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
-                enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
-                trigger: trigger
-            )
-            return
-        }
-
-        pendingStatsRefreshTask?.cancel()
-        pendingStatsRefreshTask = nil
-
-        do {
-            database.reopenIfNeeded()
-            let nextStats = try database.dashboardStats(
-                activityWindowMinutes: Self.defaultActivityWindowMinutes,
-                bucketCount: Self.defaultBucketCount
-            )
-            let queueFlushRate = recordPendingStoreQueueDepth(nextStats.pendingStoreQueueDepth, now: snapshotTime)
-            stats = nextStats.withPendingStoreFlushRate(queueFlushRate)
-            daemon = nextDaemon
-            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
-            lastDataFetchedAt = Date()
-            if !force {
-                lastNonForcedStatsRefreshAt = snapshotTime
-            }
-        } catch {
-            daemon = nextDaemon
-            if force {
-                stats = DashboardStats(
-                    chunkCount: 0,
-                    enrichedChunkCount: 0,
-                    pendingEnrichmentCount: 0,
-                    enrichmentPercent: 0,
-                    enrichmentRatePerMinute: 0,
-                    databaseSizeBytes: 0,
-                    recentActivityBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
-                    recentEnrichmentBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
-                    activityWindowMinutes: Self.defaultActivityWindowMinutes,
-                    bucketCount: Self.defaultBucketCount
-                )
-            }
-            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
-        }
-
-        logDashboardRefresh(
-            timestamp: snapshotTime,
-            startUnix: startUnix,
-            endUnix: Date().timeIntervalSince1970,
-            rows: stats.chunkCount,
-            writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
-            enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
-            trigger: trigger
-        )
+        requestRefresh(force: force, trigger: trigger)
     }
 
     private func finishRequestedRefresh(
@@ -307,18 +221,19 @@ final class StatsCollector: ObservableObject {
         force: Bool,
         trigger: DashboardRefreshTrigger
     ) {
+        let finishDaemon = daemonMonitor.sample() ?? nextDaemon
         switch result {
         case .success(let nextStats):
             let queueFlushRate = recordPendingStoreQueueDepth(nextStats.pendingStoreQueueDepth, now: snapshotTime)
             stats = nextStats.withPendingStoreFlushRate(queueFlushRate)
-            daemon = nextDaemon
-            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            daemon = finishDaemon
+            state = PipelineState.derive(daemon: finishDaemon, stats: stats)
             lastDataFetchedAt = Date()
             if !force {
                 lastNonForcedStatsRefreshAt = snapshotTime
             }
         case .failure:
-            daemon = nextDaemon
+            daemon = finishDaemon
             if force {
                 stats = DashboardStats(
                     chunkCount: 0,
@@ -333,7 +248,7 @@ final class StatsCollector: ObservableObject {
                     bucketCount: Self.defaultBucketCount
                 )
             }
-            state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            state = PipelineState.derive(daemon: finishDaemon, stats: stats)
         }
 
         isRefreshing = false
@@ -350,14 +265,6 @@ final class StatsCollector: ObservableObject {
             enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
             trigger: trigger
         )
-    }
-
-    private func cancelInFlightDashboardRefresh() {
-        guard dashboardRefreshTask != nil else { return }
-        dashboardRefreshTask?.cancel()
-        dashboardRefreshTask = nil
-        dashboardRefreshGeneration += 1
-        isManualRefreshInProgress = false
     }
 
     private func recordPendingStoreQueueDepth(_ depth: Int, now: Date) -> Double {

--- a/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
@@ -25,7 +25,7 @@ final class BrainBarRuntimeWiringTests: XCTestCase {
         XCTAssertNil(runtime.collector)
     }
 
-    func testWireRuntimePopulatesDatabaseAndInjectionStore() {
+    func testWireRuntimePopulatesDatabaseAndLazilyLoadsInjectionStore() {
         let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
         let collector = BrainBarAppSupport.makeStatsCollector(
             dbPath: tempDBPath,
@@ -43,19 +43,23 @@ final class BrainBarRuntimeWiringTests: XCTestCase {
             + "the UI gates 'Warming memory…' / QuickCaptureViewModel on database != nil. "
             + "See PR #312 (FastAPI daemon removal) — UI process must open SQLite directly."
         )
+        XCTAssertNil(
+            runtime.injectionStore,
+            "Dashboard startup should not eagerly open InjectionStore; it owns an extra writable SQLite handle."
+        )
+        runtime.ensureInjectionStore()
         XCTAssertNotNil(
             runtime.injectionStore,
-            "Regression guard: BrainBarApp must wire InjectionStore — "
-            + "the Injections tab placeholder shows when injectionStore == nil."
+            "Regression guard: BrainBarApp must provide a lazy InjectionStore factory so the Injections tab can load on demand."
         )
         XCTAssertNotNil(runtime.collector)
     }
 
     func testWireRuntimeOpensReadonlyHandleEvenWhenDBFileMissing() {
-        // Fresh-install scenario: brainlayer.db doesn't exist yet. InjectionStore
-        // must create the file first; the read-only BrainDatabase must then open
-        // successfully. Otherwise the runtime installs a permanently-closed handle
-        // that satisfies `database != nil` but breaks search/graph downstream.
+        // Fresh-install scenario: brainlayer.db doesn't exist yet. wireRuntime
+        // must bootstrap the file before installing the read-only BrainDatabase.
+        // Otherwise the runtime carries a closed handle and search/graph stay
+        // broken until app restart.
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: tempDBPath),
             "Test precondition: DB file must NOT exist at start"
@@ -75,10 +79,8 @@ final class BrainBarRuntimeWiringTests: XCTestCase {
         XCTAssertNotNil(runtime.database)
         XCTAssertTrue(
             runtime.database?.isOpen == true,
-            "Regression guard for Cursor Bugbot + ChatGPT-Codex flag (PR #314 review): "
-            + "on fresh install, wireRuntime must order InjectionStore (creates file) "
-            + "BEFORE the read-only BrainDatabase open — otherwise the runtime carries "
-            + "a closed handle and search/graph stay broken until app restart."
+            "Regression guard for fresh installs: wireRuntime must create the DB "
+            + "before installing the read-only BrainDatabase handle."
         )
     }
 }

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -101,7 +101,7 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activityWindowMinutes: 60,
                 now: now
             ),
-            "\(Self.absoluteTime(now.addingTimeInterval(-90))) (2m ago)"
+            "\(Self.absoluteTime(now.addingTimeInterval(-90))) (1m ago)"
         )
     }
 
@@ -170,7 +170,7 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(summary.ingress.status, .idle)
         XCTAssertEqual(summary.queue.status, .draining)
         XCTAssertEqual(summary.enrichment.status, .recent)
-        XCTAssertEqual(summary.enrichment.lastEventText, "\(Self.absoluteTime(now.addingTimeInterval(-90))) (2m ago)")
+        XCTAssertEqual(summary.enrichment.lastEventText, "\(Self.absoluteTime(now.addingTimeInterval(-90))) (1m ago)")
     }
 
     func testDashboardQueueSummaryReportsActiveDrainingForSmallFreshStoreQueue() {

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -93,7 +93,7 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activityWindowMinutes: 60,
                 now: now
             ),
-            "Just now"
+            "\(Self.absoluteTime(now.addingTimeInterval(-30))) (Just now)"
         )
         XCTAssertEqual(
             DashboardMetricFormatter.lastCompletionString(
@@ -101,7 +101,7 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activityWindowMinutes: 60,
                 now: now
             ),
-            "2m ago"
+            "\(Self.absoluteTime(now.addingTimeInterval(-90))) (2m ago)"
         )
     }
 
@@ -170,7 +170,7 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(summary.ingress.status, .idle)
         XCTAssertEqual(summary.queue.status, .draining)
         XCTAssertEqual(summary.enrichment.status, .recent)
-        XCTAssertEqual(summary.enrichment.lastEventText, "2m ago")
+        XCTAssertEqual(summary.enrichment.lastEventText, "\(Self.absoluteTime(now.addingTimeInterval(-90))) (2m ago)")
     }
 
     func testDashboardQueueSummaryReportsActiveDrainingForSmallFreshStoreQueue() {
@@ -342,5 +342,11 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(layout.overviewMetricColumns, 4)
         XCTAssertEqual(layout.diagnosticColumns, 2)
         XCTAssertTrue(layout.usesQueueRail)
+    }
+
+    private static func absoluteTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
@@ -69,8 +69,14 @@ final class BrainBarWindowStateTests: XCTestCase {
         let presentation = BrainBarLivePresentation.derive(stats: stats, now: now)
 
         XCTAssertEqual(presentation.sparklineStyle, .idle)
-        XCTAssertEqual(presentation.badgeText, "2m ago")
+        XCTAssertEqual(presentation.badgeText, "\(Self.absoluteTime(now.addingTimeInterval(-90))) (2m ago)")
         XCTAssertEqual(presentation.statusText, "No enrichments in the last 60s")
+    }
+
+    private static func absoluteTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
@@ -69,7 +69,7 @@ final class BrainBarWindowStateTests: XCTestCase {
         let presentation = BrainBarLivePresentation.derive(stats: stats, now: now)
 
         XCTAssertEqual(presentation.sparklineStyle, .idle)
-        XCTAssertEqual(presentation.badgeText, "\(Self.absoluteTime(now.addingTimeInterval(-90))) (2m ago)")
+        XCTAssertEqual(presentation.badgeText, "\(Self.absoluteTime(now.addingTimeInterval(-90))) (1m ago)")
         XCTAssertEqual(presentation.statusText, "No enrichments in the last 60s")
     }
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -245,7 +245,26 @@ final class DashboardTests: XCTestCase {
 
         XCTAssertEqual(
             DashboardMetricFormatter.lastEventString(lastEventAt: lastEvent, now: now),
-            "\(Self.absoluteTime(lastEvent)) (3m ago)"
+            "\(Self.absoluteTime(lastEvent)) (2m ago)"
+        )
+    }
+
+    func testDashboardMetricFormatterDoesNotOverstateRelativeBoundaries() {
+        let now = Date(timeIntervalSince1970: 1_764_236_400)
+
+        XCTAssertEqual(
+            DashboardMetricFormatter.relativeEventString(
+                lastEventAt: now.addingTimeInterval(-60.1),
+                now: now
+            ),
+            "1m ago"
+        )
+        XCTAssertEqual(
+            DashboardMetricFormatter.relativeEventString(
+                lastEventAt: now.addingTimeInterval(-3600.1),
+                now: now
+            ),
+            "1h ago"
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -335,9 +335,24 @@ final class DashboardTests: XCTestCase {
 
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: -10 * 3600)
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
+        let utcTimeZone = TimeZone(secondsFromGMT: 0)!
         let recent = Date().addingTimeInterval(-60)
+        let utcHour = Calendar(identifier: .gregorian)
+            .dateComponents(in: utcTimeZone, from: recent)
+            .hour ?? 0
+        let crossingOffsetHours = utcHour >= 10 ? 14 : -12
+        formatter.timeZone = TimeZone(secondsFromGMT: crossingOffsetHours * 3600)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
+
+        let utcDay = DateFormatter()
+        utcDay.locale = Locale(identifier: "en_US_POSIX")
+        utcDay.timeZone = utcTimeZone
+        utcDay.dateFormat = "yyyy-MM-dd"
+        let offsetDay = DateFormatter()
+        offsetDay.locale = Locale(identifier: "en_US_POSIX")
+        offsetDay.timeZone = formatter.timeZone
+        offsetDay.dateFormat = "yyyy-MM-dd"
+        XCTAssertNotEqual(utcDay.string(from: recent), offsetDay.string(from: recent))
 
         db.exec("""
             UPDATE chunks
@@ -498,7 +513,7 @@ final class DashboardTests: XCTestCase {
     }
 
     @MainActor
-    func testReadOnlyStatsCollectorReopensAfterDaemonCreatesDatabase() throws {
+    func testReadOnlyStatsCollectorReopensAfterDaemonCreatesDatabase() async throws {
         db.close()
         try? FileManager.default.removeItem(atPath: tempDBPath)
         try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
@@ -512,6 +527,7 @@ final class DashboardTests: XCTestCase {
         defer { collector.stop() }
 
         collector.refresh(force: true)
+        try await waitForCollector(collector) { !$0.isRefreshing }
         XCTAssertEqual(collector.stats.chunkCount, 0)
 
         let writer = BrainDatabase(path: tempDBPath)
@@ -526,6 +542,7 @@ final class DashboardTests: XCTestCase {
         )
 
         collector.refresh(force: true)
+        try await waitForCollector(collector) { $0.stats.chunkCount == 1 }
 
         XCTAssertEqual(collector.stats.chunkCount, 1)
     }
@@ -579,7 +596,7 @@ final class DashboardTests: XCTestCase {
     }
 
     @MainActor
-    func testStatsCollectorComputesPendingStoreFlushRateFromDepthDrops() throws {
+    func testStatsCollectorComputesPendingStoreFlushRateFromDepthDrops() async throws {
         let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("pending-stores-collector-\(UUID().uuidString).jsonl")
         let restoreQueuePath = setDashboardPendingStoreQueuePath(queuePath)
@@ -597,11 +614,15 @@ final class DashboardTests: XCTestCase {
         defer { collector.stop() }
 
         collector.refresh(force: true)
+        try await waitForCollector(collector) { $0.stats.pendingStoreQueueDepth == 3 }
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 3)
         XCTAssertEqual(collector.stats.pendingStoreFlushRatePerMinute, 0)
 
         try writeDashboardPendingStoreQueue(count: 1, to: queuePath)
         collector.refresh(force: true)
+        try await waitForCollector(collector) {
+            $0.stats.pendingStoreQueueDepth == 1 && $0.stats.pendingStoreFlushRatePerMinute == 2
+        }
 
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 1)
         XCTAssertEqual(collector.stats.pendingStoreFlushRatePerMinute, 2)
@@ -645,10 +666,12 @@ final class DashboardTests: XCTestCase {
         defer { collector.stop() }
 
         collector.refresh(force: true)
+        try await waitForCollector(collector) { $0.stats.pendingStoreQueueDepth == 3 }
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 3)
 
         try writeDashboardPendingStoreQueue(count: 2, to: queuePath)
         collector.refresh(force: false)
+        try await waitForCollector(collector) { $0.stats.pendingStoreQueueDepth == 2 }
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 2)
 
         try writeDashboardPendingStoreQueue(count: 1, to: queuePath)
@@ -656,7 +679,7 @@ final class DashboardTests: XCTestCase {
 
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 2)
 
-        try await Task.sleep(for: .milliseconds(120))
+        try await waitForCollector(collector) { $0.stats.pendingStoreQueueDepth == 1 }
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 1)
     }
 
@@ -683,13 +706,13 @@ final class DashboardTests: XCTestCase {
             importance: 5
         )
 
-        try await Task.sleep(for: .milliseconds(500))
+        try await waitForCollector(collector) { $0.stats.chunkCount == 1 }
 
         XCTAssertEqual(collector.stats.chunkCount, 1)
     }
 
     @MainActor
-    func testStatsCollectorRetriesAfterFailedNonForcedRefresh() throws {
+    func testStatsCollectorRetriesAfterFailedNonForcedRefresh() async throws {
         let brokenPath = NSTemporaryDirectory() + "brainbar-dashboard-broken-\(UUID().uuidString).db"
         try FileManager.default.createDirectory(
             atPath: brokenPath,
@@ -709,6 +732,7 @@ final class DashboardTests: XCTestCase {
         defer { collector.stop() }
 
         collector.refresh(force: false)
+        try await waitForCollector(collector) { !$0.isRefreshing }
         XCTAssertEqual(collector.stats.chunkCount, 0)
 
         try FileManager.default.removeItem(atPath: brokenPath)
@@ -724,6 +748,7 @@ final class DashboardTests: XCTestCase {
         repairedDB.close()
 
         collector.refresh(force: false)
+        try await waitForCollector(collector) { $0.stats.chunkCount == 1 }
 
         XCTAssertEqual(collector.stats.chunkCount, 1)
     }
@@ -922,6 +947,18 @@ final class DashboardTests: XCTestCase {
         XCTAssertFalse(viewController.isViewLoaded)
         _ = viewController.view
         XCTAssertTrue(viewController.isViewLoaded)
+    }
+
+    @MainActor
+    private func waitForCollector(
+        _ collector: StatsCollector,
+        timeout: TimeInterval = 2.0,
+        until predicate: (StatsCollector) -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !predicate(collector), Date() < deadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
     }
 
     private static func absoluteTime(_ date: Date) -> String {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -193,30 +193,60 @@ final class DashboardTests: XCTestCase {
     }
 
     func testSparklineChartPresentationCarriesBucketsAndVoiceOverMetadata() {
+        let now = Date(timeIntervalSince1970: 1_764_236_400)
         let presentation = SparklineChartPresentation(
             label: "Recent activity sparkline",
             values: [0, 2, 5, 3],
-            activityWindowMinutes: 20
+            activityWindowMinutes: 20,
+            fetchedAt: now
         )
 
         XCTAssertEqual(presentation.points.map(\.bucket), [0, 1, 2, 3])
         XCTAssertEqual(presentation.points.map(\.value), [0, 2, 5, 3])
         XCTAssertEqual(presentation.accessibilityLabel, "Recent activity sparkline")
         XCTAssertEqual(presentation.accessibilityValue, "latest bucket count 3, trending down")
-        XCTAssertEqual(presentation.bucketLabel(for: 0), "20m-15m ago")
-        XCTAssertEqual(presentation.bucketLabel(for: 3), "last 5m")
-        XCTAssertEqual(presentation.tooltipText(forBucket: 2), "10m-5m ago: 5")
+        XCTAssertEqual(
+            presentation.bucketLabel(for: 0),
+            "\(Self.shortTime(now.addingTimeInterval(-20 * 60)))-\(Self.shortTime(now.addingTimeInterval(-15 * 60)))"
+        )
+        XCTAssertEqual(
+            presentation.bucketLabel(for: 3),
+            "\(Self.shortTime(now.addingTimeInterval(-5 * 60)))-\(Self.shortTime(now))"
+        )
+        XCTAssertEqual(
+            presentation.tooltipText(forBucket: 2),
+            "\(Self.shortTime(now.addingTimeInterval(-10 * 60)))-\(Self.shortTime(now.addingTimeInterval(-5 * 60))) (10m-5m ago): 5"
+        )
     }
 
     func testSparklineChartPresentationLabelsPartialMinuteBucketsLikeDatabase() {
+        let now = Date(timeIntervalSince1970: 1_764_236_400)
         let presentation = SparklineChartPresentation(
             label: "Recent activity sparkline",
             values: Array(repeating: 0, count: 12),
-            activityWindowMinutes: 31
+            activityWindowMinutes: 31,
+            fetchedAt: now
         )
 
-        XCTAssertEqual(presentation.bucketLabel(for: 0), "31m-28m 25s ago")
-        XCTAssertEqual(presentation.bucketLabel(for: 11), "last 2m 35s")
+        let bucketWidth = Double(31 * 60) / 12
+        XCTAssertEqual(
+            presentation.bucketLabel(for: 0),
+            "\(Self.shortTime(now.addingTimeInterval(-31 * 60)))-\(Self.shortTime(now.addingTimeInterval(-(31 * 60 - bucketWidth))))"
+        )
+        XCTAssertEqual(
+            presentation.bucketLabel(for: 11),
+            "\(Self.shortTime(now.addingTimeInterval(-bucketWidth)))-\(Self.shortTime(now))"
+        )
+    }
+
+    func testDashboardMetricFormatterRequiresAbsoluteLastEventText() {
+        let now = Date(timeIntervalSince1970: 1_764_236_400)
+        let lastEvent = now.addingTimeInterval(-125)
+
+        XCTAssertEqual(
+            DashboardMetricFormatter.lastEventString(lastEventAt: lastEvent, now: now),
+            "\(Self.absoluteTime(lastEvent)) (3m ago)"
+        )
     }
 
     func testSparklineRendererCompactClassificationMatchesEndpointAndChartPadding() {
@@ -272,6 +302,33 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.recentActivityBuckets.reduce(0, +), 1)
         let lastWriteAt = try XCTUnwrap(stats.lastWriteAt)
         XCTAssertLessThan(abs(lastWriteAt.timeIntervalSince(now)), 5)
+    }
+
+    func testDashboardStatsCountsRecentOffsetTimestampCrossingUTCDateBoundary() throws {
+        try db.insertChunk(
+            id: "dash-offset-crossing",
+            content: "Recent chunk written with an offset timestamp on a different UTC date",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6
+        )
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: -10 * 3600)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
+        let recent = Date().addingTimeInterval(-60)
+
+        db.exec("""
+            UPDATE chunks
+            SET created_at = '\(formatter.string(from: recent))'
+            WHERE id = 'dash-offset-crossing'
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 5, bucketCount: 5)
+
+        XCTAssertEqual(stats.recentActivityBuckets.reduce(0, +), 1)
     }
 
     func testDashboardStatsTracksRecentEnrichmentSeparatelyFromIncomingWrites() throws {
@@ -473,7 +530,7 @@ final class DashboardTests: XCTestCase {
     }
 
     @MainActor
-    func testStatsCollectorRefreshesImmediatelyWithBrainBusEvents() throws {
+    func testStatsCollectorRefreshesWithBrainBusEvents() async throws {
         try db.insertChunk(
             id: "dash-preexisting",
             content: "Inserted before collector start",
@@ -492,6 +549,11 @@ final class DashboardTests: XCTestCase {
         defer { collector.stop() }
 
         collector.start()
+
+        let deadline = Date().addingTimeInterval(2.0)
+        while collector.stats.chunkCount == 0 && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
 
         XCTAssertEqual(eventSource.streamRequestCount, 1)
         XCTAssertEqual(collector.stats.chunkCount, 1)
@@ -577,6 +639,34 @@ final class DashboardTests: XCTestCase {
 
         try await Task.sleep(for: .milliseconds(120))
         XCTAssertEqual(collector.stats.pendingStoreQueueDepth, 1)
+    }
+
+    @MainActor
+    func testStatsCollectorAutoRefreshesWithoutBrainBusEvents() async throws {
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 60,
+            autoRefreshInterval: 0.05,
+            brainBusEvents: nil
+        )
+        defer { collector.stop() }
+
+        collector.start()
+        XCTAssertEqual(collector.stats.chunkCount, 0)
+
+        try db.insertChunk(
+            id: "auto-refresh-after-silence",
+            content: "Fallback refresh should pick this up",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+
+        try await Task.sleep(for: .milliseconds(500))
+
+        XCTAssertEqual(collector.stats.chunkCount, 1)
     }
 
     @MainActor
@@ -813,6 +903,18 @@ final class DashboardTests: XCTestCase {
         XCTAssertFalse(viewController.isViewLoaded)
         _ = viewController.view
         XCTAssertTrue(viewController.isViewLoaded)
+    }
+
+    private static func absoluteTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+
+    private static func shortTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -52,6 +52,67 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
     }
 
+    func testDashboardStatsSamplesPendingStoreQueueBeforeReadTransaction() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainDatabase.swift")
+        let methodRange = try XCTUnwrap(source.range(of: "func dashboardStats("))
+        let methodSource = source[methodRange.lowerBound...]
+        let queueSnapshotRange = try XCTUnwrap(methodSource.range(of: "let pendingStoreQueue = pendingStoreQueueSnapshot()"))
+        let transactionRange = try XCTUnwrap(methodSource.range(of: "try withReadTransaction"))
+
+        XCTAssertLessThan(
+            queueSnapshotRange.lowerBound,
+            transactionRange.lowerBound,
+            "dashboardStats must not acquire the pending-store file lock while holding the SQLite read transaction."
+        )
+    }
+
+    func testBrainBarHeaderRefreshControlsObserveStatsCollector() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertTrue(
+            source.contains("private struct BrainBarHeaderRefreshControls: View"),
+            "Refresh UI should live in a child view so it can observe StatsCollector directly."
+        )
+        XCTAssertTrue(
+            source.contains("@ObservedObject private var collector: StatsCollector")
+                || source.contains("@ObservedObject var collector: StatsCollector"),
+            "Refresh UI must observe StatsCollector so spinner/disabled state update without unrelated header redraws."
+        )
+    }
+
+    func testStatsCollectorDoesNotKeepUnusedDatabaseConnection() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/Dashboard/StatsCollector.swift")
+
+        XCTAssertFalse(
+            source.contains("private let database: BrainDatabase"),
+            "StatsCollector refreshes through short-lived background handles and should not keep an unused DB connection open."
+        )
+        XCTAssertFalse(
+            source.contains("database.close()"),
+            "Removing the retained DB handle also removes the matching close call."
+        )
+    }
+
+    func testDashboardLatestEventFallbackUsesSQLMaxWithoutTextOrderingLimit() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainDatabase.swift")
+        let methodRange = try XCTUnwrap(source.range(of: "private func latestIndexedTimestampEpoch("))
+        let nextMethodRange = try XCTUnwrap(source[methodRange.upperBound...].range(of: "private func latestIndexedEpochSince("))
+        let methodSource = source[methodRange.lowerBound..<nextMethodRange.lowerBound]
+
+        XCTAssertTrue(
+            methodSource.contains("SELECT MAX(event_epoch)"),
+            "Fallback latest-event lookup should compute the max normalized epoch in SQL."
+        )
+        XCTAssertFalse(
+            methodSource.contains("ORDER BY \\(column) DESC"),
+            "Fallback must not text-sort raw timestamp strings before comparing normalized epochs."
+        )
+        XCTAssertFalse(
+            methodSource.contains("LIMIT 1000"),
+            "Fallback must not cap rows before finding the max normalized epoch."
+        )
+    }
+
     func testDashboardStatsCountsTerminalEnrichmentStatusesAsCovered() throws {
         try db.insertChunk(
             id: "dash-success",
@@ -1018,6 +1079,15 @@ private func setDashboardPendingStoreQueuePath(_ path: URL) -> () -> Void {
             unsetenv("BRAINBAR_PENDING_STORES_PATH")
         }
     }
+}
+
+private func brainBarSourceFile(_ relativePath: String, testFilePath: StaticString = #filePath) throws -> String {
+    let packageRoot = URL(fileURLWithPath: "\(testFilePath)")
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let sourceURL = packageRoot.appendingPathComponent(relativePath)
+    return try String(contentsOf: sourceURL, encoding: .utf8)
 }
 
 private func writeDashboardPendingStoreQueue(count: Int, to path: URL) throws {


### PR DESCRIPTION
## Summary
- Refresh BrainBar dashboard stats off the main startup path with auto/manual/tab refresh state.
- Render the sparkline endpoint with Swift Charts PointMark so the dot stays on the line.
- Add freshness timestamps, absolute bucket labels, and richer sparkline tooltips.
- Use more index-friendly dashboard timestamp queries while preserving a consistent read snapshot.
- Defer InjectionStore initialization until the Injections tab is opened.

## Test plan
- [x] swift test --package-path brain-bar
- [x] TZ=UTC swift test --package-path brain-bar --filter DashboardTests|BrainBarUXLogicTests|BrainBarWindowStateTests
- [x] Computer Use: installed app opens Dashboard, endpoint dot is on line, manual Refresh now completes and updates logs
- [x] Installed app smoke: build-app --force-dirty + launchctl kickstart daemon/UI
- [x] Git pre-push pytest/Bun/shell hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQLite dashboard query semantics, background refresh concurrency, and lazy InjectionStore wiring—behavior changes are user-visible but scoped to BrainBar UI and read paths.
> 
> **Overview**
> **Dashboard stats** no longer load on the main thread via a long-lived DB handle: `StatsCollector` opens short-lived read-only connections in a detached task, coalesces overlapping refreshes, and exposes `isRefreshing`, `lastDataFetchedAt`, and manual refresh state. A **30s auto-refresh loop** and **tab-switch** refresh are added; the header gets **Refresh now** (⌘R) and the dashboard shows **data fetched at** plus refresh indicators.
> 
> **Startup** defers **`InjectionStore`** until the Injections tab (`ensureInjectionStore` + factory); missing DB files are **bootstrapped** without eager writable opens at wire time.
> 
> **`BrainDatabase.dashboardStats`** wraps reads in a transaction, snapshots pending-store queue **before** the read lock, and replaces `unixepoch('now', …)` window queries with **indexed, `now`-anchored** timestamp scans plus SQL `MAX` fallbacks for latest events.
> 
> **Sparklines / metrics**: bucket labels and tooltips use **absolute HH:mm ranges** tied to fetch time; last-event strings become **`HH:mm:ss (relative)`**; charts highlight the latest point with Swift Charts and drop the pulse ring overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76c4cad011207bd1024bbaf7ee8b24ee5652287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh BrainBar dashboard without blocking startup by making InjectionStore lazy and DB connections transient
> - `StatsCollector` no longer holds a persistent `BrainDatabase`; each refresh opens a temporary connection, reads stats, and closes it, avoiding file-lock contention on startup.
> - `InjectionStore` is now created lazily via a factory closure (`ensureInjectionStore()`) rather than eagerly at wire time; it is instantiated only when the Injections tab is first selected.
> - Switching to the Dashboard tab now triggers an immediate forced stats refresh; the header gains a manual "Refresh now" button (also bound to Cmd+R) with a progress indicator.
> - Dashboard view gains a freshness line showing the last fetch timestamp; sparkline bucket labels switch from relative to absolute time ranges (e.g. "12:00–12:05"), and the animated endpoint pulse is removed.
> - `DashboardMetricFormatter.lastEventString` now returns `"HH:mm:ss (Xm ago)"` instead of only a relative string, and relative rounding changed from `.up` to `.towardZero`.
> - Behavioral Change: `StatsCollector` adds a 30-second auto-refresh loop independent of mutation notifications; dashboards will refresh periodically even with no writes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c76c4ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Refresh now" button to dashboard header for manual data refresh with progress indication.
  * Dashboard now displays data freshness indicator showing when data was last fetched.
  * Auto-refresh enabled for periodic automatic updates.
  * Metrics now display absolute timestamps alongside relative time indicators (e.g., "14:23:45 (2m ago)").

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->