### PR TITLE
fix(brainbar): stabilize graph selection and drill-ins

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -965,7 +965,7 @@ private struct BrainBarHeroBadge: View {
             .minimumScaleFactor(0.72)
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .frame(maxWidth: 190, alignment: .leading)
+            .fixedSize(horizontal: true, vertical: false)
             .background(.white.opacity(0.18), in: Capsule())
     }
 }
@@ -1068,6 +1068,7 @@ private struct BrainBarAgentPresencePill: View {
             Capsule()
                 .stroke(Color(nsColor: presence.family.accentColor).opacity(presence.isActive ? 0.28 : 0.1), lineWidth: 1)
         )
+        .fixedSize(horizontal: true, vertical: false)
     }
 }
 
@@ -1133,7 +1134,7 @@ private struct BrainBarFlowStatusPill: View {
             .minimumScaleFactor(0.72)
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .frame(maxWidth: 150, alignment: .leading)
+            .fixedSize(horizontal: true, vertical: false)
             .background(accentColor.opacity(0.16), in: Capsule())
             .overlay(
                 Capsule()

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3504,7 +3504,7 @@ final class BrainDatabase: @unchecked Sendable {
 
         // First try exact name match
         let exactSQL = """
-            SELECT id, entity_type, name, metadata, description
+            SELECT id, entity_type, name, metadata, description, importance
             FROM kg_entities
             WHERE name = ?
               AND (? IS NULL OR entity_type = ?)
@@ -3533,7 +3533,8 @@ final class BrainDatabase: @unchecked Sendable {
                 "entity_type": columnText(exactStmt, 1) as Any,
                 "name": columnText(exactStmt, 2) as Any,
                 "metadata": columnText(exactStmt, 3) as Any,
-                "description": columnText(exactStmt, 4) as Any
+                "description": columnText(exactStmt, 4) as Any,
+                "importance": sqlite3_column_double(exactStmt, 5)
             ]
         }
         sqlite3_finalize(exactStmt)
@@ -3541,7 +3542,7 @@ final class BrainDatabase: @unchecked Sendable {
         // If no exact match, try LIKE
         if result == nil {
             let likeSQL = """
-                SELECT id, entity_type, name, metadata, description
+                SELECT id, entity_type, name, metadata, description, importance
                 FROM kg_entities
                 WHERE name LIKE ?
                   AND (? IS NULL OR entity_type = ?)
@@ -3567,7 +3568,8 @@ final class BrainDatabase: @unchecked Sendable {
                     "entity_type": columnText(likeStmt, 1) as Any,
                     "name": columnText(likeStmt, 2) as Any,
                     "metadata": columnText(likeStmt, 3) as Any,
-                    "description": columnText(likeStmt, 4) as Any
+                    "description": columnText(likeStmt, 4) as Any,
+                    "importance": sqlite3_column_double(likeStmt, 5)
                 ]
             }
             sqlite3_finalize(likeStmt)
@@ -3577,14 +3579,14 @@ final class BrainDatabase: @unchecked Sendable {
         if let entityId, result != nil {
             let expirationSelects = try kgRelationExpirationSelects(alias: "r")
             let relSQL = """
-                SELECT r.relation_type, e.name, 'outgoing' AS direction,
+                SELECT r.relation_type, e.name, r.target_id AS related_entity_id, 'outgoing' AS direction,
                        \(expirationSelects.validUntil), \(expirationSelects.expiredAt)
                 FROM kg_relations r
                 LEFT JOIN kg_entities e ON e.id = r.target_id
                 WHERE r.source_id = ?
                   AND r.relation_type != 'co_occurs_with'
                 UNION ALL
-                SELECT r.relation_type, e.name, 'incoming' AS direction,
+                SELECT r.relation_type, e.name, r.source_id AS related_entity_id, 'incoming' AS direction,
                        \(expirationSelects.validUntil), \(expirationSelects.expiredAt)
                 FROM kg_relations r
                 LEFT JOIN kg_entities e ON e.id = r.source_id
@@ -3601,13 +3603,14 @@ final class BrainDatabase: @unchecked Sendable {
                 var relations: [[String: Any]] = []
                 while sqlite3_step(relStmt) == SQLITE_ROW {
                     let targetName = columnText(relStmt, 1) ?? ""
-                    let direction = columnText(relStmt, 2) ?? "outgoing"
+                    let direction = columnText(relStmt, 3) ?? "outgoing"
                     relations.append([
                         "relation_type": columnText(relStmt, 0) as Any,
                         "target_name": targetName as Any,
+                        "target_entity_id": columnText(relStmt, 2) as Any,
                         "direction": direction as Any,
-                        "valid_until": columnText(relStmt, 3) as Any,
-                        "expired_at": columnText(relStmt, 4) as Any
+                        "valid_until": columnText(relStmt, 4) as Any,
+                        "expired_at": columnText(relStmt, 5) as Any
                     ])
                 }
                 result?["relations"] = relations

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -65,6 +65,7 @@ struct InjectionFeedView: View {
     @Binding var filterText: String
     @StateObject private var presentationModel = InjectionFeedPresentationModel()
     @State private var expandedBurstIDs: Set<String> = []
+    @State private var pendingExpandedBurstScrollID: String?
     @State private var copiedContinuationBurstID: String?
     @State private var conversationSelection = InjectionConversationSelection()
     @State private var loadingConversationChunkID: String?
@@ -83,27 +84,43 @@ struct InjectionFeedView: View {
         GeometryReader { proxy in
             let wideLayout = proxy.size.width >= 960
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    header(snapshot: snapshot)
-                    overviewStrip(snapshot: snapshot)
+            ScrollViewReader { scrollProxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        header(snapshot: snapshot)
+                        overviewStrip(snapshot: snapshot)
 
-                    if snapshot.bursts.isEmpty {
-                        emptyState
-                    } else if wideLayout {
-                        HStack(alignment: .top, spacing: 16) {
-                            feedColumn(snapshot: snapshot)
-                            sideRail(snapshot: snapshot)
-                                .frame(width: 260)
+                        if snapshot.bursts.isEmpty {
+                            emptyState
+                        } else if wideLayout {
+                            HStack(alignment: .top, spacing: 16) {
+                                feedColumn(snapshot: snapshot)
+                                sideRail(snapshot: snapshot)
+                                    .frame(width: 260)
+                            }
+                        } else {
+                            VStack(alignment: .leading, spacing: 16) {
+                                feedColumn(snapshot: snapshot)
+                                sideRail(snapshot: snapshot)
+                            }
                         }
-                    } else {
-                        VStack(alignment: .leading, spacing: 16) {
-                            feedColumn(snapshot: snapshot)
-                            sideRail(snapshot: snapshot)
+                    }
+                    .padding(20)
+                }
+                .onChange(of: pendingExpandedBurstScrollID) { _, scrollID in
+                    guard let scrollID else { return }
+                    DispatchQueue.main.async {
+                        let scroll = {
+                            scrollProxy.scrollTo(scrollID, anchor: .top)
+                            pendingExpandedBurstScrollID = nil
+                        }
+                        if reduceMotion {
+                            scroll()
+                        } else {
+                            withAnimation(.easeInOut(duration: 0.18), scroll)
                         }
                     }
                 }
-                .padding(20)
             }
             .background(pageBackground)
         }
@@ -334,6 +351,7 @@ struct InjectionFeedView: View {
                         eventRow(event)
                     }
                 }
+                .id(Self.expandedBurstDetailsID(burstID: burst.id))
             } else {
                 collapsedChunkPreview(for: burst)
             }
@@ -734,6 +752,7 @@ struct InjectionFeedView: View {
                 expandedBurstIDs.remove(burstID)
             } else {
                 expandedBurstIDs.insert(burstID)
+                pendingExpandedBurstScrollID = Self.expandedBurstDetailsID(burstID: burstID)
             }
         }
 
@@ -742,6 +761,10 @@ struct InjectionFeedView: View {
         } else {
             withAnimation(.easeInOut(duration: 0.16), update)
         }
+    }
+
+    nonisolated static func expandedBurstDetailsID(burstID: String) -> String {
+        "expanded-burst-details-\(burstID)"
     }
 
     private func shortSessionID(_ sessionID: String) -> String {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -74,6 +74,11 @@ struct KGCanvasView: View {
                         hasChunkLoadError: viewModel.selectedEntityChunkSidebarLoadFailed,
                         hasFileLoadError: viewModel.selectedEntityFileSidebarLoadFailed,
                         onOpenConversation: { viewModel.openConversation(chunkID: $0) },
+                        onSelectRelation: { relation in
+                            if viewModel.selectRelatedEntity(from: relation) {
+                                stopSimulation()
+                            }
+                        },
                         onLoadMoreChunks: { viewModel.loadMoreChunks() },
                         onLoadMoreFiles: { viewModel.loadMoreFiles() },
                         onClose: { viewModel.selectNode(id: nil) }
@@ -99,7 +104,7 @@ struct KGCanvasView: View {
                     hasLoadedGraph = true
                     if reduceMotion {
                         _ = viewModel.tick(reduceMotionEnabled: true)
-                    } else {
+                    } else if !viewModel.isLayoutPinned {
                         startSimulation()
                     }
                 })
@@ -120,6 +125,11 @@ struct KGCanvasView: View {
             }
             .onChange(of: viewModel.layoutMode) { _, _ in
                 startSimulation()
+            }
+            .onChange(of: viewModel.isLayoutPinned) { _, pinned in
+                if !pinned {
+                    startSimulation()
+                }
             }
             .onDisappear {
                 stopSimulation()
@@ -360,6 +370,7 @@ struct KGCanvasView: View {
             .onEnded { value in
                 let point = canvasPoint(from: value.location, in: canvasSize)
                 if let node = nodeAt(point: point, visibleNodes: snapshot.visibleNodes) {
+                    stopSimulation()
                     viewModel.selectNode(id: node.id)
                 } else {
                     viewModel.selectNode(id: nil)
@@ -509,7 +520,7 @@ struct KGCanvasView: View {
     }
 
     private func startSimulation() {
-        guard isActive, !reduceMotion, hasLoadedGraph, viewModel.nodes.count > 1 else { return }
+        guard isActive, !reduceMotion, !viewModel.isLayoutPinned, hasLoadedGraph, viewModel.nodes.count > 1 else { return }
         simulationController.setActive(true)
         simulationController.start {
             viewModel.tick(reduceMotionEnabled: reduceMotion)

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -13,27 +13,39 @@ struct KGSidebarView: View {
     let hasChunkLoadError: Bool
     let hasFileLoadError: Bool
     let onOpenConversation: (String) -> Void
+    let onSelectRelation: (EntityCard.Relation) -> Void
     let onLoadMoreChunks: () -> Void
     let onLoadMoreFiles: () -> Void
     let onClose: () -> Void
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: true) {
-            VStack(alignment: .leading, spacing: 16) {
-                if let entity {
+        VStack(alignment: .leading, spacing: 0) {
+            if let entity {
+                VStack(alignment: .leading, spacing: 12) {
                     header(entity)
                     synopsis(entity)
-                    relationsSection(entity.relations)
-                    if !entity.metadata.isEmpty {
-                        metadataSection(entity.metadata)
+                }
+                .padding(18)
+                .background(Color(nsColor: .controlBackgroundColor))
+
+                ScrollView(.vertical, showsIndicators: true) {
+                    VStack(alignment: .leading, spacing: 16) {
+                        relationsSection(entity.relations)
+                        if !entity.metadata.isEmpty {
+                            metadataSection(entity.metadata)
+                        }
+                        chunksSection()
+                        filesSection()
                     }
-                    chunksSection()
-                    filesSection()
-                } else {
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 18)
+                }
+            } else {
+                ScrollView(.vertical, showsIndicators: true) {
                     emptyState
+                        .padding(18)
                 }
             }
-            .padding(18)
         }
         .frame(width: KGCanvasMetrics.sidebarWidth)
         .background(
@@ -73,6 +85,12 @@ struct KGSidebarView: View {
                             labelChip("chunks loading", tint: .green)
                         } else {
                             labelChip("\(chunkTotal) chunks", tint: .green)
+                        }
+                        if let importance = entity.importance {
+                            labelChip(String(format: "imp %.1f", importance), tint: .amber)
+                        }
+                        if let altitudeTierTitle = entity.altitudeTierTitle {
+                            labelChip("Tier: \(altitudeTierTitle)", tint: .blue)
                         }
                         if fileTotal > 0, !(hasFileLoadError && files.isEmpty) {
                             if hasFileLoadError, files.count < fileTotal {
@@ -137,32 +155,41 @@ struct KGSidebarView: View {
             } else {
                 ForEach(Array(relations.enumerated()), id: \.offset) { _, relation in
                     let presentation = KGRelationPresentation(relation: relation)
-                    HStack(alignment: .top, spacing: 10) {
-                        Text(relation.direction == "incoming" ? "←" : "→")
-                            .font(.system(size: 13, weight: .bold, design: .rounded))
-                            .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
-                            .frame(width: 14)
+                    Button {
+                        onSelectRelation(relation)
+                    } label: {
+                        HStack(alignment: .top, spacing: 10) {
+                            Text(relation.direction == "incoming" ? "←" : "→")
+                                .font(.system(size: 13, weight: .bold, design: .rounded))
+                                .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
+                                .frame(width: 14)
 
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(alignment: .firstTextBaseline, spacing: 6) {
-                                Text(relation.targetName)
-                                    .font(.system(size: 13, weight: .semibold))
-                                if let expiration = presentation.inlinePill {
-                                    ExpirationPill(date: expiration.date, label: expiration.label)
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                    Text(relation.targetName)
+                                        .font(.system(size: 13, weight: .semibold))
+                                    if let expiration = presentation.inlinePill {
+                                        ExpirationPill(date: expiration.date, label: expiration.label)
+                                    }
+                                }
+                                Text(relation.relationType.replacingOccurrences(of: "_", with: " "))
+                                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
+                                if let expiredText = presentation.expiredFooterText {
+                                    Text(expiredText)
+                                        .font(.system(size: 10, weight: .medium))
+                                        .foregroundStyle(.tertiary)
                                 }
                             }
-                            Text(relation.relationType.replacingOccurrences(of: "_", with: " "))
-                                .font(.system(size: 11, weight: .medium, design: .monospaced))
-                                .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
-                            if let expiredText = presentation.expiredFooterText {
-                                Text(expiredText)
-                                    .font(.system(size: 10, weight: .medium))
-                                    .foregroundStyle(.tertiary)
-                            }
-                        }
 
-                        Spacer()
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 11, weight: .bold))
+                                .foregroundStyle(.tertiary)
+                        }
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Open related entity \(relation.targetName)")
                     .foregroundStyle(presentation.isDimmed ? .tertiary : .primary)
                     .padding(12)
                     .background(

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -27,6 +27,7 @@ final class KGViewModel: ObservableObject {
     @Published private(set) var selectedEntityFileSidebarLoadFailed = false
     @Published private(set) var degradationState: DegradationState = .healthy
     @Published var layoutMode: KGAtlasMode = .tieredAltitude
+    @Published private(set) var isLayoutPinned = false
 
     /// Set by KGCanvasView via GeometryReader — used for centering force
     var canvasCenter: CGPoint = CGPoint(x: 300, y: 250)
@@ -259,6 +260,7 @@ final class KGViewModel: ObservableObject {
         selectedNodeId = id
 
         guard let id else {
+            isLayoutPinned = false
             selectedEntity = nil
             resetSelectedEntitySidebarState(isLoading: false, loadFailed: false)
             selectedConversation = nil
@@ -266,13 +268,21 @@ final class KGViewModel: ObservableObject {
         }
 
         guard let database, let node = nodeById(id) else {
+            isLayoutPinned = false
             selectedEntity = nil
             resetSelectedEntitySidebarState(isLoading: false, loadFailed: false)
             selectedConversation = nil
             return
         }
+        pinLayout()
 
-        selectedEntity = (try? database.lookupEntity(query: node.name)).map(EntityCard.init(lookupPayload:))
+        selectedEntity = (try? database.lookupEntity(query: node.name)).map {
+            EntityCard(
+                lookupPayload: $0,
+                importance: node.importance,
+                altitudeTierTitle: KGAltitudeTier.tier(for: node).title
+            )
+        }
         selectedConversation = nil
         resetSelectedEntitySidebarState(isLoading: true, loadFailed: false)
         let chunkPageSize = selectedEntityChunkPageSize
@@ -306,6 +316,27 @@ final class KGViewModel: ObservableObject {
                 }
             }
         }
+    }
+
+    @discardableResult
+    func selectRelatedEntity(from relation: EntityCard.Relation) -> Bool {
+        if let targetEntityId = relation.targetEntityId,
+           nodes.contains(where: { $0.id == targetEntityId }) {
+            selectNode(id: targetEntityId)
+            return true
+        }
+
+        let targetName = relation.targetName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !targetName.isEmpty else { return false }
+        guard let node = nodes.first(where: {
+            $0.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                .localizedCaseInsensitiveCompare(targetName) == .orderedSame
+        }) else {
+            return false
+        }
+
+        selectNode(id: node.id)
+        return true
     }
 
     func loadMoreChunks() {
@@ -389,7 +420,7 @@ final class KGViewModel: ObservableObject {
 
     func tick(reduceMotionEnabled: Bool = false) -> CGFloat {
         guard nodes.count > 1 else { return 0 }
-        if reduceMotionEnabled {
+        if reduceMotionEnabled || isLayoutPinned {
             freezeLayout()
             return 0
         }
@@ -465,6 +496,11 @@ final class KGViewModel: ObservableObject {
         for index in nodes.indices {
             nodes[index].velocity = .zero
         }
+    }
+
+    private func pinLayout() {
+        isLayoutPinned = true
+        freezeLayout()
     }
 
     private func pinOwnerEntityIfPresent() {

--- a/brain-bar/Sources/BrainBar/Models/EntityCard.swift
+++ b/brain-bar/Sources/BrainBar/Models/EntityCard.swift
@@ -4,6 +4,7 @@ struct EntityCard: Equatable {
     struct Relation: Equatable {
         let relationType: String
         let targetName: String
+        let targetEntityId: String?
         let direction: String  // "outgoing" or "incoming"
         let validUntil: Date?
         let expiredAt: Date?
@@ -11,12 +12,14 @@ struct EntityCard: Equatable {
         init(
             relationType: String,
             targetName: String,
+            targetEntityId: String? = nil,
             direction: String = "outgoing",
             validUntil: Date? = nil,
             expiredAt: Date? = nil
         ) {
             self.relationType = relationType
             self.targetName = targetName
+            self.targetEntityId = targetEntityId
             self.direction = direction
             self.validUntil = validUntil
             self.expiredAt = expiredAt
@@ -49,6 +52,8 @@ struct EntityCard: Equatable {
     let memoryCount: Int
     let metadata: [String: String]
     let chunks: [String]
+    let importance: Double?
+    let altitudeTierTitle: String?
 
     init(
         id: String,
@@ -63,7 +68,9 @@ struct EntityCard: Equatable {
         memories: [Memory] = [],
         memoryCount: Int? = nil,
         metadata: [String: String] = [:],
-        chunks: [String] = []
+        chunks: [String] = [],
+        importance: Double? = nil,
+        altitudeTierTitle: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -78,9 +85,11 @@ struct EntityCard: Equatable {
         self.memoryCount = memoryCount ?? memories.count
         self.metadata = metadata
         self.chunks = chunks
+        self.importance = importance
+        self.altitudeTierTitle = altitudeTierTitle
     }
 
-    init(lookupPayload: [String: Any]) {
+    init(lookupPayload: [String: Any], importance: Double? = nil, altitudeTierTitle: String? = nil) {
         id = (lookupPayload["entity_id"] as? String) ?? (lookupPayload["id"] as? String) ?? ""
         name = lookupPayload["name"] as? String ?? "Unknown"
         entityType = lookupPayload["entity_type"] as? String ?? ""
@@ -95,6 +104,7 @@ struct EntityCard: Equatable {
                 Relation(
                     relationType: $0["relation_type"] as? String ?? "related_to",
                     targetName: ($0["target_name"] as? String) ?? (($0["name"] as? String) ?? (($0["target"] as? [String: Any])?["name"] as? String ?? "")),
+                    targetEntityId: ($0["target_entity_id"] as? String) ?? ($0["target_id"] as? String),
                     direction: $0["direction"] as? String ?? "outgoing",
                     validUntil: KGTemporalDate.parse($0["valid_until"] ?? $0["validUntil"]),
                     expiredAt: KGTemporalDate.parse($0["expired_at"] ?? $0["expiredAt"])
@@ -106,6 +116,8 @@ struct EntityCard: Equatable {
         chunks = ((lookupPayload["chunks"] as? [[String: Any]]) ?? []).compactMap {
             ($0["content"] as? String) ?? ($0["summary"] as? String)
         }
+        self.importance = importance ?? EntityCard.decodeDouble(lookupPayload["importance"])
+        self.altitudeTierTitle = altitudeTierTitle ?? (lookupPayload["altitude_tier"] as? String)
     }
 
     private static func decodeMetadata(_ raw: Any?) -> [String: String] {
@@ -121,5 +133,18 @@ struct EntityCard: Equatable {
             result[key] = String(describing: value)
         }
         return result
+    }
+
+    private static func decodeDouble(_ raw: Any?) -> Double? {
+        if let value = raw as? Double {
+            return value
+        }
+        if let value = raw as? Int {
+            return Double(value)
+        }
+        if let text = raw as? String {
+            return Double(text)
+        }
+        return nil
     }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -2,6 +2,13 @@ import XCTest
 @testable import BrainBar
 
 final class InjectionPresentationTests: XCTestCase {
+    func testExpandedBurstDetailsIDTargetsRevealedContentForScroll() {
+        XCTAssertEqual(
+            InjectionFeedView.expandedBurstDetailsID(burstID: "burst-42"),
+            "expanded-burst-details-burst-42"
+        )
+    }
+
     func testInjectionEventDeduplicatesChunkIDsForClickableRows() {
         let event = makeEvent(
             id: 1,

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -280,6 +280,8 @@ final class KGDatabaseTests: XCTestCase {
         let relation = try XCTUnwrap(card.relations.first)
 
         XCTAssertEqual(relation.targetName, "Domica")
+        XCTAssertEqual(relation.targetEntityId, "company-domica")
+        XCTAssertEqual(relation.direction, "outgoing")
         XCTAssertNotNil(relation.expiredAt)
         XCTAssertNotNil(relation.validUntil)
     }
@@ -300,6 +302,8 @@ final class KGDatabaseTests: XCTestCase {
         XCTAssertNil(relations.first?.validUntil)
         XCTAssertNil(relations.first?.expiredAt)
         XCTAssertEqual(card.relations.first?.targetName, "Domica")
+        XCTAssertEqual(card.relations.first?.targetEntityId, "company-domica")
+        XCTAssertEqual(card.relations.first?.direction, "outgoing")
         XCTAssertNil(card.relations.first?.validUntil)
         XCTAssertNil(card.relations.first?.expiredAt)
     }
@@ -1111,6 +1115,51 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertEqual(vm.selectedEntity?.name, "Alice")
     }
 
+    func testSelectNodePinsLayoutAndSubsequentTickDoesNotMoveNodes() async throws {
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+        let vm = KGViewModel(database: db)
+        await vm.loadGraph()
+        vm.nodes[0].position = CGPoint(x: 120, y: 160)
+        vm.nodes[1].position = CGPoint(x: 420, y: 360)
+        vm.nodes[0].velocity = CGVector(dx: 12, dy: -8)
+        vm.nodes[1].velocity = CGVector(dx: -6, dy: 11)
+
+        vm.selectNode(id: "a")
+        let positionsAfterSelect = vm.nodes.map(\.position)
+        let energy = vm.tick()
+
+        XCTAssertTrue(vm.isLayoutPinned)
+        XCTAssertEqual(energy, 0)
+        XCTAssertEqual(vm.nodes.map(\.position), positionsAfterSelect)
+        XCTAssertTrue(vm.nodes.allSatisfy { $0.velocity == .zero })
+    }
+
+    func testSelectRelatedEntityDrillsIntoTargetNodeAndShowsTierMetadata() async throws {
+        try db.insertEntity(id: "person-etan", type: "person", name: "Etan")
+        try db.insertEntity(id: "project-brainlayer", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "person-etan", targetId: "project-brainlayer", relationType: "builds")
+        guard let handle = db.dbHandle else {
+            XCTFail("Expected database handle")
+            return
+        }
+        XCTAssertEqual(sqlite3_exec(handle, "UPDATE kg_entities SET importance = 8.0 WHERE id = 'project-brainlayer'", nil, nil, nil), SQLITE_OK)
+
+        let vm = KGViewModel(database: db)
+        await vm.loadGraph()
+        vm.selectNode(id: "person-etan")
+        let relation = try XCTUnwrap(vm.selectedEntity?.relations.first)
+
+        XCTAssertTrue(vm.selectRelatedEntity(from: relation))
+
+        XCTAssertEqual(vm.selectedNodeId, "project-brainlayer")
+        XCTAssertEqual(vm.selectedEntity?.name, "BrainLayer")
+        XCTAssertEqual(vm.selectedEntity?.importance, 8.0)
+        XCTAssertEqual(vm.selectedEntity?.altitudeTierTitle, "Signal")
+        XCTAssertTrue(vm.isLayoutPinned)
+    }
+
     func testSelectNodeWithMissingNodeDoesNotLookupArbitraryEntity() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
@@ -1125,6 +1174,7 @@ final class KGViewModelTests: XCTestCase {
         vm.selectNode(id: "a")
 
         XCTAssertNil(vm.selectedEntity)
+        XCTAssertFalse(vm.isLayoutPinned)
         XCTAssertFalse(vm.isLoadingSelectedEntityChunks)
         XCTAssertTrue(vm.selectedEntityChunks.isEmpty)
     }
@@ -1140,6 +1190,7 @@ final class KGViewModelTests: XCTestCase {
         vm.selectNode(id: nil)
         XCTAssertNil(vm.selectedNodeId)
         XCTAssertNil(vm.selectedEntity)
+        XCTAssertFalse(vm.isLayoutPinned)
     }
 
     func testSelectNodeClearsOpenConversationOverlay() async throws {


### PR DESCRIPTION
## Summary
- Pin KG graph layout on node/relation selection so clicking nodes only highlights and opens the sidebar without restarting force layout.
- Make entity-card relation rows clickable drill-ins that select the related node and show importance/tier metadata.
- Scroll expanded injection burst details into view, keep entity header/synopsis pinned, and make dashboard status badges hug their text.

## Test plan
- [x] `git diff --cached --check`
- [x] `swift build --package-path brain-bar`
- [x] `swift test --package-path brain-bar` (546 tests, 0 failures)
- [x] pre-push BrainLayer gate: pytest unit suite (2211 passed, 9 skipped, 75 deselected, 1 xfailed), MCP registration (3 passed), isolated eval/hook routing (36 passed), bun test (1 pass), FTS5 determinism shell regression

## Review notes
- Pre-commit CodeRabbit was attempted with `cr review --plain` twice and `coderabbit review --agent`; the service stalled at the summarization phase and returned no findings. Requesting CodeRabbit again on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and read-path SQLite query changes in BrainBar with broad unit test coverage; no auth or server-side data mutation.
> 
> **Overview**
> **Knowledge graph** selection now **pins the force layout** (`isLayoutPinned`) so tapping a node or following a relation stops the simulation and keeps nodes from jumping; deselecting clears the pin. **Relation rows** in the sidebar are **buttons** that call `selectRelatedEntity`, resolving targets by `target_entity_id` or name. **`lookupEntity`** returns **importance** and **related entity IDs** on relations; **`EntityCard`** shows **importance** and **altitude tier** in the sidebar header.
> 
> **Injection feed** wraps the list in **`ScrollViewReader`** and scrolls to expanded burst details when a burst opens (respecting reduce motion).
> 
> **Dashboard** hero/agent/status **pills** use **`fixedSize(horizontal:)`** instead of fixed max widths so labels size to their text. **KG sidebar** keeps entity header/synopsis fixed above a scrollable relations/metadata/chunks section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29254d53e0fa98b709f2388508b6fb068cfd9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize knowledge graph selection by pinning layout on node select and enabling sidebar relation drill-ins
> - Selecting a node in the knowledge graph now pins the force-directed layout (freezes simulation), preventing nodes from moving while a selection is active; deselecting unpins and resumes simulation.
> - Relation rows in `KGSidebarView` are now tappable buttons that navigate to the related entity via `KGViewModel.selectRelatedEntity`, which matches by `targetEntityId` or falls back to case-insensitive name lookup.
> - `EntityCard` and `EntityCard.Relation` now carry `importance`, `altitudeTierTitle`, and `targetEntityId` fields parsed from lookup payloads; the sidebar displays importance and tier chips when present.
> - `InjectionFeedView` wraps its scroll view in a `ScrollViewReader` and automatically scrolls to newly expanded burst details, animated unless reduced motion is enabled.
> - Layout pill components (`BrainBarHeroBadge`, `BrainBarAgentPresencePill`, `BrainBarFlowStatusPill`) switch from fixed max-width frames to `.fixedSize(horizontal: true, vertical: false)` for intrinsic sizing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b29254d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->