### PR TITLE
fix: clean up BrainBar airy glass review nits

### DIFF
--- a/BUGBOT_REVIEW_352.md
+++ b/BUGBOT_REVIEW_352.md
@@ -25,9 +25,11 @@ This PR introduces the Airy Light-Glass redesign for BrainBar, adding canonical 
 ### ✅ Write Safety (IMPROVED)
 
 #### BrainDatabase.swift - Transaction Wrapper
+
 **Location**: `brain-bar/Sources/BrainBar/BrainDatabase.swift` (L887-912)
 
 **Change**: Wrapped chunk storage in `withImmediateTransaction`:
+
 ```swift
 return try withImmediateTransaction(retries: retries) {
     try runWriteStatement(on: db, sql: sql, retries: retries) { stmt in
@@ -56,9 +58,11 @@ return try withImmediateTransaction(retries: retries) {
 ### ✅ Concurrency Safety (IMPROVED)
 
 #### vector_store.py - DB Init Thread Lock
+
 **Location**: `src/brainlayer/vector_store.py` (L146-163)
 
 **Change**: Serialize same-process schema initialization per DB path:
+
 ```python
 def _init_db_thread_lock(self) -> threading.Lock:
     """Serialize same-process schema init for a DB path."""
@@ -83,9 +87,11 @@ def _init_db_thread_lock(self) -> threading.Lock:
 ### ✅ Resource Management (IMPROVED)
 
 #### StatsCollector.swift - On-Demand DB Connections
+
 **Location**: `brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift`
 
 **Change**: Replaced persistent DB reference with on-demand open/close pattern:
+
 ```swift
 // Before: self.database = BrainDatabase(path: dbPath, ...)
 // After:  Opens DB in background task, closes in defer block
@@ -104,6 +110,7 @@ defer { backgroundDatabase.close() }
 ### ✅ MCP Stability (UNCHANGED - Safe Parameter Threading)
 
 #### search_handler.py - Agent ID Plumbing
+
 **Location**: `src/brainlayer/mcp/search_handler.py`
 
 **Change**: Thread `agent_id` parameter through search call chain (14 function signatures updated).
@@ -121,6 +128,7 @@ defer { backgroundDatabase.close() }
 ## Design Token Changes (Low Risk - UI Only)
 
 ### New Files
+
 - `brain-bar/Sources/BrainBar/DesignTokens.swift` (164 lines)
   - Ground-truth colors, glass alphas, blur scales, typography, shadows
   - Six semantic state themes (idle, active, loading, empty, degraded, error)
@@ -129,6 +137,7 @@ defer { backgroundDatabase.close() }
   - Tests state theme mappings
 
 ### Refactored Files (20 Swift UI files)
+
 - Migrated scattered color literals to design tokens
 - Dashboard restructured into glass panels with oversized metrics
 - SparklineRenderer, StatusPopoverView, KnowledgeGraph views updated
@@ -144,11 +153,13 @@ defer { backgroundDatabase.close() }
 ## Test Coverage
 
 ### Declared Passing (from PR description)
+
 - ✅ `swift test` (929 tests)
 - ✅ `pytest` (Python test suite)
 - ✅ pre-push gate (pytest/MCP/eval/Bun/shell)
 
 ### Pending
+
 - ⏳ Visual-fidelity pass by Claude follow-up (as noted in PR)
 
 ---
@@ -156,6 +167,7 @@ defer { backgroundDatabase.close() }
 ## Schema Changes
 
 ### agent_profiles Table (New)
+
 **Location**: `src/brainlayer/vector_store.py` (L552-559)
 
 ```sql
@@ -177,16 +189,19 @@ CREATE TABLE IF NOT EXISTS agent_profiles (
 ## Observations (Non-Blocking)
 
 ### 1. StatsCollector State Complexity
+
 The refactor adds 8 new `@Published` properties and 3 new Task references. While the on-demand DB pattern is good, the increased state surface area could make debugging harder.
 
 **Recommendation**: Consider adding state transition logging if dashboard refresh issues arise.
 
 ### 2. No Regression Tests for Transaction Wrapper
+
 The `failNextStoreAfterInsertForTesting` flag suggests a test was planned but isn't visible in the diff.
 
 **Recommendation**: Verify `BrainBarTests` includes a test that exercises the rollback path.
 
 ### 3. Dashboard Refresh Auto-Loop (New)
+
 `startAutoRefreshLoop()` now polls every 30s by default. This is fine for a foreground UI, but worth monitoring if BrainBar runs headless.
 
 **Recommendation**: Ensure auto-refresh pauses when window is minimized/hidden.

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -553,10 +553,6 @@ private struct BrainBarDashboardView: View {
         )
     }
 
-    private var flowAccentColor: NSColor {
-        collector.state.color
-    }
-
     private var flowStateTheme: BrainBarStateTheme {
         collector.state.stateTheme
     }

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -170,13 +170,13 @@ enum DashboardStoreQueueHealth: String, Sendable, Equatable {
     var color: NSColor {
         switch self {
         case .empty:
-            return .secondaryLabelColor
+            return BrainBarStateTheme.empty.theme.color
         case .activeDraining:
-            return .systemGreen
+            return BrainBarStateTheme.active.theme.color
         case .backlogAccumulating:
-            return .systemYellow
+            return BrainBarStateTheme.degraded.theme.color
         case .writerStuck:
-            return .systemRed
+            return BrainBarStateTheme.error.theme.color
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/DesignTokens.swift
+++ b/brain-bar/Sources/BrainBar/DesignTokens.swift
@@ -120,11 +120,11 @@ extension NSColor {
         let red = CGFloat((hex >> 16) & 0xFF) / 255
         let green = CGFloat((hex >> 8) & 0xFF) / 255
         let blue = CGFloat(hex & 0xFF) / 255
-        return NSColor(deviceRed: red, green: green, blue: blue, alpha: alpha)
+        return NSColor(srgbRed: red, green: green, blue: blue, alpha: alpha)
     }
 
     static func brainBarRGB(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat = 1) -> NSColor {
-        NSColor(deviceRed: red / 255, green: green / 255, blue: blue / 255, alpha: alpha)
+        NSColor(srgbRed: red / 255, green: green / 255, blue: blue / 255, alpha: alpha)
     }
 }
 

--- a/brain-bar/Sources/BrainBar/SearchPanelController.swift
+++ b/brain-bar/Sources/BrainBar/SearchPanelController.swift
@@ -152,7 +152,7 @@ private struct SearchPanelView: View {
                         Capsule()
                             .fill(viewModel.filters.primaryChip == chip ? Color.brainBarAccent.opacity(0.18) : Color.brainBarGlassSecondary)
                     )
-                    .foregroundStyle(viewModel.filters.primaryChip == chip ? Color.brainBarAccent : .primary)
+                    .foregroundStyle(viewModel.filters.primaryChip == chip ? Color.brainBarAccent : Color.brainBarTextPrimary)
                 }
             }
 

--- a/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
@@ -4,6 +4,8 @@ import XCTest
 @testable import BrainBar
 
 final class DesignTokensTests: XCTestCase {
+    deinit {}
+
     func testGroundTruthGlassRedesignTokensMatchMandate() {
         XCTAssertEqual(BrainBarDesignTokens.Colors.backgroundAbyss.hexRGB, "#070B14")
         XCTAssertEqual(BrainBarDesignTokens.Colors.backgroundBase.hexRGB, "#0C1220")


### PR DESCRIPTION
Follow-up to #352. The main Stage 1 redesign merged while the final cleanup commit was still going through the local gate, so this reapplies the review-nit cleanup on top of merged main.\n\nChanges:\n- Use sRGB NSColor helpers for fixed design-token RGB interpretation.\n- Tokenize DashboardStoreQueueHealth colors and SearchPanel unselected filter chip foreground.\n- Remove unused flowAccentColor.\n- Add explicit deinit for DesignTokensTests SwiftLint rule.\n- Fix markdownlint spacing in BUGBOT_REVIEW_352.md.\n\nValidation:\n- git diff --check origin/main...HEAD\n- swift test --filter DesignTokensTests\n- swift test --filter BrainBarUXLogicTests\n- pre-push gate: pytest unit suite, MCP registration, eval/hook routing, bun test, FTS5 determinism shell test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer and documentation tweaks only; color space change is a small visual consistency fix with no data or API impact.
> 
> **Overview**
> Follow-up cleanup on merged airy-glass work—**no behavior or backend changes**.
> 
> **Design tokens:** `brainBarHex` / `brainBarRGB` now build colors with **`NSColor(srgbRed:…)`** instead of device RGB so fixed hex/RGB values match the mandate across displays.
> 
> **UI consistency:** `DashboardStoreQueueHealth.color` switches from system colors to **`BrainBarStateTheme`** (empty/active/degraded/error). Search filter chips use **`Color.brainBarTextPrimary`** for unselected labels instead of `.primary`. Unused **`flowAccentColor`** is removed from `BrainBarWindowRootView`.
> 
> **Tests / docs:** `DesignTokensTests` gets an explicit empty **`deinit`** for SwiftLint. **`BUGBOT_REVIEW_352.md`** gets markdownlint spacing only (blank lines around headings/lists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e31a852d0fb27aa9a0f6e67d07205867c6f639d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BrainBar airy glass color handling for design tokens and UI components
> - Switches `NSColor` helpers `brainBarHex` and `brainBarRGB` in [DesignTokens.swift](https://github.com/EtanHey/brainlayer/pull/354/files#diff-675621ac3179a614fe756153c0bd972cf895fbf3fbbf9f3df67a8f5f9eaaceb4) from `deviceRed` to `srgbRed`, placing colors in the sRGB color space
> - Updates `DashboardStoreQueueHealth.color` in [PipelineState.swift](https://github.com/EtanHey/brainlayer/pull/354/files#diff-923b98d8d0af9a9b1b1359e2a37a285b990a25d2b63f664f2b0e7795893692fa) to return `BrainBarStateTheme`-derived colors instead of AppKit system colors
> - Changes unselected filter chip foreground in [SearchPanelController.swift](https://github.com/EtanHey/brainlayer/pull/354/files#diff-785d360f91a89c97766e71c726130e0453b07ad9f62def05c07b91e3e02fb7f5) from `.primary` to `Color.brainBarTextPrimary`
> - Removes the unused `flowAccentColor` computed property from [BrainBarWindowRootView.swift](https://github.com/EtanHey/brainlayer/pull/354/files#diff-57c1c80423a80417b3f4cbc4e6a402907ac480e6e897bd8e05eb027d49d3d7de)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e31a85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->