### PR TITLE
fix(brainbar): single menu-bar-mounted mode + click-off dismiss (F10, kill dual launch-mode)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -174,22 +174,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Unified Window
+    // MARK: - Menu Bar Popover
 
     @objc
     private func toggleWindowSurface(_ sender: Any?) {
         if let statusPopoverController {
             statusPopoverController.toggle(sender)
-        } else {
-            dashboardPanel?.toggle()
         }
     }
 
     func showDashboardPanel() {
         if let statusPopoverController {
             statusPopoverController.show(nil)
-        } else {
-            dashboardPanel?.show()
         }
     }
 

--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -15,10 +15,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var uiHeartbeatTimer: DispatchSourceTimer?
     private var daemonWatchdog: BrainBarLifecycleWatchdog?
 
-    private var launchMode: BrainBarLaunchMode {
-        runtime.launchMode
-    }
-
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSAppleEventManager.shared().setEventHandler(
             self,
@@ -72,11 +68,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         collector.start()
         configureQuickCaptureHotkey()
-        if launchMode == .appWindow {
-            NSApp.setActivationPolicy(.regular)
-            dashboardPanel.show()
-        }
-        NSLog("[BrainBar] Runtime wired — launchMode=%@", String(describing: launchMode))
+        NSLog("[BrainBar] Runtime wired — launchMode=%@", String(describing: runtime.launchMode))
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -186,11 +178,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc
     private func toggleWindowSurface(_ sender: Any?) {
-        dashboardPanel?.toggle()
+        if let statusPopoverController {
+            statusPopoverController.toggle(sender)
+        } else {
+            dashboardPanel?.toggle()
+        }
     }
 
     func showDashboardPanel() {
-        dashboardPanel?.show()
+        if let statusPopoverController {
+            statusPopoverController.show(nil)
+        } else {
+            dashboardPanel?.show()
+        }
     }
 
     // MARK: - Quick Capture / Search

--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -1,55 +1,41 @@
 import AppKit
 import SwiftUI
 
-final class BrainBarDashboardPanel: NSPanel {
-    var onEscape: (() -> Void)?
-    var onResignKey: (() -> Void)?
-
-    override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { true }
-
-    override func cancelOperation(_ sender: Any?) {
-        onEscape?()
-    }
-
-    override func resignKey() {
-        super.resignKey()
-        onResignKey?()
-    }
-}
-
 @MainActor
 final class BrainBarDashboardPanelController {
-    static let autosaveName = BrainBarWindowFrameAutosave.dashboardPanelName
-    static let defaultSize = NSSize(width: BrainBarWindowPlacement.defaultSize.width, height: BrainBarWindowPlacement.defaultSize.height)
-    static let minSize = NSSize(width: BrainBarWindowPlacement.minimumSize.width, height: BrainBarWindowPlacement.minimumSize.height)
+    static let defaultSize = NSSize(
+        width: BrainBarWindowPlacement.defaultSize.width,
+        height: BrainBarWindowPlacement.defaultSize.height
+    )
+    static let minSize = NSSize(
+        width: BrainBarWindowPlacement.minimumSize.width,
+        height: BrainBarWindowPlacement.minimumSize.height
+    )
 
-    let panelForTesting: BrainBarDashboardPanel
-    var needsInitialPositioningForTesting: Bool { needsInitialPositioning }
+    let popoverForTesting: NSPopover
+    let contentViewControllerForTesting: NSViewController
+    var isShownForTesting: Bool { popover.isShown }
 
-    private let panel: BrainBarDashboardPanel
-    private let runtime: BrainBarRuntime
-    private var needsInitialPositioning: Bool
+    private let popover: NSPopover
 
     init(runtime: BrainBarRuntime) {
-        self.runtime = runtime
-        needsInitialPositioning = Self.needsInitialPositioning()
-        panel = BrainBarDashboardPanel(
-            contentRect: NSRect(origin: .zero, size: Self.defaultSize),
-            styleMask: [.titled, .resizable, .closable, .nonactivatingPanel, .fullSizeContentView],
-            backing: .buffered,
-            defer: false
+        let hostingController = NSHostingController(
+            rootView: BrainBarWindowRootView(runtime: runtime, managesWindowFrame: false)
+                .frame(minWidth: Self.minSize.width, minHeight: Self.minSize.height)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         )
-        panelForTesting = panel
-        configurePanel()
-    }
+        hostingController.view.frame = NSRect(origin: .zero, size: Self.defaultSize)
+        hostingController.view.autoresizingMask = [.width, .height]
 
-    static func needsInitialPositioning(defaults: UserDefaults = .standard) -> Bool {
-        defaults.object(forKey: BrainBarWindowFrameAutosave.dashboardPanelDefaultsKey) == nil
+        popover = NSPopover()
+        popoverForTesting = popover
+        contentViewControllerForTesting = hostingController
+
+        configurePopover(contentViewController: hostingController)
     }
 
     func toggle(anchoredTo anchorView: NSView? = nil) {
-        if panel.isVisible {
+        if popover.isShown {
             dismiss()
         } else {
             show(anchoredTo: anchorView)
@@ -57,104 +43,23 @@ final class BrainBarDashboardPanelController {
     }
 
     func show(anchoredTo anchorView: NSView? = nil) {
-        if !panel.isVisible, needsInitialPositioning {
-            centerPanel()
-            needsInitialPositioning = false
-        }
-        positionPanel(anchoredTo: anchorView)
-        NSApp.activate(ignoringOtherApps: true)
-        panel.makeKeyAndOrderFront(nil)
-        panel.orderFrontRegardless()
+        guard let anchorView else { return }
+
+        popover.show(
+            relativeTo: anchorView.bounds,
+            of: anchorView,
+            preferredEdge: .minY
+        )
     }
 
     func dismiss() {
-        panel.orderOut(nil)
+        popover.performClose(nil)
     }
 
-    private func configurePanel() {
-        panel.title = "BrainBar"
-        panel.titleVisibility = .visible
-        panel.titlebarAppearsTransparent = false
-        panel.isMovable = false
-        panel.isMovableByWindowBackground = false
-        panel.isFloatingPanel = true
-        panel.level = .floating
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.minSize = Self.minSize
-        panel.isReleasedWhenClosed = false
-        panel.hidesOnDeactivate = true
-        panel.backgroundColor = .windowBackgroundColor
-        panel.isOpaque = true
-        panel.hasShadow = true
-        panel.onEscape = { [weak self] in
-            self?.dismiss()
-        }
-        panel.onResignKey = { [weak self] in
-            self?.dismiss()
-        }
-        let hostingController = NSHostingController(
-            rootView: BrainBarWindowRootView(runtime: runtime, managesWindowFrame: false)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        )
-        hostingController.view.autoresizingMask = [.width, .height]
-        panel.contentViewController = hostingController
-        panel.setFrameAutosaveName(Self.autosaveName)
-        if needsInitialPositioning {
-            panel.setFrame(initialFrame(), display: false)
-        }
-    }
-
-    private func initialFrame() -> NSRect {
-        let size = Self.defaultSize
-        guard let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame else {
-            return NSRect(origin: .zero, size: size)
-        }
-
-        let origin = NSPoint(
-            x: screenFrame.midX - size.width / 2,
-            y: screenFrame.midY - size.height / 2
-        )
-        return NSRect(origin: origin, size: size)
-    }
-
-    private func centerPanel() {
-        panel.setFrame(initialFrame(), display: true)
-    }
-
-    private func positionPanel(anchoredTo anchorView: NSView?) {
-        guard let statusItemFrame = anchorView.flatMap(Self.statusItemFrame) else { return }
-        let anchoredFrame = Self.anchoredFrameBelowStatusItem(
-            currentFrame: panel.frame,
-            statusItemFrame: statusItemFrame
-        )
-        panel.setFrame(anchoredFrame, display: true)
-    }
-
-    private static func statusItemFrame(anchorView: NSView) -> NSRect? {
-        guard let window = anchorView.window else { return nil }
-        let frameInWindow = anchorView.convert(anchorView.bounds, to: nil)
-        return window.convertToScreen(frameInWindow)
-    }
-
-    static func anchoredFrameBelowStatusItem(
-        currentFrame: NSRect,
-        statusItemFrame: NSRect,
-        visibleScreenFrames: [NSRect] = NSScreen.screens.map(\.visibleFrame),
-        gap: CGFloat = BrainBarWindowPlacement.menuBarIconGap
-    ) -> NSRect {
-        let visibleFrame = visibleScreenFrames.first(where: { $0.intersects(statusItemFrame) })
-            ?? visibleScreenFrames.first
-            ?? currentFrame
-        let targetX = statusItemFrame.midX - currentFrame.width / 2
-        let targetY = statusItemFrame.minY - gap - currentFrame.height
-        let maxOriginX = max(visibleFrame.minX, visibleFrame.maxX - currentFrame.width)
-        let maxOriginY = visibleFrame.maxY - gap - currentFrame.height
-
-        return NSRect(
-            x: min(max(targetX, visibleFrame.minX), maxOriginX),
-            y: min(max(targetY, visibleFrame.minY), maxOriginY),
-            width: currentFrame.width,
-            height: currentFrame.height
-        )
+    private func configurePopover(contentViewController: NSViewController) {
+        popover.behavior = .transient
+        popover.animates = true
+        popover.contentSize = Self.defaultSize
+        popover.contentViewController = contentViewController
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -3,12 +3,18 @@ import SwiftUI
 
 final class BrainBarDashboardPanel: NSPanel {
     var onEscape: (() -> Void)?
+    var onResignKey: (() -> Void)?
 
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
 
     override func cancelOperation(_ sender: Any?) {
         onEscape?()
+    }
+
+    override func resignKey() {
+        super.resignKey()
+        onResignKey?()
     }
 }
 
@@ -42,19 +48,20 @@ final class BrainBarDashboardPanelController {
         defaults.object(forKey: BrainBarWindowFrameAutosave.dashboardPanelDefaultsKey) == nil
     }
 
-    func toggle() {
+    func toggle(anchoredTo anchorView: NSView? = nil) {
         if panel.isVisible {
             dismiss()
         } else {
-            show()
+            show(anchoredTo: anchorView)
         }
     }
 
-    func show() {
+    func show(anchoredTo anchorView: NSView? = nil) {
         if !panel.isVisible, needsInitialPositioning {
             centerPanel()
             needsInitialPositioning = false
         }
+        positionPanel(anchoredTo: anchorView)
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
@@ -75,10 +82,14 @@ final class BrainBarDashboardPanelController {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.minSize = Self.minSize
         panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = true
         panel.backgroundColor = .windowBackgroundColor
         panel.isOpaque = true
         panel.hasShadow = true
         panel.onEscape = { [weak self] in
+            self?.dismiss()
+        }
+        panel.onResignKey = { [weak self] in
             self?.dismiss()
         }
         let hostingController = NSHostingController(
@@ -108,5 +119,42 @@ final class BrainBarDashboardPanelController {
 
     private func centerPanel() {
         panel.setFrame(initialFrame(), display: true)
+    }
+
+    private func positionPanel(anchoredTo anchorView: NSView?) {
+        guard let statusItemFrame = anchorView.flatMap(Self.statusItemFrame) else { return }
+        let anchoredFrame = Self.anchoredFrameBelowStatusItem(
+            currentFrame: panel.frame,
+            statusItemFrame: statusItemFrame
+        )
+        panel.setFrame(anchoredFrame, display: true)
+    }
+
+    private static func statusItemFrame(anchorView: NSView) -> NSRect? {
+        guard let window = anchorView.window else { return nil }
+        let frameInWindow = anchorView.convert(anchorView.bounds, to: nil)
+        return window.convertToScreen(frameInWindow)
+    }
+
+    static func anchoredFrameBelowStatusItem(
+        currentFrame: NSRect,
+        statusItemFrame: NSRect,
+        visibleScreenFrames: [NSRect] = NSScreen.screens.map(\.visibleFrame),
+        gap: CGFloat = BrainBarWindowPlacement.menuBarIconGap
+    ) -> NSRect {
+        let visibleFrame = visibleScreenFrames.first(where: { $0.intersects(statusItemFrame) })
+            ?? visibleScreenFrames.first
+            ?? currentFrame
+        let targetX = statusItemFrame.midX - currentFrame.width / 2
+        let targetY = statusItemFrame.minY - gap - currentFrame.height
+        let maxOriginX = max(visibleFrame.minX, visibleFrame.maxX - currentFrame.width)
+        let maxOriginY = visibleFrame.maxY - gap - currentFrame.height
+
+        return NSRect(
+            x: min(max(targetX, visibleFrame.minX), maxOriginX),
+            y: min(max(targetY, visibleFrame.minY), maxOriginY),
+            width: currentFrame.width,
+            height: currentFrame.height
+        )
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
@@ -27,11 +27,11 @@ final class BrainBarStatusPopoverController: NSObject {
     }
 
     func toggle(_ sender: Any?) {
-        dashboardPanelController.toggle()
+        dashboardPanelController.toggle(anchoredTo: statusItemForTesting.button)
     }
 
     func show(_ sender: Any?) {
-        dashboardPanelController.show()
+        dashboardPanelController.show(anchoredTo: statusItemForTesting.button)
     }
 
     func close(_ sender: Any?) {
@@ -104,21 +104,6 @@ final class BrainBarStatusPopoverController: NSObject {
         contextMenuForTesting.addItem(NSMenuItem.separator())
         contextMenuForTesting.addItem(
             NSMenuItem(
-                title: "Run as App Window",
-                action: #selector(runAsAppWindow(_:)),
-                keyEquivalent: ""
-            )
-        )
-        contextMenuForTesting.addItem(
-            NSMenuItem(
-                title: "Run as Menu Item Daemon",
-                action: #selector(runAsMenuItemDaemon(_:)),
-                keyEquivalent: ""
-            )
-        )
-        contextMenuForTesting.addItem(NSMenuItem.separator())
-        contextMenuForTesting.addItem(
-            NSMenuItem(
                 title: "Quit BrainBar",
                 action: #selector(quitBrainBar(_:)),
                 keyEquivalent: ""
@@ -136,15 +121,5 @@ final class BrainBarStatusPopoverController: NSObject {
 
     @objc private func quitBrainBar(_ sender: Any?) {
         BrainBarProcessControl.quit()
-    }
-
-    @objc private func runAsAppWindow(_ sender: Any?) {
-        BrainBarLaunchMode.setPreferred(.appWindow)
-        BrainBarProcessControl.restart()
-    }
-
-    @objc private func runAsMenuItemDaemon(_ sender: Any?) {
-        BrainBarLaunchMode.setPreferred(.menuItemDaemon)
-        BrainBarProcessControl.restart()
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowState.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowState.swift
@@ -3,40 +3,20 @@ import CoreGraphics
 import Foundation
 
 enum BrainBarLaunchMode: Equatable {
-    case appWindow
     case menuItemDaemon
 
     static let defaultsKey = "brainbar.launchMode"
 
     var rawValue: String {
-        switch self {
-        case .appWindow:
-            return "app-window"
-        case .menuItemDaemon:
-            return "menu-item-daemon"
-        }
+        "menu-item-daemon"
     }
 
     static func resolve(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: BrainBarKeyValueStoring = UserDefaults.standard
     ) -> BrainBarLaunchMode {
-        if let mode = parse(environment["BRAINBAR_LAUNCH_MODE"]) {
-            return mode
-        }
-
-        if isEnabled(environment["BRAINBAR_APP_WINDOW"]) {
-            return .appWindow
-        }
-
-        if isEnabled(environment["BRAINBAR_LEGACY"]) {
-            return .menuItemDaemon
-        }
-
-        if let mode = parse(defaults.string(forKey: defaultsKey)) {
-            return mode
-        }
-
+        _ = environment
+        _ = defaults
         return .menuItemDaemon
     }
 
@@ -45,30 +25,6 @@ enum BrainBarLaunchMode: Equatable {
         defaults: BrainBarKeyValueStoring = UserDefaults.standard
     ) {
         defaults.setString(mode.rawValue, forKey: defaultsKey)
-    }
-
-    private static func parse(_ value: String?) -> BrainBarLaunchMode? {
-        let rawValue = value?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-
-        switch rawValue {
-        case "app", "app-window", "appwindow", "window":
-            return .appWindow
-        case "daemon", "menu", "menu-item", "menu-item-daemon", "menuitemdaemon", "status", "status-item":
-            return .menuItemDaemon
-        default:
-            return nil
-        }
-    }
-
-    private static func isEnabled(_ value: String?) -> Bool {
-        switch value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "1", "true", "yes", "on":
-            return true
-        default:
-            return false
-        }
     }
 }
 

--- a/brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift
+++ b/brain-bar/Tests/BrainBarDaemonTests/BrainBarDaemonLaunchModeTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import BrainBarDaemon
 
 final class BrainBarDaemonLaunchModeTests: XCTestCase {
-    func testDaemonLaunchModeParsesUnifiedEnvironmentValues() {
+    func testDaemonLaunchModeAlwaysResolvesToSingleMenuItemMode() {
         XCTAssertEqual(
             BrainBarLaunchMode.resolve(
                 environment: ["BRAINBAR_LAUNCH_MODE": "app-window"],
                 defaults: FakeKeyValueStore()
             ),
-            .appWindow
+            .menuItemDaemon
         )
 
         XCTAssertEqual(
@@ -20,13 +20,13 @@ final class BrainBarDaemonLaunchModeTests: XCTestCase {
         )
     }
 
-    func testDaemonLaunchModePreservesLegacyEnvironmentCompatibility() {
+    func testDaemonLaunchModeIgnoresLegacyAppWindowEscapeHatch() {
         XCTAssertEqual(
             BrainBarLaunchMode.resolve(
                 environment: ["BRAINBAR_APP_WINDOW": "1"],
                 defaults: FakeKeyValueStore()
             ),
-            .appWindow
+            .menuItemDaemon
         )
 
         XCTAssertEqual(
@@ -38,7 +38,7 @@ final class BrainBarDaemonLaunchModeTests: XCTestCase {
         )
     }
 
-    func testDaemonLaunchModeEnvironmentOverridesPersistedPreference() {
+    func testDaemonLaunchModeEnvironmentCannotOverrideToRemovedAppWindowMode() {
         let store = FakeKeyValueStore()
         BrainBarLaunchMode.setPreferred(.menuItemDaemon, defaults: store)
 
@@ -47,14 +47,14 @@ final class BrainBarDaemonLaunchModeTests: XCTestCase {
                 environment: ["BRAINBAR_LAUNCH_MODE": "APPWINDOW"],
                 defaults: store
             ),
-            .appWindow
+            .menuItemDaemon
         )
     }
 
-    func testDaemonLaunchModeReadsPersistedPreferenceWrittenByUI() {
+    func testDaemonLaunchModeIgnoresRemovedPersistedAppWindowPreference() {
         let store = FakeKeyValueStore()
 
-        BrainBarLaunchMode.setPreferred(.appWindow, defaults: store)
+        store.setString("app-window", forKey: BrainBarLaunchMode.defaultsKey)
 
         XCTAssertEqual(
             store.string(forKey: BrainBarLaunchMode.defaultsKey),
@@ -62,7 +62,7 @@ final class BrainBarDaemonLaunchModeTests: XCTestCase {
         )
         XCTAssertEqual(
             BrainBarLaunchMode.resolve(environment: [:], defaults: store),
-            .appWindow
+            .menuItemDaemon
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
@@ -25,6 +25,7 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
         XCTAssertEqual(panel.frameAutosaveName, "BrainBarPanel")
         XCTAssertEqual(BrainBarDashboardPanelController.defaultSize, NSSize(width: 900, height: 640))
         XCTAssertEqual(panel.minSize, NSSize(width: 760, height: 560))
+        XCTAssertTrue(panel.hidesOnDeactivate)
         XCTAssertGreaterThanOrEqual(panel.frame.width, panel.minSize.width)
         XCTAssertGreaterThanOrEqual(panel.frame.height, panel.minSize.height)
         XCTAssertTrue(panel.canBecomeKey)
@@ -56,6 +57,22 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
 
         controller.toggle()
         XCTAssertFalse(controller.panelForTesting.isVisible)
+    }
+
+    func testDashboardPanelAnchorsBelowStatusItemWithoutChangingResponsiveSize() {
+        let currentFrame = NSRect(x: 200, y: 120, width: 900, height: 640)
+        let statusItemFrame = NSRect(x: 1_120, y: 872, width: 28, height: 22)
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1_200, height: 872)
+
+        let anchoredFrame = BrainBarDashboardPanelController.anchoredFrameBelowStatusItem(
+            currentFrame: currentFrame,
+            statusItemFrame: statusItemFrame,
+            visibleScreenFrames: [visibleFrame]
+        )
+
+        XCTAssertEqual(anchoredFrame.size, currentFrame.size)
+        XCTAssertEqual(anchoredFrame.maxX, visibleFrame.maxX)
+        XCTAssertEqual(anchoredFrame.maxY, statusItemFrame.minY - BrainBarWindowPlacement.menuBarIconGap)
     }
 
     func testDashboardLayoutReflowsAtMinFloorAndLargeWindowSizes() {

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
@@ -4,75 +4,21 @@ import XCTest
 
 @MainActor
 final class BrainBarDashboardPanelControllerTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        UserDefaults.standard.removeObject(forKey: "NSWindow Frame BrainBarPanel")
-    }
-
-    override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: "NSWindow Frame BrainBarPanel")
-        super.tearDown()
-    }
-
-    func testDashboardPanelUsesResizableUtilityWindowContract() {
+    func testDashboardPopoverUsesTransientMenuBarMountedContract() {
         let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
-        let panel = controller.panelForTesting
 
-        XCTAssertTrue(panel.styleMask.contains(.titled))
-        XCTAssertTrue(panel.styleMask.contains(.resizable))
-        XCTAssertTrue(panel.styleMask.contains(.closable))
-        XCTAssertTrue(panel.styleMask.contains(.nonactivatingPanel))
-        XCTAssertEqual(panel.frameAutosaveName, "BrainBarPanel")
+        XCTAssertEqual(controller.popoverForTesting.behavior, .transient)
         XCTAssertEqual(BrainBarDashboardPanelController.defaultSize, NSSize(width: 900, height: 640))
-        XCTAssertEqual(panel.minSize, NSSize(width: 760, height: 560))
-        XCTAssertTrue(panel.hidesOnDeactivate)
-        XCTAssertGreaterThanOrEqual(panel.frame.width, panel.minSize.width)
-        XCTAssertGreaterThanOrEqual(panel.frame.height, panel.minSize.height)
-        XCTAssertTrue(panel.canBecomeKey)
-        XCTAssertTrue(panel.canBecomeMain)
+        XCTAssertEqual(BrainBarDashboardPanelController.minSize, NSSize(width: 760, height: 560))
+        XCTAssertEqual(controller.popoverForTesting.contentSize, NSSize(width: 900, height: 640))
+        XCTAssertNotNil(controller.popoverForTesting.contentViewController)
     }
 
-    func testDashboardPanelOnlyNeedsInitialPositioningWithoutAutosavedFrame() {
-        XCTAssertTrue(
-            BrainBarDashboardPanelController.needsInitialPositioning(
-                defaults: UserDefaults.standard
-            )
-        )
-
-        UserDefaults.standard.set("saved frame", forKey: "NSWindow Frame BrainBarPanel")
-
-        XCTAssertFalse(
-            BrainBarDashboardPanelController.needsInitialPositioning(
-                defaults: UserDefaults.standard
-            )
-        )
-    }
-
-    func testDashboardPanelToggleControlsVisibility() {
+    func testDashboardPopoverDoesNotOpenWithoutStatusItemAnchor() {
         let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
 
         controller.toggle()
-        XCTAssertTrue(controller.panelForTesting.isVisible)
-        XCTAssertFalse(controller.needsInitialPositioningForTesting)
-
-        controller.toggle()
-        XCTAssertFalse(controller.panelForTesting.isVisible)
-    }
-
-    func testDashboardPanelAnchorsBelowStatusItemWithoutChangingResponsiveSize() {
-        let currentFrame = NSRect(x: 200, y: 120, width: 900, height: 640)
-        let statusItemFrame = NSRect(x: 1_120, y: 872, width: 28, height: 22)
-        let visibleFrame = NSRect(x: 0, y: 0, width: 1_200, height: 872)
-
-        let anchoredFrame = BrainBarDashboardPanelController.anchoredFrameBelowStatusItem(
-            currentFrame: currentFrame,
-            statusItemFrame: statusItemFrame,
-            visibleScreenFrames: [visibleFrame]
-        )
-
-        XCTAssertEqual(anchoredFrame.size, currentFrame.size)
-        XCTAssertEqual(anchoredFrame.maxX, visibleFrame.maxX)
-        XCTAssertEqual(anchoredFrame.maxY, statusItemFrame.minY - BrainBarWindowPlacement.menuBarIconGap)
+        XCTAssertFalse(controller.isShownForTesting)
     }
 
     func testDashboardLayoutReflowsAtMinFloorAndLargeWindowSizes() {
@@ -105,23 +51,35 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
             try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
         }
 
-        // Match launch order: AppDelegate creates the hidden NSPanel before the
-        // async database install lands, then the user opens BrainBar later.
-        _ = controller.panelForTesting.contentViewController?.view
+        // Match launch order: AppDelegate creates the hidden popover content before
+        // the async database install lands, then the user opens BrainBar later.
+        _ = controller.contentViewControllerForTesting.view
         runMainRunLoop()
 
         runtime.install(collector: collector, injectionStore: nil, database: db)
         runMainRunLoop()
 
-        controller.show()
+        let anchorWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 32, height: 24),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let anchorView = NSView(frame: NSRect(x: 0, y: 0, width: 32, height: 24))
+        anchorWindow.contentView = anchorView
+        anchorWindow.orderFront(nil)
+        defer { anchorWindow.orderOut(nil) }
+
+        controller.show(anchoredTo: anchorView)
         runMainRunLoop()
 
-        let field = controller.panelForTesting.contentView.flatMap {
-            findSubview(ofType: KeyHandlingCommandBarField.self, in: $0)
-        }
+        let field = findSubview(
+            ofType: KeyHandlingCommandBarField.self,
+            in: controller.contentViewControllerForTesting.view
+        )
         XCTAssertNotNil(
             field,
-            "Command bar should create its ready text field when runtime.database was installed before the panel became visible."
+            "Command bar should create its ready text field when runtime.database was installed before the popover became visible."
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
@@ -20,7 +20,7 @@ final class BrainBarStatusPopoverControllerTests: XCTestCase {
         XCTAssertEqual(windowController.panelForTesting.minSize, NSSize(width: 760, height: 560))
     }
 
-    func testStatusItemContextMenuContainsRestartModeChoicesAndQuit() {
+    func testStatusItemContextMenuContainsNoLaunchModeSwitchingChoices() {
         let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
         let windowController = BrainBarDashboardPanelController(runtime: runtime)
         let controller = BrainBarStatusPopoverController(
@@ -32,8 +32,8 @@ final class BrainBarStatusPopoverControllerTests: XCTestCase {
         let itemTitles = controller.contextMenuForTesting.items.map(\.title)
 
         XCTAssertTrue(itemTitles.contains("Restart BrainBar"))
-        XCTAssertTrue(itemTitles.contains("Run as App Window"))
-        XCTAssertTrue(itemTitles.contains("Run as Menu Item Daemon"))
+        XCTAssertFalse(itemTitles.contains("Run as App Window"))
+        XCTAssertFalse(itemTitles.contains("Run as Menu Item Daemon"))
         XCTAssertTrue(itemTitles.contains("Quit BrainBar"))
     }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
@@ -4,20 +4,21 @@ import XCTest
 
 @MainActor
 final class BrainBarStatusPopoverControllerTests: XCTestCase {
-    func testControllerWiresVariableLengthStatusItemToUnifiedWindow() {
+    func testControllerWiresVariableLengthStatusItemToMenuBarPopover() {
         let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
-        let windowController = BrainBarDashboardPanelController(runtime: runtime)
+        let popoverController = BrainBarDashboardPanelController(runtime: runtime)
         let controller = BrainBarStatusPopoverController(
             runtime: runtime,
-            dashboardPanelController: windowController
+            dashboardPanelController: popoverController
         )
         defer { controller.stop() }
 
         XCTAssertEqual(controller.statusItemForTesting.length, NSStatusItem.variableLength)
         XCTAssertEqual(controller.statusItemForTesting.button?.target as? BrainBarStatusPopoverController, controller)
         XCTAssertTrue(BrainBarStatusPopoverController.statusItemEventMask.contains(.rightMouseUp))
-        XCTAssertNotNil(windowController.panelForTesting.contentViewController)
-        XCTAssertEqual(windowController.panelForTesting.minSize, NSSize(width: 760, height: 560))
+        XCTAssertEqual(popoverController.popoverForTesting.behavior, .transient)
+        XCTAssertNotNil(popoverController.popoverForTesting.contentViewController)
+        XCTAssertEqual(popoverController.popoverForTesting.contentSize, NSSize(width: 900, height: 640))
     }
 
     func testStatusItemContextMenuContainsNoLaunchModeSwitchingChoices() {

--- a/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarWindowStateTests.swift
@@ -26,18 +26,25 @@ final class BrainBarWindowStateTests: XCTestCase {
         )
     }
 
-    func testLaunchModeCanBeChosenByEnvironmentOrStoredPreference() {
+    func testLaunchModeIgnoresRemovedAppWindowEnvironmentAndPreference() {
         XCTAssertEqual(
             BrainBarLaunchMode.resolve(
                 environment: ["BRAINBAR_LAUNCH_MODE": "app-window"],
                 defaults: FakeKeyValueStore()
             ),
-            .appWindow
+            .menuItemDaemon
+        )
+        XCTAssertEqual(
+            BrainBarLaunchMode.resolve(
+                environment: ["BRAINBAR_APP_WINDOW": "1"],
+                defaults: FakeKeyValueStore()
+            ),
+            .menuItemDaemon
         )
 
         let store = FakeKeyValueStore()
-        BrainBarLaunchMode.setPreferred(.appWindow, defaults: store)
-        XCTAssertEqual(BrainBarLaunchMode.resolve(environment: [:], defaults: store), .appWindow)
+        store.setString("app-window", forKey: BrainBarLaunchMode.defaultsKey)
+        XCTAssertEqual(BrainBarLaunchMode.resolve(environment: [:], defaults: store), .menuItemDaemon)
 
         BrainBarLaunchMode.setPreferred(.menuItemDaemon, defaults: store)
         XCTAssertEqual(BrainBarLaunchMode.resolve(environment: [:], defaults: store), .menuItemDaemon)


### PR DESCRIPTION
## Summary
- Removes the app-window/menu-item dual launch path by resolving BrainBar launch mode to the single menu-item daemon mode.
- Replaces the dashboard free-window surface with an `NSPopover` mounted from the status-item button.
- Uses `.transient` popover behavior for click-off dismissal and removes the dashboard `NSPanel` positioning/drag/autosave path.
- Removes launch-mode switching menu items from the status item context menu.
- Keeps graph rendering/pan code untouched; the dashboard root still uses `managesWindowFrame: false` inside the popover.

## Manual re-QA flags
- Open from the menu-bar icon and confirm the panel stems/anchors from the status item.
- Confirm click-off dismissal in situ.
- Confirm graph pan still works inside the popover.
- No live/canonical BrainBar was launched or driven during this work. The durable visual QA follow-up is the in-app PNG export affordance (#13).

## Test stdout

### swift build
```text
[0/1] Planning build
Building for debugging...
[0/5] Write swift-version--612961DECF7E78CD.txt
Build complete! (0.66s)
```

### swift test
```text
Test Suite 'BrainBarPackageTests.xctest' passed at 2026-05-29 23:22:48.269.
    Executed 584 tests, with 0 failures (0 unexpected) in 19.401 (19.442) seconds
Test Suite 'All tests' passed at 2026-05-29 23:22:48.269.
    Executed 584 tests, with 0 failures (0 unexpected) in 19.401 (19.443) seconds
◇ Test run started.
↳ Testing Library Version: 1902
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
```

### pre-push gate
```text
= 2231 passed, 9 skipped, 76 deselected, 1 xfailed, 102 warnings in 232.64s (0:03:52) =
PASS: pytest unit suite

============================== 3 passed in 0.82s ===============================
PASS: pytest MCP tool registration

============================== 36 passed in 1.95s ==============================
PASS: pytest isolated eval and hook routing

bun test v1.3.9 (cf6cdbbb)
(pass) stale index fixture preserves FTS order and embedding baseline [7885.34ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [7.90s]
PASS: bun test suite

PASS: regression shell test_fts5_determinism.sh

BrainLayer test gate passed.
```

## Review notes
- Local CodeRabbit CLI review could not run because the CLI reported the review limit was reached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a broad UX and shell refactor (primary entry point, window vs popover, launch-mode env/prefs ignored); behavior regressions are possible around hotkeys, URL actions, and graph/command-bar focus inside the popover, though tests were updated.
> 
> **Overview**
> BrainBar now has **one launch surface**: menu-bar accessory with the dashboard in a **transient `NSPopover`** anchored to the status-item button, instead of a separate floating **`NSPanel`** / app-window mode.
> 
> **Launch mode** is collapsed to **`menuItemDaemon` only**—`appWindow`, env overrides (`BRAINBAR_LAUNCH_MODE`, `BRAINBAR_APP_WINDOW`), and persisted app-window prefs no longer change behavior. Startup no longer switches to `.regular` activation or auto-opens a centered window.
> 
> **UI wiring**: toggle, search, and quick capture open the popover via `BrainBarStatusPopoverController` (status-item anchor required; no-op without it). Context menu **Restart** / **Quit** remain; **Run as App Window** / **Run as Menu Item Daemon** are removed.
> 
> Panel-specific behavior (frame autosave, centering, custom `NSPanel` subclass) is dropped in favor of `.transient` popover dismiss-on-click-off. Tests are updated for the popover contract and ignored legacy launch-mode inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b888de98835a3e18cac079e8822a55a1a69365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BrainBar to run exclusively as a menu bar popover, removing dual launch-mode support
> - Removes the `.appWindow` launch mode entirely; `BrainBarLaunchMode` now always resolves to `.menuItemDaemon` regardless of environment variables or stored preferences.
> - Converts the dashboard from a floating `NSPanel` to a transient `NSPopover` anchored to the status bar button, giving it automatic click-off (transient) dismiss behavior.
> - Removes the context menu items for switching launch modes ('Run as App Window' / 'Run as Menu Item Daemon') from the status item.
> - Behavioral Change: the dashboard can no longer be shown without a valid anchor view; calls to `show`/`toggle` without one are no-ops.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14b888d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->