### PR TITLE
feat: reconnect KG boost to entity FTS

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -20,12 +20,25 @@ from brainlayer.paths import get_db_path
 from brainlayer.vector_store import VectorStore
 
 
+def _open_readonly_vector_store(db_path: Path):
+    try:
+        return VectorStore(db_path, readonly=True)
+    except TypeError:
+        return VectorStore(db_path)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--db-path", default=str(get_db_path()), help="Path to the BrainLayer SQLite DB")
     parser.add_argument("--qrels-path", default="tests/eval_qrels.json", help="Path to the qrels JSON file")
     parser.add_argument("--pipeline", default="fts5", choices=["fts5", "hybrid_rrf", "hybrid_entity"])
     parser.add_argument("--n-results", type=int, default=20)
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=None,
+        help="Metrics to evaluate, e.g. --metrics recall@5 precision@5",
+    )
     args = parser.parse_args()
 
     benchmark = SearchBenchmark(args.qrels_path)
@@ -40,8 +53,8 @@ def main() -> None:
         "hybrid_entity": pipeline_hybrid_entity,
     }
 
-    store_factory = ReadOnlyBenchmarkStore if pipeline_name == "fts5" else VectorStore
-    hybrid_embed_fn = prewarm_benchmark_embedder() if pipeline_name == "hybrid_rrf" else None
+    store_factory = ReadOnlyBenchmarkStore if pipeline_name == "fts5" else _open_readonly_vector_store
+    hybrid_embed_fn = prewarm_benchmark_embedder() if pipeline_name in {"hybrid_rrf", "hybrid_entity"} else None
     with store_factory(Path(args.db_path)) as store:
         run = benchmark.run_pipeline(
             lambda query_text: pipeline_fn_map[pipeline_name](
@@ -53,7 +66,10 @@ def main() -> None:
             queries,
         )
 
-    scores = benchmark.evaluate_pipeline(run)
+    if args.metrics:
+        scores = benchmark.evaluate_pipeline(run, metrics=args.metrics)
+    else:
+        scores = benchmark.evaluate_pipeline(run)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     result_payload = {
         "pipeline": pipeline_name,

--- a/src/brainlayer/eval/benchmark.py
+++ b/src/brainlayer/eval/benchmark.py
@@ -423,6 +423,7 @@ def pipeline_hybrid_rrf(
     n_results: int = 20,
     *,
     embed_fn: Callable[[str], list[float]] | None = None,
+    kg_boost: bool = False,
 ) -> list[tuple[str, float]]:
     """Hybrid search benchmark using rank-based scores from RRF ordering."""
     if not hasattr(store, "hybrid_search"):
@@ -434,7 +435,16 @@ def pipeline_hybrid_rrf(
         embed_fn = embed_query
 
     query_embedding = embed_fn(query)
-    results = store.hybrid_search(query_embedding=query_embedding, query_text=query, n_results=n_results)
+    search_kwargs = {
+        "query_embedding": query_embedding,
+        "query_text": query,
+        "n_results": n_results,
+    }
+    if kg_boost:
+        search_kwargs["kg_boost"] = True
+    results = store.hybrid_search(
+        **search_kwargs,
+    )
     chunk_ids = results.get("ids", [[]])[0]
     return [(chunk_id, 1.0 / (rank + 1)) for rank, chunk_id in enumerate(chunk_ids)]
 
@@ -448,6 +458,12 @@ def prewarm_benchmark_embedder(model_name: str | None = None) -> Callable[[str],
     return model.embed_query
 
 
-def pipeline_hybrid_entity(store, query: str, n_results: int = 20) -> list[tuple[str, float]]:
-    """Future hybrid + entity benchmark placeholder."""
-    raise NotImplementedError("Entity-boosted benchmark pipeline is reserved for future search work.")
+def pipeline_hybrid_entity(
+    store,
+    query: str,
+    n_results: int = 20,
+    *,
+    embed_fn: Callable[[str], list[float]] | None = None,
+) -> list[tuple[str, float]]:
+    """Hybrid RRF search with KG entity-linked chunk boosting enabled."""
+    return pipeline_hybrid_rrf(store, query, n_results=n_results, embed_fn=embed_fn, kg_boost=True)

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -72,6 +72,10 @@ def _helper_route_enabled() -> bool:
     return os.environ.get("BRAINLAYER_MCP_USE_HELPER") == "1" or _helper_sentinel_path().exists()
 
 
+def _kg_boost_enabled() -> bool:
+    return os.environ.get("BRAINLAYER_KG_BOOST", "").strip().casefold() in {"1", "true", "yes", "on"}
+
+
 def _warm_helper_socket_candidates() -> list[str]:
     candidates: list[tuple[float, str]] = []
     for path in glob.glob(_HELPER_SOCKET_GLOB):
@@ -1564,6 +1568,7 @@ async def _search(
                         include_audit=include_audit,
                         include_operational=include_operational,
                         content_class_filter=content_class_filter,
+                        kg_boost=_kg_boost_enabled(),
                         profile_query_id=profile_query_id,
                         profile_scope=profile_scope,
                         brainbar_helper_fast_profile=brainbar_helper_fast_profile,

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -76,6 +76,35 @@ _NOISE_CONTENT_PATTERNS = (
 _NOISE_RERANK_DEMOTION = 0.05
 _RECENCY_SINGLE_TERM_RE = re.compile(r"\b(?:current|latest|recent|today)\b", re.IGNORECASE)
 _RECENCY_THIS_WEEK_RE = re.compile(r"\bthis\s+week\b", re.IGNORECASE)
+_ENTITY_SURFACE_TOKEN_RE = re.compile(r"[/@]?[A-Za-z0-9][A-Za-z0-9_.@/-]*")
+_ENTITY_SURFACE_STOPWORDS = frozenset(
+    {
+        "about",
+        "after",
+        "before",
+        "current",
+        "decide",
+        "decided",
+        "detail",
+        "details",
+        "does",
+        "from",
+        "have",
+        "implementation",
+        "latest",
+        "recent",
+        "search",
+        "that",
+        "this",
+        "today",
+        "what",
+        "when",
+        "where",
+        "which",
+        "with",
+        "work",
+    }
+)
 AUDIT_RECURSION_TAG_PATTERNS = (
     "{tag_expr} = 'audit'",
     "{tag_expr} = 'audit-recursion'",
@@ -93,6 +122,141 @@ _hybrid_cache: "OrderedDict[tuple, tuple[dict, float]]" = OrderedDict()
 def _has_recency_intent(query_text: str) -> bool:
     """Return true when recency words appear as terms, not substrings."""
     return bool(_RECENCY_SINGLE_TERM_RE.search(query_text) or _RECENCY_THIS_WEEK_RE.search(query_text))
+
+
+def _normalize_entity_surface(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.casefold())
+
+
+def _entity_single_token_signal(token: str) -> bool:
+    value = token.strip()
+    if not value:
+        return False
+    lowered = value.casefold()
+    if lowered in _ENTITY_SURFACE_STOPWORDS:
+        return False
+    return (
+        value.startswith(("/", "@"))
+        or "." in value
+        or any(character.isdigit() for character in value)
+        or any(character.isupper() for character in value)
+    )
+
+
+def _kg_boost_query_surface_keys(query_text: str) -> tuple[set[str], set[str]]:
+    tokens = _ENTITY_SURFACE_TOKEN_RE.findall(query_text or "")
+    if not tokens:
+        return set(), set()
+
+    alias_keys: set[str] = set()
+    fts_name_keys: set[str] = set()
+    max_ngram = min(4, len(tokens))
+    for size in range(1, max_ngram + 1):
+        for start in range(0, len(tokens) - size + 1):
+            surface = " ".join(tokens[start : start + size])
+            key = _normalize_entity_surface(surface)
+            if not key:
+                continue
+            alias_keys.add(key)
+            if size > 1 or _entity_single_token_signal(tokens[start]):
+                fts_name_keys.add(key)
+    return alias_keys, fts_name_keys
+
+
+def _kg_boost_entity_matches(store: Any, query_text: str, *, limit: int = 8) -> list[dict[str, str]]:
+    """Resolve query-mentioned entities through kg_entities_fts plus exact aliases.
+
+    The FTS query is a shortlist only; rows must still match a normalized query
+    surface exactly so generic lower-case topic words do not trigger KG boosts.
+    """
+    alias_keys, fts_name_keys = _kg_boost_query_surface_keys(query_text)
+    if not alias_keys and not fts_name_keys:
+        return []
+
+    fts_query = _escape_fts5_query(query_text, match_mode="or")
+    if not fts_query:
+        return []
+
+    cursor = store._read_cursor()
+    alias_values = sorted(alias_keys)
+    alias_placeholders = ", ".join("?" for _ in alias_values)
+    alias_normalizer = """
+        LOWER(
+            REPLACE(
+                REPLACE(
+                    REPLACE(
+                        REPLACE(
+                            REPLACE(
+                                REPLACE(a.alias, '-', ''),
+                            '_', ''),
+                        '.', ''),
+                    ' ', ''),
+                '/', ''),
+            '@', '')
+        )
+    """
+    rows = list(
+        cursor.execute(
+            f"""
+            WITH fts_matches AS (
+                SELECT e.id, e.name, e.entity_type, NULL AS matched_alias, f.rank
+                FROM kg_entities_fts f
+                JOIN kg_entities e ON f.entity_id = e.id
+                WHERE kg_entities_fts MATCH ?
+                ORDER BY f.rank
+                LIMIT ?
+            ),
+            alias_matches AS (
+                SELECT e.id, e.name, e.entity_type, a.alias AS matched_alias, NULL AS rank
+                FROM kg_entity_aliases a
+                JOIN kg_entities e ON a.entity_id = e.id
+                WHERE {alias_normalizer} IN ({alias_placeholders})
+                ORDER BY e.name, e.id
+                LIMIT ?
+            )
+            SELECT id, name, entity_type, matched_alias, rank FROM fts_matches
+            UNION ALL
+            SELECT id, name, entity_type, matched_alias, rank FROM alias_matches
+            """,
+            (fts_query, max(limit * 5, 20), *alias_values, max(limit * 5, 20)),
+        )
+    )
+
+    matches: list[dict[str, str]] = []
+    seen_ids: set[str] = set()
+    for entity_id, name, entity_type, matched_alias, _rank in rows:
+        name_key = _normalize_entity_surface(str(name))
+        alias_key = _normalize_entity_surface(str(matched_alias)) if matched_alias else ""
+        if not ((matched_alias and alias_key in alias_keys) or name_key in fts_name_keys):
+            continue
+        if entity_id in seen_ids:
+            continue
+        seen_ids.add(str(entity_id))
+        matches.append({"id": str(entity_id), "name": str(name), "entity_type": str(entity_type)})
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+def _kg_linked_chunk_ids_for_query(store: Any, query_text: str, *, entity_limit: int = 8) -> set[str]:
+    matches = _kg_boost_entity_matches(store, query_text, limit=entity_limit)
+    entity_ids = [match["id"] for match in matches]
+    if not entity_ids:
+        return set()
+
+    cursor = store._read_cursor()
+    placeholders = ", ".join("?" for _ in entity_ids)
+    rows = list(
+        cursor.execute(
+            f"""
+            SELECT DISTINCT chunk_id
+            FROM kg_entity_chunks
+            WHERE entity_id IN ({placeholders})
+            """,
+            entity_ids,
+        )
+    )
+    return {str(row[0]) for row in rows}
 
 
 def clear_hybrid_search_cache(store_key: Any = None) -> None:
@@ -2040,29 +2204,7 @@ class SearchMixin:
         # KG boost: chunks linked to entities detected in the query get a score bump
         if kg_boost and query_text:
             try:
-                cursor = self._read_cursor()
-                # Find entity IDs that match words in the query
-                kg_linked_ids: set = set()
-                words = query_text.split()
-                for w in words:
-                    if len(w) < 3:
-                        continue
-                    rows = list(
-                        cursor.execute(
-                            "SELECT id FROM kg_entities WHERE LOWER(name) LIKE ?",
-                            (f"%{w.lower()}%",),
-                        )
-                    )
-                    for row in rows:
-                        linked = list(
-                            cursor.execute(
-                                "SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = ?",
-                                (row[0],),
-                            )
-                        )
-                        for lrow in linked:
-                            kg_linked_ids.add(lrow[0])
-
+                kg_linked_ids = _kg_linked_chunk_ids_for_query(self, query_text)
                 if kg_linked_ids:
                     KG_BOOST_FACTOR = 1.3
                     for i, (score, cid, doc, meta, dist) in enumerate(scored):

--- a/tests/test_kg_boost_reconnect.py
+++ b/tests/test_kg_boost_reconnect.py
@@ -1,0 +1,149 @@
+import sqlite3
+
+import apsw
+
+
+def test_kg_boost_feature_flag_defaults_off(monkeypatch):
+    from brainlayer.mcp.search_handler import _kg_boost_enabled
+
+    monkeypatch.delenv("BRAINLAYER_KG_BOOST", raising=False)
+    assert _kg_boost_enabled() is False
+
+    monkeypatch.setenv("BRAINLAYER_KG_BOOST", "1")
+    assert _kg_boost_enabled() is True
+
+
+def _execute(conn, sql, params=()):
+    return conn.cursor().execute(sql, params)
+
+
+def _create_kg_fixture(conn):
+    statements = [
+        """
+        CREATE TABLE kg_entities (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            metadata TEXT DEFAULT '{}',
+            created_at TEXT,
+            updated_at TEXT,
+            UNIQUE(entity_type, name)
+        )
+        """,
+        """
+        CREATE VIRTUAL TABLE kg_entities_fts USING fts5(
+            name, metadata, entity_id UNINDEXED
+        )
+        """,
+        """
+        CREATE TABLE kg_entity_aliases (
+            alias TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            alias_type TEXT DEFAULT 'name',
+            created_at TEXT,
+            PRIMARY KEY (alias, entity_id)
+        )
+        """,
+        """
+        CREATE TABLE kg_entity_chunks (
+            entity_id TEXT NOT NULL,
+            chunk_id TEXT NOT NULL,
+            relevance REAL DEFAULT 1.0,
+            PRIMARY KEY (entity_id, chunk_id)
+        )
+        """,
+    ]
+    for statement in statements:
+        _execute(conn, statement)
+    return conn
+
+
+def _sqlite_fixture(tmp_path):
+    return _create_kg_fixture(sqlite3.connect(tmp_path / "kg-boost.db"))
+
+
+def _apsw_fixture(tmp_path):
+    return _create_kg_fixture(apsw.Connection(str(tmp_path / "kg-boost-apsw.db")))
+
+
+def _entity(conn, entity_id, entity_type, name):
+    _execute(
+        conn,
+        "INSERT INTO kg_entities (id, entity_type, name, metadata) VALUES (?, ?, ?, '{}')",
+        (entity_id, entity_type, name),
+    )
+    _execute(
+        conn,
+        "INSERT INTO kg_entities_fts (name, metadata, entity_id) VALUES (?, '{}', ?)",
+        (name, entity_id),
+    )
+
+
+def _alias(conn, alias, entity_id, alias_type="name"):
+    _execute(
+        conn,
+        "INSERT INTO kg_entity_aliases (alias, entity_id, alias_type) VALUES (?, ?, ?)",
+        (alias, entity_id, alias_type),
+    )
+
+
+class _Store:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def _read_cursor(self):
+        return self.conn.cursor()
+
+
+def _assert_fts_entity_lookup_resolves_deduped_canonical(conn):
+    from brainlayer import search_repo
+
+    _entity(conn, "person-etan", "person", "Etan Heyman")
+    _alias(conn, "ETAN HEYMAN", "person-etan")
+    _alias(conn, "etanheyman", "person-etan", alias_type="handle")
+
+    store = _Store(conn)
+
+    spaced_matches = search_repo._kg_boost_entity_matches(store, "What did ETAN HEYMAN decide?", limit=10)
+    assert spaced_matches == [{"id": "person-etan", "name": "Etan Heyman", "entity_type": "person"}]
+
+    handle_matches = search_repo._kg_boost_entity_matches(store, "etanheyman search relevance", limit=10)
+    assert handle_matches == [{"id": "person-etan", "name": "Etan Heyman", "entity_type": "person"}]
+
+
+def test_fts_entity_lookup_resolves_deduped_canonical_sqlite(tmp_path):
+    _assert_fts_entity_lookup_resolves_deduped_canonical(_sqlite_fixture(tmp_path))
+
+
+def test_fts_entity_lookup_resolves_deduped_canonical_apsw(tmp_path):
+    _assert_fts_entity_lookup_resolves_deduped_canonical(_apsw_fixture(tmp_path))
+
+
+def _assert_kg_linked_chunks_only_when_entity_detected(conn):
+    from brainlayer import search_repo
+
+    _entity(conn, "person-etan", "person", "Etan Heyman")
+    _entity(conn, "concept-architecture", "concept", "Architecture")
+    _execute(
+        conn,
+        "INSERT INTO kg_entity_chunks (entity_id, chunk_id) VALUES (?, ?)",
+        ("person-etan", "chunk-etan"),
+    )
+    _execute(
+        conn,
+        "INSERT INTO kg_entity_chunks (entity_id, chunk_id) VALUES (?, ?)",
+        ("concept-architecture", "chunk-architecture"),
+    )
+
+    store = _Store(conn)
+
+    assert search_repo._kg_linked_chunk_ids_for_query(store, "Etan Heyman BrainLayer work") == {"chunk-etan"}
+    assert search_repo._kg_linked_chunk_ids_for_query(store, "architecture implementation details") == set()
+
+
+def test_kg_linked_chunks_only_when_entity_detected_sqlite(tmp_path):
+    _assert_kg_linked_chunks_only_when_entity_detected(_sqlite_fixture(tmp_path))
+
+
+def test_kg_linked_chunks_only_when_entity_detected_apsw(tmp_path):
+    _assert_kg_linked_chunks_only_when_entity_detected(_apsw_fixture(tmp_path))


### PR DESCRIPTION
## Summary
- gate MCP KG boosting behind BRAINLAYER_KG_BOOST, default off
- replace per-token kg_entities LIKE scan with kg_entities_fts MATCH plus exact normalized alias matching
- wire hybrid_entity benchmark mode to run the KG-boosted path and add recall/precision metric selection
- add sqlite and APSW fixture coverage for deduped canonical entity aliases and entity-only chunk boosting

## Verification
- pytest -q tests/test_kg_boost_reconnect.py tests/test_audit_search_quality.py tests/test_eval_framework.py -> 29 passed
- pytest -q -> 2516 passed, 48 skipped, 5 xfailed, 328 warnings
- pre-push BrainLayer gate -> passed (2442 passed, 9 skipped, 77 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook 40 passed; bun/regression passed)
- cr review --plain -> no findings
- scoped ruff check/format on touched files -> clean
- repo-wide ruff check/format still fail on pre-existing unrelated script formatting/import baseline

## Read-only A/B Eval
- live DB opened read-only; no live DB mutation and no --apply
- 9-query KG/search-audit subset
- kg_boost OFF: recall@5=0.006309585912319108 precision@5=0.036734693877551024
- kg_boost ON: recall@5=0.0054932593817068635 precision@5=0.0326530612244898
- delta: recall@5=-0.0008163265306122443 precision@5=-0.004081632653061225

Flag remains default-off pending BL-LEAD review of the measured regression on this qrels subset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When enabled, KG boost changes hybrid ranking on production search paths; the flag defaults off, but author A/B on a qrels subset showed a small recall/precision regression with boost on.
> 
> **Overview**
> **KG-boosted hybrid search** is reconnected with stricter entity detection and an opt-in rollout. MCP search passes `kg_boost` only when **`BRAINLAYER_KG_BOOST`** is set (default **off**).
> 
> The old **per-token `LIKE` scan** on `kg_entities` is replaced by **`kg_entities_fts` shortlisting** plus **exact normalized alias/name matching**, so generic lowercase topic words (e.g. “architecture”) do not trigger boosts. Matched entities map to chunks via **`kg_entity_chunks`**, still applying the existing **1.3×** score multiplier in hybrid ranking.
> 
> **Benchmark tooling**: `hybrid_entity` runs hybrid RRF with `kg_boost=True`; `run_benchmark.py` adds **`--metrics`**, read-only `VectorStore` opening for hybrid pipelines, and embedder prewarm for both hybrid modes. New tests cover the env flag, alias deduplication, and entity-only chunk boosting (sqlite + APSW).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3b8b5d12bd11b90697409aef12112d1dfe7a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconnect KG boost in `hybrid_search` to entity FTS and alias matching
> - Replaces naive per-word `LIKE` matching in `SearchMixin.hybrid_search` with FTS5 and alias-table lookups via new helpers in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/445/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472), improving entity detection accuracy.
> - Adds n-gram tokenization (up to 4-grams) and single-token heuristics to identify entity surface forms in queries before boosting linked chunk scores.
> - Implements `pipeline_hybrid_entity` in [benchmark.py](https://github.com/EtanHey/brainlayer/pull/445/files#diff-db6381100ea96e00b18211e9704f102aed5b7b3b5f877e997df2ab98bbd411e9), which previously raised `NotImplementedError`, by delegating to `pipeline_hybrid_rrf` with `kg_boost=True`.
> - Adds `BRAINLAYER_KG_BOOST` environment variable in [search_handler.py](https://github.com/EtanHey/brainlayer/pull/445/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) to toggle KG boosting in MCP search at runtime.
> - New tests in [test_kg_boost_reconnect.py](https://github.com/EtanHey/brainlayer/pull/445/files#diff-ec0ced054c64e3ef04e95a357c5ae42349e1fbd50ef31eb77967445a1954f7b2) cover entity resolution and chunk linking across both sqlite3 and APSW connections.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5a3b8b5. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Graph boost feature for enhanced hybrid search, toggleable via environment variable configuration
  * Extended benchmark CLI with `--metrics` option to specify custom evaluation metrics
  * Implemented hybrid entity search pipeline with knowledge-graph-aware result ranking

* **Tests**
  * Added comprehensive test coverage for Knowledge Graph boost functionality and entity resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->