### PR TITLE
feat: isolate ABCDE experiment store

### DIFF
--- a/docs/abcde-experiment-isolation.md
+++ b/docs/abcde-experiment-isolation.md
@@ -1,0 +1,28 @@
+# ABCDE Experiment Isolation
+
+PR-ISO keeps ABCDE experiment data physically separate from the live BrainLayer DB.
+
+## Paths
+
+- Live DB, forbidden: `~/.local/share/brainlayer/brainlayer.db`
+- Experiment DB: `~/.local/share/brainlayer/experiments/abcde-experiment.db`
+- Read-only snapshot DB: `~/.local/share/brainlayer/experiments/abcde-snapshot.db`
+- Verified backup source: `Brain Drive/06_ARCHIVE/backups/brainlayer-db`
+
+## Snapshot Materialization
+
+Materialization is an explicit operator action. Do not run this in CI.
+
+```bash
+PYTHONPATH=src python3 -m brainlayer.eval.experiment_store materialize-snapshot \
+  --backup-gzip-path "/path/to/Brain Drive/06_ARCHIVE/backups/brainlayer-db/<backup>.db.gz"
+```
+
+The loader refuses to write to the live DB path and writes the decompressed snapshot to
+`~/.local/share/brainlayer/experiments/abcde-snapshot.db` by default. Pass
+`--snapshot-db-path` to use a different experiment snapshot path.
+
+## CI Contract
+
+CI tests use synthetic SQLite fixtures only. They must not open the live DB and must not
+download or decompress the 4GB backup.

--- a/src/brainlayer/eval/experiment_store.py
+++ b/src/brainlayer/eval/experiment_store.py
@@ -1,0 +1,321 @@
+"""Isolated ABCDE experiment storage.
+
+The ABCDE experiment is allowed to read a snapshot and write only to its own
+experiment namespace DB. This module deliberately avoids VectorStore so it
+cannot share a live BrainLayer connection or write into live FTS/vector tables.
+
+Snapshot materialization is an explicit operator action:
+
+    python -m brainlayer.eval.experiment_store materialize-snapshot \
+      --backup-gzip-path "/path/to/Brain Drive/06_ARCHIVE/backups/brainlayer-db/<backup>.db.gz"
+
+Do not run that command in CI. Unit tests should use tiny synthetic SQLite DBs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from brainlayer import paths
+
+EXPERIMENT_DIR = Path("~/.local/share/brainlayer/experiments").expanduser()
+DEFAULT_EXPERIMENT_DB_PATH = EXPERIMENT_DIR / "abcde-experiment.db"
+DEFAULT_SNAPSHOT_DB_PATH = EXPERIMENT_DIR / "abcde-snapshot.db"
+CANONICAL_LIVE_DB_PATH = Path("~/.local/share/brainlayer/brainlayer.db").expanduser()
+VALID_VARIANT_IDS = frozenset({"A", "B", "C", "D", "E"})
+VALID_JUDGMENT_SOURCES = frozenset({"llm", "human"})
+
+
+def _normalized_path(path: str | Path) -> Path:
+    return Path(path).expanduser().absolute()
+
+
+def _path_key(path: str | Path) -> str:
+    expanded = Path(path).expanduser()
+    try:
+        return str(expanded.resolve())
+    except OSError:
+        return str(expanded.absolute())
+
+
+def _live_db_keys() -> set[str]:
+    return {_path_key(CANONICAL_LIVE_DB_PATH), _path_key(paths.DEFAULT_DB_PATH), _path_key(paths.get_db_path())}
+
+
+def _guard_not_live_db(path: str | Path, *, role: str) -> Path:
+    guarded = _normalized_path(path)
+    if _path_key(guarded) in _live_db_keys():
+        raise ValueError(f"Refusing to open the live BrainLayer DB as {role}: {guarded}")
+    return guarded
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+class ExperimentStore:
+    """SQLite store for the isolated ABCDE experiment namespace."""
+
+    def __init__(
+        self,
+        *,
+        experiment_db_path: str | Path = DEFAULT_EXPERIMENT_DB_PATH,
+        snapshot_db_path: str | Path = DEFAULT_SNAPSHOT_DB_PATH,
+    ) -> None:
+        self.experiment_db_path = _guard_not_live_db(experiment_db_path, role="experiment DB")
+        self.snapshot_db_path = _guard_not_live_db(snapshot_db_path, role="experiment snapshot DB")
+        self.snapshot_conn = self._open_snapshot_readonly(self.snapshot_db_path)
+        self.experiment_db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(self.experiment_db_path)
+        self.conn.execute("PRAGMA foreign_keys=ON")
+        self._ensure_schema()
+
+    @staticmethod
+    def _open_snapshot_readonly(snapshot_db_path: Path) -> sqlite3.Connection:
+        if not snapshot_db_path.exists():
+            raise FileNotFoundError(
+                f"Experiment snapshot DB does not exist: {snapshot_db_path}. "
+                "Run materialize-snapshot outside CI before a real experiment run."
+            )
+        conn = sqlite3.connect(f"file:{snapshot_db_path}?mode=ro", uri=True)
+        conn.execute("PRAGMA query_only=ON")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        self.conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS exp_chunks (
+                chunk_id TEXT PRIMARY KEY,
+                source_chunk_id TEXT NOT NULL UNIQUE,
+                raw_text TEXT NOT NULL,
+                content_type TEXT NOT NULL DEFAULT '',
+                content_class TEXT NOT NULL DEFAULT '',
+                strata TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS exp_variants (
+                chunk_id TEXT NOT NULL,
+                variant_id TEXT NOT NULL CHECK (variant_id IN ('A', 'B', 'C', 'D', 'E')),
+                enrichment_json TEXT NOT NULL,
+                model TEXT NOT NULL,
+                prompt_hash TEXT NOT NULL,
+                grader_scores_json TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (chunk_id, variant_id),
+                FOREIGN KEY (chunk_id) REFERENCES exp_chunks(chunk_id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS exp_judgments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chunk_id TEXT NOT NULL,
+                variant_id TEXT NOT NULL CHECK (variant_id IN ('A', 'B', 'C', 'D', 'E')),
+                source TEXT NOT NULL CHECK (source IN ('llm', 'human')),
+                scores_json TEXT NOT NULL,
+                better_option_flag INTEGER NOT NULL CHECK (better_option_flag IN (0, 1)),
+                rationale TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (chunk_id, variant_id) REFERENCES exp_variants(chunk_id, variant_id)
+                    ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS exp_index_documents (
+                chunk_id TEXT NOT NULL,
+                variant_id TEXT NOT NULL CHECK (variant_id IN ('A', 'B', 'C', 'D', 'E')),
+                index_payload_json TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (chunk_id, variant_id),
+                FOREIGN KEY (chunk_id, variant_id) REFERENCES exp_variants(chunk_id, variant_id)
+                    ON DELETE CASCADE
+            );
+            """
+        )
+        self.conn.commit()
+
+    def upsert_chunk(
+        self,
+        *,
+        source_chunk_id: str,
+        raw_text: str,
+        content_type: str,
+        content_class: str,
+        strata: dict[str, Any],
+    ) -> str:
+        chunk_id = source_chunk_id
+        self.conn.execute(
+            """
+            INSERT INTO exp_chunks (
+                chunk_id, source_chunk_id, raw_text, content_type, content_class, strata
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_chunk_id) DO UPDATE SET
+                raw_text = excluded.raw_text,
+                content_type = excluded.content_type,
+                content_class = excluded.content_class,
+                strata = excluded.strata,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (chunk_id, source_chunk_id, raw_text, content_type, content_class, _json_dumps(strata)),
+        )
+        self.conn.commit()
+        return chunk_id
+
+    def upsert_variant(
+        self,
+        *,
+        chunk_id: str,
+        variant_id: str,
+        enrichment: dict[str, Any],
+        model: str,
+        prompt_hash: str,
+        grader_scores: dict[str, Any] | None = None,
+    ) -> None:
+        if variant_id not in VALID_VARIANT_IDS:
+            raise ValueError(f"variant_id must be one of A..E, got {variant_id!r}")
+        self.conn.execute(
+            """
+            INSERT INTO exp_variants (
+                chunk_id, variant_id, enrichment_json, model, prompt_hash, grader_scores_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(chunk_id, variant_id) DO UPDATE SET
+                enrichment_json = excluded.enrichment_json,
+                model = excluded.model,
+                prompt_hash = excluded.prompt_hash,
+                grader_scores_json = excluded.grader_scores_json,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (
+                chunk_id,
+                variant_id,
+                _json_dumps(enrichment),
+                model,
+                prompt_hash,
+                None if grader_scores is None else _json_dumps(grader_scores),
+            ),
+        )
+        self.conn.commit()
+
+    def add_judgment(
+        self,
+        *,
+        chunk_id: str,
+        variant_id: str,
+        source: str,
+        scores: dict[str, Any],
+        better_option_flag: bool,
+        rationale: str,
+    ) -> None:
+        if variant_id not in VALID_VARIANT_IDS:
+            raise ValueError(f"variant_id must be one of A..E, got {variant_id!r}")
+        if source not in VALID_JUDGMENT_SOURCES:
+            raise ValueError(f"source must be one of llm|human, got {source!r}")
+        self.conn.execute(
+            """
+            INSERT INTO exp_judgments (
+                chunk_id, variant_id, source, scores_json, better_option_flag, rationale
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (chunk_id, variant_id, source, _json_dumps(scores), int(better_option_flag), rationale),
+        )
+        self.conn.commit()
+
+    def reserve_exp_index_document(self, *, chunk_id: str, variant_id: str, index_payload: dict[str, Any]) -> None:
+        """Reserve the future isolated re-index write path inside the experiment DB only."""
+        if variant_id not in VALID_VARIANT_IDS:
+            raise ValueError(f"variant_id must be one of A..E, got {variant_id!r}")
+        self.conn.execute(
+            """
+            INSERT INTO exp_index_documents (chunk_id, variant_id, index_payload_json)
+            VALUES (?, ?, ?)
+            ON CONFLICT(chunk_id, variant_id) DO UPDATE SET
+                index_payload_json = excluded.index_payload_json,
+                created_at = CURRENT_TIMESTAMP
+            """,
+            (chunk_id, variant_id, _json_dumps(index_payload)),
+        )
+        self.conn.commit()
+
+    def close(self) -> None:
+        self.snapshot_conn.close()
+        self.conn.close()
+
+    def __enter__(self) -> "ExperimentStore":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+def materialize_snapshot(
+    *,
+    backup_gzip_path: str | Path | None,
+    snapshot_db_path: str | Path = DEFAULT_SNAPSHOT_DB_PATH,
+    overwrite: bool = False,
+) -> Path:
+    """Decompress the verified Brain Drive DB backup into the experiment snapshot path.
+
+    This is intentionally opt-in and requires an explicit gzip path so CI cannot
+    accidentally download or decompress the 4GB backup. The target path is
+    guarded against the live BrainLayer DB and should normally be:
+    ~/.local/share/brainlayer/experiments/abcde-snapshot.db.
+    """
+    if backup_gzip_path is None:
+        raise ValueError(
+            "backup_gzip_path is required; use the verified Brain Drive backup under "
+            "Brain Drive/06_ARCHIVE/backups/brainlayer-db"
+        )
+    source = Path(backup_gzip_path).expanduser().absolute()
+    target = _guard_not_live_db(snapshot_db_path, role="experiment snapshot DB")
+    if not source.exists():
+        raise FileNotFoundError(f"Verified backup gzip not found: {source}")
+    if target.exists() and not overwrite:
+        raise FileExistsError(f"Snapshot already exists: {target}. Pass overwrite=True to replace it.")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary_target = target.with_suffix(target.suffix + ".tmp")
+    with gzip.open(source, "rb") as compressed, temporary_target.open("wb") as output:
+        shutil.copyfileobj(compressed, output)
+    temporary_target.replace(target)
+    target.chmod(0o444)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="ABCDE experiment store utilities")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    materialize = subparsers.add_parser(
+        "materialize-snapshot",
+        help="Decompress the verified Brain Drive backup into the experiment snapshot DB",
+    )
+    materialize.add_argument("--backup-gzip-path", required=True)
+    materialize.add_argument("--snapshot-db-path", default=str(DEFAULT_SNAPSHOT_DB_PATH))
+    materialize.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "materialize-snapshot":
+        target = materialize_snapshot(
+            backup_gzip_path=args.backup_gzip_path,
+            snapshot_db_path=args.snapshot_db_path,
+            overwrite=args.overwrite,
+        )
+        print(target)
+        return 0
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_experiment_store.py
+++ b/tests/test_experiment_store.py
@@ -1,0 +1,178 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _create_snapshot(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            content_type TEXT,
+            content_class TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO chunks (id, content, content_type, content_class) VALUES (?, ?, ?, ?)",
+        ("source-1", "Synthetic experiment isolation chunk", "conversation", "knowledge"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _create_live_stand_in(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, content TEXT NOT NULL)")
+    conn.execute("CREATE VIRTUAL TABLE chunks_fts USING fts5(id, content)")
+    rows = [
+        ("live-1", "BrainLayer search isolation must remain stable."),
+        ("live-2", "Unrelated note about local testing."),
+    ]
+    conn.executemany("INSERT INTO chunks (id, content) VALUES (?, ?)", rows)
+    conn.executemany("INSERT INTO chunks_fts (id, content) VALUES (?, ?)", rows)
+    conn.commit()
+    conn.close()
+
+
+def _live_state(path: Path) -> dict[str, object]:
+    conn = sqlite3.connect(path)
+    tables = [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') ORDER BY name"
+        ).fetchall()
+    ]
+    chunks = conn.execute("SELECT id, content FROM chunks ORDER BY id").fetchall()
+    fts_rows = conn.execute("SELECT id, content FROM chunks_fts ORDER BY id").fetchall()
+    conn.close()
+    return {"tables": tables, "chunks": chunks, "fts_rows": fts_rows}
+
+
+def _synthetic_brain_search(path: Path, query: str) -> list[tuple[str, str]]:
+    conn = sqlite3.connect(path)
+    rows = conn.execute(
+        """
+        SELECT chunks.id, chunks.content
+        FROM chunks_fts
+        JOIN chunks ON chunks.id = chunks_fts.id
+        WHERE chunks_fts MATCH ?
+        ORDER BY rank
+        """,
+        (query,),
+    ).fetchall()
+    conn.close()
+    return rows
+
+
+def test_experiment_store_rejects_canonical_live_db_path():
+    from brainlayer.eval.experiment_store import ExperimentStore
+    from brainlayer.paths import get_db_path
+
+    with pytest.raises(ValueError, match="live BrainLayer DB"):
+        ExperimentStore(experiment_db_path=get_db_path())
+
+
+def test_experiment_store_rejects_snapshot_at_canonical_live_db_path():
+    from brainlayer.eval.experiment_store import ExperimentStore
+    from brainlayer.paths import get_db_path
+
+    with pytest.raises(ValueError, match="live BrainLayer DB"):
+        ExperimentStore(snapshot_db_path=get_db_path())
+
+
+def test_experiment_write_cycle_stays_in_namespace_db_and_leaves_live_stand_in_untouched(tmp_path):
+    from brainlayer.eval.experiment_store import ExperimentStore
+
+    live_db = tmp_path / "brainlayer.db"
+    snapshot_db = tmp_path / "experiments" / "abcde-snapshot.db"
+    experiment_db = tmp_path / "experiments" / "abcde-experiment.db"
+    snapshot_db.parent.mkdir()
+    _create_live_stand_in(live_db)
+    _create_snapshot(snapshot_db)
+
+    before_state = _live_state(live_db)
+
+    with ExperimentStore(experiment_db_path=experiment_db, snapshot_db_path=snapshot_db) as store:
+        chunk_id = store.upsert_chunk(
+            source_chunk_id="source-1",
+            raw_text="Synthetic experiment isolation chunk",
+            content_type="conversation",
+            content_class="knowledge",
+            strata={"content_type": "conversation", "content_class": "knowledge"},
+        )
+        store.upsert_variant(
+            chunk_id=chunk_id,
+            variant_id="A",
+            enrichment={"summary": "control"},
+            model="synthetic",
+            prompt_hash="prompt-a",
+            grader_scores={"schema": 1.0},
+        )
+        store.add_judgment(
+            chunk_id=chunk_id,
+            variant_id="A",
+            source="llm",
+            scores={"faithfulness": 1.0},
+            better_option_flag=False,
+            rationale="synthetic regression fixture",
+        )
+
+    assert _live_state(live_db) == before_state
+
+    conn = sqlite3.connect(experiment_db)
+    exp_tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    assert {"exp_chunks", "exp_variants", "exp_judgments", "exp_index_documents"} <= exp_tables
+    assert conn.execute("SELECT source_chunk_id, content_class FROM exp_chunks").fetchall() == [
+        ("source-1", "knowledge")
+    ]
+    assert conn.execute("SELECT variant_id, enrichment_json FROM exp_variants").fetchall() == [
+        ("A", json.dumps({"summary": "control"}, sort_keys=True))
+    ]
+    assert conn.execute("SELECT source, better_option_flag FROM exp_judgments").fetchall() == [("llm", 0)]
+    conn.close()
+
+
+def test_synthetic_brain_search_results_are_identical_after_experiment_writes(tmp_path):
+    from brainlayer.eval.experiment_store import ExperimentStore
+
+    live_db = tmp_path / "brainlayer.db"
+    snapshot_db = tmp_path / "experiments" / "abcde-snapshot.db"
+    experiment_db = tmp_path / "experiments" / "abcde-experiment.db"
+    snapshot_db.parent.mkdir()
+    _create_live_stand_in(live_db)
+    _create_snapshot(snapshot_db)
+
+    before = _synthetic_brain_search(live_db, "BrainLayer")
+    with ExperimentStore(experiment_db_path=experiment_db, snapshot_db_path=snapshot_db) as store:
+        chunk_id = store.upsert_chunk(
+            source_chunk_id="source-1",
+            raw_text="This experiment output mentions BrainLayer but must not affect live search.",
+            content_type="conversation",
+            content_class="test",
+            strata={"content_type": "conversation", "content_class": "test"},
+        )
+        store.upsert_variant(
+            chunk_id=chunk_id,
+            variant_id="B",
+            enrichment={"summary": "experiment-only BrainLayer output"},
+            model="synthetic",
+            prompt_hash="prompt-b",
+        )
+
+    assert _synthetic_brain_search(live_db, "BrainLayer") == before
+
+
+def test_materialize_snapshot_refuses_to_overwrite_live_db_or_run_without_explicit_source(tmp_path):
+    from brainlayer.eval.experiment_store import materialize_snapshot
+    from brainlayer.paths import get_db_path
+
+    with pytest.raises(ValueError, match="backup_gzip_path is required"):
+        materialize_snapshot(backup_gzip_path=None, snapshot_db_path=tmp_path / "abcde-snapshot.db")
+
+    with pytest.raises(ValueError, match="live BrainLayer DB"):
+        materialize_snapshot(backup_gzip_path=tmp_path / "backup.gz", snapshot_db_path=get_db_path())


### PR DESCRIPTION
## Summary
- Add ExperimentStore for the ABCDE experiment namespace DB with hard live-DB path refusal.
- Open the experiment snapshot read-only with PRAGMA query_only=ON and keep all experiment writes in exp_* tables.
- Add a guarded materialize-snapshot CLI/doc for the verified Brain Drive backup without CI download/decompress.
- Add offline synthetic leak-regression tests covering live path refusal, namespace-only writes, and brain_search-shape invariance.

## Verification
- pytest tests/test_experiment_store.py: 5 passed
- ruff check src/ tests/: All checks passed
- pytest: 2405 passed, 48 skipped, 5 xfailed
- pre-push BrainLayer test gate: 2331 passed, 9 skipped, 77 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun stale index 1 passed; regression shell test passed

## Guardrails
- No live DB opened.
- No 4GB backup downloaded or decompressed.
- CI coverage is synthetic/offline only.

@codex review
@cursor review
@bugbot review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New eval storage touches production DB path resolution and backup decompression, but writes are confined to separate files with explicit guards and CI stays offline/synthetic.
> 
> **Overview**
> Adds **physical isolation** for the ABCDE eval: a new `ExperimentStore` writes only to a dedicated experiment SQLite file with `exp_*` tables, opens a separate snapshot DB read-only (`mode=ro`, `PRAGMA query_only=ON`), and **refuses** any experiment or snapshot path that resolves to the live BrainLayer DB (including `get_db_path()` / `BRAINLAYER_DB`).
> 
> Operators can **`materialize-snapshot`** to decompress a verified Brain Drive gzip backup into the experiment snapshot path (guarded, atomic write, read-only file mode); docs spell out paths and a **CI contract** (synthetic fixtures only, no live DB or 4GB backup).
> 
> New tests assert live-path rejection, that experiment writes stay in the namespace DB without mutating a stand-in live DB/FTS, and that `materialize_snapshot` requires an explicit backup path and cannot target the live DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21069734efa53bf75206475c49cd6e260b6e932b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add isolated `ExperimentStore` for ABCDE experiments with live DB write guards
> - Introduces [`experiment_store.py`](https://github.com/EtanHey/brainlayer/pull/426/files#diff-4105e5491b4546a5676a77eff7e299d32d00352774650060ab47677de6ff605e) with `ExperimentStore`, a SQLite-backed store for ABCDE experiment chunks, variants, and judgments that is explicitly isolated from the live BrainLayer DB.
> - Validates all write paths against known live DB locations at construction time, raising `ValueError` on any match; the snapshot DB is opened in SQLite URI read-only mode with `PRAGMA query_only=ON`.
> - Adds `materialize_snapshot` to safely decompress a gzip backup into the read-only snapshot DB path via an atomic temp-file replace, setting 0444 permissions on the result.
> - Exposes a `materialize-snapshot` CLI subcommand runnable via `python -m brainlayer.eval.experiment_store`.
> - Tests in [`tests/test_experiment_store.py`](https://github.com/EtanHey/brainlayer/pull/426/files#diff-de162839cb07ee5f2d0c48325ecbe58789453c0386bd6480eb6f7cb42fefeeea) verify that experiment writes leave a live DB stand-in and its FTS search results completely unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a18eaa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->