### PR TITLE
fix(brainbar): wave-2a — remove tier bands (F2), relations padding (F4), panel divider/radius (F9), enrichment-chart label (F7)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -675,7 +675,9 @@ private struct BrainBarFlowLaneCard: View {
             }
 
             BrainBarHeroSparkline(
+                label: lane.sparklineLabel,
                 values: lane.values,
+                latestBucketName: lane.latestBucketName,
                 accentColor: lane.accentColor,
                 activityWindowMinutes: lane.activityWindowMinutes,
                 fetchedAt: fetchedAt,
@@ -1193,7 +1195,9 @@ private struct BrainBarFlowStatusPill: View {
 }
 
 private struct BrainBarHeroSparkline: View {
+    let label: String
     let values: [Int]
+    let latestBucketName: String
     let accentColor: NSColor
     let activityWindowMinutes: Int
     let fetchedAt: Date
@@ -1208,9 +1212,10 @@ private struct BrainBarHeroSparkline: View {
 
             SparklineChart(
                 presentation: SparklineChartPresentation(
-                    label: "Recent activity sparkline",
+                    label: label,
                     values: values,
                     activityWindowMinutes: activityWindowMinutes,
+                    latestBucketName: latestBucketName,
                     fetchedAt: fetchedAt
                 ),
                 accentColor: accentColor,
@@ -1297,14 +1302,9 @@ private struct BrainBarGlassPanel: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .stroke(Color.brainBarBorderSoft, lineWidth: 1)
+                    .strokeBorder(Color.brainBarBorderSoft, lineWidth: 1)
             )
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.brainBarWhite.opacity(0.06))
-                    .frame(height: 1)
-                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .shadow(color: .brainBarBlack.opacity(emphasized ? 0.32 : 0.24), radius: emphasized ? 36 : 24, y: emphasized ? 18 : 12)
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -191,6 +191,8 @@ struct DashboardFlowLane: Sendable, Equatable {
     let volumeText: String
     let lastEventText: String
     let values: [Int]
+    let sparklineLabel: String
+    let latestBucketName: String
     let accentColor: NSColor
 }
 
@@ -291,21 +293,11 @@ struct DashboardFlowSummary: Sendable, Equatable {
             detail = "No writes or enrichments landed in \(windowLabel.lowercased())."
         }
 
-        let enrichmentStatusText: String
-        switch enrichmentStatus {
-        case .live:
-            enrichmentStatusText = "Enrichments live now"
-        case .draining:
-            enrichmentStatusText = "Recent enrichments are draining backlog"
-        case .queued:
-            enrichmentStatusText = "Backlog is queued without live enrichments"
-        case .recent:
-            enrichmentStatusText = "Recent enrichments in \(windowLabel.lowercased())"
-        case .idle:
-            enrichmentStatusText = "No recent enrichments"
-        case .unavailable:
-            enrichmentStatusText = "Unavailable"
-        }
+        let enrichmentStatusText = enrichmentStatusText(
+            status: enrichmentStatus,
+            stats: stats,
+            windowLabel: windowLabel
+        )
 
         return DashboardFlowSummary(
             headline: headline,
@@ -331,6 +323,8 @@ struct DashboardFlowSummary: Sendable, Equatable {
                     now: now
                 ),
                 values: stats.recentActivityBuckets,
+                sparklineLabel: "Writes over \(windowLabel)",
+                latestBucketName: "latest write bucket",
                 accentColor: ingressColor
             ),
             queue: DashboardQueueSummary(
@@ -382,9 +376,53 @@ struct DashboardFlowSummary: Sendable, Equatable {
                     now: now
                 ),
                 values: stats.recentEnrichmentBuckets,
+                sparklineLabel: "Enrichment completions over \(windowLabel)",
+                latestBucketName: "latest enrichment bucket",
                 accentColor: enrichmentColor
             )
         )
+    }
+
+    private static func enrichmentStatusText(
+        status: DashboardFlowLaneStatus,
+        stats: DashboardStats,
+        windowLabel: String
+    ) -> String {
+        if let burstText = enrichmentBurstText(stats: stats) {
+            return burstText
+        }
+
+        switch status {
+        case .live:
+            return "Enrichments live now"
+        case .draining:
+            return "Recent enrichments are draining backlog"
+        case .queued:
+            return "Backlog is queued without live enrichments"
+        case .recent:
+            return "Recent enrichments in \(windowLabel.lowercased())"
+        case .idle:
+            return "No recent enrichments"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+
+    private static func enrichmentBurstText(stats: DashboardStats) -> String? {
+        guard stats.pendingEnrichmentCount > 0,
+              let latestBucketCount = stats.recentEnrichmentBuckets.last,
+              latestBucketCount >= 25 else {
+            return nil
+        }
+
+        let earlierBucketTotal = stats.recentEnrichmentBuckets.dropLast().reduce(0, +)
+        guard latestBucketCount >= max(earlierBucketTotal * 2, 25) else {
+            return nil
+        }
+
+        let bucketMinutes = max(1, stats.activityWindowMinutes / max(stats.bucketCount, 1))
+        let bucketLabel = DashboardMetricFormatter.shortWindowLabel(minutes: bucketMinutes)
+        return "Backlog drain burst: \(latestBucketCount) enriched in latest \(bucketLabel)"
     }
 
     private static func storeQueueHealth(depth: Int, oldestAgeSeconds: Int?) -> DashboardStoreQueueHealth {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -150,10 +150,6 @@ struct KGCanvasView: View {
             let nodeIndex = Dictionary(uniqueKeysWithValues: snapshot.visibleNodes.map { ($0.id, $0) })
             let labelledNodeIDs = labelledNodeIDs(for: snapshot.visibleNodes)
 
-            for region in snapshot.regions {
-                drawRegionBackdrop(region: region, in: &ctx, environment: environment)
-            }
-
             for edge in snapshot.visibleEdges {
                 guard let source = nodeIndex[edge.sourceId], let target = nodeIndex[edge.targetId] else { continue }
                 let highlighted = viewModel.selectedNodeId == edge.sourceId || viewModel.selectedNodeId == edge.targetId
@@ -328,42 +324,6 @@ struct KGCanvasView: View {
         .background(toolbarBackground)
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-    }
-
-    private func drawRegionBackdrop(
-        region: KGAtlasPresentation.Region,
-        in context: inout GraphicsContext,
-        environment: EnvironmentValues
-    ) {
-        guard !region.nodes.isEmpty else { return }
-
-        let xs = region.nodes.map { $0.position.x }
-        let ys = region.nodes.map { $0.position.y }
-        guard let minX = xs.min(), let maxX = xs.max(), let minY = ys.min(), let maxY = ys.max() else {
-            return
-        }
-
-        let rect = CGRect(
-            x: minX - 64,
-            y: minY - 52,
-            width: max((maxX - minX) + 128, 180),
-            height: max((maxY - minY) + 112, 132)
-        )
-
-        let tint = region.nodes.first?.color ?? .secondary
-        context.fill(
-            Ellipse().path(in: rect),
-            with: .color(tint.opacity(colorScheme == .dark ? 0.14 : 0.10))
-        )
-
-        let label = Text(region.title.uppercased())
-            .font(.system(size: 10, weight: .semibold, design: .monospaced))
-            .foregroundColor(Color.brainBarTextPrimary.opacity(0.55))
-        context.draw(
-            context.resolve(label),
-            at: CGPoint(x: rect.midX, y: rect.minY - 14),
-            anchor: .center
-        )
     }
 
     private func tapGesture(snapshot: KGAtlasPresentation.Snapshot) -> some Gesture {

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -38,6 +38,7 @@ struct KGSidebarView: View {
                         filesSection()
                         chunksSection()
                     }
+                    .padding(.top, 16)
                     .padding(.horizontal, 18)
                     .padding(.bottom, 18)
                 }

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -173,6 +173,31 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(summary.enrichment.lastEventText, "\(Self.absoluteTime(now.addingTimeInterval(-90))) (1m ago)")
     }
 
+    func testDashboardFlowSummaryLabelsRightEdgeEnrichmentBurstAsBacklogDrain() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 100_000,
+            enrichedChunkCount: 20_000,
+            pendingEnrichmentCount: 80_000,
+            enrichmentPercent: 20,
+            enrichmentRatePerMinute: 34.25,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 1],
+            recentEnrichmentBuckets: [0, 0, 0, 2_055],
+            activityWindowMinutes: 60,
+            bucketCount: 4,
+            liveWindowMinutes: 1,
+            lastEnrichedAt: now.addingTimeInterval(-10)
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+
+        XCTAssertEqual(summary.enrichment.sparklineLabel, "Enrichment completions over Last 1h")
+        XCTAssertEqual(summary.enrichment.latestBucketName, "latest enrichment bucket")
+        XCTAssertEqual(summary.enrichment.statusText, "Backlog drain burst: 2055 enriched in latest 15m")
+        XCTAssertEqual(summary.enrichment.volumeText, "2055 in 1h")
+    }
+
     func testDashboardQueueSummaryReportsActiveDrainingForSmallFreshStoreQueue() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(


### PR DESCRIPTION
## Summary
- F2: removed the graph region/tier-band backdrop drawing and labels while leaving node layout, edge rendering, clustering, and gestures intact.
- F4: added top spacing to the Knowledge Graph sidebar scroll content so Relations is not pinned to the panel chrome.
- F9: changed the glass panel border to an inset stroke clipped to the rounded shape and removed the separate top divider rule.
- F7: presentation-only enrichment chart wording: lane-specific sparkline labels plus a backlog-drain burst status when the latest enrichment bucket is a visible backlog drain. Bucket math/data sources are unchanged.

## Static QA Mapping
- Findings F2 `docs.local/brainbar-qa-2026-05-29-findings.md` line 60/64: `KGCanvasView.swift:153` now goes directly from node index setup to edge drawing; the old `drawRegionBackdrop` ellipse/uppercase label path was removed before `tapGesture` at `KGCanvasView.swift:329`.
- Findings F4 line 141: `KGSidebarView.swift:41` adds `.padding(.top, 16)` to the selected-entity scroll content.
- Findings F9 lines 78-81/142: `BrainBarWindowRootView.swift:1303-1307` uses `strokeBorder` and clips the rounded panel; the full-width top `Rectangle` divider overlay is gone.
- Findings F7 lines 133-136: `PipelineState.swift:378-425` changes only labels/status presentation for enrichment bursts; no DB bucket query or bucket math was changed. `BrainBarWindowRootView.swift:677-680` threads the lane labels into chart presentation.

## Verification
No live/canonical BrainBar was launched or poked. No screenshots taken under the corrected gate. Visual feel still needs Etan manual re-QA for rendered pixels.

Focused TDD test:
```text
swift test --filter BrainBarUXLogicTests/testDashboardFlowSummaryLabelsRightEdgeEnrichmentBurstAsBacklogDrain
Test Suite 'Selected tests' passed at 2026-05-29 22:37:15.910.
    Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.002) seconds
```

Swift build:
```text
[0/1] Planning build
Building for debugging...
[0/5] Write swift-version--612961DECF7E78CD.txt
Build complete! (0.80s)
```

Swift test:
```text
Test Suite 'BrainBarPackageTests.xctest' passed at 2026-05-29 22:38:38.920.
    Executed 585 tests, with 0 failures (0 unexpected) in 22.013 (22.051) seconds
Test Suite 'All tests' passed at 2026-05-29 22:38:38.920.
    Executed 585 tests, with 0 failures (0 unexpected) in 22.013 (22.054) seconds
```

Pre-push gate:
```text
pytest unit suite: 2231 passed, 9 skipped, 76 deselected, 1 xfailed, 102 warnings in 337.21s
pytest MCP tool registration: 3 passed in 1.18s
pytest isolated eval and hook routing: 36 passed, 5 warnings in 4.29s
bun test suite: 1 pass, 0 fail
regression shell test_fts5_determinism.sh: PASS
BrainLayer test gate passed.
```

`cr review --plain` was attempted locally before commit and returned CodeRabbit CLI rate-limit (`Review limit reached`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and rendering tweaks only; no auth, data paths, or bucket query changes. Enrichment burst text is derived from existing stats with test coverage.
> 
> **Overview**
> BrainBar wave-2a QA fixes are **presentation-only** across the dashboard, knowledge graph canvas, and sidebar.
> 
> The **knowledge graph canvas** no longer draws region/tier ellipse backdrops and uppercase region labels on the graph; nodes, edges, and toolbar region chips are unchanged.
> 
> The **KG sidebar** scroll content gets **top padding** so Relations is not flush against the header chrome.
> 
> **Glass dashboard panels** use an inset `strokeBorder` clipped to the rounded rect instead of a separate full-width top divider overlay.
> 
> **Pipeline dashboard** sparklines now take **per-lane labels** and **latest-bucket names** (writes vs enrichments). Enrichment lane status copy can show a **“backlog drain burst”** message when the latest bucket spikes with pending backlog—using existing bucket arrays only, with a new unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a78e074f85356c0f404659bd082eebbf94a5ce3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BrainBar panel visuals, remove region backdrops, and add enrichment burst detection
> - Removes tier-band region backdrops from `KGCanvasView` (deletes `drawRegionBackdrop` and its call site)
> - Fixes `BrainBarGlassPanel` border rendering by switching to `.strokeBorder`, removing the top highlight overlay, and clipping to the rounded rectangle shape
> - Adds `sparklineLabel` and `latestBucketName` to `DashboardFlowLane` and threads them through to `BrainBarHeroSparkline` for chart labeling
> - Adds enrichment burst detection in `DashboardFlowSummary.derive`: when the latest enrichment bucket is large relative to prior buckets and pending enrichment exists, `statusText` reports a backlog drain burst
> - Adds 16pt top padding to `KGSidebarView` scroll content when an entity is selected
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a78e074.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->