### PR TITLE
fix(ci): make CI resilient to HuggingFace 429 on bge-large (unblocks all PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: ${{ runner.os }}-hf-bge-large-en-v1.5
+          key: ${{ runner.os }}-hf-bge-large-en-v1.5-bge-m3
 
       - name: Install
         run: pip install -e ".[dev]"
@@ -42,21 +42,22 @@ jobs:
 
           from huggingface_hub import snapshot_download
 
-          model_id = "BAAI/bge-large-en-v1.5"
+          model_ids = ["BAAI/bge-large-en-v1.5", "BAAI/bge-m3"]
           delays = [5, 15, 30]
 
-          for attempt in range(1, len(delays) + 2):
-              try:
-                  snapshot_download(repo_id=model_id)
-                  print(f"Warmed Hugging Face cache for {model_id}")
-                  break
-              except Exception as exc:
-                  if attempt == len(delays) + 1:
-                      print(f"::warning::Unable to warm Hugging Face cache for {model_id}: {exc!r}")
+          for model_id in model_ids:
+              for attempt in range(1, len(delays) + 2):
+                  try:
+                      snapshot_download(repo_id=model_id)
+                      print(f"Warmed Hugging Face cache for {model_id}")
                       break
-                  delay = delays[attempt - 1]
-                  print(f"Unable to warm Hugging Face cache for {model_id} on attempt {attempt}; retrying in {delay}s: {exc!r}")
-                  time.sleep(delay)
+                  except Exception as exc:
+                      if attempt == len(delays) + 1:
+                          print(f"::warning::Unable to warm Hugging Face cache for {model_id}: {exc!r}")
+                          break
+                      delay = delays[attempt - 1]
+                      print(f"Unable to warm Hugging Face cache for {model_id} on attempt {attempt}; retrying in {delay}s: {exc!r}")
+                      time.sleep(delay)
           PY
 
       - name: Unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,43 @@ jobs:
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: ${{ runner.os }}-hf-bge-large-en-v1.5
+
       - name: Install
         run: pip install -e ".[dev]"
 
+      - name: Warm Hugging Face model cache
+        run: |
+          python - <<'PY'
+          import time
+
+          from huggingface_hub import snapshot_download
+
+          model_id = "BAAI/bge-large-en-v1.5"
+          delays = [5, 15, 30]
+
+          for attempt in range(1, len(delays) + 2):
+              try:
+                  snapshot_download(repo_id=model_id)
+                  print(f"Warmed Hugging Face cache for {model_id}")
+                  break
+              except Exception as exc:
+                  if attempt == len(delays) + 1:
+                      print(f"::warning::Unable to warm Hugging Face cache for {model_id}: {exc!r}")
+                      break
+                  delay = delays[attempt - 1]
+                  print(f"Unable to warm Hugging Face cache for {model_id} on attempt {attempt}; retrying in {delay}s: {exc!r}")
+                  time.sleep(delay)
+          PY
+
       - name: Unit tests
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: >
           pytest tests/ -v --tb=short -m "not integration and not live" -x
           --ignore=tests/test_eval_framework.py
@@ -37,6 +70,9 @@ jobs:
           --ignore=tests/test_prompt_classification.py
 
       - name: Isolated eval and hook routing tests
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: >
           pytest
           tests/test_eval_framework.py
@@ -45,6 +81,9 @@ jobs:
           -v --tb=short -x
 
       - name: MCP tool registration
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: pytest tests/test_think_recall_integration.py::TestMCPToolCount -v --tb=short
 
   lint:

--- a/tests/regression/test_drift_detection.py
+++ b/tests/regression/test_drift_detection.py
@@ -3,8 +3,25 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 from deepchecks.tabular import Dataset
 from deepchecks.tabular.checks import FeatureDrift
+
+try:
+    import httpx
+except ImportError:  # pragma: no cover - optional transitive dependency
+    httpx = None
+
+try:
+    from huggingface_hub.errors import HfHubHTTPError, LocalEntryNotFoundError
+except ImportError:  # pragma: no cover - fixture test dependencies provide this in CI
+    HfHubHTTPError = None
+    LocalEntryNotFoundError = None
+
+try:
+    from huggingface_hub.errors import OfflineModeIsEnabled
+except ImportError:  # pragma: no cover - older huggingface_hub releases may omit this
+    OfflineModeIsEnabled = None
 
 from tests.regression._stale_index_fixture import (
     baseline_embedding_rows,
@@ -12,6 +29,8 @@ from tests.regression._stale_index_fixture import (
     current_embedding_rows,
     load_fixture,
 )
+
+HF_MODEL_UNAVAILABLE_SKIP_REASON = "HF model unavailable in CI (429/offline) — infra, not a regression"
 
 
 def _embedding_frame(rows: list[list[float]]) -> pd.DataFrame:
@@ -22,10 +41,87 @@ def _embedding_frame(rows: list[list[float]]) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=columns)
 
 
+def _exception_chain(exc: BaseException) -> list[BaseException]:
+    seen: set[int] = set()
+    pending = [exc]
+    chain = []
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        chain.append(current)
+
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if not current.__suppress_context__ and current.__context__ is not None:
+            pending.append(current.__context__)
+        if isinstance(current, BaseExceptionGroup):
+            pending.extend(current.exceptions)
+
+    return chain
+
+
+def _status_code(exc: BaseException) -> int | None:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+
+    status_code = getattr(exc, "status_code", None)
+    return status_code if isinstance(status_code, int) else None
+
+
+def _is_hf_model_unavailable_error(exc: BaseException) -> bool:
+    for chained in _exception_chain(exc):
+        if httpx is not None and isinstance(chained, httpx.HTTPStatusError) and _status_code(chained) == 429:
+            return True
+        if HfHubHTTPError is not None and isinstance(chained, HfHubHTTPError) and _status_code(chained) == 429:
+            return True
+        if LocalEntryNotFoundError is not None and isinstance(chained, LocalEntryNotFoundError):
+            return True
+        if OfflineModeIsEnabled is not None and isinstance(chained, OfflineModeIsEnabled):
+            return True
+    return False
+
+
+def _current_embedding_rows_or_skip() -> list[list[float]]:
+    try:
+        return current_embedding_rows()
+    except Exception as exc:
+        if _is_hf_model_unavailable_error(exc):
+            pytest.skip(HF_MODEL_UNAVAILABLE_SKIP_REASON)
+        raise
+
+
+def test_current_embedding_rows_or_skip_skips_hf_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    httpx = pytest.importorskip("httpx")
+    request = httpx.Request("HEAD", "https://huggingface.co/BAAI/bge-large-en-v1.5/resolve/main/config.json")
+    response = httpx.Response(429, request=request)
+
+    def raise_hf_429() -> list[list[float]]:
+        raise httpx.HTTPStatusError("rate limited", request=request, response=response)
+
+    monkeypatch.setattr("tests.regression.test_drift_detection.current_embedding_rows", raise_hf_429)
+
+    with pytest.raises(pytest.skip.Exception, match="HF model unavailable"):
+        _current_embedding_rows_or_skip()
+
+
+def test_current_embedding_rows_or_skip_reraises_non_hf_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_real_failure() -> list[list[float]]:
+        raise ValueError("embedding math regressed")
+
+    monkeypatch.setattr("tests.regression.test_drift_detection.current_embedding_rows", raise_real_failure)
+
+    with pytest.raises(ValueError, match="embedding math regressed"):
+        _current_embedding_rows_or_skip()
+
+
 def test_fixture_embeddings_pass_deepchecks_and_cosine_threshold() -> None:
     fixture = load_fixture()
     baseline_rows = baseline_embedding_rows()
-    current_rows = current_embedding_rows()
+    current_rows = _current_embedding_rows_or_skip()
     min_cosine_similarity = fixture["sample_text"]["min_cosine_similarity"]
 
     assert len(baseline_rows) == len(current_rows)

--- a/tests/test_reembed_bgem3.py
+++ b/tests/test_reembed_bgem3.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "reembed_bgem3.py"
+HF_MODEL_UNAVAILABLE_SKIP_REASON = "HF BGE-M3 model unavailable in CI/offline — infra, not a regression"
 
 
 def _create_test_db(tmp_path):
@@ -32,6 +35,49 @@ def _create_test_db(tmp_path):
     conn.commit()
     conn.close()
     return db_path
+
+
+def _assert_script_succeeded_or_skip_hf_unavailable(result: subprocess.CompletedProcess[str]) -> None:
+    if result.returncode == 0:
+        return
+
+    output = f"{result.stdout}\n{result.stderr}"
+    is_hf_model_unavailable = (
+        "huggingface_hub.errors.LocalEntryNotFoundError" in output
+        or "couldn't connect to 'https://huggingface.co'" in output
+        or "Cannot find the requested files in the disk cache and outgoing traffic has been disabled" in output
+    )
+    if is_hf_model_unavailable:
+        pytest.skip(HF_MODEL_UNAVAILABLE_SKIP_REASON)
+
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+
+def test_script_success_assertion_skips_offline_hf_model_unavailable() -> None:
+    result = subprocess.CompletedProcess(
+        args=["scripts/reembed_bgem3.py", "--test"],
+        returncode=1,
+        stdout="Loading BAAI/bge-m3 on cpu...\n",
+        stderr=(
+            "huggingface_hub.errors.LocalEntryNotFoundError: Cannot find the requested files in the disk cache "
+            "and outgoing traffic has been disabled."
+        ),
+    )
+
+    with pytest.raises(pytest.skip.Exception, match="HF BGE-M3 model unavailable"):
+        _assert_script_succeeded_or_skip_hf_unavailable(result)
+
+
+def test_script_success_assertion_preserves_real_failures() -> None:
+    result = subprocess.CompletedProcess(
+        args=["scripts/reembed_bgem3.py", "--test"],
+        returncode=1,
+        stdout="",
+        stderr="sqlite write failed",
+    )
+
+    with pytest.raises(AssertionError, match="sqlite write failed"):
+        _assert_script_succeeded_or_skip_hf_unavailable(result)
 
 
 class TestReembedScript:
@@ -88,7 +134,7 @@ class TestReembedScript:
             text=True,
             timeout=300,
         )
-        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        _assert_script_succeeded_or_skip_hf_unavailable(result)
         assert "Processed" in result.stdout or "processed" in result.stdout.lower()
 
         # Verify embeddings were updated (not all zeros anymore)
@@ -119,7 +165,7 @@ class TestReembedScript:
             text=True,
             timeout=300,
         )
-        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        _assert_script_succeeded_or_skip_hf_unavailable(result)
         assert checkpoint_path.exists(), "Checkpoint file should be created"
 
         import json
@@ -159,7 +205,7 @@ class TestReembedScript:
             text=True,
             timeout=300,
         )
-        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        _assert_script_succeeded_or_skip_hf_unavailable(result)
         # Should mention skipping or resuming
         output = result.stdout.lower()
         assert "skip" in output or "resum" in output or "already" in output
@@ -187,7 +233,7 @@ class TestReembedScript:
             text=True,
             timeout=300,
         )
-        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        _assert_script_succeeded_or_skip_hf_unavailable(result)
 
         conn = sqlite3.connect(str(db_path))
         row = conn.execute("SELECT embedding FROM chunk_vectors_binary WHERE chunk_id = 'chunk_0'").fetchone()


### PR DESCRIPTION
## What
CI test jobs (3.11/3.12/3.13) were failing **repo-wide** at `tests/regression/test_drift_detection.py::test_fixture_embeddings_pass_deepchecks_and_cosine_threshold` with `httpx HTTP 429 Too Many Requests` fetching `BAAI/bge-large-en-v1.5` from HuggingFace. Because `pytest -x` aborts on first failure, **the whole suite died** — blocking every PR (incl. #435 drain fix and #436 provenance).

Root cause: the test job cached only pip (not the HF model) and ran no offline mode, so `huggingface_hub` made a metadata HEAD request to HF every run and got rate-limited — even though the model would otherwise be cached.

## Fix
- `.github/workflows/ci.yml`: cache `~/.cache/huggingface`; **warm** the model once with retry/backoff; set `HF_HUB_OFFLINE=1` + `TRANSFORMERS_OFFLINE=1` on all pytest steps so a cached model skips the HEAD request.
- `tests/regression/test_drift_detection.py`: detect HF-429 / offline / missing-entry conditions (across the exception chain incl. `BaseExceptionGroup`) and `pytest.skip` — so a transient HF outage never red-bars the suite again. Real assertion path preserved when the model is present. Adds 2 unit tests (skips on 429; re-raises genuine failures).

## Verified locally
`test_drift_detection` **3/3 pass** (real path + `HF_HUB_OFFLINE=1`), ruff clean, `ci.yml` valid YAML.

## Provenance
Implemented by **brainlayerCodex** (worker); verified + landed by **BL-LEAD** after the worker pane was killed mid-task by a fleet topology reshuffle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow and test skip/assertion helpers; no production embedding or application logic is modified.
> 
> **Overview**
> **CI** now caches `~/.cache/huggingface`, pre-downloads `BAAI/bge-large-en-v1.5` and `BAAI/bge-m3` with retry/backoff (warnings only if warm-up fails), and runs all pytest steps with `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` so tests prefer the local cache instead of hitting Hugging Face on every run.
> 
> **Tests** that load embedding models no longer fail the whole job when the failure is infrastructure: drift regression uses `_current_embedding_rows_or_skip()` to `pytest.skip` on 429, offline mode, or missing cache entries (with unit tests for skip vs real failures), and BGE-M3 re-embed subprocess tests use `_assert_script_succeeded_or_skip_hf_unavailable()` for the same offline/cache-miss cases while still asserting on genuine script errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 294ecf89fcc75ed90443834965a953b79b13acc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make CI resilient to HuggingFace 429 rate limits for BGE model downloads
> - Adds a HuggingFace model cache step in [ci.yml](.github/workflows/ci.yml) keyed by OS and model ID, with a warm-up step that downloads `BAAI/bge-large-en-v1.5` and `BAAI/bge-m3` with retry/backoff before tests run.
> - Sets `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1` for unit tests and isolated eval steps so models are loaded from cache rather than fetched at runtime.
> - Adds `_current_embedding_rows_or_skip()` in [test_drift_detection.py](https://github.com/EtanHey/brainlayer/pull/437/files#diff-2b37ac08a10376e12235e639138e953786a11a951649aaafac5945804a1af0b6) and `_assert_script_succeeded_or_skip_hf_unavailable()` in [test_reembed_bgem3.py](https://github.com/EtanHey/brainlayer/pull/437/files#diff-292934145f5dc0aa3f11a891eced975d1bc9bb3816dbc4dfdb92b4d39b369f6f) to skip tests on HF 429, `LocalEntryNotFoundError`, or offline-mode errors instead of failing.
> - Behavioral Change: tests that previously failed on HF model unavailability now report as skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 294ecf8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->