### PR TITLE
feat(eval): ABCDE enrichment variant runner + deterministic report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ claude.scratchpad.md
 # Local eval outputs (tracked baselines remain tracked)
 tests/eval_results/
 
+# Raw enriched eval rows contain PERSONAL chunk content — NEVER commit (privacy).
+# Aggregate metrics go in results/ instead; raw rows archived to Brain Drive.
+eval_results/*.jsonl
+
 # Progress trackers (ephemeral)
 scripts/.kg_rebuild_progress.json
 

--- a/eval_results/abcde_results_summary.md
+++ b/eval_results/abcde_results_summary.md
@@ -1,0 +1,13 @@
+# ABCDE Enrichment Results Summary
+
+| Variant | label | n | ok | gen errors | schema pass % | banned % | mean importance | mean tags | mean key facts | mean entities | mean unsupported entities | mean resolved queries | mean completion tokens | total cost USD | error reasons |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| A | production | 24 | 23 | 1 | 0.0 | 0.0 | 7.13 | 6.70 | 3.61 | 3.22 | 0.57 | 3.00 | 418.2 | 0.807056 | transport_error: HTTPSConnectionPool(host='api.x.ai', port=443): Read timed out. (read timeout=60) x1 |
+| B | faceted-v2 | 24 | 23 | 1 | 0.0 | 0.0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 92.0 | 0.390148 | transport_error: HTTPSConnectionPool(host='api.x.ai', port=443): Read timed out. (read timeout=60) x1 |
+| C | density-max | 24 | 24 | 0 | 87.5 | 0.0 | 6.88 | 6.62 | 14.38 | 2.58 | 0.75 | 3.00 | 609.6 | 0.793276 | - |
+| D | entity-first | 24 | 23 | 1 | 91.3 | 0.0 | 6.52 | 6.13 | 2.26 | 5.30 | 1.00 | 3.00 | 447.2 | 0.588029 | transport_error: HTTPSConnectionPool(host='api.x.ai', port=443): Read timed out. (read timeout=60) x1 |
+| E | hyde-structure | 24 | 23 | 1 | 95.7 | 0.0 | 6.43 | 6.91 | 6.09 | 3.22 | 1.00 | 3.00 | 538.7 | 0.634110 | transport_error: HTTPSConnectionPool(host='api.x.ai', port=443): Read timed out. (read timeout=60) x1 |
+
+TOTALS: 120 calls, 116 ok, 4 generation errors, $3.212619 metered in this JSONL. Smoke added ~$0.55 separately.
+
+Read: variant E looks strongest on deterministic signals among variants with 0.0% banned-pattern hits: schema pass 95.7%, mean key facts 6.09, mean entities 3.22, mean unsupported entities 1.00. Variant A fails schema_gate only on the missing legacy `resolved_query` key; it has `resolved_queries` x3. Variant B uses the faceted-tagger schema, not the enrichment schema. LLM judge pass is separate/pending.

--- a/results/abcde_n893_summary.json
+++ b/results/abcde_n893_summary.json
@@ -1,0 +1,60 @@
+{
+  "meta": {
+    "n_chunks": 893,
+    "method": "pure-python term-overlap\u00d7idf; queries=top-12 raw-content tokens (variant-agnostic); gold=source chunk; FULL run n=893 (Nebius Llama-3.3-70B re-enrich); self-retrieval \u2014 favors verbatim-copying variants (caveat)",
+    "generated": "2026-06-02",
+    "source": "eval_results/abcde_enrich_nebius.jsonl (2624 ok / 2679, $0.99)"
+  },
+  "per_variant": {
+    "A": {
+      "ok_chunks": 880,
+      "scored_queries": 879,
+      "indexed_coverage": 0.99,
+      "recall@1": 0.62,
+      "recall@5": 0.849,
+      "recall@10": 0.917,
+      "mrr": 0.726,
+      "ndcg@10": 0.769
+    },
+    "B": {
+      "ok_chunks": 0,
+      "scored_queries": 0,
+      "indexed_coverage": 0,
+      "recall@1": 0.0,
+      "recall@5": 0.0,
+      "recall@10": 0.0,
+      "mrr": 0,
+      "ndcg@10": 0
+    },
+    "C": {
+      "ok_chunks": 868,
+      "scored_queries": 867,
+      "indexed_coverage": 0.97,
+      "recall@1": 0.625,
+      "recall@5": 0.858,
+      "recall@10": 0.934,
+      "mrr": 0.731,
+      "ndcg@10": 0.778
+    },
+    "D": {
+      "ok_chunks": 0,
+      "scored_queries": 0,
+      "indexed_coverage": 0,
+      "recall@1": 0.0,
+      "recall@5": 0.0,
+      "recall@10": 0.0,
+      "mrr": 0,
+      "ndcg@10": 0
+    },
+    "E": {
+      "ok_chunks": 876,
+      "scored_queries": 875,
+      "indexed_coverage": 1.0,
+      "recall@1": 0.638,
+      "recall@5": 0.874,
+      "recall@10": 0.93,
+      "mrr": 0.741,
+      "ndcg@10": 0.784
+    }
+  }
+}

--- a/results/abcde_n893_summary.md
+++ b/results/abcde_n893_summary.md
@@ -1,0 +1,33 @@
+# ABCDE Enrichment Retrieval Benchmark — n=893 (aggregate, PII-free)
+
+> Aggregate metrics only. Raw enriched rows contain personal chunk content and are **gitignored + archived to Brain Drive** (not committed).
+
+## Run metadata
+- **Date:** 2026-06-02
+- **Sample:** 893 chunks × 3 variants (A production, C density-max, E hyde-structure) = 2,679 enrichment calls
+- **Backend:** Nebius `meta-llama/Llama-3.3-70B-Instruct` (OpenAI-compatible)
+- **Outcome:** 2,624 ok / 55 transient errors (2%), 0 safety-blocks, ~67 min, **$0.99**
+- **Code SHA:** `a1d16429` (branch `feat/brainlayer-abcde-enrich-runner`, PR #430)
+- **Raw data (gitignored):** `eval_results/abcde_enrich_nebius.jsonl` → archived to Brain Drive
+
+## Method
+Self-retrieval: per variant, build an in-corpus index over the enriched text (summary + tags + key_facts + resolved_queries); query = top-12 distinctive tokens from each chunk's **raw** content (variant-agnostic); gold = the source chunk. Pure term-overlap × idf ranking. Same queries across variants.
+
+## Results (recall@k / MRR / nDCG@10)
+
+| variant | recall@1 | recall@5 | recall@10 | MRR | nDCG@10 |
+|---|---|---|---|---|---|
+| A — production | 0.620 | 0.849 | 0.917 | 0.726 | 0.769 |
+| C — density-max | 0.625 | 0.858 | **0.934** | 0.731 | 0.778 |
+| **E — hyde-structure** | **0.638** | **0.874** | 0.930 | **0.741** | **0.784** |
+
+(B/D not run this pass — only A,C,E were re-enriched.)
+
+## Finding (honest)
+**E (hyde-structure) is consistently the best enrichment recipe** for retrieval (wins 4/5 metrics; C edges recall@10) — **but the effect is modest**: A/C/E are within ~3% (recall@1 E vs A = +0.018). Ordering E > C > A is real and consistent; magnitude is small at scale.
+
+**Correction:** an earlier n=24 micro-benchmark showed a dramatic gap (C 0.96 vs A 0.61). That was a **small-corpus artifact** amplified by the self-retrieval method. The n=893 result above is the realistic picture.
+
+## Caveats
+- Self-retrieval measures **term-preservation**, not real-query relevance over the corpus.
+- The definitive verdict needs the human-labeled query set (Task B, 51 queries) with gold judgments, plus the LLM-judge **quality** pass (pending calibration floors).

--- a/scripts/abcde_report.py
+++ b/scripts/abcde_report.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Build a deterministic per-variant report for ABCDE enrichment generations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from brainlayer.eval.enrichment_graders import (
+    find_banned_summary_pattern,
+    score_entities,
+    validate_schema_gate,
+)
+
+DEFAULT_INPUT = Path("eval_results/abcde_enrich.jsonl")
+DEFAULT_OUTPUT = Path("eval_results/abcde_results_summary.md")
+TICK_USD = 1e-9
+VARIANT_IDS = ("A", "B", "C", "D", "E")
+LABELS = {
+    "A": "production",
+    "B": "faceted-v2",
+    "C": "density-max",
+    "D": "entity-first",
+    "E": "hyde-structure",
+}
+
+
+@dataclass(frozen=True)
+class VariantSummary:
+    variant_id: str
+    label: str
+    n: int
+    ok_n: int
+    gen_error_n: int
+    error_reasons: dict[str, int]
+    schema_error_reasons: dict[str, int]
+    schema_pass_pct: float
+    banned_pattern_pct: float
+    mean_importance: float
+    mean_tags: float
+    mean_key_facts: float
+    mean_entities: float
+    mean_unsupported_entities: float
+    mean_resolved_queries: float
+    mean_completion_tokens: float
+    total_cost_usd: float
+
+
+@dataclass(frozen=True)
+class Report:
+    variants: dict[str, VariantSummary]
+    table: str
+    totals_line: str
+    read_paragraph: str
+    markdown: str
+
+
+@dataclass
+class _VariantAccumulator:
+    variant_id: str
+    n: int = 0
+    ok_n: int = 0
+    gen_error_n: int = 0
+    schema_pass_n: int = 0
+    banned_pattern_n: int = 0
+    importances: list[float] = field(default_factory=list)
+    tags_counts: list[int] = field(default_factory=list)
+    key_facts_counts: list[int] = field(default_factory=list)
+    entities_counts: list[int] = field(default_factory=list)
+    unsupported_entity_counts: list[int] = field(default_factory=list)
+    resolved_queries_counts: list[int] = field(default_factory=list)
+    completion_tokens: list[int] = field(default_factory=list)
+    total_cost_usd: float = 0.0
+    error_reasons: Counter[str] = field(default_factory=Counter)
+    schema_error_reasons: Counter[str] = field(default_factory=Counter)
+
+    def record(self, row: Mapping[str, Any], *, tick_usd: float) -> None:
+        self.n += 1
+        generation = _mapping(row.get("generation"))
+        usage = _mapping(generation.get("usage"))
+        self.completion_tokens.append(_non_negative_int(usage.get("completion_tokens")))
+        self.total_cost_usd += _non_negative_int(usage.get("cost_in_usd_ticks")) * tick_usd
+
+        status = generation.get("status")
+        if status != "ok":
+            self.gen_error_n += 1
+            reason = str(generation.get("error") or status or "unknown_error")
+            self.error_reasons[reason] += 1
+            return
+
+        self.ok_n += 1
+        enrichment = _mapping(row.get("enrichment"))
+        chunk_text = str(row.get("chunk_text") or "")
+
+        schema = validate_schema_gate(enrichment)
+        if schema.passed:
+            self.schema_pass_n += 1
+        else:
+            self.schema_error_reasons.update(schema.errors)
+        if find_banned_summary_pattern(str(enrichment.get("summary") or "")) is not None:
+            self.banned_pattern_n += 1
+
+        importance = enrichment.get("importance")
+        if isinstance(importance, (int, float)) and not isinstance(importance, bool):
+            self.importances.append(float(importance))
+
+        self.tags_counts.append(_list_len(enrichment.get("tags")))
+        self.key_facts_counts.append(_list_len(enrichment.get("key_facts")))
+        self.entities_counts.append(_list_len(enrichment.get("entities")))
+        self.resolved_queries_counts.append(_list_len(enrichment.get("resolved_queries")))
+        entity_metrics = score_entities(enrichment, {"gold_entities": []}, chunk_text)
+        self.unsupported_entity_counts.append(len(entity_metrics.hallucinated_entities))
+
+    def summary(self) -> VariantSummary:
+        return VariantSummary(
+            variant_id=self.variant_id,
+            label=LABELS.get(self.variant_id, "unknown"),
+            n=self.n,
+            ok_n=self.ok_n,
+            gen_error_n=self.gen_error_n,
+            error_reasons=dict(sorted(self.error_reasons.items())),
+            schema_error_reasons=dict(sorted(self.schema_error_reasons.items())),
+            schema_pass_pct=_pct(self.schema_pass_n, self.ok_n),
+            banned_pattern_pct=_pct(self.banned_pattern_n, self.ok_n),
+            mean_importance=_mean(self.importances),
+            mean_tags=_mean(self.tags_counts),
+            mean_key_facts=_mean(self.key_facts_counts),
+            mean_entities=_mean(self.entities_counts),
+            mean_unsupported_entities=_mean(self.unsupported_entity_counts),
+            mean_resolved_queries=_mean(self.resolved_queries_counts),
+            mean_completion_tokens=_mean(self.completion_tokens),
+            total_cost_usd=self.total_cost_usd,
+        )
+
+
+def build_report(input_path: Path | str = DEFAULT_INPUT, *, tick_usd: float = TICK_USD) -> Report:
+    rows = list(_read_jsonl(Path(input_path)))
+    accumulators = {variant_id: _VariantAccumulator(variant_id) for variant_id in VARIANT_IDS}
+    for row in rows:
+        variant_id = str(row.get("variant_id") or "")
+        if variant_id not in accumulators:
+            accumulators[variant_id] = _VariantAccumulator(variant_id)
+        accumulators[variant_id].record(row, tick_usd=tick_usd)
+
+    variant_order = [*VARIANT_IDS, *sorted(set(accumulators) - set(VARIANT_IDS))]
+    variants = {variant_id: accumulators[variant_id].summary() for variant_id in variant_order}
+    table = _format_table(variants.values())
+    totals_line = _format_totals(variants.values())
+    read_paragraph = _format_read(variants.values())
+    markdown = "\n\n".join(("# ABCDE Enrichment Results Summary", table, totals_line, read_paragraph)) + "\n"
+    return Report(variants=variants, table=table, totals_line=totals_line, read_paragraph=read_paragraph, markdown=markdown)
+
+
+def write_report(report: Report, output_path: Path | str = DEFAULT_OUTPUT) -> None:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(report.markdown, encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--tick-usd", type=float, default=TICK_USD)
+    args = parser.parse_args(argv)
+
+    report = build_report(args.input, tick_usd=args.tick_usd)
+    write_report(report, args.output)
+    print(report.table)
+    return 0
+
+
+def _read_jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number} is not a JSON object")
+            yield row
+
+
+def _format_table(summaries: Iterable[VariantSummary]) -> str:
+    lines = [
+        "| Variant | label | n | ok | gen errors | schema pass % | banned % | mean importance | "
+        "mean tags | mean key facts | mean entities | mean unsupported entities | mean resolved queries | "
+        "mean completion tokens | total cost USD | error reasons |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for summary in summaries:
+        lines.append(
+            f"| {summary.variant_id} | {summary.label} | {summary.n} | {summary.ok_n} | {summary.gen_error_n} | "
+            f"{summary.schema_pass_pct:.1f} | {summary.banned_pattern_pct:.1f} | "
+            f"{summary.mean_importance:.2f} | {summary.mean_tags:.2f} | {summary.mean_key_facts:.2f} | "
+            f"{summary.mean_entities:.2f} | {summary.mean_unsupported_entities:.2f} | "
+            f"{summary.mean_resolved_queries:.2f} | {summary.mean_completion_tokens:.1f} | "
+            f"{summary.total_cost_usd:.6f} | {_format_error_reasons(summary.error_reasons)} |"
+        )
+    return "\n".join(lines)
+
+
+def _format_totals(summaries: Iterable[VariantSummary]) -> str:
+    summary_list = list(summaries)
+    total_calls = sum(summary.n for summary in summary_list)
+    total_ok = sum(summary.ok_n for summary in summary_list)
+    total_errors = sum(summary.gen_error_n for summary in summary_list)
+    total_cost = sum(summary.total_cost_usd for summary in summary_list)
+    return (
+        f"TOTALS: {total_calls} calls, {total_ok} ok, {total_errors} generation errors, "
+        f"${total_cost:.6f} metered in this JSONL. Smoke added ~$0.55 separately."
+    )
+
+
+def _format_read(summaries: Iterable[VariantSummary]) -> str:
+    summary_list = list(summaries)
+    candidates = [summary for summary in summary_list if summary.ok_n > 0 and summary.banned_pattern_pct == 0.0]
+    if not candidates:
+        return (
+            "Read: no variant had ok generations without banned-pattern violations; deterministic signals do not "
+            "identify a strongest variant. LLM judge pass is separate/pending."
+        )
+
+    strongest = max(
+        candidates,
+        key=lambda summary: (
+            summary.schema_pass_pct,
+            summary.mean_key_facts + summary.mean_entities,
+            summary.mean_key_facts,
+            summary.mean_entities,
+            -summary.mean_unsupported_entities,
+            summary.variant_id,
+        ),
+    )
+    notes = _schema_notes(summary_list)
+    return (
+        f"Read: variant {strongest.variant_id} looks strongest on deterministic signals among variants with "
+        f"0.0% banned-pattern hits: schema pass {strongest.schema_pass_pct:.1f}%, "
+        f"mean key facts {strongest.mean_key_facts:.2f}, mean entities {strongest.mean_entities:.2f}, "
+        f"mean unsupported entities {strongest.mean_unsupported_entities:.2f}. "
+        f"{notes} LLM judge pass is separate/pending."
+    )
+
+
+def _schema_notes(summaries: Sequence[VariantSummary]) -> str:
+    by_variant = {summary.variant_id: summary for summary in summaries}
+    notes: list[str] = []
+
+    variant_a = by_variant.get("A")
+    if (
+        variant_a is not None
+        and variant_a.ok_n > 0
+        and variant_a.schema_error_reasons == {"missing required key: resolved_query": variant_a.ok_n}
+        and variant_a.mean_resolved_queries == 3.0
+    ):
+        notes.append(
+            "Variant A fails schema_gate only on the missing legacy `resolved_query` key; "
+            "it has `resolved_queries` x3."
+        )
+
+    variant_b = by_variant.get("B")
+    if variant_b is not None and variant_b.ok_n > 0 and variant_b.schema_pass_pct == 0.0:
+        notes.append("Variant B uses the faceted-tagger schema, not the enrichment schema.")
+
+    return " ".join(notes)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_len(value: Any) -> int:
+    return len(value) if isinstance(value, list) else 0
+
+
+def _mean(values: Sequence[int | float]) -> float:
+    return float(sum(values) / len(values)) if values else 0.0
+
+
+def _pct(numerator: int, denominator: int) -> float:
+    return (numerator / denominator * 100.0) if denominator else 0.0
+
+
+def _non_negative_int(value: Any) -> int:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return max(0, int(value))
+    return 0
+
+
+def _format_error_reasons(reasons: Mapping[str, int]) -> str:
+    if not reasons:
+        return "-"
+    return "; ".join(f"{reason} x{count}" for reason, count in sorted(reasons.items()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_abcde_enrich.py
+++ b/scripts/run_abcde_enrich.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Drive the ABCDE variant enrichment run against an OpenAI-compatible backend.
+
+Read-only chunk sampling (never mutates the DB), mandatory sanitization (inside
+the runner), live cost metering with a hard spend stop. The JUDGE leg is offline
+and not invoked here.
+
+Usage:
+  # smoke: measure real per-item tokens/cost, write nothing permanent
+  op read "op://Private/grok-content-golem/credential" | \
+    python3 scripts/run_abcde_enrich.py --smoke 4 --out /tmp/abcde_smoke.jsonl
+
+  # run: auto-size N to fit the budget, write judge-ready JSONL
+  python3 scripts/run_abcde_enrich.py --run --max-usd 4.20 --avg-usd-per-call 0.019 \
+    --out eval_results/abcde_enrich.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from brainlayer.eval.abcde_enrich_runner import (  # noqa: E402
+    DEFAULT_MODEL,
+    DEFAULT_TICK_USD,
+    make_http_chat_fn,
+    run_batch,
+)
+from brainlayer.eval.abcde_variants import ABCDE_VARIANTS  # noqa: E402
+from brainlayer.paths import get_db_path  # noqa: E402
+from brainlayer.pipeline.sanitize import Sanitizer  # noqa: E402
+
+HIGH_VALUE_TYPES = ("ai_code", "user_message", "assistant_text", "stack_trace")
+
+
+def sample_chunks(n: int, *, min_chars: int = 80, seed: int | None = None) -> list[dict]:
+    """Read-only diverse sample of enrichable chunks. Never writes."""
+    db = get_db_path()
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    try:
+        placeholders = ",".join("?" for _ in HIGH_VALUE_TYPES)
+        # Deterministic-ish: order by a hash of id so the same N is stable across
+        # smoke/run invocations without a writable RANDOM() seed table.
+        rows = con.execute(
+            f"""SELECT id, content, project, content_type, source
+                FROM chunks
+                WHERE content_type IN ({placeholders})
+                  AND char_count >= ?
+                  AND content IS NOT NULL
+                ORDER BY substr(id, -6), id
+                LIMIT ?""",
+            (*HIGH_VALUE_TYPES, min_chars, n),
+        ).fetchall()
+    finally:
+        con.close()
+    return [
+        {"id": r[0], "content": r[1], "project": r[2] or "unknown",
+         "content_type": r[3] or "unknown", "source": r[4]}
+        for r in rows
+    ]
+
+
+def resolve_api_key() -> str:
+    key = os.environ.get("XAI_API_KEY") or os.environ.get("GROK_API_KEY")
+    if key:
+        return key.strip()
+    # Read piped stdin (op read "...| python ...").
+    if not sys.stdin.isatty():
+        piped = sys.stdin.read().strip()
+        if piped:
+            return piped
+    raise SystemExit("No API key. Pipe `op read op://Private/grok-content-golem/credential` or set XAI_API_KEY.")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--smoke", type=int, default=0, help="Smoke: sample this many chunks (×5 variants), measure, stop.")
+    ap.add_argument("--run", action="store_true", help="Full run with budget-sized N.")
+    ap.add_argument("--n", type=int, default=0, help="Explicit chunk count for --run (overrides auto-size).")
+    ap.add_argument("--max-usd", type=float, default=4.20, help="Hard cumulative spend ceiling (USD).")
+    ap.add_argument("--avg-usd-per-call", type=float, default=0.0,
+                    help="Measured avg $/call from smoke; used to auto-size N for --run.")
+    ap.add_argument("--base-url", default="https://api.x.ai/v1")
+    ap.add_argument("--model", default=DEFAULT_MODEL, help="Backend model sent to the OpenAI-compatible API.")
+    ap.add_argument("--tick-usd", type=float, default=DEFAULT_TICK_USD)
+    ap.add_argument("--min-chars", type=int, default=80)
+    ap.add_argument("--out", default="/tmp/abcde_enrich.jsonl")
+    args = ap.parse_args()
+
+    variants = list(ABCDE_VARIANTS)
+    key = resolve_api_key()
+    chat_fn = make_http_chat_fn(base_url=args.base_url, api_key=key, model_override=args.model)
+    sanitizer = Sanitizer.from_env()
+
+    if args.smoke > 0:
+        chunks = sample_chunks(args.smoke, min_chars=args.min_chars)
+        print(f"SMOKE: {len(chunks)} chunks × {len(variants)} variants = {len(chunks)*len(variants)} calls", file=sys.stderr)
+        t0 = time.time()
+        stats = run_batch(chunks, variants, sanitizer, chat_fn, output_path=args.out,
+                          max_usd=args.max_usd, tick_usd=args.tick_usd)
+        out = stats.as_dict()
+        out["wall_seconds"] = round(time.time() - t0, 1)
+        out["per_variant"] = {}  # filled below
+        print(json.dumps(out, indent=2))
+        return
+
+    if args.run:
+        if args.n > 0:
+            n = args.n
+        elif args.avg_usd_per_call > 0:
+            # 5 variants per chunk; 85% safety margin on the budget.
+            n = max(1, int((args.max_usd * 0.85) / (len(variants) * args.avg_usd_per_call)))
+        else:
+            raise SystemExit("--run needs --n or --avg-usd-per-call")
+        chunks = sample_chunks(n, min_chars=args.min_chars)
+        print(f"RUN: N={len(chunks)} chunks × {len(variants)} variants = {len(chunks)*len(variants)} calls "
+              f"(max_usd={args.max_usd})", file=sys.stderr)
+        t0 = time.time()
+        stats = run_batch(chunks, variants, sanitizer, chat_fn, output_path=args.out,
+                          max_usd=args.max_usd, tick_usd=args.tick_usd)
+        out = stats.as_dict()
+        out["wall_seconds"] = round(time.time() - t0, 1)
+        out["output_jsonl"] = args.out
+        print(json.dumps(out, indent=2))
+        return
+
+    raise SystemExit("Pass --smoke N or --run.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_abcde_enrich.py
+++ b/scripts/run_abcde_enrich.py
@@ -28,6 +28,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from brainlayer.eval.abcde_enrich_runner import (  # noqa: E402
+    DEFAULT_FALLBACK_USD_PER_1M,
     DEFAULT_MODEL,
     DEFAULT_TICK_USD,
     make_http_chat_fn,
@@ -67,8 +68,28 @@ def sample_chunks(n: int, *, min_chars: int = 80, seed: int | None = None) -> li
     ]
 
 
+def select_variants(variant_filter: str | None = None) -> list:
+    """Filter ABCDE variants by comma-separated ids while preserving registry order."""
+    if not variant_filter:
+        return list(ABCDE_VARIANTS)
+
+    requested = {item.strip().upper() for item in variant_filter.split(",") if item.strip()}
+    if not requested:
+        return list(ABCDE_VARIANTS)
+
+    available = {variant.id for variant in ABCDE_VARIANTS}
+    unknown = sorted(requested - available)
+    if unknown:
+        raise SystemExit(f"Unknown variant id(s): {','.join(unknown)}")
+
+    selected = [variant for variant in ABCDE_VARIANTS if variant.id in requested]
+    if not selected:
+        raise SystemExit("No variants selected.")
+    return selected
+
+
 def resolve_api_key() -> str:
-    key = os.environ.get("XAI_API_KEY") or os.environ.get("GROK_API_KEY")
+    key = os.environ.get("XAI_API_KEY") or os.environ.get("GROK_API_KEY") or os.environ.get("DEEPSEEK_API_KEY")
     if key:
         return key.strip()
     # Read piped stdin (op read "...| python ...").
@@ -76,7 +97,10 @@ def resolve_api_key() -> str:
         piped = sys.stdin.read().strip()
         if piped:
             return piped
-    raise SystemExit("No API key. Pipe `op read op://Private/grok-content-golem/credential` or set XAI_API_KEY.")
+    raise SystemExit(
+        "No API key. Pipe `op read op://Private/grok-content-golem/credential` "
+        "or set XAI_API_KEY, GROK_API_KEY, or DEEPSEEK_API_KEY."
+    )
 
 
 def main() -> None:
@@ -87,14 +111,20 @@ def main() -> None:
     ap.add_argument("--max-usd", type=float, default=4.20, help="Hard cumulative spend ceiling (USD).")
     ap.add_argument("--avg-usd-per-call", type=float, default=0.0,
                     help="Measured avg $/call from smoke; used to auto-size N for --run.")
+    ap.add_argument("--variants", default="", help="Comma-separated variant ids to run, e.g. A,C,E (default: all).")
+    ap.add_argument("--concurrency", type=int, default=1, help="Concurrent backend calls (default: 1).")
+    ap.add_argument("--max-calls", type=int, default=0, help="Hard cap on successful+failed backend calls (0 = unlimited).")
     ap.add_argument("--base-url", default="https://api.x.ai/v1")
     ap.add_argument("--model", default=DEFAULT_MODEL, help="Backend model sent to the OpenAI-compatible API.")
     ap.add_argument("--tick-usd", type=float, default=DEFAULT_TICK_USD)
+    ap.add_argument("--fallback-usd-per-1m", type=float, default=DEFAULT_FALLBACK_USD_PER_1M,
+                    help="Fallback blended USD per 1M tokens when backend omits cost ticks.")
     ap.add_argument("--min-chars", type=int, default=80)
     ap.add_argument("--out", default="/tmp/abcde_enrich.jsonl")
     args = ap.parse_args()
 
-    variants = list(ABCDE_VARIANTS)
+    variants = select_variants(args.variants)
+    max_calls = args.max_calls if args.max_calls > 0 else None
     key = resolve_api_key()
     chat_fn = make_http_chat_fn(base_url=args.base_url, api_key=key, model_override=args.model)
     sanitizer = Sanitizer.from_env()
@@ -104,7 +134,8 @@ def main() -> None:
         print(f"SMOKE: {len(chunks)} chunks × {len(variants)} variants = {len(chunks)*len(variants)} calls", file=sys.stderr)
         t0 = time.time()
         stats = run_batch(chunks, variants, sanitizer, chat_fn, output_path=args.out,
-                          max_usd=args.max_usd, tick_usd=args.tick_usd)
+                          max_usd=args.max_usd, max_calls=max_calls, tick_usd=args.tick_usd,
+                          fallback_usd_per_1m=args.fallback_usd_per_1m, concurrency=args.concurrency)
         out = stats.as_dict()
         out["wall_seconds"] = round(time.time() - t0, 1)
         out["per_variant"] = {}  # filled below
@@ -121,10 +152,11 @@ def main() -> None:
             raise SystemExit("--run needs --n or --avg-usd-per-call")
         chunks = sample_chunks(n, min_chars=args.min_chars)
         print(f"RUN: N={len(chunks)} chunks × {len(variants)} variants = {len(chunks)*len(variants)} calls "
-              f"(max_usd={args.max_usd})", file=sys.stderr)
+              f"(max_usd={args.max_usd}, max_calls={max_calls or 'unlimited'})", file=sys.stderr)
         t0 = time.time()
         stats = run_batch(chunks, variants, sanitizer, chat_fn, output_path=args.out,
-                          max_usd=args.max_usd, tick_usd=args.tick_usd)
+                          max_usd=args.max_usd, max_calls=max_calls, tick_usd=args.tick_usd,
+                          fallback_usd_per_1m=args.fallback_usd_per_1m, concurrency=args.concurrency)
         out = stats.as_dict()
         out["wall_seconds"] = round(time.time() - t0, 1)
         out["output_jsonl"] = args.out

--- a/src/brainlayer/eval/abcde_enrich_runner.py
+++ b/src/brainlayer/eval/abcde_enrich_runner.py
@@ -1,0 +1,325 @@
+"""ABCDE variant enrichment runner for OpenAI-compatible backends (xAI Grok, DeepSeek).
+
+This is the GENERATION leg of the ABCDE eval: it takes a frozen variant prompt
+(from the registry) plus a source chunk, calls an OpenAI-compatible chat API, and
+parses the result into the production enrichment JSON schema. The output rows are
+consumable by ``enrichment_judge.build_judge_request`` / ``score_jsonl_inline``.
+
+Design constraints:
+  * Sanitization is MANDATORY. ``build_external_prompt`` requires a Sanitizer, so
+    personal data is scrubbed before any external API call — same guarantee the
+    production Gemini path gives.
+  * The JUDGE leg stays offline (a free CLI-agent pane). This module only does
+    generation.
+  * Cost is metered live via ``cost_in_usd_ticks`` (xAI returns it) with a hard
+    cumulative spend stop, so a run can never exceed its budget even if the
+    per-item estimate is wrong.
+
+The HTTP call is injected (``ChatFn``) so tests never hit a real API.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
+
+from brainlayer.eval.abcde_variants import ABCDEVariant
+from brainlayer.pipeline.enrichment import build_external_prompt, parse_enrichment
+
+DEFAULT_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_MODEL = "grok-4.20-0309-non-reasoning"
+# Only 1e-9 USD/tick is physically plausible: 1e-8 implies ~$76/1M tokens and
+# 1e-7 implies ~$765/1M, neither of which exists. See orc gen-7 smoke analysis.
+DEFAULT_TICK_USD = 1e-9
+# Pessimistic blended fallback price when a backend omits cost_in_usd_ticks
+# (e.g. DeepSeek). Used only for the budget meter, never to fabricate telemetry.
+DEFAULT_FALLBACK_USD_PER_1M = 10.0
+
+# (model, prompt, params) -> (http_status, response_json)
+ChatFn = Callable[[str, str, Mapping[str, Any]], "tuple[int, dict]"]
+
+STATUS_OK = "ok"
+STATUS_SAFETY_BLOCKED = "safety_blocked"
+STATUS_ERROR = "error"
+
+
+@dataclass(frozen=True)
+class Usage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost_in_usd_ticks: int = 0
+
+    @property
+    def has_ticks(self) -> bool:
+        return self.cost_in_usd_ticks > 0
+
+
+@dataclass
+class CallResult:
+    status: str
+    enrichment: Optional[dict]
+    raw_text: Optional[str]
+    usage: Usage
+    error: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == STATUS_OK
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised by the driver when the cumulative spend ceiling is reached."""
+
+
+def _to_openai_params(variant_params: Mapping[str, Any]) -> dict[str, Any]:
+    """Map registry params (Gemini-style) to OpenAI-compatible chat params."""
+    params: dict[str, Any] = {}
+    if "temperature" in variant_params:
+        params["temperature"] = variant_params["temperature"]
+    # Registry uses Gemini's max_output_tokens; OpenAI-compatible uses max_tokens.
+    if "max_output_tokens" in variant_params:
+        params["max_tokens"] = variant_params["max_output_tokens"]
+    elif "max_tokens" in variant_params:
+        params["max_tokens"] = variant_params["max_tokens"]
+    return params
+
+
+def _extract_usage(body: Mapping[str, Any]) -> Usage:
+    raw = body.get("usage") if isinstance(body, Mapping) else None
+    if not isinstance(raw, Mapping):
+        return Usage()
+
+    def _int(*names: str) -> int:
+        for name in names:
+            value = raw.get(name)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return max(0, int(value))
+        return 0
+
+    return Usage(
+        prompt_tokens=_int("prompt_tokens"),
+        completion_tokens=_int("completion_tokens"),
+        total_tokens=_int("total_tokens"),
+        cost_in_usd_ticks=_int("cost_in_usd_ticks"),
+    )
+
+
+def _is_safety_block(status: int, body: Mapping[str, Any]) -> bool:
+    if status != 403:
+        return False
+    text = json.dumps(body).lower()
+    return "safety_check" in text or "usage guidelines" in text or "safety" in text
+
+
+def _error_message(body: Mapping[str, Any]) -> str:
+    err = body.get("error") if isinstance(body, Mapping) else None
+    if isinstance(err, Mapping):
+        return str(err.get("message") or err)
+    if isinstance(err, str):
+        return err
+    return json.dumps(body)[:300]
+
+
+def enrich_one(
+    variant: ABCDEVariant,
+    chunk: Mapping[str, Any],
+    sanitizer: Any,
+    chat_fn: ChatFn,
+    *,
+    extra_params: Optional[Mapping[str, Any]] = None,
+) -> CallResult:
+    """Enrich a single chunk with a single variant via an OpenAI-compatible chat API.
+
+    The chunk's content is sanitized inside ``build_external_prompt`` before the
+    prompt is sent to ``chat_fn``.
+    """
+    prompt, _sanitize_result = build_external_prompt(
+        dict(chunk), sanitizer, prompt_template=variant.prompt_template
+    )
+    params = _to_openai_params(variant.params)
+    if extra_params:
+        params.update(extra_params)
+
+    try:
+        status, body = chat_fn(variant.model, prompt, params)
+    except Exception as exc:  # noqa: BLE001 — surface transport errors as a result row
+        return CallResult(STATUS_ERROR, None, None, Usage(), f"transport_error: {exc}")
+
+    if not isinstance(body, Mapping):
+        return CallResult(STATUS_ERROR, None, None, Usage(), f"non_json_response (http {status})")
+
+    usage = _extract_usage(body)
+
+    if status == 200:
+        try:
+            text = body["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            return CallResult(STATUS_ERROR, None, None, usage, "malformed_choices")
+        enrichment = parse_enrichment(text)
+        if enrichment:
+            return CallResult(STATUS_OK, enrichment, text, usage)
+        return CallResult(STATUS_ERROR, None, text, usage, "invalid_enrichment")
+
+    if _is_safety_block(status, body):
+        return CallResult(STATUS_SAFETY_BLOCKED, None, None, usage, _error_message(body))
+
+    return CallResult(STATUS_ERROR, None, None, usage, f"http_{status}: {_error_message(body)}")
+
+
+def usage_to_usd(usage: Usage, *, tick_usd: float = DEFAULT_TICK_USD,
+                 fallback_usd_per_1m: float = DEFAULT_FALLBACK_USD_PER_1M) -> float:
+    """Cost of one call in USD. Prefer authoritative cost_in_usd_ticks; else fall
+    back to a pessimistic blended per-token rate so the budget meter never
+    under-counts an unknown backend."""
+    if usage.has_ticks:
+        return usage.cost_in_usd_ticks * tick_usd
+    tokens = usage.total_tokens or (usage.prompt_tokens + usage.completion_tokens)
+    return tokens * fallback_usd_per_1m / 1_000_000
+
+
+def judge_row(
+    variant: ABCDEVariant,
+    chunk: Mapping[str, Any],
+    result: CallResult,
+) -> dict[str, Any]:
+    """Build a JSONL row shaped for enrichment_judge.build_judge_request.
+
+    Includes generation telemetry (status/usage) for cost accounting; the judge
+    only reads chunk_id/variant_id/chunk_text/enrichment/model/prompt_hash.
+    """
+    return {
+        "chunk_id": str(chunk["id"]),
+        "variant_id": variant.id,
+        "chunk_text": chunk.get("content", ""),
+        "enrichment": result.enrichment if result.enrichment is not None else {},
+        "model": variant.model,
+        "prompt_hash": variant.prompt_hash,
+        "generation": {
+            "status": result.status,
+            "error": result.error,
+            "usage": {
+                "prompt_tokens": result.usage.prompt_tokens,
+                "completion_tokens": result.usage.completion_tokens,
+                "total_tokens": result.usage.total_tokens,
+                "cost_in_usd_ticks": result.usage.cost_in_usd_ticks,
+            },
+        },
+    }
+
+
+@dataclass
+class RunStats:
+    calls: int = 0
+    ok: int = 0
+    safety_blocked: int = 0
+    errors: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost_in_usd_ticks: int = 0
+    usd_spent: float = 0.0
+
+    def record(self, result: CallResult, usd: float) -> None:
+        self.calls += 1
+        if result.status == STATUS_OK:
+            self.ok += 1
+        elif result.status == STATUS_SAFETY_BLOCKED:
+            self.safety_blocked += 1
+        else:
+            self.errors += 1
+        self.prompt_tokens += result.usage.prompt_tokens
+        self.completion_tokens += result.usage.completion_tokens
+        self.total_tokens += result.usage.total_tokens
+        self.cost_in_usd_ticks += result.usage.cost_in_usd_ticks
+        self.usd_spent += usd
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "calls": self.calls,
+            "ok": self.ok,
+            "safety_blocked": self.safety_blocked,
+            "errors": self.errors,
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+            "cost_in_usd_ticks": self.cost_in_usd_ticks,
+            "usd_spent": round(self.usd_spent, 6),
+            "avg_total_tokens_per_call": (self.total_tokens / self.calls) if self.calls else 0.0,
+            "avg_usd_per_call": (self.usd_spent / self.calls) if self.calls else 0.0,
+        }
+
+
+def run_batch(
+    chunks: Sequence[Mapping[str, Any]],
+    variants: Sequence[ABCDEVariant],
+    sanitizer: Any,
+    chat_fn: ChatFn,
+    *,
+    output_path: Optional[str] = None,
+    max_usd: Optional[float] = None,
+    tick_usd: float = DEFAULT_TICK_USD,
+    fallback_usd_per_1m: float = DEFAULT_FALLBACK_USD_PER_1M,
+    on_row: Optional[Callable[[dict[str, Any]], None]] = None,
+) -> RunStats:
+    """Run every (chunk, variant) pair, writing judge-ready rows.
+
+    Hard budget stop: before each call, if the next call could push cumulative
+    spend past ``max_usd``, stop cleanly (rows written so far are preserved).
+    """
+    stats = RunStats()
+    sink = None
+    if output_path is not None:
+        sink = open(output_path, "w", encoding="utf-8")  # noqa: SIM115 — closed in finally
+    try:
+        for chunk in chunks:
+            for variant in variants:
+                if max_usd is not None and stats.calls > 0:
+                    projected = stats.usd_spent + (stats.usd_spent / stats.calls)
+                    if projected > max_usd:
+                        return stats
+                result = enrich_one(variant, chunk, sanitizer, chat_fn)
+                usd = usage_to_usd(result.usage, tick_usd=tick_usd, fallback_usd_per_1m=fallback_usd_per_1m)
+                stats.record(result, usd)
+                row = judge_row(variant, chunk, result)
+                if sink is not None:
+                    sink.write(json.dumps(row, sort_keys=True) + "\n")
+                    sink.flush()
+                if on_row is not None:
+                    on_row(row)
+                if max_usd is not None and stats.usd_spent >= max_usd:
+                    return stats
+    finally:
+        if sink is not None:
+            sink.close()
+    return stats
+
+
+def make_http_chat_fn(*, base_url: str, api_key: str, timeout: int = 60) -> ChatFn:
+    """Build a ChatFn backed by a live OpenAI-compatible endpoint.
+
+    No response_format is forced: the variant prompts already instruct "Return
+    ONLY the JSON object", and forcing json_object mode tripped xAI's content
+    filter on some inputs during smoke testing.
+    """
+    import requests
+
+    url = f"{base_url.rstrip('/')}/chat/completions"
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def _chat(model: str, prompt: str, params: Mapping[str, Any]) -> tuple[int, dict]:
+        payload = {"model": model, "messages": [{"role": "user", "content": prompt}], **params}
+        for attempt in range(3):
+            resp = requests.post(url, headers=headers, json=payload, timeout=timeout)
+            if resp.status_code in (429, 500, 502, 503, 504) and attempt < 2:
+                time.sleep(2 ** attempt)
+                continue
+            try:
+                return resp.status_code, resp.json()
+            except ValueError:
+                return resp.status_code, {"error": {"message": resp.text[:300]}}
+        return resp.status_code, {"error": {"message": "retries_exhausted"}}
+
+    return _chat

--- a/src/brainlayer/eval/abcde_enrich_runner.py
+++ b/src/brainlayer/eval/abcde_enrich_runner.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import json
 import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any, Callable, Mapping, Optional, Sequence
 
 from brainlayer.eval.abcde_variants import ABCDEVariant
@@ -349,8 +351,10 @@ def run_batch(
     *,
     output_path: Optional[str] = None,
     max_usd: Optional[float] = None,
+    max_calls: Optional[int] = None,
     tick_usd: float = DEFAULT_TICK_USD,
     fallback_usd_per_1m: float = DEFAULT_FALLBACK_USD_PER_1M,
+    concurrency: int = 1,
     on_row: Optional[Callable[[dict[str, Any]], None]] = None,
 ) -> RunStats:
     """Run every (chunk, variant) pair, writing judge-ready rows.
@@ -358,28 +362,81 @@ def run_batch(
     Hard budget stop: before each call, if the next call could push cumulative
     spend past ``max_usd``, stop cleanly (rows written so far are preserved).
     """
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    if max_calls is not None and max_calls < 0:
+        raise ValueError("max_calls must be >= 0")
+
     stats = RunStats()
+    lock = Lock()
     sink = None
     if output_path is not None:
         sink = open(output_path, "w", encoding="utf-8")  # noqa: SIM115 — closed in finally
+
+    def should_stop_locked(pending_calls: int = 0) -> bool:
+        if max_calls is not None and stats.calls + pending_calls >= max_calls:
+            return True
+        if max_usd is None:
+            return False
+        if stats.usd_spent >= max_usd:
+            return True
+        if stats.calls == 0:
+            # Submit one call to learn the backend's token/cost shape before
+            # fanning out under a hard spend ceiling.
+            return pending_calls > 0
+        avg_usd = stats.usd_spent / stats.calls
+        projected = stats.usd_spent + (avg_usd * (pending_calls + 1))
+        return projected >= max_usd
+
+    def record_result(variant: ABCDEVariant, chunk: Mapping[str, Any], result: CallResult) -> None:
+        usd = usage_to_usd(result.usage, tick_usd=tick_usd, fallback_usd_per_1m=fallback_usd_per_1m)
+        row = judge_row(variant, chunk, result)
+        with lock:
+            stats.record(result, usd)
+            if sink is not None:
+                sink.write(json.dumps(row, sort_keys=True) + "\n")
+                sink.flush()
+            if on_row is not None:
+                on_row(row)
+
     try:
-        for chunk in chunks:
-            for variant in variants:
-                if max_usd is not None and stats.calls > 0:
-                    projected = stats.usd_spent + (stats.usd_spent / stats.calls)
-                    if projected > max_usd:
+        work_items = ((chunk, variant) for chunk in chunks for variant in variants)
+        if concurrency == 1:
+            for chunk, variant in work_items:
+                with lock:
+                    if should_stop_locked():
                         return stats
                 result = enrich_one(variant, chunk, sanitizer, chat_fn)
-                usd = usage_to_usd(result.usage, tick_usd=tick_usd, fallback_usd_per_1m=fallback_usd_per_1m)
-                stats.record(result, usd)
-                row = judge_row(variant, chunk, result)
-                if sink is not None:
-                    sink.write(json.dumps(row, sort_keys=True) + "\n")
-                    sink.flush()
-                if on_row is not None:
-                    on_row(row)
-                if max_usd is not None and stats.usd_spent >= max_usd:
-                    return stats
+                record_result(variant, chunk, result)
+                with lock:
+                    if should_stop_locked():
+                        return stats
+            return stats
+
+        pending: dict[Future[CallResult], tuple[Mapping[str, Any], ABCDEVariant]] = {}
+
+        def submit_next(executor: ThreadPoolExecutor) -> bool:
+            with lock:
+                if should_stop_locked(pending_calls=len(pending)):
+                    return False
+            try:
+                chunk, variant = next(work_items)
+            except StopIteration:
+                return False
+            pending[executor.submit(enrich_one, variant, chunk, sanitizer, chat_fn)] = (chunk, variant)
+            return True
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            while len(pending) < concurrency and submit_next(executor):
+                pass
+
+            while pending:
+                done, _not_done = wait(pending, return_when=FIRST_COMPLETED)
+                for future in done:
+                    chunk, variant = pending.pop(future)
+                    record_result(variant, chunk, future.result())
+                while len(pending) < concurrency and submit_next(executor):
+                    pass
     finally:
         if sink is not None:
             sink.close()

--- a/src/brainlayer/eval/abcde_enrich_runner.py
+++ b/src/brainlayer/eval/abcde_enrich_runner.py
@@ -182,9 +182,7 @@ def enrich_one(
     The chunk's content is sanitized inside ``build_external_prompt`` before the
     prompt is sent to ``chat_fn``.
     """
-    prompt, _sanitize_result = build_external_prompt(
-        dict(chunk), sanitizer, prompt_template=variant.prompt_template
-    )
+    prompt, _sanitize_result = build_external_prompt(dict(chunk), sanitizer, prompt_template=variant.prompt_template)
     params = _to_openai_params(variant.params)
     if extra_params:
         params.update(extra_params)
@@ -259,8 +257,9 @@ def enrich_one(
     )
 
 
-def usage_to_usd(usage: Usage, *, tick_usd: float = DEFAULT_TICK_USD,
-                 fallback_usd_per_1m: float = DEFAULT_FALLBACK_USD_PER_1M) -> float:
+def usage_to_usd(
+    usage: Usage, *, tick_usd: float = DEFAULT_TICK_USD, fallback_usd_per_1m: float = DEFAULT_FALLBACK_USD_PER_1M
+) -> float:
     """Cost of one call in USD. Prefer authoritative cost_in_usd_ticks; else fall
     back to a pessimistic blended per-token rate so the budget meter never
     under-counts an unknown backend."""
@@ -467,7 +466,7 @@ def make_http_chat_fn(
         for attempt in range(3):
             resp = requests.post(url, headers=headers, json=payload, timeout=timeout)
             if resp.status_code in (429, 500, 502, 503, 504) and attempt < 2:
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
                 continue
             try:
                 return resp.status_code, resp.json()

--- a/src/brainlayer/eval/abcde_enrich_runner.py
+++ b/src/brainlayer/eval/abcde_enrich_runner.py
@@ -22,11 +22,11 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import dataclass, field
-from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from brainlayer.eval.abcde_variants import ABCDEVariant
-from brainlayer.pipeline.enrichment import build_external_prompt, parse_enrichment
+from brainlayer.pipeline.enrichment import build_external_prompt
 
 DEFAULT_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_MODEL = "grok-4.20-0309-non-reasoning"
@@ -64,6 +64,7 @@ class CallResult:
     raw_text: Optional[str]
     usage: Usage
     error: Optional[str] = None
+    backend_model: Optional[str] = None
 
     @property
     def ok(self) -> bool:
@@ -114,6 +115,49 @@ def _is_safety_block(status: int, body: Mapping[str, Any]) -> bool:
     return "safety_check" in text or "usage guidelines" in text or "safety" in text
 
 
+def _extract_json_object(text: str) -> Optional[dict[str, Any]]:
+    """Extract the first balanced top-level JSON object embedded in text."""
+    if not text:
+        return None
+
+    for start, char in enumerate(text):
+        if char != "{":
+            continue
+
+        depth = 0
+        in_string = False
+        escaped = False
+        for end in range(start, len(text)):
+            current = text[end]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif current == "\\":
+                    escaped = True
+                elif current == '"':
+                    in_string = False
+                continue
+
+            if current == '"':
+                in_string = True
+            elif current == "{":
+                depth += 1
+            elif current == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        parsed = json.loads(text[start : end + 1])
+                    except json.JSONDecodeError:
+                        break
+                    if isinstance(parsed, dict):
+                        return parsed
+                    break
+                if depth < 0:
+                    break
+
+    return None
+
+
 def _error_message(body: Mapping[str, Any]) -> str:
     err = body.get("error") if isinstance(body, Mapping) else None
     if isinstance(err, Mapping):
@@ -143,13 +187,29 @@ def enrich_one(
     if extra_params:
         params.update(extra_params)
 
+    backend_model = getattr(chat_fn, "backend_model", None) or variant.model
+
     try:
         status, body = chat_fn(variant.model, prompt, params)
     except Exception as exc:  # noqa: BLE001 — surface transport errors as a result row
-        return CallResult(STATUS_ERROR, None, None, Usage(), f"transport_error: {exc}")
+        return CallResult(
+            STATUS_ERROR,
+            None,
+            None,
+            Usage(),
+            f"transport_error: {exc}",
+            backend_model=backend_model,
+        )
 
     if not isinstance(body, Mapping):
-        return CallResult(STATUS_ERROR, None, None, Usage(), f"non_json_response (http {status})")
+        return CallResult(
+            STATUS_ERROR,
+            None,
+            None,
+            Usage(),
+            f"non_json_response (http {status})",
+            backend_model=backend_model,
+        )
 
     usage = _extract_usage(body)
 
@@ -157,16 +217,44 @@ def enrich_one(
         try:
             text = body["choices"][0]["message"]["content"]
         except (KeyError, IndexError, TypeError):
-            return CallResult(STATUS_ERROR, None, None, usage, "malformed_choices")
-        enrichment = parse_enrichment(text)
-        if enrichment:
-            return CallResult(STATUS_OK, enrichment, text, usage)
-        return CallResult(STATUS_ERROR, None, text, usage, "invalid_enrichment")
+            return CallResult(
+                STATUS_ERROR,
+                None,
+                None,
+                usage,
+                "malformed_choices",
+                backend_model=backend_model,
+            )
+        enrichment = _extract_json_object(text)
+        if enrichment is None:
+            return CallResult(
+                STATUS_ERROR,
+                None,
+                text,
+                usage,
+                "invalid_json",
+                backend_model=backend_model,
+            )
+        return CallResult(STATUS_OK, enrichment, text, usage, backend_model=backend_model)
 
     if _is_safety_block(status, body):
-        return CallResult(STATUS_SAFETY_BLOCKED, None, None, usage, _error_message(body))
+        return CallResult(
+            STATUS_SAFETY_BLOCKED,
+            None,
+            None,
+            usage,
+            _error_message(body),
+            backend_model=backend_model,
+        )
 
-    return CallResult(STATUS_ERROR, None, None, usage, f"http_{status}: {_error_message(body)}")
+    return CallResult(
+        STATUS_ERROR,
+        None,
+        None,
+        usage,
+        f"http_{status}: {_error_message(body)}",
+        backend_model=backend_model,
+    )
 
 
 def usage_to_usd(usage: Usage, *, tick_usd: float = DEFAULT_TICK_USD,
@@ -200,6 +288,7 @@ def judge_row(
         "generation": {
             "status": result.status,
             "error": result.error,
+            "backend_model": result.backend_model,
             "usage": {
                 "prompt_tokens": result.usage.prompt_tokens,
                 "completion_tokens": result.usage.completion_tokens,
@@ -297,7 +386,13 @@ def run_batch(
     return stats
 
 
-def make_http_chat_fn(*, base_url: str, api_key: str, timeout: int = 60) -> ChatFn:
+def make_http_chat_fn(
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: int = 60,
+    model_override: Optional[str] = None,
+) -> ChatFn:
     """Build a ChatFn backed by a live OpenAI-compatible endpoint.
 
     No response_format is forced: the variant prompts already instruct "Return
@@ -310,7 +405,8 @@ def make_http_chat_fn(*, base_url: str, api_key: str, timeout: int = 60) -> Chat
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
     def _chat(model: str, prompt: str, params: Mapping[str, Any]) -> tuple[int, dict]:
-        payload = {"model": model, "messages": [{"role": "user", "content": prompt}], **params}
+        payload_model = model_override or model
+        payload = {"model": payload_model, "messages": [{"role": "user", "content": prompt}], **params}
         for attempt in range(3):
             resp = requests.post(url, headers=headers, json=payload, timeout=timeout)
             if resp.status_code in (429, 500, 502, 503, 504) and attempt < 2:
@@ -322,4 +418,6 @@ def make_http_chat_fn(*, base_url: str, api_key: str, timeout: int = 60) -> Chat
                 return resp.status_code, {"error": {"message": resp.text[:300]}}
         return resp.status_code, {"error": {"message": "retries_exhausted"}}
 
+    if model_override is not None:
+        _chat.backend_model = model_override  # type: ignore[attr-defined]
     return _chat

--- a/src/brainlayer/eval/abcde_variants.yaml
+++ b/src/brainlayer/eval/abcde_variants.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-frozen_at: '2026-06-01T08:47:49+00:00'
+frozen_at: '2026-06-01T15:15:09+00:00'
 hash_algorithm: sha256
 variants:
 - id: A
@@ -181,127 +181,144 @@ variants:
   source_section: Enrichment Prompt (copy-paste into pipeline)
   prompt_hash: df3ee7a5768f735ea90c557d3bf22dba0a5cc7b4ae36b374ba1643ba6960091e
 - id: C
-  label: inline-density-max-recall
-  prompt_template: "You are a recall-maximizing knowledge extraction engine for BrainLayer. Your output will be embedded for\
-    \ vector search and indexed for full-text search. Extract dense, fact-rich metadata from the chunk; do not describe the\
-    \ chunk.\n\nAXIS: density-max-recall. Prefer preserving too many concrete facts over producing a tidy short abstraction.\
-    \ The summary, key_facts, tags, and resolved_queries should make the chunk findable by names, numbers, paths, errors,\
-    \ projects, dates, and decisions.\n\nRULES:\n1. Write as the expert stating facts, not as a cataloger describing source\
-    \ text.\n2. Preserve every concrete value verbatim: people, projects, PRs, issue numbers, commit hashes, dates, file paths,\
-    \ URLs, versions, costs, command names, config keys, model names, errors, ports, and metrics.\n3. Summary must be standalone\
-    \ and front-loaded with the most unique facts.\n4. key_facts is the recall ledger: include every retrievable atomic fact,\
-    \ even when the summary already mentions it.\n5. If the chunk is short or conversational, extract commitments, decisions,\
-    \ blockers, and actionable facts; ignore filler.\n\nBANNED PATTERNS:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
+  label: density-max-recall-extraction
+  prompt_template: "You are a recall-maximizing knowledge extraction engine for a personal knowledge graph. Your output is\
+    \ embedded for vector search AND indexed for FTS. Maximize retrievable facts per token — never trade away specifics for\
+    \ brevity.\n\nAXIS (density-max-recall): Extract EVERY concrete value from the chunk into key_facts first, then write\
+    \ a summary that preserves them. Prefer over-capture to under-capture. If the chunk mentions it, it belongs in key_facts\
+    \ or summary.\n\nRULES:\n1. Write as if you ARE the expert stating facts — never as a librarian cataloging a document\n\
+    2. Preserve ALL specific values verbatim: names, numbers, dates, PR numbers, costs, file paths, URLs, error messages,\
+    \ version numbers, branch names, config keys\n3. Summary must be standalone — a reader with no context learns the key\
+    \ facts without reading the chunk\n4. Front-load the most unique/searchable facts (identifiers, decisions, outcomes)\n\
+    5. key_facts is the primary recall surface: target 6–20 verbatim strings on dense chunks; include partial lines, error\
+    \ codes, and quoted phrases when present\n6. Do not deduplicate near-duplicates in key_facts if wording differs — recall\
+    \ beats compression\n\nBANNED — never start or include these patterns:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
     \n- \"The user/assistant is asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\
-    \n- \"The conversation covers/revolves around...\"\nRewrite any meta-description into the actual facts.\n\nMETA-RESEARCH\
-    \ DETECTION:\nIf the chunk contains literal BrainLayer tool calls such as brain_search(...) or brain_entity(...), treat\
-    \ it as meta-research noise, set importance to 2, and add tag \"meta-research\".\n\nCHUNK (from project: {project}, type:\
-    \ {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON object and populate every key:\n\
-    {{\n  \"summary\": \"<3-5 dense sentences containing the main facts, decisions, names, numbers, dates, outcomes, and why\
-    \ they matter>\",\n  \"key_facts\": [\"<atomic verbatim fact 1>\", \"<atomic verbatim fact 2>\"],\n  \"tags\": [\"<3-7\
-    \ lowercase hyphenated search tags>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing,\
-    \ configuring, discussing, deciding, implementing, reviewing>\",\n  \"primary_symbols\": [\"<class/function/file names\
-    \ mentioned>\"],\n  \"resolved_query\": \"<natural-language question this chunk answers; same as resolved_queries[0]>\"\
-    ,\n  \"resolved_queries\": [\n    \"<natural-language question a future user would ask>\",\n    \"<keyword-dense query\
-    \ packed with exact anchors from the chunk>\",\n    \"<HyDE answer snippet preserving key terms for embedding similarity>\"\
-    \n  ],\n  \"epistemic_level\": \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or\
-    \ system state discussed, or null>\",\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\"\
-    : [\"<libraries or external APIs used>\"],\n  \"entities\": [{{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
-    , \"relation\": \"<relationship to other entities in this chunk, or null>\"}}],\n  \"sentiment_label\": \"<one of: frustration,\
+    \n- \"The conversation covers/revolves around...\"\n- Any sentence ABOUT the text rather than FROM the text\nIf you catch\
+    \ yourself writing about the source, DELETE it and write the actual facts instead.\n\nMETA-RESEARCH DETECTION:\n- If the\
+    \ chunk contains literal tool invocations such as brain_search(...) or brain_entity(...), treat it as meta-research noise\n\
+    - Set importance to 2\n- Add the tag \"meta-research\"\n\nSUMMARY STYLE BY CONTENT TYPE:\n- Decisions/conclusions: decision\
+    \ verbatim, who, when, why, rejected alternatives\n- Corrections: old → new, who corrected, what is superseded\n- Code/technical:\
+    \ all symbol names, paths, config values, errors verbatim; intent around them\n- Conversation: speakers, commitments,\
+    \ agreements, open questions — not filler flow\n- Entity/biographical: full names, aliases, roles, relationships, dated\
+    \ facts\n- SHORT/CONVERSATIONAL: extract actionable items and commitments only\n\nFEW-SHOT (recall discipline):\nBAD:\
+    \ \"Two /yash missions fixed nativewind and MCP SDK issues.\"\nGOOD summary + key_facts: summary states dates, PR #1722,\
+    \ bug class, merge/deploy; key_facts lists each PR, file paths, error strings, version numbers separately.\n\nCHUNK (from\
+    \ project: {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure:\n\
+    {{\n  \"summary\": \"<3–5 dense sentences — include ALL numbers, names, dates, PRs, paths from the chunk; never compress\
+    \ away specifics>\",\n  \"key_facts\": [\"<verbatim fact 1>\", \"<verbatim fact 2>\", \"... exhaust the chunk — PRs, amounts,\
+    \ dates, paths, URLs, versions, errors, entity names>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"],\n  \"importance\": <1-10\
+    \ integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\"\
+    ,\n  \"primary_symbols\": [\"<class/function/file names mentioned>\"],\n  \"resolved_query\": \"<copy resolved_queries[0]\
+    \ — natural-language question this chunk answers>\",\n  \"resolved_queries\": [\n    \"<NL question a user would ask —\
+    \ everyday vocabulary>\",\n    \"<keyword-dense BM25 query — pack identifiers, names, paths, error codes>\",\n    \"<HyDE\
+    \ answer snippet 1–2 sentences — same terms as summary/key_facts for embedding recall>\"\n  ],\n  \"epistemic_level\"\
+    : \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or system state discussed, or null>\"\
+    ,\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"<libraries or external APIs\
+    \ used>\"],\n  \"entities\": [\n    {{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<relationship to other entities, or null>\"}}\n  ],\n  \"sentiment_label\": \"<one of: frustration,\
     \ confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float from -1.0 to 1.0>,\n  \"sentiment_signals\"\
-    : [\"<words/phrases that indicate sentiment>\"]\n}}\n\nQUALITY GATE:\n- resolved_query must equal resolved_queries[0].\n\
-    - key_facts must include all PR numbers, dates, file paths, URLs, versions, model names, and error strings from the chunk.\n\
-    - Summary must not begin with \"This chunk\", \"This message\", \"The user\", or \"The assistant\".\n- Tags must be 3-7\
-    \ lowercase hyphenated strings unless the chunk is true noise.\nReturn ONLY the JSON object, no markdown."
+    : [\"<words/phrases indicating sentiment>\"]\n}}\n\nTAG RULES: lowercase hyphenated; 3–7 tags; languages, frameworks,\
+    \ concepts, actions.\nIMPORTANCE: 1–3 trivial; 4–6 moderate; 7–9 high; 10 critical.\nENTITIES: non-code only; no variable/function/path\
+    \ as entities.\n\nRECALL QUALITY GATE (mandatory):\n✓ Every PR number, date, dollar amount, path, URL, version, and error\
+    \ string in the chunk appears in key_facts OR summary (prefer both)\n✓ key_facts has at least 3 items when chunk length\
+    \ > 200 chars\n✓ Summary does NOT start with banned patterns\n✓ resolved_queries[2] reuses key terms from summary (HyDE\
+    \ alignment)\n\nEPISTEMIC: hypothesis = proposed/unverified; substantiated = evidence in chunk; validated = merge/deploy/confirmation\
+    \ stated\nDEBT: introduction = new debt/TODO/blocker; resolution = closes debt; none = no change\nSENTIMENT: frustration\
+    \ = blocked/failing; confusion = uncertain; positive = upbeat; satisfaction = resolved; neutral = factual\n\nReturn ONLY\
+    \ the JSON object, no other text."
   model: gemini-2.5-flash-lite
   params:
     temperature: 0.2
     max_output_tokens: 4096
   provenance: llm-proposed
   axis: density-max-recall
-  source_path: inline-llm-reasoning:abcde_inline_proposals.json
+  source_path: inline-llm-reasoning:abcde_llm_proposals.json
   source_section: llm-proposed-C
-  prompt_hash: f0f4f5f77f9d09d59d5714ee9b4e632b7ad57dba73b93a9cf6a079611eb381ad
+  prompt_hash: 732bedd2d92bd0995af8fcb7a3bbe4bdf2c72b5c04b81ad30b409a3a59ebf84a
 - id: D
-  label: inline-entity-relation-first
-  prompt_template: "You are an entity/relation-first enrichment engine for BrainLayer. Build the chunk's knowledge graph first,\
-    \ then write search metadata that reflects that graph. Your output is used for retrieval and offline evaluation, so it\
-    \ must be concrete, faithful, and schema-complete.\n\nAXIS: entity-relation-first. Prioritize named entities, their types,\
-    \ their relations, and the factual edges connecting them. Summary and queries should reuse the same entity names and relation\
-    \ language.\n\nPROCESS:\n1. Identify every non-code entity: person, company, project, technology, tool, or concept.\n\
-    2. Identify code symbols separately as primary_symbols: files, functions, classes, methods, commands, tables.\n3. For\
-    \ every entity, write a relation to another entity or to the chunk's main event when available.\n4. Write the summary\
-    \ as facts about those entities: who did what, to which system, when, why, with what result.\n5. Use key_facts for evidence:\
-    \ exact dates, paths, PRs, errors, configs, metrics, and quoted values.\n\nBANNED PATTERNS:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\
-    \n- \"The user/assistant is asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\
-    \n- \"The conversation covers/revolves around...\"\nFacts only; never describe the text as text.\n\nMETA-RESEARCH DETECTION:\n\
-    Literal brain_search(...), brain_entity(...), brain_expand(...), or similar tool calls mean meta-research noise: importance\
-    \ 2 and tag \"meta-research\", unless the chunk records a durable decision or result from that research.\n\nCHUNK (from\
-    \ project: {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON object\
-    \ and populate every key:\n{{\n  \"summary\": \"<2-4 dense sentences naming entities and their relations, preserving concrete\
-    \ values and outcomes>\",\n  \"key_facts\": [\"<verbatim evidence for the entity graph>\"],\n  \"tags\": [\"<3-7 lowercase\
-    \ hyphenated tags, including subject/entity tags when useful>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"\
-    <one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\",\n  \"primary_symbols\":\
-    \ [\"<code symbols, file paths, commands, tables, or APIs mentioned>\"],\n  \"resolved_query\": \"<question about the\
-    \ primary entity/relation; same as resolved_queries[0]>\",\n  \"resolved_queries\": [\n    \"<natural-language question\
-    \ naming the primary subject>\",\n    \"<keyword-dense query with entity names, relation terms, and exact anchors>\",\n\
-    \    \"<HyDE answer snippet that names the entities, relation, and outcome>\"\n  ],\n  \"epistemic_level\": \"<one of:\
-    \ hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or system state discussed, or null>\",\n \
-    \ \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"<external libraries or APIs\
-    \ used>\"],\n  \"entities\": [{{\"name\": \"<canonical entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
-    , \"relation\": \"<how this entity connects to another entity or event, or null>\"}}],\n  \"sentiment_label\": \"<one\
-    \ of: frustration, confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float from -1.0 to 1.0>,\n\
-    \  \"sentiment_signals\": [\"<phrases showing sentiment>\"]\n}}\n\nQUALITY GATE:\n- Entities must not include code symbols,\
-    \ file paths, variables, or functions. Put those in primary_symbols.\n- If two entities are connected, relation must say\
-    \ how; avoid null relation when a relation is evident.\n- resolved_query must equal resolved_queries[0].\n- Summary must\
-    \ use entity names from entities[].name when entities exist.\nReturn ONLY the JSON object, no markdown."
+  label: entity-relation-graph-first
+  prompt_template: "You are a knowledge-graph extraction engine for a personal knowledge base. Build an explicit entity–relation\
+    \ graph from each chunk, then write search-facing fields that preserve that graph. Dense facts only — never meta-descriptions.\n\
+    \nAXIS (entity-relation-first): Identify entities and their relations BEFORE writing summary. The entities array is the\
+    \ source of truth; summary narrates the same graph in prose.\n\nRULES:\n1. State facts as the expert — never describe\
+    \ \"what the chunk is about\"\n2. Preserve verbatim: names, numbers, dates, PR numbers, paths, URLs, errors, versions\n\
+    3. Every named person, project, company, product, tool, or technology in the chunk → entities entry (if not a code symbol)\n\
+    4. When two+ entities appear, set relation on each to explain how they connect (developer-of, depends-on, blocks, owns,\
+    \ uses, competes-with, etc.)\n5. Do NOT put function names, variables, or file paths in entities — use primary_symbols\
+    \ instead\n\nBANNED patterns (reject and rewrite):\n- \"This chunk/message describes...\"\n- \"The user/assistant is asking/instructing...\"\
+    \n- \"This is a conversation/discussion about...\"\n- \"The conversation covers/revolves around...\"\n\nMETA-RESEARCH:\
+    \ brain_search(...) / brain_entity(...) in chunk → importance 2, tag \"meta-research\"\n\nENTITY WORKFLOW (do this order):\n\
+    1. List all non-code named things\n2. Assign type: person|company|project|technology|tool|concept\n3. Fill relation linking\
+    \ to another entity in this chunk (null only if truly isolated)\n4. Write summary as a graph walk: who did what to which\
+    \ project/tool, with dates and outcomes\n5. Mirror entity names in key_facts and tags where relevant\n\nCHUNK (from project:\
+    \ {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure:\n{{\n\
+    \  \"summary\": \"<2–4 sentences naming entities and relations explicitly — e.g. 'Etan (person) merged PR #93 into BrainLayer\
+    \ (project) fixing importance inflation (concept)'>\",\n  \"key_facts\": [\"<verbatim values supporting the entity graph\
+    \ — dates, PRs, metrics, paths>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\"\
+    : \"<one of: debugging, designing, configuring, discussing, deciding, implementing, reviewing>\",\n  \"primary_symbols\"\
+    : [\"<code symbols only — classes, functions, files>\"],\n  \"resolved_query\": \"<resolved_queries[0] — question about\
+    \ the main entity/subject>\",\n  \"resolved_queries\": [\n    \"<question naming the primary entity/project>\",\n    \"\
+    <keyword query with entity names + domain terms>\",\n    \"<HyDE answer naming entities and relations with key facts>\"\
+    \n  ],\n  \"epistemic_level\": \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or\
+    \ system state, or null>\",\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\": [\"\
+    <external libraries/APIs>\"],\n  \"entities\": [\n    {{\"name\": \"<canonical name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
+    , \"relation\": \"<required when another entity exists — how they connect>\"}}\n  ],\n  \"sentiment_label\": \"<one of:\
+    \ frustration, confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float -1.0 to 1.0>,\n  \"sentiment_signals\"\
+    : [\"<affect phrases>\"]\n}}\n\nTAG RULES: 3–7 lowercase hyphenated tags; include project/technology tags when entities\
+    \ imply them.\nIMPORTANCE: standard 1–10 scale.\n\nENTITY QUALITY GATE:\n✓ At least one entities row when chunk names\
+    \ any person/project/company/tool/technology\n✓ No code symbols in entities\n✓ relation is non-null when chunk mentions\
+    \ 2+ linkable entities\n✓ summary uses the same entity names as entities[].name\n✓ Summary passes banned-pattern check\n\
+    \nEPISTEMIC / DEBT / SENTIMENT rubrics: same as production — hypothesis|substantiated|validated; introduction|resolution|none;\
+    \ frustration|confusion|positive|satisfaction|neutral.\n\nReturn ONLY the JSON object, no other text."
   model: gemini-2.5-flash-lite
   params:
     temperature: 0.2
     max_output_tokens: 4096
   provenance: llm-proposed
   axis: entity-relation-first
-  source_path: inline-llm-reasoning:abcde_inline_proposals.json
+  source_path: inline-llm-reasoning:abcde_llm_proposals.json
   source_section: llm-proposed-D
-  prompt_hash: 4ccdd1d080546423db0f4f166b4ed73908c6e0eacca78875992235b8ead27166
+  prompt_hash: ea0093578f78f94b60e65f6c5826eca2f9f4e3c8dc2694ce0abbdbc9268149a0
 - id: E
-  label: inline-hyde-structure-faithfulness
-  prompt_template: "You are a schema-faithful HyDE/structure enrichment engine for BrainLayer. Your job is to produce exact\
-    \ JSON metadata that improves both vector search and keyword search without hallucinating beyond the chunk.\n\nAXIS: structure-HyDE-faithfulness.\
-    \ Design the retrieval surface first: resolved_query and resolved_queries must be precise, faithful, and aligned with\
-    \ summary/key_facts. Every field must satisfy the runtime schema exactly.\n\nFIELD DISCIPLINE:\n1. resolved_queries[0]\
-    \ is the everyday question this chunk answers. resolved_query must be an exact copy.\n2. resolved_queries[1] is the keyword-dense\
-    \ query: exact names, paths, PRs, errors, tools, and tags; minimal filler.\n3. resolved_queries[2] is a HyDE answer snippet:\
-    \ 1-2 factual sentences that sound like the answer a searcher wants.\n4. summary must align with resolved_queries[2] and\
-    \ must not add unsupported claims.\n5. key_facts must provide verbatim anchors supporting the queries and summary.\n\n\
-    BANNED PATTERNS:\n- \"This chunk/message describes/details/outlines/provides/contains...\"\n- \"The user/assistant is\
-    \ asking/instructing/discussing/explaining...\"\n- \"This is a conversation/discussion about...\"\n- \"The conversation\
-    \ covers/revolves around...\"\nIf you write meta-description, delete it and write the actual fact.\n\nMETA-RESEARCH DETECTION:\n\
-    If the chunk is mainly raw BrainLayer tool invocation text like brain_search(...) or brain_entity(...), set importance\
-    \ to 2 and tag \"meta-research\" unless it records a durable result, decision, or benchmark.\n\nCHUNK (from project: {project},\
-    \ type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON object and populate every\
-    \ key:\n{{\n  \"summary\": \"<2-4 dense, faithful sentences aligned with the HyDE answer and grounded only in the chunk>\"\
-    ,\n  \"key_facts\": [\"<verbatim anchors that support summary and queries>\"],\n  \"tags\": [\"<3-7 lowercase hyphenated\
-    \ tags>\"],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing,\
-    \ deciding, implementing, reviewing>\",\n  \"primary_symbols\": [\"<class/function/file names mentioned>\"],\n  \"resolved_query\"\
-    : \"<exact copy of resolved_queries[0]>\",\n  \"resolved_queries\": [\n    \"<natural-language question this chunk answers>\"\
-    ,\n    \"<keyword-dense exact-anchor query>\",\n    \"<1-2 sentence HyDE answer snippet using only chunk-supported facts>\"\
-    \n  ],\n  \"epistemic_level\": \"<one of: hypothesis, substantiated, validated>\",\n  \"version_scope\": \"<version or\
-    \ system state discussed, or null>\",\n  \"debt_impact\": \"<one of: introduction, resolution, none>\",\n  \"external_deps\"\
-    : [\"<libraries or external APIs used>\"],\n  \"entities\": [{{\"name\": \"<entity name>\", \"type\": \"<person|company|project|technology|tool|concept>\"\
-    , \"relation\": \"<relationship to other entities in this chunk, or null>\"}}],\n  \"sentiment_label\": \"<one of: frustration,\
-    \ confusion, positive, satisfaction, neutral>\",\n  \"sentiment_score\": <float from -1.0 to 1.0>,\n  \"sentiment_signals\"\
-    : [\"<phrases that indicate sentiment>\"]\n}}\n\nSTRICT VALIDATION BEFORE RETURN:\n- JSON object only; no markdown, no\
-    \ trailing prose.\n- resolved_queries has exactly 3 strings.\n- resolved_query is byte-identical to resolved_queries[0].\n\
-    - importance is an integer 1-10, sentiment_score is a finite float -1.0 to 1.0.\n- summary contains at least one concrete\
-    \ anchor when the chunk has any concrete anchor.\n- No unsupported extrapolation beyond chunk/context_section.\nReturn\
-    \ ONLY the JSON object."
+  label: structure-hyde-faithfulness
+  prompt_template: "You are a structured retrieval-metadata extractor. Your job is to produce schema-faithful JSON where HyDE-style\
+    \ resolved_query fields are the retrieval backbone and every other field aligns to them. Dense, fact-rich — never meta-description.\n\
+    \nAXIS (structure-hyde-faithfulness): Draft resolved_queries FIRST (all three slots), then write summary and key_facts\
+    \ to match. resolved_query MUST equal resolved_queries[0]. Field order in your reasoning: queries → facts → summary →\
+    \ entities/tags/sentiment.\n\nRULES:\n1. Expert voice stating facts — never \"this chunk describes...\"\n2. Preserve verbatim\
+    \ identifiers in key_facts and resolved_queries[1]\n3. resolved_queries[2] is a hypothetical ANSWER (HyDE document), not\
+    \ a question — write as if answering resolved_queries[0]\n4. summary must reuse the same anchor terms as resolved_queries[1]\
+    \ and [2] (names, PRs, paths, errors)\n5. Exactly 3 strings in resolved_queries — no more, no fewer\n\nBANNED:\n- \"This\
+    \ chunk/message describes/details/outlines/provides/contains...\"\n- \"The user/assistant is asking/instructing/discussing/explaining...\"\
+    \n- \"This is a conversation/discussion about...\"\n- \"The conversation covers/revolves around...\"\n\nMETA-RESEARCH:\
+    \ literal brain_search(...) / brain_entity(...) → importance 2, tag \"meta-research\"\n\nHyDE SLOT SPEC (strict):\n- resolved_queries[0]:\
+    \ natural-language user question (8–20 words, no jargon unless in chunk)\n- resolved_queries[1]: keyword/BM25 string —\
+    \ comma or space separated anchors, no filler words\n- resolved_queries[2]: 1–2 sentence answer snippet with facts; must\
+    \ stand alone for embedding similarity\n- resolved_query: identical copy of resolved_queries[0]\n\nCHUNK (from project:\
+    \ {project}, type: {content_type}):\n---\n{content}\n---\n\n{context_section}\n\nReturn this exact JSON structure (populate\
+    \ every key; types must match):\n{{\n  \"summary\": \"<2–4 dense sentences aligned to resolved_queries[2] — facts only,\
+    \ no meta>\",\n  \"key_facts\": [\"<verbatim strings supporting the HyDE answer>\"],\n  \"tags\": [\"<tag1>\", \"<tag2>\"\
+    ],\n  \"importance\": <1-10 integer>,\n  \"intent\": \"<one of: debugging, designing, configuring, discussing, deciding,\
+    \ implementing, reviewing>\",\n  \"primary_symbols\": [\"<code symbols mentioned>\"],\n  \"resolved_query\": \"<MUST equal\
+    \ resolved_queries[0]>\",\n  \"resolved_queries\": [\n    \"<NL question>\",\n    \"<keyword-dense query>\",\n    \"<HyDE\
+    \ answer snippet>\"\n  ],\n  \"epistemic_level\": \"<hypothesis|substantiated|validated>\",\n  \"version_scope\": \"<string\
+    \ or null>\",\n  \"debt_impact\": \"<introduction|resolution|none>\",\n  \"external_deps\": [\"<deps>\"],\n  \"entities\"\
+    : [\n    {{\"name\": \"<name>\", \"type\": \"<person|company|project|technology|tool|concept>\", \"relation\": \"<string\
+    \ or null>\"}}\n  ],\n  \"sentiment_label\": \"<frustration|confusion|positive|satisfaction|neutral>\",\n  \"sentiment_score\"\
+    : <float -1.0 to 1.0>,\n  \"sentiment_signals\": [\"<signals>\"]\n}}\n\nTAG RULES: 3–7 lowercase hyphenated tags.\nENTITIES:\
+    \ non-code only; relation when co-entities exist.\n\nSTRUCTURE QUALITY GATE:\n✓ resolved_query === resolved_queries[0]\
+    \ (character-for-character)\n✓ len(resolved_queries) === 3\n✓ resolved_queries[2] contains at least one specific anchor\
+    \ from the chunk (PR, path, number, or name)\n✓ summary and key_facts do not contradict resolved_queries[2]\n✓ No banned\
+    \ summary openers\n\nEPISTEMIC: hypothesis = unverified proposal; substantiated = evidence in chunk; validated = confirmed\
+    \ outcome\nDEBT: introduction | resolution | none\nSENTIMENT: label + score + signals consistent with chunk tone\n\nReturn\
+    \ ONLY the JSON object, no other text."
   model: gemini-2.5-flash-lite
   params:
     temperature: 0.2
     max_output_tokens: 4096
   provenance: llm-proposed
   axis: structure-hyde-faithfulness
-  source_path: inline-llm-reasoning:abcde_inline_proposals.json
+  source_path: inline-llm-reasoning:abcde_llm_proposals.json
   source_section: llm-proposed-E
-  prompt_hash: d9c3fc764c2e72bad7994ee1e9562a518de826a03f7dd3bb929479fcb20b5a23
+  prompt_hash: dd974abf35dfc0717239bf3ec56aa8ff090dd9f566e3c6e6ab0691cbe2c9dcc0

--- a/tests/test_abcde_enrich_runner.py
+++ b/tests/test_abcde_enrich_runner.py
@@ -21,6 +21,7 @@ from brainlayer.eval.abcde_enrich_runner import (
 from brainlayer.eval.abcde_variants import ABCDE_VARIANTS_BY_ID
 from brainlayer.eval.enrichment_graders import REQUIRED_ENRICHMENT_KEYS, validate_schema_gate
 from brainlayer.eval.enrichment_judge import build_judge_request
+from scripts import run_abcde_enrich as abcde_driver
 
 
 class FakeSanitizer:
@@ -211,6 +212,49 @@ def test_make_http_chat_fn_model_override_ignores_variant_model(monkeypatch):
     assert captured["payload"]["model"] == "grok-x"
 
 
+def test_make_http_chat_fn_deepseek_base_url_and_model(monkeypatch):
+    captured: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def json(self):
+            return {"choices": [{"message": {"content": "{}"}}]}
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["payload"] = json
+        return FakeResponse()
+
+    monkeypatch.setattr("requests.post", fake_post)
+    chat_fn = make_http_chat_fn(
+        base_url="https://api.deepseek.com",
+        api_key="test-key",
+        model_override="deepseek-v4-flash",
+    )
+
+    status, _body = chat_fn("ignored-variant-model", "prompt", {"temperature": 0})
+
+    assert status == 200
+    assert captured["url"] == "https://api.deepseek.com/chat/completions"
+    assert captured["payload"]["model"] == "deepseek-v4-flash"
+
+
+def test_driver_variants_filter_selects_requested_ids_in_registry_order():
+    selected = abcde_driver.select_variants("E,A,C")
+
+    assert [variant.id for variant in selected] == ["A", "C", "E"]
+
+
+def test_driver_resolve_api_key_reads_deepseek_env(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("GROK_API_KEY", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "  deepseek-test-key  ")
+
+    assert abcde_driver.resolve_api_key() == "deepseek-test-key"
+
+
 def test_run_batch_writes_rows_and_aggregates(tmp_path):
     chunks = [_chunk(), {**_chunk(), "id": "chunk-2"}]
     variants = [ABCDE_VARIANTS_BY_ID["C"], ABCDE_VARIANTS_BY_ID["D"]]
@@ -224,6 +268,48 @@ def test_run_batch_writes_rows_and_aggregates(tmp_path):
     assert stats.cost_in_usd_ticks == 4 * 12000
 
 
+def test_run_batch_concurrency_writes_all_rows(tmp_path):
+    chunks = [{**_chunk(), "id": f"chunk-{i}"} for i in range(5)]
+    variants = [ABCDE_VARIANTS_BY_ID["A"], ABCDE_VARIANTS_BY_ID["C"]]
+    out = tmp_path / "rows.jsonl"
+
+    stats = run_batch(
+        chunks,
+        variants,
+        FakeSanitizer(),
+        _ok_chat_fn(ticks=0, ptok=100, ctok=100),
+        output_path=str(out),
+        concurrency=4,
+        fallback_usd_per_1m=0.3,
+    )
+
+    lines = out.read_text().strip().splitlines()
+    assert stats.calls == 10
+    assert stats.ok == 10
+    assert len(lines) == 10
+    assert {json.loads(line)["variant_id"] for line in lines} == {"A", "C"}
+
+
+def test_run_batch_concurrency_respects_max_calls(tmp_path):
+    chunks = [{**_chunk(), "id": f"chunk-{i}"} for i in range(10)]
+    variants = [ABCDE_VARIANTS_BY_ID["A"], ABCDE_VARIANTS_BY_ID["C"]]
+    out = tmp_path / "rows.jsonl"
+
+    stats = run_batch(
+        chunks,
+        variants,
+        FakeSanitizer(),
+        _ok_chat_fn(ticks=0, ptok=100, ctok=100),
+        output_path=str(out),
+        concurrency=4,
+        max_calls=7,
+        fallback_usd_per_1m=0.3,
+    )
+
+    assert stats.calls == 7
+    assert len(out.read_text().strip().splitlines()) == 7
+
+
 def test_run_batch_hard_budget_stop():
     # Each call costs 0.001 USD (1e6 ticks * 1e-9). Ceiling 0.0025 → stop after ~2 calls.
     chunks = [{**_chunk(), "id": f"c{i}"} for i in range(10)]
@@ -235,3 +321,24 @@ def test_run_batch_hard_budget_stop():
     )
     assert stats.usd_spent <= 0.0025 + 1e-9
     assert stats.calls < 10  # stopped early, did not run all 10
+
+
+def test_run_batch_concurrency_respects_max_usd_with_fallback_tokens(tmp_path):
+    chunks = [{**_chunk(), "id": f"chunk-{i}"} for i in range(10)]
+    variants = [ABCDE_VARIANTS_BY_ID["C"]]
+    out = tmp_path / "rows.jsonl"
+
+    stats = run_batch(
+        chunks,
+        variants,
+        FakeSanitizer(),
+        _ok_chat_fn(ticks=0, ptok=500, ctok=500),
+        output_path=str(out),
+        concurrency=4,
+        max_usd=0.00075,
+        fallback_usd_per_1m=0.3,
+    )
+
+    assert stats.calls == 2
+    assert stats.usd_spent == pytest.approx(0.0006)
+    assert len(out.read_text().strip().splitlines()) == 2

--- a/tests/test_abcde_enrich_runner.py
+++ b/tests/test_abcde_enrich_runner.py
@@ -77,9 +77,14 @@ def _ok_chat_fn(captured=None, *, ticks=12000, ptok=1200, ctok=400):
             captured["params"] = params
         return 200, {
             "choices": [{"message": {"content": json.dumps(_good_enrichment())}}],
-            "usage": {"prompt_tokens": ptok, "completion_tokens": ctok,
-                      "total_tokens": ptok + ctok, "cost_in_usd_ticks": ticks},
+            "usage": {
+                "prompt_tokens": ptok,
+                "completion_tokens": ctok,
+                "total_tokens": ptok + ctok,
+                "cost_in_usd_ticks": ticks,
+            },
         }
+
     return fn
 
 
@@ -315,9 +320,12 @@ def test_run_batch_hard_budget_stop():
     chunks = [{**_chunk(), "id": f"c{i}"} for i in range(10)]
     variants = [ABCDE_VARIANTS_BY_ID["C"]]
     stats = run_batch(
-        chunks, variants, FakeSanitizer(),
+        chunks,
+        variants,
+        FakeSanitizer(),
         _ok_chat_fn(ticks=1_000_000),
-        max_usd=0.0025, tick_usd=1e-9,
+        max_usd=0.0025,
+        tick_usd=1e-9,
     )
     assert stats.usd_spent <= 0.0025 + 1e-9
     assert stats.calls < 10  # stopped early, did not run all 10

--- a/tests/test_abcde_enrich_runner.py
+++ b/tests/test_abcde_enrich_runner.py
@@ -1,0 +1,237 @@
+"""Tests for the ABCDE variant enrichment runner. No live API — ChatFn is mocked."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from brainlayer.eval.abcde_enrich_runner import (
+    STATUS_ERROR,
+    STATUS_OK,
+    STATUS_SAFETY_BLOCKED,
+    Usage,
+    enrich_one,
+    judge_row,
+    make_http_chat_fn,
+    run_batch,
+    usage_to_usd,
+)
+from brainlayer.eval.abcde_variants import ABCDE_VARIANTS_BY_ID
+from brainlayer.eval.enrichment_graders import REQUIRED_ENRICHMENT_KEYS, validate_schema_gate
+from brainlayer.eval.enrichment_judge import build_judge_request
+
+
+class FakeSanitizer:
+    """Records what it saw; returns content unchanged with a PII marker on a token."""
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def sanitize(self, content, metadata=None):
+        self.seen.append(content)
+        replaced = content.replace("SECRET@EMAIL", "[EMAIL]")
+        return SimpleNamespace(
+            sanitized=replaced,
+            replacements=[("SECRET@EMAIL", "[EMAIL]")] if "SECRET@EMAIL" in content else [],
+            pii_detected="SECRET@EMAIL" in content,
+        )
+
+
+def _good_enrichment() -> dict:
+    return {
+        "summary": "PR #426 merged the ExperimentStore firewall on 2026-06-01.",
+        "key_facts": ["PR #426", "2026-06-01", "ExperimentStore"],
+        "tags": ["isolation", "ci-gate", "brainlayer"],
+        "importance": 8,
+        "intent": "implementing",
+        "primary_symbols": ["ExperimentStore"],
+        "resolved_query": "How was the experiment store isolated?",
+        "resolved_queries": [
+            "How was the experiment store isolated?",
+            "ExperimentStore firewall leak-regression PR 426",
+            "PR #426 added an ExperimentStore firewall with a leak-regression CI gate.",
+        ],
+        "epistemic_level": "validated",
+        "version_scope": None,
+        "debt_impact": "resolution",
+        "external_deps": [],
+        "entities": [{"name": "BrainLayer", "type": "project", "relation": "owns the experiment store"}],
+        "sentiment_label": "satisfaction",
+        "sentiment_score": 0.6,
+        "sentiment_signals": ["merged"],
+    }
+
+
+def _chunk(content="ExperimentStore firewall merged in PR #426 on 2026-06-01."):
+    return {"id": "chunk-1", "content": content, "project": "brainlayer", "content_type": "assistant_text"}
+
+
+def _ok_chat_fn(captured=None, *, ticks=12000, ptok=1200, ctok=400):
+    def fn(model, prompt, params):
+        if captured is not None:
+            captured["model"] = model
+            captured["prompt"] = prompt
+            captured["params"] = params
+        return 200, {
+            "choices": [{"message": {"content": json.dumps(_good_enrichment())}}],
+            "usage": {"prompt_tokens": ptok, "completion_tokens": ctok,
+                      "total_tokens": ptok + ctok, "cost_in_usd_ticks": ticks},
+        }
+    return fn
+
+
+def test_enrich_one_ok_parses_and_passes_schema_gate():
+    variant = ABCDE_VARIANTS_BY_ID["C"]
+    res = enrich_one(variant, _chunk(), FakeSanitizer(), _ok_chat_fn())
+    assert res.status == STATUS_OK
+    assert validate_schema_gate(res.enrichment).passed
+    assert res.usage.cost_in_usd_ticks == 12000
+
+
+def test_enrich_one_keeps_raw_json_object_without_schema_parsing():
+    raw = {
+        **_good_enrichment(),
+        "tags": ["MiXeD", "Ci-Gate", "BrainLayer"],
+        "importance": 8,
+        "version_scope": None,
+        "external_deps": [],
+        "payload": {"nested": True},
+    }
+
+    def raw_fn(model, prompt, params):
+        return 200, {
+            "choices": [{"message": {"content": f"prefix {json.dumps(raw)} suffix"}}],
+            "usage": {"total_tokens": 50},
+        }
+
+    res = enrich_one(ABCDE_VARIANTS_BY_ID["A"], _chunk(), FakeSanitizer(), raw_fn)
+    assert res.status == STATUS_OK
+    assert res.enrichment == raw
+    assert set(REQUIRED_ENRICHMENT_KEYS).issubset(res.enrichment)
+    assert "version_scope" in res.enrichment
+    assert "external_deps" in res.enrichment
+    assert isinstance(res.enrichment["importance"], int)
+    assert res.enrichment["resolved_queries"] == raw["resolved_queries"]
+    assert len(res.enrichment["resolved_queries"]) == 3
+    assert validate_schema_gate(res.enrichment).passed
+    assert res.error is None
+
+
+def test_prompt_uses_variant_template_and_sanitized_content():
+    captured: dict = {}
+    variant = ABCDE_VARIANTS_BY_ID["D"]
+    san = FakeSanitizer()
+    enrich_one(variant, _chunk("contact SECRET@EMAIL for ExperimentStore"), san, _ok_chat_fn(captured))
+    # Sanitizer was invoked on the chunk content...
+    assert any("SECRET@EMAIL" in s for s in san.seen)
+    # ...and the raw secret never reaches the prompt sent to the backend.
+    assert "SECRET@EMAIL" not in captured["prompt"]
+    assert "[EMAIL]" in captured["prompt"]
+    # Variant D's model + Gemini-style param mapping reached the chat layer.
+    assert captured["model"] == variant.model
+    assert "max_tokens" in captured["params"]  # mapped from max_output_tokens
+
+
+def test_safety_block_classified_not_crashed():
+    def safety_fn(model, prompt, params):
+        return 403, {"error": {"message": "Content violates usage guidelines. Failed check: SAFETY_CHECK_TYPE_BIO"}}
+
+    res = enrich_one(ABCDE_VARIANTS_BY_ID["E"], _chunk(), FakeSanitizer(), safety_fn)
+    assert res.status == STATUS_SAFETY_BLOCKED
+    assert res.enrichment is None
+
+
+def test_invalid_json_is_error_not_exception():
+    def bad_fn(model, prompt, params):
+        return 200, {"choices": [{"message": {"content": "not json at all"}}], "usage": {"total_tokens": 50}}
+
+    res = enrich_one(ABCDE_VARIANTS_BY_ID["A"], _chunk(), FakeSanitizer(), bad_fn)
+    assert res.status == STATUS_ERROR
+    assert res.error == "invalid_json"
+
+
+def test_transport_exception_becomes_error_row():
+    def boom(model, prompt, params):
+        raise ConnectionError("network down")
+
+    res = enrich_one(ABCDE_VARIANTS_BY_ID["A"], _chunk(), FakeSanitizer(), boom)
+    assert res.status == STATUS_ERROR
+    assert "transport_error" in res.error
+
+
+def test_usage_to_usd_prefers_ticks_then_falls_back():
+    assert usage_to_usd(Usage(cost_in_usd_ticks=1_000_000), tick_usd=1e-9) == pytest.approx(0.001)
+    # No ticks → pessimistic per-token fallback.
+    assert usage_to_usd(Usage(total_tokens=1_000_000), fallback_usd_per_1m=10.0) == pytest.approx(10.0)
+
+
+def test_judge_row_shape_is_consumable_by_judge():
+    variant = ABCDE_VARIANTS_BY_ID["C"]
+    chat_fn = _ok_chat_fn()
+    chat_fn.backend_model = "grok-x"
+    res = enrich_one(variant, _chunk(), FakeSanitizer(), chat_fn)
+    row = judge_row(variant, _chunk(), res)
+    # The offline judge must accept the row without raising.
+    request = build_judge_request(row)
+    assert request["variant_id"] == "C"
+    assert request["chunk_id"] == "chunk-1"
+    assert request["input"]["enrichment"]["summary"].startswith("PR #426")
+    assert row["model"] == variant.model
+    assert row["generation"]["backend_model"] == "grok-x"
+    assert row["prompt_hash"] == variant.prompt_hash
+
+
+def test_make_http_chat_fn_model_override_ignores_variant_model(monkeypatch):
+    captured: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def json(self):
+            return {"choices": [{"message": {"content": "{}"}}]}
+
+    def fake_post(url, headers, json, timeout):
+        captured["payload"] = json
+        return FakeResponse()
+
+    monkeypatch.setattr("requests.post", fake_post)
+    variant = ABCDE_VARIANTS_BY_ID["A"]
+    chat_fn = make_http_chat_fn(
+        base_url="https://example.test/v1",
+        api_key="test-key",
+        model_override="grok-x",
+    )
+
+    status, _body = chat_fn(variant.model, "prompt", {"temperature": 0})
+
+    assert status == 200
+    assert captured["payload"]["model"] == "grok-x"
+
+
+def test_run_batch_writes_rows_and_aggregates(tmp_path):
+    chunks = [_chunk(), {**_chunk(), "id": "chunk-2"}]
+    variants = [ABCDE_VARIANTS_BY_ID["C"], ABCDE_VARIANTS_BY_ID["D"]]
+    out = tmp_path / "rows.jsonl"
+    stats = run_batch(chunks, variants, FakeSanitizer(), _ok_chat_fn(), output_path=str(out), tick_usd=1e-9)
+    assert stats.calls == 4
+    assert stats.ok == 4
+    lines = out.read_text().strip().splitlines()
+    assert len(lines) == 4
+    assert all(json.loads(line)["variant_id"] in ("C", "D") for line in lines)
+    assert stats.cost_in_usd_ticks == 4 * 12000
+
+
+def test_run_batch_hard_budget_stop():
+    # Each call costs 0.001 USD (1e6 ticks * 1e-9). Ceiling 0.0025 → stop after ~2 calls.
+    chunks = [{**_chunk(), "id": f"c{i}"} for i in range(10)]
+    variants = [ABCDE_VARIANTS_BY_ID["C"]]
+    stats = run_batch(
+        chunks, variants, FakeSanitizer(),
+        _ok_chat_fn(ticks=1_000_000),
+        max_usd=0.0025, tick_usd=1e-9,
+    )
+    assert stats.usd_spent <= 0.0025 + 1e-9
+    assert stats.calls < 10  # stopped early, did not run all 10

--- a/tests/test_abcde_report.py
+++ b/tests/test_abcde_report.py
@@ -1,0 +1,84 @@
+"""Tests for deterministic ABCDE enrichment report aggregation."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.abcde_report import build_report
+
+
+def _row(variant_id: str, enrichment: dict, *, status: str = "ok", error: str | None = None) -> dict:
+    return {
+        "chunk_id": f"{variant_id}-1",
+        "variant_id": variant_id,
+        "chunk_text": "BrainLayer shipped ExperimentStore with Python and SQLite.",
+        "enrichment": enrichment,
+        "model": "gemini-2.5-flash-lite",
+        "prompt_hash": "hash",
+        "generation": {
+            "status": status,
+            "error": error,
+            "usage": {
+                "completion_tokens": 100,
+                "cost_in_usd_ticks": 1_000_000,
+                "prompt_tokens": 200,
+                "total_tokens": 300,
+            },
+        },
+    }
+
+
+def _schema_complete_enrichment() -> dict:
+    return {
+        "summary": "ExperimentStore isolated eval storage for BrainLayer.",
+        "key_facts": ["ExperimentStore shipped", "SQLite storage isolated"],
+        "tags": ["brainlayer", "sqlite", "eval"],
+        "importance": 8,
+        "intent": "implementing",
+        "primary_symbols": ["ExperimentStore"],
+        "resolved_query": "How was ExperimentStore isolated?",
+        "resolved_queries": [
+            "How was ExperimentStore isolated?",
+            "BrainLayer ExperimentStore SQLite eval storage",
+            "ExperimentStore isolated eval storage for BrainLayer using SQLite.",
+        ],
+        "epistemic_level": "validated",
+        "version_scope": None,
+        "debt_impact": "resolution",
+        "external_deps": [],
+        "entities": [{"name": "BrainLayer", "type": "project", "relation": "owns ExperimentStore"}],
+        "sentiment_label": "satisfaction",
+        "sentiment_score": 0.5,
+        "sentiment_signals": ["shipped"],
+    }
+
+
+def test_build_report_aggregates_per_variant_from_raw_enrichment(tmp_path):
+    input_path = tmp_path / "abcde.jsonl"
+    rows = [
+        _row("A", _schema_complete_enrichment()),
+        _row("A", {}, status="error", error="invalid_json"),
+        _row(
+            "B",
+            {
+                **_schema_complete_enrichment(),
+                "summary": "This chunk describes ExperimentStore isolation.",
+                "entities": [{"name": "Imaginary Vendor", "type": "company", "relation": None}],
+            },
+        ),
+    ]
+    input_path.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n")
+
+    report = build_report(input_path)
+
+    assert report.variants["A"].n == 2
+    assert report.variants["A"].ok_n == 1
+    assert report.variants["A"].gen_error_n == 1
+    assert report.variants["A"].error_reasons == {"invalid_json": 1}
+    assert report.variants["A"].schema_pass_pct == 100.0
+    assert report.variants["A"].mean_resolved_queries == 3.0
+    assert report.variants["A"].total_cost_usd == 0.002
+
+    assert report.variants["B"].banned_pattern_pct == 100.0
+    assert report.variants["B"].mean_unsupported_entities == 1.0
+    assert "| Variant | label | n | ok | gen errors |" in report.table


### PR DESCRIPTION
ABCDE enrichment-variant eval: OpenAI-compatible runner (xAI Grok / DeepSeek / Nebius via base_url swap), deterministic per-variant report, frozen A–E variant registry, and a DeepSeek/Nebius-scale path (concurrency + --variants + --max-calls).

**Privacy note:** raw enriched rows contain personal chunk content and are NOT committed — `eval_results/*.jsonl` is gitignored; only **aggregate** metrics are committed under `results/` (raw rows archived to private Brain Drive). This branch was history-purged of a previously-committed raw eval file (supersedes closed PR #430).

Headline result (n=893, Nebius Llama-3.3-70B): variant **E (hyde-structure)** is consistently the best enrichment recipe for retrieval, though the effect is modest (E > C > A within ~3%). See `results/abcde_n893_summary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eval-only tooling that sends sanitized chunk text to external LLM APIs and writes PII-bearing JSONL locally; production enrichment path is unchanged, mitigated by mandatory sanitization and gitignore rules.
> 
> **Overview**
> This PR adds the **generation leg** of the ABCDE enrichment experiment: run frozen A–E prompt variants against chunks via any OpenAI-compatible backend (xAI, DeepSeek, Nebius), with mandatory sanitization through `build_external_prompt`, live USD metering, and hard stops on spend and call count.
> 
> **New code:** `abcde_enrich_runner.py` (single-call + concurrent `run_batch`, judge-ready JSONL rows), `run_abcde_enrich.py` (read-only SQLite chunk sampling, smoke/run modes, variant filter, API key resolution), and `abcde_report.py` (per-variant markdown table using existing `enrichment_graders`).
> 
> **Privacy / artifacts:** `eval_results/*.jsonl` is gitignored so personal chunk content stays out of git; committed **PII-free** aggregates live under `results/` (n=893 self-retrieval summary) plus a small deterministic sample under `eval_results/abcde_results_summary.md`.
> 
> **Registry:** `abcde_variants.yaml` bumps `frozen_at` and rewrites variants **C** (density-max), **D** (entity-graph-first), and **E** (HyDE-structure) with new labels, prompts, source paths, and `prompt_hash` values.
> 
> **Tests:** Broad coverage for runner, HTTP client wiring, budget/concurrency caps, driver helpers, and report aggregation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c3798b99a7377c340b601e2ac37af449746b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ABCDE enrichment evaluation framework with CLI tools for running variant experiments and budget controls.
  * Introduced three enhanced variant strategies (density-max-recall, entity-relation-graph, structure-hyde) and automated benchmark/report generation.

* **Documentation**
  * Added human-readable benchmark and results summaries (Markdown + JSON) detailing per-variant metrics and findings.

* **Tests**
  * Added comprehensive tests covering the enrichment runner, reporting aggregation, budget/stop behavior, and HTTP/chat integrations.

* **Chores**
  * Updated .gitignore to exclude raw eval result files and note sensitive content shouldn't be committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ABCDE enrichment variant runner and deterministic report generator
> - Adds [`abcde_enrich_runner.py`](https://github.com/EtanHey/brainlayer/pull/431/files#diff-8fb58249d3a33c7f07d05e3e3682d3d19ac6830509674661915a8d1af677b49d) which runs enrichment calls across variants A–E via any OpenAI-compatible HTTP endpoint, with concurrency, spend ceilings, retry on 5xx/429, and JSONL telemetry output.
> - Adds [`scripts/run_abcde_enrich.py`](https://github.com/EtanHey/brainlayer/pull/431/files#diff-a4b481fda368ab1cbd38e5ca737d23c12990663022a0daf7df0505e0d703e418) as a CLI driver that samples chunks deterministically from SQLite, selects variants, resolves API keys, and delegates to `run_batch`.
> - Adds [`scripts/abcde_report.py`](https://github.com/EtanHey/brainlayer/pull/431/files#diff-913d0fe8f51865aa146679d1651be9b58a3e87ffcc81871f171d11aa5e72160c) which reads the output JSONL and produces a deterministic markdown report with per-variant metrics (schema pass rate, banned-pattern rate, entity counts, cost) and selects the strongest non-banned variant.
> - Updates [`abcde_variants.yaml`](https://github.com/EtanHey/brainlayer/pull/431/files#diff-71300dafe71512f0980fa4b552be898bfc6aa9a211bcc33cb832a1b18b6ec75f) with revised prompt templates and labels for variants A, D, and E.
> - Raw enriched JSONL output is gitignored to prevent personal chunk content from being committed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36c3798.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->