### PR TITLE
fix: harden drain against DB open locks

### DIFF
--- a/scripts/launchd/com.brainlayer.index.plist
+++ b/scripts/launchd/com.brainlayer.index.plist
@@ -9,8 +9,13 @@
 		<string>__BRAINLAYER_BIN__</string>
 		<string>index</string>
 	</array>
-	<key>StartInterval</key>
-	<integer>1800</integer>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>3</integer>
+		<key>Minute</key>
+		<integer>15</integer>
+	</dict>
 	<key>StandardOutPath</key>
 	<string>__HOME__/Library/Logs/brainlayer/index.out.log</string>
 	<key>StandardErrorPath</key>
@@ -24,8 +29,6 @@
 		<key>BRAINLAYER_REPO_ROOT</key>
 		<string>__BRAINLAYER_DIR__</string>
 	</dict>
-	<key>RunAtLoad</key>
-	<true/>
 	<key>Nice</key>
 	<integer>10</integer>
 	<key>ProcessType</key>

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -18,7 +18,7 @@ from typing import Any, Callable
 import apsw
 import sqlite_vec
 
-from ._helpers import serialize_f32
+from ._helpers import _is_sqlite_busy_error, serialize_f32
 from .chunk_origin import detect_chunk_origin
 from .content_class import classify_content_class, normalize_content_class
 from .dedupe import (
@@ -36,6 +36,9 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_DRAIN_BUSY_TIMEOUT_MS = 30000
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
+_DEFAULT_DRAIN_OPEN_MAX_RETRIES = 12
+_DEFAULT_DRAIN_OPEN_RETRY_BASE_DELAY_MS = 250.0
+_DEFAULT_DRAIN_OPEN_RETRY_MAX_DELAY_MS = 5000.0
 _DEFAULT_MAX_EVENTS_PER_TRANSACTION = 5
 _DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION = 5000
 _DEFAULT_POST_COMMIT_YIELD_MS = 10.0
@@ -91,6 +94,22 @@ def _post_commit_yield_seconds() -> float:
     return _nonnegative_float_env("BRAINLAYER_DRAIN_POST_COMMIT_YIELD_MS", _DEFAULT_POST_COMMIT_YIELD_MS) / 1000.0
 
 
+def _drain_open_max_retries() -> int:
+    return _positive_int_env("BRAINLAYER_DRAIN_OPEN_MAX_RETRIES", _DEFAULT_DRAIN_OPEN_MAX_RETRIES)
+
+
+def _drain_open_retry_delay_seconds(attempt: int) -> float:
+    base_ms = _nonnegative_float_env(
+        "BRAINLAYER_DRAIN_OPEN_RETRY_BASE_DELAY_MS",
+        _DEFAULT_DRAIN_OPEN_RETRY_BASE_DELAY_MS,
+    )
+    max_ms = _nonnegative_float_env(
+        "BRAINLAYER_DRAIN_OPEN_RETRY_MAX_DELAY_MS",
+        _DEFAULT_DRAIN_OPEN_RETRY_MAX_DELAY_MS,
+    )
+    return min(base_ms * (2**attempt), max_ms) / 1000.0
+
+
 @dataclass
 class ApplyResult:
     chunk_id: str | None = None
@@ -129,7 +148,24 @@ def _log(path: Path, message: str) -> None:
 
 
 def _open_connection(db_path: Path) -> apsw.Connection:
-    conn = apsw.Connection(str(db_path))
+    max_retries = _drain_open_max_retries()
+    for attempt in range(max_retries + 1):
+        try:
+            conn = apsw.Connection(str(db_path))
+            break
+        except Exception as exc:
+            if not _is_busy_error(exc) or attempt >= max_retries:
+                raise
+            delay = _drain_open_retry_delay_seconds(attempt)
+            logger.warning(
+                "Drain DB open hit SQLITE_BUSY (attempt %d/%d); retrying in %.2fs",
+                attempt + 1,
+                max_retries + 1,
+                delay,
+            )
+            time.sleep(delay)
+    else:
+        raise RuntimeError("unreachable drain open retry state")
     conn.setbusytimeout(_drain_busy_timeout_ms())
     conn.enableloadextension(True)
     conn.loadextension(sqlite_vec.loadable_path())
@@ -533,7 +569,7 @@ def _table_names(conn: apsw.Connection) -> set[str]:
 
 
 def _is_busy_error(exc: BaseException) -> bool:
-    return isinstance(exc, apsw.BusyError)
+    return _is_sqlite_busy_error(exc)
 
 
 def _default_embed_fn() -> Callable[[str], list[float]]:
@@ -806,11 +842,12 @@ def drain_once(
             remaining_events = events[len(events_to_apply) :]
 
             for attempt in range(5):
-                conn = _open_connection(db_path)
+                conn: apsw.Connection | None = None
                 attempt_drained = 0
                 collision_ids: list[str] = []
                 store_chunk_ids: list[str] = []
                 try:
+                    conn = _open_connection(db_path)
                     conn.execute("BEGIN IMMEDIATE")
                     ensure_dedupe_schema(conn)
                     for event in events_to_apply:
@@ -852,10 +889,11 @@ def drain_once(
                         time.sleep(yield_seconds)
                     break
                 except Exception as exc:
-                    try:
-                        conn.execute("ROLLBACK")
-                    except Exception:
-                        pass
+                    if conn is not None:
+                        try:
+                            conn.execute("ROLLBACK")
+                        except Exception:
+                            pass
                     if _is_busy_error(exc) and attempt < 4:
                         delay = 0.05 * (2**attempt)
                         _log(log_path, f"drain busy; retrying in {delay:.2f}s")
@@ -864,7 +902,8 @@ def drain_once(
                     _log(log_path, f"drain failed for {path.name}: {exc}")
                     break
                 finally:
-                    conn.close()
+                    if conn is not None:
+                        conn.close()
     finally:
         fcntl.flock(lock_fd, fcntl.LOCK_UN)
         os.close(lock_fd)

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -110,6 +110,15 @@ def test_all_script_launchd_plists_have_common_hygiene():
         _assert_common_hygiene(plistlib.loads(path.read_bytes()))
 
 
+def test_index_launchagent_runs_nightly_without_keepalive_or_run_at_load():
+    index = _load("scripts/launchd/com.brainlayer.index.plist")
+
+    assert "KeepAlive" not in index
+    assert "RunAtLoad" not in index
+    assert "StartInterval" not in index
+    assert index["StartCalendarInterval"] == {"Hour": 3, "Minute": 15}
+
+
 def test_canonical_launchagent_env_has_no_concrete_dev_src_paths():
     plist_paths = [
         *sorted((REPO_ROOT / "scripts/launchd").glob("com.brainlayer.*.plist")),

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -681,6 +681,49 @@ def test_drain_busy_timeout_30s(tmp_path, monkeypatch):
         conn.close()
 
 
+def test_drain_open_retries_busy_error_before_connection_exists(tmp_path, monkeypatch):
+    attempts = 0
+    sleep_calls: list[float] = []
+
+    class FakeConnection:
+        def __init__(self, path: str):
+            self.path = path
+            self.busy_timeout_ms = None
+            self.extension_enabled: list[bool] = []
+            self.loaded_extensions: list[str] = []
+
+        def setbusytimeout(self, timeout_ms: int) -> None:
+            self.busy_timeout_ms = timeout_ms
+
+        def enableloadextension(self, enabled: bool) -> None:
+            self.extension_enabled.append(enabled)
+
+        def loadextension(self, path: str) -> None:
+            self.loaded_extensions.append(path)
+
+    def flaky_connection(path: str):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise apsw.BusyError("database is locked")
+        return FakeConnection(path)
+
+    monkeypatch.setenv("BRAINLAYER_DRAIN_OPEN_MAX_RETRIES", "4")
+    monkeypatch.setenv("BRAINLAYER_DRAIN_OPEN_RETRY_BASE_DELAY_MS", "25")
+    monkeypatch.setenv("BRAINLAYER_DRAIN_OPEN_RETRY_MAX_DELAY_MS", "100")
+    monkeypatch.setattr(drain.apsw, "Connection", flaky_connection)
+    monkeypatch.setattr(drain.sqlite_vec, "loadable_path", lambda: "sqlite_vec")
+    monkeypatch.setattr(drain.time, "sleep", lambda delay: sleep_calls.append(delay))
+
+    conn = drain._open_connection(tmp_path / "drain.db")
+
+    assert attempts == 3
+    assert sleep_calls == [0.025, 0.05]
+    assert conn.busy_timeout_ms >= 30000
+    assert conn.loaded_extensions == ["sqlite_vec"]
+    assert conn.extension_enabled == [True, False]
+
+
 def test_drain_busy_timeout_invalid_env_falls_back_to_30s(tmp_path, monkeypatch):
     monkeypatch.setenv("BRAINLAYER_DRAIN_BUSY_TIMEOUT_MS", "not-an-int")
 


### PR DESCRIPTION
## Summary
- Add bounded retry/backoff around drain DB connection construction so APSW open-time BusyError from bestpractice/optimize does not kill the drain on transient locks.
- Route open failures through drain_once's existing busy retry path and guard rollback/close when the connection never opened.
- Change the index LaunchAgent from RunAtLoad + 30 minute StartInterval to a nightly StartCalendarInterval job at 03:15, with no KeepAlive, so realtime capture remains handled by `brainlayer watch` and full reindexing does not chronically contend with drain.

## Operational notes
- To apply the index LaunchAgent change on a machine with an installed agent, rerun `scripts/launchd/install.sh index`.
- `scripts/launchd/com.brainlayer.index.plist` on current `origin/main` already lacked KeepAlive, but it still ran at login and every 30 minutes; this PR removes that recurring full-reindex shape.
- CodeRabbit CLI pre-commit gate was attempted with `cr review --plain`, but the CLI returned `Review limit reached` before producing findings. PR reviewers are requested below.

## Test plan
- [x] Red test observed: `pytest tests/test_writer_pidfile_mutex.py::test_drain_open_retries_busy_error_before_connection_exists tests/test_launchd_hygiene.py::test_index_launchagent_runs_nightly_without_keepalive_or_run_at_load -q` failed before implementation.
- [x] `pytest tests/test_writer_pidfile_mutex.py::test_drain_open_retries_busy_error_before_connection_exists tests/test_launchd_hygiene.py::test_index_launchagent_runs_nightly_without_keepalive_or_run_at_load -q`
- [x] `pytest tests/test_writer_pidfile_mutex.py tests/test_launchd_hygiene.py -q`
- [x] `ruff check src/ && ruff format src/`
- [x] `pytest` (2469 passed, 48 skipped, 5 xfailed)
- [x] pre-push BrainLayer test gate (2395 passed, 9 skipped, 77 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; Bun 1 passed; FTS5 determinism regression passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core drain DB access and launchd scheduling; mis-tuned retries could delay drain under sustained lock, and operators must reinstall the index agent to pick up the new schedule.
> 
> **Overview**
> **Drain** now **retries opening the SQLite connection** with exponential backoff when `SQLITE_BUSY` happens at APSW connect time (configurable via `BRAINLAYER_DRAIN_OPEN_*` env vars), instead of failing immediately when optimize/best-practice or other writers hold the DB. Busy detection is aligned with the shared `_is_sqlite_busy_error` helper.
> 
> In **`drain_once`**, the connection is opened **inside** the transaction retry loop and **`conn` starts as `None`**, so a failed open no longer triggers rollback/close on a missing connection.
> 
> The **`com.brainlayer.index` LaunchAgent** switches from **RunAtLoad + every 30 minutes** to a **single nightly run at 03:15**, reducing chronic full reindex contention with drain while realtime capture stays on `watch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1654f1d6efe590ec30f6c4641c6fb1244addb4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `_open_connection` in drain against SQLite busy errors with exponential backoff retry
> - `_open_connection` in [drain.py](https://github.com/EtanHey/brainlayer/pull/435/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) now retries on `SQLITE_BUSY` using exponential backoff, with retry count and delays configurable via environment variables.
> - `drain_once` initializes `conn` to `None` and moves `_open_connection` inside the try block, so a failed connection open no longer triggers ROLLBACK or close on a non-existent connection.
> - Busy error detection in `_is_busy_error` is unified with the `_is_sqlite_busy_error` helper instead of a direct `apsw.BusyError` check.
> - The `com.brainlayer.index` LaunchAgent plist is changed to run once daily at 03:15 instead of every 1800 seconds, and `RunAtLoad` is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1654f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->