### PR TITLE
fix: kill sqlite-vec tail in BrainBar helper search

### DIFF
--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -55,6 +55,14 @@ def _get_vector_store():
     return _get_search_vector_store()
 
 
+def _is_sqlite_vec_knn_error(exc: Exception) -> bool:
+    """Return true for sqlite-vec KNN errors that should not trigger a second hybrid scan."""
+    if not isinstance(exc, apsw.SQLError):
+        return False
+    message = str(exc).lower()
+    return "sqlite-vec" in message or ("knn" in message and ("limit" in message or "too large" in message))
+
+
 def _helper_sentinel_path() -> Path:
     return Path("~/.local/share/brainlayer/use-helper-socket").expanduser()
 
@@ -931,6 +939,7 @@ async def _brain_search_dispatch(
         structured_results = []
         kg_degraded = False
         kg_degrade_reason = None
+        kg_fail_fast = False
 
         def _emit_kg_degrade(reason: str) -> None:
             if not os.environ.get("AXIOM_TOKEN"):
@@ -1009,7 +1018,11 @@ async def _brain_search_dispatch(
             kg_degrade_reason = reason
             _emit_kg_degrade(reason)
         except Exception as e:
-            reason = e.__class__.__name__
+            if _is_sqlite_vec_knn_error(e):
+                reason = "sqlite_vec_knn"
+                kg_fail_fast = True
+            else:
+                reason = e.__class__.__name__
             logger.warning(
                 "KG hybrid search degraded (unexpected): reason=%s entity=%s query=%r err=%s",
                 reason,
@@ -1037,6 +1050,20 @@ async def _brain_search_dispatch(
             formatted_text = format_kg_search(entity_name, structured_results, fact_items, query)
             if kg_degraded:
                 formatted_text += f"\n⚠ KG search degraded — reason={kg_degrade_reason} — showing SQL-only results"
+            return ([TextContent(type="text", text=formatted_text)], structured)
+
+        if kg_fail_fast:
+            structured = {
+                "query": query,
+                "entity": entity_name,
+                "total": 0,
+                "results": [],
+                "facts": fact_items,
+                "kg_degraded": True,
+                "kg_degrade_reason": kg_degrade_reason,
+            }
+            formatted_text = format_search_results(query, [], 0)
+            formatted_text += f"\n⚠ KG search degraded — reason={kg_degrade_reason} — skipping second hybrid search"
             return ([TextContent(type="text", text=formatted_text)], structured)
 
         if kg_degraded:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -42,6 +42,8 @@ try:
 except (TypeError, ValueError):
     _MMR_LAMBDA = 1.0
 _FILTERED_KNN_MAX = 2000
+# sqlite-vec rejects vec0 KNN queries above this hard limit.
+_SQLITE_VEC_MAX_K = 4096
 META_NOISE_PATTERNS = [
     "brain_search(",
     "brain_entity(",
@@ -528,7 +530,8 @@ class SearchMixin:
             include_checkpoints,
             cap_filtered=cap_filtered,
         )
-        return self._audit_filtered_knn_k(effective_k, include_audit, cap_filtered=cap_filtered)
+        effective_k = self._audit_filtered_knn_k(effective_k, include_audit, cap_filtered=cap_filtered)
+        return min(effective_k, _SQLITE_VEC_MAX_K)
 
     def _load_chunk_embeddings(self, chunk_ids: List[str]) -> Dict[str, np.ndarray]:
         """Fetch float embeddings for the provided chunk IDs."""

--- a/tests/test_audit_recursion_filter.py
+++ b/tests/test_audit_recursion_filter.py
@@ -266,6 +266,24 @@ def test_audit_overfetch_scales_with_filtered_row_count(tmp_path, monkeypatch):
         store.close()
 
 
+def test_uncapped_filtered_knn_retry_never_exceeds_sqlite_vec_limit(tmp_path, monkeypatch):
+    store = VectorStore(tmp_path / "audit-filter-overfetch-sqlite-vec-cap.db")
+    try:
+        monkeypatch.setattr(store, "_audit_recursion_count", lambda: 5000)
+
+        retry_k = store._effective_knn_k(
+            50,
+            needs_overfetch=True,
+            include_checkpoints=True,
+            include_audit=False,
+            cap_filtered=False,
+        )
+
+        assert retry_k == 4096
+    finally:
+        store.close()
+
+
 def test_audit_count_cache_invalidates_after_same_connection_upsert(tmp_path):
     store = VectorStore(tmp_path / "audit-filter-cache-invalidation.db")
     try:

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -14,6 +14,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import apsw
+
 from brainlayer.mcp.search_handler import _brain_recall, _brain_search
 
 
@@ -464,6 +466,39 @@ class TestKgDegradeObservability:
             and "entity=Etan" in message
             for message in messages
         )
+
+    def test_sqlite_vec_knn_sqLError_does_not_run_second_hybrid_search(self):
+        """sqlite-vec KNN errors must not pay KG hybrid and then full hybrid fallback."""
+        store = MagicMock(count=MagicMock(return_value=100))
+        store.kg_hybrid_search.side_effect = apsw.SQLError(
+            "k value in knn query too large, provided 4290 and the limit is 4096"
+        )
+
+        with (
+            patch("brainlayer.mcp.search_handler._get_vector_store", return_value=store),
+            patch(
+                "brainlayer.mcp.search_handler._get_embedding_model",
+                return_value=MagicMock(embed_query=MagicMock(return_value=[0.1] * 1024)),
+            ),
+            patch(
+                "brainlayer.mcp.search_handler._detect_entities",
+                return_value=[{"id": "e1", "name": "Etan", "entity_type": "person"}],
+            ),
+            patch("brainlayer.mcp.search_handler._kg_facts_sql", return_value=[]),
+            patch(
+                "brainlayer.mcp.search_handler._search",
+                new_callable=AsyncMock,
+                return_value=([MagicMock(type="text", text="fallback")], {"total": 1}),
+            ) as mock_search,
+            patch("brainlayer.mcp.search_handler._normalize_project_name", return_value=None),
+        ):
+            _content, structured = asyncio.run(_brain_search(query="Etan BrainLayer context"))
+
+        store.kg_hybrid_search.assert_called_once()
+        mock_search.assert_not_awaited()
+        assert structured["kg_degraded"] is True
+        assert structured["kg_degrade_reason"] == "sqlite_vec_knn"
+        assert structured["total"] == 0
 
     def test_kg_degrade_axiom_emit_attempted(self, monkeypatch):
         """Axiom degrade telemetry is attempted when AXIOM_TOKEN is configured."""


### PR DESCRIPTION
## Summary
- cap sqlite-vec KNN retry `k` at the vec0 hard limit of 4096 so filtered/audit overfetch cannot produce `k value ... > 4096`
- treat sqlite-vec KNN `SQLError` in the KG route as fail-fast, returning a degraded result instead of paying KG hybrid and then a second full hybrid fallback
- add regression tests for the retry cap and the no-double-work SQLError path

## Context
This is PR-1 for A2 helper tail-killers. It keeps the existing BrainBar helper budget and does not rebuild/restart BrainBar. Deployment/restart is owned by Etan after merge.

## Test plan
- RED verified before implementation:
  - retry cap test failed with `5500 == 4096`
  - sqlite-vec SQLError test failed because `_search` was awaited once
- `pytest tests/test_audit_recursion_filter.py::test_uncapped_filtered_knn_retry_never_exceeds_sqlite_vec_limit tests/test_search_filter_params.py::TestKgDegradeObservability::test_sqlite_vec_knn_sqLError_does_not_run_second_hybrid_search -q` → 2 passed
- `pytest tests/test_audit_recursion_filter.py tests/test_search_filter_params.py tests/test_search_handler.py tests/test_brainbar_hybrid_helper.py -q` → 60 passed
- `ruff check src/brainlayer/search_repo.py src/brainlayer/mcp/search_handler.py tests/test_audit_recursion_filter.py tests/test_search_filter_params.py` → all checks passed
- `pytest -q` → 2350 passed, 49 skipped, 5 xfailed, 102 warnings
- push hook BrainLayer test gate passed:
  - pytest unit suite → 2281 passed, 9 skipped, 77 deselected, 1 xfailed, 102 warnings
  - MCP tool registration → 3 passed
  - isolated eval and hook routing → 36 passed
  - bun stale-index query test → 1 passed
  - regression shell `test_fts5_determinism.sh` → passed

## Notes
- CodeRabbit local pre-commit review returned two minor findings; both were addressed before the final test rerun.
- Follow-up PR-2 remains steady-state profiling/candidate-overfetch/index work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes KNN sizing and entity-route degradation/fallback behavior on hot search paths; mitigated by targeted tests and narrow error detection.
> 
> **Overview**
> Caps **sqlite-vec** KNN `k` at **4096** in `_effective_knn_k`, so checkpoint/audit overfetch and uncapped retries can no longer trigger vec0 errors like `k value ... too large`.
> 
> When entity-aware **KG hybrid** hits a sqlite-vec KNN `SQLError`, the MCP path now **fail-fast** with `kg_degrade_reason=sqlite_vec_knn` instead of running a second full `_search` hybrid fallback.
> 
> Regression tests cover the retry cap and the no-double-hybrid behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610f0248ad95208e4b014c52e46215429d3d7f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sqlite-vec KNN tail in `_brain_search_dispatch` by capping K and failing fast on oversized queries
> - Caps the computed KNN K at 4096 in `SearchMixin._effective_knn_k` ([search_repo.py](https://github.com/EtanHey/brainlayer/pull/418/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472)) to match the sqlite-vec `vec0` limit.
> - Adds `_is_sqlite_vec_knn_error` in [search_handler.py](https://github.com/EtanHey/brainlayer/pull/418/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) to detect `apsw.SQLError` instances whose message indicates a KNN limit violation.
> - When this error is raised during KG hybrid search, `_brain_search_dispatch` now fails fast: it returns a degraded response with `kg_degrade_reason='sqlite_vec_knn'` and skips the second hybrid search fallback entirely.
> - Behavioral Change: queries that previously triggered a sqlite-vec error and fell through to the fallback search path now return early with a degraded result and `total=0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 610f024.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of KNN search errors by detecting specific failures and returning early with available results instead of attempting fallback searches
  * Added a maximum K value cap (4096) for KNN queries to prevent parameter-related errors

* **Tests**
  * Added tests verifying KNN retry values stay within SQLite vector limits
  * Added regression test for hybrid search error handling when KNN queries exceed limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->