### PR TITLE
fix: prewarm benchmark embedder once per run

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -14,6 +14,7 @@ from brainlayer.eval.benchmark import (
     pipeline_fts5_only,
     pipeline_hybrid_entity,
     pipeline_hybrid_rrf,
+    prewarm_benchmark_embedder,
 )
 from brainlayer.paths import get_db_path
 from brainlayer.vector_store import VectorStore
@@ -40,9 +41,16 @@ def main() -> None:
     }
 
     store_factory = ReadOnlyBenchmarkStore if pipeline_name == "fts5" else VectorStore
+    hybrid_embed_fn = prewarm_benchmark_embedder() if pipeline_name == "hybrid_rrf" else None
     with store_factory(Path(args.db_path)) as store:
         run = benchmark.run_pipeline(
-            lambda query_text: pipeline_fn_map[pipeline_name](store, query_text, n_results=args.n_results), queries
+            lambda query_text: pipeline_fn_map[pipeline_name](
+                store,
+                query_text,
+                n_results=args.n_results,
+                **({"embed_fn": hybrid_embed_fn} if hybrid_embed_fn is not None else {}),
+            ),
+            queries,
         )
 
     scores = benchmark.evaluate_pipeline(run)

--- a/src/brainlayer/eval/__init__.py
+++ b/src/brainlayer/eval/__init__.py
@@ -10,6 +10,7 @@ from .benchmark import (
     pipeline_fts5_only,
     pipeline_hybrid_entity,
     pipeline_hybrid_rrf,
+    prewarm_benchmark_embedder,
 )
 from .enrichment_gold import sample_enrichment_gold
 
@@ -23,5 +24,6 @@ __all__ = [
     "pipeline_fts5_only",
     "pipeline_hybrid_entity",
     "pipeline_hybrid_rrf",
+    "prewarm_benchmark_embedder",
     "sample_enrichment_gold",
 ]

--- a/src/brainlayer/eval/benchmark.py
+++ b/src/brainlayer/eval/benchmark.py
@@ -439,6 +439,15 @@ def pipeline_hybrid_rrf(
     return [(chunk_id, 1.0 / (rank + 1)) for rank, chunk_id in enumerate(chunk_ids)]
 
 
+def prewarm_benchmark_embedder(model_name: str | None = None) -> Callable[[str], list[float]]:
+    """Create one warmed query embedder for an entire benchmark run."""
+    from brainlayer.embeddings import DEFAULT_MODEL, get_embedding_model
+
+    model = get_embedding_model(model_name or DEFAULT_MODEL)
+    model._load_model()
+    return model.embed_query
+
+
 def pipeline_hybrid_entity(store, query: str, n_results: int = 20) -> list[tuple[str, float]]:
     """Future hybrid + entity benchmark placeholder."""
     raise NotImplementedError("Entity-boosted benchmark pipeline is reserved for future search work.")

--- a/tests/test_eval_framework.py
+++ b/tests/test_eval_framework.py
@@ -4,6 +4,8 @@ import importlib.util
 import json
 import math
 import os
+import sys
+import types
 from pathlib import Path
 
 os.environ.setdefault("NUMBA_DISABLE_JIT", "1")
@@ -335,3 +337,100 @@ def test_pipeline_hybrid_rrf_returns_rank_scores():
     results = pipeline_hybrid_rrf(FakeStore(), "hybrid query", n_results=3, embed_fn=lambda query: [0.1, 0.2])
 
     assert results == [("chunk-a", 1.0), ("chunk-b", 0.5), ("chunk-c", 1.0 / 3.0)]
+
+
+def test_prewarm_benchmark_embedder_loads_model_once(monkeypatch):
+    from brainlayer.eval.benchmark import prewarm_benchmark_embedder
+
+    class FakeModel:
+        def __init__(self):
+            self.load_count = 0
+            self.queries = []
+
+        def _load_model(self):
+            self.load_count += 1
+            return object()
+
+        def embed_query(self, query):
+            self.queries.append(query)
+            return [float(len(query))]
+
+    fake_model = FakeModel()
+    fake_embeddings = types.SimpleNamespace(
+        DEFAULT_MODEL="fake-model",
+        get_embedding_model=lambda model_name: fake_model,
+    )
+    monkeypatch.setitem(sys.modules, "brainlayer.embeddings", fake_embeddings)
+
+    embed_fn = prewarm_benchmark_embedder()
+
+    assert fake_model.load_count == 1
+    assert embed_fn("alpha") == [5.0]
+    assert embed_fn("beta") == [4.0]
+    assert fake_model.load_count == 1
+    assert fake_model.queries == ["alpha", "beta"]
+
+
+def test_run_benchmark_reuses_prewarmed_embedder_for_hybrid_rrf(monkeypatch, tmp_path: Path):
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "run_benchmark.py"
+    spec = importlib.util.spec_from_file_location("run_benchmark_module", module_path)
+    assert spec and spec.loader
+    run_benchmark_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(run_benchmark_module)
+
+    prewarm_calls = []
+    embedded_queries = []
+
+    def fake_prewarm_benchmark_embedder():
+        prewarm_calls.append("prewarm")
+
+        def embed(query):
+            embedded_queries.append(query)
+            return [0.1, 0.2]
+
+        return embed
+
+    class FakeStore:
+        def __init__(self, db_path):
+            self.db_path = db_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+    class FakeRun:
+        pass
+
+    class FakeBenchmark:
+        def __init__(self, qrels_path):
+            self.qrels_path = qrels_path
+
+        def queries_in_qrels(self, queries):
+            return [("q1", "first query"), ("q2", "second query")]
+
+        def run_pipeline(self, pipeline_fn, queries):
+            for _query_id, query_text in queries:
+                pipeline_fn(query_text)
+            return FakeRun()
+
+        def evaluate_pipeline(self, run):
+            return {"ndcg@3": 1.0, "precision@3": 1.0, "recall@20": 1.0}
+
+    def fake_pipeline_hybrid_rrf(store, query, n_results=20, *, embed_fn=None):
+        assert embed_fn is not None
+        assert embed_fn(query) == [0.1, 0.2]
+        return [(f"doc-{query}", 1.0)]
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["run_benchmark.py", "--pipeline", "hybrid_rrf"])
+    monkeypatch.setattr(run_benchmark_module, "SearchBenchmark", FakeBenchmark)
+    monkeypatch.setattr(run_benchmark_module, "VectorStore", FakeStore)
+    monkeypatch.setattr(run_benchmark_module, "prewarm_benchmark_embedder", fake_prewarm_benchmark_embedder)
+    monkeypatch.setattr(run_benchmark_module, "pipeline_hybrid_rrf", fake_pipeline_hybrid_rrf)
+
+    run_benchmark_module.main()
+
+    assert prewarm_calls == ["prewarm"]
+    assert embedded_queries == ["first query", "second query"]


### PR DESCRIPTION
## Summary
- add a benchmark helper that instantiates and warms the query embedder once per harness run
- pass the warmed embedder into every `hybrid_rrf` query evaluation from `scripts/run_benchmark.py`
- add regression coverage proving the helper loads once and the harness reuses one embed function across queries

## Test plan
- `PYTHONPATH=src pytest -q tests/test_eval_framework.py`
- fixture-backed 3x hybrid determinism check: all runs `ndcg@3=1.0`, `p@3=0.3333333333333333`, `recall@20=1.0`
- `PYTHONPATH=src pytest -q`
- pre-push BrainLayer test gate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Eval/benchmark harness only; no production search or auth paths. Behavior change is performance (fewer model loads), with regression tests.
> 
> **Overview**
> **Hybrid RRF benchmarks** no longer pay per-query embedding model startup: a new **`prewarm_benchmark_embedder()`** loads the default (or named) model once via **`get_embedding_model`** / **`_load_model`** and returns a reusable **`embed_query`** callable.
> 
> **`scripts/run_benchmark.py`** calls that helper only when **`--pipeline hybrid_rrf`**, then passes the same **`embed_fn`** into every **`pipeline_hybrid_rrf`** invocation instead of letting each query fall back to **`embed_query`**.
> 
> The helper is exported from **`brainlayer.eval`**. Tests assert a single model load across multiple embed calls and that the benchmark script prewarms once and reuses the embedder for all queries in the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107a065b309147d7fcbec3343a9e0311ef7f2cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prewarm the benchmark embedder once per run for the hybrid_rrf pipeline
> Previously, each query in a benchmark run would implicitly load the embedding model, incurring repeated initialization overhead. This PR adds `prewarm_benchmark_embedder()` in [`benchmark.py`](https://github.com/EtanHey/brainlayer/pull/424/files#diff-db6381100ea96e00b18211e9704f102aed5b7b3b5f877e997df2ab98bbd411e9) which loads the model once and returns a reusable `embed_query` callable. [`run_benchmark.py`](https://github.com/EtanHey/brainlayer/pull/424/files#diff-b8a53e8d2f422dc2739a7d91cca978a06fe5791aaf9d0122153f95a8d990dc22) now calls this before the query loop when `--pipeline hybrid_rrf` is selected, passing the same `embed_fn` to every pipeline invocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 107a065.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->