### PR TITLE
feat: define pure engine package boundary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ Documentation = "https://etanhey.github.io/brainlayer"
 Issues = "https://github.com/EtanHey/brainlayer/issues"
 
 [project.scripts]
-brainlayer = "brainlayer.cli:app"
 brainlayer-mcp = "brainlayer.mcp:serve"
 
 [build-system]
@@ -114,7 +113,23 @@ per-file-ignores = {"src/brainlayer/cli/__init__.py" = ["F401"]}
 asyncio_mode = "auto"
 pythonpath = ["src"]
 markers = [
+    "engine: pure-library engine tests (excludes CLI, dashboard, BrainBar, launchd, and root orchestration surfaces)",
     "integration: tests that need the real production DB (268K+ chunks)",
     "live: tests that need the live production DB or mutable local hooks state",
     "slow: tests that load ML models or take >30s",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/brainlayer"]
+exclude = [
+    "src/brainlayer/cli",
+    "src/brainlayer/cli_new.py",
+    "src/brainlayer/dashboard",
+]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "src/brainlayer/cli/**",
+    "src/brainlayer/cli_new.py",
+    "src/brainlayer/dashboard/**",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,16 +2,55 @@
 
 import os
 import uuid
+from pathlib import Path
 
 import pytest
+
+ENGINE_TEST_MARK = "engine"
+ENGINE_TEST_EXCLUDED_FILES = {
+    "tests/test_agent_profiles.py",
+    "tests/test_behavioral_pr_loop.py",
+    "tests/test_brainbar_build_app_guards.py",
+    "tests/test_cli_direct_sqlite.py",
+    "tests/test_cli_enrich.py",
+    "tests/test_dashboard.py",
+    "tests/test_dev_dependencies.py",
+    "tests/test_enrich_defaults.py",
+    "tests/test_git_learning.py",
+    "tests/test_launchd_hygiene.py",
+    "tests/test_newsyslog_config.py",
+    "tests/test_run_tests_script.py",
+    "tests/test_wizard.py",
+}
+ENGINE_TEST_EXCLUDED_DIR_PARTS = {
+    "tests/mock_mcp",
+}
+ENGINE_TEST_FILES = frozenset(
+    rel_path
+    for path in (Path(__file__).resolve().parents[1] / "tests").rglob("test_*.py")
+    if (rel_path := path.relative_to(Path(__file__).resolve().parents[1]).as_posix()) not in ENGINE_TEST_EXCLUDED_FILES
+    and not any(rel_path.startswith(prefix) for prefix in ENGINE_TEST_EXCLUDED_DIR_PARTS)
+)
 
 
 def pytest_configure(config):
     """Register custom pytest marks."""
     config.addinivalue_line(
         "markers",
+        "engine: pure-library engine tests (excludes CLI, dashboard, BrainBar, launchd, and root orchestration surfaces)",
+    )
+    config.addinivalue_line(
+        "markers",
         "live: mark test as requiring a live production DB (skipped in CI if DB absent)",
     )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Make the pure-library engine suite runnable as `pytest -m engine`."""
+    for item in items:
+        rel_path = Path(str(item.fspath)).resolve().relative_to(Path(__file__).resolve().parents[1]).as_posix()
+        if rel_path in ENGINE_TEST_FILES:
+            item.add_marker(pytest.mark.engine)
 
 
 @pytest.fixture

--- a/tests/test_engine_package_boundary.py
+++ b/tests/test_engine_package_boundary.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import tests.conftest as test_config
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_engine_package_boundary.py
+++ b/tests/test_engine_package_boundary.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import tests.conftest as test_config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pyproject_declares_pure_engine_package_boundary() -> None:
+    payload = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    wheel_config = payload["tool"]["hatch"]["build"]["targets"]["wheel"]
+    sdist_config = payload["tool"]["hatch"]["build"]["targets"]["sdist"]
+
+    assert payload["project"]["name"] == "brainlayer"
+    assert payload["project"]["scripts"] == {"brainlayer-mcp": "brainlayer.mcp:serve"}
+    assert wheel_config["packages"] == ["src/brainlayer"]
+    assert "src/brainlayer/cli" in wheel_config["exclude"]
+    assert "src/brainlayer/cli_new.py" in wheel_config["exclude"]
+    assert "src/brainlayer/dashboard" in wheel_config["exclude"]
+    assert "src/brainlayer/cli/**" in sdist_config["exclude"]
+    assert "src/brainlayer/cli_new.py" in sdist_config["exclude"]
+    assert "src/brainlayer/dashboard/**" in sdist_config["exclude"]
+
+
+def test_engine_suite_selection_is_explicit_and_excludes_root_surfaces() -> None:
+    assert test_config.ENGINE_TEST_MARK == "engine"
+    assert "tests/test_vector_store.py" in test_config.ENGINE_TEST_FILES
+    assert "tests/test_search_quality.py" in test_config.ENGINE_TEST_FILES
+    assert "tests/test_hybrid_helper_contract.py" in test_config.ENGINE_TEST_FILES
+
+    assert "tests/test_cli_direct_sqlite.py" not in test_config.ENGINE_TEST_FILES
+    assert "tests/test_cli_enrich.py" not in test_config.ENGINE_TEST_FILES
+    assert "tests/test_dashboard.py" not in test_config.ENGINE_TEST_FILES
+    assert "tests/test_brainbar_build_app_guards.py" not in test_config.ENGINE_TEST_FILES
+    assert "tests/test_launchd_hygiene.py" not in test_config.ENGINE_TEST_FILES


### PR DESCRIPTION
## Summary
- Keeps the distribution name `brainlayer` while declaring the wheel/sdist engine boundary.
- Excludes CLI/TUI surfaces from the packaged engine boundary (`cli/`, `cli_new.py`, `dashboard/`).
- Adds an explicit `engine` pytest marker and reproducible selection command: `python3 -m pytest -m engine -q`.

## Engine gate stdout
```text
................................. [ 96%]
........................................................................ [ 99%]
.........                                                                [100%]
=============================== warnings summary ===============================
../../Library/Python/3.13/lib/python/site-packages/deepchecks/core/serialization/dataframe/html.py:16
  /Users/etanheyman/Library/Python/3.13/lib/python/site-packages/deepchecks/core/serialization/dataframe/html.py:16: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    from pkg_resources import parse_version

../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pkg_resources/__init__.py:3146
  /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pkg_resources/__init__.py:3146: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../Library/Python/3.13/lib/python/site-packages/sklearn/metrics/_scorer.py:610
  /Users/etanheyman/Library/Python/3.13/lib/python/site-packages/sklearn/metrics/_scorer.py:610: FutureWarning: The `needs_threshold` and `needs_proba` parameter are deprecated in version 1.4 and will be removed in 1.6. You can either let `response_method` be `None` or set it to `predict` to preserve the same behaviour.
    warnings.warn(

tests/test_phase2_plugin_queue.py: 100 warnings
  /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=72415) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

tests/test_semantic_style.py: 75 warnings
  /Users/etanheyman/Library/Python/3.13/lib/python/site-packages/sklearn/utils/extmath.py:205: RuntimeWarning: divide by zero encountered in matmul
    ret = a @ b

tests/test_semantic_style.py: 75 warnings
  /Users/etanheyman/Library/Python/3.13/lib/python/site-packages/sklearn/utils/extmath.py:205: RuntimeWarning: overflow encountered in matmul
    ret = a @ b

tests/test_semantic_style.py: 75 warnings
  /Users/etanheyman/Library/Python/3.13/lib/python/site-packages/sklearn/utils/extmath.py:205: RuntimeWarning: invalid value encountered in matmul
    ret = a @ b

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2189 passed, 47 skipped, 115 deselected, 5 xfailed, 328 warnings in 311.81s (0:05:11)
```

## Additional verification
- `python3 -m pytest tests/test_engine_package_boundary.py tests/test_hybrid_helper_contract.py -q` -> `3 passed in 0.90s`
- Pre-push hook passed: `BrainLayer test gate passed.`

## Notes
- No live install changed.
- No `com.brainlayer.*` daemon restarted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Published installs no longer expose the `brainlayer` CLI entry point; consumers relying on it from PyPI must use `brainlayer-mcp` or install from source. Packaging excludes are structural and could hide import errors if engine code still depends on excluded modules.
> 
> **Overview**
> This PR **narrows what ships in the `brainlayer` wheel/sdist** and **adds a reproducible “engine-only” test gate**, while keeping the distribution name `brainlayer`.
> 
> **Packaging:** The **`brainlayer` console entry point is removed** from `[project.scripts]`; only **`brainlayer-mcp`** remains. Hatch is configured to **exclude** `src/brainlayer/cli`, `cli_new.py`, and `src/brainlayer/dashboard` from **wheel and sdist** builds so published artifacts represent the core library/MCP surface, not CLI/TUI.
> 
> **Testing:** A new **`engine` pytest marker** is registered, and **`pytest_collection_modifyitems`** auto-applies it to all `test_*.py` files except an explicit denylist (CLI, dashboard, BrainBar, launchd, wizard, etc.) and `tests/mock_mcp`. Run the suite with **`pytest -m engine`**.
> 
> **Guardrails:** **`tests/test_engine_package_boundary.py`** asserts `pyproject.toml` scripts and Hatch excludes match the intended boundary, and that engine suite selection includes core tests while excluding root/orchestration surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef47df8f481942beab5228e738a7da87fcda9dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Define pure engine package boundary by excluding CLI and dashboard from builds
> - Updates [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/387/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) to exclude `src/brainlayer/cli`, `src/brainlayer/cli_new.py`, and `src/brainlayer/dashboard` from wheel and sdist builds, and removes the `brainlayer` console script entry point.
> - Adds auto-marking of engine tests in [tests/conftest.py](https://github.com/EtanHey/brainlayer/pull/387/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) via `pytest_collection_modifyitems`, enabling selection with `pytest -m engine`.
> - Adds [tests/test_engine_package_boundary.py](https://github.com/EtanHey/brainlayer/pull/387/files#diff-72aeb2ce945d937ee3417cf30da7c6ecc62c17f696f3044368834e7effd603f1) to assert that packaging exclusions and engine test suite membership match the defined boundaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ef47df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `brainlayer` CLI command; only `brainlayer-mcp` is now available.

* **Tests**
  * Added validation tests for packaging boundaries and test suite organization.

* **Chores**
  * Updated build configuration and pytest markers for improved test categorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->