### PR TITLE
feat: converge BrainBar window modes

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -1,31 +1,19 @@
 import AppKit
-import ApplicationServices
 import BrainBarLifecycle
-import Combine
 import SwiftUI
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let runtime = BrainBarRuntime()
-    private static let menuBarWindowAutosaveKey = "NSWindow Frame BrainBarMenuBarExtraWindow"
 
     private var statusPopoverController: BrainBarStatusPopoverController?
-    private var legacyStatusItem: NSStatusItem?
-    private var legacyPopover: NSPopover?
     private var collector: StatsCollector?
-    private var searchPanel: SearchPanelController?
     private var dashboardPanel: BrainBarDashboardPanelController?
     private var quickCaptureHotkey: HotkeyManager?
-    private weak var menuBarExtraWindow: NSWindow?
-    private weak var discoveredMenuBarWindow: NSWindow?
-    private var cancellables: Set<AnyCancellable> = []
     private var pendingBrainBarURLs: [URL] = []
     private var hotkeyFileWatcher: DispatchSourceFileSystemObject?
-    private var menuBarWindowObservers: [NSObjectProtocol] = []
-    private var menuBarWindowSyncTask: Task<Void, Never>?
     private var uiHeartbeatTimer: DispatchSourceTimer?
     private var daemonWatchdog: BrainBarLifecycleWatchdog?
-    private var wasVisibleAccessibilityWindow = false
 
     private var launchMode: BrainBarLaunchMode {
         runtime.launchMode
@@ -64,11 +52,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.configureQuickCaptureHotkey()
         }
 
-        if launchMode == .menuBarWindow {
-            statusPopoverController = BrainBarStatusPopoverController(runtime: runtime)
-        } else if launchMode == .legacyStatusItem {
-            createLegacyStatusItem()
-        }
+        let dashboardPanel = BrainBarDashboardPanelController(runtime: runtime)
+        self.dashboardPanel = dashboardPanel
+        statusPopoverController = BrainBarStatusPopoverController(
+            runtime: runtime,
+            dashboardPanelController: dashboardPanel
+        )
 
         let dbPath = BrainBarServer.defaultDBPath()
         NSLog("[BrainBar] Starting UI shell; database at %@", dbPath)
@@ -81,22 +70,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         flushPendingBrainBarURLs()
 
-        if launchMode == .legacyStatusItem {
-            installLegacyMenuBarSurface(with: collector)
-        }
-
         collector.start()
         configureQuickCaptureHotkey()
+        if launchMode == .appWindow {
+            NSApp.setActivationPolicy(.regular)
+            dashboardPanel.show()
+        }
         NSLog("[BrainBar] Runtime wired — launchMode=%@", String(describing: launchMode))
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        menuBarWindowObservers.forEach(NotificationCenter.default.removeObserver)
-        menuBarWindowObservers.removeAll()
         statusPopoverController?.stop()
         statusPopoverController = nil
-        menuBarWindowSyncTask?.cancel()
-        menuBarWindowSyncTask = nil
+        dashboardPanel?.dismiss()
+        dashboardPanel = nil
         uiHeartbeatTimer?.cancel()
         uiHeartbeatTimer = nil
         daemonWatchdog?.stop()
@@ -115,23 +102,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func showSearchPanel() {
-        guard launchMode == .menuBarWindow else {
-            searchPanel?.show()
-            return
-        }
-
         runtime.presentQuickAction(.search)
-        statusPopoverController?.show(nil)
+        showDashboardPanel()
     }
 
     func showQuickCapturePanel() {
-        guard launchMode == .menuBarWindow else {
-            NSLog("[BrainBar] Quick capture requires the menu-bar command surface in UI-split mode")
-            return
-        }
-
         runtime.presentQuickAction(.capture)
-        statusPopoverController?.show(nil)
+        showDashboardPanel()
     }
 
     private func configureRuntimeCallbacks() {
@@ -205,561 +182,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Legacy Shell
-
-    private func createLegacyStatusItem() {
-        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        if let button = item.button {
-            button.image = NSImage(systemSymbolName: "brain", accessibilityDescription: "BrainBar")
-            button.target = self
-            button.action = #selector(toggleLegacySurface(_:))
-            button.toolTip = "BrainBar legacy shell — loading..."
-        }
-        legacyStatusItem = item
-    }
+    // MARK: - Unified Window
 
     @objc
     private func toggleWindowSurface(_ sender: Any?) {
-        if launchMode == .legacyStatusItem {
-            toggleLegacySurface(sender)
-            return
-        }
-
-        if launchMode == .menuBarWindow, let statusPopoverController {
-            statusPopoverController.toggle(sender)
-            return
-        }
-
-        if let dashboardPanel {
-            dashboardPanel.toggle()
-            return
-        }
-
-        if let window = menuBarExtraWindow ?? discoverMenuBarWindow() {
-            runtime.windowCoordinator.attach(window: window)
-            ensureDefaultMenuBarWindowFrame(window)
-            if window.isVisible {
-                BrainBarWindowFrameStore().persist(frame: window.frame)
-                window.orderOut(sender)
-            } else {
-                showMenuBarWindow(sender)
-            }
-            return
-        }
-
-        if visibleMenuBarExtraAccessibilityWindow() != nil {
-            persistVisibleMenuBarWindowFrame()
-            _ = pressMenuBarExtraItem()
-            return
-        }
-
-        if pressMenuBarExtraItem() {
-            scheduleVisibleMenuBarWindowRestore()
-            return
-        }
-
-        guard let window = discoverMenuBarWindow() else {
-            NSLog("[BrainBar] Could not discover MenuBarExtra window for toggle request")
-            return
-        }
-
-        runtime.windowCoordinator.attach(window: window)
-        ensureDefaultMenuBarWindowFrame(window)
-        if window.isVisible {
-            window.orderOut(sender)
-        } else {
-            showMenuBarWindow(sender)
-        }
+        dashboardPanel?.toggle()
     }
 
     func showDashboardPanel() {
-        guard launchMode == .menuBarWindow else {
-            toggleLegacySurface(nil)
-            return
-        }
-
-        if let statusPopoverController {
-            statusPopoverController.show(nil)
-            return
-        }
-
         dashboardPanel?.show()
-    }
-
-    private func showMenuBarWindow(_ sender: Any?) {
-        if launchMode == .menuBarWindow, let statusPopoverController {
-            statusPopoverController.show(sender)
-            return
-        }
-
-        if launchMode == .menuBarWindow, let dashboardPanel {
-            dashboardPanel.show()
-            return
-        }
-
-        if let window = menuBarExtraWindow ?? discoverMenuBarWindow() {
-            runtime.windowCoordinator.attach(window: window)
-            ensureDefaultMenuBarWindowFrame(window)
-            NSApp.activate(ignoringOtherApps: true)
-            window.makeKeyAndOrderFront(sender)
-            window.orderFrontRegardless()
-            return
-        }
-
-        if visibleMenuBarExtraAccessibilityWindow() != nil {
-            _ = restoreVisibleMenuBarWindowFrame()
-            return
-        }
-
-        if pressMenuBarExtraItem() {
-            scheduleVisibleMenuBarWindowRestore()
-            return
-        }
-
-        guard let window = discoverMenuBarWindow() else {
-            NSLog("[BrainBar] Could not discover MenuBarExtra window for show request")
-            return
-        }
-
-        runtime.windowCoordinator.attach(window: window)
-        ensureDefaultMenuBarWindowFrame(window)
-        NSApp.activate(ignoringOtherApps: true)
-        window.makeKeyAndOrderFront(sender)
-        window.orderFrontRegardless()
-    }
-
-    private func discoverMenuBarWindow() -> NSWindow? {
-        if let menuBarExtraWindow {
-            return menuBarExtraWindow
-        }
-
-        if let discoveredMenuBarWindow {
-            return discoveredMenuBarWindow
-        }
-
-        let window = NSApp.windows.first { candidate in
-            let isExcluded = searchPanel?.panelForTesting === candidate
-            return !isExcluded &&
-                candidate.title == "BrainBar" &&
-                candidate.frame.width >= 400 &&
-                candidate.frame.height >= 300
-        }
-        discoveredMenuBarWindow = window
-        return window
-    }
-
-    private func orderedScreensByMouseLocation() -> [NSScreen] {
-        let screens = NSScreen.screens
-        guard let preferredIndex = screens.firstIndex(where: { $0.frame.contains(NSEvent.mouseLocation) }) else {
-            return screens
-        }
-        var ordered = screens
-        let preferredScreen = ordered.remove(at: preferredIndex)
-        ordered.insert(preferredScreen, at: 0)
-        return ordered
-    }
-
-    private func startMenuBarWindowSync() {
-        menuBarWindowSyncTask?.cancel()
-        menuBarWindowSyncTask = Task { [weak self] in
-            while let self, !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(250))
-                guard !Task.isCancelled else { break }
-                self.syncVisibleMenuBarWindow()
-            }
-        }
-    }
-
-    private func syncVisibleMenuBarWindow() {
-        guard let window = visibleMenuBarExtraAccessibilityWindow() else {
-            wasVisibleAccessibilityWindow = false
-            return
-        }
-
-        if !wasVisibleAccessibilityWindow {
-            _ = restoreVisibleMenuBarWindowFrame(window: window)
-        }
-
-        persistVisibleMenuBarWindowFrame(window: window)
-        wasVisibleAccessibilityWindow = true
-    }
-
-    private func pressMenuBarExtraItem() -> Bool {
-        guard let item = menuBarExtraItemAccessibilityElement() else { return false }
-        return AXUIElementPerformAction(item, kAXPressAction as CFString) == .success
-    }
-
-    private func menuBarExtraItemAccessibilityElement() -> AXUIElement? {
-        let appElement = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
-        var extrasBarRef: CFTypeRef?
-        let extrasBarError = AXUIElementCopyAttributeValue(
-            appElement,
-            kAXExtrasMenuBarAttribute as CFString,
-            &extrasBarRef
-        )
-        guard extrasBarError == .success, let extrasBar = extrasBarRef else {
-            return nil
-        }
-
-        var childrenRef: CFTypeRef?
-        let childrenError = AXUIElementCopyAttributeValue(
-            extrasBar as! AXUIElement,
-            kAXChildrenAttribute as CFString,
-            &childrenRef
-        )
-        guard childrenError == .success, let children = childrenRef as? [AXUIElement] else {
-            return nil
-        }
-
-        let mouseLocation = NSEvent.mouseLocation
-        var titledMatches: [(element: AXUIElement, frame: CGRect)] = []
-        var fallbackMatches: [(element: AXUIElement, frame: CGRect)] = []
-
-        for item in children {
-            var titleRef: CFTypeRef?
-            _ = AXUIElementCopyAttributeValue(item, kAXTitleAttribute as CFString, &titleRef)
-            let title = (titleRef as? String)?.lowercased() ?? ""
-            guard let frame = accessibilityElementFrame(item) else { continue }
-            if title == "brain" || title == "brainbar" {
-                titledMatches.append((item, frame))
-            } else {
-                fallbackMatches.append((item, frame))
-            }
-        }
-
-        if let preferredFrame = BrainBarWindowPlacement.preferredMenuBarItemFrame(
-            candidates: titledMatches.map(\.frame),
-            mouseLocation: mouseLocation
-        ) {
-            return titledMatches.first(where: { $0.frame == preferredFrame })?.element
-        }
-
-        if let preferredFrame = BrainBarWindowPlacement.preferredMenuBarItemFrame(
-            candidates: fallbackMatches.map(\.frame),
-            mouseLocation: mouseLocation
-        ) {
-            return fallbackMatches.first(where: { $0.frame == preferredFrame })?.element
-        }
-
-        return children.first
-    }
-
-    private func visibleMenuBarExtraAccessibilityWindow() -> AXUIElement? {
-        let appElement = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
-        var windowsRef: CFTypeRef?
-        let windowsError = AXUIElementCopyAttributeValue(
-            appElement,
-            kAXWindowsAttribute as CFString,
-            &windowsRef
-        )
-        guard windowsError == .success, let windows = windowsRef as? [AXUIElement] else {
-            return nil
-        }
-
-        var dialogCandidate: AXUIElement?
-        for window in windows {
-            var titleRef: CFTypeRef?
-            var subroleRef: CFTypeRef?
-            _ = AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef)
-            _ = AXUIElementCopyAttributeValue(window, kAXSubroleAttribute as CFString, &subroleRef)
-            let title = titleRef as? String ?? ""
-            let subrole = subroleRef as? String ?? ""
-            let frame = accessibilityElementFrame(window)
-            let isMainWindowSize = (frame?.width ?? 0) >= 760 && (frame?.height ?? 0) >= 560
-
-            if title == "BrainBar" && isMainWindowSize {
-                return window
-            }
-
-            if subrole == (kAXSystemDialogSubrole as String), isMainWindowSize {
-                dialogCandidate = dialogCandidate ?? window
-            }
-        }
-
-        return dialogCandidate
-    }
-
-    private func accessibilityElementFrame(_ element: AXUIElement) -> CGRect? {
-        var positionRef: CFTypeRef?
-        var sizeRef: CFTypeRef?
-        let positionError = AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef)
-        let sizeError = AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef)
-        guard positionError == .success,
-              sizeError == .success,
-              let positionValue = positionRef,
-              let sizeValue = sizeRef
-        else {
-            return nil
-        }
-
-        var position = CGPoint.zero
-        var size = CGSize.zero
-        guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
-              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
-        else {
-            return nil
-        }
-
-        return CGRect(origin: position, size: size)
-    }
-
-    private func applyAccessibilityFrame(_ frame: CGRect, to window: AXUIElement) -> Bool {
-        var size = frame.size
-        guard let sizeValue = AXValueCreate(.cgSize, &size) else { return false }
-        let sizeError = AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue)
-
-        var position = frame.origin
-        guard let positionValue = AXValueCreate(.cgPoint, &position) else { return false }
-        let positionError = AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, positionValue)
-
-        return sizeError == .success && positionError == .success
-    }
-
-    private func persistVisibleMenuBarWindowFrame(window: AXUIElement? = nil) {
-        let screenFrames = NSScreen.screens.map(\.frame)
-        guard let window = window ?? visibleMenuBarExtraAccessibilityWindow(),
-              let accessibilityFrame = accessibilityElementFrame(window),
-              let appKitFrame = BrainBarWindowPlacement.appKitFrame(
-                  fromAccessibility: accessibilityFrame,
-                  screenFrames: screenFrames
-              )
-        else {
-            return
-        }
-
-        BrainBarWindowFrameStore().persist(frame: appKitFrame)
-        discoveredMenuBarWindow?.setFrame(appKitFrame, display: false)
-    }
-
-    private func restoreVisibleMenuBarWindowFrame(window: AXUIElement? = nil) -> Bool {
-        let screenFrames = NSScreen.screens.map(\.frame)
-        let visibleScreenFrames = NSScreen.screens.map(\.visibleFrame)
-        let preferredVisibleScreenFrames = orderedScreensByMouseLocation().map(\.visibleFrame)
-        guard let window = window ?? visibleMenuBarExtraAccessibilityWindow()
-        else {
-            return false
-        }
-
-        let persistedFrame = BrainBarWindowFrameStore().persistedFrame()
-        let targetFrame: CGRect
-
-        if let persistedFrame,
-           BrainBarWindowPlacement.isRestorable(frame: persistedFrame, screenFrames: visibleScreenFrames) {
-            targetFrame = BrainBarWindowPlacement.clearingMenuBar(
-                frame: persistedFrame,
-                screenFrames: visibleScreenFrames
-            )
-        } else if let currentWindowFrame = accessibilityElementFrame(window),
-                  let iconElement = menuBarExtraItemAccessibilityElement(),
-                  let iconFrame = accessibilityElementFrame(iconElement),
-                  let anchoredFrame = BrainBarWindowPlacement.anchoredFrameBelowMenuBarItem(
-                      currentAccessibilityFrame: currentWindowFrame,
-                      menuBarItemAccessibilityFrame: iconFrame,
-                      screenFrames: screenFrames,
-                      visibleScreenFrames: visibleScreenFrames,
-                      gap: BrainBarWindowPlacement.menuBarIconGap
-                  ) {
-            targetFrame = anchoredFrame
-        } else if let resolvedFrame = BrainBarWindowPlacement.resolvedFrame(
-            persistedFrame: nil,
-            screenFrames: preferredVisibleScreenFrames
-        ) {
-            targetFrame = resolvedFrame
-        } else {
-            return false
-        }
-
-        guard let accessibilityFrame = BrainBarWindowPlacement.accessibilityFrame(
-            fromAppKit: targetFrame,
-            screenFrames: screenFrames
-        ) else {
-            return false
-        }
-
-        let applied = applyAccessibilityFrame(accessibilityFrame, to: window)
-        if applied {
-            discoveredMenuBarWindow?.setFrame(targetFrame, display: false)
-            BrainBarWindowFrameStore().persist(frame: targetFrame)
-        }
-        return applied
-    }
-
-    private func scheduleVisibleMenuBarWindowRestore(attempt: Int = 0) {
-        if restoreVisibleMenuBarWindowFrame() {
-            return
-        }
-
-        guard attempt < 12 else {
-            NSLog("[BrainBar] Timed out waiting for MenuBarExtra accessibility window")
-            return
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.scheduleVisibleMenuBarWindowRestore(attempt: attempt + 1)
-        }
-    }
-
-    private func ensureDefaultMenuBarWindowFrame(_ window: NSWindow) {
-        let screenFrames = NSScreen.screens.map(\.visibleFrame)
-        let fullScreenFrames = NSScreen.screens.map(\.frame)
-        let preferredVisibleScreenFrames = orderedScreensByMouseLocation().map(\.visibleFrame)
-        let isUsableSize = window.frame.width >= 760 && window.frame.height >= 560
-        let isUsablePosition = BrainBarWindowPlacement.isRestorable(
-            frame: window.frame,
-            screenFrames: screenFrames
-        )
-
-        guard !isUsableSize || !isUsablePosition else { return }
-
-        let persistedFrame = BrainBarWindowFrameStore().persistedFrame()
-        if persistedFrame == nil,
-           let iconElement = menuBarExtraItemAccessibilityElement(),
-           let iconFrame = accessibilityElementFrame(iconElement),
-           let anchoredFrame = BrainBarWindowPlacement.anchoredFrameBelowMenuBarItem(
-               currentFrame: CGRect(origin: window.frame.origin, size: BrainBarWindowPlacement.defaultSize),
-               menuBarItemAccessibilityFrame: iconFrame,
-               screenFrames: fullScreenFrames,
-               visibleScreenFrames: screenFrames,
-               gap: BrainBarWindowPlacement.menuBarIconGap
-           ) {
-            window.setFrame(anchoredFrame, display: false)
-            BrainBarWindowFrameStore().persist(frame: anchoredFrame)
-            return
-        }
-
-        guard let resolvedFrame = BrainBarWindowPlacement.resolvedFrame(
-            persistedFrame: persistedFrame,
-            screenFrames: preferredVisibleScreenFrames
-        ) else {
-            return
-        }
-
-        window.setFrame(resolvedFrame, display: false)
-    }
-
-    private func installMenuBarWindowObservers() {
-        let center = NotificationCenter.default
-        menuBarWindowObservers = [
-            center.addObserver(
-                forName: NSWindow.didBecomeKeyNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let window = notification.object as? NSWindow else { return }
-                Task { @MainActor [weak self] in
-                    self?.handleMenuBarWindowBecameKey(window)
-                }
-            },
-            center.addObserver(
-                forName: NSWindow.didMoveNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let window = notification.object as? NSWindow else { return }
-                Task { @MainActor [weak self] in
-                    self?.persistObservedMenuBarWindowFrame(window)
-                }
-            },
-            center.addObserver(
-                forName: NSWindow.didEndLiveResizeNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let window = notification.object as? NSWindow else { return }
-                Task { @MainActor [weak self] in
-                    self?.persistObservedMenuBarWindowFrame(window)
-                }
-            },
-        ]
-    }
-
-    private func handleMenuBarWindowBecameKey(_ window: NSWindow) {
-        guard isMenuBarExtraWindow(window) else { return }
-
-        menuBarExtraWindow = window
-        discoveredMenuBarWindow = window
-        runtime.windowCoordinator.attach(window: window)
-        ensureDefaultMenuBarWindowFrame(window)
-    }
-
-    private func persistObservedMenuBarWindowFrame(_ window: NSWindow) {
-        guard isMenuBarExtraWindow(window) else { return }
-
-        menuBarExtraWindow = window
-        discoveredMenuBarWindow = window
-        BrainBarWindowFrameStore().persist(frame: window.frame)
-    }
-
-    private func isMenuBarExtraWindow(_ window: NSWindow) -> Bool {
-        guard searchPanel?.panelForTesting !== window else { return false }
-        return window.title == "BrainBar" &&
-            window.frame.width >= 760 &&
-            window.frame.height >= 560
-    }
-
-    @objc
-    private func toggleLegacySurface(_ sender: Any?) {
-        guard launchMode == .legacyStatusItem, let button = legacyStatusItem?.button else { return }
-
-        guard let popover = legacyPopover else {
-            showLegacyLoadingPopover(relativeTo: button)
-            return
-        }
-
-        if popover.isShown {
-            popover.performClose(sender)
-        } else {
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            popover.contentViewController?.view.window?.makeKey()
-        }
-    }
-
-    private func showLegacyLoadingPopover(relativeTo button: NSStatusBarButton) {
-        let loadingPopover = NSPopover()
-        loadingPopover.behavior = .transient
-        loadingPopover.contentSize = NSSize(width: 320, height: 96)
-
-        let hosting = NSHostingController(
-            rootView: BrainBarLoadingView(
-                title: "BrainBar",
-                subtitle: "Opening database and warming the dashboard..."
-            )
-            .frame(width: 320, height: 96)
-        )
-
-        loadingPopover.contentViewController = hosting
-        loadingPopover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-    }
-
-    private func installLegacyMenuBarSurface(with collector: StatsCollector) {
-        guard launchMode == .legacyStatusItem, let item = legacyStatusItem, let button = item.button else {
-            return
-        }
-
-        let popover = NSPopover()
-        popover.behavior = .transient
-        popover.contentSize = NSSize(width: 760, height: 560)
-        popover.contentViewController = NSHostingController(
-            rootView: BrainBarWindowRootView(runtime: runtime)
-                .frame(width: 760, height: 560)
-        )
-        legacyPopover = popover
-
-        button.target = self
-        button.action = #selector(toggleLegacySurface(_:))
-        button.toolTip = "BrainBar legacy shell"
-
-        Publishers.CombineLatest(collector.$stats, collector.$state)
-            .receive(on: RunLoop.main)
-            .sink { [weak self] stats, state in
-                let livePresentation = BrainBarLivePresentation.derive(stats: stats)
-                self?.legacyStatusItem?.button?.image = SparklineRenderer.render(
-                    state: state,
-                    values: stats.recentEnrichmentBuckets,
-                    accentColor: livePresentation.accentColor
-                )
-            }
-            .store(in: &cancellables)
     }
 
     // MARK: - Quick Capture / Search

--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -14,17 +14,20 @@ final class BrainBarDashboardPanel: NSPanel {
 
 @MainActor
 final class BrainBarDashboardPanelController {
-    static let autosaveName = "BrainBarPanel"
-    static let defaultSize = NSSize(width: 1_348, height: 1_078)
-    static let minSize = NSSize(width: 760, height: 560)
+    static let autosaveName = BrainBarWindowFrameAutosave.dashboardPanelName
+    static let defaultSize = NSSize(width: BrainBarWindowPlacement.defaultSize.width, height: BrainBarWindowPlacement.defaultSize.height)
+    static let minSize = NSSize(width: BrainBarWindowPlacement.minimumSize.width, height: BrainBarWindowPlacement.minimumSize.height)
 
     let panelForTesting: BrainBarDashboardPanel
+    var needsInitialPositioningForTesting: Bool { needsInitialPositioning }
 
     private let panel: BrainBarDashboardPanel
     private let runtime: BrainBarRuntime
+    private var needsInitialPositioning: Bool
 
     init(runtime: BrainBarRuntime) {
         self.runtime = runtime
+        needsInitialPositioning = Self.needsInitialPositioning()
         panel = BrainBarDashboardPanel(
             contentRect: NSRect(origin: .zero, size: Self.defaultSize),
             styleMask: [.titled, .resizable, .closable, .nonactivatingPanel, .fullSizeContentView],
@@ -33,6 +36,10 @@ final class BrainBarDashboardPanelController {
         )
         panelForTesting = panel
         configurePanel()
+    }
+
+    static func needsInitialPositioning(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: BrainBarWindowFrameAutosave.dashboardPanelDefaultsKey) == nil
     }
 
     func toggle() {
@@ -44,8 +51,9 @@ final class BrainBarDashboardPanelController {
     }
 
     func show() {
-        if !panel.isVisible, panel.frame.origin == .zero {
+        if !panel.isVisible, needsInitialPositioning {
             centerPanel()
+            needsInitialPositioning = false
         }
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
@@ -78,8 +86,10 @@ final class BrainBarDashboardPanelController {
         )
         hostingController.view.autoresizingMask = [.width, .height]
         panel.contentViewController = hostingController
-        panel.setFrame(initialFrame(), display: false)
         panel.setFrameAutosaveName(Self.autosaveName)
+        if needsInitialPositioning {
+            panel.setFrame(initialFrame(), display: false)
+        }
     }
 
     private func initialFrame() -> NSRect {

--- a/brain-bar/Sources/BrainBar/BrainBarRuntime.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarRuntime.swift
@@ -43,9 +43,6 @@ final class BrainBarRuntime: ObservableObject {
     }
 
     func handleToggleRequest() {
-        if launchMode == .menuBarWindow, windowCoordinator.toggleVisibility() {
-            return
-        }
         onToggleRequested?()
     }
 

--- a/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
@@ -4,42 +4,38 @@ import SwiftUI
 
 @MainActor
 final class BrainBarStatusPopoverController: NSObject {
-    static let contentSize = NSSize(width: 900, height: 640)
+    static let statusItemEventMask: NSEvent.EventTypeMask = [.leftMouseUp, .rightMouseUp]
 
     let statusItemForTesting: NSStatusItem
-    let popoverForTesting: NSPopover
+    let contextMenuForTesting: NSMenu
 
     private let runtime: BrainBarRuntime
+    private let dashboardPanelController: BrainBarDashboardPanelController
     private var runtimeCancellables: Set<AnyCancellable> = []
     private var collectorCancellables: Set<AnyCancellable> = []
 
-    init(runtime: BrainBarRuntime) {
+    init(runtime: BrainBarRuntime, dashboardPanelController: BrainBarDashboardPanelController) {
         self.runtime = runtime
+        self.dashboardPanelController = dashboardPanelController
         statusItemForTesting = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        popoverForTesting = NSPopover()
+        contextMenuForTesting = NSMenu(title: "BrainBar")
         super.init()
 
+        configureContextMenu()
         configureStatusItem()
-        prewarmPopover()
         bindRuntime()
     }
 
     func toggle(_ sender: Any?) {
-        if popoverForTesting.isShown {
-            popoverForTesting.performClose(sender)
-        } else {
-            show(sender)
-        }
+        dashboardPanelController.toggle()
     }
 
     func show(_ sender: Any?) {
-        guard let button = statusItemForTesting.button else { return }
-        popoverForTesting.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-        popoverForTesting.contentViewController?.view.window?.makeKey()
+        dashboardPanelController.show()
     }
 
     func close(_ sender: Any?) {
-        popoverForTesting.performClose(sender)
+        dashboardPanelController.dismiss()
     }
 
     func stop() {
@@ -52,19 +48,8 @@ final class BrainBarStatusPopoverController: NSObject {
         button.image = NSImage(systemSymbolName: "brain", accessibilityDescription: "BrainBar")
         button.target = self
         button.action = #selector(toggleFromStatusItem(_:))
+        button.sendAction(on: Self.statusItemEventMask)
         button.toolTip = "BrainBar"
-    }
-
-    private func prewarmPopover() {
-        popoverForTesting.behavior = .transient
-        popoverForTesting.contentSize = Self.contentSize
-
-        let hosting = NSHostingController(
-            rootView: BrainBarWindowRootView(runtime: runtime, managesWindowFrame: false)
-                .frame(width: Self.contentSize.width, height: Self.contentSize.height)
-        )
-        _ = hosting.view
-        popoverForTesting.contentViewController = hosting
     }
 
     private func bindRuntime() {
@@ -99,6 +84,67 @@ final class BrainBarStatusPopoverController: NSObject {
     }
 
     @objc private func toggleFromStatusItem(_ sender: Any?) {
+        if let event = NSApp.currentEvent, event.type == .rightMouseUp,
+           let button = statusItemForTesting.button {
+            NSMenu.popUpContextMenu(contextMenuForTesting, with: event, for: button)
+            return
+        }
+
         toggle(sender)
+    }
+
+    private func configureContextMenu() {
+        contextMenuForTesting.addItem(
+            NSMenuItem(
+                title: "Restart BrainBar",
+                action: #selector(restartBrainBar(_:)),
+                keyEquivalent: ""
+            )
+        )
+        contextMenuForTesting.addItem(NSMenuItem.separator())
+        contextMenuForTesting.addItem(
+            NSMenuItem(
+                title: "Run as App Window",
+                action: #selector(runAsAppWindow(_:)),
+                keyEquivalent: ""
+            )
+        )
+        contextMenuForTesting.addItem(
+            NSMenuItem(
+                title: "Run as Menu Item Daemon",
+                action: #selector(runAsMenuItemDaemon(_:)),
+                keyEquivalent: ""
+            )
+        )
+        contextMenuForTesting.addItem(NSMenuItem.separator())
+        contextMenuForTesting.addItem(
+            NSMenuItem(
+                title: "Quit BrainBar",
+                action: #selector(quitBrainBar(_:)),
+                keyEquivalent: ""
+            )
+        )
+
+        for item in contextMenuForTesting.items where item.action != nil {
+            item.target = self
+        }
+    }
+
+    @objc private func restartBrainBar(_ sender: Any?) {
+        BrainBarProcessControl.restart()
+    }
+
+    @objc private func quitBrainBar(_ sender: Any?) {
+        BrainBarProcessControl.quit()
+    }
+
+    @objc private func runAsAppWindow(_ sender: Any?) {
+        BrainBarLaunchMode.setPreferred(.appWindow)
+        BrainBarProcessControl.restart()
+    }
+
+    @objc private func runAsMenuItemDaemon(_ sender: Any?) {
+        BrainBarLaunchMode.setPreferred(.menuItemDaemon)
+        BrainBarProcessControl.restart()
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -193,35 +193,31 @@ private struct BrainBarWindowHeader: View {
 
     var body: some View {
         VStack(spacing: 10) {
-            HStack(alignment: .center, spacing: 16) {
-                Label("BrainBar", systemImage: "brain")
-                    .font(.system(size: 18, weight: .semibold))
-                    .labelStyle(.titleAndIcon)
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center, spacing: 16) {
+                    brand
+                    Spacer(minLength: 16)
+                    sectionPicker(maxWidth: 280)
+                    refreshControls
+                    BrainBarAppControlMenu()
+                    Spacer(minLength: 12)
+                    hotkeyLabel
+                }
 
-                Spacer(minLength: 16)
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .center, spacing: 12) {
+                        brand
+                        Spacer(minLength: 12)
+                        BrainBarAppControlMenu()
+                        hotkeyLabel
+                            .frame(maxWidth: 180, alignment: .trailing)
+                    }
 
-                Picker("Section", selection: $selectedTab) {
-                    ForEach(BrainBarTab.allCases) { tab in
-                        Text(tab.title).tag(tab)
+                    HStack(alignment: .center, spacing: 10) {
+                        sectionPicker(maxWidth: .infinity)
+                        refreshControls
                     }
                 }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 280)
-                .labelsHidden()
-
-                if let collector {
-                    BrainBarHeaderRefreshControls(collector: collector)
-                }
-
-                BrainBarAppControlMenu()
-
-                Spacer(minLength: 12)
-
-                Text(hotkeyStatus)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
             }
 
             BrainBarCommandBar(viewModel: commandBarViewModel)
@@ -231,6 +227,39 @@ private struct BrainBarWindowHeader: View {
         .padding(.bottom, 12)
         .background(BrainBarDesignTokens.Glass.primaryMaterial)
         .background(WindowDragHandle())
+    }
+
+    private var brand: some View {
+        Label("BrainBar", systemImage: "brain")
+            .font(.system(size: 18, weight: .semibold))
+            .labelStyle(.titleAndIcon)
+            .lineLimit(1)
+    }
+
+    private var hotkeyLabel: some View {
+        Text(hotkeyStatus)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+
+    @ViewBuilder
+    private var refreshControls: some View {
+        if let collector {
+            BrainBarHeaderRefreshControls(collector: collector)
+        }
+    }
+
+    private func sectionPicker(maxWidth: CGFloat) -> some View {
+        Picker("Section", selection: $selectedTab) {
+            ForEach(BrainBarTab.allCases) { tab in
+                Text(tab.title).tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: maxWidth)
+        .labelsHidden()
     }
 }
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowState.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowState.swift
@@ -3,19 +3,71 @@ import CoreGraphics
 import Foundation
 
 enum BrainBarLaunchMode: Equatable {
-    case menuBarWindow
-    case legacyStatusItem
+    case appWindow
+    case menuItemDaemon
 
-    static func resolve(environment: [String: String] = ProcessInfo.processInfo.environment) -> BrainBarLaunchMode {
-        let rawValue = environment["BRAINBAR_LEGACY"]?
+    static let defaultsKey = "brainbar.launchMode"
+
+    var rawValue: String {
+        switch self {
+        case .appWindow:
+            return "app-window"
+        case .menuItemDaemon:
+            return "menu-item-daemon"
+        }
+    }
+
+    static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: BrainBarKeyValueStoring = UserDefaults.standard
+    ) -> BrainBarLaunchMode {
+        if let mode = parse(environment["BRAINBAR_LAUNCH_MODE"]) {
+            return mode
+        }
+
+        if isEnabled(environment["BRAINBAR_APP_WINDOW"]) {
+            return .appWindow
+        }
+
+        if isEnabled(environment["BRAINBAR_LEGACY"]) {
+            return .menuItemDaemon
+        }
+
+        if let mode = parse(defaults.string(forKey: defaultsKey)) {
+            return mode
+        }
+
+        return .menuItemDaemon
+    }
+
+    static func setPreferred(
+        _ mode: BrainBarLaunchMode,
+        defaults: BrainBarKeyValueStoring = UserDefaults.standard
+    ) {
+        defaults.setString(mode.rawValue, forKey: defaultsKey)
+    }
+
+    private static func parse(_ value: String?) -> BrainBarLaunchMode? {
+        let rawValue = value?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
 
         switch rawValue {
-        case "1", "true", "yes", "on":
-            return .legacyStatusItem
+        case "app", "app-window", "appwindow", "window":
+            return .appWindow
+        case "daemon", "menu", "menu-item", "menu-item-daemon", "menuitemdaemon", "status", "status-item":
+            return .menuItemDaemon
         default:
-            return .menuBarWindow
+            return nil
+        }
+    }
+
+    private static func isEnabled(_ value: String?) -> Bool {
+        switch value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
         }
     }
 }
@@ -126,8 +178,16 @@ struct BrainBarWindowFrameStore {
     }
 }
 
+enum BrainBarWindowFrameAutosave {
+    static let dashboardPanelName = "BrainBarPanel"
+    static let dashboardPanelDefaultsKey = "NSWindow Frame \(dashboardPanelName)"
+}
+
 enum BrainBarWindowPlacement {
     static let defaultSize = CGSize(width: 900, height: 640)
+    // Floor is intentionally the old menu-bar popover size: below 760x560 the
+    // dashboard data density stops fitting cleanly, so AppKit should clamp.
+    static let minimumSize = CGSize(width: 760, height: 560)
     static let menuBarClearance: CGFloat = 18
     static let menuBarIconGap: CGFloat = 4
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
@@ -23,7 +23,7 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
         XCTAssertTrue(panel.styleMask.contains(.closable))
         XCTAssertTrue(panel.styleMask.contains(.nonactivatingPanel))
         XCTAssertEqual(panel.frameAutosaveName, "BrainBarPanel")
-        XCTAssertEqual(BrainBarDashboardPanelController.defaultSize, NSSize(width: 1_348, height: 1_078))
+        XCTAssertEqual(BrainBarDashboardPanelController.defaultSize, NSSize(width: 900, height: 640))
         XCTAssertEqual(panel.minSize, NSSize(width: 760, height: 560))
         XCTAssertGreaterThanOrEqual(panel.frame.width, panel.minSize.width)
         XCTAssertGreaterThanOrEqual(panel.frame.height, panel.minSize.height)
@@ -31,14 +31,43 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
         XCTAssertTrue(panel.canBecomeMain)
     }
 
+    func testDashboardPanelOnlyNeedsInitialPositioningWithoutAutosavedFrame() {
+        XCTAssertTrue(
+            BrainBarDashboardPanelController.needsInitialPositioning(
+                defaults: UserDefaults.standard
+            )
+        )
+
+        UserDefaults.standard.set("saved frame", forKey: "NSWindow Frame BrainBarPanel")
+
+        XCTAssertFalse(
+            BrainBarDashboardPanelController.needsInitialPositioning(
+                defaults: UserDefaults.standard
+            )
+        )
+    }
+
     func testDashboardPanelToggleControlsVisibility() {
         let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
 
         controller.toggle()
         XCTAssertTrue(controller.panelForTesting.isVisible)
+        XCTAssertFalse(controller.needsInitialPositioningForTesting)
 
         controller.toggle()
         XCTAssertFalse(controller.panelForTesting.isVisible)
+    }
+
+    func testDashboardLayoutReflowsAtMinFloorAndLargeWindowSizes() {
+        let floorLayout = BrainBarDashboardLayout(containerSize: CGSize(width: 760, height: 560))
+        XCTAssertEqual(floorLayout.chartColumns, 1)
+        XCTAssertEqual(floorLayout.diagnosticColumns, 1)
+        XCTAssertTrue(floorLayout.compactCards)
+
+        let largeLayout = BrainBarDashboardLayout(containerSize: CGSize(width: 1_348, height: 1_078))
+        XCTAssertEqual(largeLayout.chartColumns, 2)
+        XCTAssertEqual(largeLayout.diagnosticColumns, 2)
+        XCTAssertFalse(largeLayout.compactCards)
     }
 
     func testCommandBarBecomesReadyWhenDatabaseWasInstalledWhilePanelWasHidden() {

--- a/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarRuntimeWiringTests.swift
@@ -19,14 +19,14 @@ final class BrainBarRuntimeWiringTests: XCTestCase {
     }
 
     func testRuntimeStartsWithDatabaseAndInjectionStoreNil() {
-        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
+        let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
         XCTAssertNil(runtime.database)
         XCTAssertNil(runtime.injectionStore)
         XCTAssertNil(runtime.collector)
     }
 
     func testWireRuntimePopulatesDatabaseAndLazilyLoadsInjectionStore() {
-        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
+        let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
         let collector = BrainBarAppSupport.makeStatsCollector(
             dbPath: tempDBPath,
             targetPID: ProcessInfo.processInfo.processIdentifier,
@@ -65,7 +65,7 @@ final class BrainBarRuntimeWiringTests: XCTestCase {
             "Test precondition: DB file must NOT exist at start"
         )
 
-        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
+        let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
         let collector = BrainBarAppSupport.makeStatsCollector(
             dbPath: tempDBPath,
             targetPID: ProcessInfo.processInfo.processIdentifier,

--- a/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
@@ -4,15 +4,37 @@ import XCTest
 
 @MainActor
 final class BrainBarStatusPopoverControllerTests: XCTestCase {
-    func testControllerPrewarmsVariableLengthStatusItemPopover() {
-        let runtime = BrainBarRuntime(launchMode: .menuBarWindow)
-        let controller = BrainBarStatusPopoverController(runtime: runtime)
+    func testControllerWiresVariableLengthStatusItemToUnifiedWindow() {
+        let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
+        let windowController = BrainBarDashboardPanelController(runtime: runtime)
+        let controller = BrainBarStatusPopoverController(
+            runtime: runtime,
+            dashboardPanelController: windowController
+        )
         defer { controller.stop() }
 
         XCTAssertEqual(controller.statusItemForTesting.length, NSStatusItem.variableLength)
-        XCTAssertEqual(controller.popoverForTesting.behavior, NSPopover.Behavior.transient)
-        XCTAssertNotNil(controller.popoverForTesting.contentViewController)
-        XCTAssertTrue(controller.popoverForTesting.contentViewController?.isViewLoaded == true)
+        XCTAssertEqual(controller.statusItemForTesting.button?.target as? BrainBarStatusPopoverController, controller)
+        XCTAssertTrue(BrainBarStatusPopoverController.statusItemEventMask.contains(.rightMouseUp))
+        XCTAssertNotNil(windowController.panelForTesting.contentViewController)
+        XCTAssertEqual(windowController.panelForTesting.minSize, NSSize(width: 760, height: 560))
+    }
+
+    func testStatusItemContextMenuContainsRestartModeChoicesAndQuit() {
+        let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
+        let windowController = BrainBarDashboardPanelController(runtime: runtime)
+        let controller = BrainBarStatusPopoverController(
+            runtime: runtime,
+            dashboardPanelController: windowController
+        )
+        defer { controller.stop() }
+
+        let itemTitles = controller.contextMenuForTesting.items.map(\.title)
+
+        XCTAssertTrue(itemTitles.contains("Restart BrainBar"))
+        XCTAssertTrue(itemTitles.contains("Run as App Window"))
+        XCTAssertTrue(itemTitles.contains("Run as Menu Item Daemon"))
+        XCTAssertTrue(itemTitles.contains("Quit BrainBar"))
     }
 
     func testAppSupportCollectorFactoryWiresBrainBusEvents() {

--- a/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
@@ -4,23 +4,47 @@ import XCTest
 @testable import BrainBar
 
 final class BrainBarWindowStateTests: XCTestCase {
-    func testLaunchModeDefaultsToMenuBarWindow() {
-        XCTAssertEqual(BrainBarLaunchMode.resolve(environment: [:]), .menuBarWindow)
+    func testLaunchModeDefaultsToMenuItemDaemon() {
         XCTAssertEqual(
-            BrainBarLaunchMode.resolve(environment: ["BRAINBAR_LEGACY": "0"]),
-            .menuBarWindow
+            BrainBarLaunchMode.resolve(environment: [:], defaults: FakeKeyValueStore()),
+            .menuItemDaemon
+        )
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(environment: ["BRAINBAR_LEGACY": "0"], defaults: FakeKeyValueStore()),
+            .menuItemDaemon
         )
     }
 
-    func testLaunchModeUsesLegacyModeWhenEscapeHatchEnabled() {
+    func testLaunchModeUsesMenuItemDaemonWhenLegacyEscapeHatchEnabled() {
         XCTAssertEqual(
-            BrainBarLaunchMode.resolve(environment: ["BRAINBAR_LEGACY": "1"]),
-            .legacyStatusItem
+            BrainBarLaunchMode.resolve(environment: ["BRAINBAR_LEGACY": "1"], defaults: FakeKeyValueStore()),
+            .menuItemDaemon
         )
         XCTAssertEqual(
-            BrainBarLaunchMode.resolve(environment: ["BRAINBAR_LEGACY": "true"]),
-            .legacyStatusItem
+            BrainBarLaunchMode.resolve(environment: ["BRAINBAR_LEGACY": "true"], defaults: FakeKeyValueStore()),
+            .menuItemDaemon
         )
+    }
+
+    func testLaunchModeCanBeChosenByEnvironmentOrStoredPreference() {
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_LAUNCH_MODE": "app-window"],
+                defaults: FakeKeyValueStore()
+            ),
+            .appWindow
+        )
+
+        let store = FakeKeyValueStore()
+        BrainBarLaunchMode.setPreferred(.appWindow, defaults: store)
+        XCTAssertEqual(BrainBarLaunchMode.resolve(environment: [:], defaults: store), .appWindow)
+
+        BrainBarLaunchMode.setPreferred(.menuItemDaemon, defaults: store)
+        XCTAssertEqual(BrainBarLaunchMode.resolve(environment: [:], defaults: store), .menuItemDaemon)
+    }
+
+    func testLaunchModeAutosaveFrameDefaultsKeyMatchesAppKitWindowName() {
+        XCTAssertEqual(BrainBarWindowFrameAutosave.dashboardPanelDefaultsKey, "NSWindow Frame BrainBarPanel")
     }
 
     func testBrainBarTabsCoverDashboardInjectionsAndGraph() {
@@ -303,7 +327,7 @@ final class BrainBarWindowCoordinatorTests: XCTestCase {
         XCTAssertEqual(
             searchRequests,
             2,
-            "Runtime.showSearchPanel must fire onSearchRequested so AppDelegate can route to the integrated command bar (menuBarWindow mode) or the legacy floating panel (legacyStatusItem mode)."
+            "Runtime.showSearchPanel must fire onSearchRequested so AppDelegate can route to the integrated command bar in the unified window."
         )
     }
 
@@ -318,7 +342,7 @@ final class BrainBarWindowCoordinatorTests: XCTestCase {
         XCTAssertEqual(
             captureRequests,
             1,
-            "Runtime.showQuickCapturePanel must fire onQuickCaptureRequested so AppDelegate can route to the integrated command bar (menuBarWindow mode) or the legacy floating panel (legacyStatusItem mode)."
+            "Runtime.showQuickCapturePanel must fire onQuickCaptureRequested so AppDelegate can route to the integrated command bar in the unified window."
         )
     }
 }


### PR DESCRIPTION
## Summary
- Converges BrainBar launch/toggle/search paths onto one responsive, resizable `BrainBarDashboardPanelController` window instead of separate MenuBarExtra/legacy popover surfaces.
- Adds explicit launch-mode choice: `menu-item-daemon` default, `app-window` via `BRAINBAR_LAUNCH_MODE`, `BRAINBAR_APP_WINDOW=1`, or the status-item context menu mode actions.
- Sets and documents the 760x560 min-size floor, defaults the unified window to 900x640, and reflows the dashboard header/body between the floor and large window sizes.
- Adds right-click status-item context menu actions for Restart, mode switching, and Quit as an escape hatch when the window UI is frozen.

## Functional self-QA vs spec
- Responsive at two sizes: covered by `testDashboardLayoutReflowsAtMinFloorAndLargeWindowSizes`; floor size uses 1-column compact cards, 1348x1078 uses 2-column large layout. Header now uses `ViewThatFits` to reflow into compact rows at narrow width.
- Min-size floor: covered by `testDashboardPanelUsesResizableUtilityWindowContract`; `panel.minSize == 760x560`, documented in `BrainBarWindowPlacement.minimumSize`.
- Mode toggle works: covered by `testLaunchModeCanBeChosenByEnvironmentOrStoredPreference`; context menu exposes app-window and menu-item-daemon restart actions.
- Right-click menu present: covered by `testControllerWiresVariableLengthStatusItemToUnifiedWindow` and `testStatusItemContextMenuContainsRestartModeChoicesAndQuit`; status item listens for `.rightMouseUp` and contains Restart + Quit.
- One windowing model: `BrainBarApp.swift` no longer routes through MenuBarExtra accessibility discovery or legacy NSPopover; toggle/search/URL paths show the same panel.

## Test plan
- [x] `swift build --package-path brain-bar`
- [x] `swift test --package-path brain-bar` (572 tests, 0 failures)
- [x] Push hook BrainLayer gate: `pytest` 2219 passed, 9 skipped, 75 deselected, 1 xfailed; MCP registration 3 passed; eval/hook routing 36 passed; bun test 1 passed; FTS shell regression passed
- [x] CodeRabbit local pre-commit review run. Initial repo-wide scan surfaced unrelated existing findings outside touched windowing files; scoped test review had no findings; source-only retry hit the CLI free review limit, so PR CodeRabbit remains the clean-gate source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large deletion of macOS windowing and accessibility paths could regress menu-bar positioning or hotkey/URL routing, though behavior is covered by updated unit tests.
> 
> **Overview**
> BrainBar now routes **toggle, search, and quick capture** through one **`BrainBarDashboardPanelController`** window instead of separate MenuBarExtra accessibility hacks, legacy `NSPopover` shells, and mode-specific branches in **`BrainBarApp`**.
> 
> The status item no longer hosts a large popover: **`BrainBarStatusPopoverController`** drives the shared panel, adds a **right-click menu** (restart, quit, switch between **app window** and **menu item daemon**), and **`BrainBarLaunchMode`** is reduced to those two modes with env vars plus persisted **`UserDefaults`**. **`app-window`** mode switches to a regular app activation policy and shows the panel at launch.
> 
> The dashboard panel defaults to **900×640**, enforces a **760×560** minimum (aligned with **`BrainBarWindowPlacement`**), centers only when no AppKit autosaved frame exists, and the header uses **`ViewThatFits`** so controls reflow on narrow widths. **`BrainBarRuntime.handleToggleRequest`** no longer toggles via **`windowCoordinator`**; visibility is owned by the panel path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48ecc25794bf8d60e41831674877d13e177c08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose between app window or menu bar daemon launch mode, with preference automatically saved
  * Right-click status bar for context menu with launch mode options, restart, and quit
  * Responsive layout that adapts to window resizing for improved usability

* **Bug Fixes**
  * Enhanced window resizing behavior and minimum size constraints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Converge BrainBar window modes to a unified dashboard panel
> - Removes the legacy `NSPopover` and `MenuBarExtra` window paths; all UI entry points (search, quick capture, toggle) now route through a single `BrainBarDashboardPanelController`.
> - `BrainBarStatusPopoverController` is reworked to left-click toggle the dashboard window and right-click show a context menu with Restart, mode selectors (App Window / Menu Item Daemon), and Quit.
> - `BrainBarLaunchMode` replaces prior cases with `.appWindow` and `.menuItemDaemon`, defaults to `.menuItemDaemon`, and supports `BRAINBAR_LAUNCH_MODE` env var and persisted user preference via `setPreferred(_:defaults:)`.
> - The dashboard panel now tracks an autosave frame name and only applies initial centering when no saved frame exists, with default/minimum sizes sourced from shared `BrainBarWindowPlacement` constants.
> - Behavioral Change: the status item is now present in all modes; the popover is gone and toggle requests no longer call `windowCoordinator.toggleVisibility()` directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a48ecc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->