### PR TITLE
feat: pin engine↔UI contract + MODULE-MAP + fix chunks_fts drift (Phase 0)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -22,7 +22,7 @@ final class BrainDatabase: @unchecked Sendable {
     private static let previewExpression = """
         trim(substr(replace(replace(replace(coalesce(nullif(summary, ''), content), char(10), ' '), char(13), ' '), char(9), ' '), 1, 220))
     """
-    private static let ftsColumns = "content, summary, tags, resolved_query, chunk_id UNINDEXED"
+    private static let ftsColumns = "content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED"
     private static let ftsOptions = "prefix='2 3 4', tokenize='unicode61 remove_diacritics 2'"
     private static let trigramFTSOptions = "tokenize='trigram'"
     private static let synchronousTrigramBackfillChunkLimit = 10_000
@@ -385,6 +385,9 @@ final class BrainDatabase: @unchecked Sendable {
                     tag_confidence REAL,
                     summary TEXT,
                     preview_text TEXT,
+                    resolved_query TEXT,
+                    key_facts TEXT,
+                    resolved_queries TEXT,
                     importance REAL DEFAULT 5,
                     intent TEXT,
                     enriched_at TEXT,
@@ -558,6 +561,7 @@ final class BrainDatabase: @unchecked Sendable {
         try ensureKGEntityColumns()
         try ensureKGRelationColumns()
         try ensureKGEntityAliasTable()
+        try rebuildFTSTableIfNeeded()
         try rebuildTrigramFTSTableIfNeeded()
     }
 
@@ -2259,6 +2263,15 @@ final class BrainDatabase: @unchecked Sendable {
         if !existingColumns.contains("preview_text") {
             try execute("ALTER TABLE chunks ADD COLUMN preview_text TEXT")
         }
+        if !existingColumns.contains("resolved_query") {
+            try execute("ALTER TABLE chunks ADD COLUMN resolved_query TEXT")
+        }
+        if !existingColumns.contains("key_facts") {
+            try execute("ALTER TABLE chunks ADD COLUMN key_facts TEXT")
+        }
+        if !existingColumns.contains("resolved_queries") {
+            try execute("ALTER TABLE chunks ADD COLUMN resolved_queries TEXT")
+        }
         if !existingColumns.contains("source") {
             try execute("ALTER TABLE chunks ADD COLUMN source TEXT DEFAULT 'claude_code'")
         }
@@ -2502,17 +2515,22 @@ final class BrainDatabase: @unchecked Sendable {
                 \(Self.ftsOptions)
             )
         """)
-        try execute("DELETE FROM chunks_fts")
-        try execute("""
-            INSERT INTO chunks_fts(content, summary, tags, resolved_query, chunk_id)
-            SELECT content, summary, tags, NULL, id FROM chunks
-        """)
+        let ftsCount = try countRows(in: "chunks_fts")
+        let chunkCount = try countRows(in: "chunks")
+        let needsBackfill = needsRebuild || ftsCount != chunkCount
+        if needsBackfill {
+            try execute("DELETE FROM chunks_fts")
+            try execute("""
+                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+            """)
+        }
 
         try execute("DROP TRIGGER IF EXISTS chunks_fts_insert")
         try execute("""
             CREATE TRIGGER IF NOT EXISTS chunks_fts_insert AFTER INSERT ON chunks BEGIN
-                INSERT INTO chunks_fts(content, summary, tags, resolved_query, chunk_id)
-                VALUES (new.content, new.summary, new.tags, NULL, new.id);
+                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
             END
         """)
 
@@ -2525,15 +2543,22 @@ final class BrainDatabase: @unchecked Sendable {
 
         try execute("DROP TRIGGER IF EXISTS chunks_fts_update")
         try execute("""
-            CREATE TRIGGER IF NOT EXISTS chunks_fts_update AFTER UPDATE ON chunks BEGIN
+            CREATE TRIGGER IF NOT EXISTS chunks_fts_update
+            AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries ON chunks BEGIN
                 DELETE FROM chunks_fts WHERE chunk_id = old.id;
-                INSERT INTO chunks_fts(content, summary, tags, resolved_query, chunk_id)
-                VALUES (new.content, new.summary, new.tags, NULL, new.id);
+                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
             END
         """)
     }
 
     private func rebuildTrigramFTSTable() throws {
+        if try trigramFTSTableNeedsRebuild() {
+            try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_insert")
+            try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_delete")
+            try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_update")
+            try execute("DROP TABLE IF EXISTS chunks_fts_trigram")
+        }
         try ensureTrigramFTSSchemaAndTriggers()
         try execute("DELETE FROM chunks_fts_trigram")
         try backfillTrigramFTSTable()
@@ -2550,8 +2575,8 @@ final class BrainDatabase: @unchecked Sendable {
         try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_insert")
         try execute("""
             CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_insert AFTER INSERT ON chunks BEGIN
-                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
-                VALUES (new.content, new.summary, new.tags, NULL, new.id);
+                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
             END
         """)
 
@@ -2564,18 +2589,19 @@ final class BrainDatabase: @unchecked Sendable {
 
         try execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_update")
         try execute("""
-            CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_update AFTER UPDATE ON chunks BEGIN
+            CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_update
+            AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries ON chunks BEGIN
                 DELETE FROM chunks_fts_trigram WHERE chunk_id = old.id;
-                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
-                VALUES (new.content, new.summary, new.tags, NULL, new.id);
+                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
             END
         """)
     }
 
     private func backfillTrigramFTSTable() throws {
         try execute("""
-            INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
-            SELECT content, summary, tags, NULL, id FROM chunks
+            INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
         """)
     }
 
@@ -2624,8 +2650,8 @@ final class BrainDatabase: @unchecked Sendable {
                 )
                 try executeUpdate(
                     """
-                    INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, chunk_id)
-                    SELECT content, summary, tags, NULL, id
+                    INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                    SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id
                     FROM chunks
                     WHERE rowid > ? AND rowid <= ?
                     ORDER BY rowid ASC
@@ -2767,7 +2793,9 @@ final class BrainDatabase: @unchecked Sendable {
         let normalizedSQL = sql.lowercased()
         let schemaIsValid = normalizedSQL.contains("tokenize='trigram'") &&
             normalizedSQL.contains("summary") &&
-            normalizedSQL.contains("resolved_query")
+            normalizedSQL.contains("resolved_query") &&
+            normalizedSQL.contains("key_facts") &&
+            normalizedSQL.contains("resolved_queries")
 
         let chunkCount = try countRows(in: "chunks")
         let trigramCount = try countRows(in: "chunks_fts_trigram")
@@ -2776,7 +2804,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     private func countRows(in tableName: String) throws -> Int {
         guard let db else { throw DBError.notOpen }
-        let allowedTables = ["chunks", "chunks_fts_trigram"]
+        let allowedTables = ["chunks", "chunks_fts", "chunks_fts_trigram"]
         guard allowedTables.contains(tableName) else { throw DBError.exec(SQLITE_ERROR, "invalid count table") }
 
         var stmt: OpaquePointer?
@@ -2794,7 +2822,20 @@ final class BrainDatabase: @unchecked Sendable {
         return !normalizedSQL.contains("prefix='2 3 4'") ||
             !normalizedSQL.contains("tokenize='unicode61 remove_diacritics 2'") ||
             !normalizedSQL.contains("summary") ||
-            !normalizedSQL.contains("resolved_query")
+            !normalizedSQL.contains("resolved_query") ||
+            !normalizedSQL.contains("key_facts") ||
+            !normalizedSQL.contains("resolved_queries")
+    }
+
+    private func trigramFTSTableNeedsRebuild() throws -> Bool {
+        guard let db else { throw DBError.notOpen }
+        guard let sql = try sqliteMasterSQL(name: "chunks_fts_trigram", on: db) else { return false }
+        let normalizedSQL = sql.lowercased()
+        return !normalizedSQL.contains("tokenize='trigram'") ||
+            !normalizedSQL.contains("summary") ||
+            !normalizedSQL.contains("resolved_query") ||
+            !normalizedSQL.contains("key_facts") ||
+            !normalizedSQL.contains("resolved_queries")
     }
 
     private func backfillPreviewText() throws {

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -93,6 +93,168 @@ final class DatabaseTests: XCTestCase {
         )
     }
 
+    func testLegacyFiveColumnFTSSchemaMigratesToSevenColumnsAndKeepsSearchWorking() throws {
+        let legacyPath = NSTemporaryDirectory() + "brainbar-legacy-fts-\(UUID().uuidString).db"
+        try sqliteExecWrite(
+            path: legacyPath,
+            sql: """
+                CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    content TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    source_file TEXT NOT NULL DEFAULT 'brainbar',
+                    project TEXT,
+                    content_type TEXT DEFAULT 'assistant_text',
+                    char_count INTEGER DEFAULT 0,
+                    source TEXT DEFAULT 'claude_code',
+                    conversation_id TEXT,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    tags TEXT DEFAULT '[]',
+                    summary TEXT,
+                    importance REAL DEFAULT 5
+                );
+                CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                    content, summary, tags, resolved_query, chunk_id UNINDEXED,
+                    prefix='2 3 4',
+                    tokenize='unicode61 remove_diacritics 2'
+                );
+                CREATE VIRTUAL TABLE chunks_fts_trigram USING fts5(
+                    content, summary, tags, resolved_query, chunk_id UNINDEXED,
+                    tokenize='trigram'
+                );
+                CREATE TRIGGER chunks_fts_insert AFTER INSERT ON chunks BEGIN
+                    INSERT INTO chunks_fts(content, summary, tags, resolved_query, chunk_id)
+                    VALUES (new.content, new.summary, new.tags, NULL, new.id);
+                END;
+                CREATE TRIGGER chunks_fts_update AFTER UPDATE ON chunks BEGIN
+                    DELETE FROM chunks_fts WHERE chunk_id = old.id;
+                    INSERT INTO chunks_fts(content, summary, tags, resolved_query, chunk_id)
+                    VALUES (new.content, new.summary, new.tags, NULL, new.id);
+                END;
+                INSERT INTO chunks (
+                    id, content, metadata, source_file, project, content_type,
+                    char_count, source, conversation_id, tags, summary, importance
+                )
+                VALUES (
+                    'legacy-fts-row',
+                    'Legacy Swift FTS row mentions ContractNeedle',
+                    '{}',
+                    'brainbar',
+                    'brainlayer',
+                    'assistant_text',
+                    43,
+                    'mcp',
+                    'legacy-session',
+                    '["schema"]',
+                    'Legacy summary',
+                    5
+                );
+            """
+        )
+        defer {
+            try? FileManager.default.removeItem(atPath: legacyPath)
+            try? FileManager.default.removeItem(atPath: legacyPath + "-wal")
+            try? FileManager.default.removeItem(atPath: legacyPath + "-shm")
+        }
+
+        let migrated = BrainDatabase(path: legacyPath)
+        XCTAssertTrue(migrated.isOpen)
+        XCTAssertNil(migrated.lastOpenError)
+
+        let ftsColumns = try sqliteTableColumns(path: legacyPath, table: "chunks_fts")
+        let trigramColumns = try sqliteTableColumns(path: legacyPath, table: "chunks_fts_trigram")
+        XCTAssertTrue(ftsColumns.isSuperset(of: ["content", "summary", "tags", "resolved_query", "key_facts", "resolved_queries", "chunk_id"]))
+        XCTAssertTrue(trigramColumns.isSuperset(of: ["content", "summary", "tags", "resolved_query", "key_facts", "resolved_queries", "chunk_id"]))
+
+        let results = try migrated.search(query: "ContractNeedle", limit: 10)
+        XCTAssertEqual(results.first?["chunk_id"] as? String, "legacy-fts-row")
+        XCTAssertEqual(try sqliteCount(path: legacyPath, table: "chunks_fts"), 1)
+        XCTAssertEqual(try sqliteCount(path: legacyPath, table: "chunks_fts_trigram"), 1)
+        migrated.close()
+
+        let reopened = BrainDatabase(path: legacyPath)
+        defer { reopened.close() }
+        XCTAssertTrue(reopened.isOpen)
+        XCTAssertEqual(try sqliteCount(path: legacyPath, table: "chunks_fts"), 1)
+        XCTAssertEqual(try sqliteCount(path: legacyPath, table: "chunks_fts_trigram"), 1)
+        XCTAssertEqual(try reopened.search(query: "ContractNeedle", limit: 10).first?["chunk_id"] as? String, "legacy-fts-row")
+    }
+
+    func testValidSevenColumnFTSOpenDoesNotRepopulateWhenCountsMatch() throws {
+        let legacyPath = NSTemporaryDirectory() + "brainbar-valid-fts-\(UUID().uuidString).db"
+        try sqliteExecWrite(
+            path: legacyPath,
+            sql: """
+                CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    content TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    source_file TEXT NOT NULL DEFAULT 'brainbar',
+                    project TEXT,
+                    content_type TEXT DEFAULT 'assistant_text',
+                    char_count INTEGER DEFAULT 0,
+                    source TEXT DEFAULT 'claude_code',
+                    conversation_id TEXT,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    tags TEXT DEFAULT '[]',
+                    summary TEXT,
+                    resolved_query TEXT,
+                    key_facts TEXT,
+                    resolved_queries TEXT,
+                    importance REAL DEFAULT 5
+                );
+                CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                    content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED,
+                    prefix='2 3 4',
+                    tokenize='unicode61 remove_diacritics 2'
+                );
+                INSERT INTO chunks (
+                    id, content, metadata, source_file, project, content_type,
+                    char_count, source, conversation_id, tags, summary, importance
+                )
+                VALUES (
+                    'valid-fts-row',
+                    'Valid FTS row mentions NoRepopulateNeedle',
+                    '{}',
+                    'brainbar',
+                    'brainlayer',
+                    'assistant_text',
+                    43,
+                    'mcp',
+                    'valid-session',
+                    '["schema"]',
+                    'Chunk table summary',
+                    5
+                );
+                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                VALUES (
+                    'Valid FTS row mentions NoRepopulateNeedle',
+                    'FTS sentinel summary',
+                    '["schema"]',
+                    NULL,
+                    NULL,
+                    NULL,
+                    'valid-fts-row'
+                );
+            """
+        )
+        defer {
+            try? FileManager.default.removeItem(atPath: legacyPath)
+            try? FileManager.default.removeItem(atPath: legacyPath + "-wal")
+            try? FileManager.default.removeItem(atPath: legacyPath + "-shm")
+        }
+
+        let migrated = BrainDatabase(path: legacyPath)
+        defer { migrated.close() }
+
+        XCTAssertTrue(migrated.isOpen)
+        XCTAssertEqual(
+            try sqliteScalarString(path: legacyPath, sql: "SELECT summary FROM chunks_fts WHERE chunk_id = 'valid-fts-row'"),
+            "FTS sentinel summary"
+        )
+        XCTAssertEqual(try migrated.search(query: "NoRepopulateNeedle", limit: 10).first?["chunk_id"] as? String, "valid-fts-row")
+    }
+
     func testLegacyChunksSchemaAddsSenderColumnOnOpen() throws {
         let legacyPath = NSTemporaryDirectory() + "brainbar-legacy-sender-\(UUID().uuidString).db"
         try sqliteExecWrite(
@@ -1449,6 +1611,16 @@ private func sqliteCount(path: String, table: String) throws -> Int {
 private func sqliteCount(path: String, sql: String) throws -> Int {
     try withSQLiteConnection(path: path) { db in
         try scalarInt(
+            db: db,
+            sql: sql,
+            bind: { _ in }
+        )
+    }
+}
+
+private func sqliteScalarString(path: String, sql: String) throws -> String? {
+    try withSQLiteConnection(path: path) { db in
+        try scalarString(
             db: db,
             sql: sql,
             bind: { _ in }

--- a/contracts/engine-ui-contract.md
+++ b/contracts/engine-ui-contract.md
@@ -1,0 +1,74 @@
+# Engine UI Contract
+
+Phase 0 contract-only boundary for the future BrainLayer package split. This pins the live engine UI surfaces without moving modules or extracting packages.
+
+## 1. Shared SQLite Schema
+
+The canonical database path is `~/.local/share/brainlayer/brainlayer.db`, overridden by `BRAINLAYER_DB` in Python (`src/brainlayer/paths.py`). BrainBar and Python both create and migrate shared tables, so schema changes must stay dual-owned.
+
+Pinned shared surfaces:
+
+- `chunks`: Python creates the base table at `src/brainlayer/vector_store.py:544` and adds enrichment columns including `resolved_query`, `key_facts`, and `resolved_queries` at `src/brainlayer/vector_store.py:606`. BrainBar creates the same live columns at `brain-bar/Sources/BrainBar/BrainDatabase.swift:369` and upgrades existing DBs at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2257`.
+- `chunks_fts`: the column contract is `content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED`. Python pins it at `src/brainlayer/vector_store.py:815`; BrainBar pins it at `brain-bar/Sources/BrainBar/BrainDatabase.swift:25`.
+- `chunks_fts` rebuild and triggers: Python drops/recreates old FTS schemas at `src/brainlayer/vector_store.py:821` and installs 7-column insert/update triggers at `src/brainlayer/vector_store.py:866` and `src/brainlayer/vector_store.py:922`. BrainBar drops/recreates old FTS schemas at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2503`, repopulates at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2520`, and installs 7-column insert/update triggers at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2526` and `brain-bar/Sources/BrainBar/BrainDatabase.swift:2541`.
+- `chunks_fts_trigram`: Python creates the 7-column trigram table at `src/brainlayer/vector_store.py:840` and installs its 7-column triggers at `src/brainlayer/vector_store.py:884` and `src/brainlayer/vector_store.py:943`. BrainBar creates/rebuilds it at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2562`, installs 7-column triggers at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2572` and `brain-bar/Sources/BrainBar/BrainDatabase.swift:2587`, and repopulates full/table batches at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2596` and `brain-bar/Sources/BrainBar/BrainDatabase.swift:2648`.
+- `kg_*`: BrainBar owns `kg_entities`, `kg_relations`, `kg_entity_chunks`, and `kg_entity_aliases` creation at `brain-bar/Sources/BrainBar/BrainDatabase.swift:456`, `brain-bar/Sources/BrainBar/BrainDatabase.swift:471`, `brain-bar/Sources/BrainBar/BrainDatabase.swift:484`, and `brain-bar/Sources/BrainBar/BrainDatabase.swift:493`. Python owns the matching KG schema at `src/brainlayer/vector_store.py:1294`, `src/brainlayer/vector_store.py:1312`, `src/brainlayer/vector_store.py:1332`, and `src/brainlayer/vector_store.py:1379`.
+- Atomic migration marker: both owners use `atomic_brick_chunks_v1`; Python checks/inserts it at `src/brainlayer/vector_store.py:579` and `src/brainlayer/vector_store.py:758`, while BrainBar checks/inserts it at `brain-bar/Sources/BrainBar/BrainDatabase.swift:2255` and `brain-bar/Sources/BrainBar/BrainDatabase.swift:2373`.
+
+## 2. BrainBar MCP Router Over `/tmp/brainbar.sock`
+
+BrainBar is the MCP surface of record. Its router dispatches 17 tools at `brain-bar/Sources/BrainBar/MCPRouter.swift:195` and defines the tool schemas at `brain-bar/Sources/BrainBar/MCPRouter.swift:950`.
+
+Canonical BrainBar tools:
+
+`brain_search`, `brain_store`, `brain_get_person`, `brain_recall`, `brain_entity`, `brain_digest`, `brain_update`, `brain_expand`, `brain_tags`, `brain_supersede`, `brain_archive`, `brain_enrich`, `brain_subscribe`, `brain_unsubscribe`, `brain_ack`, `brain_maintenance_rebuild_trigram`, `brain_backup_vacuum_into`.
+
+Python `src/brainlayer/mcp/` remains the secondary transport with 13 tools defined at `src/brainlayer/mcp/__init__.py:387`, `src/brainlayer/mcp/__init__.py:543`, `src/brainlayer/mcp/__init__.py:568`, `src/brainlayer/mcp/__init__.py:672`, `src/brainlayer/mcp/__init__.py:701`, `src/brainlayer/mcp/__init__.py:862`, `src/brainlayer/mcp/__init__.py:905`, `src/brainlayer/mcp/__init__.py:974`, `src/brainlayer/mcp/__init__.py:999`, `src/brainlayer/mcp/__init__.py:1042`, `src/brainlayer/mcp/__init__.py:1080`, `src/brainlayer/mcp/__init__.py:1113`, and `src/brainlayer/mcp/__init__.py:1135`.
+
+Differences:
+
+- BrainBar-only: `brain_subscribe`, `brain_unsubscribe`, `brain_ack`, `brain_maintenance_rebuild_trigram`, `brain_backup_vacuum_into`.
+- Python-only: `brain_resume`.
+
+## 3. Hybrid Helper Subprocess And Socket
+
+BrainBar starts the helper from `HybridSearchHelperClient` with `-m brainlayer.brainbar_hybrid_helper --socket-path ... --db-path ...`; see the invocation at `brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift:189`. If `pythonExecutable` resolves to `/usr/bin/env`, BrainBar invokes `python3`; otherwise it invokes the resolved Python executable directly.
+
+Environment contract:
+
+- `BRAINBAR_PYTHON` overrides Python executable resolution at `brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift:53`.
+- `BRAINLAYER_REPO_ROOT` is used to resolve `<repo>/src` for `PYTHONPATH` at `brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift:78`.
+- `PYTHONPATH` is passed through or set before launch at `brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift:213`.
+- `BRAINLAYER_DB` is set to the selected DB path at `brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift:214` and by the helper at `src/brainlayer/brainbar_hybrid_helper.py:258`.
+
+Helper CLI and wire contract:
+
+- CLI args: `--socket-path` is required and `--db-path` is optional at `src/brainlayer/brainbar_hybrid_helper.py:246`.
+- The helper binds a Unix socket, chmods it `0600`, listens, and warms search at `src/brainlayer/brainbar_hybrid_helper.py:85`.
+- Request envelope: one NDJSON object with `{ "method": "brain_search", "arguments": { ... } }`. Unsupported methods are rejected at `src/brainlayer/brainbar_hybrid_helper.py:160`.
+- Response envelope: `{ "ok": true, "text": "...", "metadata": { ... } }`; `isError` is present only when the underlying MCP result reports an error at `src/brainlayer/brainbar_hybrid_helper.py:166`.
+- Accepted argument keys are read in `src/brainlayer/brainbar_hybrid_helper.py:178`: `_profile_query_id`, `source`, `query`, `project`, `tag`, `importance_min`, `agent_id`, `num_results`, `max_results`, and `detail`.
+
+## 4. Reverse Socket Backup
+
+Python daily backup calls BrainBar over `/tmp/brainbar.sock` instead of copying the live DB directly. The default socket path is `src/brainlayer/backup_daily.py:33`; the request uses MCP `tools/call` with `brain_backup_vacuum_into` and `target_path` at `src/brainlayer/backup_daily.py:119`. BrainBar exposes that tool schema at `brain-bar/Sources/BrainBar/MCPRouter.swift:1157` and dispatches it at `brain-bar/Sources/BrainBar/MCPRouter.swift:229`.
+
+## 5. Brain Bus Events
+
+Brain bus is a BrainBar socket stream, not a Python MCP tool. Clients send method `watch-brain-bus` at `brain-bar/Sources/BrainBar/BrainBusClient.swift:123`; the server handles it at `brain-bar/Sources/BrainBar/BrainBarServer.swift:482` and emits JSON-RPC notifications with method `notifications/brain-bus` at `brain-bar/Sources/BrainBar/BrainBarServer.swift:986`.
+
+Pinned event types and JSON keys come from `brain-bar/Sources/BrainBar/BrainBusEvent.swift:3` and `brain-bar/Sources/BrainBar/BrainBusEvent.swift:21`:
+
+- Types: `queue_depth`, `enrich_status`, `last_chunk_id`, `db_busy`, `health_tick`.
+- Keys: `type`, `sequence`, `generated_at`, `queue_depth`, `enrich_status`, `last_chunk_id`, `db_busy`, `open_connections`.
+
+## 6. `injection_events` Shared Table
+
+Hooks write this table; BrainBar reads it for the live viewer.
+
+- BrainBar creates `injection_events` at `brain-bar/Sources/BrainBar/BrainDatabase.swift:520`, writes local events at `brain-bar/Sources/BrainBar/BrainDatabase.swift:4678`, and reads live events at `brain-bar/Sources/BrainBar/BrainDatabase.swift:4699`.
+- The prompt hook ensures hook-specific columns and inserts rows at `hooks/brainlayer-prompt-search.py:905` and `hooks/brainlayer-prompt-search.py:940`.
+
+## 7. Launch Mode
+
+Launch mode is already pinned by `brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift:4`. The contract is the persisted `brainbar.launchMode` key plus `BRAINBAR_LAUNCH_MODE` raw values `app-window` and `menu-item-daemon`, verified at `brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift:5`, `brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift:41`, and `brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift:54`.

--- a/docs/architecture/MODULE-MAP.md
+++ b/docs/architecture/MODULE-MAP.md
@@ -1,0 +1,47 @@
+# MODULE-MAP — BrainLayer engine/package split (Phase 0, contract-only)
+
+> Author: brainlayerClaude-LEAD-v4, 2026-05-29. **v2 — corrected after a 3-lens critique** (boundary / contract-completeness / migration-risk; critiques stored this session). Supersedes MODULE-MAP-draft.md. Status: contract-only (Etan-agreed); no physical extraction this turn.
+
+## ⚠️ Corrections the critique forced (the draft was wrong on these — read first)
+1. **The live MCP server is BrainBar (Swift), NOT the Python `mcp/`.** `.mcp.json` connects Claude Code via `socat UNIX-CONNECT:/tmp/brainbar.sock` → `brain-bar/Sources/BrainBar/MCPRouter.swift` (17 tools). Python `src/brainlayer/mcp/` (13 tools, incl. `brain_resume`; entry `brainlayer-mcp`) is the SECONDARY/legacy transport. The contract pins **BrainBar's MCPRouter** as the surface of record.
+2. **The DB schema is DUAL-OWNED and ALREADY DRIFTING.** BrainBar uses **raw SQLite3 (not GRDB)** and independently CREATEs + migrates `chunks`, `chunks_fts`, `kg_*`, triggers — under the *same* migration name `atomic_brick_chunks_v1` as Python. Live drift: `chunks_fts` = **5 cols in Swift vs 7 in Python** (`key_facts`, `resolved_queries` Python-only). This is the single highest-risk surface and must be pinned.
+3. **The launch-mode contract is ALREADY pinned** — PR #361 (`BrainBarDaemonLaunchModeTests.swift`, HEAD d10bcaf6) shipped it. NOT a TODO. The real contract = UserDefaults `brainbar.launchMode` + env `BRAINBAR_LAUNCH_MODE` (rawValues `app-window`/`menu-item-daemon`); the enum lives only in the Swift target (no separate Python parser).
+4. **FABRICATION CORRECTED:** the draft called root `brainlayer.db` a "stray 9.6GB copy" — it is **0 bytes** (tracked-but-should-be-ignored). The 9.6GB is the real DB at `~/.local/share/brainlayer/`. (`/never-fabricate` miss — owned.)
+
+## Three packages (shape CONFIRMED sound; specifics corrected)
+
+### 1. `brain-engine` (Python) — write path, enrichment, search, KG, secondary MCP transport
+`src/brainlayer/` core: write path (`vector_store`, `store`, `storage`, `drain`, `queue_io`, `queue_merge`, `dedupe`), search (`search_repo`, `search_profile`, `embeddings`, `engine`, `clustering`), enrichment (`enrichment_controller`, `cloud_backfill`, `calibrate`, `decay*`), KG (`kg_repo`, `kg_promotion`, `kg/`), ingest/classify (`classify`, `chunk_origin`, `ingest_guard`, `lexical_defense`, `phonetic`, `ingest/`, `pipeline/`), watcher (`watcher`, `watcher_bridge`), support (`types`, `_helpers`, `config`, `paths`, `claude_paths`, `scoping`, `telemetry`, `migrate`, `session_repo`, `agent_profiles`, `index_new`, `git_learning`, `parent_death`), `mcp/` (secondary transport), `eval/`, `data/`, `migrations/`. **Also engine (critique fix):** `src/brainlayer/hooks/indexer.py` (RealtimeIndexer), `brainbar_hybrid_helper.py` (the bridge — see contract).
+- **Boundary rule (Decision A — orc lean 2026-05-29, HELD pending Etan confirm):** brain-engine = **PURE LIBRARY**. The CLI (`cli/`, `cli_new.py`) + Textual TUI (`dashboard/`) move to **brainlayer-root** (or a thin surface pkg) — mirroring the BrainBar UI-separation logic. **Physical move DEFERRED** (contract-only turn); recorded as the intended boundary.
+
+### 2. `BrainBar` (Swift) — standalone package `brain-bar/`, AND the live MCP server + a co-owner of the DB schema
+Self-contained Swift (`BrainBar`, `BrainBarDaemon`, `BrainBarLifecycle`). Owns `/tmp/brainbar.sock` (MCP), the brain-bus event stream, the offline pending-stores write buffer, and its own copy of the schema DDL/migrations. **Not a read-only consumer** — a co-writer.
+
+### 3. `brainlayer-root` (orchestration/packaging/docs)
+`launchd/`, `scripts/`, `.githooks/`, `.github/`, top-level `hooks/` (stdlib-only Claude Code hooks — EXCEPT `brainlayer-prompt-search.py`, which imports the engine → either relocate to engine or root-depends-on-engine), packaging (`pyproject.toml`, `uv.lock`), config (`.mcp.json`, `server.json`, `greptile.json`, `macroscope.md`), docs (`README`/`CHANGELOG`/`CONTRIBUTING`/`LICENSE`/`AGENTS`/`CLAUDE`/`GEMINI`.md, `docs/`, `mkdocs.yml`, `overrides/`, `site/`, `landing/`, `extensions/`), `CODEOWNERS`.
+- **De-dup:** `scripts/wal_checkpoint.py` must be a thin wrapper over the engine's `wal_checkpoint.py` (one canonical home), not a second copy.
+- **CLEANUP (gitignore/remove, not a package):** root `brainlayer.db` (0-byte, `git rm --cached`), `dist/`, `.perf/`, caches, `prd-json/`, `grill*/`, `progress.txt`, `.tmp-*`, `2026-*.txt`, and the **~15 `BUGBOT_*.md`/`findings.md`** pile → `docs/reviews/` or delete.
+
+## The engine↔UI contract (CORRECTED — ~7 surfaces, not 4)
+1. **Shared SQLite file + schema DDL/migrations** (dual-owned; pin the column sets + the `atomic_brick_chunks_v1` migration; FIX the `chunks_fts` 5-vs-7 drift). DB path `~/.local/share/brainlayer/brainlayer.db` (+ `BRAINLAYER_DB`).
+2. **BrainBar MCPRouter tool surface** over `/tmp/brainbar.sock` (17 tools) — the surface of record; reconcile vs Python's 13.
+3. **Hybrid-helper subprocess + socket** (BrainBar → Python): invocation `python3 -m brainlayer.brainbar_hybrid_helper --socket-path … --db-path …` with env triple `BRAINLAYER_REPO_ROOT` / `PYTHONPATH=<root>/src` / `BRAINBAR_PYTHON`; NDJSON `{method,arguments}`→`{ok,text,metadata}` (arg keys enumerated in `brainbar_hybrid_helper.py`). **Undocumented today → needs a golden-fixture contract test.**
+4. **Reverse socket** `/tmp/brainbar.sock` (Python `backup_daily.py` → BrainBar `vacuum_into`).
+5. **brain-bus event stream** (`notifications/brain-bus`, method `watch-brain-bus`): `queue_depth`/`enrich_status`/`last_chunk_id`/`db_busy`/`health_tick` (PR #360 consumer).
+6. **`injection_events` shared table** — written by `hooks/brainlayer-prompt-search.py`, read by BrainBar.
+7. **Launch-mode** (already pinned, PR #361) — keep as a contract test, don't re-author.
+
+## Migration risk = HIGH (for the LATER physical extraction)
+Driver: BrainBar hard-binds to the engine's **source-tree layout** (`<repoRoot>/src` via subprocess), and ~30 scripts + 7 launchd plists hardcode `PYTHONPATH=.../src`. Extraction breaks the UI's search + every daemon unless done atomically.
+**Guardrails the contract-only turn locks NOW:** (a) lock dist name = `brainlayer` (invariant); (b) pin the hybrid-helper invocation+wire contract in `contracts/` with a fixture test; (c) record MCP-server-of-record = BrainBar; (d) extend `tests/test_launchd_hygiene.py` + `tests/test_brainbar_build_app_guards.py` to assert no DEV/worktree `/src` path leaks into the canonical LaunchAgent env (defeats the "competing trees" hazard — the binary-flashing is already guarded by `build-app.sh` DEV-bundle/canonical rules). Safe extraction sequence: keep name → swap all `PYTHONPATH=/src` to a real editable install in ONE change (incl. Swift resolver prefers installed pkg, `/src` fallback) → pin helper protocol → extract → verify all daemons + 5 contract tests.
+
+## Open questions for agreement
+- **A.** CLI/TUI (`cli/`, `cli_new.py`, `dashboard/`) → in brain-engine or root? **RESOLVED (provisional, orc 2026-05-29):** engine = pure library → CLI/TUI to ROOT. Physical move HELD pending Etan final confirm. Does not affect the contract-only turn.
+- **B.** Fix the `chunks_fts` 5-vs-7 drift now (small PR) or fold into the extraction? (Recommend: now — it's a live data-integrity risk.)
+- **C.** Reconcile the 17(Swift)/13(Python) MCP tool sets — which is canonical, what retires?
+
+## Phase-0 close = contract-only deliverables
+1. This `MODULE-MAP.md` (committed to brainlayer repo, after A/B/C agreed).
+2. `contracts/` gains: the hybrid-helper invocation+wire spec, the MCP-server-of-record note, the schema column-set + `chunks_fts` drift fix.
+3. Contract tests: hybrid-helper golden-fixture; launchd-hygiene no-leak; (launch-mode already covered by PR #361).
+4. NO physical extraction this turn.

--- a/tests/test_atomic_brick_schema.py
+++ b/tests/test_atomic_brick_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 
 import apsw
@@ -10,6 +11,12 @@ import sqlite_vec
 
 from brainlayer._helpers import serialize_f32
 from brainlayer.vector_store import VectorStore
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _column_names(column_list: str) -> list[str]:
+    return [column.strip().split()[0] for column in column_list.split(",")]
 
 
 def _connect_with_vec(db_path: Path) -> apsw.Connection:
@@ -120,6 +127,18 @@ def _checksum_rows(db_path: Path) -> tuple[str, int]:
         count += 1
     conn.close()
     return digest.hexdigest(), count
+
+
+def test_swift_and_python_chunks_fts_column_contracts_match():
+    swift_source = (REPO_ROOT / "brain-bar/Sources/BrainBar/BrainDatabase.swift").read_text()
+    python_source = (REPO_ROOT / "src/brainlayer/vector_store.py").read_text()
+
+    swift_match = re.search(r'private static let ftsColumns = "([^"]+)"', swift_source)
+    python_match = re.search(r'_FTS5_COLUMNS = "([^"]+)"', python_source)
+
+    assert swift_match is not None
+    assert python_match is not None
+    assert _column_names(swift_match.group(1)) == _column_names(python_match.group(1))
 
 
 def test_atomic_brick_columns_are_added_to_existing_chunks_schema(tmp_path):

--- a/tests/test_hybrid_helper_contract.py
+++ b/tests/test_hybrid_helper_contract.py
@@ -95,9 +95,7 @@ search_handler._brain_search = fake_brain_search
     env = os.environ.copy()
     env["BRAINLAYER_REPO_ROOT"] = str(REPO_ROOT)
     env["BRAINBAR_PYTHON"] = sys.executable
-    env["PYTHONPATH"] = os.pathsep.join(
-        [str(sitecustomize_dir), str(SRC_ROOT), env.get("PYTHONPATH", "")]
-    )
+    env["PYTHONPATH"] = os.pathsep.join([str(sitecustomize_dir), str(SRC_ROOT), env.get("PYTHONPATH", "")])
     env["PYTHONUNBUFFERED"] = "1"
 
     process = subprocess.Popen(

--- a/tests/test_hybrid_helper_contract.py
+++ b/tests/test_hybrid_helper_contract.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+
+def _wait_for_socket(socket_path: Path, process: subprocess.Popen, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise AssertionError(f"helper exited early with {process.returncode}: {process.stderr.read()}")
+        if socket_path.exists():
+            return
+        time.sleep(0.05)
+    raise AssertionError("helper socket did not appear")
+
+
+def test_brainbar_hybrid_helper_ndjson_contract_accepts_documented_brain_search_keys(tmp_path):
+    socket_path = Path(f"/tmp/brainbar-contract-{os.getpid()}-{uuid.uuid4().hex[:8]}.sock")
+    db_path = tmp_path / "fixture.db"
+    sitecustomize_dir = tmp_path / "sitecustomize"
+    sitecustomize_dir.mkdir()
+    (sitecustomize_dir / "sitecustomize.py").write_text(
+        """
+import brainlayer.mcp._shared as shared
+import brainlayer.mcp.search_handler as search_handler
+from mcp.types import TextContent
+
+
+class FakeModel:
+    def embed_query(self, query):
+        return [0.01] * 1024
+
+
+class FakeCursor:
+    def execute(self, _sql):
+        return self
+
+    def fetchone(self):
+        return (0,)
+
+
+class FakeStore:
+    _binary_index_available = False
+
+    def _read_cursor(self):
+        return FakeCursor()
+
+    def hybrid_search(self, **_kwargs):
+        return []
+
+    def get_chunk(self, chunk_id):
+        if chunk_id != "contract-fixture-001":
+            return None
+        return {
+            "id": "contract-fixture-001",
+            "content": "Contract fixture chunk returned through the helper.",
+            "project": "brainlayer",
+            "content_type": "assistant_text",
+            "source_file": "contract-fixture.jsonl",
+            "created_at": "2026-05-29T00:00:00Z",
+            "importance": 8,
+            "summary": "Contract fixture summary",
+            "tags": '["contract"]',
+            "status": "active",
+            "chunk_origin": "unknown",
+        }
+
+
+shared._get_embedding_model = lambda: FakeModel()
+shared._get_search_vector_store = lambda: FakeStore()
+
+
+async def fake_brain_search(**kwargs):
+    return (
+        [TextContent(type="text", text="contract helper result")],
+        {"query": kwargs["query"], "accepted_keys": sorted(kwargs.keys())},
+    )
+
+
+search_handler._brain_search = fake_brain_search
+""",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["BRAINLAYER_REPO_ROOT"] = str(REPO_ROOT)
+    env["BRAINBAR_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(sitecustomize_dir), str(SRC_ROOT), env.get("PYTHONPATH", "")]
+    )
+    env["PYTHONUNBUFFERED"] = "1"
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "brainlayer.brainbar_hybrid_helper",
+            "--socket-path",
+            str(socket_path),
+            "--db-path",
+            str(db_path),
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        _wait_for_socket(socket_path, process)
+        request = {
+            "method": "brain_search",
+            "arguments": {
+                "query": "contract-fixture-001",
+                "project": "brainlayer",
+                "source": "all",
+                "tag": "contract",
+                "importance_min": 7,
+                "agent_id": "contract-test-agent",
+                "num_results": 3,
+                "max_results": 9,
+                "detail": "compact",
+                "_profile_query_id": "contract-profile-id",
+            },
+        }
+
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(2)
+            client.connect(str(socket_path))
+            client.sendall(json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n")
+            payload = b""
+            while not payload.endswith(b"\n"):
+                payload += client.recv(65536)
+
+        response = json.loads(payload.decode("utf-8"))
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=2)
+        socket_path.unlink(missing_ok=True)
+
+    assert response["ok"] is True
+    assert response["text"] == "contract helper result"
+    assert set(response) == {"ok", "text", "metadata"}
+    structured = response["metadata"]["structuredContent"]
+    assert structured["query"] == "contract-fixture-001"
+    assert structured["accepted_keys"] == [
+        "agent_id",
+        "allow_helper_route",
+        "detail",
+        "importance_min",
+        "max_results",
+        "num_results",
+        "profile_query_id",
+        "profile_scope",
+        "project",
+        "query",
+        "source",
+        "tag",
+    ]

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import os
 import plistlib
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LOG_ROOT = "__HOME__/Library/Logs/brainlayer/"
 RENDERED_LOG_ROOT = "/Users/etanheyman/Library/Logs/brainlayer/"
 REQUIRED_PATH_PARTS = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+DEV_SRC_PATH_RE = re.compile(r"/Users/[^:\s]+/Gits/[^:\s]+/src(?:$|:)")
 
 
 def _load(path: str) -> dict:
@@ -30,6 +32,16 @@ def _assert_common_hygiene(plist: dict) -> None:
     assert limits.get("NumberOfFiles", 0) >= 4096
     assert "ProcessType" in plist
     assert "ExitTimeOut" in plist
+
+
+def _assert_no_dev_src_path_in_canonical_env(path: Path, plist: dict) -> None:
+    label = plist.get("Label", "")
+    if not isinstance(label, str) or not label.startswith("com.brainlayer."):
+        return
+    env = plist.get("EnvironmentVariables") or {}
+    assert isinstance(env, dict), str(path)
+    for key, value in env.items():
+        assert not DEV_SRC_PATH_RE.search(str(value)), f"{path}: {key} leaks a concrete dev /src path"
 
 
 def test_active_daemon_launchd_hygiene_matrix():
@@ -90,3 +102,15 @@ def test_active_daemon_launchd_hygiene_matrix():
 def test_all_script_launchd_plists_have_common_hygiene():
     for path in sorted((REPO_ROOT / "scripts/launchd").glob("com.brainlayer.*.plist")):
         _assert_common_hygiene(plistlib.loads(path.read_bytes()))
+
+
+def test_canonical_launchagent_env_has_no_concrete_dev_src_paths():
+    plist_paths = [
+        *sorted((REPO_ROOT / "scripts/launchd").glob("com.brainlayer.*.plist")),
+        REPO_ROOT / "launchd/com.brainlayer.watch.plist",
+        REPO_ROOT / "brain-bar/bundle/com.brainlayer.brainbar.plist",
+        REPO_ROOT / "brain-bar/bundle/com.brainlayer.brainbar-daemon.plist",
+    ]
+
+    for path in plist_paths:
+        _assert_no_dev_src_path_in_canonical_env(path, plistlib.loads(path.read_bytes()))


### PR DESCRIPTION
## Summary

- Adds the Phase 0 MODULE-MAP and pins the engine↔UI contract in `contracts/engine-ui-contract.md` with live file:line-verified surfaces.
- Adds contract tests for the hybrid helper NDJSON envelope and launchd hygiene no-DEV-/src path leaks.
- Aligns Swift `chunks_fts` and `chunks_fts_trigram` to Python's 7-column FTS schema, including legacy 5-column migration, trigger rebuilds, FTS repopulation, and idempotency coverage.

Contract-only Phase 0: no physical package extraction. `PHASE0-CONTRACT-SPEC.md` remains untracked intentionally.

## Test stdout

```text
$ PYTHONPATH=/Users/etanheyman/Gits/brainlayer-phase0/src /Users/etanheyman/Gits/brainlayer/.venv/bin/python -m pytest tests/test_atomic_brick_schema.py::test_swift_and_python_chunks_fts_column_contracts_match -q
1 passed in 0.13s
```

```text
$ cd brain-bar && swift test --filter DatabaseTests/testLegacyFiveColumnFTSSchemaMigratesToSevenColumnsAndKeepsSearchWorking
Test Suite 'Selected tests' passed.
Executed 1 test, with 0 failures (0 unexpected).
```

```text
$ PYTHONPATH=/Users/etanheyman/Gits/brainlayer-phase0/src /Users/etanheyman/Gits/brainlayer/.venv/bin/python -m pytest tests/test_hybrid_helper_contract.py tests/test_launchd_hygiene.py tests/test_atomic_brick_schema.py tests/test_brainbar_hybrid_helper.py -q
22 passed in 11.63s
```

```text
$ cd brain-bar && swift test --filter 'DatabaseTests/testLegacyFiveColumnFTSSchemaMigratesToSevenColumnsAndKeepsSearchWorking|DatabaseTests/testValidSevenColumnFTSOpenDoesNotRepopulateWhenCountsMatch'
Test Suite 'Selected tests' passed.
Executed 2 tests, with 0 failures (0 unexpected) in 0.056 seconds.
```

```text
$ PYTHONPATH=/Users/etanheyman/Gits/brainlayer-phase0/src /Users/etanheyman/Gits/brainlayer/.venv/bin/python -m ruff check src/ tests/test_hybrid_helper_contract.py tests/test_launchd_hygiene.py tests/test_atomic_brick_schema.py
All checks passed!
```

```text
$ PYTHONPATH=/Users/etanheyman/Gits/brainlayer-phase0/src /Users/etanheyman/Gits/brainlayer/.venv/bin/python -m ruff format src/
108 files left unchanged
```

```text
$ git push -u origin phase0/module-map-contracts
= 2231 passed, 9 skipped, 76 deselected, 1 xfailed, 102 warnings in 396.93s (0:06:36) =
PASS: pytest unit suite

==> pytest MCP tool registration
3 passed in 1.00s
PASS: pytest MCP tool registration

==> pytest isolated eval and hook routing
36 passed, 5 warnings in 3.41s
PASS: pytest isolated eval and hook routing

==> bun test suite
1 pass
0 fail
Ran 1 test across 1 file. [8.39s]
PASS: bun test suite

==> regression shell test_fts5_determinism.sh
PASS: regression shell test_fts5_determinism.sh

BrainLayer test gate passed.
```

## Review notes

- CodeRabbit pre-commit review found one major issue: valid 7-column Swift FTS tables were being repopulated unnecessarily on open. Fixed with count/schema-aware rebuild logic and a sentinel preservation regression test.
- CodeRabbit's remaining minor suggestion edits LEAD-authored `docs/architecture/MODULE-MAP.md`; left unchanged per Phase 0 instruction to include the module map as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared SQLite FTS migration and dual-owned schema on open; wrong rebuild logic could affect search or wipe FTS data, but behavior is heavily tested.
> 
> **Overview**
> **Phase 0 contract-only work** documents the future engine/package split in `docs/architecture/MODULE-MAP.md` and pins live boundaries in `contracts/engine-ui-contract.md` (shared SQLite, BrainBar MCP, hybrid helper, backup socket, brain-bus, injection events).
> 
> **Swift `BrainDatabase` closes the `chunks_fts` 5-vs-7 column drift with Python** by adding `resolved_query`, `key_facts`, and `resolved_queries` on `chunks`, extending FTS5/trigram column lists, and wiring migrations, triggers, and backfills to use real chunk values instead of `NULL` for `resolved_query`. FTS rebuild is **count- and schema-aware** so valid 7-column tables are not wiped on every open; trigram gets matching rebuild detection. Startup now calls `rebuildFTSTableIfNeeded()` on the shared open path.
> 
> **New contract tests:** Python asserts Swift/Python `ftsColumns` strings match; hybrid helper NDJSON `brain_search` envelope; launchd plists must not leak concrete dev `/src` paths. **Swift tests** cover legacy 5→7 FTS migration (search still works) and idempotent open when FTS row counts already match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cfb1a7d2632791278e84f6ab2b402970adb8dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin engine↔UI contract, add MODULE-MAP, and fix `chunks_fts` schema drift
> - Expands the FTS column schema from 5 to 7 columns by adding `key_facts` and `resolved_queries` to both `chunks_fts` and `chunks_fts_trigram` virtual tables in [BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/375/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc).
> - Changes FTS rebuild logic to be conditional: backfill only runs when a schema or row-count mismatch is detected, rather than unconditionally on every open.
> - Adds a new [engine-ui-contract.md](https://github.com/EtanHey/brainlayer/pull/375/files#diff-0fc3d9159a3da880f26497586ac061c390f97f57e32e8b122961677161cce914) pinning the shared SQLite schema, MCP router tools, brain bus events, and launch mode boundaries between Swift and Python components.
> - Adds [MODULE-MAP.md](https://github.com/EtanHey/brainlayer/pull/375/files#diff-13785bdcd75ca7d20c2f91609fcd809c0fff9a4a38ad41fa7c2115d858dd310f) documenting the Phase 0 package split, boundaries, and migration risks.
> - Adds cross-language contract tests asserting that Swift and Python FTS column definitions stay in sync, and tests covering legacy 5-column to 7-column migration.
> - Behavioral Change: databases created with the old 5-column schema are automatically migrated on next open; `resolved_query` is no longer set to NULL during backfill.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5197263.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended search indexing to include resolved queries and key facts for improved search comprehensiveness.

* **Documentation**
  * Added architecture documentation defining component contracts, responsibilities, and cross-language interfaces.
  * Added Engine UI contract specification.

* **Tests**
  * Added contract tests ensuring search schema consistency across implementations.
  * Added protocol and environment validation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->