### PR TITLE
feat(eval): braintrust ingest + db-shrink/phoenix plan docs (split from held FTS work)

### DIFF
--- a/docs/plans/2026-06-01-db-shrink-fts5-dedup.md
+++ b/docs/plans/2026-06-01-db-shrink-fts5-dedup.md
@@ -1,0 +1,44 @@
+# DB Shrink FTS5 + Content Dedup Plan
+
+## Constraints
+
+- Never write to `~/.local/share/brainlayer/brainlayer.db` unless an explicit live override is passed.
+- Materialize and mutate only temp snapshot copies.
+- Benchmark the same qrels before and after migration; do not ship if quality regresses beyond noise.
+
+## Snapshot Source
+
+- Drive folder: `brainlayer-db`
+- File: `2026-06-01-pre-contentclass-apply-014318.db.gz`
+- Drive file id: `1F-K1dxLb81fpGy-Fa6I1SSkTz-7VVLsx`
+- Local matching gzip: `/Users/etanheyman/.local/share/brainlayer/backups/2026-06-01-pre-contentclass-apply-014318.db.gz`
+- Temp baseline: `/tmp/brainlayer-db-shrink/baseline.db` (read-only)
+- Temp migration copy: `/tmp/brainlayer-db-shrink/after.db`
+
+## Implementation
+
+1. Add `brainlayer.db_shrink` with parameterized APIs for:
+   - live-path guard with `--i-know-this-is-live`;
+   - FTS table sizing and counts;
+   - FTS migration to a compact single trigram table;
+   - exact normalized-content duplicate analysis;
+   - physical duplicate delete with canonical aliases and direct reference repoints.
+2. Add `scripts/db_shrink_migrate.py` as the operator CLI.
+3. Add `scripts/db_shrink_eval.py` to run before/after benchmarks and persist `eval_results/db-shrink-2026-06-01.json`.
+4. Update search/vector-store behavior only as needed to avoid recreating the removed redundant FTS table.
+
+## Tests
+
+1. Guard refuses the canonical DB path without `--i-know-this-is-live`.
+2. FTS migration converts a dual-table FTS fixture into compact single-trigram mode and keeps counts synced.
+3. Content dedup keeps protected/qrel chunk IDs canonical, writes aliases, repoints direct references, transfers tags/entities, and deletes duplicate chunk/vector rows.
+4. CLI smoke tests cover dry-run/analyze paths where practical.
+
+## Eval
+
+Run `scripts/run_benchmark.py` or the new eval wrapper for at least:
+
+- `fts5`
+- `hybrid_rrf`
+
+Capture metrics: `ndcg@3`, `precision@3`, `ndcg@10`, `recall@20`, `map@10`, `mrr`.

--- a/docs/plans/2026-06-02-phoenix-eval-integration.md
+++ b/docs/plans/2026-06-02-phoenix-eval-integration.md
@@ -1,0 +1,172 @@
+# Phoenix Eval Integration — Design Doc
+
+> Author: brainlayerClaude-LEAD-v6 · 2026-06-02
+> Status: **DESIGN (gate-before-build)**. The BUILD is delegated to a fresh Codex (xhigh) and gated by LEAD.
+> Decision context: Etan picked **Arize Phoenix** as the local retrieval-eval platform (see `/tmp/eval_platform_comparison.md`, v5's cited comparison; Phoenix = top pick on all 4 needs + strongest privacy + lowest setup).
+
+---
+
+## 0. TL;DR
+
+Stand up **Arize Phoenix self-hosted at `localhost:6006`** as a **read-only eval viewer** over our existing ABCDE retrieval data. Phoenix gets its **own storage** (its SQLite/Postgres volume) — it **never** touches the BrainLayer DB and **never** calls `brain_store`. We push two things into it:
+
+1. **A labeled dataset** (51 queries → returned chunks → relevance labels) so Etan can see **query + retrieved context + per-metric pass/fail** cleanly.
+2. **Experiments** comparing ABCDE variants **A / C / E** on `recall@{1,5,10}`, `MRR`, `nDCG@10` over the n=893 benchmark — as side-by-side experiment runs.
+
+Pure retrieval metrics = **ZERO network** (air-gapped). The only optional egress is an LLM-judge relevance pass, which uses a provider key we already hold (Nebius/Grok). Phone access: recommend a **Tailscale tunnel to `localhost:6006`** for live viewing, with **agent-html static snapshots** as the zero-trust fallback.
+
+**Plus two reconciliations folded in (§6, §7):** the *promptfoo* UI Etan saw tonight (a deviation from the Phoenix standard), and the query-vs-description / truncation / only-failing display confusion (a quirk of that promptfoo tool, fixed by Phoenix's layout).
+
+---
+
+## 1. Our data → Phoenix datasets + experiments
+
+Phoenix's model: a **Dataset** is a versioned set of examples (input → expected → metadata); an **Experiment** runs a task over a dataset and attaches **evaluators** (scores) per example; the UI diffs experiments and supports **human annotations**. We map our two artifacts onto this directly.
+
+### 1a. Labeled retrieval set → Phoenix **Dataset** (the human-label / inspection surface)
+
+Source: `/tmp/labeled_eval_candidates.json` — **51 queries**, each with `returned_chunks[]` (machine-proposed labels). Distribution: **236 `relevant` + 20 `not`** chunk labels; **5 queries flagged `suspected_miss`**, **8 `suspected_misorder`**.
+
+Per-query record shape (verified):
+```
+{ "query": "...",                       # the search string sent to the retriever
+  "returned_chunks": [
+    { "id": "brainbar-7f14a516-78a",
+      "snippet": "...",                 # retrieved context (what the user actually grades)
+      "machine_label": "relevant"|"not",
+      "why": "token overlap 0.86 ..." } ],
+  "suspected_miss": bool, "suspected_misorder": bool, "notes": "..." }
+```
+
+**Mapping → one Phoenix dataset `brainlayer-labeled-51`:**
+- **example input** = `query` (the retriever input — keep this distinct from any human label; see §7).
+- **example output / reference** = the ordered `returned_chunks` (id + snippet + `why`), rendered as the **retrieved context** block.
+- **metadata** = `machine_label` per chunk, `suspected_miss`, `suspected_misorder`, `notes`, `n_chunks`.
+- **annotations** = Etan's human relevance label per chunk (Phoenix human-annotation UI), which **supersedes** `machine_label`. This is the "is this chunk actually relevant?" pass.
+
+This is the surface that answers Etan's confusion: each row shows **query** (input) + **retrieved chunks** (context, full snippet, not truncated) + **per-chunk label** and **per-query flags**, and **all rows are navigable** (not just failures).
+
+### 1b. ABCDE benchmark → Phoenix **Experiments** (variant comparison)
+
+Source: `/tmp/retrieval_benchmark_results.json` (aggregate metrics, n=893) + raw rows `~/Gits/brainlayer-abcde/eval_results/abcde_enrich_nebius.jsonl` (**2624 ok / 2679 — PERSONAL, stays local**).
+
+Verified `meta`: `n_chunks=893`, method = pure-python term-overlap×idf self-retrieval (queries = top-12 raw-content tokens, variant-agnostic; gold = source chunk). **Caveat baked into meta:** self-retrieval favors verbatim-copying variants — real quality needs the LLM-judge pass (parked).
+
+Verified `per_variant[A..E]` keys: `ok_chunks, scored_queries, indexed_coverage, recall@1, recall@5, recall@10, mrr, ndcg@10`. Example (A): recall@1 **0.620**, recall@5 0.849, recall@10 0.917, MRR 0.726, nDCG@10 0.769.
+
+**Mapping → Phoenix experiments, one per variant we care about (A / C / E):**
+- Build a **dataset `brainlayer-abcde-893`** from the n=893 gold pairs (query tokens → gold chunk id), metadata-only (no full personal text needed for the metric — the metric is id-match).
+- Each **variant = one experiment run** over that dataset; the **task** = "retrieve top-k for this query under variant V"; the **evaluators** = `recall@1/5/10`, `MRR`, `nDCG@10` (Phoenix native retrieval evals: nDCG@k / precision@k / hit).
+- Phoenix's **experiment-diff** view then shows **A vs C vs E side-by-side** per metric — exactly the comparison the headline result needs.
+
+**Headline to preserve in the UI (from boot):** E (hyde-structure) consistently best but **MODEST** — E>C>A within ~3% (recall@1 E 0.638 / C 0.625 / A 0.620). The n=24 micro (C 0.96 vs A 0.61) **OVERSTATED** it — small-corpus artifact. The Phoenix experiment-diff makes the "modest, not dramatic" truth visually obvious (overlapping bars), which is the honest framing.
+
+> **Ingest path, two options for the Codex (gate on whichever is cleaner):**
+> (a) **Pre-computed provider** (fastest, mirrors what already works): a thin task fn that *replays* our precomputed `returned_chunks` per query — no live retrieval call, deterministic, fully offline. Recommended for v1.
+> (b) **Live retrieval task**: task fn calls BrainLayer's retriever (read-only `brain_search`-equivalent) at eval time. Higher fidelity but couples Phoenix runs to the live DB; defer to v2.
+
+---
+
+## 2. Sandbox from BrainLayer (hard isolation)
+
+**Requirement: Phoenix must not read or write the BrainLayer DB, and must never `brain_store`.**
+
+- **Storage:** Phoenix self-host uses its **own** persistence — a dedicated Docker volume (Postgres) or a local SQLite file under a Phoenix-only working dir (e.g. `~/.local/share/phoenix/`). **Never** point `PHOENIX_SQL_DATABASE_URL` at `~/.local/share/brainlayer/brainlayer.db`.
+- **Data flow is one-way and snapshot-based:** we *export* JSON snapshots (the 51-query set; the n=893 aggregate + id-only gold pairs) from `/tmp` artifacts into Phoenix datasets. BrainLayer is the source; Phoenix is a downstream read-only mirror. No process writes back to BrainLayer.
+- **No MCP write tools in the Phoenix path.** The Codex build gets **read-only** data files; it does **not** import `vector_store.py` write paths and does **not** call any `brain_*` mutate tool.
+- **Process isolation:** Phoenix runs in its own container / venv. It does not share BrainLayer's socket (`/tmp/brainlayer.sock`), enrichment lock, or WAL. Zero contention with the indexer/enrichment workers (respects the CLAUDE.md bulk-op safety rules by simply never touching the DB).
+
+Net: a leak is structurally impossible because Phoenix has no handle to the BrainLayer DB and no write tool.
+
+---
+
+## 3. Phone-access layer (compute stays on the Mac)
+
+Phoenix UI binds `localhost:6006` on the Mac. Three ways to reach it from a phone:
+
+| Option | What Etan gets | Privacy posture | Effort |
+|---|---|---|---|
+| **(a) Tailscale tunnel** ⭐ | **LIVE** Phoenix UI on phone (annotate, diff experiments) over the tailnet | Data never leaves Etan's devices; WireGuard E2E, no public exposure | **Low** (already-common in this ecosystem) |
+| (b) agent-html / Lakebed **static snapshots** | **Read-only** rendered tables/charts on phone, published as static HTML | Snapshot is a derived view; **must scrub personal chunk text before publish** | Low-Med |
+| (c) MCP endpoint | Query eval results via an MCP tool from any Claude surface | Stays in the agent layer; no browser | Med (build a tool) |
+
+**Recommendation: (a) Tailscale** for live interaction (Etan can actually *annotate* relevance from the phone, which (b) can't do), with **(b) static snapshots as the zero-trust fallback** for quick read-only glances and for sharing a frozen result. (c) is a nice-to-have later, not v1.
+
+**Guardrail for (b):** static snapshots of the **labeled-51** set contain personal chunk snippets → snapshots must be **metric/aggregate-only** OR scrubbed. The **893 experiment-diff** (id-match metrics, no full text) is safe to snapshot as-is. This mirrors the live PII-incident lesson (§ parked) — never publish raw personal chunk text.
+
+---
+
+## 4. Air-gapped confirmation (for Etan)
+
+- **Pure retrieval metrics** (`recall@k`, `MRR`, `nDCG@10`) over our own labels/gold = **ZERO network**. Phoenix self-host is explicitly air-gappable ("fully air-gapped, nothing sent to Arize" — `arize.com/docs/phoenix/self-hosting`). Disable any usage telemetry env flag at boot to be belt-and-suspenders.
+- **The ONLY optional egress** is the **LLM-judge relevance scoring** (faithfulness/usefulness) — and that's opt-in, calling a provider **we** pick with **our** key (Nebius working / Grok ~$1 left). Smoke-first the key before any metered judge run (boot rule). The deterministic metric path needs **no** key at all.
+- Verify post-boot: `lsof -i -P | grep phoenix` should show only `localhost:6006` listeners, no outbound — confirm during the build gate.
+
+---
+
+## 5. Clean display: query + retrieved-context + per-metric pass/fail
+
+This is the explicit ask. Phoenix's example/experiment view must render, per row:
+1. **Query** — labeled "Query (retriever input)": the exact search string sent to the retriever (vectorized + FTS).
+2. **Retrieved context** — the ordered chunks (id, importance, type, full snippet, retrieval `why`), **not truncated**, scrollable.
+3. **Per-metric pass/fail** — each evaluator (`recall@1`, `hit`, `nDCG@10`, human-relevance) shown as its own column with a clear pass/fail/score, **all rows navigable** regardless of pass/fail.
+
+The `provider.js` rendering already built in `brainlayer-eval-ui` (renders id + machine_label + importance + type + tags + key_facts + summary + full_text per chunk) is a **good content template** to port into the Phoenix task fn — we reuse the rendering, drop the promptfoo harness (§6).
+
+---
+
+## 6. RECONCILE: promptfoo deviation (found tonight)
+
+**Finding: an agent stood up a `promptfoo` eval UI — this is a deviation from the Phoenix standard.**
+
+- **Location:** `~/Gits/brainlayer-eval-ui/` (separate repo). Created **today 2026-06-02, 12:16–12:20**.
+- **Contents:** `package.json` → `promptfoo@^0.121.13`; `promptfooconfig.json` (26 KB, "BrainLayer ABCDE Retrieval Grading — human relevance labeling", 51 tests); `provider.js` (custom provider that **replays** precomputed BrainLayer retrieval results — **no LLM calls**); `data/eval_dataset.json` (627 KB, **personal chunk text — local only**); `node_modules/`.
+- **It ran:** a task output shows `Port 15500 is already in use. Do you have another Promptfoo instance running?` → `promptfoo view` was launched. This is the eval UI Etan saw tonight.
+- **Risk: LOW / contained.** The repo is **local-only**: `master` has **no commits**, **no remote**, everything untracked. The 627 KB personal dataset has **not** left the machine. No public exposure (unlike the PR #430 incident). But it does hold raw personal chunks on disk in a stray repo.
+
+**Disposition (LEAD recommendation):**
+- ✅ **Standardize on Arize Phoenix** (Etan's pick). promptfoo was a quick-and-dirty local grading harness, not the chosen platform.
+- ♻️ **Salvage, don't trash:** port `provider.js`'s chunk-rendering and reuse `data/eval_dataset.json` as a Phoenix dataset source. The *data* is good; only the *harness* changes.
+- 🧹 **Retire `brainlayer-eval-ui`** once Phoenix replays the same 51 set — and **scrub `data/eval_dataset.json`** (personal text) or move it under `docs.local/` (gitignored) so it's not a loose personal-data repo. **Ask Etan before deleting** (personal-data rule).
+- 📌 No git history to purge (no commits, no remote) — cleanup is just `rm -rf` after Phoenix parity + Etan OK.
+
+**Why it confused the picture:** it's a *second* eval UI living outside the brainlayer repo, named `brainlayer-eval-ui`, so "I thought we were using Phoenix" is exactly right — we *are*; this was an unsanctioned detour.
+
+---
+
+## 7. RECONCILE: Etan's eval-UI observations (folded into the Phoenix design)
+
+Etan saw, in the promptfoo UI: (1) **"query" and "description" nearly identical**, some descriptions **cut mid**; (2) could **only navigate FAILING cases**. Root causes, verified against `promptfooconfig.json`/`provider.js`:
+
+- **query == description:** In `promptfooconfig.json` **every test sets `description` = the `query` string verbatim** (e.g. both = `"gen-6 orc SESSION CHECKPOINT 2026-06-01 ETAN DECISIONS"`). They look identical **because they are the same string** — the generator used the query as the human label.
+  - **Clarification for Etan:** **`query`** = the search string sent to the retriever (vectorized + FTS). **`description`** = a human label *of the test case*. They only collide here because whoever generated the config set the label = the query. In Phoenix we'll label the column **"Query (retriever input)"** and keep any human description as a *distinct* optional field, so they never masquerade as each other.
+- **descriptions cut mid:** promptfoo's web table **truncates** the description column. A **display quirk of that tool**, not missing data — the full string is present in the config. Phoenix renders the full query + scrollable context (§5).
+- **only FAILING cases navigable:** `promptfooconfig.json` injects synthetic **always-fail** assertions on flagged rows — `false /* ZERO-CHUNK GAP */` and `false /* SUSPECTED MISS */`. So the only "failures" promptfoo surfaces are the **auto-flagged** rows (the 5 misses / 8 misorders), and promptfoo's UI lets you filter to failures. That's a **filter/assertion artifact**, not "passing cases are hidden." Phoenix shows **all 51 rows**, every metric as its own pass/fail column, navigable regardless of outcome.
+
+Net: all three are **display/harness quirks of promptfoo**, fully explained, and **designed away** by the Phoenix layout in §5.
+
+---
+
+## 8. Build plan (delegated to Codex xhigh — gated by LEAD)
+
+**Scope for the worker (v1, read-only, offline-first):**
+1. Phoenix self-host at `localhost:6006`, **own storage** (Phoenix-only volume/dir), telemetry off, sandboxed from BrainLayer DB (§2).
+2. Loader script: `/tmp/labeled_eval_candidates.json` → dataset `brainlayer-labeled-51` (input=query, context=chunks, metadata=labels/flags), human-annotation enabled.
+3. Loader script: n=893 aggregate + id-only gold → dataset `brainlayer-abcde-893`; **experiments A / C / E** with native `recall@k`/`nDCG@10`/`hit` evaluators; experiment-diff view.
+4. Reuse `brainlayer-eval-ui/provider.js` chunk-rendering for the context block (§5); **drop promptfoo**.
+5. Verify air-gap: `lsof` shows only localhost listener, no outbound on the metric path (§4).
+6. **Do NOT** wire any `brain_*` write tool; **do NOT** open the BrainLayer DB; **do NOT** commit personal data (`eval_results/*.jsonl`, `data/eval_dataset.json` stay local/gitignored).
+
+**Gate (LEAD verifies before "done"):** (a) `localhost:6006` up, datasets + experiments visible; (b) a row shows query + full context + per-metric columns, all 51 navigable; (c) `lsof` clean (no egress on metric path); (d) no BrainLayer DB handle, no `brain_store` call, no personal data staged for commit; (e) A/C/E diff reproduces the modest E>C>A (~3%) headline.
+
+**Out of scope v1 (parked):** LLM-judge quality pass (needs Research-B kappa floors + metered key smoke-first); live-retrieval task fn (§1b option b); MCP endpoint (§3c); Tailscale wiring (Etan device-side).
+
+---
+
+## References
+- `/tmp/eval_platform_comparison.md` — cited platform comparison (Phoenix top pick).
+- `/tmp/labeled_eval_candidates.json` — 51-query labeled set (236 relevant / 20 not; 5 miss / 8 misorder).
+- `/tmp/retrieval_benchmark_results.json` — n=893 per-variant metrics (A..E).
+- `~/Gits/brainlayer-abcde/eval_results/abcde_enrich_nebius.jsonl` — raw rows (2624 ok, PERSONAL, local-only).
+- `~/Gits/brainlayer-eval-ui/` — the promptfoo deviation (local, uncommitted) — salvage data, retire harness.
+- Phoenix self-host / air-gap / retrieval evals: arize.com/docs/phoenix/self-hosting · /deployment-options/docker · /cookbook/evaluation/evaluate-rag

--- a/eval_results/db-shrink-2026-06-01.json
+++ b/eval_results/db-shrink-2026-06-01.json
@@ -1,0 +1,116 @@
+{
+  "after": {
+    "fts5": {
+      "metrics": {
+        "map@10": 0.1607754814494109,
+        "mrr": 0.6841836734693877,
+        "ndcg@10": 0.5262024270927425,
+        "ndcg@3": 0.5888992169720909,
+        "precision@3": 0.6054421768707483,
+        "recall@20": 0.31571284374957126
+      },
+      "query_count": 49,
+      "query_timeout_ms": 10000,
+      "timed_out_queries": [
+        "frustration_001",
+        "frustration_007",
+        "frustration_014",
+        "frustration_015",
+        "frustration_022",
+        "frustration_023",
+        "frustration_024"
+      ]
+    }
+  },
+  "after_bytes": 6620393472,
+  "after_db": "/private/tmp/brainlayer-db-shrink/after.db",
+  "before": {
+    "fts5": {
+      "metrics": {
+        "map@10": 0.16458297362080643,
+        "mrr": 0.6258503401360543,
+        "ndcg@10": 0.5159834653232883,
+        "ndcg@3": 0.5351326443056971,
+        "precision@3": 0.5578231292517006,
+        "recall@20": 0.3493554919872343
+      },
+      "query_count": 49,
+      "query_timeout_ms": 10000,
+      "timed_out_queries": [
+        "frustration_001",
+        "frustration_007",
+        "frustration_011",
+        "frustration_014",
+        "frustration_015",
+        "frustration_021",
+        "frustration_022",
+        "frustration_023",
+        "frustration_024"
+      ]
+    }
+  },
+  "before_bytes": 9213992960,
+  "before_db": "/private/tmp/brainlayer-db-shrink/baseline.db",
+  "dbstat_top_after": {
+    "chunk_clusters": 149237760,
+    "chunk_fts_rowids": 36392960,
+    "chunk_tags": 228278272,
+    "chunk_vectors_binary_vector_chunks00": 37900288,
+    "chunk_vectors_vector_chunks00": 1284874240,
+    "chunks": 1009987584,
+    "chunks_fts_content": 579264512,
+    "chunks_fts_data": 179687424,
+    "chunks_fts_trigram_content": 579264512,
+    "chunks_fts_trigram_data": 1272573952,
+    "dedupe_audit": 36532224,
+    "idx_chunk_tags_tag": 39600128,
+    "idx_chunks_source_uri": 38014976,
+    "idx_kg_ec_chunk": 69763072,
+    "kg_entity_chunks": 100982784,
+    "sqlite_autoindex_chunk_clusters_1": 100126720,
+    "sqlite_autoindex_chunk_fts_rowids_1": 34091008,
+    "sqlite_autoindex_chunk_tags_1": 228630528,
+    "sqlite_autoindex_chunks_1": 34103296,
+    "sqlite_autoindex_kg_entity_chunks_1": 82911232
+  },
+  "dbstat_top_before": {
+    "chunk_clusters": 152559616,
+    "chunk_fts_rowids": 43556864,
+    "chunk_tags": 230883328,
+    "chunk_vectors_binary_vector_chunks00": 37900288,
+    "chunk_vectors_vector_chunks00": 1284874240,
+    "chunks": 1226002432,
+    "chunks_fts_content": 698257408,
+    "chunks_fts_data": 1542946816,
+    "chunks_fts_trigram_content": 684785664,
+    "chunks_fts_trigram_data": 1998745600,
+    "idx_chunk_tags_tag": 42602496,
+    "idx_chunks_brick_id": 39485440,
+    "idx_chunks_source_uri": 47558656,
+    "idx_kg_ec_chunk": 73641984,
+    "kg_entity_chunks": 107634688,
+    "sqlite_autoindex_chunk_clusters_1": 101654528,
+    "sqlite_autoindex_chunk_fts_rowids_1": 40595456,
+    "sqlite_autoindex_chunk_tags_1": 231227392,
+    "sqlite_autoindex_chunks_1": 40591360,
+    "sqlite_autoindex_kg_entity_chunks_1": 87932928
+  },
+  "gate": {
+    "max_regression": 0.005,
+    "regressions": [
+      {
+        "after": 0.31571284374957126,
+        "before": 0.3493554919872343,
+        "delta": -0.03364264823766305,
+        "metric": "recall@20",
+        "pipeline": "fts5"
+      }
+    ],
+    "verdict": "fail"
+  },
+  "pipelines": [
+    "fts5"
+  ],
+  "reclaimed_bytes": 2593599488,
+  "timestamp": "20260601T121715Z"
+}

--- a/scripts/braintrust_ingest.py
+++ b/scripts/braintrust_ingest.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Dry-run-first Braintrust ingestion for BrainLayer retrieval grading.
+
+Doc-verified SDK/API notes:
+- Braintrust SDK auth defaults to BRAINTRUST_API_KEY and prompts login without it:
+  https://www.braintrust.dev/docs/reference/sdks/python/latest
+- Dataset creation uses init_dataset(project=..., name=..., api_key=..., use_output=False).
+- Dataset rows use Dataset.insert(input=..., expected=..., metadata=..., id=..., tags=...).
+- Experiments use Eval(name, data=..., task=..., scores=..., experiment_name=..., metadata=...).
+- Autoevals LLMClassifier supports prompt_template and choice_scores, but any semantic
+  relevance judge needs raw query/evidence text, so this script never enables it for
+  Braintrust cloud sends.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+DEFAULT_LABELED_PATH = Path("/tmp/labeled_eval_candidates.json")
+DEFAULT_RETRIEVAL_PATH = Path("/tmp/retrieval_benchmark_results.json")
+DEFAULT_RAW_ENRICHED_PATH = Path("/Users/etanheyman/Gits/brainlayer-abcde/eval_results/abcde_enrich_nebius.jsonl")
+DEFAULT_PROJECT = "BrainLayer Retrieval Grading"
+DEFAULT_DATASET = "retrieval-grading-candidates"
+DEFAULT_EXPERIMENT = "abcde-retrieval-grading"
+RELEVANT_LABEL = "relevant"
+DOC_VERIFIED_SOURCES = [
+    "https://www.braintrust.dev/docs/admin/self-hosting",
+    "https://www.braintrust.dev/docs/admin/self-hosting/deploy",
+    "https://www.braintrust.dev/docs/reference/sdks/python/latest",
+    "https://www.braintrust.dev/docs/annotate/datasets/create",
+    "https://github.com/braintrustdata/autoevals",
+]
+
+
+@dataclass(frozen=True)
+class IngestionPayload:
+    dataset_records: list[dict[str, Any]]
+    retrieval_metrics: dict[str, Any]
+    counts: dict[str, int]
+    dataset_metadata: dict[str, Any]
+
+    @property
+    def eval_cases(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "input": record["input"],
+                "expected": record["expected"],
+                "metadata": record["metadata"],
+                "tags": record["tags"],
+            }
+            for record in self.dataset_records
+        ]
+
+    def as_dry_run_dict(self) -> dict[str, Any]:
+        sample_record = self.dataset_records[0] if self.dataset_records else None
+        return {
+            "mode": "dry-run",
+            "counts": self.counts,
+            "project_payload": {
+                "dataset_records": "redacted records; raw query/chunk text omitted",
+                "sample_record": sample_record,
+                "retrieval_metrics": self.retrieval_metrics,
+                "dataset_metadata": self.dataset_metadata,
+            },
+            "privacy": "No raw query text, chunk snippets, chunk rationale, or notes are included.",
+        }
+
+
+@dataclass(frozen=True)
+class BraintrustSettings:
+    project: str
+    dataset: str
+    experiment: str
+    api_key: str | None
+
+
+def stable_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _count_jsonl_rows(path: Path) -> int:
+    if not path.exists():
+        return 0
+    with path.open("r", encoding="utf-8") as handle:
+        return sum(1 for _line in handle)
+
+
+def _label_counts(chunks: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for chunk in chunks:
+        label = str(chunk.get("machine_label") or "unknown")
+        counts[label] = counts.get(label, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _chunk_id_hash(chunk_id: Any) -> str:
+    return stable_hash(str(chunk_id))
+
+
+def _relevant_chunk_id_hashes(chunks: list[dict[str, Any]]) -> list[str]:
+    return [
+        _chunk_id_hash(chunk["id"])
+        for chunk in chunks
+        if chunk.get("id") and str(chunk.get("machine_label", "")).lower() == RELEVANT_LABEL
+    ]
+
+
+def _returned_chunk_id_hashes(chunks: list[dict[str, Any]]) -> list[str]:
+    return [_chunk_id_hash(chunk["id"]) for chunk in chunks if chunk.get("id")]
+
+
+def _redacted_source_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    safe_meta: dict[str, Any] = {}
+    for key in ("n_chunks", "method", "generated"):
+        if key in meta:
+            safe_meta[key] = meta[key]
+    if "source" in meta:
+        safe_meta["source_redacted"] = True
+    return safe_meta
+
+
+def _sanitize_retrieval_metrics(retrieval_results: dict[str, Any]) -> dict[str, Any]:
+    per_variant = retrieval_results.get("per_variant", {})
+    sanitized_variants: dict[str, dict[str, int | float]] = {}
+    for variant, metrics in sorted(per_variant.items()):
+        sanitized_variants[str(variant)] = {
+            str(key): value
+            for key, value in sorted(metrics.items())
+            if isinstance(value, int | float) and not isinstance(value, bool)
+        }
+    return {
+        "meta": _redacted_source_meta(retrieval_results.get("meta", {})),
+        "per_variant": sanitized_variants,
+    }
+
+
+def _build_dataset_record(item: dict[str, Any], index: int) -> dict[str, Any]:
+    chunks = item.get("returned_chunks") or []
+    query_id = f"query-{index:04d}"
+    query_text = str(item.get("query") or "")
+    label_source = str(item.get("label_source") or "unknown")
+    metadata = {
+        "source_index": index - 1,
+        "label_source": label_source,
+        "label_counts": _label_counts(chunks),
+        "returned_count": len(chunks),
+        "suspected_miss_present": item.get("suspected_miss") is not None,
+        "suspected_misorder_present": item.get("suspected_misorder") is not None,
+        "notes_redacted": bool(item.get("notes")),
+        "raw_text_policy": "query_snippet_why_notes_redacted",
+    }
+    return {
+        "id": query_id,
+        "input": {
+            "query_id": query_id,
+            "query_sha256": stable_hash(query_text),
+            "query_text_redacted": True,
+            "returned_chunk_id_hashes": _returned_chunk_id_hashes(chunks),
+        },
+        "expected": {
+            "relevant_chunk_id_hashes": _relevant_chunk_id_hashes(chunks),
+        },
+        "metadata": metadata,
+        "tags": ["brainlayer", "retrieval-grading", label_source],
+    }
+
+
+def build_ingestion_payload(labeled_path: Path, retrieval_path: Path, raw_enriched_path: Path) -> IngestionPayload:
+    labeled_candidates = _load_json(labeled_path)
+    retrieval_results = _load_json(retrieval_path)
+    if not isinstance(labeled_candidates, list):
+        raise ValueError(f"Expected labeled candidates JSON array at {labeled_path}")
+    if not isinstance(retrieval_results, dict):
+        raise ValueError(f"Expected retrieval results JSON object at {retrieval_path}")
+
+    dataset_records = [
+        _build_dataset_record(item, index)
+        for index, item in enumerate(labeled_candidates, start=1)
+        if isinstance(item, dict)
+    ]
+    retrieval_metrics = _sanitize_retrieval_metrics(retrieval_results)
+    raw_count = _count_jsonl_rows(raw_enriched_path)
+    counts = {
+        "labeled_queries": len(labeled_candidates),
+        "dataset_records": len(dataset_records),
+        "raw_enriched_rows_local_only": raw_count,
+        "retrieval_variants": len(retrieval_metrics["per_variant"]),
+    }
+    dataset_metadata = {
+        "privacy": "raw_query_and_chunk_text_redacted",
+        "labeled_source_file": labeled_path.name,
+        "retrieval_source_file": retrieval_path.name,
+        "raw_enriched_rows_local_only": raw_count,
+        "doc_verified_sources": DOC_VERIFIED_SOURCES,
+    }
+    return IngestionPayload(
+        dataset_records=dataset_records,
+        retrieval_metrics=retrieval_metrics,
+        counts=counts,
+        dataset_metadata=dataset_metadata,
+    )
+
+
+def make_recall_at_k_scorer(k: int) -> Callable[..., float | None]:
+    def recall_at_k(input: dict[str, Any], output: dict[str, Any], expected: dict[str, Any] | None = None, **_kwargs):
+        expected = expected or {}
+        relevant = set(expected.get("relevant_chunk_id_hashes") or expected.get("relevant_chunk_ids") or [])
+        if not relevant:
+            return None
+        retrieved = list(
+            output.get("retrieved_chunk_id_hashes")
+            or output.get("retrieved_chunk_ids")
+            or input.get("returned_chunk_id_hashes")
+            or input.get("returned_chunk_ids")
+            or []
+        )
+        hits = relevant.intersection(retrieved[:k])
+        return len(hits) / len(relevant)
+
+    recall_at_k.__name__ = f"recall_at_{k}"
+    return recall_at_k
+
+
+def make_relevance_llm_judge(model: str | None = None):
+    """Construct an Autoevals LLM judge for local/self-host-only semantic relevance.
+
+    This scorer requires raw query/evidence text to be meaningful. It is intentionally
+    not attached to Braintrust cloud sends in this script because the task forbids
+    uploading Etan's personal query/chunk content.
+    """
+
+    from autoevals.llm import LLMClassifier
+
+    return LLMClassifier(
+        name="retrieval_relevance_llm_judge",
+        prompt_template=(
+            "Decide whether the retrieved evidence is relevant to the search query.\n"
+            "Query: {{input}}\n"
+            "Retrieved evidence: {{output}}\n"
+            "Expected relevant evidence or label: {{expected}}\n"
+            "Choose exactly one label."
+        ),
+        choice_scores={"relevant": 1, "not_relevant": 0},
+        model=model,
+        use_cot=True,
+    )
+
+
+def _task_return_retrieved_ids(input: dict[str, Any]) -> dict[str, Any]:
+    return {"retrieved_chunk_id_hashes": input.get("returned_chunk_id_hashes") or []}
+
+
+def _import_braintrust() -> ModuleType:
+    try:
+        import braintrust
+    except ImportError as exc:
+        raise RuntimeError("Install the Braintrust SDK first: python3 -m pip install braintrust autoevals") from exc
+    return braintrust
+
+
+def send_payload(
+    payload: IngestionPayload,
+    settings: BraintrustSettings,
+    *,
+    braintrust_module: Any | None = None,
+) -> dict[str, Any]:
+    api_key = settings.api_key
+    if not api_key:
+        raise RuntimeError("BRAINTRUST_API_KEY is required for --send")
+
+    braintrust = braintrust_module or _import_braintrust()
+    dataset = braintrust.init_dataset(
+        project=settings.project,
+        name=settings.dataset,
+        api_key=api_key,
+        use_output=False,
+        metadata=payload.dataset_metadata,
+    )
+    for record in payload.dataset_records:
+        dataset.insert(
+            id=record["id"],
+            input=record["input"],
+            expected=record["expected"],
+            metadata=record["metadata"],
+            tags=record["tags"],
+        )
+    dataset.flush()
+
+    braintrust.Eval(
+        settings.project,
+        data=payload.eval_cases,
+        task=_task_return_retrieved_ids,
+        scores=[make_recall_at_k_scorer(1), make_recall_at_k_scorer(5), make_recall_at_k_scorer(10)],
+        experiment_name=settings.experiment,
+        metadata={
+            **payload.dataset_metadata,
+            "retrieval_metrics": payload.retrieval_metrics,
+            "privacy": "raw_query_and_chunk_text_redacted",
+            "llm_judge_status": "not_enabled_for_cloud_personal_content_guardrail",
+        },
+        tags=["brainlayer", "retrieval-grading", "redacted"],
+        no_send_logs=False,
+    )
+    return {"dataset_records_sent": len(payload.dataset_records), "eval_invoked": True}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--labeled-path", type=Path, default=DEFAULT_LABELED_PATH)
+    parser.add_argument("--retrieval-path", type=Path, default=DEFAULT_RETRIEVAL_PATH)
+    parser.add_argument("--raw-enriched-path", type=Path, default=DEFAULT_RAW_ENRICHED_PATH)
+    parser.add_argument("--project", default=DEFAULT_PROJECT)
+    parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    parser.add_argument("--experiment", default=DEFAULT_EXPERIMENT)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True, help="Print sanitized payload shape; send nothing")
+    mode.add_argument("--send", action="store_false", dest="dry_run", help="Send redacted records to Braintrust")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    payload = build_ingestion_payload(args.labeled_path, args.retrieval_path, args.raw_enriched_path)
+    if args.dry_run:
+        print(json.dumps(payload.as_dry_run_dict(), indent=2, sort_keys=True))
+        return
+
+    settings = BraintrustSettings(
+        project=args.project,
+        dataset=args.dataset,
+        experiment=args.experiment,
+        api_key=os.environ.get("BRAINTRUST_API_KEY"),
+    )
+    try:
+        result = send_payload(payload, settings)
+    except RuntimeError as exc:
+        raise SystemExit(f"BLOCKED: {exc}") from None
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_braintrust_ingest.py
+++ b/tests/test_braintrust_ingest.py
@@ -1,0 +1,175 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import braintrust_ingest
+
+
+def _write_fixture_files(tmp_path: Path) -> tuple[Path, Path, Path]:
+    labeled_path = tmp_path / "labeled_eval_candidates.json"
+    labeled_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": "personal query text",
+                    "returned_chunks": [
+                        {
+                            "id": "chunk-relevant",
+                            "snippet": "personal chunk text",
+                            "machine_label": "relevant",
+                            "why": "personal rationale",
+                        },
+                        {
+                            "id": "chunk-not",
+                            "snippet": "other personal chunk text",
+                            "machine_label": "not",
+                            "why": "personal rationale",
+                        },
+                    ],
+                    "suspected_miss": None,
+                    "suspected_misorder": None,
+                    "notes": "personal label notes",
+                    "label_source": "machine",
+                }
+            ]
+        )
+    )
+    retrieval_path = tmp_path / "retrieval_benchmark_results.json"
+    retrieval_path.write_text(
+        json.dumps(
+            {
+                "meta": {"n_chunks": 893, "method": "fixture", "source": "local", "generated": "2026-06-02"},
+                "per_variant": {
+                    "A": {
+                        "ok_chunks": 893,
+                        "scored_queries": 51,
+                        "indexed_coverage": 0.9,
+                        "recall@1": 0.1,
+                        "recall@5": 0.5,
+                        "recall@10": 0.8,
+                        "mrr": 0.4,
+                        "ndcg@10": 0.7,
+                    }
+                },
+            }
+        )
+    )
+    raw_path = tmp_path / "abcde_enrich_nebius.jsonl"
+    raw_path.write_text('{"personal":"row"}\n{"personal":"row2"}\n')
+    return labeled_path, retrieval_path, raw_path
+
+
+def test_payload_redacts_personal_content_and_keeps_ids(tmp_path: Path):
+    labeled_path, retrieval_path, raw_path = _write_fixture_files(tmp_path)
+
+    payload = braintrust_ingest.build_ingestion_payload(labeled_path, retrieval_path, raw_path)
+
+    assert payload.counts == {
+        "labeled_queries": 1,
+        "dataset_records": 1,
+        "raw_enriched_rows_local_only": 2,
+        "retrieval_variants": 1,
+    }
+    record = payload.dataset_records[0]
+    assert record["id"] == "query-0001"
+    relevant_hash = braintrust_ingest.stable_hash("chunk-relevant")
+    not_hash = braintrust_ingest.stable_hash("chunk-not")
+    assert record["input"] == {
+        "query_id": "query-0001",
+        "query_sha256": braintrust_ingest.stable_hash("personal query text"),
+        "query_text_redacted": True,
+        "returned_chunk_id_hashes": [relevant_hash, not_hash],
+    }
+    assert record["expected"] == {"relevant_chunk_id_hashes": [relevant_hash]}
+    assert record["tags"] == ["brainlayer", "retrieval-grading", "machine"]
+    assert record["metadata"]["label_counts"] == {"not": 1, "relevant": 1}
+    assert record["metadata"]["notes_redacted"] is True
+
+    serialized = json.dumps(payload.as_dry_run_dict())
+    assert "personal query text" not in serialized
+    assert "personal chunk text" not in serialized
+    assert "personal label notes" not in serialized
+
+
+def test_recall_scorer_uses_expected_relevant_ids():
+    scorer = braintrust_ingest.make_recall_at_k_scorer(2)
+
+    score = scorer(
+        input={"returned_chunk_id_hashes": ["chunk-a", "chunk-b", "chunk-c"]},
+        output={"retrieved_chunk_id_hashes": ["chunk-a", "chunk-b", "chunk-c"]},
+        expected={"relevant_chunk_id_hashes": ["chunk-b", "chunk-z"]},
+    )
+
+    assert score == pytest.approx(0.5)
+    assert scorer.__name__ == "recall_at_2"
+
+
+def test_send_payload_uses_braintrust_sdk_without_leaking_raw_text(tmp_path: Path):
+    labeled_path, retrieval_path, raw_path = _write_fixture_files(tmp_path)
+    payload = braintrust_ingest.build_ingestion_payload(labeled_path, retrieval_path, raw_path)
+
+    class FakeDataset:
+        def __init__(self):
+            self.inserted = []
+            self.flushed = False
+
+        def insert(self, **kwargs):
+            self.inserted.append(kwargs)
+            return kwargs["id"]
+
+        def flush(self):
+            self.flushed = True
+
+    class FakeBraintrust:
+        def __init__(self):
+            self.dataset = FakeDataset()
+            self.init_dataset_calls = []
+            self.eval_calls = []
+
+        def init_dataset(self, **kwargs):
+            self.init_dataset_calls.append(kwargs)
+            return self.dataset
+
+        def Eval(self, *args, **kwargs):
+            self.eval_calls.append((args, kwargs))
+            return {"ok": True}
+
+    fake = FakeBraintrust()
+    settings = braintrust_ingest.BraintrustSettings(
+        project="BrainLayer Retrieval",
+        dataset="Candidates",
+        experiment="ABCD-E",
+        api_key="env-key",
+    )
+
+    result = braintrust_ingest.send_payload(payload, settings, braintrust_module=fake)
+
+    assert result == {"dataset_records_sent": 1, "eval_invoked": True}
+    assert fake.init_dataset_calls == [
+        {
+            "project": "BrainLayer Retrieval",
+            "name": "Candidates",
+            "api_key": "env-key",
+            "use_output": False,
+            "metadata": payload.dataset_metadata,
+        }
+    ]
+    assert fake.dataset.inserted == [
+        {
+            "id": "query-0001",
+            "input": payload.dataset_records[0]["input"],
+            "expected": payload.dataset_records[0]["expected"],
+            "metadata": payload.dataset_records[0]["metadata"],
+            "tags": payload.dataset_records[0]["tags"],
+        }
+    ]
+    assert fake.dataset.flushed is True
+    assert fake.eval_calls[0][0] == ("BrainLayer Retrieval",)
+    assert fake.eval_calls[0][1]["experiment_name"] == "ABCD-E"
+    assert fake.eval_calls[0][1]["metadata"]["privacy"] == "raw_query_and_chunk_text_redacted"
+    assert fake.eval_calls[0][1]["no_send_logs"] is False
+
+    serialized = json.dumps(fake.eval_calls, default=str)
+    assert "personal query text" not in serialized
+    assert "personal chunk text" not in serialized


### PR DESCRIPTION
## Summary
- `scripts/braintrust_ingest.py` + 3 tests — standalone, no dependency on held code
- `docs/plans/`: db-shrink FTS5+dedup plan and Phoenix eval-integration plan (gen-10 work)
- `eval_results/db-shrink-2026-06-01.json` — the before/after eval record

## Context
Split per orc/Etan decision (2026-06-05, collab `2026-06-05-kg-cleanup.md`): ship the uncontroversial parts of the gen-10 db-shrink branch now. **HELD and NOT in this PR:** the FTS migration (`db_shrink.py`, migrate/eval scripts, vector_store diff) — its own eval showed recall@20 −3.4pp (~10% relative), violating the plan's no-regression constraint. Phase-2 item open to understand the recall drop (suspect: dedup removing retrieval-redundant but recall-counted near-duplicates). The included eval JSON is the evidence for that hold.

## Test plan
- [x] 3 braintrust_ingest tests pass on main
- [x] ruff clean
- [x] Full pre-push gate green (2,458 pytest + bun + FTS5 determinism)

**Review-required policy — orc merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New optional cloud path via Braintrust `--send` (redacted IDs only, but still external egress with an API key). Committed eval JSON and plan docs reference local paths and personal eval artifacts—review for accidental PII before merge.
> 
> **Overview**
> Ships **eval tooling and documentation** split from held DB-shrink/FTS migration work—no changes to live retrieval or `vector_store`.
> 
> **`scripts/braintrust_ingest.py`** loads labeled retrieval candidates and benchmark metrics from local JSON, builds **redacted** Braintrust dataset rows (SHA-256 query fingerprints and hashed chunk IDs only—no snippets, notes, or raw text), and optionally **`--send`**s them plus a recall@k **Eval** when `BRAINTRUST_API_KEY` is set. Default mode is **`--dry-run`**. LLM semantic judges are defined but **not** wired for cloud upload. **`tests/test_braintrust_ingest.py`** covers redaction, scorers, and a fake SDK send path.
> 
> **`docs/plans/`** adds the **FTS5 + content-dedup shrink** plan (temp DB only, qrel gates) and the **Phoenix self-hosted eval UI** design (isolation from BrainLayer DB, dataset/experiment mapping, promptfoo retirement).
> 
> **`eval_results/db-shrink-2026-06-01.json`** records a snapshot migration that reclaimed ~2.6GB but **failed** the quality gate: **fts5 recall@20** dropped ~3.4pp vs the 0.005 max-regression threshold—documenting why the actual shrink code stays out of this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3cce4afdffc20e0397cb5fec842e3478dc5d13e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Braintrust ingestion script for privacy-preserving retrieval eval
> - Adds [scripts/braintrust_ingest.py](https://github.com/EtanHey/brainlayer/pull/448/files#diff-e696c0c9b10da957fed20c841b419e09081c7092c4cd991b6b2ad2ea005f2199) — a CLI tool that builds a redacted eval payload from labeled retrieval results and sends it to Braintrust, defaulting to dry-run mode that prints a preview without sending.
> - All query text and chunk IDs are SHA-256 hashed before export; source metadata is filtered to a safe subset to prevent PII leakage.
> - Recall@1/5/10 scorers run deterministically by replaying hashed retrieved IDs, avoiding live retrieval during eval.
> - Adds tests in [tests/test_braintrust_ingest.py](https://github.com/EtanHey/brainlayer/pull/448/files#diff-aa1bf6e9996d166aee8a13bd1bcdff39ca8995208eb0ac98d78902190d75c29d) covering payload redaction, recall scorer correctness, and SDK interaction.
> - Adds design plan docs for the DB shrink/FTS5 dedup effort and Arize Phoenix eval integration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3cce4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->