### PR TITLE
feat(l0): correction judge (Gemini-reuse + swap seam)

### DIFF
--- a/SLICE-B-BRIEF.md
+++ b/SLICE-B-BRIEF.md
@@ -1,0 +1,29 @@
+# L0 Slice B — Correction JUDGE (Grokipedia adjudication) (brainlayerCodex brief)
+
+You are **brainlayerCodex-l0-sliceB**. Worktree: `~/Gits/brainlayer-l0-slice-b` (branch `feat/l0-correction-judge`, off main `81315a12` which already has Slice A's `entity_facts`). cd there; work THERE only (not canonical). Full design: `~/Gits/brainlayer/docs.local/plans/2026-05-30-L0-compound-memory/README.md` ("CORRECTION MODEL" + "Slice B").
+
+## WHAT (the adjudication layer on top of Slice A's entity_facts)
+When a NEW assertion about an entity CONFLICTS with an existing active `entity_facts` row (e.g. new "BrainLayer uses sqlite-vec" vs existing "BrainLayer uses ChromaDB"), an **LLM-as-judge** decides: **SUPERSEDE** (new replaces old → mark old `status='superseded'`, `superseded_by`=new, new active), **MERGE**, or **NOISE** (ignore). This judged decision IS the supersession mechanism that makes corrections override stale facts (the North Star). Slice A built the fact store + frequency; Slice B adds the judge.
+
+## REUSE the existing Gemini backend — NO new endpoint/key/infra (Etan directive)
+The judge MUST reuse BrainLayer's existing enrichment Gemini path, NOT a new API:
+- `src/brainlayer/enrichment_controller.py`: `_get_gemini_client()` (line ~491), `_build_gemini_config()` (~558), `GEMINI_REALTIME_MODEL` = `gemini-2.5-flash-lite` (~34), and the rate-limited call `_generate_content_with_rate_limit(client, model, prompt, config, rate_limiter)` (~929). Reuse these for the judge's per-correction call (cheapest, no new keys).
+
+## SWAP-TO-LOCAL SEAM (Etan directive — zero-rewrite later)
+Define a backend-agnostic judge interface so a local LLM can drop in later with NO change to adjudication logic:
+- `CorrectionJudge` protocol/ABC: `judge(entity, new_fact, conflicting_fact, context) -> Verdict{action: supersede|merge|noise, confidence, reasoning}`.
+- `GeminiCorrectionJudge(CorrectionJudge)` — reuses the enrichment Gemini client/model/rate-limiter above + a judge prompt + a strict JSON `response_schema` for the verdict.
+- A `LocalCorrectionJudge` STUB (raises NotImplementedError / TODO) to prove the seam — selected via `BRAINLAYER_JUDGE_BACKEND=gemini|local` (default gemini). Swapping backends must touch ONLY the factory, not the adjudication wiring.
+
+## SCOPE (TDD, additive, PR-loop)
+1. `src/brainlayer/correction_judge.py` — the `CorrectionJudge` ABC + `Verdict` + `GeminiCorrectionJudge` (reusing enrichment Gemini path) + `LocalCorrectionJudge` stub + a `get_correction_judge()` factory (env-selected).
+2. **Conflict detection + adjudication** in the entity_facts path (kg_repo): when aggregating/adding a fact that conflicts with an existing active fact for the same entity, call the judge → apply the verdict (supersede → update `entity_facts.status`/`superseded_by`; merge; noise=skip). Keep it OFF the hot read path — adjudicate at digest/refresh time, not per brain_entity call.
+3. Tests (TDD, RED first): (a) verdict JSON parsing + factory/seam (mock the Gemini client — do NOT hit the real API in unit tests); (b) adjudication state transitions on entity_facts (supersede marks old superseded + new active); (c) one e2e with the judge MOCKED returning supersede → brain_entity shows the corrected fact, stale gone. Add a LIVE-gated (skipped-by-default, `@pytest.mark.live`) real-Gemini test for manual runs.
+
+## MANDATE
+- **TDD** (RED first, paste stdout). Additive — don't change Slice A's deterministic aggregation behavior; the judge is layered ON it.
+- **PR-loop** off `feat/l0-correction-judge`; do NOT merge — COMMANDER (s:7) reviews + runs the FUNCTIONAL acceptance (a real correction supersedes the stale entity_fact, brain_entity reflects it) + merges.
+- Run ONLY targeted tests (your new test files + the entity_facts ones) — NOT the full flaky pre-push suite; if pre-push blocks, push with `git push --no-verify` (CI runs the full suite).
+- Do NOT touch BrainBar UI. You do NOT need brain_* MCP tools — pure Python + pytest + the enrichment Gemini client. BrainLayer recall is best-effort; never block on it.
+- **FUNCTIONAL acceptance:** seed an entity with a stale fact + feed a conflicting correction → judge (mock in test; real Gemini for the live demo) supersedes → `brain_entity` shows the correction, stale fact superseded. Report literal output.
+- Sync progress in `~/Gits/orchestrator/docs.local/plans/2026-05-30-ecosystem-stabilization/collab.md` (L0 Slice-B note). Report concisely; never go silent. Emit TASK_DONE + PR link when pushed.

--- a/src/brainlayer/correction_judge.py
+++ b/src/brainlayer/correction_judge.py
@@ -1,0 +1,171 @@
+"""LLM-backed adjudication for conflicting entity facts."""
+
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .enrichment_controller import (
+    GEMINI_REALTIME_MODEL,
+    _build_gemini_config,
+    _generate_content_with_rate_limit,
+    _get_gemini_client,
+    _get_store_rate_limiter,
+)
+
+JudgeAction = Literal["supersede", "merge", "noise"]
+
+
+@dataclass(frozen=True)
+class Verdict:
+    action: JudgeAction
+    confidence: float
+    reasoning: str
+
+
+class CorrectionJudge(ABC):
+    @abstractmethod
+    def judge(
+        self,
+        entity: str | dict[str, Any],
+        new_fact: str | dict[str, Any],
+        conflicting_fact: str | dict[str, Any],
+        context: dict[str, Any] | None = None,
+    ) -> Verdict:
+        """Return an adjudication verdict for two possibly conflicting facts."""
+
+
+JUDGE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {"type": "string", "enum": ["supersede", "merge", "noise"]},
+        "confidence": {"type": "number"},
+        "reasoning": {"type": "string"},
+    },
+    "required": ["action", "confidence", "reasoning"],
+}
+
+
+def _fact_text(fact: str | dict[str, Any]) -> str:
+    if isinstance(fact, str):
+        return fact
+    value = fact.get("fact_text") or fact.get("text") or ""
+    return str(value)
+
+
+def _entity_name(entity: str | dict[str, Any]) -> str:
+    if isinstance(entity, str):
+        return entity
+    value = entity.get("name") or entity.get("entity_id") or entity.get("id") or ""
+    return str(value)
+
+
+def _build_judge_prompt(
+    entity: str | dict[str, Any],
+    new_fact: str | dict[str, Any],
+    conflicting_fact: str | dict[str, Any],
+    context: dict[str, Any] | None,
+) -> str:
+    payload = {
+        "entity": _entity_name(entity),
+        "new_fact": _fact_text(new_fact),
+        "existing_active_fact": _fact_text(conflicting_fact),
+        "context": context or {},
+    }
+    return (
+        "You adjudicate conflicts between active BrainLayer entity facts.\n"
+        "Return strict JSON only with action, confidence, and reasoning.\n"
+        "Choose supersede when the new fact corrects or replaces the existing fact.\n"
+        "Choose merge when both facts should collapse into one memory.\n"
+        "Choose noise when the new assertion is irrelevant, low-signal, or not a correction.\n"
+        f"Input:\n{json.dumps(payload, ensure_ascii=False, sort_keys=True)}"
+    )
+
+
+def _build_judge_config() -> dict[str, Any]:
+    config = dict(_build_gemini_config())
+    config["response_schema"] = JUDGE_RESPONSE_SCHEMA
+    return config
+
+
+def _coerce_verdict(payload: Any) -> Verdict:
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if not isinstance(payload, dict):
+        raise ValueError("correction judge response must be a JSON object")
+
+    action = str(payload.get("action", "")).strip().lower()
+    if action not in {"supersede", "merge", "noise"}:
+        raise ValueError(f"invalid correction judge action: {action!r}")
+
+    raw_confidence = payload.get("confidence")
+    try:
+        confidence = float(raw_confidence)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"correction judge confidence must be a number, got {raw_confidence!r}") from exc
+    if confidence < 0 or confidence > 1:
+        raise ValueError("correction judge confidence must be between 0 and 1")
+
+    reasoning = str(payload.get("reasoning") or "").strip()
+    if not reasoning:
+        raise ValueError("correction judge reasoning is required")
+
+    return Verdict(action=action, confidence=confidence, reasoning=reasoning)  # type: ignore[arg-type]
+
+
+def _response_payload(response: Any) -> Any:
+    parsed = getattr(response, "parsed", None)
+    if parsed is not None:
+        return parsed
+    text = getattr(response, "text", None)
+    if text is not None:
+        return text
+    return response
+
+
+class GeminiCorrectionJudge(CorrectionJudge):
+    def __init__(self, *, client: Any | None = None, rate_limiter: Any | None = None) -> None:
+        self._client = client
+        self._rate_limiter = rate_limiter
+
+    def judge(
+        self,
+        entity: str | dict[str, Any],
+        new_fact: str | dict[str, Any],
+        conflicting_fact: str | dict[str, Any],
+        context: dict[str, Any] | None = None,
+    ) -> Verdict:
+        client = self._client or _get_gemini_client()
+        prompt = _build_judge_prompt(entity, new_fact, conflicting_fact, context)
+        response = _generate_content_with_rate_limit(
+            client,
+            GEMINI_REALTIME_MODEL,
+            prompt,
+            _build_judge_config(),
+            self._rate_limiter,
+        )
+        return _coerce_verdict(_response_payload(response))
+
+
+class LocalCorrectionJudge(CorrectionJudge):
+    def judge(
+        self,
+        entity: str | dict[str, Any],
+        new_fact: str | dict[str, Any],
+        conflicting_fact: str | dict[str, Any],
+        context: dict[str, Any] | None = None,
+    ) -> Verdict:
+        raise NotImplementedError("LocalCorrectionJudge is a swap-to-local stub.")
+
+
+def get_correction_judge(*, store: Any | None = None) -> CorrectionJudge:
+    backend = os.environ.get("BRAINLAYER_JUDGE_BACKEND", "gemini").strip().lower()
+    if backend == "gemini":
+        rate_limiter = _get_store_rate_limiter(store) if store is not None else None
+        return GeminiCorrectionJudge(rate_limiter=rate_limiter)
+    if backend == "local":
+        return LocalCorrectionJudge()
+    raise ValueError(f"Unsupported BRAINLAYER_JUDGE_BACKEND: {backend!r}")

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -824,10 +824,11 @@ class KGMixin:
         for existing_fact_text, new_fact in merge_updates.items():
             existing_fact = existing_by_text[existing_fact_text]
             merged_provenance = sorted(
-                set(existing_fact.get("provenance_chunk_ids") or [])
-                | set(new_fact.get("provenance_chunk_ids") or [])
+                set(existing_fact.get("provenance_chunk_ids") or []) | set(new_fact.get("provenance_chunk_ids") or [])
             )
-            first_seen_values = [value for value in (existing_fact.get("first_seen"), new_fact.get("first_seen")) if value]
+            first_seen_values = [
+                value for value in (existing_fact.get("first_seen"), new_fact.get("first_seen")) if value
+            ]
             last_seen_values = [value for value in (existing_fact.get("last_seen"), new_fact.get("last_seen")) if value]
             cursor.execute(
                 """

--- a/src/brainlayer/kg_repo.py
+++ b/src/brainlayer/kg_repo.py
@@ -1,11 +1,35 @@
 """Knowledge graph CRUD and traversal methods for VectorStore (mixin)."""
 
 import json
+import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from ._helpers import _escape_fts5_query, serialize_f32
 from .phonetic import phonetic_key, phonetic_tokens
+
+logger = logging.getLogger(__name__)
+
+_ENTITY_FACT_CONFLICT_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "by",
+    "for",
+    "from",
+    "in",
+    "is",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+}
 
 
 class KGMixin:
@@ -16,6 +40,45 @@ class KGMixin:
         if not isinstance(value, str):
             return ""
         return " ".join(value.strip().split())
+
+    @staticmethod
+    def _entity_fact_tokens(value: str) -> set[str]:
+        return {
+            token
+            for token in re.findall(r"[\w]+", value.casefold())
+            if token and token not in _ENTITY_FACT_CONFLICT_STOPWORDS
+        }
+
+    @classmethod
+    def _entity_facts_may_conflict(cls, new_fact_text: str, existing_fact_text: str) -> bool:
+        if new_fact_text == existing_fact_text:
+            return False
+        new_tokens = cls._entity_fact_tokens(new_fact_text)
+        existing_tokens = cls._entity_fact_tokens(existing_fact_text)
+        return len(new_tokens & existing_tokens) >= 2
+
+    @staticmethod
+    def _decode_entity_fact_provenance(value: Any) -> list[str]:
+        try:
+            provenance_chunk_ids = json.loads(value) if value else []
+        except json.JSONDecodeError:
+            provenance_chunk_ids = []
+        if not isinstance(provenance_chunk_ids, list):
+            return []
+        return [str(chunk_id) for chunk_id in provenance_chunk_ids if chunk_id]
+
+    @classmethod
+    def _entity_fact_row_to_dict(cls, row: Any) -> Dict[str, Any]:
+        return {
+            "entity_id": row[0],
+            "fact_text": row[1],
+            "frequency": row[2],
+            "first_seen": row[3],
+            "last_seen": row[4],
+            "status": row[5],
+            "superseded_by": row[6],
+            "provenance_chunk_ids": cls._decode_entity_fact_provenance(row[7]),
+        }
 
     @classmethod
     def _chunk_fact_candidates(
@@ -631,8 +694,10 @@ class KGMixin:
         entity_id: str,
         *,
         include_audit: bool = False,
+        correction_judge: Any | None = None,
+        adjudicate_corrections: bool = True,
     ) -> List[Dict[str, Any]]:
-        """Rebuild persisted active facts for an entity and return the live aggregation."""
+        """Rebuild persisted facts for an entity and return active facts after adjudication."""
         facts = self.aggregate_entity_facts(entity_id, include_audit=include_audit)
         if getattr(self, "_readonly", False):
             return facts
@@ -642,11 +707,26 @@ class KGMixin:
         active_fact_texts = {fact["fact_text"] for fact in facts}
         existing_rows = list(
             cursor.execute(
-                "SELECT fact_text FROM entity_facts WHERE entity_id = ? AND status = 'active'",
+                """
+                SELECT entity_id, fact_text, frequency, first_seen, last_seen,
+                       status, superseded_by, provenance_chunk_ids
+                FROM entity_facts
+                WHERE entity_id = ?
+                """,
                 (entity_id,),
             )
         )
-        for (fact_text,) in existing_rows:
+        existing_by_text = {row[1]: self._entity_fact_row_to_dict(row) for row in existing_rows}
+        existing_active = {
+            fact_text: fact for fact_text, fact in existing_by_text.items() if fact.get("status") == "active"
+        }
+        judged_superseded_texts = {
+            fact_text
+            for fact_text, fact in existing_by_text.items()
+            if fact.get("status") == "superseded" and fact.get("superseded_by")
+        }
+
+        for fact_text in existing_active:
             if fact_text not in active_fact_texts:
                 cursor.execute(
                     """
@@ -659,7 +739,63 @@ class KGMixin:
                     (now, entity_id, fact_text),
                 )
 
+        skipped_fact_texts: set[str] = set()
+        supersede_updates: dict[str, str] = {}
+        merge_updates: dict[str, Dict[str, Any]] = {}
+        effective_correction_judge = correction_judge
+        if not adjudicate_corrections:
+            effective_correction_judge = None
+        elif effective_correction_judge is None:
+            try:
+                from .correction_judge import get_correction_judge
+
+                effective_correction_judge = get_correction_judge(store=self)
+            except Exception:
+                logger.warning("Correction judge factory failed for entity fact refresh", exc_info=True)
+                effective_correction_judge = None
+
         for fact in facts:
+            fact_text = fact["fact_text"]
+            if fact_text in judged_superseded_texts:
+                continue
+
+            if effective_correction_judge is not None and fact_text not in existing_active:
+                for existing_fact_text, existing_fact in existing_active.items():
+                    if existing_fact_text in supersede_updates:
+                        continue
+                    if not self._entity_facts_may_conflict(fact_text, existing_fact_text):
+                        continue
+                    try:
+                        verdict = effective_correction_judge.judge(
+                            {"entity_id": entity_id},
+                            fact,
+                            existing_fact,
+                            {
+                                "entity_id": entity_id,
+                                "include_audit": include_audit,
+                                "new_provenance_chunk_ids": fact.get("provenance_chunk_ids", []),
+                                "existing_provenance_chunk_ids": existing_fact.get("provenance_chunk_ids", []),
+                            },
+                        )
+                    except Exception:
+                        logger.warning("Correction judge failed for entity fact refresh", exc_info=True)
+                        continue
+
+                    action = getattr(verdict, "action", None)
+                    if action == "supersede":
+                        supersede_updates[existing_fact_text] = fact_text
+                        break
+                    if action == "merge":
+                        merge_updates[existing_fact_text] = fact
+                        skipped_fact_texts.add(fact_text)
+                        break
+                    if action == "noise":
+                        skipped_fact_texts.add(fact_text)
+                        break
+
+            if fact_text in skipped_fact_texts:
+                continue
+
             cursor.execute(
                 """
                 INSERT INTO entity_facts (
@@ -677,14 +813,81 @@ class KGMixin:
                 """,
                 (
                     entity_id,
-                    fact["fact_text"],
+                    fact_text,
                     fact["frequency"],
                     fact["first_seen"],
                     fact["last_seen"],
                     json.dumps(fact["provenance_chunk_ids"]),
                 ),
             )
-        return facts
+
+        for existing_fact_text, new_fact in merge_updates.items():
+            existing_fact = existing_by_text[existing_fact_text]
+            merged_provenance = sorted(
+                set(existing_fact.get("provenance_chunk_ids") or [])
+                | set(new_fact.get("provenance_chunk_ids") or [])
+            )
+            first_seen_values = [value for value in (existing_fact.get("first_seen"), new_fact.get("first_seen")) if value]
+            last_seen_values = [value for value in (existing_fact.get("last_seen"), new_fact.get("last_seen")) if value]
+            cursor.execute(
+                """
+                UPDATE entity_facts
+                SET frequency = ?,
+                    first_seen = ?,
+                    last_seen = ?,
+                    status = 'active',
+                    superseded_by = NULL,
+                    provenance_chunk_ids = ?
+                WHERE entity_id = ? AND fact_text = ?
+                """,
+                (
+                    int(existing_fact.get("frequency") or 0) + int(new_fact.get("frequency") or 0),
+                    min(first_seen_values) if first_seen_values else None,
+                    max(last_seen_values) if last_seen_values else None,
+                    json.dumps(merged_provenance),
+                    entity_id,
+                    existing_fact_text,
+                ),
+            )
+            cursor.execute(
+                """
+                INSERT INTO entity_facts (
+                    entity_id, fact_text, frequency, first_seen, last_seen,
+                    status, superseded_by, provenance_chunk_ids
+                )
+                VALUES (?, ?, ?, ?, ?, 'superseded', ?, ?)
+                ON CONFLICT(entity_id, fact_text) DO UPDATE SET
+                    frequency = excluded.frequency,
+                    first_seen = excluded.first_seen,
+                    last_seen = excluded.last_seen,
+                    status = 'superseded',
+                    superseded_by = excluded.superseded_by,
+                    provenance_chunk_ids = excluded.provenance_chunk_ids
+                """,
+                (
+                    entity_id,
+                    new_fact["fact_text"],
+                    new_fact["frequency"],
+                    new_fact["first_seen"],
+                    new_fact["last_seen"],
+                    existing_fact_text,
+                    json.dumps(new_fact["provenance_chunk_ids"]),
+                ),
+            )
+
+        for old_fact_text, new_fact_text in supersede_updates.items():
+            cursor.execute(
+                """
+                UPDATE entity_facts
+                SET status = 'superseded',
+                    last_seen = ?,
+                    superseded_by = ?
+                WHERE entity_id = ? AND fact_text = ?
+                """,
+                (now, new_fact_text, entity_id, old_fact_text),
+            )
+
+        return self.get_entity_facts(entity_id, limit=max(len(facts), len(existing_by_text), 20))
 
     def get_entity_facts(
         self,
@@ -714,25 +917,32 @@ class KGMixin:
         )
         facts = []
         for row in rows:
-            try:
-                provenance_chunk_ids = json.loads(row[7]) if row[7] else []
-            except json.JSONDecodeError:
-                provenance_chunk_ids = []
-            if not isinstance(provenance_chunk_ids, list):
-                provenance_chunk_ids = []
-            facts.append(
-                {
-                    "entity_id": row[0],
-                    "fact_text": row[1],
-                    "frequency": row[2],
-                    "first_seen": row[3],
-                    "last_seen": row[4],
-                    "status": row[5],
-                    "superseded_by": row[6],
-                    "provenance_chunk_ids": provenance_chunk_ids,
-                }
-            )
+            facts.append(self._entity_fact_row_to_dict(row))
         return facts
+
+    def get_superseded_entity_fact_chunk_ids(self, entity_id: str) -> set[str]:
+        """Return chunks that only support judged-superseded facts for an entity."""
+        cursor = self._read_cursor()
+        rows = list(
+            cursor.execute(
+                """
+                SELECT status, superseded_by, provenance_chunk_ids
+                FROM entity_facts
+                WHERE entity_id = ?
+                  AND (status = 'active' OR (status = 'superseded' AND superseded_by IS NOT NULL))
+                """,
+                (entity_id,),
+            )
+        )
+        active_chunk_ids: set[str] = set()
+        superseded_chunk_ids: set[str] = set()
+        for status, superseded_by, provenance_value in rows:
+            chunk_ids = set(self._decode_entity_fact_provenance(provenance_value))
+            if status == "active":
+                active_chunk_ids.update(chunk_ids)
+            elif status == "superseded" and superseded_by:
+                superseded_chunk_ids.update(chunk_ids)
+        return superseded_chunk_ids - active_chunk_ids
 
     def search_entities(
         self,

--- a/src/brainlayer/pipeline/digest.py
+++ b/src/brainlayer/pipeline/digest.py
@@ -903,7 +903,11 @@ def entity_lookup(
 
     facts_by_text: dict[str, Dict[str, Any]] = {}
     for aggregate_id in aggregate_entity_ids:
-        for fact in store.refresh_entity_facts(aggregate_id, include_audit=include_audit):
+        for fact in store.refresh_entity_facts(
+            aggregate_id,
+            include_audit=include_audit,
+            adjudicate_corrections=False,
+        ):
             fact_text = fact.get("fact_text")
             if not fact_text:
                 continue
@@ -934,6 +938,14 @@ def entity_lookup(
     for fact in facts:
         fact["provenance_chunk_ids"] = sorted(fact["provenance_chunk_ids"])
     facts.sort(key=lambda fact: (-int(fact["frequency"]), fact["fact_text"]))
+    superseded_fact_chunk_ids: set[str] = set()
+    try:
+        for aggregate_id in aggregate_entity_ids:
+            superseded_fact_chunk_ids.update(store.get_superseded_entity_fact_chunk_ids(aggregate_id))
+    except Exception:
+        superseded_fact_chunk_ids = set()
+    if superseded_fact_chunk_ids:
+        evidence = [chunk for chunk in evidence if chunk.get("chunk_id") not in superseded_fact_chunk_ids]
 
     # R49: Include health data if available
     completeness_score = None

--- a/tests/test_correction_judge.py
+++ b/tests/test_correction_judge.py
@@ -1,0 +1,86 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_gemini_correction_judge_parses_strict_json_and_uses_enrichment_backend(monkeypatch):
+    from brainlayer import correction_judge
+    from brainlayer.correction_judge import GeminiCorrectionJudge
+    from brainlayer.enrichment_controller import GEMINI_REALTIME_MODEL
+
+    captured = {}
+
+    def fake_get_client():
+        return SimpleNamespace(models=SimpleNamespace())
+
+    def fake_generate(client, model, prompt, config, rate_limiter):
+        captured["client"] = client
+        captured["model"] = model
+        captured["prompt"] = prompt
+        captured["config"] = config
+        captured["rate_limiter"] = rate_limiter
+        return SimpleNamespace(
+            text='{"action":"supersede","confidence":0.91,"reasoning":"The new fact corrects the stale backend."}'
+        )
+
+    monkeypatch.setattr(correction_judge, "_get_gemini_client", fake_get_client)
+    monkeypatch.setattr(correction_judge, "_generate_content_with_rate_limit", fake_generate)
+
+    verdict = GeminiCorrectionJudge(rate_limiter="limiter").judge(
+        entity="BrainLayer",
+        new_fact={"fact_text": "BrainLayer uses sqlite-vec."},
+        conflicting_fact={"fact_text": "BrainLayer uses ChromaDB."},
+        context={"source": "unit-test"},
+    )
+
+    assert verdict.action == "supersede"
+    assert verdict.confidence == pytest.approx(0.91)
+    assert verdict.reasoning == "The new fact corrects the stale backend."
+    assert captured["model"] == GEMINI_REALTIME_MODEL
+    assert captured["rate_limiter"] == "limiter"
+    assert captured["config"]["response_mime_type"] == "application/json"
+    assert captured["config"]["response_schema"]["properties"]["action"]["enum"] == [
+        "supersede",
+        "merge",
+        "noise",
+    ]
+    assert "BrainLayer uses sqlite-vec." in captured["prompt"]
+    assert "BrainLayer uses ChromaDB." in captured["prompt"]
+
+
+def test_correction_judge_factory_defaults_to_gemini_and_keeps_local_seam(monkeypatch):
+    from brainlayer.correction_judge import GeminiCorrectionJudge, LocalCorrectionJudge, get_correction_judge
+
+    monkeypatch.delenv("BRAINLAYER_JUDGE_BACKEND", raising=False)
+    assert isinstance(get_correction_judge(), GeminiCorrectionJudge)
+
+    monkeypatch.setenv("BRAINLAYER_JUDGE_BACKEND", "local")
+    judge = get_correction_judge()
+    assert isinstance(judge, LocalCorrectionJudge)
+    with pytest.raises(NotImplementedError):
+        judge.judge("BrainLayer", "new", "old", {})
+
+
+def test_verdict_parser_rejects_missing_confidence_with_value_error():
+    from brainlayer.correction_judge import _coerce_verdict
+
+    with pytest.raises(ValueError, match="confidence must be a number"):
+        _coerce_verdict({"action": "supersede", "reasoning": "missing confidence"})
+
+
+@pytest.mark.live
+@pytest.mark.skipif(os.environ.get("BRAINLAYER_RUN_LIVE_JUDGE") != "1", reason="set BRAINLAYER_RUN_LIVE_JUDGE=1")
+def test_live_gemini_correction_judge_can_adjudicate_real_conflict():
+    from brainlayer.correction_judge import GeminiCorrectionJudge
+
+    verdict = GeminiCorrectionJudge().judge(
+        entity="BrainLayer",
+        new_fact={"fact_text": "BrainLayer uses sqlite-vec for vector search."},
+        conflicting_fact={"fact_text": "BrainLayer uses ChromaDB for vector search."},
+        context={"purpose": "manual live smoke test"},
+    )
+
+    assert verdict.action in {"supersede", "merge", "noise"}
+    assert 0 <= verdict.confidence <= 1
+    assert verdict.reasoning

--- a/tests/test_entity_fact_correction_judge.py
+++ b/tests/test_entity_fact_correction_judge.py
@@ -72,14 +72,18 @@ def test_refresh_entity_facts_supersedes_conflicting_active_fact(tmp_path):
     assert judge.calls[0]["new_fact"]["fact_text"] == "BrainLayer uses sqlite-vec."
     assert judge.calls[0]["conflicting_fact"]["fact_text"] == "BrainLayer uses ChromaDB."
 
-    row = store.conn.cursor().execute(
-        """
+    row = (
+        store.conn.cursor()
+        .execute(
+            """
         SELECT status, superseded_by
         FROM entity_facts
         WHERE entity_id = ? AND fact_text = ?
         """,
-        (entity_id, "BrainLayer uses ChromaDB."),
-    ).fetchone()
+            (entity_id, "BrainLayer uses ChromaDB."),
+        )
+        .fetchone()
+    )
     assert row == ("superseded", "BrainLayer uses sqlite-vec.")
 
 

--- a/tests/test_entity_fact_correction_judge.py
+++ b/tests/test_entity_fact_correction_judge.py
@@ -1,0 +1,159 @@
+import asyncio
+
+from brainlayer.correction_judge import Verdict
+from brainlayer.vector_store import VectorStore
+
+
+def _dummy_embed(text):  # noqa: ARG001
+    return [0.1] * 1024
+
+
+def _insert_chunk(store: VectorStore, chunk_id: str, content: str, *, key_fact: str) -> None:
+    store.upsert_chunks(
+        [
+            {
+                "id": chunk_id,
+                "content": content,
+                "metadata": {"source_file": "judge-test.jsonl", "project": "brainlayer"},
+                "source_file": "judge-test.jsonl",
+                "project": "brainlayer",
+                "content_type": "user_message",
+                "char_count": len(content),
+                "source": "claude_code",
+            }
+        ],
+        [_dummy_embed(content)],
+    )
+    store.update_enrichment(chunk_id, key_facts=[key_fact], summary=key_fact)
+
+
+class SupersedeJudge:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def judge(self, entity, new_fact, conflicting_fact, context):
+        self.calls.append(
+            {
+                "entity": entity,
+                "new_fact": new_fact,
+                "conflicting_fact": conflicting_fact,
+                "context": context,
+            }
+        )
+        return Verdict(action="supersede", confidence=0.96, reasoning="The new backend corrects the old one.")
+
+
+def test_refresh_entity_facts_supersedes_conflicting_active_fact(tmp_path):
+    store = VectorStore(tmp_path / "test.db")
+    entity_id = store.upsert_entity("project-brainlayer", "project", "BrainLayer", embedding=_dummy_embed("BrainLayer"))
+
+    _insert_chunk(
+        store,
+        "stale-backend",
+        "BrainLayer uses ChromaDB for vector search.",
+        key_fact="BrainLayer uses ChromaDB.",
+    )
+    store.link_entity_chunk(entity_id, "stale-backend", relevance=0.9, context="stale backend")
+    store.refresh_entity_facts(entity_id)
+
+    _insert_chunk(
+        store,
+        "corrected-backend",
+        "Correction: BrainLayer uses sqlite-vec for vector search.",
+        key_fact="BrainLayer uses sqlite-vec.",
+    )
+    store.link_entity_chunk(entity_id, "corrected-backend", relevance=0.95, context="corrected backend")
+
+    judge = SupersedeJudge()
+    store.refresh_entity_facts(entity_id, correction_judge=judge)
+
+    active_facts = store.get_entity_facts(entity_id)
+    assert [fact["fact_text"] for fact in active_facts] == ["BrainLayer uses sqlite-vec."]
+    assert judge.calls[0]["new_fact"]["fact_text"] == "BrainLayer uses sqlite-vec."
+    assert judge.calls[0]["conflicting_fact"]["fact_text"] == "BrainLayer uses ChromaDB."
+
+    row = store.conn.cursor().execute(
+        """
+        SELECT status, superseded_by
+        FROM entity_facts
+        WHERE entity_id = ? AND fact_text = ?
+        """,
+        (entity_id, "BrainLayer uses ChromaDB."),
+    ).fetchone()
+    assert row == ("superseded", "BrainLayer uses sqlite-vec.")
+
+
+def test_refresh_entity_facts_uses_factory_judge_by_default(tmp_path, monkeypatch):
+    import brainlayer.correction_judge as correction_judge
+
+    store = VectorStore(tmp_path / "test.db")
+    entity_id = store.upsert_entity("project-brainlayer", "project", "BrainLayer", embedding=_dummy_embed("BrainLayer"))
+
+    _insert_chunk(
+        store,
+        "stale-backend",
+        "BrainLayer uses ChromaDB for vector search.",
+        key_fact="BrainLayer uses ChromaDB.",
+    )
+    store.link_entity_chunk(entity_id, "stale-backend", relevance=0.9, context="stale backend")
+    store.refresh_entity_facts(entity_id, adjudicate_corrections=False)
+
+    _insert_chunk(
+        store,
+        "corrected-backend",
+        "Correction: BrainLayer uses sqlite-vec for vector search.",
+        key_fact="BrainLayer uses sqlite-vec.",
+    )
+    store.link_entity_chunk(entity_id, "corrected-backend", relevance=0.95, context="corrected backend")
+
+    judge = SupersedeJudge()
+    monkeypatch.setattr(correction_judge, "get_correction_judge", lambda *, store=None: judge)
+
+    store.refresh_entity_facts(entity_id)
+
+    assert [fact["fact_text"] for fact in store.get_entity_facts(entity_id)] == ["BrainLayer uses sqlite-vec."]
+    assert len(judge.calls) == 1
+
+
+def test_brain_entity_shows_corrected_fact_without_reactivating_stale_fact(tmp_path, monkeypatch):
+    import brainlayer.correction_judge as correction_judge
+    from brainlayer.mcp.entity_handler import _brain_entity
+
+    store = VectorStore(tmp_path / "test.db")
+    entity_id = store.upsert_entity("project-brainlayer", "project", "BrainLayer", embedding=_dummy_embed("BrainLayer"))
+
+    _insert_chunk(
+        store,
+        "stale-backend",
+        "BrainLayer uses ChromaDB for vector search.",
+        key_fact="BrainLayer uses ChromaDB.",
+    )
+    store.link_entity_chunk(entity_id, "stale-backend", relevance=0.9, context="stale backend")
+    store.refresh_entity_facts(entity_id)
+
+    _insert_chunk(
+        store,
+        "corrected-backend",
+        "Correction: BrainLayer uses sqlite-vec for vector search.",
+        key_fact="BrainLayer uses sqlite-vec.",
+    )
+    store.link_entity_chunk(entity_id, "corrected-backend", relevance=0.95, context="corrected backend")
+    store.refresh_entity_facts(entity_id, correction_judge=SupersedeJudge())
+
+    class DummyModel:
+        def embed_query(self, text: str) -> list[float]:
+            return _dummy_embed(text)
+
+    monkeypatch.setattr("brainlayer.mcp.entity_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.entity_handler._get_embedding_model", lambda: DummyModel())
+    monkeypatch.setattr(
+        correction_judge,
+        "get_correction_judge",
+        lambda *, store=None: (_ for _ in ()).throw(AssertionError("brain_entity must not build a judge")),
+    )
+
+    result = asyncio.run(_brain_entity("BrainLayer", entity_type="project"))
+    output = result.content[0].text
+
+    assert "BrainLayer uses sqlite-vec." in output
+    assert "ChromaDB" not in output


### PR DESCRIPTION
## Summary
- Add `CorrectionJudge` ABC, `Verdict`, `GeminiCorrectionJudge`, `LocalCorrectionJudge` stub, and `get_correction_judge()` factory selected by `BRAINLAYER_JUDGE_BACKEND`.
- Reuse the existing enrichment Gemini path: `_get_gemini_client`, `_generate_content_with_rate_limit`, and `GEMINI_REALTIME_MODEL` (`gemini-2.5-flash-lite`); no new endpoint/key/infra.
- Wire correction adjudication into `entity_facts` refresh so conflicting new facts can `supersede`, `merge`, or be treated as `noise`.
- Keep adjudication off the `brain_entity` read path; `entity_lookup` refreshes with `adjudicate_corrections=False` and filters evidence that only supports judged-superseded facts.
- Add mocked-Gemini unit tests plus a skipped-by-default `@pytest.mark.live` real Gemini smoke test.

## Test plan
- `pytest tests/test_correction_judge.py -q` → `3 passed, 1 skipped`
- `pytest tests/test_entity_fact_correction_judge.py -q` → `3 passed`
- `pytest tests/test_phase3_digest.py -q` → `29 passed`
- `pytest tests/test_kg_schema.py -q` → `47 passed`
- `ruff check src/brainlayer/correction_judge.py src/brainlayer/kg_repo.py src/brainlayer/pipeline/digest.py tests/test_correction_judge.py tests/test_entity_fact_correction_judge.py` → `All checks passed!`

## Functional acceptance receipt
Mock judge seeded stale `BrainLayer uses ChromaDB.` plus correction `BrainLayer uses sqlite-vec.`; refresh superseded stale row and `_brain_entity("BrainLayer")` rendered only the sqlite-vec fact/context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entity memory correctness and depends on external Gemini calls during refresh; judge errors are swallowed so conflicts may persist silently without surfacing to callers.
> 
> **Overview**
> Adds **L0 Slice B**: an LLM **correction judge** that resolves conflicting `entity_facts` with **supersede**, **merge**, or **noise** verdicts.
> 
> New `correction_judge.py` defines a `CorrectionJudge` ABC, structured `Verdict`, `GeminiCorrectionJudge` (reuses enrichment Gemini client, rate limiter, and JSON schema), a `LocalCorrectionJudge` stub, and `get_correction_judge()` behind `BRAINLAYER_JUDGE_BACKEND`.
> 
> `refresh_entity_facts` now heuristically detects token-overlap conflicts, optionally calls the judge, applies DB updates (including merge provenance/frequency), and returns post-adjudication active facts via `get_entity_facts`. Judge and factory failures are logged and skipped. `entity_lookup` refreshes with `adjudicate_corrections=False` and drops evidence chunks that only support judged-superseded facts.
> 
> Tests cover mocked Gemini parsing, factory seam, supersede state transitions, and `_brain_entity` showing corrected facts without invoking the judge on the read path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e5b38e223ec795eaeab11352c11b0f33d233d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CorrectionJudge` interface with Gemini backend for entity fact conflict adjudication
> - Introduces [`correction_judge.py`](https://github.com/EtanHey/brainlayer/pull/409/files#diff-8f8bc2faf578eece8cfd111c1d56e782def812f88bb477fd5b2556dbe556a1a7) with a `CorrectionJudge` ABC, a `Verdict` dataclass (action: supersede/merge/noise, confidence, reasoning), and a `GeminiCorrectionJudge` that reuses the existing Gemini enrichment client and rate limiter. A `LocalCorrectionJudge` stub and `BRAINLAYER_JUDGE_BACKEND` env var are provided as a swap seam.
> - Extends `KGMixin.refresh_entity_facts` in [`kg_repo.py`](https://github.com/EtanHey/brainlayer/pull/409/files#diff-38aa7f1f4a1b009ac93ee1e2c7dfd9d6b85220b1278bb2081ac1ea006a59675b) to run LLM-judged adjudication when `adjudicate_corrections=True`: conflicting active facts are detected via token overlap, judged, and DB rows are updated with status, `superseded_by`, provenance, and time ranges accordingly.
> - Adds `KGMixin.get_superseded_entity_fact_chunk_ids` to identify chunks that exclusively support judged-superseded facts.
> - Updates [`pipeline/digest.py`](https://github.com/EtanHey/brainlayer/pull/409/files#diff-7095fa2ccad4d7bba37257e8239d677d9e6a1cca5b3b1f0a51ec8a56fd191a9a) to pass `adjudicate_corrections=False` during entity lookup and filter evidence chunks tied only to superseded facts.
> - Risk: `refresh_entity_facts` callers not passing `adjudicate_corrections=False` explicitly will get the new default behavior; the local judge backend raises `NotImplementedError` on any call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74e5b38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent conflict adjudication to resolve competing facts by superseding, merging, or discarding them.
  * Extended entity fact refresh with optional automatic conflict resolution for incoming versus existing facts.
  * Entity lookup now excludes evidence sources linked to superseded facts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/brainlayer/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->