### PR TITLE
fix: enable MMR diversity by default

### DIFF
--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -35,13 +35,14 @@ from .ingest_guard import recursive_mcp_output_reason
 _HYBRID_CACHE_TTL = 60.0  # seconds
 _HYBRID_CACHE_MAX = 128  # max entries (LRU eviction)
 _MMR_CANDIDATE_LIMIT = 50
+_DEFAULT_MMR_LAMBDA = 0.7
 try:
-    _MMR_LAMBDA = float(os.environ.get("BRAINLAYER_MMR_LAMBDA", "1.0"))
+    _MMR_LAMBDA = float(os.environ.get("BRAINLAYER_MMR_LAMBDA", str(_DEFAULT_MMR_LAMBDA)))
     if not math.isfinite(_MMR_LAMBDA):
         raise ValueError
     _MMR_LAMBDA = max(0.0, min(1.0, _MMR_LAMBDA))
 except (TypeError, ValueError):
-    _MMR_LAMBDA = 1.0
+    _MMR_LAMBDA = _DEFAULT_MMR_LAMBDA
 _FILTERED_KNN_MAX = 2000
 # BrainBar helper requests need a bounded candidate scan so semantic results
 # can beat the Swift fallback budget even when checkpoint/audit filters are large.
@@ -603,7 +604,19 @@ class SearchMixin:
         top_candidates = scored[:candidate_limit]
         tail_candidates = scored[candidate_limit:]
 
-        embeddings_by_id = self._load_chunk_embeddings([candidate[1] for candidate in top_candidates])
+        raw_embeddings_by_id = self._load_chunk_embeddings([candidate[1] for candidate in top_candidates])
+        embeddings_by_id: dict[str, np.ndarray] = {}
+        expected_shape: tuple[int, ...] | None = None
+        for chunk_id, embedding in raw_embeddings_by_id.items():
+            vector = np.asarray(embedding, dtype=np.float32)
+            if vector.ndim != 1 or vector.size == 0 or not np.isfinite(vector).all():
+                continue
+            if expected_shape is None:
+                expected_shape = vector.shape
+            if vector.shape != expected_shape:
+                continue
+            embeddings_by_id[chunk_id] = vector
+
         mmr_candidates = [candidate for candidate in top_candidates if candidate[1] in embeddings_by_id]
         if len(mmr_candidates) < 2:
             return scored
@@ -616,11 +629,25 @@ class SearchMixin:
             normalized_relevance = np.ones_like(relevance)
 
         matrix = np.stack([embeddings_by_id[candidate[1]] for candidate in mmr_candidates]).astype(
-            np.float32, copy=False
+            np.float64, copy=False
         )
         norms = np.linalg.norm(matrix, axis=1, keepdims=True)
-        norms = np.maximum(norms, 1e-12)
-        cosine = np.clip((matrix / norms) @ (matrix / norms).T, -1.0, 1.0)
+        usable_rows = np.isfinite(norms[:, 0]) & (norms[:, 0] > 0.0)
+        if not np.all(usable_rows):
+            mmr_candidates = [candidate for candidate, usable in zip(mmr_candidates, usable_rows) if usable]
+            matrix = matrix[usable_rows]
+            norms = norms[usable_rows]
+            normalized_relevance = normalized_relevance[usable_rows]
+        if len(mmr_candidates) < 2:
+            return scored
+
+        normalized_matrix = matrix / np.maximum(norms, 1e-12)
+        normalized_matrix = np.nan_to_num(normalized_matrix, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
+        normalized_matrix = np.clip(normalized_matrix, -1.0, 1.0)
+        with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+            cosine = normalized_matrix @ normalized_matrix.T
+        cosine = np.nan_to_num(cosine, copy=False, nan=0.0, posinf=1.0, neginf=-1.0)
+        cosine = np.clip(cosine, -1.0, 1.0)
         np.fill_diagonal(cosine, 0.0)
 
         selected: list[int] = [int(np.argmax(normalized_relevance))]
@@ -641,9 +668,10 @@ class SearchMixin:
         reranked = [mmr_candidates[idx] for idx in selected]
         reranked.extend(candidate for candidate in mmr_candidates if candidate[1] not in reranked_ids)
 
+        mmr_candidate_ids = {candidate[1] for candidate in mmr_candidates}
         reranked_iter = iter(reranked)
         recombined = [
-            next(reranked_iter) if candidate[1] in embeddings_by_id else candidate for candidate in top_candidates
+            next(reranked_iter) if candidate[1] in mmr_candidate_ids else candidate for candidate in top_candidates
         ]
         return recombined + tail_candidates
 

--- a/tests/test_mmr_default_off.py
+++ b/tests/test_mmr_default_off.py
@@ -1,4 +1,7 @@
 import importlib
+import warnings
+
+import numpy as np
 
 
 def _scored_candidates():
@@ -18,7 +21,25 @@ class _SpyStore:
         return {}
 
 
-def test_mmr_default_is_off_and_does_not_load_embeddings(monkeypatch):
+class _EmbeddingStore:
+    def _load_chunk_embeddings(self, chunk_ids):
+        return {
+            "a": np.array([1.0, 0.0], dtype=np.float32),
+            "b": np.array([np.finfo(np.float32).max, np.finfo(np.float32).max], dtype=np.float32),
+            "c": np.array([0.0, 1.0], dtype=np.float32),
+        }
+
+
+class _ZeroNormEmbeddingStore:
+    def _load_chunk_embeddings(self, chunk_ids):
+        return {
+            "a": np.array([1.0, 0.0], dtype=np.float32),
+            "b": np.array([0.0, 0.0], dtype=np.float32),
+            "c": np.array([0.0, 1.0], dtype=np.float32),
+        }
+
+
+def test_mmr_default_enables_diversity_and_loads_embeddings(monkeypatch):
     monkeypatch.delenv("BRAINLAYER_MMR_LAMBDA", raising=False)
     import brainlayer.search_repo as search_repo
 
@@ -28,9 +49,9 @@ def test_mmr_default_is_off_and_does_not_load_embeddings(monkeypatch):
 
     reranked = search_repo.SearchMixin._mmr_rerank_scored_results(store, scored, n_results=2)
 
-    assert search_repo._MMR_LAMBDA == 1.0
+    assert search_repo._MMR_LAMBDA == 0.7
     assert reranked == scored
-    assert store.embedding_load_calls == 0
+    assert store.embedding_load_calls == 1
 
 
 def test_mmr_env_override_reenables_embedding_load(monkeypatch):
@@ -46,22 +67,22 @@ def test_mmr_env_override_reenables_embedding_load(monkeypatch):
     assert store.embedding_load_calls == 1
 
 
-def test_invalid_mmr_env_override_falls_back_to_default_off(monkeypatch):
+def test_invalid_mmr_env_override_falls_back_to_default(monkeypatch):
     monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "not-a-float")
     import brainlayer.search_repo as search_repo
 
     search_repo = importlib.reload(search_repo)
 
-    assert search_repo._MMR_LAMBDA == 1.0
+    assert search_repo._MMR_LAMBDA == 0.7
 
 
-def test_nonfinite_mmr_env_override_falls_back_to_default_off(monkeypatch):
+def test_nonfinite_mmr_env_override_falls_back_to_default(monkeypatch):
     monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "nan")
     import brainlayer.search_repo as search_repo
 
     search_repo = importlib.reload(search_repo)
 
-    assert search_repo._MMR_LAMBDA == 1.0
+    assert search_repo._MMR_LAMBDA == 0.7
 
 
 def test_out_of_range_mmr_env_override_is_clamped(monkeypatch):
@@ -76,3 +97,37 @@ def test_out_of_range_mmr_env_override_is_clamped(monkeypatch):
     search_repo = importlib.reload(search_repo)
 
     assert search_repo._MMR_LAMBDA == 1.0
+
+
+def test_mmr_ignores_pathological_embeddings_without_warning(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "0.7")
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        reranked = search_repo.SearchMixin._mmr_rerank_scored_results(
+            _EmbeddingStore(),
+            _scored_candidates(),
+            n_results=2,
+        )
+
+    assert len(reranked) == 3
+    assert {candidate[1] for candidate in reranked} == {"a", "b", "c"}
+
+
+def test_mmr_keeps_zero_norm_candidates_without_exhausting_rerank(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "0.7")
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+
+    reranked = search_repo.SearchMixin._mmr_rerank_scored_results(
+        _ZeroNormEmbeddingStore(),
+        _scored_candidates(),
+        n_results=3,
+    )
+
+    assert len(reranked) == 3
+    assert {candidate[1] for candidate in reranked} == {"a", "b", "c"}


### PR DESCRIPTION
## Summary
- Default `BRAINLAYER_MMR_LAMBDA` to `0.7` so MMR diversity is active without an env override.
- Harden MMR reranking against invalid/pathological embeddings and zero-norm rows when diversity is enabled.
- Update MMR config tests for the new default and warning/zero-norm regressions.

## A/B search audit
Fixture: `tests/eval_qrels.json` BrainLayer/search audit subset (`n_results=5`, live readonly DB, `SearchBenchmark` + `pipeline_hybrid_rrf`).

Query IDs:
- `conceptual_agent_memory`
- `conceptual_search_quality`
- `frustration_search_recall_miss`
- `known_entity_brainlayer_architecture`
- `temporal_recent_brainlayer_work`
- `temporal_recent_job_search`

| `BRAINLAYER_MMR_LAMBDA` | recall@5 | precision@5 |
| --- | ---: | ---: |
| `1.0` | `0.004551733615773024` | `0.02857142857142857` |
| `0.7` | `0.004551733615773024` | `0.02857142857142857` |

Verdict: recall held exactly; precision also held exactly.

## Verification
- `pytest -q` -> `2490 passed, 48 skipped, 5 xfailed, 328 warnings in 399.49s`
- `ruff check src tests` -> pass
- `ruff format --check src tests` -> `312 files already formatted`
- pre-push gate -> unit `2416 passed, 9 skipped, 77 deselected, 1 xfailed`; MCP tool registration `3 passed`; isolated eval/hook routing `40 passed`; bun `1 pass`; FTS5 regression shell pass
- `BRAINLAYER_MMR_LAMBDA=0.7` warning-escalated live audit smoke -> same recall/precision as above, exit 0
- `cr review --plain` attempted; CodeRabbit CLI returned review-limit reached, so reviewers requested on PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default hybrid-search ranking changes for all callers unless they set BRAINLAYER_MMR_LAMBDA=1.0; eval recall/precision were unchanged on the reported audit subset, but ordering can still shift and MMR now loads chunk embeddings on typical queries.
> 
> **Overview**
> **Hybrid search now applies MMR diversification by default** (`BRAINLAYER_MMR_LAMBDA` **0.7** instead of **1.0**, which previously skipped MMR). Invalid env values fall back to **0.7** as well. Pure relevance-only ranking remains available via **`BRAINLAYER_MMR_LAMBDA=1.0`**.
> 
> **`_mmr_rerank_scored_results`** is hardened before that default matters: embeddings are validated (finite, consistent shape), zero-norm rows are dropped from the cosine step without losing candidates in the final list, and similarity uses **float64** normalization with **`nan_to_num`** / clipped cosines so pathological vectors do not emit **RuntimeWarning**s or break reranking.
> 
> Tests in **`test_mmr_default_off.py`** were flipped for the new default (embedding load on by default) and add coverage for extreme and zero-norm embeddings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4fc76f778e507755230e2d18643ce3c4698c343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable MMR diversity by default by changing the default `_MMR_LAMBDA` from 1.0 to 0.7
> - Changes the default value of `_MMR_LAMBDA` in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/439/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) from `1.0` to `0.7`, so MMR-based result diversification is active when `BRAINLAYER_MMR_LAMBDA` is unset or invalid.
> - Hardens `_mmr_rerank_scored_results` to skip malformed, non-finite, mismatched-dimension, and zero-norm embeddings, and computes cosine similarity using `float64` with NaN/inf guards to avoid runtime warnings.
> - Behavioral Change: any deployment that previously relied on the implicit `1.0` default (pure relevance, no diversification) will now receive diversified results unless `BRAINLAYER_MMR_LAMBDA=1.0` is explicitly set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4fc76f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->