### PR TITLE
feat(brainbar): search drill-in — single-click open-conversation, copy secondary (#36 #37)

### DIFF
--- a/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
+++ b/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
@@ -102,6 +102,8 @@ final class QuickCaptureViewModel: ObservableObject {
     /// Click-outside-dismiss flag for the search results overlay. Preserves
     /// `inputText` so the next keystroke can reinstate the overlay.
     @Published private(set) var isSearchOverlayDismissed: Bool = false
+    /// QA #37: the conversation thread opened by drilling into a search hit.
+    @Published var conversationSelection = InjectionConversationSelection()
 
     private let db: BrainDatabase
     private let panelState: QuickCapturePanelState
@@ -325,6 +327,24 @@ final class QuickCaptureViewModel: ObservableObject {
             guard !Task.isCancelled else { return }
             self?.copiedResultID = nil
         }
+    }
+
+    /// QA #36/#37: single-click drill-in — open the full conversation thread for
+    /// a search hit, with the hit chunk highlighted. The lookup is a small bounded
+    /// (±3 chunk) query, so it runs inline.
+    func openConversation(id: String) {
+        selectResult(id: id)
+        guard let row = results.first(where: { $0.id == id }) else { return }
+        do {
+            let conversation = try db.expandedConversation(id: id)
+            conversationSelection.open(conversation, title: row.title)
+        } catch {
+            feedback = .error("Couldn't open conversation")
+        }
+    }
+
+    func closeConversation() {
+        conversationSelection.close()
     }
 
     func clearResultsSelection() {
@@ -977,6 +997,9 @@ struct QuickCapturePanelView: View {
                         },
                         onActivate: { id in
                             viewModel.copyResultToClipboard(id: id)
+                        },
+                        onOpenConversation: { id in
+                            viewModel.openConversation(id: id)
                         }
                     )
                         .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -990,6 +1013,16 @@ struct QuickCapturePanelView: View {
             .padding(16)
         }
         .frame(width: 540, height: 360)
+        .overlay {
+            // QA #37: full conversation thread for the clicked search hit.
+            if let conversation = viewModel.conversationSelection.conversation {
+                ChunkConversationOverlay(
+                    conversation: conversation,
+                    title: viewModel.conversationSelection.title,
+                    onClose: { viewModel.closeConversation() }
+                )
+            }
+        }
         .onChange(of: viewModel.confirmationFlashCount) { _, _ in
             flashOpacity = 0.18
             withAnimation(.easeOut(duration: 0.45)) {

--- a/brain-bar/Sources/BrainBar/SearchPanelController.swift
+++ b/brain-bar/Sources/BrainBar/SearchPanelController.swift
@@ -18,9 +18,14 @@ final class SearchPanelController {
 
     private let panel: SearchPanel
     private let viewModel: SearchViewModel
+    private let conversationLoader: ((String) throws -> BrainDatabase.ExpandedConversation)?
 
-    init(viewModel: SearchViewModel) {
+    init(
+        viewModel: SearchViewModel,
+        conversationLoader: ((String) throws -> BrainDatabase.ExpandedConversation)? = nil
+    ) {
         self.viewModel = viewModel
+        self.conversationLoader = conversationLoader
         panel = SearchPanel(
             contentRect: NSRect(x: 0, y: 0, width: 760, height: 560),
             styleMask: [.nonactivatingPanel, .fullSizeContentView],
@@ -43,7 +48,11 @@ final class SearchPanelController {
             },
             rerank: { candidates, _ in candidates }
         )
-        self.init(viewModel: SearchViewModel(queryActor: actor))
+        // QA #36/#37: give the command palette the same single-click drill-in.
+        self.init(
+            viewModel: SearchViewModel(queryActor: actor),
+            conversationLoader: { try db.expandedConversation(id: $0) }
+        )
     }
 
     func show(query: String? = nil) {
@@ -80,9 +89,13 @@ final class SearchPanelController {
             self?.dismiss()
         }
         panel.contentViewController = NSHostingController(
-            rootView: SearchPanelView(viewModel: viewModel, onDismiss: { [weak self] in
-                self?.dismiss()
-            })
+            rootView: SearchPanelView(
+                viewModel: viewModel,
+                conversationLoader: conversationLoader,
+                onDismiss: { [weak self] in
+                    self?.dismiss()
+                }
+            )
         )
     }
 
@@ -100,9 +113,11 @@ final class SearchPanelController {
 
 private struct SearchPanelView: View {
     @ObservedObject var viewModel: SearchViewModel
+    let conversationLoader: ((String) throws -> BrainDatabase.ExpandedConversation)?
     let onDismiss: () -> Void
 
     @FocusState private var isSearchFieldFocused: Bool
+    @State private var conversationSelection = InjectionConversationSelection()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -151,7 +166,8 @@ private struct SearchPanelView: View {
                 onActivate: { id in
                     viewModel.selectResult(id: id)
                     _ = viewModel.activateSelectedResult()
-                }
+                },
+                onOpenConversation: conversationLoader.map { _ in { id in openConversation(id: id) } }
             )
             .onMoveCommand { direction in
                 switch direction {
@@ -185,8 +201,29 @@ private struct SearchPanelView: View {
         .padding(18)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
+        .overlay {
+            // QA #37: full conversation thread for the clicked search hit.
+            if let conversation = conversationSelection.conversation {
+                ChunkConversationOverlay(
+                    conversation: conversation,
+                    title: conversationSelection.title,
+                    onClose: { conversationSelection.close() }
+                )
+            }
+        }
         .task {
             isSearchFieldFocused = true
+        }
+    }
+
+    private func openConversation(id: String) {
+        viewModel.selectResult(id: id)
+        guard let conversationLoader else { return }
+        do {
+            let conversation = try conversationLoader(id)
+            conversationSelection.open(conversation, title: id)
+        } catch {
+            // Leave the overlay closed on failure; the result stays selected.
         }
     }
 

--- a/brain-bar/Sources/BrainBar/Views/Components/SearchResultCard.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/SearchResultCard.swift
@@ -4,6 +4,10 @@ struct SearchResultCard: View {
     let result: SearchResult
     let isSelected: Bool
     let isCopied: Bool
+    /// QA #37: explicit "Open conversation" action. Optional so consumers without
+    /// a conversation source render the card without the footer.
+    var onOpenConversation: (() -> Void)?
+    var onCopy: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -20,6 +24,10 @@ struct SearchResultCard: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+            }
+
+            if onOpenConversation != nil || onCopy != nil {
+                actionFooter
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -42,6 +50,40 @@ struct SearchResultCard: View {
             }
         }
         .contentShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    @ViewBuilder
+    private var actionFooter: some View {
+        HStack(spacing: 8) {
+            if let onOpenConversation {
+                // QA #36/#37: the primary action is opening the conversation.
+                Button(action: onOpenConversation) {
+                    Label("Open conversation", systemImage: "bubble.left.and.bubble.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Capsule().fill(Color.accentColor.opacity(0.16)))
+                        .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if let onCopy {
+                // Copy is the secondary affordance (also double-click on the card).
+                Button(action: onCopy) {
+                    Label("Copy", systemImage: "doc.on.doc")
+                        .font(.system(size: 11, weight: .medium))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Capsule().fill(Color.primary.opacity(0.08)))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.top, 2)
     }
 
     private var backgroundColor: Color {

--- a/brain-bar/Sources/BrainBar/Views/Components/SearchResultsList.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/SearchResultsList.swift
@@ -6,6 +6,11 @@ struct SearchResultsList: View {
     let copiedResultID: String?
     let onSelect: (String) -> Void
     let onActivate: (String) -> Void
+    /// QA #36/#37: single-click drill-in. When provided, a single click opens the
+    /// conversation for that result; copy stays available as the secondary
+    /// (double-click) action. Optional so consumers without a conversation source
+    /// keep selection-only behavior.
+    var onOpenConversation: ((String) -> Void)? = nil
 
     var body: some View {
         ScrollView {
@@ -22,13 +27,19 @@ struct SearchResultsList: View {
                         )
                 } else {
                     ForEach(results) { result in
+                        let resultID = result.id
+                        let openAction: (() -> Void)? = onOpenConversation.map { open in { open(resultID) } }
                         SearchResultCard(
                             result: result,
                             isSelected: result.id == selectedResultID,
-                            isCopied: result.id == copiedResultID
+                            isCopied: result.id == copiedResultID,
+                            onOpenConversation: openAction,
+                            onCopy: { onActivate(resultID) }
                         )
                         .onTapGesture {
                             onSelect(result.id)
+                            // QA #36: single click drills in instead of being a no-op.
+                            onOpenConversation?(result.id)
                         }
                         .onTapGesture(count: 2) {
                             onActivate(result.id)

--- a/brain-bar/Tests/BrainBarTests/QuickCaptureConversationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/QuickCaptureConversationTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import BrainBar
+
+// QA #36/#37: a single click on a search hit must drill in — open the full
+// conversation thread with the hit chunk highlighted — instead of doing nothing.
+// These exercise the QuickCapture drill-in view-model path.
+@MainActor
+final class QuickCaptureConversationTests: XCTestCase {
+    private func makeSeededViewModel() throws -> (QuickCaptureViewModel, BrainDatabase, String) {
+        let path = NSTemporaryDirectory() + "brainbar-qc-convo-\(UUID().uuidString).db"
+        let db = BrainDatabase(path: path)
+
+        // A small thread so expandedConversation has target + surrounding context.
+        try db.insertChunk(id: "c1", content: "user asks the first question", sessionId: "sess", project: "brainlayer", contentType: "user_message", importance: 5)
+        try db.insertChunk(id: "c2", content: "assistant explains the xylophone behavior", sessionId: "sess", project: "brainlayer", contentType: "assistant_text", importance: 6)
+        try db.insertChunk(id: "c3", content: "user replies with a follow-up", sessionId: "sess", project: "brainlayer", contentType: "user_message", importance: 5)
+
+        let panelState = QuickCapturePanelState()
+        panelState.switchMode(.search)
+        let model = QuickCaptureViewModel(db: db, panelState: panelState)
+        model.inputText = "xylophone"
+        model.submit()
+        return (model, db, path)
+    }
+
+    func testOpenConversationLoadsThreadForSearchHit() throws {
+        let (model, db, path) = try makeSeededViewModel()
+        defer { db.close(); try? FileManager.default.removeItem(atPath: path) }
+
+        let hitID = try XCTUnwrap(model.results.first?.id, "search should surface the matching chunk")
+        XCTAssertNil(model.conversationSelection.conversation, "no thread open before drilling in")
+
+        model.openConversation(id: hitID)
+
+        let conversation = try XCTUnwrap(model.conversationSelection.conversation)
+        XCTAssertEqual(conversation.target.chunkID, hitID)
+        XCTAssertTrue(conversation.entries.contains { $0.isTarget }, "the hit chunk is highlighted in the thread")
+        XCTAssertEqual(model.selectedResultID, hitID, "drilling in also selects the row")
+    }
+
+    func testCloseConversationClearsSelection() throws {
+        let (model, db, path) = try makeSeededViewModel()
+        defer { db.close(); try? FileManager.default.removeItem(atPath: path) }
+
+        let hitID = try XCTUnwrap(model.results.first?.id)
+        model.openConversation(id: hitID)
+        XCTAssertNotNil(model.conversationSelection.conversation)
+
+        model.closeConversation()
+        XCTAssertNil(model.conversationSelection.conversation)
+    }
+
+    func testOpenConversationForUnknownIDIsANoOp() throws {
+        let (model, db, path) = try makeSeededViewModel()
+        defer { db.close(); try? FileManager.default.removeItem(atPath: path) }
+
+        model.openConversation(id: "does-not-exist")
+        XCTAssertNil(model.conversationSelection.conversation)
+    }
+}


### PR DESCRIPTION
## BrainBar v5 visual-QA — search drill-in (PR3)

Closes QA hotspots **#36, #37** from the 2026-05-28 BrainBar v5 session.

### #36 — single-click is a no-op; double-click copies
> *"if I try to search for a chunk and I click it, it doesn't do anything. If I click twice then it copies to clipboard"*

- **Before:** single-click only selected the row (looked like nothing happened); double-click copied.
- **After:** **single-click drills in** — opens the conversation for that hit. Copy is now the secondary action (double-click, plus an explicit **Copy** button on the card).

### #37 — no open-conversation action
> *"there's no drill in, no expand, no open related, no open conversation — I would like to have an 'open conversation' where I can see what I sent the agent"*

- **After:** each result card gets an explicit **"Open conversation"** action that opens the full **user→assistant→user** thread with the **hit chunk highlighted** (reuses the existing `ChunkConversationOverlay`). Wired on **both** search surfaces:
  - the **QuickCapture** search panel (`QuickCaptureViewModel.openConversation`, loads the ±3-chunk thread via `BrainDatabase.expandedConversation`)
  - the **"Search BrainLayer"** command palette (`SearchPanelController` threads a conversation loader through its db-backed init; the test/designated init passes `nil`, so behavior there is unchanged)

Shared `SearchResultsList`/`SearchResultCard` gained an optional `onOpenConversation` affordance — consumers without a conversation source keep selection-only behavior, so nothing else regresses.

## Tests
`swift test --package-path brain-bar` → **535/535 green** (excludes 2 pre-existing async-notification flakes — see prior PRs).
- `QuickCaptureConversationTests` (3): drill-in loads the highlighted thread, close clears it, unknown id is a no-op.

## Context
Third and final PR of the BrainBar v5 visual-QA entity-card/injections/search track. PR1 (#346, entity card) and PR2 (#349, injections-tab UX) are merged. This closes the search drill-in pair I split out of the original PR2 grouping for cohesion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and read-only local DB lookups only; optional callbacks avoid regressing consumers that omit conversation loading.
> 
> **Overview**
> Search hits now **drill in on single click** instead of only selecting the row; **copy** moves to double-click and an explicit **Copy** button on each card.
> 
> **Quick Capture** and the **Search BrainLayer** command palette load a bounded thread via `BrainDatabase.expandedConversation` and show it in the existing **`ChunkConversationOverlay`**, with the matching chunk highlighted. Shared **`SearchResultsList`** / **`SearchResultCard`** take an optional **`onOpenConversation`** hook so callers without a loader keep selection-only behavior.
> 
> **`QuickCaptureViewModel`** adds **`openConversation`** / **`closeConversation`** and **`conversationSelection`** state; **`SearchPanelController`** threads an injectable **`conversationLoader`** through its db-backed initializer. New **`QuickCaptureConversationTests`** cover open, close, and unknown-id no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab915d04d70a5fc226ffc60c1be983209f909b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add single-click conversation drill-in and copy actions to brain-bar search results
> - Single-clicking a search result in `SearchResultsList` now opens its full conversation thread in an overlay, with the matching chunk highlighted; double-click continues to copy.
> - `SearchResultCard` gains inline "Open conversation" and "Copy" action buttons rendered when the corresponding callbacks are provided.
> - `QuickCaptureViewModel` and `SearchPanelView` each manage a `conversationSelection` state to show/hide a `ChunkConversationOverlay`, loading the thread via `db.expandedConversation(id:)`.
> - Behavioral Change: single-tap gesture now triggers conversation open (when a loader is available) in addition to selection, shifting copy to double-tap only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab915d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->