### PR TITLE
fix: merge slash-command reclassify collisions

### DIFF
--- a/scripts/kg_entity_dedup.py
+++ b/scripts/kg_entity_dedup.py
@@ -473,11 +473,39 @@ def find_slash_command_entities(conn: Any) -> list[dict[str, Any]]:
     return commands
 
 
+def _same_name_tool(conn: Any, name: str, exclude_id: str) -> dict[str, Any] | None:
+    rows = fetch_dicts(
+        conn,
+        """
+        SELECT id, name, entity_type
+        FROM kg_entities
+        WHERE entity_type = 'tool'
+          AND name = ?
+          AND id != ?
+        ORDER BY id
+        LIMIT 1
+        """,
+        (name, exclude_id),
+    )
+    return rows[0] if rows else None
+
+
 def reclassify_slash_commands(conn: Any) -> Counter[str]:
     commands = find_slash_command_entities(conn)
     stats: Counter[str] = Counter()
+    adapter = MergeStoreAdapter(conn)
     for command in commands:
-        execute(conn, "UPDATE kg_entities SET entity_type = 'tool' WHERE id = ?", (command["id"],))
+        source = adapter.get_entity(command["id"])
+        if not source or source["entity_type"] == "tool":
+            continue
+        tool = _same_name_tool(conn, source["name"], source["id"])
+        if tool:
+            merge_stats = merge_entities_preserving_links(adapter, tool["id"], source["id"])
+            stats.update(merge_stats)
+            stats["reclassified_via_merge"] += 1
+        else:
+            execute(conn, "UPDATE kg_entities SET entity_type = 'tool' WHERE id = ?", (source["id"],))
+            stats["reclassified_via_update"] += 1
         stats["reclassified_commands"] += 1
     return stats
 

--- a/tests/test_kg_entity_dedup.py
+++ b/tests/test_kg_entity_dedup.py
@@ -411,10 +411,188 @@ def _assert_reclassify_slash_commands(dedup, conn):
     stats = dedup.reclassify_slash_commands(conn)
 
     assert stats["reclassified_commands"] == 2
+    assert stats["reclassified_via_update"] == 2
+    assert stats["reclassified_via_merge"] == 0
     assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'cmd-code-review'").fetchone()[0] == "tool"
     assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'cmd-batch-subagents'").fetchone()[0] == "tool"
     assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'path-absolute'").fetchone()[0] == "concept"
     assert conn.execute("SELECT entity_type FROM kg_entities WHERE id = 'normal'").fetchone()[0] == "concept"
+
+
+def _assert_reclassify_slash_command_merges_into_existing_tool(dedup, conn):
+    _entity(conn, "tool-yash", "tool", "/yash")
+    _entity(conn, "concept-yash", "concept", "/yash")
+    _entity(conn, "other-target", "concept", "Target")
+    conn.execute(
+        """
+        INSERT INTO kg_entity_chunks (entity_id, chunk_id, relevance, context, mention_type, relation_tier, weight)
+        VALUES ('tool-yash', 'shared-chunk', 0.3, 'tool context', 'implicit', 4, 0.25)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO kg_entity_chunks (entity_id, chunk_id, relevance, context, mention_type, relation_tier, weight)
+        VALUES ('concept-yash', 'shared-chunk', 0.9, 'concept context', 'explicit', 2, 0.8)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO kg_entity_chunks (entity_id, chunk_id, relevance, context, mention_type)
+        VALUES ('concept-yash', 'concept-only-chunk', 0.7, 'concept only', 'explicit')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO kg_relations (id, source_id, target_id, relation_type, fact, importance)
+        VALUES ('rel-tool-target', 'tool-yash', 'other-target', 'invoked_by', 'tool fact', 0.2)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO kg_relations (id, source_id, target_id, relation_type, fact, importance)
+        VALUES ('rel-concept-target', 'concept-yash', 'other-target', 'invoked_by', 'concept fact', 0.9)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO kg_relations (id, source_id, target_id, relation_type, fact)
+        VALUES ('rel-target-concept', 'other-target', 'concept-yash', 'mentions', 'target mentions command')
+        """
+    )
+    conn.execute(
+        "INSERT INTO kg_entity_aliases (alias, entity_id, alias_type) VALUES ('old-yash', 'concept-yash', 'name')"
+    )
+    conn.execute("INSERT INTO kg_vec_entities (entity_id, embedding) VALUES ('concept-yash', x'0102')")
+
+    stats = dedup.reclassify_slash_commands(conn)
+
+    assert stats["reclassified_commands"] == 1
+    assert stats["reclassified_via_merge"] == 1
+    assert stats["entities_deleted"] == 1
+    assert stats["chunk_links_moved"] == 1
+    assert stats["chunk_conflicts_merged"] == 1
+    assert stats["relations_moved"] == 1
+    assert stats["relation_conflicts_merged"] == 1
+    assert conn.execute("SELECT id, entity_type FROM kg_entities WHERE name = '/yash'").fetchall() == [
+        ("tool-yash", "tool")
+    ]
+    assert conn.execute("SELECT id FROM kg_entities WHERE id = 'concept-yash'").fetchone() is None
+    assert _scalar(conn, "SELECT count(*) FROM kg_vec_entities WHERE entity_id = 'concept-yash'") == 0
+    assert _scalar(conn, "SELECT count(*) FROM kg_entity_chunks WHERE entity_id = 'concept-yash'") == 0
+    assert _scalar(conn, "SELECT count(*) FROM kg_entity_chunks WHERE entity_id = 'tool-yash'") == 2
+    merged_chunk = conn.execute(
+        """
+        SELECT relevance, context, mention_type, relation_tier, weight
+        FROM kg_entity_chunks
+        WHERE entity_id = 'tool-yash' AND chunk_id = 'shared-chunk'
+        """
+    ).fetchone()
+    assert merged_chunk == (0.9, "concept context", "explicit", 2, 0.8)
+    assert (
+        conn.execute("SELECT target_id FROM kg_relations WHERE id = 'rel-target-concept'").fetchone()[0] == "tool-yash"
+    )
+    assert _scalar(conn, "SELECT count(*) FROM kg_relations WHERE relation_type = 'invoked_by'") == 1
+    assert conn.execute("SELECT importance FROM kg_relations WHERE id = 'rel-tool-target'").fetchone()[0] == 0.9
+    aliases = {row[0] for row in conn.execute("SELECT alias FROM kg_entity_aliases WHERE entity_id = 'tool-yash'")}
+    assert {"old-yash", "/yash"}.issubset(aliases)
+
+
+def test_reclassify_slash_command_merges_into_existing_tool_sqlite(tmp_path):
+    dedup = _load_script()
+    conn = _connect_fixture(tmp_path)
+
+    _assert_reclassify_slash_command_merges_into_existing_tool(dedup, conn)
+
+
+def test_reclassify_slash_command_merges_into_existing_tool_apsw(tmp_path):
+    dedup = _load_script()
+    conn = _connect_apsw_fixture(tmp_path)
+
+    _assert_reclassify_slash_command_merges_into_existing_tool(dedup, conn)
+
+
+def _assert_reclassify_slash_command_merges_multiple_types(dedup, conn):
+    _entity(conn, "tool-loop", "tool", "/loop")
+    _entity(conn, "concept-loop", "concept", "/loop")
+    _entity(conn, "person-loop", "person", "/loop")
+    _entity(conn, "project-loop", "project", "/loop")
+    for entity_id in ("concept-loop", "person-loop", "project-loop"):
+        conn.execute(
+            "INSERT INTO kg_entity_chunks (entity_id, chunk_id, context) VALUES (?, ?, ?)",
+            (entity_id, f"chunk-{entity_id}", f"context {entity_id}"),
+        )
+
+    stats = dedup.reclassify_slash_commands(conn)
+
+    assert stats["reclassified_commands"] == 3
+    assert stats["reclassified_via_merge"] == 3
+    assert stats["entities_deleted"] == 3
+    assert conn.execute("SELECT id, entity_type FROM kg_entities WHERE name = '/loop'").fetchall() == [
+        ("tool-loop", "tool")
+    ]
+    assert _scalar(conn, "SELECT count(*) FROM kg_entity_chunks WHERE entity_id = 'tool-loop'") == 3
+    assert (
+        _scalar(
+            conn,
+            "SELECT count(*) FROM kg_entities WHERE id IN ('concept-loop', 'person-loop', 'project-loop')",
+        )
+        == 0
+    )
+
+
+def test_reclassify_slash_command_merges_multiple_types_sqlite(tmp_path):
+    dedup = _load_script()
+    conn = _connect_fixture(tmp_path)
+
+    _assert_reclassify_slash_command_merges_multiple_types(dedup, conn)
+
+
+def test_reclassify_slash_command_merges_multiple_types_apsw(tmp_path):
+    dedup = _load_script()
+    conn = _connect_apsw_fixture(tmp_path)
+
+    _assert_reclassify_slash_command_merges_multiple_types(dedup, conn)
+
+
+def _assert_reclassify_commands_dry_run_merges_collision_without_mutating(dedup, conn):
+    _entity(conn, "tool-orc", "tool", "/orc")
+    _entity(conn, "concept-orc", "concept", "/orc")
+    _entity(conn, "target", "concept", "Target")
+    conn.execute(
+        "INSERT INTO kg_entity_chunks (entity_id, chunk_id, context) VALUES ('concept-orc', 'chunk-orc', 'orc')"
+    )
+    conn.execute(
+        """
+        INSERT INTO kg_relations (id, source_id, target_id, relation_type)
+        VALUES ('rel-orc', 'concept-orc', 'target', 'mentions')
+        """
+    )
+
+    diff = dedup.build_dry_run_diff(conn, [], reclassify_commands=True, skip_path_purge=True)
+
+    assert diff["before"]["kg_entities"] == 3
+    assert diff["after"]["kg_entities"] == 2
+    assert diff["merge_stats"]["reclassified_via_merge"] == 1
+    assert diff["merge_stats"]["entities_deleted"] == 1
+    assert diff["merge_stats"]["chunk_links_moved"] == 1
+    assert diff["merge_stats"]["relations_moved"] == 1
+    assert _scalar(conn, "SELECT count(*) FROM kg_entities WHERE name = '/orc'") == 2
+    assert conn.execute("SELECT source_id FROM kg_relations WHERE id = 'rel-orc'").fetchone()[0] == "concept-orc"
+    assert _scalar(conn, "SELECT count(*) FROM kg_entity_chunks WHERE entity_id = 'concept-orc'") == 1
+
+
+def test_reclassify_commands_dry_run_merges_collision_without_mutating_sqlite(tmp_path):
+    dedup = _load_script()
+    conn = _connect_fixture(tmp_path)
+
+    _assert_reclassify_commands_dry_run_merges_collision_without_mutating(dedup, conn)
+
+
+def test_reclassify_commands_dry_run_merges_collision_without_mutating_apsw(tmp_path):
+    dedup = _load_script()
+    conn = _connect_apsw_fixture(tmp_path)
+
+    _assert_reclassify_commands_dry_run_merges_collision_without_mutating(dedup, conn)
 
 
 def test_reclassify_slash_commands_sets_tool_only_for_commands_sqlite(tmp_path):


### PR DESCRIPTION
## Summary
- Fix `--reclassify-commands` when a slash-command already exists as `tool` plus another entity type.
- Merge non-tool `/command` rows into the existing same-name `tool` with `merge_entities_preserving_links`, preserving/repointing chunks, relations, aliases, and vec rows through the established helper path.
- Keep the no-collision path as a plain `entity_type='tool'` update and add stats for `reclassified_via_update` vs `reclassified_via_merge`.

## Test plan
- `pytest -q tests/test_kg_entity_dedup.py` = 21 passed in 0.88s
- `pytest -q tests/test_kg_entity_dedup.py tests/test_kg_p2_crosstype_cleanup.py` = 25 passed in 1.02s
- `ruff check scripts/kg_entity_dedup.py tests/test_kg_entity_dedup.py` = All checks passed
- `ruff format --check scripts/kg_entity_dedup.py tests/test_kg_entity_dedup.py` = 2 files already formatted
- `git diff --check` = clean
- Pre-push BrainLayer gate passed: pytest unit suite 2437 passed, 9 skipped, 77 deselected, 1 xfailed in 313.69s; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun 1 pass; regression shell passed

## Notes
- Full-repo `ruff check` and `ruff format --check` still fail on unrelated pre-existing scripts/hooks baseline issues; the touched files are clean.
- No live DB mutation; no `--apply` run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk KG dedup can delete entities and repoint graph links; changes run on apply/dry-run clone paths but affect production data when `--apply` is used with `--reclassify-commands`.
> 
> **Overview**
> **`--reclassify-commands`** no longer only flips `entity_type` to `tool` when a same-name **`tool`** row already exists. It now **merges** the non-tool slash-command entity into that canonical tool via **`merge_entities_preserving_links`**, so duplicate `(entity_type, name)` pairs are avoided and chunks, relations, aliases, and vec rows are consolidated instead of leaving parallel entities.
> 
> When there is **no** name collision, behavior is unchanged: a direct **`entity_type = 'tool'`** update. Counters **`reclassified_via_update`** vs **`reclassified_via_merge`** distinguish the two paths.
> 
> Tests cover merge semantics (conflict resolution on shared chunks/relations), multiple non-tool types for one command name, and dry-run previews that simulate merges without mutating the live connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b96d77f723161ab74a768763fbcc070b4c270a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced slash-command entity consolidation to intelligently merge related entities into existing ones instead of unconditionally converting all entities, reducing unnecessary duplication.

* **Tests**
  * Added comprehensive test coverage for entity merging and deduplication scenarios, including dry-run validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Merge slash-command entities into existing same-name tool entities during reclassification
> - `reclassify_slash_commands` in [kg_entity_dedup.py](https://github.com/EtanHey/brainlayer/pull/444/files#diff-2eba6ab18949def90ce77f60c8d11a882f22b4e12ba4cb7bd4da70e67ddc5f49) now checks for an existing `tool` entity with the same name before updating; if one exists, it merges the slash-command entity into it via `merge_entities_preserving_links` instead of doing a plain type UPDATE.
> - Adds a `_same_name_tool` helper that queries `kg_entities` for a `tool` entity sharing a name, excluding a given entity ID.
> - Returns two new counters: `reclassified_via_merge` and `reclassified_via_update`, and skips entities already typed as `tool`.
> - New tests in [test_kg_entity_dedup.py](https://github.com/EtanHey/brainlayer/pull/444/files#diff-0071a10ff59210966df01f9289806c7f1387e5015b6978e833290a634694890b) cover single-entity merge, multi-type merge, and dry-run behavior on both sqlite and APSW backends.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b96d77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->