### PR TITLE
fix: keep KG layout stable across selection

### DIFF
--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -232,16 +232,19 @@ final class KGViewModel: ObservableObject {
     }
 
     func updateCanvasSize(_ size: CGSize) {
-        guard size != .zero else { return }
+        guard size.width > 0, size.height > 0 else { return }
         guard layoutCanvasSize != size else {
             canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
             return
         }
+        let isFirstResolvedCanvasSize = layoutCanvasSize == nil
         layoutCanvasSize = size
         canvasCenter = CGPoint(x: size.width / 2, y: size.height / 2)
         guard !nodes.isEmpty else { return }
-        nodes = KGAtlasLayout.seededNodes(nodes, canvasSize: size, mode: layoutMode)
-        pinOwnerEntityIfPresent()
+        if isFirstResolvedCanvasSize {
+            nodes = KGAtlasLayout.seededNodes(nodes, canvasSize: size, mode: layoutMode)
+            pinOwnerEntityIfPresent()
+        }
     }
 
     func setLayoutMode(_ mode: KGAtlasMode) {
@@ -260,7 +263,8 @@ final class KGViewModel: ObservableObject {
         selectedNodeId = id
 
         guard let id else {
-            isLayoutPinned = false
+            // Selection changes only affect emphasis; keep the pinned layout in place.
+            freezeLayout()
             selectedEntity = nil
             resetSelectedEntitySidebarState(isLoading: false, loadFailed: false)
             selectedConversation = nil
@@ -268,7 +272,8 @@ final class KGViewModel: ObservableObject {
         }
 
         guard let database, let node = nodeById(id) else {
-            isLayoutPinned = false
+            // Missing nodes should clear selection without restarting the simulation.
+            freezeLayout()
             selectedEntity = nil
             resetSelectedEntitySidebarState(isLoading: false, loadFailed: false)
             selectedConversation = nil

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -931,6 +931,27 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertEqual(nodeB.position.y, 240, accuracy: 0.001)
     }
 
+    func testCollapsedCanvasSizeDoesNotConsumeFirstResolvedLayout() async throws {
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+
+        let vm = KGViewModel(database: db)
+        vm.setLayoutMode(.importance)
+        vm.updateCanvasSize(CGSize(width: 0, height: 800))
+        await vm.loadGraph()
+
+        vm.updateCanvasSize(CGSize(width: 1_200, height: 800))
+
+        XCTAssertEqual(vm.canvasCenter, CGPoint(x: 600, y: 400))
+        let nodeA = try XCTUnwrap(vm.nodes.first { $0.id == "a" })
+        let nodeB = try XCTUnwrap(vm.nodes.first { $0.id == "b" })
+        XCTAssertEqual(nodeA.position.x, 312, accuracy: 0.001)
+        XCTAssertEqual(nodeA.position.y, 448, accuracy: 0.001)
+        XCTAssertEqual(nodeB.position.x, 600, accuracy: 0.001)
+        XCTAssertEqual(nodeB.position.y, 240, accuracy: 0.001)
+    }
+
     func testLoadGraphKeepsMainActorAvailableWhileLoading() async throws {
         try db.insertEntity(id: "a", type: "person", name: "Alice")
         try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
@@ -1174,7 +1195,7 @@ final class KGViewModelTests: XCTestCase {
         vm.selectNode(id: "a")
 
         XCTAssertNil(vm.selectedEntity)
-        XCTAssertFalse(vm.isLayoutPinned)
+        XCTAssertTrue(vm.isLayoutPinned)
         XCTAssertFalse(vm.isLoadingSelectedEntityChunks)
         XCTAssertTrue(vm.selectedEntityChunks.isEmpty)
     }
@@ -1190,7 +1211,56 @@ final class KGViewModelTests: XCTestCase {
         vm.selectNode(id: nil)
         XCTAssertNil(vm.selectedNodeId)
         XCTAssertNil(vm.selectedEntity)
-        XCTAssertFalse(vm.isLayoutPinned)
+        XCTAssertTrue(vm.isLayoutPinned)
+    }
+
+    func testSelectionLifecycleKeepsNodePositionsStable() async throws {
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertEntity(id: "c", type: "agent", name: "brainClaude")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+        try db.insertRelation(sourceId: "b", targetId: "c", relationType: "uses")
+
+        let vm = KGViewModel(database: db)
+        vm.setLayoutMode(.importance)
+        vm.updateCanvasSize(CGSize(width: 1_200, height: 800))
+        await vm.loadGraph()
+        let seededState: [String: (position: CGPoint, velocity: CGVector)] = [
+            "a": (CGPoint(x: 120, y: 160), CGVector(dx: 14, dy: -9)),
+            "b": (CGPoint(x: 420, y: 360), CGVector(dx: -8, dy: 11)),
+            "c": (CGPoint(x: 760, y: 260), CGVector(dx: 5, dy: 7))
+        ]
+        for (nodeId, state) in seededState {
+            let index = try XCTUnwrap(vm.nodes.firstIndex { $0.id == nodeId })
+            vm.nodes[index].position = state.position
+            vm.nodes[index].velocity = state.velocity
+        }
+
+        vm.selectNode(id: "a")
+        let positionsAfterSelect = vm.nodes.map(\.position)
+        vm.updateCanvasSize(CGSize(width: 860, height: 800))
+
+        XCTAssertTrue(vm.isLayoutPinned)
+        XCTAssertEqual(vm.nodes.map(\.position), positionsAfterSelect)
+
+        vm.selectNode(id: nil)
+        let positionsAfterDeselect = vm.nodes.map(\.position)
+        let deselectEnergy = vm.tick()
+
+        XCTAssertNil(vm.selectedNodeId)
+        XCTAssertTrue(vm.isLayoutPinned)
+        XCTAssertEqual(deselectEnergy, 0)
+        XCTAssertEqual(positionsAfterDeselect, positionsAfterSelect)
+        XCTAssertEqual(vm.nodes.map(\.position), positionsAfterSelect)
+
+        vm.updateCanvasSize(CGSize(width: 1_200, height: 800))
+        vm.selectNode(id: nil)
+        let backgroundClickEnergy = vm.tick()
+
+        XCTAssertTrue(vm.isLayoutPinned)
+        XCTAssertEqual(backgroundClickEnergy, 0)
+        XCTAssertEqual(vm.nodes.map(\.position), positionsAfterSelect)
+        XCTAssertTrue(vm.nodes.allSatisfy { $0.velocity == .zero })
     }
 
     func testSelectNodeClearsOpenConversationOverlay() async throws {


### PR DESCRIPTION
## Summary
- Keep KG layout pinned when selection is cleared or invalid, so deselect/background-click does not restart the force simulation.
- Preserve existing node positions across post-layout canvas resize changes such as sidebar show/hide.
- Add a regression test for select -> deselect -> background-click stability, including sidebar-width resize.

## Test plan
- [x] swift build --package-path brain-bar
- [x] swift test --package-path brain-bar --filter KGViewModelTests
- [x] swift test --package-path brain-bar
- [x] pytest
- [x] pre-push BrainLayer test gate

Co-Authored-By: OpenAI Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Knowledge Graph view-model behavior with targeted regression tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes Knowledge Graph nodes jumping when users deselect, click the background, or resize the canvas (e.g. sidebar open/close).
> 
> **`updateCanvasSize`** ignores non-positive dimensions so a transient zero-width layout does not steal the “first layout” seed. Node reseeding via `KGAtlasLayout.seededNodes` runs only on the **first** valid canvas size; later size changes update `canvasCenter` only and leave positions unchanged.
> 
> **`selectNode`** on nil or missing nodes calls **`freezeLayout()`** (zero velocities) instead of clearing **`isLayoutPinned`**, so deselect/invalid selection no longer unpins and restarts the force simulation via `KGCanvasView`.
> 
> Tests cover collapsed-then-real canvas seeding, pinned state after deselect/invalid select, and a full select → resize → deselect → background-click lifecycle with stable positions and zero tick energy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b5b1e4d5edb4626d452d78812a1cebac5f41bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep KG layout stable across node selection and canvas resize
> - `KGViewModel.updateCanvasSize` now reseeds nodes and pins the owner entity only on the first resolved (non-zero) canvas size; subsequent resize events update `canvasCenter` but skip reseeding when nodes are already present.
> - `KGViewModel.selectNode` calls `freezeLayout()` instead of unpinning when clearing a selection or selecting a missing node, keeping the layout pinned through select/deselect cycles.
> - Behavioral Change: deselecting a node or selecting a missing node no longer restarts the force simulation; the layout stays frozen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89b5b1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Knowledge Graph canvas resizing to preserve node positions on subsequent size updates instead of re-initializing them.
  * Enhanced node selection and deselection behavior to maintain more consistent and stable layout state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->