### PR TITLE
fix: clean brain_store MCP output

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -216,7 +216,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     enum StoreWriteOutcome: Sendable, Equatable {
         case stored(StoredChunk)
-        case queued(queueID: String, queuedAt: String)
+        case queued(queueID: String, queuedAt: String, chunkID: String)
     }
 
     struct PendingStoreItem: Codable, Sendable {
@@ -226,6 +226,7 @@ final class BrainDatabase: @unchecked Sendable {
         let source: String
         let queueID: String?
         let queuedAt: String?
+        let chunkID: String?
 
         enum CodingKeys: String, CodingKey {
             case content
@@ -234,6 +235,7 @@ final class BrainDatabase: @unchecked Sendable {
             case source
             case queueID = "queue_id"
             case queuedAt = "queued_at"
+            case chunkID = "chunk_id"
         }
 
         init(
@@ -242,7 +244,8 @@ final class BrainDatabase: @unchecked Sendable {
             importance: Int,
             source: String,
             queueID: String? = nil,
-            queuedAt: String? = nil
+            queuedAt: String? = nil,
+            chunkID: String? = nil
         ) {
             self.content = content
             self.tags = tags
@@ -250,6 +253,7 @@ final class BrainDatabase: @unchecked Sendable {
             self.source = source
             self.queueID = queueID
             self.queuedAt = queuedAt
+            self.chunkID = chunkID
         }
 
         init(from decoder: Decoder) throws {
@@ -260,6 +264,7 @@ final class BrainDatabase: @unchecked Sendable {
             source = try container.decodeIfPresent(String.self, forKey: .source) ?? "mcp"
             queueID = try container.decodeIfPresent(String.self, forKey: .queueID)
             queuedAt = try container.decodeIfPresent(String.self, forKey: .queuedAt)
+            chunkID = try container.decodeIfPresent(String.self, forKey: .chunkID)
         }
     }
 
@@ -866,18 +871,23 @@ final class BrainDatabase: @unchecked Sendable {
         return (results, maxRowID)
     }
 
+    private static func makeChunkID() -> String {
+        "brainbar-\(UUID().uuidString.lowercased().prefix(12))"
+    }
+
     func store(
         content: String,
         tags: [String],
         importance: Int,
         source: String,
+        chunkID: String? = nil,
         queueID: String? = nil,
         refreshStatistics: Bool = true,
         retries: Int = 3,
         busyTimeoutMillis: Int32? = nil
     ) throws -> StoredChunk {
         guard let db else { throw DBError.notOpen }
-        let chunkID = "brainbar-\(UUID().uuidString.lowercased().prefix(12))"
+        let chunkID = chunkID ?? Self.makeChunkID()
         let tagsJSON = (try? encodeJSON(tags)) ?? "[]"
         let metadataJSON = Self.storeMetadataJSON(queueID: queueID)
         let sql = """
@@ -926,12 +936,14 @@ final class BrainDatabase: @unchecked Sendable {
         source: String,
         busyTimeoutMillis: Int32 = 50
     ) throws -> StoreWriteOutcome {
+        let chunkID = Self.makeChunkID()
         do {
             let stored = try store(
                 content: content,
                 tags: tags,
                 importance: importance,
                 source: source,
+                chunkID: chunkID,
                 refreshStatistics: true,
                 retries: 0,
                 busyTimeoutMillis: busyTimeoutMillis
@@ -941,8 +953,14 @@ final class BrainDatabase: @unchecked Sendable {
             guard shouldQueueStoreError(error) else {
                 throw error
             }
-            let queued = try queuePendingStore(content: content, tags: tags, importance: importance, source: source)
-            return .queued(queueID: queued.queueID, queuedAt: queued.queuedAt)
+            let queued = try queuePendingStore(
+                content: content,
+                tags: tags,
+                importance: importance,
+                source: source,
+                chunkID: chunkID
+            )
+            return .queued(queueID: queued.queueID, queuedAt: queued.queuedAt, chunkID: queued.chunkID)
         }
     }
 
@@ -973,12 +991,32 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     @discardableResult
-    func queuePendingStore(content: String, tags: [String], importance: Int, source: String) throws -> (queueID: String, queuedAt: String) {
-        try Self.queuePendingStore(dbPath: path, content: content, tags: tags, importance: importance, source: source)
+    func queuePendingStore(
+        content: String,
+        tags: [String],
+        importance: Int,
+        source: String,
+        chunkID: String? = nil
+    ) throws -> (queueID: String, queuedAt: String, chunkID: String) {
+        try Self.queuePendingStore(
+            dbPath: path,
+            content: content,
+            tags: tags,
+            importance: importance,
+            source: source,
+            chunkID: chunkID
+        )
     }
 
     @discardableResult
-    static func queuePendingStore(dbPath: String, content: String, tags: [String], importance: Int, source: String) throws -> (queueID: String, queuedAt: String) {
+    static func queuePendingStore(
+        dbPath: String,
+        content: String,
+        tags: [String],
+        importance: Int,
+        source: String,
+        chunkID: String? = nil
+    ) throws -> (queueID: String, queuedAt: String, chunkID: String) {
         Self.pendingStoreFileLock.lock()
         defer { Self.pendingStoreFileLock.unlock() }
 
@@ -989,18 +1027,20 @@ final class BrainDatabase: @unchecked Sendable {
         )
         let queueID = UUID().uuidString.lowercased()
         let queuedAt = Self.timestamp()
+        let chunkID = chunkID ?? Self.makeChunkID()
         let item = PendingStoreItem(
             content: content,
             tags: tags,
             importance: importance,
             source: source,
             queueID: queueID,
-            queuedAt: queuedAt
+            queuedAt: queuedAt,
+            chunkID: chunkID
         )
         var line = try JSONEncoder().encode(item)
         line.append(0x0A)
         try appendPendingStoreLine(line, to: path)
-        return (queueID: queueID, queuedAt: queuedAt)
+        return (queueID: queueID, queuedAt: queuedAt, chunkID: chunkID)
     }
 
     func flushPendingStores() -> [FlushedPendingStore] {
@@ -1033,7 +1073,8 @@ final class BrainDatabase: @unchecked Sendable {
                     }
 
                     let queueID = Self.pendingStoreQueueID(for: item, lineIndex: lineIndex)
-                    let replayLine = Self.pendingStoreReplayLine(for: item, queueID: queueID) ?? line
+                    let chunkID = item.chunkID ?? Self.makeChunkID()
+                    let replayLine = Self.pendingStoreReplayLine(for: item, queueID: queueID, chunkID: chunkID) ?? line
                     do {
                         if try hasStoredQueuedItem(queueID: queueID) {
                             continue
@@ -1050,6 +1091,7 @@ final class BrainDatabase: @unchecked Sendable {
                             tags: item.tags,
                             importance: item.importance,
                             source: item.source,
+                            chunkID: chunkID,
                             queueID: queueID,
                             refreshStatistics: false
                         )
@@ -3133,14 +3175,15 @@ final class BrainDatabase: @unchecked Sendable {
         )
     }
 
-    private static func pendingStoreReplayLine(for item: PendingStoreItem, queueID: String) -> Data? {
+    private static func pendingStoreReplayLine(for item: PendingStoreItem, queueID: String, chunkID: String) -> Data? {
         let replayItem = PendingStoreItem(
             content: item.content,
             tags: item.tags,
             importance: item.importance,
             source: item.source,
             queueID: queueID,
-            queuedAt: item.queuedAt
+            queuedAt: item.queuedAt,
+            chunkID: chunkID
         )
         return try? JSONEncoder().encode(replayItem)
     }

--- a/brain-bar/Sources/BrainBar/Formatters.swift
+++ b/brain-bar/Sources/BrainBar/Formatters.swift
@@ -167,13 +167,18 @@ enum Formatters {
     static func formatStoreResult(
         chunkId: String,
         superseded: String? = nil,
+        tags: [String] = [],
         queued: Bool = false,
         useColor: Bool = true
     ) -> String {
         if queued {
-            return "\u{2502} \u{23f3} Memory queued (DB busy) \u{2500} will flush on next successful store."
+            let idSuffix = chunkId.isEmpty ? "" : " \u{2192} \(val(chunkId, useColor))"
+            return "\u{23f3} Memory queued (DB busy)\(idSuffix) \u{2014} will flush on next successful store."
         }
         var parts = ["\u{2714} Stored \u{2192} \(val(chunkId, useColor))"]
+        if !tags.isEmpty {
+            parts.append(" [tags: \(tags.joined(separator: ", "))]")
+        }
         if let superseded {
             parts.append(" (superseded \(val(superseded, useColor)))")
         }

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -481,7 +481,7 @@ final class MCPRouter: @unchecked Sendable {
             case .stored(let stored):
                 let flushedStores = db.flushPendingStores()
                 return ToolOutput(
-                    text: Formatters.formatStoreResult(chunkId: stored.chunkID),
+                    text: Formatters.formatStoreResult(chunkId: stored.chunkID, tags: tags, useColor: false),
                     metadata: [
                         "queued": false,
                         "flushed_count": flushedStores.count,
@@ -500,8 +500,8 @@ final class MCPRouter: @unchecked Sendable {
                         }
                     ]
                 )
-            case .queued(let queueID, let queuedAt):
-                return queuedBrainStoreOutput(queueID: queueID, queuedAt: queuedAt)
+            case .queued(let queueID, let queuedAt, let chunkID):
+                return queuedBrainStoreOutput(queueID: queueID, queuedAt: queuedAt, chunkID: chunkID)
             }
         } catch BrainDatabase.DBError.notOpen {
             return try queueBrainStore(content: content, tags: tags, importance: importance, source: "mcp")
@@ -519,16 +519,17 @@ final class MCPRouter: @unchecked Sendable {
             importance: importance,
             source: source
         )
-        return queuedBrainStoreOutput(queueID: queued.queueID, queuedAt: queued.queuedAt)
+        return queuedBrainStoreOutput(queueID: queued.queueID, queuedAt: queued.queuedAt, chunkID: queued.chunkID)
     }
 
-    private func queuedBrainStoreOutput(queueID: String, queuedAt: String) -> ToolOutput {
+    private func queuedBrainStoreOutput(queueID: String, queuedAt: String, chunkID: String) -> ToolOutput {
         ToolOutput(
-            text: Formatters.formatStoreResult(chunkId: "", queued: true),
+            text: Formatters.formatStoreResult(chunkId: chunkID, queued: true, useColor: false),
             metadata: [
                 "queued": true,
                 "queue_id": queueID,
-                "queued_at": queuedAt
+                "queued_at": queuedAt,
+                "chunk_id": chunkID
             ]
         )
     }

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -405,16 +405,82 @@ final class DatabaseTests: XCTestCase {
             busyTimeoutMillis: 1
         )
 
-        guard case .queued(let queueID, let queuedAt) = outcome else {
+        guard case .queued(let queueID, let queuedAt, let chunkID) = outcome else {
             XCTFail("Expected queued outcome, got \(outcome)")
             return
         }
         XCTAssertFalse(queueID.isEmpty)
+        XCTAssertTrue(chunkID.hasPrefix("brainbar-"))
         XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
         let queuedPayload = try String(contentsOf: queuePath, encoding: .utf8)
         XCTAssertTrue(queuedPayload.contains("Queued because the BrainBar DB handle is read-only"))
         XCTAssertTrue(queuedPayload.contains(queueID))
         XCTAssertTrue(queuedPayload.contains(queuedAt))
+        XCTAssertTrue(queuedPayload.contains(chunkID))
+    }
+
+    func testQueuedStorePreassignsChunkIDAndFlushReusesIt() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("brainbar-preassigned-queue-\(UUID().uuidString).jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer {
+            unsetenv("BRAINBAR_PENDING_STORES_PATH")
+            try? FileManager.default.removeItem(at: queuePath)
+        }
+
+        var lockDB: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        XCTAssertEqual(sqlite3_open_v2(tempDBPath, &lockDB, flags, nil), SQLITE_OK)
+        guard let lockDB else {
+            XCTFail("Failed to open secondary lock connection")
+            return
+        }
+        defer { sqlite3_close(lockDB) }
+
+        XCTAssertEqual(sqlite3_exec(lockDB, "BEGIN IMMEDIATE", nil, nil, nil), SQLITE_OK)
+        var lockHeld = true
+        defer {
+            if lockHeld {
+                sqlite3_exec(lockDB, "ROLLBACK", nil, nil, nil)
+            }
+        }
+
+        let queuedContent = "Queued store should preserve its preassigned chunk id"
+        let outcome = try db.storeOrQueueWithinBudget(
+            content: queuedContent,
+            tags: ["queue-id-reuse"],
+            importance: 6,
+            source: "mcp",
+            busyTimeoutMillis: 1
+        )
+
+        guard case .queued(let queueID, let queuedAt, let chunkID) = outcome else {
+            XCTFail("Expected queued outcome, got \(outcome)")
+            return
+        }
+        XCTAssertFalse(queueID.isEmpty)
+        XCTAssertTrue(chunkID.hasPrefix("brainbar-"))
+        XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
+
+        let queuedLines = try String(contentsOf: queuePath, encoding: .utf8)
+            .split(whereSeparator: \.isNewline)
+        let firstQueuedLine = try XCTUnwrap(queuedLines.first)
+        let queuedData = Data(firstQueuedLine.utf8)
+        let queuedPayload = try XCTUnwrap(JSONSerialization.jsonObject(with: queuedData) as? [String: Any])
+        XCTAssertEqual(queuedPayload["content"] as? String, queuedContent)
+        XCTAssertEqual(queuedPayload["queue_id"] as? String, queueID)
+        XCTAssertEqual(queuedPayload["chunk_id"] as? String, chunkID)
+
+        XCTAssertEqual(sqlite3_exec(lockDB, "ROLLBACK", nil, nil, nil), SQLITE_OK)
+        lockHeld = false
+
+        let flushed = db.flushPendingStores()
+        XCTAssertEqual(flushed.count, 1)
+        XCTAssertEqual(flushed.first?.storedChunk.chunkID, chunkID)
+        XCTAssertEqual(
+            try sqliteScalarString(path: tempDBPath, sql: "SELECT id FROM chunks WHERE content = '\(queuedContent)'"),
+            chunkID
+        )
     }
 
     func testInjectionEventsTableExists() throws {

--- a/brain-bar/Tests/BrainBarTests/FormattersTests.swift
+++ b/brain-bar/Tests/BrainBarTests/FormattersTests.swift
@@ -73,6 +73,26 @@ final class FormattersTests: XCTestCase {
         XCTAssertTrue(out.contains("rt-abc123-xyz"))
     }
 
+    func testFormatStoreResultPlainOutputOmitsANSIWhenColorDisabled() {
+        let out = Formatters.formatStoreResult(chunkId: "brainbar-abc123", useColor: false)
+        XCTAssertEqual(out, "\u{2714} Stored \u{2192} brainbar-abc123")
+        XCTAssertFalse(out.contains("\u{1b}["))
+    }
+
+    func testFormatStoreResultIncludesTagsWhenProvided() {
+        let out = Formatters.formatStoreResult(
+            chunkId: "brainbar-tags123",
+            tags: ["correction", "orc", "phoenix"],
+            useColor: false
+        )
+        XCTAssertEqual(out, "\u{2714} Stored \u{2192} brainbar-tags123 [tags: correction, orc, phoenix]")
+    }
+
+    func testFormatStoreResultOmitsEmptyTags() {
+        let out = Formatters.formatStoreResult(chunkId: "brainbar-notags", tags: [], useColor: false)
+        XCTAssertEqual(out, "\u{2714} Stored \u{2192} brainbar-notags")
+    }
+
     func testFormatStoreResultWithSuperseded() {
         let out = Formatters.formatStoreResult(chunkId: "new-1", superseded: "old-1")
         XCTAssertTrue(out.contains("new-1"))
@@ -81,9 +101,14 @@ final class FormattersTests: XCTestCase {
     }
 
     func testFormatStoreResultQueued() {
-        let out = Formatters.formatStoreResult(chunkId: "", queued: true)
+        let out = Formatters.formatStoreResult(chunkId: "brainbar-queued123", queued: true, useColor: false)
         XCTAssertTrue(out.contains("\u{23f3}"))  // ⏳
         XCTAssertTrue(out.contains("queued"))
+        XCTAssertEqual(
+            out,
+            "\u{23f3} Memory queued (DB busy) \u{2192} brainbar-queued123 \u{2014} will flush on next successful store."
+        )
+        XCTAssertFalse(out.contains("\u{1b}["))
     }
 
     // MARK: - Entity Card

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -448,6 +448,41 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertNil(result["structuredContent"])
     }
 
+    func testBrainStoreMCPResultIsPlainAndShowsTagsWithoutContent() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-store-output-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+        let fullContent = "Sensitive full content must not be echoed in the MCP store response"
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 178,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": fullContent,
+                    "tags": ["correction", "orc", "phoenix"],
+                    "importance": 8
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+        let text = try XCTUnwrap(content.first?["text"] as? String)
+        let storedChunk = try XCTUnwrap(result["_brainbarStoredChunk"] as? [String: Any])
+        let chunkID = try XCTUnwrap(storedChunk["chunk_id"] as? String)
+
+        XCTAssertEqual(text, "\u{2714} Stored \u{2192} \(chunkID) [tags: correction, orc, phoenix]")
+        XCTAssertFalse(text.contains("\u{1b}["))
+        XCTAssertFalse(text.contains(fullContent))
+    }
+
     func testBrainSearchFallbackStillPrependsSwiftKGFacts() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-hybrid-fallback-kg-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }
@@ -1438,13 +1473,22 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(result["queued"] as? Bool, true)
         let queueID = try XCTUnwrap(result["queue_id"] as? String)
         let queuedAt = try XCTUnwrap(result["queued_at"] as? String)
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+        let text = try XCTUnwrap((result["content"] as? [[String: Any]])?.first?["text"] as? String)
         XCTAssertFalse(queueID.isEmpty)
+        XCTAssertTrue(chunkID.hasPrefix("brainbar-"))
         XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
+        XCTAssertEqual(
+            text,
+            "\u{23f3} Memory queued (DB busy) \u{2192} \(chunkID) \u{2014} will flush on next successful store."
+        )
+        XCTAssertFalse(text.contains("\u{1b}["))
 
         let queuedPayload = try XCTUnwrap(readSinglePendingStorePayload(queuePath: queuePath))
         XCTAssertEqual(queuedPayload["content"] as? String, "Store should queue even before the database opens")
         XCTAssertEqual(queuedPayload["queue_id"] as? String, queueID)
         XCTAssertEqual(queuedPayload["queued_at"] as? String, queuedAt)
+        XCTAssertEqual(queuedPayload["chunk_id"] as? String, chunkID)
     }
 
     func testBrainStoreQueuesWhenDatabaseHandleIsNotOpen() throws {
@@ -1478,9 +1522,17 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertEqual(result["queued"] as? Bool, true)
         XCTAssertFalse((result["queue_id"] as? String ?? "").isEmpty)
         XCTAssertFalse((result["queued_at"] as? String ?? "").isEmpty)
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+        let text = try XCTUnwrap((result["content"] as? [[String: Any]])?.first?["text"] as? String)
+        XCTAssertEqual(
+            text,
+            "\u{23f3} Memory queued (DB busy) \u{2192} \(chunkID) \u{2014} will flush on next successful store."
+        )
+        XCTAssertFalse(text.contains("\u{1b}["))
 
         let queuedPayload = try XCTUnwrap(readSinglePendingStorePayload(queuePath: queuePath))
         XCTAssertEqual(queuedPayload["content"] as? String, "Store should queue when the database handle is not open")
+        XCTAssertEqual(queuedPayload["chunk_id"] as? String, chunkID)
     }
 
     func testBrainStoreQueuesWhenWriteHitsTransientSQLiteLock() throws {
@@ -1525,14 +1577,22 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertTrue(text.localizedCaseInsensitiveContains("queued"))
         let queueID = try XCTUnwrap(result?["queue_id"] as? String)
         let queuedAt = try XCTUnwrap(result?["queued_at"] as? String)
+        let chunkID = try XCTUnwrap(result?["chunk_id"] as? String)
         XCTAssertFalse(queueID.isEmpty)
+        XCTAssertTrue(chunkID.hasPrefix("brainbar-"))
         XCTAssertNotNil(ISO8601DateFormatter().date(from: queuedAt))
+        XCTAssertEqual(
+            text,
+            "\u{23f3} Memory queued (DB busy) \u{2192} \(chunkID) \u{2014} will flush on next successful store."
+        )
+        XCTAssertFalse(text.contains("\u{1b}["))
         XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))
 
         let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
         XCTAssertTrue(queuedText.contains("Store should queue after transient SQLite lock"))
         XCTAssertTrue(queuedText.contains(queueID))
         XCTAssertTrue(queuedText.contains(queuedAt))
+        XCTAssertTrue(queuedText.contains(chunkID))
     }
 
     func testBrainStoreFlushesPendingQueueAfterSuccessfulStore() throws {


### PR DESCRIPTION
## Summary
- Return plain, non-ANSI `brain_store` text from the Swift BrainBar MCP path.
- Show tags beside the stored chunk id without echoing full stored content.
- Preassign `brainbar-...` chunk ids before write attempts, persist them in pending-store JSONL records, and reuse them when queued stores flush.

## Test plan
- `cd brain-bar && swift test` — 612 XCTest tests, 0 failures; Swift Testing runner 0 tests.
- Push hook gate passed: pytest unit suite `2416 passed, 9 skipped, 77 deselected, 1 xfailed`; MCP registration `3 passed`; isolated eval/hook routing `40 passed`; bun `1 pass`; regression shell passed.

## Deploy note
This Swift change is NOT live until BrainBar.app is rebuilt and the BrainBar daemon is restarted. The running daemon is a compiled binary, so BL-LEAD/orc should schedule the rebuild and daemon restart after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core store/queue/flush persistence and MCP contract; behavior change for queued chunk ids is intentional but must stay consistent across flush and dedupe.
> 
> **Overview**
> **`brain_store` MCP responses** now use plain text (no ANSI) via `useColor: false`, optionally append **tags** next to the chunk id, and never echo full stored content. Queued messages show the preassigned **`brainbar-...` id** instead of a generic “DB busy” line.
> 
> **Write path:** chunk ids are generated once (`makeChunkID`) before insert or queue. `store` accepts an optional `chunkID`; `StoreWriteOutcome.queued` and pending-store JSONL gain **`chunk_id`**, and **`flushPendingStores`** reuses that id when replaying (legacy lines without `chunk_id` still get a new id). MCP metadata includes **`chunk_id`** for queued stores.
> 
> Tests cover id reuse on flush, formatter/MCP text shape, and updated queue assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54f23474f84950a65a710268c5e1bb81128e7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `brain_store` MCP output to be plain text and include chunk IDs
> - Preassigns a stable `chunk_id` (format `brainbar-<12-char-uuid>`) at queue time in `BrainDatabase`, so the same ID is reused when the queued item is later flushed.
> - Exposes `chunk_id` in the `StoreWriteOutcome.queued` case, persists it in the pending store queue file, and includes it in MCP response metadata.
> - Updates `Formatters.formatStoreResult` to accept a `useColor` flag and a `tags` list; MCP responses now use `useColor: false` to strip ANSI codes from tool output.
> - Behavioral Change: the `brain_store` MCP tool response text is now plain (no ANSI escape codes) and queued responses include the preassigned chunk ID in both the message and metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f54f234.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->