### PR TITLE
fix(mcp): lazy-import torch off the MCP startup path (Codex boot-hang root fix)

### DIFF
--- a/src/brainlayer/embeddings.py
+++ b/src/brainlayer/embeddings.py
@@ -1,13 +1,21 @@
 """Fast embeddings using sentence-transformers with bge-large-en-v1.5."""
 
+# `from __future__ import annotations` keeps every annotation in this module a
+# lazy string, so a SentenceTransformer type hint never forces the (~3.7s) torch
+# import at module-load time. torch + sentence_transformers are imported lazily
+# inside _load_model() — this keeps `import brainlayer.embeddings` cheap, which
+# is what lets the MCP server answer its initialize/tools/list handshake fast
+# instead of stalling on the startup critical path (fix/mcp-lazy-connect).
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import Callable, List, Optional
-
-import torch
-from sentence_transformers import SentenceTransformer
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from .pipeline.chunk import Chunk
+
+if TYPE_CHECKING:  # for type-checkers only; never imported at runtime module-load
+    from sentence_transformers import SentenceTransformer
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +44,16 @@ class EmbeddingModel:
         self._model: Optional[SentenceTransformer] = None
 
     def _load_model(self) -> SentenceTransformer:
-        """Load model on first use."""
+        """Load model on first use.
+
+        torch + sentence_transformers are imported here (not at module scope) so
+        that merely importing this module — e.g. during MCP server startup
+        validation — never pays the ~3.7s torch import cost.
+        """
         if self._model is None:
+            import torch
+            from sentence_transformers import SentenceTransformer
+
             logger.info(f"Loading embedding model: {self.model_name}")
             device = "mps" if torch.backends.mps.is_available() else "cpu"
             self._model = SentenceTransformer(self.model_name, device=device)

--- a/src/brainlayer/pipeline/semantic_style.py
+++ b/src/brainlayer/pipeline/semantic_style.py
@@ -31,12 +31,14 @@ try:
 except ImportError:
     HAS_NUMPY = False
 
-try:
-    from sentence_transformers import SentenceTransformer
+# Probe availability via find_spec instead of importing — importing
+# sentence_transformers eagerly pulls in torch (~3.7s) at module load, and this
+# module is imported by pipeline/__init__, which sits on the MCP server's startup
+# critical path. The actual import is deferred to SemanticStyleAnalyzer.model
+# (first real use). See fix/mcp-lazy-connect.
+import importlib.util as _importlib_util
 
-    HAS_SENTENCE_TRANSFORMERS = True
-except ImportError:
-    HAS_SENTENCE_TRANSFORMERS = False
+HAS_SENTENCE_TRANSFORMERS = _importlib_util.find_spec("sentence_transformers") is not None
 
 try:
     from sklearn.metrics.pairwise import cosine_similarity
@@ -157,6 +159,8 @@ class SemanticStyleAnalyzer:
     def model(self) -> SentenceTransformer:
         """Lazy load the embedding model."""
         if self._model is None:
+            from sentence_transformers import SentenceTransformer
+
             logger.info("Loading %s...", self.model_name)
             self._model = SentenceTransformer(self.model_name)
         return self._model

--- a/src/brainlayer/pipeline/semantic_style.py
+++ b/src/brainlayer/pipeline/semantic_style.py
@@ -159,7 +159,14 @@ class SemanticStyleAnalyzer:
     def model(self) -> SentenceTransformer:
         """Lazy load the embedding model."""
         if self._model is None:
-            from sentence_transformers import SentenceTransformer
+            # find_spec only proves the package is on disk, not importable — a
+            # broken install (e.g. corrupt torch dep) passes the __init__ guard
+            # but fails here, so re-raise with the same friendly message the old
+            # module-level try/except gave.
+            try:
+                from sentence_transformers import SentenceTransformer
+            except ImportError as e:
+                raise ImportError("sentence-transformers required. Install: pip install sentence-transformers") from e
 
             logger.info("Loading %s...", self.model_name)
             self._model = SentenceTransformer(self.model_name)

--- a/tests/test_mcp_lazy_startup.py
+++ b/tests/test_mcp_lazy_startup.py
@@ -33,6 +33,7 @@ _REPO_SRC = str(Path(__file__).resolve().parent.parent / "src")
 
 
 def _child_env() -> dict:
+    """Environment for subprocesses, with this worktree's src prepended to PYTHONPATH."""
     env = dict(os.environ)
     env["PYTHONPATH"] = _REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
     return env
@@ -65,10 +66,7 @@ def test_importing_embeddings_does_not_load_torch():
 
 def test_validate_config_does_not_load_torch():
     """serve()'s startup validation must not pull torch onto the critical path."""
-    out = _run_snippet(
-        "import sys, brainlayer.mcp as m; m.validate_config(); "
-        "print('torch' in sys.modules)"
-    )
+    out = _run_snippet("import sys, brainlayer.mcp as m; m.validate_config(); print('torch' in sys.modules)")
     assert out == "False", "validate_config() eagerly imported torch (blocks the MCP handshake)"
 
 
@@ -90,6 +88,7 @@ HANDSHAKE_BUDGET_SEC = 3.0  # must beat Codex's startup_timeout_sec=5 with margi
 
 
 def _hold_exclusive_lock(db_path, stop_event, ready_event):
+    """Hold a SQLite write lock on db_path until stop_event; signal ready_event once held."""
     conn = apsw.Connection(str(db_path))
     conn.cursor().execute("PRAGMA busy_timeout=200")  # fail fast, don't block on a real writer
     try:
@@ -110,6 +109,7 @@ def _hold_exclusive_lock(db_path, stop_event, ready_event):
 
 
 def _read_json_line(proc, timeout):
+    """Read one newline-delimited JSON-RPC message from proc.stdout, or None on timeout."""
     box = {}
 
     def _r():
@@ -133,9 +133,7 @@ def test_handshake_fast_under_db_write_lock():
 
     stop_event = threading.Event()
     ready_event = threading.Event()
-    lock_thread = threading.Thread(
-        target=_hold_exclusive_lock, args=(db_path, stop_event, ready_event), daemon=True
-    )
+    lock_thread = threading.Thread(target=_hold_exclusive_lock, args=(db_path, stop_event, ready_event), daemon=True)
     lock_thread.start()
     assert ready_event.wait(timeout=10), "could not acquire exclusive DB lock"
 
@@ -148,11 +146,21 @@ def test_handshake_fast_under_db_write_lock():
     )
     try:
         proc.stdin.write(
-            (json.dumps({
-                "jsonrpc": "2.0", "id": 1, "method": "initialize",
-                "params": {"protocolVersion": "2024-11-05", "capabilities": {},
-                           "clientInfo": {"name": "test", "version": "0"}},
-            }) + "\n").encode()
+            (
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {"name": "test", "version": "0"},
+                        },
+                    }
+                )
+                + "\n"
+            ).encode()
         )
         proc.stdin.flush()
         t0 = time.time()
@@ -160,12 +168,13 @@ def test_handshake_fast_under_db_write_lock():
         elapsed = time.time() - t0
         assert init_resp is not None, "initialize never responded"
         assert elapsed < HANDSHAKE_BUDGET_SEC, (
-            f"initialize took {elapsed:.2f}s (budget {HANDSHAKE_BUDGET_SEC}s) — would trip "
-            f"Codex startup_timeout_sec=5"
+            f"initialize took {elapsed:.2f}s (budget {HANDSHAKE_BUDGET_SEC}s) — would trip Codex startup_timeout_sec=5"
         )
 
         proc.stdin.write((json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n").encode())
-        proc.stdin.write((json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}) + "\n").encode())
+        proc.stdin.write(
+            (json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}) + "\n").encode()
+        )
         proc.stdin.flush()
         tools_resp = _read_json_line(proc, timeout=HANDSHAKE_BUDGET_SEC)
         assert tools_resp is not None, "tools/list never responded"

--- a/tests/test_mcp_lazy_startup.py
+++ b/tests/test_mcp_lazy_startup.py
@@ -1,0 +1,176 @@
+"""Lazy-connect / non-blocking MCP startup contract (fix/mcp-lazy-connect).
+
+Root cause of the Codex boot-hang: brainlayer-mcp's initialize+tools/list
+handshake was delayed 4-9s because serve() -> validate_config() eagerly imported
+`torch` (via embeddings.py module-load), routinely exceeding Codex's
+startup_timeout_sec=5. The DB itself was never the blocker (the store is already
+lazy; the handshake never touches it).
+
+These tests pin the contract: importing the MCP/embeddings modules and running
+startup validation must NOT pull in torch, and the live handshake must return
+quickly even when the DB is held under an exclusive write lock.
+
+Each "no torch" check runs in a fresh interpreter subprocess so a torch import
+elsewhere in the test session can't mask a regression.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import apsw
+import pytest
+
+from brainlayer.paths import get_db_path
+
+# Run subprocesses against THIS worktree's src (not whatever editable install is
+# active), so the test exercises the code under review pre-merge.
+_REPO_SRC = str(Path(__file__).resolve().parent.parent / "src")
+
+
+def _child_env() -> dict:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+def _run_snippet(snippet: str) -> str:
+    """Run a Python snippet in a fresh interpreter; return its stdout (stripped)."""
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=_child_env(),
+    )
+    assert proc.returncode == 0, f"snippet failed:\n{proc.stderr}"
+    return proc.stdout.strip()
+
+
+def test_importing_embeddings_does_not_load_torch():
+    """`import brainlayer.embeddings` must not eagerly import torch.
+
+    torch import is ~3.7s cold; keeping it lazy is the core of the fix.
+    """
+    out = _run_snippet(
+        "import sys; import brainlayer.embeddings; "
+        "print('torch' in sys.modules or 'sentence_transformers' in sys.modules)"
+    )
+    assert out == "False", "importing brainlayer.embeddings eagerly loaded torch/sentence_transformers"
+
+
+def test_validate_config_does_not_load_torch():
+    """serve()'s startup validation must not pull torch onto the critical path."""
+    out = _run_snippet(
+        "import sys, brainlayer.mcp as m; m.validate_config(); "
+        "print('torch' in sys.modules)"
+    )
+    assert out == "False", "validate_config() eagerly imported torch (blocks the MCP handshake)"
+
+
+def test_get_embedding_model_is_cheap_wrapper():
+    """get_embedding_model() returns a wrapper without loading torch or the model."""
+    out = _run_snippet(
+        "import sys; from brainlayer.embeddings import get_embedding_model; "
+        "m = get_embedding_model(); "
+        "print('torch' in sys.modules, m.__class__.__name__)"
+    )
+    loaded, cls = out.split()
+    assert loaded == "False", "get_embedding_model() eagerly imported torch"
+    assert cls == "EmbeddingModel"
+
+
+# --- Live handshake under DB write-lock (the brief's requested integration test) ---
+
+HANDSHAKE_BUDGET_SEC = 3.0  # must beat Codex's startup_timeout_sec=5 with margin
+
+
+def _hold_exclusive_lock(db_path, stop_event, ready_event):
+    conn = apsw.Connection(str(db_path))
+    conn.cursor().execute("PRAGMA busy_timeout=200")  # fail fast, don't block on a real writer
+    try:
+        conn.cursor().execute("BEGIN IMMEDIATE")  # reserve the write lock (WAL-friendly)
+        conn.cursor().execute("CREATE TABLE IF NOT EXISTS _repro_lock(x)")
+    except apsw.Error:
+        # A real writer (the enrichment pipeline) already holds the lock — that is
+        # itself the contended condition we want to test against, so proceed.
+        pass
+    ready_event.set()
+    while not stop_event.is_set():
+        time.sleep(0.05)
+    try:
+        conn.cursor().execute("ROLLBACK")
+    except apsw.Error:
+        pass
+    conn.close()
+
+
+def _read_json_line(proc, timeout):
+    box = {}
+
+    def _r():
+        box["line"] = proc.stdout.readline()
+
+    t = threading.Thread(target=_r, daemon=True)
+    t.start()
+    t.join(timeout)
+    if t.is_alive() or not box.get("line"):
+        return None
+    return json.loads(box["line"])
+
+
+@pytest.mark.live
+def test_handshake_fast_under_db_write_lock():
+    """brainlayer-mcp must answer initialize+tools/list within budget even when the
+    10GB DB is held under an exclusive write lock."""
+    db_path = get_db_path()
+    if not db_path.exists():
+        pytest.skip("real DB not present")
+
+    stop_event = threading.Event()
+    ready_event = threading.Event()
+    lock_thread = threading.Thread(
+        target=_hold_exclusive_lock, args=(db_path, stop_event, ready_event), daemon=True
+    )
+    lock_thread.start()
+    assert ready_event.wait(timeout=10), "could not acquire exclusive DB lock"
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "from brainlayer.mcp import serve; serve()"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        env=_child_env(),
+    )
+    try:
+        proc.stdin.write(
+            (json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                           "clientInfo": {"name": "test", "version": "0"}},
+            }) + "\n").encode()
+        )
+        proc.stdin.flush()
+        t0 = time.time()
+        init_resp = _read_json_line(proc, timeout=HANDSHAKE_BUDGET_SEC + 5)
+        elapsed = time.time() - t0
+        assert init_resp is not None, "initialize never responded"
+        assert elapsed < HANDSHAKE_BUDGET_SEC, (
+            f"initialize took {elapsed:.2f}s (budget {HANDSHAKE_BUDGET_SEC}s) — would trip "
+            f"Codex startup_timeout_sec=5"
+        )
+
+        proc.stdin.write((json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n").encode())
+        proc.stdin.write((json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}) + "\n").encode())
+        proc.stdin.flush()
+        tools_resp = _read_json_line(proc, timeout=HANDSHAKE_BUDGET_SEC)
+        assert tools_resp is not None, "tools/list never responded"
+        assert len(tools_resp["result"]["tools"]) > 0
+    finally:
+        proc.kill()
+        stop_event.set()
+        lock_thread.join(timeout=5)


### PR DESCRIPTION
## Summary

Durable root fix for the Codex MCP-init **boot-hang** (worker wedged ~25min at "Starting MCP servers (7/9)"). Replaces the `startup_timeout_sec=5` workaround with a real non-blocking startup.

## Bisect — the brief's diagnosis was wrong (literal evidence)

Per-server `initialize`+`tools/list` timing via a stdio harness:

| server | handshake |
|---|---|
| **brainlayer-mcp** | **4–9s** (9.4s cold, 3.96s warm) |
| voicelayer-mcp | 0.33s |
| cmux (bun) | 0.13s |

Holding an **EXCLUSIVE write lock** on the 10GB DB made brainlayer's handshake *faster* (3.96s) than the unlocked baseline (9.4s) → **the handshake never touches the DB** (the store is already lazy, `tools/list` is static). So "querying the contended DB never returns" was not the cause.

## Real root cause

`serve() → validate_config()` runs **before** `server.run()` and did `from ..embeddings import get_embedding_model`. `embeddings.py` imported `torch` at module scope, and `pipeline/__init__` eagerly imported `semantic_style`, which imported `sentence_transformers` at module scope. That dragged a **~3.7s cold `torch` import onto the startup critical path**, so the first JSON-RPC response took 4–9s — routinely exceeding Codex's `startup_timeout_sec=5` and wedging the worker.

## Fix — defer the heavy imports to first real use

- **`embeddings.py`**: `from __future__ import annotations` + `TYPE_CHECKING` guard; import `torch` / `sentence_transformers` inside `_load_model()`.
- **`pipeline/semantic_style.py`**: probe availability with `importlib.util.find_spec` (no import); import `SentenceTransformer` inside `SemanticStyleAnalyzer.model`.

## Results (literal)

- `validate_config()`: **2–4s → 0.00s** (torch never loaded)
- Live MCP handshake **under an exclusive DB write-lock: 1.69s**
- `brain_search` still returns real results (model loads lazily on first tool call, ~33s under DB load — off the startup path, as intended)
- All **39** existing embedding/semantic tests pass; **BrainLayer test gate passed** (pre-push regression harness)

## Test plan

- [x] TDD contract: `tests/test_mcp_lazy_startup.py` — importing embeddings/mcp + `validate_config` must not load torch; live handshake answers <3s under an exclusive DB write-lock
- [x] Daemon Gate: real stdio client — `initialize` 1.69s + `brain_search` returns real results
- [x] Full regression gate green (`scripts/run_tests.sh`)
- [x] No code references the removed module-level `torch`/`SentenceTransformer` names

## Bisect answers (for orc gen-10)

- Non-brainlayer servers (cmux/voicelayer) do **not** stall (<0.4s) — not the wedge.
- brainlayer straddled the 5s boundary → flaky regardless of whether the per-client timeout was picked up. This fix removes the boundary entirely. A global default startup-timeout remains reasonable defense-in-depth but is not the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-path performance fix with deferred imports; embedding and semantic behavior unchanged until first model use, with regression tests guarding the contract.
> 
> **Overview**
> Fixes Codex MCP boot hangs by keeping **~3.7s `torch` / `sentence_transformers` imports off** the path that runs before `initialize`/`tools/list`.
> 
> **`embeddings.py`** drops module-level ML imports: `from __future__ import annotations` plus `TYPE_CHECKING` for `SentenceTransformer`, and **`torch` / `SentenceTransformer` load only inside `EmbeddingModel._load_model()`** on first embed.
> 
> **`semantic_style.py`** (pulled in via `pipeline/__init__`) **probes install with `importlib.util.find_spec`** instead of importing the package at load time, and **imports `SentenceTransformer` in the `SemanticStyleAnalyzer.model` property** (with the same friendly `ImportError` if the install is broken).
> 
> **`tests/test_mcp_lazy_startup.py`** locks the contract: fresh-subprocess checks that importing embeddings / running **`validate_config()`** / **`get_embedding_model()`** do not put `torch` in `sys.modules`, plus a **`@pytest.mark.live`** test that **`serve()`** answers **`initialize`** and **`tools/list`** within **3s** while the DB is held under an exclusive write lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e24f0344296f42d7cc46880e59e9b1049a65a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lazy-import torch and sentence_transformers off the MCP startup path to fix Codex boot hang
> - `torch` and `sentence_transformers` were imported eagerly at module load in [embeddings.py](https://github.com/EtanHey/brainlayer/pull/369/files#diff-a66c3335f636eacc8b2192acffc9d01b3443a146803c6dfc1ab4e441bcddfdc9) and [semantic_style.py](https://github.com/EtanHey/brainlayer/pull/369/files#diff-34f7ca200c57160a86d0b721a51e8c923dd12fadf9ee3470a57d4e02db9026e6), blocking MCP startup until heavy ML packages finished loading.
> - Moves `import torch` and `from sentence_transformers import SentenceTransformer` inside `EmbeddingModel._load_model()` and the `SemanticStyleAnalyzer.model` property so they only run on first use.
> - Replaces the module-level `try/except` import in `semantic_style.py` with an `importlib.util.find_spec` probe to detect availability without importing the package.
> - Adds [tests/test_mcp_lazy_startup.py](https://github.com/EtanHey/brainlayer/pull/369/files#diff-dd8e8980b890c344bcde191804a7d5dd6ee9937f2352624ccd86650587a59b4a) with subprocess-isolated tests asserting `torch` is absent from `sys.modules` after import, and a live integration test verifying MCP handshake completes within budget while a DB write lock is held.
> - Behavioral Change: if `sentence_transformers` is installed but broken, `ImportError` is now raised on first `SemanticStyleAnalyzer.model` access rather than at module import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79e24f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Module imports now complete faster through deferred loading of heavy dependencies in embeddings and semantic analysis components
  * MCP server startup performance improved with verified fast response times even during concurrent database operations

* **Tests**
  * Added comprehensive startup performance and lazy-loading behavior verification tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->