### PR TITLE
feat: add BrainLayer maintenance routine

### DIFF
--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -20,7 +20,7 @@ Daily at 03:17 local time via `com.brainlayer.backup-daily`.
 
 Retention:
 
-Keep the latest 30 daily snapshots plus the latest snapshot for each of the latest 12 months.
+Keep the latest 7 daily snapshots. Weekly maintenance uses the same Drive API path with a 4-snapshot retention policy.
 
 ## Why This Approach
 
@@ -36,7 +36,7 @@ That mount is not present after repair, and `/Applications/Google Drive.app` is 
 
 Repo files:
 
-- `src/brainlayer/backup_daily.py`: creates the SQLite backup, gzips it, uploads it to Drive, and prunes retention.
+- `src/brainlayer/backup_daily.py`: creates the SQLite backup, gzips it, uploads it to Drive, verifies the uploaded file, removes the local staging copy, and prunes retention.
 - `scripts/launchd/backup-daily.sh`: launchd wrapper installed to `~/.local/lib/brainlayer/backup-daily.sh`.
 - `scripts/launchd/com.brainlayer.backup-daily.plist`: LaunchAgent template.
 - `scripts/launchd/install.sh backup`: installs the wrapper and LaunchAgent.

--- a/scripts/launchd/com.brainlayer.maintenance-nightly.plist
+++ b/scripts/launchd/com.brainlayer.maintenance-nightly.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.brainlayer.maintenance-nightly</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__PYTHON_BIN__</string>
+		<string>__REPO_ROOT__/scripts/maintenance/brainlayer_maintenance.py</string>
+		<string>--light</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>4</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/maintenance-nightly.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/maintenance-nightly.err.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+		<key>PYTHONUNBUFFERED</key>
+		<string>1</string>
+		<key>BRAINLAYER_REPO_ROOT</key>
+		<string>__BRAINLAYER_DIR__</string>
+	</dict>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>ExitTimeOut</key>
+	<integer>1800</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>SoftResourceLimits</key>
+	<dict>
+		<key>NumberOfFiles</key>
+		<integer>4096</integer>
+	</dict>
+</dict>
+</plist>

--- a/scripts/launchd/com.brainlayer.maintenance-weekly.plist
+++ b/scripts/launchd/com.brainlayer.maintenance-weekly.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.brainlayer.maintenance-weekly</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__PYTHON_BIN__</string>
+		<string>__REPO_ROOT__/scripts/maintenance/brainlayer_maintenance.py</string>
+		<string>--full</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Weekday</key>
+		<integer>0</integer>
+		<key>Hour</key>
+		<integer>4</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/maintenance-weekly.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/maintenance-weekly.err.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+		<key>PYTHONUNBUFFERED</key>
+		<string>1</string>
+		<key>BRAINLAYER_REPO_ROOT</key>
+		<string>__BRAINLAYER_DIR__</string>
+	</dict>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>ExitTimeOut</key>
+	<integer>7200</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>SoftResourceLimits</key>
+	<dict>
+		<key>NumberOfFiles</key>
+		<integer>4096</integer>
+	</dict>
+</dict>
+</plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -13,6 +13,7 @@
 #   ./scripts/launchd/install.sh checkpoint   # Install WAL checkpoint only
 #   ./scripts/launchd/install.sh repair-fts   # Install weekly explicit FTS repair
 #   ./scripts/launchd/install.sh backup       # Install daily DB backup only
+#   ./scripts/launchd/install.sh maintenance  # Install recurring maintenance jobs
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
 set -euo pipefail
 
@@ -173,6 +174,16 @@ case "${1:-all}" in
         install_backup_script
         install_plist backup-daily
         ;;
+    maintenance-nightly)
+        install_plist maintenance-nightly
+        ;;
+    maintenance-weekly)
+        install_plist maintenance-weekly
+        ;;
+    maintenance)
+        install_plist maintenance-nightly
+        install_plist maintenance-weekly
+        ;;
     all)
         install_plist index
         install_plist drain
@@ -183,6 +194,8 @@ case "${1:-all}" in
         install_plist repair-fts
         install_backup_script
         install_plist backup-daily
+        install_plist maintenance-nightly
+        install_plist maintenance-weekly
         # Remove old enrich plist if present
         remove_plist enrich 2>/dev/null || true
         ;;
@@ -196,10 +209,12 @@ case "${1:-all}" in
         remove_plist wal-checkpoint
         remove_plist repair-fts 2>/dev/null || true
         remove_plist backup-daily 2>/dev/null || true
+        remove_plist maintenance-nightly 2>/dev/null || true
+        remove_plist maintenance-weekly 2>/dev/null || true
         rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
         ;;
     *)
-        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|repair-fts|load [name]|unload [name]|checkpoint|backup|all|remove]"
+        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|repair-fts|load [name]|unload [name]|checkpoint|backup|maintenance|maintenance-nightly|maintenance-weekly|all|remove]"
         exit 1
         ;;
 esac

--- a/scripts/maintenance/brainlayer_maintenance.py
+++ b/scripts/maintenance/brainlayer_maintenance.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Launchd-safe wrapper for BrainLayer recurring maintenance."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from brainlayer.maintenance import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -19,6 +19,7 @@ import sqlite3
 import tempfile
 import time
 import traceback
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,21 @@ DEFAULT_BRAINBAR_SOCKET_PATH = "/tmp/brainbar.sock"
 BACKUP_TIMEOUT_ENV = "BRAINLAYER_BACKUP_TIMEOUT_SECONDS"
 DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
 DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
+DEFAULT_DAILY_KEEP = 7
+DEFAULT_WEEKLY_KEEP = 4
+
+
+@dataclass(frozen=True)
+class DriveRetentionPolicy:
+    keep_latest: int
+
+    def __post_init__(self) -> None:
+        if self.keep_latest < 1:
+            raise ValueError("keep_latest must be at least 1")
+
+
+DAILY_RETENTION = DriveRetentionPolicy(keep_latest=DEFAULT_DAILY_KEEP)
+WEEKLY_RETENTION = DriveRetentionPolicy(keep_latest=DEFAULT_WEEKLY_KEEP)
 
 
 def _today() -> str:
@@ -333,8 +349,28 @@ def _parse_snapshot_date(name: str) -> dt.date | None:
         return None
 
 
-def prune_drive_backups(service: Any, folder_parts: list[str] = DEFAULT_FOLDER_PARTS) -> list[str]:
-    """Keep 30 latest daily snapshots plus latest snapshot for each of 12 months."""
+def verify_drive_upload(service: Any, *, file_id: str, expected_name: str, expected_size: int) -> None:
+    """Verify that Drive can see the uploaded file with the expected name and byte size."""
+    metadata = service.files().get(fileId=file_id, fields="id,name,size,trashed", supportsAllDrives=True).execute()
+    if metadata.get("trashed"):
+        raise RuntimeError(f"Uploaded Drive backup is trashed: {file_id}")
+    if metadata.get("name") != expected_name:
+        raise RuntimeError(f"Uploaded Drive backup name mismatch: {metadata.get('name')!r} != {expected_name!r}")
+    try:
+        actual_size = int(metadata.get("size", -1))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"Uploaded Drive backup size is not numeric: {metadata.get('size')!r}") from exc
+    if actual_size != expected_size:
+        raise RuntimeError(f"Uploaded Drive backup size mismatch: {actual_size} != {expected_size}")
+
+
+def prune_drive_backups(
+    service: Any,
+    *,
+    folder_parts: list[str] = DEFAULT_FOLDER_PARTS,
+    retention_policy: DriveRetentionPolicy = DAILY_RETENTION,
+) -> list[str]:
+    """Keep only the latest N verified snapshots in the Drive backup folder."""
     folder_id = ensure_drive_folder_chain(service, folder_parts)
     files: list[dict[str, str]] = []
     page_token = None
@@ -362,17 +398,7 @@ def prune_drive_backups(service: Any, folder_parts: list[str] = DEFAULT_FOLDER_P
             dated.append((parsed, item))
 
     dated.sort(key=lambda pair: pair[0], reverse=True)
-    keep_ids = {item["id"] for _, item in dated[:30]}
-
-    months_seen: set[tuple[int, int]] = set()
-    for snapshot_date, item in dated:
-        month = (snapshot_date.year, snapshot_date.month)
-        if month in months_seen:
-            continue
-        if len(months_seen) >= 12:
-            continue
-        months_seen.add(month)
-        keep_ids.add(item["id"])
+    keep_ids = {item["id"] for _, item in dated[: retention_policy.keep_latest]}
 
     deleted: list[str] = []
     for _, item in dated:
@@ -389,20 +415,40 @@ def run_backup(
     folder_parts: list[str] = DEFAULT_FOLDER_PARTS,
     date_stamp: str | None = None,
     upload: bool = True,
+    retention_policy: DriveRetentionPolicy = DAILY_RETENTION,
+    remove_local_after_upload: bool = True,
 ) -> dict[str, Any]:
     snapshot = create_sqlite_backup_gzip(db_path or get_db_path(), staging_dir, date_stamp=date_stamp)
+    snapshot_size = snapshot.stat().st_size
     result: dict[str, Any] = {
         "db": str(db_path or get_db_path()),
         "snapshot": str(snapshot),
-        "bytes": snapshot.stat().st_size,
+        "bytes": snapshot_size,
         "uploaded": False,
+        "local_removed": False,
     }
     if upload:
         credentials = get_drive_credentials()
         service = build_drive_service()
         folder_id = ensure_drive_folder_chain(service, folder_parts)
         uploaded = upload_file_to_drive_raw(snapshot, folder_id, credentials)
-        deleted = prune_drive_backups(service, folder_parts=folder_parts)
+        file_id = uploaded.get("id")
+        if not file_id:
+            raise RuntimeError(f"Drive upload response missing file id: {uploaded!r}")
+        verify_drive_upload(
+            service,
+            file_id=file_id,
+            expected_name=snapshot.name,
+            expected_size=snapshot_size,
+        )
+        if remove_local_after_upload:
+            snapshot.unlink()
+            result["local_removed"] = True
+        deleted = prune_drive_backups(
+            service,
+            folder_parts=folder_parts,
+            retention_policy=retention_policy,
+        )
         result.update({"uploaded": True, "drive_file": uploaded, "retention_deleted": deleted})
     return result
 

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -10,7 +10,7 @@ import logging
 import os
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_DRAIN_BUSY_TIMEOUT_MS = 30000
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _DEFAULT_MAX_EVENTS_PER_TRANSACTION = 5
+_DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION = 5000
 _DEFAULT_POST_COMMIT_YIELD_MS = 10.0
 # The post-commit WAL checkpoint is best-effort. Bound how long TRUNCATE may wait
 # on readers so a pinned reader can't stall every other writer for the full drain
@@ -93,6 +94,16 @@ def _post_commit_yield_seconds() -> float:
 class ApplyResult:
     chunk_id: str | None = None
     collision_chunk_id: str | None = None
+
+
+@dataclass
+class BurnDrainResult:
+    scanned_files: int = 0
+    applied_events: int = 0
+    skipped_verified_stale: int = 0
+    files_deleted: int = 0
+    failed_files: int = 0
+    checkpoints: int = 0
 
 
 def _default_db_path() -> Path:
@@ -567,6 +578,172 @@ def _rewrite_events_file(path: Path, events: list[dict[str, Any]]) -> None:
     tmp_path.replace(path)
 
 
+def _select_burn_batch(
+    files: list[Path], max_events_per_transaction: int
+) -> tuple[list[tuple[Path, list[dict[str, Any]]]], int]:
+    selected: list[tuple[Path, list[dict[str, Any]]]] = []
+    scanned = 0
+    event_count = 0
+    for path in files:
+        scanned += 1
+        try:
+            events = _read_events(path)
+        except (UnicodeDecodeError, OSError) as exc:
+            raise RuntimeError(f"failed to read queue file {path.name}: {exc}") from exc
+        if not events:
+            selected.append((path, []))
+            continue
+        if selected and event_count + len(events) > max_events_per_transaction:
+            break
+        selected.append((path, events))
+        event_count += len(events)
+        if event_count >= max_events_per_transaction:
+            break
+    return selected, scanned
+
+
+def _prefetch_enrichment_state(
+    conn: apsw.Connection, events: list[dict[str, Any]]
+) -> dict[str, tuple[str | None, str | None, str | None]]:
+    cols = _columns(conn, "chunks")
+    if not {"content_hash", "enrich_status", "enriched_at"}.issubset(cols):
+        return {}
+    chunk_ids = sorted(
+        {
+            str(event.get("chunk_id"))
+            for event in events
+            if _event_payload(event).get("kind") == "enrichment_update" and event.get("chunk_id")
+        }
+    )
+    if not chunk_ids:
+        return {}
+    placeholders = ", ".join("?" for _ in chunk_ids)
+    rows = conn.execute(
+        f"SELECT id, content_hash, enrich_status, enriched_at FROM chunks WHERE id IN ({placeholders})",
+        chunk_ids,
+    )
+    return {str(row[0]): (row[1], row[2], row[3]) for row in rows}
+
+
+def _already_enriched(enrich_status: str | None, enriched_at: str | None) -> bool:
+    return enrich_status == "success" or bool(enriched_at)
+
+
+def _is_verified_redundant_enrichment(
+    event: dict[str, Any],
+    prefetched_state: dict[str, tuple[str | None, str | None, str | None]],
+) -> bool:
+    payload = _event_payload(event)
+    if payload.get("kind") != "enrichment_update":
+        return False
+    chunk_id = payload.get("chunk_id")
+    expected_hash = payload.get("content_hash")
+    if not chunk_id or not expected_hash:
+        return False
+    state = prefetched_state.get(str(chunk_id))
+    if state is None:
+        return False
+    content_hash, enrich_status, enriched_at = state
+    return content_hash == expected_hash and _already_enriched(enrich_status, enriched_at)
+
+
+def burn_drain_once(
+    *,
+    db_path: Path | None = None,
+    queue_dir: Path | None = None,
+    batch_size: int = 5000,
+    max_events_per_transaction: int = _DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION,
+    log_path: Path | None = None,
+    embed_fn: Callable[[str], list[float]] | None = None,
+) -> BurnDrainResult:
+    """Drain a large queue backlog with one writer and one commit per large batch.
+
+    Queue files are unlinked only after the transaction commits. Verified redundant
+    enrichment updates are skipped inside the same committed batch so old queue
+    files can be safely removed without reapplying stale work.
+    """
+    db_path = db_path or _default_db_path()
+    queue_dir = queue_dir or _default_queue_dir()
+    log_path = log_path or _default_log_path()
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    max_events_per_transaction = max(1, max_events_per_transaction)
+
+    result = BurnDrainResult()
+    lock_fd = _acquire_queue_lock(queue_dir)
+    try:
+        files = sorted(queue_dir.glob("*.jsonl"), key=lambda path: (path.name.startswith("enrichment-"), path.name))[
+            :batch_size
+        ]
+        if not files:
+            return result
+        try:
+            batch, scanned = _select_burn_batch(files, max_events_per_transaction)
+        except RuntimeError as exc:
+            _log(log_path, f"burn drain failed before transaction: {exc}")
+            result.failed_files = 1
+            return result
+        result.scanned_files = scanned
+        if not batch:
+            return result
+
+        all_events = [event for _, events in batch for event in events]
+        conn = _open_connection(db_path)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            prefetched_state = _prefetch_enrichment_state(conn, all_events)
+            store_chunk_ids: list[str] = []
+            for _, events in batch:
+                for event in events:
+                    if _is_verified_redundant_enrichment(event, prefetched_state):
+                        result.skipped_verified_stale += 1
+                        continue
+                    applied = _apply_event(conn, event)
+                    result.applied_events += 1
+                    if applied.chunk_id:
+                        store_chunk_ids.append(applied.chunk_id)
+            if _embedding_enabled():
+                _embed_store_chunks(conn, store_chunk_ids, embed_fn)
+            conn.execute("COMMIT")
+            conn.setbusytimeout(_checkpoint_busy_timeout_ms())
+            try:
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                result.checkpoints += 1
+            except apsw.Error as exc:
+                _log(log_path, f"burn drain checkpoint skipped: {exc}")
+            finally:
+                conn.setbusytimeout(_drain_busy_timeout_ms())
+        except Exception as exc:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            result.failed_files = len(batch)
+            _log(log_path, f"burn drain failed; batch preserved: {exc}")
+            return result
+        finally:
+            conn.close()
+
+        for path, _events in batch:
+            try:
+                path.unlink()
+                result.files_deleted += 1
+            except FileNotFoundError:
+                result.files_deleted += 1
+            except OSError as exc:
+                _log(log_path, f"burn drain committed but could not unlink {path}: {exc}")
+        if result.applied_events or result.skipped_verified_stale:
+            _log(
+                log_path,
+                "burn drained="
+                f"{result.applied_events} skipped_verified_stale={result.skipped_verified_stale} "
+                f"files_deleted={result.files_deleted}",
+            )
+        return result
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
 def drain_once(
     *,
     db_path: Path | None = None,
@@ -686,9 +863,24 @@ def main() -> int:
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--once", action="store_true")
+    parser.add_argument("--burn", action="store_true")
     parser.add_argument("--interval", type=float, default=0.5)
     parser.add_argument("--batch-size", type=int, default=250)
+    parser.add_argument("--max-events-per-transaction", type=int, default=_DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION)
     args = parser.parse_args()
+    if args.burn:
+        print(
+            json.dumps(
+                asdict(
+                    burn_drain_once(
+                        batch_size=args.batch_size,
+                        max_events_per_transaction=args.max_events_per_transaction,
+                    )
+                ),
+                sort_keys=True,
+            )
+        )
+        return 0
     if args.once:
         print(drain_once(batch_size=args.batch_size))
         return 0

--- a/src/brainlayer/maintenance.py
+++ b/src/brainlayer/maintenance.py
@@ -1,0 +1,565 @@
+"""Safety-gated recurring maintenance for the local BrainLayer database."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import plistlib
+import sqlite3
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import apsw
+
+from .backup_daily import WEEKLY_RETENTION, run_backup
+from .drain import BurnDrainResult, burn_drain_once
+from .paths import get_db_path
+from .queue_io import get_queue_dir
+from .wal_checkpoint import checkpoint
+
+MAINTENANCE_DATASET = "brainlayer-maintenance"
+DEFAULT_SERVICES = ("watch", "enrichment", "index", "drain")
+REFEED_SERVICES = ("watch", "enrichment", "index")
+EXPECTED_WRITER_PATTERNS = (
+    "BrainBar",
+    "brainlayer watch",
+    "brainlayer enrich",
+    "brainlayer index",
+    "drain_daemon.py",
+    "com.brainlayer.",
+)
+
+
+class MaintenanceAbort(RuntimeError):
+    def __init__(self, reason: str, *, code: int = 75) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.code = code
+
+
+@dataclass(frozen=True)
+class LsofEntry:
+    pid: int
+    command: str
+    fd: str
+    path: str
+
+
+@dataclass
+class StaleQueueResult:
+    scanned_files: int = 0
+    candidate_files: int = 0
+    quarantined_files: int = 0
+    kept_files: int = 0
+    invalid_files: int = 0
+    dry_run: bool = False
+    quarantine_dir: str | None = None
+
+
+@dataclass
+class MaintenanceResult:
+    mode: str
+    dry_run: bool
+    stale_queue: StaleQueueResult = field(default_factory=StaleQueueResult)
+    burn: BurnDrainResult | None = None
+    checkpoint: tuple[int, int, int] | None = None
+    db_before_bytes: int | None = None
+    db_after_bytes: int | None = None
+    queue_before_files: int | None = None
+    queue_after_files: int | None = None
+    data_dir_before_bytes: int | None = None
+    data_dir_after_bytes: int | None = None
+    search_latency_ms: float | None = None
+    vacuum_before_bytes: int | None = None
+    vacuum_after_bytes: int | None = None
+    actions: list[str] = field(default_factory=list)
+
+
+@dataclass
+class MaintenanceConfig:
+    db_path: Path = field(default_factory=get_db_path)
+    queue_dir: Path = field(default_factory=get_queue_dir)
+    quarantine_root: Path = field(default_factory=lambda: Path.home() / ".brainlayer" / "quarantine" / "stale-queue")
+    log_path: Path = field(
+        default_factory=lambda: Path.home() / ".local" / "share" / "brainlayer" / "logs" / "maintenance.log"
+    )
+    repo_root: Path = field(default_factory=lambda: Path(os.environ.get("BRAINLAYER_REPO_ROOT", Path.cwd())))
+    now_fn: Callable[[], dt.datetime] = field(default_factory=lambda: lambda: dt.datetime.now().astimezone())
+    quiet_window_start_hour: int = 4
+    quiet_window_duration_minutes: int = 120
+    idle_sample_seconds: float = 5.0
+    recent_write_grace_seconds: float = 180.0
+    expected_writer_patterns: Sequence[str] = EXPECTED_WRITER_PATTERNS
+
+
+def run_command(args: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), text=True, capture_output=True, check=check)
+
+
+def _write_log(path: Path, event: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"ts": dt.datetime.now(dt.UTC).isoformat(), **event}
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _emit_telemetry(event: dict[str, Any]) -> None:
+    try:
+        from .telemetry import emit
+
+        emit(MAINTENANCE_DATASET, event)
+    except Exception:
+        return
+
+
+def _minutes_since_midnight(now: dt.datetime) -> int:
+    return now.hour * 60 + now.minute
+
+
+def _check_quiet_window(config: MaintenanceConfig) -> None:
+    now = config.now_fn()
+    start = config.quiet_window_start_hour * 60
+    end = (start + config.quiet_window_duration_minutes) % (24 * 60)
+    current = _minutes_since_midnight(now)
+    if start <= end:
+        in_window = start <= current < end
+    else:
+        in_window = current >= start or current < end
+    if not in_window:
+        raise MaintenanceAbort(
+            f"outside quiet window: now={now.isoformat()} start_hour={config.quiet_window_start_hour} "
+            f"duration_minutes={config.quiet_window_duration_minutes}"
+        )
+
+
+def _queue_files(queue_dir: Path) -> list[Path]:
+    if not queue_dir.exists():
+        return []
+    return sorted(queue_dir.glob("*.jsonl"))
+
+
+def _check_idle(config: MaintenanceConfig) -> None:
+    files_before = _queue_files(config.queue_dir)
+    if config.recent_write_grace_seconds > 0:
+        now_ts = config.now_fn().timestamp()
+        recent = [
+            path
+            for path in files_before
+            if path.exists() and now_ts - path.stat().st_mtime < config.recent_write_grace_seconds
+        ]
+        if recent:
+            raise MaintenanceAbort(f"recent queue write activity: {len(recent)} file(s) modified recently")
+
+    if config.idle_sample_seconds > 0:
+        before = len(files_before)
+        time.sleep(config.idle_sample_seconds)
+        after = len(_queue_files(config.queue_dir))
+        if after > before:
+            raise MaintenanceAbort(f"queue depth growing: before={before} after={after}")
+
+
+def _process_command_line(pid: int) -> str | None:
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    command = result.stdout.strip()
+    return command or None
+
+
+def collect_lsof_entries(paths: Sequence[Path]) -> list[LsofEntry]:
+    existing = [str(path) for path in paths if path.exists()]
+    if not existing:
+        return []
+    try:
+        result = subprocess.run(
+            ["lsof", "-F", "pcfn", "--", *existing],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise MaintenanceAbort("lsof not found; cannot prove database writer cleanliness") from exc
+    if result.returncode not in {0, 1}:
+        raise MaintenanceAbort(f"lsof failed: {result.stderr.strip()}")
+
+    entries: list[LsofEntry] = []
+    pid: int | None = None
+    command = ""
+    fd = ""
+    ps_cache: dict[int, str | None] = {}
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        kind, value = line[0], line[1:]
+        if kind == "p":
+            try:
+                pid = int(value)
+            except ValueError:
+                pid = None
+            command = ""
+            fd = ""
+        elif kind == "c":
+            command = value
+        elif kind == "f":
+            fd = value
+        elif kind == "n" and pid is not None:
+            if pid not in ps_cache:
+                ps_cache[pid] = _process_command_line(pid)
+            full_command = ps_cache[pid] or command
+            entries.append(LsofEntry(pid=pid, command=full_command, fd=fd, path=value))
+    return entries
+
+
+def _is_write_fd(fd: str) -> bool:
+    return "w" in fd or "u" in fd
+
+
+def _is_expected_writer(entry: LsofEntry, patterns: Sequence[str]) -> bool:
+    haystack = f"{entry.command} {entry.path}"
+    return any(pattern in haystack for pattern in patterns)
+
+
+def _check_lsof_clean(config: MaintenanceConfig) -> None:
+    paths = [config.db_path, Path(f"{config.db_path}-wal"), Path(f"{config.db_path}-shm")]
+    entries = collect_lsof_entries(paths)
+    unexpected = [
+        entry
+        for entry in entries
+        if _is_write_fd(entry.fd) and not _is_expected_writer(entry, config.expected_writer_patterns)
+    ]
+    if unexpected:
+        details = ", ".join(f"pid={entry.pid} command={entry.command!r} fd={entry.fd}" for entry in unexpected)
+        raise MaintenanceAbort(f"unexpected writer holds BrainLayer DB: {details}")
+
+
+def _read_queue_events(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if not isinstance(value, dict):
+            raise ValueError(f"non-object queue event in {path.name}")
+        events.append(value)
+    return events
+
+
+def _event_kind(event: dict[str, Any]) -> str:
+    return str(event.get("kind") or "")
+
+
+def _already_enriched(enrich_status: str | None, enriched_at: str | None) -> bool:
+    return enrich_status == "success" or bool(enriched_at)
+
+
+def _chunk_states(
+    conn: apsw.Connection, chunk_ids: Sequence[str]
+) -> dict[str, tuple[str | None, str | None, str | None]]:
+    if not chunk_ids:
+        return {}
+    placeholders = ", ".join("?" for _ in chunk_ids)
+    rows = conn.execute(
+        f"SELECT id, content_hash, enrich_status, enriched_at FROM chunks WHERE id IN ({placeholders})",
+        list(chunk_ids),
+    )
+    return {str(row[0]): (row[1], row[2], row[3]) for row in rows}
+
+
+def _file_is_redundant_enrichment(conn: apsw.Connection, events: list[dict[str, Any]]) -> bool:
+    if not events or any(_event_kind(event) != "enrichment_update" for event in events):
+        return False
+    chunk_ids = [str(event.get("chunk_id")) for event in events if event.get("chunk_id")]
+    if len(chunk_ids) != len(events):
+        return False
+    states = _chunk_states(conn, chunk_ids)
+    for event in events:
+        chunk_id = str(event["chunk_id"])
+        expected_hash = event.get("content_hash")
+        if not expected_hash:
+            return False
+        state = states.get(chunk_id)
+        if state is None:
+            return False
+        content_hash, enrich_status, enriched_at = state
+        if content_hash != expected_hash or not _already_enriched(enrich_status, enriched_at):
+            return False
+    return True
+
+
+def quarantine_stale_queue_files(
+    *,
+    db_path: Path,
+    queue_dir: Path,
+    quarantine_root: Path,
+    dry_run: bool,
+    now: dt.datetime | None = None,
+) -> StaleQueueResult:
+    result = StaleQueueResult(dry_run=dry_run)
+    files = _queue_files(queue_dir)
+    result.scanned_files = len(files)
+    if not files:
+        return result
+
+    stamp = (now or dt.datetime.now(dt.UTC)).strftime("%Y%m%d-%H%M%S")
+    quarantine_dir = quarantine_root / stamp
+    result.quarantine_dir = str(quarantine_dir)
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        for path in files:
+            try:
+                events = _read_queue_events(path)
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+                result.invalid_files += 1
+                result.kept_files += 1
+                continue
+            if not _file_is_redundant_enrichment(conn, events):
+                result.kept_files += 1
+                continue
+            result.candidate_files += 1
+            if dry_run:
+                continue
+            quarantine_dir.mkdir(parents=True, exist_ok=True)
+            target = quarantine_dir / path.name
+            counter = 1
+            while target.exists():
+                target = quarantine_dir / f"{path.stem}.{counter}{path.suffix}"
+                counter += 1
+            path.replace(target)
+            result.quarantined_files += 1
+    finally:
+        conn.close()
+    return result
+
+
+def _launchd_label(service: str) -> str:
+    return f"com.brainlayer.{service}"
+
+
+def _bootout_service(service: str) -> None:
+    run_command(["launchctl", "bootout", f"gui/{os.getuid()}/{_launchd_label(service)}"], check=False)
+
+
+def _verify_enrichment_template_flex_backend(repo_root: Path) -> None:
+    plist_path = repo_root / "scripts/launchd/com.brainlayer.enrichment.plist"
+    with plist_path.open("rb") as handle:
+        plist = plistlib.load(handle)
+    env = plist.get("EnvironmentVariables") or {}
+    if env.get("BRAINLAYER_GEMINI_SERVICE_TIER") != "flex":
+        raise MaintenanceAbort("enrichment launchd template no longer uses Gemini Flex backend")
+
+
+def _resume_service(repo_root: Path, service: str) -> None:
+    if service == "enrichment":
+        _verify_enrichment_template_flex_backend(repo_root)
+    run_command([str(repo_root / "scripts/launchd/install.sh"), service], check=True)
+
+
+def _quiesce_services(services: Sequence[str]) -> None:
+    for service in services:
+        _bootout_service(service)
+
+
+def _resume_services(repo_root: Path, services: Sequence[str]) -> None:
+    for service in services:
+        _resume_service(repo_root, service)
+
+
+def _checkpoint_full(db_path: Path) -> tuple[int, int, int]:
+    return checkpoint(str(db_path), "FULL")
+
+
+def _file_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _directory_size(path: Path) -> int:
+    if not path.exists():
+        return 0
+    total = 0
+    for child in path.rglob("*"):
+        if child.is_file():
+            total += _file_size(child)
+    return total
+
+
+def _verify_search_latency(db_path: Path, *, threshold_ms: float = 50.0) -> float | None:
+    if not db_path.exists():
+        return None
+    started = time.perf_counter()
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1)
+    try:
+        has_fts = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'chunks_fts' LIMIT 1"
+        ).fetchone()
+        if has_fts:
+            conn.execute("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? LIMIT 1", ("brainlayer",)).fetchall()
+        else:
+            conn.execute("SELECT id FROM chunks LIMIT 1").fetchall()
+    finally:
+        conn.close()
+    latency_ms = (time.perf_counter() - started) * 1000
+    if latency_ms > threshold_ms:
+        raise MaintenanceAbort(f"post-maintenance search latency too high: {latency_ms:.1f}ms > {threshold_ms:.1f}ms")
+    return latency_ms
+
+
+def _vacuum(db_path: Path) -> tuple[int, int]:
+    before = db_path.stat().st_size
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("VACUUM")
+    finally:
+        conn.close()
+    return before, db_path.stat().st_size
+
+
+def _run_burn_until_empty(config: MaintenanceConfig, *, max_batches: int = 1000) -> BurnDrainResult:
+    total = BurnDrainResult()
+    for _ in range(max_batches):
+        batch = burn_drain_once(
+            db_path=config.db_path, queue_dir=config.queue_dir, batch_size=5000, log_path=config.log_path
+        )
+        total.scanned_files += batch.scanned_files
+        total.applied_events += batch.applied_events
+        total.skipped_verified_stale += batch.skipped_verified_stale
+        total.files_deleted += batch.files_deleted
+        total.failed_files += batch.failed_files
+        total.checkpoints += batch.checkpoints
+        if batch.failed_files or batch.files_deleted == 0:
+            break
+    return total
+
+
+def _run_gates(config: MaintenanceConfig) -> None:
+    _check_quiet_window(config)
+    _check_idle(config)
+    _check_lsof_clean(config)
+
+
+def run_maintenance(mode: str, *, config: MaintenanceConfig | None = None, dry_run: bool = False) -> MaintenanceResult:
+    if mode not in {"light", "full", "burn"}:
+        raise ValueError(f"unsupported maintenance mode: {mode}")
+    config = config or MaintenanceConfig()
+    _run_gates(config)
+
+    result = MaintenanceResult(mode=mode, dry_run=dry_run)
+    result.db_before_bytes = _file_size(config.db_path)
+    result.queue_before_files = len(_queue_files(config.queue_dir))
+    result.data_dir_before_bytes = _directory_size(config.db_path.parent)
+    result.stale_queue = quarantine_stale_queue_files(
+        db_path=config.db_path,
+        queue_dir=config.queue_dir,
+        quarantine_root=config.quarantine_root,
+        dry_run=True if dry_run else False,
+        now=config.now_fn(),
+    )
+    if dry_run:
+        result.actions.append(f"would run {mode} maintenance")
+        _write_log(config.log_path, {"mode": mode, "dry_run": True, "stale_queue": asdict(result.stale_queue)})
+        return result
+
+    services = DEFAULT_SERVICES
+    if mode == "burn":
+        services = (*REFEED_SERVICES, "drain")
+    _quiesce_services(services)
+    try:
+        result.checkpoint = _checkpoint_full(config.db_path)
+        if mode == "full":
+            backup = run_backup(retention_policy=WEEKLY_RETENTION)
+            result.actions.append(f"verified_drive_backup={backup.get('drive_file', {}).get('id')}")
+            result.vacuum_before_bytes, result.vacuum_after_bytes = _vacuum(config.db_path)
+            result.checkpoint = _checkpoint_full(config.db_path)
+        if mode == "burn":
+            result.burn = _run_burn_until_empty(config)
+            if result.burn.failed_files:
+                raise MaintenanceAbort("burn drain failed; queue files preserved")
+        else:
+            result.stale_queue = quarantine_stale_queue_files(
+                db_path=config.db_path,
+                queue_dir=config.queue_dir,
+                quarantine_root=config.quarantine_root,
+                dry_run=False,
+                now=config.now_fn(),
+            )
+    finally:
+        _resume_services(config.repo_root, services)
+
+    result.db_after_bytes = _file_size(config.db_path)
+    result.queue_after_files = len(_queue_files(config.queue_dir))
+    result.data_dir_after_bytes = _directory_size(config.db_path.parent)
+    result.search_latency_ms = _verify_search_latency(config.db_path)
+    event = {
+        "mode": mode,
+        "dry_run": False,
+        "stale_queue": asdict(result.stale_queue),
+        "burn": asdict(result.burn) if result.burn else None,
+        "checkpoint": result.checkpoint,
+        "db_before_bytes": result.db_before_bytes,
+        "db_after_bytes": result.db_after_bytes,
+        "queue_before_files": result.queue_before_files,
+        "queue_after_files": result.queue_after_files,
+        "data_dir_before_bytes": result.data_dir_before_bytes,
+        "data_dir_after_bytes": result.data_dir_after_bytes,
+        "search_latency_ms": result.search_latency_ms,
+        "vacuum_before_bytes": result.vacuum_before_bytes,
+        "vacuum_after_bytes": result.vacuum_after_bytes,
+    }
+    _write_log(config.log_path, event)
+    _emit_telemetry(event)
+    return result
+
+
+def _result_to_dict(result: MaintenanceResult) -> dict[str, Any]:
+    return {
+        "mode": result.mode,
+        "dry_run": result.dry_run,
+        "stale_queue": asdict(result.stale_queue),
+        "burn": asdict(result.burn) if result.burn else None,
+        "checkpoint": result.checkpoint,
+        "db_before_bytes": result.db_before_bytes,
+        "db_after_bytes": result.db_after_bytes,
+        "queue_before_files": result.queue_before_files,
+        "queue_after_files": result.queue_after_files,
+        "data_dir_before_bytes": result.data_dir_before_bytes,
+        "data_dir_after_bytes": result.data_dir_after_bytes,
+        "search_latency_ms": result.search_latency_ms,
+        "vacuum_before_bytes": result.vacuum_before_bytes,
+        "vacuum_after_bytes": result.vacuum_after_bytes,
+        "actions": result.actions,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run safety-gated BrainLayer maintenance.")
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--light", action="store_true", help="Run the nightly light pass")
+    modes.add_argument("--full", action="store_true", help="Run the weekly full pass")
+    modes.add_argument("--burn", action="store_true", help="Run the single-writer bulk queue drain")
+    parser.add_argument("--dry-run", action="store_true", help="Run gates and report actions without touching state")
+    args = parser.parse_args(argv)
+    mode = "full" if args.full else "burn" if args.burn else "light"
+    try:
+        result = run_maintenance(mode, dry_run=args.dry_run)
+    except MaintenanceAbort as exc:
+        print(json.dumps({"status": "aborted", "reason": exc.reason}, sort_keys=True), flush=True)
+        return exc.code
+    print(json.dumps({"status": "ok", **_result_to_dict(result)}, sort_keys=True), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -168,6 +168,104 @@ def test_ensure_drive_folder_chain_creates_missing_folders():
     assert ("brainlayer-db", "folder-backups") in service.files().created
 
 
+def test_run_backup_verifies_upload_removes_local_and_rotates_last_n(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    snapshot = tmp_path / "2026-05-30.db.gz"
+    snapshot.write_bytes(b"backup-bytes")
+    verified: list[tuple[str, str, int]] = []
+    pruned: list[backup_daily.DriveRetentionPolicy] = []
+
+    monkeypatch.setattr(backup_daily, "create_sqlite_backup_gzip", lambda *args, **kwargs: snapshot)
+    monkeypatch.setattr(backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id")
+    monkeypatch.setattr(
+        backup_daily,
+        "upload_file_to_drive_raw",
+        lambda file_path, folder_id, credentials: {
+            "id": "drive-file-id",
+            "name": Path(file_path).name,
+            "size": str(Path(file_path).stat().st_size),
+        },
+    )
+
+    def fake_verify(service, *, file_id: str, expected_name: str, expected_size: int) -> None:  # noqa: ARG001
+        verified.append((file_id, expected_name, expected_size))
+
+    def fake_prune(service, *, folder_parts, retention_policy):  # noqa: ARG001
+        pruned.append(retention_policy)
+        return ["2026-05-01.db.gz"]
+
+    monkeypatch.setattr(backup_daily, "verify_drive_upload", fake_verify)
+    monkeypatch.setattr(backup_daily, "prune_drive_backups", fake_prune)
+
+    result = backup_daily.run_backup(
+        db_path=tmp_path / "brainlayer.db",
+        staging_dir=tmp_path,
+        date_stamp="2026-05-30",
+        upload=True,
+        retention_policy=backup_daily.DriveRetentionPolicy(keep_latest=7),
+    )
+
+    assert verified == [("drive-file-id", "2026-05-30.db.gz", len(b"backup-bytes"))]
+    assert pruned == [backup_daily.DriveRetentionPolicy(keep_latest=7)]
+    assert result["uploaded"] is True
+    assert result["local_removed"] is True
+    assert result["retention_deleted"] == ["2026-05-01.db.gz"]
+    assert not snapshot.exists()
+
+
+def test_prune_drive_backups_keeps_only_latest_n_snapshots():
+    from brainlayer.backup_daily import DriveRetentionPolicy, prune_drive_backups
+
+    class FakeExecute:
+        def __init__(self, value):
+            self.value = value
+
+        def execute(self):
+            return self.value
+
+    class FakeFiles:
+        def __init__(self):
+            self.deleted: list[str] = []
+            self.files = [{"id": f"id-{day}", "name": f"2026-05-{day:02d}.db.gz"} for day in range(1, 10)]
+
+        def list(self, **kwargs):  # noqa: ARG002
+            query = kwargs["q"]
+            if "mimeType = 'application/vnd.google-apps.folder'" in query:
+                return FakeExecute({"files": [{"id": "folder-id", "name": "brainlayer-db"}]})
+            return FakeExecute({"files": self.files})
+
+        def delete(self, fileId, **kwargs):  # noqa: N803, ARG002
+            self.deleted.append(fileId)
+            return FakeExecute({})
+
+    class FakeService:
+        def __init__(self):
+            self._files = FakeFiles()
+
+        def files(self):
+            return self._files
+
+    service = FakeService()
+
+    deleted = prune_drive_backups(
+        service,
+        folder_parts=["brainlayer-db"],
+        retention_policy=DriveRetentionPolicy(keep_latest=4),
+    )
+
+    assert deleted == [
+        "2026-05-05.db.gz",
+        "2026-05-04.db.gz",
+        "2026-05-03.db.gz",
+        "2026-05-02.db.gz",
+        "2026-05-01.db.gz",
+    ]
+    assert service.files().deleted == ["id-5", "id-4", "id-3", "id-2", "id-1"]
+
+
 def test_launchd_installer_knows_backup_target():
     install_path = Path("scripts/launchd/install.sh")
     wrapper_path = Path("scripts/launchd/backup-daily.sh")

--- a/tests/test_maintenance_routine.py
+++ b/tests/test_maintenance_routine.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import plistlib
+from pathlib import Path
+
+import apsw
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(event) + "\n" for event in events), encoding="utf-8")
+
+
+def _create_enrichment_db(path: Path) -> None:
+    conn = apsw.Connection(str(path))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE chunks (
+                id TEXT PRIMARY KEY,
+                content TEXT,
+                summary TEXT,
+                enriched_at TEXT,
+                enrich_status TEXT,
+                content_hash TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO chunks (id, content, summary, enriched_at, enrich_status, content_hash)
+            VALUES
+                ('already-done', 'same content', 'old summary', '2026-05-30T00:00:00Z', 'success', 'hash-ok'),
+                ('needs-update', 'same content', NULL, NULL, NULL, 'hash-ok'),
+                ('hash-moved', 'new content', 'old summary', '2026-05-30T00:00:00Z', 'success', 'hash-new')
+            """
+        )
+    finally:
+        conn.close()
+
+
+def _config(tmp_path: Path, *, now: dt.datetime):
+    from brainlayer.maintenance import MaintenanceConfig
+
+    return MaintenanceConfig(
+        db_path=tmp_path / "brainlayer.db",
+        queue_dir=tmp_path / "queue",
+        quarantine_root=tmp_path / "quarantine",
+        log_path=tmp_path / "maintenance.log",
+        repo_root=REPO_ROOT,
+        now_fn=lambda: now,
+        quiet_window_start_hour=4,
+        quiet_window_duration_minutes=120,
+        idle_sample_seconds=0,
+        recent_write_grace_seconds=0,
+    )
+
+
+def test_off_window_gate_aborts_before_touching_queue(tmp_path, monkeypatch):
+    from brainlayer import maintenance
+
+    config = _config(tmp_path, now=dt.datetime(2026, 5, 30, 2, 30, tzinfo=dt.timezone.utc))
+    config.queue_dir.mkdir(parents=True)
+    queued = config.queue_dir / "enrichment-stale.jsonl"
+    queued.write_text("{}\n", encoding="utf-8")
+    commands: list[list[str]] = []
+    monkeypatch.setattr(maintenance, "collect_lsof_entries", lambda _paths: [])
+    monkeypatch.setattr(maintenance, "run_command", lambda args, **_kwargs: commands.append(args))
+
+    with pytest.raises(maintenance.MaintenanceAbort, match="outside quiet window"):
+        maintenance.run_maintenance("light", config=config, dry_run=True)
+
+    assert queued.exists()
+    assert commands == []
+
+
+def test_lsof_gate_aborts_on_unexpected_writer(tmp_path, monkeypatch):
+    from brainlayer import maintenance
+
+    config = _config(tmp_path, now=dt.datetime(2026, 5, 30, 4, 5, tzinfo=dt.timezone.utc))
+    config.db_path.write_bytes(b"db")
+    config.queue_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        maintenance,
+        "collect_lsof_entries",
+        lambda _paths: [
+            maintenance.LsofEntry(pid=4242, command="python3", fd="9u", path=str(config.db_path)),
+        ],
+    )
+
+    with pytest.raises(maintenance.MaintenanceAbort, match="unexpected writer"):
+        maintenance.run_maintenance("light", config=config, dry_run=True)
+
+
+def test_recent_queue_activity_abort_message_reports_count(tmp_path, monkeypatch):
+    from brainlayer import maintenance
+
+    config = _config(tmp_path, now=dt.datetime(2026, 5, 30, 4, 5, tzinfo=dt.timezone.utc))
+    config.recent_write_grace_seconds = 300
+    config.queue_dir.mkdir(parents=True)
+    (config.queue_dir / "a.jsonl").write_text("{}\n", encoding="utf-8")
+    (config.queue_dir / "z.jsonl").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(maintenance, "collect_lsof_entries", lambda _paths: [])
+
+    with pytest.raises(maintenance.MaintenanceAbort, match=r"2 file\(s\) modified recently"):
+        maintenance.run_maintenance("light", config=config, dry_run=True)
+
+
+def test_dry_run_runs_gates_and_reports_without_moving_queue_files(tmp_path, monkeypatch):
+    from brainlayer import maintenance
+
+    config = _config(tmp_path, now=dt.datetime(2026, 5, 30, 4, 5, tzinfo=dt.timezone.utc))
+    _create_enrichment_db(config.db_path)
+    stale = config.queue_dir / "enrichment-stale.jsonl"
+    _write_jsonl(
+        stale,
+        [
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "already-done",
+                "content_hash": "hash-ok",
+                "enrichment": {"summary": "new summary"},
+            }
+        ],
+    )
+    monkeypatch.setattr(maintenance, "collect_lsof_entries", lambda _paths: [])
+
+    result = maintenance.run_maintenance("light", config=config, dry_run=True)
+
+    assert result.dry_run is True
+    assert result.stale_queue.quarantined_files == 0
+    assert result.stale_queue.candidate_files == 1
+    assert stale.exists()
+    assert not config.quarantine_root.exists()
+
+
+def test_stale_queue_quarantine_moves_only_already_enriched_matching_hash(tmp_path):
+    from brainlayer.maintenance import quarantine_stale_queue_files
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    quarantine_root = tmp_path / "quarantine"
+    _create_enrichment_db(db_path)
+    stale = queue_dir / "enrichment-stale.jsonl"
+    needs_update = queue_dir / "enrichment-needs-update.jsonl"
+    mismatch = queue_dir / "enrichment-mismatch.jsonl"
+    missing = queue_dir / "enrichment-missing.jsonl"
+    _write_jsonl(
+        stale,
+        [
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "already-done",
+                "content_hash": "hash-ok",
+                "enrichment": {"summary": "new summary"},
+            }
+        ],
+    )
+    _write_jsonl(
+        needs_update,
+        [
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "needs-update",
+                "content_hash": "hash-ok",
+                "enrichment": {"summary": "real update"},
+            }
+        ],
+    )
+    _write_jsonl(
+        mismatch,
+        [
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "hash-moved",
+                "content_hash": "hash-old",
+                "enrichment": {"summary": "stale hash mismatch"},
+            }
+        ],
+    )
+    _write_jsonl(
+        missing,
+        [
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "missing",
+                "content_hash": "hash-ok",
+                "enrichment": {"summary": "missing chunk"},
+            }
+        ],
+    )
+
+    result = quarantine_stale_queue_files(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        quarantine_root=quarantine_root,
+        dry_run=False,
+        now=dt.datetime(2026, 5, 30, 4, 10, tzinfo=dt.timezone.utc),
+    )
+
+    assert result.scanned_files == 4
+    assert result.candidate_files == 1
+    assert result.quarantined_files == 1
+    assert not stale.exists()
+    assert needs_update.exists()
+    assert mismatch.exists()
+    assert missing.exists()
+    quarantined = list(quarantine_root.rglob("enrichment-stale.jsonl"))
+    assert len(quarantined) == 1
+
+
+def test_maintenance_launchd_plists_and_installer_wiring():
+    nightly_path = REPO_ROOT / "scripts/launchd/com.brainlayer.maintenance-nightly.plist"
+    weekly_path = REPO_ROOT / "scripts/launchd/com.brainlayer.maintenance-weekly.plist"
+
+    with nightly_path.open("rb") as handle:
+        nightly = plistlib.load(handle)
+    with weekly_path.open("rb") as handle:
+        weekly = plistlib.load(handle)
+
+    assert nightly["Label"] == "com.brainlayer.maintenance-nightly"
+    assert weekly["Label"] == "com.brainlayer.maintenance-weekly"
+    assert "--light" in nightly["ProgramArguments"]
+    assert "--full" in weekly["ProgramArguments"]
+    assert nightly["StartCalendarInterval"] == {"Hour": 4, "Minute": 0}
+    assert weekly["StartCalendarInterval"] == {"Weekday": 0, "Hour": 4, "Minute": 0}
+    for plist in (nightly, weekly):
+        assert plist["Nice"] == 10
+        assert plist["ProcessType"] == "Background"
+        assert plist["EnvironmentVariables"]["BRAINLAYER_REPO_ROOT"] == "__BRAINLAYER_DIR__"
+
+    install = (REPO_ROOT / "scripts/launchd/install.sh").read_text(encoding="utf-8")
+    assert "maintenance-nightly" in install
+    assert "maintenance-weekly" in install

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -451,6 +451,112 @@ def test_drain_limits_enrichment_events_per_transaction(tmp_path, monkeypatch):
     assert summaries == {"c0": "s0", "c1": "s1", "c2": None, "c3": None}
 
 
+def _create_burn_drain_db(path):
+    conn = apsw.Connection(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            summary TEXT,
+            enriched_at TEXT,
+            enrich_status TEXT,
+            content_hash TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO chunks (id, content, summary, enriched_at, enrich_status, content_hash)
+        VALUES
+            ('already-done', 'content 1', 'old summary', '2026-05-30T00:00:00Z', 'success', 'h1'),
+            ('needs-update', 'content 2', NULL, NULL, NULL, 'h2')
+        """
+    )
+    conn.close()
+
+
+def test_burn_drain_skips_verified_stale_enrichment_and_applies_real_update(tmp_path):
+    from brainlayer.drain import burn_drain_once
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    log_path = tmp_path / "burn.log"
+    _create_burn_drain_db(db_path)
+    stale = enqueue_enrichment_updates(
+        [
+            {
+                "chunk_id": "already-done",
+                "content_hash": "h1",
+                "enrichment": {"summary": "redundant summary"},
+            }
+        ],
+        queue_dir=queue_dir,
+    )
+    real = enqueue_enrichment_updates(
+        [
+            {
+                "chunk_id": "needs-update",
+                "content_hash": "h2",
+                "enrichment": {"summary": "real summary"},
+            }
+        ],
+        queue_dir=queue_dir,
+    )
+
+    result = burn_drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10, log_path=log_path)
+
+    assert result.applied_events == 1
+    assert result.skipped_verified_stale == 1
+    assert result.files_deleted == 2
+    assert result.checkpoints == 1
+    assert not stale.exists()
+    assert not real.exists()
+    conn = apsw.Connection(str(db_path))
+    try:
+        rows = dict(conn.execute("SELECT id, summary FROM chunks ORDER BY id"))
+    finally:
+        conn.close()
+    assert rows == {"already-done": "old summary", "needs-update": "real summary"}
+
+
+def test_burn_drain_preserves_queue_file_when_batch_rolls_back(tmp_path, monkeypatch):
+    from brainlayer import drain
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    log_path = tmp_path / "burn.log"
+    _create_burn_drain_db(db_path)
+    queued = enqueue_enrichment_updates(
+        [
+            {
+                "chunk_id": "needs-update",
+                "content_hash": "h2",
+                "enrichment": {"summary": "must not commit"},
+            }
+        ],
+        queue_dir=queue_dir,
+    )
+
+    def fail_apply(*_args, **_kwargs):
+        raise RuntimeError("synthetic batch failure")
+
+    monkeypatch.setattr(drain, "_apply_event", fail_apply)
+
+    result = drain.burn_drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10, log_path=log_path)
+
+    assert result.failed_files == 1
+    assert result.files_deleted == 0
+    assert queued.exists()
+    conn = apsw.Connection(str(db_path))
+    try:
+        summary = conn.execute("SELECT summary FROM chunks WHERE id = 'needs-update'").fetchone()[0]
+    finally:
+        conn.close()
+    assert summary is None
+
+
 class TestBrainUpdateRetryOnLock:
     """brain_update should retry on BusyError before failing."""
 


### PR DESCRIPTION
## Summary
- Add safety-gated BrainLayer maintenance routine with --light, --full, --dry-run, and --burn modes.
- Add nightly/weekly launchd plists and install.sh wiring.
- Harden Drive backup archive flow: verify upload, remove local staging copy, and rotate last-N snapshots.
- Add burn-drain batching with verified-stale enrichment skipping and delete-after-commit durability.

## Test plan
- pytest tests/test_maintenance_routine.py tests/test_backup_daily.py::test_run_backup_verifies_upload_removes_local_and_rotates_last_n tests/test_backup_daily.py::test_prune_drive_backups_keeps_only_latest_n_snapshots tests/test_write_queue.py::test_burn_drain_skips_verified_stale_enrichment_and_applies_real_update tests/test_write_queue.py::test_burn_drain_preserves_queue_file_when_batch_rolls_back
- ruff check scripts/maintenance/brainlayer_maintenance.py src/brainlayer/backup_daily.py src/brainlayer/drain.py src/brainlayer/maintenance.py tests/test_backup_daily.py tests/test_write_queue.py tests/test_maintenance_routine.py
- ruff format --check scripts/maintenance/brainlayer_maintenance.py src/brainlayer/backup_daily.py src/brainlayer/drain.py src/brainlayer/maintenance.py tests/test_backup_daily.py tests/test_write_queue.py tests/test_maintenance_routine.py

## Ops gate
Commander s:7 gates runtime behavior with a dry-run gate-abort check plus a real --light run in a quiet window before scheduling --full.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Maintenance stops live writers, runs VACUUM/full checkpoint, and deletes or quarantines queue files; mis-gating or failed resume could affect ingestion until services are restored.
> 
> **Overview**
> Adds a **safety-gated recurring maintenance** path for the local BrainLayer DB, with **launchd** wiring for nightly `--light` and weekly `--full` runs via `scripts/maintenance/brainlayer_maintenance.py` and new plists in `install.sh`.
> 
> **Maintenance** (`src/brainlayer/maintenance.py`) runs only inside a quiet window after idle and `lsof` checks. **Light** mode quiesces writers, checkpoints, and quarantines queue files that are verified-redundant enrichment updates. **Full** adds a verified Drive backup (weekly retention), `VACUUM`, and post-run search latency checks. **Burn** mode bulk-drains the queue via the new burn path. Services are booted out and reinstalled through `install.sh` in a `finally` block.
> 
> **Drive backups** are tightened: post-upload **name/size verification**, optional **local staging removal**, and retention simplified from 30 daily + 12 monthly to **keep-latest-N** (7 daily, 4 for weekly maintenance), documented in `docs/backup-strategy.md`.
> 
> **Queue drain** gains **`burn_drain_once`**: large batches in one transaction, skip enrichment events already applied at matching `content_hash`, unlink queue files only after commit, and expose **`--burn`** on the drain CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dcabe9cc55c71c59abde859c5638952e890e34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add BrainLayer nightly and weekly maintenance routines with safety gates and DB maintenance
> - Adds [maintenance.py](https://github.com/EtanHey/brainlayer/pull/410/files#diff-5623eb0b0ddbc791b2b25c828a74927787f1cf710501ff90555ebf92981b041d) with `run_maintenance` supporting `--light`, `--full`, and `--burn` modes; gates abort maintenance if the quiet window, idle check, or lsof writer check fails
> - Full mode runs a verified Drive backup with weekly 4-snapshot retention, VACUUM, and WAL checkpoint; light mode quarantines redundant enrichment queue files or runs burn drain
> - Adds [brainlayer_maintenance.py](https://github.com/EtanHey/brainlayer/pull/410/files#diff-a73bca4b2c147ad07c8a624fd58a368bb3ac5c23ef367ad527375eb3ffc6e7b4) as a launchd entrypoint, plus nightly (04:00 `--light`) and weekly (Monday 04:00 `--full`) LaunchAgent plists
> - Updates [install.sh](https://github.com/EtanHey/brainlayer/pull/410/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756) to support `maintenance-nightly`, `maintenance-weekly`, and `maintenance` targets, included in `all` and `remove` flows
> - Replaces the previous 30-daily + 12-monthly Drive retention in [backup_daily.py](https://github.com/EtanHey/brainlayer/pull/410/files#diff-7478d7f165ea261a3912ebf2e9fb51ab469e9e8d211be7aa70cc123b4c9b97b8) with a configurable `DriveRetentionPolicy`; default daily keeps 7 snapshots, weekly keeps 4; adds post-upload verification by name and size
> - Behavioral Change: local staging snapshots are now deleted by default after successful Drive upload verification
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7dcabe9. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->