### PR TITLE
feat(eval): add enrichment gold scaffold

### DIFF
--- a/src/brainlayer/eval/__init__.py
+++ b/src/brainlayer/eval/__init__.py
@@ -11,6 +11,7 @@ from .benchmark import (
     pipeline_hybrid_entity,
     pipeline_hybrid_rrf,
 )
+from .enrichment_gold import sample_enrichment_gold
 
 __all__ = [
     "DEFAULT_COMPARE_METRICS",
@@ -22,4 +23,5 @@ __all__ = [
     "pipeline_fts5_only",
     "pipeline_hybrid_entity",
     "pipeline_hybrid_rrf",
+    "sample_enrichment_gold",
 ]

--- a/src/brainlayer/eval/enrichment_gold.py
+++ b/src/brainlayer/eval/enrichment_gold.py
@@ -1,0 +1,291 @@
+"""Snapshot-only gold-set sampler for BrainLayer enrichment label evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from brainlayer.eval.benchmark import ReadOnlyBenchmarkStore, canonical_eval_doc_id
+
+DEFAULT_TARGET_SIZE = 60
+DEFAULT_OUTPUT_PATH = Path(__file__).resolve().parent / "fixtures" / "enrichment-gold.jsonl"
+LIVE_BRAINLAYER_DB = Path("~/.local/share/brainlayer/brainlayer.db").expanduser()
+
+
+@dataclass(frozen=True)
+class Stratum:
+    name: str
+    patterns: tuple[str, ...] = ()
+    columns: tuple[str, ...] = ("content", "tags", "summary")
+    extra_conditions: tuple[str, ...] = ()
+
+
+STRATA: tuple[Stratum, ...] = (
+    Stratum(
+        "decision",
+        patterns=("decision", "decided", "deciding", "choose", "chosen", "tradeoff", "because"),
+        columns=("content", "tags", "summary", "intent"),
+    ),
+    Stratum(
+        "code",
+        patterns=("code", "def ", "class ", "function ", "import ", "pytest", "```", ".py", ".ts", ".tsx"),
+        columns=("content", "source_file", "content_type", "tags", "primary_symbols"),
+    ),
+    Stratum(
+        "conversation",
+        patterns=("user:", "assistant:", "claude_counter", "<user", "<assistant"),
+        columns=("content", "metadata", "source_file"),
+    ),
+    Stratum(
+        "correction",
+        patterns=("correction", "wrong", "mistake", "missed", "actually", "fix", "regression"),
+        columns=("content", "tags", "summary", "sentiment_label"),
+    ),
+    Stratum(
+        "entity_bio",
+        patterns=("bio", "person", "owner", "founder", "works at", "is the", "profile"),
+        columns=("content", "tags", "summary", "entities"),
+    ),
+    Stratum(
+        "short_conversational",
+        patterns=("ok", "yes", "no", "thanks", "done", "go"),
+        columns=("content", "sender", "metadata"),
+        extra_conditions=("length(content) <= 120",),
+    ),
+    Stratum(
+        "long_truncation",
+        extra_conditions=("length(content) > 8000",),
+    ),
+    Stratum(
+        "meta_research",
+        patterns=("brain_search(", "brain_entity(", "research", "meta-research", "scope doc", "benchmark"),
+        columns=("content", "tags", "summary"),
+    ),
+    Stratum(
+        "sentiment",
+        patterns=("frustrat", "confus", "angry", "upset", "satisfaction", "positive", "excited"),
+        columns=("content", "tags", "summary", "sentiment_label", "sentiment_signals"),
+        extra_conditions=("coalesce(sentiment_label, '') not in ('', 'neutral')",),
+    ),
+)
+
+OUTPUT_COLUMNS = (
+    "id",
+    "content",
+    "source_file",
+    "project",
+    "content_type",
+    "tags",
+    "summary",
+    "sentiment_label",
+    "sender",
+    "created_at",
+)
+
+
+def _guard_snapshot_path(snapshot_path: str | Path) -> Path:
+    path = Path(snapshot_path).expanduser()
+    if path == LIVE_BRAINLAYER_DB:
+        raise ValueError(f"Refusing to sample the live BrainLayer DB: {LIVE_BRAINLAYER_DB}")
+    if path.exists() and LIVE_BRAINLAYER_DB.exists() and path.resolve() == LIVE_BRAINLAYER_DB.resolve():
+        raise ValueError(f"Refusing to sample the live BrainLayer DB: {LIVE_BRAINLAYER_DB}")
+    return path
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    cursor = conn.execute(f"PRAGMA table_info({table})")
+    return {str(row[1]) for row in cursor.fetchall()}
+
+
+def _condition_for_stratum(stratum: Stratum, columns: set[str]) -> str:
+    extra_conditions = list(stratum.extra_conditions)
+    pattern_conditions: list[str] = []
+    for column in stratum.columns:
+        if column not in columns:
+            continue
+        for pattern in stratum.patterns:
+            pattern_conditions.append(f"lower(coalesce({column}, '')) like ?")
+    if extra_conditions and pattern_conditions:
+        return "(" + " AND ".join(extra_conditions) + " AND (" + " OR ".join(pattern_conditions) + "))"
+    conditions = extra_conditions + pattern_conditions
+    if not conditions:
+        return "1 = 1"
+    return "(" + " OR ".join(conditions) + ")"
+
+
+def _params_for_stratum(stratum: Stratum, columns: set[str]) -> list[str]:
+    params: list[str] = []
+    for column in stratum.columns:
+        if column not in columns:
+            continue
+        params.extend(f"%{pattern.lower()}%" for pattern in stratum.patterns)
+    return params
+
+
+def _quotas(target_size: int) -> dict[str, int]:
+    if target_size < 1:
+        raise ValueError("--target-size must be at least 1")
+    base = target_size // len(STRATA)
+    remainder = target_size % len(STRATA)
+    return {stratum.name: base + (1 if index < remainder else 0) for index, stratum in enumerate(STRATA)}
+
+
+def _fetch_candidates(
+    store: ReadOnlyBenchmarkStore,
+    stratum: Stratum,
+    columns: set[str],
+    *,
+    candidate_limit: int,
+) -> list[dict[str, Any]]:
+    selected_columns = [column for column in OUTPUT_COLUMNS if column in columns]
+    if "id" not in selected_columns or "content" not in selected_columns:
+        raise ValueError("Snapshot chunks table must include id and content columns")
+
+    condition = _condition_for_stratum(stratum, columns)
+    params = _params_for_stratum(stratum, columns)
+    order_column = "created_at" if "created_at" in columns else "id"
+    sql = f"""
+        SELECT {", ".join(selected_columns)}
+        FROM chunks
+        WHERE content IS NOT NULL
+          AND length(trim(content)) > 0
+          AND {condition}
+        ORDER BY {order_column} DESC, id ASC
+        LIMIT ?
+    """
+    cursor = store._read_cursor()
+    cursor.execute(sql, [*params, candidate_limit])
+    rows = cursor.fetchall()
+    return [dict(zip(selected_columns, row, strict=True)) for row in rows]
+
+
+def _record_from_row(row: dict[str, Any], stratum: str) -> dict[str, Any]:
+    chunk_id = str(row["id"])
+    source_file = str(row.get("source_file") or "")
+    base_doc_id = source_file if source_file else chunk_id
+    return {
+        "chunk_id": chunk_id,
+        "eval_doc_id": f"{canonical_eval_doc_id(base_doc_id)}#{chunk_id}",
+        "stratum": stratum,
+        "content": str(row["content"]),
+        "content_length": len(str(row["content"])),
+        "source_file": source_file or None,
+        "project": row.get("project"),
+        "content_type": row.get("content_type"),
+        "tags": row.get("tags"),
+        "summary": row.get("summary"),
+        "sentiment_label": row.get("sentiment_label"),
+        "sender": row.get("sender"),
+        "created_at": row.get("created_at"),
+    }
+
+
+def sample_enrichment_gold(
+    *,
+    snapshot_path: str | Path,
+    output_path: str | Path = DEFAULT_OUTPUT_PATH,
+    target_size: int = DEFAULT_TARGET_SIZE,
+    seed: int = 20260601,
+    candidate_limit_per_stratum: int | None = None,
+) -> list[dict[str, Any]]:
+    """Sample stratified raw chunks from a read-only snapshot and write JSONL.
+
+    Chunk content is untrusted data. This sampler copies it as inert labeler input only;
+    it must not be interpreted as agent instructions.
+
+    # TODO(PR1-followup): run the real 60-chunk pull from a vacuumed snapshot when
+    # machine load permits, then commit/update fixtures/enrichment-gold.jsonl.
+    """
+
+    snapshot = _guard_snapshot_path(snapshot_path)
+    output = Path(output_path).expanduser()
+    quotas = _quotas(target_size)
+    candidate_limit = candidate_limit_per_stratum or max(100, target_size * 20)
+    rng = random.Random(seed)
+
+    records: list[dict[str, Any]] = []
+    used_chunk_ids: set[str] = set()
+    leftovers: list[tuple[str, dict[str, Any]]] = []
+
+    with ReadOnlyBenchmarkStore(snapshot) as store:
+        columns = _table_columns(store.conn, "chunks")
+        for stratum in STRATA:
+            candidates = _fetch_candidates(
+                store,
+                stratum,
+                columns,
+                candidate_limit=candidate_limit,
+            )
+            rng.shuffle(candidates)
+            quota = quotas[stratum.name]
+            picked = 0
+            for row in candidates:
+                chunk_id = str(row["id"])
+                if chunk_id in used_chunk_ids:
+                    continue
+                if picked < quota:
+                    records.append(_record_from_row(row, stratum.name))
+                    used_chunk_ids.add(chunk_id)
+                    picked += 1
+                else:
+                    leftovers.append((stratum.name, row))
+
+        if len(records) < target_size:
+            rng.shuffle(leftovers)
+            for stratum_name, row in leftovers:
+                chunk_id = str(row["id"])
+                if chunk_id in used_chunk_ids:
+                    continue
+                records.append(_record_from_row(row, stratum_name))
+                used_chunk_ids.add(chunk_id)
+                if len(records) >= target_size:
+                    break
+
+    records = records[:target_size]
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = "\n".join(json.dumps(record, ensure_ascii=False, sort_keys=True) for record in records)
+    output.write_text(f"{payload}\n" if payload else "", encoding="utf-8")
+    return records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sample enrichment gold chunks from a read-only BrainLayer snapshot.")
+    parser.add_argument(
+        "--snapshot-path", required=True, help="Path to a read-only SQLite snapshot. Live DB is rejected."
+    )
+    parser.add_argument(
+        "--output", default=str(DEFAULT_OUTPUT_PATH), help=f"JSONL output path (default: {DEFAULT_OUTPUT_PATH})"
+    )
+    parser.add_argument(
+        "--target-size", type=int, default=DEFAULT_TARGET_SIZE, help="Target number of chunks to sample."
+    )
+    parser.add_argument("--seed", type=int, default=20260601, help="Deterministic shuffle seed.")
+    parser.add_argument(
+        "--candidate-limit-per-stratum",
+        type=int,
+        default=None,
+        help="Max candidate rows read per stratum before Python-side sampling.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    records = sample_enrichment_gold(
+        snapshot_path=args.snapshot_path,
+        output_path=args.output,
+        target_size=args.target_size,
+        seed=args.seed,
+        candidate_limit_per_stratum=args.candidate_limit_per_stratum,
+    )
+    print(f"Wrote {len(records)} enrichment gold records to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/eval/fixtures/README.md
+++ b/src/brainlayer/eval/fixtures/README.md
@@ -1,0 +1,8 @@
+# Enrichment Gold Fixtures
+
+`enrichment_gold.py` writes `enrichment-gold.jsonl` here by default when run with
+`--snapshot-path` against a read-only SQLite snapshot.
+
+The initial PR intentionally does not include a live sampled fixture because the production
+BrainLayer DB is under load. See `# TODO(PR1-followup)` in the sampler for the real
+60-chunk snapshot pull.

--- a/src/brainlayer/eval/labeling/enrichment-labeler.html
+++ b/src/brainlayer/eval/labeling/enrichment-labeler.html
@@ -1,0 +1,318 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BrainLayer enrichment gold labeler</title>
+<style>
+  :root {
+    --bg: #f6f7f9;
+    --panel: #ffffff;
+    --panel-soft: #f0f3f7;
+    --ink: #1f2933;
+    --muted: #687385;
+    --line: #d8dee8;
+    --accent: #245f73;
+    --accent-ink: #ffffff;
+    --done: #dff3e4;
+    --warn: #f8e4c8;
+    --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink); font: 14px/1.45 var(--sans); }
+  header {
+    position: sticky; top: 0; z-index: 2;
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+    padding: 12px 18px; background: rgba(246, 247, 249, 0.96);
+    border-bottom: 1px solid var(--line); backdrop-filter: blur(8px);
+  }
+  h1 { margin: 0; font-size: 17px; font-weight: 650; flex: 1; }
+  button, label.button {
+    border: 1px solid var(--line); background: var(--panel); color: var(--ink);
+    border-radius: 6px; padding: 7px 11px; font: 600 13px var(--sans); cursor: pointer;
+  }
+  button.primary { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); }
+  .progress { display: flex; align-items: center; gap: 8px; color: var(--muted); font: 12px var(--mono); }
+  .bar { width: 180px; height: 8px; background: var(--line); border-radius: 4px; overflow: hidden; }
+  .bar div { height: 100%; width: 0; background: var(--accent); }
+  main { display: grid; grid-template-columns: minmax(0, 1fr) 380px; gap: 16px; padding: 16px; max-width: 1320px; margin: 0 auto; }
+  .queue, .judge { min-width: 0; }
+  .card {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+    margin-bottom: 12px; overflow: hidden;
+  }
+  .card.done { border-color: #8fc99d; background: var(--done); }
+  .row { display: flex; align-items: center; gap: 9px; padding: 10px 12px; cursor: pointer; }
+  .row:hover { background: var(--panel-soft); }
+  .pill { font: 11px var(--mono); color: var(--accent); background: #dbeaf0; border-radius: 999px; padding: 2px 7px; white-space: nowrap; }
+  .id { font: 12px var(--mono); color: var(--muted); white-space: nowrap; }
+  .preview { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .body { display: none; border-top: 1px solid var(--line); padding: 12px; }
+  .card.active .body { display: block; }
+  .meta { display: grid; grid-template-columns: 110px 1fr; gap: 4px 10px; color: var(--muted); font-size: 12px; margin-bottom: 10px; }
+  .meta code { color: var(--ink); font-family: var(--mono); word-break: break-all; }
+  pre {
+    margin: 0; max-height: 560px; overflow: auto; white-space: pre-wrap; word-break: break-word;
+    background: #fbfcfd; border: 1px solid var(--line); border-radius: 6px; padding: 12px;
+    font: 13px/1.5 var(--mono);
+  }
+  .judge {
+    position: sticky; top: 64px; align-self: start;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 14px;
+  }
+  .judge h2 { margin: 0 0 10px; font-size: 15px; }
+  .field { margin-bottom: 13px; }
+  .field label { display: block; color: var(--muted); font-size: 12px; font-weight: 700; margin-bottom: 5px; text-transform: uppercase; }
+  textarea, input[type=text] {
+    width: 100%; border: 1px solid var(--line); border-radius: 6px; padding: 8px 9px;
+    font: 13px/1.4 var(--sans); color: var(--ink); background: #fbfcfd;
+  }
+  textarea { min-height: 86px; resize: vertical; }
+  .range { display: flex; align-items: center; gap: 10px; }
+  .range input { flex: 1; accent-color: var(--accent); }
+  .range strong { width: 34px; text-align: right; font: 700 14px var(--mono); }
+  .hint { color: var(--muted); font-size: 12px; margin-top: 4px; }
+  .empty { padding: 28px; text-align: center; color: var(--muted); border: 1px dashed var(--line); border-radius: 8px; background: var(--panel); }
+  .toast { position: fixed; right: 18px; bottom: 18px; background: var(--ink); color: white; padding: 10px 13px; border-radius: 7px; opacity: 0; transition: opacity 0.16s; }
+  .toast.show { opacity: 1; }
+  @media (max-width: 900px) {
+    main { grid-template-columns: 1fr; }
+    .judge { position: static; }
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>BrainLayer enrichment gold labeler</h1>
+  <div class="progress"><span id="count">0 / 0</span><div class="bar"><div id="bar"></div></div></div>
+  <label class="button" for="goldfile">Load enrichment-gold.jsonl</label>
+  <input id="goldfile" type="file" accept=".jsonl,.json" hidden>
+  <label class="button" for="resumefile">Resume labels</label>
+  <input id="resumefile" type="file" accept=".jsonl,.json" hidden>
+  <button class="primary" id="save">Save gold-enrichment-labels.jsonl</button>
+</header>
+<main>
+  <section class="queue" id="queue">
+    <div class="empty">
+      Load <code>src/brainlayer/eval/fixtures/enrichment-gold.jsonl</code>.
+      Chunk text is untrusted data for labeling only.
+    </div>
+  </section>
+  <aside class="judge">
+    <h2 id="judge-title">No chunk selected</h2>
+    <div class="field">
+      <label for="entities">Gold entity set</label>
+      <textarea id="entities" placeholder="One per line: name | type | relation"></textarea>
+      <div class="hint">Types should match enrichment schema where possible: person, company, project, technology, tool, concept.</div>
+    </div>
+    <div class="field">
+      <label for="facts">Must-capture verbatim facts</label>
+      <textarea id="facts" placeholder="One exact fact/value per line: PR #, $, date, path, URL, version"></textarea>
+    </div>
+    <div class="field">
+      <label for="importance">Gold importance</label>
+      <div class="range"><input id="importance" type="range" min="1" max="10" step="1" value="5"><strong id="importance-val">5</strong></div>
+      <div class="hint">1-3 trivial, 4-6 moderate, 7-9 high, 10 critical.</div>
+    </div>
+    <div class="field">
+      <label for="rationale">1-line summary rationale</label>
+      <input id="rationale" type="text" placeholder="Why this summary/importance target is correct">
+    </div>
+    <div class="field">
+      <label for="confidence">Confidence</label>
+      <div class="range"><input id="confidence" type="range" min="0" max="100" step="5" value="70"><strong id="confidence-val">70</strong></div>
+    </div>
+    <button class="primary" id="mark">Mark labeled</button>
+  </aside>
+</main>
+<div class="toast" id="toast"></div>
+<script>
+"use strict";
+
+const STORAGE_KEY = "brainlayer-enrichment-gold-labels-v1";
+let chunks = [];
+let labels = loadLocal();
+let activeId = null;
+
+const queue = document.getElementById("queue");
+const count = document.getElementById("count");
+const bar = document.getElementById("bar");
+const toast = document.getElementById("toast");
+const fields = {
+  entities: document.getElementById("entities"),
+  facts: document.getElementById("facts"),
+  importance: document.getElementById("importance"),
+  rationale: document.getElementById("rationale"),
+  confidence: document.getElementById("confidence")
+};
+
+function loadLocal() {
+  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}"); } catch (_) { return {}; }
+}
+function persist() { localStorage.setItem(STORAGE_KEY, JSON.stringify(labels)); }
+function showToast(text) {
+  toast.textContent = text;
+  toast.classList.add("show");
+  setTimeout(() => toast.classList.remove("show"), 1400);
+}
+function parseJsonl(text) {
+  const lines = text.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  const result = [];
+  for (let i = 0; i < lines.length; i++) {
+    try {
+      result.push(JSON.parse(lines[i]));
+    } catch (err) {
+      const message = err && err.message ? err.message : String(err);
+      showToast(`JSONL parse error on line ${i + 1}`);
+      throw new Error(`Malformed JSONL at line ${i + 1}: ${message}`);
+    }
+  }
+  return result;
+}
+function splitLines(text) {
+  return text.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+}
+function entityLinesToObjects(text) {
+  return splitLines(text).map(line => {
+    const [name = "", type = "", relation = ""] = line.split("|").map(part => part.trim());
+    return { name, type, relation };
+  });
+}
+function entityObjectsToLines(items) {
+  return (items || []).map(item => [item.name, item.type, item.relation].filter(Boolean).join(" | ")).join("\n");
+}
+function labelFor(id) {
+  if (!labels[id]) {
+    labels[id] = { chunk_id: id, gold_entities: [], must_capture_facts: [], gold_importance: 5, summary_rationale: "", confidence: 70, labeled_at: null };
+  }
+  return labels[id];
+}
+function activeChunk() {
+  return chunks.find(chunk => chunk.chunk_id === activeId) || null;
+}
+function readFields() {
+  if (!activeId) return;
+  const label = labelFor(activeId);
+  label.gold_entities = entityLinesToObjects(fields.entities.value);
+  label.must_capture_facts = splitLines(fields.facts.value);
+  label.gold_importance = Number(fields.importance.value);
+  label.summary_rationale = fields.rationale.value.trim();
+  label.confidence = Number(fields.confidence.value);
+  persist();
+}
+function writeFields(id) {
+  const label = labelFor(id);
+  fields.entities.value = entityObjectsToLines(label.gold_entities);
+  fields.facts.value = (label.must_capture_facts || []).join("\n");
+  fields.importance.value = label.gold_importance || 5;
+  fields.rationale.value = label.summary_rationale || "";
+  fields.confidence.value = label.confidence == null ? 70 : label.confidence;
+  document.getElementById("importance-val").textContent = fields.importance.value;
+  document.getElementById("confidence-val").textContent = fields.confidence.value;
+}
+function render() {
+  const done = chunks.filter(chunk => labels[chunk.chunk_id] && labels[chunk.chunk_id].labeled_at).length;
+  count.textContent = `${done} / ${chunks.length}`;
+  bar.style.width = chunks.length ? `${Math.round(done * 100 / chunks.length)}%` : "0";
+  if (!chunks.length) return;
+  queue.innerHTML = "";
+  for (const chunk of chunks) {
+    const labeled = labels[chunk.chunk_id] && labels[chunk.chunk_id].labeled_at;
+    const card = document.createElement("article");
+    card.className = `card${labeled ? " done" : ""}${chunk.chunk_id === activeId ? " active" : ""}`;
+    card.innerHTML = `
+      <div class="row">
+        <span class="pill">${escapeHtml(chunk.stratum || "unknown")}</span>
+        <span class="id">${escapeHtml(chunk.chunk_id)}</span>
+        <span class="preview">${escapeHtml((chunk.content || "").slice(0, 180))}</span>
+      </div>
+      <div class="body">
+        <div class="meta">
+          <span>eval_doc_id</span><code>${escapeHtml(chunk.eval_doc_id || "")}</code>
+          <span>project</span><code>${escapeHtml(chunk.project || "")}</code>
+          <span>source</span><code>${escapeHtml(chunk.source_file || "")}</code>
+          <span>length</span><code>${Number(chunk.content_length || (chunk.content || "").length)}</code>
+        </div>
+        <pre>${escapeHtml(chunk.content || "")}</pre>
+      </div>`;
+    card.querySelector(".row").addEventListener("click", () => {
+      readFields();
+      activeId = chunk.chunk_id;
+      document.getElementById("judge-title").textContent = `${chunk.stratum} / ${chunk.chunk_id}`;
+      writeFields(activeId);
+      render();
+    });
+    queue.appendChild(card);
+  }
+}
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, ch => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" }[ch]));
+}
+function download(filename, text) {
+  const blob = new Blob([text], { type: "application/jsonl" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+document.getElementById("goldfile").addEventListener("change", async event => {
+  const file = event.target.files[0];
+  if (!file) return;
+  chunks = parseJsonl(await file.text()).filter(row => row && row.chunk_id);
+  activeId = chunks[0] ? chunks[0].chunk_id : null;
+  if (activeId) {
+    document.getElementById("judge-title").textContent = `${chunks[0].stratum} / ${activeId}`;
+    writeFields(activeId);
+  }
+  render();
+  showToast(`Loaded ${chunks.length} chunks`);
+});
+document.getElementById("resumefile").addEventListener("change", async event => {
+  const file = event.target.files[0];
+  if (!file) return;
+  for (const row of parseJsonl(await file.text())) {
+    if (!row || !row.chunk_id) {
+      showToast("Skipped label row without chunk_id");
+      continue;
+    }
+    labels[row.chunk_id] = row;
+  }
+  persist();
+  if (activeId) writeFields(activeId);
+  render();
+  showToast("Labels resumed");
+});
+for (const field of Object.values(fields)) {
+  field.addEventListener("input", () => {
+    document.getElementById("importance-val").textContent = fields.importance.value;
+    document.getElementById("confidence-val").textContent = fields.confidence.value;
+    readFields();
+    render();
+  });
+}
+document.getElementById("mark").addEventListener("click", () => {
+  if (!activeId) return;
+  readFields();
+  labels[activeId].labeled_at = new Date().toISOString();
+  persist();
+  render();
+  showToast("Marked labeled");
+});
+document.getElementById("save").addEventListener("click", () => {
+  readFields();
+  const ordered = chunks.map(chunk => labels[chunk.chunk_id]).filter(Boolean);
+  download("gold-enrichment-labels.jsonl", ordered.map(row => JSON.stringify(row)).join("\n") + "\n");
+});
+document.addEventListener("keydown", event => {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+    event.preventDefault();
+    document.getElementById("save").click();
+  }
+});
+</script>
+</body>
+</html>

--- a/tests/test_enrichment_gold.py
+++ b/tests/test_enrichment_gold.py
@@ -1,0 +1,125 @@
+import json
+import sqlite3
+
+import pytest
+
+
+def _insert_chunk(conn: sqlite3.Connection, chunk_id: str, content: str, **fields: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO chunks (
+            id, content, source_file, project, content_type, tags, summary,
+            sentiment_label, sender, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            chunk_id,
+            content,
+            fields.get("source_file", f"/tmp/{chunk_id}.jsonl"),
+            fields.get("project", "brainlayer"),
+            fields.get("content_type", ""),
+            fields.get("tags", "[]"),
+            fields.get("summary", ""),
+            fields.get("sentiment_label", ""),
+            fields.get("sender", "user"),
+            fields.get("created_at", "2026-06-01T00:00:00Z"),
+        ),
+    )
+
+
+def test_stratified_enrichment_gold_sampler_writes_portable_jsonl(tmp_path):
+    from brainlayer.eval.enrichment_gold import sample_enrichment_gold
+
+    db_path = tmp_path / "snapshot.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            source_file TEXT,
+            project TEXT,
+            content_type TEXT,
+            tags TEXT,
+            summary TEXT,
+            sentiment_label TEXT,
+            sender TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    claude_source = "/Users/etan/.claude/projects/-Users-etan-Gits-brainlayer/session.jsonl"
+    _insert_chunk(
+        conn,
+        "decision-1",
+        "Decision: keep the enrichment gold sampler snapshot-only because live DB load is unsafe.",
+        source_file=claude_source,
+        tags='["decision"]',
+    )
+    _insert_chunk(conn, "code-1", "def sample_enrichment_gold(snapshot_path):\n    return []", content_type="code")
+    _insert_chunk(conn, "conversation-1", "User: can we label this?\nAssistant: yes, using a local HTML labeler.")
+    _insert_chunk(conn, "correction-1", "Correction: the prior summary missed PR #413 and must be fixed.")
+    _insert_chunk(conn, "entity-1", "Etan Heyman is the owner of BrainLayer and VoiceLayer.", tags='["person","bio"]')
+    _insert_chunk(conn, "short-1", "ok", sender="assistant")
+    _insert_chunk(conn, "long-1", "A" * 8101)
+    _insert_chunk(
+        conn, "meta-1", "brain_search('enrichment prompt eval') returned prior research.", tags='["meta-research"]'
+    )
+    _insert_chunk(
+        conn,
+        "sentiment-1",
+        "This is frustrating and confusing; the DB lock wasted the run.",
+        sentiment_label="frustration",
+    )
+    conn.commit()
+    conn.close()
+
+    output_path = tmp_path / "gold.jsonl"
+    records = sample_enrichment_gold(
+        snapshot_path=db_path,
+        output_path=output_path,
+        target_size=9,
+        seed=123,
+    )
+
+    written = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert records == written
+    assert len(written) == 9
+    assert {row["stratum"] for row in written} == {
+        "decision",
+        "code",
+        "conversation",
+        "correction",
+        "entity_bio",
+        "short_conversational",
+        "long_truncation",
+        "meta_research",
+        "sentiment",
+    }
+    assert {row["chunk_id"] for row in written} == {
+        "decision-1",
+        "code-1",
+        "conversation-1",
+        "correction-1",
+        "entity-1",
+        "short-1",
+        "long-1",
+        "meta-1",
+        "sentiment-1",
+    }
+    decision = next(row for row in written if row["chunk_id"] == "decision-1")
+    assert decision["eval_doc_id"] == "claude-project:Gits-brainlayer/session.jsonl#decision-1"
+    long_record = next(row for row in written if row["stratum"] == "long_truncation")
+    assert long_record["content_length"] == 8101
+    assert long_record["content"] == "A" * 8101
+
+
+def test_sampler_rejects_live_production_db_path():
+    from brainlayer.eval.enrichment_gold import sample_enrichment_gold
+
+    with pytest.raises(ValueError, match="live BrainLayer DB"):
+        sample_enrichment_gold(
+            snapshot_path="~/.local/share/brainlayer/brainlayer.db",
+            output_path="/tmp/unused.jsonl",
+        )


### PR DESCRIPTION
## Summary
- Add snapshot-only enrichment gold sampler for stratified raw chunk selection from a read-only SQLite snapshot.
- Add offline enrichment labeler HTML for gold entities, must-capture facts, importance, rationale, confidence, and resumable JSONL labels.
- Add synthetic SQLite unit coverage so the scaffold is green without touching the live BrainLayer DB.

## Guardrails
- No live DB access; sampler rejects ~/.local/share/brainlayer/brainlayer.db.
- No enrichment runs.
- No changes to enrichment_controller.py or daily cost cap paths.
- Real 60-chunk snapshot pull is left as TODO(PR1-followup) for a low-load snapshot pass.

## Test plan
- [x] PYTHONPATH=src pytest -q tests/test_enrichment_gold.py
- [x] ruff check src/brainlayer/eval/enrichment_gold.py tests/test_enrichment_gold.py
- [x] ruff format --check src/brainlayer/eval/enrichment_gold.py tests/test_enrichment_gold.py
- [x] node --check on extracted labeler script
- [x] git push test gate: pytest unit suite, MCP registration, isolated eval/hook routing, bun test, regression shell
- [x] cr review --plain: No findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Eval-only tooling and tests; no enrichment controller or production DB access paths are modified.
> 
> **Overview**
> Adds **enrichment label evaluation scaffolding**: a snapshot-only stratified sampler, an offline HTML labeler, and unit tests—without shipping a live gold fixture or touching enrichment runtime.
> 
> **`sample_enrichment_gold`** pulls quota-balanced chunks from nine strata (decision, code, conversation, etc.) via `ReadOnlyBenchmarkStore`, writes default **`fixtures/enrichment-gold.jsonl`**, and **refuses** the live `~/.local/share/brainlayer/brainlayer.db`. Records include `eval_doc_id` from `canonical_eval_doc_id`. A follow-up TODO covers the real 60-chunk snapshot commit.
> 
> **`enrichment-labeler.html`** is a local tool to load gold JSONL, capture gold entities, must-capture facts, importance, rationale, and confidence, with **localStorage** resume and export to **`gold-enrichment-labels.jsonl`**. Chunk text is treated as untrusted (escaped in the UI).
> 
> **`brainlayer.eval`** re-exports **`sample_enrichment_gold`**. Tests use a synthetic SQLite DB for strata coverage and live-DB rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61537af3a21c4043f2325fef9d552e24ad05c312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stratified enrichment gold sampler and browser-based labeling UI
> - Adds [`enrichment_gold.py`](https://github.com/EtanHey/brainlayer/pull/423/files#diff-03e3dd7709dfb1efdad24b19a9c4811dd7c16d6682deecf91e60c64d6fbf3c9a) implementing a deterministic, stratified sampler over a read-only SQLite snapshot of BrainLayer chunks, writing output as JSONL with per-stratum quotas, duplicate avoidance, and backfill logic.
> - Exposes `sample_enrichment_gold` as a public export from `brainlayer.eval` and provides a CLI entry point via `build_parser`/`main`.
> - Adds a self-contained [`enrichment-labeler.html`](https://github.com/EtanHey/brainlayer/pull/423/files#diff-23fa163f73bd326447f4d23a49f1ff99264c2990c1614d658002cf15c202bf8c) browser tool for reviewing and labeling enrichment gold records, with localStorage persistence and JSONL import/export.
> - Adds tests covering stratified output correctness and the guard that rejects the live production DB path.
> - Risk: the live-DB guard compares resolved paths; symlinks or unusual mounts could bypass it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61537af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enrichment dataset sampling tool accessible via CLI and library for extracting labeled subsets from SQLite snapshots.
  * Introduced browser-based labeling interface with progress tracking and local state persistence for enrichment datasets.

* **Documentation**
  * Added guidance for the enrichment fixtures directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->