### PR TITLE
feat(eval): add Phoenix regression gate

### DIFF
--- a/src/brainlayer/eval/phoenix_gate/__init__.py
+++ b/src/brainlayer/eval/phoenix_gate/__init__.py
@@ -1,0 +1,14 @@
+"""Phoenix-backed eval regression gate for BrainLayer surfaces."""
+
+from brainlayer.eval.phoenix_gate.baseline_store import BaselineRecord, JsonBaselineStore
+from brainlayer.eval.phoenix_gate.models import BaselineKey, ExperimentScore, HarnessFault
+from brainlayer.eval.phoenix_gate.regression_gate import RegressionGate
+
+__all__ = [
+    "BaselineKey",
+    "BaselineRecord",
+    "ExperimentScore",
+    "HarnessFault",
+    "JsonBaselineStore",
+    "RegressionGate",
+]

--- a/src/brainlayer/eval/phoenix_gate/__main__.py
+++ b/src/brainlayer/eval/phoenix_gate/__main__.py
@@ -1,0 +1,3 @@
+from brainlayer.eval.phoenix_gate.cli import main
+
+raise SystemExit(main())

--- a/src/brainlayer/eval/phoenix_gate/baseline_store.py
+++ b/src/brainlayer/eval/phoenix_gate/baseline_store.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -71,7 +73,17 @@ class JsonBaselineStore:
         ordered = sorted(records, key=lambda record: record.identity)
         payload = {"baselines": [record.to_dict() for record in ordered]}
         try:
-            self.path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+            content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            fd, temp_path = tempfile.mkstemp(dir=self.path.parent, prefix=f".{self.path.name}.", text=True)
+            try:
+                os.write(fd, content.encode("utf-8"))
+                os.fsync(fd)
+                os.close(fd)
+                os.replace(temp_path, self.path)
+            except Exception:
+                os.close(fd) if fd >= 0 else None
+                Path(temp_path).unlink(missing_ok=True)
+                raise
         except OSError as exc:
             raise HarnessFault(f"Failed to write baseline store {self.path}: {exc}") from exc
 
@@ -109,7 +121,7 @@ class JsonBaselineStore:
         if not candidates:
             return None
 
-        def rank(record: BaselineRecord) -> tuple[int, str]:
+        def rank(record: BaselineRecord) -> tuple[int, float, str]:
             comparable_matches = sum(
                 (
                     record.key.condition == key.condition,
@@ -117,7 +129,8 @@ class JsonBaselineStore:
                     record.key.catalog_context == key.catalog_context,
                 )
             )
-            return (comparable_matches, record.created_at)
+            mean_score = sum(record.evaluator_means.values()) / len(record.evaluator_means) if record.evaluator_means else 0.0
+            return (comparable_matches, mean_score, record.created_at)
 
         return max(candidates, key=rank)
 

--- a/src/brainlayer/eval/phoenix_gate/baseline_store.py
+++ b/src/brainlayer/eval/phoenix_gate/baseline_store.py
@@ -1,0 +1,125 @@
+"""Versioned JSON baseline store for Phoenix regression gates."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from brainlayer.eval.phoenix_gate.models import BaselineKey, HarnessFault
+
+DEFAULT_BASELINE_STORE_PATH = Path(__file__).with_name("phoenix_baselines.json")
+GREEN_STATUS = "GREEN"
+
+
+@dataclass(frozen=True)
+class BaselineRecord:
+    key: BaselineKey
+    created_at: str
+    evaluator_means: dict[str, float]
+    source_experiment_id: str | None = None
+    status: str = GREEN_STATUS
+
+    @property
+    def identity(self) -> str:
+        return json.dumps([*self.key.as_tuple(), self.created_at], separators=(",", ":"), ensure_ascii=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "identity": self.identity,
+            "key": self.key.to_dict(),
+            "created_at": self.created_at,
+            "evaluator_means": dict(sorted(self.evaluator_means.items())),
+            "source_experiment_id": self.source_experiment_id,
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "BaselineRecord":
+        return cls(
+            key=BaselineKey.from_metadata(raw["key"]),
+            created_at=str(raw["created_at"]),
+            evaluator_means={str(name): float(value) for name, value in raw["evaluator_means"].items()},
+            source_experiment_id=raw.get("source_experiment_id"),
+            status=str(raw.get("status", GREEN_STATUS)),
+        )
+
+
+class JsonBaselineStore:
+    """Read/write immutable GREEN baseline records from a JSON file."""
+
+    def __init__(self, path: str | Path = DEFAULT_BASELINE_STORE_PATH) -> None:
+        self.path = Path(path)
+
+    def _read_records(self) -> list[BaselineRecord]:
+        if not self.path.exists():
+            return []
+        try:
+            payload = json.loads(self.path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            raise HarnessFault(f"Failed to read baseline store {self.path}: {exc}") from exc
+        if not isinstance(payload, dict) or not isinstance(payload.get("baselines", []), list):
+            raise HarnessFault(f"Baseline store {self.path} must contain a baselines list")
+        try:
+            return [BaselineRecord.from_dict(record) for record in payload.get("baselines", [])]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise HarnessFault(f"Baseline store {self.path} contains malformed baseline records: {exc}") from exc
+
+    def _write_records(self, records: list[BaselineRecord]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ordered = sorted(records, key=lambda record: record.identity)
+        payload = {"baselines": [record.to_dict() for record in ordered]}
+        try:
+            self.path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        except OSError as exc:
+            raise HarnessFault(f"Failed to write baseline store {self.path}: {exc}") from exc
+
+    def add_green(self, record: BaselineRecord) -> None:
+        if record.status != GREEN_STATUS:
+            raise HarnessFault(f"Only GREEN baselines can be stored, got status={record.status!r}")
+        if not record.created_at:
+            raise HarnessFault("Baseline created_at is required")
+        if not record.evaluator_means:
+            raise HarnessFault("Baseline evaluator_means must be non-empty")
+        records = self._read_records()
+        identities = {existing.identity for existing in records}
+        if record.identity not in identities:
+            records.append(record)
+        else:
+            records = [record if existing.identity == record.identity else existing for existing in records]
+        self._write_records(records)
+
+    def latest_green_exact(self, key: BaselineKey) -> BaselineRecord | None:
+        candidates = [record for record in self._read_records() if record.status == GREEN_STATUS and record.key == key]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda record: record.created_at)
+
+    def latest_green_for_comparison(self, key: BaselineKey) -> BaselineRecord | None:
+        exact = self.latest_green_exact(key)
+        if exact is not None:
+            return exact
+
+        candidates = [
+            record
+            for record in self._read_records()
+            if record.status == GREEN_STATUS and record.key.scope_tuple() == key.scope_tuple()
+        ]
+        if not candidates:
+            return None
+
+        def rank(record: BaselineRecord) -> tuple[int, str]:
+            comparable_matches = sum(
+                (
+                    record.key.condition == key.condition,
+                    record.key.model_version == key.model_version,
+                    record.key.catalog_context == key.catalog_context,
+                )
+            )
+            return (comparable_matches, record.created_at)
+
+        return max(candidates, key=rank)
+
+    def all_records(self) -> list[BaselineRecord]:
+        return self._read_records()

--- a/src/brainlayer/eval/phoenix_gate/baseline_store.py
+++ b/src/brainlayer/eval/phoenix_gate/baseline_store.py
@@ -129,7 +129,9 @@ class JsonBaselineStore:
                     record.key.catalog_context == key.catalog_context,
                 )
             )
-            mean_score = sum(record.evaluator_means.values()) / len(record.evaluator_means) if record.evaluator_means else 0.0
+            mean_score = (
+                sum(record.evaluator_means.values()) / len(record.evaluator_means) if record.evaluator_means else 0.0
+            )
             return (comparable_matches, mean_score, record.created_at)
 
         return max(candidates, key=rank)

--- a/src/brainlayer/eval/phoenix_gate/cli.py
+++ b/src/brainlayer/eval/phoenix_gate/cli.py
@@ -1,0 +1,73 @@
+"""CLI entrypoint for cron/CI-style Phoenix regression checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from brainlayer.eval.phoenix_gate.baseline_store import DEFAULT_BASELINE_STORE_PATH, JsonBaselineStore
+from brainlayer.eval.phoenix_gate.models import HarnessFault
+from brainlayer.eval.phoenix_gate.phoenix_client import DEFAULT_BASE_URL, PhoenixRestClient
+from brainlayer.eval.phoenix_gate.regression_gate import RegressionGate
+from brainlayer.eval.phoenix_gate.triggers import diff_rerun_triggers
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check a Phoenix experiment against stored GREEN baselines.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check", help="Fetch and score a Phoenix experiment.")
+    check.add_argument("--experiment-id", required=True, help="Phoenix REST experiment ID, e.g. RXhwZXJpbWVudDoxMA==")
+    check.add_argument(
+        "--expected-evaluator",
+        action="append",
+        dest="expected_evaluators",
+        required=True,
+        help="Expected evaluator name. Repeat for every evaluator in the suite.",
+    )
+    check.add_argument("--baseline-store", default=str(DEFAULT_BASELINE_STORE_PATH), help="JSON baseline store path.")
+    check.add_argument("--base-url", default=DEFAULT_BASE_URL, help="Phoenix base URL.")
+    check.add_argument("--threshold", type=float, default=0.0, help="Allowed score drop before alarm.")
+
+    triggers = subparsers.add_parser("triggers", help="Compare two trigger manifests.")
+    triggers.add_argument("--previous-manifest", required=True, help="Path to previous trigger manifest JSON.")
+    triggers.add_argument("--current-manifest", required=True, help="Path to current trigger manifest JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "triggers":
+        try:
+            previous = json.loads(Path(args.previous_manifest).read_text())
+            current = json.loads(Path(args.current_manifest).read_text())
+            diff = diff_rerun_triggers(previous, current)
+        except (HarnessFault, json.JSONDecodeError, OSError) as exc:
+            print(json.dumps({"status": "HARNESS_FAULT", "error": str(exc)}, sort_keys=True), file=sys.stderr)
+            return 2
+        print(json.dumps(diff.to_dict(), indent=2, sort_keys=True))
+        return 1 if diff.rerun_required else 0
+
+    if args.command != "check":
+        raise AssertionError(f"unhandled command {args.command!r}")
+
+    try:
+        client = PhoenixRestClient(base_url=args.base_url)
+        score = client.load_experiment_score(
+            args.experiment_id,
+            expected_evaluators=set(args.expected_evaluators),
+        )
+        gate = RegressionGate(JsonBaselineStore(Path(args.baseline_store)), threshold=args.threshold)
+        verdict = gate.evaluate(score)
+    except HarnessFault as exc:
+        print(json.dumps({"status": "HARNESS_FAULT", "error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return 2
+
+    print(json.dumps(verdict.to_dict(), indent=2, sort_keys=True))
+    return 1 if verdict.alarm else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/eval/phoenix_gate/models.py
+++ b/src/brainlayer/eval/phoenix_gate/models.py
@@ -44,9 +44,7 @@ class BaselineKey:
             if not isinstance(metadata.get(field), str) or not str(metadata.get(field)).strip()
         ]
         if missing:
-            raise HarnessFault(
-                "Experiment metadata missing canonical baseline tuple fields: " + ", ".join(missing)
-            )
+            raise HarnessFault("Experiment metadata missing canonical baseline tuple fields: " + ", ".join(missing))
         return cls(**{field: str(metadata[field]).strip() for field in BASELINE_KEY_FIELDS})
 
     def as_tuple(self) -> tuple[str, str, str, str, str, str]:

--- a/src/brainlayer/eval/phoenix_gate/models.py
+++ b/src/brainlayer/eval/phoenix_gate/models.py
@@ -1,0 +1,129 @@
+"""Shared models for the Phoenix regression gate."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+BASELINE_KEY_FIELDS = (
+    "surface",
+    "mode",
+    "condition",
+    "model_version",
+    "catalog_context",
+    "suite_version",
+)
+
+
+class HarnessFault(RuntimeError):
+    """Raised when Phoenix/gate data is structurally unsafe to score."""
+
+
+@dataclass(frozen=True)
+class BaselineKey:
+    """Canonical Phoenix baseline identity.
+
+    The tuple deliberately excludes Phoenix experiment global IDs because the
+    live store can reuse them after deletion. ``created_at`` is added by
+    ``BaselineRecord`` for immutable baseline identity.
+    """
+
+    surface: str
+    mode: str
+    condition: str
+    model_version: str
+    catalog_context: str
+    suite_version: str
+
+    @classmethod
+    def from_metadata(cls, metadata: Mapping[str, Any]) -> "BaselineKey":
+        missing = [
+            field
+            for field in BASELINE_KEY_FIELDS
+            if not isinstance(metadata.get(field), str) or not str(metadata.get(field)).strip()
+        ]
+        if missing:
+            raise HarnessFault(
+                "Experiment metadata missing canonical baseline tuple fields: " + ", ".join(missing)
+            )
+        return cls(**{field: str(metadata[field]).strip() for field in BASELINE_KEY_FIELDS})
+
+    def as_tuple(self) -> tuple[str, str, str, str, str, str]:
+        return (
+            self.surface,
+            self.mode,
+            self.condition,
+            self.model_version,
+            self.catalog_context,
+            self.suite_version,
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {field: value for field, value in zip(BASELINE_KEY_FIELDS, self.as_tuple(), strict=True)}
+
+    def identity_without_created_at(self) -> str:
+        return json.dumps(list(self.as_tuple()), separators=(",", ":"), ensure_ascii=True)
+
+    def scope_tuple(self) -> tuple[str, str, str]:
+        """Comparable suite scope: surface + mode + suite version."""
+        return (self.surface, self.mode, self.suite_version)
+
+
+@dataclass(frozen=True)
+class DatasetExample:
+    id: str | None
+    input: dict[str, Any]
+    output: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ExperimentScore:
+    experiment_id: str
+    dataset_id: str | None
+    created_at: str
+    key: BaselineKey
+    evaluator_means: dict[str, float]
+
+
+@dataclass(frozen=True)
+class RegressionFinding:
+    evaluator: str
+    baseline: float
+    observed: float
+    delta: float
+
+
+@dataclass(frozen=True)
+class RegressionVerdict:
+    status: str
+    alarm: bool
+    regression_attributed_to: str
+    regressions: tuple[RegressionFinding, ...]
+    candidate_key: BaselineKey
+    baseline_key: BaselineKey
+    candidate_created_at: str
+    baseline_created_at: str
+    requires_new_baseline: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "alarm": self.alarm,
+            "regression_attributed_to": self.regression_attributed_to,
+            "requires_new_baseline": self.requires_new_baseline,
+            "candidate_key": self.candidate_key.to_dict(),
+            "baseline_key": self.baseline_key.to_dict(),
+            "candidate_created_at": self.candidate_created_at,
+            "baseline_created_at": self.baseline_created_at,
+            "regressions": [
+                {
+                    "evaluator": finding.evaluator,
+                    "baseline": finding.baseline,
+                    "observed": finding.observed,
+                    "delta": finding.delta,
+                }
+                for finding in self.regressions
+            ],
+        }

--- a/src/brainlayer/eval/phoenix_gate/phoenix_client.py
+++ b/src/brainlayer/eval/phoenix_gate/phoenix_client.py
@@ -94,6 +94,11 @@ def aggregate_evaluator_means(payload: Any, *, expected_evaluators: set[str] | f
         raise HarnessFault("Phoenix experiment missing expected evaluator(s): " + ", ".join(missing))
 
     scored_expected = {name: means[name] for name in expected_evaluators}
+    # Fail-loud on all-zero to catch Phoenix evaluator setup bugs (e.g. list instead of dict)
+    # where harness silently produces zero scores. While this prevents detecting legitimate
+    # all-zero regressions, the Phoenix list→dict coercion gotcha is caught earlier by
+    # validate_evaluators_for_run, so in practice this guard catches missing annotations
+    # or broken evaluator runs that would otherwise appear as silent SHIP verdicts.
     if scored_expected and all(value == 0.0 for value in scored_expected.values()):
         raise HarnessFault("Phoenix experiment evaluator output is all-zero; likely harness fault")
     return means

--- a/src/brainlayer/eval/phoenix_gate/phoenix_client.py
+++ b/src/brainlayer/eval/phoenix_gate/phoenix_client.py
@@ -1,0 +1,210 @@
+"""REST-only Phoenix client helpers for regression-gate inputs."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from brainlayer.eval.phoenix_gate.models import BaselineKey, DatasetExample, ExperimentScore, HarnessFault
+
+PHOENIX_TAILNET_BASE_URL = "http://100.114.179.86:6006"
+DEFAULT_BASE_URL = os.environ.get("PHOENIX_BASE_URL", PHOENIX_TAILNET_BASE_URL)
+
+
+def validate_evaluators_for_run(evaluators: object) -> Mapping[str, Any]:
+    """Guard the Phoenix gotcha where a list silently zeroes evaluator output."""
+    if not isinstance(evaluators, Mapping):
+        raise HarnessFault("Phoenix evaluators must be passed as a non-empty dict, not a list")
+    if not evaluators:
+        raise HarnessFault("Phoenix evaluators dict must be non-empty")
+    if not all(isinstance(name, str) and name for name in evaluators):
+        raise HarnessFault("Phoenix evaluator names must be non-empty strings")
+    return evaluators
+
+
+def _coerce_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        for candidate_key in ("data", "rows", "examples"):
+            if candidate_key in payload:
+                rows = payload[candidate_key]
+                break
+        else:
+            rows = None
+    else:
+        rows = None
+    if not isinstance(rows, list):
+        raise HarnessFault("Phoenix experiment JSON must be a list of rows")
+    if not all(isinstance(row, dict) for row in rows):
+        raise HarnessFault("Phoenix experiment JSON rows must be objects")
+    return rows
+
+
+def _annotation_score(annotation: Mapping[str, Any]) -> float:
+    if annotation.get("error"):
+        raise HarnessFault(f"Phoenix evaluator {annotation.get('name')!r} errored: {annotation['error']}")
+    value = annotation.get("score")
+    if value is None:
+        value = annotation.get("label")
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip().lower()
+        if stripped in {"true", "pass", "passed", "yes"}:
+            return 1.0
+        if stripped in {"false", "fail", "failed", "no"}:
+            return 0.0
+        try:
+            return float(stripped)
+        except ValueError as exc:
+            raise HarnessFault(f"Phoenix evaluator {annotation.get('name')!r} has non-numeric label {value!r}") from exc
+    raise HarnessFault(f"Phoenix evaluator {annotation.get('name')!r} is missing a numeric score")
+
+
+def aggregate_evaluator_means(payload: Any, *, expected_evaluators: set[str] | frozenset[str]) -> dict[str, float]:
+    rows = _coerce_rows(payload)
+    scores: dict[str, list[float]] = defaultdict(list)
+    for row in rows:
+        annotations = row.get("annotations")
+        if not isinstance(annotations, list):
+            raise HarnessFault("Phoenix experiment row missing annotations list")
+        for annotation in annotations:
+            if not isinstance(annotation, Mapping):
+                raise HarnessFault("Phoenix annotation must be an object")
+            name = annotation.get("name")
+            if not isinstance(name, str) or not name:
+                raise HarnessFault("Phoenix annotation missing evaluator name")
+            scores[name].append(_annotation_score(annotation))
+
+    means = {name: sum(values) / len(values) for name, values in sorted(scores.items()) if values}
+    if not means:
+        raise HarnessFault("Phoenix experiment has no evaluator output")
+
+    missing = sorted(expected_evaluators - set(means))
+    if missing:
+        raise HarnessFault("Phoenix experiment missing expected evaluator(s): " + ", ".join(missing))
+
+    scored_expected = {name: means[name] for name in expected_evaluators}
+    if scored_expected and all(value == 0.0 for value in scored_expected.values()):
+        raise HarnessFault("Phoenix experiment evaluator output is all-zero; likely harness fault")
+    return means
+
+
+def extract_dataset_examples(payload: Any) -> list[DatasetExample]:
+    if not isinstance(payload, dict):
+        raise HarnessFault("Phoenix dataset payload must be an object")
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise HarnessFault("Phoenix dataset data must be an object")
+    rows = data.get("examples")
+    if not isinstance(rows, list):
+        raise HarnessFault("Phoenix get_dataset read payload missing data.examples")
+
+    examples: list[DatasetExample] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise HarnessFault("Phoenix dataset example must be an object")
+        input_value = row.get("input")
+        output_value = row.get("output", {})
+        metadata_value = row.get("metadata", {})
+        if not isinstance(input_value, dict) or not input_value:
+            raise HarnessFault(f"Phoenix dataset example {row.get('id')!r} has empty input")
+        if not isinstance(output_value, dict):
+            raise HarnessFault(f"Phoenix dataset example {row.get('id')!r} has non-object output")
+        if not isinstance(metadata_value, dict):
+            raise HarnessFault(f"Phoenix dataset example {row.get('id')!r} has non-object metadata")
+        examples.append(
+            DatasetExample(
+                id=None if row.get("id") is None else str(row.get("id")),
+                input=dict(input_value),
+                output=dict(output_value),
+                metadata=dict(metadata_value),
+            )
+        )
+    if not examples:
+        raise HarnessFault("Phoenix get_dataset read payload contains no examples")
+    return examples
+
+
+class PhoenixRestClient:
+    """Small REST client for Phoenix v1 endpoints used by the gate."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        request_json: Callable[[str], Any] | None = None,
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._request_json = request_json
+        self.timeout_seconds = timeout_seconds
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def _get_json(self, path: str) -> Any:
+        url = self._url(path)
+        if self._request_json is not None:
+            return self._request_json(url)
+        request = urllib.request.Request(url, headers={"Accept": "application/json"})
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except (urllib.error.URLError, json.JSONDecodeError) as exc:
+            raise HarnessFault(f"Phoenix REST request failed for {url}: {exc}") from exc
+
+    @staticmethod
+    def _quote_id(value: str) -> str:
+        return urllib.parse.quote(value, safe="")
+
+    def list_dataset_experiments(self, dataset_id: str) -> list[dict[str, Any]]:
+        payload = self._get_json(f"/v1/datasets/{self._quote_id(dataset_id)}/experiments")
+        if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+            raise HarnessFault("Phoenix dataset experiments payload missing data list")
+        return payload["data"]
+
+    def get_dataset_examples(self, dataset_id: str) -> list[DatasetExample]:
+        payload = self._get_json(f"/v1/datasets/{self._quote_id(dataset_id)}/examples")
+        return extract_dataset_examples(payload)
+
+    def get_experiment(self, experiment_id: str) -> dict[str, Any]:
+        payload = self._get_json(f"/v1/experiments/{self._quote_id(experiment_id)}")
+        if not isinstance(payload, dict):
+            raise HarnessFault("Phoenix experiment payload must be an object")
+        if isinstance(payload.get("data"), dict):
+            return payload["data"]
+        return payload
+
+    def get_experiment_json(self, experiment_id: str) -> list[dict[str, Any]]:
+        payload = self._get_json(f"/v1/experiments/{self._quote_id(experiment_id)}/json")
+        return _coerce_rows(payload)
+
+    def load_experiment_score(
+        self,
+        experiment_id: str,
+        *,
+        expected_evaluators: set[str] | frozenset[str],
+    ) -> ExperimentScore:
+        experiment = self.get_experiment(experiment_id)
+        metadata = experiment.get("metadata")
+        if not isinstance(metadata, Mapping):
+            raise HarnessFault("Phoenix experiment metadata must be an object")
+        key = BaselineKey.from_metadata(metadata)
+        rows = self.get_experiment_json(experiment_id)
+        return ExperimentScore(
+            experiment_id=str(experiment.get("id", experiment_id)),
+            dataset_id=None if experiment.get("dataset_id") is None else str(experiment.get("dataset_id")),
+            created_at=str(experiment.get("created_at", "")),
+            key=key,
+            evaluator_means=aggregate_evaluator_means(rows, expected_evaluators=expected_evaluators),
+        )

--- a/src/brainlayer/eval/phoenix_gate/regression_gate.py
+++ b/src/brainlayer/eval/phoenix_gate/regression_gate.py
@@ -1,0 +1,89 @@
+"""Regression verdict logic for Phoenix evaluator vectors."""
+
+from __future__ import annotations
+
+import math
+
+from brainlayer.eval.phoenix_gate.baseline_store import BaselineRecord, JsonBaselineStore
+from brainlayer.eval.phoenix_gate.models import (
+    BaselineKey,
+    ExperimentScore,
+    HarnessFault,
+    RegressionFinding,
+    RegressionVerdict,
+)
+
+OTEL_TIER2_ENABLED = False
+
+
+def _attribute_regression(baseline_key: BaselineKey, candidate_key: BaselineKey) -> str:
+    changed: set[str] = set()
+    if baseline_key.condition != candidate_key.condition:
+        changed.add("description")
+    if baseline_key.model_version != candidate_key.model_version:
+        changed.add("model")
+    if baseline_key.catalog_context != candidate_key.catalog_context:
+        changed.add("catalog")
+
+    if not changed:
+        return "unknown"
+    if len(changed) == 1:
+        return next(iter(changed))
+    return "both"
+
+
+class RegressionGate:
+    """Compare a Phoenix experiment vector against the latest GREEN baseline."""
+
+    def __init__(self, baseline_store: JsonBaselineStore, *, threshold: float = 0.0) -> None:
+        if not math.isfinite(threshold) or threshold < 0:
+            raise ValueError("threshold must be a finite value >= 0")
+        self.baseline_store = baseline_store
+        self.threshold = threshold
+
+    def _resolve_baseline(self, score: ExperimentScore) -> BaselineRecord:
+        baseline = self.baseline_store.latest_green_for_comparison(score.key)
+        if baseline is None:
+            raise HarnessFault(
+                "No GREEN Phoenix baseline found for "
+                f"surface={score.key.surface!r}, mode={score.key.mode!r}, suite_version={score.key.suite_version!r}"
+            )
+        return baseline
+
+    def evaluate(self, score: ExperimentScore) -> RegressionVerdict:
+        if not score.evaluator_means:
+            raise HarnessFault("Candidate experiment evaluator_means must be non-empty")
+        baseline = self._resolve_baseline(score)
+        missing = sorted(set(baseline.evaluator_means) - set(score.evaluator_means))
+        if missing:
+            raise HarnessFault("Candidate experiment missing baseline evaluator(s): " + ", ".join(missing))
+
+        regressions: list[RegressionFinding] = []
+        for evaluator, baseline_value in sorted(baseline.evaluator_means.items()):
+            observed = float(score.evaluator_means[evaluator])
+            delta = observed - float(baseline_value)
+            if -delta > self.threshold:
+                regressions.append(
+                    RegressionFinding(
+                        evaluator=evaluator,
+                        baseline=float(baseline_value),
+                        observed=observed,
+                        delta=delta,
+                    )
+                )
+
+        attribution = _attribute_regression(baseline.key, score.key)
+        alarm = bool(regressions)
+        status = "ITERATE" if alarm else ("SHIP_SAFE" if attribution == "unknown" else "SHIP")
+        requires_new_baseline = not alarm and baseline.key != score.key
+        return RegressionVerdict(
+            status=status,
+            alarm=alarm,
+            regression_attributed_to=attribution,
+            regressions=tuple(regressions),
+            candidate_key=score.key,
+            baseline_key=baseline.key,
+            candidate_created_at=score.created_at,
+            baseline_created_at=baseline.created_at,
+            requires_new_baseline=requires_new_baseline,
+        )

--- a/src/brainlayer/eval/phoenix_gate/triggers.py
+++ b/src/brainlayer/eval/phoenix_gate/triggers.py
@@ -1,0 +1,56 @@
+"""Re-run trigger manifest checks for Phoenix eval suites."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from brainlayer.eval.phoenix_gate.models import HarnessFault
+
+TRIGGER_FIELDS = (
+    "description_hash",
+    "skill_hash",
+    "model_version",
+    "catalog_context",
+    "suite_version",
+)
+
+FIELD_REASONS = {
+    "description_hash": "description_changed",
+    "skill_hash": "skill_changed",
+    "model_version": "model_version_changed",
+    "catalog_context": "catalog_context_changed",
+    "suite_version": "suite_version_changed",
+}
+
+
+@dataclass(frozen=True)
+class TriggerDiff:
+    rerun_required: bool
+    reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"rerun_required": self.rerun_required, "reasons": list(self.reasons)}
+
+
+def _require_manifest_fields(name: str, manifest: Mapping[str, Any]) -> None:
+    missing = [
+        field
+        for field in TRIGGER_FIELDS
+        if not isinstance(manifest.get(field), str) or not str(manifest.get(field)).strip()
+    ]
+    if missing:
+        raise HarnessFault(f"{name} trigger manifest missing required field(s): " + ", ".join(missing))
+
+
+def diff_rerun_triggers(previous: Mapping[str, Any], current: Mapping[str, Any]) -> TriggerDiff:
+    """Return the exact trigger reasons that require a fresh Phoenix eval run."""
+    _require_manifest_fields("previous", previous)
+    _require_manifest_fields("current", current)
+
+    reasons = tuple(
+        FIELD_REASONS[field]
+        for field in TRIGGER_FIELDS
+        if str(previous[field]).strip() != str(current[field]).strip()
+    )
+    return TriggerDiff(rerun_required=bool(reasons), reasons=reasons)

--- a/src/brainlayer/eval/phoenix_gate/triggers.py
+++ b/src/brainlayer/eval/phoenix_gate/triggers.py
@@ -49,8 +49,6 @@ def diff_rerun_triggers(previous: Mapping[str, Any], current: Mapping[str, Any])
     _require_manifest_fields("current", current)
 
     reasons = tuple(
-        FIELD_REASONS[field]
-        for field in TRIGGER_FIELDS
-        if str(previous[field]).strip() != str(current[field]).strip()
+        FIELD_REASONS[field] for field in TRIGGER_FIELDS if str(previous[field]).strip() != str(current[field]).strip()
     )
     return TriggerDiff(rerun_required=bool(reasons), reasons=reasons)

--- a/tests/eval/phoenix_gate/test_phoenix_gate.py
+++ b/tests/eval/phoenix_gate/test_phoenix_gate.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brainlayer.eval.phoenix_gate.baseline_store import (
+    DEFAULT_BASELINE_STORE_PATH,
+    BaselineRecord,
+    JsonBaselineStore,
+)
+from brainlayer.eval.phoenix_gate.models import BaselineKey, ExperimentScore, HarnessFault
+from brainlayer.eval.phoenix_gate.phoenix_client import (
+    DEFAULT_BASE_URL,
+    PHOENIX_TAILNET_BASE_URL,
+    aggregate_evaluator_means,
+    extract_dataset_examples,
+    validate_evaluators_for_run,
+)
+from brainlayer.eval.phoenix_gate.regression_gate import RegressionGate
+from brainlayer.eval.phoenix_gate.triggers import diff_rerun_triggers
+
+
+def _key(
+    *,
+    condition: str = "control",
+    model_version: str = "claude-opus-4-8-1m",
+    catalog_context: str = "minimal",
+) -> BaselineKey:
+    return BaselineKey(
+        surface="cmux-mcp",
+        mode="usage",
+        condition=condition,
+        model_version=model_version,
+        catalog_context=catalog_context,
+        suite_version="v0-proof",
+    )
+
+
+def _score(
+    *,
+    key: BaselineKey | None = None,
+    means: dict[str, float] | None = None,
+    created_at: str = "2026-06-03T18:52:10+00:00",
+    experiment_id: str = "RXhwZXJpbWVudDoxMQ==",
+) -> ExperimentScore:
+    return ExperimentScore(
+        experiment_id=experiment_id,
+        dataset_id="RGF0YXNldDo0",
+        created_at=created_at,
+        key=key or _key(),
+        evaluator_means=means or {"executed_not_relayed": 1.0, "success": 1.0},
+    )
+
+
+def test_baseline_key_requires_all_six_canonical_metadata_fields() -> None:
+    metadata = {
+        "surface": "cmux-mcp",
+        "mode": "usage",
+        "condition": "baseline_live",
+        "model_version": "claude-opus-4-8-1m",
+        "catalog_context": "full-fleet-live",
+        "suite_version": "v0-proof",
+    }
+
+    key = BaselineKey.from_metadata(metadata)
+
+    assert key == BaselineKey(
+        surface="cmux-mcp",
+        mode="usage",
+        condition="baseline_live",
+        model_version="claude-opus-4-8-1m",
+        catalog_context="full-fleet-live",
+        suite_version="v0-proof",
+    )
+
+    missing_model_version = dict(metadata)
+    missing_model_version.pop("model_version")
+    missing_model_version["model"] = "Opus-1M"
+
+    with pytest.raises(HarnessFault, match="model_version"):
+        BaselineKey.from_metadata(missing_model_version)
+
+
+def test_phoenix_base_url_is_tailnet_default_not_localhost() -> None:
+    assert PHOENIX_TAILNET_BASE_URL == "http://100.114.179.86:6006"
+    assert DEFAULT_BASE_URL == PHOENIX_TAILNET_BASE_URL
+
+
+def test_aggregate_evaluator_means_allows_true_zero_but_fails_silent_zero() -> None:
+    rows = [
+        {
+            "annotations": [
+                {"name": "executed_not_relayed", "annotator_kind": "CODE", "score": 1.0},
+                {"name": "focus_before_send", "annotator_kind": "CODE", "score": 1.0},
+                {"name": "abs_le2_columns", "annotator_kind": "CODE", "score": 0.0},
+                {"name": "success", "annotator_kind": "CODE", "score": 1.0},
+            ]
+        }
+    ]
+
+    means = aggregate_evaluator_means(
+        rows,
+        expected_evaluators={"executed_not_relayed", "focus_before_send", "abs_le2_columns", "success"},
+    )
+
+    assert means == {
+        "abs_le2_columns": 0.0,
+        "executed_not_relayed": 1.0,
+        "focus_before_send": 1.0,
+        "success": 1.0,
+    }
+
+    silent_zero_rows = [
+        {
+            "annotations": [
+                {"name": "executed_not_relayed", "annotator_kind": "CODE", "score": 0.0},
+                {"name": "focus_before_send", "annotator_kind": "CODE", "score": 0.0},
+                {"name": "abs_le2_columns", "annotator_kind": "CODE", "score": 0.0},
+                {"name": "success", "annotator_kind": "CODE", "score": 0.0},
+            ]
+        }
+    ]
+
+    with pytest.raises(HarnessFault, match="all-zero"):
+        aggregate_evaluator_means(
+            silent_zero_rows,
+            expected_evaluators={"executed_not_relayed", "focus_before_send", "abs_le2_columns", "success"},
+        )
+
+
+def test_aggregate_evaluator_means_fails_loud_on_absent_expected_evaluator() -> None:
+    rows = [{"annotations": [{"name": "success", "annotator_kind": "CODE", "score": 1.0}]}]
+
+    with pytest.raises(HarnessFault, match="executed_not_relayed"):
+        aggregate_evaluator_means(rows, expected_evaluators={"success", "executed_not_relayed"})
+
+
+def test_phoenix_evaluators_must_be_non_empty_dict_not_list() -> None:
+    evaluators = {"success": object()}
+
+    assert validate_evaluators_for_run(evaluators) is evaluators
+
+    with pytest.raises(HarnessFault, match="dict"):
+        validate_evaluators_for_run([object()])
+
+    with pytest.raises(HarnessFault, match="non-empty"):
+        validate_evaluators_for_run({})
+
+
+def test_get_dataset_read_shape_extracts_examples_without_empty_inputs() -> None:
+    payload = {
+        "data": {
+            "dataset_id": "RGF0YXNldDoz",
+            "version_id": "RGF0YXNldFZlcnNpb246NA==",
+            "examples": [
+                {
+                    "id": "RGF0YXNldEV4YW1wbGU6OTQ1",
+                    "input": {"case_id": "F3", "mode": "usage", "intent": "Use cmux, not a relay."},
+                    "output": {"gold_primary": "send_to"},
+                    "metadata": {"failure_id": "F3"},
+                }
+            ],
+        }
+    }
+
+    examples = extract_dataset_examples(payload)
+
+    assert examples[0].input["case_id"] == "F3"
+    assert examples[0].output["gold_primary"] == "send_to"
+    assert examples[0].metadata["failure_id"] == "F3"
+
+    bad_payload = {"data": {"examples": [{"id": "bad", "input": {}, "output": {}, "metadata": {}}]}}
+    with pytest.raises(HarnessFault, match="empty input"):
+        extract_dataset_examples(bad_payload)
+
+
+def test_baseline_store_identity_uses_tuple_and_created_at_not_experiment_global_id(tmp_path) -> None:
+    path = tmp_path / "phoenix-baselines.json"
+    store = JsonBaselineStore(path)
+    key = _key()
+
+    store.add_green(
+        BaselineRecord(
+            key=key,
+            created_at="2026-06-03T18:51:49+00:00",
+            evaluator_means={"success": 1.0},
+            source_experiment_id="RXhwZXJpbWVudDo3",
+        )
+    )
+    store.add_green(
+        BaselineRecord(
+            key=key,
+            created_at="2026-06-03T18:51:50+00:00",
+            evaluator_means={"success": 0.9},
+            source_experiment_id="RXhwZXJpbWVudDo3",
+        )
+    )
+
+    raw = json.loads(path.read_text())
+    identities = [record["identity"] for record in raw["baselines"]]
+
+    assert [json.loads(identity) for identity in identities] == [
+        [
+            "cmux-mcp",
+            "usage",
+            "control",
+            "claude-opus-4-8-1m",
+            "minimal",
+            "v0-proof",
+            "2026-06-03T18:51:49+00:00",
+        ],
+        [
+            "cmux-mcp",
+            "usage",
+            "control",
+            "claude-opus-4-8-1m",
+            "minimal",
+            "v0-proof",
+            "2026-06-03T18:51:50+00:00",
+        ],
+    ]
+    assert all("RXhwZXJpbWVudDo3" not in identity for identity in identities)
+    assert store.latest_green_exact(key).evaluator_means["success"] == 0.9
+
+
+def test_baseline_store_wraps_malformed_json_as_harness_fault(tmp_path) -> None:
+    path = tmp_path / "phoenix-baselines.json"
+    path.write_text("{not-json")
+
+    with pytest.raises(HarnessFault, match="Failed to read baseline store"):
+        JsonBaselineStore(path).all_records()
+
+
+def test_default_baseline_store_path_is_not_brainlayer_db() -> None:
+    assert DEFAULT_BASELINE_STORE_PATH.name != "brainlayer.db"
+    assert "brainlayer.db" not in str(DEFAULT_BASELINE_STORE_PATH)
+
+
+def test_regression_gate_flags_drop_and_attributes_description_axis(tmp_path) -> None:
+    store = JsonBaselineStore(tmp_path / "baselines.json")
+    store.add_green(
+        BaselineRecord(
+            key=_key(condition="control"),
+            created_at="2026-06-03T18:51:49+00:00",
+            evaluator_means={"tool_accuracy": 1.0, "no_wrong_calls": 1.0},
+            source_experiment_id="RXhwZXJpbWVudDo3",
+        )
+    )
+    candidate = _score(
+        key=_key(condition="variant1_pr121"),
+        means={"tool_accuracy": 0.75, "no_wrong_calls": 1.0},
+        experiment_id="RXhwZXJpbWVudDo4",
+    )
+
+    verdict = RegressionGate(store, threshold=0.0).evaluate(candidate)
+
+    assert verdict.alarm is True
+    assert verdict.status == "ITERATE"
+    assert verdict.regression_attributed_to == "description"
+    assert verdict.regressions[0].evaluator == "tool_accuracy"
+    assert verdict.regressions[0].delta == pytest.approx(-0.25)
+
+
+def test_regression_gate_rejects_non_finite_threshold(tmp_path) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        RegressionGate(JsonBaselineStore(tmp_path / "baselines.json"), threshold=float("nan"))
+
+
+def test_regression_gate_rekeys_model_upgrade_without_alarm_when_scores_hold(tmp_path) -> None:
+    store = JsonBaselineStore(tmp_path / "baselines.json")
+    store.add_green(
+        BaselineRecord(
+            key=_key(model_version="claude-opus-4-8-1m"),
+            created_at="2026-06-03T18:51:50+00:00",
+            evaluator_means={"success": 1.0, "executed_not_relayed": 1.0},
+            source_experiment_id="RXhwZXJpbWVudDoxMA==",
+        )
+    )
+    candidate = _score(
+        key=_key(model_version="claude-opus-4-9-1m"),
+        means={"success": 1.0, "executed_not_relayed": 1.0},
+        experiment_id="RXhwZXJpbWVudDoxMQ==",
+    )
+
+    verdict = RegressionGate(store, threshold=0.0).evaluate(candidate)
+
+    assert verdict.alarm is False
+    assert verdict.status == "SHIP"
+    assert verdict.regression_attributed_to == "model"
+    assert verdict.requires_new_baseline is True
+
+
+def test_regression_gate_same_tuple_drop_has_unknown_attribution(tmp_path) -> None:
+    store = JsonBaselineStore(tmp_path / "baselines.json")
+    store.add_green(
+        BaselineRecord(
+            key=_key(),
+            created_at="2026-06-03T18:51:50+00:00",
+            evaluator_means={"success": 1.0},
+            source_experiment_id="RXhwZXJpbWVudDoxMA==",
+        )
+    )
+    candidate = _score(key=_key(), means={"success": 0.0}, experiment_id="RXhwZXJpbWVudDoxMA==")
+
+    verdict = RegressionGate(store, threshold=0.0).evaluate(candidate)
+
+    assert verdict.alarm is True
+    assert verdict.regression_attributed_to == "unknown"
+
+
+def test_rerun_triggers_include_model_version_as_mandatory_axis() -> None:
+    previous = {
+        "description_hash": "desc-a",
+        "skill_hash": "skill-a",
+        "model_version": "claude-opus-4-8-1m",
+        "catalog_context": "minimal",
+        "suite_version": "v0-proof",
+    }
+
+    current = {
+        "description_hash": "desc-a",
+        "skill_hash": "skill-a",
+        "model_version": "claude-opus-4-9-1m",
+        "catalog_context": "minimal",
+        "suite_version": "v0-proof",
+    }
+
+    diff = diff_rerun_triggers(previous, current)
+
+    assert diff.rerun_required is True
+    assert diff.reasons == ("model_version_changed",)
+
+
+def test_rerun_triggers_fail_loud_on_missing_manifest_axis() -> None:
+    previous = {
+        "description_hash": "desc-a",
+        "skill_hash": "skill-a",
+        "model_version": "claude-opus-4-8-1m",
+        "catalog_context": "minimal",
+        "suite_version": "v0-proof",
+    }
+    current = dict(previous)
+    current.pop("model_version")
+
+    with pytest.raises(HarnessFault, match="model_version"):
+        diff_rerun_triggers(previous, current)
+
+
+def test_empty_phoenix_experiment_payload_fails_as_no_evaluator_output() -> None:
+    with pytest.raises(HarnessFault, match="no evaluator output"):
+        aggregate_evaluator_means({"data": []}, expected_evaluators={"success"})


### PR DESCRIPTION
## Summary
- Add REST-only Phoenix regression-gate package under `src/brainlayer/eval/phoenix_gate/`.
- Store GREEN baselines in JSON keyed by `{surface,mode,condition,model_version,catalog_context,suite_version}` plus `created_at`, never Phoenix experiment global IDs.
- Add fail-loud guards for missing tuple fields, missing/all-zero evaluators, Phoenix evaluator dict shape, `get_dataset()` read shape, malformed baseline stores, and non-finite thresholds.
- Emit verdicts with `regression_attributed_to` and model-upgrade re-key semantics; keep OTel Tier-2 off for v1.

## Test plan
- [x] `python3 -m pytest tests/eval/phoenix_gate/test_phoenix_gate.py -q` (16 passed)
- [x] `python3 -m ruff check src/brainlayer/eval/phoenix_gate tests/eval/phoenix_gate`
- [x] `python3 -m pytest -q` (2459 passed, 48 skipped, 5 xfailed)
- [x] Push hook: pytest unit suite (2385 passed, 9 skipped, 77 deselected, 1 xfailed), MCP registration (3 passed), isolated eval/hook routing (40 passed), bun suite (1 pass), regression shell `test_fts5_determinism.sh` passed
- [x] Live Phoenix REST smoke against `RXhwZXJpbWVudDoxMA==` returned `SHIP_SAFE` and preserved true `abs_le2_columns=0.0`

## Review policy
Review-required. orc merges; this PR should not be self-merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CI gate logic can block or pass releases based on baseline matching and score thresholds; misconfigured baselines or the all-zero evaluator guard could false-alarm, but scope is eval tooling with strong tests and no production runtime path.
> 
> **Overview**
> Introduces **`brainlayer.eval.phoenix_gate`**, a CI/cron-friendly path to pull Phoenix experiment scores over REST, compare them to stored **GREEN** baselines, and emit structured ship/iterate verdicts.
> 
> **Baseline storage** uses a versioned JSON file (`phoenix_baselines.json`) keyed by a six-field tuple (`surface`, `mode`, `condition`, `model_version`, `catalog_context`, `suite_version`) plus **`created_at`**—not Phoenix experiment global IDs—with atomic writes and scope-level fallback when an exact key is missing.
> 
> **`RegressionGate`** alarms on per-evaluator drops beyond a threshold, sets status (`ITERATE` / `SHIP` / `SHIP_SAFE`), attributes regressions to description/model/catalog axes, and flags **`requires_new_baseline`** when keys change but scores hold.
> 
> **`PhoenixRestClient`** aggregates evaluator means with fail-loud checks (missing evaluators, all-zero suites, dict-vs-list evaluator setup). **`diff_rerun_triggers`** compares trigger manifests to decide if a suite rerun is required.
> 
> **CLI** (`python -m brainlayer.eval.phoenix_gate`): **`check`** (exit 1 on alarm, 2 on harness fault) and **`triggers`**. Covered by **`tests/eval/phoenix_gate/test_phoenix_gate.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903e09822605d2b5d791411d7b1a299b2c7787f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Phoenix regression gate for experiment-based regression detection
> - Adds a new `brainlayer.eval.phoenix_gate` package that compares Phoenix experiment scores against stored GREEN baselines to produce SHIP_SAFE, SHIP, or ITERATE verdicts.
> - [`RegressionGate`](https://github.com/EtanHey/brainlayer/pull/432/files#diff-f6e9e6b0a419ff9ac43827d4f5b449a70b5275eeea64039fa3c04e05fc3dddda) resolves the best applicable baseline (exact or scope-matched), computes per-evaluator deltas, and attributes regressions to model, description, catalog, or unknown changes.
> - [`JsonBaselineStore`](https://github.com/EtanHey/brainlayer/pull/432/files#diff-ed97dbef3d14463b950ab365d78438e11ac7686ce8e6d1e59c49b2b5c7df0df5) persists GREEN baselines atomically to a JSON file with deduplication and fallback matching.
> - [`PhoenixRestClient`](https://github.com/EtanHey/brainlayer/pull/432/files#diff-1bda88dff91ff3249054b574690c026454cd1bbeefe985aa016114fedb7165d5) fetches and validates experiment runs and dataset examples from the Phoenix REST API, normalizing evaluator outputs to float scores.
> - A CLI (`python -m brainlayer.eval.phoenix_gate`) exposes `check` and `triggers` subcommands with JSON output and distinct exit codes (0=pass, 1=alarm/rerun-required, 2=harness error).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 903e098.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Phoenix evaluation regression gate system with baseline storage, retrieval, and comparison capabilities
  * CLI tools for running regression checks and analyzing trigger-based reruns
  * Phoenix REST client for fetching and processing experiment data

* **Tests**
  * Comprehensive test suite covering regression gate functionality and data processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->