### PR TITLE
fix(brainbar): anchor activity charts to wall clock

### DIFF
--- a/brain-bar/Package.swift
+++ b/brain-bar/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .executableTarget(
             name: "BrainBar",
             dependencies: [
+                "BrainBarLifecycle",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Sources/BrainBar",
@@ -27,6 +28,7 @@ let package = Package(
         .executableTarget(
             name: "BrainBarDaemon",
             dependencies: [
+                "BrainBarLifecycle",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Sources/BrainBarDaemon",
@@ -34,10 +36,15 @@ let package = Package(
                 .linkedLibrary("sqlite3"),
             ]
         ),
+        .target(
+            name: "BrainBarLifecycle",
+            path: "Sources/BrainBarLifecycle"
+        ),
         .testTarget(
             name: "BrainBarTests",
             dependencies: [
                 "BrainBar",
+                "BrainBarLifecycle",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Tests/BrainBarTests"

--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -46,9 +46,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         let otherInstances = runningInstances.filter { $0.processIdentifier != ProcessInfo.processInfo.processIdentifier }
         if let existingInstance = otherInstances.first {
-            NSLog("[BrainBar] Another instance is already running (PID %d). Exiting.", existingInstance.processIdentifier)
-            NSApp.terminate(nil)
-            return
+            if BrainBarRestartHandoff.consumeIfMatches(existingPID: existingInstance.processIdentifier) {
+                NSLog("[BrainBar] Continuing launch for requested restart while PID %d exits.", existingInstance.processIdentifier)
+            } else {
+                NSLog("[BrainBar] Another instance is already running (PID %d). Exiting.", existingInstance.processIdentifier)
+                NSApp.terminate(nil)
+                return
+            }
         }
 
         NSApp.setActivationPolicy(.accessory)

--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import BrainBarLifecycle
 import Combine
 import SwiftUI
 
@@ -22,6 +23,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkeyFileWatcher: DispatchSourceFileSystemObject?
     private var menuBarWindowObservers: [NSObjectProtocol] = []
     private var menuBarWindowSyncTask: Task<Void, Never>?
+    private var uiHeartbeatTimer: DispatchSourceTimer?
+    private var daemonWatchdog: BrainBarLifecycleWatchdog?
     private var wasVisibleAccessibilityWindow = false
 
     private var launchMode: BrainBarLaunchMode {
@@ -49,6 +52,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         NSApp.setActivationPolicy(.accessory)
+        startUIHeartbeat()
+        startDaemonWatchdog()
         configureRuntimeCallbacks()
 
         runtime.hotkeyStatus.onFallbackChange = { [weak self] in
@@ -88,6 +93,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusPopoverController = nil
         menuBarWindowSyncTask?.cancel()
         menuBarWindowSyncTask = nil
+        uiHeartbeatTimer?.cancel()
+        uiHeartbeatTimer = nil
+        daemonWatchdog?.stop()
+        daemonWatchdog = nil
         hotkeyFileWatcher?.cancel()
         quickCaptureHotkey?.stop()
         collector?.stop()
@@ -131,6 +140,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         runtime.onQuickCaptureRequested = { [weak self] in
             self?.showQuickCapturePanel()
         }
+    }
+
+    private func startUIHeartbeat() {
+        let timer = BrainBarLifecycleWatchdog.makeHeartbeatTimer(
+            path: BrainBarLifecycleWatchdog.uiHeartbeatPath,
+            interval: 5,
+            queue: .main
+        )
+        uiHeartbeatTimer = timer
+    }
+
+    private func startDaemonWatchdog() {
+        let watchdog = BrainBarLifecycleWatchdog.makeDaemonWatchdog()
+        daemonWatchdog = watchdog
+        watchdog.start()
     }
 
     @objc private func handleGetURLEvent(_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor) {

--- a/brain-bar/Sources/BrainBar/BrainBarProcessControl.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarProcessControl.swift
@@ -1,0 +1,29 @@
+import AppKit
+import Foundation
+
+@MainActor
+enum BrainBarProcessControl {
+    static func quit() {
+        NSApplication.shared.terminate(nil)
+    }
+
+    static func restart(bundlePath: String = Bundle.main.bundlePath) {
+        guard FileManager.default.fileExists(atPath: bundlePath) else {
+            NSLog("[BrainBar] Cannot restart: bundle path does not exist: %@", bundlePath)
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-n", bundlePath]
+
+        do {
+            try process.run()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NSApplication.shared.terminate(nil)
+            }
+        } catch {
+            NSLog("[BrainBar] Failed to schedule restart: %@", String(describing: error))
+        }
+    }
+}

--- a/brain-bar/Sources/BrainBar/BrainBarProcessControl.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarProcessControl.swift
@@ -1,4 +1,5 @@
 import AppKit
+import BrainBarLifecycle
 import Foundation
 
 @MainActor
@@ -13,6 +14,8 @@ enum BrainBarProcessControl {
             return
         }
 
+        BrainBarRestartHandoff.markRestartingProcess()
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
         process.arguments = ["-n", bundlePath]
@@ -23,6 +26,7 @@ enum BrainBarProcessControl {
                 NSApplication.shared.terminate(nil)
             }
         } catch {
+            BrainBarRestartHandoff.clear()
             NSLog("[BrainBar] Failed to schedule restart: %@", String(describing: error))
         }
     }

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -6,6 +6,7 @@
 // - JSON-RPC router
 // - SQLite database (single-writer)
 
+import BrainBarLifecycle
 import Foundation
 
 final class BrainBarServer: @unchecked Sendable {
@@ -109,6 +110,7 @@ final class BrainBarServer: @unchecked Sendable {
     private var lastDatabaseRetryDelayMillis: UInt64?
     private var databaseOpenInProgress = false
     private var instanceLock: BrainBarInstanceLock?
+    private var daemonHeartbeatTimer: DispatchSourceTimer?
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
     var onStartRejected: (@Sendable (String) -> Void)?
     /// Maximum EAGAIN retries before disconnecting a stalled client.
@@ -210,6 +212,7 @@ final class BrainBarServer: @unchecked Sendable {
             onStartRejected?("failed to acquire single-instance lock \(instanceLockPath): \(error)")
             return
         }
+        startDaemonHeartbeatOnQueue()
 
         let ownedHybridClient: HybridSearchHelperClient?
         let hybridClient: HybridSearchClientProtocol?
@@ -657,6 +660,8 @@ final class BrainBarServer: @unchecked Sendable {
     }
 
     private func cleanup() {
+        daemonHeartbeatTimer?.cancel()
+        daemonHeartbeatTimer = nil
         databaseRetryWorkItem?.cancel()
         databaseRetryWorkItem = nil
         listenSource?.cancel()
@@ -680,6 +685,16 @@ final class BrainBarServer: @unchecked Sendable {
         instanceLock?.release()
         instanceLock = nil
         NSLog("[BrainBar] Server stopped")
+    }
+
+    private func startDaemonHeartbeatOnQueue() {
+        daemonHeartbeatTimer?.cancel()
+        let timer = BrainBarLifecycleWatchdog.makeHeartbeatTimer(
+            path: BrainBarLifecycleWatchdog.daemonHeartbeatPath,
+            interval: 5,
+            queue: queue
+        )
+        daemonHeartbeatTimer = timer
     }
 
     private func handleSubscribeTool(fd: Int32, id: Any?, arguments: [String: Any]) -> [String: Any] {

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -103,10 +103,14 @@ struct BrainBarWindowRootView: View {
     @ViewBuilder
     private var dashboardContent: some View {
         if let collector = runtime.collector {
-            BrainBarDashboardView(
-                collector: collector,
-                hotkeyStatus: runtime.hotkeyStatus.statusLine
-            )
+            if collector.lastDataFetchedAt == nil {
+                BrainBarLoadingView(title: "BrainBar", subtitle: "Connecting to daemon and loading dashboard data...")
+            } else {
+                BrainBarDashboardView(
+                    collector: collector,
+                    hotkeyStatus: runtime.hotkeyStatus.statusLine
+                )
+            }
         } else {
             BrainBarLoadingView(title: "BrainBar", subtitle: "Opening database and warming the dashboard...")
         }
@@ -209,6 +213,8 @@ private struct BrainBarWindowHeader: View {
                     BrainBarHeaderRefreshControls(collector: collector)
                 }
 
+                BrainBarAppControlMenu()
+
                 Spacer(minLength: 12)
 
                 Text(hotkeyStatus)
@@ -252,6 +258,25 @@ private struct BrainBarHeaderRefreshControls: View {
                 .controlSize(.small)
                 .frame(width: 16, height: 16)
         }
+    }
+}
+
+private struct BrainBarAppControlMenu: View {
+    var body: some View {
+        Menu {
+            Button("Restart BrainBar") {
+                BrainBarProcessControl.restart()
+            }
+            Button("Quit BrainBar") {
+                BrainBarProcessControl.quit()
+            }
+        } label: {
+            Image(systemName: "power")
+                .frame(width: 18, height: 18)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.small)
+        .help("Restart or quit BrainBar")
     }
 }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct SparklineChartPoint: Identifiable, Equatable, Sendable {
     let bucket: Int
     let value: Int
+    let timestamp: Date
 
     var id: Int { bucket }
 }
@@ -33,7 +34,7 @@ struct SparklineChartPresentation: Equatable, Sendable {
 
     var points: [SparklineChartPoint] {
         values.enumerated().map { index, value in
-            SparklineChartPoint(bucket: index, value: value)
+            SparklineChartPoint(bucket: index, value: value, timestamp: bucketMidpoint(for: index))
         }
     }
 
@@ -51,6 +52,14 @@ struct SparklineChartPresentation: Equatable, Sendable {
 
     var maxValue: Int {
         max(values.max() ?? 0, 1)
+    }
+
+    var xAxisDomainStart: Date {
+        fetchedAt.addingTimeInterval(-Double(max(activityWindowMinutes * 60, 1)))
+    }
+
+    var xAxisDomainEnd: Date {
+        fetchedAt
     }
 
     func bucketLabel(for bucket: Int) -> String {
@@ -90,6 +99,11 @@ struct SparklineChartPresentation: Equatable, Sendable {
         let start = fetchedAt.addingTimeInterval(-(Double(totalSeconds) - bucketStart))
         let end = fetchedAt.addingTimeInterval(-(Double(totalSeconds) - bucketEnd))
         return (start, end)
+    }
+
+    private func bucketMidpoint(for bucket: Int) -> Date {
+        let range = bucketRange(for: bucket)
+        return range.start.addingTimeInterval(range.end.timeIntervalSince(range.start) / 2)
     }
 
     private static func durationLabel(seconds: Int) -> String {
@@ -145,23 +159,23 @@ struct SparklineChart: View {
             Chart(presentation.points) { point in
                 if !compact {
                     AreaMark(
-                        x: .value("Bucket", point.bucket),
+                        x: .value("Time", point.timestamp),
                         y: .value("Count", point.value)
                     )
                     .foregroundStyle(Color.brainBar(nsColor: accentColor).opacity(0.10))
                 }
 
                 LineMark(
-                    x: .value("Bucket", point.bucket),
+                    x: .value("Time", point.timestamp),
                     y: .value("Count", point.value)
                 )
-                .interpolationMethod(.catmullRom)
+                .interpolationMethod(.linear)
                 .foregroundStyle(Color.brainBar(nsColor: accentColor).opacity(0.85))
                 .lineStyle(StrokeStyle(lineWidth: compact ? 1.6 : 2, lineCap: .round, lineJoin: .round))
 
                 if point == presentation.latestPoint {
                     PointMark(
-                        x: .value("Bucket", point.bucket),
+                        x: .value("Time", point.timestamp),
                         y: .value("Count", point.value)
                     )
                     .foregroundStyle(Color.brainBar(nsColor: accentColor))
@@ -170,6 +184,7 @@ struct SparklineChart: View {
             }
             .chartXAxis(.hidden)
             .chartYAxis(.hidden)
+            .chartXScale(domain: presentation.xAxisDomainStart...presentation.xAxisDomainEnd)
             .chartYScale(domain: 0...presentation.maxValue)
             .chartPlotStyle { plotArea in
                 plotArea
@@ -250,10 +265,15 @@ struct SparklineChart: View {
         }
 
         let plotX = location.x - plotFrame.minX
-        guard let bucket: Double = chartProxy.value(atX: plotX, as: Double.self) else {
+        guard let hoveredDate: Date = chartProxy.value(atX: plotX, as: Date.self) else {
             return nil
         }
-        return min(max(Int(bucket.rounded()), 0), presentation.points.count - 1)
+        let distances = presentation.points.map { abs($0.timestamp.timeIntervalSince(hoveredDate)) }
+        guard let minDistance = distances.min(),
+              let bucket = distances.firstIndex(of: minDistance) else {
+            return nil
+        }
+        return bucket
     }
 
     private var xAxisBuckets: [Int] {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -237,11 +237,15 @@ final class StatusPopoverView: NSViewController {
         metricsRow.distribution = .fillEqually
         metricsRow.spacing = 10
 
-        let quitButton = NSButton(title: "Quit", target: self, action: #selector(quitBrainBar))
+        let restartButton = NSButton(title: "Restart BrainBar", target: self, action: #selector(restartBrainBar))
+        restartButton.bezelStyle = .rounded
+        restartButton.controlSize = .small
+
+        let quitButton = NSButton(title: "Quit BrainBar", target: self, action: #selector(quitBrainBar))
         quitButton.bezelStyle = .rounded
         quitButton.controlSize = .small
 
-        let footerRow = NSStackView(views: [daemonLabel, NSView(), hotkeyLabel, quitButton])
+        let footerRow = NSStackView(views: [daemonLabel, NSView(), hotkeyLabel, restartButton, quitButton])
         footerRow.orientation = .horizontal
         footerRow.alignment = .centerY
         footerRow.spacing = 10
@@ -406,7 +410,12 @@ final class StatusPopoverView: NSViewController {
 
     @objc
     private func quitBrainBar() {
-        NSApplication.shared.terminate(nil)
+        BrainBarProcessControl.quit()
+    }
+
+    @objc
+    private func restartBrainBar() {
+        BrainBarProcessControl.restart()
     }
 
     // MARK: - Helpers

--- a/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatusPopoverView.swift
@@ -387,7 +387,8 @@ final class StatusPopoverView: NSViewController {
             presentation: SparklineChartPresentation(
                 label: "Recent activity sparkline",
                 values: summary.enrichment.values,
-                activityWindowMinutes: summary.enrichment.activityWindowMinutes
+                activityWindowMinutes: summary.enrichment.activityWindowMinutes,
+                fetchedAt: collector.lastDataFetchedAt ?? Date()
             ),
             accentColor: collector.state.color
         )

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarDaemonMain.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarDaemonMain.swift
@@ -1,8 +1,10 @@
+import BrainBarLifecycle
 import Foundation
 
 @main
 enum BrainBarDaemonMain {
     static func main() {
+        let uiWatchdog = startUIWatchdog()
         let server = BrainBarServer()
         server.onStartRejected = { reason in
             NSLog("[BrainBarDaemon] Startup rejected: %@", reason)
@@ -13,6 +15,14 @@ enum BrainBarDaemonMain {
         }
         server.start()
         NSLog("[BrainBarDaemon] Started on %@", BrainBarServer.defaultSocketPath())
-        RunLoop.main.run()
+        withExtendedLifetime(uiWatchdog) {
+            RunLoop.main.run()
+        }
+    }
+
+    private static func startUIWatchdog() -> BrainBarLifecycleWatchdog {
+        let watchdog = BrainBarLifecycleWatchdog.makeUIWatchdog()
+        watchdog.start()
+        return watchdog
     }
 }

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarProcessControl.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarProcessControl.swift
@@ -1,0 +1,29 @@
+import AppKit
+import Foundation
+
+@MainActor
+enum BrainBarProcessControl {
+    static func quit() {
+        NSApplication.shared.terminate(nil)
+    }
+
+    static func restart(bundlePath: String = Bundle.main.bundlePath) {
+        guard FileManager.default.fileExists(atPath: bundlePath) else {
+            NSLog("[BrainBar] Cannot restart: bundle path does not exist: %@", bundlePath)
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-n", bundlePath]
+
+        do {
+            try process.run()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NSApplication.shared.terminate(nil)
+            }
+        } catch {
+            NSLog("[BrainBar] Failed to schedule restart: %@", String(describing: error))
+        }
+    }
+}

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarProcessControl.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarProcessControl.swift
@@ -1,4 +1,5 @@
 import AppKit
+import BrainBarLifecycle
 import Foundation
 
 @MainActor
@@ -13,6 +14,8 @@ enum BrainBarProcessControl {
             return
         }
 
+        BrainBarRestartHandoff.markRestartingProcess()
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
         process.arguments = ["-n", bundlePath]
@@ -23,6 +26,7 @@ enum BrainBarProcessControl {
                 NSApplication.shared.terminate(nil)
             }
         } catch {
+            BrainBarRestartHandoff.clear()
             NSLog("[BrainBar] Failed to schedule restart: %@", String(describing: error))
         }
     }

--- a/brain-bar/Sources/BrainBarLifecycle/BrainBarLifecycleWatchdog.swift
+++ b/brain-bar/Sources/BrainBarLifecycle/BrainBarLifecycleWatchdog.swift
@@ -1,0 +1,256 @@
+import AppKit
+import Darwin
+import Foundation
+
+public final class BrainBarLifecycleWatchdog: @unchecked Sendable {
+    public struct Configuration: Sendable {
+        let watchedName: String
+        let heartbeatPath: String
+        let staleTimeout: TimeInterval
+        let checkInterval: TimeInterval
+        let terminateGraceInterval: TimeInterval
+        let relaunchCommand: RelaunchCommand
+
+        public init(
+            watchedName: String,
+            heartbeatPath: String,
+            staleTimeout: TimeInterval = 45,
+            checkInterval: TimeInterval = 10,
+            terminateGraceInterval: TimeInterval = 2,
+            relaunchCommand: RelaunchCommand
+        ) {
+            self.watchedName = watchedName
+            self.heartbeatPath = heartbeatPath
+            self.staleTimeout = staleTimeout
+            self.checkInterval = checkInterval
+            self.terminateGraceInterval = terminateGraceInterval
+            self.relaunchCommand = relaunchCommand
+        }
+    }
+
+    public struct RelaunchCommand: Sendable {
+        let executablePath: String
+        let arguments: [String]
+
+        public static func launchctlKickstart(label: String) -> RelaunchCommand {
+            RelaunchCommand(
+                executablePath: "/bin/launchctl",
+                arguments: ["kickstart", "-k", "gui/\(getuid())/\(label)"]
+            )
+        }
+
+        public static func openBundle(_ bundlePath: String) -> RelaunchCommand {
+            RelaunchCommand(executablePath: "/usr/bin/open", arguments: ["-n", bundlePath])
+        }
+    }
+
+    public static let uiHeartbeatPath = "/tmp/brainbar-ui.heartbeat"
+    public static let daemonHeartbeatPath = "/tmp/brainbar-daemon.heartbeat"
+    public static let uiLaunchAgentLabel = "com.brainlayer.brainbar"
+    public static let daemonLaunchAgentLabel = "com.brainlayer.brainbar-daemon"
+
+    private let configuration: Configuration
+    private let processProvider: @Sendable () -> [pid_t]
+    private let terminateProcess: @Sendable (pid_t, Int32) -> Void
+    private let relaunch: @Sendable (RelaunchCommand) -> Void
+    private let queue = DispatchQueue(label: "com.brainlayer.brainbar.lifecycle-watchdog", qos: .utility)
+    private var timer: DispatchSourceTimer?
+    private var isRestarting = false
+
+    init(
+        configuration: Configuration,
+        processProvider: @escaping @Sendable () -> [pid_t],
+        terminateProcess: @escaping @Sendable (pid_t, Int32) -> Void = { pid, signal in
+            _ = Darwin.kill(pid, signal)
+        },
+        relaunch: @escaping @Sendable (RelaunchCommand) -> Void = { command in
+            _ = BrainBarLifecycleWatchdog.run(command: command)
+        }
+    ) {
+        self.configuration = configuration
+        self.processProvider = processProvider
+        self.terminateProcess = terminateProcess
+        self.relaunch = relaunch
+    }
+
+    public func start() {
+        queue.async { [weak self] in
+            guard let self, self.timer == nil else { return }
+            let timer = DispatchSource.makeTimerSource(queue: self.queue)
+            timer.schedule(
+                deadline: .now() + self.configuration.checkInterval,
+                repeating: self.configuration.checkInterval
+            )
+            timer.setEventHandler { [weak self] in
+                self?.check()
+            }
+            self.timer = timer
+            timer.resume()
+        }
+    }
+
+    public func stop() {
+        queue.sync {
+            timer?.cancel()
+            timer = nil
+            isRestarting = false
+        }
+    }
+
+    private func check() {
+        guard !isRestarting else { return }
+        guard Self.isHeartbeatStale(
+            atPath: configuration.heartbeatPath,
+            now: Date(),
+            timeout: configuration.staleTimeout
+        ) else {
+            return
+        }
+
+        let pids = processProvider()
+        guard !pids.isEmpty else {
+            isRestarting = true
+            NSLog("[BrainBarWatchdog] %@ heartbeat is stale and no process is running; requesting launch", configuration.watchedName)
+            relaunch(configuration.relaunchCommand)
+            queue.asyncAfter(deadline: .now() + configuration.terminateGraceInterval) { [weak self] in
+                self?.isRestarting = false
+            }
+            return
+        }
+
+        isRestarting = true
+        NSLog(
+            "[BrainBarWatchdog] %@ heartbeat stale for %.0fs; terminating PIDs %@",
+            configuration.watchedName,
+            configuration.staleTimeout,
+            pids.map(String.init).joined(separator: ",")
+        )
+        pids.forEach { terminateProcess($0, SIGTERM) }
+        let stalePIDs = pids
+        queue.asyncAfter(deadline: .now() + configuration.terminateGraceInterval) { [weak self] in
+            guard let self else { return }
+            stalePIDs.forEach { self.terminateProcess($0, SIGKILL) }
+            self.relaunch(self.configuration.relaunchCommand)
+            self.isRestarting = false
+        }
+    }
+
+    public static func isHeartbeatStale(atPath path: String, now: Date, timeout: TimeInterval) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let modifiedAt = attributes[.modificationDate] as? Date
+        else {
+            return true
+        }
+        return now.timeIntervalSince(modifiedAt) > timeout
+    }
+
+    public static func writeHeartbeat(to path: String) {
+        let url = URL(fileURLWithPath: path)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let payload = "\(Date().timeIntervalSince1970)\n"
+        try? payload.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    public static func makeHeartbeatTimer(path: String, interval: TimeInterval, queue: DispatchQueue) -> DispatchSourceTimer {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now(), repeating: interval)
+        timer.setEventHandler {
+            writeHeartbeat(to: path)
+        }
+        timer.resume()
+        return timer
+    }
+
+    public static func runningPIDs(named executableName: String, bundleIdentifiers: [String] = []) -> [pid_t] {
+        let currentPID = ProcessInfo.processInfo.processIdentifier
+        let appPIDs = NSWorkspace.shared.runningApplications.compactMap { app -> pid_t? in
+            guard app.processIdentifier != currentPID else { return nil }
+            if bundleIdentifiers.contains(app.bundleIdentifier ?? "") {
+                return app.processIdentifier
+            }
+            if app.localizedName == executableName || app.executableURL?.lastPathComponent == executableName {
+                return app.processIdentifier
+            }
+            return nil
+        }
+        if !appPIDs.isEmpty {
+            return Array(Set(appPIDs))
+        }
+
+        return pgrep(executableName).filter { $0 != currentPID }
+    }
+
+    private static func pgrep(_ executableName: String) -> [pid_t] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-x", executableName]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0,
+              let output = String(data: data, encoding: .utf8)
+        else {
+            return []
+        }
+        return output
+            .components(separatedBy: .newlines)
+            .compactMap { Int32($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+            .map { pid_t($0) }
+    }
+
+    private static func run(command: RelaunchCommand) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: command.executablePath)
+        process.arguments = command.arguments
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            NSLog("[BrainBarWatchdog] Failed to run %@ %@: %@", command.executablePath, command.arguments.joined(separator: " "), String(describing: error))
+            return false
+        }
+    }
+
+    public static func makeDaemonWatchdog() -> BrainBarLifecycleWatchdog {
+        BrainBarLifecycleWatchdog(
+            configuration: Configuration(
+                watchedName: "BrainBarDaemon",
+                heartbeatPath: daemonHeartbeatPath,
+                relaunchCommand: .launchctlKickstart(label: daemonLaunchAgentLabel)
+            ),
+            processProvider: {
+                runningPIDs(named: "BrainBarDaemon", bundleIdentifiers: ["com.brainlayer.brainbar-daemon", "com.brainlayer.BrainBarDaemon"])
+            }
+        )
+    }
+
+    public static func makeUIWatchdog(bundlePath: String = Bundle.main.bundlePath) -> BrainBarLifecycleWatchdog {
+        BrainBarLifecycleWatchdog(
+            configuration: Configuration(
+                watchedName: "BrainBar",
+                heartbeatPath: uiHeartbeatPath,
+                relaunchCommand: .launchctlKickstart(label: uiLaunchAgentLabel)
+            ),
+            processProvider: {
+                runningPIDs(named: "BrainBar", bundleIdentifiers: ["com.brainlayer.BrainBar"])
+            },
+            relaunch: { command in
+                let launchctlSucceeded = run(command: command)
+                if !launchctlSucceeded, FileManager.default.fileExists(atPath: bundlePath) {
+                    _ = run(command: .openBundle(bundlePath))
+                }
+            }
+        )
+    }
+}

--- a/brain-bar/Sources/BrainBarLifecycle/BrainBarRestartHandoff.swift
+++ b/brain-bar/Sources/BrainBarLifecycle/BrainBarRestartHandoff.swift
@@ -1,0 +1,50 @@
+import Darwin
+import Foundation
+
+public enum BrainBarRestartHandoff {
+    public static let markerPath = "/tmp/brainbar-restart-handoff"
+
+    public static func markRestartingProcess(
+        pid: pid_t = ProcessInfo.processInfo.processIdentifier,
+        at date: Date = Date(),
+        path: String = markerPath
+    ) {
+        let payload = "\(pid)\n\(date.timeIntervalSince1970)\n"
+        try? payload.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    public static func clear(path: String = markerPath) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    public static func consumeIfMatches(
+        existingPID: pid_t,
+        now: Date = Date(),
+        maxAge: TimeInterval = 10,
+        path: String = markerPath
+    ) -> Bool {
+        guard let payload = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return false
+        }
+        let lines = payload
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard lines.count >= 2,
+              let markerPID = Int32(String(lines[0])),
+              let timestamp = TimeInterval(String(lines[1]))
+        else {
+            clear(path: path)
+            return false
+        }
+
+        guard markerPID == existingPID, now.timeIntervalSince1970 - timestamp <= maxAge else {
+            if now.timeIntervalSince1970 - timestamp > maxAge {
+                clear(path: path)
+            }
+            return false
+        }
+
+        clear(path: path)
+        return true
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -222,9 +222,46 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(rootSource.contains("Quit BrainBar"))
         XCTAssertTrue(processSource.contains("static func restart"))
         XCTAssertTrue(processSource.contains("static func quit"))
+        XCTAssertTrue(processSource.contains("BrainBarRestartHandoff.markRestartingProcess()"))
+        XCTAssertTrue(processSource.contains("BrainBarRestartHandoff.clear()"))
         XCTAssertTrue(processSource.contains("FileManager.default.fileExists"))
         XCTAssertTrue(processSource.contains("URL(fileURLWithPath: \"/usr/bin/open\")"))
         XCTAssertFalse(processSource.contains("URL(fileURLWithPath: \"/bin/sh\")"))
+    }
+
+    func testRestartHandoffAllowsOnlyMatchingFreshExistingInstance() throws {
+        let markerPath = NSTemporaryDirectory() + "brainbar-restart-handoff-\(UUID().uuidString)"
+        let timestamp = Date(timeIntervalSince1970: 1_000)
+
+        BrainBarRestartHandoff.markRestartingProcess(pid: 42, at: timestamp, path: markerPath)
+
+        XCTAssertFalse(
+            BrainBarRestartHandoff.consumeIfMatches(
+                existingPID: 41,
+                now: Date(timeIntervalSince1970: 1_005),
+                path: markerPath
+            )
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerPath))
+        XCTAssertTrue(
+            BrainBarRestartHandoff.consumeIfMatches(
+                existingPID: 42,
+                now: Date(timeIntervalSince1970: 1_005),
+                path: markerPath
+            )
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: markerPath))
+
+        BrainBarRestartHandoff.markRestartingProcess(pid: 42, at: timestamp, path: markerPath)
+        XCTAssertFalse(
+            BrainBarRestartHandoff.consumeIfMatches(
+                existingPID: 42,
+                now: Date(timeIntervalSince1970: 1_020),
+                maxAge: 10,
+                path: markerPath
+            )
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: markerPath))
     }
 
     func testLegacyPopoverSparklineUsesLastFetchAnchor() throws {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -1,8 +1,41 @@
 import AppKit
 import XCTest
 @testable import BrainBar
+@testable import BrainBarLifecycle
 
 final class DashboardTests: XCTestCase {
+    private final class WatchdogTestState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var observedPIDs: [pid_t] = [111]
+        private var signals: [(pid_t, Int32)] = []
+        private var relaunchCount = 0
+
+        func processProvider() -> [pid_t] {
+            lock.lock()
+            defer { lock.unlock() }
+            return observedPIDs
+        }
+
+        func recordTermination(pid: pid_t, signal: Int32) {
+            lock.lock()
+            signals.append((pid, signal))
+            observedPIDs = [222]
+            lock.unlock()
+        }
+
+        func recordRelaunch() {
+            lock.lock()
+            relaunchCount += 1
+            lock.unlock()
+        }
+
+        func snapshot() -> (signals: [(pid_t, Int32)], relaunchCount: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            return (signals, relaunchCount)
+        }
+    }
+
     private var db: BrainDatabase!
     private var tempDBPath: String!
 
@@ -198,6 +231,95 @@ final class DashboardTests: XCTestCase {
         let source = try brainBarSourceFile("Sources/BrainBar/Dashboard/StatusPopoverView.swift")
 
         XCTAssertTrue(source.contains("fetchedAt: collector.lastDataFetchedAt ?? Date()"))
+    }
+
+    func testBrainBarLifecycleWatchdogWiresUIAndDaemonHeartbeats() throws {
+        let watchdog = try brainBarSourceFile("Sources/BrainBarLifecycle/BrainBarLifecycleWatchdog.swift")
+        let app = try brainBarSourceFile("Sources/BrainBar/BrainBarApp.swift")
+        let server = try brainBarSourceFile("Sources/BrainBar/BrainBarServer.swift")
+        let daemon = try brainBarSourceFile("Sources/BrainBarDaemon/BrainBarDaemonMain.swift")
+
+        XCTAssertTrue(watchdog.contains("brainbar-ui.heartbeat"))
+        XCTAssertTrue(watchdog.contains("brainbar-daemon.heartbeat"))
+        XCTAssertTrue(watchdog.contains("SIGTERM"))
+        XCTAssertTrue(watchdog.contains("SIGKILL"))
+        XCTAssertTrue(watchdog.contains("launchctl"))
+        XCTAssertTrue(app.contains("startUIHeartbeat"))
+        XCTAssertTrue(app.contains("startDaemonWatchdog"))
+        XCTAssertTrue(server.contains("startDaemonHeartbeatOnQueue"))
+        XCTAssertTrue(daemon.contains("startUIWatchdog"))
+    }
+
+    func testWatchdogPolicyMarksMissingAndStaleHeartbeatUnhealthy() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brainbar-watchdog-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let missing = directory.appendingPathComponent("missing.heartbeat").path
+        XCTAssertTrue(BrainBarLifecycleWatchdog.isHeartbeatStale(atPath: missing, now: Date(), timeout: 5))
+
+        let heartbeat = directory.appendingPathComponent("present.heartbeat")
+        FileManager.default.createFile(atPath: heartbeat.path, contents: Data("ok".utf8))
+        let staleDate = Date(timeIntervalSince1970: 100)
+        try FileManager.default.setAttributes([.modificationDate: staleDate], ofItemAtPath: heartbeat.path)
+
+        XCTAssertTrue(
+            BrainBarLifecycleWatchdog.isHeartbeatStale(
+                atPath: heartbeat.path,
+                now: staleDate.addingTimeInterval(6),
+                timeout: 5
+            )
+        )
+        XCTAssertFalse(
+            BrainBarLifecycleWatchdog.isHeartbeatStale(
+                atPath: heartbeat.path,
+                now: staleDate.addingTimeInterval(4),
+                timeout: 5
+            )
+        )
+    }
+
+    func testWatchdogTerminatesOnlyOriginallyStaleProcessBeforeRelaunch() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brainbar-watchdog-restart-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let heartbeatPath = directory.appendingPathComponent("missing.heartbeat").path
+        let relaunched = expectation(description: "watchdog relaunches stale process")
+        let state = WatchdogTestState()
+
+        let watchdog = BrainBarLifecycleWatchdog(
+            configuration: .init(
+                watchedName: "TestBrainBar",
+                heartbeatPath: heartbeatPath,
+                staleTimeout: 0.01,
+                checkInterval: 0.01,
+                terminateGraceInterval: 0.02,
+                relaunchCommand: .openBundle("/tmp/TestBrainBar.app")
+            ),
+            processProvider: {
+                state.processProvider()
+            },
+            terminateProcess: { pid, signal in
+                state.recordTermination(pid: pid, signal: signal)
+            },
+            relaunch: { _ in
+                state.recordRelaunch()
+                relaunched.fulfill()
+            }
+        )
+
+        watchdog.start()
+        wait(for: [relaunched], timeout: 1)
+        watchdog.stop()
+
+        let snapshot = state.snapshot()
+
+        XCTAssertEqual(snapshot.signals.map(\.0), [111, 111])
+        XCTAssertEqual(snapshot.signals.map(\.1), [SIGTERM, SIGKILL])
+        XCTAssertEqual(snapshot.relaunchCount, 1)
     }
 
     func testDashboardLatestEventFallbackUsesSQLMaxWithoutTextOrderingLimit() throws {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -194,6 +194,12 @@ final class DashboardTests: XCTestCase {
         XCTAssertFalse(processSource.contains("URL(fileURLWithPath: \"/bin/sh\")"))
     }
 
+    func testLegacyPopoverSparklineUsesLastFetchAnchor() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/Dashboard/StatusPopoverView.swift")
+
+        XCTAssertTrue(source.contains("fetchedAt: collector.lastDataFetchedAt ?? Date()"))
+    }
+
     func testDashboardLatestEventFallbackUsesSQLMaxWithoutTextOrderingLimit() throws {
         let source = try brainBarSourceFile("Sources/BrainBar/BrainDatabase.swift")
         let methodRange = try XCTUnwrap(source.range(of: "private func latestIndexedTimestampEpoch("))

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -99,6 +99,39 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 4)
     }
 
+    func testDashboardStatsBucketsEventsOnFixedWallClockWindowEndingNow() throws {
+        let fixtures: [(id: String, offset: TimeInterval)] = [
+            ("dash-wallclock-52m", -52 * 60),
+            ("dash-wallclock-27m-a", -27 * 60),
+            ("dash-wallclock-27m-b", -27 * 60),
+            ("dash-wallclock-4m", -4 * 60),
+            ("dash-wallclock-outside", -65 * 60),
+        ]
+        for fixture in fixtures {
+            try db.insertChunk(
+                id: fixture.id,
+                content: "Wall-clock enrichment fixture \(fixture.id)",
+                sessionId: "dashboard",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 5
+            )
+            db.exec("""
+                UPDATE chunks
+                SET created_at = datetime('now', '\(Int(fixture.offset)) seconds'),
+                    enriched_at = datetime('now', '\(Int(fixture.offset)) seconds'),
+                    enrich_status = 'success'
+                WHERE id = '\(fixture.id)'
+            """)
+        }
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 60, bucketCount: 12)
+
+        XCTAssertEqual(stats.recentEnrichmentBuckets, [0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1])
+        XCTAssertEqual(stats.recentEnrichmentFiveMinuteCount, 1)
+        XCTAssertEqual(stats.recentEnrichmentCount, 4)
+    }
+
     func testDashboardStatsSamplesPendingStoreQueueBeforeReadTransaction() throws {
         let source = try brainBarSourceFile("Sources/BrainBar/BrainDatabase.swift")
         let methodRange = try XCTUnwrap(source.range(of: "func dashboardStats("))
@@ -138,6 +171,27 @@ final class DashboardTests: XCTestCase {
             source.contains("database.close()"),
             "Removing the retained DB handle also removes the matching close call."
         )
+    }
+
+    func testDashboardShowsLoadingUntilFirstStatsFetchCompletes() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertTrue(source.contains("collector.lastDataFetchedAt == nil"))
+        XCTAssertTrue(source.contains("Connecting to daemon and loading dashboard data"))
+    }
+
+    func testBrainBarHeaderExposesRestartAndQuitControls() throws {
+        let rootSource = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+        let processSource = try brainBarSourceFile("Sources/BrainBar/BrainBarProcessControl.swift")
+
+        XCTAssertTrue(rootSource.contains("BrainBarAppControlMenu()"))
+        XCTAssertTrue(rootSource.contains("Restart BrainBar"))
+        XCTAssertTrue(rootSource.contains("Quit BrainBar"))
+        XCTAssertTrue(processSource.contains("static func restart"))
+        XCTAssertTrue(processSource.contains("static func quit"))
+        XCTAssertTrue(processSource.contains("FileManager.default.fileExists"))
+        XCTAssertTrue(processSource.contains("URL(fileURLWithPath: \"/usr/bin/open\")"))
+        XCTAssertFalse(processSource.contains("URL(fileURLWithPath: \"/bin/sh\")"))
     }
 
     func testDashboardLatestEventFallbackUsesSQLMaxWithoutTextOrderingLimit() throws {
@@ -345,6 +399,27 @@ final class DashboardTests: XCTestCase {
             presentation.bucketLabel(for: 11),
             "\(Self.shortTime(now.addingTimeInterval(-bucketWidth)))-\(Self.shortTime(now))"
         )
+    }
+
+    func testSparklineChartPresentationAnchorsPointsToWallClockBucketMidpoints() {
+        let now = Date(timeIntervalSince1970: 1_764_236_400)
+        let presentation = SparklineChartPresentation(
+            label: "Recent enrichment sparkline",
+            values: [0, 3, 0, 1],
+            activityWindowMinutes: 20,
+            fetchedAt: now
+        )
+
+        XCTAssertEqual(presentation.points.map(\.bucket), [0, 1, 2, 3])
+        XCTAssertEqual(presentation.points.map(\.value), [0, 3, 0, 1])
+        XCTAssertEqual(presentation.points.map(\.timestamp), [
+            now.addingTimeInterval(-17.5 * 60),
+            now.addingTimeInterval(-12.5 * 60),
+            now.addingTimeInterval(-7.5 * 60),
+            now.addingTimeInterval(-2.5 * 60),
+        ])
+        XCTAssertEqual(presentation.xAxisDomainStart, now.addingTimeInterval(-20 * 60))
+        XCTAssertEqual(presentation.xAxisDomainEnd, now)
     }
 
     func testSparklineTooltipPlacementClampsHorizontally() {


### PR DESCRIPTION
## Summary
- anchor BrainBar activity sparklines to a fixed wall-clock domain ending at fetch time, preserving empty bins instead of compressing buckets by sequence
- keep recent enrichment/write counters tied to the same dashboard window assumptions and add tests for known timestamp placement, including empty bins
- show a launch loading state until the first dashboard fetch completes instead of rendering zero stats as real data
- add user-facing Restart BrainBar and Quit BrainBar controls in the SwiftUI dashboard header and legacy status popover

## Validation
- swift build --package-path brain-bar
- swift test --package-path brain-bar (557 tests, 0 failures)
- push hook BrainLayer gate: 2211 Python tests passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 36 passed; bun suite 1 passed; FTS5 regression shell passed
- CodeRabbit local CLI: restart/chart findings fixed; final remaining finding is a pre-existing unrelated minor in KGCanvasView hardcoded label behavior outside this PR scope

## Notes
- Native SwiftUI/AppKit app; no browser/Playwright verification target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutual watchdogs can terminate and relaunch UI/daemon processes on stale heartbeats; incorrect staleness or PID matching could cause disruptive restarts, though scope is local process lifecycle rather than data or auth.
> 
> **Overview**
> Introduces a **`BrainBarLifecycle`** module shared by the UI app and daemon. Each side writes a 5s heartbeat file; the peer runs a watchdog that treats missing/stale heartbeats as unhealthy, sends **SIGTERM/SIGKILL**, and relaunches via **`launchctl kickstart`** (UI relaunch falls back to **`open -n`**). **`BrainBarRestartHandoff`** lets a deliberate restart launch a new instance while the old PID is still exiting instead of hitting the usual single-instance exit.
> 
> **Restart BrainBar** and **Quit BrainBar** are exposed from the SwiftUI header menu and the legacy status popover through **`BrainBarProcessControl`** (`open -n`, then terminate after a short delay).
> 
> Dashboard **sparklines** now plot bucket counts on a fixed **wall-clock** domain ending at **`lastDataFetchedAt`** (time-based chart axis, linear interpolation, time-aware hover). The main dashboard stays on a **loading** state until the first stats fetch completes so zeros are not shown as live data. Tests cover watchdog behavior, restart handoff, sparkline anchoring, and related wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6356c43a2a0cf205fab7e1f36175a65b35101b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Anchor activity sparkline charts to wall-clock time and add mutual UI/daemon watchdogs
> - Sparkline charts in [SparklineRenderer.swift](https://github.com/EtanHey/brainlayer/pull/355/files#diff-27c132f6a3e15acfd5900246f3fc1e277502117e1e22c5b47ee78581e8e13a02) now render against a wall-clock time axis (using `Date` timestamps per point and an explicit x-axis domain) with linear interpolation; hover detection uses time-proximity instead of bucket index rounding.
> - Adds a new `BrainBarLifecycle` module with [BrainBarLifecycleWatchdog](https://github.com/EtanHey/brainlayer/pull/355/files#diff-b5546b9bc5c8c86898a9c799768e2487f6d5b84733f72e5349f17c924db97a85) that lets the UI supervise the daemon and the daemon supervise the UI: each side emits a heartbeat file every 5s and the peer watchdog restarts the stale process via `launchctl` or `open`.
> - Adds [BrainBarRestartHandoff](https://github.com/EtanHey/brainlayer/pull/355/files#diff-d153dd779d2c613feb94a7189a4c44891c6d1578893fbfa2468d36f83dfa2969) so a restarting instance can hand off to its replacement without triggering the single-instance exit guard.
> - Adds in-app Restart/Quit controls in the main window header (`BrainBarAppControlMenu`) and the status popover; the dashboard shows a loading state until the first stats fetch completes.
> - Behavioral Change: sparkline x-axis domain is now bounded by `xAxisDomainStart`/`xAxisDomainEnd` derived from fetch timestamps, so charts with no data yet show a time-anchored empty axis rather than a zero-indexed one.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 66cc39b. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->