### PR TITLE
feat: refine KG dedup path detector

### DIFF
--- a/scripts/kg_entity_dedup.py
+++ b/scripts/kg_entity_dedup.py
@@ -83,6 +83,7 @@ PATH_EXTENSION_RE = re.compile(
     r"\.(md|json|py|pyi|ts|tsx|js|jsx|swift|toml|ya?ml|sh|sql|db|sqlite|txt|html|css|plist)$",
     re.IGNORECASE,
 )
+SINGLE_SEGMENT_SLASH_COMMAND_RE = re.compile(r"^/[A-Za-z][\w-]*( [\w-]+)*$")
 
 
 class MergeStoreAdapter:
@@ -396,9 +397,15 @@ def apply_reviewed_name_mapping(conn: Any, mapping: list[dict[str, Any]]) -> Cou
     return stats
 
 
+def is_single_segment_slash_command(name: str) -> bool:
+    return bool(SINGLE_SEGMENT_SLASH_COMMAND_RE.fullmatch(name.strip()))
+
+
 def path_pseudo_entity_reason(name: str) -> str | None:
     value = name.strip()
     if not value:
+        return None
+    if is_single_segment_slash_command(value):
         return None
     if value.startswith("/"):
         return "absolute-path"
@@ -440,6 +447,39 @@ def find_path_pseudo_entities(conn: Any) -> list[dict[str, Any]]:
             row["reason"] = reason
             candidates.append(row)
     return candidates
+
+
+def find_slash_command_entities(conn: Any) -> list[dict[str, Any]]:
+    rows = fetch_dicts(
+        conn,
+        """
+        SELECT id, name, entity_type
+        FROM kg_entities
+        WHERE name LIKE '/%'
+        ORDER BY lower(name), id
+        """,
+    )
+    commands = []
+    for row in rows:
+        if is_single_segment_slash_command(str(row["name"])) and row["entity_type"] != "tool":
+            commands.append(
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "old_type": row["entity_type"],
+                    "new_type": "tool",
+                }
+            )
+    return commands
+
+
+def reclassify_slash_commands(conn: Any) -> Counter[str]:
+    commands = find_slash_command_entities(conn)
+    stats: Counter[str] = Counter()
+    for command in commands:
+        execute(conn, "UPDATE kg_entities SET entity_type = 'tool' WHERE id = ?", (command["id"],))
+        stats["reclassified_commands"] += 1
+    return stats
 
 
 def _entity_ids(rows_or_ids: list[dict[str, Any]] | list[str]) -> list[str]:
@@ -687,15 +727,22 @@ def preview_merge_groups(conn: Any, mapping: list[dict[str, Any]]) -> list[dict[
 
 
 def build_dry_run_diff(
-    conn: Any, mapping: list[dict[str, Any]], name_mapping: list[dict[str, Any]] | None = None
+    conn: Any,
+    mapping: list[dict[str, Any]],
+    name_mapping: list[dict[str, Any]] | None = None,
+    *,
+    reclassify_commands: bool = False,
+    skip_path_purge: bool = False,
 ) -> dict[str, Any]:
     name_mapping = name_mapping or []
     before = table_counts(conn)
-    purge_candidates = find_path_pseudo_entities(conn)
+    purge_candidates = [] if skip_path_purge else find_path_pseudo_entities(conn)
+    command_reclassifications = find_slash_command_entities(conn) if reclassify_commands else []
     clone = clone_kg_subset(conn)
     merge_stats = apply_approved_mapping(clone, mapping)
     name_merge_stats = apply_reviewed_name_mapping(clone, name_mapping)
-    purge_stats = purge_entities(clone, find_path_pseudo_entities(clone))
+    command_stats = reclassify_slash_commands(clone) if reclassify_commands else Counter()
+    purge_stats = Counter() if skip_path_purge else purge_entities(clone, find_path_pseudo_entities(clone))
     after = table_counts(clone)
     clone.close()
     return {
@@ -704,7 +751,10 @@ def build_dry_run_diff(
         "merge_previews": preview_merge_groups(conn, mapping)
         + preview_merge_groups(conn, reviewed_name_mapping_to_id_mapping(conn, name_mapping)),
         "purge_candidates": purge_candidates,
-        "merge_stats": dict(merge_stats + name_merge_stats),
+        "command_reclassifications": command_reclassifications,
+        "reclassify_commands_requested": reclassify_commands,
+        "skip_path_purge": skip_path_purge,
+        "merge_stats": dict(merge_stats + name_merge_stats + command_stats),
         "purge_stats": dict(purge_stats),
     }
 
@@ -734,8 +784,17 @@ def print_diff(diff: dict[str, Any]) -> None:
                 f"chunks={source.get('chunks', 0)} relations={source.get('relations', 0)}"
             )
 
+    if diff.get("reclassify_commands_requested"):
+        print("Slash-command reclassifications:")
+        if not diff["command_reclassifications"]:
+            print("  (none)")
+        for row in diff["command_reclassifications"]:
+            print(f"  reclassify {row['id']} name={row['name']!r} type={row['old_type']} -> {row['new_type']}")
+
     print("Path pseudo-entity purges:")
-    if not diff["purge_candidates"]:
+    if diff.get("skip_path_purge"):
+        print("  (skipped by --skip-path-purge)")
+    elif not diff["purge_candidates"]:
         print("  (none)")
     for row in diff["purge_candidates"]:
         print(
@@ -790,6 +849,8 @@ def apply_with_safety(
     name_mapping: list[dict[str, Any]] | None = None,
     batch_size: int,
     checkpoint_every: int,
+    reclassify_commands: bool = False,
+    skip_path_purge: bool = False,
 ) -> Counter[str]:
     name_mapping = name_mapping or []
     stats: Counter[str] = Counter()
@@ -814,17 +875,27 @@ def apply_with_safety(
             execute(conn, "ROLLBACK")
             raise
 
-    purge_candidates = find_path_pseudo_entities(conn)
-    for batch_number, batch in enumerate(_batches(purge_candidates, batch_size), start=1):
+    if reclassify_commands:
         execute(conn, "BEGIN IMMEDIATE")
         try:
-            stats.update(purge_entities(conn, batch))
+            stats.update(reclassify_slash_commands(conn))
             execute(conn, "COMMIT")
         except Exception:
             execute(conn, "ROLLBACK")
             raise
-        if checkpoint_every > 0 and batch_number % checkpoint_every == 0:
-            checkpoint_wal(conn, "PASSIVE")
+
+    if not skip_path_purge:
+        purge_candidates = find_path_pseudo_entities(conn)
+        for batch_number, batch in enumerate(_batches(purge_candidates, batch_size), start=1):
+            execute(conn, "BEGIN IMMEDIATE")
+            try:
+                stats.update(purge_entities(conn, batch))
+                execute(conn, "COMMIT")
+            except Exception:
+                execute(conn, "ROLLBACK")
+                raise
+            if checkpoint_every > 0 and batch_number % checkpoint_every == 0:
+                checkpoint_wal(conn, "PASSIVE")
 
     checkpoint_wal(conn, "FULL")
     return stats
@@ -853,6 +924,12 @@ def main() -> int:
     parser.add_argument("--mapping", type=Path, help="Reviewed JSON mapping; defaults to APPROVED_MERGES in this file")
     parser.add_argument("--apply", action="store_true", help="Apply approved mapping and path purge")
     parser.add_argument("--suggest", action="store_true", help="Suggest candidate clusters only; never applies")
+    parser.add_argument(
+        "--reclassify-commands",
+        action="store_true",
+        help="Review or apply single-segment slash-command entity_type changes to tool",
+    )
+    parser.add_argument("--skip-path-purge", action="store_true", help="Apply/dry-run merges without path purges")
     parser.add_argument("--min-shared-chunks", type=int, default=2, help="Minimum shared chunks for --suggest pairs")
     parser.add_argument("--batch-size", type=int, default=5000, help="Entities to purge per write batch")
     parser.add_argument(
@@ -872,7 +949,13 @@ def main() -> int:
             print_suggestions(suggest_candidate_clusters(store.conn, min_shared_chunks=args.min_shared_chunks))
             return 0
 
-        diff = build_dry_run_diff(store.conn, mapping, name_mapping)
+        diff = build_dry_run_diff(
+            store.conn,
+            mapping,
+            name_mapping,
+            reclassify_commands=args.reclassify_commands,
+            skip_path_purge=args.skip_path_purge,
+        )
         print_diff(diff)
         if not args.apply:
             print("To apply: review the mapping, stop enrichment, then rerun with --apply")
@@ -884,6 +967,8 @@ def main() -> int:
             name_mapping=name_mapping,
             batch_size=args.batch_size,
             checkpoint_every=args.checkpoint_every,
+            reclassify_commands=args.reclassify_commands,
+            skip_path_purge=args.skip_path_purge,
         )
         print("APPLIED")
         for key, value in sorted(stats.items()):

--- a/tests/test_kg_entity_dedup.py
+++ b/tests/test_kg_entity_dedup.py
@@ -77,7 +77,7 @@ def _connect_fixture(tmp_path):
 
 def _connect_apsw_fixture(tmp_path):
     conn = apsw.Connection(str(tmp_path / "kg-apsw.db"))
-    conn.execute(
+    for sql in [
         """
         CREATE TABLE kg_entities (
             id TEXT PRIMARY KEY,
@@ -91,9 +91,25 @@ def _connect_apsw_fixture(tmp_path):
             expired_at TEXT,
             UNIQUE(entity_type, name)
         )
+        """,
         """
-    )
-    conn.execute(
+        CREATE TABLE kg_relations (
+            id TEXT PRIMARY KEY,
+            source_id TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            relation_type TEXT NOT NULL,
+            properties TEXT DEFAULT '{}',
+            confidence REAL DEFAULT 1.0,
+            user_verified INTEGER DEFAULT 0,
+            fact TEXT,
+            importance REAL DEFAULT 0.5,
+            valid_from TEXT,
+            valid_until TEXT,
+            expired_at TEXT,
+            source_chunk_id TEXT,
+            UNIQUE(source_id, target_id, relation_type)
+        )
+        """,
         """
         CREATE TABLE kg_entity_chunks (
             entity_id TEXT NOT NULL,
@@ -105,8 +121,26 @@ def _connect_apsw_fixture(tmp_path):
             weight REAL DEFAULT 0.25,
             PRIMARY KEY (entity_id, chunk_id)
         )
+        """,
         """
-    )
+        CREATE TABLE kg_entity_aliases (
+            alias TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            alias_type TEXT DEFAULT 'name',
+            created_at TEXT,
+            valid_from TEXT,
+            valid_to TEXT,
+            PRIMARY KEY (alias, entity_id)
+        )
+        """,
+        """
+        CREATE TABLE kg_vec_entities (
+            entity_id TEXT PRIMARY KEY,
+            embedding BLOB
+        )
+        """,
+    ]:
+        conn.execute(sql)
     return conn
 
 
@@ -329,6 +363,120 @@ def test_cursor_description_only_swallows_apsw_completed_execution():
 
     with pytest.raises(ExecutionCompleteError, match="not APSW"):
         dedup._cursor_description(FakeCursor())
+
+
+def _assert_path_detector_spares_slash_commands(dedup, conn):
+    _entity(conn, "cmd-code-review", "concept", "/code-review")
+    _entity(conn, "cmd-batch-subagents", "project", "/batch sub-agents")
+    _entity(conn, "path-absolute", "concept", "/Users/etanheyman/Gits/brainlayer/README.md")
+    _entity(conn, "path-dotdir", "concept", ".claude/settings.json")
+    _entity(conn, "path-relative-dot", "concept", "./rel")
+    _entity(conn, "path-repo", "concept", "src/brainlayer/vector_store.py")
+    _entity(conn, "normal", "concept", "AC/DC")
+
+    candidates = dedup.find_path_pseudo_entities(conn)
+
+    assert {row["id"] for row in candidates} == {
+        "path-absolute",
+        "path-dotdir",
+        "path-relative-dot",
+        "path-repo",
+    }
+    assert dedup.path_pseudo_entity_reason("/agent-routing") is None
+    assert dedup.path_pseudo_entity_reason("/batch sub-agents") is None
+    assert dedup.path_pseudo_entity_reason("/Users/etanheyman/file.md") == "absolute-path"
+    assert dedup.path_pseudo_entity_reason(".claude/settings.json") == "file-path"
+
+
+def test_path_detector_spares_single_segment_slash_commands_sqlite(tmp_path):
+    dedup = _load_script()
+    conn = _connect_fixture(tmp_path)
+
+    _assert_path_detector_spares_slash_commands(dedup, conn)
+
+
+def test_path_detector_spares_single_segment_slash_commands_apsw(tmp_path):
+    dedup = _load_script()
+    conn = _connect_apsw_fixture(tmp_path)
+
+    _assert_path_detector_spares_slash_commands(dedup, conn)
+
+
+def _assert_reclassify_slash_commands(dedup, conn):
+    _entity(conn, "cmd-code-review", "concept", "/code-review")
+    _entity(conn, "cmd-batch-subagents", "project", "/batch sub-agents")
+    _entity(conn, "path-absolute", "concept", "/Users/etanheyman/Gits/brainlayer/README.md")
+    _entity(conn, "normal", "concept", "AC/DC")
+
+    stats = dedup.reclassify_slash_commands(conn)
+
+    assert stats["reclassified_commands"] == 2
+    assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'cmd-code-review'").fetchone()[0] == "tool"
+    assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'cmd-batch-subagents'").fetchone()[0] == "tool"
+    assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'path-absolute'").fetchone()[0] == "concept"
+    assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'normal'").fetchone()[0] == "concept"
+
+
+def test_reclassify_slash_commands_sets_tool_only_for_commands_sqlite(tmp_path):
+    dedup = _load_script()
+    conn = _connect_fixture(tmp_path)
+
+    _assert_reclassify_slash_commands(dedup, conn)
+
+
+def test_reclassify_slash_commands_sets_tool_only_for_commands_apsw(tmp_path):
+    dedup = _load_script()
+    conn = _connect_apsw_fixture(tmp_path)
+
+    _assert_reclassify_slash_commands(dedup, conn)
+
+
+def test_reclassify_commands_dry_run_previews_without_mutating(tmp_path):
+    dedup = _load_script()
+    conn = _connect_fixture(tmp_path)
+    _entity(conn, "cmd-code-review", "concept", "/code-review")
+    _entity(conn, "path-absolute", "concept", "/Users/etanheyman/Gits/brainlayer/README.md")
+
+    diff = dedup.build_dry_run_diff(conn, [], reclassify_commands=True)
+
+    assert diff["command_reclassifications"] == [
+        {"id": "cmd-code-review", "name": "/code-review", "old_type": "concept", "new_type": "tool"}
+    ]
+    assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'cmd-code-review'").fetchone()[0] == "concept"
+
+
+def test_apply_with_safety_skip_path_purge_keeps_paths_but_applies_merges(tmp_path):
+    dedup = _load_script()
+    conn = _connect_fixture(tmp_path)
+    _entity(conn, "person-etan", "person", "Etan Heyman")
+    _entity(conn, "person-fragment", "person", "Etan")
+    _entity(conn, "path-absolute", "concept", "/Users/etanheyman/Gits/brainlayer/README.md")
+    conn.execute(
+        """
+        INSERT INTO kg_entity_chunks (entity_id, chunk_id, relevance, context)
+        VALUES ('person-fragment', 'chunk-person', 0.9, 'Etan context')
+        """
+    )
+    conn.commit()
+
+    stats = dedup.apply_with_safety(
+        conn,
+        [
+            {
+                "label": "Etan only",
+                "canonical": {"id": "person-etan", "entity_type": "person", "name": "Etan Heyman"},
+                "sources": ["person-fragment"],
+            }
+        ],
+        batch_size=5000,
+        checkpoint_every=0,
+        skip_path_purge=True,
+    )
+
+    assert stats["merge_sources"] == 1
+    assert stats["purged_entities"] == 0
+    assert conn.execute("SELECT id FROM kg_entities WHERE id = 'person-fragment'").fetchone() is None
+    assert conn.execute("SELECT id FROM kg_entities WHERE id = 'path-absolute'").fetchone()[0] == "path-absolute"
 
 
 def test_path_purge_deletes_only_path_shaped_entities(tmp_path):


### PR DESCRIPTION
## Summary
- spare single-segment slash commands from KG path pseudo-entity purge detection
- add reviewable slash-command reclassification to `tool` via `--reclassify-commands`
- add `--skip-path-purge` so supervised apply can run merges/reclassification independently of path purges

## Test plan
- pytest -q tests/test_kg_entity_dedup.py
- pytest -q tests/test_kg_entity_dedup.py tests/test_kg_p2_crosstype_cleanup.py
- ruff check scripts/kg_entity_dedup.py tests/test_kg_entity_dedup.py
- ruff format --check scripts/kg_entity_dedup.py tests/test_kg_entity_dedup.py
- python3 scripts/kg_entity_dedup.py --help
- fixture purge count: 4 real path-shaped rows; slash-command rows excluded
- pre-push BrainLayer gate passed

## Notes
Full-repo `ruff check` / `ruff format --check` still hit unrelated pre-existing baseline issues in older scripts/hooks; touched files are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bulk KG maintenance behavior on live SQLite data (entity_type updates and optional path purges); mitigated by dry-run default, explicit flags, and transactional apply paths.
> 
> **Overview**
> **KG entity dedup** no longer treats single-segment slash commands (e.g. `/code-review`, `/batch sub-agents`) as path pseudo-entities, so they are not purged and still participate in merge suggestions like other normal names.
> 
> The script adds **reviewable slash-command handling**: entities whose names match that pattern and are not already `tool` can be previewed and applied as `entity_type` → `tool` via **`--reclassify-commands`**, with dry-run output listing planned reclassifications.
> 
> **`--skip-path-purge`** lets supervised **`--apply`** run approved merges (and optional reclassification) without deleting path-shaped entities; dry-run reflects skipped purges in the printed diff.
> 
> Tests cover path detection vs slash commands (sqlite + APSW), reclassification, dry-run preview without writes, and merge apply with path purge disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c0905fb6b70d9588e61cd2b65ed5bad192cd5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refine KG dedup path detector to spare slash commands and add reclassification to 'tool'
> - Fixes `path_pseudo_entity_reason` in [kg_entity_dedup.py](https://github.com/EtanHey/brainlayer/pull/443/files#diff-2eba6ab18949def90ce77f60c8d11a882f22b4e12ba4cb7bd4da70e67ddc5f49) to return `None` for single-segment slash commands (e.g. `/code-review`), preventing them from being flagged as path-like pseudo-entities.
> - Adds `reclassify_slash_commands` to update entities whose names match the single-segment slash-command pattern to `entity_type='tool'`.
> - Adds `--reclassify-commands` and `--skip-path-purge` CLI flags; both flags are threaded through `build_dry_run_diff` and `apply_with_safety` so dry-run previews and live runs respect them.
> - Adds tests in [test_kg_entity_dedup.py](https://github.com/EtanHey/brainlayer/pull/443/files#diff-0071a10ff59210966df01f9289806c7f1387e5015b6978e833290a634694890b) covering path detection, reclassification, dry-run preview, and skip-path-purge behavior across SQLite and APSW fixtures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05c0905.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->