### PR TITLE
fix: adopt salvaged worktree hardening (MMR shape selection + promised store chunk-id)

### DIFF
--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -541,6 +541,7 @@ async def _store(
     The chunk is stored immediately without waiting for embedding generation.
     A background task embeds pending chunks after the response is sent.
     """
+    promised_chunk_id = _new_manual_chunk_id()
     try:
         if os.environ.get("BRAINLAYER_ARBITRATED") == "1":
             from ..ingest_guard import reject_recursive_mcp_output
@@ -556,10 +557,9 @@ async def _store(
             reject_recursive_mcp_output(content)
             if looks_like_system_prompt(content):
                 raise ValueError("system prompt content is not stored in BrainLayer")
-            queued_chunk_id = _new_manual_chunk_id()
             _queue_store(
                 {
-                    "chunk_id": queued_chunk_id,
+                    "chunk_id": promised_chunk_id,
                     "content": content,
                     "memory_type": memory_type,
                     "project": _normalize_project_name(project),
@@ -579,8 +579,8 @@ async def _store(
                 }
             )
             clear_hybrid_search_cache()
-            structured = {"chunk_id": queued_chunk_id, "queued": True, "related": []}
-            return ([TextContent(type="text", text=format_store_result(queued_chunk_id, queued=True))], structured)
+            structured = {"chunk_id": promised_chunk_id, "queued": True, "related": []}
+            return ([TextContent(type="text", text=format_store_result(promised_chunk_id, queued=True))], structured)
 
         from ..store import embed_pending_chunks, store_memory
 
@@ -607,6 +607,7 @@ async def _store(
             file_path=file_path,
             function_name=function_name,
             line_number=line_number,
+            chunk_id=promised_chunk_id,
         )
 
         chunk_id = result["id"]
@@ -671,10 +672,9 @@ async def _store(
         return _error_result(f"Validation error: {str(e)}")
     except Exception as e:
         if _is_lock_error(e):
-            queued_chunk_id = _new_manual_chunk_id()
             _queue_store(
                 {
-                    "chunk_id": queued_chunk_id,
+                    "chunk_id": promised_chunk_id,
                     "content": content,
                     "memory_type": memory_type,
                     "project": _normalize_project_name(project),
@@ -693,8 +693,8 @@ async def _store(
                     "supersedes": supersedes,
                 }
             )
-            structured = {"chunk_id": queued_chunk_id, "queued": True, "related": []}
-            formatted = format_store_result(queued_chunk_id, queued=True)
+            structured = {"chunk_id": promised_chunk_id, "queued": True, "related": []}
+            formatted = format_store_result(promised_chunk_id, queued=True)
             return (
                 [TextContent(type="text", text=formatted)],
                 structured,

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -769,17 +769,28 @@ class SearchMixin:
         tail_candidates = scored[candidate_limit:]
 
         raw_embeddings_by_id = self._load_chunk_embeddings([candidate[1] for candidate in top_candidates])
-        embeddings_by_id: dict[str, np.ndarray] = {}
-        expected_shape: tuple[int, ...] | None = None
-        for chunk_id, embedding in raw_embeddings_by_id.items():
+        candidate_vectors: list[tuple[tuple[float, str, str, Dict[str, Any], Any], np.ndarray]] = []
+        shape_counts: dict[tuple[int, ...], int] = {}
+        shape_first_index: dict[tuple[int, ...], int] = {}
+        for candidate_index, candidate in enumerate(top_candidates):
+            embedding = raw_embeddings_by_id.get(candidate[1])
+            if embedding is None:
+                continue
             vector = np.asarray(embedding, dtype=np.float32)
             if vector.ndim != 1 or vector.size == 0 or not np.isfinite(vector).all():
                 continue
-            if expected_shape is None:
-                expected_shape = vector.shape
-            if vector.shape != expected_shape:
-                continue
-            embeddings_by_id[chunk_id] = vector
+            shape = vector.shape
+            candidate_vectors.append((candidate, vector))
+            shape_counts[shape] = shape_counts.get(shape, 0) + 1
+            shape_first_index.setdefault(shape, candidate_index)
+
+        if not shape_counts:
+            return scored
+
+        expected_shape = max(shape_counts, key=lambda shape: (shape_counts[shape], -shape_first_index[shape]))
+        embeddings_by_id = {
+            candidate[1]: vector for candidate, vector in candidate_vectors if vector.shape == expected_shape
+        }
 
         mmr_candidates = [candidate for candidate in top_candidates if candidate[1] in embeddings_by_id]
         if len(mmr_candidates) < 2:

--- a/tests/test_mmr_default_off.py
+++ b/tests/test_mmr_default_off.py
@@ -39,6 +39,16 @@ class _ZeroNormEmbeddingStore:
         }
 
 
+class _MixedDimensionEmbeddingStore:
+    def _load_chunk_embeddings(self, chunk_ids):
+        return {
+            "bad": np.array([1.0, 1.0, 1.0], dtype=np.float32),
+            "similar_a": np.array([1.0, 0.0], dtype=np.float32),
+            "similar_b": np.array([1.0, 0.0], dtype=np.float32),
+            "diverse": np.array([0.0, 1.0], dtype=np.float32),
+        }
+
+
 def test_mmr_default_enables_diversity_and_loads_embeddings(monkeypatch):
     monkeypatch.delenv("BRAINLAYER_MMR_LAMBDA", raising=False)
     import brainlayer.search_repo as search_repo
@@ -131,3 +141,29 @@ def test_mmr_keeps_zero_norm_candidates_without_exhausting_rerank(monkeypatch):
 
     assert len(reranked) == 3
     assert {candidate[1] for candidate in reranked} == {"a", "b", "c"}
+
+
+def test_mmr_chooses_common_embedding_shape_not_first_returned(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_MMR_LAMBDA", "0.7")
+    import brainlayer.search_repo as search_repo
+
+    search_repo = importlib.reload(search_repo)
+    scored = [
+        (1.0, "bad", "wrong-dimension", {}, 0.0),
+        (0.99, "similar_a", "near duplicate", {}, 0.01),
+        (0.98, "similar_b", "near duplicate", {}, 0.02),
+        (0.97, "diverse", "distinct", {}, 0.03),
+    ]
+
+    reranked = search_repo.SearchMixin._mmr_rerank_scored_results(
+        _MixedDimensionEmbeddingStore(),
+        scored,
+        n_results=2,
+    )
+
+    assert [candidate[1] for candidate in reranked] == [
+        "bad",
+        "similar_a",
+        "diverse",
+        "similar_b",
+    ]

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -38,6 +38,87 @@ async def test_busy_queue_fallback_returns_queued_chunk_id(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_store_preassigns_same_chunk_id_across_busy_retry(tmp_path, monkeypatch):
+    """The MCP handler promises one chunk ID before the first write attempt."""
+    from brainlayer.mcp.store_handler import _store
+
+    queue_dir = tmp_path / "queue"
+    seen_chunk_ids = []
+
+    def flaky_store_memory(**kwargs):
+        seen_chunk_ids.append(kwargs.get("chunk_id"))
+        if len(seen_chunk_ids) == 1:
+            raise apsw.BusyError("locked")
+        return {"id": kwargs.get("chunk_id") or "store-generated-id", "related": []}
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store"),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+        patch("brainlayer.store.store_memory", side_effect=flaky_store_memory),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        monkeypatch.setattr("brainlayer.mcp.store_handler._retry_delay", 0.001)
+        texts, structured = await _store(
+            content="retry should keep promised id",
+            memory_type="note",
+            project="test",
+        )
+
+    assert len(seen_chunk_ids) == 2
+    assert seen_chunk_ids[0] is not None
+    assert seen_chunk_ids == [structured["chunk_id"], structured["chunk_id"]]
+    assert structured["chunk_id"].startswith("manual-")
+    assert any(structured["chunk_id"] in item.text for item in texts)
+    assert not list(queue_dir.glob("mcp-*.jsonl"))
+
+
+@pytest.mark.asyncio
+async def test_busy_queue_fallback_flushes_promised_chunk_id(tmp_path, monkeypatch):
+    """DB-busy queue and drain replay persist the exact caller-visible chunk ID."""
+    from brainlayer.drain import drain_once
+    from brainlayer.mcp.store_handler import _store
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    store = VectorStore(db_path)
+    store.close()
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store"),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+        patch("brainlayer.store.store_memory", side_effect=apsw.BusyError("locked")),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        texts, structured = await _store(
+            content="queued flush must preserve promised id",
+            memory_type="note",
+            project="test",
+        )
+
+    queued_files = list(queue_dir.glob("mcp-*.jsonl"))
+    assert len(queued_files) == 1
+    queued_event = json.loads(queued_files[0].read_text())
+    promised_chunk_id = structured["chunk_id"]
+
+    assert promised_chunk_id == queued_event["chunk_id"]
+    assert promised_chunk_id.startswith("manual-")
+    assert structured["queued"] is True
+    assert any(promised_chunk_id in item.text for item in texts)
+
+    assert drain_once(db_path=db_path, queue_dir=queue_dir, log_path=tmp_path / "drain.log") == 1
+
+    conn = apsw.Connection(str(db_path))
+    try:
+        row = conn.cursor().execute("SELECT id, content FROM chunks WHERE id = ?", (promised_chunk_id,)).fetchone()
+    finally:
+        conn.close()
+
+    assert row == (promised_chunk_id, "queued flush must preserve promised id")
+
+
+@pytest.mark.asyncio
 async def test_writer_in_use_error_queues_instead_of_erroring(tmp_path):
     """Writer pidfile contention queues the store instead of returning an MCP error."""
     from brainlayer.mcp.store_handler import _store


### PR DESCRIPTION
## Summary
Two uncommitted-dirt patches salvaged from worktrees of already-merged branches, judged ADOPT per orc delegation (dispositions: orchestrator `docs.local/audits/2026-06-05-worktree-salvage/DISPOSITIONS.md`):

- **fix(search):** MMR rerank picks the modal embedding shape instead of first-seen. With MMR default-ON since #439, one wrong-dimension embedding arriving first (e.g. mid re-embedding migration) silently dropped every other candidate from the rerank. +1 regression test.
- **fix(mcp):** pre-assign one promised chunk_id before the first store attempt and thread it through store_memory, the busy queue, and drain replay — the caller-visible ID can no longer drift from the persisted one across retry/queue paths. +2 tests (retry identity, queue→drain identity).

Third salvaged patch (chunk-origin provenance tests) DISCARDED: RED TDD specs for implementation that never landed in #436.

## Test plan
- [x] All targeted tests pass on main (25 passed across the 3 affected test files)
- [x] Full pre-push gate green (2,458 pytest + bun + FTS5 determinism)

**Review-required policy — orc merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect default-on MMR reranking and MCP store identity on lock/retry paths; behavior is tightened with targeted tests but touches core search and ingest flows.
> 
> **Overview**
> **MCP store** now generates a single **`promised_chunk_id`** at the start of `_store` and uses it for the response, direct `store_memory` writes, arbitrated queueing, and DB-busy queue fallbacks (including drain replay). Callers no longer see a different ID after retries or queued writes.
> 
> **Hybrid search MMR** no longer locks embedding dimension to the first loaded vector. It picks the **most common** shape among top candidates (ties favor the earliest rank), so one wrong-dimension embedding during re-embedding migration does not drop the rest from diversification.
> 
> Regression tests cover retry/queue→drain ID stability and mixed-dimension MMR ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103bc815c3f8207256ce4d5c8ba012f59b9e612b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MMR shape selection and preassign chunk IDs in the store handler
> - [`SearchMixin._mmr_rerank_scored_results`](https://github.com/EtanHey/brainlayer/pull/449/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) now selects the most common embedding shape among top candidates instead of using the first encountered shape, then filters to that shape before running MMR diversity ranking.
> - [`_store` handler](https://github.com/EtanHey/brainlayer/pull/449/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263) now preassigns a chunk ID via `_new_manual_chunk_id()` at the start of the request and passes it through all code paths (immediate write, arbitrated write, and lock-error queue fallback), so callers always receive the same promised ID regardless of outcome.
> - Behavioral Change: MMR result order may change when top candidates have mixed-dimension embeddings, since the shape chosen can differ from the previous first-seen behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 103bc81. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->