### PR TITLE
fix(kg): land v1-conformance for kg_review_session on main (orphaned-commit recovery)

### DIFF
--- a/scripts/kg_review_session.py
+++ b/scripts/kg_review_session.py
@@ -3,7 +3,7 @@
 
 Usage:
     python3 scripts/kg_review_session.py next --batch B.json --decisions D.json [--category C]
-    python3 scripts/kg_review_session.py record --decisions D.json --cluster-id ID --decision-json '{...}'
+    python3 scripts/kg_review_session.py record --batch B.json --decisions D.json --cluster-id ID --decision-json '{...}'
     python3 scripts/kg_review_session.py rule --batch B.json --decisions D.json --rule-json '{...}'
     python3 scripts/kg_review_session.py stats --batch B.json --decisions D.json
 
@@ -36,6 +36,7 @@ def main() -> int:
     p_next.add_argument("--category")
 
     p_rec = sub.add_parser("record")
+    p_rec.add_argument("--batch", required=True)
     p_rec.add_argument("--decisions", required=True)
     p_rec.add_argument("--cluster-id", required=True)
     p_rec.add_argument("--decision-json", required=True)
@@ -58,7 +59,7 @@ def main() -> int:
             out["speak"] = speak_text(cluster)
         print(json.dumps(out, ensure_ascii=False, indent=2))
     elif args.cmd == "record":
-        stamped = record_decision(args.decisions, args.cluster_id, json.loads(args.decision_json))
+        stamped = record_decision(args.batch, args.decisions, args.cluster_id, json.loads(args.decision_json))
         print(json.dumps({"recorded": args.cluster_id, "decision": stamped}, ensure_ascii=False))
     elif args.cmd == "rule":
         n = apply_rule(args.batch, args.decisions, json.loads(args.rule_json))

--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -1,33 +1,47 @@
-"""KG flag-batch review session driver — shared by voice and visual review surfaces.
+"""KG flag-batch review session driver shared by voice and visual review surfaces.
 
 Pure-file module: reads the category-sorted flag-batch JSON emitted by phase-1
-(`eval_results/kg-phase1-flag-batch-*.json`) and maintains a decisions JSON that
-`kg_cleanup_apply.py` (or a follow-up applier) can consume. No DB access here.
+(`eval_results/kg-phase1-flag-batch-*.json`) and maintains the shared dashboard
+decisions JSON that `kg_cleanup_apply.py` (or a follow-up applier) can consume.
+No DB access here.
 
-Decisions file contract (v1 stub — coordinate changes via the kg-cleanup collab):
+Decisions file contract: `kg-flag-decisions-v1`, matching the dashboard export:
 
     {
-      "version": 1,
-      "decisions": {
-        "<category>:<stem>": {
-          "action": "merge_all" | "keep_all" | "mixed" | "skip",
-          "canonical_id": "...",            # merge_all only
-          "members": {"<id>": "merge|keep|prune"},  # mixed only
-          "note": "verbatim reviewer reasoning",
-          "source": "voice" | "visual" | "rule",
-          "decided_at": "ISO-8601"
+      "schema": "kg-flag-decisions-v1",
+      "source": "kg-phase1-flag-batch-2026-06-05",
+      "rules": {"<category>": "merge" | "keep"},
+      "per_category": {"<cat>": {total, explicit, by_rule, undecided, rule}},
+      "counts": {merge_clusters, rows_merged_away, keep, explicit, by_rule},
+      "merge": [
+        {
+          "stem": "...",
+          "category": "...",
+          "source": "explicit" | "rule" | "voice" | "voice-rule",
+          "canonical": {"id": "...", "name": "...", "type": "..."},
+          "members": [{"id": "...", "name": "...", "type": "..."}],
+          "note": "optional verbatim reasoning",
+          "decided_at": "optional ISO-8601 timestamp"
         }
-      },
-      "rules": [ {"match": {...}, "action": ..., "canonical": ..., "applied": N,
-                  "source": ..., "recorded_at": "ISO-8601"} ]
+      ],
+      "keep": [{"stem": "...", "category": "...", "source": "..."}]
     }
+
+Contract gaps handled additively:
+
+* `skip` is not exported as a decision, so it remains undecided in v1 counts.
+  The driver records optional top-level `skipped` rows so a voice session does
+  not re-ask skipped clusters.
+* `mixed` cannot be expressed in v1. The driver exports it as `keep` with a
+  `MIXED: <member map json>` note and also records optional top-level
+  `needs_v1_1` rows for the schema revision discussion.
 
 Merge-safety: every write is read-modify-write under an exclusive `fcntl.flock`
 on a sidecar lock file, then an atomic `os.replace`. Two writers (dashboard +
-voice session) interleave safely; last write per CLUSTER wins, never per file.
+voice session) interleave safely; last write per cluster wins, never per file.
 
 AIDEV-NOTE: engine-agnostic on purpose (Etan 2026-06-05: no lock-in to the old
-voice architecture) — the voice loop, a browser dashboard, and any future WS
+voice architecture) -- the voice loop, a browser dashboard, and any future WS
 bridge all drive this same module.
 """
 
@@ -36,13 +50,20 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-VALID_ACTIONS = {"merge_all", "keep_all", "mixed", "skip"}
+DECISIONS_SCHEMA = "kg-flag-decisions-v1"
+DEFAULT_SOURCE = "kg-phase1-flag-batch-2026-06-05"
+
+VALID_RECORD_ACTIONS = {"merge", "keep", "merge_all", "keep_all", "mixed", "skip"}
+VALID_RULE_ACTIONS = {"merge", "keep", "merge_all", "keep_all"}
 VALID_MEMBER_ACTIONS = {"merge", "keep", "prune"}
-VALID_SOURCES = {"voice", "visual", "rule"}
+VALID_ITEM_SOURCES = {"explicit", "rule", "voice", "voice-rule"}
+RULE_SOURCES = {"rule", "voice-rule"}
+CONTRACT_ITEM_FIELDS = {"stem", "category", "source", "canonical", "members", "note", "decided_at"}
 
 
 def cluster_id(category: str, stem: str) -> str:
@@ -67,20 +88,62 @@ def load_flag_batch(batch_path: str | Path) -> list[dict[str, Any]]:
     return clusters
 
 
-def _load_decisions(decisions_path: Path) -> dict[str, Any]:
+def _source_from_batch(batch_path: str | Path) -> str:
+    stem = Path(batch_path).stem
+    return stem or DEFAULT_SOURCE
+
+
+def _empty_decisions(source: str = DEFAULT_SOURCE) -> dict[str, Any]:
+    return {
+        "schema": DECISIONS_SCHEMA,
+        "source": source,
+        "rules": {},
+        "per_category": {},
+        "counts": {"merge_clusters": 0, "rows_merged_away": 0, "keep": 0, "explicit": 0, "by_rule": 0},
+        "merge": [],
+        "keep": [],
+    }
+
+
+def _ensure_v1_shape(data: dict[str, Any], source: str) -> dict[str, Any]:
+    if data.get("schema") != DECISIONS_SCHEMA:
+        raise ValueError(f"decisions file must use schema {DECISIONS_SCHEMA!r}; got {data.get('schema')!r}")
+    data.setdefault("source", source)
+    data.setdefault("rules", {})
+    data.setdefault("per_category", {})
+    data.setdefault("counts", _empty_decisions(source)["counts"])
+    data.setdefault("merge", [])
+    data.setdefault("keep", [])
+    if not isinstance(data["rules"], dict):
+        raise ValueError("decisions rules must be an object")
+    if not isinstance(data["merge"], list) or not isinstance(data["keep"], list):
+        raise ValueError("decisions merge and keep must be arrays")
+    return data
+
+
+def _load_decisions(decisions_path: Path, source: str = DEFAULT_SOURCE) -> dict[str, Any]:
     if decisions_path.exists():
-        return json.loads(decisions_path.read_text())
-    return {"version": 1, "decisions": {}, "rules": []}
+        data = json.loads(decisions_path.read_text())
+    else:
+        data = _empty_decisions(source)
+    return _ensure_v1_shape(data, source)
 
 
-def _write_locked(decisions_path: Path, mutate) -> Any:
+def _write_locked(
+    decisions_path: Path,
+    source: str,
+    clusters: list[dict[str, Any]],
+    mutate: Callable[[dict[str, Any]], Any],
+) -> Any:
     """Read-modify-write under flock + atomic replace. Returns mutate's result."""
     decisions_path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = decisions_path.with_suffix(decisions_path.suffix + ".lock")
     with open(lock_path, "w") as lock_fh:
         fcntl.flock(lock_fh, fcntl.LOCK_EX)
-        data = _load_decisions(decisions_path)
+        data = _load_decisions(decisions_path, source)
         result = mutate(data)
+        _recompute_rollups(data, clusters)
+        _drop_empty_optional_lists(data)
         tmp_path = decisions_path.with_suffix(decisions_path.suffix + ".tmp")
         with open(tmp_path, "w") as fh:
             json.dump(data, fh, indent=2, ensure_ascii=False)
@@ -94,37 +157,308 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _validate_decision(decision: dict[str, Any]) -> None:
-    action = decision.get("action")
-    if action not in VALID_ACTIONS:
-        raise ValueError(f"invalid action {action!r}; expected one of {sorted(VALID_ACTIONS)}")
-    if decision.get("source") not in VALID_SOURCES:
-        raise ValueError(f"invalid source {decision.get('source')!r}")
+def _normalize_action(action: Any) -> str:
+    if action not in VALID_RECORD_ACTIONS:
+        raise ValueError(f"invalid action {action!r}; expected one of {sorted(VALID_RECORD_ACTIONS)}")
+    if action == "merge_all":
+        return "merge"
+    if action == "keep_all":
+        return "keep"
+    return action
+
+
+def _normalize_rule_action(action: Any) -> str:
+    if action not in VALID_RULE_ACTIONS:
+        raise ValueError(f"invalid rule action {action!r}; rules accept merge or keep")
+    if action == "merge_all":
+        return "merge"
+    if action == "keep_all":
+        return "keep"
+    return action
+
+
+def _normalize_record_source(source: Any) -> str:
+    if source is None:
+        return "voice"
+    if source == "visual":
+        return "explicit"
+    if source not in VALID_ITEM_SOURCES:
+        raise ValueError(f"invalid source {source!r}; expected one of {sorted(VALID_ITEM_SOURCES)}")
+    return source
+
+
+def _normalize_rule_source(source: Any) -> str:
+    if source in (None, "voice", "voice-rule"):
+        return "voice-rule"
+    if source in ("visual", "explicit", "rule"):
+        return "rule"
+    raise ValueError(f"invalid rule source {source!r}")
+
+
+def _validate_member_map(members: Any) -> dict[str, str]:
+    if not isinstance(members, dict) or not members:
+        raise ValueError("mixed decision requires a non-empty members map")
+    bad = set(members.values()) - VALID_MEMBER_ACTIONS
+    if bad:
+        raise ValueError(f"invalid member actions: {sorted(bad)}")
+    return members
+
+
+def _validate_record_decision(decision: dict[str, Any]) -> tuple[str, str]:
+    action = _normalize_action(decision.get("action"))
+    source = _normalize_record_source(decision.get("source"))
     if action == "mixed":
-        members = decision.get("members")
-        if not isinstance(members, dict) or not members:
-            raise ValueError("mixed decision requires a non-empty members map")
-        bad = set(members.values()) - VALID_MEMBER_ACTIONS
-        if bad:
-            raise ValueError(f"invalid member actions: {sorted(bad)}")
-    if action == "merge_all" and not decision.get("canonical_id"):
-        raise ValueError("merge_all decision requires canonical_id")
+        _validate_member_map(decision.get("members"))
+    return action, source
+
+
+def _key(category: str, stem: str) -> tuple[str, str]:
+    return category, stem
+
+
+def _cluster_key(cluster: dict[str, Any]) -> tuple[str, str]:
+    return _key(cluster["category"], cluster["stem"])
+
+
+def _item_key(item: dict[str, Any]) -> tuple[str, str]:
+    return _key(item["category"], item["stem"])
+
+
+def _find_cluster(clusters: list[dict[str, Any]], cid: str) -> dict[str, Any]:
+    for cluster in clusters:
+        if cluster["cluster_id"] == cid:
+            return cluster
+    raise ValueError(f"unknown cluster_id {cid!r}")
+
+
+def _member_ref(member: dict[str, Any]) -> dict[str, Any]:
+    return {"id": member["id"], "name": member["name"], "type": member["type"]}
+
+
+def _canonical_override(decision: dict[str, Any]) -> tuple[str | None, str | None]:
+    canonical = decision.get("canonical")
+    canonical_id = decision.get("canonical_id")
+    canonical_name = decision.get("canonical_name")
+    if isinstance(canonical, dict):
+        canonical_id = canonical_id or canonical.get("id")
+        canonical_name = canonical_name or canonical.get("name")
+    elif isinstance(canonical, str):
+        canonical_id = canonical_id or canonical
+        canonical_name = canonical_name or canonical
+    return canonical_id, canonical_name
+
+
+def _select_canonical(cluster: dict[str, Any], decision: dict[str, Any] | None = None) -> dict[str, Any]:
+    members = cluster["members"]
+    if not members:
+        raise ValueError(f"cluster {cluster['cluster_id']!r} has no members")
+    if not decision:
+        return members[0]
+    canonical_id, canonical_name = _canonical_override(decision)
+    if not canonical_id and not canonical_name:
+        return members[0]
+    for member in members:
+        if canonical_id and member["id"] == canonical_id:
+            return member
+        if canonical_name and member["name"] == canonical_name:
+            return member
+    raise ValueError(
+        f"canonical override {canonical_id or canonical_name!r} is not in cluster {cluster['cluster_id']!r}"
+    )
+
+
+def _merge_item(
+    cluster: dict[str, Any],
+    source: str,
+    decided_at: str,
+    note: str | None = None,
+    decision: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    canonical = _select_canonical(cluster, decision)
+    item: dict[str, Any] = {
+        "stem": cluster["stem"],
+        "category": cluster["category"],
+        "source": source,
+        "canonical": _member_ref(canonical),
+        "members": [_member_ref(member) for member in cluster["members"] if member["id"] != canonical["id"]],
+        "decided_at": decided_at,
+    }
+    if note:
+        item["note"] = note
+    return item
+
+
+def _keep_item(cluster: dict[str, Any], source: str, decided_at: str, note: str | None = None) -> dict[str, Any]:
+    item = {"stem": cluster["stem"], "category": cluster["category"], "source": source, "decided_at": decided_at}
+    if note:
+        item["note"] = note
+    return item
+
+
+def _skip_item(cluster: dict[str, Any], source: str, decided_at: str, note: str | None = None) -> dict[str, Any]:
+    item = {"stem": cluster["stem"], "category": cluster["category"], "source": source, "decided_at": decided_at}
+    if note:
+        item["note"] = note
+    return item
+
+
+def _remove_keyed(data: dict[str, Any], key: tuple[str, str], fields: tuple[str, ...] = ("merge", "keep")) -> None:
+    for field in fields:
+        data[field] = [item for item in data.get(field, []) if _item_key(item) != key]
+
+
+def _upsert_keyed(data: dict[str, Any], field: str, item: dict[str, Any]) -> None:
+    key = _item_key(item)
+    data[field] = [old for old in data.get(field, []) if _item_key(old) != key]
+    data[field].append(item)
+
+
+def _upsert_optional(data: dict[str, Any], field: str, item: dict[str, Any]) -> None:
+    key = _item_key(item)
+    data[field] = [old for old in data.get(field, []) if _item_key(old) != key]
+    data[field].append(item)
+
+
+def _remove_optional(data: dict[str, Any], key: tuple[str, str], field: str) -> None:
+    if field in data:
+        data[field] = [item for item in data[field] if _item_key(item) != key]
+
+
+def _foreign_fields(data: dict[str, Any], key: tuple[str, str], fields: tuple[str, ...]) -> dict[str, Any]:
+    extras: dict[str, Any] = {}
+    for field in fields:
+        for item in data.get(field, []):
+            if _item_key(item) == key:
+                extras.update({k: v for k, v in item.items() if k not in CONTRACT_ITEM_FIELDS})
+    return extras
+
+
+def _with_foreign_fields(item: dict[str, Any], foreign: dict[str, Any]) -> dict[str, Any]:
+    return {**foreign, **item}
+
+
+def _drop_empty_optional_lists(data: dict[str, Any]) -> None:
+    for field in ("skipped", "needs_v1_1"):
+        if field in data and not data[field]:
+            del data[field]
+
+
+def _decided_keys(data: dict[str, Any]) -> set[tuple[str, str]]:
+    return {_item_key(item) for item in data.get("merge", []) + data.get("keep", [])}
+
+
+def _skipped_keys(data: dict[str, Any]) -> set[tuple[str, str]]:
+    return {_item_key(item) for item in data.get("skipped", [])}
+
+
+def _recompute_rollups(data: dict[str, Any], clusters: list[dict[str, Any]]) -> None:
+    cluster_keys = {_cluster_key(cluster) for cluster in clusters}
+    per_category: dict[str, dict[str, Any]] = {}
+    for cluster in clusters:
+        row = per_category.setdefault(
+            cluster["category"],
+            {"total": 0, "explicit": 0, "by_rule": 0, "undecided": 0, "rule": data["rules"].get(cluster["category"])},
+        )
+        row["total"] += 1
+
+    merge = data.get("merge", [])
+    keep = data.get("keep", [])
+    exported = merge + keep
+    seen: set[tuple[str, str]] = set()
+    for item in exported:
+        item_key = _item_key(item)
+        if item_key in seen:
+            raise ValueError(f"duplicate decision for {item['category']}:{item['stem']}")
+        seen.add(item_key)
+        if item_key not in cluster_keys:
+            raise ValueError(f"decision references unknown cluster {item['category']}:{item['stem']}")
+        if item["source"] not in VALID_ITEM_SOURCES:
+            raise ValueError(f"invalid decision source {item['source']!r}")
+        row = per_category[item["category"]]
+        if item["source"] in RULE_SOURCES:
+            row["by_rule"] += 1
+        else:
+            row["explicit"] += 1
+
+    for category, rule in data["rules"].items():
+        if rule not in {"merge", "keep"}:
+            raise ValueError(f"invalid rule for {category!r}: {rule!r}")
+        per_category.setdefault(category, {"total": 0, "explicit": 0, "by_rule": 0, "undecided": 0, "rule": rule})
+        per_category[category]["rule"] = rule
+
+    for row in per_category.values():
+        row["undecided"] = row["total"] - row["explicit"] - row["by_rule"]
+        if row["undecided"] < 0:
+            raise ValueError("decision counts exceed category total")
+
+    data["per_category"] = per_category
+    data["counts"] = {
+        "merge_clusters": len(merge),
+        "rows_merged_away": sum(len(item["members"]) for item in merge),
+        "keep": len(keep),
+        "explicit": sum(1 for item in exported if item["source"] not in RULE_SOURCES),
+        "by_rule": sum(1 for item in exported if item["source"] in RULE_SOURCES),
+    }
 
 
 def record_decision(
+    batch_path: str | Path,
     decisions_path: str | Path,
     cluster_id: str,
     decision: dict[str, Any],
 ) -> dict[str, Any]:
-    """Validate + persist one cluster decision. Stamps decided_at."""
-    _validate_decision(decision)
-    stamped = {**decision, "decided_at": _now()}
+    """Validate and persist one cluster decision in kg-flag-decisions-v1 shape."""
+    action, source = _validate_record_decision(decision)
+    clusters = load_flag_batch(batch_path)
+    cluster = _find_cluster(clusters, cluster_id)
+    source_name = _source_from_batch(batch_path)
+    decided_at = _now()
+    key = _cluster_key(cluster)
+    note = decision.get("note")
 
     def mutate(data: dict[str, Any]) -> dict[str, Any]:
-        data["decisions"][cluster_id] = stamped
-        return stamped
+        foreign = _foreign_fields(data, key, ("merge", "keep", "skipped"))
+        needs_foreign = _foreign_fields(data, key, ("needs_v1_1",))
+        _remove_keyed(data, key, fields=("merge", "keep"))
+        _remove_optional(data, key, "skipped")
+        _remove_optional(data, key, "needs_v1_1")
 
-    return _write_locked(Path(decisions_path), mutate)
+        if action == "skip":
+            item = _with_foreign_fields(_skip_item(cluster, source, decided_at, note), foreign)
+            _upsert_optional(data, "skipped", item)
+            return item
+
+        if action == "mixed":
+            member_map = _validate_member_map(decision.get("members"))
+            mixed_json = json.dumps(member_map, sort_keys=True, ensure_ascii=False)
+            mixed_note = f"MIXED: {mixed_json}"
+            if note:
+                mixed_note = f"{mixed_note}; {note}"
+            item = _with_foreign_fields(_keep_item(cluster, source, decided_at, mixed_note), foreign)
+            _upsert_keyed(data, "keep", item)
+            needs_item: dict[str, Any] = {
+                "stem": cluster["stem"],
+                "category": cluster["category"],
+                "source": source,
+                "members": member_map,
+                "decided_at": decided_at,
+            }
+            if note:
+                needs_item["note"] = note
+            needs_item = _with_foreign_fields(needs_item, needs_foreign)
+            _upsert_optional(data, "needs_v1_1", needs_item)
+            return item
+
+        if action == "merge":
+            item = _with_foreign_fields(_merge_item(cluster, source, decided_at, note, decision), foreign)
+            _upsert_keyed(data, "merge", item)
+            return item
+
+        item = _with_foreign_fields(_keep_item(cluster, source, decided_at, note), foreign)
+        _upsert_keyed(data, "keep", item)
+        return item
+
+    return _write_locked(Path(decisions_path), source_name, clusters, mutate)
 
 
 def next_undecided(
@@ -132,20 +466,18 @@ def next_undecided(
     decisions_path: str | Path,
     category: str | None = None,
 ) -> dict[str, Any] | None:
-    """Next cluster (batch order) without a recorded decision."""
-    decided = set(_load_decisions(Path(decisions_path))["decisions"])
-    for cluster in load_flag_batch(batch_path):
+    """Next cluster (batch order) without an exported decision or session skip."""
+    clusters = load_flag_batch(batch_path)
+    data = _load_decisions(Path(decisions_path), _source_from_batch(batch_path))
+    decided = _decided_keys(data)
+    skipped = _skipped_keys(data)
+    for cluster in clusters:
         if category and cluster["category"] != category:
             continue
-        if cluster["cluster_id"] not in decided:
+        key = _cluster_key(cluster)
+        if key not in decided and key not in skipped:
             return cluster
     return None
-
-
-def _pick_canonical(members: list[dict[str, Any]], strategy: str) -> str:
-    if strategy != "most_chunks":
-        raise ValueError(f"unknown canonical strategy {strategy!r}")
-    return max(members, key=lambda m: m.get("chunks", 0))["id"]
 
 
 def apply_rule(
@@ -153,46 +485,53 @@ def apply_rule(
     decisions_path: str | Path,
     rule: dict[str, Any],
 ) -> int:
-    """Bulk-decide all UNDECIDED clusters matching the rule. Never overwrites.
+    """Bulk-decide all undecided clusters in one category. Never overwrites.
 
-    rule = {match: {category?, stem_contains?}, action, canonical?, note?, source}
-    Returns number of clusters decided.
+    rule = {match: {category}, action: "merge"|"keep", note?, source?}
+    Returns number of clusters newly decided.
 
-    `mixed` is rejected for rules: it needs a per-member map, which a bulk
-    rule cannot supply for arbitrary clusters.
+    `mixed` is rejected for rules: it needs a per-member map, which a bulk rule
+    cannot supply for arbitrary clusters. `skip` is also rejected because v1
+    rules are only per-category merge/keep decisions.
     """
-    if rule.get("action") not in VALID_ACTIONS - {"mixed"}:
-        raise ValueError(
-            f"invalid rule action {rule.get('action')!r}; "
-            f"rules accept {sorted(VALID_ACTIONS - {'mixed'})} (mixed is per-cluster only)"
-        )
+    action = _normalize_rule_action(rule.get("action"))
+    source = _normalize_rule_source(rule.get("source"))
     match = rule.get("match", {})
+    category = match.get("category") or rule.get("category")
+    if not category:
+        raise ValueError("rule requires match.category")
+    if set(match) - {"category"}:
+        raise ValueError("kg-flag-decisions-v1 rules are per-category only")
+
     clusters = load_flag_batch(batch_path)
+    source_name = _source_from_batch(batch_path)
+    decided_at = _now()
+    note = rule.get("note")
 
     def mutate(data: dict[str, Any]) -> int:
         applied = 0
         for cluster in clusters:
-            if cluster["cluster_id"] in data["decisions"]:
-                continue  # manual decisions always win; rules never overwrite
-            if match.get("category") and cluster["category"] != match["category"]:
+            if cluster["category"] != category:
                 continue
-            if match.get("stem_contains") and match["stem_contains"] not in cluster["stem"]:
+            key = _cluster_key(cluster)
+            if key in _decided_keys(data):
                 continue
-            decision: dict[str, Any] = {
-                "action": rule["action"],
-                "source": "rule",
-                "decided_at": _now(),
-            }
-            if rule.get("note"):
-                decision["note"] = rule["note"]
-            if rule["action"] == "merge_all":
-                decision["canonical_id"] = _pick_canonical(cluster["members"], rule.get("canonical", "most_chunks"))
-            data["decisions"][cluster["cluster_id"]] = decision
+            foreign = _foreign_fields(data, key, ("skipped",))
+            _remove_optional(data, key, "skipped")
+            if action == "merge":
+                _upsert_keyed(
+                    data, "merge", _with_foreign_fields(_merge_item(cluster, source, decided_at, note), foreign)
+                )
+            else:
+                _upsert_keyed(
+                    data, "keep", _with_foreign_fields(_keep_item(cluster, source, decided_at, note), foreign)
+                )
             applied += 1
-        data["rules"].append({**rule, "applied": applied, "recorded_at": _now()})
+        if applied:
+            data["rules"][category] = action
         return applied
 
-    return _write_locked(Path(decisions_path), mutate)
+    return _write_locked(Path(decisions_path), source_name, clusters, mutate)
 
 
 def speak_text(cluster: dict[str, Any]) -> str:
@@ -211,11 +550,7 @@ def speak_text(cluster: dict[str, Any]) -> str:
 
 
 def stats(batch_path: str | Path, decisions_path: str | Path) -> dict[str, Any]:
-    decided = set(_load_decisions(Path(decisions_path))["decisions"])
-    out: dict[str, Any] = {}
-    for cluster in load_flag_batch(batch_path):
-        bucket = out.setdefault(cluster["category"], {"total": 0, "decided": 0})
-        bucket["total"] += 1
-        if cluster["cluster_id"] in decided:
-            bucket["decided"] += 1
-    return out
+    clusters = load_flag_batch(batch_path)
+    data = _load_decisions(Path(decisions_path), _source_from_batch(batch_path))
+    _recompute_rollups(data, clusters)
+    return {"counts": data["counts"], "per_category": data["per_category"]}

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -1,7 +1,7 @@
 """Tests for kg_review_session — voice/visual flag-batch review session driver.
 
-Pure-file driver: reads the flag-batch JSON, maintains a decisions JSON
-(stub contract, merge-safe for two writers), no DB access.
+Pure-file driver: reads the flag-batch JSON, maintains the dashboard-compatible
+kg-flag-decisions-v1 file, and has no DB access.
 """
 
 import json
@@ -43,12 +43,34 @@ FLAG_BATCH = {
             "stem": "docker",
             "size": 2,
             "members": [
-                {"id": "d1", "name": "docker", "type": "tool", "chunks": 50},
                 {"id": "d2", "name": "Docker", "type": "tool", "chunks": 70},
+                {"id": "d1", "name": "docker", "type": "tool", "chunks": 50},
             ],
         },
     ],
 }
+
+DECISIONS_SCHEMA = "kg-flag-decisions-v1"
+V1_SOURCES = {"explicit", "rule", "voice", "voice-rule"}
+RULE_SOURCES = {"rule", "voice-rule"}
+
+
+def assert_v1(data):
+    assert data["schema"] == DECISIONS_SCHEMA
+    assert "version" not in data
+    assert "decisions" not in data
+    assert set(data) >= {"schema", "source", "rules", "per_category", "counts", "merge", "keep"}
+
+    exported = data["merge"] + data["keep"]
+    assert all(item["source"] in V1_SOURCES for item in exported)
+    assert data["counts"]["merge_clusters"] == len(data["merge"])
+    assert data["counts"]["rows_merged_away"] == sum(len(item["members"]) for item in data["merge"])
+    assert data["counts"]["keep"] == len(data["keep"])
+    assert data["counts"]["explicit"] == sum(1 for item in exported if item["source"] not in RULE_SOURCES)
+    assert data["counts"]["by_rule"] == sum(1 for item in exported if item["source"] in RULE_SOURCES)
+    for cat, row in data["per_category"].items():
+        assert set(row) == {"total", "explicit", "by_rule", "undecided", "rule"}, cat
+        assert row["explicit"] + row["by_rule"] + row["undecided"] == row["total"], cat
 
 
 @pytest.fixture
@@ -75,63 +97,119 @@ def test_load_flag_batch_flattens_with_ids(batch_file):
     assert all("category" in c and "members" in c for c in clusters)
 
 
-def test_next_undecided_walks_category_in_order(batch_file, decisions_file):
+def test_next_undecided_is_idempotent_until_decision_or_skip(batch_file, decisions_file):
+    first = next_undecided(batch_file, decisions_file, category="case-only")
+    second = next_undecided(batch_file, decisions_file, category="case-only")
+    assert first["cluster_id"] == "case-only:agent"
+    assert second["cluster_id"] == "case-only:agent"
+
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="case-only:agent",
+        decision={"action": "skip", "note": "ask later", "source": "voice"},
+    )
+
     c = next_undecided(batch_file, decisions_file, category="case-only")
-    assert c["cluster_id"] == "case-only:agent"
+    assert c["cluster_id"] == "case-only:docker"
+    data = json.loads(decisions_file.read_text())
+    assert data["merge"] == []
+    assert data["keep"] == []
+    assert data["skipped"][0]["stem"] == "agent"
+    assert data["skipped"][0]["note"] == "ask later"
+    assert data["per_category"]["case-only"]["undecided"] == 2
+    assert_v1(data)
 
 
 def test_record_decision_then_next_advances(batch_file, decisions_file):
     record_decision(
+        batch_file,
         decisions_file,
         cluster_id="case-only:agent",
         decision={
-            "action": "keep_all",
+            "action": "keep",
             "note": "topic tag vs concept, different things",
             "source": "voice",
         },
     )
     c = next_undecided(batch_file, decisions_file, category="case-only")
     assert c["cluster_id"] == "case-only:docker"
+    data = json.loads(decisions_file.read_text())
+    assert data["keep"][0]["source"] == "voice"
+    assert data["keep"][0]["note"] == "topic tag vs concept, different things"
+    assert "decided_at" in data["keep"][0]
+    assert data["counts"]["keep"] == 1
+    assert data["counts"]["explicit"] == 1
+    assert_v1(data)
 
 
-def test_record_decision_is_merge_safe_and_stamped(decisions_file):
+def test_record_decision_is_merge_safe_and_stamped(batch_file, decisions_file):
     record_decision(
+        batch_file,
         decisions_file,
         cluster_id="case-only:docker",
-        decision={"action": "merge_all", "canonical_id": "d2", "source": "voice"},
+        decision={
+            "action": "merge",
+            "canonical_id": "d1",
+            "note": "lower-case is the alias I meant",
+            "source": "voice",
+        },
     )
     data = json.loads(decisions_file.read_text())
-    d = data["decisions"]["case-only:docker"]
-    assert d["action"] == "merge_all"
-    assert d["canonical_id"] == "d2"
+    d = data["merge"][0]
+    assert d["canonical"]["id"] == "d1"  # user-named canonical overrides members[0]
+    assert [m["id"] for m in d["members"]] == ["d2"]
     assert d["source"] == "voice"
+    assert d["note"] == "lower-case is the alias I meant"
     assert "decided_at" in d
     # second writer updates a different cluster without clobbering
     record_decision(
+        batch_file,
         decisions_file,
         cluster_id="case-only:agent",
-        decision={"action": "keep_all", "source": "visual"},
+        decision={"action": "keep", "source": "explicit"},
     )
     data = json.loads(decisions_file.read_text())
-    assert set(data["decisions"]) == {"case-only:docker", "case-only:agent"}
+    assert {(d["category"], d["stem"]) for d in data["merge"]} == {("case-only", "docker")}
+    assert {(d["category"], d["stem"]) for d in data["keep"]} == {("case-only", "agent")}
+    assert_v1(data)
 
 
-def test_record_decision_validates_action(decisions_file):
+def test_record_decision_validates_action(batch_file, decisions_file):
     with pytest.raises(ValueError):
         record_decision(
+            batch_file,
             decisions_file,
             cluster_id="x:y",
             decision={"action": "explode", "source": "voice"},
         )
 
 
-def test_mixed_decision_requires_member_map(decisions_file):
+def test_mixed_decision_requires_member_map_and_exports_v1_gap(batch_file, decisions_file):
     with pytest.raises(ValueError):
         record_decision(
+            batch_file,
             decisions_file,
             cluster_id="x:y",
             decision={"action": "mixed", "source": "voice"},
         )
+
+    member_map = {"p1": "merge", "t1": "keep", "t2": "keep"}
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="diagnosis-flag:agent c",
+        decision={"action": "mixed", "members": member_map, "note": "person vs tools", "source": "voice"},
+    )
+    data = json.loads(decisions_file.read_text())
+    assert data["merge"] == []
+    assert data["keep"][0]["stem"] == "agent c"
+    assert data["keep"][0]["note"].startswith('MIXED: {"p1": "merge", "t1": "keep", "t2": "keep"}')
+    assert data["needs_v1_1"][0]["members"] == member_map
+    assert data["needs_v1_1"][0]["note"] == "person vs tools"
+    assert data["counts"]["keep"] == 1
+    assert data["counts"]["explicit"] == 1
+    assert_v1(data)
 
 
 def test_speak_text_mentions_names_types_and_counts(batch_file):
@@ -144,59 +222,63 @@ def test_speak_text_mentions_names_types_and_counts(batch_file):
 
 
 def test_apply_rule_bulk_decides_matching_undecided(batch_file, decisions_file):
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="case-only:agent",
+        decision={"action": "keep", "source": "voice"},
+    )
     n = apply_rule(
         batch_file,
         decisions_file,
         rule={
             "match": {"category": "case-only"},
-            "action": "merge_all",
-            "canonical": "most_chunks",
+            "action": "merge",
             "note": "case-only variants merge, most chunks wins",
             "source": "voice",
         },
     )
-    assert n == 2
+    assert n == 1
     data = json.loads(decisions_file.read_text())
-    docker = data["decisions"]["case-only:docker"]
-    assert docker["action"] == "merge_all"
-    assert docker["canonical_id"] == "d2"  # 70 chunks > 50
-    assert docker["source"] == "rule"
-    assert data["rules"], "rule itself must be recorded"
-    # rule must NOT overwrite an existing manual decision
-    record_decision(
-        decisions_file,
-        cluster_id="diagnosis-flag:agent c",
-        decision={"action": "keep_all", "source": "voice"},
-    )
+    docker = data["merge"][0]
+    assert docker["canonical"]["id"] == "d2"  # members[0] from the flag batch
+    assert docker["source"] == "voice-rule"
+    assert docker["note"] == "case-only variants merge, most chunks wins"
+    assert data["rules"] == {"case-only": "merge"}
+    assert data["keep"][0]["stem"] == "agent"  # rule must NOT overwrite manual decisions
+    assert data["per_category"]["case-only"] == {
+        "total": 2,
+        "explicit": 1,
+        "by_rule": 1,
+        "undecided": 0,
+        "rule": "merge",
+    }
+    assert_v1(data)
+
     n2 = apply_rule(
         batch_file,
         decisions_file,
         rule={
-            "match": {"category": "diagnosis-flag"},
-            "action": "merge_all",
-            "canonical": "most_chunks",
+            "match": {"category": "case-only"},
+            "action": "keep",
             "source": "voice",
         },
     )
     assert n2 == 0
+    data = json.loads(decisions_file.read_text())
+    assert data["keep"][0]["stem"] == "agent"
 
 
 def test_apply_rule_rejects_mixed_and_invalid_actions(batch_file, decisions_file):
-    # mixed cannot be bulk-applied: it requires a per-member map per cluster
-    with pytest.raises(ValueError):
-        apply_rule(
-            batch_file,
-            decisions_file,
-            rule={"match": {"category": "case-only"}, "action": "mixed", "source": "voice"},
-        )
-    with pytest.raises(ValueError):
-        apply_rule(
-            batch_file,
-            decisions_file,
-            rule={"match": {"category": "case-only"}, "action": "explode", "source": "voice"},
-        )
+    for action in ("mixed", "skip", "explode"):
+        with pytest.raises(ValueError):
+            apply_rule(
+                batch_file,
+                decisions_file,
+                rule={"match": {"category": "case-only"}, "action": action, "source": "voice"},
+            )
     # nothing persisted by rejected rules
-    assert not decisions_file.exists() or json.loads(decisions_file.read_text())["decisions"] == {}
+    assert not decisions_file.exists()
 
 
 def test_cli_runs_from_plain_checkout_without_pythonpath(batch_file, decisions_file):
@@ -227,11 +309,93 @@ def test_cli_runs_from_plain_checkout_without_pythonpath(batch_file, decisions_f
 
 def test_stats_reports_progress(batch_file, decisions_file):
     record_decision(
+        batch_file,
         decisions_file,
         cluster_id="case-only:agent",
-        decision={"action": "keep_all", "source": "voice"},
+        decision={"action": "keep", "source": "voice"},
     )
     s = stats(batch_file, decisions_file)
-    assert s["case-only"]["total"] == 2
-    assert s["case-only"]["decided"] == 1
-    assert s["diagnosis-flag"]["decided"] == 0
+    assert s["per_category"]["case-only"]["total"] == 2
+    assert s["per_category"]["case-only"]["explicit"] == 1
+    assert s["per_category"]["case-only"]["undecided"] == 1
+    assert s["per_category"]["diagnosis-flag"]["undecided"] == 1
+    assert s["counts"]["keep"] == 1
+
+
+def test_dashboard_export_round_trips_voice_decision_as_v1(batch_file, decisions_file):
+    dashboard_export = {
+        "schema": DECISIONS_SCHEMA,
+        "source": "kg-phase1-flag-batch-2026-06-05",
+        "rules": {},
+        "per_category": {
+            "diagnosis-flag": {"total": 1, "explicit": 0, "by_rule": 0, "undecided": 1, "rule": None},
+            "case-only": {"total": 2, "explicit": 1, "by_rule": 0, "undecided": 1, "rule": None},
+        },
+        "counts": {"merge_clusters": 1, "rows_merged_away": 1, "keep": 0, "explicit": 1, "by_rule": 0},
+        "dashboard_state": {"sample": True},
+        "merge": [
+            {
+                "stem": "agent",
+                "category": "case-only",
+                "source": "explicit",
+                "canonical": {"id": "a1", "name": "agent", "type": "topic"},
+                "members": [{"id": "a2", "name": "Agent", "type": "concept"}],
+                "dashboard_flag": "untouched",
+            }
+        ],
+        "keep": [],
+    }
+    decisions_file.write_text(json.dumps(dashboard_export))
+
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="diagnosis-flag:agent c",
+        decision={"action": "keep", "note": "real person vs tools", "source": "voice"},
+    )
+
+    data = json.loads(decisions_file.read_text())
+    assert data["schema"] == dashboard_export["schema"]
+    assert data["source"] == dashboard_export["source"]
+    assert data["rules"] == dashboard_export["rules"]
+    assert data["dashboard_state"] == dashboard_export["dashboard_state"]
+    assert data["merge"] == dashboard_export["merge"]
+    assert data["keep"][0]["stem"] == "agent c"
+    assert data["counts"] == {"merge_clusters": 1, "rows_merged_away": 1, "keep": 1, "explicit": 2, "by_rule": 0}
+    assert_v1(data)
+
+
+def test_voice_rewrite_preserves_unknown_dashboard_fields(batch_file, decisions_file):
+    decisions_file.write_text(
+        json.dumps(
+            {
+                "schema": DECISIONS_SCHEMA,
+                "source": "kg-phase1-flag-batch-2026-06-05",
+                "rules": {},
+                "per_category": {},
+                "counts": {},
+                "merge": [],
+                "keep": [
+                    {
+                        "stem": "agent",
+                        "category": "case-only",
+                        "source": "explicit",
+                        "dashboard_row_id": "row-17",
+                    }
+                ],
+            }
+        )
+    )
+
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="case-only:agent",
+        decision={"action": "keep", "note": "non-deterministic voice answer", "source": "voice"},
+    )
+
+    data = json.loads(decisions_file.read_text())
+    assert data["keep"][0]["source"] == "voice"
+    assert data["keep"][0]["note"] == "non-deterministic voice answer"
+    assert data["keep"][0]["dashboard_row_id"] == "row-17"
+    assert_v1(data)


### PR DESCRIPTION
## Summary
Cherry-pick of `b2a8cf94` (W2's v1-conformance: kg_review_session driver → `kg-flag-decisions-v1` schema — note/decided_at fields, skipped[]/needs_v1_1[] handling, legacy normalization, flock last-write-wins) onto fresh `origin/main`.

## Context
The original commit was pushed to #451's branch AFTER that PR merged (12:26) — verified absent from main via merge-base. The live voice server runs the conformed copy from a worktree (tonight unaffected), but main's driver was stale: Etan's next fresh run would mismatch the merged voice page. The diff was already lead-approved by the voice lead with its 14 tests rerun green.

## Test plan
- [x] Clean cherry-pick, zero conflicts
- [x] `tests/test_kg_review_session.py`: 14/14 on the new branch
- [x] Full pre-push gate green

**Review-required — orc merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk decisions contract and CLI for `record`; wrong rollout could break voice/dashboard interop, though flock semantics and extensive tests mitigate regression risk.
> 
> **Overview**
> Replaces the stub `version`/`decisions` map with the **`kg-flag-decisions-v1`** shape used by the dashboard and **`kg_cleanup_apply`**: `merge`/`keep` arrays, `rules`, `counts`, and `per_category` rollups recomputed on every locked write.
> 
> **`record_decision`** now requires the flag **`--batch`** (CLI and API) so merges can emit canonical/member refs from cluster data; it normalizes legacy actions (`merge_all`/`keep_all` → `merge`/`keep`, `visual` → `explicit`), stamps **`note`** / **`decided_at`**, and handles v1 gaps via optional **`skipped`** (skip without counting as decided) and **`needs_v1_1`** plus a **`MIXED:`** note on **`keep`** for mixed decisions. Dashboard-only fields on existing rows are preserved on rewrite.
> 
> **`apply_rule`** is narrowed to per-category bulk **`merge`**/**`keep`** (no `stem_contains` or `most_chunks` canonical strategy); rules are stored in **`rules[category]`** with **`voice-rule`** vs **`rule`** sources. **`next_undecided`** and **`stats`** use the new rollups; manual decisions still win over rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de2b643fb6ebc47490fb739a6accdad8e12b249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `kg_review_session` decisions format to v1 schema contract
> - Rewrites [kg_review_session.py](https://github.com/EtanHey/brainlayer/pull/454/files#diff-a3ec1e9b0f8f2c609df6eec2ed276fc4776b5e0df1f6532ff43950b785cc9a1c) to produce and consume a new `kg-flag-decisions-v1` schema with top-level `merge`/`keep` arrays, per-category `rules` map, and auto-computed `counts`/`per_category` rollups on every write.
> - Adds `record_decision`, `next_undecided`, `apply_rule`, and `stats` implementations aligned to v1 semantics: `skip` writes to an optional `skipped` list (excluded from export), `mixed` writes a `keep` entry plus an auxiliary `needs_v1_1` entry, and `merge` supports canonical override by id or name.
> - Adds a `--batch` required argument to the `record` CLI subcommand in [scripts/kg_review_session.py](https://github.com/EtanHey/brainlayer/pull/454/files#diff-69f97868200aab4809d64d5c2fcc7924c546a285770244ed7e3bf15dd59a6411); calls without `--batch` will error.
> - Updates [tests/test_kg_review_session.py](https://github.com/EtanHey/brainlayer/pull/454/files#diff-f3e0a580e40f8225f12f8dc5d29235b330a08652d7b7fd3f5ed13cb38af85b87) to cover v1 schema validation, skip/mixed behaviors, canonical selection, foreign-field preservation, and rule application semantics.
> - Behavioral Change: existing decisions files in the legacy schema are migrated/validated to v1 shape on first load; missing keys are auto-populated rather than raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7de2b64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->