### PR TITLE
P2 KG entity safe cleanup

### DIFF
--- a/BUGBOT_REREVIEW_P2_KG_CLEANUP.md
+++ b/BUGBOT_REREVIEW_P2_KG_CLEANUP.md
@@ -1,0 +1,478 @@
+# Bugbot Re-Review: P2 KG Entity Safe Cleanup (PR #411)
+
+**Re-Review Date:** 2026-05-31 08:44 UTC  
+**Branch:** `feat/l0-kg-entity-cleanup`  
+**Latest Commit:** `9f5f5ff11540dd9f32c8b40e74eeb01f1016a0ce`  
+**Previous Review:** `7e81877` (BUGBOT_REVIEW_P2_KG_CLEANUP.md)
+
+## Executive Summary
+
+Re-reviewed after follow-up commit `9f5f5ff` which addressed several initial concerns. The implementation has improved significantly, but **3 critical issues remain** that should be addressed before production use.
+
+**Current Status:** ⚠️ **CONDITIONAL APPROVAL** - Safe for one-time P2 cleanup execution, but needs hardening before general use
+
+**Test Results:**
+- ✅ 31/31 entity dedup and cleanup tests pass (was 28)
+- ✅ New tests for validity window preservation and voice matching
+- ✅ No lint errors
+
+---
+
+## Changes Since Initial Review (9f5f5ff)
+
+### ✅ Fixed Issues
+
+1. **Relation Validity Window Preservation** ✅ FIXED
+   - Added `_earliest_present()` and `_latest_valid_until()` helpers
+   - Now preserves widest validity window when merging duplicate relations
+   - Addresses Codex concern about dropping active relation evidence
+   - Test coverage: `test_merge_relation_conflict_preserves_widest_validity_window`
+
+2. **Voice Substring Matching** ✅ FIXED
+   - Replaced substring matching with exact normalized variant keys
+   - Uses `VOICE_VARIANT_KEYS` set for explicit matching
+   - Prevents false positives on arbitrary substring matches
+   - Test coverage: `test_voice_sources_do_not_match_arbitrary_voicelayerclaude_substrings`
+
+3. **PERSON Placeholder Cross-Type Rows** ✅ DOCUMENTED
+   - Added comment explaining that PERSON_token placeholders are intentionally absorbed
+   - Clarifies these are extraction artifacts, not real ontology entities
+   - Test coverage: `test_person_placeholder_family_sources_include_mistyped_placeholder_rows`
+
+4. **Archive Entity Robustness** ✅ IMPROVED
+   - Added fallback to `cursor.rowcount` when `conn.changes()` not available
+   - Handles both APSW and sqlite3 connection types
+
+---
+
+## Critical Issues (Must Fix Before General Use)
+
+### 🔴 CRITICAL #1: Missing WAL Checkpoint & Writer Coordination
+
+**Severity:** Critical (Production Risk)  
+**File:** `scripts/kg_p2_safe_cleanup.py:321-328`  
+**Impact:** Violates bulk DB operation safety contract; can cause WAL bloat, writer starvation, and potential data corruption
+
+**Issue:**
+
+The cleanup script performs large-scale mutations (585 person merges, 491 archives, multiple named entity merges) without:
+1. Acquiring exclusive writer coordination lock
+2. Running `PRAGMA wal_checkpoint(FULL)` before and after mutations
+3. Ensuring enrichment workers are stopped
+
+Per `CLAUDE.md` Bulk DB Operations (SAFETY):
+```
+1. Stop enrichment workers first — never run bulk ops while enrichment is writing
+2. Checkpoint WAL before and after: PRAGMA wal_checkpoint(FULL)
+```
+
+**Current Code:**
+```python
+# Line 321-328
+cursor = store.conn.cursor()
+cursor.execute("BEGIN IMMEDIATE")
+try:
+    stats = apply_plan(store, plan)
+    cursor.execute("COMMIT")
+except Exception:
+    cursor.execute("ROLLBACK")
+    raise
+```
+
+**Missing:**
+- No lock file acquisition (`/tmp/brainlayer-enrichment.lock` or similar)
+- No WAL checkpoint before mutations
+- No WAL checkpoint after mutations
+- No verification that other writers are idle
+
+**Recommendation:**
+
+```python
+import fcntl
+from pathlib import Path
+
+def apply_plan_safely(store: VectorStore, plan: dict[str, Any]) -> Counter[str]:
+    """Apply cleanup plan with full bulk-op safety envelope."""
+    lock_path = Path("/tmp/brainlayer-kg-cleanup.lock")
+    lock_fd = None
+    
+    try:
+        # 1. Acquire exclusive writer lock
+        lock_fd = open(lock_path, "w")
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        
+        # 2. Checkpoint WAL before mutations
+        store.conn.cursor().execute("PRAGMA wal_checkpoint(FULL)")
+        
+        # 3. Perform mutations in transaction
+        cursor = store.conn.cursor()
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            stats = apply_plan(store, plan)
+            cursor.execute("COMMIT")
+        except Exception:
+            cursor.execute("ROLLBACK")
+            raise
+        
+        # 4. Checkpoint WAL after mutations
+        store.conn.cursor().execute("PRAGMA wal_checkpoint(FULL)")
+        
+        return stats
+        
+    finally:
+        if lock_fd:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+            lock_fd.close()
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+```
+
+**Why This Matters:**
+- The P2 cleanup merges 585 entity groups and archives 491 entities
+- Without WAL checkpoints, this creates massive WAL files (can grow to 4.7GB per CLAUDE.md)
+- Concurrent enrichment writers can cause SQLITE_BUSY lock contention
+- WAL bloat can freeze the database or cause out-of-disk-space errors
+
+**Mitigation for P2 Cleanup:**
+The one-time P2 cleanup was executed with:
+- Manual verification that no other writers were active
+- Database backup before execution
+- Transaction safety (BEGIN IMMEDIATE/COMMIT/ROLLBACK)
+
+This mitigates the risk for the **one-time execution**, but the script should be hardened before reuse.
+
+---
+
+### 🔴 CRITICAL #2: Relation Properties JSON Keys Are Lost
+
+**Severity:** High (Data Loss)  
+**File:** `src/brainlayer/pipeline/entity_resolution.py:299-301`  
+**Impact:** Merging duplicate relations loses unique keys from the merged relation's properties JSON
+
+**Issue:**
+
+When two duplicate relations both have non-empty `properties` JSON, the merge logic keeps only the canonical relation's properties and discards unique keys from the duplicate:
+
+```python
+merged_properties = existing_properties
+if (not existing_properties or existing_properties == "{}") and properties:
+    merged_properties = properties
+```
+
+This is an all-or-nothing replacement instead of a proper JSON merge.
+
+**Evidence:**
+
+```
+Before merge:
+  rel-keep: props={"role": "engineer", "department": "R&D"}
+  rel-merge: props={"level": "senior", "start_date": "2020"}
+
+After merge:
+  rel-keep: props={"role": "engineer", "department": "R&D"}
+  ⚠️ Lost 'level' and 'start_date' keys from merged relation!
+```
+
+**Recommendation:**
+
+```python
+import json
+
+# Merge properties JSON
+merged_properties = existing_properties
+if properties and properties != "{}":
+    if not existing_properties or existing_properties == "{}":
+        merged_properties = properties
+    else:
+        # Merge JSON keys, preserving canonical keys when both exist
+        try:
+            existing_dict = json.loads(existing_properties)
+            merge_dict = json.loads(properties)
+            # Keep canonical values for overlapping keys, add unique keys from merge
+            for key, value in merge_dict.items():
+                if key not in existing_dict:
+                    existing_dict[key] = value
+            merged_properties = json.dumps(existing_dict, sort_keys=True)
+        except (json.JSONDecodeError, TypeError):
+            # Fallback to existing if JSON parse fails
+            merged_properties = existing_properties
+```
+
+**Why This Matters:**
+- Relation properties contain important context (role, level, dates, etc.)
+- The whole point of `merge_entities_preserving_links` is to preserve stronger evidence
+- Losing unique keys contradicts the "preserving" design goal
+- This affects all entity merges going forward, not just P2 cleanup
+
+---
+
+### 🟠 MAJOR #3: No SQLITE_BUSY Retry Handling
+
+**Severity:** Major (Reliability Risk)  
+**File:** `src/brainlayer/pipeline/entity_resolution.py:164-374`  
+**Impact:** Merge operations fail immediately on lock contention instead of retrying
+
+**Issue:**
+
+The `merge_entities_preserving_links()` function performs many direct `cursor.execute()` calls without handling `SQLITE_BUSY` errors. Under concurrent writers, the first lock contention aborts the entire merge mid-flight.
+
+Per `CLAUDE.md`:
+```
+Concurrency: retry on SQLITE_BUSY; each worker uses its own connection
+```
+
+**Current Code:**
+```python
+# No retry logic - fails immediately on SQLITE_BUSY
+chunk_rows = list(cursor.execute("SELECT ... FROM kg_entity_chunks WHERE entity_id = ?", (merge_id,)))
+# ... many more cursor.execute() calls ...
+```
+
+**Recommendation:**
+
+Add a retry wrapper for all database operations in the merge function:
+
+```python
+import time
+from contextlib import contextmanager
+
+@contextmanager
+def sqlite_busy_retry(max_attempts=5, base_delay_ms=100):
+    """Retry context for SQLITE_BUSY errors."""
+    for attempt in range(max_attempts):
+        try:
+            yield
+            return
+        except Exception as e:
+            error_msg = str(e).lower()
+            is_busy = (
+                "database is locked" in error_msg 
+                or "sqlite_busy" in error_msg
+                or "busy" in error_msg
+            )
+            if is_busy and attempt < max_attempts - 1:
+                delay = (base_delay_ms / 1000.0) * (2 ** attempt)
+                time.sleep(delay)
+                continue
+            raise
+
+# Then wrap critical sections:
+with sqlite_busy_retry():
+    chunk_rows = list(cursor.execute("SELECT ... FROM kg_entity_chunks ..."))
+```
+
+**Why This Matters:**
+- The enrichment workers, watcher, and MCP tools all write concurrently
+- SQLITE_BUSY errors are expected in a multi-writer environment
+- Without retry logic, legitimate merges fail and leave partial state
+- This makes the merge operation unreliable in production
+
+**Mitigation for P2 Cleanup:**
+- The cleanup was run when no other writers were active
+- Transaction safety (BEGIN IMMEDIATE) provides some protection
+- One-time execution reduces exposure
+
+---
+
+## Minor Issues (Recommended Fixes)
+
+### 📝 MINOR #1: Archived Entities Still Returned by Lookups
+
+**Severity:** Low (UX Issue)  
+**File:** Multiple lookup paths  
+**Reported by:** @chatgpt-codex-connector
+
+**Issue:**
+
+Archiving entities only sets `status='archived'` and `expired_at`, but lookup functions don't filter on these fields:
+- `search_entities()`
+- `get_entity_by_alias()`
+- `resolve_entity()` fallbacks
+
+Result: The 491 archived junk entities can still be returned in searches and resolution.
+
+**Recommendation:**
+
+Add `status != 'archived'` filter to entity lookup queries:
+
+```python
+# In search_entities, get_entity_by_alias, etc.
+WHERE e.status != 'archived' AND ...
+```
+
+**Impact:** Low priority since:
+- Archived entities have low relevance scores (chunks <= 10, rels = 0)
+- They're junk labels that wouldn't rank high anyway
+- Fix can be applied separately
+
+---
+
+### 📝 MINOR #2: Self-Referencing Relations Create Self-Loops
+
+**Severity:** Low (Edge Case)  
+**File:** `src/brainlayer/pipeline/entity_resolution.py:274-275`  
+**Status:** Documented in initial review
+
+**Issue:**
+
+When an entity has a self-referencing relation (A→A) and is merged into another entity (B), the result is a self-loop (B→B).
+
+**Code:**
+```python
+new_source_id = keep_id if source_id == merge_id else source_id
+new_target_id = keep_id if target_id == merge_id else target_id
+# If both were merge_id, both become keep_id → self-loop
+```
+
+**Recommendation:**
+
+Add self-loop detection:
+
+```python
+new_source_id = keep_id if source_id == merge_id else source_id
+new_target_id = keep_id if target_id == merge_id else target_id
+
+if new_source_id == new_target_id:
+    # Skip self-loops or log warning
+    logger.debug(f"Skipping self-loop relation {relation_type} on {keep_id}")
+    cursor.execute("DELETE FROM kg_relations WHERE id = ?", (relation_id,))
+    stats["self_loops_removed"] += 1
+    continue
+```
+
+**Impact:** Low priority since:
+- Self-referencing relations are rare in current dataset
+- May be intentional (entity references itself)
+- Not causing issues in P2 cleanup
+
+---
+
+## Review of Other Bot Findings
+
+### CodeRabbit Findings Assessment
+
+1. **WAL Checkpoint Missing** ✅ VALID → Promoted to Critical #1
+2. **SQLITE_BUSY Retry Missing** ✅ VALID → Promoted to Major #3  
+3. **Properties JSON Merge** ✅ VALID → Promoted to Critical #2
+4. **Documentation Wording** ❌ NOT BLOCKING → Minor markdown issues
+
+### Cursor Bot Finding Assessment
+
+1. **Relation Merge Drops Richer Facts** ✅ VALID → Same as Critical #2 (properties issue)
+
+### Codex Bot Findings Assessment
+
+1. **Validity Window Preservation** ✅ FIXED → Addressed in 9f5f5ff
+2. **Archived Entities in Lookups** ✅ VALID → Downgraded to Minor #1 (low impact)
+
+---
+
+## Verification Tests Performed
+
+### Test 1: Entity Dedup and Cleanup Suite
+```bash
+pytest tests/test_entity_dedup.py tests/test_kg_p2_safe_cleanup.py -v
+```
+**Result:** ✅ 31/31 passed
+
+### Test 2: Properties Merging (New Test)
+```
+Created two relations with different properties:
+  - rel-keep: {"role": "engineer", "department": "R&D"}
+  - rel-merge: {"level": "senior", "start_date": "2020"}
+  
+After merge: ⚠️ Lost "level" and "start_date" keys
+```
+**Result:** 🔴 Confirms Critical #2
+
+### Test 3: WAL Checkpoint Presence
+```bash
+grep -r "wal_checkpoint" scripts/kg_p2_safe_cleanup.py
+```
+**Result:** 🔴 No matches - Confirms Critical #1
+
+### Test 4: SQLITE_BUSY Retry
+```bash
+grep -r "SQLITE_BUSY\|OperationalError.*locked" src/brainlayer/pipeline/entity_resolution.py
+```
+**Result:** 🔴 No matches - Confirms Major #3
+
+---
+
+## Updated Recommendations
+
+### Critical (Block General Use)
+1. ✅ ~~Archive entity return value~~ - FIXED in 7e81877
+2. ✅ ~~Validity window preservation~~ - FIXED in 9f5f5ff
+3. ✅ ~~Voice substring matching~~ - FIXED in 9f5f5ff
+4. 🔴 **Add WAL checkpoint and writer coordination** - NEW
+5. 🔴 **Fix relation properties JSON merge** - NEW
+6. 🟠 **Add SQLITE_BUSY retry handling** - NEW
+
+### High Priority (Fix Soon)
+1. Add archived entity filtering to lookup paths
+2. Add self-loop detection/removal in merge logic
+
+### Medium Priority (Consider)
+1. Document or add explicit handling for self-referencing relations
+2. Add performance benchmarks for large-scale merges
+
+---
+
+## Production Readiness Assessment
+
+### For One-Time P2 Cleanup: ✅ SAFE
+- Transaction safety (BEGIN IMMEDIATE/COMMIT/ROLLBACK) ✅
+- Validation guards (expected counts, allow-count-drift) ✅  
+- Pre-execution backup created ✅
+- Manual verification of no concurrent writers ✅
+- Orphan checks passed (0 orphans) ✅
+- All regression tests pass (31/31) ✅
+
+### For General/Repeated Use: ⚠️ NOT READY
+- Missing WAL checkpoint envelope 🔴
+- Properties merging loses data 🔴
+- No SQLITE_BUSY retry handling 🟠
+- Archived entities not filtered 📝
+
+---
+
+## Conclusion
+
+The P2 cleanup implementation has **significantly improved** since the initial review:
+- Fixed validity window preservation
+- Fixed voice matching false positives
+- Documented PERSON placeholder behavior
+- Improved archive entity robustness
+- Added comprehensive test coverage
+
+**However**, three critical issues remain that prevent this code from being **production-ready for general use**:
+
+1. **WAL Checkpoint & Writer Coordination** - Violates bulk-op safety contract
+2. **Properties JSON Merge** - Loses relation evidence (contradicts "preserving" goal)
+3. **SQLITE_BUSY Retry** - Unreliable under concurrent load
+
+### Final Recommendation
+
+✅ **APPROVE for one-time P2 cleanup execution** - The manual safeguards (backup, verification, transaction safety) make the specific P2 run safe.
+
+⚠️ **CONDITIONAL APPROVAL for merge** - Safe to merge as-is since P2 cleanup is complete, BUT:
+- Add FIXME comments for the three critical issues
+- Create follow-up issue/PR to harden before script reuse
+- Document that script is for one-time use only until hardened
+
+🔴 **BLOCK general/repeated use** - Script should not be run again without fixes for Critical #1, #2, and Major #3.
+
+---
+
+## Sign-off
+
+**Reviewer:** @bugbot  
+**Recommendation:** ✅ Conditional Approval (one-time use only, harden before reuse)  
+**Risk Level:** Low for P2 execution, High for repeated use  
+**Test Coverage:** Excellent (31 tests, comprehensive scenarios)  
+**Code Quality:** Good (with noted critical improvements needed)
+
+**Grade:** B+ (was A- after initial review, downgraded due to newly discovered issues, upgraded for fixes made)

--- a/BUGBOT_REVIEW_P2_KG_CLEANUP.md
+++ b/BUGBOT_REVIEW_P2_KG_CLEANUP.md
@@ -1,0 +1,274 @@
+# Bugbot Review: P2 KG Entity Safe Cleanup (PR #411)
+
+**Review Date:** 2026-05-31  
+**Branch:** `feat/l0-kg-entity-cleanup`  
+**Commit:** `6001e7bb2ffe642e5309ab9881701915b0c6427d`
+
+## Executive Summary
+
+Reviewed the P2 KG entity safe cleanup implementation including:
+- New `merge_entities_preserving_links()` function in `entity_resolution.py`
+- One-shot P2 safe cleanup script `kg_p2_safe_cleanup.py`
+- Regression test suite in `test_entity_dedup.py`
+
+**Overall Assessment:** ✅ **SAFE TO MERGE** with one minor bug fix recommended
+
+**Test Results:**
+- ✅ All 25 entity dedup tests pass
+- ✅ No lint errors (ruff check)
+- ✅ Transaction safety verified
+- ✅ Edge case handling confirmed
+
+## Findings
+
+### 🐛 BUG #1: `archive_entity()` returns incorrect success status
+
+**Severity:** Minor  
+**File:** `scripts/kg_p2_safe_cleanup.py:200-224`  
+**Impact:** Function returns `True` even when entity is already archived and no update occurs
+
+**Current Code:**
+
+```python
+def archive_entity(store: VectorStore, entity_id: str, reason: str, archived_at: str) -> bool:
+    row = store.conn.cursor().execute("SELECT metadata FROM kg_entities WHERE id = ?", (entity_id,)).fetchone()
+    if not row:
+        return False
+    # ... metadata preparation ...
+    store.conn.cursor().execute(
+        """
+        UPDATE kg_entities
+        SET status = 'archived',
+            expired_at = ?,
+            metadata = ?,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+        WHERE id = ? AND status = 'active'
+        """,
+        (archived_at, json.dumps(metadata, sort_keys=True), entity_id),
+    )
+    return True  # ⚠️ Always returns True, even if WHERE clause didn't match
+```
+
+**Issue:** The `WHERE id = ? AND status = 'active'` clause prevents re-archiving already-archived entities, but the function still returns `True` indicating success. This is misleading.
+
+**Evidence:**
+```
+First archive: status=archived, metadata={'p2_cleanup': {'reason': 'first'}}
+Second archive: returns True but metadata unchanged (still shows 'first')
+```
+
+**Recommendation:** Check `cursor.rowcount` to return accurate status:
+
+```python
+def archive_entity(store: VectorStore, entity_id: str, reason: str, archived_at: str) -> bool:
+    row = store.conn.cursor().execute("SELECT metadata FROM kg_entities WHERE id = ?", (entity_id,)).fetchone()
+    if not row:
+        return False
+    try:
+        metadata = json.loads(row[0]) if row[0] else {}
+    except json.JSONDecodeError:
+        metadata = {"_previous_metadata_raw": row[0]}
+    metadata["p2_cleanup"] = {
+        "action": "archive-junk",
+        "reason": reason,
+        "archived_at": archived_at,
+    }
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """
+        UPDATE kg_entities
+        SET status = 'archived',
+            expired_at = ?,
+            metadata = ?,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+        WHERE id = ? AND status = 'active'
+        """,
+        (archived_at, json.dumps(metadata, sort_keys=True), entity_id),
+    )
+    return cursor.rowcount > 0  # Return True only if row was actually updated
+```
+
+**Workaround:** The script only archives each entity once per execution, so this bug won't cause issues in the current P2 cleanup run. However, it should be fixed for correctness.
+
+---
+
+### ⚠️ EDGE CASE #1: Self-referencing relations create self-loops after merge
+
+**Severity:** Low (Informational)  
+**File:** `src/brainlayer/pipeline/entity_resolution.py:274-275`  
+**Impact:** Merging an entity with a self-referencing relation creates a self-loop on the target entity
+
+**Scenario:**
+```python
+# Entity A has relation: A -> A (self-reference)
+# Merge A into B
+# Result: B -> B (self-loop)
+```
+
+**Evidence:**
+```
+Before merge: ('person-2', 'person-2', 'knows_self')
+After merge:  ('person-1', 'person-1', 'knows_self')
+```
+
+**Code:**
+```python
+new_source_id = keep_id if source_id == merge_id else source_id
+new_target_id = keep_id if target_id == merge_id else target_id
+# If both source_id and target_id == merge_id, both become keep_id
+```
+
+**Assessment:** This behavior may be intentional (preserving all relation semantics). Self-referencing relations are uncommon in the current dataset. If this is undesired, the merge function could detect and skip self-loops:
+
+```python
+# After computing new_source_id and new_target_id
+if new_source_id == new_target_id:
+    # Skip self-loop or log warning
+    stats["self_loops_skipped"] += 1
+    continue
+```
+
+**Recommendation:** Document this behavior or add explicit self-loop handling if undesired.
+
+---
+
+### 📝 EDGE CASE #2: Context selection with equal relevance scores
+
+**Severity:** Minor (Informational)  
+**File:** `src/brainlayer/pipeline/entity_resolution.py:215`  
+**Impact:** When both chunk links have equal relevance (including `None`), incoming context overwrites existing
+
+**Code:**
+```python
+if context and (not existing_context or (relevance or 0.0) >= (existing_relevance or 0.0)):
+    merged_context = context
+```
+
+**Behavior:**
+- Both relevance = `None` → converts to `0.0 >= 0.0` (True) → uses incoming context
+- Both relevance = `0.5` → `0.5 >= 0.5` (True) → uses incoming context
+
+**Assessment:** This is reasonable tie-breaking logic, but could be clarified. When relevance scores are equal, it slightly favors the incoming entity's context.
+
+**Recommendation:** No change required, but consider adding a comment explaining the tie-breaking behavior.
+
+---
+
+## ✅ Good Practices Observed
+
+1. **Transaction Safety**
+   - Uses `BEGIN IMMEDIATE` for write transactions
+   - Proper `COMMIT`/`ROLLBACK` error handling
+   - Lines 322-328 in `kg_p2_safe_cleanup.py`
+
+2. **Validation Guards**
+   - Hardcoded expected counts with validation
+   - `--allow-count-drift` escape hatch for count changes
+   - Orphan count verification after execution
+
+3. **Graceful Error Handling**
+   - `merge_many()` checks `store.get_entity()` before merging non-existent sources
+   - `archive_entity()` returns `False` for non-existent entities
+
+4. **Comprehensive Test Coverage**
+   - 25 regression tests covering:
+     - Alias CRUD operations
+     - Entity resolution cascading
+     - Hebrew prefix stripping
+     - Merge operations (basic and conflict scenarios)
+     - Duplicate chunk-link merging
+     - Duplicate relation merging
+     - Expiration consolidation
+
+5. **Merge Logic - Richer Evidence Preservation**
+   - Preserves higher relevance scores
+   - Keeps explicit mentions over inferred
+   - Uses better context based on relevance
+   - Merges relations with richer facts/properties
+   - Handles expiration dates correctly (keeps later expiration or None if either is active)
+
+---
+
+## Verification Tests Performed
+
+### Test 1: Entity Dedup Regression Suite
+```bash
+pytest tests/test_entity_dedup.py -v
+```
+**Result:** ✅ 25/25 passed
+
+### Test 2: Lint Check
+```bash
+ruff check scripts/kg_p2_safe_cleanup.py src/brainlayer/pipeline/entity_resolution.py tests/test_entity_dedup.py
+```
+**Result:** ✅ All checks passed
+
+### Test 3: Self-Referencing Relation Edge Case
+**Result:** ⚠️ Creates self-loops (may be intentional)
+
+### Test 4: Archive Re-archival
+**Result:** 🐛 Returns True but doesn't update (Bug #1)
+
+### Test 5: Merge with Missing Source
+**Result:** ✅ Handled gracefully (skipped)
+
+### Test 6: Chunk Conflict Merging with None Relevance
+**Result:** ✅ Works correctly (favors incoming context on tie)
+
+---
+
+## Recommendations
+
+### Critical (Before Merge)
+- **None** - No blocking issues
+
+### High Priority (Fix Soon)
+1. Fix `archive_entity()` return value to check `cursor.rowcount`
+
+### Medium Priority (Consider)
+1. Document or add explicit handling for self-referencing relation merges
+2. Add comment explaining tie-breaking logic in context selection
+
+### Low Priority (Nice to Have)
+1. Add test case for self-referencing relation merge behavior
+2. Add test case for re-archival scenario
+
+---
+
+## Database Safety Assessment
+
+✅ **Safe for production execution**
+
+The cleanup script has been executed locally with:
+- Pre-execution backup created
+- Orphan checks: 0 orphans after execution
+- Expected counts matched
+- All regression tests pass
+
+**Backup location:** `/Users/etanheyman/.local/share/brainlayer/brainlayer-pre-p2-kg-cleanup-20260531T071844Z.db`
+
+---
+
+## Conclusion
+
+The P2 KG entity safe cleanup implementation is **well-designed and safe to merge**. The code demonstrates:
+- Strong transaction safety
+- Comprehensive validation
+- Good test coverage
+- Thoughtful handling of duplicate evidence
+
+The one minor bug in `archive_entity()` return value does not affect the P2 cleanup execution since each entity is only archived once. However, it should be fixed for correctness and future reuse.
+
+The self-referencing relation behavior is an edge case that should be documented but does not pose a risk for the current cleanup operation.
+
+**Overall Grade: A-** (Excellent with minor improvements recommended)
+
+---
+
+## Sign-off
+
+**Reviewer:** @bugbot  
+**Recommendation:** ✅ Approve with minor bug fix recommended  
+**Risk Level:** Low  
+**Test Coverage:** Excellent (25 regression tests)  
+**Code Quality:** High

--- a/scripts/kg_p2_safe_cleanup.py
+++ b/scripts/kg_p2_safe_cleanup.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Apply approved P2 KG safe cleanup buckets.
+
+Approved scope:
+- Named fixes: brainClaude -> brainlayerClaude, voiceClaude -> voicelayerClaude,
+  GLiNER tool -> GLiNER technology, clod no-op.
+- Soft archive low-support junk labels.
+- Merge duplicate PERSON_xxxxxxxx families into the person canonical.
+
+This intentionally does not touch cross-type ontology families such as
+BrainLayer/VoiceLayer/Golems project-vs-tool-vs-technology rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from brainlayer.paths import get_db_path
+from brainlayer.pipeline.entity_resolution import merge_entities_preserving_links
+from brainlayer.vector_store import VectorStore
+
+BRAIN_TARGET_ID = "173733c921d4e817"
+VOICE_TARGET_ID = "golem-224489db81b9"
+GLINER_TARGET_ID = "5cc471c76ffdab6d"
+GLINER_TOOL_ID = "fb6b880f-de32-5a7c-b1ba-a8657c68af98"
+
+EXPECTED = {
+    "brain_sources": 10,
+    "voice_sources": 9,
+    "gliner_sources": 1,
+    "person_groups": 585,
+    "person_sources": 887,
+    "junk": 491,
+}
+
+
+def normalize_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def person_token_key(value: str) -> str | None:
+    match = re.fullmatch(r"\[?(PERSON_[0-9a-f]{8})\]?", value, re.I)
+    return match.group(1).lower() if match else None
+
+
+def fetch_entities(store: VectorStore) -> list[dict[str, Any]]:
+    cursor = store._read_cursor()
+    columns = ["id", "name", "entity_type", "status", "metadata", "rels", "chunks", "canonical_name"]
+    return [
+        dict(zip(columns, row))
+        for row in cursor.execute(
+            """
+            WITH rc AS (
+              SELECT source_id AS entity_id, count(*) AS c FROM kg_relations GROUP BY source_id
+              UNION ALL
+              SELECT target_id AS entity_id, count(*) AS c FROM kg_relations GROUP BY target_id
+            ), rs AS (SELECT entity_id, sum(c) AS rels FROM rc GROUP BY entity_id),
+            cc AS (SELECT entity_id, count(*) AS chunks FROM kg_entity_chunks GROUP BY entity_id)
+            SELECT e.id, e.name, e.entity_type, e.status, e.metadata,
+                   coalesce(rs.rels, 0) AS rels,
+                   coalesce(cc.chunks, 0) AS chunks,
+                   coalesce(e.canonical_name, '') AS canonical_name
+            FROM kg_entities e
+            LEFT JOIN rs ON rs.entity_id = e.id
+            LEFT JOIN cc ON cc.entity_id = e.id
+            ORDER BY lower(e.name), e.entity_type, e.id
+            """
+        )
+    ]
+
+
+def is_local_path_or_file(name: str) -> bool:
+    lower = name.lower()
+    if (
+        name.startswith("/Users/")
+        or name.startswith("/private/")
+        or name.startswith("/tmp/")
+        or name.startswith("./")
+        or name.startswith("~/")
+    ):
+        return True
+    # Deliberately excludes .js because names like Node.js/Next.js are real entities.
+    return (
+        "/" not in name
+        and re.search(r"\.(md|json|py|ts|tsx|swift|toml|ya?ml|sh|db|sqlite|mov)$", lower) is not None
+    )
+
+
+def junk_reasons(row: dict[str, Any]) -> list[str]:
+    name = str(row["name"])
+    lower = name.lower()
+    reasons: list[str] = []
+    if re.fullmatch(r"[-_/\\.:@#~]+", name) or len(name.strip()) <= 1:
+        reasons.append("fragment")
+    if "http://" in lower or "https://" in lower:
+        reasons.append("url-label")
+    if is_local_path_or_file(name):
+        reasons.append("path-or-file-label")
+    if re.fullmatch(r"[0-9a-f]{8,}", lower):
+        reasons.append("hex-id-fragment")
+    if "\x08" in name or len(name) > 120:
+        reasons.append("control/long-fragment")
+    return reasons
+
+
+def build_plan(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    by_id = {row["id"]: row for row in rows}
+
+    brain_named = [row for row in rows if normalize_name(row["name"]) in {"brainclaude", "brainlayerclaude"}]
+    voice_named = [
+        row
+        for row in rows
+        if normalize_name(row["name"]) in {"voiceclaude", "voicelayerclaude"}
+        or "voicelayerclaude" in row["name"].lower()
+    ]
+    gliner_sources = [by_id[GLINER_TOOL_ID]] if GLINER_TOOL_ID in by_id else []
+
+    person_groups: list[dict[str, Any]] = []
+    person_by_key: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        key = person_token_key(row["name"])
+        if key:
+            person_by_key[key].append(row)
+    for key, family in person_by_key.items():
+        persons = [row for row in family if row["entity_type"] == "person"]
+        if not persons or len(family) <= 1:
+            continue
+        target = max(persons, key=lambda row: (row["chunks"], row["rels"], row["name"]))
+        sources = [row for row in family if row["id"] != target["id"]]
+        person_groups.append({"key": key, "target": target, "sources": sources})
+    person_groups.sort(key=lambda group: (-sum(row["chunks"] for row in group["sources"]), group["key"]))
+
+    junk = []
+    for row in rows:
+        reasons = junk_reasons(row)
+        if reasons and row["rels"] == 0 and row["chunks"] <= 10:
+            row = dict(row)
+            row["reason"] = ",".join(reasons)
+            junk.append(row)
+    junk.sort(key=lambda row: (row["reason"], -row["chunks"], row["name"].lower(), row["id"]))
+
+    return {
+        "brain_target": by_id.get(BRAIN_TARGET_ID),
+        "brain_sources": [row for row in brain_named if row["id"] != BRAIN_TARGET_ID],
+        "voice_target": by_id.get(VOICE_TARGET_ID),
+        "voice_sources": [row for row in voice_named if row["id"] != VOICE_TARGET_ID],
+        "gliner_target": by_id.get(GLINER_TARGET_ID),
+        "gliner_sources": gliner_sources,
+        "person_groups": person_groups,
+        "junk": junk,
+    }
+
+
+def plan_counts(plan: dict[str, Any]) -> dict[str, int]:
+    return {
+        "brain_sources": len(plan["brain_sources"]),
+        "voice_sources": len(plan["voice_sources"]),
+        "gliner_sources": len(plan["gliner_sources"]),
+        "person_groups": len(plan["person_groups"]),
+        "person_sources": sum(len(group["sources"]) for group in plan["person_groups"]),
+        "junk": len(plan["junk"]),
+    }
+
+
+def validate_plan(plan: dict[str, Any], *, allow_count_drift: bool = False) -> None:
+    if not plan["brain_target"]:
+        raise RuntimeError(f"brain target missing: {BRAIN_TARGET_ID}")
+    if not plan["voice_target"]:
+        raise RuntimeError(f"voice target missing: {VOICE_TARGET_ID}")
+    if not plan["gliner_target"]:
+        raise RuntimeError(f"GLiNER target missing: {GLINER_TARGET_ID}")
+    counts = plan_counts(plan)
+    mismatches = {key: (counts[key], expected) for key, expected in EXPECTED.items() if counts[key] != expected}
+    if mismatches and not allow_count_drift:
+        raise RuntimeError(f"candidate counts drifted: {mismatches}")
+
+
+def set_entity_name(store: VectorStore, entity_id: str, name: str, canonical_name: str) -> None:
+    store.conn.cursor().execute(
+        """
+        UPDATE kg_entities
+        SET name = ?,
+            canonical_name = ?,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+        WHERE id = ?
+        """,
+        (name, canonical_name, entity_id),
+    )
+
+
+def archive_entity(store: VectorStore, entity_id: str, reason: str, archived_at: str) -> bool:
+    row = store.conn.cursor().execute("SELECT metadata FROM kg_entities WHERE id = ?", (entity_id,)).fetchone()
+    if not row:
+        return False
+    try:
+        metadata = json.loads(row[0]) if row[0] else {}
+    except json.JSONDecodeError:
+        metadata = {"_previous_metadata_raw": row[0]}
+    metadata["p2_cleanup"] = {
+        "action": "archive-junk",
+        "reason": reason,
+        "archived_at": archived_at,
+    }
+    store.conn.cursor().execute(
+        """
+        UPDATE kg_entities
+        SET status = 'archived',
+            expired_at = ?,
+            metadata = ?,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+        WHERE id = ? AND status = 'active'
+        """,
+        (archived_at, json.dumps(metadata, sort_keys=True), entity_id),
+    )
+    return True
+
+
+def merge_many(store: VectorStore, target_id: str, sources: list[dict[str, Any]], stats: Counter[str]) -> None:
+    for source in sources:
+        if not store.get_entity(source["id"]):
+            continue
+        merge_stats = merge_entities_preserving_links(store, target_id, source["id"])
+        stats.update({f"merge_{key}": value for key, value in merge_stats.items()})
+
+
+def apply_plan(store: VectorStore, plan: dict[str, Any]) -> Counter[str]:
+    stats: Counter[str] = Counter()
+    archived_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    set_entity_name(store, BRAIN_TARGET_ID, "brainlayerClaude", "brainlayerclaude")
+    store.add_entity_alias("brainClaude", BRAIN_TARGET_ID, alias_type="merged")
+    store.add_entity_alias("BrainLayer Claude", BRAIN_TARGET_ID, alias_type="merged")
+    store.add_entity_alias("brainlayer Claude", BRAIN_TARGET_ID, alias_type="merged")
+    merge_many(store, BRAIN_TARGET_ID, plan["brain_sources"], stats)
+    stats["named_brain_sources"] = len(plan["brain_sources"])
+
+    set_entity_name(store, VOICE_TARGET_ID, "voicelayerClaude", "voicelayerclaude")
+    store.add_entity_alias("voiceClaude", VOICE_TARGET_ID, alias_type="merged")
+    merge_many(store, VOICE_TARGET_ID, plan["voice_sources"], stats)
+    stats["named_voice_sources"] = len(plan["voice_sources"])
+
+    merge_many(store, GLINER_TARGET_ID, plan["gliner_sources"], stats)
+    stats["named_gliner_sources"] = len(plan["gliner_sources"])
+
+    for group in plan["person_groups"]:
+        merge_many(store, group["target"]["id"], group["sources"], stats)
+    stats["person_groups"] = len(plan["person_groups"])
+    stats["person_sources"] = sum(len(group["sources"]) for group in plan["person_groups"])
+
+    archived = 0
+    for row in plan["junk"]:
+        if archive_entity(store, row["id"], row["reason"], archived_at):
+            archived += 1
+    stats["junk_archived"] = archived
+    return stats
+
+
+def orphan_counts(store: VectorStore) -> dict[str, int]:
+    cursor = store._read_cursor()
+    return {
+        "entity_chunk_orphans": cursor.execute(
+            """
+            SELECT count(*)
+            FROM kg_entity_chunks ec
+            LEFT JOIN kg_entities e ON e.id = ec.entity_id
+            WHERE e.id IS NULL
+            """
+        ).fetchone()[0],
+        "relation_source_orphans": cursor.execute(
+            """
+            SELECT count(*)
+            FROM kg_relations r
+            LEFT JOIN kg_entities e ON e.id = r.source_id
+            WHERE e.id IS NULL
+            """
+        ).fetchone()[0],
+        "relation_target_orphans": cursor.execute(
+            """
+            SELECT count(*)
+            FROM kg_relations r
+            LEFT JOIN kg_entities e ON e.id = r.target_id
+            WHERE e.id IS NULL
+            """
+        ).fetchone()[0],
+    }
+
+
+def print_plan(plan: dict[str, Any]) -> None:
+    counts = plan_counts(plan)
+    print("P2 safe cleanup plan")
+    for key in sorted(counts):
+        print(f"  {key}: {counts[key]}")
+    print("  clod: no-op (0 entity/alias rows in audit)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Apply approved safe cleanup buckets")
+    parser.add_argument("--allow-count-drift", action="store_true", help="Do not abort if audited counts changed")
+    args = parser.parse_args()
+
+    store = VectorStore(get_db_path(), readonly=not args.apply)
+    try:
+        plan = build_plan(fetch_entities(store))
+        validate_plan(plan, allow_count_drift=args.allow_count_drift)
+        print_plan(plan)
+
+        if not args.apply:
+            print("DRY-RUN: no DB writes performed")
+            return 0
+
+        cursor = store.conn.cursor()
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            stats = apply_plan(store, plan)
+            cursor.execute("COMMIT")
+        except Exception:
+            cursor.execute("ROLLBACK")
+            raise
+
+        print("APPLIED")
+        for key in sorted(stats):
+            print(f"  {key}: {stats[key]}")
+        print("Orphan counts:")
+        for key, value in orphan_counts(store).items():
+            print(f"  {key}: {value}")
+        return 0
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kg_p2_safe_cleanup.py
+++ b/scripts/kg_p2_safe_cleanup.py
@@ -42,6 +42,12 @@ EXPECTED = {
     "junk": 491,
 }
 
+VOICE_VARIANT_KEYS = {
+    "voiceclaude",
+    "voicelayerclaude",
+    "voicelayerclaudeworkeremail1",
+}
+
 
 def normalize_name(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", value.lower())
@@ -89,10 +95,7 @@ def is_local_path_or_file(name: str) -> bool:
     ):
         return True
     # Deliberately excludes .js because names like Node.js/Next.js are real entities.
-    return (
-        "/" not in name
-        and re.search(r"\.(md|json|py|ts|tsx|swift|toml|ya?ml|sh|db|sqlite|mov)$", lower) is not None
-    )
+    return "/" not in name and re.search(r"\.(md|json|py|ts|tsx|swift|toml|ya?ml|sh|db|sqlite|mov)$", lower) is not None
 
 
 def junk_reasons(row: dict[str, Any]) -> list[str]:
@@ -116,12 +119,7 @@ def build_plan(rows: list[dict[str, Any]]) -> dict[str, Any]:
     by_id = {row["id"]: row for row in rows}
 
     brain_named = [row for row in rows if normalize_name(row["name"]) in {"brainclaude", "brainlayerclaude"}]
-    voice_named = [
-        row
-        for row in rows
-        if normalize_name(row["name"]) in {"voiceclaude", "voicelayerclaude"}
-        or "voicelayerclaude" in row["name"].lower()
-    ]
+    voice_named = [row for row in rows if normalize_name(row["name"]) in VOICE_VARIANT_KEYS]
     gliner_sources = [by_id[GLINER_TOOL_ID]] if GLINER_TOOL_ID in by_id else []
 
     person_groups: list[dict[str, Any]] = []
@@ -135,6 +133,9 @@ def build_plan(rows: list[dict[str, Any]]) -> dict[str, Any]:
         if not persons or len(family) <= 1:
             continue
         target = max(persons, key=lambda row: (row["chunks"], row["rels"], row["name"]))
+        # Approved P2 scope intentionally absorbs all PERSON_token placeholder rows,
+        # including rows that KG extraction mistyped as project/tool/etc. These are not
+        # real cross-type ontology entities.
         sources = [row for row in family if row["id"] != target["id"]]
         person_groups.append({"key": key, "target": target, "sources": sources})
     person_groups.sort(key=lambda group: (-sum(row["chunks"] for row in group["sources"]), group["key"]))
@@ -210,7 +211,8 @@ def archive_entity(store: VectorStore, entity_id: str, reason: str, archived_at:
         "reason": reason,
         "archived_at": archived_at,
     }
-    store.conn.cursor().execute(
+    cursor = store.conn.cursor()
+    cursor.execute(
         """
         UPDATE kg_entities
         SET status = 'archived',
@@ -221,7 +223,10 @@ def archive_entity(store: VectorStore, entity_id: str, reason: str, archived_at:
         """,
         (archived_at, json.dumps(metadata, sort_keys=True), entity_id),
     )
-    return store.conn.changes() > 0
+    changes = getattr(store.conn, "changes", None)
+    if callable(changes):
+        return changes() > 0
+    return getattr(cursor, "rowcount", 0) > 0
 
 
 def merge_many(store: VectorStore, target_id: str, sources: list[dict[str, Any]], stats: Counter[str]) -> None:

--- a/scripts/kg_p2_safe_cleanup.py
+++ b/scripts/kg_p2_safe_cleanup.py
@@ -221,7 +221,7 @@ def archive_entity(store: VectorStore, entity_id: str, reason: str, archived_at:
         """,
         (archived_at, json.dumps(metadata, sort_keys=True), entity_id),
     )
-    return True
+    return store.conn.changes() > 0
 
 
 def merge_many(store: VectorStore, target_id: str, sources: list[dict[str, Any]], stats: Counter[str]) -> None:

--- a/src/brainlayer/pipeline/entity_resolution.py
+++ b/src/brainlayer/pipeline/entity_resolution.py
@@ -154,6 +154,22 @@ def _min_present(left: int | None, right: int | None) -> int | None:
     return min(left, right)
 
 
+def _earliest_present(left: str | None, right: str | None) -> str | None:
+    """Return the earliest non-null comparable timestamp."""
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return min(left, right)
+
+
+def _latest_valid_until(left: str | None, right: str | None) -> str | None:
+    """Return the widest valid-until bound; None represents open-ended validity."""
+    if left is None or right is None:
+        return None
+    return max(left, right)
+
+
 def _merge_mention_type(left: str | None, right: str | None) -> str | None:
     """Preserve explicit mentions over inferred/implicit support."""
     if left == "explicit" or right == "explicit":
@@ -323,8 +339,8 @@ def merge_entities_preserving_links(store: VectorStore, keep_id: str, merge_id: 
                     max(existing_user_verified or 0, user_verified or 0),
                     existing_fact or fact,
                     _max_present(existing_importance, importance),
-                    existing_valid_from or valid_from,
-                    existing_valid_until or valid_until,
+                    _earliest_present(existing_valid_from, valid_from),
+                    _latest_valid_until(existing_valid_until, valid_until),
                     merged_expired_at,
                     existing_source_chunk_id or source_chunk_id,
                     existing_id,

--- a/src/brainlayer/pipeline/entity_resolution.py
+++ b/src/brainlayer/pipeline/entity_resolution.py
@@ -136,6 +136,230 @@ def resolve_entity(
     return store.upsert_entity(entity_id, entity_type, name, metadata={}, embedding=embedding)
 
 
+def _max_present(left: float | None, right: float | None) -> float | None:
+    """Return the larger non-null numeric value."""
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return max(left, right)
+
+
+def _min_present(left: int | None, right: int | None) -> int | None:
+    """Return the smaller non-null integer value."""
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return min(left, right)
+
+
+def _merge_mention_type(left: str | None, right: str | None) -> str | None:
+    """Preserve explicit mentions over inferred/implicit support."""
+    if left == "explicit" or right == "explicit":
+        return "explicit"
+    return left or right
+
+
+def merge_entities_preserving_links(store: VectorStore, keep_id: str, merge_id: str) -> dict[str, int]:
+    """Merge merge_id into keep_id while preserving stronger duplicate evidence.
+
+    Steps:
+    1. Move chunk links from merge_id to keep_id
+    2. Merge duplicate chunk-link support instead of dropping richer conflicts
+    3. Move relations (both directions) from merge_id to keep_id
+    4. Merge duplicate relation support instead of dropping richer conflicts
+    5. Store merged entity's name as alias on keep_id
+    6. Delete merge_id entity
+    """
+    stats = {
+        "chunk_links_moved": 0,
+        "chunk_conflicts_merged": 0,
+        "relations_moved": 0,
+        "relation_conflicts_merged": 0,
+        "aliases_moved": 0,
+        "entities_deleted": 0,
+    }
+    if keep_id == merge_id:
+        return stats
+
+    cursor = store.conn.cursor()
+    merged = store.get_entity(merge_id)
+    if not merged:
+        return stats
+
+    # 1. Move chunk links, merging same-chunk conflicts into the canonical row.
+    chunk_rows = list(
+        cursor.execute(
+            """
+            SELECT chunk_id, relevance, context, mention_type, relation_tier, weight
+            FROM kg_entity_chunks
+            WHERE entity_id = ?
+            """,
+            (merge_id,),
+        )
+    )
+    for chunk_id, relevance, context, mention_type, relation_tier, weight in chunk_rows:
+        existing = cursor.execute(
+            """
+            SELECT relevance, context, mention_type, relation_tier, weight
+            FROM kg_entity_chunks
+            WHERE entity_id = ? AND chunk_id = ?
+            """,
+            (keep_id, chunk_id),
+        ).fetchone()
+        if existing:
+            existing_relevance, existing_context, existing_mention_type, existing_tier, existing_weight = existing
+            merged_relevance = _max_present(existing_relevance, relevance)
+            merged_context = existing_context
+            if context and (not existing_context or (relevance or 0.0) >= (existing_relevance or 0.0)):
+                merged_context = context
+            cursor.execute(
+                """
+                UPDATE kg_entity_chunks
+                SET relevance = ?,
+                    context = ?,
+                    mention_type = ?,
+                    relation_tier = ?,
+                    weight = ?
+                WHERE entity_id = ? AND chunk_id = ?
+                """,
+                (
+                    merged_relevance,
+                    merged_context,
+                    _merge_mention_type(existing_mention_type, mention_type),
+                    _min_present(existing_tier, relation_tier),
+                    _max_present(existing_weight, weight),
+                    keep_id,
+                    chunk_id,
+                ),
+            )
+            stats["chunk_conflicts_merged"] += 1
+        else:
+            cursor.execute(
+                "UPDATE kg_entity_chunks SET entity_id = ? WHERE entity_id = ? AND chunk_id = ?",
+                (keep_id, merge_id, chunk_id),
+            )
+            stats["chunk_links_moved"] += 1
+    cursor.execute("DELETE FROM kg_entity_chunks WHERE entity_id = ?", (merge_id,))
+
+    # 2. Move relations, merging UNIQUE(source,target,type) conflicts into the canonical edge.
+    relation_rows = list(
+        cursor.execute(
+            """
+            SELECT id, source_id, target_id, relation_type, properties, confidence,
+                   user_verified, fact, importance, valid_from, valid_until,
+                   expired_at, source_chunk_id
+            FROM kg_relations
+            WHERE source_id = ? OR target_id = ?
+            """,
+            (merge_id, merge_id),
+        )
+    )
+    for (
+        relation_id,
+        source_id,
+        target_id,
+        relation_type,
+        properties,
+        confidence,
+        user_verified,
+        fact,
+        importance,
+        valid_from,
+        valid_until,
+        expired_at,
+        source_chunk_id,
+    ) in relation_rows:
+        new_source_id = keep_id if source_id == merge_id else source_id
+        new_target_id = keep_id if target_id == merge_id else target_id
+        existing = cursor.execute(
+            """
+            SELECT id, properties, confidence, user_verified, fact, importance,
+                   valid_from, valid_until, expired_at, source_chunk_id
+            FROM kg_relations
+            WHERE source_id = ? AND target_id = ? AND relation_type = ? AND id != ?
+            LIMIT 1
+            """,
+            (new_source_id, new_target_id, relation_type, relation_id),
+        ).fetchone()
+        if existing:
+            (
+                existing_id,
+                existing_properties,
+                existing_confidence,
+                existing_user_verified,
+                existing_fact,
+                existing_importance,
+                existing_valid_from,
+                existing_valid_until,
+                existing_expired_at,
+                existing_source_chunk_id,
+            ) = existing
+            merged_properties = existing_properties
+            if (not existing_properties or existing_properties == "{}") and properties:
+                merged_properties = properties
+            if existing_expired_at is None or expired_at is None:
+                merged_expired_at = None
+            else:
+                merged_expired_at = max(existing_expired_at, expired_at)
+            cursor.execute(
+                """
+                UPDATE kg_relations
+                SET properties = ?,
+                    confidence = ?,
+                    user_verified = ?,
+                    fact = ?,
+                    importance = ?,
+                    valid_from = ?,
+                    valid_until = ?,
+                    expired_at = ?,
+                    source_chunk_id = ?
+                WHERE id = ?
+                """,
+                (
+                    merged_properties,
+                    _max_present(existing_confidence, confidence),
+                    max(existing_user_verified or 0, user_verified or 0),
+                    existing_fact or fact,
+                    _max_present(existing_importance, importance),
+                    existing_valid_from or valid_from,
+                    existing_valid_until or valid_until,
+                    merged_expired_at,
+                    existing_source_chunk_id or source_chunk_id,
+                    existing_id,
+                ),
+            )
+            cursor.execute("DELETE FROM kg_relations WHERE id = ?", (relation_id,))
+            stats["relation_conflicts_merged"] += 1
+        else:
+            cursor.execute(
+                "UPDATE kg_relations SET source_id = ?, target_id = ? WHERE id = ?",
+                (new_source_id, new_target_id, relation_id),
+            )
+            stats["relations_moved"] += 1
+
+    # 3. Move aliases from merged entity to kept entity.
+    alias_rows = list(cursor.execute("SELECT alias FROM kg_entity_aliases WHERE entity_id = ?", (merge_id,)))
+    cursor.execute(
+        "UPDATE OR IGNORE kg_entity_aliases SET entity_id = ? WHERE entity_id = ?",
+        (keep_id, merge_id),
+    )
+    cursor.execute("DELETE FROM kg_entity_aliases WHERE entity_id = ?", (merge_id,))
+    stats["aliases_moved"] += len(alias_rows)
+
+    # Store merged entity's name as alias.
+    store.add_entity_alias(merged["name"], keep_id, alias_type="merged")
+
+    # 4. Delete vector embedding for merged entity.
+    cursor.execute("DELETE FROM kg_vec_entities WHERE entity_id = ?", (merge_id,))
+
+    # 5. Delete the merged entity (FTS5 trigger handles cleanup).
+    cursor.execute("DELETE FROM kg_entities WHERE id = ?", (merge_id,))
+    stats["entities_deleted"] = 1
+    return stats
+
+
 def merge_entities(store: VectorStore, keep_id: str, merge_id: str) -> None:
     """Merge merge_id into keep_id. Preserves all links and relations.
 
@@ -146,50 +370,4 @@ def merge_entities(store: VectorStore, keep_id: str, merge_id: str) -> None:
     4. Delete merge_id entity
     5. Clean up duplicate links/relations
     """
-    if keep_id == merge_id:
-        return
-
-    cursor = store.conn.cursor()
-
-    # Get the merged entity's name before deleting it
-    merged = store.get_entity(merge_id)
-    if not merged:
-        return
-
-    # 1. Move chunk links
-    cursor.execute(
-        "UPDATE OR IGNORE kg_entity_chunks SET entity_id = ? WHERE entity_id = ?",
-        (keep_id, merge_id),
-    )
-    # Delete any remaining (duplicates that couldn't be updated due to UNIQUE constraint)
-    cursor.execute("DELETE FROM kg_entity_chunks WHERE entity_id = ?", (merge_id,))
-
-    # 2. Move relations (source side)
-    cursor.execute(
-        "UPDATE OR IGNORE kg_relations SET source_id = ? WHERE source_id = ?",
-        (keep_id, merge_id),
-    )
-    cursor.execute("DELETE FROM kg_relations WHERE source_id = ?", (merge_id,))
-
-    # 2b. Move relations (target side)
-    cursor.execute(
-        "UPDATE OR IGNORE kg_relations SET target_id = ? WHERE target_id = ?",
-        (keep_id, merge_id),
-    )
-    cursor.execute("DELETE FROM kg_relations WHERE target_id = ?", (merge_id,))
-
-    # 3. Move aliases from merged entity to kept entity
-    cursor.execute(
-        "UPDATE OR IGNORE kg_entity_aliases SET entity_id = ? WHERE entity_id = ?",
-        (keep_id, merge_id),
-    )
-    cursor.execute("DELETE FROM kg_entity_aliases WHERE entity_id = ?", (merge_id,))
-
-    # Store merged entity's name as alias
-    store.add_entity_alias(merged["name"], keep_id, alias_type="merged")
-
-    # 4. Delete vector embedding for merged entity
-    cursor.execute("DELETE FROM kg_vec_entities WHERE entity_id = ?", (merge_id,))
-
-    # 5. Delete the merged entity (FTS5 trigger handles cleanup)
-    cursor.execute("DELETE FROM kg_entities WHERE id = ?", (merge_id,))
+    merge_entities_preserving_links(store, keep_id, merge_id)

--- a/tests/test_entity_dedup.py
+++ b/tests/test_entity_dedup.py
@@ -363,3 +363,51 @@ class TestMergeEntities:
         rows = list(store.conn.cursor().execute("SELECT expired_at FROM kg_relations"))
         assert len(rows) == 1
         assert rows[0][0] == "2026-02-01T00:00:00Z"
+
+
+# ── Archive Operation ──
+
+
+class TestArchiveEntity:
+    """Archive entity operation tests from kg_p2_safe_cleanup.py."""
+
+    def test_archive_nonexistent_entity_returns_false(self, store):
+        """Archiving a non-existent entity should return False."""
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        from kg_p2_safe_cleanup import archive_entity
+
+        result = archive_entity(store, "nonexistent-id", "test", "2026-05-31T00:00:00.000000Z")
+        assert result is False
+
+    def test_archive_active_entity_returns_true(self, store):
+        """Archiving an active entity should return True."""
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        from kg_p2_safe_cleanup import archive_entity
+
+        entity_id = _upsert(store, "person", "Test Person")
+        result = archive_entity(store, entity_id, "test-reason", "2026-05-31T00:00:00.000000Z")
+        assert result is True
+
+        row = store.conn.cursor().execute("SELECT status FROM kg_entities WHERE id = ?", (entity_id,)).fetchone()
+        assert row[0] == "archived"
+
+    def test_rearchive_archived_entity_returns_false(self, store):
+        """Re-archiving an already archived entity should return False."""
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        from kg_p2_safe_cleanup import archive_entity
+
+        entity_id = _upsert(store, "person", "Test Person")
+        
+        # Archive once
+        result1 = archive_entity(store, entity_id, "first-reason", "2026-05-31T00:00:00.000000Z")
+        assert result1 is True
+
+        # Try to archive again
+        result2 = archive_entity(store, entity_id, "second-reason", "2026-05-31T01:00:00.000000Z")
+        assert result2 is False, "Re-archiving should return False since entity is already archived"

--- a/tests/test_entity_dedup.py
+++ b/tests/test_entity_dedup.py
@@ -281,3 +281,85 @@ class TestMergeEntities:
 
         assert store.get_entity(merge_id) is None
         assert store.get_entity(keep_id) is not None
+
+    def test_merge_combines_duplicate_chunk_links_without_losing_stronger_support(self, store):
+        """Duplicate chunk links should keep the strongest support on the canonical entity."""
+        from brainlayer.pipeline.entity_resolution import merge_entities_preserving_links
+
+        keep_id = _upsert(store, "person", "Etan Heyman")
+        merge_id = _upsert(store, "person", "Etan")
+
+        store.link_entity_chunk(keep_id, "chunk-1", relevance=0.2, context="weak", mention_type="inferred")
+        store.link_entity_chunk(merge_id, "chunk-1", relevance=0.9, context="strong", mention_type="explicit")
+
+        stats = merge_entities_preserving_links(store, keep_id, merge_id)
+
+        row = store.conn.cursor().execute(
+            "SELECT entity_id, relevance, context, mention_type FROM kg_entity_chunks WHERE chunk_id = 'chunk-1'"
+        ).fetchone()
+        assert row == (keep_id, 0.9, "strong", "explicit")
+        assert stats["chunk_conflicts_merged"] == 1
+        assert store.conn.cursor().execute(
+            "SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?", (merge_id,)
+        ).fetchone()[0] == 0
+
+    def test_merge_combines_duplicate_relations_without_losing_richer_fact(self, store):
+        """Relation conflicts should keep a single canonical edge with richer evidence."""
+        from brainlayer.pipeline.entity_resolution import merge_entities_preserving_links
+
+        keep_id = _upsert(store, "person", "Etan Heyman")
+        merge_id = _upsert(store, "person", "Etan")
+        company_id = _upsert(store, "company", "Domica")
+
+        store.add_relation("rel-weak", keep_id, company_id, "works_at", confidence=0.2, importance=0.1)
+        store.add_relation(
+            "rel-rich",
+            merge_id,
+            company_id,
+            "works_at",
+            confidence=0.9,
+            fact="Etan works at Domica",
+            importance=0.8,
+            source_chunk_id="chunk-rich",
+        )
+
+        stats = merge_entities_preserving_links(store, keep_id, merge_id)
+
+        rows = list(
+            store.conn.cursor().execute(
+                """
+                SELECT source_id, target_id, relation_type, confidence, fact, importance, source_chunk_id
+                FROM kg_relations
+                """
+            )
+        )
+        assert rows == [(keep_id, company_id, "works_at", 0.9, "Etan works at Domica", 0.8, "chunk-rich")]
+        assert stats["relation_conflicts_merged"] == 1
+        assert store.conn.cursor().execute(
+            "SELECT COUNT(*) FROM kg_relations WHERE source_id = ? OR target_id = ?", (merge_id, merge_id)
+        ).fetchone()[0] == 0
+
+    def test_merge_relation_conflict_keeps_later_expiration(self, store):
+        """When both conflicting relations are expired, keep the later expiration."""
+        from brainlayer.pipeline.entity_resolution import merge_entities_preserving_links
+
+        keep_id = _upsert(store, "person", "Etan Heyman")
+        merge_id = _upsert(store, "person", "Etan")
+        company_id = _upsert(store, "company", "Domica")
+
+        store.add_relation("rel-old", keep_id, company_id, "works_at")
+        store.add_relation("rel-new", merge_id, company_id, "works_at")
+        store.conn.cursor().execute(
+            "UPDATE kg_relations SET expired_at = ? WHERE id = ?",
+            ("2026-01-01T00:00:00Z", "rel-old"),
+        )
+        store.conn.cursor().execute(
+            "UPDATE kg_relations SET expired_at = ? WHERE id = ?",
+            ("2026-02-01T00:00:00Z", "rel-new"),
+        )
+
+        merge_entities_preserving_links(store, keep_id, merge_id)
+
+        rows = list(store.conn.cursor().execute("SELECT expired_at FROM kg_relations"))
+        assert len(rows) == 1
+        assert rows[0][0] == "2026-02-01T00:00:00Z"

--- a/tests/test_entity_dedup.py
+++ b/tests/test_entity_dedup.py
@@ -294,14 +294,21 @@ class TestMergeEntities:
 
         stats = merge_entities_preserving_links(store, keep_id, merge_id)
 
-        row = store.conn.cursor().execute(
-            "SELECT entity_id, relevance, context, mention_type FROM kg_entity_chunks WHERE chunk_id = 'chunk-1'"
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT entity_id, relevance, context, mention_type FROM kg_entity_chunks WHERE chunk_id = 'chunk-1'"
+            )
+            .fetchone()
+        )
         assert row == (keep_id, 0.9, "strong", "explicit")
         assert stats["chunk_conflicts_merged"] == 1
-        assert store.conn.cursor().execute(
-            "SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?", (merge_id,)
-        ).fetchone()[0] == 0
+        assert (
+            store.conn.cursor()
+            .execute("SELECT COUNT(*) FROM kg_entity_chunks WHERE entity_id = ?", (merge_id,))
+            .fetchone()[0]
+            == 0
+        )
 
     def test_merge_combines_duplicate_relations_without_losing_richer_fact(self, store):
         """Relation conflicts should keep a single canonical edge with richer evidence."""
@@ -335,9 +342,12 @@ class TestMergeEntities:
         )
         assert rows == [(keep_id, company_id, "works_at", 0.9, "Etan works at Domica", 0.8, "chunk-rich")]
         assert stats["relation_conflicts_merged"] == 1
-        assert store.conn.cursor().execute(
-            "SELECT COUNT(*) FROM kg_relations WHERE source_id = ? OR target_id = ?", (merge_id, merge_id)
-        ).fetchone()[0] == 0
+        assert (
+            store.conn.cursor()
+            .execute("SELECT COUNT(*) FROM kg_relations WHERE source_id = ? OR target_id = ?", (merge_id, merge_id))
+            .fetchone()[0]
+            == 0
+        )
 
     def test_merge_relation_conflict_keeps_later_expiration(self, store):
         """When both conflicting relations are expired, keep the later expiration."""
@@ -364,6 +374,36 @@ class TestMergeEntities:
         assert len(rows) == 1
         assert rows[0][0] == "2026-02-01T00:00:00Z"
 
+    def test_merge_relation_conflict_preserves_widest_validity_window(self, store):
+        """Relation conflicts should keep the earliest start and latest end dates."""
+        from brainlayer.pipeline.entity_resolution import merge_entities_preserving_links
+
+        keep_id = _upsert(store, "person", "Etan Heyman")
+        merge_id = _upsert(store, "person", "Etan")
+        company_id = _upsert(store, "company", "Domica")
+
+        store.add_relation(
+            "rel-short",
+            keep_id,
+            company_id,
+            "works_at",
+            valid_from="2026-05-01T00:00:00Z",
+            valid_until="2026-06-01T00:00:00Z",
+        )
+        store.add_relation(
+            "rel-wide",
+            merge_id,
+            company_id,
+            "works_at",
+            valid_from="2026-01-01T00:00:00Z",
+            valid_until="2026-12-01T00:00:00Z",
+        )
+
+        merge_entities_preserving_links(store, keep_id, merge_id)
+
+        rows = list(store.conn.cursor().execute("SELECT valid_from, valid_until FROM kg_relations"))
+        assert rows == [("2026-01-01T00:00:00Z", "2026-12-01T00:00:00Z")]
+
 
 # ── Archive Operation ──
 
@@ -375,6 +415,7 @@ class TestArchiveEntity:
         """Archiving a non-existent entity should return False."""
         import sys
         from pathlib import Path
+
         sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
         from kg_p2_safe_cleanup import archive_entity
 
@@ -385,6 +426,7 @@ class TestArchiveEntity:
         """Archiving an active entity should return True."""
         import sys
         from pathlib import Path
+
         sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
         from kg_p2_safe_cleanup import archive_entity
 
@@ -399,11 +441,12 @@ class TestArchiveEntity:
         """Re-archiving an already archived entity should return False."""
         import sys
         from pathlib import Path
+
         sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
         from kg_p2_safe_cleanup import archive_entity
 
         entity_id = _upsert(store, "person", "Test Person")
-        
+
         # Archive once
         result1 = archive_entity(store, entity_id, "first-reason", "2026-05-31T00:00:00.000000Z")
         assert result1 is True

--- a/tests/test_kg_p2_safe_cleanup.py
+++ b/tests/test_kg_p2_safe_cleanup.py
@@ -1,0 +1,59 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_script():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "kg_p2_safe_cleanup.py"
+    spec = importlib.util.spec_from_file_location("kg_p2_safe_cleanup_under_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row(entity_id, name, entity_type, *, chunks=1, rels=0):
+    return {
+        "id": entity_id,
+        "name": name,
+        "entity_type": entity_type,
+        "status": "active",
+        "metadata": "{}",
+        "rels": rels,
+        "chunks": chunks,
+        "canonical_name": "",
+    }
+
+
+def test_voice_sources_do_not_match_arbitrary_voicelayerclaude_substrings():
+    cleanup = _load_script()
+    rows = [
+        _row(cleanup.VOICE_TARGET_ID, "voiceClaude", "agent", chunks=100),
+        _row("voice-exact", "voicelayerClaude", "tool"),
+        _row("voice-worker", "voicelayerClaude (worker) <[EMAIL_1]>", "person"),
+        _row("voice-overmatch", "voicelayerClaude archive export", "project"),
+    ]
+
+    plan = cleanup.build_plan(rows)
+
+    assert {row["id"] for row in plan["voice_sources"]} == {"voice-exact", "voice-worker"}
+
+
+def test_person_placeholder_family_sources_include_mistyped_placeholder_rows():
+    cleanup = _load_script()
+    rows = [
+        _row("person-canonical", "PERSON_deadbeef", "person", chunks=10),
+        _row("person-duplicate", "PERSON_deadbeef", "person", chunks=2),
+        _row("mistyped-tool-placeholder", "PERSON_deadbeef", "tool", chunks=1),
+        _row("mistyped-project-placeholder", "[PERSON_deadbeef]", "project", chunks=1),
+    ]
+
+    plan = cleanup.build_plan(rows)
+
+    assert len(plan["person_groups"]) == 1
+    group = plan["person_groups"][0]
+    assert group["target"]["id"] == "person-canonical"
+    assert {row["id"] for row in group["sources"]} == {
+        "person-duplicate",
+        "mistyped-tool-placeholder",
+        "mistyped-project-placeholder",
+    }


### PR DESCRIPTION
## Summary
- add `merge_entities_preserving_links()` so KG entity merges preserve chunk links, relations, aliases, and richer duplicate evidence instead of dropping UNIQUE conflicts
- add the approved one-shot P2 safe cleanup script for named fixes, junk soft-archive, and PERSON token duplicate-family merges
- add regression coverage for duplicate chunk-link conflicts, relation conflicts, and relation expiration consolidation

## Safe Bucket Execution
- executed approved safe buckets only against the live KG DB
- renamed/merged `brainClaude` variants into `brainlayerClaude` agent `173733c921d4e817`
- renamed/merged `voiceClaude` variants into `voicelayerClaude` agent `golem-224489db81b9`
- merged `GLiNER` tool row into canonical `GLiNER` technology `5cc471c76ffdab6d`
- soft archived 491 junk entities
- merged 585 `PERSON_xxxxxxxx` duplicate families into canonical person rows
- held the cross-type ontology bucket unchanged for `brainlayerClaude-LEAD-v3`

## Verification
- `pytest tests/test_entity_dedup.py -q` -> 25 passed
- `cr review --plain` -> no findings after two addressed minor findings
- `pytest` -> 2321 passed, 48 skipped, 5 xfailed, 328 warnings
- pre-push gate -> passed: Python 3.12 unit suite, MCP registration, isolated eval/hook routing, Bun test, regression shell test

## DB Acceptance
- live KG orphan checks: `entity_chunk_orphans=0`, `relation_source_orphans=0`, `relation_target_orphans=0`
- active leftovers for `brainClaude`/`voiceClaude`/`G-Liner`/`clod`: 0
- backup before execution: `/Users/etanheyman/.local/share/brainlayer/brainlayer-pre-p2-kg-cleanup-20260531T071844Z.db`
- local execution report: `docs.local/P2-EXECUTION-REPORT.md`

Do not merge yet; commander gates merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core merge semantics and performs large-scale KG writes; the cleanup script lacks WAL checkpoint/writer coordination and relation `properties` JSON is not deep-merged on conflicts, risking silent evidence loss under reuse or concurrency.
> 
> **Overview**
> Adds **`merge_entities_preserving_links`** in `entity_resolution.py` and routes existing **`merge_entities`** through it. Duplicate chunk links and relations are consolidated instead of dropped on UNIQUE conflicts—stronger relevance, explicit mentions, facts, confidence, expiration, and validity windows are kept.
> 
> Introduces **`scripts/kg_p2_safe_cleanup.py`**: dry-run by default, audited count validation, optional **`--apply`** inside **`BEGIN IMMEDIATE`**. Plan covers named brain/voice/GLiNER merges, **`PERSON_*`** family merges (including mistyped placeholder rows), and soft-archiving low-support junk. **`archive_entity`** now reports success via row count.
> 
> Regression tests cover merge conflicts, archive idempotency, voice variant matching, and person placeholder grouping. Two Bugbot review markdown files document verification and open hardening items (WAL checkpoints, properties JSON deep-merge, **`SQLITE_BUSY`** retries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078c0e9a21a596e0cabdbb2189cdabece569ba84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced entity deduplication to preserve stronger evidence and resolve relation conflicts more safely.

* **Maintenance Tool**
  * Added a one-shot knowledge-graph cleanup utility with planning, validation, and an optional apply mode to merge duplicates and archive junk entities.

* **Tests**
  * Added unit tests covering duplicate-entity merging, duplicate relation consolidation, and expiration-tie conflict handling.

* **Documentation**
  * Added a review doc detailing the cleanup approach, verification steps, and recommended fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add safe one-shot CLI to merge and archive P2 knowledge graph entities
> - Adds [scripts/kg_p2_safe_cleanup.py](https://github.com/EtanHey/brainlayer/pull/411/files#diff-5186bb660e3e712b431bd58158fd280609f87a472d1a17227777437c63682108), a CLI that builds a deterministic cleanup plan: merges brain/voice/gliner duplicate entities, groups `PERSON_token` placeholder families, and archives low-signal junk entities (fragments, URLs, local paths, long hex strings).
> - Refactors `merge_entities` in [entity_resolution.py](https://github.com/EtanHey/brainlayer/pull/411/files#diff-8a533cdbaf4b5040ab7d495773bb68f328c48a3bd6652c19aec70e9100b88492) to delegate to a new `merge_entities_preserving_links` function that consolidates duplicate chunk links and relations (preserving stronger evidence, widest validity window, richer facts) instead of dropping conflicts.
> - Adds a `--dry-run` mode and count-drift gating via `validate_plan`; when `--apply` is set, the full plan executes inside a `BEGIN IMMEDIATE`/`COMMIT` transaction with rollback on error.
> - Covers the new merge and archive behavior with tests in [tests/test_entity_dedup.py](https://github.com/EtanHey/brainlayer/pull/411/files#diff-4adcee3b4d3f467e8b3ce9fa87660afb156d534a5c41f2ffa5c907a6142f9634) and [tests/test_kg_p2_safe_cleanup.py](https://github.com/EtanHey/brainlayer/pull/411/files#diff-77e40b03d1f3fec3883002580bbc7f29099d0101eeb1d14f0739f9d3999bf8e5).
> - Behavioral Change: `merge_entities` now delegates entirely to `merge_entities_preserving_links` and returns a stats dict; callers that ignored the return value are unaffected, but callers expecting no return value will now receive one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 078c0e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->