### PR TITLE
feat(brainbar): add tiered graph altitude option

### DIFF
--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -112,8 +112,9 @@ final class StatusPopoverView: NSViewController {
     // MARK: - Tab Switching
 
     func showTab(_ tab: PopoverTab) {
-        containerView.subviews.forEach { $0.removeFromSuperview() }
         currentTab = tab
+        updateGraphActivation()
+        containerView.subviews.forEach { $0.removeFromSuperview() }
 
         let content: NSView
         switch tab {
@@ -134,6 +135,7 @@ final class StatusPopoverView: NSViewController {
             content.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
         ])
 
+        updateGraphActivation()
         preferredContentSize = tab.contentSize
         onPreferredSizeChange?(tab.contentSize)
     }
@@ -314,10 +316,20 @@ final class StatusPopoverView: NSViewController {
         }
 
         let viewModel = KGViewModel(database: db)
-        let hosting = NSHostingController(rootView: PopoverGraphTab(viewModel: viewModel))
+        let hosting = NSHostingController(
+            rootView: PopoverGraphTab(viewModel: viewModel, isActive: currentTab == .graph)
+        )
         graphHosting = hosting
         addChild(hosting)
         return hosting.view
+    }
+
+    private func updateGraphActivation() {
+        guard let hosting = graphHosting else { return }
+        hosting.rootView = PopoverGraphTab(
+            viewModel: hosting.rootView.viewModel,
+            isActive: currentTab == .graph
+        )
     }
 
     // MARK: - Data Binding
@@ -446,9 +458,10 @@ struct PopoverInjectionTab: View {
 
 struct PopoverGraphTab: View {
     @ObservedObject var viewModel: KGViewModel
+    let isActive: Bool
 
     var body: some View {
-        KGCanvasView(viewModel: viewModel, isActive: true)
+        KGCanvasView(viewModel: viewModel, isActive: isActive)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .clipped()
     }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasLayout.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasLayout.swift
@@ -2,7 +2,22 @@ import CoreGraphics
 import Foundation
 
 enum KGAtlasLayout {
-    static func seededNodes(_ nodes: [KGNode], canvasSize: CGSize) -> [KGNode] {
+    static func seededNodes(
+        _ nodes: [KGNode],
+        canvasSize: CGSize,
+        mode: KGAtlasMode = .importance
+    ) -> [KGNode] {
+        let width = max(canvasSize.width, 640)
+        let height = max(canvasSize.height, 480)
+        switch mode {
+        case .importance:
+            return seededImportanceNodes(nodes, canvasSize: CGSize(width: width, height: height))
+        case .tieredAltitude:
+            return seededTieredAltitudeNodes(nodes, canvasSize: CGSize(width: width, height: height))
+        }
+    }
+
+    private static func seededImportanceNodes(_ nodes: [KGNode], canvasSize: CGSize) -> [KGNode] {
         let width = max(canvasSize.width, 640)
         let height = max(canvasSize.height, 480)
         let regionCenters = makeRegionCenters(canvasSize: CGSize(width: width, height: height))
@@ -31,19 +46,65 @@ enum KGAtlasLayout {
         return seeded
     }
 
+    private static func seededTieredAltitudeNodes(_ nodes: [KGNode], canvasSize: CGSize) -> [KGNode] {
+        let width = max(canvasSize.width, 640)
+        let height = max(canvasSize.height, 480)
+        let tierRows = tierRowCenters(canvasSize: CGSize(width: width, height: height))
+        let grouped = Dictionary(grouping: nodes.enumerated()) { indexedNode in
+            KGAltitudeTier.tier(for: indexedNode.element)
+        }
+
+        var seeded = nodes
+        for tier in KGAltitudeTier.allCases {
+            guard let indexedNodes = grouped[tier], !indexedNodes.isEmpty else { continue }
+            let sorted = indexedNodes.sorted {
+                if $0.element.importance == $1.element.importance {
+                    return $0.element.name.localizedCaseInsensitiveCompare($1.element.name) == .orderedAscending
+                }
+                return $0.element.importance > $1.element.importance
+            }
+
+            for (offset, indexed) in sorted.enumerated() {
+                seeded[indexed.offset].position = tieredPosition(
+                    for: offset,
+                    total: sorted.count,
+                    rowY: tierRows[tier] ?? height * 0.5,
+                    canvasSize: CGSize(width: width, height: height),
+                    tier: tier
+                )
+                seeded[indexed.offset].velocity = .zero
+            }
+        }
+
+        return seeded
+    }
+
     private static func makeRegionCenters(canvasSize: CGSize) -> [String: CGPoint] {
+        let width = max(canvasSize.width, 640)
+        let height = max(canvasSize.height, 480)
         let columns: [CGFloat] = [0.26, 0.5, 0.78]
         let rows: [CGFloat] = [0.30, 0.56, 0.76]
 
         return [
-            "person": CGPoint(x: canvasSize.width * columns[0], y: canvasSize.height * rows[1]),
-            "project": CGPoint(x: canvasSize.width * columns[1], y: canvasSize.height * rows[0]),
-            "tool": CGPoint(x: canvasSize.width * columns[2], y: canvasSize.height * rows[0]),
-            "technology": CGPoint(x: canvasSize.width * columns[0], y: canvasSize.height * rows[2]),
-            "agent": CGPoint(x: canvasSize.width * columns[1], y: canvasSize.height * rows[1]),
-            "company": CGPoint(x: canvasSize.width * columns[2], y: canvasSize.height * rows[1]),
-            "topic": CGPoint(x: canvasSize.width * columns[1], y: canvasSize.height * rows[2]),
-            "decision": CGPoint(x: canvasSize.width * columns[2], y: canvasSize.height * rows[2]),
+            "person": CGPoint(x: width * columns[0], y: height * rows[1]),
+            "project": CGPoint(x: width * columns[1], y: height * rows[0]),
+            "tool": CGPoint(x: width * columns[2], y: height * rows[0]),
+            "technology": CGPoint(x: width * columns[0], y: height * rows[2]),
+            "agent": CGPoint(x: width * columns[1], y: height * rows[1]),
+            "company": CGPoint(x: width * columns[2], y: height * rows[1]),
+            "topic": CGPoint(x: width * columns[1], y: height * rows[2]),
+            "decision": CGPoint(x: width * columns[2], y: height * rows[2]),
+        ]
+    }
+
+    private static func tierRowCenters(canvasSize: CGSize) -> [KGAltitudeTier: CGFloat] {
+        let height = max(canvasSize.height, 480)
+        return [
+            .summit: height * 0.26,
+            .orbit: height * 0.40,
+            .signal: height * 0.55,
+            .field: height * 0.70,
+            .ground: height * 0.84,
         ]
     }
 
@@ -64,5 +125,24 @@ enum KGAtlasLayout {
             x: center.x + cos(angle) * radius,
             y: center.y + sin(angle) * radius * 0.72
         )
+    }
+
+    private static func tieredPosition(
+        for offset: Int,
+        total: Int,
+        rowY: CGFloat,
+        canvasSize: CGSize,
+        tier: KGAltitudeTier
+    ) -> CGPoint {
+        guard total > 1 else {
+            return CGPoint(x: canvasSize.width * (tier == .summit ? 0.42 : 0.5), y: rowY)
+        }
+
+        let usableWidth = max(canvasSize.width - 180, 360)
+        let step = usableWidth / CGFloat(max(total - 1, 1))
+        let x = 90 + CGFloat(offset) * step
+        let stagger = (offset % 2 == 0 ? -1.0 : 1.0) * min(18, canvasSize.height * 0.025)
+
+        return CGPoint(x: x, y: rowY + stagger)
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasMode.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasMode.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+enum KGAtlasMode: String, CaseIterable, Identifiable {
+    case importance
+    case tieredAltitude
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .importance: "Importance"
+        case .tieredAltitude: "Tiered"
+        }
+    }
+}
+
+enum KGAltitudeTier: Int, CaseIterable, Identifiable {
+    case summit = 0
+    case orbit = 1
+    case signal = 2
+    case field = 3
+    case ground = 4
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .summit: "Summit"
+        case .orbit: "Orbit"
+        case .signal: "Signal"
+        case .field: "Field"
+        case .ground: "Ground"
+        }
+    }
+
+    var caption: String {
+        switch self {
+        case .summit: "Etan + Claude Code"
+        case .orbit: "core operators"
+        case .signal: "high-signal systems"
+        case .field: "active context"
+        case .ground: "full graph"
+        }
+    }
+
+    static func tier(for node: KGNode) -> KGAltitudeTier {
+        let canonicalName = node.name.trimmingCharacters(in: .whitespacesAndNewlines).localizedLowercase
+        if topAltitudeEntityNames.contains(canonicalName) {
+            return .summit
+        }
+
+        if node.importance >= 8.5 || (node.entityType == "agent" && node.importance >= 8) {
+            return .orbit
+        }
+
+        if node.importance >= 7 || node.linkedChunkCount >= 50 {
+            return .signal
+        }
+
+        if node.importance >= 5 || node.linkedChunkCount >= 15 {
+            return .field
+        }
+
+        return .ground
+    }
+
+    static func visibleTiers(at altitude: Double) -> Set<KGAltitudeTier> {
+        let clampedAltitude = max(0, min(Double(KGAltitudeTier.allCases.count - 1), altitude))
+        let level = Int(clampedAltitude.rounded())
+        return Set(KGAltitudeTier.allCases.filter { $0.rawValue <= level })
+    }
+
+    static func tier(at altitude: Double) -> KGAltitudeTier {
+        let clampedAltitude = max(0, min(Double(KGAltitudeTier.allCases.count - 1), altitude))
+        return KGAltitudeTier(rawValue: Int(clampedAltitude.rounded())) ?? .signal
+    }
+
+    private static let topAltitudeEntityNames: Set<String> = [
+        "etan",
+        "etan heyman",
+        "claude code",
+    ]
+}

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasMode.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasMode.swift
@@ -78,6 +78,8 @@ enum KGAltitudeTier: Int, CaseIterable, Identifiable {
     private static let topAltitudeEntityNames: Set<String> = [
         "etan",
         "etan heyman",
+        "claudecode",
+        "claude-code",
         "claude code",
     ]
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
@@ -14,6 +14,7 @@ struct KGAtlasPresentation {
         let visibleNodes: [KGNode]
         let visibleEdges: [KGEdge]
         let selectedRegion: Region?
+        let activeAltitudeTier: KGAltitudeTier
     }
 
     static func snapshot(
@@ -21,28 +22,26 @@ struct KGAtlasPresentation {
         edges: [KGEdge],
         selectedNodeId: String?,
         minimumImportance: Double,
+        mode: KGAtlasMode = .importance,
+        altitude: Double = Double(KGAltitudeTier.signal.rawValue),
         userDefaults: UserDefaults = .standard
     ) -> Snapshot {
+        let activeAltitudeTier = KGAltitudeTier.tier(at: altitude)
+        let visibleAltitudeTiers = KGAltitudeTier.visibleTiers(at: altitude)
         let visibleNodes = nodes.filter { node in
-            node.importance >= minimumImportance
-                || node.id == selectedNodeId
-                || pinnedEntityNames.contains(node.name.localizedLowercase)
+            switch mode {
+            case .importance:
+                node.importance >= minimumImportance
+                    || node.id == selectedNodeId
+                    || pinnedEntityNames.contains(node.name.localizedLowercase)
+            case .tieredAltitude:
+                visibleAltitudeTiers.contains(KGAltitudeTier.tier(for: node))
+                    || node.id == selectedNodeId
+                    || pinnedEntityNames.contains(node.name.localizedLowercase)
+            }
         }
 
-        let grouped = Dictionary(grouping: visibleNodes, by: \.entityType)
-        let regions: [Region] = orderedEntityTypes.compactMap { entityType in
-            guard let values = grouped[entityType], !values.isEmpty else { return nil }
-            return Region(
-                entityType: entityType,
-                title: title(for: entityType),
-                nodes: values.sorted {
-                    if $0.importance == $1.importance {
-                        return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-                    }
-                    return $0.importance > $1.importance
-                }
-            )
-        }
+        let regions = regions(for: visibleNodes, mode: mode)
         let renderableNodes = regions.flatMap { $0.nodes }
         let renderableIDs = Set(renderableNodes.map(\.id))
         let visibleEdges = virtualizedVisibleEdges(
@@ -59,7 +58,8 @@ struct KGAtlasPresentation {
             regions: regions,
             visibleNodes: renderableNodes,
             visibleEdges: visibleEdges,
-            selectedRegion: selectedRegion
+            selectedRegion: selectedRegion,
+            activeAltitudeTier: activeAltitudeTier
         )
     }
 
@@ -95,6 +95,42 @@ struct KGAtlasPresentation {
     private static func maxLinksPerNode(from userDefaults: UserDefaults) -> Int {
         let configuredValue = userDefaults.integer(forKey: maxLinksPerNodeKey)
         return configuredValue > 0 ? configuredValue : defaultMaxLinksPerNode
+    }
+
+    private static func regions(for visibleNodes: [KGNode], mode: KGAtlasMode) -> [Region] {
+        switch mode {
+        case .importance:
+            let grouped = Dictionary(grouping: visibleNodes, by: \.entityType)
+            return orderedEntityTypes.compactMap { entityType in
+                guard let values = grouped[entityType], !values.isEmpty else { return nil }
+                return Region(
+                    entityType: entityType,
+                    title: title(for: entityType),
+                    nodes: sortNodes(values)
+                )
+            }
+        case .tieredAltitude:
+            let grouped = Dictionary(grouping: visibleNodes) { node in
+                KGAltitudeTier.tier(for: node)
+            }
+            return KGAltitudeTier.allCases.compactMap { tier in
+                guard let values = grouped[tier], !values.isEmpty else { return nil }
+                return Region(
+                    entityType: "altitude-\(tier.rawValue)",
+                    title: tier.title,
+                    nodes: sortNodes(values)
+                )
+            }
+        }
+    }
+
+    private static func sortNodes(_ nodes: [KGNode]) -> [KGNode] {
+        nodes.sorted {
+            if $0.importance == $1.importance {
+                return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            return $0.importance > $1.importance
+        }
     }
 
     private static func virtualizedVisibleEdges(

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -28,6 +28,7 @@ struct KGCanvasView: View {
     @State private var lastScale: CGFloat = 1.0
     @State private var canvasSize: CGSize = .zero
     @State private var minimumImportance: Double = 6
+    @State private var altitudeLevel: Double = Double(KGAltitudeTier.signal.rawValue)
     @State private var hasLoadedGraph = false
     @State private var simulationController = KGSimulationController()
     @GestureState private var toolbarInteractionActive = false
@@ -37,7 +38,9 @@ struct KGCanvasView: View {
             nodes: viewModel.nodes,
             edges: viewModel.edges,
             selectedNodeId: viewModel.selectedNodeId,
-            minimumImportance: minimumImportance
+            minimumImportance: minimumImportance,
+            mode: viewModel.layoutMode,
+            altitude: altitudeLevel
         )
     }
 
@@ -113,6 +116,9 @@ struct KGCanvasView: View {
                 }
             }
             .onChange(of: viewModel.nodes.count) { _, _ in
+                startSimulation()
+            }
+            .onChange(of: viewModel.layoutMode) { _, _ in
                 startSimulation()
             }
             .onDisappear {
@@ -219,19 +225,29 @@ struct KGCanvasView: View {
 
                 Spacer(minLength: 12)
 
-                labelChip("importance ≥ \(Int(minimumImportance))")
+                labelChip(statusChipText(snapshot: snapshot))
             }
+
+            Picker("Graph mode", selection: Binding(
+                get: { viewModel.layoutMode },
+                set: { viewModel.setLayoutMode($0) }
+            )) {
+                ForEach(KGAtlasMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Text("Altitude")
                         .font(.system(size: 11, weight: .semibold))
                     Spacer()
-                    Text("Lower values reveal more nodes")
+                    Text(altitudeReadout(snapshot: snapshot))
                         .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(.secondary)
                 }
-                Slider(value: $minimumImportance, in: 0...10, step: 1)
+                altitudeSlider
             }
 
             ScrollView(.horizontal, showsIndicators: false) {
@@ -434,6 +450,34 @@ struct KGCanvasView: View {
                 Capsule()
                     .fill(Color.primary.opacity(0.08))
             )
+    }
+
+    @ViewBuilder
+    private var altitudeSlider: some View {
+        switch viewModel.layoutMode {
+        case .importance:
+            Slider(value: $minimumImportance, in: 0...10, step: 1)
+        case .tieredAltitude:
+            Slider(value: $altitudeLevel, in: 0...Double(KGAltitudeTier.allCases.count - 1), step: 1)
+        }
+    }
+
+    private func statusChipText(snapshot: KGAtlasPresentation.Snapshot) -> String {
+        switch viewModel.layoutMode {
+        case .importance:
+            return "importance ≥ \(Int(minimumImportance))"
+        case .tieredAltitude:
+            return "\(snapshot.activeAltitudeTier.title) \(Int(altitudeLevel) + 1)/\(KGAltitudeTier.allCases.count)"
+        }
+    }
+
+    private func altitudeReadout(snapshot: KGAtlasPresentation.Snapshot) -> String {
+        switch viewModel.layoutMode {
+        case .importance:
+            return "importance \(Int(minimumImportance))/10"
+        case .tieredAltitude:
+            return "\(snapshot.activeAltitudeTier.caption) · lower reveals more"
+        }
     }
 
     private func labelledNodeIDs(for nodes: [KGNode]) -> Set<String> {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -26,7 +26,7 @@ final class KGViewModel: ObservableObject {
     @Published private(set) var selectedEntityChunkSidebarLoadFailed = false
     @Published private(set) var selectedEntityFileSidebarLoadFailed = false
     @Published private(set) var degradationState: DegradationState = .healthy
-    @Published var layoutMode: KGAtlasMode = .importance
+    @Published var layoutMode: KGAtlasMode = .tieredAltitude
 
     /// Set by KGCanvasView via GeometryReader — used for centering force
     var canvasCenter: CGPoint = CGPoint(x: 300, y: 250)

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -26,6 +26,7 @@ final class KGViewModel: ObservableObject {
     @Published private(set) var selectedEntityChunkSidebarLoadFailed = false
     @Published private(set) var selectedEntityFileSidebarLoadFailed = false
     @Published private(set) var degradationState: DegradationState = .healthy
+    @Published var layoutMode: KGAtlasMode = .importance
 
     /// Set by KGCanvasView via GeometryReader — used for centering force
     var canvasCenter: CGPoint = CGPoint(x: 300, y: 250)
@@ -199,7 +200,11 @@ final class KGViewModel: ObservableObject {
                 velocity: existingNode?.velocity ?? .zero
             )
         }
-        let seededNodes = KGAtlasLayout.seededNodes(incomingNodes, canvasSize: graphCanvasSize)
+        let seededNodes = KGAtlasLayout.seededNodes(
+            incomingNodes,
+            canvasSize: graphCanvasSize,
+            mode: layoutMode
+        )
         nodes = zip(incomingNodes, seededNodes).map { incomingNode, seededNode in
             existingNodes[incomingNode.id] == nil ? seededNode : incomingNode
         }
@@ -234,7 +239,14 @@ final class KGViewModel: ObservableObject {
         layoutCanvasSize = size
         canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
         guard !nodes.isEmpty else { return }
-        nodes = KGAtlasLayout.seededNodes(nodes, canvasSize: size)
+        nodes = KGAtlasLayout.seededNodes(nodes, canvasSize: size, mode: layoutMode)
+        pinOwnerEntityIfPresent()
+    }
+
+    func setLayoutMode(_ mode: KGAtlasMode) {
+        guard layoutMode != mode else { return }
+        layoutMode = mode
+        nodes = KGAtlasLayout.seededNodes(nodes, canvasSize: graphCanvasSize, mode: mode)
         pinOwnerEntityIfPresent()
     }
 
@@ -424,6 +436,13 @@ final class KGViewModel: ObservableObject {
             forces[i].dy += (center.y - nodes[i].position.y) * centeringStrength
         }
 
+        if layoutMode == .tieredAltitude {
+            for i in 0..<nodes.count {
+                let targetY = tierTargetY(for: nodes[i])
+                forces[i].dy += (targetY - nodes[i].position.y) * 0.035
+            }
+        }
+
         // Apply forces with damping
         var totalKineticEnergy: CGFloat = 0
         for i in 0..<nodes.count {
@@ -461,7 +480,23 @@ final class KGViewModel: ObservableObject {
 
     private var ownerAnchor: CGPoint {
         let size = graphCanvasSize
-        return CGPoint(x: size.width * 0.30, y: size.height * 0.64)
+        switch layoutMode {
+        case .importance:
+            return CGPoint(x: size.width * 0.30, y: size.height * 0.64)
+        case .tieredAltitude:
+            return CGPoint(x: size.width * 0.30, y: size.height * 0.26)
+        }
+    }
+
+    private func tierTargetY(for node: KGNode) -> CGFloat {
+        let size = graphCanvasSize
+        return switch KGAltitudeTier.tier(for: node) {
+        case .summit: size.height * 0.26
+        case .orbit: size.height * 0.40
+        case .signal: size.height * 0.55
+        case .field: size.height * 0.70
+        case .ground: size.height * 0.84
+        }
     }
 
     private func nodeById(_ id: String) -> KGNode? {

--- a/brain-bar/Sources/BrainBar/Views/Components/WrappingPillLayout.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/WrappingPillLayout.swift
@@ -14,8 +14,8 @@ struct WrappingPillLayout: Layout {
         subviews: Subviews,
         cache: inout Void
     ) -> CGSize {
-        let maxWidth = proposal.width ?? subviews.reduce(CGFloat.zero) { width, subview in
-            width + subview.sizeThatFits(.unspecified).width + spacing
+        let maxWidth = proposal.width ?? subviews.enumerated().reduce(CGFloat.zero) { width, pair in
+            width + pair.element.sizeThatFits(.unspecified).width + (pair.offset > 0 ? spacing : 0)
         }
         let rows = makeRows(subviews: subviews, maxWidth: max(maxWidth, 1))
         let height = rows.reduce(CGFloat.zero) { total, row in

--- a/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGAtlasMode.swift
+++ b/brain-bar/Sources/BrainBarDaemon/KnowledgeGraph/KGAtlasMode.swift
@@ -1,0 +1,1 @@
+../../BrainBar/KnowledgeGraph/KGAtlasMode.swift

--- a/brain-bar/Tests/BrainBarTests/KGAtlasLayoutTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasLayoutTests.swift
@@ -57,4 +57,26 @@ final class KGAtlasLayoutTests: XCTestCase {
         XCTAssertGreaterThan(owner.position.y, 240)
         XCTAssertLessThan(owner.position.x, 300)
     }
+
+    func testTieredAltitudeLayoutPlacesNodesInDescendingRows() {
+        let seeded = KGAtlasLayout.seededNodes(
+            [
+                KGNode(id: "owner", name: "Etan Heyman", entityType: "person", importance: 10, position: .zero),
+                KGNode(id: "claude", name: "Claude Code", entityType: "agent", importance: 6, position: .zero),
+                KGNode(id: "brainlayer", name: "brainlayer", entityType: "project", importance: 8, position: .zero),
+                KGNode(id: "scratch", name: "Scratch", entityType: "topic", importance: 1, position: .zero),
+            ],
+            canvasSize: CGSize(width: 1_000, height: 800),
+            mode: .tieredAltitude
+        )
+
+        let owner = seeded.first { $0.id == "owner" }!
+        let claude = seeded.first { $0.id == "claude" }!
+        let brainlayer = seeded.first { $0.id == "brainlayer" }!
+        let scratch = seeded.first { $0.id == "scratch" }!
+
+        XCTAssertLessThan(owner.position.y, brainlayer.position.y)
+        XCTAssertLessThan(claude.position.y, brainlayer.position.y)
+        XCTAssertLessThan(brainlayer.position.y, scratch.position.y)
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
@@ -91,6 +91,77 @@ final class KGAtlasPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.visibleEdges.map(\.id), ["owner-owns-site"])
     }
 
+    func testTieredAltitudeSummitShowsOnlyTopEntities() {
+        let nodes = [
+            KGNode(id: "owner", name: "Etan Heyman", entityType: "person", importance: 10, position: .zero),
+            KGNode(id: "claude", name: "Claude Code", entityType: "agent", importance: 6, position: .zero),
+            KGNode(id: "brainlayer", name: "brainlayer", entityType: "project", importance: 10, position: .zero),
+            KGNode(id: "scratch", name: "Scratch", entityType: "topic", importance: 1, position: .zero),
+        ]
+        let edges = [
+            KGEdge(sourceId: "owner", targetId: "claude", relationType: "uses"),
+            KGEdge(sourceId: "owner", targetId: "brainlayer", relationType: "owns"),
+        ]
+
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: edges,
+            selectedNodeId: nil,
+            minimumImportance: 0,
+            mode: .tieredAltitude,
+            altitude: 0,
+            userDefaults: testUserDefaults
+        )
+
+        XCTAssertEqual(snapshot.visibleNodes.map(\.id), ["owner", "claude"])
+        XCTAssertEqual(snapshot.visibleEdges.map(\.id), ["owner-uses-claude"])
+        XCTAssertEqual(snapshot.regions.map(\.title), ["Summit"])
+        XCTAssertEqual(snapshot.activeAltitudeTier, .summit)
+    }
+
+    func testTieredAltitudeRevealsProgressivelyMoreNodes() {
+        let nodes = [
+            KGNode(id: "owner", name: "Etan Heyman", entityType: "person", importance: 10, position: .zero),
+            KGNode(id: "claude", name: "Claude Code", entityType: "agent", importance: 6, position: .zero),
+            KGNode(id: "core", name: "Core Agent", entityType: "agent", importance: 8, position: .zero),
+            KGNode(id: "signal", name: "MCP", entityType: "tool", importance: 7, position: .zero),
+            KGNode(id: "field", name: "BrainBar", entityType: "project", importance: 5, position: .zero),
+            KGNode(id: "ground", name: "Scratch", entityType: "topic", importance: 1, position: .zero),
+        ]
+
+        let summit = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: [],
+            selectedNodeId: nil,
+            minimumImportance: 0,
+            mode: .tieredAltitude,
+            altitude: 0,
+            userDefaults: testUserDefaults
+        )
+        let signal = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: [],
+            selectedNodeId: nil,
+            minimumImportance: 0,
+            mode: .tieredAltitude,
+            altitude: 2,
+            userDefaults: testUserDefaults
+        )
+        let ground = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: [],
+            selectedNodeId: nil,
+            minimumImportance: 0,
+            mode: .tieredAltitude,
+            altitude: 4,
+            userDefaults: testUserDefaults
+        )
+
+        XCTAssertEqual(summit.visibleNodes.map(\.id), ["owner", "claude"])
+        XCTAssertEqual(signal.visibleNodes.map(\.id), ["owner", "claude", "core", "signal"])
+        XCTAssertEqual(ground.visibleNodes.map(\.id), ["owner", "claude", "core", "signal", "field", "ground"])
+    }
+
     func testSnapshotVirtualizesHubLinksAtDefaultFiftyVisibleRelations() {
         let graph = makeHubGraph(edgeCount: 60)
 

--- a/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGAtlasPresentationTests.swift
@@ -94,7 +94,7 @@ final class KGAtlasPresentationTests: XCTestCase {
     func testTieredAltitudeSummitShowsOnlyTopEntities() {
         let nodes = [
             KGNode(id: "owner", name: "Etan Heyman", entityType: "person", importance: 10, position: .zero),
-            KGNode(id: "claude", name: "Claude Code", entityType: "agent", importance: 6, position: .zero),
+            KGNode(id: "claude", name: "ClaudeCode", entityType: "agent", importance: 6, position: .zero),
             KGNode(id: "brainlayer", name: "brainlayer", entityType: "project", importance: 10, position: .zero),
             KGNode(id: "scratch", name: "Scratch", entityType: "topic", importance: 1, position: .zero),
         ]

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -859,6 +859,12 @@ final class KGViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func testGraphDefaultsToTieredAltitudeOptionB() {
+        let vm = KGViewModel(database: db)
+
+        XCTAssertEqual(vm.layoutMode, .tieredAltitude)
+    }
+
     func testLoadGraphPopulatesNodesAndEdges() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
@@ -904,6 +910,7 @@ final class KGViewModelTests: XCTestCase {
         try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
 
         let vm = KGViewModel(database: db)
+        vm.setLayoutMode(.importance)
         await vm.loadGraph()
         let defaultPositions = Dictionary(uniqueKeysWithValues: vm.nodes.map { ($0.id, $0.position) })
 
@@ -1069,6 +1076,7 @@ final class KGViewModelTests: XCTestCase {
             ]
         )
         let vm = KGViewModel(graphReader: reader)
+        vm.setLayoutMode(.importance)
         vm.updateCanvasSize(CGSize(width: 860, height: 500))
 
         let loaded = await vm.loadGraph()
@@ -1488,6 +1496,7 @@ final class KGCanvasSimulationTests: XCTestCase {
 
     func testStableGraphStopsWithinTwoSecondsWorthOfFrames() async {
         let vm = KGViewModel(database: db)
+        vm.setLayoutMode(.importance)
         vm.canvasCenter = CGPoint(x: 300, y: 250)
         vm.nodes = makeStableFixture(center: vm.canvasCenter)
         vm.edges = []

--- a/tests/test_brainbar_hybrid_helper.py
+++ b/tests/test_brainbar_hybrid_helper.py
@@ -141,6 +141,7 @@ def test_helper_preserves_agent_id_for_brain_search(monkeypatch, tmp_path):
     )
 
     assert response["ok"] is True
+    assert len(calls) == 1
     assert calls[0]["agent_id"] == "codex-test-agent"
 
 


### PR DESCRIPTION
## Summary
- Adds Option B for BrainBar KG: a true tiered-altitude atlas mode where summit altitude shows only Etan + ClaudeCode/Claude Code, and lower altitude levels progressively reveal more tiers.
- Keeps the current importance-filter graph as a switchable mode for side-by-side comparison, while defaulting this branch to the tiered option.
- Keeps the f0f777b5 Etan pin/centering behavior and adds tier-aware layout forces/row placement, numeric altitude readout, and graph-mode tests.
- Addresses local CodeRabbit findings: dynamic popover graph activation, wrapping layout width math, and clearer helper-test assertion.

## Forensics
- Stage 0/Phase 1 forensic spec verdict: negative recovery. No committed lost hierarchical graph exists; this PR builds the Stage 1 behavior from spec.

## Test plan
- [x] swift build --package-path brain-bar
- [x] swift test --package-path brain-bar — 522 tests, 0 failures
- [x] pytest — 2280 passed, 46 skipped, 5 xfailed
- [x] pytest tests/test_brainbar_hybrid_helper.py — 8 passed
- [x] pre-push BrainLayer test gate — 2210 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; eval/hook routing 36 passed; bun 1 passed; shell regression passed

## Review notes
- Local `cr review --plain` completed once with 3 findings; all three were fixed.
- Immediate local CodeRabbit rerun was blocked by the CLI review limit, so PR-side CodeRabbit is required before merge.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI and layout surface area in the knowledge graph viewer with new default mode and simulation lifecycle tied to tab visibility; no auth or data-path changes.
> 
> **Overview**
> Adds a **Tiered** knowledge-atlas mode alongside the existing **Importance** filter, defaulting the graph to tiered altitude (Option B).
> 
> **Tiered altitude** groups entities into five tiers (Summit → Ground) with rules for pinned names, importance, and linked-chunk counts. The altitude slider reveals cumulative tiers from summit-only up to the full graph; layout seeds nodes in horizontal rows per tier and the force simulation adds vertical pull toward tier rows. Presentation builds regions by tier instead of entity type, and the toolbar shows mode-specific chips and readouts.
> 
> **Importance mode** is unchanged in behavior but shares the same atlas pipeline via `KGAtlasMode`. Switching modes re-seeds layout and restarts simulation; owner (Etan) pinning stays mode-aware.
> 
> The status popover graph tab now passes **`isActive`** so load/refresh and simulation run only when the Graph tab is selected, with updates on tab switches.
> 
> Minor fixes: **`WrappingPillLayout`** width fallback only adds spacing between pills; hybrid helper test asserts a single **`brain_search`** call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 351827ac30e83eda08a04a7dc9879592c09d0a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tiered altitude graph layout mode to the BrainBar knowledge graph
> - Introduces a `KGAtlasMode` enum with `importance` and `tieredAltitude` cases, and a `KGAltitudeTier` classifier that groups nodes into horizontal rows by altitude tier.
> - Adds `KGAtlasLayout.seededTieredAltitudeNodes` to place nodes in tier rows at initial seed, and a vertical force in `KGViewModel.tick` to stabilize nodes toward their row during simulation.
> - Updates `KGCanvasView` with a segmented mode picker and a mode-specific altitude slider; status chip text and visible nodes update to reflect the active tier.
> - Sets default layout mode to `.tieredAltitude` in `KGViewModel`.
> - Behavioral Change: existing graph consumers will now default to tiered-altitude layout instead of importance-based layout on first load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 351827a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->