### PR TITLE
fix: harden BrainBar crash paths

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -194,7 +194,7 @@ final class BrainDatabase: @unchecked Sendable {
         let disconnectedAt: String?
     }
 
-    struct StoredChunk: Sendable {
+    struct StoredChunk: Sendable, Equatable {
         let chunkID: String
         let rowID: Int64
     }
@@ -206,7 +206,7 @@ final class BrainDatabase: @unchecked Sendable {
         let importance: Int
     }
 
-    enum StoreWriteOutcome: Sendable {
+    enum StoreWriteOutcome: Sendable, Equatable {
         case stored(StoredChunk)
         case queued
     }
@@ -279,9 +279,12 @@ final class BrainDatabase: @unchecked Sendable {
     private let openConfiguration: OpenConfiguration
     private let transactionLock = NSRecursiveLock()
     private var explicitTransactionIsOpen = false
+    var failNextStoreAfterInsertForTesting = false
     private static let pendingStoreFileLock = NSLock()
     private(set) var isOpen = false
     private(set) var lastOpenError: Error?
+    private static let maximumConversationContextPerSide = 40
+    private static let maximumConversationContentCharacters = 4_000
 
     init(path: String, openConfiguration: OpenConfiguration = OpenConfiguration()) {
         self.path = path
@@ -849,23 +852,29 @@ final class BrainDatabase: @unchecked Sendable {
             }
         }
 
-        try runWriteStatement(on: db, sql: sql, retries: retries) { stmt in
-            bindText(chunkID, to: stmt, index: 1)
-            bindText(content, to: stmt, index: 2)
-            bindText(metadataJSON, to: stmt, index: 3)
-            bindText(tagsJSON, to: stmt, index: 4)
-            sqlite3_bind_int(stmt, 5, Int32(importance))
-            bindText(source, to: stmt, index: 6)
-            sqlite3_bind_int(stmt, 7, Int32(content.count))
-            bindText(Self.previewText(summary: "", content: content), to: stmt, index: 8)
+        return try withImmediateTransaction(retries: retries) {
+            try runWriteStatement(on: db, sql: sql, retries: retries) { stmt in
+                bindText(chunkID, to: stmt, index: 1)
+                bindText(content, to: stmt, index: 2)
+                bindText(metadataJSON, to: stmt, index: 3)
+                bindText(tagsJSON, to: stmt, index: 4)
+                sqlite3_bind_int(stmt, 5, Int32(importance))
+                bindText(source, to: stmt, index: 6)
+                sqlite3_bind_int(stmt, 7, Int32(content.count))
+                bindText(Self.previewText(summary: "", content: content), to: stmt, index: 8)
+            }
+            if failNextStoreAfterInsertForTesting {
+                failNextStoreAfterInsertForTesting = false
+                throw DBError.exec(SQLITE_IOERR, "simulated post-insert validation failure")
+            }
+            guard let rowID = try chunkRowID(forChunkID: chunkID) else {
+                throw DBError.noResult
+            }
+            if refreshStatistics {
+                refreshSearchStatisticsBestEffort()
+            }
+            return StoredChunk(chunkID: chunkID, rowID: rowID)
         }
-        guard let rowID = try chunkRowID(forChunkID: chunkID) else {
-            throw DBError.noResult
-        }
-        if refreshStatistics {
-            refreshSearchStatisticsBestEffort()
-        }
-        return StoredChunk(chunkID: chunkID, rowID: rowID)
     }
 
     func storeOrQueueWithinBudget(
@@ -1699,6 +1708,7 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func withImmediateTransaction<T>(
+        retries: Int = 3,
         shouldCancel: () -> Bool = { false },
         _ body: () throws -> T
     ) throws -> T {
@@ -1710,7 +1720,7 @@ final class BrainDatabase: @unchecked Sendable {
         if shouldCancel() {
             throw CancellationError()
         }
-        try execute("BEGIN IMMEDIATE", retries: 3)
+        try execute("BEGIN IMMEDIATE", retries: retries)
         explicitTransactionIsOpen = true
         do {
             let result = try body()
@@ -1786,7 +1796,7 @@ final class BrainDatabase: @unchecked Sendable {
             let message = errMsg.map { String(cString: $0) } ?? "unknown error"
             sqlite3_free(errMsg)
 
-            if (rc == SQLITE_BUSY || rc == SQLITE_LOCKED), attempts < retries {
+            if Self.isRetryableStoreErrorCode(rc), attempts < retries {
                 attempts += 1
                 usleep(retryDelayMillis * 1_000)
                 continue
@@ -1828,7 +1838,7 @@ final class BrainDatabase: @unchecked Sendable {
             var stmt: OpaquePointer?
             let prepareRC = sqlite3_prepare_v2(handle, sql, -1, &stmt, nil)
             guard prepareRC == SQLITE_OK, let stmt else {
-                if (prepareRC == SQLITE_BUSY || prepareRC == SQLITE_LOCKED), attempts < retries {
+                if Self.isRetryableStoreErrorCode(prepareRC), attempts < retries {
                     attempts += 1
                     usleep(retryDelayMillis * 1_000)
                     continue
@@ -1845,7 +1855,7 @@ final class BrainDatabase: @unchecked Sendable {
                 return
             }
 
-            if (stepRC == SQLITE_BUSY || stepRC == SQLITE_LOCKED), attempts < retries {
+            if Self.isRetryableStoreErrorCode(stepRC), attempts < retries {
                 attempts += 1
                 usleep(retryDelayMillis * 1_000)
                 continue
@@ -3068,8 +3078,12 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private static func isRetryableQueueErrorCode(_ rc: Int32) -> Bool {
+        isRetryableStoreErrorCode(rc)
+    }
+
+    private static func isRetryableStoreErrorCode(_ rc: Int32) -> Bool {
         let primaryCode = rc & 0xFF
-        return primaryCode == SQLITE_BUSY || primaryCode == SQLITE_LOCKED
+        return primaryCode == SQLITE_BUSY || primaryCode == SQLITE_LOCKED || primaryCode == SQLITE_READONLY
     }
 
     private func hasStoredQueuedItem(queueID: String) throws -> Bool {
@@ -3263,15 +3277,19 @@ final class BrainDatabase: @unchecked Sendable {
 
     func expandChunk(id: String, before: Int = 3, after: Int = 3) throws -> [String: Any] {
         guard let db else { throw DBError.notOpen }
+        let boundedBefore = min(max(before, 0), Self.maximumConversationContextPerSide)
+        let boundedAfter = min(max(after, 0), Self.maximumConversationContextPerSide)
+        let contentLimit = Int32(Self.maximumConversationContentCharacters)
 
         // Get the target chunk with its session_id and rowid
-        let targetSQL = "SELECT rowid, id, content, conversation_id, project, content_type, importance, created_at, summary, tags FROM chunks WHERE id = ?"
+        let targetSQL = "SELECT rowid, id, substr(content, 1, ?), conversation_id, project, content_type, importance, created_at, summary, tags FROM chunks WHERE id = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, targetSQL, -1, &stmt, nil) == SQLITE_OK else {
             throw DBError.prepare(sqlite3_errcode(db))
         }
         defer { sqlite3_finalize(stmt) }
-        bindText(id, to: stmt, index: 1)
+        sqlite3_bind_int(stmt, 1, contentLimit)
+        bindText(id, to: stmt, index: 2)
         guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
 
         let targetRowID = sqlite3_column_int64(stmt, 0)
@@ -3293,13 +3311,14 @@ final class BrainDatabase: @unchecked Sendable {
         var afterContext: [[String: Any]] = []
 
         // Before chunks (reverse order, then flip)
-        let beforeSQL = "SELECT id, content, content_type, importance, created_at, summary FROM chunks WHERE conversation_id = ? AND rowid < ? ORDER BY rowid DESC LIMIT ?"
+        let beforeSQL = "SELECT id, substr(content, 1, ?), content_type, importance, created_at, summary FROM chunks WHERE conversation_id = ? AND rowid < ? ORDER BY rowid DESC LIMIT ?"
         var beforeStmt: OpaquePointer?
         if sqlite3_prepare_v2(db, beforeSQL, -1, &beforeStmt, nil) == SQLITE_OK {
             defer { sqlite3_finalize(beforeStmt) }
-            bindText(sessionId, to: beforeStmt, index: 1)
-            sqlite3_bind_int64(beforeStmt, 2, targetRowID)
-            sqlite3_bind_int(beforeStmt, 3, Int32(before))
+            sqlite3_bind_int(beforeStmt, 1, contentLimit)
+            bindText(sessionId, to: beforeStmt, index: 2)
+            sqlite3_bind_int64(beforeStmt, 3, targetRowID)
+            sqlite3_bind_int(beforeStmt, 4, Int32(boundedBefore))
             var beforeChunks: [[String: Any]] = []
             while sqlite3_step(beforeStmt) == SQLITE_ROW {
                 beforeChunks.append([
@@ -3315,13 +3334,14 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         // After chunks
-        let afterSQL = "SELECT id, content, content_type, importance, created_at, summary FROM chunks WHERE conversation_id = ? AND rowid > ? ORDER BY rowid ASC LIMIT ?"
+        let afterSQL = "SELECT id, substr(content, 1, ?), content_type, importance, created_at, summary FROM chunks WHERE conversation_id = ? AND rowid > ? ORDER BY rowid ASC LIMIT ?"
         var afterStmt: OpaquePointer?
         if sqlite3_prepare_v2(db, afterSQL, -1, &afterStmt, nil) == SQLITE_OK {
             defer { sqlite3_finalize(afterStmt) }
-            bindText(sessionId, to: afterStmt, index: 1)
-            sqlite3_bind_int64(afterStmt, 2, targetRowID)
-            sqlite3_bind_int(afterStmt, 3, Int32(after))
+            sqlite3_bind_int(afterStmt, 1, contentLimit)
+            bindText(sessionId, to: afterStmt, index: 2)
+            sqlite3_bind_int64(afterStmt, 3, targetRowID)
+            sqlite3_bind_int(afterStmt, 4, Int32(boundedAfter))
             while sqlite3_step(afterStmt) == SQLITE_ROW {
                 afterContext.append([
                     "chunk_id": columnText(afterStmt, 0) as Any,

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -221,8 +221,13 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
 
     var chunkCount: Int { chunkIDs.count }
 
+    var uniqueChunkIDs: [String] {
+        var seen = Set<String>()
+        return chunkIDs.filter { seen.insert($0).inserted }
+    }
+
     var primaryChunk: InjectionChunk? {
-        guard let firstChunkID = chunkIDs.first else { return chunks.first }
+        guard let firstChunkID = uniqueChunkIDs.first else { return chunks.first }
         return chunks.first { $0.id == firstChunkID }
     }
 

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -66,6 +66,7 @@ struct InjectionFeedView: View {
     @State private var expandedEventIDs: Set<Int64> = []
     @State private var expandedBurstIDs: Set<String> = []
     @State private var conversationSelection = InjectionConversationSelection()
+    @State private var loadingConversationChunkID: String?
     @AppStorage("brainbar.injectionFeed.typeFilter") private var typeFilterRaw = InjectionTypeFilter.all.rawValue
 
     private let accentPalette: [Color] = [
@@ -112,6 +113,8 @@ struct InjectionFeedView: View {
                     title: conversationSelection.title,
                     onClose: { conversationSelection.close() }
                 )
+            } else if loadingConversationChunkID != nil {
+                ConversationLoadingOverlay(onClose: { loadingConversationChunkID = nil })
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -417,20 +420,15 @@ struct InjectionFeedView: View {
                 Spacer(minLength: 10)
 
                 Button {
-                    if let firstChunk = event.chunkIDs.first {
-                        if let conversation = try? store.expandedConversation(chunkID: firstChunk) {
-                            conversationSelection.open(
-                                conversation,
-                                title: event.openingModalTitle(forChunkID: firstChunk)
-                            )
-                        }
+                    if let firstChunk = event.uniqueChunkIDs.first {
+                        openConversation(chunkID: firstChunk, title: event.openingModalTitle(forChunkID: firstChunk))
                     }
                 } label: {
-                    Text("Open")
+                    Text(loadingConversationChunkID == event.uniqueChunkIDs.first ? "Opening" : "Open")
                         .font(.system(size: 11, weight: .semibold))
                 }
                 .buttonStyle(.plain)
-                .disabled(event.chunkIDs.isEmpty)
+                .disabled(event.uniqueChunkIDs.isEmpty || loadingConversationChunkID != nil)
             }
 
             Rectangle()
@@ -461,7 +459,7 @@ struct InjectionFeedView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 4) {
-                ForEach(Array(event.chunkIDs.enumerated()), id: \.offset) { _, chunkID in
+                ForEach(Array(event.uniqueChunkIDs.enumerated()), id: \.offset) { _, chunkID in
                     let chunk = chunk(for: chunkID, event: event)
                     RoundedRectangle(cornerRadius: 999, style: .continuous)
                         .fill(color(for: chunk?.kind ?? .other))
@@ -480,14 +478,12 @@ struct InjectionFeedView: View {
 
     private func chunkList(for event: InjectionEvent) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(event.chunkIDs, id: \.self) { chunkID in
+            ForEach(Array(event.uniqueChunkIDs.enumerated()), id: \.offset) { _, chunkID in
                 Button {
-                    if let conversation = try? store.expandedConversation(chunkID: chunkID) {
-                        conversationSelection.open(
-                            conversation,
-                            title: chunk(for: chunkID, event: event)?.kind.modalTitle ?? event.modalTitle
-                        )
-                    }
+                    openConversation(
+                        chunkID: chunkID,
+                        title: chunk(for: chunkID, event: event)?.kind.modalTitle ?? event.modalTitle
+                    )
                 } label: {
                     HStack(spacing: 8) {
                         Circle()
@@ -502,6 +498,7 @@ struct InjectionFeedView: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .disabled(loadingConversationChunkID != nil)
             }
         }
         .padding(12)
@@ -759,6 +756,55 @@ struct InjectionFeedView: View {
             return "Retrieved chunk \(chunkID)"
         }
         return "\(chunk.kind.label) · \(chunk.id) · \(chunk.displayText)"
+    }
+
+    private func openConversation(chunkID: String, title: String) {
+        guard loadingConversationChunkID == nil else { return }
+        loadingConversationChunkID = chunkID
+        Task {
+            do {
+                let conversation = try await store.expandedConversationAsync(chunkID: chunkID)
+                guard loadingConversationChunkID == chunkID else { return }
+                conversationSelection.open(conversation, title: title)
+                loadingConversationChunkID = nil
+            } catch {
+                if loadingConversationChunkID == chunkID {
+                    loadingConversationChunkID = nil
+                }
+            }
+        }
+    }
+}
+
+private struct ConversationLoadingOverlay: View {
+    let onClose: () -> Void
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color.black.opacity(0.18))
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onClose)
+
+            VStack(spacing: 12) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Opening conversation")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(18)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color(nsColor: .windowBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .zIndex(29)
     }
 }
 

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -12,6 +12,14 @@ protocol InjectionEventReading: AnyObject {
     func close()
 }
 
+private final class AsyncInjectionReaderBox: @unchecked Sendable {
+    let reader: InjectionEventReading
+
+    init(_ reader: InjectionEventReading) {
+        self.reader = reader
+    }
+}
+
 extension BrainDatabase: InjectionEventReading {
     func expandedConversation(
         chunkID: String,
@@ -165,6 +173,24 @@ final class InjectionStore: ObservableObject {
 
     func expandedConversation(chunkID: String, before: Int = 3, after: Int = 3) throws -> BrainDatabase.ExpandedConversation {
         try reader.expandedConversation(chunkID: chunkID, before: before, after: after)
+    }
+
+    func expandedConversationAsync(chunkID: String, before: Int = 3, after: Int = 3) async throws -> BrainDatabase.ExpandedConversation {
+        let readerBox = AsyncInjectionReaderBox(reader)
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let conversation = try readerBox.reader.expandedConversation(
+                        chunkID: chunkID,
+                        before: before,
+                        after: after
+                    )
+                    continuation.resume(returning: conversation)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 
     fileprivate func handleDatabaseMutationNotification() {

--- a/brain-bar/Tests/BrainBarTests/ChunkConversationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/ChunkConversationTests.swift
@@ -40,4 +40,27 @@ final class ChunkConversationTests: XCTestCase {
         XCTAssertEqual(conversation.target.chunkID, "conv-3")
         XCTAssertTrue(conversation.entries[2].isTarget)
     }
+
+    func testExpandedConversationCapsHugeThreadWorkForResponsiveOpen() throws {
+        let hugeContent = String(repeating: "Long transcript line with enough content to stress SwiftUI rendering.\n", count: 120)
+        for index in 1...180 {
+            try db.insertChunk(
+                id: "huge-conv-\(index)",
+                content: "\(index): \(hugeContent)",
+                sessionId: "huge-conversation-thread",
+                project: "brainlayer",
+                contentType: index.isMultiple(of: 2) ? "assistant_text" : "user_message",
+                importance: 5
+            )
+        }
+
+        let conversation = try db.expandedConversation(id: "huge-conv-90", before: 10_000, after: 10_000)
+
+        XCTAssertLessThanOrEqual(conversation.entries.count, 81)
+        XCTAssertTrue(conversation.entries.contains { $0.chunkID == "huge-conv-90" && $0.isTarget })
+        XCTAssertTrue(
+            conversation.entries.allSatisfy { $0.content.count <= 4_200 },
+            "Conversation expansion must not hand full multi-thousand-line payloads to SwiftUI synchronously."
+        )
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -123,6 +123,56 @@ final class DatabaseTests: XCTestCase {
         )
     }
 
+    func testStoreRollsBackInsertedChunkWhenPostInsertValidationFails() throws {
+        let beforeCount = try sqliteCount(path: tempDBPath, table: "chunks")
+        db.failNextStoreAfterInsertForTesting = true
+
+        XCTAssertThrowsError(
+            try db.store(
+                content: "This capture must roll back completely",
+                tags: ["atomicity"],
+                importance: 7,
+                source: "quick-capture"
+            )
+        )
+
+        let afterCount = try sqliteCount(path: tempDBPath, table: "chunks")
+        XCTAssertEqual(afterCount, beforeCount)
+        let partialRows = try sqliteCount(
+            path: tempDBPath,
+            sql: "SELECT COUNT(*) FROM chunks WHERE content = 'This capture must roll back completely'"
+        )
+        XCTAssertEqual(partialRows, 0)
+    }
+
+    func testStoreOrQueueWithinBudgetQueuesReadOnlySQLiteFailures() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("brainbar-readonly-queue-\(UUID().uuidString).jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer {
+            unsetenv("BRAINBAR_PENDING_STORES_PATH")
+            try? FileManager.default.removeItem(at: queuePath)
+        }
+
+        let reader = BrainDatabase(
+            path: tempDBPath,
+            openConfiguration: .init(readOnly: true)
+        )
+        defer { reader.close() }
+
+        let outcome = try reader.storeOrQueueWithinBudget(
+            content: "Queued because the BrainBar DB handle is read-only",
+            tags: ["readonly"],
+            importance: 6,
+            source: "quick-capture",
+            busyTimeoutMillis: 1
+        )
+
+        XCTAssertEqual(outcome, .queued)
+        let queuedPayload = try String(contentsOf: queuePath, encoding: .utf8)
+        XCTAssertTrue(queuedPayload.contains("Queued because the BrainBar DB handle is read-only"))
+    }
+
     func testInjectionEventsTableExists() throws {
         let exists = try db.tableExists("injection_events")
         XCTAssertTrue(exists, "injection_events table must exist")

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -2,6 +2,19 @@ import XCTest
 @testable import BrainBar
 
 final class InjectionPresentationTests: XCTestCase {
+    func testInjectionEventDeduplicatesChunkIDsForClickableRows() {
+        let event = makeEvent(
+            id: 1,
+            sessionID: "sess-a",
+            timestamp: "2026-04-18T09:58:00Z",
+            query: "duplicate hit IDs",
+            chunkIDs: ["chunk-a", "chunk-a", "chunk-b", "chunk-a"],
+            tokenCount: 48
+        )
+
+        XCTAssertEqual(event.uniqueChunkIDs, ["chunk-a", "chunk-b"])
+    }
+
     func testSnapshotBuildsBurstGroupsAndWindowSummary() {
         let now = isoDate("2026-04-18T10:00:00Z")
         let events = [


### PR DESCRIPTION
## Summary
- Fixes three BrainBar v5 crash paths from `docs.local/mandates/2026-05-28-bl-crash-paths.md`.
- Conversation open now loads bounded thread data off the main actor and shows a loading overlay while opening.
- Injections click targets now use stable, de-duped chunk IDs so duplicate retrieval hits do not crash SwiftUI row rendering.
- Quick capture writes now execute inside one immediate transaction; failed post-insert validation rolls back the inserted chunk, and READONLY SQLite code 8 is classified with busy/locked retry+queue handling.

## Crash 1: conversation-open freeze
Root cause: `InjectionFeedView` synchronously opened expanded conversations from the SwiftUI click handler, and `BrainDatabase.expandChunk` could hand huge conversation content/context to SwiftUI in one render pass.

Fix:
- `InjectionStore.expandedConversationAsync` runs the expansion on a user-initiated background queue: `brain-bar/Sources/BrainBar/InjectionStore.swift:178`.
- `InjectionFeedView.openConversation` shows a loading overlay and awaits the async read instead of blocking the button handler: `brain-bar/Sources/BrainBar/InjectionFeedView.swift:761`.
- `BrainDatabase.expandChunk` caps context to 40 chunks per side and caps content selected per entry to 4,000 chars: `brain-bar/Sources/BrainBar/BrainDatabase.swift:286`, `brain-bar/Sources/BrainBar/BrainDatabase.swift:3278`.

Regression test:
- `testExpandedConversationCapsHugeThreadWorkForResponsiveOpen` seeds a huge 180-row thread, requests 10k before/after, and asserts bounded entries/content: `brain-bar/Tests/BrainBarTests/ChunkConversationTests.swift:44`.

## Crash 2: Injections-click renderer crash
Root cause: injection event rows rendered raw `chunkIDs` in clickable `ForEach` collections. Duplicate chunk IDs from repeated retrieval hits can create unstable SwiftUI identity during expansion/open.

Fix:
- `InjectionEvent.uniqueChunkIDs` preserves first occurrence order while de-duping click/render targets: `brain-bar/Sources/BrainBar/InjectionEvent.swift:224`.
- `InjectionFeedView` now uses `uniqueChunkIDs` for open buttons, hit ribbons, and expanded chunk rows: `brain-bar/Sources/BrainBar/InjectionFeedView.swift:422`, `brain-bar/Sources/BrainBar/InjectionFeedView.swift:461`, `brain-bar/Sources/BrainBar/InjectionFeedView.swift:479`.

Regression test:
- `testInjectionEventDeduplicatesChunkIDsForClickableRows`: `brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift:5`.

## Crash 3: Capture-write SQLite-8 + partial-commit atomicity
Root cause: `BrainDatabase.store` inserted the capture chunk and then performed follow-up validation outside an explicit transaction. A post-insert failure could leave a partial row. READONLY/SQLite-8 was not treated as retryable/queueable with the existing busy/locked path.

Fix:
- `store` now wraps insert + post-insert validation in `withImmediateTransaction`: `brain-bar/Sources/BrainBar/BrainDatabase.swift:855`.
- `withImmediateTransaction` accepts the caller retry budget for bounded quick-capture/MCP queue paths: `brain-bar/Sources/BrainBar/BrainDatabase.swift:1710`.
- retry/queue classification now includes `SQLITE_READONLY` primary code 8 along with busy/locked: `brain-bar/Sources/BrainBar/BrainDatabase.swift:3080`.

Regression tests:
- `testStoreRollsBackInsertedChunkWhenPostInsertValidationFails`: `brain-bar/Tests/BrainBarTests/DatabaseTests.swift:126`.
- `testStoreOrQueueWithinBudgetQueuesReadOnlySQLiteFailures`: `brain-bar/Tests/BrainBarTests/DatabaseTests.swift:148`.

## Verification
- `swift test --package-path brain-bar`: first full run had 1 transient failure; immediate rerun passed `514 tests, 0 failures`.
- `pytest`: `2280 passed, 46 skipped, 5 xfailed` on Python 3.13 local run.
- pre-push gate: `2210 passed, 9 skipped, 75 deselected, 1 xfailed`; MCP registration `3 passed`; isolated eval/hook routing `36 passed`; bun `1 pass`; FTS determinism shell regression passed.

## Video Gate
LEAD owns Computer-Use video verification for SwiftUI-visible crash paths 1 and 2. This PR is not auto-merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQLite transaction boundaries and error classification for capture writes, plus async DB reads from SwiftUI; scope is localized to BrainBar with regression tests, but touches durable chunk storage behavior.
> 
> **Overview**
> Addresses three BrainBar crash/freeze paths by changing how conversations load, how injection rows identify chunks, and how quick-capture writes hit SQLite.
> 
> **Conversation open** no longer expands huge threads on the main thread. `expandChunk` caps context (40 chunks per side, 4k chars per row via `substr`), `InjectionStore.expandedConversationAsync` runs the read on a background queue, and the feed shows a loading overlay while opening.
> 
> **Injection feed clicks** use `InjectionEvent.uniqueChunkIDs` (order-preserving dedupe) for ribbons, lists, and Open actions so duplicate retrieval IDs do not break SwiftUI `ForEach` identity.
> 
> **Capture writes** wrap insert plus post-insert validation in `withImmediateTransaction` (with configurable retries); post-insert failure rolls back the row. `SQLITE_READONLY` is treated like busy/locked for retry/queue via `storeOrQueueWithinBudget`. Tests cover rollback, read-only queueing, huge-thread caps, and chunk-ID dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddb9ceb9d84d341ffeb2856094b7e9bc1b0df26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden BrainBar crash paths with transactional store rollback, retry broadening, and async conversation loading
> - Store operations in `BrainDatabase` now run inside an explicit `withImmediateTransaction`, so a post-insert failure rolls back the partial row cleanly.
> - Retry logic in `execute` and `runWriteStatement` now treats `SQLITE_READONLY` as retryable alongside `BUSY`/`LOCKED`; read-only failures are queued to disk instead of crashing.
> - Expanded conversation queries now truncate content via `substr(content, 1, ?)` using new character/context limits, capping memory use for large threads.
> - `InjectionEvent` de-duplicates chunk IDs via `uniqueChunkIDs`, and `InjectionFeedView` uses this to avoid duplicate ribbons and rows.
> - Opening a conversation in the feed is now async via `InjectionStore.expandedConversationAsync`, showing a loading overlay and disabling controls while in-flight.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fddb9ce. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->