### PR TITLE
fix(brainbar): isolate injection feed chunks

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4762,8 +4762,9 @@ final class BrainDatabase: @unchecked Sendable {
             return nil
         }
 
+        let knownChunkIDs = Set(chunks.map(\.id))
         let liveChunkIDs = event.chunkIDs.filter { chunkID in
-            liveChunks.contains { $0.id == chunkID }
+            liveChunks.contains { $0.id == chunkID } || !knownChunkIDs.contains(chunkID)
         }
         let scopedChunkIDs = liveChunkIDs.isEmpty ? liveChunks.map(\.id) : liveChunkIDs
         return InjectionEvent(

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4663,7 +4663,10 @@ final class BrainDatabase: @unchecked Sendable {
     func listInjectionEvents(sessionID: String? = nil, limit: Int = 20) throws -> [InjectionEvent] {
         guard let db else { throw DBError.notOpen }
         var sql = "SELECT id, session_id, timestamp, query, chunk_ids, token_count FROM injection_events"
-        if sessionID != nil { sql += " WHERE session_id = ?" }
+        var conditions: [String] = []
+        if sessionID != nil { conditions.append("session_id = ?") }
+        conditions.append(Self.liveInjectionEventSQLPredicate(eventTable: "injection_events"))
+        sql += " WHERE \(conditions.joined(separator: " AND "))"
         sql += " ORDER BY timestamp DESC LIMIT ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
@@ -4689,19 +4692,104 @@ final class BrainDatabase: @unchecked Sendable {
             ]
             if var event = try? InjectionEvent(row: row) {
                 let details = (try? injectionChunkDetails(ids: event.chunkIDs)) ?? []
+                guard let scopedEvent = injectionFeedScopedEvent(event, chunks: details) else {
+                    continue
+                }
                 event = InjectionEvent(
-                    id: event.id,
-                    sessionID: event.sessionID,
-                    timestamp: event.timestamp,
-                    query: event.query,
-                    chunkIDs: event.chunkIDs,
-                    tokenCount: event.tokenCount,
-                    chunks: details
+                    id: scopedEvent.id,
+                    sessionID: scopedEvent.sessionID,
+                    timestamp: scopedEvent.timestamp,
+                    query: scopedEvent.query,
+                    chunkIDs: scopedEvent.chunkIDs,
+                    tokenCount: scopedEvent.tokenCount,
+                    chunks: scopedEvent.chunks
                 )
                 events.append(event)
             }
         }
         return events
+    }
+
+    private static func liveInjectionEventSQLPredicate(eventTable: String) -> String {
+        let chunkIDRows = "json_each(\(eventTable).chunk_ids)"
+        return """
+            (
+                NOT EXISTS (
+                    SELECT 1
+                    FROM \(chunkIDRows) AS chunk_id
+                    WHERE TRIM(CAST(chunk_id.value AS TEXT)) != ''
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM \(chunkIDRows) AS chunk_id
+                    LEFT JOIN chunks AS feed_chunk
+                        ON feed_chunk.id = CAST(chunk_id.value AS TEXT)
+                    WHERE TRIM(CAST(chunk_id.value AS TEXT)) != ''
+                      AND (
+                        feed_chunk.id IS NULL
+                        OR (
+                            COALESCE(LOWER(TRIM(feed_chunk.source)), '') != 'youtube'
+                            AND COALESCE(LOWER(TRIM(feed_chunk.source_file)), '') NOT LIKE 'youtube:%'
+                            AND COALESCE(LOWER(TRIM(feed_chunk.content_type)), '') NOT IN ('transcript', 'podcast', 'seed')
+                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"manual_seed"%'
+                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"seed"%'
+                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"imported"%'
+                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"podcast"%'
+                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"youtube"%'
+                        )
+                      )
+                )
+            )
+        """
+    }
+
+    private func injectionFeedScopedEvent(_ event: InjectionEvent, chunks: [InjectionChunk]) -> InjectionEvent? {
+        guard !chunks.isEmpty else {
+            return event
+        }
+
+        let liveChunks = chunks.filter(Self.isLiveInjectionFeedChunk)
+        guard !liveChunks.isEmpty else {
+            return nil
+        }
+
+        let liveChunkIDs = event.chunkIDs.filter { chunkID in
+            liveChunks.contains { $0.id == chunkID }
+        }
+        let scopedChunkIDs = liveChunkIDs.isEmpty ? liveChunks.map(\.id) : liveChunkIDs
+        return InjectionEvent(
+            id: event.id,
+            sessionID: event.sessionID,
+            timestamp: event.timestamp,
+            query: event.query,
+            chunkIDs: scopedChunkIDs,
+            tokenCount: event.tokenCount,
+            chunks: liveChunks
+        )
+    }
+
+    private static func isLiveInjectionFeedChunk(_ chunk: InjectionChunk) -> Bool {
+        let source = chunk.source.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let sourceFile = chunk.sourceFile.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let contentType = chunk.contentType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let tags = chunk.tags.map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+
+        if source == "youtube" || sourceFile.hasPrefix("youtube:") {
+            return false
+        }
+        if contentType == "transcript" || contentType == "podcast" || contentType == "seed" {
+            return false
+        }
+        if tags.contains(where: { tag in
+            tag == "manual_seed" ||
+                tag == "seed" ||
+                tag == "imported" ||
+                tag == "podcast" ||
+                tag == "youtube"
+        }) {
+            return false
+        }
+        return true
     }
 
     private func injectionChunkDetails(ids: [String]) throws -> [InjectionChunk] {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4690,21 +4690,12 @@ final class BrainDatabase: @unchecked Sendable {
                 "chunk_ids": columnText(stmt, 4) as Any,
                 "token_count": Int(sqlite3_column_int(stmt, 5))
             ]
-            if var event = try? InjectionEvent(row: row) {
+            if let event = try? InjectionEvent(row: row) {
                 let details = (try? injectionChunkDetails(ids: event.chunkIDs)) ?? []
                 guard let scopedEvent = injectionFeedScopedEvent(event, chunks: details) else {
                     continue
                 }
-                event = InjectionEvent(
-                    id: scopedEvent.id,
-                    sessionID: scopedEvent.sessionID,
-                    timestamp: scopedEvent.timestamp,
-                    query: scopedEvent.query,
-                    chunkIDs: scopedEvent.chunkIDs,
-                    tokenCount: scopedEvent.tokenCount,
-                    chunks: scopedEvent.chunks
-                )
-                events.append(event)
+                events.append(scopedEvent)
             }
         }
         return events
@@ -4722,33 +4713,37 @@ final class BrainDatabase: @unchecked Sendable {
                 OR EXISTS (
                     SELECT 1
                     FROM \(chunkIDRows) AS chunk_id
-                    LEFT JOIN chunks AS feed_chunk
+                    JOIN chunks AS feed_chunk
                         ON feed_chunk.id = CAST(chunk_id.value AS TEXT)
                     WHERE TRIM(CAST(chunk_id.value AS TEXT)) != ''
                       AND (
-                        feed_chunk.id IS NULL
-                        OR (
-                            COALESCE(LOWER(TRIM(feed_chunk.source)), '') != 'youtube'
-                            AND COALESCE(LOWER(TRIM(feed_chunk.source_file)), '') NOT LIKE 'youtube:%'
-                            AND COALESCE(LOWER(TRIM(feed_chunk.content_type)), '') NOT IN ('transcript', 'podcast', 'seed')
-                            AND NOT EXISTS (
-                                SELECT 1
-                                FROM json_each(
-                                    CASE
-                                        WHEN json_valid(feed_chunk.tags) THEN feed_chunk.tags
-                                        ELSE '[]'
-                                    END
-                                ) AS feed_tag
-                                WHERE LOWER(TRIM(CAST(feed_tag.value AS TEXT))) IN (
-                                    'manual_seed',
-                                    'seed',
-                                    'imported',
-                                    'podcast',
-                                    'youtube'
-                                )
+                        COALESCE(LOWER(TRIM(feed_chunk.source)), '') != 'youtube'
+                        AND COALESCE(LOWER(TRIM(feed_chunk.source_file)), '') NOT LIKE 'youtube:%'
+                        AND COALESCE(LOWER(TRIM(feed_chunk.content_type)), '') NOT IN ('transcript', 'podcast', 'seed')
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM json_each(
+                                CASE
+                                    WHEN json_valid(feed_chunk.tags) THEN feed_chunk.tags
+                                    ELSE '[]'
+                                END
+                            ) AS feed_tag
+                            WHERE LOWER(TRIM(CAST(feed_tag.value AS TEXT))) IN (
+                                'manual_seed',
+                                'seed',
+                                'imported',
+                                'podcast',
+                                'youtube'
                             )
                         )
                       )
+                )
+                OR NOT EXISTS (
+                    SELECT 1
+                    FROM \(chunkIDRows) AS chunk_id
+                    JOIN chunks AS feed_chunk
+                        ON feed_chunk.id = CAST(chunk_id.value AS TEXT)
+                    WHERE TRIM(CAST(chunk_id.value AS TEXT)) != ''
                 )
             )
         """

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4731,11 +4731,22 @@ final class BrainDatabase: @unchecked Sendable {
                             COALESCE(LOWER(TRIM(feed_chunk.source)), '') != 'youtube'
                             AND COALESCE(LOWER(TRIM(feed_chunk.source_file)), '') NOT LIKE 'youtube:%'
                             AND COALESCE(LOWER(TRIM(feed_chunk.content_type)), '') NOT IN ('transcript', 'podcast', 'seed')
-                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"manual_seed"%'
-                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"seed"%'
-                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"imported"%'
-                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"podcast"%'
-                            AND COALESCE(LOWER(feed_chunk.tags), '') NOT LIKE '%"youtube"%'
+                            AND NOT EXISTS (
+                                SELECT 1
+                                FROM json_each(
+                                    CASE
+                                        WHEN json_valid(feed_chunk.tags) THEN feed_chunk.tags
+                                        ELSE '[]'
+                                    END
+                                ) AS feed_tag
+                                WHERE LOWER(TRIM(CAST(feed_tag.value AS TEXT))) IN (
+                                    'manual_seed',
+                                    'seed',
+                                    'imported',
+                                    'podcast',
+                                    'youtube'
+                                )
+                            )
                         )
                       )
                 )
@@ -4748,6 +4759,9 @@ final class BrainDatabase: @unchecked Sendable {
             return event
         }
 
+        // Mixed events are kept, but only the live hook chunks remain visible
+        // in the feed; imported seed chunks stay out of counts, previews, and
+        // expansion targets.
         let liveChunks = chunks.filter(Self.isLiveInjectionFeedChunk)
         guard !liveChunks.isEmpty else {
             return nil

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -631,7 +631,8 @@ final class DashboardTests: XCTestCase {
     func testStatsCollectorRefreshesAfterDatabaseWriteNotification() async throws {
         let collector = StatsCollector(
             dbPath: tempDBPath,
-            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier)
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 0.05
         )
         defer { collector.stop() }
 

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -842,6 +842,22 @@ final class DatabaseTests: XCTestCase {
             WHERE id = 'youtube:UIy-WQCZdAM:179'
         """)
 
+        try db.insertChunk(
+            id: "seed-with-spaces",
+            content: "Imported seed tagged with whitespace should not consume the feed limit.",
+            sessionId: "seed-spaced",
+            project: "coach",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        db.exec("""
+            UPDATE chunks
+            SET source = 'mcp',
+                source_file = 'seed:manual',
+                tags = '[" seed "]'
+            WHERE id = 'seed-with-spaces'
+        """)
+
         db.recordInjectionEvent(
             sessionID: "claude-session-1",
             query: "actual live hook",
@@ -855,6 +871,13 @@ final class DatabaseTests: XCTestCase {
             chunkIDs: ["youtube:UIy-WQCZdAM:179"],
             tokenCount: 57,
             timestamp: "2026-05-29T00:02:00.000Z"
+        )
+        db.recordInjectionEvent(
+            sessionID: "claude-session-1",
+            query: "spaced seed should not consume limit",
+            chunkIDs: ["seed-with-spaces"],
+            tokenCount: 31,
+            timestamp: "2026-05-29T00:03:00.000Z"
         )
 
         let events = try db.listInjectionEvents(sessionID: "claude-session-1", limit: 1)

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -879,6 +879,13 @@ final class DatabaseTests: XCTestCase {
             tokenCount: 31,
             timestamp: "2026-05-29T00:03:00.000Z"
         )
+        db.recordInjectionEvent(
+            sessionID: "claude-session-1",
+            query: "missing and seed should not consume limit",
+            chunkIDs: ["missing-live-candidate", "youtube:UIy-WQCZdAM:179"],
+            tokenCount: 44,
+            timestamp: "2026-05-29T00:04:00.000Z"
+        )
 
         let events = try db.listInjectionEvents(sessionID: "claude-session-1", limit: 1)
 

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -809,6 +809,63 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(event.primaryKind.label, "Checkpoint")
     }
 
+    func testListInjectionEventsRejectsImportedYoutubeSeedChunks() throws {
+        try db.insertChunk(
+            id: "live-hook",
+            content: "Injected project context for brainlayer hook session.",
+            sessionId: "session-live",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        db.exec("""
+            UPDATE chunks
+            SET source = 'mcp',
+                source_file = 'precompact:live-hook',
+                tags = '["hook-injection"]'
+            WHERE id = 'live-hook'
+        """)
+
+        try db.insertChunk(
+            id: "youtube:UIy-WQCZdAM:179",
+            content: "Andrew Huberman and Andy Galpin discuss WHOOP overtraining podcast rules.",
+            sessionId: "seed-video",
+            project: "coach",
+            contentType: "transcript",
+            importance: 5
+        )
+        db.exec("""
+            UPDATE chunks
+            SET source = 'youtube',
+                source_file = 'youtube:UIy-WQCZdAM',
+                tags = '["manual_seed","podcast"]'
+            WHERE id = 'youtube:UIy-WQCZdAM:179'
+        """)
+
+        db.recordInjectionEvent(
+            sessionID: "claude-session-1",
+            query: "actual live hook",
+            chunkIDs: ["live-hook"],
+            tokenCount: 24,
+            timestamp: "2026-05-29T00:01:00.000Z"
+        )
+        db.recordInjectionEvent(
+            sessionID: "claude-session-1",
+            query: "video seed should not render",
+            chunkIDs: ["youtube:UIy-WQCZdAM:179"],
+            tokenCount: 57,
+            timestamp: "2026-05-29T00:02:00.000Z"
+        )
+
+        let events = try db.listInjectionEvents(sessionID: "claude-session-1", limit: 1)
+
+        XCTAssertEqual(events.map(\.query), ["actual live hook"])
+        XCTAssertEqual(events.first?.chunkIDs, ["live-hook"])
+        XCTAssertFalse(events.flatMap(\.chunks).contains { chunk in
+            chunk.source == "youtube" || chunk.sourceFile.hasPrefix("youtube:")
+        })
+    }
+
     func testListInjectionEventsFiltersBySessionAndNewestFirst() throws {
         try db.recordInjectionEvent(
             sessionID: "session-a",

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -896,6 +896,37 @@ final class DatabaseTests: XCTestCase {
         })
     }
 
+    func testListInjectionEventsKeepsUnresolvedIDsWhenLiveChunkExists() throws {
+        try db.insertChunk(
+            id: "live-hook",
+            content: "Injected project context for brainlayer hook session.",
+            sessionId: "session-live",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        db.exec("""
+            UPDATE chunks
+            SET source = 'mcp',
+                source_file = 'precompact:live-hook',
+                tags = '["hook-injection"]'
+            WHERE id = 'live-hook'
+        """)
+
+        db.recordInjectionEvent(
+            sessionID: "claude-session-1",
+            query: "live hook with unresolved legacy id",
+            chunkIDs: ["missing-legacy-id", "live-hook"],
+            tokenCount: 24,
+            timestamp: "2026-05-29T00:01:00.000Z"
+        )
+
+        let event = try XCTUnwrap(db.listInjectionEvents(sessionID: "claude-session-1", limit: 1).first)
+
+        XCTAssertEqual(event.chunkIDs, ["missing-legacy-id", "live-hook"])
+        XCTAssertEqual(event.chunks.map(\.id), ["live-hook"])
+    }
+
     func testListInjectionEventsFiltersBySessionAndNewestFirst() throws {
         try db.recordInjectionEvent(
             sessionID: "session-a",


### PR DESCRIPTION
## Summary
- Scope BrainBar injection feed SQL to events with at least one live/non-imported chunk before applying `LIMIT`.
- Strip imported seed chunks from hydrated injection events so `youtube:*`, transcript, podcast, and seed-tagged chunks cannot render as live injection feed content.
- Add a regression guard using the WHOOP/Huberman-style `youtube:UIy-WQCZdAM` seed leak shape.

## Test plan
- [x] `swift build --package-path brain-bar`
- [x] `swift test --package-path brain-bar`
- [x] `swift test --package-path brain-bar --filter DatabaseTests/testListInjectionEventsRejectsImportedYoutubeSeedChunks`
- [x] `pytest`
- [x] pre-push BrainLayer test gate: pytest unit subset, MCP registration, isolated eval/hook routing, bun test, FTS5 regression shell

## Review notes
- `BrainBarDaemon/BrainDatabase.swift` is a symlink to `BrainBar/BrainDatabase.swift`, so the query scoping is shared by BrainBar and BrainBarDaemon.
- Local CodeRabbit CLI initially compared against stale local `main` and reported existing unrelated findings outside this two-file C1 diff. PR reviewers are requested below against remote `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes feed semantics and SQL filtering for injection events; wrong predicates could hide legitimate hooks or leave seed content visible, but scope is read-path only with targeted regression tests.
> 
> **Overview**
> **Injection feed listing** now hides imported and seed content so BrainBar’s live hook timeline is not crowded by YouTube/podcast/manual-seed chunks.
> 
> `listInjectionEvents` adds a SQL **`liveInjectionEventSQLPredicate`** so `LIMIT` applies only to events that still have at least one “live” chunk (or empty/unresolved chunk IDs). After hydration, **`injectionFeedScopedEvent`** strips non-live chunks from mixed events and drops events that are seed-only; **`isLiveInjectionFeedChunk`** mirrors the same rules in Swift (youtube source/`youtube:*` paths, transcript/podcast/seed types, seed/imported tags).
> 
> **Tests:** regression for WHOOP-style `youtube:*` seed leaks, mixed events keeping unresolved legacy IDs when a live chunk exists, and a faster **`statsRefreshCoalesceInterval`** in a dashboard stats test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba5b67a802234390350bf0849aa462ae4e00e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter seed, podcast, and YouTube chunks from `BrainDatabase.listInjectionEvents` results
> - Adds SQL-level pre-filtering via `liveInjectionEventSQLPredicate` to exclude injection events with no live chunks before loading details.
> - Adds `injectionFeedScopedEvent` to strip non-live chunks from returned events, dropping events entirely if no live chunks remain after filtering.
> - Live chunks are defined by `isLiveInjectionFeedChunk`: excludes chunks from YouTube sources or with content types/tags of transcript, podcast, seed, imported, or manual_seed.
> - Unresolved chunk IDs (those without loaded details) are preserved in `event.chunkIDs` so they remain visible even when their details are absent.
> - Behavioral Change: `listInjectionEvents` now omits seed/podcast/YouTube events entirely and strips non-live chunks from mixed events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ba5b67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->