### PR TITLE
style: ruff format 3 files to unblock lint gate

### DIFF
--- a/src/brainlayer/ingest/codex.py
+++ b/src/brainlayer/ingest/codex.py
@@ -278,9 +278,7 @@ def parse_codex_session(file_path: Path) -> Iterator[dict]:
 
 
 _STACK_TRACE_RE = re.compile(
-    r"Traceback \(most recent call last\)|"
-    r"at\s+[\w.]+\([\w.]+:\d+\)|"
-    r'File "[^"]+", line \d+',
+    r"Traceback \(most recent call last\)|" r"at\s+[\w.]+\([\w.]+:\d+\)|" r'File "[^"]+", line \d+',
     re.MULTILINE,
 )
 

--- a/src/brainlayer/pipeline/operation_grouping.py
+++ b/src/brainlayer/pipeline/operation_grouping.py
@@ -88,8 +88,7 @@ def _extract_tool_info(chunk: Dict[str, Any]) -> Dict[str, Any]:
     import re
 
     file_match = re.search(
-        r'(?:file_path|path)[=:]\s*["\']?'
-        r'([^\s"\']+\.\w+)',
+        r'(?:file_path|path)[=:]\s*["\']?' r'([^\s"\']+\.\w+)',
         content,
     )
     if file_match:

--- a/src/brainlayer/pipeline/unified_timeline.py
+++ b/src/brainlayer/pipeline/unified_timeline.py
@@ -327,8 +327,7 @@ def _parse_gemini_html(activity_path: Path) -> Iterator[dict]:
     # Simple extraction: look for activity entries with title and time
     # HTML format varies; common pattern: div with data
     pattern = re.compile(
-        r'<[^>]+class="[^"]*content[^"]*"[^>]*>([^<]+)</[^>]+>.*?'
-        r"(\d{4}-\d{2}-\d{2}T[\d:.]+Z)?",
+        r'<[^>]+class="[^"]*content[^"]*"[^>]*>([^<]+)</[^>]+>.*?' r"(\d{4}-\d{2}-\d{2}T[\d:.]+Z)?",
         re.DOTALL | re.IGNORECASE,
     )
     # Fallback: generic title-like text


### PR DESCRIPTION
## Summary
Pre-existing `ruff format` debt on `main` in 3 files (implicit string concatenation across lines) was red-flagging the **lint** CI check on *every* open PR — including #411 (P2 KG safe cleanup), whose own diff is clean and whose tests/CodeRabbit/Macroscope all pass.

## Change
`ruff format` (v0.6.9, the exact CI formatter) on:
- `src/brainlayer/ingest/codex.py`
- `src/brainlayer/pipeline/operation_grouping.py`
- `src/brainlayer/pipeline/unified_timeline.py`

3 files, +3/-7. **Format-only, zero functional change** (collapses multi-line implicit str-concat into single lines).

## Verify
- `ruff format --check src/` → `110 files already formatted` (was: 3 would reformat → lint fail)
- `ruff check src/...` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only formatting on regex literals; no runtime, security, or data-path changes.
> 
> **Overview**
> **Format-only** fix for pre-existing `ruff format` drift on `main` that was failing the repo **lint** CI on unrelated PRs.
> 
> Applies **ruff format** (v0.6.9) to three modules, collapsing multi-line **implicit string concatenation** in `re.compile` / `re.search` patterns onto single lines: `_STACK_TRACE_RE` in `codex.py`, the file-path regex in `operation_grouping.py`, and the Gemini HTML activity pattern in `unified_timeline.py`. **No logic or behavior change**—only whitespace/layout so `ruff format --check src/` passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27a6bb8ab2a630c49d0909773921f1ceec0e155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format regex literals in 3 pipeline files to pass lint gate
> Collapses adjacent raw string literals into single lines in regex patterns across [codex.py](https://github.com/EtanHey/brainlayer/pull/412/files#diff-4a0d1900da18247cb27cd5e1444320c86c9cad6fe4e810bfa93a6776289581f6), [operation_grouping.py](https://github.com/EtanHey/brainlayer/pull/412/files#diff-72940793d6c0d912f0df23e44b04ad87317abc6e59216a048c6b11b1e10d432e), and [unified_timeline.py](https://github.com/EtanHey/brainlayer/pull/412/files#diff-4eaeb17c25050ab070434a1b3b8df10c2bf2df0987b84573dfb06310ffaeb4d3). No logic or regex patterns are changed — this is a pure formatting fix to satisfy the ruff lint gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b27a6bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->