### PR TITLE
fix(enrichment): keep arbitrated writes queued

### DIFF
--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -324,7 +324,7 @@ def run_enrich_supervisor(
 
     db_path = Path(db_path)
     stats = EnrichmentSupervisorResult()
-    store = vector_store_cls(db_path)
+    store = _open_enrich_supervisor_store(vector_store_cls, db_path)
     logger.info("VectorStore initialized for enrich supervisor: %s", db_path)
     try:
         while stop_event is None or not stop_event.is_set():
@@ -458,6 +458,16 @@ def _arbitrated_writes_enabled() -> bool:
     return os.environ.get("BRAINLAYER_ARBITRATED") == "1"
 
 
+def _open_enrich_supervisor_store(vector_store_cls, db_path: Path):
+    if not _arbitrated_writes_enabled():
+        return vector_store_cls(db_path)
+    try:
+        return vector_store_cls(db_path, readonly=True)
+    except TypeError:
+        logger.debug("VectorStore class does not accept readonly=True; opening with default constructor")
+        return vector_store_cls(db_path)
+
+
 def _current_max_commit_batch() -> int:
     return _bounded_positive_int(os.environ.get("BRAINLAYER_MAX_COMMIT_BATCH"), MAX_COMMIT_BATCH)
 
@@ -587,6 +597,9 @@ def _enqueue_meta_research_write(chunk: dict[str, Any]) -> None:
 
 
 def _ensure_enrichment_columns(store, *, yield_after: bool = True) -> None:
+    if _arbitrated_writes_enabled():
+        return
+
     key = _store_queue_key(store)
     with _ENRICHMENT_COLUMN_LOCK:
         if key in _ENRICHMENT_COLUMN_READY:
@@ -1070,7 +1083,8 @@ def enrich_single(store, chunk_id: str, max_retries: int = 2) -> dict[str, Any] 
 
     _begin_store_operation(store)
     try:
-        _ensure_enrichment_columns(store)
+        if not _arbitrated_writes_enabled():
+            _ensure_enrichment_columns(store)
 
         chunk = _get_chunk_readonly(store, chunk_id)
         if not chunk:
@@ -1228,7 +1242,8 @@ def enrich_realtime(
             _emit_enrichment_complete(result, 0)
             return result
 
-        _ensure_enrichment_columns(store, yield_after=rate_per_second > 0)
+        if not _arbitrated_writes_enabled():
+            _ensure_enrichment_columns(store, yield_after=rate_per_second > 0)
 
         client = _get_gemini_client()
         sanitizer = Sanitizer.from_env()
@@ -1333,7 +1348,8 @@ def enrich_batch(
             _emit_enrichment_complete(result, duration_ms)
             return result
 
-        _ensure_enrichment_columns(store)
+        if not _arbitrated_writes_enabled():
+            _ensure_enrichment_columns(store)
 
         try:
             client = _get_gemini_client()

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -27,7 +27,16 @@ _QUEUE_MAX_SIZE = 100
 
 
 def _is_lock_error(exc: BaseException) -> bool:
-    return isinstance(exc, apsw.BusyError) or "locked" in str(exc).lower() or "busy" in str(exc).lower()
+    from ..vector_store import WriterInUseError
+
+    text = str(exc).lower()
+    return (
+        isinstance(exc, apsw.BusyError)
+        or isinstance(exc, WriterInUseError)
+        or "locked" in text
+        or "busy" in text
+        or "sqlite prepare failed" in text
+    )
 
 
 def _new_manual_chunk_id() -> str:

--- a/tests/test_enrich_supervisor.py
+++ b/tests/test_enrich_supervisor.py
@@ -54,6 +54,53 @@ def test_supervisor_reuses_one_vector_store_across_cycles(tmp_path):
     assert result.enriched == 3
 
 
+def test_supervisor_uses_readonly_store_when_arbitrated(tmp_path, monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    monkeypatch.setenv("BRAINLAYER_ARBITRATED", "1")
+    init_args = []
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path, readonly: bool = False):
+            init_args.append((db_path, readonly))
+
+        def close(self):
+            pass
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        max_cycles=1,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=lambda store, **kwargs: _result(attempted=0),
+        sleep_fn=lambda seconds: None,
+    )
+
+    assert init_args == [(tmp_path / "brainlayer.db", True)]
+    assert result.cycles == 1
+
+
+def test_enrich_realtime_skips_schema_writer_when_arbitrated(monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    monkeypatch.setenv("BRAINLAYER_ARBITRATED", "1")
+    monkeypatch.setattr(
+        controller,
+        "_ensure_enrichment_columns",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not open schema writer")),
+    )
+    monkeypatch.setattr(controller, "_enqueue_enrichment_write_batch", lambda items: None)
+    monkeypatch.setattr(controller, "_get_gemini_client", lambda: object())
+
+    class FakeStore:
+        def get_enrichment_candidates(self, **kwargs):  # noqa: ARG002
+            return [{"id": "c1", "content": "brain_search('recursive MCP output')"}]
+
+    result = controller.enrich_realtime(FakeStore(), limit=1, rate_per_second=0)
+
+    assert result.skipped == 1
+    assert result.failed == 0
+
+
 def test_supervisor_logs_gemini_error_and_continues(tmp_path, caplog):
     from brainlayer import enrichment_controller as controller
 

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -38,6 +38,63 @@ async def test_busy_queue_fallback_returns_queued_chunk_id(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_writer_in_use_error_queues_instead_of_erroring(tmp_path):
+    """Writer pidfile contention queues the store instead of returning an MCP error."""
+    from brainlayer.mcp.store_handler import _store
+    from brainlayer.vector_store import WriterInUseError
+
+    queue_dir = tmp_path / "queue"
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store"),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+        patch(
+            "brainlayer.store.store_memory",
+            side_effect=WriterInUseError("another writer is using brainlayer.db (pid 123)"),
+        ),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        texts, structured = await _store(
+            content="queued under held writer pidfile",
+            memory_type="note",
+            project="test",
+        )
+
+    assert structured["queued"] is True
+    assert structured["chunk_id"] != "queued"
+    assert any("queued" in item.text.lower() for item in texts)
+    assert len(list(queue_dir.glob("mcp-*.jsonl"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_sqlite_prepare_lock_error_queues_instead_of_erroring(tmp_path):
+    """Prepare-time transient SQLite lock failures are queueable store failures."""
+    from brainlayer.mcp.store_handler import _store
+
+    queue_dir = tmp_path / "queue"
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store"),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+        patch(
+            "brainlayer.store.store_memory",
+            side_effect=RuntimeError("SQLite prepare failed: database schema is locked"),
+        ),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        texts, structured = await _store(
+            content="queued under prepare-time sqlite lock",
+            memory_type="note",
+            project="test",
+        )
+
+    assert structured["queued"] is True
+    assert structured["chunk_id"] != "queued"
+    assert any("queued" in item.text.lower() for item in texts)
+    assert len(list(queue_dir.glob("mcp-*.jsonl"))) == 1
+
+
+@pytest.mark.asyncio
 async def test_busy_queue_fallback_preserves_supersedes(tmp_path):
     """DB-busy fallback queues supersedes so the deferred write keeps lifecycle intent."""
     from brainlayer.mcp.store_handler import _store


### PR DESCRIPTION
## Summary
- open the enrichment supervisor store readonly when `BRAINLAYER_ARBITRATED=1`
- skip enrichment schema writes in arbitrated mode so the drain path remains the sole writer
- classify `WriterInUseError` and SQLite prepare-lock failures as queueable MCP store lock errors

## Tests
- RED first: targeted tests failed before implementation for readonly supervisor wiring, arbitrated schema-write skipping, and WriterInUse queue fallback
- `uv run --extra dev pytest tests/test_enrich_supervisor.py tests/test_store_handler.py -k 'readonly_store_when_arbitrated or skips_schema_writer_when_arbitrated or writer_in_use_error_queues or sqlite_prepare_lock_error_queues'`
- `uv run --extra dev ruff check src/brainlayer/enrichment_controller.py src/brainlayer/mcp/store_handler.py tests/test_enrich_supervisor.py tests/test_store_handler.py`
- `uv run --extra dev pytest tests/test_enrich_supervisor.py tests/test_store_handler.py tests/test_write_queue.py tests/test_enrichment_bounded_commit.py tests/test_enrichment_controller.py`
- `uv run --extra dev pytest`

## Notes
- normal push was used; no `--no-verify` bypass was used on this branch
- do not merge until commander gate approval

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes single-writer arbitration for enrichment and MCP store failure paths; incorrect readonly or skip logic could drop writes or leave schema stale, but scope is env-gated and covered by targeted tests.
> 
> **Overview**
> When **`BRAINLAYER_ARBITRATED=1`**, enrichment no longer competes with the drain path for the DB writer. The enrich supervisor opens **`VectorStore` in readonly mode** via `_open_enrich_supervisor_store`, and **`_ensure_enrichment_columns` is skipped** in realtime, batch, and `enrich_single` so schema DDL is not run from enrichment; updates stay on the existing enqueue/drain path.
> 
> MCP **`brain_store`** lock handling is broadened: **`WriterInUseError`** and **SQLite prepare-time schema lock** messages are treated like busy/locked errors, so stores **queue to JSONL** instead of failing the tool call after retries.
> 
> Tests cover readonly supervisor wiring, arbitrated schema-write skipping, and the two new queue fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d16c29526db1c26fcf315ea9fa9da01166e2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep arbitrated writes queued by opening VectorStore in readonly mode and skipping schema writes
> - When `BRAINLAYER_ARBITRATED=1` is set, the enrichment supervisor now opens the VectorStore in readonly mode (via `_open_enrich_supervisor_store` in [enrichment_controller.py](https://github.com/EtanHey/brainlayer/pull/414/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb)), falling back to default construction if `readonly=True` is not supported.
> - `_ensure_enrichment_columns` returns early under arbitration, and the guard is applied in `enrich_single`, `enrich_realtime`, and `enrich_batch` to prevent schema writes.
> - `_is_lock_error` in [store_handler.py](https://github.com/EtanHey/brainlayer/pull/414/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263) now also matches `WriterInUseError` and prepare-time SQLite lock errors, routing them to the existing busy-queue fallback instead of surfacing an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95d16c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database contention handling with enhanced detection of lock and busy errors.
  * Added support for queuing operations when database writer conflicts occur, reducing failures during concurrent access scenarios.

* **Tests**
  * Added test coverage for arbitrated writes mode with read-only store access.
  * Added test coverage for database lock error handling and operation queuing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->