### PR TITLE
test: pin BrainBarDaemon launch mode contract

### DIFF
--- a/brain-bar/Package.swift
+++ b/brain-bar/Package.swift
@@ -49,5 +49,12 @@ let package = Package(
             ],
             path: "Tests/BrainBarTests"
         ),
+        .testTarget(
+            name: "BrainBarDaemonTests",
+            dependencies: [
+                "BrainBarDaemon",
+            ],
+            path: "Tests/BrainBarDaemonTests"
+        ),
     ]
 )

--- a/brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift
+++ b/brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import BrainBarDaemon
+
+final class BrainBarDaemonLaunchModeTests: XCTestCase {
+    func testDaemonLaunchModeParsesUnifiedEnvironmentValues() {
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_LAUNCH_MODE": "app-window"],
+                defaults: FakeKeyValueStore()
+            ),
+            .appWindow
+        )
+
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_LAUNCH_MODE": "menu-item-daemon"],
+                defaults: FakeKeyValueStore()
+            ),
+            .menuItemDaemon
+        )
+    }
+
+    func testDaemonLaunchModePreservesLegacyEnvironmentCompatibility() {
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_APP_WINDOW": "1"],
+                defaults: FakeKeyValueStore()
+            ),
+            .appWindow
+        )
+
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_LEGACY": "1"],
+                defaults: FakeKeyValueStore()
+            ),
+            .menuItemDaemon
+        )
+    }
+
+    func testDaemonLaunchModeEnvironmentOverridesPersistedPreference() {
+        let store = FakeKeyValueStore()
+        BrainBarLaunchMode.setPreferred(.menuItemDaemon, defaults: store)
+
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_LAUNCH_MODE": "APPWINDOW"],
+                defaults: store
+            ),
+            .appWindow
+        )
+    }
+
+    func testDaemonLaunchModeReadsPersistedPreferenceWrittenByUI() {
+        let store = FakeKeyValueStore()
+
+        BrainBarLaunchMode.setPreferred(.appWindow, defaults: store)
+
+        XCTAssertEqual(
+            store.string(forKey: BrainBarLaunchMode.defaultsKey),
+            "app-window"
+        )
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(environment: [:], defaults: store),
+            .appWindow
+        )
+    }
+
+    func testDaemonLaunchModeFallsBackToMenuItemDaemonForInvalidInputs() {
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_LAUNCH_MODE": "not-a-mode"],
+                defaults: FakeKeyValueStore()
+            ),
+            .menuItemDaemon
+        )
+
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_LAUNCH_MODE": ""],
+                defaults: FakeKeyValueStore()
+            ),
+            .menuItemDaemon
+        )
+    }
+
+    @MainActor
+    func testDaemonRuntimeRoutesToggleThroughUnifiedWindowHandler() {
+        var toggles = 0
+        let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
+        runtime.onToggleRequested = {
+            toggles += 1
+        }
+
+        runtime.handleToggleRequest()
+
+        XCTAssertEqual(toggles, 1)
+    }
+
+    @MainActor
+    func testDaemonRuntimeDefaultInitializerResolvesLaunchMode() {
+        let runtime = BrainBarRuntime()
+
+        XCTAssertEqual(runtime.launchMode, .menuItemDaemon)
+    }
+}
+
+private final class FakeKeyValueStore: BrainBarKeyValueStoring {
+    private var values: [String: String] = [:]
+
+    func string(forKey defaultName: String) -> String? {
+        values[defaultName]
+    }
+
+    func setString(_ value: String?, forKey defaultName: String) {
+        values[defaultName] = value
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a dedicated `BrainBarDaemonTests` target so daemon launch-mode behavior is tested through the daemon module, not only the UI module.
- Asserts the daemon parses the unified `BRAINBAR_LAUNCH_MODE` values, reads the shared `brainbar.launchMode` persisted key written by UI mode selection, and routes toggle requests through the unified window handler.
- Confirms current main already syncs daemon code through symlinked BrainBar source files; this PR closes the CI coverage gap Spark found.

## Test plan
- [x] `swift test --package-path brain-bar --filter BrainBarDaemonLaunchModeTests`
- [x] `swift build --package-path brain-bar`
- [x] `swift test --package-path brain-bar` (578 tests)
- [x] Local CodeRabbit `cr review --plain` (no findings)
- [x] Full pre-push BrainLayer gate

## Notes
- No dashboard files touched.
- Daemon `BrainBarWindowState.swift` and `BrainBarRuntime.swift` are symlinks to the UI implementations, so the daemon already receives the unified enum/resolve path from #358; this PR adds daemon-module regression coverage so that cannot silently drift again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or packaging behavior modifications beyond a new test target.
> 
> **Overview**
> Adds a **`BrainBarDaemonTests`** SPM target and **`BrainBarDaemonLaunchModeTests`** so launch-mode behavior is asserted against the **BrainBarDaemon** module, not only UI tests.
> 
> The new suite pins **`BrainBarLaunchMode.resolve`** (unified `BRAINBAR_LAUNCH_MODE`, legacy env vars, env-over-persisted preference, invalid fallback to menu-item daemon), **`setPreferred`** / shared defaults key round-trips via an in-memory **`FakeKeyValueStore`**, and **`BrainBarRuntime`** default launch mode plus **`handleToggleRequest()`** invoking **`onToggleRequested`** once. No production code changes—CI coverage for the daemon launch contract only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7251d3445845471c2f10fd55d5fbb1f9ada3e7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin contract tests for `BrainBarDaemon` launch mode parsing and runtime behavior
> - Adds a new `BrainBarDaemonTests` test target in [Package.swift](https://github.com/EtanHey/brainlayer/pull/361/files#diff-b51d56888cdd363445419485ee9a5c99493cf63d44e6fc20c3b8e33e51b0ce46) pointing to `Tests/BrainBarDaemonTests`.
> - Introduces [BrainBarDaemonLaunchModeTests.swift](https://github.com/EtanHey/brainlayer/pull/361/files#diff-3940662d2127bbc25fa3cd77a981fe7099846bfcb0b176de1f314e1b2fe81ee3) covering `BrainBarLaunchMode` parsing from env vars (`BRAINBAR_LAUNCH_MODE`, legacy `BRAINBAR_APP_WINDOW`/`BRAINBAR_LEGACY`), persisted preference key resolution, invalid/empty fallback to `.menuItemDaemon`, and `BrainBarRuntime` toggle routing.
> - Adds a `FakeKeyValueStore` in-memory helper implementing `BrainBarKeyValueStoring` for test isolation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7251d34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->