### PR TITLE
docs: fix MCP tool count (12→13), add June 2026 hardening notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,12 @@ brainlayer enrich
 - Rate configurable via `BRAINLAYER_ENRICH_RATE` env var (default 0.2 = 12 RPM)
 - Adds metadata (summary, tags, importance, intent); session enrichment captures decisions/corrections
 
-<!-- MCP-SERVERS: add new MCP tool entries to mcp/ dir; entrypoint is `brainlayer-mcp`; 11 tools: brain_search, brain_store, brain_recall, brain_entity, brain_expand, brain_update, brain_digest, brain_get_person, brain_tags, brain_supersede, brain_archive -->
+<!-- MCP-SERVERS: add new MCP tool entries to mcp/ dir; entrypoint is `brainlayer-mcp`; 13 tools: brain_search, brain_store, brain_recall, brain_resume, brain_entity, brain_expand, brain_update, brain_digest, brain_get_person, brain_enrich, brain_tags, brain_supersede, brain_archive -->
 ## Interfaces
 - Daemon API (core): `/health`, `/stats`, `/search`, `/context/{chunk_id}`, `/session/{session_id}`
 - Brain graph API: `/brain/graph`, `/brain/node/{node_id}`
 - Backlog API: `/backlog/items` (GET/POST/PATCH/DELETE)
-- MCP tools (11): `brain_search`, `brain_store`, `brain_recall`, `brain_entity`, `brain_expand`, `brain_update`, `brain_digest`, `brain_get_person`, `brain_tags`, `brain_supersede`, `brain_archive` (legacy `brainlayer_*` aliases still work)
+- MCP tools (13): `brain_search`, `brain_store`, `brain_recall`, `brain_resume`, `brain_entity`, `brain_expand`, `brain_update`, `brain_digest`, `brain_get_person`, `brain_enrich`, `brain_tags`, `brain_supersede`, `brain_archive` (legacy `brainlayer_*` aliases still work; note: `brain_update`, `brain_expand`, `brain_tags` are deprecated in the Python MCP path and return errors — use the BrainBar native path for these)
 - MCP server entrypoint: `brainlayer-mcp`
 
 <!-- COMMANDS: `brainlayer brain-export` → graph JSON for dashboard | `brainlayer export-obsidian` → Markdown vault with backlinks + tags -->

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ graph LR
 
 | | BrainLayer | Mem0 | Zep/Graphiti | Letta |
 |---|:---:|:---:|:---:|:---:|
-| **MCP tools** | 12 | 1 | 1 | 0 |
+| **MCP tools** | 13 | 1 | 1 | 0 |
 | **Local-first** | SQLite | Cloud-first | Cloud-only | Docker+PG |
 | **Zero infra** | `pip install` | API key | API key | Docker |
 | **Real-time indexing** | ~1s | No | No | No |
@@ -201,6 +201,14 @@ Two-week stability sprint behind the next presentation. Every line below traces 
 - **Diagnostic + PreCompact noise rejection at ingest** ([#289](https://github.com/EtanHey/brainlayer/pull/289)) — `recursive_mcp_output_reason` now detects BrainLayer-MCP-unavailable diagnostics and PreCompact checkpoint payloads, rejecting them at the watcher / drain / store ingestion heads so tooling failures do not become durable memory. The hybrid reranker *demotes* (not removes) any chunk tagged with precompact/quarantine signals so explicit `include_checkpoints` callers still see them. Pre-push gate: `1995 passed, 9 skipped, 75 deselected, 1 xfailed`. A dry-run-first `scripts/quarantine_noise.py` is available for back-filling existing infra noise — live DB mutation requires explicit `--apply`.
 - **Persist digest LLM entities** ([#290](https://github.com/EtanHey/brainlayer/pull/290)) — fixes a KG persistence regression where `brain_digest` silently skipped Gemini entity extraction because `process_chunk` passed `use_llm=llm_caller is not None` and the MCP/CLI path never sets `llm_caller`. Non-seed person entities were never materialized into `kg_entities` / `kg_entity_chunks`. The 2026-04-06 entity-recall recurrence root-caused to this code path. RED-first regression test (`test_digest_content_persists_llm_people_entities_for_lookup`) now guards the fix.
 - **Enrichment LaunchAgent recovered** — `com.brainlayer.enrichment` was silently unloaded since 2026-05-15 11:50 IDT (no entity extraction running). Bootstrapped back on 2026-05-17 against the 56K-chunk backfill; throttled by Gemini 503s on flex tier but actively draining (verified via `launchctl list | grep enrichment` returning a live PID).
+
+**June 2026 search & KG hardening** ([#433](https://github.com/EtanHey/brainlayer/pull/433)–[#445](https://github.com/EtanHey/brainlayer/pull/445))
+- **Hook failures are now loud** ([#433](https://github.com/EtanHey/brainlayer/pull/433)) — BrainLayer hook DB failures raise clearly instead of silently swallowing errors.
+- **Drain hardening** ([#435](https://github.com/EtanHey/brainlayer/pull/435)) — drain is now resilient to DB open locks under writer contention.
+- **chunk_origin provenance** ([#436](https://github.com/EtanHey/brainlayer/pull/436)) — enrichment stamps `chunk_origin` on every processed chunk; a backfill pass covers existing unknowns, making provenance queryable across the full corpus.
+- **MMR diversity is now on by default** ([#439](https://github.com/EtanHey/brainlayer/pull/439)) — `brain_search` applies Maximal Marginal Relevance post-retrieval dedup automatically; pass `mmr=false` to opt out.
+- **KG entity dedup tooling** ([#441](https://github.com/EtanHey/brainlayer/pull/441)–[#443](https://github.com/EtanHey/brainlayer/pull/443)) — new path-detector and APSW-safe dedup suggestions for cleaning duplicate KG entities; slash-command reclassify collisions also resolved ([#444](https://github.com/EtanHey/brainlayer/pull/444)).
+- **KG boost reconnected to entity FTS** ([#445](https://github.com/EtanHey/brainlayer/pull/445)) — entity-aware ranking is now wired end-to-end through the FTS path.
 
 ## Data Sources
 


### PR DESCRIPTION
## Summary

- Comparison table claimed `12` MCP tools; correct count is **13** (verified against `src/brainlayer/mcp/__init__.py` — 13 tool registrations)
- CLAUDE.md Interfaces comment updated: 11→13 tools; added `brain_resume` and `brain_enrich` to the tool list; added note that `brain_update`/`brain_expand`/`brain_tags` are deprecated in the Python MCP path (return isError) but work via the BrainBar native path
- Added **June 2026 search & KG hardening** section documenting PRs #433–#445: loud hook failures, drain hardening, `chunk_origin` provenance stamping, MMR default-ON (#439), KG entity dedup tooling (#441–#443), KG boost→entity-FTS reconnect (#445)

## Test plan

- [x] Docs-only change, no source code modified
- [x] Tool count verified against `src/brainlayer/mcp/__init__.py` (13 tool registrations confirmed)
- [x] BrainBar stub status verified in `brain-bar/Sources/BrainBarDaemon/MCPRouter.swift` (all 3 tools have real implementations since PR #135)
- [x] PR numbers verified against `gh pr list --state merged --limit 20`

🤖 Generated with [Claude Code](https://claude.com/claude-code) (maintenanceClaude docs sweep 2026-06-05)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime or source modifications.
> 
> **Overview**
> Documentation-only updates align **MCP tool count to 13** in `CLAUDE.md` and the README comparison table (replacing stale 11/12 figures), and expand the documented tool roster with **`brain_resume`** and **`brain_enrich`**.
> 
> `CLAUDE.md` now clarifies that **`brain_update`**, **`brain_expand`**, and **`brain_tags`** are deprecated on the **Python MCP path** (they error there) while remaining available via the **BrainBar native** path.
> 
> The README adds a **June 2026 search & KG hardening** changelog block (PRs #433–#445): loud hook failures, drain lock resilience, **`chunk_origin`** provenance, **MMR on by default** for `brain_search`, KG entity dedup tooling, and KG boost reconnected to entity FTS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1564721332407e0503b571b58f35e30ee43ff119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP tool count to 13 and add June 2026 search & KG hardening changelog
> - Updates MCP tool count from 12 to 13 in [CLAUDE.md](https://github.com/EtanHey/brainlayer/pull/446/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) and [README.md](https://github.com/EtanHey/brainlayer/pull/446/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), adding `brain_resume` and `brain_enrich` to the tool list.
> - Adds deprecation note that `brain_update`, `brain_expand`, and `brain_tags` return errors on the Python MCP path; users should use the BrainBar native path instead.
> - Adds a "June 2026 search & KG hardening" section covering: loud hook failure surfacing, drain hardening, `chunk_origin` provenance stamping and backfill, default-on MMR in `brain_search`, KG entity dedup tooling, and reconnected KG boost to entity FTS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1564721.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->