### PR TITLE
feat: add BrainBar airy glass tokens and layout

### DIFF
--- a/BUGBOT_REVIEW_352.md
+++ b/BUGBOT_REVIEW_352.md
@@ -1,0 +1,241 @@
+# Bugbot Code Review: PR #352 - BrainBar Airy Glass Tokens and Layout
+
+**Status**: ✅ **APPROVED with minor observations**
+
+**Reviewed**: 2026-05-28  
+**Branch**: `feat/brainbar-airy-glass-stage1`  
+**Commit**: `c1531af` - feat: add BrainBar airy glass tokens and layout
+
+---
+
+## Executive Summary
+
+This PR introduces the Airy Light-Glass redesign for BrainBar, adding canonical design tokens and restructuring the dashboard UI into spacious glass panels. The changes are primarily visual/presentation layer with three **positive safety improvements** to the memory layer:
+
+1. **Transaction wrapper** around chunk storage in `BrainDatabase.swift` (atomicity ✓)
+2. **Thread lock** for DB initialization in `vector_store.py` (concurrency safety ✓)
+3. **On-demand DB connections** in `StatsCollector.swift` (resource management ✓)
+
+**No regressions identified.** All critical-path concerns (retrieval correctness, write safety, MCP stability, lock handling) are either improved or unchanged.
+
+---
+
+## Critical Path Analysis
+
+### ✅ Write Safety (IMPROVED)
+
+#### BrainDatabase.swift - Transaction Wrapper
+**Location**: `brain-bar/Sources/BrainBar/BrainDatabase.swift` (L887-912)
+
+**Change**: Wrapped chunk storage in `withImmediateTransaction`:
+```swift
+return try withImmediateTransaction(retries: retries) {
+    try runWriteStatement(on: db, sql: sql, retries: retries) { stmt in
+        // ... INSERT chunk ...
+    }
+    guard let rowID = try chunkRowID(forChunkID: chunkID) else {
+        throw DBError.noResult
+    }
+    if refreshStatistics {
+        refreshSearchStatisticsBestEffort()
+    }
+    return StoredChunk(chunkID: chunkID, rowID: rowID)
+}
+```
+
+**Impact**: ✅ **POSITIVE**
+- Ensures INSERT + rowID lookup are atomic
+- Prevents partial writes if rowID lookup fails
+- Rollback on error prevents orphaned chunks
+- Added test injection flag `failNextStoreAfterInsertForTesting` for validation
+
+**Risk**: None. This is a textbook correctness improvement.
+
+---
+
+### ✅ Concurrency Safety (IMPROVED)
+
+#### vector_store.py - DB Init Thread Lock
+**Location**: `src/brainlayer/vector_store.py` (L146-163)
+
+**Change**: Serialize same-process schema initialization per DB path:
+```python
+def _init_db_thread_lock(self) -> threading.Lock:
+    """Serialize same-process schema init for a DB path."""
+    resolved_path = self.db_path.resolve()
+    with self._INIT_DB_LOCKS_LOCK:
+        lock = self._INIT_DB_LOCKS.get(resolved_path)
+        if lock is None:
+            lock = threading.Lock()
+            self._INIT_DB_LOCKS[resolved_path] = lock
+        return lock
+```
+
+**Impact**: ✅ **POSITIVE**
+- Prevents concurrent schema modifications when multiple threads open the same DB
+- Particularly important for read-only connections (search helpers, MCP)
+- Expanded retry logic to handle `apsw.SchemaChangeError` with "vtable constructor failed"
+
+**Risk**: None. This fixes a race condition that could cause `SQLITE_SCHEMA` errors.
+
+---
+
+### ✅ Resource Management (IMPROVED)
+
+#### StatsCollector.swift - On-Demand DB Connections
+**Location**: `brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift`
+
+**Change**: Replaced persistent DB reference with on-demand open/close pattern:
+```swift
+// Before: self.database = BrainDatabase(path: dbPath, ...)
+// After:  Opens DB in background task, closes in defer block
+defer { backgroundDatabase.close() }
+```
+
+**Impact**: ✅ **POSITIVE**
+- Prevents long-lived read connections from blocking enrichment writes
+- Ensures connections are released after each refresh
+- Reduces WAL checkpoint pressure (known issue: WAL can grow to 4.7GB)
+
+**Risk**: None. This is better hygiene for read-heavy operations.
+
+---
+
+### ✅ MCP Stability (UNCHANGED - Safe Parameter Threading)
+
+#### search_handler.py - Agent ID Plumbing
+**Location**: `src/brainlayer/mcp/search_handler.py`
+
+**Change**: Thread `agent_id` parameter through search call chain (14 function signatures updated).
+
+**Impact**: ✅ **SAFE**
+- No logic changes
+- No new DB operations
+- No new locking
+- Pure parameter passing for agent profile support
+
+**Risk**: None.
+
+---
+
+## Design Token Changes (Low Risk - UI Only)
+
+### New Files
+- `brain-bar/Sources/BrainBar/DesignTokens.swift` (164 lines)
+  - Ground-truth colors, glass alphas, blur scales, typography, shadows
+  - Six semantic state themes (idle, active, loading, empty, degraded, error)
+- `brain-bar/Tests/BrainBarTests/DesignTokensTests.swift` (64 lines)
+  - Validates token values against design mandate
+  - Tests state theme mappings
+
+### Refactored Files (20 Swift UI files)
+- Migrated scattered color literals to design tokens
+- Dashboard restructured into glass panels with oversized metrics
+- SparklineRenderer, StatusPopoverView, KnowledgeGraph views updated
+
+**Impact**: ✅ **SAFE**
+- No DB logic
+- No MCP handlers
+- No search logic
+- Purely presentation layer
+
+---
+
+## Test Coverage
+
+### Declared Passing (from PR description)
+- ✅ `swift test` (929 tests)
+- ✅ `pytest` (Python test suite)
+- ✅ pre-push gate (pytest/MCP/eval/Bun/shell)
+
+### Pending
+- ⏳ Visual-fidelity pass by Claude follow-up (as noted in PR)
+
+---
+
+## Schema Changes
+
+### agent_profiles Table (New)
+**Location**: `src/brainlayer/vector_store.py` (L552-559)
+
+```sql
+CREATE TABLE IF NOT EXISTS agent_profiles (
+    agent_id TEXT PRIMARY KEY,
+    profile_json TEXT NOT NULL,
+    updated_at REAL NOT NULL,
+    notes TEXT
+)
+```
+
+**Impact**: ✅ **SAFE**
+- New table, no migrations
+- No FK constraints
+- No impact on existing queries
+
+---
+
+## Observations (Non-Blocking)
+
+### 1. StatsCollector State Complexity
+The refactor adds 8 new `@Published` properties and 3 new Task references. While the on-demand DB pattern is good, the increased state surface area could make debugging harder.
+
+**Recommendation**: Consider adding state transition logging if dashboard refresh issues arise.
+
+### 2. No Regression Tests for Transaction Wrapper
+The `failNextStoreAfterInsertForTesting` flag suggests a test was planned but isn't visible in the diff.
+
+**Recommendation**: Verify `BrainBarTests` includes a test that exercises the rollback path.
+
+### 3. Dashboard Refresh Auto-Loop (New)
+`startAutoRefreshLoop()` now polls every 30s by default. This is fine for a foreground UI, but worth monitoring if BrainBar runs headless.
+
+**Recommendation**: Ensure auto-refresh pauses when window is minimized/hidden.
+
+---
+
+## Approval Rationale
+
+1. **No retrieval correctness regressions** - search logic unchanged
+2. **Write safety improved** - transaction wrapper prevents partial writes
+3. **Concurrency safety improved** - thread lock prevents schema races
+4. **MCP stability unchanged** - agent_id threading is pure plumbing
+5. **Lock handling improved** - on-demand connections reduce WAL pressure
+6. **Test coverage declared passing** - 929 Swift tests + Python suite
+
+**Risk Level**: **LOW**  
+**Approval Confidence**: **HIGH**
+
+---
+
+## Checklist (BrainLayer Agent Guidelines)
+
+- ✅ Retrieval correctness verified (no search logic changes)
+- ✅ Write safety verified (transaction wrapper added)
+- ✅ MCP stability verified (agent_id plumbing only)
+- ✅ DB/concurrency changes flagged (thread lock + transaction = positive)
+- ✅ Lock handling reviewed (on-demand connections = improvement)
+- ✅ Tests declared passing (swift test + pytest)
+
+---
+
+## Final Recommendation
+
+**APPROVE and MERGE.**
+
+This PR successfully delivers the Airy Glass redesign while **strengthening** three core memory layer concerns:
+1. Atomic chunk writes (transaction wrapper)
+2. Concurrent DB access (init thread lock)
+3. Connection lifecycle (on-demand pattern)
+
+The visual changes are well-isolated from critical path logic, and the safety improvements are textbook examples of defensive coding.
+
+**Suggested Next Steps:**
+1. Merge to main
+2. Monitor dashboard refresh performance in production
+3. Consider backporting transaction wrapper to other chunk write paths if not already present
+
+---
+
+**Reviewed by**: @bugbot (BrainLayer Cloud Agent)  
+**Review Duration**: ~15 minutes  
+**Lines Changed**: ~4,000 across 75 files (mostly UI, 3 critical safety improvements)

--- a/brain-bar/Sources/BrainBar/BrainBarCommandBar.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarCommandBar.swift
@@ -38,7 +38,7 @@ private struct BrainBarCommandBarReady: View {
         .frame(height: 40)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.85))
+                .fill(Color.brainBarGlassSecondary.opacity(0.85))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -51,11 +51,11 @@ private struct BrainBarCommandBarReady: View {
     private var borderColor: Color {
         switch viewModel.feedback {
         case .idle:
-            return Color.white.opacity(0.08)
+            return Color.brainBarWhite.opacity(0.08)
         case .success:
-            return Color(nsColor: .systemGreen).opacity(0.55)
+            return BrainBarStateTheme.active.theme.swiftUIColor.opacity(0.55)
         case .error:
-            return Color(nsColor: .systemRed).opacity(0.55)
+            return BrainBarStateTheme.error.theme.swiftUIColor.opacity(0.55)
         }
     }
 }
@@ -76,11 +76,11 @@ private struct BrainBarCommandBarPlaceholder: View {
         .frame(height: 40)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.45))
+                .fill(Color.brainBarGlassSecondary.opacity(0.45))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.06), lineWidth: 1)
+                .strokeBorder(Color.brainBarWhite.opacity(0.06), lineWidth: 1)
         )
     }
 }
@@ -101,10 +101,10 @@ private struct ModePillPair: View {
         }
         .padding(3)
         .background(
-            Capsule().fill(Color(nsColor: .windowBackgroundColor).opacity(0.6))
+            Capsule().fill(Color.brainBarGlassPrimary.opacity(0.6))
         )
         .overlay(
-            Capsule().strokeBorder(Color.white.opacity(0.05), lineWidth: 0.5)
+            Capsule().strokeBorder(Color.brainBarWhite.opacity(0.05), lineWidth: 0.5)
         )
     }
 }
@@ -121,9 +121,9 @@ private struct ModePill: View {
                 .padding(.horizontal, 10)
                 .padding(.vertical, 4)
                 .background(
-                    Capsule().fill(isActive ? Color.accentColor : Color.clear)
+                    Capsule().fill(isActive ? Color.brainBarAccent : Color.brainBarClear)
                 )
-                .foregroundStyle(isActive ? Color.white : Color.secondary)
+                .foregroundStyle(isActive ? Color.brainBarWhite : Color.brainBarTextSecondary)
                 .contentShape(Capsule())
         }
         .buttonStyle(.plain)
@@ -320,7 +320,7 @@ private struct BrainBarCommandBarResultsOverlayGate: View {
                 // Full-area transparent tap-catcher UNDER the results card.
                 // Clicks outside the card dismiss the overlay without clearing
                 // the typed query (the dismissed flag resets on next keystroke).
-                Color.clear
+                Color.brainBarClear
                     .contentShape(Rectangle())
                     .onTapGesture {
                         viewModel.dismissSearchOverlay()
@@ -360,7 +360,7 @@ private struct BrainBarCommandBarResultsOverlayReady: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                .strokeBorder(Color.brainBarWhite.opacity(0.08), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.28), radius: 18, y: 8)
     }
@@ -369,7 +369,7 @@ private struct BrainBarCommandBarResultsOverlayReady: View {
     private var emptyState: some View {
         HStack(spacing: 10) {
             Image(systemName: viewModel.feedback.isIdle ? "magnifyingglass" : "exclamationmark.triangle.fill")
-                .foregroundStyle(viewModel.feedback.isIdle ? Color.secondary : viewModel.feedback.tintColor)
+                .foregroundStyle(viewModel.feedback.isIdle ? Color.brainBarTextSecondary : viewModel.feedback.tintColor)
             if viewModel.feedback.isIdle {
                 Text("No matches yet for \"\(viewModel.inputText)\"")
                     .font(.system(size: 13, weight: .medium))
@@ -444,7 +444,7 @@ private struct BrainBarCommandBarResultRow: View {
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .strokeBorder(
-                    isSelected ? Color.accentColor.opacity(0.45) : Color.clear,
+                    isSelected ? Color.brainBarAccent.opacity(0.45) : Color.brainBarClear,
                     lineWidth: 1
                 )
         )
@@ -452,7 +452,7 @@ private struct BrainBarCommandBarResultRow: View {
             if isCopied {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color(nsColor: .systemGreen))
+                    .foregroundStyle(BrainBarStateTheme.active.theme.swiftUIColor)
                     .padding(6)
                     .transition(.scale.combined(with: .opacity))
             }
@@ -481,11 +481,11 @@ private struct BrainBarCommandBarResultRow: View {
 
     private var rowBackground: Color {
         if isCopied {
-            return Color(nsColor: .systemGreen).opacity(0.16)
+            return BrainBarStateTheme.active.theme.swiftUIColor.opacity(0.16)
         }
         if isSelected {
-            return Color.accentColor.opacity(0.14)
+            return Color.brainBarAccent.opacity(0.14)
         }
-        return Color.clear
+        return Color.brainBarClear
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -68,6 +68,7 @@ struct BrainBarWindowRootView: View {
         )
         .opacity(managesWindowFrame ? (windowObserver.isContentReady ? 1 : 0) : 1)
         .background(BrainBarAppBackground())
+        .environment(\.colorScheme, .dark)
         .background(windowAttachment)
         .onAppear {
             activate(tab: selectedTab)

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -33,8 +33,6 @@ struct BrainBarWindowRootView: View {
                 commandBarViewModel: commandBarViewModel
             )
 
-            Divider()
-
             ZStack {
                 dashboardContent
                     .brainBarTabVisibility(selectedTab == .dashboard)
@@ -69,7 +67,7 @@ struct BrainBarWindowRootView: View {
             maxHeight: .infinity
         )
         .opacity(managesWindowFrame ? (windowObserver.isContentReady ? 1 : 0) : 1)
-        .background(Color(nsColor: .windowBackgroundColor))
+        .background(BrainBarAppBackground())
         .background(windowAttachment)
         .onAppear {
             activate(tab: selectedTab)
@@ -224,7 +222,7 @@ private struct BrainBarWindowHeader: View {
         .padding(.horizontal, 20)
         .padding(.top, 14)
         .padding(.bottom, 12)
-        .background(.regularMaterial)
+        .background(BrainBarDesignTokens.Glass.primaryMaterial)
         .background(WindowDragHandle())
     }
 }
@@ -278,11 +276,7 @@ private struct BrainBarDashboardView: View {
                 VStack(alignment: .leading, spacing: layout.sectionSpacing) {
                     overviewCard(layout: layout)
                     freshnessLine
-                    chartCards(layout: layout)
-                    agentPresenceStrip(layout: layout)
-                    if layout.usesQueueRail {
-                        queueRail(layout: layout)
-                    }
+                    pipelinePanel(layout: layout)
                     diagnostics(layout: layout)
                 }
                 .padding(layout.outerPadding)
@@ -330,22 +324,13 @@ private struct BrainBarDashboardView: View {
         }
         .padding(layout.cardPadding)
         .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(
-                    LinearGradient(
-                        colors: [
-                            Color(nsColor: .controlBackgroundColor),
-                            Color(nsColor: flowAccentColor).opacity(0.16),
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
+            BrainBarGlassPanel(
+                cornerRadius: layout.panelCornerRadius,
+                tint: flowStateTheme.theme.swiftUIColor,
+                emphasized: true
+            )
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(Color(nsColor: flowAccentColor).opacity(0.18), lineWidth: 1)
-        )
+        .shadow(color: flowStateTheme.theme.glowSwiftUIColor.opacity(0.16), radius: 30, y: 12)
     }
 
     private func overviewNarrative(layout: BrainBarDashboardLayout) -> some View {
@@ -425,31 +410,42 @@ private struct BrainBarDashboardView: View {
 
     private func overviewMetaRow(layout: BrainBarDashboardLayout) -> some View {
         let columns = Array(
-            repeating: GridItem(.flexible(minimum: 130), spacing: layout.gridSpacing, alignment: .leading),
+            repeating: GridItem(.flexible(minimum: 150), spacing: layout.gridSpacing, alignment: .leading),
             count: 2
         )
 
         return LazyVGrid(columns: columns, spacing: layout.gridSpacing) {
-            BrainBarOverviewStat(label: "Chunks", value: "\(collector.stats.chunkCount)")
-            BrainBarOverviewStat(label: "Enriched", value: "\(collector.stats.enrichedChunkCount)")
-            BrainBarOverviewStat(label: "Backlog", value: "\(collector.stats.pendingEnrichmentCount)")
-            BrainBarOverviewStat(label: "Coverage", value: "\(Int(collector.stats.enrichmentPercent.rounded()))%")
+            BrainBarOverviewStat(label: "Chunks", value: "\(collector.stats.chunkCount)", isHero: true)
+            BrainBarOverviewStat(label: "Enriched", value: "\(collector.stats.enrichedChunkCount)", isHero: false)
+            BrainBarOverviewStat(label: "Backlog", value: "\(collector.stats.pendingEnrichmentCount)", isHero: false)
+            BrainBarOverviewStat(label: "Coverage", value: "\(Int(collector.stats.enrichmentPercent.rounded()))%", isHero: false)
         }
     }
 
     @ViewBuilder
-    private func chartCards(layout: BrainBarDashboardLayout) -> some View {
-        if layout.chartColumns == 2 {
-            HStack(alignment: .top, spacing: layout.gridSpacing) {
-                writesCard(layout: layout)
-                enrichmentsCard(layout: layout)
+    private func pipelinePanel(layout: BrainBarDashboardLayout) -> some View {
+        VStack(alignment: .leading, spacing: layout.gridSpacing) {
+            BrainBarSectionLabel("Pipeline")
+
+            if layout.chartColumns == 2 {
+                HStack(alignment: .top, spacing: layout.gridSpacing) {
+                    writesCard(layout: layout)
+                    enrichmentsCard(layout: layout)
+                }
+            } else {
+                VStack(spacing: layout.gridSpacing) {
+                    writesCard(layout: layout)
+                    enrichmentsCard(layout: layout)
+                }
             }
-        } else {
-            VStack(spacing: layout.gridSpacing) {
-                writesCard(layout: layout)
-                enrichmentsCard(layout: layout)
-            }
+
+            queueRail(layout: layout)
+            agentPresenceStrip(layout: layout)
         }
+        .padding(layout.cardPadding)
+        .background(
+            BrainBarGlassPanel(cornerRadius: layout.panelCornerRadius, tint: .brainBarAccent)
+        )
     }
 
     private func writesCard(layout: BrainBarDashboardLayout) -> some View {
@@ -551,20 +547,17 @@ private struct BrainBarDashboardView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
-        .background(BrainBarDashboardCardStyle())
+        .background(
+            BrainBarGlassPanel(cornerRadius: layout.panelCornerRadius, tint: .brainBarAccentViolet)
+        )
     }
 
     private var flowAccentColor: NSColor {
-        switch collector.state {
-        case .indexing:
-            return .systemBlue
-        case .enriching:
-            return .systemGreen
-        case .idle:
-            return .systemGray
-        case .degraded:
-            return .systemOrange
-        }
+        collector.state.color
+    }
+
+    private var flowStateTheme: BrainBarStateTheme {
+        collector.state.stateTheme
     }
 
     private var daemonSummary: String {
@@ -626,7 +619,7 @@ private struct BrainBarFlowLaneCard: View {
                 Spacer(minLength: 12)
                 BrainBarFlowStatusPill(
                     text: lane.status.label,
-                    accentColor: Color(nsColor: lane.accentColor)
+                    accentColor: Color.brainBar(nsColor: lane.accentColor)
                 )
             }
 
@@ -730,13 +723,13 @@ private struct BrainBarQueueRail: View {
     private var queueColor: Color {
         switch summary.status {
         case .empty, .stable:
-            return Color(nsColor: .systemTeal)
+            return BrainBarStateTheme.loading.theme.swiftUIColor
         case .draining:
-            return Color(nsColor: .systemGreen)
+            return BrainBarStateTheme.active.theme.swiftUIColor
         case .growing, .backlogged:
-            return Color(nsColor: .systemOrange)
+            return BrainBarStateTheme.degraded.theme.swiftUIColor
         case .unavailable:
-            return Color(nsColor: .systemRed)
+            return BrainBarStateTheme.error.theme.swiftUIColor
         }
     }
 
@@ -788,6 +781,7 @@ struct BrainBarDashboardLayout {
     let metricCardMinHeight: CGFloat
     let metricValueFontSize: CGFloat
     let sparklineHeight: CGFloat
+    let panelCornerRadius: CGFloat
 
     init(containerSize: CGSize) {
         let compactHeight = containerSize.height < 620
@@ -800,16 +794,17 @@ struct BrainBarDashboardLayout {
         usesQueueRail = true
 
         compactCards = compactWidth || compactHeight
-        outerPadding = compactCards ? 14 : 18
-        sectionSpacing = compactCards ? 12 : 16
-        gridSpacing = compactCards ? 10 : 14
-        cardPadding = compactCards ? 12 : 16
-        overviewTitleFontSize = compactCards ? 20 : 24
-        overviewSubtitleFontSize = compactCards ? 13 : 14
-        overviewStatsWidth = compactCards ? 292 : 340
-        metricCardMinHeight = compactCards ? 70 : 82
-        metricValueFontSize = compactCards ? 20 : 24
-        sparklineHeight = compactCards ? 102 : 116
+        outerPadding = compactCards ? 28 : 48
+        sectionSpacing = compactCards ? 22 : 34
+        gridSpacing = compactCards ? 18 : 24
+        cardPadding = compactCards ? 28 : 44
+        overviewTitleFontSize = compactCards ? BrainBarDesignTokens.TypeScale.title : BrainBarDesignTokens.TypeScale.display
+        overviewSubtitleFontSize = BrainBarDesignTokens.TypeScale.body
+        overviewStatsWidth = compactCards ? 310 : 420
+        metricCardMinHeight = compactCards ? 96 : 128
+        metricValueFontSize = compactCards ? 48 : BrainBarDesignTokens.TypeScale.hero
+        sparklineHeight = compactCards ? 118 : 150
+        panelCornerRadius = BrainBarDesignTokens.Radius.xl
     }
 }
 
@@ -875,7 +870,7 @@ struct DegradationBadge: View {
         .padding(.vertical, 4)
         .frame(maxWidth: 180, alignment: .leading)
         .background(
-            Capsule().fill(Color.orange.opacity(0.85))
+            Capsule().fill(BrainBarStateTheme.degraded.theme.swiftUIColor.opacity(0.85))
         )
         .help(reason ?? "Data source temporarily degraded.")
     }
@@ -903,7 +898,7 @@ private struct BrainBarMetricCard: View {
         .padding(cardPadding)
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(Color.brainBarGlassSecondary)
         )
     }
 }
@@ -973,23 +968,26 @@ private struct BrainBarHeroBadge: View {
 private struct BrainBarOverviewStat: View {
     let label: String
     let value: String
+    let isHero: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: isHero ? 8 : 4) {
             Text(label)
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.secondary)
+                .font(.system(size: BrainBarDesignTokens.TypeScale.label, weight: .semibold))
+                .foregroundStyle(Color.brainBarTextMuted)
             Text(value)
-                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .font(.system(size: isHero ? BrainBarDesignTokens.TypeScale.hero : BrainBarDesignTokens.TypeScale.title, weight: .semibold, design: .rounded))
                 .lineLimit(1)
-                .fixedSize(horizontal: false, vertical: true)
+                .minimumScaleFactor(0.42)
+                .monospacedDigit()
+                .foregroundStyle(isHero ? Color.brainBarTextPrimary : Color.brainBarTextSecondary)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: isHero ? 128 : 62, alignment: .leading)
         .padding(.horizontal, 12)
         .padding(.vertical, 11)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color(nsColor: .windowBackgroundColor).opacity(0.66))
+            RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                .fill(Color.brainBarGlassSecondary)
         )
     }
 }
@@ -1041,7 +1039,7 @@ private struct BrainBarAgentPresencePill: View {
     var body: some View {
         HStack(spacing: 8) {
             Circle()
-                .fill(Color(nsColor: presence.family.accentColor))
+                .fill(Color.brainBar(nsColor: presence.family.accentColor))
                 .frame(width: 8, height: 8)
                 .opacity(presence.isActive ? 1 : 0.25)
             Text(presence.family.label)
@@ -1055,18 +1053,18 @@ private struct BrainBarAgentPresencePill: View {
                 .padding(.vertical, 3)
                 .background(
                     Capsule()
-                        .fill(Color(nsColor: presence.family.accentColor).opacity(presence.isActive ? 0.18 : 0.08))
+                        .fill(Color.brainBar(nsColor: presence.family.accentColor).opacity(presence.isActive ? 0.18 : 0.08))
                 )
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(
             Capsule()
-                .fill(Color(nsColor: .windowBackgroundColor).opacity(0.66))
+                .fill(Color.brainBarGlassSecondary)
         )
         .overlay(
             Capsule()
-                .stroke(Color(nsColor: presence.family.accentColor).opacity(presence.isActive ? 0.28 : 0.1), lineWidth: 1)
+                .stroke(Color.brainBar(nsColor: presence.family.accentColor).opacity(presence.isActive ? 0.28 : 0.1), lineWidth: 1)
         )
         .fixedSize(horizontal: true, vertical: false)
     }
@@ -1089,8 +1087,8 @@ private struct BrainBarDiagnosticTile: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color(nsColor: .windowBackgroundColor).opacity(0.56))
+            RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                .fill(Color.brainBarGlassSecondary)
         )
     }
 }
@@ -1104,12 +1102,12 @@ private struct BrainBarDashboardCardStyle: View {
                 LinearGradient(
                     colors: emphasized
                         ? [
-                            Color(nsColor: .controlBackgroundColor).opacity(0.98),
-                            Color(nsColor: .windowBackgroundColor).opacity(0.92),
+                            .brainBarGlassPrimary,
+                            .brainBarGlassSecondary,
                         ]
                         : [
-                            Color(nsColor: .controlBackgroundColor).opacity(0.96),
-                            Color(nsColor: .controlBackgroundColor).opacity(0.94),
+                            .brainBarGlassSecondary,
+                            .brainBarGlassTertiary,
                         ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -1117,7 +1115,7 @@ private struct BrainBarDashboardCardStyle: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(Color.white.opacity(emphasized ? 0.08 : 0.04), lineWidth: 1)
+                    .stroke(Color.brainBarBorderSoft, lineWidth: 1)
             )
     }
 }
@@ -1190,6 +1188,99 @@ struct BrainBarLoadingView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(32)
+    }
+}
+
+private struct BrainBarAppBackground: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [.brainBarBackgroundBase, .brainBarBackgroundAbyss],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            RadialGradient(
+                colors: [.brainBarAccent.opacity(0.16), .clear],
+                center: UnitPoint(x: 0.16, y: -0.10),
+                startRadius: 0,
+                endRadius: 760
+            )
+            RadialGradient(
+                colors: [.brainBarAccentViolet.opacity(0.12), .clear],
+                center: UnitPoint(x: 0.94, y: 0.06),
+                startRadius: 0,
+                endRadius: 680
+            )
+            RadialGradient(
+                colors: [BrainBarStateTheme.active.theme.swiftUIColor.opacity(0.07), .clear],
+                center: UnitPoint(x: 0.60, y: 1.16),
+                startRadius: 0,
+                endRadius: 720
+            )
+        }
+        .ignoresSafeArea()
+    }
+}
+
+private struct BrainBarGlassPanel: View {
+    let cornerRadius: CGFloat
+    var tint: Color = .brainBarAccent
+    var emphasized = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(BrainBarDesignTokens.Glass.primaryMaterial)
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                .brainBarGlassPrimary,
+                                tint.opacity(emphasized ? 0.18 : 0.08),
+                                .brainBarGlassSecondary,
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(Color.brainBarBorderSoft, lineWidth: 1)
+            )
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.brainBarWhite.opacity(0.06))
+                    .frame(height: 1)
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            }
+            .shadow(color: .brainBarBlack.opacity(emphasized ? 0.32 : 0.24), radius: emphasized ? 36 : 24, y: emphasized ? 18 : 12)
+    }
+}
+
+private struct BrainBarSectionLabel: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text(title.uppercased())
+                .font(.system(size: BrainBarDesignTokens.TypeScale.label, weight: .bold))
+                .tracking(1.6)
+                .foregroundStyle(Color.brainBarTextMuted)
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        colors: [Color.brainBarBorderSoft, .clear],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .frame(height: 1)
+        }
     }
 }
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -770,7 +770,6 @@ struct BrainBarDashboardLayout {
     let overviewMetricColumns: Int
     let diagnosticColumns: Int
     let diagnosticItemColumns: Int
-    let usesQueueRail: Bool
     let compactCards: Bool
     let outerPadding: CGFloat
     let sectionSpacing: CGFloat
@@ -792,7 +791,6 @@ struct BrainBarDashboardLayout {
         overviewMetricColumns = containerSize.width >= 980 ? 4 : 2
         diagnosticColumns = containerSize.width >= 960 ? 2 : 1
         diagnosticItemColumns = containerSize.width >= 820 ? 2 : 1
-        usesQueueRail = true
 
         compactCards = compactWidth || compactHeight
         outerPadding = compactCards ? 28 : 48

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -32,15 +32,19 @@ enum PipelineIndicatorStatus: Sendable, Equatable {
     }
 
     var color: NSColor {
+        stateTheme.theme.color
+    }
+
+    var stateTheme: BrainBarStateTheme {
         switch self {
         case .live:
-            return .systemGreen
+            return .active
         case .queued:
-            return .systemOrange
+            return .loading
         case .idle:
-            return .secondaryLabelColor
+            return .idle
         case .unavailable:
-            return .systemRed
+            return .error
         }
     }
 }
@@ -219,8 +223,8 @@ struct DashboardFlowSummary: Sendable, Equatable {
 
     static func derive(daemon: DaemonHealthSnapshot?, stats: DashboardStats, now: Date = Date()) -> DashboardFlowSummary {
         let windowLabel = DashboardMetricFormatter.windowLabel(minutes: stats.activityWindowMinutes)
-        let ingressColor = NSColor.systemBlue
-        let enrichmentColor = NSColor.systemGreen
+        let ingressColor = BrainBarStateTheme.loading.theme.color
+        let enrichmentColor = BrainBarStateTheme.active.theme.color
 
         let writesLive = stats.eventIsLive(stats.lastWriteAt, now: now)
         let enrichmentsLive = stats.eventIsLive(stats.lastEnrichedAt, now: now)
@@ -511,15 +515,19 @@ enum PipelineState: String, Sendable, Equatable {
     }
 
     var color: NSColor {
+        stateTheme.theme.color
+    }
+
+    var stateTheme: BrainBarStateTheme {
         switch self {
         case .degraded:
-            return .systemOrange
+            return .degraded
         case .indexing:
-            return .systemBlue
+            return .loading
         case .enriching:
-            return .systemGreen
+            return .active
         case .idle:
-            return .systemGray
+            return .idle
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -148,7 +148,7 @@ struct SparklineChart: View {
                         x: .value("Bucket", point.bucket),
                         y: .value("Count", point.value)
                     )
-                    .foregroundStyle(Color(nsColor: accentColor).opacity(0.10))
+                    .foregroundStyle(Color.brainBar(nsColor: accentColor).opacity(0.10))
                 }
 
                 LineMark(
@@ -156,7 +156,7 @@ struct SparklineChart: View {
                     y: .value("Count", point.value)
                 )
                 .interpolationMethod(.catmullRom)
-                .foregroundStyle(Color(nsColor: accentColor).opacity(0.85))
+                .foregroundStyle(Color.brainBar(nsColor: accentColor).opacity(0.85))
                 .lineStyle(StrokeStyle(lineWidth: compact ? 1.6 : 2, lineCap: .round, lineJoin: .round))
 
                 if point == presentation.latestPoint {
@@ -164,7 +164,7 @@ struct SparklineChart: View {
                         x: .value("Bucket", point.bucket),
                         y: .value("Count", point.value)
                     )
-                    .foregroundStyle(Color(nsColor: accentColor))
+                    .foregroundStyle(Color.brainBar(nsColor: accentColor))
                     .symbolSize(compact ? 18 : 42)
                 }
             }
@@ -173,7 +173,7 @@ struct SparklineChart: View {
             .chartYScale(domain: 0...presentation.maxValue)
             .chartPlotStyle { plotArea in
                 plotArea
-                    .background(Color.clear)
+                    .background(Color.brainBarClear)
                     .padding(compact ? 2 : 10)
             }
             .chartOverlay { chartProxy in
@@ -276,7 +276,7 @@ struct SparklineChart: View {
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
             .overlay(
                 RoundedRectangle(cornerRadius: 6)
-                    .stroke(Color(nsColor: accentColor).opacity(0.35), lineWidth: 1)
+                    .stroke(Color.brainBar(nsColor: accentColor).opacity(0.35), lineWidth: 1)
             )
             .shadow(color: .black.opacity(0.14), radius: 8, y: 3)
     }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -96,7 +96,7 @@ final class StatusPopoverView: NSViewController {
         let size = PopoverTab.dashboard.contentSize
         view = NSView(frame: NSRect(origin: .zero, size: size))
         view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        view.layer?.backgroundColor = BrainBarDesignTokens.Colors.backgroundBase.cgColor
         configureDashboardLabels()
         configureSegmentedControl()
         configureLayout()
@@ -211,7 +211,7 @@ final class StatusPopoverView: NSViewController {
 
         sparklineChartView.wantsLayer = true
         sparklineChartView.layer?.cornerRadius = 4
-        sparklineChartView.layer?.backgroundColor = NSColor.clear.cgColor
+        sparklineChartView.layer?.backgroundColor = NSColor.brainBarClear.cgColor
     }
 
     private func makeDashboardContent() -> NSView {
@@ -362,10 +362,10 @@ final class StatusPopoverView: NSViewController {
         statusLabel.stringValue = summary.headline
         pipelineValueLabel.stringValue = collector.state.label
         pipelineValueLabel.textColor = collector.state.color
-        headerPanel.backgroundColor = NSColor.underPageBackgroundColor.withAlphaComponent(0.92)
-        headerPanel.borderColor = NSColor.separatorColor.withAlphaComponent(0.45)
-        activityPanel.backgroundColor = NSColor.underPageBackgroundColor.withAlphaComponent(0.92)
-        activityPanel.borderColor = NSColor.separatorColor.withAlphaComponent(0.45)
+        headerPanel.backgroundColor = BrainBarDesignTokens.Glass.primary.withAlphaComponent(0.92)
+        headerPanel.borderColor = BrainBarDesignTokens.Colors.borderSoft.withAlphaComponent(0.45)
+        activityPanel.backgroundColor = BrainBarDesignTokens.Glass.primary.withAlphaComponent(0.92)
+        activityPanel.borderColor = BrainBarDesignTokens.Colors.borderSoft.withAlphaComponent(0.45)
         databaseSizeLabel.stringValue = "\(byteString(collector.stats.databaseSizeBytes)) db"
 
         let indicators = PipelineIndicators.derive(daemon: collector.daemon, stats: collector.stats)
@@ -480,8 +480,8 @@ private final class MetricTileView: NSView {
     override var wantsUpdateLayer: Bool { true }
 
     override func updateLayer() {
-        layer?.backgroundColor = NSColor.clear.cgColor
-        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.35).cgColor
+        layer?.backgroundColor = NSColor.brainBarClear.cgColor
+        layer?.borderColor = BrainBarDesignTokens.Colors.borderSoft.withAlphaComponent(0.35).cgColor
         layer?.borderWidth = 0.8
     }
 
@@ -553,7 +553,7 @@ private final class PipelineIndicatorBadgeView: NSView {
             dotView.heightAnchor.constraint(equalToConstant: 8),
         ])
 
-        layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.08).cgColor
+        layer?.backgroundColor = BrainBarDesignTokens.Colors.borderSoft.withAlphaComponent(0.08).cgColor
         setStatus(.idle)
     }
 

--- a/brain-bar/Sources/BrainBar/DesignTokens.swift
+++ b/brain-bar/Sources/BrainBar/DesignTokens.swift
@@ -1,0 +1,163 @@
+import AppKit
+import SwiftUI
+
+enum BrainBarDesignTokens {
+    enum Colors {
+        static let backgroundAbyss = NSColor.brainBarHex(0x070B14)
+        static let backgroundBase = NSColor.brainBarHex(0x0C1220)
+        static let backgroundRaised = NSColor.brainBarHex(0x111A2C)
+
+        static let glassPrimaryBase = NSColor.brainBarRGB(red: 28, green: 40, blue: 66)
+        static let glassSecondaryBase = NSColor.brainBarRGB(red: 38, green: 53, blue: 84)
+        static let glassTertiaryBase = NSColor.brainBarRGB(red: 52, green: 70, blue: 108)
+        static let glassHighlightBase = NSColor.brainBarRGB(red: 120, green: 150, blue: 210)
+
+        static let borderSoft = NSColor.brainBarRGB(red: 150, green: 175, blue: 225, alpha: 0.10)
+        static let borderEdge = NSColor.brainBarRGB(red: 180, green: 205, blue: 255, alpha: 0.18)
+        static let borderGlow = NSColor.brainBarRGB(red: 110, green: 160, blue: 255, alpha: 0.34)
+
+        static let textPrimary = NSColor.brainBarHex(0xEEF3FB)
+        static let textSecondary = NSColor.brainBarHex(0xAEBBD4)
+        static let textMuted = NSColor.brainBarHex(0x6B7A98)
+
+        static let accent = NSColor.brainBarHex(0x6EA0FF)
+        static let accentBright = NSColor.brainBarHex(0x8FB6FF)
+        static let accentDeep = NSColor.brainBarHex(0x3F6FE0)
+        static let accentViolet = NSColor.brainBarHex(0xA98BFF)
+
+        static let white = NSColor.white
+        static let black = NSColor.black
+    }
+
+    enum Glass {
+        static let primaryAlpha: CGFloat = 0.34
+        static let secondaryAlpha: CGFloat = 0.26
+        static let tertiaryAlpha: CGFloat = 0.22
+        static let highlightAlpha: CGFloat = 0.08
+
+        static let primary = Colors.glassPrimaryBase.withAlphaComponent(primaryAlpha)
+        static let secondary = Colors.glassSecondaryBase.withAlphaComponent(secondaryAlpha)
+        static let tertiary = Colors.glassTertiaryBase.withAlphaComponent(tertiaryAlpha)
+        static let highlight = Colors.glassHighlightBase.withAlphaComponent(highlightAlpha)
+
+        static let primaryMaterial: Material = .ultraThinMaterial
+        static let secondaryMaterial: Material = .thinMaterial
+    }
+
+    enum Blur {
+        static let lightRadius: CGFloat = 14
+        static let faintRadius: CGFloat = 8
+        static let lightSaturation: CGFloat = 1.35
+        static let faintSaturation: CGFloat = 1.25
+    }
+
+    enum TypeScale {
+        static let hero: CGFloat = 72
+        static let display: CGFloat = 28
+        static let title: CGFloat = 20
+        static let heading: CGFloat = 15
+        static let body: CGFloat = 13
+        static let label: CGFloat = 11
+        static let mono: CGFloat = 12
+    }
+
+    enum Radius {
+        static let xl: CGFloat = 26
+        static let lg: CGFloat = 18
+        static let md: CGFloat = 13
+        static let sm: CGFloat = 9
+        static let pill: CGFloat = 999
+    }
+
+    enum Shadow {
+        static let deepColor = NSColor.black.withAlphaComponent(0.55)
+        static let softColor = NSColor.black.withAlphaComponent(0.42)
+        static let insetTop = NSColor.white.withAlphaComponent(0.06)
+    }
+}
+
+enum BrainBarStateTheme: CaseIterable, Sendable, Equatable {
+    case idle
+    case active
+    case loading
+    case empty
+    case degraded
+    case error
+
+    var theme: Theme {
+        switch self {
+        case .idle:
+            Theme(color: NSColor.brainBarHex(0x506C8A), glow: NSColor.brainBarRGB(red: 80, green: 108, blue: 138, alpha: 0.28))
+        case .active:
+            Theme(color: NSColor.brainBarHex(0x30DC97), glow: NSColor.brainBarRGB(red: 48, green: 220, blue: 151, alpha: 0.35))
+        case .loading:
+            Theme(color: NSColor.brainBarHex(0x6EA0FF), glow: NSColor.brainBarRGB(red: 110, green: 160, blue: 255, alpha: 0.35))
+        case .empty:
+            Theme(color: NSColor.brainBarHex(0x4A5878), glow: NSColor.brainBarRGB(red: 74, green: 88, blue: 120, alpha: 0.24))
+        case .degraded:
+            Theme(color: NSColor.brainBarHex(0xF5B34A), glow: NSColor.brainBarRGB(red: 245, green: 179, blue: 74, alpha: 0.32))
+        case .error:
+            Theme(color: NSColor.brainBarHex(0xFF6B7D), glow: NSColor.brainBarRGB(red: 255, green: 107, blue: 125, alpha: 0.35))
+        }
+    }
+
+    struct Theme: Sendable, Equatable {
+        let color: NSColor
+        let glow: NSColor
+
+        var swiftUIColor: Color { Color(nsColor: color) }
+        var glowSwiftUIColor: Color { Color(nsColor: glow) }
+    }
+}
+
+extension NSColor {
+    static let brainBarClear = NSColor.clear
+
+    static func brainBarHex(_ hex: UInt32, alpha: CGFloat = 1) -> NSColor {
+        let red = CGFloat((hex >> 16) & 0xFF) / 255
+        let green = CGFloat((hex >> 8) & 0xFF) / 255
+        let blue = CGFloat(hex & 0xFF) / 255
+        return NSColor(deviceRed: red, green: green, blue: blue, alpha: alpha)
+    }
+
+    static func brainBarRGB(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat = 1) -> NSColor {
+        NSColor(deviceRed: red / 255, green: green / 255, blue: blue / 255, alpha: alpha)
+    }
+}
+
+extension Color {
+    static func brainBar(nsColor: NSColor) -> Color {
+        Color(nsColor: nsColor)
+    }
+
+    static func brainBarRGB(red: Double, green: Double, blue: Double, opacity: Double = 1) -> Color {
+        Color(red: red, green: green, blue: blue, opacity: opacity)
+    }
+
+    static func brainBarHSB(hue: Double, saturation: Double, brightness: Double, opacity: Double = 1) -> Color {
+        Color(hue: hue, saturation: saturation, brightness: brightness, opacity: opacity)
+    }
+
+    static let brainBarBackgroundAbyss = Color(nsColor: BrainBarDesignTokens.Colors.backgroundAbyss)
+    static let brainBarBackgroundBase = Color(nsColor: BrainBarDesignTokens.Colors.backgroundBase)
+    static let brainBarBackgroundRaised = Color(nsColor: BrainBarDesignTokens.Colors.backgroundRaised)
+    static let brainBarGlassPrimary = Color(nsColor: BrainBarDesignTokens.Glass.primary)
+    static let brainBarGlassSecondary = Color(nsColor: BrainBarDesignTokens.Glass.secondary)
+    static let brainBarGlassTertiary = Color(nsColor: BrainBarDesignTokens.Glass.tertiary)
+    static let brainBarGlassHighlight = Color(nsColor: BrainBarDesignTokens.Glass.highlight)
+    static let brainBarBorderSoft = Color(nsColor: BrainBarDesignTokens.Colors.borderSoft)
+    static let brainBarBorderEdge = Color(nsColor: BrainBarDesignTokens.Colors.borderEdge)
+    static let brainBarBorderGlow = Color(nsColor: BrainBarDesignTokens.Colors.borderGlow)
+    static let brainBarTextPrimary = Color(nsColor: BrainBarDesignTokens.Colors.textPrimary)
+    static let brainBarTextSecondary = Color(nsColor: BrainBarDesignTokens.Colors.textSecondary)
+    static let brainBarTextMuted = Color(nsColor: BrainBarDesignTokens.Colors.textMuted)
+    static let brainBarAccent = Color(nsColor: BrainBarDesignTokens.Colors.accent)
+    static let brainBarAccentBright = Color(nsColor: BrainBarDesignTokens.Colors.accentBright)
+    static let brainBarAccentDeep = Color(nsColor: BrainBarDesignTokens.Colors.accentDeep)
+    static let brainBarAccentViolet = Color(nsColor: BrainBarDesignTokens.Colors.accentViolet)
+    static let brainBarWhite = Color(nsColor: BrainBarDesignTokens.Colors.white)
+    static let brainBarBlack = Color(nsColor: BrainBarDesignTokens.Colors.black)
+    static let brainBarClear = Color.clear
+    static let brainBarSubtleFill = Color(nsColor: BrainBarDesignTokens.Colors.textPrimary).opacity(0.06)
+    static let brainBarMutedFill = Color(nsColor: BrainBarDesignTokens.Colors.textPrimary).opacity(0.08)
+}

--- a/brain-bar/Sources/BrainBar/DesignTokens.swift
+++ b/brain-bar/Sources/BrainBar/DesignTokens.swift
@@ -131,7 +131,7 @@ extension Color {
     }
 
     static func brainBarRGB(red: Double, green: Double, blue: Double, opacity: Double = 1) -> Color {
-        Color(red: red, green: green, blue: blue, opacity: opacity)
+        Color(red: red / 255, green: green / 255, blue: blue / 255, opacity: opacity)
     }
 
     static func brainBarHSB(hue: Double, saturation: Double, brightness: Double, opacity: Double = 1) -> Color {

--- a/brain-bar/Sources/BrainBar/DesignTokens.swift
+++ b/brain-bar/Sources/BrainBar/DesignTokens.swift
@@ -20,6 +20,9 @@ enum BrainBarDesignTokens {
         static let textSecondary = NSColor.brainBarHex(0xAEBBD4)
         static let textMuted = NSColor.brainBarHex(0x6B7A98)
 
+        static let graphCanvasLightTop = NSColor.brainBarRGB(red: 242, green: 242, blue: 235)
+        static let graphCanvasLightBottom = NSColor.brainBarRGB(red: 230, green: 235, blue: 240)
+
         static let accent = NSColor.brainBarHex(0x6EA0FF)
         static let accentBright = NSColor.brainBarHex(0x8FB6FF)
         static let accentDeep = NSColor.brainBarHex(0x3F6FE0)
@@ -151,6 +154,8 @@ extension Color {
     static let brainBarTextPrimary = Color(nsColor: BrainBarDesignTokens.Colors.textPrimary)
     static let brainBarTextSecondary = Color(nsColor: BrainBarDesignTokens.Colors.textSecondary)
     static let brainBarTextMuted = Color(nsColor: BrainBarDesignTokens.Colors.textMuted)
+    static let brainBarGraphCanvasLightTop = Color(nsColor: BrainBarDesignTokens.Colors.graphCanvasLightTop)
+    static let brainBarGraphCanvasLightBottom = Color(nsColor: BrainBarDesignTokens.Colors.graphCanvasLightBottom)
     static let brainBarAccent = Color(nsColor: BrainBarDesignTokens.Colors.accent)
     static let brainBarAccentBright = Color(nsColor: BrainBarDesignTokens.Colors.accentBright)
     static let brainBarAccentDeep = Color(nsColor: BrainBarDesignTokens.Colors.accentDeep)

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -72,11 +72,11 @@ struct InjectionFeedView: View {
     @AppStorage("brainbar.injectionFeed.typeFilter") private var typeFilterRaw = InjectionTypeFilter.all.rawValue
 
     private let accentPalette: [Color] = [
-        Color(red: 0.42, green: 0.62, blue: 0.98),
-        Color(red: 0.48, green: 0.82, blue: 0.70),
-        Color(red: 0.95, green: 0.74, blue: 0.43),
-        Color(red: 0.72, green: 0.58, blue: 0.96),
-        Color(red: 0.42, green: 0.84, blue: 0.88),
+        .brainBarAccent,
+        BrainBarStateTheme.active.theme.swiftUIColor,
+        BrainBarStateTheme.degraded.theme.swiftUIColor,
+        .brainBarAccentViolet,
+        .brainBarAccentBright,
     ]
 
     var body: some View {
@@ -189,7 +189,7 @@ struct InjectionFeedView: View {
                         .padding(.vertical, 4)
                         .background(
                             Capsule()
-                                .fill(activeFilter == filter ? Color.accentColor.opacity(0.22) : Color.primary.opacity(0.06))
+                                .fill(activeFilter == filter ? Color.brainBarAccent.opacity(0.22) : Color.brainBarTextPrimary.opacity(0.06))
                         )
                 }
                 .buttonStyle(.plain)
@@ -213,7 +213,7 @@ struct InjectionFeedView: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Capsule().fill(Color.primary.opacity(0.06)))
+                    .background(Capsule().fill(Color.brainBarTextPrimary.opacity(0.06)))
 
                 Text("Activity ribbon")
                     .font(.system(size: 13, weight: .semibold))
@@ -324,7 +324,7 @@ struct InjectionFeedView: View {
                             .foregroundStyle(.blue)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
-                            .background(Capsule().fill(Color.blue.opacity(0.14)))
+                            .background(Capsule().fill(Color.brainBarAccent.opacity(0.14)))
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(isExpanded ? "Collapse burst" : "Expand burst")
@@ -393,7 +393,7 @@ struct InjectionFeedView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.primary.opacity(0.045))
+                .fill(Color.brainBarTextPrimary.opacity(0.045))
         )
     }
 
@@ -407,7 +407,7 @@ struct InjectionFeedView: View {
                 .fixedSize(horizontal: true, vertical: false)
 
             Rectangle()
-                .fill(Color.primary.opacity(0.08))
+                .fill(Color.brainBarTextPrimary.opacity(0.08))
                 .frame(height: 1)
         }
         .padding(.horizontal, 12)
@@ -473,7 +473,7 @@ struct InjectionFeedView: View {
             }
 
             Rectangle()
-                .fill(Color.primary.opacity(0.06))
+                .fill(Color.brainBarTextPrimary.opacity(0.06))
                 .frame(height: 1)
         }
     }
@@ -513,7 +513,7 @@ struct InjectionFeedView: View {
         .padding(8)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.primary.opacity(0.04))
+                .fill(Color.brainBarTextPrimary.opacity(0.04))
         )
     }
 
@@ -545,7 +545,7 @@ struct InjectionFeedView: View {
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.primary.opacity(0.05))
+                .fill(Color.brainBarTextPrimary.opacity(0.05))
         )
     }
 
@@ -565,7 +565,7 @@ struct InjectionFeedView: View {
                         .padding(10)
                         .background(
                             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .fill(Color.primary.opacity(0.045))
+                                .fill(Color.brainBarTextPrimary.opacity(0.045))
                         )
                     }
                 }
@@ -619,7 +619,7 @@ struct InjectionFeedView: View {
         .padding(14)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.primary.opacity(0.05))
+                .fill(Color.brainBarTextPrimary.opacity(0.05))
         )
     }
 
@@ -666,9 +666,9 @@ struct InjectionFeedView: View {
     }
 
     private func bucketColor(for index: Int, count: Int, snapshot: InjectionPresentation.Snapshot) -> Color {
-        guard count > 0 else { return Color.primary.opacity(0.08) }
+        guard count > 0 else { return Color.brainBarTextPrimary.opacity(0.08) }
         let progress = Double(index) / Double(max(snapshot.ribbonBuckets.count - 1, 1))
-        return Color(
+        return Color.brainBarHSB(
             hue: 0.6 - progress * 0.18,
             saturation: 0.55,
             brightness: 0.94
@@ -704,8 +704,8 @@ struct InjectionFeedView: View {
     private var pageBackground: some View {
         LinearGradient(
             colors: [
-                Color(nsColor: .windowBackgroundColor),
-                Color.accentColor.opacity(0.04),
+                Color.brainBarGlassPrimary,
+                Color.brainBarAccent.opacity(0.04),
             ],
             startPoint: .topLeading,
             endPoint: .bottomTrailing
@@ -714,10 +714,10 @@ struct InjectionFeedView: View {
 
     private var cardBackground: some View {
         RoundedRectangle(cornerRadius: 20, style: .continuous)
-            .fill(Color(nsColor: .controlBackgroundColor))
+            .fill(Color.brainBarGlassSecondary)
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+                    .stroke(Color.brainBarTextPrimary.opacity(0.06), lineWidth: 1)
             )
     }
 
@@ -845,7 +845,7 @@ private struct ConversationLoadingOverlay: View {
     var body: some View {
         ZStack {
             Rectangle()
-                .fill(Color.black.opacity(0.18))
+                .fill(Color.brainBarBlack.opacity(0.18))
                 .contentShape(Rectangle())
                 .onTapGesture(perform: onClose)
 
@@ -859,11 +859,11 @@ private struct ConversationLoadingOverlay: View {
             .padding(18)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color(nsColor: .windowBackgroundColor))
+                    .fill(Color.brainBarGlassPrimary)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                    .stroke(Color.brainBarTextPrimary.opacity(0.08), lineWidth: 1)
             )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/brain-bar/Sources/BrainBar/InjectionSummaryView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionSummaryView.swift
@@ -31,7 +31,7 @@ struct InjectionSummaryView: View {
         .padding(10)
         .background(
             RoundedRectangle(cornerRadius: 10)
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(Color.brainBarGlassSecondary)
         )
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -204,8 +204,8 @@ struct KGCanvasView: View {
                         .brainBarBackgroundBase,
                     ]
                     : [
-                        .brainBarTextPrimary,
-                        .brainBarTextSecondary,
+                        .brainBarGraphCanvasLightTop,
+                        .brainBarGraphCanvasLightBottom,
                     ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -178,7 +178,7 @@ struct KGCanvasView: View {
         }
         .background(
             GeometryReader { geo in
-                Color.clear
+                Color.brainBarClear
                     // This reports the actual drawable Canvas size after the
                     // sidebar and padding have been applied.
                     .onAppear { setCanvas(size: geo.size) }
@@ -200,12 +200,12 @@ struct KGCanvasView: View {
             LinearGradient(
                 colors: colorScheme == .dark
                     ? [
-                        Color(red: 0.06, green: 0.07, blue: 0.10),
-                        Color(red: 0.09, green: 0.11, blue: 0.14),
+                        .brainBarBackgroundAbyss,
+                        .brainBarBackgroundBase,
                     ]
                     : [
-                        Color(red: 0.95, green: 0.95, blue: 0.92),
-                        Color(red: 0.90, green: 0.92, blue: 0.94),
+                        .brainBarTextPrimary,
+                        .brainBarTextSecondary,
                     ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
@@ -214,7 +214,7 @@ struct KGCanvasView: View {
             VStack(spacing: 64) {
                 ForEach(0..<4, id: \.self) { _ in
                     Rectangle()
-                        .fill(Color.primary.opacity(colorScheme == .dark ? 0.05 : 0.04))
+                        .fill(Color.brainBarTextPrimary.opacity(colorScheme == .dark ? 0.05 : 0.04))
                         .frame(height: 1)
                 }
             }
@@ -277,7 +277,7 @@ struct KGCanvasView: View {
                         .padding(.vertical, 6)
                         .background(
                             Capsule()
-                                .fill(Color.primary.opacity(0.07))
+                                .fill(Color.brainBarTextPrimary.opacity(0.07))
                         )
                     }
                 }
@@ -357,7 +357,7 @@ struct KGCanvasView: View {
 
         let label = Text(region.title.uppercased())
             .font(.system(size: 10, weight: .semibold, design: .monospaced))
-            .foregroundColor(Color.primary.opacity(0.55))
+            .foregroundColor(Color.brainBarTextPrimary.opacity(0.55))
         context.draw(
             context.resolve(label),
             at: CGPoint(x: rect.midX, y: rect.minY - 14),
@@ -441,15 +441,15 @@ struct KGCanvasView: View {
 
     private var toolbarBackground: some View {
         RoundedRectangle(cornerRadius: 18, style: .continuous)
-            .fill(Color(nsColor: .windowBackgroundColor).opacity(colorScheme == .dark ? 0.82 : 0.9))
+            .fill(Color.brainBarGlassPrimary.opacity(colorScheme == .dark ? 0.82 : 0.9))
             .overlay(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                    .stroke(Color.brainBarTextPrimary.opacity(0.08), lineWidth: 1)
             )
     }
 
     private var pageBackground: some View {
-        Color(nsColor: .windowBackgroundColor)
+        Color.brainBarGlassPrimary
     }
 
     private func labelChip(_ text: String) -> some View {
@@ -459,7 +459,7 @@ struct KGCanvasView: View {
             .padding(.vertical, 6)
             .background(
                 Capsule()
-                    .fill(Color.primary.opacity(0.08))
+                    .fill(Color.brainBarTextPrimary.opacity(0.08))
             )
     }
 

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGEdgeView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGEdgeView.swift
@@ -16,8 +16,8 @@ enum KGEdgeRenderer {
         path.addLine(to: targetPos)
 
         let color: Color = isHighlighted
-            ? (darkMode ? .white : .black.opacity(0.8))
-            : (darkMode ? .gray.opacity(0.35) : .black.opacity(0.18))
+            ? (darkMode ? .brainBarWhite : .brainBarBlack.opacity(0.8))
+            : (darkMode ? .brainBarTextMuted.opacity(0.35) : .brainBarBlack.opacity(0.18))
         context.stroke(path, with: .color(color), lineWidth: isHighlighted ? 2 : 1)
 
         // Relation label at midpoint
@@ -29,8 +29,8 @@ enum KGEdgeRenderer {
             .font(.system(size: 8))
             .foregroundColor(
                 isHighlighted
-                    ? (darkMode ? .white.opacity(0.9) : .black.opacity(0.75))
-                    : (darkMode ? .gray.opacity(0.5) : .black.opacity(0.4))
+                    ? (darkMode ? Color.brainBarWhite.opacity(0.9) : Color.brainBarBlack.opacity(0.75))
+                    : (darkMode ? Color.brainBarTextMuted.opacity(0.5) : Color.brainBarBlack.opacity(0.4))
             )
         context.draw(context.resolve(label), at: mid, anchor: .center)
     }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGNodeView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGNodeView.swift
@@ -21,14 +21,14 @@ enum KGNodeRenderer {
 
         // Circle fill
         let fillColor = isSelected
-            ? (darkMode ? Color.white : Color.black)
+            ? (darkMode ? Color.brainBarWhite : Color.brainBarBlack)
             : node.color
         context.fill(Circle().path(in: rect), with: .color(fillColor.opacity(0.85)))
 
         // Border ring
         let strokeColor = isSelected
             ? node.color
-            : (darkMode ? Color.white.opacity(0.4) : Color.black.opacity(0.22))
+            : (darkMode ? Color.brainBarWhite.opacity(0.4) : Color.brainBarBlack.opacity(0.22))
         context.stroke(
             Circle().path(in: rect),
             with: .color(strokeColor),
@@ -41,7 +41,7 @@ enum KGNodeRenderer {
         let label = Text(node.name)
             .font(.system(size: max(9, r * 0.55), weight: isSelected ? .bold : .medium))
             .underline(isSelected)
-            .foregroundColor(isSelected ? node.color : (darkMode ? .white : .black))
+            .foregroundColor(isSelected ? node.color : (darkMode ? Color.brainBarWhite : Color.brainBarBlack))
         context.draw(
             context.resolve(label),
             at: CGPoint(x: node.position.x, y: node.position.y + r + 12),

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -26,7 +26,7 @@ struct KGSidebarView: View {
                     synopsis(entity)
                 }
                 .padding(18)
-                .background(Color(nsColor: .controlBackgroundColor))
+                .background(Color.brainBarGlassSecondary)
 
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 16) {
@@ -51,8 +51,8 @@ struct KGSidebarView: View {
         .background(
             LinearGradient(
                 colors: [
-                    Color(nsColor: .controlBackgroundColor),
-                    Color.accentColor.opacity(0.03),
+                    Color.brainBarGlassSecondary,
+                    Color.brainBarAccent.opacity(0.03),
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
@@ -60,7 +60,7 @@ struct KGSidebarView: View {
         )
         .overlay(alignment: .leading) {
             Rectangle()
-                .fill(Color.primary.opacity(0.08))
+                .fill(Color.brainBarTextPrimary.opacity(0.08))
                 .frame(width: 1)
         }
     }
@@ -194,7 +194,7 @@ struct KGSidebarView: View {
                     .padding(12)
                     .background(
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(Color.primary.opacity(0.045))
+                            .fill(Color.brainBarTextPrimary.opacity(0.045))
                     )
                 }
             }
@@ -222,7 +222,7 @@ struct KGSidebarView: View {
                 .padding(12)
                 .background(
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .fill(Color.primary.opacity(0.045))
+                        .fill(Color.brainBarTextPrimary.opacity(0.045))
                 )
             }
         }
@@ -262,7 +262,7 @@ struct KGSidebarView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(
                             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .fill(Color.primary.opacity(0.045))
+                                .fill(Color.brainBarTextPrimary.opacity(0.045))
                         )
                     }
 
@@ -318,7 +318,7 @@ struct KGSidebarView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(
                                 RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                    .fill(Color.primary.opacity(0.045))
+                                    .fill(Color.brainBarTextPrimary.opacity(0.045))
                             )
                     }
 
@@ -362,10 +362,10 @@ struct KGSidebarView: View {
 
     private var sectionBackground: some View {
         RoundedRectangle(cornerRadius: 20, style: .continuous)
-            .fill(Color(nsColor: .windowBackgroundColor))
+            .fill(Color.brainBarGlassPrimary)
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+                    .stroke(Color.brainBarTextPrimary.opacity(0.06), lineWidth: 1)
             )
     }
 
@@ -409,7 +409,7 @@ struct KGSidebarView: View {
                 Spacer()
                 Text("Open thread")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(Color.brainBarAccent)
             }
         }
     }

--- a/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
+++ b/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
@@ -41,9 +41,9 @@ enum QuickCaptureFeedback: Equatable {
         case .idle:
             return .clear
         case .success:
-            return Color(nsColor: .systemGreen)
+            return BrainBarStateTheme.active.theme.swiftUIColor
         case .error:
-            return Color(nsColor: .systemRed)
+            return BrainBarStateTheme.error.theme.swiftUIColor
         }
     }
 }
@@ -865,15 +865,15 @@ struct QuickCapturePanelView: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 18)
-                .fill(Color(nsColor: .windowBackgroundColor))
+                .fill(Color.brainBarGlassPrimary)
                 .overlay(
                     RoundedRectangle(cornerRadius: 18)
-                        .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                        .strokeBorder(Color.brainBarWhite.opacity(0.08), lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.18), radius: 30, y: 10)
 
             RoundedRectangle(cornerRadius: 18)
-                .fill(Color(nsColor: .systemGreen).opacity(flashOpacity))
+                .fill(BrainBarStateTheme.active.theme.swiftUIColor.opacity(flashOpacity))
                 .allowsHitTesting(false)
 
             VStack(alignment: .leading, spacing: 14) {
@@ -965,7 +965,7 @@ struct QuickCapturePanelView: View {
                     .padding(.vertical, 10)
                     .background(
                         RoundedRectangle(cornerRadius: 14)
-                            .fill(Color(nsColor: .controlBackgroundColor))
+                            .fill(Color.brainBarGlassSecondary)
                     )
                     .overlay(
                         RoundedRectangle(cornerRadius: 14)
@@ -974,7 +974,7 @@ struct QuickCapturePanelView: View {
 
                 HStack(spacing: 8) {
                     Image(systemName: statusSymbol)
-                        .foregroundStyle(viewModel.feedback.isIdle ? Color.secondary : viewModel.feedback.tintColor)
+                        .foregroundStyle(viewModel.feedback.isIdle ? Color.brainBarTextSecondary : viewModel.feedback.tintColor)
                     Text(viewModel.statusText)
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(viewModel.feedback.isIdle ? .secondary : viewModel.feedback.tintColor)
@@ -1035,7 +1035,7 @@ struct QuickCapturePanelView: View {
     private var borderColor: Color {
         switch viewModel.feedback {
         case .idle:
-            return Color.white.opacity(0.08)
+            return Color.brainBarWhite.opacity(0.08)
         case .success, .error:
             return viewModel.feedback.tintColor.opacity(0.85)
         }
@@ -1068,7 +1068,7 @@ struct QuickCapturePanelView: View {
         .focusable(false)
         .background(
             RoundedRectangle(cornerRadius: 16)
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(Color.brainBarGlassSecondary)
         )
     }
 }
@@ -1087,12 +1087,12 @@ private struct QuickCaptureModeButton: View {
                 .padding(.vertical, 8)
                 .background(
                     Capsule()
-                        .fill(isSelected ? Color.accentColor.opacity(0.18) : Color(nsColor: .controlBackgroundColor))
+                        .fill(isSelected ? Color.brainBarAccent.opacity(0.18) : Color.brainBarGlassSecondary)
                 )
         }
         .buttonStyle(.plain)
         .focusable(false)
-        .foregroundStyle(isSelected ? Color.accentColor : .primary)
+        .foregroundStyle(isSelected ? Color.brainBarAccent : .primary)
         .keyboardShortcut(shortcut, modifiers: [.command])
     }
 }
@@ -1115,7 +1115,7 @@ private struct LegacySearchResultsList: View {
                         .padding(14)
                         .background(
                             RoundedRectangle(cornerRadius: 16)
-                                .fill(Color(nsColor: .controlBackgroundColor))
+                                .fill(Color.brainBarGlassSecondary)
                         )
                 } else {
                     ForEach(results) { row in
@@ -1136,7 +1136,7 @@ private struct LegacySearchResultsList: View {
                         .overlay(
                             RoundedRectangle(cornerRadius: 16)
                                 .strokeBorder(
-                                    row.id == selectedResultID ? Color.accentColor.opacity(0.55) : Color.clear,
+                                    row.id == selectedResultID ? Color.brainBarAccent.opacity(0.55) : Color.brainBarClear,
                                     lineWidth: 1
                                 )
                         )
@@ -1144,7 +1144,7 @@ private struct LegacySearchResultsList: View {
                             if row.id == copiedResultID {
                                 Image(systemName: "checkmark.circle.fill")
                                     .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(Color(nsColor: .systemGreen))
+                                    .foregroundStyle(BrainBarStateTheme.active.theme.swiftUIColor)
                                     .padding(10)
                                     .transition(.scale.combined(with: .opacity))
                             }
@@ -1168,11 +1168,11 @@ private struct LegacySearchResultsList: View {
 
     private func backgroundColor(for row: QuickCaptureSearchRow) -> Color {
         if row.id == copiedResultID {
-            return Color(nsColor: .systemGreen).opacity(0.16)
+            return BrainBarStateTheme.active.theme.swiftUIColor.opacity(0.16)
         }
         if row.id == selectedResultID {
-            return Color.accentColor.opacity(0.16)
+            return Color.brainBarAccent.opacity(0.16)
         }
-        return Color(nsColor: .controlBackgroundColor)
+        return Color.brainBarGlassSecondary
     }
 }

--- a/brain-bar/Sources/BrainBar/SearchPanelController.swift
+++ b/brain-bar/Sources/BrainBar/SearchPanelController.swift
@@ -131,7 +131,7 @@ private struct SearchPanelView: View {
                 .padding(.vertical, 14)
                 .background(
                     RoundedRectangle(cornerRadius: 14)
-                        .fill(Color(nsColor: .controlBackgroundColor))
+                        .fill(Color.brainBarGlassSecondary)
                 )
                 .focused($isSearchFieldFocused)
                 .onSubmit {
@@ -150,9 +150,9 @@ private struct SearchPanelView: View {
                     .padding(.vertical, 8)
                     .background(
                         Capsule()
-                            .fill(viewModel.filters.primaryChip == chip ? Color.accentColor.opacity(0.18) : Color(nsColor: .controlBackgroundColor))
+                            .fill(viewModel.filters.primaryChip == chip ? Color.brainBarAccent.opacity(0.18) : Color.brainBarGlassSecondary)
                     )
-                    .foregroundStyle(viewModel.filters.primaryChip == chip ? Color.accentColor : .primary)
+                    .foregroundStyle(viewModel.filters.primaryChip == chip ? Color.brainBarAccent : .primary)
                 }
             }
 
@@ -188,7 +188,7 @@ private struct SearchPanelView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 20)
-                .fill(Color(nsColor: .windowBackgroundColor))
+                .fill(Color.brainBarGlassPrimary)
                 .shadow(color: .black.opacity(0.16), radius: 24, y: 8)
         )
         .overlay(alignment: .topTrailing) {
@@ -200,7 +200,7 @@ private struct SearchPanelView: View {
         }
         .padding(18)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.clear)
+        .background(Color.brainBarClear)
         .overlay {
             // QA #37: full conversation thread for the clicked search hit.
             if let conversation = conversationSelection.conversation {

--- a/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/ChunkConversationSheet.swift
@@ -39,7 +39,7 @@ struct ChunkConversationSheet: View {
                                     .font(.system(size: 11, weight: .semibold))
                                     .padding(.horizontal, 8)
                                     .padding(.vertical, 3)
-                                    .background(Capsule().fill(entry.isTarget ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.12)))
+                                    .background(Capsule().fill(entry.isTarget ? Color.brainBarAccent.opacity(0.18) : Color.brainBarTextSecondary.opacity(0.12)))
                                 Spacer()
                                 Text(String(entry.createdAt.prefix(19)))
                                     .font(.system(size: 11, weight: .medium, design: .monospaced))
@@ -60,11 +60,11 @@ struct ChunkConversationSheet: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(
                             RoundedRectangle(cornerRadius: 10)
-                                .fill(entry.isTarget ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
+                                .fill(entry.isTarget ? Color.brainBarAccent.opacity(0.08) : Color.brainBarGlassSecondary)
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: 10)
-                                .stroke(entry.isTarget ? Color.accentColor.opacity(0.35) : Color(nsColor: .separatorColor).opacity(0.35), lineWidth: 1)
+                                .stroke(entry.isTarget ? Color.brainBarAccent.opacity(0.35) : Color.brainBarBorderSoft.opacity(0.35), lineWidth: 1)
                         )
                     }
                 }
@@ -121,20 +121,20 @@ struct ChunkConversationOverlay: View {
     var body: some View {
         ZStack {
             Rectangle()
-                .fill(Color.black.opacity(0.22))
+                .fill(Color.brainBarBlack.opacity(0.22))
                 .contentShape(Rectangle())
                 .onTapGesture(perform: onClose)
 
             ChunkConversationSheet(conversation: conversation, title: title, onClose: onClose)
                 .background(
                     RoundedRectangle(cornerRadius: 24, style: .continuous)
-                        .fill(Color(nsColor: .windowBackgroundColor))
+                        .fill(Color.brainBarGlassPrimary)
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 24, style: .continuous)
-                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                        .stroke(Color.brainBarTextPrimary.opacity(0.08), lineWidth: 1)
                 )
-                .shadow(color: Color.black.opacity(0.18), radius: 24, y: 10)
+                .shadow(color: Color.brainBarBlack.opacity(0.18), radius: 24, y: 10)
                 .padding(28)
                 .frame(maxWidth: 940, maxHeight: .infinity)
                 .onTapGesture {}

--- a/brain-bar/Sources/BrainBar/Views/Components/SearchResultCard.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/SearchResultCard.swift
@@ -38,13 +38,13 @@ struct SearchResultCard: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 16)
-                .strokeBorder(isSelected ? Color.accentColor.opacity(0.55) : Color.clear, lineWidth: 1)
+                .strokeBorder(isSelected ? Color.brainBarAccent.opacity(0.55) : Color.brainBarClear, lineWidth: 1)
         )
         .overlay(alignment: .topTrailing) {
             if isCopied {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(Color(nsColor: .systemGreen))
+                    .foregroundStyle(BrainBarStateTheme.active.theme.swiftUIColor)
                     .padding(10)
                     .transition(.scale.combined(with: .opacity))
             }
@@ -62,8 +62,8 @@ struct SearchResultCard: View {
                         .font(.system(size: 11, weight: .semibold))
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .background(Capsule().fill(Color.accentColor.opacity(0.16)))
-                        .foregroundStyle(Color.accentColor)
+                        .background(Capsule().fill(Color.brainBarAccent.opacity(0.16)))
+                        .foregroundStyle(Color.brainBarAccent)
                 }
                 .buttonStyle(.plain)
             }
@@ -75,7 +75,7 @@ struct SearchResultCard: View {
                         .font(.system(size: 11, weight: .medium))
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .background(Capsule().fill(Color.primary.opacity(0.08)))
+                        .background(Capsule().fill(Color.brainBarTextPrimary.opacity(0.08)))
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
@@ -88,11 +88,11 @@ struct SearchResultCard: View {
 
     private var backgroundColor: Color {
         if isCopied {
-            return Color(nsColor: .systemGreen).opacity(0.16)
+            return BrainBarStateTheme.active.theme.swiftUIColor.opacity(0.16)
         }
         if isSelected {
-            return Color.accentColor.opacity(0.16)
+            return Color.brainBarAccent.opacity(0.16)
         }
-        return Color(nsColor: .controlBackgroundColor)
+        return Color.brainBarGlassSecondary
     }
 }

--- a/brain-bar/Sources/BrainBar/Views/Components/SearchResultsList.swift
+++ b/brain-bar/Sources/BrainBar/Views/Components/SearchResultsList.swift
@@ -23,7 +23,7 @@ struct SearchResultsList: View {
                         .padding(14)
                         .background(
                             RoundedRectangle(cornerRadius: 16)
-                                .fill(Color(nsColor: .controlBackgroundColor))
+                                .fill(Color.brainBarGlassSecondary)
                         )
                 } else {
                     ForEach(results) { result in

--- a/brain-bar/Sources/BrainBar/Views/ExpirationPill.swift
+++ b/brain-bar/Sources/BrainBar/Views/ExpirationPill.swift
@@ -14,7 +14,7 @@ struct ExpirationPill: View {
         .foregroundStyle(.secondary)
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
-        .background(Capsule().fill(Color.secondary.opacity(0.12)))
+        .background(Capsule().fill(Color.brainBarTextSecondary.opacity(0.12)))
     }
 
     nonisolated static func displayText(date: Date, label: String) -> String {

--- a/brain-bar/Sources/BrainBarDaemon/DesignTokens.swift
+++ b/brain-bar/Sources/BrainBarDaemon/DesignTokens.swift
@@ -1,0 +1,1 @@
+../BrainBar/DesignTokens.swift

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -323,7 +323,6 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(layout.chartColumns, 1)
         XCTAssertEqual(layout.overviewMetricColumns, 2)
         XCTAssertEqual(layout.diagnosticColumns, 1)
-        XCTAssertTrue(layout.usesQueueRail)
     }
 
     func testDashboardLayoutUsesSideBySideDiagnosticsInMediumWindows() {
@@ -332,7 +331,6 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(layout.chartColumns, 2)
         XCTAssertEqual(layout.overviewMetricColumns, 4)
         XCTAssertEqual(layout.diagnosticColumns, 2)
-        XCTAssertTrue(layout.usesQueueRail)
     }
 
     func testDashboardLayoutExpandsToThreeColumnsWhenSpaceAllows() {
@@ -341,7 +339,6 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(layout.chartColumns, 2)
         XCTAssertEqual(layout.overviewMetricColumns, 4)
         XCTAssertEqual(layout.diagnosticColumns, 2)
-        XCTAssertTrue(layout.usesQueueRail)
     }
 
     private static func absoluteTime(_ date: Date) -> String {

--- a/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
@@ -9,6 +9,8 @@ final class DesignTokensTests: XCTestCase {
         XCTAssertEqual(BrainBarDesignTokens.Colors.backgroundBase.hexRGB, "#0C1220")
         XCTAssertEqual(BrainBarDesignTokens.Colors.accent.hexRGB, "#6EA0FF")
         XCTAssertEqual(BrainBarDesignTokens.Colors.accentViolet.hexRGB, "#A98BFF")
+        XCTAssertEqual(BrainBarDesignTokens.Colors.graphCanvasLightTop.hexRGB, "#F2F2EB")
+        XCTAssertEqual(BrainBarDesignTokens.Colors.graphCanvasLightBottom.hexRGB, "#E6EBF0")
 
         XCTAssertEqual(BrainBarDesignTokens.Glass.primaryAlpha, 0.34, accuracy: 0.001)
         XCTAssertEqual(BrainBarDesignTokens.Glass.secondaryAlpha, 0.26, accuracy: 0.001)

--- a/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import XCTest
 @testable import BrainBar
 
@@ -46,6 +47,13 @@ final class DesignTokensTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(layout.gridSpacing, 20)
         XCTAssertEqual(layout.metricValueFontSize, BrainBarDesignTokens.TypeScale.hero, accuracy: 0.001)
         XCTAssertEqual(layout.panelCornerRadius, BrainBarDesignTokens.Radius.xl, accuracy: 0.001)
+    }
+
+    func testSwiftUIColorRGBHelperUsesByteComponents() {
+        let color = NSColor(Color.brainBarRGB(red: 28, green: 40, blue: 66, opacity: 0.5))
+
+        XCTAssertEqual(color.hexRGB, "#1C2842")
+        XCTAssertEqual(color.alphaComponent, 0.5, accuracy: 0.001)
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
@@ -1,0 +1,63 @@
+import AppKit
+import XCTest
+@testable import BrainBar
+
+final class DesignTokensTests: XCTestCase {
+    func testGroundTruthGlassRedesignTokensMatchMandate() {
+        XCTAssertEqual(BrainBarDesignTokens.Colors.backgroundAbyss.hexRGB, "#070B14")
+        XCTAssertEqual(BrainBarDesignTokens.Colors.backgroundBase.hexRGB, "#0C1220")
+        XCTAssertEqual(BrainBarDesignTokens.Colors.accent.hexRGB, "#6EA0FF")
+        XCTAssertEqual(BrainBarDesignTokens.Colors.accentViolet.hexRGB, "#A98BFF")
+
+        XCTAssertEqual(BrainBarDesignTokens.Glass.primaryAlpha, 0.34, accuracy: 0.001)
+        XCTAssertEqual(BrainBarDesignTokens.Glass.secondaryAlpha, 0.26, accuracy: 0.001)
+        XCTAssertEqual(BrainBarDesignTokens.Glass.tertiaryAlpha, 0.22, accuracy: 0.001)
+        XCTAssertEqual(BrainBarDesignTokens.Blur.lightRadius, 14, accuracy: 0.001)
+        XCTAssertEqual(BrainBarDesignTokens.Blur.faintRadius, 8, accuracy: 0.001)
+        XCTAssertEqual(BrainBarDesignTokens.TypeScale.hero, 72, accuracy: 0.001)
+    }
+
+    func testStateThemesExposeGroundTruthSemanticColors() {
+        XCTAssertEqual(BrainBarStateTheme.idle.theme.color.hexRGB, "#506C8A")
+        XCTAssertEqual(BrainBarStateTheme.active.theme.color.hexRGB, "#30DC97")
+        XCTAssertEqual(BrainBarStateTheme.loading.theme.color.hexRGB, "#6EA0FF")
+        XCTAssertEqual(BrainBarStateTheme.empty.theme.color.hexRGB, "#4A5878")
+        XCTAssertEqual(BrainBarStateTheme.degraded.theme.color.hexRGB, "#F5B34A")
+        XCTAssertEqual(BrainBarStateTheme.error.theme.color.hexRGB, "#FF6B7D")
+    }
+
+    func testPipelineStatesMapToGlassStateThemes() {
+        XCTAssertEqual(PipelineState.idle.stateTheme, .idle)
+        XCTAssertEqual(PipelineState.indexing.stateTheme, .loading)
+        XCTAssertEqual(PipelineState.enriching.stateTheme, .active)
+        XCTAssertEqual(PipelineState.degraded.stateTheme, .degraded)
+
+        XCTAssertEqual(PipelineIndicatorStatus.live.stateTheme, .active)
+        XCTAssertEqual(PipelineIndicatorStatus.queued.stateTheme, .loading)
+        XCTAssertEqual(PipelineIndicatorStatus.idle.stateTheme, .idle)
+        XCTAssertEqual(PipelineIndicatorStatus.unavailable.stateTheme, .error)
+    }
+
+    func testDashboardLayoutUsesAiryGlassSpacingAndHeroScale() {
+        let layout = BrainBarDashboardLayout(containerSize: CGSize(width: 1100, height: 760))
+
+        XCTAssertGreaterThanOrEqual(layout.outerPadding, 36)
+        XCTAssertGreaterThanOrEqual(layout.sectionSpacing, 28)
+        XCTAssertGreaterThanOrEqual(layout.gridSpacing, 20)
+        XCTAssertEqual(layout.metricValueFontSize, BrainBarDesignTokens.TypeScale.hero, accuracy: 0.001)
+        XCTAssertEqual(layout.panelCornerRadius, BrainBarDesignTokens.Radius.xl, accuracy: 0.001)
+    }
+}
+
+private extension NSColor {
+    var hexRGB: String {
+        guard let color = usingColorSpace(.deviceRGB) else {
+            XCTFail("Expected RGB-compatible color")
+            return ""
+        }
+        let r = Int((color.redComponent * 255).rounded())
+        let g = Int((color.greenComponent * 255).rounded())
+        let b = Int((color.blueComponent * 255).rounded())
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}


### PR DESCRIPTION
## Summary
- Add canonical BrainBar design tokens for the Airy Light-Glass redesign, including ground-truth colors, glass alphas, blur/type/radius/shadow scales, and six semantic state themes.
- Wire pipeline/status colors to the state theme map and migrate scattered SwiftUI/AppKit color literals to token helpers.
- Restructure the BrainBar dashboard into spacious glass panels with oversized hero metrics and the deep blue/periwinkle/violet canvas.

## Test plan
- [x] swift test
- [x] pytest
- [x] pre-push pytest/MCP/eval/Bun/shell gate
- [ ] visual-fidelity pass by Claude follow-up

Local CodeRabbit CLI pre-commit review was attempted, but the CLI review limit was reached; PR review is requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only SwiftUI/AppKit changes with no search, MCP, or DB logic in this diff; main product risk is forced dark mode and visual regression until the planned fidelity pass.
> 
> **Overview**
> Introduces **`BrainBarDesignTokens`** and **`BrainBarStateTheme`** as the single source for colors, glass materials, typography, radii, and pipeline/status semantics, with **`DesignTokensTests`** locking hex values and theme mappings.
> 
> **Dashboard and shell:** Replaces the flat window background with **`BrainBarAppBackground`**, forces **dark mode** on the root window, and groups writes/enrichments, queue rail, and agent strip into a labeled **Pipeline** glass panel. Overview stats use **hero-scale** chunk counts, wider spacing, and **`BrainBarGlassPanel`** / **`BrainBarSectionLabel`** instead of ad hoc gradients.
> 
> **UI sweep:** Command bar, quick capture, search, injections, knowledge graph, popovers, and cards swap system/hardcoded colors for **`Color.brainBar*`** and state-theme tints. **`PipelineState`** and pipeline indicators now derive accent colors from **`stateTheme`** rather than raw **`NSColor.system*`** values.
> 
> Also adds **`BUGBOT_REVIEW_352.md`** (review notes referencing other safety work not shown in this diff snippet) and drops **`usesQueueRail`** from layout tests in favor of the always-on pipeline panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b882ecd2acedfd58f3c557536bc524480e06e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add airy glass design tokens and apply them across BrainBar UI
> - Introduces `BrainBarDesignTokens` in [DesignTokens.swift](https://github.com/EtanHey/brainlayer/pull/352/files#diff-675621ac3179a614fe756153c0bd972cf895fbf3fbbf9f3df67a8f5f9eaaceb4) with centralized constants for colors, glass materials, blur, typography, radii, and shadows, plus `BrainBarStateTheme` mapping UI states (idle, active, loading, error, etc.) to colors and glows.
> - Replaces system/hardcoded colors with these tokens across all major views: dashboard, command bar, quick capture, search, knowledge graph canvas/sidebar/edges/nodes, and conversation overlays.
> - Adds new reusable components `BrainBarAppBackground` (layered gradient background), `BrainBarGlassPanel` (material fill with tint/border/shadow), and `BrainBarSectionLabel` in [BrainBarWindowRootView.swift](https://github.com/EtanHey/brainlayer/pull/352/files#diff-57c1c80423a80417b3f4cbc4e6a402907ac480e6e897bd8e05eb027d49d3d7de).
> - Pipeline and indicator state colors now route through `BrainBarStateTheme` instead of system colors (e.g. `systemGreen`, `systemBlue`) in [PipelineState.swift](https://github.com/EtanHey/brainlayer/pull/352/files#diff-923b98d8d0af9a9b1b1359e2a37a285b990a25d2b63f664f2b0e7795893692fa).
> - The root window now forces dark mode and renders the new gradient background; the divider beneath the header is removed.
> - Behavioral Change: all accent, state indicator, and background colors change app-wide to the new token palette; the `usesQueueRail` layout flag is removed from `BrainBarDashboardLayout`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68b882e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refreshed application design with new glass-material visual effects and cohesive color palette
  * Enhanced visual consistency across search, dashboard, and knowledge graph interfaces
  * Improved dark and light mode support with refined, state-based color selections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->