### PR TITLE
Fix BrainBar hybrid helper warm readiness lifecycle

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -119,7 +119,8 @@ final class BrainBarServer: @unchecked Sendable {
     /// below the UI budget while still bounding serial-queue stalls.
     static let maxWriteRetries = 50
     private static let readOnlyBusyTimeoutMillis: Int32 = 250
-    private static let hybridSearchBudgetSeconds: TimeInterval = 0.8
+    static let hybridSearchBudgetSeconds: TimeInterval = 0.8
+    static let hybridHelperSocketIOTimeoutSeconds: TimeInterval = 120
     private let debugLogPath = "/tmp/brainbar-debug.log"
 
     private func debugLog(_ msg: String) {
@@ -225,7 +226,7 @@ final class BrainBarServer: @unchecked Sendable {
         } else if providedDatabase == nil && enableHybridSearchHelper {
             let client = HybridSearchHelperClient(
                 dbPath: dbPath,
-                socketIOTimeout: Self.hybridSearchBudgetSeconds
+                socketIOTimeout: Self.hybridHelperSocketIOTimeoutSeconds
             )
             ownedHybridClient = client
             hybridClient = client
@@ -310,11 +311,6 @@ final class BrainBarServer: @unchecked Sendable {
 
         if let ownedHybridClient {
             hybridSearchHelperClient = ownedHybridClient
-            do {
-                try ownedHybridClient.start()
-            } catch {
-                NSLog("[BrainBar] Hybrid search helper startup deferred after failure: %@", String(describing: error))
-            }
         }
 
         // 3. NOW open the database (may take time on cold start with 8 GB file).
@@ -374,6 +370,7 @@ final class BrainBarServer: @unchecked Sendable {
             database = db
             readDatabase = readDB
             router.setDatabases(write: db, read: readDB)
+            hybridSearchHelperClient?.startWarming()
             onDatabaseReady?(db)
             brainBus.publish(.dbBusy(false))
             brainBus.publish(.queueDepth(brainBusQueueDepthEstimate))

--- a/brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift
+++ b/brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift
@@ -14,31 +14,51 @@ protocol HybridSearchClientProtocol: AnyObject, Sendable {
     func search(arguments: [String: Any]) throws -> HybridSearchResponse
 }
 
-final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sendable {
+protocol HybridSearchReadinessProviding: AnyObject, Sendable {
+    var isReady: Bool { get }
+    func startWarming()
+}
+
+final class HybridSearchHelperClient: HybridSearchClientProtocol, HybridSearchReadinessProviding, @unchecked Sendable {
     private static let maxResponseBytes = 10 * 1024 * 1024
     private static let defaultSocketIOTimeout: TimeInterval = 60
+    private static let defaultReadinessTimeout: TimeInterval = 180
+    private static let defaultReadinessProbeInterval: TimeInterval = 0.25
+    private static let defaultReadinessProbeTimeout: TimeInterval = 1
     private static let queueKey = DispatchSpecificKey<UUID>()
     private let socketPath: String
     private let dbPath: String
     private let pythonExecutable: String
     private let environment: [String: String]
     private let socketIOTimeout: TimeInterval
+    private let readinessTimeout: TimeInterval
+    private let readinessProbeInterval: TimeInterval
+    private let readinessProbeTimeout: TimeInterval
     private let queue = DispatchQueue(label: "com.brainlayer.brainbar.hybrid-helper")
     private let queueID = UUID()
+    private let stateLock = NSLock()
     private var process: Process?
+    private var ready = false
+    private var warming = false
 
     init(
         socketPath: String? = nil,
         dbPath: String,
         pythonExecutable: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        socketIOTimeout: TimeInterval = defaultSocketIOTimeout
+        socketIOTimeout: TimeInterval = defaultSocketIOTimeout,
+        readinessTimeout: TimeInterval = defaultReadinessTimeout,
+        readinessProbeInterval: TimeInterval = defaultReadinessProbeInterval,
+        readinessProbeTimeout: TimeInterval = defaultReadinessProbeTimeout
     ) {
         self.socketPath = socketPath ?? Self.defaultSocketPath()
         self.dbPath = dbPath
         self.pythonExecutable = pythonExecutable ?? Self.resolvePythonExecutable(environment: environment)
         self.environment = environment
         self.socketIOTimeout = socketIOTimeout
+        self.readinessTimeout = max(0.001, readinessTimeout)
+        self.readinessProbeInterval = max(0.001, readinessProbeInterval)
+        self.readinessProbeTimeout = max(0.001, readinessProbeTimeout)
         queue.setSpecific(key: Self.queueKey, value: queueID)
     }
 
@@ -120,9 +140,30 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
         }
     }
 
+    var isReady: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return ready
+    }
+
     func start() throws {
         try queue.sync {
             try startLocked()
+        }
+    }
+
+    func startWarming() {
+        guard markWarmingIfNeeded() else { return }
+        queue.async {
+            defer { self.setWarming(false) }
+            do {
+                try self.startLocked()
+                try self.waitUntilReadyLocked(timeout: self.readinessTimeout)
+                NSLog("[BrainBar] Hybrid search helper ready socket=%@", self.socketPath)
+            } catch {
+                NSLog("[BrainBar] Hybrid search helper warmup failed: %@", String(describing: error))
+                self.stopLocked()
+            }
         }
     }
 
@@ -144,6 +185,9 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
         do {
             let response = try queue.sync {
                 try startLocked()
+                guard isReady else {
+                    throw HybridSearchHelperError.notReady
+                }
                 do {
                     return try send(arguments: arguments)
                 } catch {
@@ -173,12 +217,31 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
     }
 
     private func stopLocked() {
+        setReady(false)
+        setWarming(false)
         if let process, process.isRunning {
             process.terminate()
-            process.waitUntilExit()
+            Self.waitForProcessExit(process, timeout: 2.0)
+            if process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+                Self.waitForProcessExit(process, timeout: 1.0)
+            }
         }
         process = nil
         unlink(socketPath)
+    }
+
+    private static func waitForProcessExit(_ process: Process, timeout: TimeInterval) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !process.isRunning {
+                return
+            }
+            if kill(process.processIdentifier, 0) == -1 && errno == ESRCH {
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
     }
 
     private func startLocked() throws {
@@ -186,6 +249,7 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
             return
         }
 
+        setReady(false)
         try Self.validateSocketPath(socketPath)
         unlink(socketPath)
 
@@ -237,22 +301,7 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
     }
 
     private func send(arguments: [String: Any]) throws -> HybridSearchResponse {
-        let fd = try connectWithRetry()
-        defer { close(fd) }
-
-        let payload: [String: Any] = [
-            "method": "brain_search",
-            "arguments": arguments
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload)
-        var framed = data
-        framed.append(0x0A)
-        try writeAll(fd: fd, data: framed)
-        let responseData = try readLine(fd: fd)
-        let decoded = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
-        guard let decoded else {
-            throw HybridSearchHelperError.invalidResponse
-        }
+        let decoded = try sendRequest(method: "brain_search", arguments: arguments, timeout: socketIOTimeout)
         if let ok = decoded["ok"] as? Bool, !ok {
             let message = decoded["error"] as? String ?? "unknown helper error"
             throw HybridSearchHelperError.helperError(message)
@@ -264,7 +313,78 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
         return HybridSearchResponse(text: text, metadata: metadata)
     }
 
-    private func connectWithRetry() throws -> Int32 {
+    private func sendStatusProbeLocked() throws -> Bool {
+        let decoded = try sendRequest(method: "status", arguments: nil, timeout: readinessProbeTimeout)
+        guard let ok = decoded["ok"] as? Bool, ok else {
+            return false
+        }
+        return decoded["ready"] as? Bool == true
+    }
+
+    private func sendRequest(method: String, arguments: [String: Any]?, timeout: TimeInterval) throws -> [String: Any] {
+        let fd = try connectWithRetry(timeout: timeout)
+        defer { close(fd) }
+
+        var payload: [String: Any] = ["method": method]
+        if let arguments {
+            payload["arguments"] = arguments
+        }
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        var framed = data
+        framed.append(0x0A)
+        try writeAll(fd: fd, data: framed)
+        let responseData = try readLine(fd: fd)
+        guard let decoded = try JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+            throw HybridSearchHelperError.invalidResponse
+        }
+        return decoded
+    }
+
+    private func waitUntilReadyLocked(timeout: TimeInterval) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            guard process?.isRunning == true else {
+                throw HybridSearchHelperError.notReady
+            }
+            if FileManager.default.fileExists(atPath: socketPath) {
+                do {
+                    if try sendStatusProbeLocked() {
+                        setReady(true)
+                        return
+                    }
+                } catch {
+                    // A helper may create the socket slightly before accept is ready.
+                    // Keep polling until the readiness deadline.
+                }
+            }
+            Thread.sleep(forTimeInterval: readinessProbeInterval)
+        }
+        throw HybridSearchHelperError.notReady
+    }
+
+    private func setReady(_ isReady: Bool) {
+        stateLock.lock()
+        ready = isReady
+        stateLock.unlock()
+    }
+
+    private func markWarmingIfNeeded() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        if ready || warming {
+            return false
+        }
+        warming = true
+        return true
+    }
+
+    private func setWarming(_ isWarming: Bool) {
+        stateLock.lock()
+        warming = isWarming
+        stateLock.unlock()
+    }
+
+    private func connectWithRetry(timeout: TimeInterval? = nil) throws -> Int32 {
         var lastErrno: Int32 = 0
         for attempt in 0..<50 {
             let fd = socket(AF_UNIX, SOCK_STREAM, 0)
@@ -296,7 +416,7 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
             }
             if rc == 0 {
                 do {
-                    try Self.configureSocketTimeouts(fd: fd, timeout: socketIOTimeout)
+                    try Self.configureSocketTimeouts(fd: fd, timeout: timeout ?? socketIOTimeout)
                     return fd
                 } catch {
                     close(fd)
@@ -349,7 +469,7 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, @unchecked Sen
         switch helperError {
         case .connect, .configureSocket, .write, .read, .responseTooLarge, .invalidResponse:
             return true
-        case .socket, .socketPathTooLong, .launch, .helperError:
+        case .socket, .socketPathTooLong, .launch, .helperError, .notReady:
             return false
         }
     }
@@ -419,6 +539,7 @@ enum HybridSearchHelperError: LocalizedError {
     case responseTooLarge(Int)
     case invalidResponse
     case helperError(String)
+    case notReady
 
     var errorDescription: String? {
         switch self {
@@ -442,6 +563,8 @@ enum HybridSearchHelperError: LocalizedError {
             return "hybrid helper returned an invalid response"
         case .helperError(let message):
             return "hybrid helper error: \(message)"
+        case .notReady:
+            return "hybrid helper is not ready"
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -404,6 +404,11 @@ final class MCPRouter: @unchecked Sendable {
 
     private func hybridSearchWithinBudget(arguments: [String: Any]) throws -> HybridSearchResponse? {
         guard let hybridSearchClient else { return nil }
+        if let readinessProvider = hybridSearchClient as? HybridSearchReadinessProviding,
+           !readinessProvider.isReady {
+            readinessProvider.startWarming()
+            return nil
+        }
 
         let group = DispatchGroup()
         let argumentBox = HybridSearchArgumentBox(arguments: arguments)

--- a/brain-bar/Tests/BrainBarTests/HybridSearchHelperClientTests.swift
+++ b/brain-bar/Tests/BrainBarTests/HybridSearchHelperClientTests.swift
@@ -137,4 +137,203 @@ final class HybridSearchHelperClientTests: XCTestCase {
         XCTAssertEqual(getsockopt(fds[0], SOL_SOCKET, SO_NOSIGPIPE, &value, &length), 0)
         XCTAssertEqual(value, 1)
     }
+
+    func testBrainBarHelperSocketTimeoutIsDecoupledFromSearchBudget() {
+        XCTAssertGreaterThan(
+            BrainBarServer.hybridHelperSocketIOTimeoutSeconds,
+            BrainBarServer.hybridSearchBudgetSeconds * 10
+        )
+    }
+
+    func testStartWarmingMarksHelperReadyAfterStatusHandshake() throws {
+        let fixture = try makeFakeHybridHelperFixture(searchDelay: 0.01, warmDelay: 0.15)
+        defer { fixture.cleanup() }
+
+        let client = HybridSearchHelperClient(
+            socketPath: fixture.socketPath,
+            dbPath: fixture.dbPath,
+            pythonExecutable: fixture.executablePath,
+            environment: [:],
+            socketIOTimeout: 2.0,
+            readinessTimeout: 2.0,
+            readinessProbeInterval: 0.02
+        )
+        defer { client.stop() }
+
+        client.startWarming()
+
+        XCTAssertTrue(waitUntil(timeout: 2.0) { client.isReady })
+        XCTAssertTrue(client.isRunning)
+
+        let response = try client.search(arguments: ["query": "ready helper"])
+        XCTAssertEqual(response.text, "fake hybrid result")
+    }
+
+    func testRouterBudgetMissDoesNotStopReadyHelperProcess() throws {
+        let fixture = try makeFakeHybridHelperFixture(searchDelay: 0.25, warmDelay: 0.0)
+        defer { fixture.cleanup() }
+        let tempDB = fixture.dbPath
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try db.insertChunk(
+            id: "budget-miss-fallback",
+            content: "Budget miss fallback content from Swift database",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+
+        let client = HybridSearchHelperClient(
+            socketPath: fixture.socketPath,
+            dbPath: fixture.dbPath,
+            pythonExecutable: fixture.executablePath,
+            environment: [:],
+            socketIOTimeout: 2.0,
+            readinessTimeout: 2.0,
+            readinessProbeInterval: 0.02
+        )
+        defer { client.stop() }
+        client.startWarming()
+        XCTAssertTrue(waitUntil(timeout: 2.0) { client.isReady })
+
+        let router = MCPRouter(hybridSearchClient: client, hybridSearchBudget: 0.05)
+        router.setDatabase(db)
+
+        let started = Date()
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_search",
+                "arguments": ["query": "budget miss fallback", "num_results": 5]
+            ] as [String: Any]
+        ])
+        let elapsed = Date().timeIntervalSince(started)
+
+        XCTAssertLessThan(elapsed, 0.20)
+        let text = try toolText(response)
+        XCTAssertTrue(text.contains("Budget miss fallback content"), text)
+        XCTAssertTrue(waitUntil(timeout: 1.0) { client.isRunning && client.isReady })
+    }
+
+    func testStopDoesNotWaitForeverWhenHelperIgnoresTerminate() throws {
+        let fixture = try makeFakeHybridHelperFixture(
+            searchDelay: 0.01,
+            warmDelay: 0.0,
+            ignoreTerminate: true
+        )
+        defer { fixture.cleanup() }
+
+        let client = HybridSearchHelperClient(
+            socketPath: fixture.socketPath,
+            dbPath: fixture.dbPath,
+            pythonExecutable: fixture.executablePath,
+            environment: [:],
+            socketIOTimeout: 2.0,
+            readinessTimeout: 2.0,
+            readinessProbeInterval: 0.02
+        )
+        client.startWarming()
+        XCTAssertTrue(waitUntil(timeout: 2.0) { client.isReady })
+
+        let started = Date()
+        client.stop()
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 3.5)
+        XCTAssertFalse(client.isRunning)
+    }
+
+    private struct FakeHybridHelperFixture {
+        let directory: URL
+        let executablePath: String
+        let socketPath: String
+        let dbPath: String
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(atPath: socketPath)
+        }
+    }
+
+    private func makeFakeHybridHelperFixture(
+        searchDelay: TimeInterval,
+        warmDelay: TimeInterval,
+        ignoreTerminate: Bool = false
+    ) throws -> FakeHybridHelperFixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brainbar-fake-helper-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let scriptURL = directory.appendingPathComponent("fake-helper.py")
+        let socketPath = "/tmp/bb-fake-\(UUID().uuidString.prefix(8)).sock"
+        try? FileManager.default.removeItem(atPath: socketPath)
+        let dbPath = directory.appendingPathComponent("brain.db").path
+        let script = """
+#!/usr/bin/env python3
+import json
+import os
+import signal
+import socket
+import sys
+import time
+
+socket_path = sys.argv[sys.argv.index("--socket-path") + 1]
+if \(ignoreTerminate ? "True" : "False"):
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+try:
+    os.unlink(socket_path)
+except FileNotFoundError:
+    pass
+time.sleep(\(warmDelay))
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(socket_path)
+server.listen(8)
+while True:
+    conn, _ = server.accept()
+    with conn:
+        data = b""
+        while b"\\n" not in data:
+            chunk = conn.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+        if not data:
+            continue
+        request = json.loads(data.split(b"\\n", 1)[0].decode("utf-8"))
+        if request.get("method") == "status":
+            response = {"ok": True, "ready": True}
+        elif request.get("method") == "brain_search":
+            time.sleep(\(searchDelay))
+            response = {"ok": True, "text": "fake hybrid result", "metadata": {}}
+        else:
+            response = {"ok": False, "error": "unsupported"}
+        conn.sendall(json.dumps(response).encode("utf-8") + b"\\n")
+"""
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        chmod(scriptURL.path, 0o755)
+        return FakeHybridHelperFixture(
+            directory: directory,
+            executablePath: scriptURL.path,
+            socketPath: socketPath,
+            dbPath: dbPath
+        )
+    }
+
+    private func waitUntil(timeout: TimeInterval, predicate: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        return predicate()
+    }
+
+    private func toolText(_ response: [String: Any]) throws -> String {
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+        return content.compactMap { $0["text"] as? String }.joined(separator: "\n")
+    }
 }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -593,6 +593,39 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertFalse(text.contains("slow helper should not win"), text)
     }
 
+    func testBrainSearchDoesNotCallHybridHelperBeforeItIsReady() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-hybrid-not-ready-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try db.insertChunk(
+            id: "hybrid-not-ready-fallback",
+            content: "Hybrid not ready fallback content from Swift database",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+
+        let helper = RecordingHybridSearchClient(
+            response: HybridSearchResponse(text: "helper should not be called while warming")
+        )
+        helper.ready = false
+        let router = MCPRouter(hybridSearchClient: helper)
+        router.setDatabase(db)
+
+        let response = router.handle(toolCall(id: 308, name: "brain_search", arguments: [
+            "query": "hybrid not ready fallback",
+            "num_results": 5
+        ]))
+
+        XCTAssertEqual(helper.requests.count, 0)
+        XCTAssertEqual(helper.warmStarts, 1)
+        let text = try toolText(response)
+        XCTAssertTrue(text.contains("Hybrid not ready fallback content"), text)
+        XCTAssertFalse(text.contains("helper should not be called while warming"), text)
+    }
+
     func testBrainSearchUnreadOnlyStaysOnBrainBarQueuePathWhenHybridHelperExists() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-unread-helper-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }

--- a/brain-bar/Tests/BrainBarTests/RecordingHybridSearchClient.swift
+++ b/brain-bar/Tests/BrainBarTests/RecordingHybridSearchClient.swift
@@ -17,11 +17,19 @@ final class RecordingHybridSearchClient: HybridSearchClientProtocol, @unchecked 
     private let delay: TimeInterval
     private let lock = NSLock()
     private var recordedRequests: [[String: Any]] = []
+    private var recordedWarmStarts = 0
+    var ready = true
 
     var requests: [[String: Any]] {
         lock.lock()
         defer { lock.unlock() }
         return recordedRequests
+    }
+
+    var warmStarts: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedWarmStarts
     }
 
     init(response: HybridSearchResponse, delay: TimeInterval = 0) {
@@ -44,5 +52,17 @@ final class RecordingHybridSearchClient: HybridSearchClientProtocol, @unchecked 
             Thread.sleep(forTimeInterval: delay)
         }
         return try result.get()
+    }
+}
+
+extension RecordingHybridSearchClient: HybridSearchReadinessProviding {
+    var isReady: Bool {
+        ready
+    }
+
+    func startWarming() {
+        lock.lock()
+        recordedWarmStarts += 1
+        lock.unlock()
     }
 }

--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -41,6 +41,7 @@ class HybridSearchHelper:
         self.db_path = db_path
         self._stopped = False
         self._warm_called = False
+        self._ready = False
 
     def warm(self) -> None:
         self._warm_called = True
@@ -58,6 +59,7 @@ class HybridSearchHelper:
         model = _get_embedding_model()
         warmup_query = "brainbar hybrid helper warmup"
         model.embed_query(warmup_query)
+        self._ready = True
 
     def serve_forever(self) -> None:
         if self.socket_path.exists():
@@ -65,11 +67,11 @@ class HybridSearchHelper:
 
         server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
+            self.warm()
             server.bind(os.fspath(self.socket_path))
             os.chmod(self.socket_path, 0o600)
             server.listen(16)
             server.settimeout(_ACCEPT_TIMEOUT_SECONDS)
-            self.warm()
 
             while not self._stopped:
                 try:
@@ -134,6 +136,8 @@ class HybridSearchHelper:
         return b"".join(chunks)
 
     def _handle_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        if request.get("method") == "status":
+            return {"ok": True, "ready": self._ready}
         if request.get("method") != "brain_search":
             raise ValueError(f"unsupported method: {request.get('method')}")
         arguments = request.get("arguments") or {}

--- a/tests/test_brainbar_hybrid_helper.py
+++ b/tests/test_brainbar_hybrid_helper.py
@@ -1,3 +1,8 @@
+import threading
+import time
+import uuid
+from pathlib import Path
+
 import pytest
 from mcp.types import CallToolResult, TextContent
 
@@ -24,6 +29,49 @@ def test_warm_preloads_embedding_without_running_hybrid_search(monkeypatch, tmp_
     helper.warm()
 
     assert calls == [("embed_query", "brainbar hybrid helper warmup")]
+
+
+def test_status_reports_helper_readiness(tmp_path):
+    helper = HybridSearchHelper(socket_path=tmp_path / "helper.sock", db_path=tmp_path / "brain.db")
+
+    assert helper._handle_request({"method": "status"}) == {"ok": True, "ready": False}
+
+    helper._ready = True
+
+    assert helper._handle_request({"method": "status"}) == {"ok": True, "ready": True}
+
+
+def test_helper_does_not_bind_socket_until_warm_finishes(tmp_path):
+    socket_path = Path(f"/tmp/bl-hh-{uuid.uuid4().hex[:8]}.sock")
+    try:
+        socket_path.unlink()
+    except FileNotFoundError:
+        pass
+    helper = HybridSearchHelper(socket_path=socket_path, db_path=tmp_path / "brain.db")
+    warm_started = threading.Event()
+    allow_warm_to_finish = threading.Event()
+
+    def slow_warm():
+        warm_started.set()
+        assert not socket_path.exists()
+        allow_warm_to_finish.wait(timeout=2)
+        helper.stop()
+
+    helper.warm = slow_warm  # type: ignore[method-assign]
+    thread = threading.Thread(target=helper.serve_forever)
+    thread.start()
+    try:
+        assert warm_started.wait(timeout=1)
+        time.sleep(0.05)
+        assert not socket_path.exists()
+    finally:
+        allow_warm_to_finish.set()
+        thread.join(timeout=2)
+        helper.stop()
+        try:
+            socket_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def test_warm_does_not_sleep_for_hybrid_search_retries(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes the BrainBar hybrid helper lifecycle bug where the helper bound its socket before `warm()` completed, causing live search requests to hit the 800ms read budget, fall back, and restart/unlink the helper before it ever reached a warm persistent state.

Changes:
- Python helper now warms before binding/listening and exposes a `status` readiness method.
- BrainBar starts helper warmup after DB-ready and routes search to the helper only after readiness is confirmed.
- Helper socket I/O timeout is decoupled from the 800ms search budget, so a per-request budget miss falls back without killing the helper process.
- Readiness warmup is idempotent and retriggered when router sees an unready helper, so crash/failure recovery does not strand search in fallback-only mode.
- Helper shutdown is bounded, so tests/app shutdown cannot hang if a helper ignores SIGTERM.

Not included:
- No 550ms budget change.
- No relevance/content-class/RRF work.
- No BrainBar restart/deploy from this branch.

## Verification

- `swift build --package-path brain-bar` ✅
- `swift test --package-path brain-bar` ✅ 607 tests, 0 failures
- `swift test --package-path brain-bar --filter 'HybridSearchHelperClientTests|MCPRouterTests/testBrainSearchDoesNotCallHybridHelperBeforeItIsReady'` ✅ 13 tests, 0 failures
- `/Users/etanheyman/Gits/brainlayer/.venv/bin/pytest tests/test_brainbar_hybrid_helper.py tests/test_hybrid_helper_contract.py tests/test_parent_death.py -q` ✅ 14 passed
- `BRAINLAYER_ENRICH_COST_DIR=$(mktemp -d) /Users/etanheyman/Gits/brainlayer/.venv/bin/pytest -q` ✅ 2357 passed, 49 skipped, 5 xfailed

Note: default-env full `pytest -q` failed only in `tests/test_auto_enrich.py` because the local live daily enrichment cost counter is already at `spent=$5.000835 cap=$5.00`. The isolated `BRAINLAYER_ENRICH_COST_DIR` rerun removes that local-state coupling and passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core brain_search routing and Python/Swift helper IPC lifecycle; mis-timed readiness could prolong SQLite fallback, but behavior is covered by new tests and bounded shutdown.
> 
> **Overview**
> Fixes a lifecycle bug where the Python hybrid helper could accept connections before embedding warmup finished, so early `brain_search` calls hit the ~800ms router budget, fell back to SQLite, and could restart or unlink the helper before it stayed warm.
> 
> The Python helper now runs **`warm()` before bind/listen** and adds a **`status`** RPC that reports `ready`. Swift **`HybridSearchHelperClient`** gains **`startWarming()`**, polls **`status`**, tracks **`isReady`**, and rejects **`search`** with **`notReady`** until warm. **`BrainBarServer`** no longer starts the helper at listen time; it calls **`startWarming()`** after the database is ready and uses a **120s** helper socket I/O timeout separate from the **0.8s** search budget so budget misses fall back without tearing down a healthy helper. **`MCPRouter`** skips hybrid RPC when not ready (kicks warming, SQLite fallback) and **`stop()`** is bounded with SIGKILL if SIGTERM is ignored.
> 
> Tests cover status handshake, router behavior before ready, budget miss keeping the helper alive, and shutdown timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9f8e5969b304d13063d934b75aaee9482493a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BrainBar hybrid helper warm readiness lifecycle to gate search on readiness
> - The hybrid helper in [brainbar_hybrid_helper.py](https://github.com/EtanHey/brainlayer/pull/420/files#diff-d3d5162fd8f713352fe31ea2b66de6014b80c7e9af406132cdd41d99375a7b21) now completes `warm()` before binding its Unix socket, and exposes a `status` request that reports readiness.
> - [HybridSearchHelperClient](https://github.com/EtanHey/brainlayer/pull/420/files#diff-c005f2849273dedb87dbd8219bb3e7268f67871c6cd44f0eaa0c69d4b4c8c40a) adds a `startWarming()` method that polls the helper's `status` endpoint until ready; `search()` throws `HybridSearchHelperError.notReady` if called before warmup completes.
> - [BrainBarServer](https://github.com/EtanHey/brainlayer/pull/420/files#diff-4602849889150805f4b12b90f751f36f54c87a22076f044e0669a2276500e981) no longer starts the helper at launch; it calls `startWarming()` only after databases are ready in `attemptDatabaseOpen()`. The socket I/O timeout is now fixed at 120s, independent of the search budget.
> - [MCPRouter](https://github.com/EtanHey/brainlayer/pull/420/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f) skips hybrid search and falls back to local search when the helper is not yet ready, triggering `startWarming()` on the first such request.
> - `stop()` now terminates the helper process with bounded waits and escalates to SIGKILL if `terminate()` does not stop it.
> - Behavioral Change: hybrid search returns local results (instead of waiting or erroring) until the helper finishes warming up.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab9f8e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hybrid search helper now includes a warmup phase to ensure proper initialization before handling search requests.
  * Implemented readiness verification that automatically falls back to local search if the helper is unavailable.

* **Bug Fixes**
  * Improved hybrid search helper process shutdown with better resource cleanup and termination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->