### PR TITLE
feat(l0): entity_facts aggregation layer

### DIFF
--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -12,6 +12,46 @@ class KGMixin:
     """Knowledge graph methods, mixed into VectorStore."""
 
     @staticmethod
+    def _normalize_fact_text(value: Any) -> str:
+        if not isinstance(value, str):
+            return ""
+        return " ".join(value.strip().split())
+
+    @classmethod
+    def _chunk_fact_candidates(
+        cls,
+        key_facts_value: Optional[str],
+        summary: Optional[str],
+        content: Optional[str],
+    ) -> list[str]:
+        candidates: list[str] = []
+        if key_facts_value:
+            try:
+                parsed_key_facts = json.loads(key_facts_value)
+            except (TypeError, json.JSONDecodeError):
+                parsed_key_facts = key_facts_value
+
+            if isinstance(parsed_key_facts, list):
+                candidates.extend(item for item in parsed_key_facts if isinstance(item, str))
+            elif isinstance(parsed_key_facts, str):
+                candidates.append(parsed_key_facts)
+
+        seen: set[str] = set()
+        facts: list[str] = []
+        for candidate in candidates:
+            fact_text = cls._normalize_fact_text(candidate)
+            if fact_text and fact_text not in seen:
+                seen.add(fact_text)
+                facts.append(fact_text)
+        for fallback in (summary, content):
+            if facts:
+                break
+            fallback_fact = cls._normalize_fact_text(fallback)
+            if fallback_fact:
+                facts.append(fallback_fact)
+        return facts
+
+    @staticmethod
     def _entity_row_to_dict(row: Any) -> Dict[str, Any]:
         return {
             "id": row[0],
@@ -528,6 +568,171 @@ class KGMixin:
             }
             for row in rows
         ]
+
+    def aggregate_entity_facts(
+        self,
+        entity_id: str,
+        *,
+        include_audit: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Aggregate deterministic facts for an entity from linked chunk metadata."""
+        cursor = self._read_cursor()
+        where_clauses = ["ec.entity_id = ?"]
+        if not include_audit:
+            where_clauses.append(self._audit_recursion_exclusion_sql("c.id", "c.tags", "c.content"))
+        where_sql = " AND ".join(where_clauses)
+        rows = list(
+            cursor.execute(
+                f"""
+                SELECT ec.chunk_id, c.key_facts, c.summary, c.content, c.created_at
+                FROM kg_entity_chunks ec
+                JOIN chunks c ON ec.chunk_id = c.id
+                WHERE {where_sql}
+                ORDER BY COALESCE(c.created_at, ''), ec.chunk_id
+                """,
+                (entity_id,),
+            )
+        )
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        facts_by_text: dict[str, Dict[str, Any]] = {}
+        for chunk_id, key_facts_value, summary, content, created_at in rows:
+            observed_at = created_at or now
+            for fact_text in self._chunk_fact_candidates(key_facts_value, summary, content):
+                fact = facts_by_text.setdefault(
+                    fact_text,
+                    {
+                        "entity_id": entity_id,
+                        "fact_text": fact_text,
+                        "frequency": 0,
+                        "first_seen": observed_at,
+                        "last_seen": observed_at,
+                        "status": "active",
+                        "superseded_by": None,
+                        "provenance_chunk_ids": [],
+                    },
+                )
+                fact["frequency"] += 1
+                if observed_at < fact["first_seen"]:
+                    fact["first_seen"] = observed_at
+                if observed_at > fact["last_seen"]:
+                    fact["last_seen"] = observed_at
+                if chunk_id not in fact["provenance_chunk_ids"]:
+                    fact["provenance_chunk_ids"].append(chunk_id)
+
+        facts = list(facts_by_text.values())
+        for fact in facts:
+            fact["provenance_chunk_ids"] = sorted(fact["provenance_chunk_ids"])
+        facts.sort(key=lambda fact: (-int(fact["frequency"]), fact["fact_text"]))
+        return facts
+
+    def refresh_entity_facts(
+        self,
+        entity_id: str,
+        *,
+        include_audit: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Rebuild persisted active facts for an entity and return the live aggregation."""
+        facts = self.aggregate_entity_facts(entity_id, include_audit=include_audit)
+        if getattr(self, "_readonly", False):
+            return facts
+
+        cursor = self.conn.cursor()
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        active_fact_texts = {fact["fact_text"] for fact in facts}
+        existing_rows = list(
+            cursor.execute(
+                "SELECT fact_text FROM entity_facts WHERE entity_id = ? AND status = 'active'",
+                (entity_id,),
+            )
+        )
+        for (fact_text,) in existing_rows:
+            if fact_text not in active_fact_texts:
+                cursor.execute(
+                    """
+                    UPDATE entity_facts
+                    SET status = 'superseded',
+                        last_seen = ?,
+                        superseded_by = NULL
+                    WHERE entity_id = ? AND fact_text = ?
+                    """,
+                    (now, entity_id, fact_text),
+                )
+
+        for fact in facts:
+            cursor.execute(
+                """
+                INSERT INTO entity_facts (
+                    entity_id, fact_text, frequency, first_seen, last_seen,
+                    status, superseded_by, provenance_chunk_ids
+                )
+                VALUES (?, ?, ?, ?, ?, 'active', NULL, ?)
+                ON CONFLICT(entity_id, fact_text) DO UPDATE SET
+                    frequency = excluded.frequency,
+                    first_seen = excluded.first_seen,
+                    last_seen = excluded.last_seen,
+                    status = 'active',
+                    superseded_by = NULL,
+                    provenance_chunk_ids = excluded.provenance_chunk_ids
+                """,
+                (
+                    entity_id,
+                    fact["fact_text"],
+                    fact["frequency"],
+                    fact["first_seen"],
+                    fact["last_seen"],
+                    json.dumps(fact["provenance_chunk_ids"]),
+                ),
+            )
+        return facts
+
+    def get_entity_facts(
+        self,
+        entity_id: str,
+        limit: int = 20,
+        *,
+        refresh: bool = False,
+        include_audit: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Return active facts for an entity, optionally refreshing from linked chunks first."""
+        if refresh:
+            return self.refresh_entity_facts(entity_id, include_audit=include_audit)[:limit]
+
+        cursor = self._read_cursor()
+        rows = list(
+            cursor.execute(
+                """
+                SELECT entity_id, fact_text, frequency, first_seen, last_seen,
+                       status, superseded_by, provenance_chunk_ids
+                FROM entity_facts
+                WHERE entity_id = ? AND status = 'active'
+                ORDER BY frequency DESC, fact_text ASC
+                LIMIT ?
+                """,
+                (entity_id, limit),
+            )
+        )
+        facts = []
+        for row in rows:
+            try:
+                provenance_chunk_ids = json.loads(row[7]) if row[7] else []
+            except json.JSONDecodeError:
+                provenance_chunk_ids = []
+            if not isinstance(provenance_chunk_ids, list):
+                provenance_chunk_ids = []
+            facts.append(
+                {
+                    "entity_id": row[0],
+                    "fact_text": row[1],
+                    "frequency": row[2],
+                    "first_seen": row[3],
+                    "last_seen": row[4],
+                    "status": row[5],
+                    "superseded_by": row[6],
+                    "provenance_chunk_ids": provenance_chunk_ids,
+                }
+            )
+        return facts
 
     def search_entities(
         self,

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -212,8 +212,16 @@ def format_entity_simple(entity: dict) -> str:
 
     # Relations from entity_lookup result (filter co_occurs_with)
     lines.extend(["", "### KG Facts"])
+    facts = entity.get("facts", [])
     relations = entity.get("relations", [])
     semantic_rels = [r for r in relations if isinstance(r, dict) and r.get("relation_type") != "co_occurs_with"]
+    if facts:
+        for fact in facts[:10]:
+            fact_text = fact.get("fact_text", "") if isinstance(fact, dict) else str(fact)
+            frequency = int(fact.get("frequency") or 0) if isinstance(fact, dict) else 0
+            suffix = f" (x{frequency})" if frequency > 1 else ""
+            if fact_text:
+                lines.append(f"- {_truncate(fact_text, 140)}{suffix}")
     if semantic_rels:
         for rel in semantic_rels[:10]:
             rtype = rel.get("relation_type", "related_to")
@@ -221,7 +229,7 @@ def format_entity_simple(entity: dict) -> str:
             if expired := _expired_date(rel):
                 line += f" (expired {expired})"
             lines.append(line)
-    else:
+    if not facts and not semantic_rels:
         lines.append("- None")
 
     # Chunks / memories

--- a/src/brainlayer/mcp/entity_handler.py
+++ b/src/brainlayer/mcp/entity_handler.py
@@ -44,6 +44,8 @@ async def _brain_entity(
 
     entity_id = result["id"]
     entity_record = await loop.run_in_executor(None, lambda: store.get_entity(entity_id))
+    facts = await loop.run_in_executor(None, lambda: store.get_entity_facts(entity_id))
+    result["facts"] = facts
     if entity_record and entity_record.get("parent_id"):
         parent = await loop.run_in_executor(None, lambda: store.get_entity_parent(entity_id))
         if parent is not None:

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -901,6 +901,40 @@ def entity_lookup(
         for e in evidence_raw
     ]
 
+    facts_by_text: dict[str, Dict[str, Any]] = {}
+    for aggregate_id in aggregate_entity_ids:
+        for fact in store.refresh_entity_facts(aggregate_id, include_audit=include_audit):
+            fact_text = fact.get("fact_text")
+            if not fact_text:
+                continue
+            merged = facts_by_text.setdefault(
+                fact_text,
+                {
+                    "entity_id": entity_id,
+                    "fact_text": fact_text,
+                    "frequency": 0,
+                    "first_seen": fact.get("first_seen"),
+                    "last_seen": fact.get("last_seen"),
+                    "status": fact.get("status", "active"),
+                    "superseded_by": fact.get("superseded_by"),
+                    "provenance_chunk_ids": [],
+                },
+            )
+            merged["frequency"] += int(fact.get("frequency") or 0)
+            first_seen = fact.get("first_seen")
+            if first_seen and (not merged.get("first_seen") or first_seen < merged["first_seen"]):
+                merged["first_seen"] = first_seen
+            last_seen = fact.get("last_seen")
+            if last_seen and (not merged.get("last_seen") or last_seen > merged["last_seen"]):
+                merged["last_seen"] = last_seen
+            for chunk_id in fact.get("provenance_chunk_ids") or []:
+                if chunk_id not in merged["provenance_chunk_ids"]:
+                    merged["provenance_chunk_ids"].append(chunk_id)
+    facts = list(facts_by_text.values())
+    for fact in facts:
+        fact["provenance_chunk_ids"] = sorted(fact["provenance_chunk_ids"])
+    facts.sort(key=lambda fact: (-int(fact["frequency"]), fact["fact_text"]))
+
     # R49: Include health data if available
     completeness_score = None
     health_level = None
@@ -925,6 +959,7 @@ def entity_lookup(
         "metadata": entity.get("metadata", {}),
         "relations": relations,
         "evidence": evidence,
+        "facts": facts,
         "completeness_score": completeness_score,
         "health_level": health_level,
     }

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -1341,6 +1341,21 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_kg_ec_chunk ON kg_entity_chunks(chunk_id)")
 
         cursor.execute("""
+            CREATE TABLE IF NOT EXISTS entity_facts (
+                entity_id TEXT NOT NULL,
+                fact_text TEXT NOT NULL,
+                frequency INTEGER DEFAULT 1,
+                first_seen TEXT,
+                last_seen TEXT,
+                status TEXT DEFAULT 'active',
+                superseded_by TEXT,
+                provenance_chunk_ids TEXT DEFAULT '[]',
+                PRIMARY KEY (entity_id, fact_text)
+            )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_entity_facts_entity_status ON entity_facts(entity_id, status)")
+
+        cursor.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS kg_vec_entities USING vec0(
                 entity_id TEXT PRIMARY KEY,
                 embedding FLOAT[1024]

--- a/tests/test_kg_schema.py
+++ b/tests/test_kg_schema.py
@@ -62,6 +62,11 @@ class TestKGTableCreation:
         tables = {row[0] for row in cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")}
         assert "kg_entity_chunks" in tables
 
+    def test_entity_facts_table_exists(self, store):
+        cursor = store._read_cursor()
+        tables = {row[0] for row in cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert "entity_facts" in tables
+
     def test_kg_vec_entities_virtual_table_exists(self, store):
         cursor = store._read_cursor()
         # Virtual tables show up in sqlite_master too
@@ -123,6 +128,24 @@ class TestKGTableCreation:
         cursor = store._read_cursor()
         cols = {row[1] for row in cursor.execute("PRAGMA table_info(kg_entity_chunks)")}
         assert cols == {"entity_id", "chunk_id", "relevance", "context", "mention_type", "relation_tier", "weight"}
+
+    def test_entity_facts_columns_and_index(self, store):
+        cursor = store._read_cursor()
+        cols = {row[1] for row in cursor.execute("PRAGMA table_info(entity_facts)")}
+        expected = {
+            "entity_id",
+            "fact_text",
+            "frequency",
+            "first_seen",
+            "last_seen",
+            "status",
+            "superseded_by",
+            "provenance_chunk_ids",
+        }
+        assert cols == expected
+
+        indexes = {row[1] for row in cursor.execute("PRAGMA index_list(entity_facts)")}
+        assert "idx_entity_facts_entity_status" in indexes
 
     def test_source_project_id_column_on_chunks(self, store):
         cursor = store._read_cursor()

--- a/tests/test_mcp_format.py
+++ b/tests/test_mcp_format.py
@@ -264,6 +264,18 @@ class TestFormatEntitySimple:
         assert "knows" in result
         assert "Y" in result
 
+    def test_with_long_fact_truncates_output(self):
+        long_fact = "A" * 180
+        entity = {
+            "name": "X",
+            "id": "1",
+            "entity_type": "project",
+            "facts": [{"fact_text": long_fact, "frequency": 2}],
+        }
+        result = format_entity_simple(entity)
+        assert long_fact not in result
+        assert f"- {'A' * 139}\u2026 (x2)" in result
+
     def test_with_chunks(self):
         entity = {
             "name": "X",

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -457,6 +457,68 @@ def test_entity_lookup_uses_summary_when_key_facts_normalize_empty(tmp_path):
     assert result["facts"][0]["frequency"] == 1
 
 
+def test_brain_entity_handler_surfaces_persisted_entity_facts(tmp_path, monkeypatch):
+    """brain_entity output includes persisted entity_facts with frequency."""
+    import asyncio
+
+    from brainlayer.mcp.entity_handler import _brain_entity
+    from brainlayer.pipeline import digest as digest_module
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    eid = store.upsert_entity("project-brainlayer", "project", "BrainLayer", embedding=dummy_embed("BrainLayer"))
+    _insert_chunks(
+        store,
+        ["bl-handler-1", "bl-handler-2"],
+        [
+            "BrainLayer stores durable memory for the golems ecosystem.",
+            "BrainLayer stores durable memory and indexes memories for recall.",
+        ],
+        [
+            {"source_file": "t.jsonl", "project": "brainlayer"},
+            {"source_file": "t.jsonl", "project": "brainlayer"},
+        ],
+        [dummy_embed("handler fact 1"), dummy_embed("handler fact 2")],
+    )
+    store.update_enrichment(
+        "bl-handler-1",
+        key_facts=["BrainLayer stores durable memory."],
+        summary="BrainLayer stores durable memory.",
+    )
+    store.update_enrichment(
+        "bl-handler-2",
+        key_facts=["BrainLayer stores durable memory."],
+        summary="BrainLayer stores durable memory.",
+    )
+    store.link_entity_chunk(eid, "bl-handler-1", relevance=0.9, context="durable memory")
+    store.link_entity_chunk(eid, "bl-handler-2", relevance=0.8, context="durable memory")
+    store.refresh_entity_facts(eid)
+
+    class DummyModel:
+        def embed_query(self, text: str) -> list[float]:  # noqa: ARG002
+            return dummy_embed(text)
+
+    def entity_lookup_without_facts(*args, **kwargs):  # noqa: ARG001
+        return {
+            "id": eid,
+            "name": "BrainLayer",
+            "entity_type": "project",
+            "description": "",
+            "metadata": {},
+            "relations": [],
+            "evidence": [],
+        }
+
+    monkeypatch.setattr("brainlayer.mcp.entity_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.entity_handler._get_embedding_model", lambda: DummyModel())
+    monkeypatch.setattr(digest_module, "entity_lookup", entity_lookup_without_facts)
+
+    result = asyncio.run(_brain_entity("BrainLayer", entity_type="project"))
+
+    assert "- BrainLayer stores durable memory. (x2)" in result.content[0].text
+
+
 def test_entity_lookup_not_found(tmp_path):
     """entity_lookup returns None for unknown entities."""
     from brainlayer.pipeline.digest import entity_lookup

--- a/tests/test_phase3_digest.py
+++ b/tests/test_phase3_digest.py
@@ -385,6 +385,78 @@ def test_entity_lookup_returns_structured_data(tmp_path):
     assert len(result["evidence"]) >= 1
 
 
+def test_entity_lookup_returns_aggregated_facts_from_linked_chunks(tmp_path):
+    """brain_entity includes deterministic fact frequencies from linked chunks."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    eid = store.upsert_entity("project-brainlayer", "project", "BrainLayer", embedding=dummy_embed("BrainLayer"))
+    _insert_chunks(
+        store,
+        ["bl-fact-1", "bl-fact-2"],
+        [
+            "BrainLayer stores durable memory for the golems ecosystem.",
+            "BrainLayer stores durable memory and indexes memories for recall.",
+        ],
+        [
+            {"source_file": "t.jsonl", "project": "brainlayer"},
+            {"source_file": "t.jsonl", "project": "brainlayer"},
+        ],
+        [dummy_embed("fact1"), dummy_embed("fact2")],
+    )
+    store.update_enrichment(
+        "bl-fact-1",
+        key_facts=["BrainLayer stores durable memory.", "BrainLayer uses SQLite."],
+        summary="BrainLayer stores durable memory.",
+    )
+    store.update_enrichment(
+        "bl-fact-2",
+        key_facts=["BrainLayer stores durable memory."],
+        summary="BrainLayer indexes memories for recall.",
+    )
+    store.link_entity_chunk(eid, "bl-fact-1", relevance=0.9, context="durable memory")
+    store.link_entity_chunk(eid, "bl-fact-2", relevance=0.8, context="durable memory")
+
+    result = entity_lookup("BrainLayer", store, dummy_embed, entity_type="project")
+
+    assert result is not None
+    facts = result["facts"]
+    assert facts[0]["fact_text"] == "BrainLayer stores durable memory."
+    assert facts[0]["frequency"] == 2
+    assert set(facts[0]["provenance_chunk_ids"]) == {"bl-fact-1", "bl-fact-2"}
+
+
+def test_entity_lookup_uses_summary_when_key_facts_normalize_empty(tmp_path):
+    """Empty key_facts do not block summary fallback for entity facts."""
+    from brainlayer.pipeline.digest import entity_lookup
+
+    store = VectorStore(tmp_path / "test.db")
+    dummy_embed = _dummy_embed
+
+    eid = store.upsert_entity("project-brainlayer", "project", "BrainLayer", embedding=dummy_embed("BrainLayer"))
+    _insert_chunks(
+        store,
+        ["bl-summary-fallback"],
+        ["BrainLayer summary should become the fact when key facts are empty."],
+        [{"source_file": "t.jsonl", "project": "brainlayer"}],
+        [dummy_embed("summary fallback")],
+    )
+    store.update_enrichment(
+        "bl-summary-fallback",
+        key_facts=["   "],
+        summary="BrainLayer summarizes linked chunks into facts.",
+    )
+    store.link_entity_chunk(eid, "bl-summary-fallback", relevance=0.9, context="summary fallback")
+
+    result = entity_lookup("BrainLayer", store, dummy_embed, entity_type="project")
+
+    assert result is not None
+    assert result["facts"][0]["fact_text"] == "BrainLayer summarizes linked chunks into facts."
+    assert result["facts"][0]["frequency"] == 1
+
+
 def test_entity_lookup_not_found(tmp_path):
     """entity_lookup returns None for unknown entities."""
     from brainlayer.pipeline.digest import entity_lookup


### PR DESCRIPTION
## Summary
- Add an idempotent `entity_facts` table with `(entity_id, fact_text)` primary key, active/superseded status, frequency, first/last seen timestamps, and JSON provenance chunk IDs.
- Add deterministic entity fact aggregation from `kg_entity_chunks` joined to chunk `key_facts`, with summary/content fallback, exact normalized string dedupe, frequency counts, and provenance tracking.
- Surface aggregated active facts through `entity_lookup` / `brain_entity` as `facts: []`, ordered by frequency descending, and render them in the `KG Facts` section with frequency markers.

## TDD / Verification
- RED: `test_entity_lookup_returns_aggregated_facts_from_linked_chunks` failed with `KeyError: 'facts'` before implementation.
- RED: `test_entity_facts_table_exists` / `test_entity_facts_columns_and_index` failed before schema creation.
- RED: review-fix tests caught empty `key_facts` fallback and long fact rendering before fixes.
- GREEN: `pytest -q tests/test_phase3_digest.py tests/test_kg_schema.py tests/test_mcp_format.py` -> `119 passed in 5.53s`.
- GREEN: `pytest -q` -> `2311 passed, 47 skipped, 5 xfailed, 328 warnings in 263.23s`.
- GREEN: `ruff check ...` and `git diff --check`.
- CodeRabbit local scoped review (`--base origin/main --type uncommitted`) -> no findings after fixes.
- Functional acceptance: seeded `BrainLayer` entity returned `BrainLayer stores durable memory. (x2)` from `_brain_entity`, with structured `facts` JSON showing `frequency: 2` and provenance `acceptance-1`, `acceptance-2`.

## Notes
- No LLM/judge logic in this slice.
- No search/ranking behavior changed.
- No BrainBar Swift UI touched.
- Pre-push hook was bypassed per commander instruction because the hook hit known flaky infra on `test_cli_stats_p95_under_200ms_with_direct_readonly_store`; the exact failing test passed on immediate rerun (`1 passed in 0.33s`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Entity lookup and MCP entity tools now trigger fact refresh writes and supersede updates on each call (unless readonly), which changes read-path side effects and SQLite load without touching auth or search ranking.
> 
> **Overview**
> Adds a persisted **`entity_facts`** layer and wires it into entity lookup and MCP output so KG “facts” come from linked chunk enrichment, not only relations.
> 
> **Storage & aggregation:** New SQLite table `entity_facts` (composite key on `entity_id` + `fact_text`, frequency, timestamps, active/superseded status, JSON provenance). `KGMixin` gains helpers to normalize/dedupe fact strings from chunk `key_facts` (with summary/content fallback), **`aggregate_entity_facts`**, **`refresh_entity_facts`** (upserts active rows and marks missing ones superseded; no-ops writes when `_readonly`), and **`get_entity_facts`**.
> 
> **API & UX:** `entity_lookup` refreshes facts for all aggregated entity IDs, merges by text (sums frequency, unions provenance), and returns a **`facts`** field. **`brain_entity`** loads persisted facts via `get_entity_facts` for display. **`format_entity_simple`** lists facts in **KG Facts** (truncate 140 chars, `(xN)` when frequency &gt; 1) alongside semantic relations.
> 
> **Behavioral note:** Non-readonly **`entity_lookup`** / **`brain_entity`** paths now perform DB writes on refresh during lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abbee8cd83169148f6a4b4f2059a24a89a66bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `entity_facts` aggregation layer to knowledge graph entities
> - Adds a new `entity_facts` table (via [`vector_store.py`](https://github.com/EtanHey/brainlayer/pull/408/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261)) storing per-entity facts with frequency, timestamps, provenance chunk IDs, and a supersession status.
> - Adds `aggregate_entity_facts`, `refresh_entity_facts`, and `get_entity_facts` methods to `KGMixin` in [`kg_repo.py`](https://github.com/EtanHey/brainlayer/pull/408/files#diff-38aa7f1f4a1b009ac93ee1e2c7dfd9d6b85220b1278bb2081ac1ea006a59675b); facts are derived from `key_facts`, `summary`, or `content` enrichment fields on linked chunks.
> - Updates `entity_lookup` in [`digest.py`](https://github.com/EtanHey/brainlayer/pull/408/files#diff-7095fa2ccad4d7bba37257e8239d677d9e6a1cca5b3b1f0a51ec8a56fd191a9a) to call `refresh_entity_facts` and return a merged `facts` list across aggregate entity IDs.
> - Surfaces entity facts in the `brain_entity` MCP handler and `format_entity_simple` formatter, showing up to 10 facts with truncation at 140 chars and `(xN)` frequency suffix.
> - Behavioral Change: stale active facts are marked `superseded` on each refresh rather than deleted, and `entity_lookup` results now include a `facts` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5abbee8. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->