### PR TITLE
fix: make KG dedup suggestions APSW-safe

### DIFF
--- a/scripts/kg_entity_dedup.py
+++ b/scripts/kg_entity_dedup.py
@@ -121,10 +121,24 @@ def execute(conn: Any, sql: str, params: tuple[Any, ...] | list[Any] = ()) -> An
     return conn.cursor().execute(sql, params)
 
 
+def _cursor_description(cursor: Any) -> list[Any]:
+    try:
+        getdescription = getattr(cursor, "getdescription", None)
+        if callable(getdescription):
+            return list(getdescription() or [])
+        return list(getattr(cursor, "description", None) or [])
+    except Exception as exc:
+        if exc.__class__.__name__ == "ExecutionCompleteError" and exc.__class__.__module__ == "apsw":
+            return []
+        raise
+
+
 def fetch_dicts(conn: Any, sql: str, params: tuple[Any, ...] | list[Any] = ()) -> list[dict[str, Any]]:
     cursor = conn.cursor()
-    rows = list(cursor.execute(sql, params))
-    columns = [description[0] for description in cursor.description or []]
+    rows = cursor.execute(sql, params)
+    columns = [description[0] for description in _cursor_description(cursor)]
+    if not columns:
+        return []
     return [dict(zip(columns, row)) for row in rows]
 
 

--- a/tests/test_kg_entity_dedup.py
+++ b/tests/test_kg_entity_dedup.py
@@ -2,6 +2,7 @@ import importlib.util
 import sqlite3
 from pathlib import Path
 
+import apsw
 import pytest
 
 
@@ -69,6 +70,41 @@ def _connect_fixture(tmp_path):
             entity_id TEXT PRIMARY KEY,
             embedding BLOB
         );
+        """
+    )
+    return conn
+
+
+def _connect_apsw_fixture(tmp_path):
+    conn = apsw.Connection(str(tmp_path / "kg-apsw.db"))
+    conn.execute(
+        """
+        CREATE TABLE kg_entities (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            metadata TEXT DEFAULT '{}',
+            canonical_name TEXT,
+            status TEXT DEFAULT 'active',
+            created_at TEXT,
+            updated_at TEXT,
+            expired_at TEXT,
+            UNIQUE(entity_type, name)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE kg_entity_chunks (
+            entity_id TEXT NOT NULL,
+            chunk_id TEXT NOT NULL,
+            relevance REAL DEFAULT 1.0,
+            context TEXT,
+            mention_type TEXT,
+            relation_tier INTEGER DEFAULT 4,
+            weight REAL DEFAULT 0.25,
+            PRIMARY KEY (entity_id, chunk_id)
+        )
         """
     )
     return conn
@@ -270,6 +306,29 @@ def test_suggest_lists_cross_type_domain_fragments_without_applying_them(tmp_pat
     assert cross_type
     assert {row["id"] for row in cross_type[0]["entities"]} == {"domain-project", "domain-tool", "domain-concept"}
     assert _scalar(conn, "SELECT count(*) FROM kg_entities") == 3
+
+
+def test_apsw_fetch_dicts_handles_completed_zero_row_selects(tmp_path):
+    dedup = _load_script()
+    conn = _connect_apsw_fixture(tmp_path)
+
+    assert dedup.fetch_dicts(conn, "SELECT id, name FROM kg_entities WHERE name = ?", ("missing",)) == []
+    assert dedup.suggest_candidate_clusters(conn) == []
+
+
+def test_cursor_description_only_swallows_apsw_completed_execution():
+    dedup = _load_script()
+
+    class ExecutionCompleteError(Exception):
+        pass
+
+    class FakeCursor:
+        @property
+        def description(self):
+            raise ExecutionCompleteError("not APSW")
+
+    with pytest.raises(ExecutionCompleteError, match="not APSW"):
+        dedup._cursor_description(FakeCursor())
 
 
 def test_path_purge_deletes_only_path_shaped_entities(tmp_path):


### PR DESCRIPTION
## Summary
- make kg_entity_dedup fetch_dicts read cursor descriptions before row exhaustion for APSW compatibility
- add APSW regression coverage for zero-row selects and suggest_candidate_clusters
- tighten completed-statement exception handling to APSW's ExecutionCompleteError only

## Test plan
- pytest -q tests/test_kg_entity_dedup.py
- ruff check scripts/kg_entity_dedup.py tests/test_kg_entity_dedup.py
- ruff format --check scripts/kg_entity_dedup.py tests/test_kg_entity_dedup.py
- live read-only --suggest against production DB using fixed worktree code: exit 0, suggestion output, no traceback
- pre-push BrainLayer gate passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow helper change in a maintenance script with regression tests; no apply/merge behavior changes.
> 
> **Overview**
> Fixes **KG dedup** read paths when the DB connection is **APSW** (e.g. production via `VectorStore`), where the previous `fetch_dicts` could fail on empty or completed selects.
> 
> **`fetch_dicts`** no longer materializes rows before reading column metadata; it uses a new **`_cursor_description`** helper that prefers `getdescription()` when present and treats **APSW’s `ExecutionCompleteError`** as “no columns” instead of swallowing unrelated errors.
> 
> Tests add an APSW fixture for zero-row **`fetch_dicts`** / **`suggest_candidate_clusters`**, plus a guard that non-APSW `ExecutionCompleteError` still propagates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61e6a9caae27e9387cfccf7b067a5b3e0eaf89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `fetch_dicts` in KG dedup to handle APSW cursor `ExecutionCompleteError` on zero-row SELECTs
> APSW cursors raise `ExecutionCompleteError` when accessing `.description` after a completed zero-row SELECT, causing `fetch_dicts` and `suggest_candidate_clusters` to crash. This PR adds a `_cursor_description` helper in [kg_entity_dedup.py](https://github.com/EtanHey/brainlayer/pull/442/files#diff-2eba6ab18949def90ce77f60c8d11a882f22b4e12ba4cb7bd4da70e67ddc5f49) that catches only APSW's `ExecutionCompleteError` and returns an empty list, while re-raising all other exceptions. `fetch_dicts` is updated to use this helper and short-circuits to return an empty list when no column metadata is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d61e6a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the entity deduplication process to handle different database library cursor implementations reliably.
  * Enhanced error handling to gracefully manage cases where database column metadata may be unavailable.
  * Added fallback mechanisms to prevent processing failures in edge cases.

* **Tests**
  * Expanded test coverage with new scenarios for database library compatibility.
  * Added tests to verify correct behavior in edge cases during data retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->