### PR TITLE
Fix BrainBar chart live refresh

### DIFF
--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -37,11 +37,14 @@ final class StatsCollector: ObservableObject {
     private let agentActivityMonitor: AgentActivityMonitor
     private let agentActivitySampleInterval: TimeInterval
     private let statsRefreshCoalesceInterval: TimeInterval
+    private let liveStatsRefreshDelay: TimeInterval
     private let autoRefreshInterval: TimeInterval
     private let brainBusEvents: BrainBusEventSource?
     private var brainBusTask: Task<Void, Never>?
     private var autoRefreshTask: Task<Void, Never>?
     private var pendingStatsRefreshTask: Task<Void, Never>?
+    private var pendingStatsRefreshFireAt: Date?
+    private var pendingStatsRefreshBypassesCoalescing = false
     private var dashboardRefreshTask: Task<Void, Never>?
     private var dashboardRefreshGeneration = 0
     private var isRunning = false
@@ -58,6 +61,7 @@ final class StatsCollector: ObservableObject {
         agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor(),
         agentActivitySampleInterval: TimeInterval = 5,
         statsRefreshCoalesceInterval: TimeInterval = 5,
+        liveStatsRefreshDelay: TimeInterval = 0.2,
         autoRefreshInterval: TimeInterval = 30,
         brainBusEvents: BrainBusEventSource? = nil,
         databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
@@ -68,6 +72,7 @@ final class StatsCollector: ObservableObject {
         self.agentActivityMonitor = agentActivityMonitor
         self.agentActivitySampleInterval = agentActivitySampleInterval
         self.statsRefreshCoalesceInterval = statsRefreshCoalesceInterval
+        self.liveStatsRefreshDelay = liveStatsRefreshDelay
         self.autoRefreshInterval = autoRefreshInterval
         self.brainBusEvents = brainBusEvents
         self.stats = DashboardStats(
@@ -123,7 +128,9 @@ final class StatsCollector: ObservableObject {
         dashboardRefreshTask = nil
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
-        hasPendingStatsRefresh = false
+        pendingStatsRefreshFireAt = nil
+        pendingStatsRefreshBypassesCoalescing = false
+        hasPendingStatsRefresh = pendingStatsRefreshTask != nil
         isRefreshing = false
         isManualRefreshInProgress = false
         if isRunning {
@@ -142,16 +149,22 @@ final class StatsCollector: ObservableObject {
         NSLog("[BrainBar] manual refresh requested at %@", ISO8601DateFormatter().string(from: Date()))
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
+        pendingStatsRefreshFireAt = nil
+        pendingStatsRefreshBypassesCoalescing = false
         hasPendingStatsRefresh = false
         requestRefresh(force: true, trigger: .manual)
     }
 
-    func requestRefresh(force: Bool = false, trigger: DashboardRefreshTrigger = .auto) {
+    func requestRefresh(
+        force: Bool = false,
+        trigger: DashboardRefreshTrigger = .auto,
+        bypassCoalescing: Bool = false
+    ) {
         let nextDaemon = daemonMonitor.sample()
         let snapshotTime = Date()
         refreshAgentActivity(force: force, now: snapshotTime)
 
-        if !force, let coalescedDelay = coalescedStatsRefreshDelay(now: snapshotTime) {
+        if !force, !bypassCoalescing, let coalescedDelay = coalescedStatsRefreshDelay(now: snapshotTime) {
             daemon = nextDaemon
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
             schedulePendingStatsRefresh(after: coalescedDelay)
@@ -169,6 +182,8 @@ final class StatsCollector: ObservableObject {
 
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
+        pendingStatsRefreshFireAt = nil
+        pendingStatsRefreshBypassesCoalescing = false
         hasPendingStatsRefresh = false
         dashboardRefreshTask?.cancel()
         dashboardRefreshGeneration += 1
@@ -265,7 +280,7 @@ final class StatsCollector: ObservableObject {
         }
 
         isRefreshing = false
-        hasPendingStatsRefresh = false
+        hasPendingStatsRefresh = pendingStatsRefreshTask != nil
         if trigger == .manual {
             isManualRefreshInProgress = false
         }
@@ -303,10 +318,20 @@ final class StatsCollector: ObservableObject {
         return statsRefreshCoalesceInterval - elapsed
     }
 
-    private func schedulePendingStatsRefresh(after delay: TimeInterval) {
+    private func schedulePendingStatsRefresh(after delay: TimeInterval, bypassCoalescing: Bool = false) {
+        let fireAt = Date().addingTimeInterval(delay)
         hasPendingStatsRefresh = true
-        guard pendingStatsRefreshTask == nil else { return }
+        if pendingStatsRefreshTask != nil {
+            let shouldReplacePendingRefresh =
+                (bypassCoalescing && !pendingStatsRefreshBypassesCoalescing) ||
+                pendingStatsRefreshFireAt.map { fireAt < $0 } ?? false
+            guard shouldReplacePendingRefresh else { return }
+            pendingStatsRefreshTask?.cancel()
+            pendingStatsRefreshTask = nil
+        }
 
+        pendingStatsRefreshFireAt = fireAt
+        pendingStatsRefreshBypassesCoalescing = bypassCoalescing
         pendingStatsRefreshTask = Task { [weak self] in
             do {
                 try await Task.sleep(for: .seconds(delay))
@@ -319,10 +344,20 @@ final class StatsCollector: ObservableObject {
             await MainActor.run {
                 guard let self, !self.isStopped else { return }
                 self.pendingStatsRefreshTask = nil
+                self.pendingStatsRefreshFireAt = nil
+                let shouldBypassCoalescing = self.pendingStatsRefreshBypassesCoalescing
+                self.pendingStatsRefreshBypassesCoalescing = false
                 self.hasPendingStatsRefresh = false
-                self.requestRefresh(force: false, trigger: .auto)
+                self.requestRefresh(force: false, trigger: .auto, bypassCoalescing: shouldBypassCoalescing)
             }
         }
+    }
+
+    private func scheduleLiveStatsRefresh() {
+        schedulePendingStatsRefresh(
+            after: min(statsRefreshCoalesceInterval, liveStatsRefreshDelay),
+            bypassCoalescing: true
+        )
     }
 
     private func startAutoRefreshLoop() {
@@ -341,6 +376,8 @@ final class StatsCollector: ObservableObject {
                     guard let self, !self.isStopped else { return }
                     self.pendingStatsRefreshTask?.cancel()
                     self.pendingStatsRefreshTask = nil
+                    self.pendingStatsRefreshFireAt = nil
+                    self.pendingStatsRefreshBypassesCoalescing = false
                     self.hasPendingStatsRefresh = false
                     self.requestRefresh(force: false, trigger: .auto)
                 }
@@ -367,7 +404,7 @@ final class StatsCollector: ObservableObject {
             trigger: "darwin_db_notification",
             timestamp: Date()
         )
-        schedulePendingStatsRefresh(after: statsRefreshCoalesceInterval)
+        schedulePendingStatsRefresh(after: max(statsRefreshCoalesceInterval, 1.0))
     }
 
     private func handleBrainBusEvent(_ event: BrainBusEvent) {
@@ -383,7 +420,7 @@ final class StatsCollector: ObservableObject {
             refreshAgentActivity(force: false, now: Date())
             state = PipelineState.derive(daemon: daemon, stats: stats)
         case .queueDepth, .enrichStatus, .lastChunkID, .dbBusy:
-            schedulePendingStatsRefresh(after: statsRefreshCoalesceInterval)
+            scheduleLiveStatsRefresh()
         }
     }
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -1030,6 +1030,46 @@ final class DashboardTests: XCTestCase {
     }
 
     @MainActor
+    func testBrainBusDataEventRefreshesEnrichmentBucketsWithoutLongCoalesceDelay() async throws {
+        let eventSource = RecordingBrainBusEventSource()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 60,
+            autoRefreshInterval: 60,
+            brainBusEvents: eventSource
+        )
+        defer { collector.stop() }
+
+        collector.start()
+        try await waitForCollector(collector) { $0.lastDataFetchedAt != nil }
+        XCTAssertEqual(collector.stats.recentEnrichmentBuckets.reduce(0, +), 0)
+
+        try db.insertChunk(
+            id: "brain-bus-live-enrichment",
+            content: "BrainBus enrichment events should refresh the dashboard chart promptly",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        db.exec("""
+            UPDATE chunks
+            SET enriched_at = datetime('now'),
+                enrich_status = 'success'
+            WHERE id = 'brain-bus-live-enrichment'
+        """)
+
+        eventSource.publish(.enrichStatus("running"))
+
+        try await waitForCollector(collector, timeout: 0.5) {
+            $0.stats.recentEnrichmentBuckets.reduce(0, +) == 1
+        }
+
+        XCTAssertEqual(collector.stats.recentEnrichmentBuckets.reduce(0, +), 1)
+    }
+
+    @MainActor
     func testManualRefreshRepopulatesRecentEnrichmentBuckets() async throws {
         let collector = StatsCollector(
             dbPath: tempDBPath,


### PR DESCRIPTION
## Summary
- let BrainBus data events schedule a near-immediate stats refresh that bypasses the long dashboard coalescing window
- allow live refreshes to preempt slower pending coalesced refreshes so enrichment/write buckets repaint while data is flowing
- keep Darwin database notifications as a slower fallback to avoid reader-triggered refresh loops

## Verification
- Red first: `swift test --package-path brain-bar --filter DashboardTests/testBrainBusDataEventRefreshesEnrichmentBucketsWithoutLongCoalesceDelay` failed before implementation with enrichment buckets stuck at 0
- `swift test --package-path brain-bar --filter DashboardTests/testBrainBusDataEventRefreshesEnrichmentBucketsWithoutLongCoalesceDelay --filter DashboardTests/testHeartbeatMarksStatsSnapshotPendingDuringCoalescedRefresh --filter DashboardTests/testBrainBusEventsUpdateHeartbeatAndScheduleCoalescedStatsRefresh`
- `swift test --package-path brain-bar --filter DashboardTests` (58 passed)
- `swift build --package-path brain-bar`
- `swift test --package-path brain-bar` (570 passed)
- pre-push BrainLayer test gate passed: Python 3.12 pytest unit suite (2219 passed, 9 skipped, 75 deselected, 1 xfailed), MCP registration (3 passed), isolated eval/hook routing (36 passed), bun test (1 passed), FTS5 determinism shell test
- live DB read confirmed recent chart-window data: 670 successful enrichments in last 30m, latest 2026-05-29T11:51:57Z; 82 writes in last 30m

## Review note
- Local `cr review --plain` was attempted, but the CodeRabbit CLI review limit is currently exhausted; relying on the PR CodeRabbit check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to BrainBar dashboard refresh timing and coalescing; no auth, data migration, or cross-service API changes.
> 
> **Overview**
> **BrainBar dashboard charts** now repaints write/enrichment buckets soon after pipeline activity instead of sitting behind the full stats coalesce window.
> 
> `StatsCollector` adds a **`liveStatsRefreshDelay`** (default 0.2s) and **`scheduleLiveStatsRefresh()`**, which schedules a pending refresh with **`bypassCoalescing: true`**. BrainBus data events (`.queueDepth`, `.enrichStatus`, `.lastChunkID`, `.dbBusy`) call that path instead of the long coalesce delay. **`requestRefresh`** accepts **`bypassCoalescing`** so those refreshes skip the post-refresh coalesce gate.
> 
> Pending refreshes are **smarter**: they track fire time and whether coalescing is bypassed, can **replace** an existing pending task when a sooner or higher-priority live refresh arrives, and **`hasPendingStatsRefresh`** stays accurate when a follow-up task remains after a refresh finishes.
> 
> **Darwin DB mutation** notifications still coalesce but use **`max(statsRefreshCoalesceInterval, 1.0)`** as a slower fallback to reduce refresh churn from reader-triggered writes.
> 
> A new **`DashboardTests`** case asserts an `enrichStatus` BrainBus event updates enrichment buckets within 0.5s even when coalesce is 60s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99322eecfe971be9d728e68bafb08dbc4c00ea2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BrainBar chart live refresh by bypassing coalescing for BrainBus events
> - BrainBus data events (`.queueDepth`, `.enrichStatus`, `.lastChunkID`, `.dbBusy`) now trigger a fast refresh via a new `scheduleLiveStatsRefresh()` helper that bypasses the normal coalescing delay, using a configurable `liveStatsRefreshDelay` (default 0.2s).
> - Pending refreshes are now tracked with a scheduled fire time and a bypass flag, allowing a new refresh request to replace an existing one if it fires earlier or upgrades it to bypass coalescing.
> - Database mutation-triggered refreshes now use a minimum 1-second delay (`max(statsRefreshCoalesceInterval, 1.0)`) to avoid over-refreshing on rapid writes.
> - A new test in [DashboardTests.swift](https://github.com/EtanHey/brainlayer/pull/360/files#diff-300f6ba025d1a85e02dab4ebdab7270b2e612b0975457dd52dd626c7ccabfda7) validates that an `enrichStatus` event triggers a refresh within 0.5s even when `statsRefreshCoalesceInterval` is 60s.
> - Behavioral Change: BrainBus live events now refresh the dashboard significantly faster than before, while mutation-triggered refreshes are now delayed by at least 1 second regardless of the coalescing interval.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 99322ee. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->