### PR TITLE
fix(brainbar): sync dashboard freshness indicators

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -391,6 +391,11 @@ private struct BrainBarDashboardView: View {
                     .font(.system(size: 11, weight: .medium))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
+                if collector.isHeartbeatAheadOfStats {
+                    Text("updating...")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer(minLength: 0)
         }
@@ -1161,6 +1166,7 @@ private struct BrainBarHeroSparkline: View {
                 accentColor: accentColor,
                 compact: SparklineRenderer.isCompact(size: renderSize)
             )
+            .id(pulseRevision)
             .frame(width: proxy.size.width, height: proxy.size.height)
         }
     }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -75,6 +75,8 @@ final class BrainDatabase: @unchecked Sendable {
         let databaseSizeBytes: Int64
         let recentActivityBuckets: [Int]
         let recentEnrichmentBuckets: [Int]
+        let recentWriteFiveMinuteCount: Int
+        let recentEnrichmentFiveMinuteCount: Int
         let activityWindowMinutes: Int
         let bucketCount: Int
         let liveWindowMinutes: Int
@@ -94,6 +96,8 @@ final class BrainDatabase: @unchecked Sendable {
             databaseSizeBytes: Int64,
             recentActivityBuckets: [Int],
             recentEnrichmentBuckets: [Int],
+            recentWriteFiveMinuteCount: Int = 0,
+            recentEnrichmentFiveMinuteCount: Int = 0,
             activityWindowMinutes: Int = 30,
             bucketCount: Int = 12,
             liveWindowMinutes: Int = 1,
@@ -112,6 +116,8 @@ final class BrainDatabase: @unchecked Sendable {
             self.databaseSizeBytes = databaseSizeBytes
             self.recentActivityBuckets = recentActivityBuckets
             self.recentEnrichmentBuckets = recentEnrichmentBuckets
+            self.recentWriteFiveMinuteCount = recentWriteFiveMinuteCount
+            self.recentEnrichmentFiveMinuteCount = recentEnrichmentFiveMinuteCount
             self.activityWindowMinutes = activityWindowMinutes
             self.bucketCount = bucketCount
             self.liveWindowMinutes = liveWindowMinutes
@@ -165,6 +171,8 @@ final class BrainDatabase: @unchecked Sendable {
                 databaseSizeBytes: databaseSizeBytes,
                 recentActivityBuckets: recentActivityBuckets,
                 recentEnrichmentBuckets: recentEnrichmentBuckets,
+                recentWriteFiveMinuteCount: recentWriteFiveMinuteCount,
+                recentEnrichmentFiveMinuteCount: recentEnrichmentFiveMinuteCount,
                 activityWindowMinutes: activityWindowMinutes,
                 bucketCount: bucketCount,
                 liveWindowMinutes: liveWindowMinutes,
@@ -1361,6 +1369,8 @@ final class BrainDatabase: @unchecked Sendable {
                     databaseSizeBytes: databaseSizeBytes(),
                     recentActivityBuckets: [],
                     recentEnrichmentBuckets: [],
+                    recentWriteFiveMinuteCount: 0,
+                    recentEnrichmentFiveMinuteCount: 0,
                     activityWindowMinutes: activityWindowMinutes,
                     bucketCount: bucketCount,
                     liveWindowMinutes: liveWindowMinutes
@@ -1384,6 +1394,8 @@ final class BrainDatabase: @unchecked Sendable {
                 bucketCount: bucketCount,
                 now: now
             )
+            let recentWriteFiveMinuteCount = try recentActivityCount(windowSeconds: 300, now: now)
+            let recentEnrichmentFiveMinuteCount = try recentEnrichmentCount(windowSeconds: 300, now: now)
 
             return DashboardStats(
                 chunkCount: chunkCount,
@@ -1394,6 +1406,8 @@ final class BrainDatabase: @unchecked Sendable {
                 databaseSizeBytes: databaseSizeBytes(),
                 recentActivityBuckets: recentActivityBuckets,
                 recentEnrichmentBuckets: recentEnrichmentBuckets,
+                recentWriteFiveMinuteCount: recentWriteFiveMinuteCount,
+                recentEnrichmentFiveMinuteCount: recentEnrichmentFiveMinuteCount,
                 activityWindowMinutes: activityWindowMinutes,
                 bucketCount: bucketCount,
                 liveWindowMinutes: liveWindowMinutes,
@@ -1493,6 +1507,24 @@ final class BrainDatabase: @unchecked Sendable {
             bucketCount: bucketCount,
             now: now
         )
+    }
+
+    private func recentActivityCount(windowSeconds: TimeInterval, now: Date) throws -> Int {
+        guard windowSeconds > 0 else { return 0 }
+        return try indexedTimestampEpochs(
+            column: "created_at",
+            whereClause: nil,
+            since: now.addingTimeInterval(-windowSeconds)
+        ).count
+    }
+
+    private func recentEnrichmentCount(windowSeconds: TimeInterval, now: Date) throws -> Int {
+        guard windowSeconds > 0 else { return 0 }
+        return try indexedTimestampEpochs(
+            column: "enriched_at",
+            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            since: now.addingTimeInterval(-windowSeconds)
+        ).count
     }
 
     private func recentEnrichmentRatePerMinute(windowMinutes: Int, now: Date) throws -> Double {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -27,6 +27,7 @@ final class StatsCollector: ObservableObject {
     @Published private(set) var state: PipelineState
     @Published private(set) var isRefreshing = false
     @Published private(set) var isManualRefreshInProgress = false
+    @Published private(set) var hasPendingStatsRefresh = false
     @Published private(set) var lastDataFetchedAt: Date?
     @Published private(set) var heartbeat: DashboardHeartbeat
 
@@ -86,6 +87,12 @@ final class StatsCollector: ObservableObject {
         self.heartbeat = .empty
     }
 
+    var isHeartbeatAheadOfStats: Bool {
+        guard hasPendingStatsRefresh, let heartbeatUpdatedAt = heartbeat.updatedAt else { return false }
+        guard let lastDataFetchedAt else { return true }
+        return heartbeatUpdatedAt > lastDataFetchedAt
+    }
+
     func start() {
         guard !isRunning else { return }
         resetRefreshTimingState()
@@ -116,6 +123,7 @@ final class StatsCollector: ObservableObject {
         dashboardRefreshTask = nil
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
+        hasPendingStatsRefresh = false
         isRefreshing = false
         isManualRefreshInProgress = false
         if isRunning {
@@ -134,6 +142,7 @@ final class StatsCollector: ObservableObject {
         NSLog("[BrainBar] manual refresh requested at %@", ISO8601DateFormatter().string(from: Date()))
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
+        hasPendingStatsRefresh = false
         requestRefresh(force: true, trigger: .manual)
     }
 
@@ -160,6 +169,7 @@ final class StatsCollector: ObservableObject {
 
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
+        hasPendingStatsRefresh = false
         dashboardRefreshTask?.cancel()
         dashboardRefreshGeneration += 1
         let generation = dashboardRefreshGeneration
@@ -180,8 +190,8 @@ final class StatsCollector: ObservableObject {
             startUnix: startUnix,
             endUnix: nil,
             rows: startStats.chunkCount,
-            writes5m: startStats.recentActivityBuckets.suffix(1).reduce(0, +),
-            enrich5m: startStats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
+            writes5m: startStats.recentWriteFiveMinuteCount,
+            enrich5m: startStats.recentEnrichmentFiveMinuteCount,
             trigger: trigger
         )
 
@@ -245,6 +255,8 @@ final class StatsCollector: ObservableObject {
                     databaseSizeBytes: 0,
                     recentActivityBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
                     recentEnrichmentBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
+                    recentWriteFiveMinuteCount: 0,
+                    recentEnrichmentFiveMinuteCount: 0,
                     activityWindowMinutes: Self.defaultActivityWindowMinutes,
                     bucketCount: Self.defaultBucketCount
                 )
@@ -253,6 +265,7 @@ final class StatsCollector: ObservableObject {
         }
 
         isRefreshing = false
+        hasPendingStatsRefresh = false
         if trigger == .manual {
             isManualRefreshInProgress = false
         }
@@ -262,8 +275,8 @@ final class StatsCollector: ObservableObject {
             startUnix: startUnix,
             endUnix: Date().timeIntervalSince1970,
             rows: stats.chunkCount,
-            writes5m: stats.recentActivityBuckets.suffix(1).reduce(0, +),
-            enrich5m: stats.recentEnrichmentBuckets.suffix(1).reduce(0, +),
+            writes5m: stats.recentWriteFiveMinuteCount,
+            enrich5m: stats.recentEnrichmentFiveMinuteCount,
             trigger: trigger
         )
     }
@@ -291,6 +304,7 @@ final class StatsCollector: ObservableObject {
     }
 
     private func schedulePendingStatsRefresh(after delay: TimeInterval) {
+        hasPendingStatsRefresh = true
         guard pendingStatsRefreshTask == nil else { return }
 
         pendingStatsRefreshTask = Task { [weak self] in
@@ -305,6 +319,7 @@ final class StatsCollector: ObservableObject {
             await MainActor.run {
                 guard let self, !self.isStopped else { return }
                 self.pendingStatsRefreshTask = nil
+                self.hasPendingStatsRefresh = false
                 self.requestRefresh(force: false, trigger: .auto)
             }
         }
@@ -326,6 +341,7 @@ final class StatsCollector: ObservableObject {
                     guard let self, !self.isStopped else { return }
                     self.pendingStatsRefreshTask?.cancel()
                     self.pendingStatsRefreshTask = nil
+                    self.hasPendingStatsRefresh = false
                     self.requestRefresh(force: false, trigger: .auto)
                 }
             }

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -52,6 +52,53 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
     }
 
+    func testDashboardStatsRecentEnrichmentCountSharesBucketSource() {
+        let stats = DashboardStats(
+            chunkCount: 12,
+            enrichedChunkCount: 8,
+            pendingEnrichmentCount: 4,
+            enrichmentPercent: 66.7,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [1, 0, 2, 0],
+            recentEnrichmentBuckets: [0, 2, 0, 3]
+        )
+
+        XCTAssertEqual(stats.recentEnrichmentCount, stats.recentEnrichmentBuckets.reduce(0, +))
+    }
+
+    func testDashboardStatsTrailingFiveMinuteCountsUseTrueFiveMinuteWindow() throws {
+        let offsets: [(String, TimeInterval)] = [
+            ("dash-enrich-2m", -120),
+            ("dash-enrich-4m", -240),
+            ("dash-enrich-6m", -360),
+            ("dash-enrich-45m", -2_700),
+        ]
+        for (id, offset) in offsets {
+            try db.insertChunk(
+                id: id,
+                content: "Enrichment fixture \(id)",
+                sessionId: "dashboard",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 5
+            )
+            db.exec("""
+                UPDATE chunks
+                SET created_at = datetime('now', '\(Int(offset)) seconds'),
+                    enriched_at = datetime('now', '\(Int(offset)) seconds'),
+                    enrich_status = 'success'
+                WHERE id = '\(id)'
+            """)
+        }
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 60, bucketCount: 12)
+
+        XCTAssertEqual(stats.recentWriteFiveMinuteCount, 2)
+        XCTAssertEqual(stats.recentEnrichmentFiveMinuteCount, 2)
+        XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 4)
+    }
+
     func testDashboardStatsSamplesPendingStoreQueueBeforeReadTransaction() throws {
         let source = try brainBarSourceFile("Sources/BrainBar/BrainDatabase.swift")
         let methodRange = try XCTUnwrap(source.range(of: "func dashboardStats("))
@@ -715,6 +762,67 @@ final class DashboardTests: XCTestCase {
         try await waitForCollector(collector) { $0.lastDataFetchedAt != fetchedAt }
 
         XCTAssertNotEqual(collector.lastDataFetchedAt, fetchedAt)
+    }
+
+    @MainActor
+    func testHeartbeatMarksStatsSnapshotPendingDuringCoalescedRefresh() async throws {
+        let eventSource = RecordingBrainBusEventSource()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 60,
+            autoRefreshInterval: 60,
+            brainBusEvents: eventSource
+        )
+        defer { collector.stop() }
+
+        collector.start()
+        try await waitForCollector(collector) { $0.lastDataFetchedAt != nil }
+        let fetchedAt = try XCTUnwrap(collector.lastDataFetchedAt)
+
+        eventSource.publish(.lastChunkID("pending-stats-refresh"))
+        try await waitForCollector(collector) { $0.heartbeat.lastEvent?.lastChunkID == "pending-stats-refresh" }
+
+        XCTAssertEqual(collector.lastDataFetchedAt, fetchedAt)
+        XCTAssertTrue(collector.hasPendingStatsRefresh)
+        XCTAssertTrue(collector.isHeartbeatAheadOfStats)
+    }
+
+    @MainActor
+    func testManualRefreshRepopulatesRecentEnrichmentBuckets() async throws {
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 60,
+            autoRefreshInterval: 60
+        )
+        defer { collector.stop() }
+
+        collector.refresh(force: true)
+        try await waitForCollector(collector) { !$0.isRefreshing }
+        XCTAssertEqual(collector.stats.recentEnrichmentBuckets.reduce(0, +), 0)
+
+        try db.insertChunk(
+            id: "manual-refresh-enrichment",
+            content: "Manual refresh should repopulate the enrichment sparkline buckets",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        db.exec("""
+            UPDATE chunks
+            SET created_at = datetime('now', '-45 minutes'),
+                enriched_at = datetime('now'),
+                enrich_status = 'success'
+            WHERE id = 'manual-refresh-enrichment'
+        """)
+
+        collector.manualRefresh()
+        try await waitForCollector(collector) { $0.stats.recentEnrichmentBuckets.reduce(0, +) == 1 }
+
+        XCTAssertEqual(collector.stats.recentEnrichmentCount, 1)
+        XCTAssertEqual(collector.stats.recentEnrichmentBuckets.reduce(0, +), 1)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Keep BrainBar heartbeat freshness honest during #340 coalesced refreshes by exposing pending stats refresh state and showing `updating...` when a heartbeat is newer than the fetched `DashboardStats` snapshot.
- Add true trailing-300s write/enrichment counts to `DashboardStats` and use them for `writes_5m`/`enrich_5m` telemetry instead of arbitrary last bucket counts.
- Ensure enrichment sparkline rendering invalidates with its pulse revision and add tests covering shared bucket source, true 5m counts, pending heartbeat freshness, and manual refresh enrichment buckets.

## Verified root cause
- Shared source: within one `DashboardStats`, `recentEnrichmentCount` is `recentEnrichmentBuckets.reduce(0, +)`, so chart/counter cannot diverge inside the same snapshot.
- Defect A: heartbeat freshness could update immediately while chart/counter stayed on the coalesced stats snapshot, creating visible \"fresh heartbeat, stale graph\" contradiction.
- Defect B: `writes5m`/`enrich5m` telemetry used `suffix(1)` of arbitrary-width buckets; at 60m/12 this is 5m by accident, at other windows it is mislabeled.

## Files / lines changed
- `brain-bar/Sources/BrainBar/BrainDatabase.swift`: added true trailing five-minute fields to `DashboardStats` (lines 78-100), populated them in `dashboardStats` (lines 1397-1410), and added timestamp-count helpers (lines 1512-1525).
- `brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift`: added pending stats refresh state / heartbeat-ahead detection (lines 30, 90-94), clears it across refresh lifecycle (lines 141-172, 267-269, 306-345), and logs true 5m counts (lines 273-280).
- `brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift`: shows `updating...` while heartbeat is ahead of stats (lines 389-398) and invalidates sparkline on pulse revision (lines 1159-1170).
- `brain-bar/Tests/BrainBarTests/DashboardTests.swift`: added invariants for shared enrichment buckets, true trailing 5m counts, pending heartbeat freshness, and manual refresh enrichment buckets (lines 55-100, 767-824).

## Test plan
- [x] `swift test --package-path brain-bar` — 514 tests, 0 failures.
- [x] `bash scripts/run_tests.sh` — pytest unit 2210 passed / 9 skipped / 75 deselected / 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 36 passed; Bun 1 pass; regression shell PASS; BrainLayer test gate passed.
- [x] CodeRabbit CLI pre-commit review — 6 unrelated findings outside this PR's dashboard files; no scoped changes required.

## Merge note
LEAD owns Computer-Use video gate before merge. Do not auto-merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard UI and read-side stats aggregation only; no auth, writes, or schema changes beyond computed fields on existing queries.
> 
> **Overview**
> Aligns BrainBar dashboard freshness with coalesced stats refreshes and fixes mislabeled 5-minute telemetry.
> 
> **StatsCollector** exposes `hasPendingStatsRefresh` and `isHeartbeatAheadOfStats` so the UI can tell when a newer heartbeat arrived before the next `DashboardStats` snapshot. The freshness line shows **updating...** in that gap instead of implying charts are current.
> 
> **DashboardStats** adds `recentWriteFiveMinuteCount` and `recentEnrichmentFiveMinuteCount` from true 300s DB counts; refresh logging uses these instead of the last activity bucket (which only matched 5m by accident for some window/bucket settings).
> 
> **Sparklines** get `.id(pulseRevision)` so enrichment/write charts redraw when pulse state changes. Tests cover shared bucket totals, true 5m counts, pending heartbeat during coalesce, and manual refresh repopulating enrichment buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126e5f9f64792e1acdc73c287af0272a219e1258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync dashboard freshness indicators with heartbeat state in BrainBar
> - Adds `isHeartbeatAheadOfStats` computed property to `StatsCollector` and a `hasPendingStatsRefresh` flag to signal when a coalesced stats refresh is queued but not yet complete.
> - Shows an `updating...` label in the diagnostics footer when a heartbeat arrives ahead of the latest stats snapshot.
> - Adds `recentWriteFiveMinuteCount` and `recentEnrichmentFiveMinuteCount` to `DashboardStats`, computed from true 5-minute time windows via new `recentActivityCount` and `recentEnrichmentCount` helpers in `BrainDatabase`.
> - Applies `.id(pulseRevision)` to the sparkline chart to force re-render when the pulse revision changes.
> - Adds unit and async UI tests covering five-minute window accuracy, pending refresh signaling, and manual refresh repopulation of enrichment buckets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 126e5f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->