### PR TITLE
feat: add benchmark content-class filtering

### DIFF
--- a/scripts/backfill_content_class.py
+++ b/scripts/backfill_content_class.py
@@ -22,7 +22,7 @@ from brainlayer.content_class import (
 from brainlayer.paths import get_db_path
 from brainlayer.vector_store import VectorStore
 
-_CLASS_ORDER = ("decision", "knowledge", "operational", "test")
+_CLASS_ORDER = ("decision", "knowledge", "operational", "test", "benchmark")
 def _preview(content: str | None, limit: int = 260) -> str:
     return re.sub(r"\s+", " ", content or "").strip()[:limit]
 
@@ -123,10 +123,13 @@ def build_backfill_report(store: VectorStore, *, sample_limit: int = 30) -> dict
                 sample = _sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=signals)
                 sample["residual_after_marker_strip"] = _preview(strip_operational_markers(row.get("content")), 180)
                 operational_marker_kept_samples.append(sample)
-        if proposed in {"operational", "test"} and signals:
-            hidden_risk_rows.append(_sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=signals))
+        if proposed in {"operational", "test", "benchmark"}:
+            benchmark_signals = [signal for signal in signals if signal != "decision_language"]
+            risk_signals = benchmark_signals if proposed == "benchmark" else signals
+            if risk_signals:
+                hidden_risk_rows.append(_sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=risk_signals))
 
-    hidden_total = counts["operational"] + counts["test"]
+    hidden_total = counts["operational"] + counts["test"] + counts["benchmark"]
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "mode": "dry_run",
@@ -193,7 +196,7 @@ def main() -> int:
     if args.apply and not args.confirm_apply:
         parser.error("--apply requires --confirm-apply")
 
-    store = VectorStore(args.db_path)
+    store = VectorStore(args.db_path, readonly=not args.apply)
     try:
         report = apply_backfill(store, limit=args.limit) if args.apply else build_backfill_report(
             store,

--- a/scripts/backfill_content_class.py
+++ b/scripts/backfill_content_class.py
@@ -23,6 +23,8 @@ from brainlayer.paths import get_db_path
 from brainlayer.vector_store import VectorStore
 
 _CLASS_ORDER = ("decision", "knowledge", "operational", "test", "benchmark")
+
+
 def _preview(content: str | None, limit: int = 260) -> str:
     return re.sub(r"\s+", " ", content or "").strip()[:limit]
 
@@ -127,7 +129,9 @@ def build_backfill_report(store: VectorStore, *, sample_limit: int = 30) -> dict
             benchmark_signals = [signal for signal in signals if signal != "decision_language"]
             risk_signals = benchmark_signals if proposed == "benchmark" else signals
             if risk_signals:
-                hidden_risk_rows.append(_sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=risk_signals))
+                hidden_risk_rows.append(
+                    _sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=risk_signals)
+                )
 
     hidden_total = counts["operational"] + counts["test"] + counts["benchmark"]
     return {
@@ -198,9 +202,13 @@ def main() -> int:
 
     store = VectorStore(args.db_path, readonly=not args.apply)
     try:
-        report = apply_backfill(store, limit=args.limit) if args.apply else build_backfill_report(
-            store,
-            sample_limit=args.sample_limit,
+        report = (
+            apply_backfill(store, limit=args.limit)
+            if args.apply
+            else build_backfill_report(
+                store,
+                sample_limit=args.sample_limit,
+            )
         )
     finally:
         store.close()

--- a/scripts/backfill_content_class.py
+++ b/scripts/backfill_content_class.py
@@ -14,8 +14,10 @@ from brainlayer.content_class import (
     CONTENT_CLASS_VALUES,
     classify_content_class,
     classify_content_class_raw,
+    has_operational_marker,
     keep_visible_signals,
     normalize_content_class,
+    strip_operational_markers,
 )
 from brainlayer.paths import get_db_path
 from brainlayer.vector_store import VectorStore
@@ -96,7 +98,9 @@ def build_backfill_report(store: VectorStore, *, sample_limit: int = 30) -> dict
     samples = {key: [] for key in _CLASS_ORDER}
     hidden_risk_rows: list[dict[str, Any]] = []
     keep_visible_override_samples: list[dict[str, Any]] = []
+    operational_marker_kept_samples: list[dict[str, Any]] = []
     keep_visible_override_total = 0
+    operational_marker_kept_total = 0
     updates_needed = 0
 
     for row, proposed_raw, proposed, signals in iter_classifications(store):
@@ -113,6 +117,12 @@ def build_backfill_report(store: VectorStore, *, sample_limit: int = 30) -> dict
                 keep_visible_override_samples.append(
                     _sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=signals)
                 )
+        if proposed not in {"operational", "test"} and has_operational_marker(row.get("content")):
+            operational_marker_kept_total += 1
+            if len(operational_marker_kept_samples) < 8:
+                sample = _sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=signals)
+                sample["residual_after_marker_strip"] = _preview(strip_operational_markers(row.get("content")), 180)
+                operational_marker_kept_samples.append(sample)
         if proposed in {"operational", "test"} and signals:
             hidden_risk_rows.append(_sample_row(row, proposed, proposed_raw=proposed_raw, risk_signals=signals))
 
@@ -125,6 +135,8 @@ def build_backfill_report(store: VectorStore, *, sample_limit: int = 30) -> dict
         "hidden_total": hidden_total,
         "keep_visible_override_total": keep_visible_override_total,
         "keep_visible_override_samples": keep_visible_override_samples,
+        "operational_marker_kept_total": operational_marker_kept_total,
+        "operational_marker_kept_samples": operational_marker_kept_samples,
         "personal_hidden": len(hidden_risk_rows),
         "hidden_decision_or_personal_risk_total": len(hidden_risk_rows),
         "samples": samples,

--- a/src/brainlayer/content_class.py
+++ b/src/brainlayer/content_class.py
@@ -8,6 +8,7 @@ from typing import Any
 DEFAULT_CONTENT_CLASS = "knowledge"
 CONTENT_CLASS_VALUES = frozenset({"knowledge", "decision", "operational", "test"})
 DEFAULT_HIDDEN_CONTENT_CLASSES = frozenset({"operational", "test"})
+_OPERATIONAL_RESIDUAL_TRIVIAL_MAX_CHARS = 20
 
 _DECISION_RE = re.compile(
     r"\b("
@@ -27,6 +28,21 @@ _OPERATIONAL_RE = re.compile(
 )
 _BL_OPERATIONAL_RE = re.compile(
     r"\[bl-[^\]]*(?:tick|status|heartbeat|claude_counter|working|poll|surface|monitor|done)",
+    re.IGNORECASE,
+)
+_TASK_NOTIFICATION_BLOCK_RE = re.compile(
+    r"<task-notification\b[^>]*>.*?</task-notification>",
+    re.IGNORECASE | re.DOTALL,
+)
+_OPERATIONAL_MARKER_LINE_RE = re.compile(
+    r"^\s*("
+    r"\[?\s*claude_counter\b(?:\s*:?\s*\d+)?\s*\]?|"
+    r"\[bl-[^\]]*(?:tick|status|heartbeat|claude_counter|working|poll|surface|monitor|done)[^\]]*\].*|"
+    r"(?:orc\s+)?tick\b.*|loop tick\b.*|(?:watcher\s+)?heartbeat\b.*|"
+    r"surface:\d+\b.*|bare status\b.*|status only\b.*|"
+    r"task[_ -]?notification\b.*|milestone\b.*|retraction\b.*|done_fixes\b.*|"
+    r"worker done\b.*|agent coordination\b.*"
+    r")\s*$",
     re.IGNORECASE,
 )
 _TEST_RE = re.compile(
@@ -127,6 +143,45 @@ def keep_visible_signals(content: str | None, *, content_type: str | None = None
     return signals
 
 
+def strip_operational_markers(content: str | None) -> str:
+    """Remove operational-only marker lines/blocks while preserving substantive text."""
+    if not content:
+        return ""
+    without_blocks = _TASK_NOTIFICATION_BLOCK_RE.sub("\n", content)
+    residual_lines = [
+        "" if _OPERATIONAL_MARKER_LINE_RE.match(line) else line
+        for line in without_blocks.splitlines()
+    ]
+    return "\n".join(residual_lines).strip()
+
+
+def _residual_is_trivial(residual: str) -> bool:
+    compact = re.sub(r"\s+", " ", residual).strip()
+    if not compact:
+        return True
+    if len(compact) <= _OPERATIONAL_RESIDUAL_TRIVIAL_MAX_CHARS:
+        return True
+    return not any(char.isalnum() for char in compact)
+
+
+def has_operational_marker(content: str | None) -> bool:
+    """Return true when content contains operational markers, regardless of dominance."""
+    if not content:
+        return False
+    if _TASK_NOTIFICATION_BLOCK_RE.search(content):
+        return True
+    if _OPERATIONAL_RE.search(content) or _BL_OPERATIONAL_RE.search(content):
+        return True
+    return any(_OPERATIONAL_MARKER_LINE_RE.match(line) for line in content.splitlines())
+
+
+def has_dominant_operational_marker(content: str | None) -> bool:
+    """Return true only when operational markers dominate the chunk content."""
+    if not has_operational_marker(content):
+        return False
+    return _residual_is_trivial(strip_operational_markers(content))
+
+
 def classify_content_class_raw(
     content: str | None,
     *,
@@ -153,7 +208,7 @@ def classify_content_class_raw(
 
     if _TEST_RE.search(text):
         return "test"
-    if _OPERATIONAL_RE.search(text) or _BL_OPERATIONAL_RE.search(text):
+    if has_dominant_operational_marker(text):
         return "operational"
 
     return DEFAULT_CONTENT_CLASS

--- a/src/brainlayer/content_class.py
+++ b/src/brainlayer/content_class.py
@@ -6,8 +6,8 @@ import re
 from typing import Any
 
 DEFAULT_CONTENT_CLASS = "knowledge"
-CONTENT_CLASS_VALUES = frozenset({"knowledge", "decision", "operational", "test"})
-DEFAULT_HIDDEN_CONTENT_CLASSES = frozenset({"operational", "test"})
+CONTENT_CLASS_VALUES = frozenset({"knowledge", "decision", "operational", "test", "benchmark"})
+DEFAULT_HIDDEN_CONTENT_CLASSES = frozenset({"operational", "test", "benchmark"})
 _OPERATIONAL_RESIDUAL_TRIVIAL_MAX_CHARS = 20
 
 _DECISION_RE = re.compile(
@@ -52,6 +52,12 @@ _TEST_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
+_BENCHMARK_RE = re.compile(
+    r"("
+    r"^\W*(?:brainlayer search benchmark|bl quality bench(?:mark)?|eval (?:final )?results)\b"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
 _PERSONAL_RE = re.compile(
     r"("
     r"\bjournal\b|\bpersonal\b|\bmy life\b|\betan's life\b|\bfamily\b|"
@@ -88,6 +94,25 @@ _OPERATIONAL_INTENT_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
+_BENCHMARK_INTENT_RE = re.compile(
+    r"\b(?:benchmark|diagnostic prompt|qrels|search quality eval)\b",
+    re.IGNORECASE,
+)
+
+
+def has_benchmark_signal(content: str | None, *, tags: Any = None, source_file: str | None = None) -> bool:
+    """Return true for benchmark/diagnostic prompt chunks that should not pollute search."""
+    del tags, source_file
+    text = content or ""
+    compact_prefix = re.sub(r"\s+", "", text[:512]).casefold()
+    if compact_prefix.startswith("┌─brain_") or text.lstrip().casefold().startswith(
+        "mcp brainlayer memory: invalid json-rpc message"
+    ):
+        return True
+    text_head = text[:1200]
+    if _BENCHMARK_RE.search(text_head):
+        return True
+    return False
 
 
 def normalize_content_class(value: Any) -> str:
@@ -193,14 +218,15 @@ def classify_content_class_raw(
 ) -> str:
     """Classify a chunk before keep-visible safety overrides.
 
-    Decision signals are intentionally evaluated before operational/test signals:
-    durable "why we did X" records must stay visible even when they include
-    coordination prefixes like "[BL-LEAD]".
+    Benchmark signals are evaluated first because audit-recursion prompts often
+    look substantive. Decision signals still outrank operational/test markers.
     """
-    del tags, source, source_file, project  # Reserved for future cheap signals.
+    del source, project  # Reserved for future cheap signals.
     text = (content or "").strip()
     type_key = (content_type or "").strip().lower()
 
+    if has_benchmark_signal(text, tags=tags, source_file=source_file):
+        return "benchmark"
     if type_key == "decision":
         return "decision"
     if type_key != "learning" and has_decision_language(text, content_type=content_type):
@@ -232,14 +258,18 @@ def classify_content_class(
         source_file=source_file,
         project=project,
     )
-    if proposed in DEFAULT_HIDDEN_CONTENT_CLASSES and keep_visible_signals(content, content_type=content_type):
-        return DEFAULT_CONTENT_CLASS
+    if proposed in DEFAULT_HIDDEN_CONTENT_CLASSES:
+        signals = keep_visible_signals(content, content_type=content_type)
+        if proposed == "benchmark":
+            signals = [signal for signal in signals if signal != "decision_language"]
+        if signals:
+            return DEFAULT_CONTENT_CLASS
     return proposed
 
 
 def query_signals_operational_intent(query: str | None) -> bool:
-    """Cheap opt-in for users explicitly searching operational/test material."""
-    return bool(query and _OPERATIONAL_INTENT_RE.search(query))
+    """Cheap opt-in for users explicitly searching operational/test/benchmark material."""
+    return bool(query and (_OPERATIONAL_INTENT_RE.search(query) or _BENCHMARK_INTENT_RE.search(query)))
 
 
 def content_class_is_default_hidden(value: Any) -> bool:

--- a/src/brainlayer/content_class.py
+++ b/src/brainlayer/content_class.py
@@ -173,10 +173,7 @@ def strip_operational_markers(content: str | None) -> str:
     if not content:
         return ""
     without_blocks = _TASK_NOTIFICATION_BLOCK_RE.sub("\n", content)
-    residual_lines = [
-        "" if _OPERATIONAL_MARKER_LINE_RE.match(line) else line
-        for line in without_blocks.splitlines()
-    ]
+    residual_lines = ["" if _OPERATIONAL_MARKER_LINE_RE.match(line) else line for line in without_blocks.splitlines()]
     return "\n".join(residual_lines).strip()
 
 

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -532,11 +532,11 @@ async def list_tools() -> list[Tool]:
                         "include_operational": {
                             "type": "boolean",
                             "default": False,
-                            "description": "Opt in to operational/test chunks that default search hides to avoid status and eval pollution.",
+                            "description": "Opt in to operational/test/benchmark chunks that default search hides to avoid status and eval pollution.",
                         },
                         "content_class": {
                             "type": "string",
-                            "enum": ["knowledge", "decision", "operational", "test"],
+                            "enum": ["knowledge", "decision", "operational", "test", "benchmark"],
                             "description": "Restrict search to one content_class. Defaults to visible knowledge/decision classes.",
                         },
                         "detail": {
@@ -868,11 +868,11 @@ async def list_tools() -> list[Tool]:
                         "include_operational": {
                             "type": "boolean",
                             "default": False,
-                            "description": "Opt in to operational/test chunks in mode=search.",
+                            "description": "Opt in to operational/test/benchmark chunks in mode=search.",
                         },
                         "content_class": {
                             "type": "string",
-                            "enum": ["knowledge", "decision", "operational", "test"],
+                            "enum": ["knowledge", "decision", "operational", "test", "benchmark"],
                             "description": "Restrict mode=search results to one content_class.",
                         },
                     },

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -173,7 +173,7 @@ def _content_class_where(
     include_operational: bool = False,
     content_class_filter: str | None = None,
 ) -> tuple[str | None, list[Any]]:
-    """Build SQL enforcing default operational/test exclusion.
+    """Build SQL enforcing default operational/test/benchmark exclusion.
 
     NULL is treated as knowledge so pre-backfill rows remain visible.
     """
@@ -184,7 +184,7 @@ def _content_class_where(
         ]
     if include_operational or query_signals_operational_intent(query_text):
         return None, []
-    return f"COALESCE({column_expr}, ?) NOT IN ('operational', 'test')", [DEFAULT_CONTENT_CLASS]
+    return f"COALESCE({column_expr}, ?) NOT IN ('operational', 'test', 'benchmark')", [DEFAULT_CONTENT_CLASS]
 
 
 def _content_class_expr(store: Any, alias: str | None = None) -> str:

--- a/tests/test_content_class.py
+++ b/tests/test_content_class.py
@@ -87,6 +87,11 @@ def test_content_class_schema_defaults_to_knowledge(tmp_path: Path) -> None:
         ("[BL-LEAD tick] Etan heartbeat status", "note", "knowledge"),
         ("[BL-LEAD tick] health finance heartbeat status", "note", "knowledge"),
         ("ad-hoc eval test query for search ranking", "note", "test"),
+        (
+            "BrainLayer Search Benchmark diagnostic prompt: evaluate conceptual queries and rank recall results",
+            "note",
+            "benchmark",
+        ),
         ("ambiguous coordination note with useful context", "note", "knowledge"),
     ],
 )
@@ -124,6 +129,86 @@ def test_operational_markers_must_dominate_content(content: str, expected: str) 
     from brainlayer.content_class import classify_content_class
 
     assert classify_content_class(content, content_type="note") == expected
+
+
+def test_audit_recursion_benchmark_class_does_not_require_trivial_residual() -> None:
+    from brainlayer.content_class import classify_content_class
+
+    content = (
+        "BrainLayer Search Benchmark\n\n"
+        "Diagnostic prompt: run conceptual query coverage for memory retrieval, compare ranked results, "
+        "and explain why the benchmark prompt ranked itself first."
+    )
+
+    assert classify_content_class(content, content_type="note", tags='["audit", "r02"]') == "benchmark"
+
+
+def test_audit_tagged_substantive_analysis_that_mentions_search_stays_visible() -> None:
+    from brainlayer.content_class import classify_content_class
+
+    content = (
+        "BrainLayer MCP implementation audit found a real handler issue. "
+        "The fix is to preserve structured errors in search_handler.py and add coverage."
+    )
+
+    assert classify_content_class(content, content_type="note", tags='["audit", "r02"]') == "knowledge"
+
+
+def test_audit_tagged_project_search_prompt_stays_visible_without_benchmark_signals() -> None:
+    from brainlayer.content_class import classify_content_class
+
+    content = (
+        "Audit story: search the codebase for localStorage usage and report mismatches between visitorId "
+        "and email usage in SongScript."
+    )
+
+    assert classify_content_class(content, content_type="note", tags='["audit"]') == "knowledge"
+
+
+def test_metric_reference_without_eval_table_stays_visible() -> None:
+    from brainlayer.content_class import classify_content_class
+
+    content = (
+        "The demo framing says k=60 was a flat optimum and MAP moved only 0.0023, "
+        "which affects BrainLayer top-K design."
+    )
+
+    assert classify_content_class(content, content_type="note", tags='["audit", "r02"]') == "knowledge"
+
+
+def test_eval_results_table_is_benchmark() -> None:
+    from brainlayer.content_class import classify_content_class
+
+    content = (
+        "EVAL FINAL RESULTS with pooled qrels:\n"
+        "| Metric | FTS5 | Hybrid |\n"
+        "| ndcg@10 | 0.910 | 0.930 |\n"
+        "| recall@20 | 0.671 | 0.700 |"
+    )
+
+    assert classify_content_class(content, content_type="note") == "benchmark"
+
+
+def test_leading_brain_search_dump_is_benchmark() -> None:
+    from brainlayer.content_class import classify_content_class
+
+    content = '┌─ brain_search: "overnight sprint" ─ 3 results\n│ result dump'
+
+    assert classify_content_class(content, content_type="note") == "benchmark"
+
+
+def test_embedded_brain_search_reference_in_analysis_stays_visible() -> None:
+    from brainlayer.content_class import classify_content_class, content_class_is_default_hidden
+
+    content = (
+        "Results are there with non-zero scores. The issue is that some chunks contain text like "
+        "`┌─ brain_search: ...` because those chunks are search output; the fix is an ingest guard."
+    )
+
+    content_class = classify_content_class(content, content_type="note")
+
+    assert content_class != "benchmark"
+    assert content_class_is_default_hidden(content_class) is False
 
 
 def test_bundled_counter_substance_is_never_default_hidden() -> None:
@@ -191,6 +276,13 @@ def test_hybrid_search_excludes_operational_and_test_by_default(tmp_path: Path) 
         )
         _insert_chunk(
             store,
+            chunk_id="benchmark-semantic",
+            content="BrainLayer Search Benchmark diagnostic exactmatch",
+            content_class="benchmark",
+            embedding=query_embedding,
+        )
+        _insert_chunk(
+            store,
             chunk_id="knowledge-survivor",
             content="durable knowledge memory exactmatch",
             content_class="knowledge",
@@ -222,6 +314,7 @@ def test_hybrid_search_excludes_operational_and_test_by_default(tmp_path: Path) 
     assert default_results["ids"][0] == ["knowledge-survivor"]
     assert "operational-semantic" in opt_in_results["ids"][0]
     assert "test-semantic" in opt_in_results["ids"][0]
+    assert "benchmark-semantic" in opt_in_results["ids"][0]
     assert class_filter_results["ids"][0] == ["operational-semantic"]
 
 
@@ -319,6 +412,7 @@ def test_dry_run_backfill_reports_counts_and_samples_without_updating(tmp_path: 
                 ('decision-visible', '[BL-LEAD DECISION: chose X over Y because durable]', '{}', 'test', 'brainlayer', 'note', 57),
                 ('operational-hidden', '[BL-LEAD tick] CLAUDE_COUNTER: 4', '{}', 'test', 'brainlayer', 'note', 33),
                 ('test-hidden', 'ad-hoc eval test query', '{}', 'test', 'brainlayer', 'note', 22),
+                ('benchmark-hidden', 'BrainLayer Search Benchmark diagnostic exactmatch', '{}', 'test', 'brainlayer', 'note', 46),
                 ('bundled-visible', 'CLAUDE_COUNTER: 8\n\nCreated two update.json stories and refreshed fixture coverage for onboarding screens.', '{}', 'test', 'brainlayer', 'note', 94),
                 ('hebrew-visible', '[BL-LEAD tick] שלום heartbeat status', '{}', 'test', 'brainlayer', 'note', 38),
                 ('person-visible', '[BL-LEAD tick] Etan heartbeat status', '{}', 'test', 'brainlayer', 'note', 37),
@@ -330,7 +424,7 @@ def test_dry_run_backfill_reports_counts_and_samples_without_updating(tmp_path: 
     finally:
         store.close()
 
-    assert report["counts"] == {"decision": 1, "knowledge": 4, "operational": 1, "test": 1}
+    assert report["counts"] == {"decision": 1, "knowledge": 4, "operational": 1, "test": 1, "benchmark": 1}
     assert report["keep_visible_override_total"] == 3
     assert report["operational_marker_kept_total"] == 4
     assert report["personal_hidden"] == 0
@@ -340,12 +434,14 @@ def test_dry_run_backfill_reports_counts_and_samples_without_updating(tmp_path: 
     marker_kept_ids = {row["chunk_id"] for row in report["operational_marker_kept_samples"]}
     assert "bundled-visible" in marker_kept_ids
     assert [row["chunk_id"] for row in report["samples"]["operational"]] == ["operational-hidden"]
+    assert [row["chunk_id"] for row in report["samples"]["benchmark"]] == ["benchmark-hidden"]
     assert [row["chunk_id"] for row in report["samples"]["decision"]] == ["decision-visible"]
     assert rows_after == {
         "decision-visible": "knowledge",
         "bundled-visible": "knowledge",
         "operational-hidden": "knowledge",
         "test-hidden": "knowledge",
+        "benchmark-hidden": "knowledge",
         "hebrew-visible": "knowledge",
         "person-visible": "knowledge",
         "personal-visible": "knowledge",

--- a/tests/test_content_class.py
+++ b/tests/test_content_class.py
@@ -96,6 +96,50 @@ def test_classify_content_class_decision_first(content: str, content_type: str, 
     assert classify_content_class(content, content_type=content_type) == expected
 
 
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("CLAUDE_COUNTER: 4", "operational"),
+        (
+            "CLAUDE_COUNTER: 7\n\n"
+            "Fixed the BrainBar helper readiness path and added coverage for persistent helper lifecycle "
+            "state, socket startup, and search request forwarding.",
+            "knowledge",
+        ),
+        ("Done.\n\nCLAUDE_COUNTER: 3", "operational"),
+        ("<task-notification><result>worker done</result></task-notification>", "operational"),
+        (
+            "<task-notification><result>worker done</result></task-notification>\n\n"
+            "The worker result means the schema migration needs a second verification pass before rollout.",
+            "knowledge",
+        ),
+        (
+            "Created two stories in update.json and documented the offline sync route, MCP socket path, "
+            "screen owners, rollout checklist, and fixture coverage.\n\nheartbeat",
+            "knowledge",
+        ),
+    ],
+)
+def test_operational_markers_must_dominate_content(content: str, expected: str) -> None:
+    from brainlayer.content_class import classify_content_class
+
+    assert classify_content_class(content, content_type="note") == expected
+
+
+def test_bundled_counter_substance_is_never_default_hidden() -> None:
+    from brainlayer.content_class import classify_content_class, content_class_is_default_hidden
+
+    content = (
+        "CLAUDE_COUNTER: 11\n\n"
+        "Created two stories in update.json for the new onboarding flow and updated the fixtures, "
+        "screen-state notes, animation timing checklist, and release checklist."
+    )
+    content_class = classify_content_class(content, content_type="note")
+
+    assert content_class == "knowledge"
+    assert content_class_is_default_hidden(content_class) is False
+
+
 def test_store_memory_persists_content_class_decision_first(tmp_path: Path) -> None:
     store = VectorStore(tmp_path / "content-class-store.db")
     try:
@@ -275,6 +319,7 @@ def test_dry_run_backfill_reports_counts_and_samples_without_updating(tmp_path: 
                 ('decision-visible', '[BL-LEAD DECISION: chose X over Y because durable]', '{}', 'test', 'brainlayer', 'note', 57),
                 ('operational-hidden', '[BL-LEAD tick] CLAUDE_COUNTER: 4', '{}', 'test', 'brainlayer', 'note', 33),
                 ('test-hidden', 'ad-hoc eval test query', '{}', 'test', 'brainlayer', 'note', 22),
+                ('bundled-visible', 'CLAUDE_COUNTER: 8\n\nCreated two update.json stories and refreshed fixture coverage for onboarding screens.', '{}', 'test', 'brainlayer', 'note', 94),
                 ('hebrew-visible', '[BL-LEAD tick] שלום heartbeat status', '{}', 'test', 'brainlayer', 'note', 38),
                 ('person-visible', '[BL-LEAD tick] Etan heartbeat status', '{}', 'test', 'brainlayer', 'note', 37),
                 ('personal-visible', '[BL-LEAD tick] health finance heartbeat status', '{}', 'test', 'brainlayer', 'note', 47)"""
@@ -285,16 +330,20 @@ def test_dry_run_backfill_reports_counts_and_samples_without_updating(tmp_path: 
     finally:
         store.close()
 
-    assert report["counts"] == {"decision": 1, "knowledge": 3, "operational": 1, "test": 1}
+    assert report["counts"] == {"decision": 1, "knowledge": 4, "operational": 1, "test": 1}
     assert report["keep_visible_override_total"] == 3
+    assert report["operational_marker_kept_total"] == 4
     assert report["personal_hidden"] == 0
     assert report["hidden_decision_or_personal_risk_total"] == 0
     rescued_ids = {row["chunk_id"] for row in report["keep_visible_override_samples"]}
     assert rescued_ids == {"hebrew-visible", "person-visible", "personal-visible"}
+    marker_kept_ids = {row["chunk_id"] for row in report["operational_marker_kept_samples"]}
+    assert "bundled-visible" in marker_kept_ids
     assert [row["chunk_id"] for row in report["samples"]["operational"]] == ["operational-hidden"]
     assert [row["chunk_id"] for row in report["samples"]["decision"]] == ["decision-visible"]
     assert rows_after == {
         "decision-visible": "knowledge",
+        "bundled-visible": "knowledge",
         "operational-hidden": "knowledge",
         "test-hidden": "knowledge",
         "hebrew-visible": "knowledge",


### PR DESCRIPTION
## Summary
- Add `content_class=benchmark` as a third default-hidden content class alongside `operational` and `test`.
- Keep dominant-operational behavior conservative: operational markers only hide chunks when marker-stripped residual content is trivial, so marker+substance chunks remain visible.
- Classify only dominant benchmark/search-pollution forms as `benchmark`: leading recursive `brain_*` dumps, BrainLayer search benchmark headings, BL quality bench headings, and eval-result summaries.
- Make the content-class dry-run open the live DB with `readonly=True` and include benchmark in hidden totals/risk reporting.

## Rationale
Operational acks and recursive benchmark/search dumps pollute default search without carrying durable user knowledge. The benchmark classifier is intentionally structural and conservative after sample-checking false positives: ordinary analysis, decisions, and audit findings that merely mention benchmarks/search remain default-visible.

## Dry-run
Authoritative dry-run is locked at `/tmp/brainlayer-content-class-FINAL.json` after marker:

`DRYRUN_FINAL_DONE /tmp/brainlayer-content-class-FINAL.json`

Read-only live DB dry-run numbers:
- `hidden_total=1,736`
- `operational=1,444`
- `test=279`
- `benchmark=13`
- `knowledge=345,072`
- `decision=70,993`
- `personal_hidden=0`
- `keep_visible_override_total=200`
- `operational_marker_kept_total=78,061`
- `updates_needed=72,661`

Benchmark sample-check:
- First broad rule was rejected after sample-check found substantive false positives.
- Final structural rule sample checked all 13 benchmark rows from the final dry-run.
- Verdict: 13/13 were dominant benchmark/eval-result dumps or leading recursive `brain_search` dumps.

## Backfill Boundary
APPLY is NOT part of this PR. Backfill apply is gated on Etan/orc approval + DB backup + harness re-measure.

## Verification
- `cr review --plain` -> no findings.
- `PYTHONPATH=src pytest -q tests/test_content_class.py tests/test_audit_recursion_filter.py` -> 55 passed in 3.11s.
- Pre-push BrainLayer gate passed:
  - pytest unit suite: 2,324 passed, 9 skipped, 77 deselected, 1 xfailed, 102 warnings in 227.62s
  - MCP tool registration: 3 passed
  - isolated eval and hook routing: 38 passed
  - bun test suite: 1 pass, 0 fail
  - regression shell `test_fts5_determinism.sh`: PASS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default search visibility and classification for a large corpus (dry-run ~72k updates); misclassification could hide substantive audit/analysis or leave pollution visible, though tests target conservative benchmark/operational rules.
> 
> **Overview**
> Introduces **`benchmark`** as a third default-hidden `content_class` (with `operational` and `test`) so eval dumps, recursive `brain_*` output, and search-benchmark headings stay out of normal retrieval unless opted in.
> 
> **Classification** runs benchmark detection first via structural signals (`has_benchmark_signal`, leading `┌─brain_` dumps, eval-result headings). **Operational** hiding now requires **dominant** markers: `strip_operational_markers` / `has_dominant_operational_marker` so chunks with status lines plus real prose stay **knowledge**. Keep-visible overrides for hidden classes no longer promote **benchmark** rows on `decision_language` alone.
> 
> **Search and MCP** extend default SQL exclusion and `include_operational` / `content_class` enums to **`benchmark`**; query intent can opt into benchmark material. The **backfill dry-run** opens the DB **readonly**, tracks **`operational_marker_kept_*`** samples, and includes benchmark in hidden totals and risk reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f31cd9e724a853494e2aef1742c906f716ae6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "benchmark" content classification category to better organize search results and prevent benchmark content from appearing in standard searches.
  * Enhanced operational marker detection to more accurately identify and filter operational/test content.

* **Improvements**
  * Updated search and recall tools to recognize and respect the new benchmark classification in filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'benchmark' content class with detection, filtering, and classification logic
> - Adds `'benchmark'` to `CONTENT_CLASS_VALUES` and `DEFAULT_HIDDEN_CONTENT_CLASSES` in [content_class.py](https://github.com/EtanHey/brainlayer/pull/422/files#diff-887c29b196ce7795217d72c9bf6db09325e76f09c49661b6fed58de8d0b265d3), making it hidden by default alongside `operational` and `test`.
> - Introduces `has_benchmark_signal` to detect benchmark content (eval result tables, `brain_search` dumps, diagnostic prompts) and classifies matching chunks as `'benchmark'` early in `classify_content_class_raw`.
> - Operational classification now requires markers to *dominate* content via `has_dominant_operational_marker`; content with non-trivial substantive text alongside markers stays `'knowledge'`.
> - Extends default search exclusion in `_content_class_where` to include `'benchmark'`, and exposes `content_class='benchmark'` in MCP tool schemas.
> - Behavioral Change: existing content previously classified as `'operational'` due to marker presence may now be reclassified as `'knowledge'` if substantive text is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8cfa88d. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->