### PR TITLE
feat(kg): decisions-import mode for flag-batch review (phase-1.5)

### DIFF
--- a/scripts/kg_cleanup_apply.py
+++ b/scripts/kg_cleanup_apply.py
@@ -21,6 +21,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from brainlayer.kg_cleanup import (  # noqa: E402
     DeviationError,
+    apply_keep_separate,
     apply_merges,
     apply_prune,
     ensure_log_table,
@@ -29,6 +30,8 @@ from brainlayer.kg_cleanup import (  # noqa: E402
 )
 
 DB = Path.home() / ".local/share/brainlayer/brainlayer.db"
+DECISIONS_SCHEMA = "kg-flag-decisions-v1"
+DECISION_APPLY_COUNT_KEYS = ("merge_clusters", "rows_merged_away", "keep")
 
 
 def checkpoint(con):
@@ -36,24 +39,132 @@ def checkpoint(con):
     print(f"WAL checkpoint: busy={mode} log_frames={logf} checkpointed={ckpt}")
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--scope", required=True)
-    ap.add_argument("--run-id", required=True)
-    ap.add_argument("--rollback", action="store_true")
-    args = ap.parse_args()
+def load_decisions(path: str | Path) -> dict:
+    decisions = json.loads(Path(path).read_text(encoding="utf-8"))
+    if decisions.get("schema") != DECISIONS_SCHEMA:
+        raise ValueError(f"decisions schema must be {DECISIONS_SCHEMA!r}, got {decisions.get('schema')!r}")
+    if not isinstance(decisions.get("counts"), dict):
+        raise ValueError("decisions JSON must include object field 'counts'")
+    if not isinstance(decisions.get("merge", []), list):
+        raise ValueError("decisions JSON field 'merge' must be a list")
+    if not isinstance(decisions.get("keep", []), list):
+        raise ValueError("decisions JSON field 'keep' must be a list")
+    return decisions
 
-    con = sqlite3.connect(DB, timeout=60)
-    con.row_factory = sqlite3.Row
-    con.execute("PRAGMA busy_timeout=60000")
+
+def _decision_counts(decisions: dict) -> dict:
+    counts = decisions["counts"]
+    return {
+        "merge_clusters": int(counts.get("merge_clusters", 0)),
+        "rows_merged_away": int(counts.get("rows_merged_away", 0)),
+        "keep": int(counts.get("keep", 0)),
+        "explicit": int(counts.get("explicit", 0)),
+        "by_rule": int(counts.get("by_rule", 0)),
+    }
+
+
+def _within_one_percent(actual: int, expected: int) -> bool:
+    if expected == 0:
+        return actual == 0
+    return abs(actual - expected) / expected <= 0.01
+
+
+def _guard_decision_deviation(actual: dict, expected: dict) -> None:
+    for key in DECISION_APPLY_COUNT_KEYS:
+        actual_value = int(actual.get(key, 0))
+        expected_value = int(expected.get(key, 0))
+        if not _within_one_percent(actual_value, expected_value):
+            raise DeviationError(f"{key} actual {actual_value} deviates >1% from decisions JSON {expected_value}")
+
+
+def _prepare_decision_merges(
+    con: sqlite3.Connection, decisions: dict
+) -> tuple[list[dict], list[dict], list[dict], dict]:
+    live_clusters = []
+    skipped_members = []
+    protected_losers = []
+    for cluster in decisions.get("merge", []):
+        ok_members = []
+        for member in cluster.get("members", []):
+            row = con.execute(
+                "SELECT status, user_verified, importance FROM kg_entities WHERE id=?",
+                (member["id"],),
+            ).fetchone()
+            if row and row["status"] == "active":
+                ok_members.append(member)
+                if row["user_verified"] == 1 or (row["importance"] or 0) >= 0.7:
+                    protected_losers.append(
+                        {
+                            "stem": cluster.get("stem"),
+                            "name": member.get("name"),
+                            "id": member["id"],
+                            "user_verified": row["user_verified"],
+                            "importance": row["importance"],
+                        }
+                    )
+            else:
+                skipped_members.append(
+                    {
+                        "stem": cluster.get("stem"),
+                        "name": member.get("name"),
+                        "id": member["id"],
+                        "status": row["status"] if row else "missing",
+                    }
+                )
+        if ok_members:
+            live_clusters.append({**cluster, "members": ok_members})
+    actual = {
+        "merge_clusters": len(live_clusters),
+        "rows_merged_away": sum(len(cluster["members"]) for cluster in live_clusters),
+        "keep": len(decisions.get("keep", [])),
+    }
+    return live_clusters, skipped_members, protected_losers, actual
+
+
+def run_decisions(
+    con: sqlite3.Connection | None,
+    decisions_path: str | Path,
+    run_id: str,
+    execute: bool = False,
+) -> dict:
+    decisions = load_decisions(decisions_path)
+    counts = _decision_counts(decisions)
+    summary = {
+        "mode": "decisions",
+        "schema": decisions["schema"],
+        "source": decisions.get("source"),
+        "dry_run": not execute,
+        "counts": counts,
+    }
+    if not execute:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return summary
+
+    if con is None:
+        raise ValueError("run_decisions execute=True requires a sqlite connection")
+
+    live_clusters, skipped_members, protected_losers, actual = _prepare_decision_merges(con, decisions)
+    _guard_decision_deviation(actual, counts)
+
     ensure_log_table(con)
+    merge_stats = apply_merges(con, live_clusters, run_id=run_id)
+    keep_logged = apply_keep_separate(con, decisions.get("keep", []), run_id=run_id)
+    report = {
+        **summary,
+        "dry_run": False,
+        "actual": actual,
+        "merge_stats": merge_stats,
+        "keep_logged": keep_logged,
+        "skipped_changed_members": skipped_members,
+        "protected_merge_losers": protected_losers,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return report
 
-    if args.rollback:
-        counts = rollback(con, args.run_id)
-        print(f"ROLLED BACK run {args.run_id}: {counts}")
-        return
 
-    scope = json.loads(Path(args.scope).read_text())
+def run_scope(con: sqlite3.Connection, scope_path: str | Path, run_id: str) -> None:
+    ensure_log_table(con)
+    scope = json.loads(Path(scope_path).read_text(encoding="utf-8"))
     approved_prune = scope["auto_prune"]["total"]
     clusters = (
         scope["auto_merge"]["tier1_diagnosis_named"]["all_clusters"]
@@ -65,7 +176,7 @@ def main():
     # ---- prune (1% deviation guard inside apply_prune) ----
     selection = select_prune(con)
     try:
-        n = apply_prune(con, selection, run_id=args.run_id, expected=approved_prune)
+        n = apply_prune(con, selection, run_id=run_id, expected=approved_prune)
     except DeviationError as e:
         print(f"🛑 STOP: {e}")
         sys.exit(2)
@@ -83,7 +194,7 @@ def main():
                 skipped_members.append((c["stem"], m["name"], m["id"]))
         if ok_members:
             live_clusters.append({**c, "members": ok_members})
-    stats = apply_merges(con, live_clusters, run_id=args.run_id)
+    stats = apply_merges(con, live_clusters, run_id=run_id)
     print(f"MERGED: {stats}  skipped_changed_members={len(skipped_members)}")
     for s in skipped_members:
         print(f"  skipped: {s}")
@@ -94,15 +205,13 @@ def main():
     active = con.execute("SELECT COUNT(*) FROM kg_entities WHERE status='active'").fetchone()[0]
     archived = con.execute("SELECT COUNT(*) FROM kg_entities WHERE status='archived'").fetchone()[0]
     log_counts = dict(
-        con.execute(
-            "SELECT action, COUNT(*) FROM kg_cleanup_log WHERE run_id=? GROUP BY action", (args.run_id,)
-        ).fetchall()
+        con.execute("SELECT action, COUNT(*) FROM kg_cleanup_log WHERE run_id=? GROUP BY action", (run_id,)).fetchall()
     )
     protected_hit = con.execute(
         "SELECT COUNT(*) FROM kg_cleanup_log l JOIN kg_entities e"
         " ON e.id=l.entity_id WHERE l.run_id=?"
         " AND (e.user_verified=1 OR e.importance>=0.7)",
-        (args.run_id,),
+        (run_id,),
     ).fetchone()[0]
     print(
         json.dumps(
@@ -115,6 +224,48 @@ def main():
             indent=2,
         )
     )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    group = ap.add_mutually_exclusive_group()
+    group.add_argument("--scope")
+    group.add_argument("--decisions")
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--execute", action="store_true")
+    ap.add_argument("--rollback", action="store_true")
+    args = ap.parse_args()
+
+    if not args.rollback and not args.scope and not args.decisions:
+        ap.error("one of --scope or --decisions is required unless --rollback is set")
+
+    if args.decisions and not args.execute and not args.rollback:
+        try:
+            run_decisions(None, args.decisions, run_id=args.run_id, execute=False)
+        except ValueError as e:
+            print(f"🛑 STOP: {e}", file=sys.stderr)
+            sys.exit(2)
+        return
+
+    con = sqlite3.connect(DB, timeout=60)
+    con.row_factory = sqlite3.Row
+    con.execute("PRAGMA busy_timeout=60000")
+
+    if args.rollback:
+        ensure_log_table(con)
+        counts = rollback(con, args.run_id)
+        print(f"ROLLED BACK run {args.run_id}: {counts}")
+        return
+
+    if args.decisions:
+        try:
+            run_decisions(con, args.decisions, run_id=args.run_id, execute=args.execute)
+        except (DeviationError, ValueError) as e:
+            print(f"🛑 STOP: {e}", file=sys.stderr)
+            sys.exit(2)
+        return
+
+    run_scope(con, args.scope, run_id=args.run_id)
 
 
 if __name__ == "__main__":

--- a/scripts/kg_flag_batch.py
+++ b/scripts/kg_flag_batch.py
@@ -57,9 +57,47 @@ def categorize(stem: str, names: list[str]) -> str:
     return "sep-variants"
 
 
+def load_keep_separate_decisions(con: sqlite3.Connection) -> set[tuple[str, str]]:
+    try:
+        rows = con.execute(
+            "SELECT entity_id, evidence, payload_json FROM kg_cleanup_log WHERE action='keep_separate'"
+        ).fetchall()
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e):
+            return set()
+        raise
+
+    out = set()
+    for row in rows:
+        try:
+            payload = json.loads(row["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        decision = payload.get("decision", payload)
+        stem = str(decision.get("stem") or "").strip()
+        category = str(decision.get("category") or row["evidence"] or "").strip()
+        if not stem and row["entity_id"]:
+            entity_id = str(row["entity_id"])
+            if entity_id.startswith("cat:") and ":stem:" in entity_id:
+                stem = entity_id.split(":stem:", 1)[1]
+            elif entity_id.startswith(("stem:", "id:", "decision:")):
+                stem = entity_id.split(":", 1)[1]
+            else:
+                stem = entity_id.split(":", 1)[-1]
+        if stem:
+            out.add((category, normalize_stem(stem)))
+    return out
+
+
+def should_skip_keep_separate(category: str, stem: str, keep_decisions: set[tuple[str, str]]) -> bool:
+    normalized = normalize_stem(stem)
+    return (category, normalized) in keep_decisions or ("", normalized) in keep_decisions
+
+
 def main() -> None:
     con = sqlite3.connect(f"file:{DB}?mode=ro", uri=True)
     con.row_factory = sqlite3.Row
+    keep_decisions = load_keep_separate_decisions(con)
     rows = con.execute(
         """SELECT e.id, e.entity_type, e.name,
                   (SELECT COUNT(*) FROM kg_entity_chunks c
@@ -76,6 +114,9 @@ def main() -> None:
         if len(members) < 2 or not stem:
             continue
         names = [m["name"] for m in members]
+        category = categorize(stem, names)
+        if should_skip_keep_separate(category, stem, keep_decisions):
+            continue
         cluster = {
             "stem": stem,
             "size": len(members),
@@ -84,7 +125,7 @@ def main() -> None:
                 for m in sorted(members, key=lambda m: -m["n_chunks"])
             ],
         }
-        cats[categorize(stem, names)].append(cluster)
+        cats[category].append(cluster)
 
     out_json = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("eval_results/kg-phase1-flag-batch-2026-06-05.json")
     out_json.write_text(json.dumps(dict(cats), indent=2))

--- a/src/brainlayer/kg_cleanup.py
+++ b/src/brainlayer/kg_cleanup.py
@@ -10,6 +10,7 @@ Everything reversible:
 No ``DELETE FROM kg_entities`` anywhere.
 """
 
+import hashlib
 import json
 import re
 import sqlite3
@@ -224,6 +225,51 @@ def apply_merges(con: sqlite3.Connection, clusters: list[dict], run_id: str) -> 
     return {"clusters": len(clusters), "rows_merged_away": merged_away}
 
 
+def _keep_separate_entity_id(decision: dict) -> str:
+    stem = str(decision.get("stem") or "").strip()
+    category = str(decision.get("category") or "").strip()
+    if stem and category:
+        return f"cat:{category}:stem:{stem}"
+    if stem:
+        return f"stem:{stem}"
+    if decision.get("id"):
+        return f"id:{decision['id']}"
+    digest = hashlib.sha256(json.dumps(decision, sort_keys=True).encode("utf-8")).hexdigest()
+    return f"decision:{digest[:16]}"
+
+
+def apply_keep_separate(
+    con: sqlite3.Connection,
+    decisions: list[dict],
+    run_id: str,
+    batch_size: int = 5000,
+) -> int:
+    """Persist human keep-separate decisions as log-only rows."""
+    ts = _now()
+    logged = 0
+    for i in range(0, len(decisions), batch_size):
+        batch = decisions[i : i + batch_size]
+        for decision in batch:
+            con.execute(
+                "INSERT INTO kg_cleanup_log (run_id, action, entity_id,"
+                " canonical_id, mechanism, evidence, payload_json, ts)"
+                " VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    run_id,
+                    "keep_separate",
+                    _keep_separate_entity_id(decision),
+                    None,
+                    "flag_decision_keep_separate",
+                    str(decision.get("category") or decision.get("source") or ""),
+                    json.dumps({"decision": decision}, sort_keys=True),
+                    ts,
+                ),
+            )
+            logged += 1
+        con.commit()
+    return logged
+
+
 def rollback(con: sqlite3.Connection, run_id: str) -> dict:
     """Reverse-replay the log for ``run_id`` (newest first)."""
     entries = con.execute(
@@ -265,7 +311,11 @@ def rollback(con: sqlite3.Connection, run_id: str) -> dict:
                     "UPDATE kg_relations SET source_id=?, target_id=? WHERE id=?",
                     (rel["source_id"], rel["target_id"], rel["id"]),
                 )
-        counts[e["action"]] += 1
+        elif e["action"] == "keep_separate":
+            pass
+        else:
+            raise RuntimeError(f"unknown kg cleanup action: {e['action']}")
+        counts[e["action"]] = counts.get(e["action"], 0) + 1
         con.execute("DELETE FROM kg_cleanup_log WHERE rowid=?", (e["rowid"],))
     con.commit()
     return counts

--- a/tests/test_kg_cleanup.py
+++ b/tests/test_kg_cleanup.py
@@ -3,10 +3,13 @@
 Fixture DB only. Mirrors the live kg_* schema minimally (no FTS/triggers).
 """
 
+import json
 import sqlite3
 
 import pytest
 
+import scripts.kg_cleanup_apply as kg_apply
+import scripts.kg_flag_batch as kg_flag_batch
 from brainlayer.kg_cleanup import (
     DeviationError,
     apply_merges,
@@ -75,12 +78,46 @@ def con(tmp_path):
 
 CLUSTER = {
     "stem": "codex",
+    "category": "prefix-variants",
+    "source": "explicit",
     "canonical": {"id": "c1", "name": "Codex", "type": "tool"},
     "members": [
         {"id": "c2", "name": "codex", "type": "concept"},
         {"id": "c3", "name": "@codex", "type": "person"},
     ],
 }
+
+
+def _decisions_path(tmp_path, *, schema="kg-flag-decisions-v1", merge=None, keep=None, counts=None):
+    merge = [] if merge is None else merge
+    keep = [] if keep is None else keep
+    if counts is None:
+        counts = {
+            "merge_clusters": len(merge),
+            "rows_merged_away": sum(len(c["members"]) for c in merge),
+            "keep": len(keep),
+            "explicit": sum(1 for c in merge + keep if c.get("source") == "explicit"),
+            "by_rule": sum(1 for c in merge + keep if c.get("source") == "by_rule"),
+        }
+    doc = {
+        "schema": schema,
+        "source": "kg-phase1-flag-batch-2026-06-05",
+        "rules": {"identical-name": "merge"},
+        "per_category": {},
+        "counts": counts,
+        "merge": merge,
+        "keep": keep,
+    }
+    path = tmp_path / "decisions.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+def _cluster():
+    return json.loads(json.dumps(CLUSTER))
+
+
+KEEP_DECISION = {"stem": "agent c", "category": "diagnosis-flag", "source": "explicit"}
 
 
 def test_select_prune_matches_junk_families_only(con):
@@ -164,3 +201,120 @@ def test_rollback_restores_exact_state(con):
     ]
     # merge aliases removed on rollback
     assert con.execute("SELECT COUNT(*) FROM kg_entity_aliases").fetchone()[0] == 0
+
+
+def test_decisions_schema_validation_fails_loud(tmp_path):
+    path = _decisions_path(tmp_path, schema="wrong-schema")
+
+    with pytest.raises(ValueError, match="kg-flag-decisions-v1"):
+        kg_apply.load_decisions(path)
+
+
+def test_decisions_dry_run_prints_counts_and_writes_nothing(con, tmp_path, capsys):
+    path = _decisions_path(tmp_path, merge=[_cluster()], keep=[KEEP_DECISION])
+    before_changes = con.total_changes
+
+    report = kg_apply.run_decisions(con, path, run_id="test-run", execute=False)
+
+    assert report["dry_run"] is True
+    out = capsys.readouterr().out
+    assert '"merge_clusters": 1' in out
+    assert '"rows_merged_away": 2' in out
+    assert '"keep": 1' in out
+    assert con.total_changes == before_changes
+    assert con.execute("SELECT name FROM sqlite_master WHERE name='kg_cleanup_log'").fetchone() is None
+    assert con.execute("SELECT COUNT(*) FROM kg_entities WHERE status='active'").fetchone()[0] == 10
+
+
+def test_decisions_execute_reuses_merge_path(con, tmp_path):
+    path = _decisions_path(tmp_path, merge=[_cluster()])
+
+    report = kg_apply.run_decisions(con, path, run_id="test-run", execute=True)
+
+    assert report["merge_stats"] == {"clusters": 1, "rows_merged_away": 2}
+    assert report["skipped_changed_members"] == []
+    assert tuple(con.execute("SELECT status, parent_id FROM kg_entities WHERE id='c2'").fetchone()) == (
+        "archived",
+        "c1",
+    )
+    assert tuple(con.execute("SELECT status, parent_id FROM kg_entities WHERE id='c3'").fetchone()) == (
+        "archived",
+        "c1",
+    )
+    assert con.execute("SELECT COUNT(*) FROM kg_cleanup_log WHERE action='merge'").fetchone()[0] == 2
+
+
+def test_decisions_execute_logs_keep_separate_only(con, tmp_path):
+    path = _decisions_path(tmp_path, keep=[KEEP_DECISION])
+
+    report = kg_apply.run_decisions(con, path, run_id="test-run", execute=True)
+
+    assert report["keep_logged"] == 1
+    assert con.execute("SELECT COUNT(*) FROM kg_entities WHERE status='active'").fetchone()[0] == 10
+    row = con.execute(
+        "SELECT action, entity_id, canonical_id, mechanism, evidence, payload_json FROM kg_cleanup_log"
+    ).fetchone()
+    assert row["action"] == "keep_separate"
+    assert row["entity_id"] == "cat:diagnosis-flag:stem:agent c"
+    assert row["canonical_id"] is None
+    assert row["mechanism"] == "flag_decision_keep_separate"
+    assert row["evidence"] == "diagnosis-flag"
+    assert json.loads(row["payload_json"])["decision"] == KEEP_DECISION
+
+
+def test_decisions_deviation_aborts_before_writes(con, tmp_path):
+    path = _decisions_path(
+        tmp_path,
+        merge=[_cluster()],
+        counts={"merge_clusters": 1, "rows_merged_away": 100, "keep": 0, "explicit": 1, "by_rule": 0},
+    )
+
+    with pytest.raises(DeviationError, match="rows_merged_away"):
+        kg_apply.run_decisions(con, path, run_id="test-run", execute=True)
+
+    assert con.execute("SELECT COUNT(*) FROM kg_entities WHERE status='active'").fetchone()[0] == 10
+    assert con.execute("SELECT name FROM sqlite_master WHERE name='kg_cleanup_log'").fetchone() is None
+
+
+def test_decisions_execute_skips_changed_members_and_reports(con, tmp_path):
+    con.execute("UPDATE kg_entities SET status='archived' WHERE id='c3'")
+    con.commit()
+    path = _decisions_path(
+        tmp_path,
+        merge=[_cluster()],
+        counts={"merge_clusters": 1, "rows_merged_away": 1, "keep": 0, "explicit": 1, "by_rule": 0},
+    )
+
+    report = kg_apply.run_decisions(con, path, run_id="test-run", execute=True)
+
+    assert report["merge_stats"] == {"clusters": 1, "rows_merged_away": 1}
+    assert report["skipped_changed_members"] == [{"stem": "codex", "name": "@codex", "id": "c3", "status": "archived"}]
+    assert tuple(con.execute("SELECT status, parent_id FROM kg_entities WHERE id='c2'").fetchone()) == (
+        "archived",
+        "c1",
+    )
+    assert con.execute("SELECT parent_id FROM kg_entities WHERE id='c3'").fetchone()["parent_id"] is None
+    assert con.execute("SELECT COUNT(*) FROM kg_cleanup_log WHERE action='merge'").fetchone()[0] == 1
+
+
+def test_rollback_removes_keep_separate_log_rows(con, tmp_path):
+    path = _decisions_path(tmp_path, merge=[_cluster()], keep=[KEEP_DECISION])
+
+    kg_apply.run_decisions(con, path, run_id="test-run", execute=True)
+    counts = rollback(con, run_id="test-run")
+
+    assert counts["keep_separate"] == 1
+    assert counts["merge"] == 2
+    assert con.execute("SELECT COUNT(*) FROM kg_cleanup_log WHERE run_id='test-run'").fetchone()[0] == 0
+    assert tuple(con.execute("SELECT status, parent_id FROM kg_entities WHERE id='c2'").fetchone()) == ("active", None)
+    assert tuple(con.execute("SELECT status, parent_id FROM kg_entities WHERE id='c3'").fetchone()) == ("active", None)
+
+
+def test_flag_batch_skips_logged_keep_separate_clusters(con, tmp_path):
+    path = _decisions_path(tmp_path, keep=[{"stem": "codex", "category": "prefix-variants", "source": "explicit"}])
+    kg_apply.run_decisions(con, path, run_id="test-run", execute=True)
+
+    keep_decisions = kg_flag_batch.load_keep_separate_decisions(con)
+
+    assert kg_flag_batch.should_skip_keep_separate("prefix-variants", "codex", keep_decisions)
+    assert not kg_flag_batch.should_skip_keep_separate("case-only", "codex", keep_decisions)


### PR DESCRIPTION
## Summary
- Add `--decisions` mode to `scripts/kg_cleanup_apply.py` for `kg-flag-decisions-v1` review exports, with dry-run-by-default counts and `--execute` apply mode.
- Reuse phase-1 merge machinery, preflight active-member skips and 1% deviation guards before writes, and report protected merge losers.
- Persist keep decisions as reversible `kg_cleanup_log` rows and filter them from future flag batches.

## Test plan
- `pytest tests/test_kg_cleanup.py`
- `pytest -m "not live and not integration"`
- `ruff check src/`
- `ruff format --check src/`
- `ruff check scripts/kg_cleanup_apply.py scripts/kg_flag_batch.py tests/test_kg_cleanup.py`
- `ruff format --check scripts/kg_cleanup_apply.py scripts/kg_flag_batch.py tests/test_kg_cleanup.py`
- `python3 scripts/kg_cleanup_apply.py --decisions <tmp decisions json> --run-id kg-phase15-2026-06-05`
- Pre-push gate: `scripts/run_tests.sh`

## Notes
- Did not run against the live BrainLayer DB.
- Full `ruff check .` still reports unrelated pre-existing lint in legacy scripts; the documented `src/` lint gate and touched files are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Execute mode mutates KG entities via merges and writes cleanup logs to the live DB path, with deviation guards but no hard block on merging protected high-importance losers (only reported).
> 
> **Overview**
> Adds a **decisions** path alongside the existing **scope** apply flow so human flag-batch review exports (`kg-flag-decisions-v1`) can be validated and applied without touching prunes.
> 
> **`kg_cleanup_apply.py`** now accepts `--decisions` (mutually exclusive with `--scope`). Default is dry-run JSON summary only; `--execute` opens the DB, prefilters merge clusters to still-active members, enforces **1% deviation** on `merge_clusters`, `rows_merged_away`, and `keep` vs the file’s `counts`, then runs existing merge logic plus new keep logging. Reports skipped members and **protected merge losers** (verified / high importance) without blocking the run.
> 
> **`kg_cleanup.py`** gains **`apply_keep_separate`**, which writes reversible **`keep_separate`** rows to `kg_cleanup_log` (no entity mutations). **`rollback`** treats `keep_separate` as log-only removal and rejects unknown actions.
> 
> **`kg_flag_batch.py`** loads prior keep decisions from the log and **omits** matching `(category, stem)` clusters from the next review batch.
> 
> Tests cover schema validation, dry-run no-ops, execute paths, deviation abort-before-write, rollback, and flag-batch filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263629a2cfed03137f33ae3e6c35d48d02e6b1d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--decisions` mode to kg cleanup scripts for applying human-reviewed flag-batch decisions
> - Adds a `--decisions` flag to [kg_cleanup_apply.py](https://github.com/EtanHey/brainlayer/pull/452/files#diff-07830c0287bcd634673494d56a1b05b55c28aff9037d4a779765305326f025ad) that accepts a human-reviewed decisions JSON file and applies merge and keep-separate decisions, with `--execute`/`--rollback` flow and dry-run support.
> - Validates that observed entity counts match expected counts from the decisions file within 1% before making any writes, aborting with an error on deviation.
> - Adds `apply_keep_separate` to [kg_cleanup.py](https://github.com/EtanHey/brainlayer/pull/452/files#diff-016e5677eb26ba60c19048b8e5f6eb723f45089899a2ff611980f89c6529e4d4) to persist keep-separate decisions as log-only entries in `kg_cleanup_log`; rollback now handles these entries cleanly.
> - Updates [kg_flag_batch.py](https://github.com/EtanHey/brainlayer/pull/452/files#diff-f808a65e85e8fc5a4186fb434ec9f53711684cc1763bed901c5c7267abced3c1) to load prior keep-separate decisions from `kg_cleanup_log` and skip clusters that have already been decided.
> - Risk: The 1% deviation tolerance means small discrepancies in entity state between decision authoring and execution are silently accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 263629a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->