### PR TITLE
feat: KG flag-batch review session driver (shared voice+visual decisions)

### DIFF
--- a/scripts/kg_review_session.py
+++ b/scripts/kg_review_session.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""CLI for the KG flag-batch review session driver (voice + visual surfaces).
+
+Usage:
+    python3 scripts/kg_review_session.py next --batch B.json --decisions D.json [--category C]
+    python3 scripts/kg_review_session.py record --decisions D.json --cluster-id ID --decision-json '{...}'
+    python3 scripts/kg_review_session.py rule --batch B.json --decisions D.json --rule-json '{...}'
+    python3 scripts/kg_review_session.py stats --batch B.json --decisions D.json
+
+`next` prints {"cluster": {...}, "speak": "..."} or {"cluster": null} when done.
+See brainlayer/kg_review_session.py for the decisions-file contract.
+"""
+
+import argparse
+import json
+import sys
+
+from brainlayer.kg_review_session import (
+    apply_rule,
+    next_undecided,
+    record_decision,
+    speak_text,
+    stats,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_next = sub.add_parser("next")
+    p_next.add_argument("--batch", required=True)
+    p_next.add_argument("--decisions", required=True)
+    p_next.add_argument("--category")
+
+    p_rec = sub.add_parser("record")
+    p_rec.add_argument("--decisions", required=True)
+    p_rec.add_argument("--cluster-id", required=True)
+    p_rec.add_argument("--decision-json", required=True)
+
+    p_rule = sub.add_parser("rule")
+    p_rule.add_argument("--batch", required=True)
+    p_rule.add_argument("--decisions", required=True)
+    p_rule.add_argument("--rule-json", required=True)
+
+    p_stats = sub.add_parser("stats")
+    p_stats.add_argument("--batch", required=True)
+    p_stats.add_argument("--decisions", required=True)
+
+    args = ap.parse_args()
+
+    if args.cmd == "next":
+        cluster = next_undecided(args.batch, args.decisions, category=args.category)
+        out = {"cluster": cluster}
+        if cluster:
+            out["speak"] = speak_text(cluster)
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+    elif args.cmd == "record":
+        stamped = record_decision(args.decisions, args.cluster_id, json.loads(args.decision_json))
+        print(json.dumps({"recorded": args.cluster_id, "decision": stamped}, ensure_ascii=False))
+    elif args.cmd == "rule":
+        n = apply_rule(args.batch, args.decisions, json.loads(args.rule_json))
+        print(json.dumps({"applied": n}))
+    elif args.cmd == "stats":
+        print(json.dumps(stats(args.batch, args.decisions), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kg_review_session.py
+++ b/scripts/kg_review_session.py
@@ -14,8 +14,10 @@ See brainlayer/kg_review_session.py for the decisions-file contract.
 import argparse
 import json
 import sys
+from pathlib import Path
 
-from brainlayer.kg_review_session import (
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from brainlayer.kg_review_session import (  # noqa: E402
     apply_rule,
     next_undecided,
     record_decision,

--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -1,0 +1,215 @@
+"""KG flag-batch review session driver — shared by voice and visual review surfaces.
+
+Pure-file module: reads the category-sorted flag-batch JSON emitted by phase-1
+(`eval_results/kg-phase1-flag-batch-*.json`) and maintains a decisions JSON that
+`kg_cleanup_apply.py` (or a follow-up applier) can consume. No DB access here.
+
+Decisions file contract (v1 stub — coordinate changes via the kg-cleanup collab):
+
+    {
+      "version": 1,
+      "decisions": {
+        "<category>:<stem>": {
+          "action": "merge_all" | "keep_all" | "mixed" | "skip",
+          "canonical_id": "...",            # merge_all only
+          "members": {"<id>": "merge|keep|prune"},  # mixed only
+          "note": "verbatim reviewer reasoning",
+          "source": "voice" | "visual" | "rule",
+          "decided_at": "ISO-8601"
+        }
+      },
+      "rules": [ {"match": {...}, "action": ..., "canonical": ..., "applied": N,
+                  "source": ..., "recorded_at": "ISO-8601"} ]
+    }
+
+Merge-safety: every write is read-modify-write under an exclusive `fcntl.flock`
+on a sidecar lock file, then an atomic `os.replace`. Two writers (dashboard +
+voice session) interleave safely; last write per CLUSTER wins, never per file.
+
+AIDEV-NOTE: engine-agnostic on purpose (Etan 2026-06-05: no lock-in to the old
+voice architecture) — the voice loop, a browser dashboard, and any future WS
+bridge all drive this same module.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+VALID_ACTIONS = {"merge_all", "keep_all", "mixed", "skip"}
+VALID_MEMBER_ACTIONS = {"merge", "keep", "prune"}
+VALID_SOURCES = {"voice", "visual", "rule"}
+
+
+def cluster_id(category: str, stem: str) -> str:
+    return f"{category}:{stem}"
+
+
+def load_flag_batch(batch_path: str | Path) -> list[dict[str, Any]]:
+    """Flatten {category: [cluster, ...]} into a stable ordered list with ids."""
+    raw = json.loads(Path(batch_path).read_text())
+    clusters: list[dict[str, Any]] = []
+    for category in raw:
+        for cluster in raw[category]:
+            clusters.append(
+                {
+                    "cluster_id": cluster_id(category, cluster["stem"]),
+                    "category": category,
+                    "stem": cluster["stem"],
+                    "size": cluster.get("size", len(cluster.get("members", []))),
+                    "members": cluster.get("members", []),
+                }
+            )
+    return clusters
+
+
+def _load_decisions(decisions_path: Path) -> dict[str, Any]:
+    if decisions_path.exists():
+        return json.loads(decisions_path.read_text())
+    return {"version": 1, "decisions": {}, "rules": []}
+
+
+def _write_locked(decisions_path: Path, mutate) -> Any:
+    """Read-modify-write under flock + atomic replace. Returns mutate's result."""
+    decisions_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = decisions_path.with_suffix(decisions_path.suffix + ".lock")
+    with open(lock_path, "w") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        data = _load_decisions(decisions_path)
+        result = mutate(data)
+        tmp_path = decisions_path.with_suffix(decisions_path.suffix + ".tmp")
+        with open(tmp_path, "w") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, decisions_path)
+    return result
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_decision(decision: dict[str, Any]) -> None:
+    action = decision.get("action")
+    if action not in VALID_ACTIONS:
+        raise ValueError(f"invalid action {action!r}; expected one of {sorted(VALID_ACTIONS)}")
+    if decision.get("source") not in VALID_SOURCES:
+        raise ValueError(f"invalid source {decision.get('source')!r}")
+    if action == "mixed":
+        members = decision.get("members")
+        if not isinstance(members, dict) or not members:
+            raise ValueError("mixed decision requires a non-empty members map")
+        bad = set(members.values()) - VALID_MEMBER_ACTIONS
+        if bad:
+            raise ValueError(f"invalid member actions: {sorted(bad)}")
+    if action == "merge_all" and not decision.get("canonical_id"):
+        raise ValueError("merge_all decision requires canonical_id")
+
+
+def record_decision(
+    decisions_path: str | Path,
+    cluster_id: str,
+    decision: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate + persist one cluster decision. Stamps decided_at."""
+    _validate_decision(decision)
+    stamped = {**decision, "decided_at": _now()}
+
+    def mutate(data: dict[str, Any]) -> dict[str, Any]:
+        data["decisions"][cluster_id] = stamped
+        return stamped
+
+    return _write_locked(Path(decisions_path), mutate)
+
+
+def next_undecided(
+    batch_path: str | Path,
+    decisions_path: str | Path,
+    category: str | None = None,
+) -> dict[str, Any] | None:
+    """Next cluster (batch order) without a recorded decision."""
+    decided = set(_load_decisions(Path(decisions_path))["decisions"])
+    for cluster in load_flag_batch(batch_path):
+        if category and cluster["category"] != category:
+            continue
+        if cluster["cluster_id"] not in decided:
+            return cluster
+    return None
+
+
+def _pick_canonical(members: list[dict[str, Any]], strategy: str) -> str:
+    if strategy != "most_chunks":
+        raise ValueError(f"unknown canonical strategy {strategy!r}")
+    return max(members, key=lambda m: m.get("chunks", 0))["id"]
+
+
+def apply_rule(
+    batch_path: str | Path,
+    decisions_path: str | Path,
+    rule: dict[str, Any],
+) -> int:
+    """Bulk-decide all UNDECIDED clusters matching the rule. Never overwrites.
+
+    rule = {match: {category?, stem_contains?}, action, canonical?, note?, source}
+    Returns number of clusters decided.
+    """
+    if rule.get("action") not in VALID_ACTIONS:
+        raise ValueError(f"invalid rule action {rule.get('action')!r}")
+    match = rule.get("match", {})
+    clusters = load_flag_batch(batch_path)
+
+    def mutate(data: dict[str, Any]) -> int:
+        applied = 0
+        for cluster in clusters:
+            if cluster["cluster_id"] in data["decisions"]:
+                continue  # manual decisions always win; rules never overwrite
+            if match.get("category") and cluster["category"] != match["category"]:
+                continue
+            if match.get("stem_contains") and match["stem_contains"] not in cluster["stem"]:
+                continue
+            decision: dict[str, Any] = {
+                "action": rule["action"],
+                "source": "rule",
+                "decided_at": _now(),
+            }
+            if rule.get("note"):
+                decision["note"] = rule["note"]
+            if rule["action"] == "merge_all":
+                decision["canonical_id"] = _pick_canonical(cluster["members"], rule.get("canonical", "most_chunks"))
+            data["decisions"][cluster["cluster_id"]] = decision
+            applied += 1
+        data["rules"].append({**rule, "applied": applied, "recorded_at": _now()})
+        return applied
+
+    return _write_locked(Path(decisions_path), mutate)
+
+
+def speak_text(cluster: dict[str, Any]) -> str:
+    """Spoken summary of a cluster, optimized for TTS (short, concrete)."""
+    members = cluster["members"]
+    names = sorted({m["name"] for m in members})
+    parts = [f"Cluster {cluster['stem']!r}, category {cluster['category']}, {len(members)} entries."]
+    if len(names) == 1:
+        parts.append(f"All named {names[0]}.")
+    else:
+        parts.append("Name variants: " + ", ".join(names) + ".")
+    by_member = ", ".join(f"{m['name']} as {m['type']} with {m.get('chunks', 0)} chunks" for m in members)
+    parts.append(by_member + ".")
+    parts.append("Merge, keep separate, mixed, or skip?")
+    return " ".join(parts)
+
+
+def stats(batch_path: str | Path, decisions_path: str | Path) -> dict[str, Any]:
+    decided = set(_load_decisions(Path(decisions_path))["decisions"])
+    out: dict[str, Any] = {}
+    for cluster in load_flag_batch(batch_path):
+        bucket = out.setdefault(cluster["category"], {"total": 0, "decided": 0})
+        bucket["total"] += 1
+        if cluster["cluster_id"] in decided:
+            bucket["decided"] += 1
+    return out

--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -157,9 +157,15 @@ def apply_rule(
 
     rule = {match: {category?, stem_contains?}, action, canonical?, note?, source}
     Returns number of clusters decided.
+
+    `mixed` is rejected for rules: it needs a per-member map, which a bulk
+    rule cannot supply for arbitrary clusters.
     """
-    if rule.get("action") not in VALID_ACTIONS:
-        raise ValueError(f"invalid rule action {rule.get('action')!r}")
+    if rule.get("action") not in VALID_ACTIONS - {"mixed"}:
+        raise ValueError(
+            f"invalid rule action {rule.get('action')!r}; "
+            f"rules accept {sorted(VALID_ACTIONS - {'mixed'})} (mixed is per-cluster only)"
+        )
     match = rule.get("match", {})
     clusters = load_flag_batch(batch_path)
 

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -181,6 +181,50 @@ def test_apply_rule_bulk_decides_matching_undecided(batch_file, decisions_file):
     assert n2 == 0
 
 
+def test_apply_rule_rejects_mixed_and_invalid_actions(batch_file, decisions_file):
+    # mixed cannot be bulk-applied: it requires a per-member map per cluster
+    with pytest.raises(ValueError):
+        apply_rule(
+            batch_file,
+            decisions_file,
+            rule={"match": {"category": "case-only"}, "action": "mixed", "source": "voice"},
+        )
+    with pytest.raises(ValueError):
+        apply_rule(
+            batch_file,
+            decisions_file,
+            rule={"match": {"category": "case-only"}, "action": "explode", "source": "voice"},
+        )
+    # nothing persisted by rejected rules
+    assert not decisions_file.exists() or json.loads(decisions_file.read_text())["decisions"] == {}
+
+
+def test_cli_runs_from_plain_checkout_without_pythonpath(batch_file, decisions_file):
+    import os
+    import subprocess
+    import sys as _sys
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "kg_review_session.py"
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    result = subprocess.run(
+        [
+            _sys.executable,
+            str(script),
+            "stats",
+            "--batch",
+            str(batch_file),
+            "--decisions",
+            str(decisions_file),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "case-only" in result.stdout
+
+
 def test_stats_reports_progress(batch_file, decisions_file):
     record_decision(
         decisions_file,

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -1,0 +1,193 @@
+"""Tests for kg_review_session — voice/visual flag-batch review session driver.
+
+Pure-file driver: reads the flag-batch JSON, maintains a decisions JSON
+(stub contract, merge-safe for two writers), no DB access.
+"""
+
+import json
+
+import pytest
+
+from brainlayer.kg_review_session import (
+    apply_rule,
+    cluster_id,
+    load_flag_batch,
+    next_undecided,
+    record_decision,
+    speak_text,
+    stats,
+)
+
+FLAG_BATCH = {
+    "diagnosis-flag": [
+        {
+            "stem": "agent c",
+            "size": 3,
+            "members": [
+                {"id": "p1", "name": "Agent C", "type": "person", "chunks": 4},
+                {"id": "t1", "name": "Agent C", "type": "tool", "chunks": 3},
+                {"id": "t2", "name": "Agent-C", "type": "tool", "chunks": 2},
+            ],
+        },
+    ],
+    "case-only": [
+        {
+            "stem": "agent",
+            "size": 2,
+            "members": [
+                {"id": "a1", "name": "agent", "type": "topic", "chunks": 643},
+                {"id": "a2", "name": "Agent", "type": "concept", "chunks": 30},
+            ],
+        },
+        {
+            "stem": "docker",
+            "size": 2,
+            "members": [
+                {"id": "d1", "name": "docker", "type": "tool", "chunks": 50},
+                {"id": "d2", "name": "Docker", "type": "tool", "chunks": 70},
+            ],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def batch_file(tmp_path):
+    p = tmp_path / "flag-batch.json"
+    p.write_text(json.dumps(FLAG_BATCH))
+    return p
+
+
+@pytest.fixture
+def decisions_file(tmp_path):
+    return tmp_path / "decisions.json"
+
+
+def test_cluster_id_is_category_and_stem():
+    assert cluster_id("case-only", "agent") == "case-only:agent"
+
+
+def test_load_flag_batch_flattens_with_ids(batch_file):
+    clusters = load_flag_batch(batch_file)
+    ids = [c["cluster_id"] for c in clusters]
+    assert "diagnosis-flag:agent c" in ids
+    assert "case-only:docker" in ids
+    assert all("category" in c and "members" in c for c in clusters)
+
+
+def test_next_undecided_walks_category_in_order(batch_file, decisions_file):
+    c = next_undecided(batch_file, decisions_file, category="case-only")
+    assert c["cluster_id"] == "case-only:agent"
+
+
+def test_record_decision_then_next_advances(batch_file, decisions_file):
+    record_decision(
+        decisions_file,
+        cluster_id="case-only:agent",
+        decision={
+            "action": "keep_all",
+            "note": "topic tag vs concept, different things",
+            "source": "voice",
+        },
+    )
+    c = next_undecided(batch_file, decisions_file, category="case-only")
+    assert c["cluster_id"] == "case-only:docker"
+
+
+def test_record_decision_is_merge_safe_and_stamped(decisions_file):
+    record_decision(
+        decisions_file,
+        cluster_id="case-only:docker",
+        decision={"action": "merge_all", "canonical_id": "d2", "source": "voice"},
+    )
+    data = json.loads(decisions_file.read_text())
+    d = data["decisions"]["case-only:docker"]
+    assert d["action"] == "merge_all"
+    assert d["canonical_id"] == "d2"
+    assert d["source"] == "voice"
+    assert "decided_at" in d
+    # second writer updates a different cluster without clobbering
+    record_decision(
+        decisions_file,
+        cluster_id="case-only:agent",
+        decision={"action": "keep_all", "source": "visual"},
+    )
+    data = json.loads(decisions_file.read_text())
+    assert set(data["decisions"]) == {"case-only:docker", "case-only:agent"}
+
+
+def test_record_decision_validates_action(decisions_file):
+    with pytest.raises(ValueError):
+        record_decision(
+            decisions_file,
+            cluster_id="x:y",
+            decision={"action": "explode", "source": "voice"},
+        )
+
+
+def test_mixed_decision_requires_member_map(decisions_file):
+    with pytest.raises(ValueError):
+        record_decision(
+            decisions_file,
+            cluster_id="x:y",
+            decision={"action": "mixed", "source": "voice"},
+        )
+
+
+def test_speak_text_mentions_names_types_and_counts(batch_file):
+    clusters = load_flag_batch(batch_file)
+    cluster = [c for c in clusters if c["cluster_id"] == "diagnosis-flag:agent c"][0]
+    text = speak_text(cluster)
+    assert "Agent C" in text
+    assert "person" in text and "tool" in text
+    assert "3" in text  # member count or chunks
+
+
+def test_apply_rule_bulk_decides_matching_undecided(batch_file, decisions_file):
+    n = apply_rule(
+        batch_file,
+        decisions_file,
+        rule={
+            "match": {"category": "case-only"},
+            "action": "merge_all",
+            "canonical": "most_chunks",
+            "note": "case-only variants merge, most chunks wins",
+            "source": "voice",
+        },
+    )
+    assert n == 2
+    data = json.loads(decisions_file.read_text())
+    docker = data["decisions"]["case-only:docker"]
+    assert docker["action"] == "merge_all"
+    assert docker["canonical_id"] == "d2"  # 70 chunks > 50
+    assert docker["source"] == "rule"
+    assert data["rules"], "rule itself must be recorded"
+    # rule must NOT overwrite an existing manual decision
+    record_decision(
+        decisions_file,
+        cluster_id="diagnosis-flag:agent c",
+        decision={"action": "keep_all", "source": "voice"},
+    )
+    n2 = apply_rule(
+        batch_file,
+        decisions_file,
+        rule={
+            "match": {"category": "diagnosis-flag"},
+            "action": "merge_all",
+            "canonical": "most_chunks",
+            "source": "voice",
+        },
+    )
+    assert n2 == 0
+
+
+def test_stats_reports_progress(batch_file, decisions_file):
+    record_decision(
+        decisions_file,
+        cluster_id="case-only:agent",
+        decision={"action": "keep_all", "source": "voice"},
+    )
+    s = stats(batch_file, decisions_file)
+    assert s["case-only"]["total"] == 2
+    assert s["case-only"]["decided"] == 1
+    assert s["diagnosis-flag"]["decided"] == 0


### PR DESCRIPTION
## Summary
- `brainlayer/kg_review_session.py` + thin CLI `scripts/kg_review_session.py`: pure-file driver for the phase-1.5 flag-batch review
- Reads the category-sorted flag batch (`eval_results/kg-phase1-flag-batch-2026-06-05.json`), maintains a **merge-safe decisions JSON** (flock + atomic replace — dashboard and voice session can interleave writes safely)
- Per-cluster decisions: `merge_all` (canonical required) / `keep_all` / `mixed` (per-member map) / `skip`, with verbatim reviewer `note` + `source: voice|visual|rule` + `decided_at`
- Generalization `rules` bulk-apply to UNDECIDED clusters only (manual decisions always win), `most_chunks` canonical strategy (matches phase-1's approved rule)
- `speak_text()` spoken cluster summaries for the voice loop; `stats` progress per category
- **Contract is a v1 stub** — coordinated in `collab/2026-06-05-kg-cleanup.md`; will conform to the dashboard's export schema when @brainlayerClaude posts it

## Test plan
- [x] TDD: 10 new tests (RED→GREEN), `tests/test_kg_review_session.py`
- [x] Adjacent suite: `test_kg_cleanup.py` still green (16 total)
- [x] ruff check + format clean
- [x] Dry-run against the real 1,041-cluster flag batch (stats/next/record verified)
- [x] Pre-push gate (full suite) passed

Part of voice-review collab: `orchestrator/collab/2026-06-05-voice-review.md`. Merge policy: review-required (@orcClaude merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New offline tooling with no DB or auth changes; decisions schema is an explicit v1 stub pending dashboard alignment.
> 
> **Overview**
> Introduces a **pure-file review workflow** for phase-1.5 KG flag batches: a shared `brainlayer/kg_review_session` module plus a thin CLI so voice loops, dashboards, and future bridges can drive the same decisions file without touching the DB.
> 
> The driver loads category-sorted flag-batch JSON, walks **next undecided** clusters in batch order, and persists per-cluster decisions (`merge_all`, `keep_all`, `mixed`, `skip`) under a **v1 decisions JSON contract** meant for a later `kg_cleanup_apply` (or similar) consumer. Writes use **`fcntl.flock` + atomic replace** so concurrent voice/visual writers stay safe; manual decisions win over bulk rules.
> 
> **Bulk rules** match undecided clusters by category and/or stem substring, apply non-`mixed` actions only, pick **`merge_all` canonicals via `most_chunks`**, and append rule metadata. **`speak_text`** builds TTS-friendly cluster summaries; **`stats`** reports decided vs total per category.
> 
> Coverage lives in `tests/test_kg_review_session.py`, including validation, locking behavior, rule non-overwrite, and CLI invocation without `PYTHONPATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f2bd9a347613e24eccea6871e1060772992b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add KG flag-batch review session driver with shared voice and visual decisions
> - Adds [kg_review_session.py](https://github.com/EtanHey/brainlayer/pull/451/files#diff-a3ec1e9b0f8f2c609df6eec2ed276fc4776b5e0df1f6532ff43950b785cc9a1c) with handlers for `next_undecided`, `record_decision`, `apply_rule`, and `stats` to manage review progress over a flagged KG cluster batch.
> - Decisions are validated (action, source, member map for `mixed`, canonical for `merge_all`) and persisted atomically via `flock`+temp-file swap to prevent concurrent clobbering.
> - `apply_rule` bulk-decides all matching undecided clusters by category/stem substring without overwriting existing decisions, and records the rule with applied count and timestamp.
> - Adds [kg_review_session.py](https://github.com/EtanHey/brainlayer/pull/451/files#diff-69f97868200aab4809d64d5c2fcc7924c546a285770244ed7e3bf15dd59a6411) as a CLI entrypoint exposing `next`, `record`, `rule`, and `stats` subcommands that print JSON to stdout.
> - `speak_text` generates a TTS-friendly cluster summary for voice-driven review sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18f2bd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->