### PR TITLE
fix(brainbar): wave3 live QA fixes

### DIFF
--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -455,6 +455,9 @@ struct DashboardFlowSummary: Sendable, Equatable {
         backlogCount: Int,
         storeHealth: DashboardStoreQueueHealth
     ) -> String {
+        if storeHealth == .writerStuck {
+            return "Q: \(storeHealth.label)"
+        }
         if storeHealth != .empty {
             return "Queue \(storeHealth.label)"
         }

--- a/brain-bar/Sources/BrainBar/InjectionContinuation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionContinuation.swift
@@ -6,16 +6,45 @@ import Foundation
 /// command must use Claude Code's resumable JSONL UUID, not BrainLayer's
 /// internal session_id.
 enum InjectionContinuation {
-    static func resumeCommand(conversationID: String, fallbackSessionID: String = "") -> String {
+    static func resumeCommand(
+        conversationID: String,
+        fallbackSessionID: String = "",
+        projectPath: String = ""
+    ) -> String {
         let resumableID = conversationID.trimmingCharacters(in: .whitespacesAndNewlines)
         if UUID(uuidString: resumableID) != nil {
-            return "claude --resume \(resumableID)"
+            return withProjectPath(projectPath, command: "claude --resume \(resumableID)")
         }
         let fallback = fallbackSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
         let safeCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
         guard !fallback.isEmpty, fallback.unicodeScalars.allSatisfy({ safeCharacters.contains($0) }) else {
             return "claude --continue"
         }
-        return "claude --resume \(fallback)"
+        return withProjectPath(projectPath, command: "claude --resume \(fallback)")
+    }
+
+    static func projectPath(fromClaudeSourceFile sourceFile: String) -> String {
+        let components = sourceFile.split(separator: "/").map(String.init)
+        guard let projectsIndex = components.lastIndex(of: "projects"),
+              components.indices.contains(projectsIndex + 1) else {
+            return ""
+        }
+        let encoded = components[projectsIndex + 1]
+        guard encoded.hasPrefix("-") else { return "" }
+        return "/" + encoded.dropFirst().split(separator: "-").joined(separator: "/")
+    }
+
+    private static func withProjectPath(_ projectPath: String, command: String) -> String {
+        let path = projectPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else { return command }
+        return "cd \(shellEscaped(path)) && \(command)"
+    }
+
+    private static func shellEscaped(_ value: String) -> String {
+        let safeCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "/._-"))
+        if value.unicodeScalars.allSatisfy({ safeCharacters.contains($0) }) {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -21,6 +21,10 @@ struct InjectionChunk: Equatable, Sendable, Identifiable {
         InjectionKind.classify(source: source, sourceFile: sourceFile, tags: tags, content: content)
     }
 
+    var claudeProjectPath: String {
+        InjectionContinuation.projectPath(fromClaudeSourceFile: sourceFile)
+    }
+
     init(
         id: String,
         content: String,
@@ -245,6 +249,10 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         return kinds.isEmpty ? [.other] : kinds
     }
 
+    var claudeProjectPath: String {
+        chunks.lazy.map(\.claudeProjectPath).first { !$0.isEmpty } ?? ""
+    }
+
     func matches(typeFilter: InjectionTypeFilter) -> Bool {
         if chunks.isEmpty, !chunkIDs.isEmpty, typeFilter != .all {
             return true
@@ -259,8 +267,17 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         return InjectionChunk.elide(query, limit: 80)
     }
 
+    var expandedRowKindLabel: String? {
+        let label = primaryKind.label
+        return Self.normalizedForDedupe(label) == Self.normalizedForDedupe(displayTitle) ? nil : label
+    }
+
     var triggeredByText: String {
         "Triggered by: \(InjectionChunk.elide(query, limit: 96))"
+    }
+
+    var expandedRowTriggeredByText: String? {
+        Self.normalizedForDedupe(query) == Self.normalizedForDedupe(displayTitle) ? nil : triggeredByText
     }
 
     var modalTitle: String {
@@ -273,6 +290,14 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
 
     var summaryLine: String {
         "\(query) • \(chunkCount) chunks • \(tokenCount) tok"
+    }
+
+    private static func normalizedForDedupe(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .lowercased()
     }
 
     init(

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -161,9 +161,19 @@ struct InjectionFeedView: View {
 
             VStack(alignment: .trailing, spacing: 8) {
                 TextField("Filter injections", text: $filterText)
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(.plain)
                     .font(.system(size: 12))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
                     .frame(minWidth: 220, maxWidth: 280)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(Self.filterControlFillColor)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Self.filterControlBorderColor, lineWidth: 1)
+                    )
 
                 if !filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Text("Showing \(snapshot.filteredEvents.count) matching events")
@@ -189,7 +199,11 @@ struct InjectionFeedView: View {
                         .padding(.vertical, 4)
                         .background(
                             Capsule()
-                                .fill(activeFilter == filter ? Color.brainBarAccent.opacity(0.22) : Color.brainBarTextPrimary.opacity(0.06))
+                                .fill(activeFilter == filter ? Self.filterControlSelectedFillColor : Self.filterControlFillColor)
+                        )
+                        .overlay(
+                            Capsule()
+                                .stroke(activeFilter == filter ? Self.filterControlBorderColor : .clear, lineWidth: 1)
                         )
                 }
                 .buttonStyle(.plain)
@@ -200,12 +214,7 @@ struct InjectionFeedView: View {
 
     private func overviewStrip(snapshot: InjectionPresentation.Snapshot) -> some View {
         VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 12) {
-                overviewMetric(label: "Queries", value: "\(snapshot.summary.queryCount)")
-                overviewMetric(label: "Chunks", value: "\(snapshot.summary.chunkCount)")
-                overviewMetric(label: "Tokens", value: "\(snapshot.summary.tokenCount)")
-                overviewMetric(label: "Sessions", value: "\(snapshot.summary.activeSessionCount)")
-            }
+            InjectionSummaryView(events: snapshot.windowEvents)
 
             HStack(alignment: .center, spacing: 12) {
                 Text("Last 1h")
@@ -309,9 +318,11 @@ struct InjectionFeedView: View {
                     VStack(alignment: .trailing, spacing: 2) {
                         Text("\(burst.chunkCount)")
                             .font(.system(size: 24, weight: .bold, design: .rounded))
-                        Text("retrieved chunks")
+                        Text(Self.burstChunkCounterLabel)
                             .font(.system(size: 11, weight: .medium))
                             .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.trailing)
+                            .lineLimit(2)
                     }
 
                     // QA #56: the expand affordance was a faint text link that hid
@@ -427,17 +438,21 @@ struct InjectionFeedView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 7) {
                         Text(event.primaryKind.glyph)
-                        Text(event.primaryKind.label)
-                            .font(.system(size: 11, weight: .semibold))
+                        if let kindLabel = event.expandedRowKindLabel {
+                            Text(kindLabel)
+                                .font(.system(size: 11, weight: .semibold))
+                        }
                         Text(event.displayTitle)
                             .font(.system(size: 14, weight: .semibold))
                             .lineLimit(2)
                     }
 
-                    Text(event.triggeredByText)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
+                    if let triggeredBy = event.expandedRowTriggeredByText {
+                        Text(triggeredBy)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
 
                     HStack(spacing: 10) {
                         Text("Session \(shortSessionID(event.sessionID))")
@@ -724,7 +739,8 @@ struct InjectionFeedView: View {
     private func copyContinuation(for burst: InjectionPresentation.Burst) {
         let command = InjectionContinuation.resumeCommand(
             conversationID: burst.claudeConversationID,
-            fallbackSessionID: burst.sessionID
+            fallbackSessionID: burst.sessionID,
+            projectPath: burst.claudeProjectPath
         )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -891,7 +907,23 @@ struct InjectionConversationSelection: Equatable {
     }
 }
 
-private extension InjectionFeedView {
+extension InjectionFeedView {
+    nonisolated static var filterControlsUseAccentTint: Bool { false }
+
+    nonisolated static let burstChunkCounterLabel = "memories surfaced into context"
+
+    static var filterControlFillColor: Color {
+        Color.brainBarTextPrimary.opacity(0.06)
+    }
+
+    static var filterControlSelectedFillColor: Color {
+        Color.brainBarTextPrimary.opacity(0.11)
+    }
+
+    static var filterControlBorderColor: Color {
+        Color.brainBarTextPrimary.opacity(0.14)
+    }
+
     enum BurstChipTint {
         case neutral
         case blue

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -35,6 +35,9 @@ struct InjectionPresentation {
         var queryCount: Int { events.count }
         var chunkCount: Int { events.reduce(0) { $0 + $1.chunkCount } }
         var tokenCount: Int { events.reduce(0) { $0 + $1.tokenCount } }
+        var claudeProjectPath: String {
+            events.lazy.map(\.claudeProjectPath).first { !$0.isEmpty } ?? ""
+        }
 
         var summaryTitle: String {
             if let chunkTitle = InjectionPresentation.previewChunks(for: events, limit: 1).first?.displayText,

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -18,6 +18,7 @@ struct KGSidebarView: View {
     let onLoadMoreChunks: () -> Void
     let onLoadMoreFiles: () -> Void
     let onClose: () -> Void
+    @State private var isFilesExpanded = Self.filesSectionDefaultExpanded
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -35,7 +36,7 @@ struct KGSidebarView: View {
                         if !entity.metadata.isEmpty {
                             metadataSection(entity.metadata)
                         }
-                        filesSection()
+                        filesAccordion()
                         chunksSection()
                     }
                     .padding(.top, 16)
@@ -232,6 +233,26 @@ struct KGSidebarView: View {
         .background(sectionBackground)
     }
 
+    private func filesAccordion() -> some View {
+        DisclosureGroup(isExpanded: $isFilesExpanded) {
+            filesSection()
+                .padding(.top, 10)
+        } label: {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Files")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Text(fileCountSummary)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(16)
+        .background(sectionBackground)
+    }
+
     private func chunksSection() -> some View {
         return VStack(alignment: .leading, spacing: 12) {
             Text("Linked chunks")
@@ -295,10 +316,6 @@ struct KGSidebarView: View {
 
     private func filesSection() -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Files")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.secondary)
-
             if hasFileLoadError, files.isEmpty {
                 Text("Source files are unavailable right now.")
                     .font(.system(size: 13, weight: .medium))
@@ -350,8 +367,6 @@ struct KGSidebarView: View {
                 }
             }
         }
-        .padding(16)
-        .background(sectionBackground)
     }
 
     private var emptyState: some View {
@@ -402,6 +417,17 @@ struct KGSidebarView: View {
 
     private func relevanceText(for file: BrainDatabase.SourceFileRow) -> String {
         "\(Int((file.topRelevance * 100).rounded()))%"
+    }
+
+    private var fileCountSummary: String {
+        if hasFileLoadError, files.isEmpty {
+            return "unavailable"
+        }
+        if isLoadingFiles, files.isEmpty {
+            return "loading"
+        }
+        let count = fileTotal > 0 ? fileTotal : files.count
+        return "\(count) \(count == 1 ? "file" : "files")"
     }
 
     private func chunkCard(_ chunk: BrainDatabase.KGChunkRow) -> some View {
@@ -456,6 +482,8 @@ struct KGSidebarView: View {
     nonisolated static func fileLoadMoreTriggerID(visibleCount: Int) -> String {
         "file-load-more-\(visibleCount)"
     }
+
+    nonisolated static let filesSectionDefaultExpanded = false
 
     nonisolated static let noLinkedChunksMessage = "No linked chunks are stored yet."
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import AppKit
+import SwiftUI
 @testable import BrainBar
 
 final class BrainBarUXLogicTests: XCTestCase {
@@ -267,7 +269,34 @@ final class BrainBarUXLogicTests: XCTestCase {
 
         XCTAssertEqual(summary.queue.storeHealth, .writerStuck)
         XCTAssertEqual(summary.queue.storeHealthText, "writer stuck - investigate")
-        XCTAssertEqual(summary.queue.title, "Queue writer stuck - investigate")
+        XCTAssertEqual(summary.queue.title, "Q: writer stuck - investigate")
+    }
+
+    @MainActor
+    func testRendersWriterStuckQueueLabelQAImage() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 120,
+            pendingEnrichmentCount: 0,
+            enrichmentPercent: 100,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [0, 0, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0, 0],
+            pendingStoreQueueDepth: 7,
+            pendingStoreOldestQueuedAt: now.addingTimeInterval(-300),
+            pendingStoreFlushRatePerMinute: 0
+        )
+        let title = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now).queue.title
+        let view = Text(title)
+            .font(.system(size: 18, weight: .semibold))
+            .padding(.horizontal, 18)
+            .padding(.vertical, 12)
+            .background(.thinMaterial, in: Capsule())
+            .frame(width: 360, height: 80)
+
+        try renderPNG(view, name: "bug1-writer-stuck-label.png")
     }
 
     func testIncomingRelationDisplayPutsEntityNameBeforeRelationVerb() {
@@ -371,4 +400,26 @@ final class BrainBarUXLogicTests: XCTestCase {
         formatter.dateFormat = "HH:mm:ss"
         return formatter.string(from: date)
     }
+}
+
+@MainActor
+private func renderPNG<V: View>(_ view: V, name: String) throws {
+    let renderer = ImageRenderer(content: view)
+    renderer.scale = 2
+    guard let image = renderer.nsImage,
+          let tiff = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiff),
+          let png = bitmap.representation(using: .png, properties: [:]) else {
+        XCTFail("Expected renderer to produce a PNG")
+        return
+    }
+
+    let url = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("docs.local/wave3-qa/\(name)")
+    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try png.write(to: url)
+    XCTAssertGreaterThan(png.count, 1_000)
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionContinuationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionContinuationTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import AppKit
+import SwiftUI
 @testable import BrainBar
 
 // QA #51: "copy to continue thread" must use Claude Code's resumable
@@ -6,8 +8,12 @@ import XCTest
 final class InjectionContinuationTests: XCTestCase {
     func testResumeCommandUsesConversationID() {
         XCTAssertEqual(
-            InjectionContinuation.resumeCommand(conversationID: "3679128a-f371-445f-82ba-b3946e2f20b6", fallbackSessionID: "session-abc"),
-            "claude --resume 3679128a-f371-445f-82ba-b3946e2f20b6"
+            InjectionContinuation.resumeCommand(
+                conversationID: "3679128a-f371-445f-82ba-b3946e2f20b6",
+                fallbackSessionID: "session-abc",
+                projectPath: "/Users/etanheyman/Gits/brainlayer"
+            ),
+            "cd /Users/etanheyman/Gits/brainlayer && claude --resume 3679128a-f371-445f-82ba-b3946e2f20b6"
         )
     }
 
@@ -44,5 +50,43 @@ final class InjectionContinuationTests: XCTestCase {
             InjectionContinuation.resumeCommand(conversationID: "not-a-uuid", fallbackSessionID: "sess-42; rm -rf /"),
             "claude --continue"
         )
+    }
+
+    @MainActor
+    func testRendersCwdAwareResumeCommandQAImage() throws {
+        let command = InjectionContinuation.resumeCommand(
+            conversationID: "3679128a-f371-445f-82ba-b3946e2f20b6",
+            fallbackSessionID: "session-abc",
+            projectPath: "/Users/etanheyman/Gits/brainlayer"
+        )
+        let view = Text(command)
+            .font(.system(size: 12, weight: .medium, design: .monospaced))
+            .lineLimit(2)
+            .padding(18)
+            .frame(width: 620, height: 90, alignment: .leading)
+
+        try renderContinuationPNG(view, name: "bug6-cwd-aware-resume-command.png")
+    }
+
+    @MainActor
+    private func renderContinuationPNG<V: View>(_ view: V, name: String) throws {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        guard let image = renderer.nsImage,
+              let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:]) else {
+            XCTFail("Expected renderer to produce a PNG")
+            return
+        }
+
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("docs.local/wave3-qa/\(name)")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try png.write(to: url)
+        XCTAssertGreaterThan(png.count, 1_000)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import AppKit
+import SwiftUI
 @testable import BrainBar
 
 final class InjectionPresentationTests: XCTestCase {
@@ -7,6 +9,148 @@ final class InjectionPresentationTests: XCTestCase {
             InjectionFeedView.expandedBurstDetailsID(burstID: "burst-42"),
             "expanded-burst-details-burst-42"
         )
+    }
+
+    func testFilterControlsUseNeutralTint() {
+        XCTAssertFalse(InjectionFeedView.filterControlsUseAccentTint)
+    }
+
+    func testBurstChunkCounterUsesMeaningfulLabel() {
+        XCTAssertEqual(InjectionFeedView.burstChunkCounterLabel, "memories surfaced into context")
+    }
+
+    func testExpandedEventFieldsSuppressDuplicateKindAndTrigger() {
+        let event = makeEvent(
+            id: 1,
+            sessionID: "sess-a",
+            timestamp: "2026-04-18T09:58:00Z",
+            query: "Realtime Capture",
+            chunkIDs: ["chunk-1"],
+            tokenCount: 10,
+            chunks: [
+                makeChunk(
+                    id: "chunk-1",
+                    content: "Realtime Capture",
+                    source: "realtime_watcher"
+                )
+            ]
+        )
+
+        XCTAssertEqual(event.displayTitle, "Realtime Capture")
+        XCTAssertNil(event.expandedRowKindLabel)
+        XCTAssertNil(event.expandedRowTriggeredByText)
+    }
+
+    func testInjectionFeedRendersSummaryViewOnLivePath() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/InjectionFeedView.swift")
+        XCTAssertTrue(source.contains("InjectionSummaryView(events: snapshot.windowEvents)"))
+    }
+
+    @MainActor
+    func testRendersInjectionSummaryLivePathQAImage() throws {
+        let events = [
+            makeEvent(id: 1, sessionID: "sess-a", timestamp: "2026-04-18T09:58:00Z", query: "auth refactor", chunkIDs: ["chunk-1", "chunk-2"], tokenCount: 48),
+            makeEvent(id: 2, sessionID: "sess-a", timestamp: "2026-04-18T09:55:00Z", query: "db migration", chunkIDs: ["chunk-3"], tokenCount: 52),
+        ]
+        let view = InjectionSummaryView(events: events)
+            .padding(24)
+            .frame(width: 430, height: 120)
+
+        try renderInjectionPNG(view, name: "bug2-injection-summary-live-path.png")
+    }
+
+    @MainActor
+    func testRendersDedupedExpandedEventQAImage() throws {
+        let event = makeEvent(
+            id: 1,
+            sessionID: "sess-a",
+            timestamp: "2026-04-18T09:58:00Z",
+            query: "Realtime Capture",
+            chunkIDs: ["chunk-1"],
+            tokenCount: 10,
+            chunks: [
+                makeChunk(id: "chunk-1", content: "Realtime Capture", source: "realtime_watcher")
+            ]
+        )
+
+        let view = VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 7) {
+                Text(event.primaryKind.glyph)
+                if let kindLabel = event.expandedRowKindLabel {
+                    Text(kindLabel)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                Text(event.displayTitle)
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            if let triggeredBy = event.expandedRowTriggeredByText {
+                Text(triggeredBy)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+            Text("Session sess-a   1 chunks   10 tok")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .padding(18)
+        .frame(width: 420, height: 120, alignment: .leading)
+
+        try renderInjectionPNG(view, name: "bug4-deduped-expanded-event.png")
+    }
+
+    @MainActor
+    func testRendersBurstChunkCounterQAImage() throws {
+        let view = VStack(alignment: .trailing, spacing: 2) {
+            Text("3")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+            Text(InjectionFeedView.burstChunkCounterLabel)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+        }
+        .padding(24)
+        .frame(width: 240, height: 120, alignment: .trailing)
+
+        try renderInjectionPNG(view, name: "bug5-meaningful-chunk-counter.png")
+    }
+
+    @MainActor
+    func testRendersNeutralFilterControlsQAImage() throws {
+        let view = VStack(alignment: .trailing, spacing: 8) {
+            TextField("Filter injections", text: .constant(""))
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .frame(width: 260)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(InjectionFeedView.filterControlFillColor)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(InjectionFeedView.filterControlBorderColor, lineWidth: 1)
+                )
+
+            HStack(spacing: 6) {
+                Text("All")
+                    .font(.system(size: 11, weight: .semibold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(InjectionFeedView.filterControlSelectedFillColor))
+                    .overlay(Capsule().stroke(InjectionFeedView.filterControlBorderColor, lineWidth: 1))
+                Text("Claude")
+                    .font(.system(size: 11, weight: .semibold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(InjectionFeedView.filterControlFillColor))
+            }
+        }
+        .padding(24)
+        .frame(width: 340, height: 140)
+
+        try renderInjectionPNG(view, name: "bug3-neutral-filter-controls.png")
     }
 
     func testInjectionEventDeduplicatesChunkIDsForClickableRows() {
@@ -375,12 +519,12 @@ final class InjectionPresentationTests: XCTestCase {
         )
     }
 
-    private func makeChunk(id: String, content: String) -> InjectionChunk {
+    private func makeChunk(id: String, content: String, source: String = "mcp") -> InjectionChunk {
         InjectionChunk(
             id: id,
             content: content,
             summary: "",
-            source: "mcp",
+            source: source,
             sourceFile: "",
             tags: [],
             contentType: "memory"
@@ -397,5 +541,34 @@ final class InjectionPresentationTests: XCTestCase {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.string(from: date)
+    }
+
+    @MainActor
+    private func renderInjectionPNG<V: View>(_ view: V, name: String) throws {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        guard let image = renderer.nsImage,
+              let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:]) else {
+            XCTFail("Expected renderer to produce a PNG")
+            return
+        }
+
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("docs.local/wave3-qa/\(name)")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try png.write(to: url)
+        XCTAssertGreaterThan(png.count, 1_000)
+    }
+
+    private func brainBarSourceFile(_ relativePath: String, testFilePath: StaticString = #filePath) throws -> String {
+        let testsDir = URL(fileURLWithPath: "\(testFilePath)").deletingLastPathComponent()
+        let packageRoot = testsDir.deletingLastPathComponent().deletingLastPathComponent()
+        let url = packageRoot.appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -6,6 +6,8 @@
 
 import XCTest
 import SQLite3
+import AppKit
+import SwiftUI
 @testable import BrainBar
 
 private final class DashboardChangeNotificationProbe {
@@ -42,6 +44,81 @@ final class KGSidebarViewTests: XCTestCase {
             KGSidebarView.fileLoadMoreTriggerID(visibleCount: 15),
             KGSidebarView.fileLoadMoreTriggerID(visibleCount: 30)
         )
+    }
+
+    func testFilesSectionAccordionStartsCollapsed() {
+        XCTAssertFalse(KGSidebarView.filesSectionDefaultExpanded)
+    }
+
+    @MainActor
+    func testRendersFilesAccordionQAImage() throws {
+        let entity = EntityCard(
+            id: "person-etan",
+            name: "Etan Heyman",
+            entityType: "person",
+            description: "BrainLayer owner.",
+            relations: [
+                .init(relationType: "builds", targetName: "BrainLayer"),
+                .init(relationType: "uses", targetName: "Claude Code"),
+            ]
+        )
+        let files = (0..<18).map {
+            BrainDatabase.SourceFileRow(
+                sourceFile: "/Users/etanheyman/Gits/brainlayer/Sources/BrainBar/File\($0).swift",
+                chunkCount: 3 + $0,
+                topRelevance: 0.92
+            )
+        }
+        let chunks = [
+            BrainDatabase.KGChunkRow(
+                chunkID: "chunk-1",
+                snippet: "Linked chunks remain visible without expanding the long files list.",
+                importance: 8,
+                relevance: 0.94
+            ),
+        ]
+        let view = KGSidebarView(
+            entity: entity,
+            chunks: chunks,
+            chunkTotal: chunks.count,
+            isLoadingChunks: false,
+            canLoadMoreChunks: false,
+            files: files,
+            fileTotal: files.count,
+            isLoadingFiles: false,
+            canLoadMoreFiles: false,
+            hasChunkLoadError: false,
+            hasFileLoadError: false,
+            onOpenConversation: { _ in },
+            onOpenFile: { _ in },
+            onSelectRelation: { _ in },
+            onLoadMoreChunks: {},
+            onLoadMoreFiles: {},
+            onClose: {}
+        )
+        .frame(width: KGCanvasMetrics.sidebarWidth, height: 720)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        guard let image = renderer.nsImage,
+              let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:]) else {
+            XCTFail("Expected KG sidebar renderer to produce a PNG")
+            return
+        }
+
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("docs.local/wave3-qa/bug7-atlas-files-accordion.png")
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try png.write(to: url)
+        XCTAssertGreaterThan(png.count, 1_000)
     }
 }
 


### PR DESCRIPTION
## Summary
- Bug 7: collapsed Atlas FILES into a default-closed accordion at `brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift:236`.
- Bug 1: changed only writer-stuck queue state to `Q: writer stuck - investigate` at `brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift:453`.
- Bug 3: made injection filter controls neutral instead of orange/accent at `brain-bar/Sources/BrainBar/InjectionFeedView.swift:202`.
- Bug 5: relabeled the burst counter to `memories surfaced into context` at `brain-bar/Sources/BrainBar/InjectionFeedView.swift:321`.
- Bug 4: deduped expanded event kind/trigger fields at `brain-bar/Sources/BrainBar/InjectionEvent.swift:270` and render path `brain-bar/Sources/BrainBar/InjectionFeedView.swift:441`.
- Bug 2: moved `InjectionSummaryView` onto the live injection feed render path at `brain-bar/Sources/BrainBar/InjectionFeedView.swift:217`.
- Bug 6: made resume commands cwd-aware from Claude source paths at `brain-bar/Sources/BrainBar/InjectionContinuation.swift:9` and copy path `brain-bar/Sources/BrainBar/InjectionFeedView.swift:740`.
- Bug 8 skipped as low-priority per brief/time ordering.

## RED evidence
- Bug 7: `error: type 'KGSidebarView' has no member 'filesSectionDefaultExpanded'`
- Bug 1: `XCTAssertEqual failed: (\"Queue writer stuck - investigate\") is not equal to (\"Q: writer stuck - investigate\")`
- Bug 3: `error: type 'InjectionFeedView' has no member 'filterControlsUseAccentTint'`
- Bug 5: `error: type 'InjectionFeedView' has no member 'burstChunkCounterLabel'`
- Bug 4: `error: value of type 'InjectionEvent' has no member 'expandedRowKindLabel'`
- Bug 2: `XCTAssertTrue failed` in `testInjectionFeedRendersSummaryViewOnLivePath`
- Bug 6: `error: extra argument 'projectPath' in call`

## QA artifacts
Generated locally by ImageRenderer tests under ignored local artifact dir:
- `brain-bar/docs.local/wave3-qa/bug1-writer-stuck-label.png`
- `brain-bar/docs.local/wave3-qa/bug2-injection-summary-live-path.png`
- `brain-bar/docs.local/wave3-qa/bug3-neutral-filter-controls.png`
- `brain-bar/docs.local/wave3-qa/bug4-deduped-expanded-event.png`
- `brain-bar/docs.local/wave3-qa/bug5-meaningful-chunk-counter.png`
- `brain-bar/docs.local/wave3-qa/bug6-cwd-aware-resume-command.png`
- `brain-bar/docs.local/wave3-qa/bug7-atlas-files-accordion.png`

## Test plan
- `swift test --package-path brain-bar` -> `Executed 597 tests, with 0 failures (0 unexpected)`
- pre-push gate first cold run failed once: `tests/test_cli_direct_sqlite.py::test_cli_stats_p95_under_200ms_with_direct_readonly_store` with `assert 0.7474601249850821 < 0.2`; isolated rerun passed: `1 passed in 0.25s`.
- normal push retry passed full hook: `2236 passed, 9 skipped, 76 deselected, 1 xfailed, 102 warnings in 233.48s`; MCP registration `3 passed`; isolated eval/hook routing `36 passed`; bun `1 pass`; regression shell `PASS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly SwiftUI copy and styling; the only behavioral change is clipboard resume commands with path parsing and shell escaping, which is bounded and already covered by tests.
> 
> **Overview**
> Wave 3 QA polish across BrainBar dashboard, injection feed, knowledge atlas sidebar, and “copy to continue” clipboard commands.
> 
> **Dashboard** shows a shorter writer-stuck queue title (`Q: writer stuck - investigate`) when store health is stuck.
> 
> **Injection feed** swaps the overview metrics row for **`InjectionSummaryView`** on the live path, retints filter controls to neutral fills/borders, relabels burst chunk counts to **“memories surfaced into context”**, and hides redundant kind/trigger lines on expanded events when they duplicate the title. **Copy to continue** now builds **`cd <project> && claude --resume …`** by deriving project paths from Claude `source_file` paths and threading them through bursts/events.
> 
> **Knowledge atlas** wraps the Files list in a **default-collapsed** accordion with a file-count summary so linked chunks stay visible.
> 
> Tests add assertions and **ImageRenderer** PNG fixtures under `docs.local/wave3-qa/` for the fixed UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b0fca6500075c8b40f0b8362037fbcec310408d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix wave3 live QA issues in BrainBar dashboard, injection feed, and KG sidebar
> - Resume commands in [InjectionFeedView](https://github.com/EtanHey/brainlayer/pull/403/files#diff-6332189fd07a82bbf0d03eba69489afb10493291f2ed71f888c418002b6e54f2) now include a `cd <projectPath> &&` prefix when a project path can be derived from the Claude source file
> - Expanded burst rows suppress redundant kind/trigger labels when they duplicate the display title
> - The files list in [KGSidebarView](https://github.com/EtanHey/brainlayer/pull/403/files#diff-dfab7879313467f5fca34be4f1a1f87bab391bf34b01c8d68f6f5fb06748aac7) is now collapsed by default behind a `DisclosureGroup` accordion showing a file count summary
> - Writer-stuck queue title changes from `Queue writer stuck - investigate` to `Q: writer stuck - investigate`
> - Filter controls in the injection feed are restyled to use neutral fill/border colors instead of accent-rounded borders
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5b0fca6. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume commands now include working directory context, automatically navigating to the project folder.
  * Files section in Knowledge Graph sidebar is now collapsible.

* **Improvements**
  * Updated queue title formatting for specific queue states.
  * Event kind labels and triggered-by text now display conditionally to reduce redundancy.
  * Enhanced filter control styling with updated borders and colors.
  * Replaced metric overview with a new summary component.

* **Tests**
  * Added UI rendering tests for QA documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->