### PR TITLE
Queue BrainBar stores when DB handle is unavailable

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -230,7 +230,7 @@ final class BrainBarServer: @unchecked Sendable {
 
         // 1. Create router FIRST (no DB dependency).
         //    initialize + tools/list work without a database.
-        router = MCPRouter(hybridSearchClient: hybridClient)
+        router = MCPRouter(hybridSearchClient: hybridClient, dbPath: dbPath)
 
         // 2. Bind socket BEFORE database init.
         //    After a restart the socket must exist before Claude Code tries

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -216,7 +216,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     enum StoreWriteOutcome: Sendable, Equatable {
         case stored(StoredChunk)
-        case queued
+        case queued(queueID: String, queuedAt: String)
     }
 
     struct PendingStoreItem: Codable, Sendable {
@@ -941,8 +941,8 @@ final class BrainDatabase: @unchecked Sendable {
             guard shouldQueueStoreError(error) else {
                 throw error
             }
-            try queuePendingStore(content: content, tags: tags, importance: importance, source: source)
-            return .queued
+            let queued = try queuePendingStore(content: content, tags: tags, importance: importance, source: source)
+            return .queued(queueID: queued.queueID, queuedAt: queued.queuedAt)
         }
     }
 
@@ -972,26 +972,35 @@ final class BrainDatabase: @unchecked Sendable {
         }
     }
 
-    func queuePendingStore(content: String, tags: [String], importance: Int, source: String) throws {
+    @discardableResult
+    func queuePendingStore(content: String, tags: [String], importance: Int, source: String) throws -> (queueID: String, queuedAt: String) {
+        try Self.queuePendingStore(dbPath: path, content: content, tags: tags, importance: importance, source: source)
+    }
+
+    @discardableResult
+    static func queuePendingStore(dbPath: String, content: String, tags: [String], importance: Int, source: String) throws -> (queueID: String, queuedAt: String) {
         Self.pendingStoreFileLock.lock()
         defer { Self.pendingStoreFileLock.unlock() }
 
-        let path = pendingStorePath()
+        let path = pendingStorePath(forDBPath: dbPath)
         try FileManager.default.createDirectory(
             at: path.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
+        let queueID = UUID().uuidString.lowercased()
+        let queuedAt = Self.timestamp()
         let item = PendingStoreItem(
             content: content,
             tags: tags,
             importance: importance,
             source: source,
-            queueID: UUID().uuidString.lowercased(),
-            queuedAt: Self.timestamp()
+            queueID: queueID,
+            queuedAt: queuedAt
         )
         var line = try JSONEncoder().encode(item)
         line.append(0x0A)
         try appendPendingStoreLine(line, to: path)
+        return (queueID: queueID, queuedAt: queuedAt)
     }
 
     func flushPendingStores() -> [FlushedPendingStore] {
@@ -1002,7 +1011,7 @@ final class BrainDatabase: @unchecked Sendable {
         do {
             return try Self.withPendingStoreProcessLock(for: path) {
                 guard FileManager.default.fileExists(atPath: path.path) else { return [] }
-                guard let snapshot = readPendingStoreData(at: path) else {
+                guard let snapshot = Self.readPendingStoreData(at: path) else {
                     NSLog("[BrainBar] Failed to read pending stores queue at %@", path.path)
                     return []
                 }
@@ -2873,14 +2882,18 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func pendingStorePath() -> URL {
+        Self.pendingStorePath(forDBPath: path)
+    }
+
+    private static func pendingStorePath(forDBPath dbPath: String) -> URL {
         if let override = ProcessInfo.processInfo.environment["BRAINBAR_PENDING_STORES_PATH"],
            !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return URL(fileURLWithPath: override)
         }
-        return URL(fileURLWithPath: path).deletingLastPathComponent().appendingPathComponent("pending-stores.jsonl")
+        return URL(fileURLWithPath: dbPath).deletingLastPathComponent().appendingPathComponent("pending-stores.jsonl")
     }
 
-    private func appendPendingStoreLine(_ line: Data, to path: URL) throws {
+    private static func appendPendingStoreLine(_ line: Data, to path: URL) throws {
         try Self.withPendingStoreProcessLock(for: path) {
             let fd = open(path.path, O_RDWR | O_CREAT | O_APPEND, 0o600)
             guard fd >= 0 else {
@@ -2890,7 +2903,7 @@ final class BrainDatabase: @unchecked Sendable {
             defer { Darwin.close(fd) }
             try Self.enforcePendingStoreFileMode(fd: fd, path: path)
 
-            let existingLineCount = Self.pendingStoreLines(from: readPendingStoreData(at: path) ?? Data()).count
+            let existingLineCount = Self.pendingStoreLines(from: Self.readPendingStoreData(at: path) ?? Data()).count
             let maxLines = Self.pendingStoreMaxLines()
             guard existingLineCount < maxLines else {
                 throw DBError.exec(
@@ -2903,7 +2916,7 @@ final class BrainDatabase: @unchecked Sendable {
         }
     }
 
-    private func readPendingStoreData(at path: URL) -> Data? {
+    private static func readPendingStoreData(at path: URL) -> Data? {
         try? Data(contentsOf: path)
     }
 
@@ -2915,7 +2928,7 @@ final class BrainDatabase: @unchecked Sendable {
         do {
             return try Self.withPendingStoreProcessLock(for: path) {
                 guard FileManager.default.fileExists(atPath: path.path),
-                      let data = readPendingStoreData(at: path) else {
+                      let data = Self.readPendingStoreData(at: path) else {
                     return PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil)
                 }
 

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -34,6 +34,7 @@ final class MCPRouter: @unchecked Sendable {
 
     private var database: BrainDatabase?
     private let hybridSearchClient: HybridSearchClientProtocol?
+    private let dbPath: String?
     let entityCache = EntityCache()
     private static let defaultStringMaxLength = 256
     private static let defaultStringArrayMaxItems = 100
@@ -60,8 +61,9 @@ final class MCPRouter: @unchecked Sendable {
         "tags": (maxItems: 100, itemMaxLength: 128)
     ]
 
-    init(hybridSearchClient: HybridSearchClientProtocol? = nil) {
+    init(hybridSearchClient: HybridSearchClientProtocol? = nil, dbPath: String? = nil) {
         self.hybridSearchClient = hybridSearchClient
+        self.dbPath = dbPath
     }
 
     /// Inject database for tool handlers + load entity cache.
@@ -391,37 +393,63 @@ final class MCPRouter: @unchecked Sendable {
         let tags = args["tags"] as? [String] ?? []
         let importance = args["importance"] as? Int ?? 5
         guard let db = database else {
+            return try queueBrainStore(content: content, tags: tags, importance: importance, source: "mcp")
+        }
+        do {
+            switch try db.storeOrQueueWithinBudget(content: content, tags: tags, importance: importance, source: "mcp") {
+            case .stored(let stored):
+                let flushedStores = db.flushPendingStores()
+                return ToolOutput(
+                    text: Formatters.formatStoreResult(chunkId: stored.chunkID),
+                    metadata: [
+                        "queued": false,
+                        "flushed_count": flushedStores.count,
+                        "_brainbarStoredChunk": [
+                            "chunk_id": stored.chunkID,
+                            "rowid": stored.rowID
+                        ],
+                        "_brainbarFlushedQueuedChunks": flushedStores.map { flushed in
+                            [
+                                "chunk_id": flushed.storedChunk.chunkID,
+                                "rowid": flushed.storedChunk.rowID,
+                                "content": flushed.content,
+                                "tags": flushed.tags,
+                                "importance": flushed.importance
+                            ] as [String: Any]
+                        }
+                    ]
+                )
+            case .queued(let queueID, let queuedAt):
+                return queuedBrainStoreOutput(queueID: queueID, queuedAt: queuedAt)
+            }
+        } catch BrainDatabase.DBError.notOpen {
+            return try queueBrainStore(content: content, tags: tags, importance: importance, source: "mcp")
+        }
+    }
+
+    private func queueBrainStore(content: String, tags: [String], importance: Int, source: String) throws -> ToolOutput {
+        guard let dbPath else {
             throw ToolError.noDatabase
         }
-        switch try db.storeOrQueueWithinBudget(content: content, tags: tags, importance: importance, source: "mcp") {
-        case .stored(let stored):
-            let flushedStores = db.flushPendingStores()
-            return ToolOutput(
-                text: Formatters.formatStoreResult(chunkId: stored.chunkID),
-                metadata: [
-                    "queued": false,
-                    "flushed_count": flushedStores.count,
-                    "_brainbarStoredChunk": [
-                        "chunk_id": stored.chunkID,
-                        "rowid": stored.rowID
-                    ],
-                    "_brainbarFlushedQueuedChunks": flushedStores.map { flushed in
-                        [
-                            "chunk_id": flushed.storedChunk.chunkID,
-                            "rowid": flushed.storedChunk.rowID,
-                            "content": flushed.content,
-                            "tags": flushed.tags,
-                            "importance": flushed.importance
-                        ] as [String: Any]
-                    }
-                ]
-            )
-        case .queued:
-            return ToolOutput(
-                text: Formatters.formatStoreResult(chunkId: "", queued: true),
-                metadata: ["queued": true]
-            )
-        }
+        let queued = try BrainDatabase.queuePendingStore(
+            dbPath: dbPath,
+            content: content,
+            tags: tags,
+            importance: importance,
+            source: source
+        )
+        return queuedBrainStoreOutput(queueID: queued.queueID, queuedAt: queued.queuedAt)
+    }
+
+    private func queuedBrainStoreOutput(queueID: String, queuedAt: String) -> ToolOutput {
+        ToolOutput(
+            text: Formatters.formatStoreResult(chunkId: "", queued: true),
+            metadata: [
+                "queued": true,
+                "queue_id": queueID,
+                "queued_at": queuedAt
+            ]
+        )
     }
 
     private func handleBrainGetPerson(_ args: [String: Any]) throws -> ToolOutput {

--- a/brain-bar/Tests/BrainBarTests/BrainBarReliabilityTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarReliabilityTests.swift
@@ -129,7 +129,15 @@ final class BrainBarReliabilityTests: XCTestCase {
         XCTAssertLessThan(Date().timeIntervalSince(started), 0.20)
         let result = try XCTUnwrap(response["result"] as? [String: Any])
         XCTAssertEqual(result["queued"] as? Bool, true)
+        let queueID = try XCTUnwrap(result["queue_id"] as? String)
+        let queuedAt = try XCTUnwrap(result["queued_at"] as? String)
+        XCTAssertFalse(queueID.isEmpty)
+        XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
         XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath))
+        let queuedText = try String(contentsOfFile: queuePath, encoding: .utf8)
+        XCTAssertTrue(queuedText.contains("Queued while another writer holds the database lock"))
+        XCTAssertTrue(queuedText.contains(queueID))
+        XCTAssertTrue(queuedText.contains(queuedAt))
     }
 
     func testQueuedWriteBurstDoesNotTakeReadPathDown() throws {

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -405,9 +405,16 @@ final class DatabaseTests: XCTestCase {
             busyTimeoutMillis: 1
         )
 
-        XCTAssertEqual(outcome, .queued)
+        guard case .queued(let queueID, let queuedAt) = outcome else {
+            XCTFail("Expected queued outcome, got \(outcome)")
+            return
+        }
+        XCTAssertFalse(queueID.isEmpty)
+        XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
         let queuedPayload = try String(contentsOf: queuePath, encoding: .utf8)
         XCTAssertTrue(queuedPayload.contains("Queued because the BrainBar DB handle is read-only"))
+        XCTAssertTrue(queuedPayload.contains(queueID))
+        XCTAssertTrue(queuedPayload.contains(queuedAt))
     }
 
     func testInjectionEventsTableExists() throws {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -1275,6 +1275,78 @@ final class MCPRouterTests: XCTestCase {
 
     // MARK: - brain_store queue fallback
 
+    func testBrainStoreQueuesWithoutDatabaseWhenRouterHasDBPath() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let router = MCPRouter(dbPath: dbPath)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 30,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Store should queue even before the database opens",
+                    "tags": ["queue-on-lock"],
+                    "importance": 8
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertNil(result["isError"])
+        XCTAssertEqual(result["queued"] as? Bool, true)
+        let queueID = try XCTUnwrap(result["queue_id"] as? String)
+        let queuedAt = try XCTUnwrap(result["queued_at"] as? String)
+        XCTAssertFalse(queueID.isEmpty)
+        XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
+
+        let queuedPayload = try XCTUnwrap(readSinglePendingStorePayload(queuePath: queuePath))
+        XCTAssertEqual(queuedPayload["content"] as? String, "Store should queue even before the database opens")
+        XCTAssertEqual(queuedPayload["queue_id"] as? String, queueID)
+        XCTAssertEqual(queuedPayload["queued_at"] as? String, queuedAt)
+    }
+
+    func testBrainStoreQueuesWhenDatabaseHandleIsNotOpen() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let db = BrainDatabase(path: dbPath)
+        db.close()
+
+        let router = MCPRouter(dbPath: dbPath)
+        router.setDatabase(db)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 31,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Store should queue when the database handle is not open",
+                    "tags": ["queue-on-lock"],
+                    "importance": 7
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertNil(result["isError"])
+        XCTAssertEqual(result["queued"] as? Bool, true)
+        XCTAssertFalse((result["queue_id"] as? String ?? "").isEmpty)
+        XCTAssertFalse((result["queued_at"] as? String ?? "").isEmpty)
+
+        let queuedPayload = try XCTUnwrap(readSinglePendingStorePayload(queuePath: queuePath))
+        XCTAssertEqual(queuedPayload["content"] as? String, "Store should queue when the database handle is not open")
+    }
+
     func testBrainStoreQueuesWhenWriteHitsTransientSQLiteLock() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -1315,10 +1387,16 @@ final class MCPRouterTests: XCTestCase {
 
         XCTAssertNotEqual(result?["isError"] as? Bool, true, "brain_store should queue instead of surfacing a transient lock")
         XCTAssertTrue(text.localizedCaseInsensitiveContains("queued"))
+        let queueID = try XCTUnwrap(result?["queue_id"] as? String)
+        let queuedAt = try XCTUnwrap(result?["queued_at"] as? String)
+        XCTAssertFalse(queueID.isEmpty)
+        XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
         XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))
 
         let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
         XCTAssertTrue(queuedText.contains("Store should queue after transient SQLite lock"))
+        XCTAssertTrue(queuedText.contains(queueID))
+        XCTAssertTrue(queuedText.contains(queuedAt))
     }
 
     func testBrainStoreFlushesPendingQueueAfterSuccessfulStore() throws {
@@ -1758,6 +1836,15 @@ private func setPendingStoreQueueMaxLines(_ maxLines: Int) -> () -> Void {
 private func posixPermissions(path: URL) throws -> Int {
     let attributes = try FileManager.default.attributesOfItem(atPath: path.path)
     return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0
+}
+
+private func readSinglePendingStorePayload(queuePath: URL) throws -> [String: Any]? {
+    guard FileManager.default.fileExists(atPath: queuePath.path) else { return nil }
+    let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
+    let lines = queuedText.split(whereSeparator: \.isNewline)
+    guard lines.count == 1 else { return nil }
+    let data = Data(lines[0].utf8)
+    return try JSONSerialization.jsonObject(with: data) as? [String: Any]
 }
 
 private func chunkContents(path: String) throws -> [String] {


### PR DESCRIPTION
## Summary
- Add `BrainDatabase.queuePendingStore(dbPath:content:tags:importance:source:)` so pending-store append can run without an open database instance while preserving the existing `pending-stores.jsonl` format, file lock, line cap, and private permissions.
- Give `MCPRouter` the configured DB path and queue `brain_store` when the database handle is missing or `DBError.notOpen` is thrown.
- Return queued metadata as `queued=true`, `queue_id`, and `queued_at` while keeping the existing queued text response.
- Updated this branch after Task A PR #416 merged; current head composes Task A readDB/helper-budget behavior with Task B queue-on-lock behavior.

## Verification
- RED first: new Task B tests failed on missing `MCPRouter(dbPath:)` initializer before implementation.
- Task B focused filter passed: 5 tests, 0 failures.
- Pre-merge `swift build --package-path brain-bar` passed.
- Pre-merge `swift test --package-path brain-bar` passed: 599 tests, 0 failures.
- After merging current `origin/main` with Task A: `swift build --package-path brain-bar` passed.
- After merging current `origin/main` with Task A: `swift test --package-path brain-bar` passed: 602 tests, 0 failures.
- `git diff --check` and `git diff --cached --check` passed.
- Pre-push BrainLayer gate passed before and after the Task A merge update. Latest run: 2279 passed, 9 skipped, 77 deselected, 1 xfailed, 102 warnings; MCP registration 3 passed; isolated eval/hook routing 36 passed; bun 1 passed; FTS determinism PASS.
- CodeRabbit CLI pre-commit review attempted but blocked by review limit.

## Notes
- `DBError.open` is intentionally not made queueable here. If it surfaces directly, it remains a hard error; the approved core fix queues `brain_store` for nil database handle and `DBError.notOpen` only.
- No BrainBar restart, rebuild, merge, or daemon operation performed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Queue BrainBar stores when the DB handle is unavailable or not open
> - `MCPRouter.handleBrainStore` now falls back to queuing via `BrainDatabase.queuePendingStore` when no database is set or when the database handle is not open (`DBError.notOpen`).
> - A new static `BrainDatabase.queuePendingStore(dbPath:...)` enables queueing without a live DB instance, using `dbPath` passed from `BrainBarServer` through `MCPRouter.init`.
> - `StoreWriteOutcome.queued` now carries `queueID` and `queuedAt` metadata; queued `brain_store` responses include `queue_id` and `queued_at` fields.
> - New and updated tests in [MCPRouterTests.swift](https://github.com/EtanHey/brainlayer/pull/417/files#diff-6a1a5be7d76811bedc4d3f0ebcb2043c90a2a0119ea214a29764bcd53b19af15) and [BrainBarReliabilityTests.swift](https://github.com/EtanHey/brainlayer/pull/417/files#diff-d1790cadc31b072a4854c0b60b265fa40609aac0f52c36cd8a6a28c8b151cf12) validate queue metadata presence and JSONL file contents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b61e4f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->