### PR TITLE
feat(search): add agent profiles for per-agent ranking

### DIFF
--- a/scripts/seed_agent_profiles.py
+++ b/scripts/seed_agent_profiles.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Seed the default hand-tuned BrainLayer agent ranking profiles."""
+
+from __future__ import annotations
+
+import sys
+
+import apsw
+
+from brainlayer.agent_profiles import DEFAULT_AGENT_PROFILES
+from brainlayer.paths import get_db_path
+from brainlayer.vector_store import VectorStore, WriterInUseError
+
+
+def main() -> None:
+    try:
+        store = VectorStore(get_db_path())
+    except WriterInUseError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        print("Stop BrainLayer writer services before seeding agent profiles.", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except apsw.BusyError as exc:
+        print("ERROR: Database is locked. Retry after other BrainLayer processes finish.", file=sys.stderr)
+        raise SystemExit(1) from exc
+    try:
+        for agent_id, profile in DEFAULT_AGENT_PROFILES.items():
+            store.set_agent_profile(agent_id, profile, notes="seed_agent_profiles.py default")
+            print(f"seeded {agent_id}")
+        print("Note: other running BrainLayer processes may keep cached search results for up to 60 seconds.")
+        print("Profile updates are last-writer-wins; coordinate concurrent operator updates manually.")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/agent_profiles.py
+++ b/src/brainlayer/agent_profiles.py
@@ -1,0 +1,140 @@
+"""Agent ranking profile helpers.
+
+Profile JSON schema:
+
+```json
+{
+  "boost_weights": {
+    "fts_weight": 1.4,
+    "vector_weight": 0.9,
+    "importance_weight": 1.0,
+    "recency_weight": 1.0,
+    "recency_intent_weight": 1.0,
+    "decay_weight": 1.0,
+    "kg_weight": 1.0
+  },
+  "source_weights": {
+    "precompact": 1.3
+  }
+}
+```
+
+All weights are optional positive numbers. Missing profile rows, missing keys,
+and unknown agents fall back to weight `1.0`, preserving current ranking.
+Short keys such as `"fts"` are accepted as aliases for `"fts_weight"`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+
+MAX_PROFILE_WEIGHT = 1000.0
+
+DEFAULT_AGENT_PROFILES: dict[str, dict[str, Any]] = {
+    "orcClaude": {
+        "boost_weights": {
+            "fts_weight": 3.0,
+            "vector_weight": 0.5,
+            "importance_weight": 1.0,
+            "recency_weight": 1.0,
+            "recency_intent_weight": 1.0,
+            "decay_weight": 1.0,
+            "kg_weight": 1.0,
+        },
+        "source_weights": {},
+    },
+    "coachClaude": {
+        "boost_weights": {
+            "fts_weight": 0.85,
+            "vector_weight": 1.3,
+            "importance_weight": 1.05,
+            "recency_weight": 1.0,
+            "recency_intent_weight": 1.0,
+            "decay_weight": 1.0,
+            "kg_weight": 1.0,
+        },
+        "source_weights": {},
+    },
+    "skillCreatorClaude": {
+        "boost_weights": {
+            "fts_weight": 1.0,
+            "vector_weight": 1.0,
+            "importance_weight": 1.0,
+            "recency_weight": 1.0,
+            "recency_intent_weight": 1.0,
+            "decay_weight": 1.0,
+            "kg_weight": 1.0,
+        },
+        "source_weights": {"precompact": 1.3},
+    },
+}
+
+
+def load_profile_json(raw: str) -> dict[str, Any]:
+    """Parse and validate an agent profile JSON object."""
+    try:
+        profile = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc.msg}") from exc
+    return validate_agent_profile(profile)
+
+
+def validate_agent_profile(profile: Any) -> dict[str, Any]:
+    """Return a normalized profile or raise ValueError."""
+    if not isinstance(profile, dict):
+        raise ValueError("Agent profile must be a JSON object")
+
+    normalized: dict[str, Any] = {}
+    boost_weights = _validate_weight_map(profile.get("boost_weights", {}), "boost_weights")
+    source_weights = _validate_weight_map(profile.get("source_weights", {}), "source_weights")
+    normalized["boost_weights"] = boost_weights
+    normalized["source_weights"] = source_weights
+    return normalized
+
+
+def boost_weight(profile: dict[str, Any] | None, feature: str) -> float:
+    """Return the configured feature boost weight, defaulting to 1.0."""
+    if not profile:
+        return 1.0
+    weights = profile.get("boost_weights") or {}
+    value = weights.get(feature, weights.get(f"{feature}_weight", 1.0))
+    return float(value)
+
+
+def source_weight(profile: dict[str, Any] | None, source: str | None) -> float:
+    """Return the configured source boost weight, defaulting to 1.0."""
+    if not profile or not source:
+        return 1.0
+    weights = profile.get("source_weights") or {}
+    weight = weights.get(source)
+    if weight is None and source == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT:
+        weight = weights.get("precompact")
+    return float(weight or 1.0)
+
+
+def _validate_weight_map(value: Any, field_name: str) -> dict[str, float]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+
+    normalized: dict[str, float] = {}
+    for key, weight in value.items():
+        if not isinstance(key, str):
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        key_stripped = key.strip()
+        if not key_stripped:
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        if key_stripped in normalized:
+            raise ValueError(f"{field_name}.{key_stripped} is duplicated after trimming whitespace")
+        if isinstance(weight, bool) or not isinstance(weight, int | float):
+            raise ValueError(f"{field_name}.{key_stripped} must be a number")
+        numeric = float(weight)
+        if not math.isfinite(numeric) or numeric <= 0 or numeric > MAX_PROFILE_WEIGHT:
+            raise ValueError(f"{field_name}.{key_stripped} must be positive and <= {MAX_PROFILE_WEIGHT:g}")
+        normalized[key_stripped] = numeric
+    return normalized

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -32,6 +32,8 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
+agent_profile_app = typer.Typer(help="Manage per-agent search ranking profiles")
+app.add_typer(agent_profile_app, name="agent-profile")
 
 
 @app.command()
@@ -87,6 +89,59 @@ def search(
     from ..cli_new import search_command
 
     search_command(query, n, project, content_type, agent_id, text, hybrid)
+
+
+@agent_profile_app.command("show")
+def agent_profile_show(agent_id: str = typer.Argument(..., help="Agent id to inspect")) -> None:
+    """Show a stored agent ranking profile as JSON."""
+    from ..vector_store import VectorStore
+
+    db_path = get_db_path()
+    if not db_path.exists():
+        rprint(f"[yellow]No profile found for {agent_id}[/]")
+        raise typer.Exit(1)
+
+    store = VectorStore(db_path, readonly=True)
+    try:
+        profile = store.get_agent_profile(agent_id)
+    finally:
+        store.close()
+    if profile is None:
+        rprint(f"[yellow]No profile found for {agent_id}[/]")
+        raise typer.Exit(1)
+    typer.echo(json.dumps(profile, indent=2, sort_keys=True))
+
+
+@agent_profile_app.command("set")
+def agent_profile_set(
+    agent_id: str = typer.Argument(..., help="Agent id to update"),
+    json_file_or_stdin: str = typer.Argument(..., help="JSON file path, or '-' to read stdin"),
+    notes: str | None = typer.Option(None, "--notes", help="Optional operator notes"),
+) -> None:
+    """Validate and persist an agent ranking profile."""
+    from ..agent_profiles import load_profile_json
+    from ..vector_store import VectorStore
+
+    if json_file_or_stdin == "-":
+        raw = sys.stdin.read()
+    else:
+        try:
+            raw = Path(json_file_or_stdin).read_text()
+        except (FileNotFoundError, PermissionError, OSError) as exc:
+            rprint(f"[red]Could not read profile JSON:[/] {exc}")
+            raise typer.Exit(2) from exc
+    try:
+        profile = load_profile_json(raw)
+    except ValueError as exc:
+        rprint(f"[red]Invalid profile:[/] {exc}")
+        raise typer.Exit(1) from exc
+
+    store = VectorStore(get_db_path())
+    try:
+        stored = store.set_agent_profile(agent_id, profile, notes=notes)
+    finally:
+        store.close()
+    rprint(f"[green]Stored profile for {stored['agent_id']}[/]")
 
 
 @app.command()

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from . import search_profile
 from ._helpers import _escape_fts5_query, _is_sqlite_busy_error, serialize_f32
+from .agent_profiles import boost_weight, source_weight, validate_agent_profile
 from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_checkpoint_content
 from .dedupe import resolve_chunk_id
 from .ingest_guard import recursive_mcp_output_reason
@@ -319,8 +320,70 @@ def _precompact_content_exclusion_sql(content_expr: str) -> str:
     )
 
 
+def _profiled_multiplier(base: float, profile: dict[str, Any] | None, feature: str) -> float:
+    """Scale a multiplier's deviation from neutral by an agent profile weight."""
+    weighted = 1.0 + (base - 1.0) * boost_weight(profile, feature)
+    return min(max(weighted, 0.01), 100.0)
+
+
 class SearchMixin:
     """Search and query methods, mixed into VectorStore."""
+
+    def get_agent_profile(self, agent_id: str) -> dict[str, Any] | None:
+        """Return a validated agent ranking profile, or None when absent/invalid."""
+        if not agent_id:
+            return None
+        for attempt in range(3):
+            try:
+                row = (
+                    self._read_cursor()
+                    .execute(
+                        "SELECT profile_json, updated_at, notes FROM agent_profiles WHERE agent_id = ?",
+                        (agent_id,),
+                    )
+                    .fetchone()
+                )
+                break
+            except apsw.Error as exc:
+                if _is_sqlite_busy_error(exc):
+                    if attempt < 2:
+                        time.sleep(0.05 * (2**attempt))
+                        continue
+                    raise
+                return None
+        else:
+            return None
+        if row is None:
+            return None
+        try:
+            profile = validate_agent_profile(json.loads(row[0]))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        return {"agent_id": agent_id, "profile": profile, "updated_at": row[1], "notes": row[2]}
+
+    def set_agent_profile(self, agent_id: str, profile: dict[str, Any], notes: str | None = None) -> dict[str, Any]:
+        """Validate and persist an agent ranking profile."""
+        if not agent_id or not agent_id.strip():
+            raise ValueError("agent_id is required")
+        normalized = validate_agent_profile(profile)
+        updated_at = time.time()
+        for attempt in range(3):
+            try:
+                self.conn.cursor().execute(
+                    """
+                    INSERT OR REPLACE INTO agent_profiles(agent_id, profile_json, updated_at, notes)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (agent_id, json.dumps(normalized, sort_keys=True), updated_at, notes),
+                )
+                break
+            except apsw.Error as exc:
+                if _is_sqlite_busy_error(exc) and attempt < 2:
+                    time.sleep(0.05 * (2**attempt))
+                    continue
+                raise
+        clear_hybrid_search_cache(getattr(self, "db_path", None))
+        return {"agent_id": agent_id, "profile": normalized, "updated_at": updated_at, "notes": notes}
 
     def _audit_recursion_exclusion_sql(self, chunk_id_expr: str, tags_expr: str, content_expr: str) -> str:
         return _audit_recursion_exclusion_sql(
@@ -735,12 +798,14 @@ class SearchMixin:
             )
             effective_k = self._effective_knn_k(n_results, bool(needs_overfetch), include_checkpoints, include_audit)
             params = [query_bytes, effective_k] + filter_params
+            chunk_origin_expr = "c.chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
             query = f"""
                 SELECT c.id, c.content, c.metadata, c.source_file, c.project,
                        c.content_type, c.value_type, c.char_count,
                        v.distance,
                        c.summary, c.tags, c.importance, c.intent,
-                       c.created_at, c.source, c.decay_score
+                       c.created_at, c.source, c.decay_score,
+                       {chunk_origin_expr}
                 FROM chunk_vectors v
                 JOIN chunks c ON v.chunk_id = c.id
                 WHERE v.embedding MATCH ? AND k = ? {where_sql}
@@ -819,12 +884,14 @@ class SearchMixin:
 
             params.append(n_results)
 
+            chunk_origin_expr = "chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
             query = f"""
                 SELECT id, content, metadata, source_file, project,
                        content_type, value_type, char_count,
                        NULL as distance,
                        summary, tags, importance, intent,
-                       created_at, source, decay_score
+                       created_at, source, decay_score,
+                       {chunk_origin_expr}
                 FROM chunks
                 WHERE {" AND ".join(where_clauses)}
                 ORDER BY char_count DESC
@@ -876,6 +943,8 @@ class SearchMixin:
                 metadata["source"] = row[14]
             if row[15] is not None:
                 metadata["decay_score"] = row[15]
+            if len(row) > 16 and row[16]:
+                metadata["chunk_origin"] = row[16]
             metadatas.append(metadata)
             distances.append(row[8])  # distance (None for text search)
 
@@ -1093,12 +1162,14 @@ class SearchMixin:
         )
         effective_k = self._effective_knn_k(n_results, bool(needs_overfetch), include_checkpoints, include_audit)
         params = [query_bytes, effective_k] + filter_params
+        chunk_origin_expr = "c.chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
         query = f"""
                 SELECT c.id, c.content, c.metadata, c.source_file, c.project,
                        c.content_type, c.value_type, c.char_count,
                        v.distance,
                        c.summary, c.tags, c.importance, c.intent,
-                       c.created_at, c.source
+                       c.created_at, c.source, c.decay_score,
+                       {chunk_origin_expr}
                 FROM chunk_vectors_binary v
                 JOIN chunks c ON v.chunk_id = c.id
                 WHERE v.embedding MATCH vec_quantize_binary(?) AND k = ? {where_sql}
@@ -1153,6 +1224,10 @@ class SearchMixin:
                 metadata["created_at"] = row[13]
             if row[14]:
                 metadata["source"] = row[14]
+            if row[15] is not None:
+                metadata["decay_score"] = row[15]
+            if row[16]:
+                metadata["chunk_origin"] = row[16]
             metadatas.append(metadata)
             distances.append(row[8])
 
@@ -1444,6 +1519,8 @@ class SearchMixin:
                 fts_extra.append("AND COALESCE(c.archived, 0) = 0")
                 fts_extra.append("AND COALESCE(c.status, 'active') = 'active'")
 
+            chunk_origin_expr = "c.chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
+
             def _fetch_fts_rows(table_name: str) -> list[tuple]:
                 params = [fts_query, *fts_filter_params, candidate_fetch_count]
                 return list(
@@ -1453,7 +1530,8 @@ class SearchMixin:
                            c.content, c.metadata, c.source_file, c.project,
                            c.content_type, c.value_type, c.char_count,
                            c.summary, c.tags, c.importance, c.intent,
-                           c.created_at, c.source, c.sender, c.language, c.decay_score
+                           c.created_at, c.source, c.sender, c.language, c.decay_score,
+                           {chunk_origin_expr}
                     FROM {table_name} f
                     JOIN chunks c ON f.chunk_id = c.id
                     {entity_join}
@@ -1506,6 +1584,7 @@ class SearchMixin:
                         "sender": row[15],
                         "language": row[16],
                         "decay_score": row[17],
+                        "chunk_origin": row[18],
                     },
                 )
 
@@ -1572,11 +1651,13 @@ class SearchMixin:
                 recent_extra.append("AND COALESCE(archived, 0) = 0")
                 recent_extra.append("AND COALESCE(status, 'active') = 'active'")
 
+            chunk_origin_expr = "chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
             recent_query = f"""
                     SELECT id, content, metadata, source_file, project,
                            content_type, value_type, char_count,
                            summary, tags, importance, intent,
-                           created_at, source, sender, language, decay_score
+                           created_at, source, sender, language, decay_score,
+                           {chunk_origin_expr}
                     FROM chunks
                     WHERE datetime(created_at) >= datetime('now', '-7 days') {" ".join(recent_extra)}
                     ORDER BY created_at DESC
@@ -1616,6 +1697,7 @@ class SearchMixin:
                         "sender": row[14],
                         "language": row[15],
                         "decay_score": row[16],
+                        "chunk_origin": row[17],
                     },
                 )
 
@@ -1636,6 +1718,7 @@ class SearchMixin:
         all_chunk_ids = set(semantic_by_id.keys()) | set(fts_ranks.keys()) | set(trigram_ranks.keys())
 
         scored = []
+        match_features_by_id: dict[str, dict[str, bool]] = {}
         for cid in all_chunk_ids:
             score = 0.0
             sem_entry = semantic_by_id.get(cid)
@@ -1688,6 +1771,8 @@ class SearchMixin:
                     meta["language"] = data["language"]
                 if data.get("decay_score") is not None:
                     meta["decay_score"] = data["decay_score"]
+                if data.get("chunk_origin"):
+                    meta["chunk_origin"] = data["chunk_origin"]
                 dist = None
             else:
                 continue
@@ -1710,17 +1795,32 @@ class SearchMixin:
                 if language_filter and meta.get("language") != language_filter:
                     continue
 
+            match_features_by_id[cid] = {
+                "vector": sem_entry is not None,
+                "fts": fts_rank is not None,
+                "trigram": trigram_rank is not None,
+            }
             scored.append((score, cid, doc, meta, dist))
+
+        agent_profile = None
+        if agent_id:
+            stored_profile = self.get_agent_profile(agent_id)
+            if stored_profile:
+                agent_profile = stored_profile["profile"]
 
         # Post-RRF boost: importance and recency adjustments
         now = datetime.now(timezone.utc)
         for i, (score, cid, doc, meta, dist) in enumerate(scored):
             boost = 1.0
+            for feature, matched in match_features_by_id.get(cid, {}).items():
+                if matched:
+                    boost *= boost_weight(agent_profile, feature)
 
             # Importance boost: scale 0-10 → 1.0-1.5x multiplier
             imp = meta.get("importance")
             if imp is not None and isinstance(imp, (int, float)):
-                boost *= 1.0 + min(max(float(imp), 0), 10) / 20.0  # 10/20 = 0.5 max boost
+                importance_boost = 1.0 + min(max(float(imp), 0), 10) / 20.0
+                boost *= _profiled_multiplier(importance_boost, agent_profile, "importance")
 
             # Recency boost: exponential decay with 30-day half-life
             created = meta.get("created_at")
@@ -1731,15 +1831,20 @@ class SearchMixin:
                         dt = dt.replace(tzinfo=timezone.utc)
                     age_days = max((now - dt).total_seconds() / 86400, 0)
                     recency = math.exp(-0.023 * age_days)  # ~0.5 at 30 days
-                    boost *= 0.7 + 0.3 * recency  # range: 0.7x (old) to 1.0x (fresh)
+                    # Base range: 0.7x (old) to 1.0x (fresh).
+                    recency_boost = 0.7 + 0.3 * recency
+                    boost *= _profiled_multiplier(recency_boost, agent_profile, "recency")
                     if recency_intent and age_days <= 7:
-                        boost *= 2.0
+                        boost *= _profiled_multiplier(2.0, agent_profile, "recency_intent")
                 except (ValueError, TypeError):
                     pass
 
             decay_score = meta.get("decay_score")
             if isinstance(decay_score, (int, float)):
-                boost *= float(decay_score)
+                boost *= _profiled_multiplier(float(decay_score), agent_profile, "decay")
+
+            boost *= source_weight(agent_profile, meta.get("source"))
+            boost *= source_weight(agent_profile, meta.get("chunk_origin"))
 
             scored[i] = (score * boost, cid, doc, meta, dist)
 
@@ -1773,7 +1878,13 @@ class SearchMixin:
                     KG_BOOST_FACTOR = 1.3
                     for i, (score, cid, doc, meta, dist) in enumerate(scored):
                         if cid in kg_linked_ids:
-                            scored[i] = (score * KG_BOOST_FACTOR, cid, doc, meta, dist)
+                            scored[i] = (
+                                score * _profiled_multiplier(KG_BOOST_FACTOR, agent_profile, "kg"),
+                                cid,
+                                doc,
+                                meta,
+                                dist,
+                            )
             except Exception:
                 pass  # KG tables may not exist in all DBs
 

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -115,6 +115,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     _PIDFILE_REF_PIDS: dict[Path, int] = {}
     _PIDFILE_REFS_LOCK = threading.Lock()
     _PIDFILE_ACQUIRE_LOCK = threading.Lock()
+    _INIT_DB_LOCKS: dict[Path, threading.Lock] = {}
+    _INIT_DB_LOCKS_LOCK = threading.Lock()
 
     def __init__(self, db_path: Path, readonly: bool = False):
         self.db_path = db_path
@@ -136,10 +138,21 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         else:
             self._acquire_writer_pidfile()
             try:
-                self._init_db_with_retry()
+                with self._init_db_thread_lock():
+                    self._init_db_with_retry()
             except Exception:
                 self._release_writer_pidfile()
                 raise
+
+    def _init_db_thread_lock(self) -> threading.Lock:
+        """Serialize same-process schema init for a DB path."""
+        resolved_path = self.db_path.resolve()
+        with self._INIT_DB_LOCKS_LOCK:
+            lock = self._INIT_DB_LOCKS.get(resolved_path)
+            if lock is None:
+                lock = threading.Lock()
+                self._INIT_DB_LOCKS[resolved_path] = lock
+            return lock
 
     def _writer_pidfile_path(self) -> Path:
         pidfile_dir = Path(os.environ.get("BRAINLAYER_WRITER_PIDFILE_DIR", "/tmp")).expanduser()
@@ -526,11 +539,12 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 details TEXT
             )
         """)
-
         cursor.execute("""
-            CREATE TABLE IF NOT EXISTS schema_migrations (
-                name TEXT PRIMARY KEY,
-                applied_at TEXT NOT NULL
+            CREATE TABLE IF NOT EXISTS agent_profiles (
+                agent_id TEXT PRIMARY KEY,
+                profile_json TEXT NOT NULL,
+                updated_at REAL NOT NULL,
+                notes TEXT
             )
         """)
         atomic_brick_migration_applied = (

--- a/tests/test_agent_profiles.py
+++ b/tests/test_agent_profiles.py
@@ -1,0 +1,311 @@
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from brainlayer import search_repo
+from brainlayer._helpers import serialize_f32
+from brainlayer.agent_profiles import validate_agent_profile
+from brainlayer.cli import app
+from brainlayer.search_repo import _hybrid_cache
+from brainlayer.vector_store import VectorStore
+
+
+def _embed(seed: float) -> list[float]:
+    return [seed + (i / 10000.0) for i in range(1024)]
+
+
+def _insert_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    content: str,
+    importance: float,
+    embedding: list[float] | None = None,
+    created_at: str = "2026-05-01T00:00:00Z",
+    chunk_origin: str = "unknown",
+) -> None:
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, importance, created_at, chunk_origin
+        ) VALUES (?, ?, '{}', 'agent-profile-test.jsonl', 'agent-profile-test',
+            'assistant_text', ?, 'claude_code', ?, ?, ?)""",
+        (chunk_id, content, len(content), importance, created_at, chunk_origin),
+    )
+    if embedding is not None:
+        cursor.execute(
+            "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+            (chunk_id, serialize_f32(embedding)),
+        )
+
+
+def test_agent_profiles_migration_adds_table(tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "brainlayer.db")
+    try:
+        cols = {row[1]: row[2] for row in store.conn.cursor().execute("PRAGMA table_info(agent_profiles)")}
+    finally:
+        store.close()
+
+    assert cols == {
+        "agent_id": "TEXT",
+        "profile_json": "TEXT",
+        "updated_at": "REAL",
+        "notes": "TEXT",
+    }
+
+
+def test_agent_profile_cli_set_show_roundtrip(monkeypatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "brainlayer.db"
+    profile_path = tmp_path / "orc.json"
+    profile_path.write_text(
+        json.dumps({"boost_weights": {"fts": 2.0, "vector": 0.5}, "source_weights": {"precompact": 1.3}})
+    )
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+
+    runner = CliRunner()
+    set_result = runner.invoke(app, ["agent-profile", "set", "orcClaude", str(profile_path)])
+    assert set_result.exit_code == 0, set_result.output
+
+    show_result = runner.invoke(app, ["agent-profile", "show", "orcClaude"])
+    assert show_result.exit_code == 0, show_result.output
+    shown = json.loads(show_result.stdout)
+    assert shown["agent_id"] == "orcClaude"
+    assert shown["profile"]["boost_weights"]["fts"] == 2.0
+    assert shown["profile"]["boost_weights"]["vector"] == 0.5
+    assert shown["profile"]["source_weights"]["precompact"] == 1.3
+
+
+def test_agent_profile_cli_show_uses_readonly_store(monkeypatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "brainlayer.db"
+    profile_path = tmp_path / "orc.json"
+    profile_path.write_text(json.dumps({"boost_weights": {"fts": 2.0}}))
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+
+    runner = CliRunner()
+    set_result = runner.invoke(app, ["agent-profile", "set", "orcClaude", str(profile_path)])
+    assert set_result.exit_code == 0, set_result.output
+
+    writer = VectorStore(db_path)
+    try:
+        show_result = runner.invoke(app, ["agent-profile", "show", "orcClaude"])
+    finally:
+        writer.close()
+
+    assert show_result.exit_code == 0, show_result.output
+    assert json.loads(show_result.stdout)["agent_id"] == "orcClaude"
+
+
+def test_agent_profile_rejects_unbounded_weights() -> None:
+    try:
+        validate_agent_profile({"boost_weights": {"fts": 1000.1}})
+    except ValueError as exc:
+        assert "positive and <= 1000" in str(exc)
+    else:
+        raise AssertionError("Expected unbounded profile weight to be rejected")
+
+
+def test_agent_profile_trims_weight_keys_and_rejects_trimmed_duplicates() -> None:
+    normalized = validate_agent_profile({"boost_weights": {" fts ": 2.0}})
+    assert normalized["boost_weights"] == {"fts": 2.0}
+
+    try:
+        validate_agent_profile({"boost_weights": {"fts": 1.0, " fts ": 2.0}})
+    except ValueError as exc:
+        assert "duplicated after trimming whitespace" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate trimmed keys to be rejected")
+
+
+def test_agent_profile_cli_reports_unreadable_json(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("BRAINLAYER_DB", str(tmp_path / "brainlayer.db"))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["agent-profile", "set", "orcClaude", str(tmp_path / "missing.json")])
+
+    assert result.exit_code == 2
+    assert "Could not read profile JSON" in result.output
+
+
+def test_hybrid_search_agent_profile_applies_orc_weights(tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "brainlayer.db")
+    query_embedding = _embed(0.1)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="vector-only",
+            content="semantic only result without lexical terms",
+            importance=10.0,
+            embedding=query_embedding,
+        )
+        _insert_chunk(
+            store,
+            chunk_id="fts-only",
+            content="needle phrase exact lexical result",
+            importance=1.0,
+            embedding=None,
+        )
+        store.build_binary_index()
+        store._trigram_fts_available = False
+        store.set_agent_profile(
+            "orcClaude",
+            {"boost_weights": {"fts": 3.0, "vector": 0.5}},
+            notes="test profile",
+        )
+        _hybrid_cache.clear()
+
+        default_results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="needle phrase",
+            n_results=2,
+            agent_id=None,
+        )
+        _hybrid_cache.clear()
+        profiled_results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="needle phrase",
+            n_results=2,
+            agent_id="orcClaude",
+        )
+    finally:
+        store.close()
+        _hybrid_cache.clear()
+
+    assert default_results["ids"][0][0] == "vector-only"
+    assert profiled_results["ids"][0][0] == "fts-only"
+
+
+def test_hybrid_search_agent_profile_scales_recency_intent_neutral_point(monkeypatch, tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "brainlayer.db")
+    query_embedding = _embed(0.1)
+    multiplier_calls: list[tuple[float, str]] = []
+    original_profiled_multiplier = search_repo._profiled_multiplier
+
+    def tracking_profiled_multiplier(base, profile, feature):
+        multiplier_calls.append((base, feature))
+        return original_profiled_multiplier(base, profile, feature)
+
+    monkeypatch.setattr(search_repo, "_profiled_multiplier", tracking_profiled_multiplier)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="old-vector",
+            content="needle phrase archive result",
+            importance=1.0,
+            embedding=query_embedding,
+            created_at="2026-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="recent-lexical",
+            content="needle phrase recent result",
+            importance=1.0,
+            embedding=_embed(0.3),
+            created_at="2026-05-28T00:00:00Z",
+        )
+        store.build_binary_index()
+        store._trigram_fts_available = False
+        store.set_agent_profile(
+            "recencyTest",
+            {"boost_weights": {"recency_intent": 0.5}},
+            notes="test profile",
+        )
+        _hybrid_cache.clear()
+
+        store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="latest needle phrase",
+            n_results=2,
+            agent_id="recencyTest",
+        )
+    finally:
+        store.close()
+        _hybrid_cache.clear()
+
+    assert (2.0, "recency_intent") in multiplier_calls
+    assert original_profiled_multiplier(2.0, {"boost_weights": {"recency_intent": 0.5}}, "recency_intent") == 1.5
+
+
+def test_hybrid_search_agent_profile_uses_chunk_origin_for_semantic_hits(monkeypatch, tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "brainlayer.db")
+    query_embedding = _embed(0.1)
+    observed_sources: list[str | None] = []
+    original_source_weight = search_repo.source_weight
+
+    def tracking_source_weight(profile, source):
+        observed_sources.append(source)
+        return original_source_weight(profile, source)
+
+    monkeypatch.setattr(search_repo, "source_weight", tracking_source_weight)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="semantic-origin",
+            content="semantic only result without lexical terms",
+            importance=1.0,
+            embedding=query_embedding,
+            chunk_origin="profiled_origin",
+        )
+        store.build_binary_index()
+        store._trigram_fts_available = False
+        store.set_agent_profile(
+            "originTest",
+            {"source_weights": {"profiled_origin": 1.5}},
+            notes="test profile",
+        )
+        _hybrid_cache.clear()
+
+        results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="needle phrase",
+            n_results=1,
+            agent_id="originTest",
+        )
+    finally:
+        store.close()
+        _hybrid_cache.clear()
+
+    assert results["metadatas"][0][0]["chunk_origin"] == "profiled_origin"
+    assert "profiled_origin" in observed_sources
+
+
+def test_hybrid_search_missing_profile_matches_default(tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "brainlayer.db")
+    query_embedding = _embed(0.1)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="vector-only",
+            content="semantic only result without lexical terms",
+            importance=10.0,
+            embedding=query_embedding,
+        )
+        _insert_chunk(
+            store,
+            chunk_id="fts-only",
+            content="needle phrase exact lexical result",
+            importance=1.0,
+            embedding=None,
+        )
+        store.build_binary_index()
+        store._trigram_fts_available = False
+
+        default_results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="needle phrase",
+            n_results=2,
+            agent_id=None,
+        )
+        _hybrid_cache.clear()
+        unknown_results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="needle phrase",
+            n_results=2,
+            agent_id="unknown-agent",
+        )
+    finally:
+        store.close()
+        _hybrid_cache.clear()
+
+    assert unknown_results["ids"][0] == default_results["ids"][0]


### PR DESCRIPTION
## Summary

Implements Phase 3 PR-2 from `docs.local/research/2026-05-26-research-lead/FINAL.md`.

- Adds persistent `agent_profiles` table with validated profile JSON.
- Adds `brainlayer agent-profile show|set` CLI.
- Applies per-agent profile weights during post-RRF hybrid search when `agent_id` is present, while missing agent/profile/key paths default to current behavior.
- Adds idempotent `scripts/seed_agent_profiles.py` for `orcClaude`, `coachClaude`, and `skillCreatorClaude` profiles. This script is not auto-run.
- Stabilizes same-process concurrent `VectorStore` initialization with a per-DB init lock after the existing DB-lock test exposed intermittent FTS DDL races.

## Operator Note

Run this once after deploy to seed the hand profiles:

```bash
PYTHONPATH=src python3 scripts/seed_agent_profiles.py
```

## Verification

Verification note:
`/Users/etanheyman/Library/Mobile Documents/iCloud~md~obsidian/Documents/personal/Golems/attachments/brainlayer-phase3-pr-2-verify.md`

Local gates run:

- `pytest -q tests/test_agent_profiles.py tests/test_hybrid_search.py tests/test_search_quality.py tests/test_cli_direct_sqlite.py tests/test_db_lock_resilience.py` -> `65 passed`
- `pytest -q tests/test_db_lock_resilience.py::TestVectorStoreInitRetry::test_concurrent_vectorstore_init` + 50 isolated reruns -> passed
- `ruff check src/ scripts/seed_agent_profiles.py tests/test_agent_profiles.py && ruff format src/ scripts/seed_agent_profiles.py tests/test_agent_profiles.py` -> clean
- `pytest -x -q` -> `2273 passed, 46 skipped, 5 xfailed`
- `coderabbit review --agent` -> `findings: 0` after fixing two findings
- Pre-push gate -> passed:
  - Python 3.12 unit suite: `2203 passed, 9 skipped, 75 deselected, 1 xfailed`
  - MCP registration: `3 passed`
  - isolated eval/hook routing: `36 passed`
  - bun test: `1 pass`
  - `test_fts5_determinism.sh`: passed

Search verification used a temp sqlite backup and showed `--agent orcClaude` shifts `auth implementation` toward lexical/text matches while default search remains semantic-first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ranking behavior changes for callers that pass `agent_id`, and profile mistakes can skew retrieval until updated or cache TTL expires; DB init locking reduces race risk but touches core startup paths.
> 
> **Overview**
> This PR introduces **per-agent search ranking profiles** stored in a new `agent_profiles` table, with validated JSON for `boost_weights` and `source_weights` (missing keys default to neutral 1.0).
> 
> When `hybrid_search` receives an **`agent_id`**, it loads the profile and scales post-RRF boosts: vector/FTS/trigram match weights, importance/recency/recency-intent/decay/KG multipliers, and source/chunk-origin weights. Search paths now carry **`chunk_origin`** in metadata so origin-based weights apply to semantic hits. Profile updates **clear the hybrid search cache** for that DB.
> 
> Operators get **`brainlayer agent-profile show|set`**, bundled **default profiles** for three agents, and an optional **`scripts/seed_agent_profiles.py`** (not auto-run). **`VectorStore`** writer init is serialized per DB path with a thread lock to avoid concurrent schema/FTS races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 372097d0720ae8161ee871251ffede3765faf3c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-agent ranking profiles to hybrid search
> - Introduces agent profiles with `boost_weights` and `source_weights` that scale importance, recency, decay, KG boosts, and chunk-origin contributions during `hybrid_search` when an `agent_id` is provided.
> - Adds an `agent_profiles` table to the DB schema and `get_agent_profile`/`set_agent_profile` methods on `SearchMixin`; setting a profile clears the hybrid search cache.
> - Adds a `brainlayer agent-profile show/set` CLI command group and a [`seed_agent_profiles.py`](https://github.com/EtanHey/brainlayer/pull/343/files#diff-407524b237b9f943a7359d1ea4f10a681f6b4af469591166af9ee4de4752828e) script to populate defaults for `orcClaude`, `coachClaude`, and `skillCreatorClaude`.
> - Enriches all search result metadata with `chunk_origin` for both semantic and FTS paths.
> - Risk: `hybrid_search` now performs a DB read per call when `agent_id` is set, and ranking scores will differ from previous behavior for profiled agents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 372097d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent ranking profiles to customize search result weighting per agent via new CLI commands (`agent-profile set` and `agent-profile show`)
  * Hybrid search now applies configurable feature and source weights from stored agent profiles, enabling personalized ranking behavior
  * Profiles support boost weights for different retrieval features and source-specific weights

* **Tests**
  * Added comprehensive test coverage for agent profile functionality, database persistence, and CLI integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->