### PR TITLE
fix: bound WAL to stop brain_store write starvation

### DIFF
--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -607,7 +607,13 @@ def drain_once(
                         _embed_store_chunks(conn, store_chunk_ids, embed_fn)
                     conn.execute("COMMIT")
                     try:
-                        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                        # TRUNCATE (not PASSIVE) so the WAL file is reclaimed after
+                        # each drained batch. PASSIVE leaves frames in place when a
+                        # reader pins a page, letting the WAL grow unbounded (observed
+                        # multi-GB) and starve brain_store writes. TRUNCATE checkpoints
+                        # what it can and shrinks the file; busy_timeout + the except
+                        # below keep it non-fatal if a reader briefly blocks it.
+                        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
                     except apsw.Error:
                         pass
                     drained += attempt_drained

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -37,6 +37,10 @@ _DEFAULT_DRAIN_BUSY_TIMEOUT_MS = 30000
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _DEFAULT_MAX_EVENTS_PER_TRANSACTION = 5
 _DEFAULT_POST_COMMIT_YIELD_MS = 10.0
+# The post-commit WAL checkpoint is best-effort. Bound how long TRUNCATE may wait
+# on readers so a pinned reader can't stall every other writer for the full drain
+# busy_timeout (30s). Short window → reclaim when possible, skip cheaply otherwise.
+_DEFAULT_CHECKPOINT_BUSY_TIMEOUT_MS = 1000
 
 
 def _drain_busy_timeout_ms() -> int:
@@ -46,6 +50,18 @@ def _drain_busy_timeout_ms() -> int:
         return _DEFAULT_DRAIN_BUSY_TIMEOUT_MS
     if timeout_ms <= 0 or timeout_ms > _MAX_APSW_BUSY_TIMEOUT_MS:
         return _DEFAULT_DRAIN_BUSY_TIMEOUT_MS
+    return timeout_ms
+
+
+def _checkpoint_busy_timeout_ms() -> int:
+    try:
+        timeout_ms = int(
+            os.environ.get("BRAINLAYER_DRAIN_CHECKPOINT_BUSY_TIMEOUT_MS", str(_DEFAULT_CHECKPOINT_BUSY_TIMEOUT_MS))
+        )
+    except (TypeError, ValueError):
+        return _DEFAULT_CHECKPOINT_BUSY_TIMEOUT_MS
+    if timeout_ms < 0 or timeout_ms > _MAX_APSW_BUSY_TIMEOUT_MS:
+        return _DEFAULT_CHECKPOINT_BUSY_TIMEOUT_MS
     return timeout_ms
 
 
@@ -606,16 +622,22 @@ def drain_once(
                     if should_embed:
                         _embed_store_chunks(conn, store_chunk_ids, embed_fn)
                     conn.execute("COMMIT")
+                    # Best-effort WAL reclaim. The truncating checkpoint (not PASSIVE)
+                    # shrinks the WAL file after each drained batch — PASSIVE leaves
+                    # frames in place when a reader pins a page, letting the WAL grow
+                    # unbounded (observed multi-GB) and starve brain_store writes. But it
+                    # blocks other writers while waiting for readers, so bound that wait
+                    # to a short window (default 1s): if a reader pins the WAL we skip
+                    # this round rather than stall every writer for the full drain
+                    # busy_timeout. journal_size_limit and the out-of-band wal-checkpoint
+                    # job reclaim later. The except keeps a busy checkpoint non-fatal.
+                    conn.setbusytimeout(_checkpoint_busy_timeout_ms())
                     try:
-                        # TRUNCATE (not PASSIVE) so the WAL file is reclaimed after
-                        # each drained batch. PASSIVE leaves frames in place when a
-                        # reader pins a page, letting the WAL grow unbounded (observed
-                        # multi-GB) and starve brain_store writes. TRUNCATE checkpoints
-                        # what it can and shrinks the file; busy_timeout + the except
-                        # below keep it non-fatal if a reader briefly blocks it.
                         conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
                     except apsw.Error:
                         pass
+                    finally:
+                        conn.setbusytimeout(_drain_busy_timeout_ms())
                     drained += attempt_drained
                     collisions_dropped += len(collision_ids)
                     for chunk_id in collision_ids:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -104,6 +104,19 @@ def _wal_autocheckpoint_pages() -> int:
     return max(_int_env("BRAINLAYER_WAL_AUTOCHECKPOINT", 10_000), 0)
 
 
+def _wal_size_limit_bytes() -> int:
+    """Cap the on-disk WAL file size (bytes). 0 disables (PRAGMA -1 = unlimited).
+
+    Without this, journal_size_limit defaults to -1 and the WAL file is never
+    truncated back after a checkpoint — it stays at its high-water mark. Under
+    enrichment load with reader-pinned PASSIVE checkpoints the WAL grew to
+    multi-GB (observed 2.4-3.9GB), which starved brain_store writes ("DB busy").
+    256MB is generous headroom for the largest legitimate batch while bounding
+    the file so checkpoints stay cheap and write windows reopen promptly.
+    """
+    return max(_int_env("BRAINLAYER_WAL_SIZE_LIMIT_BYTES", 256_000_000), 0)
+
+
 class WriterInUseError(RuntimeError):
     """Raised when a live process already owns the writer pidfile."""
 
@@ -520,6 +533,11 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         # WAL mode is persistent on the DB file — set it every time
         cursor.execute("PRAGMA journal_mode = WAL")
         cursor.execute(f"PRAGMA wal_autocheckpoint = {_wal_autocheckpoint_pages()}")
+        # Bound the WAL file so it truncates back after each checkpoint instead of
+        # staying at its high-water mark (default -1 = unlimited). See
+        # _wal_size_limit_bytes() for the starvation root cause this prevents.
+        _wal_limit = _wal_size_limit_bytes()
+        cursor.execute(f"PRAGMA journal_size_limit = {_wal_limit if _wal_limit > 0 else -1}")
 
         # Create tables
         cursor.execute("""

--- a/tests/test_write_resilience_under_load.py
+++ b/tests/test_write_resilience_under_load.py
@@ -120,18 +120,22 @@ def test_all_stores_land_under_concurrent_writer(tmp_path, small_wal_env):
     VectorStore(db).close()
 
     stop = threading.Event()
+    acquired = {"n": 0}
 
     def contender() -> None:
+        # Hold the write lock in short bursts to contend with the main thread's
+        # stores. BEGIN IMMEDIATE acquires the write lock immediately — no INSERT
+        # is needed (and a schema-specific INSERT here is brittle: chunks has
+        # NOT NULL columns like source_file, so a partial INSERT silently fails
+        # and exercises no contention at all). The held lock forces the main
+        # thread's store_memory to wait on its busy_timeout.
         c = apsw.Connection(str(db))
         c.setbusytimeout(5_000)
         cur = c.cursor()
         while not stop.is_set():
             try:
                 cur.execute("BEGIN IMMEDIATE")
-                cur.execute(
-                    "INSERT INTO chunks (id, content, metadata) VALUES (?, ?, ?)",
-                    (f"contend-{time.time_ns()}", "x" * 2000, "{}"),
-                )
+                acquired["n"] += 1
                 time.sleep(0.02)
                 cur.execute("COMMIT")
             except apsw.Error:
@@ -153,6 +157,7 @@ def test_all_stores_land_under_concurrent_writer(tmp_path, small_wal_env):
         stop.set()
         t.join(timeout=5)
 
+    assert acquired["n"] > 0, "contender never took the write lock — no contention was exercised"
     assert len(ids) == n, f"only {len(ids)}/{n} stores returned an id under contention"
     reader = apsw.Connection(str(db), flags=apsw.SQLITE_OPEN_READONLY)
     try:

--- a/tests/test_write_resilience_under_load.py
+++ b/tests/test_write_resilience_under_load.py
@@ -1,0 +1,164 @@
+"""Write-resilience under load — RED-first regression for the WAL-starvation fix.
+
+Root cause (confirmed live, BL-LEAD gen-10 2026-05-29): brain_store intermittently
+queued ("DB busy") because the WAL file grew unbounded — `drain.py` used a PASSIVE
+checkpoint (cannot reclaim WAL under reader load) and `journal_size_limit` was -1
+(the WAL file never truncated back after a checkpoint). Observed multi-GB WAL in
+production logs (2.4-3.9GB); a real store queued with WAL at only 33MB.
+
+The fix:
+  1. vector_store.py sets `PRAGMA journal_size_limit` (env BRAINLAYER_WAL_SIZE_LIMIT_BYTES,
+     default 256MB) on every connection so the WAL truncates back after a checkpoint.
+  2. drain.py checkpoints with TRUNCATE (not PASSIVE) so each drained batch reclaims WAL.
+
+These tests fail on origin/main (journal_size_limit == -1, WAL unbounded) and pass
+after the fix. They use isolated tmp DBs only — never the real ~/.local/share DB.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+import apsw
+import pytest
+
+from brainlayer.store import store_memory
+from brainlayer.vector_store import VectorStore
+
+
+def _wal_path(db_path) -> str:
+    return str(db_path) + "-wal"
+
+
+def _wal_bytes(db_path) -> int:
+    try:
+        return os.path.getsize(_wal_path(db_path))
+    except OSError:
+        return 0
+
+
+@pytest.fixture
+def small_wal_env(monkeypatch):
+    """Cap the WAL at 256KB and disable autocheckpoint so the test controls timing."""
+    limit = 256_000
+    monkeypatch.setenv("BRAINLAYER_WAL_SIZE_LIMIT_BYTES", str(limit))
+    monkeypatch.setenv("BRAINLAYER_WAL_AUTOCHECKPOINT", "0")
+    return limit
+
+
+def _write_chunks(store: VectorStore, n: int, prefix: str) -> list[str]:
+    ids: list[str] = []
+    for i in range(n):
+        res = store_memory(
+            store=store,
+            embed_fn=None,
+            content=f"{prefix}-{i:04d}: " + ("write-resilience load payload " * 40),
+            memory_type="note",
+            project="brainlayer-write-resilience",
+            tags=["write-resilience", "load-test", prefix],
+            importance=3,
+        )
+        cid = res.get("id") if isinstance(res, dict) else None
+        if cid:
+            ids.append(cid)
+    return ids
+
+
+def test_journal_size_limit_is_set(tmp_path, small_wal_env):
+    """RED on origin/main: journal_size_limit defaults to -1 (unbounded WAL file)."""
+    db = tmp_path / "bl.db"
+    store = VectorStore(db)
+    try:
+        limit = store.conn.cursor().execute("PRAGMA journal_size_limit").fetchone()[0]
+    finally:
+        store.close()
+    assert limit == small_wal_env, (
+        f"journal_size_limit={limit} (expected {small_wal_env}). On origin/main this is -1, "
+        "so the WAL file never truncates back after a checkpoint and grows unbounded."
+    )
+
+
+def test_wal_file_bounded_after_checkpoint(tmp_path, small_wal_env):
+    """RED on origin/main: PASSIVE checkpoint + journal_size_limit=-1 leaves a large WAL file.
+
+    Reproduces the production mechanism: WAL grows under a batch of writes, a PASSIVE
+    checkpoint runs (the old drain behaviour), and the WAL FILE must shrink back to the
+    limit. With journal_size_limit=-1 the file stays at its multi-MB high-water mark.
+    """
+    db = tmp_path / "bl.db"
+    store = VectorStore(db)
+    try:
+        # Grow the WAL well past the 256KB limit (autocheckpoint disabled).
+        _write_chunks(store, 400, "grow")
+        assert _wal_bytes(db) > small_wal_env, "precondition: WAL should exceed the limit before checkpoint"
+        # Old drain behaviour: PASSIVE checkpoint, then a tiny write to force the WAL reset
+        # at which point journal_size_limit truncation applies.
+        store.conn.cursor().execute("PRAGMA wal_checkpoint(PASSIVE)")
+        _write_chunks(store, 1, "reset")
+        store.conn.cursor().execute("PRAGMA wal_checkpoint(PASSIVE)")
+        wal_now = _wal_bytes(db)
+    finally:
+        store.close()
+    assert wal_now <= small_wal_env * 1.5, (
+        f"WAL file is {wal_now} bytes after checkpoint (limit {small_wal_env}). "
+        "On origin/main (journal_size_limit=-1) it stays at the multi-MB high-water mark — "
+        "the unbounded-WAL starvation root cause."
+    )
+
+
+def test_all_stores_land_under_concurrent_writer(tmp_path, small_wal_env):
+    """Acceptance guard: every store lands (read-back) even with a competing writer.
+
+    A background thread repeatedly takes the write lock (BEGIN IMMEDIATE + slow write),
+    reproducing the enrichment/drain contention that made MCP stores queue. All N stores
+    must be retrievable from the DB afterwards. Stays green before/after — regression net.
+    """
+    db = tmp_path / "bl.db"
+    # Initialise schema once before the contender opens its connection.
+    VectorStore(db).close()
+
+    stop = threading.Event()
+
+    def contender() -> None:
+        c = apsw.Connection(str(db))
+        c.setbusytimeout(5_000)
+        cur = c.cursor()
+        while not stop.is_set():
+            try:
+                cur.execute("BEGIN IMMEDIATE")
+                cur.execute(
+                    "INSERT INTO chunks (id, content, metadata) VALUES (?, ?, ?)",
+                    (f"contend-{time.time_ns()}", "x" * 2000, "{}"),
+                )
+                time.sleep(0.02)
+                cur.execute("COMMIT")
+            except apsw.Error:
+                try:
+                    cur.execute("ROLLBACK")
+                except apsw.Error:
+                    pass
+            time.sleep(0.005)
+        c.close()
+
+    t = threading.Thread(target=contender, daemon=True)
+    t.start()
+    try:
+        store = VectorStore(db)
+        n = 50
+        ids = _write_chunks(store, n, "land")
+        store.close()
+    finally:
+        stop.set()
+        t.join(timeout=5)
+
+    assert len(ids) == n, f"only {len(ids)}/{n} stores returned an id under contention"
+    reader = apsw.Connection(str(db), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        landed = sum(
+            1 for cid in ids if list(reader.cursor().execute("SELECT 1 FROM chunks WHERE id=? LIMIT 1", (cid,)))
+        )
+    finally:
+        reader.close()
+    assert landed == n, f"only {landed}/{n} stores landed (read-back) under writer contention"


### PR DESCRIPTION
## Problem (Etan's #1 recurring pain: "BrainLayer fails every time")
`brain_store` intermittently queues (`⏳ Memory queued (DB busy)`) and silently defers checkpoints because the **WAL file grows unbounded**:
- `drain.py` checkpointed with `PRAGMA wal_checkpoint(PASSIVE)`, which **cannot reclaim WAL frames while any reader pins a page** (BrainBar, hybrid_helper).
- `journal_size_limit` defaulted to **-1**, so the WAL file was **never truncated back** after a checkpoint — it stayed at its high-water mark.

Under enrichment load the WAL reached **multi-GB** (2.4–3.9 GB in production logs); BL-LEAD reproduced a live store queueing with WAL at 33 MB. **This is the WAL-growth follow-up explicitly deferred by the PR #359 BUGBOT review** ("WAL Growth (4.7GB) — Not Fully Addressed… consider RESTART/TRUNCATE").

## Fix (surgical, 2 files)
1. **`vector_store.py`** — set `PRAGMA journal_size_limit` on every connection (env `BRAINLAYER_WAL_SIZE_LIMIT_BYTES`, default **256 MB**) so the WAL truncates back to the cap after each checkpoint.
2. **`drain.py:610`** — checkpoint with **`TRUNCATE`** (not `PASSIVE`) so each drained batch reclaims the WAL file; kept the non-fatal `except apsw.Error` for transient busy.

## TDD — RED → GREEN (literal stdout)
`tests/test_write_resilience_under_load.py` (isolated tmp DBs only):

**Pre-fix (fix stashed): `2 failed, 1 passed`**
```
test_journal_size_limit_is_set            FAILED  (pragma == -1)
test_wal_file_bounded_after_checkpoint    FAILED
  AssertionError: WAL file is 93285072 bytes after checkpoint (limit 256000)
test_all_stores_land_under_concurrent_writer  PASSED  (landing guard)
```
→ **93 MB WAL** after a PASSIVE checkpoint vs the 256 KB cap — the unbounded-WAL root cause, reproduced.

**Post-fix: `3 passed`.** Related suites stay green: `test_write_queue + test_db_lock_resilience + test_enrichment_bounded_commit` = **36 passed**. `ruff check` clean.

## Verification beyond CI (DONE gate)
"merged" ≠ "landed". After merge: deploy to the editable install, restart daemons, then run a **live store→search round-trip under enrichment load** (50 stores, read-back each, WAL bounded). Only that = done.

## Notes for review
- Default 256 MB is generous headroom for the largest legitimate batch while bounding the file so checkpoints stay cheap and write windows reopen promptly. Tune via `BRAINLAYER_WAL_SIZE_LIMIT_BYTES`.
- Scope intentionally limited to the WAL bound + test. If write-lock contention persists at modest WAL after this, the follow-up is enrichment committing in smaller bounded windows (noted, not done here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core SQLite write/drain path and changes checkpoint semantics (TRUNCATE can wait on readers, though bounded to ~1s); mis-tuning limits could affect checkpoint frequency under heavy load.
> 
> **Overview**
> Addresses intermittent **`brain_store` "DB busy"** queuing by stopping unbounded SQLite WAL growth under enrichment and long-lived readers.
> 
> **`vector_store.py`** now applies **`PRAGMA journal_size_limit`** on writer init (default **256MB**, tunable via `BRAINLAYER_WAL_SIZE_LIMIT_BYTES`; `0` keeps unlimited `-1`).
> 
> **`drain.py`** switches post-commit checkpointing from **`wal_checkpoint(PASSIVE)`** to **`wal_checkpoint(TRUNCATE)`** so each drained batch can shrink the WAL file, with a **short separate busy timeout** (default **1s**, `BRAINLAYER_DRAIN_CHECKPOINT_BUSY_TIMEOUT_MS`) so pinned readers do not hold the drain connection at the full 30s drain timeout; checkpoint failures stay non-fatal.
> 
> Adds **`tests/test_write_resilience_under_load.py`** to assert the journal limit is set, WAL size drops after checkpoint with the limit, and stores still land under concurrent write lock contention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b30792749ee99d514b28a259f8ae812690569e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound WAL size to prevent write starvation in `brain_store`
> - Adds `PRAGMA journal_size_limit` (default 256MB) to every [`VectorStore`](https://github.com/EtanHey/brainlayer/pull/368/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261) connection to cap WAL file growth; configurable via `BRAINLAYER_WAL_SIZE_LIMIT_BYTES`.
> - Replaces `wal_checkpoint(PASSIVE)` with `wal_checkpoint(TRUNCATE)` in [`drain_once`](https://github.com/EtanHey/brainlayer/pull/368/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) so WAL space is reclaimed after each drained batch.
> - Sets a bounded busy timeout (default 1000ms, configurable via `BRAINLAYER_DRAIN_CHECKPOINT_BUSY_TIMEOUT_MS`) for checkpoint operations; checkpoint failures are non-fatal.
> - Adds write-resilience tests covering journal size limit enforcement, WAL size bounding after checkpoint, and concurrent write correctness.
> - Behavioral Change: `drain_once` now temporarily lowers the connection busy timeout during checkpoints and restores it afterward; WAL is truncated rather than passively checkpointed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b30792.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database checkpoint strategy for enhanced write performance and stability.
  * Better handling of concurrent database writes under load.

* **Tests**
  * Added comprehensive write resilience tests for concurrent load scenarios.
  * Added regression tests for database file size management and bounds checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->