### PR TITLE
chore: add first-turn BrainLayer smoke home

### DIFF
--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -1,0 +1,1 @@
+First-turn BrainLayer smoke test: run `scripts/smoke/firstturn-brainlayer-smoke.sh` to verify the BrainBar MCP socket exposes `brain_search` immediately and answers a fast query.

--- a/scripts/smoke/firstturn-brainlayer-smoke.sh
+++ b/scripts/smoke/firstturn-brainlayer-smoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Smoke test: prove the BrainLayer MCP transport exposes brain_search on the
+# first tools/list and can serve a query quickly over the BrainBar daemon socket.
+#
+# Usage:
+#   scripts/smoke/firstturn-brainlayer-smoke.sh [socket_path]
+#
+# Environment:
+#   DEADLINE_SECS=8    Response deadline for tools/list + query
+#   QUERY=agent-html   Query passed to brain_search
+
+set -u
+
+SOCK="${1:-/tmp/brainbar.sock}"
+DEADLINE_SECS="${DEADLINE_SECS:-8}"
+QUERY="${QUERY:-agent-html}"
+
+if [[ ! -S "$SOCK" ]]; then
+  echo "FAIL: socket not found: $SOCK"
+  exit 2
+fi
+
+# MCP stdio framing = newline-delimited JSON-RPC.
+init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"firstturn-smoke","version":"1.0"}}}'
+inited='{"jsonrpc":"2.0","method":"notifications/initialized"}'
+listtools='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+json_query="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$QUERY")"
+callsearch='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"brain_search","arguments":{"query":'"$json_query"',"num_results":1}}}'
+
+echo "== first-turn BrainLayer smoke =="
+echo "socket: $SOCK   deadline: ${DEADLINE_SECS}s   query: $QUERY"
+
+start=$(date +%s)
+out="$(printf '%s\n%s\n%s\n%s\n' "$init" "$inited" "$listtools" "$callsearch" \
+  | timeout "$DEADLINE_SECS" socat - "UNIX-CONNECT:$SOCK" 2>/dev/null)"
+rc=$?
+end=$(date +%s)
+elapsed=$((end - start))
+
+# CHECK 1: brain_search present on the first tools/list response (id:2).
+if grep -q '"brain_search"' <<<"$out"; then
+  echo "PASS check1: brain_search exposed on first-turn tools/list (${elapsed}s)"
+else
+  echo "FAIL check1: brain_search NOT in first tools/list (rc=$rc, ${elapsed}s)"
+  echo "--- raw (first 400 chars) ---"
+  echo "${out:0:400}"
+  exit 1
+fi
+
+# CHECK 2: the brain_search tools/call (id:3) returned a result, not a timeout/error.
+if grep -q '"id":3' <<<"$out" \
+  && ! grep -qi 'timeout\|DB may be locked\|"isError":true\|Error:' <<<"$out"; then
+  echo "PASS check2: brain_search('$QUERY') returned without timeout (${elapsed}s total)"
+else
+  echo "FAIL check2: brain_search call timed out or errored"
+  echo "--- raw (first 600 chars) ---"
+  echo "${out:0:600}"
+  exit 1
+fi
+
+echo "RESULT: PASS - first-turn BrainLayer parity OK on $SOCK"

--- a/scripts/smoke/firstturn-brainlayer-smoke.sh
+++ b/scripts/smoke/firstturn-brainlayer-smoke.sh
@@ -9,11 +9,18 @@
 #   DEADLINE_SECS=8    Response deadline for tools/list + query
 #   QUERY=agent-html   Query passed to brain_search
 
-set -u
+set -euo pipefail
 
 SOCK="${1:-/tmp/brainbar.sock}"
 DEADLINE_SECS="${DEADLINE_SECS:-8}"
 QUERY="${QUERY:-agent-html}"
+
+for cmd in date grep python3 socat timeout; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "FAIL: required command not found: $cmd"
+    exit 2
+  fi
+done
 
 if [[ ! -S "$SOCK" ]]; then
   echo "FAIL: socket not found: $SOCK"
@@ -31,11 +38,25 @@ echo "== first-turn BrainLayer smoke =="
 echo "socket: $SOCK   deadline: ${DEADLINE_SECS}s   query: $QUERY"
 
 start=$(date +%s)
+set +e
 out="$(printf '%s\n%s\n%s\n%s\n' "$init" "$inited" "$listtools" "$callsearch" \
   | timeout "$DEADLINE_SECS" socat - "UNIX-CONNECT:$SOCK" 2>/dev/null)"
 rc=$?
+set -e
 end=$(date +%s)
 elapsed=$((end - start))
+
+if [[ -z "$out" ]]; then
+  echo "FAIL: no output from MCP socket (rc=$rc, ${elapsed}s)"
+  exit 2
+fi
+
+if [[ "$rc" -eq 124 ]]; then
+  echo "FAIL: MCP socket command timed out after ${DEADLINE_SECS}s"
+  echo "--- raw (first 600 chars) ---"
+  echo "${out:0:600}"
+  exit 2
+fi
 
 # CHECK 1: brain_search present on the first tools/list response (id:2).
 if grep -q '"brain_search"' <<<"$out"; then
@@ -49,7 +70,8 @@ fi
 
 # CHECK 2: the brain_search tools/call (id:3) returned a result, not a timeout/error.
 if grep -q '"id":3' <<<"$out" \
-  && ! grep -qi 'timeout\|DB may be locked\|"isError":true\|Error:' <<<"$out"; then
+  && ! grep -q '"isError":true' <<<"$out" \
+  && ! grep -qi 'timeout\|DB may be locked\|Error:' <<<"$out"; then
   echo "PASS check2: brain_search('$QUERY') returned without timeout (${elapsed}s total)"
 else
   echo "FAIL check2: brain_search call timed out or errored"


### PR DESCRIPTION
## Summary
- Move the first-turn BrainLayer/BrainBar MCP smoke test into `scripts/smoke/firstturn-brainlayer-smoke.sh` so it survives ignored cache cleanup.
- Add `scripts/smoke/README.md` with the permanent pointer.
- Harden query JSON construction and fail the smoke on MCP `isError:true` instead of treating an error response as success.

## Test plan
- [x] `bash -n scripts/smoke/firstturn-brainlayer-smoke.sh && shellcheck scripts/smoke/firstturn-brainlayer-smoke.sh`
- [x] `ruff check src/ tests/`
- [x] `cr review --plain` (No findings)
- [x] `scripts/run_tests.sh` (unit: 2351 passed, 9 skipped, 77 deselected, 1 xfailed, 102 warnings in 228.26s; MCP registration: 3 passed; isolated eval/hooks: 40 passed; bun: 1 pass; regression shell: PASS)

## Runtime note
- `scripts/smoke/firstturn-brainlayer-smoke.sh` currently reaches `/tmp/brainbar.sock` and gets `brain_search` in `tools/list`, but the live daemon returns MCP `isError:true` with `Error: Database not available` for the `brain_search` call even with `DEADLINE_SECS=20`. This PR preserves that as a smoke failure rather than masking it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional bash smoke tooling only; no changes to runtime BrainBar or application code paths.
> 
> **Overview**
> Adds a **permanent home** for the first-turn BrainLayer smoke check under `scripts/smoke/`, so it is not lost when ignored cache paths are cleaned.
> 
> **`firstturn-brainlayer-smoke.sh`** connects to the BrainBar MCP UNIX socket (default `/tmp/brainbar.sock`), sends newline-delimited JSON-RPC (`initialize`, `tools/list`, `tools/call` for `brain_search`), and enforces two checks within `DEADLINE_SECS` (default 8s): `brain_search` appears on the first `tools/list`, and the call returns without timeout or MCP error. Query text is JSON-encoded via `python3`; check 2 **fails on** `"isError":true` and common error strings instead of treating error payloads as success. **`scripts/smoke/README.md`** documents how to run the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892bf0d180a23a45eec8b838dba9b41b2bd4dd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add first-turn BrainLayer smoke test for the BrainBar MCP socket
> - Adds [firstturn-brainlayer-smoke.sh](https://github.com/EtanHey/brainlayer/pull/429/files#diff-18d605e64c7fc048096384ef22a387445287f30369d097668b14bbca99249bfe), a Bash script that connects to a BrainBar UNIX socket and sends a JSON-RPC sequence: `initialize`, `notifications/initialized`, `tools/list`, and a `brain_search` `tools/call`.
> - Passes if `brain_search` appears in the `tools/list` response and the `brain_search` call returns a non-error result within `DEADLINE_SECS` (default 8s).
> - Accepts an optional socket path argument (default `/tmp/brainbar.sock`) and `QUERY`/`DEADLINE_SECS` env vars for configuration.
> - Adds a [README](https://github.com/EtanHey/brainlayer/pull/429/files#diff-5939d32421e4ee262c84d658ee095ec47e567447236d1894fa18a345801e5dcd) documenting how to run the script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 892bf0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal smoke test documentation and validation script to verify system component initialization and response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->