### PR TITLE
feat(kg): entity-context judge — evidence-cited type/identity/merge verdicts

### DIFF
--- a/scripts/kg_entity_judge.py
+++ b/scripts/kg_entity_judge.py
@@ -47,7 +47,12 @@ def main() -> None:
         raise SystemExit("Choose exactly one mode: --emit-prompts DIR, --collect DIR, or --judge groq")
 
     if args.collect is not None:
-        verdicts = collect_worker_verdicts(args.collect)
+        clusters = (
+            load_flag_batch_clusters(args.flag_batch, categories=args.categories, limit=args.limit)
+            if args.flag_batch is not None
+            else None
+        )
+        verdicts = collect_worker_verdicts(args.collect, clusters=clusters)
         out_path = write_verdict_outputs(verdicts, out_json=args.out, markdown_path=args.markdown, mode="collect")
         print(f"COLLECTED {len(verdicts)} verdicts to {out_path}")
         return

--- a/scripts/kg_entity_judge.py
+++ b/scripts/kg_entity_judge.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Entity-context judge CLI for KG flag-batch clusters.
+
+Default workflow for the overnight run:
+  1. --emit-prompts DIR writes self-contained prompt files for Cursor workers.
+  2. --collect DIR validates worker verdict JSONs and emits merged reports.
+
+The direct LLM path is optional fallback only: --judge groq.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from brainlayer.kg_judge import (  # noqa: E402
+    collect_worker_verdicts,
+    emit_prompt_files,
+    judge_clusters_with_backend,
+    load_flag_batch_clusters,
+    write_verdict_outputs,
+)
+from brainlayer.paths import get_db_path  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--categories", default=None, help="Comma-separated flag-batch categories to process")
+    parser.add_argument("--flag-batch", type=Path, help="Flag-batch JSON from scripts/kg_flag_batch.py")
+    parser.add_argument("--out", type=Path, default=None, help="Merged verdict JSON output path")
+    parser.add_argument("--limit", type=int, default=None, help="Process at most N clusters")
+    parser.add_argument("--markdown", type=Path, default=None, help="Optional human review markdown table path")
+    parser.add_argument("--db", type=Path, default=get_db_path(), help="BrainLayer SQLite DB path")
+    parser.add_argument("--gits-root", type=Path, default=Path.home() / "Gits", help="Local repos root")
+    parser.add_argument("--emit-prompts", type=Path, default=None, help="Write Cursor-worker judge prompts to this dir")
+    parser.add_argument(
+        "--collect", type=Path, default=None, help="Collect worker verdict JSON/JSONL files from this dir"
+    )
+    parser.add_argument("--judge", choices=["groq"], default=None, help="Optional direct LLM fallback backend")
+    args = parser.parse_args()
+
+    modes = sum(value is not None for value in (args.emit_prompts, args.collect, args.judge))
+    if modes != 1:
+        raise SystemExit("Choose exactly one mode: --emit-prompts DIR, --collect DIR, or --judge groq")
+
+    if args.collect is not None:
+        verdicts = collect_worker_verdicts(args.collect)
+        out_path = write_verdict_outputs(verdicts, out_json=args.out, markdown_path=args.markdown, mode="collect")
+        print(f"COLLECTED {len(verdicts)} verdicts to {out_path}")
+        return
+
+    if args.flag_batch is None:
+        raise SystemExit("--flag-batch is required for --emit-prompts and --judge")
+
+    clusters = load_flag_batch_clusters(args.flag_batch, categories=args.categories, limit=args.limit)
+    if args.emit_prompts is not None:
+        written = emit_prompt_files(clusters, args.emit_prompts, db_path=args.db, gits_root=args.gits_root)
+        print(f"EMITTED {len(written)} prompts to {args.emit_prompts}")
+        return
+
+    if args.judge is not None:
+        verdicts = judge_clusters_with_backend(clusters, backend=args.judge, db_path=args.db, gits_root=args.gits_root)
+        out_path = write_verdict_outputs(
+            verdicts, out_json=args.out, markdown_path=args.markdown, mode=f"judge:{args.judge}"
+        )
+        print(f"WROTE {len(verdicts)} verdicts to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/kg_judge.py
+++ b/src/brainlayer/kg_judge.py
@@ -1,0 +1,695 @@
+"""Entity-context judge harness for KG flag-batch clusters.
+
+The judge never mutates BrainLayer. It gathers read-only evidence, builds a
+self-contained prompt packet, and validates evidence-cited verdict JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from ._helpers import _escape_fts5_query
+from .paths import get_db_path
+
+JUDGE_TYPES = (
+    "Person",
+    "Organization",
+    "Place",
+    "Event",
+    "Project",
+    "Tool",
+    "Technology",
+    "D1 Concept→tag",
+    "D2 Transient→drop",
+)
+
+MERGE_DISPOSITIONS = ("merge", "keep", "split")
+CONFIDENCE_VALUES = ("high", "medium", "low")
+BACKGROUND_RELATION_TYPES = ("worked_at", "works_at", "uses", "owns", "created")
+
+CLOSED_ENUM_TEXT = (
+    'Person ("could I message/meet this individual?", never auto-merge) · '
+    "Organization (group acting as one agent; incl. communities/meetups; incl. DEFUNCT/renamed companies) · "
+    "Place (coordinates) · "
+    "Event (specific dated occurrence) · "
+    "Project (repo/deliverable ETAN owns or tracks — OWNERSHIP required, mere usage/repo-presence is NOT ownership) · "
+    "Tool (he/agents run, call, or build WITH it; functions-of-tools = part_of facet of parent) · "
+    "Technology (what tools are made of/run on) · "
+    'D1 Concept→tag (fails rigid-designator: "a/an ___" reads naturally) · '
+    "D2 Transient→drop (meaningless in 30 days)."
+)
+
+REQUIRED_SCHEMA_TEXT = """Required verdict JSON schema:
+{
+  "stem": "cluster stem",
+  "proposed_type": "Person|Organization|Place|Event|Project|Tool|Technology|D1 Concept→tag|D2 Transient→drop",
+  "identity": "one line: what this ACTUALLY is",
+  "merge_disposition": "merge|keep|split",
+  "canonical_suggestion": "canonical name or null",
+  "confidence": "high|medium|low",
+  "evidence_cited": ["refs to supplied packet evidence and/or worker-found evidence"],
+  "reasoning": "3 sentences max",
+  "evidence_degraded": false
+}
+"""
+
+
+class JudgeSchemaError(ValueError):
+    """Raised when a worker or LLM verdict violates the judge schema."""
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    ref: str
+    kind: str
+    title: str
+    data: dict[str, Any]
+
+    def to_prompt_text(self) -> str:
+        return f"[{self.ref}] {self.kind}: {self.title}\n{json.dumps(self.data, ensure_ascii=False, indent=2)}"
+
+
+@dataclass(frozen=True)
+class EvidencePacket:
+    stem: str
+    category: str | None
+    members: list[dict[str, Any]]
+    evidence: list[EvidenceItem]
+    db_path: str
+    gits_root: str
+
+    def evidence_refs(self) -> list[str]:
+        return [item.ref for item in self.evidence]
+
+    def to_prompt_text(self) -> str:
+        members_text = json.dumps(self.members, ensure_ascii=False, indent=2)
+        evidence_text = "\n\n".join(item.to_prompt_text() for item in self.evidence) or "(no evidence gathered)"
+        return (
+            f"Stem: {self.stem}\n"
+            f"Category: {self.category or 'unknown'}\n"
+            f"DB: {self.db_path}\n"
+            f"Gits root: {self.gits_root}\n\n"
+            f"Cluster members:\n{members_text}\n\n"
+            f"Evidence packet:\n{evidence_text}"
+        )
+
+
+def _connect_readonly(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?", (table,)
+    ).fetchone()
+    return row is not None
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not _table_exists(conn, table):
+        return set()
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _snippet(value: Any, limit: int = 200) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _member_ids(cluster: dict[str, Any]) -> list[str]:
+    ids = []
+    for member in cluster.get("members", []):
+        entity_id = member.get("id")
+        if isinstance(entity_id, str) and entity_id:
+            ids.append(entity_id)
+    return ids
+
+
+def _member_display(member: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": member.get("id"),
+        "name": member.get("name"),
+        "type": member.get("type", member.get("entity_type")),
+        "chunks": member.get("chunks", member.get("n_chunks", member.get("chunk_count", 0))),
+    }
+
+
+def _placeholders(values: Iterable[Any]) -> str:
+    return ",".join("?" for _ in values)
+
+
+def _normalize_repo_match(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.casefold())
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+    return slug or "cluster"
+
+
+def _fetch_linked_chunks(conn: sqlite3.Connection, member_ids: list[str]) -> list[EvidenceItem]:
+    if not member_ids or not all(_table_exists(conn, table) for table in ("kg_entity_chunks", "kg_entities", "chunks")):
+        return []
+    placeholders = _placeholders(member_ids)
+    rows = conn.execute(
+        f"""
+        SELECT ec.entity_id, e.name AS entity_name, e.entity_type, ec.relevance, ec.context,
+               c.id AS chunk_id, c.content, c.created_at, c.project
+        FROM kg_entity_chunks ec
+        JOIN kg_entities e ON e.id = ec.entity_id
+        JOIN chunks c ON c.id = ec.chunk_id
+        WHERE ec.entity_id IN ({placeholders})
+        ORDER BY COALESCE(ec.relevance, 0) DESC
+        LIMIT 5
+        """,
+        member_ids,
+    ).fetchall()
+    evidence = []
+    for index, row in enumerate(rows, start=1):
+        evidence.append(
+            EvidenceItem(
+                ref=f"linked-{index}",
+                kind="BrainLayer linked chunk",
+                title=f"{row['entity_name']} -> {row['chunk_id']}",
+                data={
+                    "entity_id": row["entity_id"],
+                    "entity_name": row["entity_name"],
+                    "entity_type": row["entity_type"],
+                    "chunk_id": row["chunk_id"],
+                    "relevance": row["relevance"],
+                    "context": row["context"],
+                    "snippet": _snippet(row["content"]),
+                    "date": row["created_at"],
+                    "project": row["project"],
+                },
+            )
+        )
+    return evidence
+
+
+def _fetch_fts_chunks(conn: sqlite3.Connection, stem: str) -> list[EvidenceItem]:
+    if not all(_table_exists(conn, table) for table in ("chunks_fts", "chunks")):
+        return []
+    query = _escape_fts5_query(stem, match_mode="or")
+    if not query:
+        return []
+    try:
+        rows = conn.execute(
+            """
+            SELECT f.chunk_id, bm25(chunks_fts) AS rank, c.content, c.created_at, c.project
+            FROM chunks_fts f
+            JOIN chunks c ON c.id = f.chunk_id
+            WHERE chunks_fts MATCH ?
+            ORDER BY rank
+            LIMIT 5
+            """,
+            (query,),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    evidence = []
+    for index, row in enumerate(rows, start=1):
+        evidence.append(
+            EvidenceItem(
+                ref=f"fts-{index}",
+                kind="BrainLayer FTS5 chunk",
+                title=f"{stem} -> {row['chunk_id']}",
+                data={
+                    "chunk_id": row["chunk_id"],
+                    "rank": row["rank"],
+                    "snippet": _snippet(row["content"]),
+                    "date": row["created_at"],
+                    "project": row["project"],
+                },
+            )
+        )
+    return evidence
+
+
+def _fetch_background_relations(conn: sqlite3.Connection, member_ids: list[str]) -> list[EvidenceItem]:
+    if not member_ids or not all(_table_exists(conn, table) for table in ("kg_relations", "kg_entities")):
+        return []
+    relation_columns = _table_columns(conn, "kg_relations")
+    expired_filter = "AND (r.expired_at IS NULL OR r.expired_at = '')" if "expired_at" in relation_columns else ""
+    placeholders = _placeholders(member_ids)
+    relation_placeholders = _placeholders(BACKGROUND_RELATION_TYPES)
+    rows = conn.execute(
+        f"""
+        SELECT r.id, r.relation_type, r.fact, r.confidence, r.source_chunk_id,
+               se.name AS source_name, se.entity_type AS source_type,
+               te.name AS target_name, te.entity_type AS target_type
+        FROM kg_relations r
+        JOIN kg_entities se ON se.id = r.source_id
+        JOIN kg_entities te ON te.id = r.target_id
+        WHERE (r.source_id IN ({placeholders}) OR r.target_id IN ({placeholders}))
+          AND r.relation_type IN ({relation_placeholders})
+          {expired_filter}
+        ORDER BY r.relation_type, r.id
+        LIMIT 20
+        """,
+        member_ids + member_ids + list(BACKGROUND_RELATION_TYPES),
+    ).fetchall()
+    evidence = []
+    for index, row in enumerate(rows, start=1):
+        evidence.append(
+            EvidenceItem(
+                ref=f"relation-{index}",
+                kind="KG relation context",
+                title=f"{row['source_name']} --{row['relation_type']}--> {row['target_name']}",
+                data={
+                    "relation_id": row["id"],
+                    "relation_type": row["relation_type"],
+                    "source": {"name": row["source_name"], "type": row["source_type"]},
+                    "target": {"name": row["target_name"], "type": row["target_type"]},
+                    "fact": row["fact"],
+                    "confidence": row["confidence"],
+                    "source_chunk_id": row["source_chunk_id"],
+                },
+            )
+        )
+    return evidence
+
+
+def _read_repo_evidence(stem: str, gits_root: Path) -> list[EvidenceItem]:
+    if not gits_root.exists() or not gits_root.is_dir():
+        return []
+    stem_key = _normalize_repo_match(stem)
+    if not stem_key:
+        return []
+    matches = []
+    for child in sorted(gits_root.iterdir(), key=lambda path: path.name.casefold()):
+        if not child.is_dir():
+            continue
+        child_key = _normalize_repo_match(child.name)
+        if stem_key in child_key or child_key in stem_key:
+            matches.append(child)
+        if len(matches) >= 5:
+            break
+
+    evidence = []
+    for index, repo in enumerate(matches, start=1):
+        readme_lines: list[str] = []
+        for candidate in ("README.md", "README", "readme.md"):
+            readme_path = repo / candidate
+            if readme_path.exists():
+                readme_lines = readme_path.read_text(encoding="utf-8", errors="replace").splitlines()[:30]
+                break
+        try:
+            git_log = subprocess.run(
+                ["git", "log", "--oneline", "-3"],
+                cwd=repo,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ).stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            git_log = ""
+        evidence.append(
+            EvidenceItem(
+                ref=f"repo-{index}",
+                kind="Local repo match",
+                title=f"{repo.name} fuzzy-matches {stem}",
+                data={
+                    "repo_path": str(repo),
+                    "README.md first lines": "\n".join(readme_lines),
+                    "git log --oneline -3": git_log,
+                },
+            )
+        )
+    return evidence
+
+
+def gather_evidence_for_cluster(
+    cluster: dict[str, Any],
+    *,
+    db_path: str | Path | None = None,
+    gits_root: str | Path | None = None,
+) -> EvidencePacket:
+    """Gather read-only evidence for one flag-batch cluster."""
+    resolved_db = Path(db_path).expanduser() if db_path is not None else get_db_path()
+    resolved_gits = Path(gits_root).expanduser() if gits_root is not None else Path.home() / "Gits"
+    stem = str(cluster.get("stem") or "").strip()
+    member_ids = _member_ids(cluster)
+    evidence: list[EvidenceItem] = []
+    conn = _connect_readonly(resolved_db)
+    try:
+        evidence.extend(_fetch_linked_chunks(conn, member_ids))
+        evidence.extend(_fetch_fts_chunks(conn, stem))
+        evidence.extend(_fetch_background_relations(conn, member_ids))
+    finally:
+        conn.close()
+    evidence.extend(_read_repo_evidence(stem, resolved_gits))
+    return EvidencePacket(
+        stem=stem,
+        category=cluster.get("category"),
+        members=[_member_display(member) for member in cluster.get("members", [])],
+        evidence=evidence,
+        db_path=str(resolved_db),
+        gits_root=str(resolved_gits),
+    )
+
+
+def build_judge_prompt(packet: EvidencePacket, *, worker_mode: bool = False) -> str:
+    worker_instruction = ""
+    if worker_mode:
+        worker_instruction = (
+            "\nWorker extra evidence instructions:\n"
+            "- Run brain_search on the stem. If brain_search times out, retry once; if it still times out, "
+            "proceed on packet evidence and set evidence_degraded:true.\n"
+            "- Also grep ~/Gits yourself for the stem, case-insensitive, and cite what you find.\n"
+            "- In reasoning, distinguish packet-supplied evidence from worker-found brain_search/grep evidence.\n"
+        )
+    return (
+        "You are the BrainLayer entity-context judge. Think carefully, but output only JSON.\n"
+        "No verdict without evidence. Unevidenced typing is the failure being corrected.\n\n"
+        "7+2 closed enum:\n"
+        f"{CLOSED_ENUM_TEXT}\n\n"
+        f"{REQUIRED_SCHEMA_TEXT}\n"
+        "Rules:\n"
+        "- proposed_type must be exactly one closed-enum label.\n"
+        "- split means the cluster contains 2+ real referents.\n"
+        "- evidence_cited must cite supplied evidence refs and any worker-found evidence refs.\n"
+        "- reasoning must be 3 sentences or fewer.\n"
+        f"{worker_instruction}\n"
+        "Supplied evidence packet:\n"
+        f"{packet.to_prompt_text()}\n"
+    )
+
+
+def _extract_json_object(raw: str) -> dict[str, Any]:
+    if not raw:
+        raise JudgeSchemaError("empty verdict response")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start < 0 or end <= start:
+            raise JudgeSchemaError("verdict response does not contain a JSON object") from None
+        try:
+            parsed = json.loads(raw[start : end + 1])
+        except json.JSONDecodeError as exc:
+            raise JudgeSchemaError(f"invalid verdict JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise JudgeSchemaError("verdict JSON must be an object")
+    return parsed
+
+
+def _sentence_count(value: str) -> int:
+    sentences = [part for part in re.split(r"[.!?]+(?:\s+|$)", value.strip()) if part.strip()]
+    return len(sentences)
+
+
+def validate_verdict(
+    verdict: dict[str, Any],
+    *,
+    allowed_evidence_refs: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    required = (
+        "stem",
+        "proposed_type",
+        "identity",
+        "merge_disposition",
+        "canonical_suggestion",
+        "confidence",
+        "evidence_cited",
+        "reasoning",
+    )
+    missing = [key for key in required if key not in verdict]
+    if missing:
+        raise JudgeSchemaError(f"missing required verdict keys: {', '.join(missing)}")
+
+    cleaned = dict(verdict)
+    if cleaned["proposed_type"] not in JUDGE_TYPES:
+        raise JudgeSchemaError(f"proposed_type must be one of {', '.join(JUDGE_TYPES)}")
+    if cleaned["merge_disposition"] not in MERGE_DISPOSITIONS:
+        raise JudgeSchemaError("merge_disposition must be merge|keep|split")
+    if cleaned["confidence"] not in CONFIDENCE_VALUES:
+        raise JudgeSchemaError("confidence must be high|medium|low")
+    if not isinstance(cleaned["evidence_cited"], list) or not cleaned["evidence_cited"]:
+        raise JudgeSchemaError("evidence_cited must be a non-empty list")
+    if not all(isinstance(ref, str) and ref.strip() for ref in cleaned["evidence_cited"]):
+        raise JudgeSchemaError("evidence_cited must contain non-empty strings")
+    allowed = set(allowed_evidence_refs or [])
+    if allowed:
+        unknown = [ref for ref in cleaned["evidence_cited"] if ref not in allowed]
+        if unknown:
+            raise JudgeSchemaError(f"evidence_cited contains unknown refs: {', '.join(unknown)}")
+    for key in ("stem", "identity", "reasoning"):
+        if not isinstance(cleaned[key], str) or not cleaned[key].strip():
+            raise JudgeSchemaError(f"{key} must be a non-empty string")
+    if "\n" in cleaned["identity"]:
+        raise JudgeSchemaError("identity must be one line")
+    if _sentence_count(cleaned["reasoning"]) > 3:
+        raise JudgeSchemaError("reasoning must be 3 sentences or fewer")
+    evidence_degraded = cleaned.get("evidence_degraded", False)
+    if not isinstance(evidence_degraded, bool):
+        raise JudgeSchemaError("evidence_degraded must be boolean")
+    cleaned["evidence_degraded"] = evidence_degraded
+    return cleaned
+
+
+def parse_verdict_json(
+    raw: str,
+    *,
+    allowed_evidence_refs: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    return validate_verdict(_extract_json_object(raw), allowed_evidence_refs=allowed_evidence_refs)
+
+
+def judge_cluster_with_llm(
+    packet: EvidencePacket,
+    *,
+    llm: Callable[[str], str],
+    max_attempts: int = 2,
+) -> dict[str, Any]:
+    prompt = build_judge_prompt(packet)
+    last_error: JudgeSchemaError | None = None
+    for attempt in range(1, max_attempts + 1):
+        retry_note = ""
+        if last_error is not None:
+            retry_note = (
+                "\n\nYour previous verdict violated the schema: "
+                f"{last_error}. Return a corrected JSON object with cited evidence."
+            )
+        raw = llm(prompt + retry_note)
+        try:
+            return parse_verdict_json(raw, allowed_evidence_refs=packet.evidence_refs())
+        except JudgeSchemaError as exc:
+            last_error = exc
+            if attempt == max_attempts:
+                raise
+    raise JudgeSchemaError("judge failed to produce a valid verdict")
+
+
+def _load_clusters_from_flag_batch(
+    flag_batch: Path,
+    *,
+    categories: list[str] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    data = json.loads(flag_batch.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("flag batch must be a JSON object keyed by category")
+    wanted = set(categories or data.keys())
+    clusters: list[dict[str, Any]] = []
+    for category, category_clusters in data.items():
+        if category not in wanted:
+            continue
+        if not isinstance(category_clusters, list):
+            continue
+        for cluster in category_clusters:
+            if not isinstance(cluster, dict):
+                continue
+            clusters.append({**cluster, "category": category})
+            if limit is not None and len(clusters) >= limit:
+                return clusters
+    return clusters
+
+
+def load_flag_batch_clusters(
+    flag_batch: str | Path,
+    *,
+    categories: str | list[str] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    if isinstance(categories, str):
+        parsed_categories = [part.strip() for part in categories.split(",") if part.strip()]
+    else:
+        parsed_categories = categories
+    return _load_clusters_from_flag_batch(Path(flag_batch), categories=parsed_categories, limit=limit)
+
+
+def emit_prompt_files(
+    clusters: list[dict[str, Any]],
+    out_dir: str | Path,
+    *,
+    db_path: str | Path | None = None,
+    gits_root: str | Path | None = None,
+) -> list[Path]:
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    written = []
+    for index, cluster in enumerate(clusters, start=1):
+        packet = gather_evidence_for_cluster(cluster, db_path=db_path, gits_root=gits_root)
+        category = cluster.get("category") or "cluster"
+        prompt_path = out_path / f"{index:03d}-{_slug(str(category))}-{_slug(packet.stem)}.prompt.md"
+        prompt_path.write_text(build_judge_prompt(packet, worker_mode=True), encoding="utf-8")
+        written.append(prompt_path)
+    return written
+
+
+def _read_verdict_payloads(path: Path) -> list[dict[str, Any]]:
+    raw = path.read_text(encoding="utf-8")
+    if path.suffix == ".jsonl":
+        payloads = []
+        for line in raw.splitlines():
+            if line.strip():
+                payload = json.loads(line)
+                if isinstance(payload, dict):
+                    payloads.append(payload)
+        return payloads
+    payload = json.loads(raw)
+    if isinstance(payload, dict) and isinstance(payload.get("verdicts"), list):
+        return [item for item in payload["verdicts"] if isinstance(item, dict)]
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        return [payload]
+    return []
+
+
+def render_markdown_table(verdicts: list[dict[str, Any]]) -> str:
+    lines = [
+        "| stem | proposed type | identity | disposition | confidence | top evidence |",
+        "|---|---|---|---|---|---|",
+    ]
+    for verdict in verdicts:
+        evidence = ", ".join(verdict.get("evidence_cited", [])[:3])
+        lines.append(
+            "| {stem} | {proposed_type} | {identity} | {merge_disposition} | {confidence} | {evidence} |".format(
+                stem=_md_cell(verdict["stem"]),
+                proposed_type=_md_cell(verdict["proposed_type"]),
+                identity=_md_cell(verdict["identity"]),
+                merge_disposition=_md_cell(verdict["merge_disposition"]),
+                confidence=_md_cell(verdict["confidence"]),
+                evidence=_md_cell(evidence),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _md_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _default_out_path() -> Path:
+    today = datetime.now(timezone.utc).date().isoformat()
+    return Path("eval_results") / f"kg-judge-verdicts-{today}.json"
+
+
+def write_verdict_outputs(
+    verdicts: list[dict[str, Any]],
+    *,
+    out_json: str | Path | None = None,
+    markdown_path: str | Path | None = None,
+    mode: str = "collect",
+) -> Path:
+    out_path = Path(out_json) if out_json is not None else _default_out_path()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "mode": mode,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "verdicts": verdicts,
+    }
+    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    if markdown_path is not None:
+        markdown = Path(markdown_path)
+        markdown.parent.mkdir(parents=True, exist_ok=True)
+        markdown.write_text(render_markdown_table(verdicts), encoding="utf-8")
+    return out_path
+
+
+def collect_worker_verdicts(
+    verdict_dir: str | Path,
+    *,
+    out_json: str | Path | None = None,
+    markdown_path: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    root = Path(verdict_dir)
+    if not root.exists():
+        raise FileNotFoundError(root)
+    files = sorted([*root.glob("*.json"), *root.glob("*.jsonl")])
+    verdicts = []
+    for path in files:
+        for payload in _read_verdict_payloads(path):
+            verdicts.append(validate_verdict(payload))
+    if out_json is not None or markdown_path is not None:
+        write_verdict_outputs(verdicts, out_json=out_json, markdown_path=markdown_path, mode="collect")
+    return verdicts
+
+
+def _llm_for_backend(backend: str) -> Callable[[str], str]:
+    from .pipeline import enrichment
+
+    resolved_backend = os.environ.get("BRAINLAYER_JUDGE_BACKEND", backend)
+
+    def call(prompt: str) -> str:
+        response = enrichment.call_llm(prompt, timeout=60, backend=resolved_backend)
+        if response is None:
+            raise RuntimeError(f"judge backend {resolved_backend} returned no response")
+        return response
+
+    return call
+
+
+def judge_clusters_with_backend(
+    clusters: list[dict[str, Any]],
+    *,
+    backend: str,
+    db_path: str | Path | None = None,
+    gits_root: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    llm = _llm_for_backend(backend)
+    verdicts = []
+    for cluster in clusters:
+        packet = gather_evidence_for_cluster(cluster, db_path=db_path, gits_root=gits_root)
+        verdicts.append(judge_cluster_with_llm(packet, llm=llm, max_attempts=2))
+        time.sleep(0.01)
+    return verdicts
+
+
+__all__ = [
+    "CLOSED_ENUM_TEXT",
+    "CONFIDENCE_VALUES",
+    "EvidenceItem",
+    "EvidencePacket",
+    "JUDGE_TYPES",
+    "JudgeSchemaError",
+    "MERGE_DISPOSITIONS",
+    "build_judge_prompt",
+    "collect_worker_verdicts",
+    "emit_prompt_files",
+    "gather_evidence_for_cluster",
+    "judge_cluster_with_llm",
+    "judge_clusters_with_backend",
+    "load_flag_batch_clusters",
+    "parse_verdict_json",
+    "render_markdown_table",
+    "validate_verdict",
+    "write_verdict_outputs",
+]

--- a/src/brainlayer/kg_judge.py
+++ b/src/brainlayer/kg_judge.py
@@ -54,7 +54,7 @@ REQUIRED_SCHEMA_TEXT = """Required verdict JSON schema:
   "proposed_type": "Person|Organization|Place|Event|Project|Tool|Technology|D1 Concept→tag|D2 Transient→drop",
   "identity": "one line: what this ACTUALLY is",
   "merge_disposition": "merge|keep|split",
-  "canonical_suggestion": "canonical name or null",
+  "canonical_suggestion": "non-empty cluster member name, or null only for D1/D2/split verdicts",
   "confidence": "high|medium|low",
   "evidence_cited": ["refs to supplied packet evidence and/or worker-found evidence"],
   "reasoning": "3 sentences max",
@@ -389,6 +389,7 @@ def build_judge_prompt(packet: EvidencePacket, *, worker_mode: bool = False) -> 
         "Rules:\n"
         "- proposed_type must be exactly one closed-enum label.\n"
         "- split means the cluster contains 2+ real referents.\n"
+        "- canonical_suggestion must be a non-empty cluster member name, or null only for D1/D2/split verdicts.\n"
         "- evidence_cited must cite supplied evidence refs and any worker-found evidence refs.\n"
         "- reasoning must be 3 sentences or fewer.\n"
         f"{worker_instruction}\n"
@@ -425,6 +426,7 @@ def validate_verdict(
     verdict: dict[str, Any],
     *,
     allowed_evidence_refs: Iterable[str] | None = None,
+    cluster_member_names: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     required = (
         "stem",
@@ -435,6 +437,7 @@ def validate_verdict(
         "confidence",
         "evidence_cited",
         "reasoning",
+        "evidence_degraded",
     )
     missing = [key for key in required if key not in verdict]
     if missing:
@@ -463,10 +466,9 @@ def validate_verdict(
         raise JudgeSchemaError("identity must be one line")
     if _sentence_count(cleaned["reasoning"]) > 3:
         raise JudgeSchemaError("reasoning must be 3 sentences or fewer")
-    evidence_degraded = cleaned.get("evidence_degraded", False)
-    if not isinstance(evidence_degraded, bool):
+    if not isinstance(cleaned["evidence_degraded"], bool):
         raise JudgeSchemaError("evidence_degraded must be boolean")
-    cleaned["evidence_degraded"] = evidence_degraded
+    _validate_canonical_suggestion(cleaned, cluster_member_names=cluster_member_names)
     return cleaned
 
 
@@ -474,8 +476,43 @@ def parse_verdict_json(
     raw: str,
     *,
     allowed_evidence_refs: Iterable[str] | None = None,
+    cluster_member_names: Iterable[str] | None = None,
 ) -> dict[str, Any]:
-    return validate_verdict(_extract_json_object(raw), allowed_evidence_refs=allowed_evidence_refs)
+    return validate_verdict(
+        _extract_json_object(raw),
+        allowed_evidence_refs=allowed_evidence_refs,
+        cluster_member_names=cluster_member_names,
+    )
+
+
+def _null_canonical_allowed(verdict: dict[str, Any]) -> bool:
+    return verdict["merge_disposition"] == "split" or verdict["proposed_type"] in {
+        "D1 Concept→tag",
+        "D2 Transient→drop",
+    }
+
+
+def _validate_canonical_suggestion(
+    verdict: dict[str, Any],
+    *,
+    cluster_member_names: Iterable[str] | None,
+) -> None:
+    canonical = verdict["canonical_suggestion"]
+    if canonical is None:
+        if not _null_canonical_allowed(verdict):
+            raise JudgeSchemaError("canonical_suggestion can be null only for D1/D2/split verdicts")
+        return
+    if not isinstance(canonical, str) or not canonical.strip():
+        raise JudgeSchemaError("canonical_suggestion must be a non-empty string")
+    canonical = canonical.strip()
+    member_names = {name.strip() for name in cluster_member_names or [] if isinstance(name, str) and name.strip()}
+    if member_names and canonical not in member_names:
+        raise JudgeSchemaError("canonical_suggestion must match one of the cluster member names")
+    verdict["canonical_suggestion"] = canonical
+
+
+def _packet_member_names(packet: EvidencePacket) -> list[str]:
+    return [str(member["name"]) for member in packet.members if isinstance(member.get("name"), str) and member["name"]]
 
 
 def judge_cluster_with_llm(
@@ -495,7 +532,11 @@ def judge_cluster_with_llm(
             )
         raw = llm(prompt + retry_note)
         try:
-            return parse_verdict_json(raw, allowed_evidence_refs=packet.evidence_refs())
+            return parse_verdict_json(
+                raw,
+                allowed_evidence_refs=packet.evidence_refs(),
+                cluster_member_names=_packet_member_names(packet),
+            )
         except JudgeSchemaError as exc:
             last_error = exc
             if attempt == max_attempts:
@@ -539,6 +580,26 @@ def load_flag_batch_clusters(
     else:
         parsed_categories = categories
     return _load_clusters_from_flag_batch(Path(flag_batch), categories=parsed_categories, limit=limit)
+
+
+def _cluster_member_names(cluster: dict[str, Any]) -> list[str]:
+    names = []
+    for member in cluster.get("members", []):
+        name = member.get("name")
+        if isinstance(name, str) and name.strip():
+            names.append(name)
+    return names
+
+
+def _member_names_by_stem(clusters: Iterable[dict[str, Any]] | None) -> dict[str, list[str]]:
+    if clusters is None:
+        return {}
+    names_by_stem: dict[str, list[str]] = {}
+    for cluster in clusters:
+        stem = cluster.get("stem")
+        if isinstance(stem, str) and stem.strip():
+            names_by_stem.setdefault(stem, []).extend(_cluster_member_names(cluster))
+    return names_by_stem
 
 
 def emit_prompt_files(
@@ -636,15 +697,19 @@ def collect_worker_verdicts(
     *,
     out_json: str | Path | None = None,
     markdown_path: str | Path | None = None,
+    clusters: Iterable[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     root = Path(verdict_dir)
     if not root.exists():
         raise FileNotFoundError(root)
     files = sorted([*root.glob("*.json"), *root.glob("*.jsonl")])
+    names_by_stem = _member_names_by_stem(clusters)
     verdicts = []
     for path in files:
         for payload in _read_verdict_payloads(path):
-            verdicts.append(validate_verdict(payload))
+            stem = payload.get("stem")
+            member_names = names_by_stem.get(stem) if isinstance(stem, str) else None
+            verdicts.append(validate_verdict(payload, cluster_member_names=member_names))
     if out_json is not None or markdown_path is not None:
         write_verdict_outputs(verdicts, out_json=out_json, markdown_path=markdown_path, mode="collect")
     return verdicts

--- a/src/brainlayer/kg_judge.py
+++ b/src/brainlayer/kg_judge.py
@@ -119,6 +119,8 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
 def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
     if not _table_exists(conn, table):
         return set()
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", table):
+        return set()
     return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
 
 

--- a/src/brainlayer/kg_judge.py
+++ b/src/brainlayer/kg_judge.py
@@ -157,6 +157,10 @@ def _normalize_repo_match(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", value.casefold())
 
 
+def _clean_git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
 def _slug(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
     return slug or "cluster"
@@ -313,6 +317,7 @@ def _read_repo_evidence(stem: str, gits_root: Path) -> list[EvidenceItem]:
             git_log = subprocess.run(
                 ["git", "log", "--oneline", "-3"],
                 cwd=repo,
+                env=_clean_git_env(),
                 check=False,
                 capture_output=True,
                 text=True,

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -647,6 +647,7 @@ def call_groq(prompt: str, timeout: int = 60) -> Optional[str]:
                 "model": GROQ_MODEL,
                 "messages": [{"role": "user", "content": prompt}],
                 "response_format": {"type": "json_object"},
+                "temperature": 0,
             },
             timeout=timeout,
         )

--- a/tests/test_kg_judge.py
+++ b/tests/test_kg_judge.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _insert_chunk(
+    conn: sqlite3.Connection,
+    chunk_id: str,
+    content: str,
+    *,
+    project: str = "brainlayer",
+    created_at: str = "2026-06-05T10:00:00Z",
+    summary: str = "",
+) -> None:
+    conn.execute(
+        """INSERT INTO chunks
+           (id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at, project)
+           VALUES (?, ?, ?, '', '', '', '', ?, ?)""",
+        (chunk_id, content, summary, created_at, project),
+    )
+    conn.execute(
+        """INSERT INTO chunks_fts
+           (content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+           VALUES (?, ?, '', '', '', '', ?)""",
+        (content, summary, chunk_id),
+    )
+
+
+def _create_judge_fixture_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE kg_entities (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            summary TEXT,
+            tags TEXT,
+            resolved_query TEXT,
+            key_facts TEXT,
+            resolved_queries TEXT,
+            created_at TEXT,
+            project TEXT
+        );
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
+        );
+        CREATE TABLE kg_entity_chunks (
+            entity_id TEXT NOT NULL,
+            chunk_id TEXT NOT NULL,
+            relevance REAL DEFAULT 1.0,
+            context TEXT,
+            PRIMARY KEY (entity_id, chunk_id)
+        );
+        CREATE TABLE kg_relations (
+            id TEXT PRIMARY KEY,
+            source_id TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            relation_type TEXT NOT NULL,
+            fact TEXT,
+            properties TEXT DEFAULT '{}',
+            confidence REAL DEFAULT 1.0,
+            expired_at TEXT,
+            source_chunk_id TEXT
+        );
+        """
+    )
+    entities = [
+        ("person-etan", "person", "Etan Heyman"),
+        ("easysend-org", "organization", "EasySend"),
+        ("easysend-project", "project", "EasySend"),
+        ("cantaloupe-org", "organization", "Cantaloupe"),
+        ("cantaloupe-person", "person", "Cantaloupe"),
+        ("claude-web-tool", "tool", "Claude Web"),
+        ("claude-web-project", "project", "Claude-Web"),
+    ]
+    conn.executemany("INSERT INTO kg_entities (id, entity_type, name) VALUES (?, ?, ?)", entities)
+
+    _insert_chunk(
+        conn,
+        "chunk-easysend-1",
+        "Etan used EasySend as a vendor company/product in delivery work; repo notes are usage records, not ownership.",
+        project="easysend-notes",
+        summary="EasySend is a company/product Etan used, not his owned project.",
+    )
+    _insert_chunk(
+        conn,
+        "chunk-easysend-2",
+        "EasySend implementation notes describe customer onboarding and vendor integration constraints.",
+        project="client-work",
+    )
+    _insert_chunk(
+        conn,
+        "chunk-cantaloupe-1",
+        "Cantaloupe was the now-dead/renamed company where Etan worked before later cleanup tasks.",
+        project="career",
+        summary="Work history says Cantaloupe was an organization, not a person.",
+    )
+    _insert_chunk(
+        conn,
+        "chunk-claude-web-1",
+        "Claude Web is the claude.ai app/container Etan uses; it contains projects but is not itself his project.",
+        project="golems",
+    )
+    _insert_chunk(
+        conn,
+        "chunk-claude-web-2",
+        "Claude Web research sessions contain project work inside the app container.",
+        project="research",
+    )
+    conn.executemany(
+        "INSERT INTO kg_entity_chunks (entity_id, chunk_id, relevance, context) VALUES (?, ?, ?, ?)",
+        [
+            ("easysend-org", "chunk-easysend-1", 0.98, "company/product usage"),
+            ("easysend-project", "chunk-easysend-2", 0.40, "repo presence only"),
+            ("cantaloupe-org", "chunk-cantaloupe-1", 0.99, "employment context"),
+            ("cantaloupe-person", "chunk-cantaloupe-1", 0.15, "bad person duplicate"),
+            ("claude-web-tool", "chunk-claude-web-1", 0.99, "tool container"),
+            ("claude-web-project", "chunk-claude-web-2", 0.40, "contains project work"),
+        ],
+    )
+    conn.executemany(
+        """INSERT INTO kg_relations
+           (id, source_id, target_id, relation_type, fact, confidence, source_chunk_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            (
+                "rel-easysend-uses",
+                "person-etan",
+                "easysend-org",
+                "uses",
+                "Etan used EasySend; usage does not imply ownership.",
+                0.95,
+                "chunk-easysend-1",
+            ),
+            (
+                "rel-cantaloupe-worked",
+                "person-etan",
+                "cantaloupe-org",
+                "worked_at",
+                "Etan worked at Cantaloupe during the company period.",
+                0.96,
+                "chunk-cantaloupe-1",
+            ),
+            (
+                "rel-claude-web-uses",
+                "person-etan",
+                "claude-web-tool",
+                "uses",
+                "Etan uses Claude Web as the claude.ai product/app.",
+                0.93,
+                "chunk-claude-web-1",
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _create_repo(root: Path, name: str, readme: str, commit_messages: list[str]) -> None:
+    repo = root / name
+    repo.mkdir(parents=True)
+    (repo / "README.md").write_text(readme, encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.email", "fixture@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Fixture User"], cwd=repo, check=True)
+    for index, message in enumerate(commit_messages):
+        (repo / f"note-{index}.txt").write_text(message, encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+
+
+def _cluster(stem: str, members: list[dict]) -> dict:
+    return {"stem": stem, "category": "diagnosis-flag", "members": members}
+
+
+@pytest.fixture
+def judge_fixture(tmp_path: Path) -> dict[str, Path]:
+    db_path = tmp_path / "brainlayer.db"
+    gits_root = tmp_path / "Gits"
+    _create_judge_fixture_db(db_path)
+    _create_repo(
+        gits_root,
+        "EasySend",
+        "# EasySend\n\nVendor integration notes.\nEtan used this product for client delivery.\n",
+        ["vendor import", "capture usage notes"],
+    )
+    _create_repo(
+        gits_root,
+        "claude-web-research",
+        "# Claude Web Research\n\nResearch sessions inside claude.ai, not an owned app repo.\n",
+        ["record claude.ai container behavior"],
+    )
+    return {"db_path": db_path, "gits_root": gits_root}
+
+
+def test_gathers_decisive_evidence_for_required_fixture_clusters(judge_fixture: dict[str, Path]):
+    from brainlayer.kg_judge import gather_evidence_for_cluster
+
+    clusters = {
+        "easysend": _cluster(
+            "EasySend",
+            [
+                {"id": "easysend-org", "name": "EasySend", "type": "organization", "chunks": 1},
+                {"id": "easysend-project", "name": "EasySend", "type": "project", "chunks": 1},
+            ],
+        ),
+        "cantaloupe": _cluster(
+            "Cantaloupe",
+            [
+                {"id": "cantaloupe-org", "name": "Cantaloupe", "type": "organization", "chunks": 1},
+                {"id": "cantaloupe-person", "name": "Cantaloupe", "type": "person", "chunks": 1},
+            ],
+        ),
+        "claude_web": _cluster(
+            "Claude Web",
+            [
+                {"id": "claude-web-tool", "name": "Claude Web", "type": "tool", "chunks": 1},
+                {"id": "claude-web-project", "name": "Claude-Web", "type": "project", "chunks": 1},
+            ],
+        ),
+    }
+
+    packets = {
+        key: gather_evidence_for_cluster(
+            cluster, db_path=judge_fixture["db_path"], gits_root=judge_fixture["gits_root"]
+        )
+        for key, cluster in clusters.items()
+    }
+
+    easysend_text = packets["easysend"].to_prompt_text()
+    assert "Etan used EasySend" in easysend_text
+    assert "usage does not imply ownership" in easysend_text
+    assert "README.md first lines" in easysend_text
+
+    cantaloupe_text = packets["cantaloupe"].to_prompt_text()
+    assert "worked_at" in cantaloupe_text
+    assert "Etan worked at Cantaloupe" in cantaloupe_text
+    assert "bad person duplicate" in cantaloupe_text
+
+    claude_web_text = packets["claude_web"].to_prompt_text()
+    assert "claude.ai app/container" in claude_web_text
+    assert "contains projects but is not itself his project" in claude_web_text
+    assert "rel-claude-web-uses" in claude_web_text
+
+
+def test_builds_worker_prompt_with_closed_enum_schema_and_self_gathering_instructions(
+    judge_fixture: dict[str, Path],
+):
+    from brainlayer.kg_judge import build_judge_prompt, gather_evidence_for_cluster
+
+    packet = gather_evidence_for_cluster(
+        _cluster(
+            "Cantaloupe",
+            [
+                {"id": "cantaloupe-org", "name": "Cantaloupe", "type": "organization", "chunks": 1},
+                {"id": "cantaloupe-person", "name": "Cantaloupe", "type": "person", "chunks": 1},
+            ],
+        ),
+        db_path=judge_fixture["db_path"],
+        gits_root=judge_fixture["gits_root"],
+    )
+
+    prompt = build_judge_prompt(packet, worker_mode=True)
+
+    assert 'Person ("could I message/meet this individual?", never auto-merge)' in prompt
+    assert "D1 Concept→tag" in prompt
+    assert "D2 Transient→drop" in prompt
+    assert '"proposed_type"' in prompt
+    assert '"evidence_cited"' in prompt
+    assert '"evidence_degraded"' in prompt
+    assert "Run brain_search on the stem" in prompt
+    assert "retry once" in prompt
+    assert "grep ~/Gits" in prompt
+    assert "worked_at" in prompt
+
+
+def test_mocked_llm_judge_retries_schema_violation_and_requires_cited_evidence(
+    judge_fixture: dict[str, Path],
+):
+    from brainlayer.kg_judge import gather_evidence_for_cluster, judge_cluster_with_llm
+
+    packet = gather_evidence_for_cluster(
+        _cluster(
+            "EasySend",
+            [
+                {"id": "easysend-org", "name": "EasySend", "type": "organization", "chunks": 1},
+                {"id": "easysend-project", "name": "EasySend", "type": "project", "chunks": 1},
+            ],
+        ),
+        db_path=judge_fixture["db_path"],
+        gits_root=judge_fixture["gits_root"],
+    )
+    first_ref = packet.evidence_refs()[0]
+    calls: list[str] = []
+
+    def fake_llm(prompt: str) -> str:
+        calls.append(prompt)
+        if len(calls) == 1:
+            return json.dumps({"stem": "EasySend", "proposed_type": "Project", "evidence_cited": []})
+        return json.dumps(
+            {
+                "stem": "EasySend",
+                "proposed_type": "Organization",
+                "identity": "EasySend is a company/product Etan used.",
+                "merge_disposition": "merge",
+                "canonical_suggestion": "EasySend",
+                "confidence": "high",
+                "evidence_cited": [first_ref],
+                "reasoning": "The packet cites vendor usage and no ownership evidence.",
+                "evidence_degraded": False,
+            }
+        )
+
+    verdict = judge_cluster_with_llm(packet, llm=fake_llm, max_attempts=2)
+
+    assert verdict["proposed_type"] == "Organization"
+    assert len(calls) == 2
+    assert "No verdict without evidence" in calls[0]
+    assert "Organization (group acting as one agent" in calls[0]
+    assert first_ref in verdict["evidence_cited"]
+
+
+def test_emit_prompt_files_write_one_self_contained_prompt_per_cluster(
+    judge_fixture: dict[str, Path],
+    tmp_path: Path,
+):
+    from brainlayer.kg_judge import emit_prompt_files
+
+    out_dir = tmp_path / "prompts"
+    written = emit_prompt_files(
+        [
+            _cluster(
+                "Claude Web",
+                [
+                    {"id": "claude-web-tool", "name": "Claude Web", "type": "tool", "chunks": 1},
+                    {"id": "claude-web-project", "name": "Claude-Web", "type": "project", "chunks": 1},
+                ],
+            )
+        ],
+        out_dir,
+        db_path=judge_fixture["db_path"],
+        gits_root=judge_fixture["gits_root"],
+    )
+
+    assert len(written) == 1
+    prompt_text = written[0].read_text(encoding="utf-8")
+    assert "Claude Web" in prompt_text
+    assert "claude.ai product/app" in prompt_text
+    assert "Run brain_search on the stem" in prompt_text
+    assert "evidence_degraded:true" in prompt_text
+    assert "Required verdict JSON schema" in prompt_text
+
+
+def test_collect_validates_worker_jsons_and_writes_json_plus_markdown(tmp_path: Path):
+    from brainlayer.kg_judge import collect_worker_verdicts
+
+    verdict_dir = tmp_path / "worker-verdicts"
+    verdict_dir.mkdir()
+    (verdict_dir / "001-easysend.json").write_text(
+        json.dumps(
+            {
+                "stem": "EasySend",
+                "proposed_type": "Organization",
+                "identity": "EasySend is a company/product Etan used.",
+                "merge_disposition": "merge",
+                "canonical_suggestion": "EasySend",
+                "confidence": "high",
+                "evidence_cited": ["linked-1"],
+                "reasoning": "Usage evidence and no ownership evidence support Organization.",
+                "evidence_degraded": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    out_json = tmp_path / "merged.json"
+    out_md = tmp_path / "merged.md"
+
+    verdicts = collect_worker_verdicts(verdict_dir, out_json=out_json, markdown_path=out_md)
+
+    assert verdicts[0]["stem"] == "EasySend"
+    assert json.loads(out_json.read_text(encoding="utf-8"))["verdicts"][0]["proposed_type"] == "Organization"
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "| stem | proposed type | identity | disposition | confidence | top evidence |" in markdown
+    assert (
+        "| EasySend | Organization | EasySend is a company/product Etan used. | merge | high | linked-1 |" in markdown
+    )
+
+
+def test_collect_rejects_invalid_worker_json(tmp_path: Path):
+    from brainlayer.kg_judge import JudgeSchemaError, collect_worker_verdicts
+
+    verdict_dir = tmp_path / "worker-verdicts"
+    verdict_dir.mkdir()
+    (verdict_dir / "bad.json").write_text(
+        json.dumps(
+            {
+                "stem": "Cantaloupe",
+                "proposed_type": "Person",
+                "identity": "Invalid because no cited evidence.",
+                "merge_disposition": "merge",
+                "canonical_suggestion": "Cantaloupe",
+                "confidence": "high",
+                "evidence_cited": [],
+                "reasoning": "Missing evidence.",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(JudgeSchemaError, match="evidence_cited"):
+        collect_worker_verdicts(verdict_dir)

--- a/tests/test_kg_judge.py
+++ b/tests/test_kg_judge.py
@@ -534,6 +534,7 @@ def test_collect_rejects_invalid_worker_json(tmp_path: Path):
                 "confidence": "high",
                 "evidence_cited": [],
                 "reasoning": "Missing evidence.",
+                "evidence_degraded": False,
             }
         ),
         encoding="utf-8",
@@ -541,3 +542,111 @@ def test_collect_rejects_invalid_worker_json(tmp_path: Path):
 
     with pytest.raises(JudgeSchemaError, match="evidence_cited"):
         collect_worker_verdicts(verdict_dir)
+
+
+def test_collect_rejects_canonical_suggestion_outside_cluster_members(tmp_path: Path):
+    from brainlayer.kg_judge import JudgeSchemaError, collect_worker_verdicts
+
+    verdict_dir = tmp_path / "worker-verdicts"
+    verdict_dir.mkdir()
+    (verdict_dir / "001-easysend.json").write_text(
+        json.dumps(
+            {
+                "stem": "EasySend",
+                "proposed_type": "Organization",
+                "identity": "EasySend is a company/product Etan used.",
+                "merge_disposition": "merge",
+                "canonical_suggestion": "Not In Cluster",
+                "confidence": "high",
+                "evidence_cited": ["linked-1"],
+                "reasoning": "Usage evidence supports Organization.",
+                "evidence_degraded": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    clusters = [
+        _cluster(
+            "EasySend",
+            [
+                {"id": "easysend-org", "name": "EasySend", "type": "organization", "chunks": 1},
+                {"id": "easysend-project", "name": "EasySend Notes", "type": "project", "chunks": 1},
+            ],
+        )
+    ]
+
+    with pytest.raises(JudgeSchemaError, match="canonical_suggestion"):
+        collect_worker_verdicts(verdict_dir, clusters=clusters)
+
+
+def test_validate_verdict_requires_evidence_degraded_bool():
+    from brainlayer.kg_judge import JudgeSchemaError, validate_verdict
+
+    verdict = {
+        "stem": "EasySend",
+        "proposed_type": "Organization",
+        "identity": "EasySend is a company/product Etan used.",
+        "merge_disposition": "merge",
+        "canonical_suggestion": "EasySend",
+        "confidence": "high",
+        "evidence_cited": ["linked-1"],
+        "reasoning": "Usage evidence supports Organization.",
+    }
+
+    with pytest.raises(JudgeSchemaError, match="evidence_degraded"):
+        validate_verdict(verdict, cluster_member_names=["EasySend", "EasySend Notes"])
+
+    verdict["evidence_degraded"] = "false"
+    with pytest.raises(JudgeSchemaError, match="evidence_degraded"):
+        validate_verdict(verdict, cluster_member_names=["EasySend", "EasySend Notes"])
+
+
+def test_validate_verdict_restricts_canonical_suggestion_to_member_names():
+    from brainlayer.kg_judge import JudgeSchemaError, validate_verdict
+
+    base_verdict = {
+        "stem": "EasySend",
+        "proposed_type": "Organization",
+        "identity": "EasySend is a company/product Etan used.",
+        "merge_disposition": "merge",
+        "canonical_suggestion": "Not In Cluster",
+        "confidence": "high",
+        "evidence_cited": ["linked-1"],
+        "reasoning": "Usage evidence supports Organization.",
+        "evidence_degraded": False,
+    }
+
+    with pytest.raises(JudgeSchemaError, match="canonical_suggestion"):
+        validate_verdict(base_verdict, cluster_member_names=["EasySend", "EasySend Notes"])
+
+    base_verdict["canonical_suggestion"] = ""
+    with pytest.raises(JudgeSchemaError, match="canonical_suggestion"):
+        validate_verdict(base_verdict, cluster_member_names=["EasySend", "EasySend Notes"])
+
+    base_verdict["canonical_suggestion"] = None
+    with pytest.raises(JudgeSchemaError, match="canonical_suggestion"):
+        validate_verdict(base_verdict, cluster_member_names=["EasySend", "EasySend Notes"])
+
+
+def test_validate_verdict_allows_null_canonical_for_d1_d2_and_split():
+    from brainlayer.kg_judge import validate_verdict
+
+    base_verdict = {
+        "stem": "fuzzy",
+        "proposed_type": "D1 Concept→tag",
+        "identity": "A concept tag, not a rigid entity.",
+        "merge_disposition": "keep",
+        "canonical_suggestion": None,
+        "confidence": "medium",
+        "evidence_cited": ["linked-1"],
+        "reasoning": "The supplied context reads naturally as a concept.",
+        "evidence_degraded": False,
+    }
+
+    assert validate_verdict(base_verdict, cluster_member_names=["fuzzy"])["canonical_suggestion"] is None
+
+    transient = {**base_verdict, "proposed_type": "D2 Transient→drop"}
+    assert validate_verdict(transient, cluster_member_names=["fuzzy"])["canonical_suggestion"] is None
+
+    split = {**base_verdict, "proposed_type": "Organization", "merge_disposition": "split"}
+    assert validate_verdict(split, cluster_member_names=["fuzzy"])["canonical_suggestion"] is None

--- a/tests/test_kg_judge.py
+++ b/tests/test_kg_judge.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -169,9 +171,36 @@ def _create_judge_fixture_db(path: Path) -> None:
 def _create_repo(root: Path, name: str, readme: str, commit_messages: list[str]) -> None:
     repo = root / name
     repo.mkdir(parents=True)
+    _test_git(repo, "init", "-b", "main")
+    _test_git(repo, "config", "user.name", "Fixture User")
+    _test_git(repo, "config", "user.email", "fixture@example.com")
     (repo / "README.md").write_text(readme, encoding="utf-8")
     for index, message in enumerate(commit_messages):
         (repo / f"note-{index}.txt").write_text(message, encoding="utf-8")
+        _test_git(repo, "add", "README.md", f"note-{index}.txt")
+        _assert_no_github_remote(repo)
+        _test_git(repo, "commit", "-m", message)
+
+
+def _clean_test_git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
+def _test_git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=_clean_test_git_env(),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_no_github_remote(repo: Path) -> None:
+    result = _test_git(repo, "remote", "-v", check=False)
+    remote_text = f"{result.stdout}\n{result.stderr}"
+    assert "github.com" not in remote_text, remote_text
 
 
 def _cluster(stem: str, members: list[dict]) -> dict:
@@ -196,6 +225,104 @@ def judge_fixture(tmp_path: Path) -> dict[str, Path]:
         ["record claude.ai container behavior"],
     )
     return {"db_path": db_path, "gits_root": gits_root}
+
+
+def test_fixture_repo_helper_ignores_parent_git_env_and_has_no_github_remote(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    parent_repo = tmp_path / "parent"
+    parent_repo.mkdir()
+    _test_git(parent_repo, "init", "-b", "main")
+    (parent_repo / "README.md").write_text("# parent\n", encoding="utf-8")
+    _test_git(parent_repo, "add", "README.md")
+    _test_git(parent_repo, "config", "user.name", "Parent User")
+    _test_git(parent_repo, "config", "user.email", "parent@example.com")
+    _test_git(parent_repo, "commit", "-m", "parent poison commit")
+    _test_git(parent_repo, "remote", "add", "origin", "https://github.com/EtanHey/brainlayer.git")
+
+    monkeypatch.setenv("GIT_DIR", str(parent_repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(parent_repo))
+
+    gits_root = tmp_path / "Gits"
+    _create_repo(
+        gits_root,
+        "EasySend",
+        "# EasySend\n\nVendor integration notes.\n",
+        ["vendor import"],
+    )
+
+    fixture_repo = gits_root / "EasySend"
+    fixture_log = _test_git(fixture_repo, "log", "--oneline", "-1")
+    parent_log = _test_git(parent_repo, "log", "--oneline", "--all")
+
+    assert "vendor import" in fixture_log.stdout
+    assert "vendor import" not in parent_log.stdout
+    _assert_no_github_remote(fixture_repo)
+
+
+def test_fixture_remote_guard_rejects_github_remote(tmp_path: Path):
+    gits_root = tmp_path / "Gits"
+    _create_repo(gits_root, "EasySend", "# EasySend\n", ["vendor import"])
+    fixture_repo = gits_root / "EasySend"
+    _test_git(fixture_repo, "remote", "add", "origin", "https://github.com/EtanHey/brainlayer.git")
+
+    with pytest.raises(AssertionError, match="github.com"):
+        _assert_no_github_remote(fixture_repo)
+
+
+def test_local_repo_evidence_ignores_parent_git_hook_env(
+    judge_fixture: dict[str, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from brainlayer.kg_judge import gather_evidence_for_cluster
+
+    parent_repo = tmp_path / "parent"
+    parent_repo.mkdir()
+    _test_git(parent_repo, "init", "-b", "main")
+    (parent_repo / "README.md").write_text("# parent\n", encoding="utf-8")
+    _test_git(parent_repo, "add", "README.md")
+    _test_git(parent_repo, "config", "user.name", "Parent User")
+    _test_git(parent_repo, "config", "user.email", "parent@example.com")
+    _test_git(parent_repo, "commit", "-m", "parent poison commit")
+
+    monkeypatch.setenv("GIT_DIR", str(parent_repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(parent_repo))
+
+    packet = gather_evidence_for_cluster(
+        _cluster(
+            "EasySend",
+            [
+                {"id": "easysend-org", "name": "EasySend", "type": "organization", "chunks": 1},
+                {"id": "easysend-project", "name": "EasySend", "type": "project", "chunks": 1},
+            ],
+        ),
+        db_path=judge_fixture["db_path"],
+        gits_root=judge_fixture["gits_root"],
+    )
+
+    packet_text = packet.to_prompt_text()
+    assert "parent poison commit" not in packet_text
+    assert "vendor import" in packet_text
+
+
+def test_git_shellout_tests_scrub_inherited_git_env():
+    test_root = Path(__file__).parent
+    git_shellout_files = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in test_root.glob("test_*.py")
+        if '["git",' in path.read_text(encoding="utf-8")
+    }
+
+    assert set(git_shellout_files) == {
+        "test_brainbar_build_app_guards.py",
+        "test_git_learning.py",
+        "test_kg_judge.py",
+    }
+    for text in git_shellout_files.values():
+        assert 'if not key.startswith("GIT_")' in text
+        assert "env=_clean_git_env()" in text or "env=_clean_test_git_env()" in text
 
 
 def test_gathers_decisive_evidence_for_required_fixture_clusters(judge_fixture: dict[str, Path]):

--- a/tests/test_kg_judge.py
+++ b/tests/test_kg_judge.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -171,13 +170,8 @@ def _create_repo(root: Path, name: str, readme: str, commit_messages: list[str])
     repo = root / name
     repo.mkdir(parents=True)
     (repo / "README.md").write_text(readme, encoding="utf-8")
-    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
-    subprocess.run(["git", "config", "user.email", "fixture@example.com"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.name", "Fixture User"], cwd=repo, check=True)
     for index, message in enumerate(commit_messages):
         (repo / f"note-{index}.txt").write_text(message, encoding="utf-8")
-        subprocess.run(["git", "add", "."], cwd=repo, check=True)
-        subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True, stdout=subprocess.DEVNULL)
 
 
 def _cluster(stem: str, members: list[dict]) -> dict:

--- a/tests/test_kg_judge.py
+++ b/tests/test_kg_judge.py
@@ -325,6 +325,13 @@ def test_git_shellout_tests_scrub_inherited_git_env():
         assert "env=_clean_git_env()" in text or "env=_clean_test_git_env()" in text
 
 
+def test_working_branch_history_has_no_fixture_git_identity():
+    repo_root = Path(__file__).resolve().parents[1]
+    authors = _test_git(repo_root, "log", "--format=%an%n%cn").stdout.splitlines()
+
+    assert "Fixture User" not in authors
+
+
 def test_gathers_decisive_evidence_for_required_fixture_clusters(judge_fixture: dict[str, Path]):
     from brainlayer.kg_judge import gather_evidence_for_cluster
 


### PR DESCRIPTION
## Summary
- Add the read-only KG entity-context judge evidence gatherer and evidence-cited verdict schema validation.
- Add CLI modes: `--emit-prompts` for Cursor worker prompt packets, `--collect` for worker JSON validation plus merged JSON/markdown output, and optional `--judge groq` fallback.
- Add fixture/golden tests for EasySend, Cantaloupe, and Claude Web, and set Groq JSON calls to temperature 0.

## Notes
- The prompt-emission path is now the primary overnight harness: each prompt tells Cursor workers to run `brain_search` on the stem, retry once on timeout, grep `~/Gits`, cite worker-found evidence separately from packet evidence, and set `evidence_degraded:true` when applicable.
- The CLI never writes to the BrainLayer DB; DB access is read-only and output goes only to requested files/directories.
- This PR uses clean branch `feat/kg-entity-judge-clean`; the earlier branch name was avoided after fixture tests accidentally produced local git commits during a pre-push run.

## Test plan
- [x] `python3 -m pytest tests/test_kg_judge.py tests/test_groq_backend.py tests/test_groq_rate_limit.py -q` — 22 passed
- [x] `python3 -m ruff check scripts/kg_entity_judge.py src/brainlayer/kg_judge.py src/brainlayer/pipeline/enrichment.py tests/test_kg_judge.py`
- [x] `python3 -m ruff format --check scripts/kg_entity_judge.py src/brainlayer/kg_judge.py src/brainlayer/pipeline/enrichment.py tests/test_kg_judge.py`
- [x] `python3 -m pytest -q` — 2531 passed, 48 skipped, 5 xfailed
- [x] emit-prompts smoke against `eval_results/kg-phase1-flag-batch-2026-06-05.json` — emitted 3 prompt files
- [x] collect smoke — collected 1 verdict to JSON and markdown
- [x] pre-push gate — passed: pytest unit suite, MCP tool registration tests, isolated eval/hook routing tests, bun test suite, and FTS5 determinism shell regression

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New offline tooling with read-only DB/git reads is low risk, but forcing Groq `temperature: 0` changes output for all `call_groq` callers (enrichment and judge), and local repo fuzzy matching plus subprocess git could behave differently on developer machines.
> 
> **Overview**
> Adds a **read-only KG entity-context judge** for flag-batch clusters: it assembles evidence (linked chunks, FTS5, relations, fuzzy local repos), builds closed-enum prompts, and validates **evidence-cited** verdict JSON (type, identity, merge disposition, canonical name).
> 
> **`scripts/kg_entity_judge.py`** exposes three mutually exclusive modes: **`--emit-prompts`** (per-cluster Cursor worker `.prompt.md` files with extra brain_search/grep instructions), **`--collect`** (validate worker JSON/JSONL and write merged JSON + optional markdown table), and optional **`--judge groq`** (direct LLM with schema retry). DB access is read-only; nothing mutates BrainLayer.
> 
> **`call_groq`** in enrichment now sends **`temperature: 0`** for more deterministic JSON judge/enrichment responses. **`tests/test_kg_judge.py`** covers fixture clusters (EasySend, Cantaloupe, Claude Web), git env scrubbing, collect/validate edge cases, and mocked LLM retry on schema violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddbe947f762576fa90f1c06132bd21575c84058b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add entity-context judge for KG type/identity/merge verdicts with evidence citation
> - Adds [kg_judge.py](https://github.com/EtanHey/brainlayer/pull/453/files#diff-62361fe3d054069bdd109489de3983793f5539add68c681d09c434505073ae0a) implementing a full LLM-based judging pipeline for knowledge graph entity clusters, producing structured verdicts (type, disposition, confidence, canonical suggestion) with required evidence citation.
> - Evidence is gathered from multiple sources per cluster: linked chunks, FTS5 chunk search, background KG relations, and local git repo READMEs/commit logs.
> - Verdicts are strictly validated against a closed schema; invalid verdicts raise `JudgeSchemaError` and LLM calls retry up to `max_attempts` on schema violations.
> - Adds [kg_entity_judge.py](https://github.com/EtanHey/brainlayer/pull/453/files#diff-06cf2259914aa67a9ca0f49e23f01e0049df5e64f7130fb34937c148b46cb49d) CLI with three modes: `--judge` (LLM batch), `--emit-prompts` (human worker prompt files), and `--collect` (aggregate worker verdicts), all writing JSON and optional markdown outputs.
> - Sets `temperature: 0` on Groq chat completions in [enrichment.py](https://github.com/EtanHey/brainlayer/pull/453/files#diff-f30fc27c3e1df5a572ae8a21eef1e434636d0811e71432bffe3067d139131a2c) for deterministic outputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddbe947.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool and end-to-end judge workflow for entity-cluster review: emit review prompts, collect worker verdicts, or run automated LLM judgement; produces JSON and optional Markdown outputs.
  * Evidence enrichment from local repositories and KG data to build self-contained review prompts.

* **Enhancement**
  * Reduced randomness for enrichment LLM calls to improve consistent outputs.

* **Tests**
  * Comprehensive test suite covering evidence gathering, prompt emission, verdict validation, collection, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->