### PR TITLE
fix: restore resume ids and entity links

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4692,13 +4692,55 @@ final class BrainDatabase: @unchecked Sendable {
             ]
             if let event = try? InjectionEvent(row: row) {
                 let details = (try? injectionChunkDetails(ids: event.chunkIDs)) ?? []
+                let resumableID = Self.resumableClaudeConversationID(event: event, chunks: details)
                 guard let scopedEvent = injectionFeedScopedEvent(event, chunks: details) else {
                     continue
                 }
-                events.append(scopedEvent)
+                events.append(
+                    InjectionEvent(
+                        id: scopedEvent.id,
+                        sessionID: scopedEvent.sessionID,
+                        timestamp: scopedEvent.timestamp,
+                        query: scopedEvent.query,
+                        chunkIDs: scopedEvent.chunkIDs,
+                        tokenCount: scopedEvent.tokenCount,
+                        chunks: scopedEvent.chunks,
+                        claudeConversationID: resumableID
+                    )
+                )
             }
         }
         return events
+    }
+
+    private static func resumableClaudeConversationID(event: InjectionEvent, chunks: [InjectionChunk]) -> String {
+        if isUUID(event.claudeConversationID) {
+            return event.claudeConversationID
+        }
+        for chunk in chunks where isUUID(chunk.claudeConversationID) {
+            return chunk.claudeConversationID
+        }
+        for chunk in chunks {
+            if let id = extractClaudeConversationID(fromSourceFile: chunk.sourceFile) {
+                return id
+            }
+        }
+        return ""
+    }
+
+    private static func extractClaudeConversationID(fromSourceFile sourceFile: String) -> String? {
+        let parts = sourceFile.split(separator: "/").map(String.init)
+        if let last = parts.last {
+            let stem = URL(fileURLWithPath: last).deletingPathExtension().lastPathComponent
+            if isUUID(stem) {
+                return stem
+            }
+        }
+        return parts.first(where: isUUID)
+    }
+
+    private static func isUUID(_ value: String) -> Bool {
+        UUID(uuidString: value) != nil
     }
 
     private static func liveInjectionEventSQLPredicate(eventTable: String) -> String {
@@ -4774,7 +4816,8 @@ final class BrainDatabase: @unchecked Sendable {
             query: event.query,
             chunkIDs: scopedChunkIDs,
             tokenCount: event.tokenCount,
-            chunks: liveChunks
+            chunks: liveChunks,
+            claudeConversationID: event.claudeConversationID
         )
     }
 
@@ -4809,7 +4852,11 @@ final class BrainDatabase: @unchecked Sendable {
 
         let placeholders = Array(repeating: "?", count: orderedIDs.count).joined(separator: ",")
         let sql = """
-            SELECT id, content, summary, source, source_file, tags, content_type
+            SELECT id, content, summary, source, source_file, tags, content_type,
+                   CASE
+                       WHEN json_valid(metadata) THEN COALESCE(json_extract(metadata, '$.claude_conversation_id'), '')
+                       ELSE ''
+                   END AS claude_conversation_id
             FROM chunks
             WHERE id IN (\(placeholders))
         """
@@ -4833,6 +4880,7 @@ final class BrainDatabase: @unchecked Sendable {
                 "source_file": columnText(stmt, 4) as Any,
                 "tags": columnText(stmt, 5) as Any,
                 "content_type": columnText(stmt, 6) as Any,
+                "claude_conversation_id": columnText(stmt, 7) as Any,
             ]
             let detail = InjectionChunk(row: row)
             detailsByID[detail.id] = detail

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4736,7 +4736,7 @@ final class BrainDatabase: @unchecked Sendable {
                 return stem
             }
         }
-        return parts.first(where: isUUID)
+        return parts.reversed().first(where: isUUID)
     }
 
     private static func isUUID(_ value: String) -> Bool {

--- a/brain-bar/Sources/BrainBar/InjectionContinuation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionContinuation.swift
@@ -8,11 +8,14 @@ import Foundation
 enum InjectionContinuation {
     static func resumeCommand(conversationID: String, fallbackSessionID: String = "") -> String {
         let resumableID = conversationID.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !resumableID.isEmpty {
+        if UUID(uuidString: resumableID) != nil {
             return "claude --resume \(resumableID)"
         }
         let fallback = fallbackSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !fallback.isEmpty else { return "claude --continue" }
+        let safeCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        guard !fallback.isEmpty, fallback.unicodeScalars.allSatisfy({ safeCharacters.contains($0) }) else {
+            return "claude --continue"
+        }
         return "claude --resume \(fallback)"
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionContinuation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionContinuation.swift
@@ -2,13 +2,17 @@ import Foundation
 
 /// Builds the clipboard command for "copy to continue thread" (QA #51).
 ///
-/// Each injection burst maps to a Claude Code session; copying a resume command
-/// lets the user pick that exact thread back up, mirroring the repo-golem `-c`
-/// continue pattern Etan referenced.
+/// Each injection burst maps to a Claude Code conversation; copying a resume
+/// command must use Claude Code's resumable JSONL UUID, not BrainLayer's
+/// internal session_id.
 enum InjectionContinuation {
-    static func resumeCommand(sessionID: String) -> String {
-        let trimmed = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "claude --continue" }
-        return "claude --resume \(trimmed)"
+    static func resumeCommand(conversationID: String, fallbackSessionID: String = "") -> String {
+        let resumableID = conversationID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !resumableID.isEmpty {
+            return "claude --resume \(resumableID)"
+        }
+        let fallback = fallbackSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !fallback.isEmpty else { return "claude --continue" }
+        return "claude --resume \(fallback)"
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -8,6 +8,7 @@ struct InjectionChunk: Equatable, Sendable, Identifiable {
     let sourceFile: String
     let tags: [String]
     let contentType: String
+    let claudeConversationID: String
 
     var displayText: String {
         let preferred = summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -27,7 +28,8 @@ struct InjectionChunk: Equatable, Sendable, Identifiable {
         source: String,
         sourceFile: String,
         tags: [String],
-        contentType: String
+        contentType: String,
+        claudeConversationID: String = ""
     ) {
         self.id = id
         self.content = content
@@ -36,6 +38,7 @@ struct InjectionChunk: Equatable, Sendable, Identifiable {
         self.sourceFile = sourceFile
         self.tags = tags
         self.contentType = contentType
+        self.claudeConversationID = claudeConversationID
     }
 
     init(row: [String: Any]) {
@@ -45,6 +48,7 @@ struct InjectionChunk: Equatable, Sendable, Identifiable {
         source = row["source"] as? String ?? ""
         sourceFile = row["source_file"] as? String ?? ""
         contentType = row["content_type"] as? String ?? ""
+        claudeConversationID = row["claude_conversation_id"] as? String ?? ""
         tags = InjectionChunk.decodeTags(row["tags"])
     }
 
@@ -218,6 +222,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
     let chunkIDs: [String]
     let tokenCount: Int
     let chunks: [InjectionChunk]
+    let claudeConversationID: String
 
     var chunkCount: Int { chunkIDs.count }
 
@@ -277,7 +282,8 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         query: String,
         chunkIDs: [String],
         tokenCount: Int,
-        chunks: [InjectionChunk] = []
+        chunks: [InjectionChunk] = [],
+        claudeConversationID: String = ""
     ) {
         self.id = id
         self.sessionID = sessionID
@@ -286,6 +292,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         self.chunkIDs = chunkIDs
         self.tokenCount = tokenCount
         self.chunks = chunks
+        self.claudeConversationID = claudeConversationID
     }
 
     init(row: [String: Any]) throws {
@@ -300,6 +307,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         timestamp = row["timestamp"] as? String ?? ""
         query = row["query"] as? String ?? ""
         tokenCount = row["token_count"] as? Int ?? 0
+        claudeConversationID = row["claude_conversation_id"] as? String ?? ""
 
         if let rawChunkIDs = row["chunk_ids"] as? [String] {
             self.chunkIDs = rawChunkIDs

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -722,7 +722,10 @@ struct InjectionFeedView: View {
     }
 
     private func copyContinuation(for burst: InjectionPresentation.Burst) {
-        let command = InjectionContinuation.resumeCommand(sessionID: burst.sessionID)
+        let command = InjectionContinuation.resumeCommand(
+            conversationID: burst.claudeConversationID,
+            fallbackSessionID: burst.sessionID
+        )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(command, forType: .string)

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -221,12 +221,15 @@ struct InjectionPresentation {
         var previousDate = first.date
 
         func flush() {
+            let conversationIDs = Set(
+                currentEvents.compactMap { event in
+                    event.event.claudeConversationID.isEmpty ? nil : event.event.claudeConversationID
+                }
+            )
             bursts.append(
                 Burst(
                     sessionID: currentSessionID,
-                    claudeConversationID: currentEvents.compactMap { event in
-                        event.event.claudeConversationID.isEmpty ? nil : event.event.claudeConversationID
-                    }.first ?? "",
+                    claudeConversationID: conversationIDs.count == 1 ? conversationIDs.first ?? "" : "",
                     topicOrSource: currentTopicOrSource,
                     startDate: oldest,
                     endDate: newest,

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -21,6 +21,7 @@ struct InjectionPresentation {
 
     struct Burst: Equatable, Identifiable {
         let sessionID: String
+        let claudeConversationID: String
         let topicOrSource: String
         let startDate: Date
         let endDate: Date
@@ -223,6 +224,9 @@ struct InjectionPresentation {
             bursts.append(
                 Burst(
                     sessionID: currentSessionID,
+                    claudeConversationID: currentEvents.compactMap { event in
+                        event.event.claudeConversationID.isEmpty ? nil : event.event.claudeConversationID
+                    }.first ?? "",
                     topicOrSource: currentTopicOrSource,
                     startDate: oldest,
                     endDate: newest,
@@ -300,6 +304,7 @@ struct InjectionPresentation {
             sectionBursts.append(
                 Burst(
                     sessionID: burst.sessionID,
+                    claudeConversationID: burst.claudeConversationID,
                     topicOrSource: burst.topicOrSource,
                     startDate: oldest,
                     endDate: newest,

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -809,6 +809,38 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(event.primaryKind.label, "Checkpoint")
     }
 
+    func testListInjectionEventsLoadsResumableClaudeConversationID() throws {
+        let conversationID = "3679128a-f371-445f-82ba-b3946e2f20b6"
+        try db.insertChunk(
+            id: "chunk-resume",
+            content: "This chunk belongs to a Claude Code JSONL conversation.",
+            sessionId: "brainlayer-session",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6
+        )
+        db.exec("""
+            UPDATE chunks
+            SET metadata = '{"session_id":"brainlayer-session","claude_conversation_id":"\(conversationID)"}',
+                source = 'realtime_watcher',
+                source_file = '/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-brainlayer/\(conversationID).jsonl'
+            WHERE id = 'chunk-resume'
+        """)
+        try db.recordInjectionEvent(
+            sessionID: "brainlayer-session",
+            query: "copy should resume Claude Code conversation",
+            chunkIDs: ["chunk-resume"],
+            tokenCount: 33,
+            timestamp: "2026-03-31T04:00:00.000Z"
+        )
+
+        let event = try XCTUnwrap(db.listInjectionEvents(limit: 1).first)
+
+        XCTAssertEqual(event.sessionID, "brainlayer-session")
+        XCTAssertEqual(event.claudeConversationID, conversationID)
+        XCTAssertEqual(event.chunks.first?.claudeConversationID, conversationID)
+    }
+
     func testListInjectionEventsRejectsImportedYoutubeSeedChunks() throws {
         try db.insertChunk(
             id: "live-hook",

--- a/brain-bar/Tests/BrainBarTests/InjectionContinuationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionContinuationTests.swift
@@ -31,4 +31,18 @@ final class InjectionContinuationTests: XCTestCase {
             "claude --continue"
         )
     }
+
+    func testResumeCommandRejectsInvalidConversationID() {
+        XCTAssertEqual(
+            InjectionContinuation.resumeCommand(conversationID: "not-a-uuid", fallbackSessionID: "sess-42"),
+            "claude --resume sess-42"
+        )
+    }
+
+    func testResumeCommandRejectsUnsafeFallbackSessionID() {
+        XCTAssertEqual(
+            InjectionContinuation.resumeCommand(conversationID: "not-a-uuid", fallbackSessionID: "sess-42; rm -rf /"),
+            "claude --continue"
+        )
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionContinuationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionContinuationTests.swift
@@ -1,27 +1,33 @@
 import XCTest
 @testable import BrainBar
 
-// QA #51: "copy to continue thread … like the repo golems command". A burst maps
-// to a Claude Code session; copying a resume command lets the user pick that exact
-// thread back up (mirrors the repo-golem `-c` continue pattern).
+// QA #51: "copy to continue thread" must use Claude Code's resumable
+// conversation UUID, not BrainLayer's internal session_id.
 final class InjectionContinuationTests: XCTestCase {
-    func testResumeCommandUsesSessionID() {
+    func testResumeCommandUsesConversationID() {
         XCTAssertEqual(
-            InjectionContinuation.resumeCommand(sessionID: "abc123"),
-            "claude --resume abc123"
+            InjectionContinuation.resumeCommand(conversationID: "3679128a-f371-445f-82ba-b3946e2f20b6", fallbackSessionID: "session-abc"),
+            "claude --resume 3679128a-f371-445f-82ba-b3946e2f20b6"
         )
     }
 
     func testResumeCommandTrimsWhitespace() {
         XCTAssertEqual(
-            InjectionContinuation.resumeCommand(sessionID: "  sess-42\n"),
+            InjectionContinuation.resumeCommand(conversationID: "  3679128a-f371-445f-82ba-b3946e2f20b6\n"),
+            "claude --resume 3679128a-f371-445f-82ba-b3946e2f20b6"
+        )
+    }
+
+    func testResumeCommandFallsBackToSessionIDWhenConversationMissing() {
+        XCTAssertEqual(
+            InjectionContinuation.resumeCommand(conversationID: "   ", fallbackSessionID: "sess-42"),
             "claude --resume sess-42"
         )
     }
 
     func testResumeCommandFallsBackToContinueWhenSessionMissing() {
         XCTAssertEqual(
-            InjectionContinuation.resumeCommand(sessionID: "   "),
+            InjectionContinuation.resumeCommand(conversationID: "   "),
             "claude --continue"
         )
     }

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -156,6 +156,25 @@ final class InjectionPresentationTests: XCTestCase {
         XCTAssertEqual(snapshot.bursts.map(\.topicOrSource), ["auth refactor", "db migration"])
     }
 
+    func testBurstAggregationKeepsConversationIDOnlyWhenEventsAgree() {
+        let now = isoDate("2026-04-18T10:00:00Z")
+        let conversationID = "3679128a-f371-445f-82ba-b3946e2f20b6"
+        let matchingEvents = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:59:00Z", query: "auth refactor", chunkIDs: ["chunk-1"], tokenCount: 10, claudeConversationID: conversationID),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:58:00Z", query: "auth refactor", chunkIDs: ["chunk-2"], tokenCount: 10, claudeConversationID: conversationID),
+        ]
+        let mixedEvents = [
+            makeEvent(id: 3, sessionID: "sess-b", timestamp: "2026-04-18T09:57:00Z", query: "db migration", chunkIDs: ["chunk-3"], tokenCount: 10, claudeConversationID: conversationID),
+            makeEvent(id: 4, sessionID: "sess-b", timestamp: "2026-04-18T09:56:00Z", query: "db migration", chunkIDs: ["chunk-4"], tokenCount: 10, claudeConversationID: "84e23cfb-dce6-4f93-a2be-41f74ae5f43f"),
+        ]
+
+        let matchingSnapshot = InjectionPresentation.snapshot(events: matchingEvents, filterText: "", now: now)
+        let mixedSnapshot = InjectionPresentation.snapshot(events: mixedEvents, filterText: "", now: now)
+
+        XCTAssertEqual(matchingSnapshot.bursts[0].claudeConversationID, conversationID)
+        XCTAssertEqual(mixedSnapshot.bursts[0].claudeConversationID, "")
+    }
+
     func testBurstAggregationUsesTriggerQueryWhenChunkSummariesDiffer() {
         let now = isoDate("2026-04-18T10:00:00Z")
         let events = [
@@ -341,7 +360,8 @@ final class InjectionPresentationTests: XCTestCase {
         query: String,
         chunkIDs: [String],
         tokenCount: Int,
-        chunks: [InjectionChunk] = []
+        chunks: [InjectionChunk] = [],
+        claudeConversationID: String = ""
     ) -> InjectionEvent {
         InjectionEvent(
             id: id,
@@ -350,7 +370,8 @@ final class InjectionPresentationTests: XCTestCase {
             query: query,
             chunkIDs: chunkIDs,
             tokenCount: tokenCount,
-            chunks: chunks
+            chunks: chunks,
+            claudeConversationID: claudeConversationID
         )
     }
 

--- a/src/brainlayer/claude_paths.py
+++ b/src/brainlayer/claude_paths.py
@@ -1,0 +1,17 @@
+"""Helpers for Claude Code transcript path metadata."""
+
+import re
+from pathlib import Path
+
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
+def extract_claude_conversation_id(source_file: str) -> str | None:
+    """Extract Claude Code's resumable conversation UUID from a JSONL source path."""
+    p = Path(source_file)
+    if UUID_RE.match(p.stem):
+        return p.stem
+    for parent in p.parents:
+        if UUID_RE.match(parent.name):
+            return parent.name
+    return None

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -1,29 +1,18 @@
 """New indexing pipeline using sqlite-vec and sentence-transformers."""
 
 import logging
-import re
 from pathlib import Path
 from typing import Callable, List, Optional
 
+from .claude_paths import extract_claude_conversation_id as _extract_claude_conversation_id
 from .embeddings import embed_chunks
 from .pipeline.chunk import Chunk
 from .pipeline.classify import looks_like_system_prompt
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
-_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
 from .paths import DEFAULT_DB_PATH
-
-
-def _extract_claude_conversation_id(source_file: str) -> str | None:
-    p = Path(source_file)
-    if _UUID_RE.match(p.stem):
-        return p.stem
-    for parent in p.parents:
-        if _UUID_RE.match(parent.name):
-            return parent.name
-    return None
 
 
 def index_chunks_to_sqlite(

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -1,6 +1,7 @@
 """New indexing pipeline using sqlite-vec and sentence-transformers."""
 
 import logging
+import re
 from pathlib import Path
 from typing import Callable, List, Optional
 
@@ -10,8 +11,19 @@ from .pipeline.classify import looks_like_system_prompt
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
 from .paths import DEFAULT_DB_PATH
+
+
+def _extract_claude_conversation_id(source_file: str) -> str | None:
+    p = Path(source_file)
+    if _UUID_RE.match(p.stem):
+        return p.stem
+    for parent in p.parents:
+        if _UUID_RE.match(parent.name):
+            return parent.name
+    return None
 
 
 def index_chunks_to_sqlite(
@@ -68,6 +80,7 @@ def index_chunks_to_sqlite(
     # Derive conversation_id: prefer session_id from chunk metadata,
     # fall back to the JSONL filename stem (which is the session UUID).
     file_stem = Path(source_file).stem
+    claude_conversation_id = _extract_claude_conversation_id(source_file)
 
     # Prepare data for vector store
     chunk_data = []
@@ -78,12 +91,15 @@ def index_chunks_to_sqlite(
 
         chunk_id = f"{source_file}:{i}"
         conversation_id = chunk.metadata.get("session_id") or file_stem
+        metadata = dict(chunk.metadata)
+        if claude_conversation_id:
+            metadata["claude_conversation_id"] = claude_conversation_id
 
         chunk_data.append(
             {
                 "id": chunk_id,
                 "content": chunk.content,
-                "metadata": chunk.metadata,
+                "metadata": metadata,
                 "source_file": source_file,
                 "project": project,
                 "content_type": chunk.content_type.value,
@@ -92,8 +108,8 @@ def index_chunks_to_sqlite(
                 "created_at": created_at,
                 "conversation_id": conversation_id,
                 "position": i,
-                "sender": chunk.metadata.get("sender"),
-                "source": chunk.metadata.get("source", "claude_code"),
+                "sender": metadata.get("sender"),
+                "source": metadata.get("source", "claude_code"),
             }
         )
 

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -78,6 +78,9 @@ class KGMixin:
         canonical_name = name.lower().replace(" ", "_")
         now = datetime.now(timezone.utc).isoformat()
 
+        if getattr(self, "_readonly", False):
+            return self.get_entity(keep["id"])
+
         if len(matches) > 1:
             from .pipeline.entity_resolution import merge_entities
 

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -830,7 +830,11 @@ def entity_lookup(
             results_by_id.setdefault(sibling["id"], sibling)
         results = list(results_by_id.values())
         entity = _select_evidence_rich_entity(store, results)
-        aggregate_entity_ids = [r["id"] for r in results if _normalize_lookup_name(r.get("name", "")) == _normalize_lookup_name(entity["name"])]
+        aggregate_entity_ids = [
+            r["id"]
+            for r in results
+            if _normalize_lookup_name(r.get("name", "")) == _normalize_lookup_name(entity["name"])
+        ]
     else:
         entity = candidate
         aggregate_entity_ids = [entity["id"]]
@@ -871,7 +875,7 @@ def entity_lookup(
             if chunk_id:
                 seen_chunk_ids.add(chunk_id)
             evidence_raw.append(evidence_chunk)
-    evidence_raw.sort(key=lambda chunk: (chunk.get("relevance") or 0), reverse=True)
+    evidence_raw.sort(key=lambda chunk: chunk.get("relevance") or 0, reverse=True)
     evidence_raw = evidence_raw[:10]
     evidence = [
         {

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -33,6 +33,7 @@ DIGEST_V2_ENABLED = os.environ.get("BRAINLAYER_DIGEST_V2", "true").lower() in ("
 HIGH_CONFIDENCE_THRESHOLD = 0.85
 MEDIUM_CONFIDENCE_THRESHOLD = 0.5
 SUPERSEDE_SIMILARITY_THRESHOLD = 0.85
+_SAFE_CROSS_TYPE_ENTITY_AGGREGATES = {"claude code"}
 
 # Length-tiered cosine similarity thresholds for dedup
 # Research-validated: SemHash defaults to 0.90, strict 0.95 misses paraphrases
@@ -819,11 +820,17 @@ def entity_lookup(
         if not results:
             return None
 
-    # Exact-name duplicates can exist across inferred entity types (for example
-    # "Claude Code" as tool/project/technology). Prefer the sibling with real
-    # evidence, but aggregate siblings so lookups do not report an empty shell.
+    # Exact-name duplicates can exist across inferred entity types for known
+    # canonical tools like "Claude Code". Prefer the sibling with real evidence,
+    # but only aggregate cross-type siblings for names that are known-safe.
     candidate = results[0]
-    exact_siblings = _exact_name_siblings(store, candidate.get("name") or query, entity_type=entity_type)
+    candidate_name = candidate.get("name") or query
+    sibling_entity_type = entity_type
+    if entity_type is None and _normalize_lookup_name(candidate_name) in _SAFE_CROSS_TYPE_ENTITY_AGGREGATES:
+        sibling_entity_type = None
+    elif entity_type is None:
+        sibling_entity_type = candidate.get("entity_type")
+    exact_siblings = _exact_name_siblings(store, candidate_name, entity_type=sibling_entity_type)
     if exact_siblings:
         results_by_id = {r["id"]: r for r in results}
         for sibling in exact_siblings:

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -832,7 +832,13 @@ def entity_lookup(
         sibling_entity_type = candidate.get("entity_type")
     exact_siblings = _exact_name_siblings(store, candidate_name, entity_type=sibling_entity_type)
     if exact_siblings:
-        results_by_id = {r["id"]: r for r in results}
+        normalized_candidate_name = _normalize_lookup_name(candidate_name)
+        results_by_id = {
+            r["id"]: r
+            for r in results
+            if _normalize_lookup_name(r.get("name", "")) == normalized_candidate_name
+            and (sibling_entity_type is None or r.get("entity_type") == sibling_entity_type)
+        }
         for sibling in exact_siblings:
             results_by_id.setdefault(sibling["id"], sibling)
         results = list(results_by_id.values())

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -819,12 +819,34 @@ def entity_lookup(
         if not results:
             return None
 
-    # Take best match
-    entity = results[0]
+    # Exact-name duplicates can exist across inferred entity types (for example
+    # "Claude Code" as tool/project/technology). Prefer the sibling with real
+    # evidence, but aggregate siblings so lookups do not report an empty shell.
+    candidate = results[0]
+    exact_siblings = _exact_name_siblings(store, candidate.get("name") or query, entity_type=entity_type)
+    if exact_siblings:
+        results_by_id = {r["id"]: r for r in results}
+        for sibling in exact_siblings:
+            results_by_id.setdefault(sibling["id"], sibling)
+        results = list(results_by_id.values())
+        entity = _select_evidence_rich_entity(store, results)
+        aggregate_entity_ids = [r["id"] for r in results if _normalize_lookup_name(r.get("name", "")) == _normalize_lookup_name(entity["name"])]
+    else:
+        entity = candidate
+        aggregate_entity_ids = [entity["id"]]
     entity_id = entity["id"]
 
     # Get relations (exclude co_occurs_with noise)
-    relations_raw = store.get_entity_relations(entity_id)
+    relations_raw = []
+    seen_relation_ids = set()
+    for aggregate_id in aggregate_entity_ids:
+        for relation in store.get_entity_relations(aggregate_id):
+            relation_id = relation.get("id")
+            if relation_id and relation_id in seen_relation_ids:
+                continue
+            if relation_id:
+                seen_relation_ids.add(relation_id)
+            relations_raw.append(relation)
     relations = [
         {
             "relation_type": r["relation_type"],
@@ -839,7 +861,18 @@ def entity_lookup(
     ]
 
     # Get evidence chunks
-    evidence_raw = store.get_entity_chunks(entity_id, limit=10, include_audit=include_audit)
+    evidence_raw = []
+    seen_chunk_ids = set()
+    for aggregate_id in aggregate_entity_ids:
+        for evidence_chunk in store.get_entity_chunks(aggregate_id, limit=10, include_audit=include_audit):
+            chunk_id = evidence_chunk.get("chunk_id")
+            if chunk_id and chunk_id in seen_chunk_ids:
+                continue
+            if chunk_id:
+                seen_chunk_ids.add(chunk_id)
+            evidence_raw.append(evidence_chunk)
+    evidence_raw.sort(key=lambda chunk: (chunk.get("relevance") or 0), reverse=True)
+    evidence_raw = evidence_raw[:10]
     evidence = [
         {
             "chunk_id": e["chunk_id"],
@@ -878,3 +911,71 @@ def entity_lookup(
         "completeness_score": completeness_score,
         "health_level": health_level,
     }
+
+
+def _normalize_lookup_name(name: str) -> str:
+    return re.sub(r"\s+", " ", name.strip().casefold())
+
+
+def _exact_name_siblings(
+    store: VectorStore,
+    name: str,
+    entity_type: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    cursor = store._read_cursor()
+    if entity_type:
+        rows = list(
+            cursor.execute(
+                """SELECT id, entity_type, name, metadata, created_at, updated_at,
+                          canonical_name, description, confidence, importance
+                   FROM kg_entities
+                   WHERE LOWER(name) = LOWER(?) AND entity_type = ?""",
+                (name, entity_type),
+            )
+        )
+    else:
+        rows = list(
+            cursor.execute(
+                """SELECT id, entity_type, name, metadata, created_at, updated_at,
+                          canonical_name, description, confidence, importance
+                   FROM kg_entities
+                   WHERE LOWER(name) = LOWER(?)""",
+                (name,),
+            )
+        )
+    return [
+        {
+            "id": row[0],
+            "entity_type": row[1],
+            "name": row[2],
+            "metadata": json.loads(row[3]) if row[3] else {},
+            "created_at": row[4],
+            "updated_at": row[5],
+            "canonical_name": row[6],
+            "description": row[7],
+            "confidence": row[8],
+            "importance": row[9],
+        }
+        for row in rows
+    ]
+
+
+def _select_evidence_rich_entity(store: VectorStore, entities: List[Dict[str, Any]]) -> Dict[str, Any]:
+    cursor = store._read_cursor()
+
+    def score(entity: Dict[str, Any]) -> tuple[int, int, float]:
+        entity_id = entity["id"]
+        chunk_count = cursor.execute(
+            "SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?",
+            (entity_id,),
+        ).fetchone()[0]
+        relation_count = cursor.execute(
+            """SELECT COUNT(*) FROM kg_relations
+               WHERE (source_id = ? OR target_id = ?)
+                 AND expired_at IS NULL""",
+            (entity_id, entity_id),
+        ).fetchone()[0]
+        importance = float(entity.get("importance") or 0)
+        return (int(chunk_count), int(relation_count), importance)
+
+    return max(entities, key=score)

--- a/src/brainlayer/pipeline/kg_extraction.py
+++ b/src/brainlayer/pipeline/kg_extraction.py
@@ -48,6 +48,12 @@ CANONICAL_RELATION_TYPES = {
 
 # Known agent names (beyond *Claude/*Golem pattern matching)
 _KNOWN_AGENTS = {"ralph", "claudegolem"}
+
+# Name-specific canonical type overrides applied before inferred/source types.
+# Extend this for stable product/project aliases that should always collapse to
+# one KG type. Keys are normalized names and values are entity_type strings,
+# e.g. "claudecode": "tool"; overrides are case-insensitive after
+# normalization and take precedence over model output.
 _CANONICAL_ENTITY_TYPES_BY_NAME = {
     "claudecode": "tool",
 }

--- a/src/brainlayer/pipeline/kg_extraction.py
+++ b/src/brainlayer/pipeline/kg_extraction.py
@@ -48,6 +48,9 @@ CANONICAL_RELATION_TYPES = {
 
 # Known agent names (beyond *Claude/*Golem pattern matching)
 _KNOWN_AGENTS = {"ralph", "claudegolem"}
+_CANONICAL_ENTITY_TYPES_BY_NAME = {
+    "claudecode": "tool",
+}
 
 _RELATION_TYPE_ALIASES = {
     "ceo_of": "leads",
@@ -94,7 +97,9 @@ def validate_extraction_result(result: ExtractionResult) -> ExtractionResult:
         name_lower = name.lower().replace("-", "").replace("_", "").replace(" ", "")
 
         # *Claude or *Golem pattern → agent
-        if re.search(r"(?i)(claude|golem)$", name):
+        if name_lower in _CANONICAL_ENTITY_TYPES_BY_NAME:
+            entity.entity_type = _CANONICAL_ENTITY_TYPES_BY_NAME[name_lower]
+        elif re.search(r"(?i)(claude|golem)$", name):
             entity.entity_type = "agent"
         # Known agent names
         elif name_lower in _KNOWN_AGENTS:

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -22,6 +22,7 @@ from typing import Any
 import apsw
 
 from .chunk_origin import detect_chunk_origin
+from .claude_paths import extract_claude_conversation_id as _extract_claude_conversation_id
 from .dedupe import find_duplicate, merge_duplicate_chunk, merge_existing_chunk_seen, normalized_exact_hash
 from .ingest_guard import recursive_mcp_output_reason
 from .paths import get_db_path
@@ -32,7 +33,6 @@ from .queue_io import enqueue_watcher_chunk
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
-_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
 # ── Pre-classify filters ─────────────────────────────────────────────────────
 
@@ -210,17 +210,6 @@ def _extract_project_from_source(source_file: str) -> str | None:
     parent_name = p.parent.name
     if parent_name:
         return _normalize_project_name(parent_name)
-    return None
-
-
-def _extract_claude_conversation_id(source_file: str) -> str | None:
-    """Extract Claude Code's resumable conversation UUID from a JSONL source path."""
-    p = Path(source_file)
-    if _UUID_RE.match(p.stem):
-        return p.stem
-    for parent in p.parents:
-        if _UUID_RE.match(parent.name):
-            return parent.name
     return None
 
 

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -32,6 +32,7 @@ from .queue_io import enqueue_watcher_chunk
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
 # ── Pre-classify filters ─────────────────────────────────────────────────────
 
@@ -212,6 +213,17 @@ def _extract_project_from_source(source_file: str) -> str | None:
     return None
 
 
+def _extract_claude_conversation_id(source_file: str) -> str | None:
+    """Extract Claude Code's resumable conversation UUID from a JSONL source path."""
+    p = Path(source_file)
+    if _UUID_RE.match(p.stem):
+        return p.stem
+    for parent in p.parents:
+        if _UUID_RE.match(parent.name):
+            return parent.name
+    return None
+
+
 # ── Flush callback ───────────────────────────────────────────────────────────
 
 
@@ -238,6 +250,7 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
             source_file = entry.get("_source_file", "unknown")
             source_files_seen.add(source_file)
             project = _extract_project_from_source(source_file)
+            claude_conversation_id = _extract_claude_conversation_id(source_file)
 
             # Layer 1: Pre-classify filter
             skip_reason = should_skip_entry(entry, source_file=source_file)
@@ -280,6 +293,9 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                     created_at = datetime.now(timezone.utc).isoformat()
 
                 conversation_id = chunk.metadata.get("session_id") or file_stem
+                metadata = dict(chunk.metadata)
+                if claude_conversation_id:
+                    metadata["claude_conversation_id"] = claude_conversation_id
                 tags = None
                 if chunk.content_type.value == "user_message":
                     correction_tags = build_correction_tags(clean_content)
@@ -292,14 +308,14 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                         enqueue_watcher_chunk(
                             chunk_id=chunk_id,
                             content=clean_content,
-                            metadata=chunk.metadata,
+                            metadata=metadata,
                             source_file=source_file,
                             project=project,
                             content_type=chunk.content_type.value,
                             value_type=chunk.value.value,
                             created_at=created_at,
                             conversation_id=conversation_id,
-                            sender=chunk.metadata.get("sender"),
+                            sender=metadata.get("sender"),
                             tags=json.loads(tags) if tags else None,
                             chunk_origin=chunk_origin,
                         )
@@ -366,7 +382,7 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                                     (
                                         chunk_id,
                                         clean_content,
-                                        json.dumps(chunk.metadata),
+                                        json.dumps(metadata),
                                         source_file,
                                         project,
                                         chunk.content_type.value,
@@ -375,7 +391,7 @@ def create_flush_callback(db_path: Path | None = None) -> callable:
                                         "realtime_watcher",
                                         created_at,
                                         conversation_id,
-                                        chunk.metadata.get("sender"),
+                                        metadata.get("sender"),
                                         tags,
                                         chunk_origin,
                                         1,

--- a/tests/test_kg_extraction.py
+++ b/tests/test_kg_extraction.py
@@ -194,6 +194,28 @@ class TestProcessExtractionResult:
         person_count = stats["entity_types"].get("person", 0)
         assert person_count == 1  # Only one "Etan" entity
 
+    def test_claude_code_is_canonical_tool(self, store_with_chunks):
+        result = ExtractionResult(
+            entities=[
+                ExtractedEntity(
+                    text="Claude Code",
+                    entity_type="project",
+                    start=0,
+                    end=11,
+                    confidence=0.95,
+                    source="llm",
+                ),
+            ],
+            relations=[],
+            chunk_id="chunk-1",
+        )
+
+        process_extraction_result(store_with_chunks, result)
+
+        entity = store_with_chunks.resolve_entity("Claude Code")
+        assert entity is not None
+        assert entity["entity_type"] == "tool"
+
     def test_empty_extraction_no_crash(self, store_with_chunks):
         result = ExtractionResult(entities=[], relations=[], chunk_id="chunk-1")
         stats = process_extraction_result(store_with_chunks, result)

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -471,6 +471,34 @@ def test_entity_lookup_aggregates_exact_name_duplicates_across_types(tmp_path):
     assert any(relation["relation_type"] == "created" for relation in result["relations"])
 
 
+def test_entity_lookup_does_not_aggregate_unallowlisted_cross_type_duplicates(tmp_path):
+    """Same-name entities in different domains should not inherit each other's evidence."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    project_id = store.upsert_entity("project-acme", "project", "Acme", embedding=dummy_embed("project acme"))
+    company_id = store.upsert_entity("company-acme", "company", "Acme", embedding=dummy_embed("company acme"))
+    api_id = store.upsert_entity("tool-api", "tool", "API", embedding=dummy_embed("api"))
+    store.add_relation("rel-acme-api", project_id, api_id, "uses")
+    _insert_chunks(
+        store,
+        ["acme-company"],
+        ["Acme company sales notes should stay attached to the company entity."],
+        [{"source_file": "t.jsonl", "project": "test"}],
+        [dummy_embed("acme company")],
+    )
+    store.link_entity_chunk(company_id, "acme-company", relevance=0.95, context="company notes")
+
+    result = entity_lookup("Acme", store, dummy_embed)
+
+    assert result is not None
+    assert result["entity_type"] == "project"
+    assert result["evidence"] == []
+    assert any(relation["relation_type"] == "uses" for relation in result["relations"])
+
+
 def test_entity_lookup_does_not_write_in_readonly_mode(tmp_path):
     """brain_entity runs against read-only DB handles and must not normalize by writing."""
     from brainlayer.pipeline.digest import entity_lookup

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -499,6 +499,39 @@ def test_entity_lookup_does_not_aggregate_unallowlisted_cross_type_duplicates(tm
     assert any(relation["relation_type"] == "uses" for relation in result["relations"])
 
 
+def test_entity_lookup_selects_only_exact_siblings_when_fts_returns_partial_hits(tmp_path):
+    """Partial FTS hits with more evidence should not replace the exact candidate."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    claude_id = store.upsert_entity("agent-claude", "agent", "Claude", embedding=dummy_embed("claude"))
+    code_id = store.upsert_entity("tool-vscode", "tool", "Visual Studio Code", embedding=dummy_embed("code"))
+    _insert_chunks(
+        store,
+        ["code-1", "code-2"],
+        [
+            "Visual Studio Code has a mature extension ecosystem.",
+            "Code editor setup notes unrelated to the Claude entity.",
+        ],
+        [
+            {"source_file": "t.jsonl", "project": "test"},
+            {"source_file": "t.jsonl", "project": "test"},
+        ],
+        [dummy_embed("code1"), dummy_embed("code2")],
+    )
+    store.link_entity_chunk(code_id, "code-1", relevance=0.95, context="editor")
+    store.link_entity_chunk(code_id, "code-2", relevance=0.9, context="editor")
+
+    result = entity_lookup("Claude", store, dummy_embed)
+
+    assert result is not None
+    assert result["id"] == claude_id
+    assert result["name"] == "Claude"
+    assert result["evidence"] == []
+
+
 def test_entity_lookup_does_not_write_in_readonly_mode(tmp_path):
     """brain_entity runs against read-only DB handles and must not normalize by writing."""
     from brainlayer.pipeline.digest import entity_lookup

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -436,6 +436,69 @@ def test_entity_lookup_merges_case_duplicate_entities(tmp_path):
     assert remaining == [(rich_id,)]
 
 
+def test_entity_lookup_aggregates_exact_name_duplicates_across_types(tmp_path):
+    """Exact-name duplicates should not hide linked chunks behind an empty shell."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    tool_id = store.upsert_entity("tool-claude-code", "tool", "Claude Code", embedding=dummy_embed("tool"))
+    project_id = store.upsert_entity("project-claude-code", "project", "Claude Code", embedding=dummy_embed("project"))
+    tech_id = store.upsert_entity("tech-anthropic", "company", "Anthropic", embedding=dummy_embed("anthropic"))
+    store.add_relation("rel-created", tech_id, tool_id, "created")
+    _insert_chunks(
+        store,
+        ["cc-1", "cc-2"],
+        [
+            "Claude Code watcher chunks should link to the real entity.",
+            "Claude Code resume commands use the JSONL conversation UUID.",
+        ],
+        [
+            {"source_file": "t.jsonl", "project": "test"},
+            {"source_file": "t.jsonl", "project": "test"},
+        ],
+        [dummy_embed("cc1"), dummy_embed("cc2")],
+    )
+    store.link_entity_chunk(project_id, "cc-1", relevance=0.9, context="watcher")
+    store.link_entity_chunk(project_id, "cc-2", relevance=0.8, context="resume")
+
+    result = entity_lookup("Claude Code", store, dummy_embed)
+
+    assert result is not None
+    assert result["name"] == "Claude Code"
+    assert len(result["evidence"]) == 2
+    assert any(relation["relation_type"] == "created" for relation in result["relations"])
+
+
+def test_entity_lookup_does_not_write_in_readonly_mode(tmp_path):
+    """brain_entity runs against read-only DB handles and must not normalize by writing."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    db_path = tmp_path / "test.db"
+    store = VectorStore(db_path)
+    dummy_embed = _dummy_embed
+    eid = store.upsert_entity("tool-claude-code", "tool", "Claude Code", embedding=dummy_embed("tool"))
+    _insert_chunks(
+        store,
+        ["cc-readonly"],
+        ["Claude Code read-only lookup should still return linked evidence."],
+        [{"source_file": "t.jsonl", "project": "test"}],
+        [dummy_embed("cc")],
+    )
+    store.link_entity_chunk(eid, "cc-readonly", relevance=0.9, context="readonly")
+    store.close()
+
+    readonly_store = VectorStore(db_path, readonly=True)
+    try:
+        result = entity_lookup("Claude Code", readonly_store, dummy_embed)
+    finally:
+        readonly_store.close()
+
+    assert result is not None
+    assert len(result["evidence"]) == 1
+
+
 def test_upsert_entity_adds_flowbar_voicebar_rename_relation(tmp_path):
     """Project upserts should seed the FlowBar -> VoiceBar rename edge."""
     store = VectorStore(tmp_path / "test.db")

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -17,6 +17,7 @@ import time
 from brainlayer.vector_store import VectorStore
 from brainlayer.watcher import JSONLTailer, JSONLWatcher
 from brainlayer.watcher_bridge import (
+    _extract_claude_conversation_id,
     _extract_project_from_source,
     _normalize_project_name,
     _strip_system_reminders,
@@ -135,6 +136,20 @@ class TestProjectExtraction:
         path = "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-brainlayer-grill/abc123.jsonl"
         assert _extract_project_from_source(path) == "brainlayer-grill"
 
+    def test_extract_claude_conversation_id_from_top_level_jsonl(self):
+        path = (
+            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-brainlayer/"
+            "3679128a-f371-445f-82ba-b3946e2f20b6.jsonl"
+        )
+        assert _extract_claude_conversation_id(path) == "3679128a-f371-445f-82ba-b3946e2f20b6"
+
+    def test_extract_claude_conversation_id_from_nested_subagent_jsonl(self):
+        path = (
+            "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-brainlayer/"
+            "3679128a-f371-445f-82ba-b3946e2f20b6/subagents/agent-acompact-123.jsonl"
+        )
+        assert _extract_claude_conversation_id(path) == "3679128a-f371-445f-82ba-b3946e2f20b6"
+
 
 # ── Flush Callback ───────────────────────────────────────────────────────────
 
@@ -154,6 +169,28 @@ class TestFlushCallback:
         rows = conn.execute("SELECT id, content, source FROM chunks WHERE source = 'realtime_watcher'").fetchall()
         conn.close()
         assert len(rows) >= 1
+
+    def test_inserts_claude_conversation_id_metadata(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        VectorStore(db_path).close()
+
+        flush = create_flush_callback(db_path)
+        conversation_id = "3679128a-f371-445f-82ba-b3946e2f20b6"
+        entry = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant", sessionId="brainlayer-session-9")
+        entry["_source_file"] = str(
+            tmp_path / "projects" / "-Users-test-Gits-myproject" / f"{conversation_id}.jsonl"
+        )
+
+        flush([entry])
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT metadata FROM chunks WHERE source = 'realtime_watcher'").fetchone()
+        conn.close()
+
+        assert row is not None
+        metadata = json.loads(row[0])
+        assert metadata["session_id"] == "brainlayer-session-9"
+        assert metadata["claude_conversation_id"] == conversation_id
 
     def test_insert_sets_ingested_at(self, tmp_path):
         db_path = tmp_path / "test.db"

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -177,9 +177,7 @@ class TestFlushCallback:
         flush = create_flush_callback(db_path)
         conversation_id = "3679128a-f371-445f-82ba-b3946e2f20b6"
         entry = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant", sessionId="brainlayer-session-9")
-        entry["_source_file"] = str(
-            tmp_path / "projects" / "-Users-test-Gits-myproject" / f"{conversation_id}.jsonl"
-        )
+        entry["_source_file"] = str(tmp_path / "projects" / "-Users-test-Gits-myproject" / f"{conversation_id}.jsonl")
 
         flush([entry])
 


### PR DESCRIPTION
## Summary
- Capture Claude Code's resumable JSONL conversation UUID alongside watcher/indexed chunks and make BrainBar copy-to-continue prefer that UUID over BrainLayer session_id.
- Fix KG entity lookup degradation by avoiding read-path writes in readonly handles, aggregating exact-name duplicate entity evidence, and coercing future Claude Code extractions to the canonical tool type.

## Root Cause
- P0-1: BrainBar copied `claude --resume <session_id>`, but Claude Code resumes by JSONL conversation UUID under `~/.claude/projects/`.
- P0-5: `brain_entity` readonly lookup hit `normalize_case_variants()`, which attempted an UPDATE and degraded with `ReadOnlyError`; existing same-name `Claude Code` entities were also split across inferred types, hiding linked chunks behind the sparse canonical row.

## Validation
- `pytest -q` -> 2287 passed, 46 skipped, 5 xfailed
- `swift test --package-path brain-bar` -> 555 tests, 0 failures
- push hook retry -> BrainLayer test gate passed (`2217 passed, 9 skipped, 75 deselected, 1 xfailed` plus MCP/eval/bun/regression gates)
- real DB readonly validation: `Claude Code` and `Etan` entity lookups return linked evidence without `ReadOnlyError`

## Notes
- First push-hook attempt had one marginal perf-budget flake (`0.203s < 0.200s`); the exact test passed immediately in the same `.venv`, and the full hook passed on retry without bypassing hooks.
- Local CodeRabbit CLI pre-commit review was attempted but blocked by CLI review limit; GitHub review requests are being posted on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resume clipboard behavior, chunk metadata, and read-path KG lookup/aggregation; fallback session IDs are restricted to safe characters to limit command injection.
> 
> **Overview**
> **Copy-to-continue** now targets Claude Code’s resumable JSONL conversation UUID instead of BrainLayer’s internal `session_id`. Ingestion (`watcher_bridge`, `index_new`) stores `claude_conversation_id` in chunk metadata from JSONL paths; BrainBar loads it on injection chunks/events, resolves a resumable ID when listing events, and **`InjectionContinuation.resumeCommand`** prefers a valid UUID with a sanitized session fallback or `claude --continue`. Bursts only carry a conversation ID when all grouped events agree.
> 
> **KG fixes:** `normalize_case_variants` no longer writes on readonly DB handles (avoiding `ReadOnlyError` on `brain_entity`). **`entity_lookup`** merges relations and evidence across exact-name duplicate rows, with cross-type aggregation limited to an allowlist (e.g. “Claude Code”). New extractions coerce **Claude Code** to entity type **`tool`** instead of misclassifying it as an agent/project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1977e26e4ec735ec442bba8e720850b13e83b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore Claude conversation IDs and entity links in resume and knowledge graph pipelines
> - Adds `claudeConversationID` to `InjectionChunk` and `InjectionEvent` models, populated from chunk metadata JSON, event data, or by parsing a UUID from the source file path.
> - Updates `resumeCommand` in [InjectionContinuation.swift](https://github.com/EtanHey/brainlayer/pull/357/files#diff-8e8b7e46b4b1c847272d1652a7a338ea85aa4a2a5fdc960a68acc7e5f74b22cd) to prefer a valid conversation UUID (`claude --resume <uuid>`), fall back to a sanitized session ID, or emit `claude --continue`.
> - Enriches indexed and watcher-ingested chunks with `claude_conversation_id` in metadata via a new [claude_paths.py](https://github.com/EtanHey/brainlayer/pull/357/files#diff-eb314ae986857a04712014b596edf08d7f7ad336d0a0941c585893efa9bd3d45) helper, enabling resume and grouping downstream.
> - Fixes `entity_lookup` in [digest.py](https://github.com/EtanHey/brainlayer/pull/357/files#diff-7095fa2ccad4d7bba37257e8239d677d9e6a1cca5b3b1f0a51ec8a56fd191a9a) to aggregate relations and evidence across exact-name duplicate entities for an allowlisted set, without performing writes.
> - Coerces entities named "Claude Code" to the `tool` type in [kg_extraction.py](https://github.com/EtanHey/brainlayer/pull/357/files#diff-ee2c9aea3660677412624d9ac9e113a4bbe156ddcba39cc7de6358a05e5f3767) via a canonical override map.
> - Fixes `_merge_case_only_duplicates` in [kg_repo.py](https://github.com/EtanHey/brainlayer/pull/357/files#diff-38aa7f1f4a1b009ac93ee1e2c7dfd9d6b85220b1278bb2081ac1ea006a59675b) to skip write operations when the store is in read-only mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe1977e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Claude Code session conversation IDs are now tracked and preserved in injection events, enabling seamless session resumption and continuation.
* Entity lookup improved to properly aggregate results and evidence when multiple entities share the same name across different types.

## Bug Fixes
* "Claude Code" entity now correctly classified as a tool type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->