### PR TITLE
Split BrainBar read path from writer

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -101,6 +101,7 @@ final class BrainBarServer: @unchecked Sendable {
     private var clients: [Int32: ClientState] = [:]
     private var router: MCPRouter!
     private var database: BrainDatabase!
+    private var readDatabase: BrainDatabase?
     private var hybridSearchHelperClient: HybridSearchHelperClient?
     private let providedHybridSearchClient: HybridSearchClientProtocol?
     private let enableHybridSearchHelper: Bool
@@ -117,6 +118,8 @@ final class BrainBarServer: @unchecked Sendable {
     /// Each retry sleeps 1ms; 50 retries keeps false-positive disconnects
     /// below the UI budget while still bounding serial-queue stalls.
     static let maxWriteRetries = 50
+    private static let readOnlyBusyTimeoutMillis: Int32 = 250
+    private static let hybridSearchBudgetSeconds: TimeInterval = 0.8
     private let debugLogPath = "/tmp/brainbar-debug.log"
 
     private func debugLog(_ msg: String) {
@@ -220,7 +223,10 @@ final class BrainBarServer: @unchecked Sendable {
             ownedHybridClient = nil
             hybridClient = providedHybridSearchClient
         } else if providedDatabase == nil && enableHybridSearchHelper {
-            let client = HybridSearchHelperClient(dbPath: dbPath)
+            let client = HybridSearchHelperClient(
+                dbPath: dbPath,
+                socketIOTimeout: Self.hybridSearchBudgetSeconds
+            )
             ownedHybridClient = client
             hybridClient = client
         } else {
@@ -230,7 +236,10 @@ final class BrainBarServer: @unchecked Sendable {
 
         // 1. Create router FIRST (no DB dependency).
         //    initialize + tools/list work without a database.
-        router = MCPRouter(hybridSearchClient: hybridClient)
+        router = MCPRouter(
+            hybridSearchClient: hybridClient,
+            hybridSearchBudget: Self.hybridSearchBudgetSeconds
+        )
 
         // 2. Bind socket BEFORE database init.
         //    After a restart the socket must exist before Claude Code tries
@@ -318,7 +327,7 @@ final class BrainBarServer: @unchecked Sendable {
         guard database == nil, !databaseOpenInProgress else { return }
 
         if let providedDatabase {
-            finishDatabaseOpen(providedDatabase)
+            finishDatabaseOpen(providedDatabase, readDatabase: providedDatabase)
             return
         }
 
@@ -330,27 +339,40 @@ final class BrainBarServer: @unchecked Sendable {
                 path: dbPath,
                 openConfiguration: .init(busyTimeoutMillis: busyTimeoutMillis)
             )
+            let readDB = db.isOpen
+                ? BrainDatabase(
+                    path: dbPath,
+                    openConfiguration: .init(
+                        busyTimeoutMillis: Self.readOnlyBusyTimeoutMillis,
+                        readOnly: true
+                    )
+                )
+                : nil
             self?.queue.async { [weak self] in
                 self?.databaseOpenInProgress = false
-                self?.finishDatabaseOpen(db)
+                self?.finishDatabaseOpen(db, readDatabase: readDB)
             }
         }
     }
 
-    private func finishDatabaseOpen(_ db: BrainDatabase) {
+    private func finishDatabaseOpen(_ db: BrainDatabase, readDatabase readDB: BrainDatabase?) {
         guard listenSource != nil else {
             if providedDatabase == nil {
+                if let readDB, readDB !== db {
+                    readDB.close()
+                }
                 db.close()
             }
             return
         }
 
-        if db.isOpen {
+        if db.isOpen, let readDB, readDB.isOpen {
             databaseRetryWorkItem?.cancel()
             databaseRetryWorkItem = nil
             lastDatabaseRetryDelayMillis = nil
             database = db
-            router.setDatabase(db)
+            readDatabase = readDB
+            router.setDatabases(write: db, read: readDB)
             onDatabaseReady?(db)
             brainBus.publish(.dbBusy(false))
             brainBus.publish(.queueDepth(brainBusQueueDepthEstimate))
@@ -359,12 +381,16 @@ final class BrainBarServer: @unchecked Sendable {
             return
         }
 
+        let lastOpenError = db.isOpen ? readDB?.lastOpenError : db.lastOpenError
         if providedDatabase == nil {
+            if let readDB, readDB !== db {
+                readDB.close()
+            }
             db.close()
         }
         NSLog("[BrainBar] ⚠️ DATABASE FAILED TO OPEN — tools/call will return errors (%@)", dbPath)
         brainBus.publish(.dbBusy(true))
-        scheduleDatabaseRetry(lastError: db.lastOpenError)
+        scheduleDatabaseRetry(lastError: lastOpenError)
     }
 
     private func scheduleDatabaseRetry(lastError: Error?) {
@@ -675,9 +701,14 @@ final class BrainBarServer: @unchecked Sendable {
         clients.removeAll()
         if listenFD >= 0 { listenFD = -1 }
         unlink(socketPath)
+        let writeDatabase = database
         if providedDatabase == nil {
-            database?.close()
+            if let readDatabase, let writeDatabase, readDatabase !== writeDatabase {
+                readDatabase.close()
+            }
+            writeDatabase?.close()
         }
+        readDatabase = nil
         database = nil
         hybridSearchHelperClient?.stop()
         hybridSearchHelperClient = nil

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -32,8 +32,31 @@ final class MCPRouter: @unchecked Sendable {
         }
     }
 
+    private struct HybridSearchArgumentBox: @unchecked Sendable {
+        let arguments: [String: Any]
+    }
+
+    private final class HybridSearchResultBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var result: Result<HybridSearchResponse, Error>?
+
+        func set(_ result: Result<HybridSearchResponse, Error>) {
+            lock.lock()
+            self.result = result
+            lock.unlock()
+        }
+
+        func get() -> Result<HybridSearchResponse, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            return result
+        }
+    }
+
     private var database: BrainDatabase?
+    private var readDatabase: BrainDatabase?
     private let hybridSearchClient: HybridSearchClientProtocol?
+    private let hybridSearchBudget: TimeInterval
     let entityCache = EntityCache()
     private static let defaultStringMaxLength = 256
     private static let defaultStringArrayMaxItems = 100
@@ -60,15 +83,37 @@ final class MCPRouter: @unchecked Sendable {
         "tags": (maxItems: 100, itemMaxLength: 128)
     ]
 
-    init(hybridSearchClient: HybridSearchClientProtocol? = nil) {
+    init(hybridSearchClient: HybridSearchClientProtocol? = nil, hybridSearchBudget: TimeInterval = 0.8) {
         self.hybridSearchClient = hybridSearchClient
+        self.hybridSearchBudget = max(0.001, hybridSearchBudget)
     }
 
     /// Inject database for tool handlers + load entity cache.
     func setDatabase(_ db: BrainDatabase) {
-        self.database = db
-        entityCache.load(from: db.dbHandle)
-        entityCache.startRefreshTimer(db: db.dbHandle)
+        setDatabases(write: db, read: db)
+    }
+
+    /// Inject separate write and read handles. Read tools use the read handle so
+    /// WAL readers do not inherit write-handle busy_timeout or transaction state.
+    func setDatabases(write writeDB: BrainDatabase, read readDB: BrainDatabase) {
+        database = writeDB
+        readDatabase = readDB
+        entityCache.load(from: readDB.dbHandle)
+        entityCache.startRefreshTimer(db: readDB.dbHandle)
+    }
+
+    private func readDB() throws -> BrainDatabase {
+        guard let db = readDatabase ?? database else {
+            throw ToolError.noDatabase
+        }
+        return db
+    }
+
+    private func writeDB() throws -> BrainDatabase {
+        guard let db = database else {
+            throw ToolError.noDatabase
+        }
+        return db
     }
 
     /// Handle a parsed JSON-RPC request and return a response.
@@ -262,9 +307,7 @@ final class MCPRouter: @unchecked Sendable {
         if unreadOnly && subscriberID == nil {
             throw ToolError.missingParameter("agent_id")
         }
-        guard let db = database else {
-            throw ToolError.noDatabase
-        }
+        let db = try readDB()
         SearchProfileLogger.log(
             scope: "search.brainbar",
             step: "router_dispatch",
@@ -309,9 +352,9 @@ final class MCPRouter: @unchecked Sendable {
         let textSection: String
         let metadata: [String: Any]
         let kgSection: String
-        if let hybridSearchClient, subscriberID == nil, !unreadOnly {
+        if hybridSearchClient != nil, subscriberID == nil, !unreadOnly {
             do {
-                let response = try hybridSearchClient.search(arguments: hybridSearchArguments(
+                let response = try hybridSearchWithinBudget(arguments: hybridSearchArguments(
                     query: query,
                     limit: limit,
                     project: project,
@@ -321,9 +364,17 @@ final class MCPRouter: @unchecked Sendable {
                     detail: args["detail"] as? String,
                     profileQueryID: profileQueryID
                 ))
-                textSection = response.text
-                metadata = sanitizedHybridMetadata(response.metadata)
-                kgSection = ""
+                if let response {
+                    textSection = response.text
+                    metadata = sanitizedHybridMetadata(response.metadata)
+                    kgSection = ""
+                } else {
+                    NSLog("[BrainBar] Hybrid search helper exceeded %.3fs budget, falling back to BrainBar database search", hybridSearchBudget)
+                    let fallback = try searchViaBrainBarDatabase()
+                    textSection = fallback.text
+                    metadata = fallback.metadata
+                    kgSection = localKGSection()
+                }
             } catch {
                 NSLog("[BrainBar] Hybrid search helper failed, falling back to BrainBar database search: %@", String(describing: error))
                 let fallback = try searchViaBrainBarDatabase()
@@ -343,6 +394,27 @@ final class MCPRouter: @unchecked Sendable {
             return ToolOutput(text: textSection, metadata: metadata)
         }
         return ToolOutput(text: kgSection + "\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n" + textSection, metadata: metadata)
+    }
+
+    private func hybridSearchWithinBudget(arguments: [String: Any]) throws -> HybridSearchResponse? {
+        guard let hybridSearchClient else { return nil }
+
+        let group = DispatchGroup()
+        let argumentBox = HybridSearchArgumentBox(arguments: arguments)
+        let resultBox = HybridSearchResultBox()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome = Result { try hybridSearchClient.search(arguments: argumentBox.arguments) }
+            resultBox.set(outcome)
+            group.leave()
+        }
+
+        let timeout = DispatchTime.now() + .nanoseconds(Int(hybridSearchBudget * 1_000_000_000))
+        guard group.wait(timeout: timeout) == .success else {
+            return nil
+        }
+
+        return try resultBox.get()?.get()
     }
 
     private func sanitizedHybridMetadata(_ metadata: [String: Any]) -> [String: Any] {
@@ -390,9 +462,7 @@ final class MCPRouter: @unchecked Sendable {
         }
         let tags = args["tags"] as? [String] ?? []
         let importance = args["importance"] as? Int ?? 5
-        guard let db = database else {
-            throw ToolError.noDatabase
-        }
+        let db = try writeDB()
         switch try db.storeOrQueueWithinBudget(content: content, tags: tags, importance: importance, source: "mcp") {
         case .stored(let stored):
             let flushedStores = db.flushPendingStores()
@@ -430,7 +500,7 @@ final class MCPRouter: @unchecked Sendable {
         }
         let context = args["context"] as? String
         let numMemories = min(args["num_memories"] as? Int ?? 10, 50)
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try readDB()
         guard let person = try db.getPersonContext(name: name, context: context, numMemories: numMemories) else {
             return ToolOutput(text: "No person entity found matching '\(name)'.")
         }
@@ -438,7 +508,7 @@ final class MCPRouter: @unchecked Sendable {
     }
 
     private func handleBrainRecall(_ args: [String: Any]) throws -> ToolOutput {
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try readDB()
         let mode = args["mode"] as? String ?? "stats"
         if mode == "injections" {
             let sessionId = args["session_id"] as? String
@@ -476,7 +546,7 @@ final class MCPRouter: @unchecked Sendable {
         guard let query = args["query"] as? String else {
             throw ToolError.missingParameter("query")
         }
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try readDB()
         guard let entity = try db.lookupEntity(query: query) else {
             return ToolOutput(text: "\u{2502} No entity found for \"\(query)\"")
         }
@@ -487,13 +557,13 @@ final class MCPRouter: @unchecked Sendable {
         guard let content = args["content"] as? String else {
             throw ToolError.missingParameter("content")
         }
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try writeDB()
         let result = try db.digest(content: content)
         return ToolOutput(text: TextFormatter.formatDigestResult(DigestResult(payload: result)))
     }
 
     private func handleBrainUpdate(_ args: [String: Any]) throws -> ToolOutput {
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try writeDB()
         let chunkId = args["chunk_id"] as? String ?? ""
         if chunkId.isEmpty {
             throw ToolError.missingParameter("chunk_id")
@@ -511,7 +581,7 @@ final class MCPRouter: @unchecked Sendable {
         guard let chunkId = args["chunk_id"] as? String else {
             throw ToolError.missingParameter("chunk_id")
         }
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try readDB()
         let before = args["before"] as? Int ?? 3
         let after = args["after"] as? Int ?? 3
         let expanded = try db.expandChunk(id: chunkId, before: before, after: after)
@@ -537,7 +607,7 @@ final class MCPRouter: @unchecked Sendable {
     }
 
     private func handleBrainTags(_ args: [String: Any]) throws -> ToolOutput {
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try readDB()
         let query = args["query"] as? String
         let limit = args["limit"] as? Int ?? 50
         let tags = try db.listTags(query: query, limit: limit)
@@ -564,7 +634,7 @@ final class MCPRouter: @unchecked Sendable {
         }
         let safetyCheck = args["safety_check"] as? String ?? "auto"
         let confirm = args["confirm"] as? Bool ?? false
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try writeDB()
 
         guard let oldChunk = try db.getChunk(id: oldChunkID) else {
             throw ToolError.notFound("Old chunk not found: \(oldChunkID)")
@@ -608,7 +678,7 @@ final class MCPRouter: @unchecked Sendable {
             throw ToolError.missingParameter("chunk_id")
         }
         let reason = args["reason"] as? String
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try writeDB()
         guard try db.archiveChunk(id: chunkID, reason: reason) else {
             throw ToolError.notFound("Chunk not found: \(chunkID)")
         }
@@ -629,7 +699,7 @@ final class MCPRouter: @unchecked Sendable {
         let phase = args["phase"] as? String ?? "run"
         let chunkIDs = args["chunk_ids"] as? [String]
         let stats = args["stats"] as? Bool ?? false
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try writeDB()
 
         if stats {
             let summary = try db.enrichmentStats()
@@ -708,7 +778,7 @@ final class MCPRouter: @unchecked Sendable {
             )
         }
 
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try writeDB()
         let batchSize = args["batch_size"] as? Int ?? 1_000
         let maxReturnedEvents = 25
         var events: [BrainDatabase.TrigramMaintenanceProgress] = []
@@ -737,7 +807,7 @@ final class MCPRouter: @unchecked Sendable {
         guard let targetPath = args["target_path"] as? String else {
             throw ToolError.missingParameter("target_path")
         }
-        guard let db = database else { throw ToolError.noDatabase }
+        let db = try writeDB()
         let bytes = try db.vacuumInto(targetPath: targetPath)
         let payload = BackupVacuumResult(status: "ok", targetPath: targetPath, bytes: bytes)
         return ToolOutput(

--- a/brain-bar/Tests/BrainBarTests/BrainBarReliabilityTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarReliabilityTests.swift
@@ -196,6 +196,60 @@ final class BrainBarReliabilityTests: XCTestCase {
         XCTAssertTrue(text.contains("read-survives-write-burst") || text.contains("read path should survive"))
     }
 
+    func testReadOnlySearchSucceedsWhileAnotherWriterHoldsImmediateTransaction() throws {
+        let directory = makeReliabilityTempDirectory()
+        let dbPath = directory.appendingPathComponent("brainbar.db").path
+
+        let writeDB = BrainDatabase(path: dbPath)
+        XCTAssertTrue(writeDB.isOpen)
+        defer { writeDB.close() }
+        try writeDB.insertChunk(
+            id: "read-db-wal-concurrent",
+            content: "Read-only WAL search survives immediate writer transaction",
+            sessionId: "s1",
+            project: "reliability",
+            contentType: "assistant_text",
+            importance: 8
+        )
+
+        let readDB = BrainDatabase(
+            path: dbPath,
+            openConfiguration: .init(busyTimeoutMillis: 250, readOnly: true)
+        )
+        XCTAssertTrue(readDB.isOpen)
+        defer { readDB.close() }
+
+        let lockDB = try openReliabilitySQLiteConnection(path: dbPath)
+        defer { sqlite3_close(lockDB) }
+        XCTAssertEqual(sqlite3_exec(lockDB, "BEGIN IMMEDIATE", nil, nil, nil), SQLITE_OK)
+        defer { sqlite3_exec(lockDB, "COMMIT", nil, nil, nil) }
+
+        let router = MCPRouter()
+        router.setDatabases(write: writeDB, read: readDB)
+
+        let started = Date()
+        let searchResponse = router.handle([
+            "jsonrpc": "2.0",
+            "id": 199,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_search",
+                "arguments": [
+                    "query": "WAL search survives",
+                    "num_results": 5,
+                    "agent_id": "force-swift-read-path"
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 0.20)
+        let result = try XCTUnwrap(searchResponse["result"] as? [String: Any])
+        XCTAssertNil(result["isError"])
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+        let text = content.compactMap { $0["text"] as? String }.joined(separator: "\n")
+        XCTAssertTrue(text.contains("Read-only WAL search survives"), text)
+    }
+
     private func makeReliabilityTempDirectory() -> URL {
         let shortID = UUID().uuidString.prefix(8)
         let directory = URL(fileURLWithPath: "/private/tmp/br-\(shortID)", isDirectory: true)

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -490,6 +490,109 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertTrue(text.contains("fallback result from BrainBar database search"), text)
     }
 
+    func testReadToolsUseReadonlyReadDatabaseWhenWriteHandleIsUnavailable() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-read-db-routing-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let setupDB = BrainDatabase(path: tempDB)
+        try setupDB.insertChunk(
+            id: "read-db-route-target",
+            content: "Read database route target content",
+            sessionId: "read-db-session",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6,
+            tags: "[\"readonly-route\"]"
+        )
+        try setupDB.insertEntity(id: "entity-readonly-person", type: "person", name: "ReadOnly Person")
+        setupDB.close()
+
+        let writeDB = BrainDatabase(path: tempDB)
+        let readDB = BrainDatabase(
+            path: tempDB,
+            openConfiguration: .init(busyTimeoutMillis: 250, readOnly: true)
+        )
+        defer { readDB.close() }
+
+        XCTAssertEqual(try sqlitePragma(handle: readDB.dbHandle, name: "query_only"), "1")
+        XCTAssertEqual(try sqlitePragma(handle: readDB.dbHandle, name: "busy_timeout"), "250")
+        writeDB.close()
+
+        let router = MCPRouter()
+        router.setDatabases(write: writeDB, read: readDB)
+
+        let searchText = try toolText(router.handle(toolCall(id: 301, name: "brain_search", arguments: [
+            "query": "read database route target",
+            "num_results": 5,
+            "agent_id": "force-swift-read-path"
+        ])))
+        XCTAssertTrue(searchText.contains("Read database route target content"), searchText)
+
+        let recallText = try toolText(router.handle(toolCall(id: 302, name: "brain_recall", arguments: [
+            "mode": "stats"
+        ])))
+        XCTAssertTrue(recallText.contains("Chunks: 1"), recallText)
+
+        let entityText = try toolText(router.handle(toolCall(id: 303, name: "brain_entity", arguments: [
+            "query": "ReadOnly Person"
+        ])))
+        XCTAssertTrue(entityText.contains("ReadOnly Person"), entityText)
+
+        let personText = try toolText(router.handle(toolCall(id: 304, name: "brain_get_person", arguments: [
+            "name": "ReadOnly Person"
+        ])))
+        XCTAssertTrue(personText.contains("ReadOnly Person"), personText)
+
+        let expandText = try toolText(router.handle(toolCall(id: 305, name: "brain_expand", arguments: [
+            "chunk_id": "read-db-route-target"
+        ])))
+        XCTAssertTrue(expandText.contains("brain_expand: read-db-route-target"), expandText)
+
+        let tagsText = try toolText(router.handle(toolCall(id: 306, name: "brain_tags", arguments: [
+            "query": "readonly"
+        ])))
+        XCTAssertTrue(tagsText.contains("readonly-route"), tagsText)
+    }
+
+    func testBrainSearchFallsBackToReadDatabaseWhenHybridHelperExceedsBudget() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-hybrid-budget-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let writeDB = BrainDatabase(path: tempDB)
+        defer { writeDB.close() }
+        try writeDB.insertChunk(
+            id: "hybrid-budget-fallback",
+            content: "Hybrid budget fallback content from Swift read database",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        let readDB = BrainDatabase(
+            path: tempDB,
+            openConfiguration: .init(busyTimeoutMillis: 250, readOnly: true)
+        )
+        defer { readDB.close() }
+
+        let helper = RecordingHybridSearchClient(
+            response: HybridSearchResponse(text: "slow helper should not win"),
+            delay: 0.50
+        )
+        let router = MCPRouter(hybridSearchClient: helper, hybridSearchBudget: 0.05)
+        router.setDatabases(write: writeDB, read: readDB)
+
+        let started = Date()
+        let response = router.handle(toolCall(id: 307, name: "brain_search", arguments: [
+            "query": "hybrid budget fallback",
+            "num_results": 5
+        ]))
+        let elapsed = Date().timeIntervalSince(started)
+
+        XCTAssertLessThan(elapsed, 0.25)
+        XCTAssertEqual(helper.requests.count, 1)
+        let text = try toolText(response)
+        XCTAssertTrue(text.contains("Hybrid budget fallback content"), text)
+        XCTAssertFalse(text.contains("slow helper should not win"), text)
+    }
+
     func testBrainSearchUnreadOnlyStaysOnBrainBarQueuePathWhenHybridHelperExists() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-unread-helper-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }
@@ -1835,6 +1938,44 @@ private func chunkEnrichedAt(path: String, id: String) throws -> String? {
     }
     guard let value = sqlite3_column_text(stmt, 0) else {
         return nil
+    }
+    return String(cString: value)
+}
+
+private func toolCall(id: Int, name: String, arguments: [String: Any]) -> [String: Any] {
+    [
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": [
+            "name": name,
+            "arguments": arguments
+        ] as [String: Any]
+    ]
+}
+
+private func toolText(_ response: [String: Any]) throws -> String {
+    let result = try XCTUnwrap(response["result"] as? [String: Any])
+    XCTAssertNil(result["isError"], String(describing: result))
+    let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+    return content.compactMap { $0["text"] as? String }.joined(separator: "\n")
+}
+
+private func sqlitePragma(handle: OpaquePointer?, name: String) throws -> String {
+    guard let handle else {
+        throw NSError(domain: "MCPRouterTests", code: Int(SQLITE_MISUSE))
+    }
+    var stmt: OpaquePointer?
+    let sql = "PRAGMA \(name)"
+    let prepareRC = sqlite3_prepare_v2(handle, sql, -1, &stmt, nil)
+    guard prepareRC == SQLITE_OK else {
+        throw NSError(domain: "MCPRouterTests", code: Int(prepareRC))
+    }
+    defer { sqlite3_finalize(stmt) }
+
+    guard sqlite3_step(stmt) == SQLITE_ROW,
+          let value = sqlite3_column_text(stmt, 0) else {
+        throw NSError(domain: "MCPRouterTests", code: Int(SQLITE_EMPTY))
     }
     return String(cString: value)
 }

--- a/brain-bar/Tests/BrainBarTests/RecordingHybridSearchClient.swift
+++ b/brain-bar/Tests/BrainBarTests/RecordingHybridSearchClient.swift
@@ -14,6 +14,7 @@ enum RecordingHybridSearchClientError: LocalizedError {
 
 final class RecordingHybridSearchClient: HybridSearchClientProtocol, @unchecked Sendable {
     private let result: Result<HybridSearchResponse, Error>
+    private let delay: TimeInterval
     private let lock = NSLock()
     private var recordedRequests: [[String: Any]] = []
 
@@ -23,12 +24,14 @@ final class RecordingHybridSearchClient: HybridSearchClientProtocol, @unchecked 
         return recordedRequests
     }
 
-    init(response: HybridSearchResponse) {
+    init(response: HybridSearchResponse, delay: TimeInterval = 0) {
         result = .success(response)
+        self.delay = delay
     }
 
-    init(error: Error = RecordingHybridSearchClientError.injectedFailure) {
+    init(error: Error = RecordingHybridSearchClientError.injectedFailure, delay: TimeInterval = 0) {
         result = .failure(error)
+        self.delay = delay
     }
 
     deinit {}
@@ -37,6 +40,9 @@ final class RecordingHybridSearchClient: HybridSearchClientProtocol, @unchecked 
         lock.lock()
         recordedRequests.append(arguments)
         lock.unlock()
+        if delay > 0 {
+            Thread.sleep(forTimeInterval: delay)
+        }
         return try result.get()
     }
 }


### PR DESCRIPTION
## Summary
- Open a dedicated BrainBar read handle and route pure read tools through it while keeping store/update/supersede/archive/digest/enrich/maintenance/backup on the write handle.
- Configure the read handle as read-only/query-only with a 250ms busy timeout, so Swift fallback reads are not tied to writer transaction state.
- Bound the hybrid helper to an 800ms router budget and fall back to Swift FTS on helper timeout or error.
- Add regression coverage for read-handle routing, helper budget fallback, and WAL reads while another connection holds `BEGIN IMMEDIATE`.

## Verification
- `swift build --package-path brain-bar` passed.
- `swift test --package-path brain-bar --filter 'MCPRouterTests/testReadToolsUseReadonlyReadDatabaseWhenWriteHandleIsUnavailable|MCPRouterTests/testBrainSearchFallsBackToReadDatabaseWhenHybridHelperExceedsBudget|BrainBarReliabilityTests/testReadOnlySearchSucceedsWhileAnotherWriterHoldsImmediateTransaction'` passed: 3 tests, 0 failures.
- `swift test --package-path brain-bar` passed: 600 tests, 0 failures.
- `pytest` passed: 2349 passed, 48 skipped, 5 xfailed, 328 warnings in 361.58s.
- Pre-push hook passed:
  - pytest unit suite: 2279 passed, 9 skipped, 77 deselected, 1 xfailed, 102 warnings in 226.05s.
  - pytest MCP tool registration: 3 passed in 0.79s.
  - pytest isolated eval and hook routing: 36 passed in 9.77s.
  - bun test suite: 1 passed, 0 failed.
  - regression shell `test_fts5_determinism.sh`: PASS.
  - BrainLayer test gate passed.
- `git diff --check` passed.
- CodeRabbit CLI pre-commit review could not run: review limit reached.

## Operational Notes
- Did not restart BrainBar or any daemon.
- Task A2 follow-up: the Python hybrid helper can still take 3.7s+ even when it succeeds. Likely causes are embedding/vec-search cost on the 9.7GB DB or helper DB contention. This PR makes live search usable regardless by bounding helper wait and falling back through the read-only Swift path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MCP database routing and search latency behavior; mis-routing could affect writes or stale reads, but behavior is covered by extensive tests.
> 
> **Overview**
> **BrainBar** now opens a second SQLite handle for reads and wires MCP tools through separate write vs read paths so searches and lookups are not blocked by the writer’s long `busy_timeout` or open transactions.
> 
> On startup, `BrainBarServer` opens a read-only connection (250ms busy timeout) alongside the writer and passes both to `MCPRouter` via `setDatabases(write:read:)`. Read tools (`brain_search`, recall, entity, expand, tags, etc.) use `readDB()`; mutations stay on `writeDB()`. Entity cache refresh uses the read handle. Shutdown closes both handles when they differ.
> 
> **Hybrid search** is capped at **800ms** at the router (matching helper socket I/O timeout). Calls run on a background queue with `DispatchGroup.wait`; on timeout the router falls back to Swift FTS on the read DB (with KG section on fallback, same as helper errors). Slow helper work may still run after the wait returns.
> 
> Regression tests cover read routing when the write handle is closed, budget fallback, and WAL reads under `BEGIN IMMEDIATE` on another connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c933ce99744fa233c9f7003ed7d51e5775262b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split BrainBar read path from write path using separate database handles
> - `BrainBarServer` now opens a second read-only `BrainDatabase` handle (with a 250ms busy timeout) alongside the write handle on startup, and passes both to `MCPRouter` via a new `setDatabases(write:read:)` method.
> - `MCPRouter` routes read tools (`brain_search`, `brain_recall`, `brain_entity`, `brain_get_person`, `brain_expand`, `brain_tags`) through a `readDB()` helper and write tools through a `writeDB()` helper.
> - `brain_search` now executes the hybrid search helper with a configurable time budget (default 0.8s); if the helper exceeds the budget or errors, it falls back to a local DB search using the read handle.
> - New tests cover read tools functioning while a writer holds an IMMEDIATE transaction, and the hybrid search fallback when the helper is slow.
> - Behavioral Change: read operations now use a separate DB connection with a shorter busy timeout, so they are less likely to block behind in-progress write transactions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70c933c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->