### PR TITLE
test: make drain arbitration test load-robust (poll-until-drained)

### DIFF
--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -443,8 +443,16 @@ def test_drain_daemon_serializes_three_concurrent_producers(tmp_path, monkeypatc
         worker.join(timeout=20)
         assert worker.exitcode == 0
 
-    deadline = time.monotonic() + 45
+    # Poll-until-drained with a generous deadline. The completion signal is the
+    # DB end-state (3000 rows + FTS + empty queue), NOT a fixed time window: under
+    # machine saturation (many concurrent agents + enrichment competing for the
+    # writer) the drain legitimately takes longer. The old 45s cap was even shorter
+    # than the ~47s isolation runtime, so it flaked as `assert 2500 == 3000` under
+    # load. We stop as soon as the queue is fully consumed (deterministic), with the
+    # deadline only as a backstop against a genuine hang.
+    deadline = time.monotonic() + 240
     total_drained = 0
+    count = fts_count = 0
     while time.monotonic() < deadline:
         total_drained += drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=250, log_path=log_path)
         with _connect_apsw(db_path) as conn:
@@ -452,13 +460,16 @@ def test_drain_daemon_serializes_three_concurrent_producers(tmp_path, monkeypatc
             fts_count = conn.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunks_fts MATCH 'arbitration'").fetchone()[
                 0
             ]
-        if count == 3000 and fts_count == 3000:
+        queue_empty = not list(queue_dir.glob("*.jsonl"))
+        if count == 3000 and fts_count == 3000 and queue_empty:
             break
         time.sleep(0.05)
 
-    assert total_drained == 3000
-    assert count == 3000
-    assert fts_count == 3000
+    assert count == 3000, (
+        f"drained {count}/3000 chunks before deadline (queue_empty={not list(queue_dir.glob('*.jsonl'))})"
+    )
+    assert fts_count == 3000, f"FTS indexed {fts_count}/3000"
+    assert total_drained == 3000, f"drain_once accumulated {total_drained} (expected 3000)"
     assert not list(queue_dir.glob("*.jsonl"))
     assert "database is locked" not in log_path.read_text(encoding="utf-8").lower()
 


### PR DESCRIPTION
## Problem
`tests/test_arbitration.py::test_drain_daemon_serializes_three_concurrent_producers` flaked **under load** (CI `assert 2500 == 3000`; blocked local pre-push gates at 2500/2750 during a multi-agent + enrichment-saturated session). Passes **3/3 in isolation** (~47s, full 3000 drained). Flagged by systemsClaude; orthogonal to #368 (WAL) and #369 (lazy-torch).

**Root cause:** the test asserted a **fixed 45s drain window** — *shorter than its own ~47s isolation runtime*. Under machine saturation the single-writer drain legitimately takes longer than 45s, so the loop hit the deadline mid-drain and asserted a partial count. Timing-window flake, not a product bug.

## Fix (test-only)
Poll-until-drained keyed on the **deterministic DB end-state** (3000 rows + FTS + empty queue), with a generous **240s deadline as a hang backstop only**. Added diagnostic messages to the asserts. The drain still drains all 3000 exactly (`total_drained == 3000` retained); the test just no longer races the wall clock under load.

## Verification (local)
- `test_drain_daemon_serializes_three_concurrent_producers` → **passed (42.5s)**
- full `tests/test_arbitration.py` → **20 passed**
- `ruff check` clean
- pre-push regression gate passed on push (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and assertion changes; no production drain or queue behavior modified.
> 
> **Overview**
> Fixes timing flake in **`test_drain_daemon_serializes_three_concurrent_producers`** by treating **full drain** (3000 chunk rows, matching FTS count, empty queue) as success instead of racing a **45s** wall clock that could expire before saturation-heavy runs finished (~47s even in isolation).
> 
> The poll loop now exits only when **`queue_empty`** is true alongside the DB counts, uses a **240s** deadline purely as a hang backstop, and asserts include clearer failure messages (`count`, FTS, `total_drained`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4d5309621cb271d141bf3bb87f291fcafef8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make drain arbitration test load-robust by polling until queue is drained
> Updates `test_drain_daemon_serializes_three_concurrent_producers` in [test_arbitration.py](https://github.com/EtanHey/brainlayer/pull/377/files#diff-106015cf4acc06b04519ec99e7c54485ee1ad0827e033f182dd076035d85afdc) to reliably pass under high load. The polling deadline increases from 45s to 240s, and the loop now exits only when both tables have 3,000 rows and the queue has no remaining `.jsonl` files. Failure assertions include diagnostic counts for easier debugging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de4d530.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->