### PR TITLE
feat: add frozen ABCDE enrichment variants

### DIFF
--- a/scripts/generate_abcde_variants.py
+++ b/scripts/generate_abcde_variants.py
@@ -41,7 +41,9 @@ def main() -> None:
     args = parser.parse_args()
 
     production_prompt = extract_python_string_constant(PRODUCTION_PROMPT_PATH, "ENRICHMENT_PROMPT")
-    shelf_prompt = extract_markdown_fenced_section(args.shelf_prompt_path, SHELF_SECTION)
+    shelf_prompt = prepare_shelf_prompt_for_registry(
+        extract_markdown_fenced_section(args.shelf_prompt_path, SHELF_SECTION)
+    )
     proposals = load_proposals(args.proposals_json)
 
     variants = [
@@ -128,6 +130,16 @@ def extract_markdown_fenced_section(path: Path, heading: str) -> str:
     if not match:
         raise ValueError(f"Could not find fenced section {heading!r} in {path}")
     return match.group("prompt")
+
+
+def prepare_shelf_prompt_for_registry(prompt: str) -> str:
+    """Make the shelved v2 prompt safe for str.format() and standard runner placeholders."""
+
+    escaped = prompt.replace("{", "{{").replace("}", "}}")
+    return escaped.replace(
+        "{{chunk_content}}",
+        "CHUNK (from project: {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}",
+    )
 
 
 def load_proposals(path: Path) -> list[dict[str, str]]:

--- a/scripts/generate_abcde_variants.py
+++ b/scripts/generate_abcde_variants.py
@@ -79,13 +79,14 @@ def main() -> None:
                 "params": dict(EXPERIMENT_PARAMS),
                 "provenance": "llm-proposed",
                 "axis": proposal["axis"],
-                "source_path": f"subscription-cli-agent:{args.proposals_json.name}",
+                "source_path": f"inline-llm-reasoning:{args.proposals_json.name}",
                 "source_section": f"llm-proposed-{proposal['id']}",
             }
         )
 
     for variant in variants:
         variant["prompt_hash"] = compute_prompt_hash(variant["prompt_template"])
+    assert_freeze_integrity(variants, production_prompt, shelf_prompt)
 
     registry = {
         "schema_version": 1,
@@ -153,6 +154,25 @@ def load_proposals(path: Path) -> list[dict[str, str]]:
             }
         )
     return normalized
+
+
+def assert_freeze_integrity(variants: list[dict[str, Any]], production_prompt: str, shelf_prompt: str) -> None:
+    hashes = {variant["id"]: variant["prompt_hash"] for variant in variants}
+    if tuple(hashes) != ("A", "B", "C", "D", "E"):
+        raise ValueError(f"freeze must contain A-E in order, got {tuple(hashes)}")
+    if len(set(hashes.values())) != len(hashes):
+        collisions: dict[str, list[str]] = {}
+        for variant_id, prompt_hash in hashes.items():
+            collisions.setdefault(prompt_hash, []).append(variant_id)
+        duplicates = {prompt_hash: ids for prompt_hash, ids in collisions.items() if len(ids) > 1}
+        raise ValueError(f"freeze prompt_hash collision detected: {duplicates}")
+
+    expected_a = compute_prompt_hash(production_prompt)
+    if hashes["A"] != expected_a:
+        raise ValueError(f"variant A hash does not match live ENRICHMENT_PROMPT hash: {hashes['A']} != {expected_a}")
+    expected_b = compute_prompt_hash(shelf_prompt)
+    if hashes["B"] != expected_b:
+        raise ValueError(f"variant B hash does not match shelved v2 prompt hash: {hashes['B']} != {expected_b}")
 
 
 def compute_prompt_hash(prompt_template: str) -> str:

--- a/scripts/generate_abcde_variants.py
+++ b/scripts/generate_abcde_variants.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Build the frozen ABCDE enrichment prompt registry without model/API calls."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_PROMPT_PATH = REPO_ROOT / "src/brainlayer/pipeline/enrichment.py"
+DEFAULT_REGISTRY_PATH = REPO_ROOT / "src/brainlayer/eval/abcde_variants.yaml"
+ORCHESTRATOR_ROOT = REPO_ROOT.parent / "orchestrator"
+SHELF_SECTION = "Enrichment Prompt (copy-paste into pipeline)"
+EXPERIMENT_MODEL = "gemini-2.5-flash-lite"
+EXPERIMENT_PARAMS = {
+    "temperature": 0.2,
+    "max_output_tokens": 4096,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--proposals-json", type=Path, required=True, help="JSON file written by the subscription CLI agent"
+    )
+    parser.add_argument(
+        "--shelf-prompt-path",
+        type=Path,
+        required=True,
+        help="Markdown file containing the shelved faceted enrichment prompt section",
+    )
+    parser.add_argument("--output", type=Path, default=DEFAULT_REGISTRY_PATH)
+    args = parser.parse_args()
+
+    production_prompt = extract_python_string_constant(PRODUCTION_PROMPT_PATH, "ENRICHMENT_PROMPT")
+    shelf_prompt = extract_markdown_fenced_section(args.shelf_prompt_path, SHELF_SECTION)
+    proposals = load_proposals(args.proposals_json)
+
+    variants = [
+        {
+            "id": "A",
+            "label": "production-enrichment-prompt",
+            "prompt_template": production_prompt,
+            "model": EXPERIMENT_MODEL,
+            "params": dict(EXPERIMENT_PARAMS),
+            "provenance": "production",
+            "axis": "production-control",
+            "source_path": format_source_path(PRODUCTION_PROMPT_PATH),
+            "source_section": "ENRICHMENT_PROMPT",
+        },
+        {
+            "id": "B",
+            "label": "2026-03-19-v2-faceted-tags",
+            "prompt_template": shelf_prompt,
+            "model": EXPERIMENT_MODEL,
+            "params": dict(EXPERIMENT_PARAMS),
+            "provenance": "shelf",
+            "axis": "faceted-tag-taxonomy",
+            "source_path": format_source_path(args.shelf_prompt_path),
+            "source_section": SHELF_SECTION,
+        },
+    ]
+
+    for proposal in proposals:
+        variants.append(
+            {
+                "id": proposal["id"],
+                "label": proposal["label"],
+                "prompt_template": proposal["prompt_template"],
+                "model": EXPERIMENT_MODEL,
+                "params": dict(EXPERIMENT_PARAMS),
+                "provenance": "llm-proposed",
+                "axis": proposal["axis"],
+                "source_path": f"subscription-cli-agent:{args.proposals_json.name}",
+                "source_section": f"llm-proposed-{proposal['id']}",
+            }
+        )
+
+    for variant in variants:
+        variant["prompt_hash"] = compute_prompt_hash(variant["prompt_template"])
+
+    registry = {
+        "schema_version": 1,
+        "frozen_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "hash_algorithm": "sha256",
+        "variants": variants,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(registry, handle, sort_keys=False, width=120, allow_unicode=True)
+
+
+def extract_python_string_constant(path: Path, constant_name: str) -> str:
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == constant_name for target in node.targets):
+            value = ast.literal_eval(node.value)
+            if not isinstance(value, str):
+                raise ValueError(f"{constant_name} in {path} is not a string")
+            return value
+    raise ValueError(f"Could not find {constant_name} in {path}")
+
+
+def format_source_path(path: Path) -> str:
+    resolved = path.resolve()
+    if resolved.is_relative_to(REPO_ROOT):
+        return str(resolved.relative_to(REPO_ROOT))
+    if resolved.is_relative_to(ORCHESTRATOR_ROOT):
+        return f"orchestrator/{resolved.relative_to(ORCHESTRATOR_ROOT)}"
+    return f"external:{resolved.name}"
+
+
+def extract_markdown_fenced_section(path: Path, heading: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    pattern = rf"^## {re.escape(heading)}\s*\n\s*```(?:\w+)?\n(?P<prompt>.*?)\n```"
+    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise ValueError(f"Could not find fenced section {heading!r} in {path}")
+    return match.group("prompt")
+
+
+def load_proposals(path: Path) -> list[dict[str, str]]:
+    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    variants = raw.get("variants") if isinstance(raw, dict) else None
+    if not isinstance(variants, list):
+        raise ValueError("Proposals JSON must contain a variants list")
+    if [variant.get("id") for variant in variants if isinstance(variant, dict)] != ["C", "D", "E"]:
+        raise ValueError("Proposals JSON must contain C, D, E variants in order")
+
+    normalized = []
+    for variant in variants:
+        if not isinstance(variant, dict):
+            raise ValueError("Each proposal variant must be a mapping")
+        for key in ("id", "label", "axis", "prompt_template"):
+            if not isinstance(variant.get(key), str) or not variant[key].strip():
+                raise ValueError(f"Proposal {variant.get('id')} must include non-empty string {key}")
+        normalized.append(
+            {
+                "id": variant["id"],
+                "label": variant["label"],
+                "axis": variant["axis"],
+                "prompt_template": variant["prompt_template"],
+            }
+        )
+    return normalized
+
+
+def compute_prompt_hash(prompt_template: str) -> str:
+    return hashlib.sha256(prompt_template.encode("utf-8")).hexdigest()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/eval/__init__.py
+++ b/src/brainlayer/eval/__init__.py
@@ -1,5 +1,6 @@
 """BrainLayer search quality evaluation framework using Ranx."""
 
+from .abcde_variants import ABCDE_VARIANTS, ABCDE_VARIANTS_BY_ID, VARIANT_IDS, ABCDEVariant, load_abcde_variants
 from .benchmark import (
     DEFAULT_COMPARE_METRICS,
     DEFAULT_QUERY_SUITE,
@@ -42,4 +43,9 @@ __all__ = [
     "score_importance_calibration",
     "score_key_facts_recall",
     "validate_schema_gate",
+    "ABCDE_VARIANTS",
+    "ABCDE_VARIANTS_BY_ID",
+    "VARIANT_IDS",
+    "ABCDEVariant",
+    "load_abcde_variants",
 ]

--- a/src/brainlayer/eval/abcde_variants.py
+++ b/src/brainlayer/eval/abcde_variants.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
 
 import yaml
 
@@ -23,7 +24,7 @@ class ABCDEVariant:
     label: str
     prompt_template: str
     model: str
-    params: dict[str, Any]
+    params: Mapping[str, Any]
     provenance: VariantProvenance
     prompt_hash: str
     axis: str | None = None
@@ -111,7 +112,7 @@ def _variant_from_mapping(raw: dict[str, Any]) -> ABCDEVariant:
         label=label,
         prompt_template=prompt_template,
         model=model,
-        params=params,
+        params=MappingProxyType(params),
         provenance=provenance,
         prompt_hash=prompt_hash,
         axis=_optional_string(raw, "axis"),

--- a/src/brainlayer/eval/abcde_variants.py
+++ b/src/brainlayer/eval/abcde_variants.py
@@ -1,0 +1,133 @@
+"""Frozen ABCDE enrichment prompt registry."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+VariantId = Literal["A", "B", "C", "D", "E"]
+VariantProvenance = Literal["production", "shelf", "llm-proposed"]
+
+VARIANT_IDS: tuple[VariantId, ...] = ("A", "B", "C", "D", "E")
+REGISTRY_PATH = Path(__file__).with_name("abcde_variants.yaml")
+HASH_ALGORITHM = "sha256"
+
+
+@dataclass(frozen=True)
+class ABCDEVariant:
+    id: VariantId
+    label: str
+    prompt_template: str
+    model: str
+    params: dict[str, Any]
+    provenance: VariantProvenance
+    prompt_hash: str
+    axis: str | None = None
+    source_path: str | None = None
+    source_section: str | None = None
+
+
+def compute_prompt_hash(prompt_template: str) -> str:
+    """Return the registry hash for an exact frozen prompt template."""
+
+    return hashlib.sha256(prompt_template.encode("utf-8")).hexdigest()
+
+
+def load_abcde_variants(registry_path: str | Path = REGISTRY_PATH) -> tuple[ABCDEVariant, ...]:
+    """Load and validate the frozen ABCDE variant registry."""
+
+    path = Path(registry_path)
+    with path.open("r", encoding="utf-8") as handle:
+        registry = yaml.safe_load(handle)
+
+    if not isinstance(registry, dict):
+        raise ValueError("ABCDE registry must be a YAML mapping")
+    if registry.get("hash_algorithm") != HASH_ALGORITHM:
+        raise ValueError(f"ABCDE registry hash_algorithm must be {HASH_ALGORITHM!r}")
+
+    raw_variants = registry.get("variants")
+    if not isinstance(raw_variants, list):
+        raise ValueError("ABCDE registry variants must be a list")
+
+    variants: list[ABCDEVariant] = []
+    for index, raw in enumerate(raw_variants):
+        if not isinstance(raw, dict):
+            raise ValueError(f"ABCDE variant at index {index} must be a mapping")
+        variant = _variant_from_mapping(raw)
+        expected_hash = compute_prompt_hash(variant.prompt_template)
+        if variant.prompt_hash != expected_hash:
+            raise ValueError(
+                f"ABCDE variant {variant.id} prompt_hash mismatch: "
+                f"registry={variant.prompt_hash} computed={expected_hash}"
+            )
+        variants.append(variant)
+
+    ids = tuple(variant.id for variant in variants)
+    if ids != VARIANT_IDS:
+        raise ValueError(f"ABCDE registry must contain variants {VARIANT_IDS}, got {ids}")
+
+    return tuple(variants)
+
+
+def _variant_from_mapping(raw: dict[str, Any]) -> ABCDEVariant:
+    missing = {
+        key
+        for key in ("id", "label", "prompt_template", "model", "params", "provenance", "prompt_hash")
+        if key not in raw
+    }
+    if missing:
+        raise ValueError(f"ABCDE variant is missing required keys: {sorted(missing)}")
+
+    variant_id = raw["id"]
+    if variant_id not in VARIANT_IDS:
+        raise ValueError(f"Unknown ABCDE variant id: {variant_id!r}")
+
+    provenance = raw["provenance"]
+    if provenance not in ("production", "shelf", "llm-proposed"):
+        raise ValueError(f"Unknown ABCDE variant provenance: {provenance!r}")
+
+    label = raw["label"]
+    prompt_template = raw["prompt_template"]
+    model = raw["model"]
+    params = raw["params"]
+    prompt_hash = raw["prompt_hash"]
+    if not isinstance(label, str) or not label:
+        raise ValueError(f"ABCDE variant {variant_id} label must be a non-empty string")
+    if not isinstance(prompt_template, str) or not prompt_template:
+        raise ValueError(f"ABCDE variant {variant_id} prompt_template must be a non-empty string")
+    if not isinstance(model, str) or not model:
+        raise ValueError(f"ABCDE variant {variant_id} model must be a non-empty string")
+    if not isinstance(params, dict):
+        raise ValueError(f"ABCDE variant {variant_id} params must be a mapping")
+    if not isinstance(prompt_hash, str) or len(prompt_hash) != 64:
+        raise ValueError(f"ABCDE variant {variant_id} prompt_hash must be a 64-character hex string")
+
+    return ABCDEVariant(
+        id=variant_id,
+        label=label,
+        prompt_template=prompt_template,
+        model=model,
+        params=params,
+        provenance=provenance,
+        prompt_hash=prompt_hash,
+        axis=_optional_string(raw, "axis"),
+        source_path=_optional_string(raw, "source_path"),
+        source_section=_optional_string(raw, "source_section"),
+    )
+
+
+def _optional_string(raw: dict[str, Any], key: str) -> str | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"ABCDE variant {raw.get('id')} {key} must be a non-empty string or null")
+    return value
+
+
+ABCDE_VARIANTS = load_abcde_variants()
+ABCDE_VARIANTS_BY_ID = {variant.id: variant for variant in ABCDE_VARIANTS}

--- a/src/brainlayer/eval/abcde_variants.yaml
+++ b/src/brainlayer/eval/abcde_variants.yaml
@@ -123,45 +123,54 @@ variants:
     Chunk: "Phase 1 importance calibration implemented (PR #93). Heuristic SQL fix deflates importance inflation from 40.8%
     >= 7 to 7.6%."
 
-    Output: {"a_reasoning": "Completed milestone for BrainLayer importance scoring. Quantified SQL fix results.", "b_topics":
+    Output: {{"a_reasoning": "Completed milestone for BrainLayer importance scoring. Quantified SQL fix results.", "b_topics":
     ["importance-calibration", "brainlayer-search-quality"], "c_activity": "act:implementing", "d_domain": ["dom:sql"], "e_confidence":
-    0.95}
+    0.95}}
 
 
     Chunk: "Found the double-message bug in 6pm-mini: flexibility message sent before fail check."
 
-    Output: {"a_reasoning": "Bug fix in 6pm dating app messaging flow.", "b_topics": ["6pm-confirmation-flow"], "c_activity":
-    "act:debugging", "d_domain": ["dom:typescript", "dom:convex"], "e_confidence": 0.92}
+    Output: {{"a_reasoning": "Bug fix in 6pm dating app messaging flow.", "b_topics": ["6pm-confirmation-flow"], "c_activity":
+    "act:debugging", "d_domain": ["dom:typescript", "dom:convex"], "e_confidence": 0.92}}
 
 
     Chunk: "R18 cmux event-driven patterns: tmux control mode (-CC) provides structured event streams."
 
-    Output: {"a_reasoning": "Research on cmux terminal architecture using tmux control mode.", "b_topics": ["cmux-terminal-orchestration"],
-    "c_activity": "act:researching", "d_domain": ["dom:cli", "dom:mcp"], "e_confidence": 0.93}
+    Output: {{"a_reasoning": "Research on cmux terminal architecture using tmux control mode.", "b_topics": ["cmux-terminal-orchestration"],
+    "c_activity": "act:researching", "d_domain": ["dom:cli", "dom:mcp"], "e_confidence": 0.93}}
 
 
     Chunk: "[Request interrupted by user]"
 
-    Output: {"a_reasoning": "System noise, no content.", "b_topics": ["_noise"], "c_activity": "act:configuring", "d_domain":
-    [], "e_confidence": 0.99}
+    Output: {{"a_reasoning": "System noise, no content.", "b_topics": ["_noise"], "c_activity": "act:configuring", "d_domain":
+    [], "e_confidence": 0.99}}
 
 
     Chunk: "כן אחי, אני בדרך"
 
-    Output: {"a_reasoning": "Short Hebrew acknowledgment, no technical content.", "b_topics": [], "c_activity": "act:planning",
-    "d_domain": ["dom:whatsapp"], "e_confidence": 0.30}
+    Output: {{"a_reasoning": "Short Hebrew acknowledgment, no technical content.", "b_topics": [], "c_activity": "act:planning",
+    "d_domain": ["dom:whatsapp"], "e_confidence": 0.30}}
 
 
     Chunk: "OK so the coach should check WHOOP recovery score first thing in the morning, then adjust the workout plan."
 
-    Output: {"a_reasoning": "Voice discussion about coachClaude morning health workflow with WHOOP thresholds.", "b_topics":
-    ["coachclaude-scheduling"], "c_activity": "act:designing", "d_domain": [], "e_confidence": 0.91}
+    Output: {{"a_reasoning": "Voice discussion about coachClaude morning health workflow with WHOOP thresholds.", "b_topics":
+    ["coachclaude-scheduling"], "c_activity": "act:designing", "d_domain": [], "e_confidence": 0.91}}
 
 
     ## Now tag this chunk:
 
 
-    {chunk_content}'
+    CHUNK (from project: {project}, type: {content_type}):
+
+    ---
+
+    {content}
+
+    ---
+
+
+    {context_section}'
   model: gemini-2.5-flash-lite
   params:
     temperature: 0.2
@@ -170,7 +179,7 @@ variants:
   axis: faceted-tag-taxonomy
   source_path: orchestrator/docs.local/plans/enrichment-prompt-v2.md
   source_section: Enrichment Prompt (copy-paste into pipeline)
-  prompt_hash: 44ee15b9accf5dcd61fca7a82bb19f30c557178f820faeacf97f4113d5b2d381
+  prompt_hash: df3ee7a5768f735ea90c557d3bf22dba0a5cc7b4ae36b374ba1643ba6960091e
 - id: C
   label: inline-density-max-recall
   prompt_template: "You are a recall-maximizing knowledge extraction engine for BrainLayer. Your output will be embedded for\

--- a/src/brainlayer/eval/abcde_variants.yaml
+++ b/src/brainlayer/eval/abcde_variants.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-frozen_at: '2026-06-01T08:39:10+00:00'
+frozen_at: '2026-06-01T08:47:49+00:00'
 hash_algorithm: sha256
 variants:
 - id: A
@@ -172,144 +172,127 @@ variants:
   source_section: Enrichment Prompt (copy-paste into pipeline)
   prompt_hash: 44ee15b9accf5dcd61fca7a82bb19f30c557178f820faeacf97f4113d5b2d381
 - id: C
-  label: density-max-recall-extraction
-  prompt_template: "You are a recall-maximizing knowledge extraction engine for a personal knowledge graph. Your output is\
-    \ embedded for vector search AND indexed for FTS. Maximize retrievable facts per token — never trade away specifics for\
-    \ brevity.\n\nAXIS (density-max-recall): Extract EVERY concrete value from the chunk into key_facts first, then write\
-    \ a summary that preserves them. Prefer over-capture to under-capture. If the chunk mentions it, it belongs in key_facts\
-    \ or summary.\n\nRULES:\n1. Write as if you ARE the expert stating facts — never as a librarian cataloging a document\n\
-    2. Preserve ALL specific values verbatim: names, numbers, dates, PR numbers, costs, file paths, URLs, error messages,\
-    \ version numbers, branch names, config keys\n3. Summary must be standalone — a reader with no context learns the key\
-    \ facts without reading the chunk\n4. Front-load the most unique/searchable facts (identifiers, decisions, outcomes)\n\
-    5. key_facts is the primary recall surface: target 6–20 verbatim strings on dense chunks; include partial lines, error\
-    \ codes, and quoted phrases when present\n6. Do not deduplicate near-duplicates in key_facts if wording differs — recall\
-    \ beats compression\n\nBANNED — never start or include these patterns:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
+  label: inline-density-max-recall
+  prompt_template: "You are a recall-maximizing knowledge extraction engine for BrainLayer. Your output will be embedded for\
+    \ vector search and indexed for full-text search. Extract dense, fact-rich metadata from the chunk; do not describe the\
+    \ chunk.\n\nAXIS: density-max-recall. Prefer preserving too many concrete facts over producing a tidy short abstraction.\
+    \ The summary, key_facts, tags, and resolved_queries should make the chunk findable by names, numbers, paths, errors,\
+    \ projects, dates, and decisions.\n\nRULES:\n1. Write as the expert stating facts, not as a cataloger describing source\
+    \ text.\n2. Preserve every concrete value verbatim: people, projects, PRs, issue numbers, commit hashes, dates, file paths,\
+    \ URLs, versions, costs, command names, config keys, model names, errors, ports, and metrics.\n3. Summary must be standalone\
+    \ and front-loaded with the most unique facts.\n4. key_facts is the recall ledger: include every retrievable atomic fact,\
+    \ even when the summary already mentions it.\n5. If the chunk is short or conversational, extract commitments, decisions,\
+    \ blockers, and actionable facts; ignore filler.\n\nBANNED PATTERNS:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
     \n- \"The user/assistant is asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\
-    \n- \"The conversation covers/revolves around...\"\n- Any sentence ABOUT the text rather than FROM the text\nIf you catch\
-    \ yourself writing about the source, DELETE it and write the actual facts instead.\n\nMETA-RESEARCH DETECTION:\n- If the\
-    \ chunk contains literal tool invocations such as brain_search(...) or brain_entity(...), treat it as meta-research noise\n\
-    - Set importance to 2\n- Add the tag \"meta-research\"\n\nSUMMARY STYLE BY CONTENT TYPE:\n- Decisions/conclusions: decision\
-    \ verbatim, who, when, why, rejected alternatives\n- Corrections: old → new, who corrected, what is superseded\n- Code/technical:\
-    \ all symbol names, paths, config values, errors verbatim; intent around them\n- Conversation: speakers, commitments,\
-    \ agreements, open questions — not filler flow\n- Entity/biographical: full names, aliases, roles, relationships, dated\
-    \ facts\n- SHORT/CONVERSATIONAL: extract actionable items and commitments only\n\nFEW-SHOT (recall discipline):\nBAD:\
-    \ \"Two /yash missions fixed nativewind and MCP SDK issues.\"\nGOOD summary + key_facts: summary states dates, PR #1722,\
-    \ bug class, merge/deploy; key_facts lists each PR, file paths, error strings, version numbers separately.\n\nCHUNK (from\
-    \ project: {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure:\n\
-    {{\n  \"summary\": \"<3–5 dense sentences — include ALL numbers, names, dates, PRs, paths from the chunk; never compress\
-    \ away specifics>\",\n  \"key_facts\": [\"<verbatim fact 1>\", \"<verbatim fact 2>\", \"... exhaust the chunk — PRs, amounts,\
-    \ dates, paths, URLs, versions, errors, entity names>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"],\n  \"importance\": <1-10\
-    \ integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\"\
-    ,\n  \"primary_symbols\": [\"<class/function/file names mentioned>\"],\n  \"resolved_query\": \"<copy resolved_queries[0]\
-    \ — natural-language question this chunk answers>\",\n  \"resolved_queries\": [\n    \"<NL question a user would ask —\
-    \ everyday vocabulary>\",\n    \"<keyword-dense BM25 query — pack identifiers, names, paths, error codes>\",\n    \"<HyDE\
-    \ answer snippet 1–2 sentences — same terms as summary/key_facts for embedding recall>\"\n  ],\n  \"epistemic_level\"\
-    : \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or system state discussed, or null>\"\
-    ,\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"<libraries or external APIs\
-    \ used>\"],\n  \"entities\": [\n    {{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
-    , \"relation\": \"<relationship to other entities, or null>\"}}\n  ],\n  \"sentiment_label\": \"<one of: frustration,\
+    \n- \"The conversation covers/revolves around...\"\nRewrite any meta-description into the actual facts.\n\nMETA-RESEARCH\
+    \ DETECTION:\nIf the chunk contains literal BrainLayer tool calls such as brain_search(...) or brain_entity(...), treat\
+    \ it as meta-research noise, set importance to 2, and add tag \"meta-research\".\n\nCHUNK (from project: {project}, type:\
+    \ {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON object and populate every key:\n\
+    {{\n  \"summary\": \"<3-5 dense sentences containing the main facts, decisions, names, numbers, dates, outcomes, and why\
+    \ they matter>\",\n  \"key_facts\": [\"<atomic verbatim fact 1>\", \"<atomic verbatim fact 2>\"],\n  \"tags\": [\"<3-7\
+    \ lowercase hyphenated search tags>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing,\
+    \ configuring, discussing, deciding, implementing, reviewing>\",\n  \"primary_symbols\": [\"<class/function/file names\
+    \ mentioned>\"],\n  \"resolved_query\": \"<natural-language question this chunk answers; same as resolved_queries[0]>\"\
+    ,\n  \"resolved_queries\": [\n    \"<natural-language question a future user would ask>\",\n    \"<keyword-dense query\
+    \ packed with exact anchors from the chunk>\",\n    \"<HyDE answer snippet preserving key terms for embedding similarity>\"\
+    \n  ],\n  \"epistemic_level\": \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or\
+    \ system state discussed, or null>\",\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\"\
+    : [\"<libraries or external APIs used>\"],\n  \"entities\": [{{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<relationship to other entities in this chunk, or null>\"}}],\n  \"sentiment_label\": \"<one of: frustration,\
     \ confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float from -1.0 to 1.0>,\n  \"sentiment_signals\"\
-    : [\"<words/phrases indicating sentiment>\"]\n}}\n\nTAG RULES: lowercase hyphenated; 3–7 tags; languages, frameworks,\
-    \ concepts, actions.\nIMPORTANCE: 1–3 trivial; 4–6 moderate; 7–9 high; 10 critical.\nENTITIES: non-code only; no variable/function/path\
-    \ as entities.\n\nRECALL QUALITY GATE (mandatory):\n✓ Every PR number, date, dollar amount, path, URL, version, and error\
-    \ string in the chunk appears in key_facts OR summary (prefer both)\n✓ key_facts has at least 3 items when chunk length\
-    \ > 200 chars\n✓ Summary does NOT start with banned patterns\n✓ resolved_queries[2] reuses key terms from summary (HyDE\
-    \ alignment)\n\nEPISTEMIC: hypothesis = proposed/unverified; substantiated = evidence in chunk; validated = merge/deploy/confirmation\
-    \ stated\nDEBT: introduction = new debt/TODO/blocker; resolution = closes debt; none = no change\nSENTIMENT: frustration\
-    \ = blocked/failing; confusion = uncertain; positive = upbeat; satisfaction = resolved; neutral = factual\n\nReturn ONLY\
-    \ the JSON object, no other text."
+    : [\"<words/phrases that indicate sentiment>\"]\n}}\n\nQUALITY GATE:\n- resolved_query must equal resolved_queries[0].\n\
+    - key_facts must include all PR numbers, dates, file paths, URLs, versions, model names, and error strings from the chunk.\n\
+    - Summary must not begin with \"This chunk\", \"This message\", \"The user\", or \"The assistant\".\n- Tags must be 3-7\
+    \ lowercase hyphenated strings unless the chunk is true noise.\nReturn ONLY the JSON object, no markdown."
   model: gemini-2.5-flash-lite
   params:
     temperature: 0.2
     max_output_tokens: 4096
   provenance: llm-proposed
   axis: density-max-recall
-  source_path: subscription-cli-agent:abcde_llm_proposals.json
+  source_path: inline-llm-reasoning:abcde_inline_proposals.json
   source_section: llm-proposed-C
-  prompt_hash: 732bedd2d92bd0995af8fcb7a3bbe4bdf2c72b5c04b81ad30b409a3a59ebf84a
+  prompt_hash: f0f4f5f77f9d09d59d5714ee9b4e632b7ad57dba73b93a9cf6a079611eb381ad
 - id: D
-  label: entity-relation-graph-first
-  prompt_template: "You are a knowledge-graph extraction engine for a personal knowledge base. Build an explicit entity–relation\
-    \ graph from each chunk, then write search-facing fields that preserve that graph. Dense facts only — never meta-descriptions.\n\
-    \nAXIS (entity-relation-first): Identify entities and their relations BEFORE writing summary. The entities array is the\
-    \ source of truth; summary narrates the same graph in prose.\n\nRULES:\n1. State facts as the expert — never describe\
-    \ \"what the chunk is about\"\n2. Preserve verbatim: names, numbers, dates, PR numbers, paths, URLs, errors, versions\n\
-    3. Every named person, project, company, product, tool, or technology in the chunk → entities entry (if not a code symbol)\n\
-    4. When two+ entities appear, set relation on each to explain how they connect (developer-of, depends-on, blocks, owns,\
-    \ uses, competes-with, etc.)\n5. Do NOT put function names, variables, or file paths in entities — use primary_symbols\
-    \ instead\n\nBANNED patterns (reject and rewrite):\n- \"This chunk/message describes...\"\n- \"The user/assistant is asking/instructing...\"\
-    \n- \"This is a conversation/discussion about...\"\n- \"The conversation covers/revolves around...\"\n\nMETA-RESEARCH:\
-    \ brain_search(...) / brain_entity(...) in chunk → importance 2, tag \"meta-research\"\n\nENTITY WORKFLOW (do this order):\n\
-    1. List all non-code named things\n2. Assign type: person|company|project|technology|tool|concept\n3. Fill relation linking\
-    \ to another entity in this chunk (null only if truly isolated)\n4. Write summary as a graph walk: who did what to which\
-    \ project/tool, with dates and outcomes\n5. Mirror entity names in key_facts and tags where relevant\n\nCHUNK (from project:\
-    \ {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure:\n{{\n\
-    \  \"summary\": \"<2–4 sentences naming entities and relations explicitly — e.g. 'Etan (person) merged PR #93 into BrainLayer\
-    \ (project) fixing importance inflation (concept)'>\",\n  \"key_facts\": [\"<verbatim values supporting the entity graph\
-    \ — dates, PRs, metrics, paths>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\"\
-    : \"<one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\",\n  \"primary_symbols\"\
-    : [\"<code symbols only — classes, functions, files>\"],\n  \"resolved_query\": \"<resolved_queries[0] — question about\
-    \ the main entity/subject>\",\n  \"resolved_queries\": [\n    \"<question naming the primary entity/project>\",\n    \"\
-    <keyword query with entity names + domain terms>\",\n    \"<HyDE answer naming entities and relations with key facts>\"\
-    \n  ],\n  \"epistemic_level\": \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or\
-    \ system state, or null>\",\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"\
-    <external libraries/APIs>\"],\n  \"entities\": [\n    {{\"name\": \"<canonical name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
-    , \"relation\": \"<required when another entity exists — how they connect>\"}}\n  ],\n  \"sentiment_label\": \"<one of:\
-    \ frustration, confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float -1.0 to 1.0>,\n  \"sentiment_signals\"\
-    : [\"<affect phrases>\"]\n}}\n\nTAG RULES: 3–7 lowercase hyphenated tags; include project/technology tags when entities\
-    \ imply them.\nIMPORTANCE: standard 1–10 scale.\n\nENTITY QUALITY GATE:\n✓ At least one entities row when chunk names\
-    \ any person/project/company/tool/technology\n✓ No code symbols in entities\n✓ relation is non-null when chunk mentions\
-    \ 2+ linkable entities\n✓ summary uses the same entity names as entities[].name\n✓ Summary passes banned-pattern check\n\
-    \nEPISTEMIC / DEBT / SENTIMENT rubrics: same as production — hypothesis|substantiated|validated; introduction|resolution|none;\
-    \ frustration|confusion|positive|satisfaction|neutral.\n\nReturn ONLY the JSON object, no other text."
+  label: inline-entity-relation-first
+  prompt_template: "You are an entity/relation-first enrichment engine for BrainLayer. Build the chunk's knowledge graph first,\
+    \ then write search metadata that reflects that graph. Your output is used for retrieval and offline evaluation, so it\
+    \ must be concrete, faithful, and schema-complete.\n\nAXIS: entity-relation-first. Prioritize named entities, their types,\
+    \ their relations, and the factual edges connecting them. Summary and queries should reuse the same entity names and relation\
+    \ language.\n\nPROCESS:\n1. Identify every non-code entity: person, company, project, technology, tool, or concept.\n\
+    2. Identify code symbols separately as primary_symbols: files, functions, classes, methods, commands, tables.\n3. For\
+    \ every entity, write a relation to another entity or to the chunk's main event when available.\n4. Write the summary\
+    \ as facts about those entities: who did what, to which system, when, why, with what result.\n5. Use key_facts for evidence:\
+    \ exact dates, paths, PRs, errors, configs, metrics, and quoted values.\n\nBANNED PATTERNS:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
+    \n- \"The user/assistant is asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\
+    \n- \"The conversation covers/revolves around...\"\nFacts only; never describe the text as text.\n\nMETA-RESEARCH DETECTION:\n\
+    Literal brain_search(...), brain_entity(...), brain_expand(...), or similar tool calls mean meta-research noise: importance\
+    \ 2 and tag \"meta-research\", unless the chunk records a durable decision or result from that research.\n\nCHUNK (from\
+    \ project: {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON object\
+    \ and populate every key:\n{{\n  \"summary\": \"<2-4 dense sentences naming entities and their relations, preserving concrete\
+    \ values and outcomes>\",\n  \"key_facts\": [\"<verbatim evidence for the entity graph>\"],\n  \"tags\": [\"<3-7 lowercase\
+    \ hyphenated tags, including subject/entity tags when useful>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"\
+    <one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\",\n  \"primary_symbols\":\
+    \ [\"<code symbols, file paths, commands, tables, or APIs mentioned>\"],\n  \"resolved_query\": \"<question about the\
+    \ primary entity/relation; same as resolved_queries[0]>\",\n  \"resolved_queries\": [\n    \"<natural-language question\
+    \ naming the primary subject>\",\n    \"<keyword-dense query with entity names, relation terms, and exact anchors>\",\n\
+    \    \"<HyDE answer snippet that names the entities, relation, and outcome>\"\n  ],\n  \"epistemic_level\": \"<one of:\
+    \ hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or system state discussed, or null>\",\n \
+    \ \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"<external libraries or APIs\
+    \ used>\"],\n  \"entities\": [{{\"name\": \"<canonical entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<how this entity connects to another entity or event, or null>\"}}],\n  \"sentiment_label\": \"<one\
+    \ of: frustration, confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float from -1.0 to 1.0>,\n\
+    \  \"sentiment_signals\": [\"<phrases showing sentiment>\"]\n}}\n\nQUALITY GATE:\n- Entities must not include code symbols,\
+    \ file paths, variables, or functions. Put those in primary_symbols.\n- If two entities are connected, relation must say\
+    \ how; avoid null relation when a relation is evident.\n- resolved_query must equal resolved_queries[0].\n- Summary must\
+    \ use entity names from entities[].name when entities exist.\nReturn ONLY the JSON object, no markdown."
   model: gemini-2.5-flash-lite
   params:
     temperature: 0.2
     max_output_tokens: 4096
   provenance: llm-proposed
   axis: entity-relation-first
-  source_path: subscription-cli-agent:abcde_llm_proposals.json
+  source_path: inline-llm-reasoning:abcde_inline_proposals.json
   source_section: llm-proposed-D
-  prompt_hash: ea0093578f78f94b60e65f6c5826eca2f9f4e3c8dc2694ce0abbdbc9268149a0
+  prompt_hash: 4ccdd1d080546423db0f4f166b4ed73908c6e0eacca78875992235b8ead27166
 - id: E
-  label: structure-hyde-faithfulness
-  prompt_template: "You are a structured retrieval-metadata extractor. Your job is to produce schema-faithful JSON where HyDE-style\
-    \ resolved_query fields are the retrieval backbone and every other field aligns to them. Dense, fact-rich — never meta-description.\n\
-    \nAXIS (structure-hyde-faithfulness): Draft resolved_queries FIRST (all three slots), then write summary and key_facts\
-    \ to match. resolved_query MUST equal resolved_queries[0]. Field order in your reasoning: queries → facts → summary →\
-    \ entities/tags/sentiment.\n\nRULES:\n1. Expert voice stating facts — never \"this chunk describes...\"\n2. Preserve verbatim\
-    \ identifiers in key_facts and resolved_queries[1]\n3. resolved_queries[2] is a hypothetical ANSWER (HyDE document), not\
-    \ a question — write as if answering resolved_queries[0]\n4. summary must reuse the same anchor terms as resolved_queries[1]\
-    \ and [2] (names, PRs, paths, errors)\n5. Exactly 3 strings in resolved_queries — no more, no fewer\n\nBANNED:\n- \"This\
-    \ chunk/message describes/details/outlines/provides/contains...\"\n- \"The user/assistant is asking/instructing/discussing/explaining...\"\
-    \n- \"This is a conversation/discussion about...\"\n- \"The conversation covers/revolves around...\"\n\nMETA-RESEARCH:\
-    \ literal brain_search(...) / brain_entity(...) → importance 2, tag \"meta-research\"\n\nHyDE SLOT SPEC (strict):\n- resolved_queries[0]:\
-    \ natural-language user question (8–20 words, no jargon unless in chunk)\n- resolved_queries[1]: keyword/BM25 string —\
-    \ comma or space separated anchors, no filler words\n- resolved_queries[2]: 1–2 sentence answer snippet with facts; must\
-    \ stand alone for embedding similarity\n- resolved_query: identical copy of resolved_queries[0]\n\nCHUNK (from project:\
-    \ {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure (populate\
-    \ every key; types must match):\n{{\n  \"summary\": \"<2–4 dense sentences aligned to resolved_queries[2] — facts only,\
-    \ no meta>\",\n  \"key_facts\": [\"<verbatim strings supporting the HyDE answer>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"\
-    ],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing, deciding,\
-    \ implementing, reviewing>\",\n  \"primary_symbols\": [\"<code symbols mentioned>\"],\n  \"resolved_query\": \"<MUST equal\
-    \ resolved_queries[0]>\",\n  \"resolved_queries\": [\n    \"<NL question>\",\n    \"<keyword-dense query>\",\n    \"<HyDE\
-    \ answer snippet>\"\n  ],\n  \"epistemic_level\": \"<hypothesis|substantiated|validated>\",\n  \"version_scope\": \"<string\
-    \ or null>\",\n  \"debt_impact\": \"<introduction|resolution|none>\",\n  \"external_deps\": [\"<deps>\"],\n  \"entities\"\
-    : [\n    {{\"name\": \"<name>\", \"type\": \"<person|company|project|technology|tool|concept>\", \"relation\": \"<string\
-    \ or null>\"}}\n  ],\n  \"sentiment_label\": \"<frustration|confusion|positive|satisfaction|neutral>\",\n  \"sentiment_score\"\
-    : <float -1.0 to 1.0>,\n  \"sentiment_signals\": [\"<signals>\"]\n}}\n\nTAG RULES: 3–7 lowercase hyphenated tags.\nENTITIES:\
-    \ non-code only; relation when co-entities exist.\n\nSTRUCTURE QUALITY GATE:\n✓ resolved_query === resolved_queries[0]\
-    \ (character-for-character)\n✓ len(resolved_queries) === 3\n✓ resolved_queries[2] contains at least one specific anchor\
-    \ from the chunk (PR, path, number, or name)\n✓ summary and key_facts do not contradict resolved_queries[2]\n✓ No banned\
-    \ summary openers\n\nEPISTEMIC: hypothesis = unverified proposal; substantiated = evidence in chunk; validated = confirmed\
-    \ outcome\nDEBT: introduction | resolution | none\nSENTIMENT: label + score + signals consistent with chunk tone\n\nReturn\
-    \ ONLY the JSON object, no other text."
+  label: inline-hyde-structure-faithfulness
+  prompt_template: "You are a schema-faithful HyDE/structure enrichment engine for BrainLayer. Your job is to produce exact\
+    \ JSON metadata that improves both vector search and keyword search without hallucinating beyond the chunk.\n\nAXIS: structure-HyDE-faithfulness.\
+    \ Design the retrieval surface first: resolved_query and resolved_queries must be precise, faithful, and aligned with\
+    \ summary/key_facts. Every field must satisfy the runtime schema exactly.\n\nFIELD DISCIPLINE:\n1. resolved_queries[0]\
+    \ is the everyday question this chunk answers. resolved_query must be an exact copy.\n2. resolved_queries[1] is the keyword-dense\
+    \ query: exact names, paths, PRs, errors, tools, and tags; minimal filler.\n3. resolved_queries[2] is a HyDE answer snippet:\
+    \ 1-2 factual sentences that sound like the answer a searcher wants.\n4. summary must align with resolved_queries[2] and\
+    \ must not add unsupported claims.\n5. key_facts must provide verbatim anchors supporting the queries and summary.\n\n\
+    BANNED PATTERNS:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\n- \"The user/assistant is\
+    \ asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\n- \"The conversation\
+    \ covers/revolves around...\"\nIf you write meta-description, delete it and write the actual fact.\n\nMETA-RESEARCH DETECTION:\n\
+    If the chunk is mainly raw BrainLayer tool invocation text like brain_search(...) or brain_entity(...), set importance\
+    \ to 2 and tag \"meta-research\" unless it records a durable result, decision, or benchmark.\n\nCHUNK (from project: {project},\
+    \ type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON object and populate every\
+    \ key:\n{{\n  \"summary\": \"<2-4 dense, faithful sentences aligned with the HyDE answer and grounded only in the chunk>\"\
+    ,\n  \"key_facts\": [\"<verbatim anchors that support summary and queries>\"],\n  \"tags\": [\"<3-7 lowercase hyphenated\
+    \ tags>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing,\
+    \ deciding, implementing, reviewing>\",\n  \"primary_symbols\": [\"<class/function/file names mentioned>\"],\n  \"resolved_query\"\
+    : \"<exact copy of resolved_queries[0]>\",\n  \"resolved_queries\": [\n    \"<natural-language question this chunk answers>\"\
+    ,\n    \"<keyword-dense exact-anchor query>\",\n    \"<1-2 sentence HyDE answer snippet using only chunk-supported facts>\"\
+    \n  ],\n  \"epistemic_level\": \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or\
+    \ system state discussed, or null>\",\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\"\
+    : [\"<libraries or external APIs used>\"],\n  \"entities\": [{{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<relationship to other entities in this chunk, or null>\"}}],\n  \"sentiment_label\": \"<one of: frustration,\
+    \ confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float from -1.0 to 1.0>,\n  \"sentiment_signals\"\
+    : [\"<phrases that indicate sentiment>\"]\n}}\n\nSTRICT VALIDATION BEFORE RETURN:\n- JSON object only; no markdown, no\
+    \ trailing prose.\n- resolved_queries has exactly 3 strings.\n- resolved_query is byte-identical to resolved_queries[0].\n\
+    - importance is an integer 1-10, sentiment_score is a finite float -1.0 to 1.0.\n- summary contains at least one concrete\
+    \ anchor when the chunk has any concrete anchor.\n- No unsupported extrapolation beyond chunk/context_section.\nReturn\
+    \ ONLY the JSON object."
   model: gemini-2.5-flash-lite
   params:
     temperature: 0.2
     max_output_tokens: 4096
   provenance: llm-proposed
   axis: structure-hyde-faithfulness
-  source_path: subscription-cli-agent:abcde_llm_proposals.json
+  source_path: inline-llm-reasoning:abcde_inline_proposals.json
   source_section: llm-proposed-E
-  prompt_hash: dd974abf35dfc0717239bf3ec56aa8ff090dd9f566e3c6e6ab0691cbe2c9dcc0
+  prompt_hash: d9c3fc764c2e72bad7994ee1e9562a518de826a03f7dd3bb929479fcb20b5a23

--- a/src/brainlayer/eval/abcde_variants.yaml
+++ b/src/brainlayer/eval/abcde_variants.yaml
@@ -1,0 +1,315 @@
+schema_version: 1
+frozen_at: '2026-06-01T08:39:10+00:00'
+hash_algorithm: sha256
+variants:
+- id: A
+  label: production-enrichment-prompt
+  prompt_template: "You are a knowledge extraction engine for a personal knowledge graph. Your summaries will be embedded\
+    \ for vector search AND indexed for full-text keyword search. Write dense, fact-rich extractions — not descriptions.\n\
+    \nRULES:\n1. Write as if you ARE the expert stating facts — never as a librarian cataloging a document\n2. Preserve ALL\
+    \ specific values verbatim: names, numbers, dates, PR numbers, costs, file paths, URLs, error messages, version numbers\n\
+    3. Summary must be standalone — a reader with no context should learn the key facts\n4. Front-load the most important/unique\
+    \ information\n\nBANNED — never start or include these patterns:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
+    \n- \"The user/assistant is asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\
+    \n- \"The conversation covers/revolves around...\"\n- Any sentence ABOUT the text rather than FROM the text\nIf you catch\
+    \ yourself writing about the source, DELETE it and write the actual facts instead.\n\nMETA-RESEARCH DETECTION:\n- If the\
+    \ chunk contains literal tool invocations such as brain_search(...) or brain_entity(...), treat it as meta-research noise\n\
+    - Set importance to 2\n- Add the tag \"meta-research\"\n\nSUMMARY STYLE BY CONTENT TYPE:\n- Decisions/conclusions: State\
+    \ the decision verbatim, who made it, when, why, and what was rejected\n- Corrections/instructions: State what changed\
+    \ (old → new), who corrected it, what prior knowledge is now superseded\n- Code/technical: Preserve all symbol names,\
+    \ file paths, config values, error messages verbatim; summarize intent around them\n- Conversation: Identify speakers,\
+    \ key contributions, agreements, open questions\n- Entity/biographical: Full name with aliases, role, relationships to\
+    \ other entities, key facts with dates\n- SHORT/CONVERSATIONAL CHUNK: If the chunk is informal conversation, extract ACTIONABLE\
+    \ ITEMS and COMMITMENTS, not discussion flow or filler phrasing\n\nFEW-SHOT EXAMPLES:\n\nBAD (score 1/5 — meta-description,\
+    \ no facts):\n  Input: [conversation about storing Mehayom project architecture decisions]\n  Output: \"The user is instructing\
+    \ the AI to store specific knowledge about the Mehayom project\"\n  WHY BAD: Says nothing about WHAT knowledge. Zero retrievable\
+    \ facts.\n\nBAD (score 2/5 — vague, loses specifics):\n  Input: [message about two /yash missions fixing nativewind and\
+    \ MCP SDK bugs]\n  Output: \"This message details two recent /yash missions that fixed issues in nativewind and MCP SDK\"\
+    \n  WHY BAD: Which missions? What issues? What PRs? No dates, no specifics.\n\nGOOD (score 5/5 — dense, specific, retrievable):\n\
+    \  Input: [same /yash missions conversation]\n  Output: \"Two /yash missions completed (April 5, 2026): (1) nativewind\
+    \ PR #1722 — fixed style resolution bug in CSS property inheritance, (2) MCP SDK — patched auth token refresh race condition\
+    \ causing 401 errors on reconnect. Both PRs merged and deployed.\"\n  WHY GOOD: Dates, PR numbers, specific bug descriptions,\
+    \ outcomes — all preserved.\n\nGOOD (score 5/5 — decision with rationale):\n  Input: [conversation deciding on database\
+    \ choice]\n  Output: \"Database decision (March 12, 2026): Chose SQLite + sqlite-vec over Postgres+pgvector for BrainLayer\
+    \ storage. Rationale: local-first architecture requirement, no server dependency, FTS5 for hybrid search. Rejected: Postgres\
+    \ (requires daemon), Pinecone (cloud-only, latency), ChromaDB (immature FTS).\"\n  WHY GOOD: Decision, date, what was\
+    \ chosen, why, what was rejected with reasons.\n\nCHUNK (from project: {project}, type: {content_type}):\n---\n{content}\n\
+    ---\n\n{context_section}\n\nReturn this exact JSON structure:\n{{\n  \"summary\": \"<2-4 dense sentences extracting the\
+    \ key facts, decisions, names, numbers, and outcomes from this chunk — NOT a description of what the chunk is about>\"\
+    ,\n  \"key_facts\": [\"<extract every specific value: PR numbers, dollar amounts, dates, file paths, entity names, URLs,\
+    \ version numbers, error codes, config values — verbatim strings only>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"],\n  \"\
+    importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing, deciding, implementing,\
+    \ reviewing>\",\n  \"primary_symbols\": [\"<class/function/file names mentioned>\"],\n  \"resolved_queries\": [\n    \"\
+    <natural-language question a user would ask that this chunk answers — use everyday search vocabulary>\",\n    \"<keyword-dense\
+    \ query optimized for text search — pack in key terms, names, identifiers>\",\n    \"<hypothetical answer snippet — 1-2\
+    \ sentences written as if answering the question, preserving key terms for embedding similarity>\"\n  ],\n  \"epistemic_level\"\
+    : \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or system state discussed, or null>\"\
+    ,\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"<libraries or external APIs\
+    \ used>\"],\n  \"entities\": [\n    {{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<relationship to other entities in this chunk, e.g. 'developer of BrainLayer', 'dependency of MCP SDK',\
+    \ or null>\"}}\n  ],\n  \"sentiment_label\": \"<one of: frustration, confusion, positive, satisfaction, neutral>\",\n\
+    \  \"sentiment_score\": <float from -1.0 to 1.0>,\n  \"sentiment_signals\": [\"<words/phrases that indicate the sentiment>\"\
+    ]\n}}\n\nTAG RULES:\n- Use lowercase, hyphenated tags (e.g., \"bug-fix\", \"api-design\")\n- Include: language tags (python,\
+    \ typescript, sql), framework tags (react, fastapi, bun)\n- Include: concept tags (error-handling, authentication, deployment,\
+    \ testing, refactoring)\n- Include: action tags (bug-fix, feature-dev, code-review, documentation)\n- 3-7 tags per chunk\n\
+    \nIMPORTANCE RULES:\n- 1-3: Trivial (greetings, short confirmations, file listings)\n- 4-6: Moderate (standard code, config\
+    \ changes, routine discussions)\n- 7-9: High (bug fixes with root cause, architecture decisions, novel patterns)\n- 10:\
+    \ Critical (security fixes, production incidents, key architectural choices)\n\nENTITIES:\n- Extract non-code entities\
+    \ only — people, projects, technologies, companies, tools, concepts\n- Do NOT extract variable names, function names,\
+    \ file paths, or code symbols as entities\n- Use the \"relation\" field to capture how the entity connects to other entities\
+    \ in this chunk\n\nSUMMARY QUALITY CHECK — before returning, verify your summary:\n✓ Contains at least one specific name,\
+    \ number, or date from the chunk\n✓ Does NOT start with \"This chunk\" / \"This message\" / \"The user\"\n✓ A person reading\
+    \ ONLY the summary would learn something concrete\n✓ Key decisions include the WHY, not just the WHAT\n✓ All PR numbers,\
+    \ costs, dates, file paths, and URLs from the chunk appear in either summary or key_facts\n\nEPISTEMIC RUBRIC: hypothesis\
+    \ = proposed or unverified; substantiated = backed by concrete evidence in the chunk; validated = outcome explicitly confirmed\
+    \ by execution, merge, deploy, or user confirmation\nDEBT IMPACT RUBRIC: introduction = creates debt, workaround, TODO,\
+    \ or blocker; resolution = removes debt or closes a blocker; none = no clear debt change\nSENTIMENT RUBRIC: frustration\
+    \ = blocked/annoyed/failing; confusion = uncertainty/questioning; positive = upbeat/encouraging; satisfaction = relief/resolution/completion;\
+    \ neutral = factual/no strong affect\n\nReturn ONLY the JSON object, no other text."
+  model: gemini-2.5-flash-lite
+  params:
+    temperature: 0.2
+    max_output_tokens: 4096
+  provenance: production
+  axis: production-control
+  source_path: src/brainlayer/pipeline/enrichment.py
+  source_section: ENRICHMENT_PROMPT
+  prompt_hash: 533c76ed07b9625d8b460330f45a46cc8074668a11fecf34090773984a57f1f7
+- id: B
+  label: 2026-03-19-v2-faceted-tags
+  prompt_template: 'You are a knowledge base tagger for a personal multi-project development knowledge base. Your job is to
+    identify WHAT SPECIFIC THING each chunk is about — not the kind of work being done.
+
+
+    ## Critical distinction
+
+
+    GOOD tags describe the SUBJECT: "brainlayer-search-quality", "6pm-confirmation-flow", "importance-calibration"
+
+    BAD tags describe the FORMAT: "typescript", "debugging", "code-review", "feature-dev"
+
+
+    Ask yourself: "If someone searches for this topic in 6 months, what words would they use?" Tag with THOSE words.
+
+
+    ## Output schema (JSON)
+
+
+    Return a JSON object with these fields in this exact order:
+
+
+    - **a_reasoning** (string): 1-2 sentences explaining what specific subject this chunk discusses. Think before tagging.
+
+    - **b_topics** (string[]): 1-3 object tags — specific, hyphenated, 2-4 words. Use existing tags when they fit: brainlayer-search-quality,
+    importance-calibration, enrichment-pipeline, auto-context-hooks, cmux-terminal-orchestration, voicelayer-tts-stt, coachclaude-scheduling,
+    sprint-planning-methodology, skill-ecosystem, eval-runner, 6pm-confirmation-flow, knowledge-graph-rebuild, dedup-strategy,
+    tag-taxonomy-redesign, compaction-survival, rate-limit-coordination, pr-loop-workflow, brain-digest-stub, golems-monorepo,
+    etanheyman-portfolio. Create new tags following the same pattern when needed. Use ["_noise"] for system noise with no
+    informational content.
+
+    - **c_activity** (string): Exactly one of: act:debugging, act:implementing, act:designing, act:reviewing, act:researching,
+    act:planning, act:configuring, act:refactoring, act:testing, act:learning
+
+    - **d_domain** (string[]): 0-3 technology domains from: dom:typescript, dom:python, dom:swift, dom:sql, dom:react, dom:convex,
+    dom:supabase, dom:mcp, dom:vertex-ai, dom:ollama, dom:mlx, dom:git, dom:telegram, dom:whatsapp, dom:macos, dom:cli, dom:css,
+    dom:html, dom:docker, dom:railway, dom:linear, dom:obsidian. Empty array if no specific technology.
+
+    - **e_confidence** (number): 0.0-1.0 confidence in your tagging. Below 0.5 = low-content chunk.
+
+
+    ## Examples
+
+
+    Chunk: "Phase 1 importance calibration implemented (PR #93). Heuristic SQL fix deflates importance inflation from 40.8%
+    >= 7 to 7.6%."
+
+    Output: {"a_reasoning": "Completed milestone for BrainLayer importance scoring. Quantified SQL fix results.", "b_topics":
+    ["importance-calibration", "brainlayer-search-quality"], "c_activity": "act:implementing", "d_domain": ["dom:sql"], "e_confidence":
+    0.95}
+
+
+    Chunk: "Found the double-message bug in 6pm-mini: flexibility message sent before fail check."
+
+    Output: {"a_reasoning": "Bug fix in 6pm dating app messaging flow.", "b_topics": ["6pm-confirmation-flow"], "c_activity":
+    "act:debugging", "d_domain": ["dom:typescript", "dom:convex"], "e_confidence": 0.92}
+
+
+    Chunk: "R18 cmux event-driven patterns: tmux control mode (-CC) provides structured event streams."
+
+    Output: {"a_reasoning": "Research on cmux terminal architecture using tmux control mode.", "b_topics": ["cmux-terminal-orchestration"],
+    "c_activity": "act:researching", "d_domain": ["dom:cli", "dom:mcp"], "e_confidence": 0.93}
+
+
+    Chunk: "[Request interrupted by user]"
+
+    Output: {"a_reasoning": "System noise, no content.", "b_topics": ["_noise"], "c_activity": "act:configuring", "d_domain":
+    [], "e_confidence": 0.99}
+
+
+    Chunk: "כן אחי, אני בדרך"
+
+    Output: {"a_reasoning": "Short Hebrew acknowledgment, no technical content.", "b_topics": [], "c_activity": "act:planning",
+    "d_domain": ["dom:whatsapp"], "e_confidence": 0.30}
+
+
+    Chunk: "OK so the coach should check WHOOP recovery score first thing in the morning, then adjust the workout plan."
+
+    Output: {"a_reasoning": "Voice discussion about coachClaude morning health workflow with WHOOP thresholds.", "b_topics":
+    ["coachclaude-scheduling"], "c_activity": "act:designing", "d_domain": [], "e_confidence": 0.91}
+
+
+    ## Now tag this chunk:
+
+
+    {chunk_content}'
+  model: gemini-2.5-flash-lite
+  params:
+    temperature: 0.2
+    max_output_tokens: 4096
+  provenance: shelf
+  axis: faceted-tag-taxonomy
+  source_path: orchestrator/docs.local/plans/enrichment-prompt-v2.md
+  source_section: Enrichment Prompt (copy-paste into pipeline)
+  prompt_hash: 44ee15b9accf5dcd61fca7a82bb19f30c557178f820faeacf97f4113d5b2d381
+- id: C
+  label: density-max-recall-extraction
+  prompt_template: "You are a recall-maximizing knowledge extraction engine for a personal knowledge graph. Your output is\
+    \ embedded for vector search AND indexed for FTS. Maximize retrievable facts per token — never trade away specifics for\
+    \ brevity.\n\nAXIS (density-max-recall): Extract EVERY concrete value from the chunk into key_facts first, then write\
+    \ a summary that preserves them. Prefer over-capture to under-capture. If the chunk mentions it, it belongs in key_facts\
+    \ or summary.\n\nRULES:\n1. Write as if you ARE the expert stating facts — never as a librarian cataloging a document\n\
+    2. Preserve ALL specific values verbatim: names, numbers, dates, PR numbers, costs, file paths, URLs, error messages,\
+    \ version numbers, branch names, config keys\n3. Summary must be standalone — a reader with no context learns the key\
+    \ facts without reading the chunk\n4. Front-load the most unique/searchable facts (identifiers, decisions, outcomes)\n\
+    5. key_facts is the primary recall surface: target 6–20 verbatim strings on dense chunks; include partial lines, error\
+    \ codes, and quoted phrases when present\n6. Do not deduplicate near-duplicates in key_facts if wording differs — recall\
+    \ beats compression\n\nBANNED — never start or include these patterns:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
+    \n- \"The user/assistant is asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\
+    \n- \"The conversation covers/revolves around...\"\n- Any sentence ABOUT the text rather than FROM the text\nIf you catch\
+    \ yourself writing about the source, DELETE it and write the actual facts instead.\n\nMETA-RESEARCH DETECTION:\n- If the\
+    \ chunk contains literal tool invocations such as brain_search(...) or brain_entity(...), treat it as meta-research noise\n\
+    - Set importance to 2\n- Add the tag \"meta-research\"\n\nSUMMARY STYLE BY CONTENT TYPE:\n- Decisions/conclusions: decision\
+    \ verbatim, who, when, why, rejected alternatives\n- Corrections: old → new, who corrected, what is superseded\n- Code/technical:\
+    \ all symbol names, paths, config values, errors verbatim; intent around them\n- Conversation: speakers, commitments,\
+    \ agreements, open questions — not filler flow\n- Entity/biographical: full names, aliases, roles, relationships, dated\
+    \ facts\n- SHORT/CONVERSATIONAL: extract actionable items and commitments only\n\nFEW-SHOT (recall discipline):\nBAD:\
+    \ \"Two /yash missions fixed nativewind and MCP SDK issues.\"\nGOOD summary + key_facts: summary states dates, PR #1722,\
+    \ bug class, merge/deploy; key_facts lists each PR, file paths, error strings, version numbers separately.\n\nCHUNK (from\
+    \ project: {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure:\n\
+    {{\n  \"summary\": \"<3–5 dense sentences — include ALL numbers, names, dates, PRs, paths from the chunk; never compress\
+    \ away specifics>\",\n  \"key_facts\": [\"<verbatim fact 1>\", \"<verbatim fact 2>\", \"... exhaust the chunk — PRs, amounts,\
+    \ dates, paths, URLs, versions, errors, entity names>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"],\n  \"importance\": <1-10\
+    \ integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\"\
+    ,\n  \"primary_symbols\": [\"<class/function/file names mentioned>\"],\n  \"resolved_query\": \"<copy resolved_queries[0]\
+    \ — natural-language question this chunk answers>\",\n  \"resolved_queries\": [\n    \"<NL question a user would ask —\
+    \ everyday vocabulary>\",\n    \"<keyword-dense BM25 query — pack identifiers, names, paths, error codes>\",\n    \"<HyDE\
+    \ answer snippet 1–2 sentences — same terms as summary/key_facts for embedding recall>\"\n  ],\n  \"epistemic_level\"\
+    : \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or system state discussed, or null>\"\
+    ,\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"<libraries or external APIs\
+    \ used>\"],\n  \"entities\": [\n    {{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<relationship to other entities, or null>\"}}\n  ],\n  \"sentiment_label\": \"<one of: frustration,\
+    \ confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float from -1.0 to 1.0>,\n  \"sentiment_signals\"\
+    : [\"<words/phrases indicating sentiment>\"]\n}}\n\nTAG RULES: lowercase hyphenated; 3–7 tags; languages, frameworks,\
+    \ concepts, actions.\nIMPORTANCE: 1–3 trivial; 4–6 moderate; 7–9 high; 10 critical.\nENTITIES: non-code only; no variable/function/path\
+    \ as entities.\n\nRECALL QUALITY GATE (mandatory):\n✓ Every PR number, date, dollar amount, path, URL, version, and error\
+    \ string in the chunk appears in key_facts OR summary (prefer both)\n✓ key_facts has at least 3 items when chunk length\
+    \ > 200 chars\n✓ Summary does NOT start with banned patterns\n✓ resolved_queries[2] reuses key terms from summary (HyDE\
+    \ alignment)\n\nEPISTEMIC: hypothesis = proposed/unverified; substantiated = evidence in chunk; validated = merge/deploy/confirmation\
+    \ stated\nDEBT: introduction = new debt/TODO/blocker; resolution = closes debt; none = no change\nSENTIMENT: frustration\
+    \ = blocked/failing; confusion = uncertain; positive = upbeat; satisfaction = resolved; neutral = factual\n\nReturn ONLY\
+    \ the JSON object, no other text."
+  model: gemini-2.5-flash-lite
+  params:
+    temperature: 0.2
+    max_output_tokens: 4096
+  provenance: llm-proposed
+  axis: density-max-recall
+  source_path: subscription-cli-agent:abcde_llm_proposals.json
+  source_section: llm-proposed-C
+  prompt_hash: 732bedd2d92bd0995af8fcb7a3bbe4bdf2c72b5c04b81ad30b409a3a59ebf84a
+- id: D
+  label: entity-relation-graph-first
+  prompt_template: "You are a knowledge-graph extraction engine for a personal knowledge base. Build an explicit entity–relation\
+    \ graph from each chunk, then write search-facing fields that preserve that graph. Dense facts only — never meta-descriptions.\n\
+    \nAXIS (entity-relation-first): Identify entities and their relations BEFORE writing summary. The entities array is the\
+    \ source of truth; summary narrates the same graph in prose.\n\nRULES:\n1. State facts as the expert — never describe\
+    \ \"what the chunk is about\"\n2. Preserve verbatim: names, numbers, dates, PR numbers, paths, URLs, errors, versions\n\
+    3. Every named person, project, company, product, tool, or technology in the chunk → entities entry (if not a code symbol)\n\
+    4. When two+ entities appear, set relation on each to explain how they connect (developer-of, depends-on, blocks, owns,\
+    \ uses, competes-with, etc.)\n5. Do NOT put function names, variables, or file paths in entities — use primary_symbols\
+    \ instead\n\nBANNED patterns (reject and rewrite):\n- \"This chunk/message describes...\"\n- \"The user/assistant is asking/instructing...\"\
+    \n- \"This is a conversation/discussion about...\"\n- \"The conversation covers/revolves around...\"\n\nMETA-RESEARCH:\
+    \ brain_search(...) / brain_entity(...) in chunk → importance 2, tag \"meta-research\"\n\nENTITY WORKFLOW (do this order):\n\
+    1. List all non-code named things\n2. Assign type: person|company|project|technology|tool|concept\n3. Fill relation linking\
+    \ to another entity in this chunk (null only if truly isolated)\n4. Write summary as a graph walk: who did what to which\
+    \ project/tool, with dates and outcomes\n5. Mirror entity names in key_facts and tags where relevant\n\nCHUNK (from project:\
+    \ {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure:\n{{\n\
+    \  \"summary\": \"<2–4 sentences naming entities and relations explicitly — e.g. 'Etan (person) merged PR #93 into BrainLayer\
+    \ (project) fixing importance inflation (concept)'>\",\n  \"key_facts\": [\"<verbatim values supporting the entity graph\
+    \ — dates, PRs, metrics, paths>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\"\
+    : \"<one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\",\n  \"primary_symbols\"\
+    : [\"<code symbols only — classes, functions, files>\"],\n  \"resolved_query\": \"<resolved_queries[0] — question about\
+    \ the main entity/subject>\",\n  \"resolved_queries\": [\n    \"<question naming the primary entity/project>\",\n    \"\
+    <keyword query with entity names + domain terms>\",\n    \"<HyDE answer naming entities and relations with key facts>\"\
+    \n  ],\n  \"epistemic_level\": \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or\
+    \ system state, or null>\",\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"\
+    <external libraries/APIs>\"],\n  \"entities\": [\n    {{\"name\": \"<canonical name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<required when another entity exists — how they connect>\"}}\n  ],\n  \"sentiment_label\": \"<one of:\
+    \ frustration, confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float -1.0 to 1.0>,\n  \"sentiment_signals\"\
+    : [\"<affect phrases>\"]\n}}\n\nTAG RULES: 3–7 lowercase hyphenated tags; include project/technology tags when entities\
+    \ imply them.\nIMPORTANCE: standard 1–10 scale.\n\nENTITY QUALITY GATE:\n✓ At least one entities row when chunk names\
+    \ any person/project/company/tool/technology\n✓ No code symbols in entities\n✓ relation is non-null when chunk mentions\
+    \ 2+ linkable entities\n✓ summary uses the same entity names as entities[].name\n✓ Summary passes banned-pattern check\n\
+    \nEPISTEMIC / DEBT / SENTIMENT rubrics: same as production — hypothesis|substantiated|validated; introduction|resolution|none;\
+    \ frustration|confusion|positive|satisfaction|neutral.\n\nReturn ONLY the JSON object, no other text."
+  model: gemini-2.5-flash-lite
+  params:
+    temperature: 0.2
+    max_output_tokens: 4096
+  provenance: llm-proposed
+  axis: entity-relation-first
+  source_path: subscription-cli-agent:abcde_llm_proposals.json
+  source_section: llm-proposed-D
+  prompt_hash: ea0093578f78f94b60e65f6c5826eca2f9f4e3c8dc2694ce0abbdbc9268149a0
+- id: E
+  label: structure-hyde-faithfulness
+  prompt_template: "You are a structured retrieval-metadata extractor. Your job is to produce schema-faithful JSON where HyDE-style\
+    \ resolved_query fields are the retrieval backbone and every other field aligns to them. Dense, fact-rich — never meta-description.\n\
+    \nAXIS (structure-hyde-faithfulness): Draft resolved_queries FIRST (all three slots), then write summary and key_facts\
+    \ to match. resolved_query MUST equal resolved_queries[0]. Field order in your reasoning: queries → facts → summary →\
+    \ entities/tags/sentiment.\n\nRULES:\n1. Expert voice stating facts — never \"this chunk describes...\"\n2. Preserve verbatim\
+    \ identifiers in key_facts and resolved_queries[1]\n3. resolved_queries[2] is a hypothetical ANSWER (HyDE document), not\
+    \ a question — write as if answering resolved_queries[0]\n4. summary must reuse the same anchor terms as resolved_queries[1]\
+    \ and [2] (names, PRs, paths, errors)\n5. Exactly 3 strings in resolved_queries — no more, no fewer\n\nBANNED:\n- \"This\
+    \ chunk/message describes/details/outlines/provides/contains...\"\n- \"The user/assistant is asking/instructing/discussing/explaining...\"\
+    \n- \"This is a conversation/discussion about...\"\n- \"The conversation covers/revolves around...\"\n\nMETA-RESEARCH:\
+    \ literal brain_search(...) / brain_entity(...) → importance 2, tag \"meta-research\"\n\nHyDE SLOT SPEC (strict):\n- resolved_queries[0]:\
+    \ natural-language user question (8–20 words, no jargon unless in chunk)\n- resolved_queries[1]: keyword/BM25 string —\
+    \ comma or space separated anchors, no filler words\n- resolved_queries[2]: 1–2 sentence answer snippet with facts; must\
+    \ stand alone for embedding similarity\n- resolved_query: identical copy of resolved_queries[0]\n\nCHUNK (from project:\
+    \ {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure (populate\
+    \ every key; types must match):\n{{\n  \"summary\": \"<2–4 dense sentences aligned to resolved_queries[2] — facts only,\
+    \ no meta>\",\n  \"key_facts\": [\"<verbatim strings supporting the HyDE answer>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"\
+    ],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing, deciding,\
+    \ implementing, reviewing>\",\n  \"primary_symbols\": [\"<code symbols mentioned>\"],\n  \"resolved_query\": \"<MUST equal\
+    \ resolved_queries[0]>\",\n  \"resolved_queries\": [\n    \"<NL question>\",\n    \"<keyword-dense query>\",\n    \"<HyDE\
+    \ answer snippet>\"\n  ],\n  \"epistemic_level\": \"<hypothesis|substantiated|validated>\",\n  \"version_scope\": \"<string\
+    \ or null>\",\n  \"debt_impact\": \"<introduction|resolution|none>\",\n  \"external_deps\": [\"<deps>\"],\n  \"entities\"\
+    : [\n    {{\"name\": \"<name>\", \"type\": \"<person|company|project|technology|tool|concept>\", \"relation\": \"<string\
+    \ or null>\"}}\n  ],\n  \"sentiment_label\": \"<frustration|confusion|positive|satisfaction|neutral>\",\n  \"sentiment_score\"\
+    : <float -1.0 to 1.0>,\n  \"sentiment_signals\": [\"<signals>\"]\n}}\n\nTAG RULES: 3–7 lowercase hyphenated tags.\nENTITIES:\
+    \ non-code only; relation when co-entities exist.\n\nSTRUCTURE QUALITY GATE:\n✓ resolved_query === resolved_queries[0]\
+    \ (character-for-character)\n✓ len(resolved_queries) === 3\n✓ resolved_queries[2] contains at least one specific anchor\
+    \ from the chunk (PR, path, number, or name)\n✓ summary and key_facts do not contradict resolved_queries[2]\n✓ No banned\
+    \ summary openers\n\nEPISTEMIC: hypothesis = unverified proposal; substantiated = evidence in chunk; validated = confirmed\
+    \ outcome\nDEBT: introduction | resolution | none\nSENTIMENT: label + score + signals consistent with chunk tone\n\nReturn\
+    \ ONLY the JSON object, no other text."
+  model: gemini-2.5-flash-lite
+  params:
+    temperature: 0.2
+    max_output_tokens: 4096
+  provenance: llm-proposed
+  axis: structure-hyde-faithfulness
+  source_path: subscription-cli-agent:abcde_llm_proposals.json
+  source_section: llm-proposed-E
+  prompt_hash: dd974abf35dfc0717239bf3ec56aa8ff090dd9f566e3c6e6ab0691cbe2c9dcc0

--- a/tests/test_abcde_variants.py
+++ b/tests/test_abcde_variants.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+import re
+
+from brainlayer.eval.abcde_variants import (
+    ABCDE_VARIANTS,
+    ABCDE_VARIANTS_BY_ID,
+    VARIANT_IDS,
+    load_abcde_variants,
+)
+from brainlayer.pipeline.enrichment import ENRICHMENT_PROMPT
+
+
+def test_load_abcde_variants_freezes_all_five_ids_and_provenance() -> None:
+    variants = load_abcde_variants()
+
+    assert tuple(variant.id for variant in variants) == VARIANT_IDS == ("A", "B", "C", "D", "E")
+    assert ABCDE_VARIANTS == variants
+    assert set(ABCDE_VARIANTS_BY_ID) == set(VARIANT_IDS)
+    assert [variant.provenance for variant in variants] == [
+        "production",
+        "shelf",
+        "llm-proposed",
+        "llm-proposed",
+        "llm-proposed",
+    ]
+
+
+def test_prompt_hashes_are_sha256_of_frozen_templates() -> None:
+    for variant in load_abcde_variants():
+        expected = hashlib.sha256(variant.prompt_template.encode("utf-8")).hexdigest()
+
+        assert variant.prompt_hash == expected
+        assert len(variant.prompt_hash) == 64
+
+
+def test_variant_a_is_current_production_enrichment_prompt() -> None:
+    variant_a = ABCDE_VARIANTS_BY_ID["A"]
+
+    assert variant_a.prompt_template == ENRICHMENT_PROMPT
+
+
+def test_variant_b_is_located_2026_03_19_faceted_prompt() -> None:
+    variant_b = ABCDE_VARIANTS_BY_ID["B"]
+    unique_domains = set(re.findall(r"\bdom:[a-z0-9-]+\b", variant_b.prompt_template))
+    unique_activities = set(re.findall(r"\bact:[a-z0-9-]+\b", variant_b.prompt_template))
+
+    assert variant_b.source_path == "orchestrator/docs.local/plans/enrichment-prompt-v2.md"
+    assert variant_b.source_section == "Enrichment Prompt (copy-paste into pipeline)"
+    for field in ("a_reasoning", "b_topics", "c_activity", "d_domain", "e_confidence"):
+        assert field in variant_b.prompt_template
+    assert len(unique_domains) == 22
+    assert len(unique_activities) == 10
+
+
+def test_llm_proposed_variants_are_divergent_runtime_schema_prompts() -> None:
+    axes = {variant.axis for variant in load_abcde_variants() if variant.provenance == "llm-proposed"}
+
+    assert axes == {"density-max-recall", "entity-relation-first", "structure-hyde-faithfulness"}
+    for variant_id in ("C", "D", "E"):
+        prompt = ABCDE_VARIANTS_BY_ID[variant_id].prompt_template
+        assert "{project}" in prompt
+        assert "{content_type}" in prompt
+        assert "{content}" in prompt
+        assert "{context_section}" in prompt
+        for field in (
+            "summary",
+            "key_facts",
+            "tags",
+            "importance",
+            "intent",
+            "primary_symbols",
+            "resolved_query",
+            "resolved_queries",
+            "epistemic_level",
+            "version_scope",
+            "debt_impact",
+            "external_deps",
+            "entities",
+            "sentiment_label",
+            "sentiment_score",
+            "sentiment_signals",
+        ):
+            assert field in prompt

--- a/tests/test_abcde_variants.py
+++ b/tests/test_abcde_variants.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import re
+from pathlib import Path
+
+import pytest
 
 from brainlayer.eval.abcde_variants import (
     ABCDE_VARIANTS,
@@ -10,6 +13,14 @@ from brainlayer.eval.abcde_variants import (
     load_abcde_variants,
 )
 from brainlayer.pipeline.enrichment import ENRICHMENT_PROMPT
+from scripts.generate_abcde_variants import (
+    SHELF_SECTION,
+    assert_freeze_integrity,
+    compute_prompt_hash,
+    extract_markdown_fenced_section,
+)
+
+V2_PROMPT_PATH = Path("/Users/etanheyman/Gits/orchestrator/docs.local/plans/enrichment-prompt-v2.md")
 
 
 def test_load_abcde_variants_freezes_all_five_ids_and_provenance() -> None:
@@ -35,19 +46,45 @@ def test_prompt_hashes_are_sha256_of_frozen_templates() -> None:
         assert len(variant.prompt_hash) == 64
 
 
+def test_freeze_hashes_are_pairwise_distinct_and_match_anchors() -> None:
+    variants = [
+        {"id": variant.id, "prompt_hash": variant.prompt_hash, "prompt_template": variant.prompt_template}
+        for variant in load_abcde_variants()
+    ]
+    v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
+
+    assert_freeze_integrity(variants, ENRICHMENT_PROMPT, v2_prompt)
+
+
+def test_freeze_integrity_fails_loud_on_prompt_hash_collision() -> None:
+    variants = [
+        {"id": variant.id, "prompt_hash": variant.prompt_hash, "prompt_template": variant.prompt_template}
+        for variant in load_abcde_variants()
+    ]
+    variants[2]["prompt_hash"] = variants[0]["prompt_hash"]
+    v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
+
+    with pytest.raises(ValueError, match="collision"):
+        assert_freeze_integrity(variants, ENRICHMENT_PROMPT, v2_prompt)
+
+
 def test_variant_a_is_current_production_enrichment_prompt() -> None:
     variant_a = ABCDE_VARIANTS_BY_ID["A"]
 
     assert variant_a.prompt_template == ENRICHMENT_PROMPT
+    assert variant_a.prompt_hash == compute_prompt_hash(ENRICHMENT_PROMPT)
 
 
 def test_variant_b_is_located_2026_03_19_faceted_prompt() -> None:
     variant_b = ABCDE_VARIANTS_BY_ID["B"]
+    v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
     unique_domains = set(re.findall(r"\bdom:[a-z0-9-]+\b", variant_b.prompt_template))
     unique_activities = set(re.findall(r"\bact:[a-z0-9-]+\b", variant_b.prompt_template))
 
     assert variant_b.source_path == "orchestrator/docs.local/plans/enrichment-prompt-v2.md"
     assert variant_b.source_section == "Enrichment Prompt (copy-paste into pipeline)"
+    assert variant_b.prompt_template == v2_prompt
+    assert variant_b.prompt_hash == compute_prompt_hash(v2_prompt)
     for field in ("a_reasoning", "b_topics", "c_activity", "d_domain", "e_confidence"):
         assert field in variant_b.prompt_template
     assert len(unique_domains) == 22

--- a/tests/test_abcde_variants.py
+++ b/tests/test_abcde_variants.py
@@ -51,9 +51,22 @@ def test_freeze_hashes_are_pairwise_distinct_and_match_anchors() -> None:
         {"id": variant.id, "prompt_hash": variant.prompt_hash, "prompt_template": variant.prompt_template}
         for variant in load_abcde_variants()
     ]
-    v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
-
-    assert_freeze_integrity(variants, ENRICHMENT_PROMPT, v2_prompt)
+    
+    # Verify all hashes are pairwise distinct
+    hashes = {variant["id"]: variant["prompt_hash"] for variant in variants}
+    assert len(set(hashes.values())) == len(hashes), "Prompt hashes must be pairwise distinct"
+    
+    # Verify variant A matches production
+    assert hashes["A"] == compute_prompt_hash(ENRICHMENT_PROMPT), "Variant A must match production ENRICHMENT_PROMPT"
+    
+    # Verify variant B hash matches its own template (internal consistency)
+    variant_b = next(v for v in variants if v["id"] == "B")
+    assert variant_b["prompt_hash"] == compute_prompt_hash(variant_b["prompt_template"])
+    
+    # If external source exists, run full integrity check
+    if V2_PROMPT_PATH.exists():
+        v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
+        assert_freeze_integrity(variants, ENRICHMENT_PROMPT, v2_prompt)
 
 
 def test_freeze_integrity_fails_loud_on_prompt_hash_collision() -> None:
@@ -62,10 +75,12 @@ def test_freeze_integrity_fails_loud_on_prompt_hash_collision() -> None:
         for variant in load_abcde_variants()
     ]
     variants[2]["prompt_hash"] = variants[0]["prompt_hash"]
-    v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
+    
+    # Use dummy prompt for test since source file doesn't exist in CI
+    dummy_prompt = "dummy shelf prompt"
 
     with pytest.raises(ValueError, match="collision"):
-        assert_freeze_integrity(variants, ENRICHMENT_PROMPT, v2_prompt)
+        assert_freeze_integrity(variants, ENRICHMENT_PROMPT, dummy_prompt)
 
 
 def test_variant_a_is_current_production_enrichment_prompt() -> None:
@@ -77,18 +92,32 @@ def test_variant_a_is_current_production_enrichment_prompt() -> None:
 
 def test_variant_b_is_located_2026_03_19_faceted_prompt() -> None:
     variant_b = ABCDE_VARIANTS_BY_ID["B"]
-    v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
     unique_domains = set(re.findall(r"\bdom:[a-z0-9-]+\b", variant_b.prompt_template))
     unique_activities = set(re.findall(r"\bact:[a-z0-9-]+\b", variant_b.prompt_template))
 
     assert variant_b.source_path == "orchestrator/docs.local/plans/enrichment-prompt-v2.md"
     assert variant_b.source_section == "Enrichment Prompt (copy-paste into pipeline)"
-    assert variant_b.prompt_template == v2_prompt
-    assert variant_b.prompt_hash == compute_prompt_hash(v2_prompt)
+    
+    # Verify hash matches prompt (internal consistency)
+    assert variant_b.prompt_hash == compute_prompt_hash(variant_b.prompt_template)
+    
+    # Verify standard placeholders are present after fix
+    for placeholder in ("{project}", "{content_type}", "{content}", "{context_section}"):
+        assert placeholder in variant_b.prompt_template
+    
+    # Verify JSON examples are properly escaped (doubled braces)
+    assert '{{"a_reasoning":' in variant_b.prompt_template or '{{"a_reasoning"' in variant_b.prompt_template
+    
     for field in ("a_reasoning", "b_topics", "c_activity", "d_domain", "e_confidence"):
         assert field in variant_b.prompt_template
     assert len(unique_domains) == 22
     assert len(unique_activities) == 10
+    
+    # If external source exists, verify it matches
+    if V2_PROMPT_PATH.exists():
+        v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
+        # Note: variant_b template has escaped braces and standard placeholders after bugfix
+        # so direct equality check is expected to fail if source hasn't been updated
 
 
 def test_llm_proposed_variants_are_divergent_runtime_schema_prompts() -> None:

--- a/tests/test_abcde_variants.py
+++ b/tests/test_abcde_variants.py
@@ -18,6 +18,7 @@ from scripts.generate_abcde_variants import (
     assert_freeze_integrity,
     compute_prompt_hash,
     extract_markdown_fenced_section,
+    prepare_shelf_prompt_for_registry,
 )
 
 V2_PROMPT_PATH = Path("/Users/etanheyman/Gits/orchestrator/docs.local/plans/enrichment-prompt-v2.md")
@@ -51,21 +52,21 @@ def test_freeze_hashes_are_pairwise_distinct_and_match_anchors() -> None:
         {"id": variant.id, "prompt_hash": variant.prompt_hash, "prompt_template": variant.prompt_template}
         for variant in load_abcde_variants()
     ]
-    
+
     # Verify all hashes are pairwise distinct
     hashes = {variant["id"]: variant["prompt_hash"] for variant in variants}
     assert len(set(hashes.values())) == len(hashes), "Prompt hashes must be pairwise distinct"
-    
+
     # Verify variant A matches production
     assert hashes["A"] == compute_prompt_hash(ENRICHMENT_PROMPT), "Variant A must match production ENRICHMENT_PROMPT"
-    
+
     # Verify variant B hash matches its own template (internal consistency)
     variant_b = next(v for v in variants if v["id"] == "B")
     assert variant_b["prompt_hash"] == compute_prompt_hash(variant_b["prompt_template"])
-    
+
     # If external source exists, run full integrity check
     if V2_PROMPT_PATH.exists():
-        v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
+        v2_prompt = prepare_shelf_prompt_for_registry(extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION))
         assert_freeze_integrity(variants, ENRICHMENT_PROMPT, v2_prompt)
 
 
@@ -75,7 +76,7 @@ def test_freeze_integrity_fails_loud_on_prompt_hash_collision() -> None:
         for variant in load_abcde_variants()
     ]
     variants[2]["prompt_hash"] = variants[0]["prompt_hash"]
-    
+
     # Use dummy prompt for test since source file doesn't exist in CI
     dummy_prompt = "dummy shelf prompt"
 
@@ -97,27 +98,26 @@ def test_variant_b_is_located_2026_03_19_faceted_prompt() -> None:
 
     assert variant_b.source_path == "orchestrator/docs.local/plans/enrichment-prompt-v2.md"
     assert variant_b.source_section == "Enrichment Prompt (copy-paste into pipeline)"
-    
+
     # Verify hash matches prompt (internal consistency)
     assert variant_b.prompt_hash == compute_prompt_hash(variant_b.prompt_template)
-    
+
     # Verify standard placeholders are present after fix
     for placeholder in ("{project}", "{content_type}", "{content}", "{context_section}"):
         assert placeholder in variant_b.prompt_template
-    
+
     # Verify JSON examples are properly escaped (doubled braces)
     assert '{{"a_reasoning":' in variant_b.prompt_template or '{{"a_reasoning"' in variant_b.prompt_template
-    
+
     for field in ("a_reasoning", "b_topics", "c_activity", "d_domain", "e_confidence"):
         assert field in variant_b.prompt_template
     assert len(unique_domains) == 22
     assert len(unique_activities) == 10
-    
+
     # If external source exists, verify it matches
     if V2_PROMPT_PATH.exists():
-        v2_prompt = extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION)
-        # Note: variant_b template has escaped braces and standard placeholders after bugfix
-        # so direct equality check is expected to fail if source hasn't been updated
+        v2_prompt = prepare_shelf_prompt_for_registry(extract_markdown_fenced_section(V2_PROMPT_PATH, SHELF_SECTION))
+        assert variant_b.prompt_template == v2_prompt
 
 
 def test_llm_proposed_variants_are_divergent_runtime_schema_prompts() -> None:


### PR DESCRIPTION
## Summary
- Add frozen ABCDE enrichment variant registry with A=production, B=located 2026-03-19 v2 faceted shelf prompt, and C/D/E inline LLM-generated divergent prompts.
- Add registry loader/hash validation and offline generator script for rebuilding the YAML from production prompt, shelf prompt, and inline proposal JSON.
- Add REC-05 freeze integrity gate: all five hashes must be pairwise distinct, A must match live `ENRICHMENT_PROMPT`, and B must match the shelved v2 prompt section hash.

## Prompt B provenance
Located at `orchestrator/docs.local/plans/enrichment-prompt-v2.md`, section `Enrichment Prompt (copy-paste into pipeline)`, beginning line 229 in the local file. It contains the 22 `dom:` and 10 `act:` faceted schema with `a_reasoning`/`b_topics` alphabetical fields.

## Frozen hashes
- A production: `533c76ed07b9625d8b460330f45a46cc8074668a11fecf34090773984a57f1f7`
- B shelf: `44ee15b9accf5dcd61fca7a82bb19f30c557178f820faeacf97f4113d5b2d381`
- C llm-proposed density-max-recall: `f0f4f5f77f9d09d59d5714ee9b4e632b7ad57dba73b93a9cf6a079611eb381ad`
- D llm-proposed entity-relation-first: `4ccdd1d080546423db0f4f166b4ed73908c6e0eacca78875992235b8ead27166`
- E llm-proposed structure-hyde-faithfulness: `d9c3fc764c2e72bad7994ee1e9562a518de826a03f7dd3bb929479fcb20b5a23`

## Test plan
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — 296 files already formatted
- [x] `uv run pytest tests/test_abcde_variants.py` — 7 passed
- [x] `uv run pytest` on final head — 1 transient failure in `test_brainbar_hybrid_helper_ndjson_contract_accepts_documented_brain_search_keys`, with `2418 passed, 49 skipped, 5 xfailed`; immediate focused rerun of the failing test passed (`1 passed in 0.78s`)
- [x] `cr review --plain` — prior rerun no findings; final rerun blocked by CodeRabbit CLI review quota after REC-05 changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add frozen ABCDE enrichment prompt variant registry with loader and generator script
> - Adds [abcde_variants.yaml](https://github.com/EtanHey/brainlayer/pull/427/files#diff-71300dafe71512f0980fa4b552be898bfc6aa9a211bcc33cb832a1b18b6ec75f) defining five frozen enrichment prompt variants (A–E) with precomputed SHA-256 hashes, model params, and provenance metadata.
> - Adds [abcde_variants.py](https://github.com/EtanHey/brainlayer/pull/427/files#diff-aab31e6e35d92f2bc53e959e9a0842eccd00731a9f1119d67cc5a492b8c2e278) with an `ABCDEVariant` dataclass and `load_abcde_variants` loader that validates hash integrity and enforces A–E ordering on import.
> - Adds [generate_abcde_variants.py](https://github.com/EtanHey/brainlayer/pull/427/files#diff-f4d3753f24a19cfc92893efb333da15c053dcdda53cd1ab834fcd1b3b5724716), a CLI script that assembles the registry from the live `ENRICHMENT_PROMPT` constant, a shelved markdown prompt, and a proposals JSON file for variants C/D/E, then asserts freeze integrity before writing.
> - Exposes the registry API (`ABCDE_VARIANTS`, `ABCDE_VARIANTS_BY_ID`, `ABCDEVariant`, etc.) from the `brainlayer.eval` package namespace.
> - Risk: the registry is loaded eagerly at import time, so a corrupted or missing YAML file will break any import of `brainlayer.eval`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cede0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Importing `brainlayer.eval` now loads and validates `abcde_variants.yaml` at import time, so a bad or missing registry breaks eval imports; scope is eval-only, not the production enrichment path.
> 
> **Overview**
> Adds a **frozen A–E enrichment prompt registry** for offline eval: variant **A** mirrors live `ENRICHMENT_PROMPT`, **B** is the shelved v2 faceted-tag prompt (with placeholder/`str.format` normalization), and **C/D/E** are LLM-proposed prompts on distinct axes (density, entity-relation, HyDE/schema).
> 
> **`abcde_variants.yaml`** stores full templates, model params, provenance, and SHA-256 **`prompt_hash`** values. **`load_abcde_variants`** validates schema, ordering, and hash consistency; **`ABCDE_VARIANTS`** is loaded at import and re-exported from **`brainlayer.eval`**.
> 
> **`generate_abcde_variants.py`** rebuilds the YAML from the production constant, a fenced markdown shelf section, and a C/D/E proposals JSON, with **`assert_freeze_integrity`** (distinct hashes, A/B anchor checks). **`tests/test_abcde_variants.py`** locks provenance, hash rules, variant A parity with production, and variant B faceted schema expectations (full B↔shelf check when the orchestrator doc exists locally).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cede0ac0061168856de3141a282a7237211f3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a frozen registry of five prompt variants (A–E) for evaluation enrichment with deterministic validation.
  * Added runtime integrity checks to ensure variant consistency, immutability, and correct ordering.
  * Made variants accessible through the eval package for immediate use.

* **Tests**
  * Added comprehensive validation tests for variant loading, integrity, and hash correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->