### PR TITLE
feat: add verified JSONL Drive backups

### DIFF
--- a/launchd/com.brainlayer.jsonl-backup.plist
+++ b/launchd/com.brainlayer.jsonl-backup.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.brainlayer.jsonl-backup</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/env</string>
+		<string>python3</string>
+		<string>-m</string>
+		<string>brainlayer.jsonl_backup</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>5</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>__HOME__/.local/share/brainlayer/logs/jsonl-backup.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/.local/share/brainlayer/logs/jsonl-backup.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+		<key>PYTHONPATH</key>
+		<string>__BRAINLAYER_DIR__/src</string>
+		<key>BRAINLAYER_BACKUP_TIMEOUT_SECONDS</key>
+		<string>1800</string>
+		<key>BRAINLAYER_JSONL_BACKUP_DRIVE_FOLDER</key>
+		<string>Brain Drive/06_ARCHIVE/backups/claude-jsonl</string>
+	</dict>
+	<key>Nice</key>
+	<integer>15</integer>
+	<key>ExitTimeOut</key>
+	<integer>1800</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityIO</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/launchd/com.brainlayer.jsonl-backup.plist
+++ b/scripts/launchd/com.brainlayer.jsonl-backup.plist
@@ -6,10 +6,7 @@
 	<string>com.brainlayer.jsonl-backup</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/bin/env</string>
-		<string>python3</string>
-		<string>-m</string>
-		<string>brainlayer.jsonl_backup</string>
+		<string>__HOME__/.local/lib/brainlayer/jsonl-backup.sh</string>
 	</array>
 	<key>StartCalendarInterval</key>
 	<dict>
@@ -19,19 +16,17 @@
 		<integer>0</integer>
 	</dict>
 	<key>StandardOutPath</key>
-	<string>__HOME__/.local/share/brainlayer/logs/jsonl-backup.log</string>
+	<string>__HOME__/Library/Logs/brainlayer/jsonl-backup.out.log</string>
 	<key>StandardErrorPath</key>
-	<string>__HOME__/.local/share/brainlayer/logs/jsonl-backup.log</string>
+	<string>__HOME__/Library/Logs/brainlayer/jsonl-backup.err.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
-		<key>PYTHONPATH</key>
-		<string>__BRAINLAYER_DIR__/src</string>
-		<key>BRAINLAYER_BACKUP_TIMEOUT_SECONDS</key>
-		<string>1800</string>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
 		<key>BRAINLAYER_JSONL_BACKUP_DRIVE_FOLDER</key>
 		<string>Brain Drive/06_ARCHIVE/backups/claude-jsonl</string>
+		<key>BRAINLAYER_REPO_ROOT</key>
+		<string>__BRAINLAYER_DIR__</string>
 	</dict>
 	<key>Nice</key>
 	<integer>15</integer>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -13,6 +13,7 @@
 #   ./scripts/launchd/install.sh checkpoint   # Install WAL checkpoint only
 #   ./scripts/launchd/install.sh repair-fts   # Install weekly explicit FTS repair
 #   ./scripts/launchd/install.sh backup       # Install daily DB backup only
+#   ./scripts/launchd/install.sh jsonl-backup # Install daily JSONL backup only
 #   ./scripts/launchd/install.sh maintenance  # Install recurring maintenance jobs
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
 set -euo pipefail
@@ -129,6 +130,24 @@ install_backup_script() {
     echo "Installed: $dst"
 }
 
+install_jsonl_backup_script() {
+    local src="$SCRIPT_DIR/jsonl-backup.sh"
+    local dst="$BRAINLAYER_LIB_DIR/jsonl-backup.sh"
+    local escaped_brainlayer_dir
+
+    if [ ! -f "$src" ]; then
+        echo "ERROR: $src not found"
+        return 1
+    fi
+
+    escaped_brainlayer_dir="$(printf '%s' "$BRAINLAYER_DIR" | sed 's/[\\&|]/\\&/g')"
+    sed \
+        -e "s|__BRAINLAYER_DIR_VALUE__|$escaped_brainlayer_dir|g" \
+        "$src" > "$dst"
+    chmod 755 "$dst"
+    echo "Installed: $dst"
+}
+
 remove_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
@@ -174,6 +193,10 @@ case "${1:-all}" in
         install_backup_script
         install_plist backup-daily
         ;;
+    jsonl|jsonl-backup)
+        install_jsonl_backup_script
+        install_plist jsonl-backup
+        ;;
     maintenance-nightly)
         install_plist maintenance-nightly
         ;;
@@ -194,6 +217,8 @@ case "${1:-all}" in
         install_plist repair-fts
         install_backup_script
         install_plist backup-daily
+        install_jsonl_backup_script
+        install_plist jsonl-backup
         install_plist maintenance-nightly
         install_plist maintenance-weekly
         # Remove old enrich plist if present
@@ -209,12 +234,14 @@ case "${1:-all}" in
         remove_plist wal-checkpoint
         remove_plist repair-fts 2>/dev/null || true
         remove_plist backup-daily 2>/dev/null || true
+        remove_plist jsonl-backup 2>/dev/null || true
         remove_plist maintenance-nightly 2>/dev/null || true
         remove_plist maintenance-weekly 2>/dev/null || true
         rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
+        rm -f "$BRAINLAYER_LIB_DIR/jsonl-backup.sh"
         ;;
     *)
-        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|repair-fts|load [name]|unload [name]|checkpoint|backup|maintenance|maintenance-nightly|maintenance-weekly|all|remove]"
+        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|all|remove]"
         exit 1
         ;;
 esac

--- a/scripts/launchd/jsonl-backup.sh
+++ b/scripts/launchd/jsonl-backup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin"
+export PYTHONUNBUFFERED=1
+: "${BRAINLAYER_BACKUP_TIMEOUT_SECONDS:=1800}"
+export BRAINLAYER_BACKUP_TIMEOUT_SECONDS
+BRAINLAYER_DIR="${BRAINLAYER_DIR:-__BRAINLAYER_DIR_VALUE__}"
+case "$BRAINLAYER_DIR" in
+    __BRAINLAYER_DIR_*) BRAINLAYER_DIR="$HOME/Gits/brainlayer" ;;
+esac
+export PYTHONPATH="$BRAINLAYER_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+exec "${BRAINLAYER_PYTHON:-python3}" -m brainlayer.jsonl_backup

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -258,13 +258,35 @@ def request_brainbar_vacuum_into(
             if not target_path.exists():
                 raise RuntimeError(f"BrainBar backup did not create snapshot: {target_path}")
             return
+        except BackupTimeoutError:
+            raise
         except Exception as exc:
             last_error = exc
+            existing_target_note = ""
+            if target_path.exists():
+                try:
+                    pragma = _sqlite_pragma_check(target_path, "quick_check")
+                except Exception as check_exc:
+                    target_path.unlink(missing_ok=True)
+                    existing_target_note = f"; removing invalid existing target after quick_check error: {check_exc}"
+                else:
+                    if pragma == "ok":
+                        print(
+                            f"BrainBar vacuum snapshot attempt {attempt}/{max_attempts} failed: {exc}; "
+                            "target exists and passed quick_check",
+                            flush=True,
+                        )
+                        return
+                    target_path.unlink(missing_ok=True)
+                    existing_target_note = f"; removing invalid existing target after quick_check={pragma!r}"
             if attempt >= max_attempts:
-                print(f"BrainBar vacuum snapshot attempt {attempt}/{max_attempts} failed: {exc}", flush=True)
+                print(
+                    f"BrainBar vacuum snapshot attempt {attempt}/{max_attempts} failed: {exc}{existing_target_note}",
+                    flush=True,
+                )
                 break
             print(
-                f"BrainBar vacuum snapshot attempt {attempt}/{max_attempts} failed: {exc}; "
+                f"BrainBar vacuum snapshot attempt {attempt}/{max_attempts} failed: {exc}{existing_target_note}; "
                 f"retrying in {retry_backoff_seconds}s",
                 flush=True,
             )

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -198,6 +198,8 @@ def create_sqlite_backup_artifact(
     deleted = (
         prune_local_uncompressed_snapshots(output_dir, keep_latest=local_uncompressed_keep) if keep_uncompressed else []
     )
+    if uncompressed_path is not None and uncompressed_path.name in deleted:
+        uncompressed_path = None
     return SQLiteBackupArtifact(
         gzip_path=final_gz,
         uncompressed_path=uncompressed_path,

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import datetime as dt
 import fcntl
 import gzip
+import hashlib
 import json
 import os
 import shutil
 import signal
 import socket
 import sqlite3
+import subprocess
 import tempfile
 import time
 import traceback
@@ -33,15 +35,19 @@ DEFAULT_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"]
 DEFAULT_STAGING_DIR = Path.home() / ".local" / "share" / "brainlayer" / "backups"
 DEFAULT_BRAINBAR_SOCKET_PATH = "/tmp/brainbar.sock"
 BACKUP_TIMEOUT_ENV = "BRAINLAYER_BACKUP_TIMEOUT_SECONDS"
+BACKUP_FULL_VERIFY_ENV = "BRAINLAYER_BACKUP_FULL_VERIFY"
 DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
 DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
 DEFAULT_DAILY_KEEP = 7
 DEFAULT_WEEKLY_KEEP = 4
+DEFAULT_LOCAL_UNCOMPRESSED_KEEP = 2
 
 
 @dataclass(frozen=True)
 class DriveRetentionPolicy:
     keep_latest: int
+    filename_prefix: str = ""
+    filename_suffix: str = ".db.gz"
 
     def __post_init__(self) -> None:
         if self.keep_latest < 1:
@@ -50,6 +56,14 @@ class DriveRetentionPolicy:
 
 DAILY_RETENTION = DriveRetentionPolicy(keep_latest=DEFAULT_DAILY_KEEP)
 WEEKLY_RETENTION = DriveRetentionPolicy(keep_latest=DEFAULT_WEEKLY_KEEP)
+
+
+@dataclass(frozen=True)
+class SQLiteBackupArtifact:
+    gzip_path: Path
+    uncompressed_path: Path | None
+    sentinel_chunks: int
+    local_retention_deleted: list[str]
 
 
 def _today() -> str:
@@ -79,12 +93,63 @@ def _raise_backup_timeout(signum, frame) -> None:  # noqa: ARG001
     raise BackupTimeoutError("backup exceeded configured wall-clock timeout")
 
 
-def create_sqlite_backup_gzip(
+def _sqlite_pragma_check(db_path: Path, pragma_name: str) -> str:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        row = conn.execute(f"PRAGMA {pragma_name}").fetchone()
+    finally:
+        conn.close()
+    return str(row[0]) if row else ""
+
+
+def _count_chunks(db_path: Path) -> int:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        row = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()
+    finally:
+        conn.close()
+    return int(row[0]) if row else 0
+
+
+def _parse_uncompressed_snapshot_date(name: str) -> dt.date | None:
+    if not name.endswith(".db") or len(name) != len("YYYY-MM-DD.db"):
+        return None
+    try:
+        return dt.date.fromisoformat(name[:10])
+    except ValueError:
+        return None
+
+
+def prune_local_uncompressed_snapshots(
+    output_dir: Path, *, keep_latest: int = DEFAULT_LOCAL_UNCOMPRESSED_KEEP
+) -> list[str]:
+    if keep_latest < 1:
+        raise ValueError("keep_latest must be at least 1")
+    output_dir = Path(output_dir).expanduser()
+    dated: list[tuple[dt.date, Path]] = []
+    if not output_dir.exists():
+        return []
+    for path in output_dir.iterdir():
+        parsed = _parse_uncompressed_snapshot_date(path.name)
+        if parsed and path.is_file():
+            dated.append((parsed, path))
+
+    dated.sort(key=lambda pair: pair[0], reverse=True)
+    deleted: list[str] = []
+    for _, path in dated[keep_latest:]:
+        path.unlink(missing_ok=True)
+        deleted.append(path.name)
+    return deleted
+
+
+def create_sqlite_backup_artifact(
     db_path: Path,
     output_dir: Path,
     date_stamp: str | None = None,
     socket_path: Path | str | None = None,
-) -> Path:
+    keep_uncompressed: bool = True,
+    local_uncompressed_keep: int = DEFAULT_LOCAL_UNCOMPRESSED_KEEP,
+) -> SQLiteBackupArtifact:
     """Create a restorable `.db.gz` snapshot through BrainBar's single-writer socket."""
     db_path = Path(db_path).expanduser()
     output_dir = Path(output_dir).expanduser()
@@ -94,7 +159,7 @@ def create_sqlite_backup_gzip(
         raise FileNotFoundError(f"BrainLayer database not found: {db_path}")
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    required_bytes = (db_path.stat().st_size * 2) + (512 * 1024 * 1024)
+    required_bytes = (db_path.stat().st_size * 3) + (512 * 1024 * 1024)
     free_bytes = shutil.disk_usage(output_dir).free
     if free_bytes < required_bytes:
         raise RuntimeError(
@@ -102,6 +167,9 @@ def create_sqlite_backup_gzip(
             f"{free_bytes} bytes free, {required_bytes} bytes required"
         )
     final_gz = output_dir / f"{date_stamp}.db.gz"
+    final_raw = output_dir / f"{date_stamp}.db"
+    sentinel_chunks = 0
+    uncompressed_path: Path | None = None
 
     with tempfile.TemporaryDirectory(prefix="brainlayer-backup-", dir=output_dir) as tmp:
         raw_snapshot = Path(tmp) / f"{date_stamp}.db"
@@ -111,6 +179,8 @@ def create_sqlite_backup_gzip(
             integrity = target.execute("PRAGMA integrity_check").fetchone()
             if not integrity or integrity[0] != "ok":
                 raise RuntimeError(f"Backup integrity check failed: {integrity!r}")
+            row = target.execute("SELECT COUNT(*) FROM chunks").fetchone()
+            sentinel_chunks = int(row[0]) if row else 0
         finally:
             target.close()
 
@@ -119,7 +189,31 @@ def create_sqlite_backup_gzip(
             shutil.copyfileobj(src, dst, length=1024 * 1024)
         shutil.move(str(temp_gz), final_gz)
 
-    return final_gz
+        if keep_uncompressed:
+            temp_raw = Path(tmp) / final_raw.name
+            shutil.move(str(raw_snapshot), temp_raw)
+            shutil.move(str(temp_raw), final_raw)
+            uncompressed_path = final_raw
+
+    deleted = (
+        prune_local_uncompressed_snapshots(output_dir, keep_latest=local_uncompressed_keep) if keep_uncompressed else []
+    )
+    return SQLiteBackupArtifact(
+        gzip_path=final_gz,
+        uncompressed_path=uncompressed_path,
+        sentinel_chunks=sentinel_chunks,
+        local_retention_deleted=deleted,
+    )
+
+
+def create_sqlite_backup_gzip(
+    db_path: Path,
+    output_dir: Path,
+    date_stamp: str | None = None,
+    socket_path: Path | str | None = None,
+) -> Path:
+    artifact = create_sqlite_backup_artifact(db_path, output_dir, date_stamp=date_stamp, socket_path=socket_path)
+    return artifact.gzip_path
 
 
 def _brainbar_socket_path(socket_path: Path | str | None = None) -> Path:
@@ -129,9 +223,15 @@ def _brainbar_socket_path(socket_path: Path | str | None = None) -> Path:
 
 
 def request_brainbar_vacuum_into(
-    target_path: Path, socket_path: Path | str | None = None, timeout_seconds: int = 300
+    target_path: Path,
+    socket_path: Path | str | None = None,
+    timeout_seconds: int = 300,
+    max_attempts: int = 3,
+    retry_backoff_seconds: int = 60,
 ) -> None:
     target_path = Path(target_path).expanduser()
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
     request = {
         "jsonrpc": "2.0",
         "id": 1,
@@ -141,16 +241,34 @@ def request_brainbar_vacuum_into(
             "arguments": {"target_path": str(target_path)},
         },
     }
-    response = _send_brainbar_json_request(_brainbar_socket_path(socket_path), request, timeout_seconds=timeout_seconds)
-    if response.get("error"):
-        raise RuntimeError(f"BrainBar backup request failed: {response['error']}")
-    result = response.get("result") or {}
-    if result.get("isError"):
-        content = result.get("content") or []
-        text = content[0].get("text") if content and isinstance(content[0], dict) else result
-        raise RuntimeError(f"BrainBar backup request failed: {text}")
-    if not target_path.exists():
-        raise RuntimeError(f"BrainBar backup did not create snapshot: {target_path}")
+    resolved_socket_path = _brainbar_socket_path(socket_path)
+    last_error: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = _send_brainbar_json_request(resolved_socket_path, request, timeout_seconds=timeout_seconds)
+            if response.get("error"):
+                raise RuntimeError(f"BrainBar backup request failed: {response['error']}")
+            result = response.get("result") or {}
+            if result.get("isError"):
+                content = result.get("content") or []
+                text = content[0].get("text") if content and isinstance(content[0], dict) else result
+                raise RuntimeError(f"BrainBar backup request failed: {text}")
+            if not target_path.exists():
+                raise RuntimeError(f"BrainBar backup did not create snapshot: {target_path}")
+            return
+        except Exception as exc:
+            last_error = exc
+            if attempt >= max_attempts:
+                print(f"BrainBar vacuum snapshot attempt {attempt}/{max_attempts} failed: {exc}", flush=True)
+                break
+            print(
+                f"BrainBar vacuum snapshot attempt {attempt}/{max_attempts} failed: {exc}; "
+                f"retrying in {retry_backoff_seconds}s",
+                flush=True,
+            )
+            time.sleep(retry_backoff_seconds)
+    if last_error is not None:
+        raise last_error
 
 
 def _send_brainbar_json_request(socket_path: Path, request: dict[str, Any], timeout_seconds: int) -> dict[str, Any]:
@@ -340,13 +458,123 @@ def upload_file_to_drive_raw(
     raise RuntimeError("Drive upload ended without final response")
 
 
-def _parse_snapshot_date(name: str) -> dt.date | None:
-    if not name.endswith(".db.gz"):
+def download_drive_file_raw(service: Any, *, file_id: str, destination: Path) -> Path:
+    """Download a Drive artifact to a local path for restore verification."""
+    from googleapiclient.http import MediaIoBaseDownload
+
+    destination = Path(destination).expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
+    with destination.open("wb") as handle:
+        downloader = MediaIoBaseDownload(handle, request, chunksize=8 * 1024 * 1024)
+        done = False
+        while not done:
+            _, done = downloader.next_chunk()
+    return destination
+
+
+def _parse_snapshot_date(name: str, *, prefix: str = "", suffix: str = ".db.gz") -> dt.date | None:
+    if prefix and not name.startswith(prefix):
         return None
+    if not name.endswith(suffix):
+        return None
+    stem = name[len(prefix) : len(name) - len(suffix)]
     try:
-        return dt.date.fromisoformat(name[:10])
+        return dt.date.fromisoformat(stem[:10])
     except ValueError:
         return None
+
+
+def _md5_file(path: Path) -> str:
+    digest = hashlib.md5()  # noqa: S324 - backup restore verification needs MD5 parity with Drive tooling.
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _gunzip_test(path: Path) -> None:
+    subprocess.run(["gunzip", "-t", str(path)], check=True, capture_output=True, text=True)
+
+
+def _decompress_gzip_to(gzip_path: Path, destination: Path) -> None:
+    with gzip.open(gzip_path, "rb") as src, destination.open("wb") as dst:
+        shutil.copyfileobj(src, dst, length=1024 * 1024)
+
+
+def _env_flag_enabled(name: str) -> bool:
+    raw = os.environ.get(name, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _should_run_full_verify(date_stamp: str | None) -> bool:
+    if _env_flag_enabled(BACKUP_FULL_VERIFY_ENV):
+        return True
+    try:
+        backup_date = dt.date.fromisoformat((date_stamp or _today())[:10])
+    except ValueError:
+        return False
+    return backup_date.weekday() == 6
+
+
+def verify_sqlite_backup_artifact(
+    artifact: SQLiteBackupArtifact,
+    *,
+    full: bool = False,
+    service: Any | None = None,
+    file_id: str | None = None,
+) -> dict[str, Any]:
+    """Run restore verification against the local gzip or the downloaded Drive copy."""
+    mode = "full" if full else "quick"
+    result: dict[str, Any] = {
+        "verified": False,
+        "verification_mode": mode,
+        "sentinel_snapshot_chunks": artifact.sentinel_chunks,
+        "sentinel_verified_chunks": None,
+    }
+    verify_path = artifact.gzip_path
+
+    try:
+        local_md5 = _md5_file(artifact.gzip_path)
+        result["local_md5"] = local_md5
+        with tempfile.TemporaryDirectory(prefix="brainlayer-restore-verify-", dir=artifact.gzip_path.parent) as tmp:
+            tmp_dir = Path(tmp)
+            if full:
+                if service is None or not file_id:
+                    result["verification_error"] = "full verification requires Drive service and file_id"
+                    return result
+                drive_copy = tmp_dir / artifact.gzip_path.name
+                download_drive_file_raw(service, file_id=file_id, destination=drive_copy)
+                drive_md5 = _md5_file(drive_copy)
+                result["drive_md5"] = drive_md5
+                result["drive_md5_match"] = drive_md5 == local_md5
+                if drive_md5 != local_md5:
+                    result["verification_error"] = "Drive download md5 mismatch"
+                    return result
+                verify_path = drive_copy
+
+            _gunzip_test(verify_path)
+            result["gzip_test"] = True
+            restored = tmp_dir / "restored.db"
+            _decompress_gzip_to(verify_path, restored)
+            pragma_name = "integrity_check" if full else "quick_check"
+            pragma = _sqlite_pragma_check(restored, pragma_name)
+            result["pragma"] = pragma
+            if pragma != "ok":
+                result["verification_error"] = f"PRAGMA {pragma_name} failed: {pragma!r}"
+                return result
+            verified_chunks = _count_chunks(restored)
+            result["sentinel_verified_chunks"] = verified_chunks
+            if verified_chunks != artifact.sentinel_chunks:
+                result["verification_error"] = (
+                    f"sentinel mismatch: snapshot={artifact.sentinel_chunks} verified={verified_chunks}"
+                )
+                return result
+            result["verified"] = True
+    except Exception as exc:
+        result.setdefault("gzip_test", False)
+        result["verification_error"] = str(exc)
+    return result
 
 
 def verify_drive_upload(service: Any, *, file_id: str, expected_name: str, expected_size: int) -> None:
@@ -393,7 +621,11 @@ def prune_drive_backups(
             break
     dated = []
     for item in files:
-        parsed = _parse_snapshot_date(item.get("name", ""))
+        parsed = _parse_snapshot_date(
+            item.get("name", ""),
+            prefix=retention_policy.filename_prefix,
+            suffix=retention_policy.filename_suffix,
+        )
         if parsed:
             dated.append((parsed, item))
 
@@ -418,14 +650,20 @@ def run_backup(
     retention_policy: DriveRetentionPolicy = DAILY_RETENTION,
     remove_local_after_upload: bool = True,
 ) -> dict[str, Any]:
-    snapshot = create_sqlite_backup_gzip(db_path or get_db_path(), staging_dir, date_stamp=date_stamp)
+    resolved_date_stamp = date_stamp or _today()
+    artifact = create_sqlite_backup_artifact(db_path or get_db_path(), staging_dir, date_stamp=resolved_date_stamp)
+    snapshot = artifact.gzip_path
     snapshot_size = snapshot.stat().st_size
     result: dict[str, Any] = {
         "db": str(db_path or get_db_path()),
         "snapshot": str(snapshot),
+        "local_uncompressed_snapshot": str(artifact.uncompressed_path) if artifact.uncompressed_path else None,
+        "local_retention_deleted": artifact.local_retention_deleted,
+        "sentinel_snapshot_chunks": artifact.sentinel_chunks,
         "bytes": snapshot_size,
         "uploaded": False,
         "local_removed": False,
+        "verified": False,
     }
     if upload:
         credentials = get_drive_credentials()
@@ -441,14 +679,25 @@ def run_backup(
             expected_name=snapshot.name,
             expected_size=snapshot_size,
         )
-        if remove_local_after_upload:
-            snapshot.unlink()
-            result["local_removed"] = True
-        deleted = prune_drive_backups(
-            service,
-            folder_parts=folder_parts,
-            retention_policy=retention_policy,
+        result.update(
+            verify_sqlite_backup_artifact(
+                artifact,
+                full=_should_run_full_verify(resolved_date_stamp),
+                service=service,
+                file_id=file_id,
+            )
         )
+        if result["verified"]:
+            if remove_local_after_upload:
+                snapshot.unlink()
+                result["local_removed"] = True
+            deleted = prune_drive_backups(
+                service,
+                folder_parts=folder_parts,
+                retention_policy=retention_policy,
+            )
+        else:
+            deleted = []
         result.update({"uploaded": True, "drive_file": uploaded, "retention_deleted": deleted})
     return result
 
@@ -480,7 +729,7 @@ def main() -> int:
             signal.setitimer(signal.ITIMER_REAL, 0)
             signal.signal(signal.SIGALRM, previous_alarm_handler)
     print(json.dumps(result, sort_keys=True), flush=True)
-    return 0
+    return 0 if result.get("verified", True) else 1
 
 
 if __name__ == "__main__":

--- a/src/brainlayer/jsonl_backup.py
+++ b/src/brainlayer/jsonl_backup.py
@@ -70,6 +70,8 @@ def _load_state(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {"files": {}}
     data = json.loads(path.read_text(encoding="utf-8") or "{}")
+    if not isinstance(data, dict):
+        return {"files": {}}
     files = data.get("files")
     if not isinstance(files, dict):
         data["files"] = {}
@@ -293,15 +295,14 @@ def run_backup(
         result.update({"uploaded": True, "drive_file": uploaded})
 
     result.update(verify_jsonl_bundle(archive_path, expected_file_count=len(changed)))
-    if result["verified"]:
+    if result["verified"] and upload:
         _atomic_write_json(state_path, _update_state_for_uploaded(state, changed))
-        if upload:
-            deleted = backup_daily.prune_drive_backups(
-                service,
-                folder_parts=folder_parts,
-                retention_policy=JSONL_RETENTION,
-            )
-            result["retention_deleted"] = deleted
+        deleted = backup_daily.prune_drive_backups(
+            service,
+            folder_parts=folder_parts,
+            retention_policy=JSONL_RETENTION,
+        )
+        result["retention_deleted"] = deleted
 
     _append_json_log(log_path, result)
     _enqueue_run_summary(result, queue_dir=queue_dir)

--- a/src/brainlayer/jsonl_backup.py
+++ b/src/brainlayer/jsonl_backup.py
@@ -1,0 +1,359 @@
+"""Nightly JSONL transcript backups to Google Drive.
+
+Install note: commit `launchd/com.brainlayer.jsonl-backup.plist`, then install it
+after merge with the repo's launchd flow or a manual `launchctl bootstrap`; this
+module intentionally does not install the agent itself.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import signal
+import subprocess
+import tarfile
+import tempfile
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import backup_daily
+from .queue_io import enqueue_store
+
+DEFAULT_SOURCE_ROOTS = [
+    Path.home() / ".claude" / "projects",
+    Path.home() / ".claude-archive",
+    Path.home() / ".codex" / "sessions",
+]
+DEFAULT_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "claude-jsonl"]
+DEFAULT_STATE_PATH = Path.home() / ".local" / "share" / "brainlayer" / "jsonl-backup-state.json"
+DEFAULT_STAGING_DIR = Path.home() / ".local" / "share" / "brainlayer" / "jsonl-backups"
+DEFAULT_LOG_PATH = Path.home() / ".local" / "share" / "brainlayer" / "logs" / "jsonl-backup.log"
+DEFAULT_ACTIVE_SKIP_SECONDS = 10 * 60
+DEFAULT_TIMEOUT_SECONDS = 1800
+JSONL_RETENTION = backup_daily.DriveRetentionPolicy(
+    keep_latest=30,
+    filename_prefix="claude-jsonl-",
+    filename_suffix=".tar.gz",
+)
+
+
+@dataclass(frozen=True)
+class JsonlCandidate:
+    path: Path
+    root: Path
+    root_index: int
+    mtime: float
+    size: int
+
+
+def _today() -> str:
+    return dt.datetime.now(dt.UTC).date().isoformat()
+
+
+def _configured_backup_timeout_seconds() -> int | None:
+    raw = os.environ.get(backup_daily.BACKUP_TIMEOUT_ENV)
+    if raw is None or raw.strip() == "":
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        seconds = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{backup_daily.BACKUP_TIMEOUT_ENV} must be an integer number of seconds") from exc
+    return seconds if seconds > 0 else None
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    path = Path(path).expanduser()
+    if not path.exists():
+        return {"files": {}}
+    data = json.loads(path.read_text(encoding="utf-8") or "{}")
+    files = data.get("files")
+    if not isinstance(files, dict):
+        data["files"] = {}
+    return data
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path = Path(path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _append_json_log(path: Path, payload: dict[str, Any]) -> None:
+    path = Path(path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _discover_jsonl_candidates(source_roots: list[Path]) -> list[JsonlCandidate]:
+    candidates: list[JsonlCandidate] = []
+    seen: set[Path] = set()
+    for index, root in enumerate(source_roots):
+        expanded_root = Path(root).expanduser()
+        if not expanded_root.exists():
+            continue
+        for path in sorted(expanded_root.rglob("*.jsonl")):
+            if not path.is_file():
+                continue
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            stat = path.stat()
+            candidates.append(
+                JsonlCandidate(
+                    path=path,
+                    root=expanded_root,
+                    root_index=index,
+                    mtime=stat.st_mtime,
+                    size=stat.st_size,
+                )
+            )
+    candidates.sort(key=lambda item: item.path.as_posix())
+    return candidates
+
+
+def _state_matches(entry: Any, candidate: JsonlCandidate) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    return entry.get("mtime") == candidate.mtime and entry.get("size") == candidate.size
+
+
+def _archive_name(candidate: JsonlCandidate) -> str:
+    try:
+        relative = candidate.path.relative_to(candidate.root)
+    except ValueError:
+        relative = Path(candidate.path.name)
+    return f"source-{candidate.root_index}/{relative.as_posix()}"
+
+
+def create_jsonl_bundle(candidates: list[JsonlCandidate], staging_dir: Path, *, date_stamp: str) -> Path:
+    if not candidates:
+        raise ValueError("create_jsonl_bundle requires at least one candidate")
+    staging_dir = Path(staging_dir).expanduser()
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = staging_dir / f"claude-jsonl-{date_stamp}.tar.gz"
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{archive_path.name}.", suffix=".tmp", dir=staging_dir, delete=False
+    ) as tmp:
+        temp_path = Path(tmp.name)
+    try:
+        with tarfile.open(temp_path, "w:gz") as tar:
+            for candidate in candidates:
+                tar.add(candidate.path, arcname=_archive_name(candidate), recursive=False)
+        os.replace(temp_path, archive_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return archive_path
+
+
+def verify_jsonl_bundle(archive_path: Path, *, expected_file_count: int) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "verified": False,
+        "bundled_file_count": expected_file_count,
+        "archive_listing_count": 0,
+    }
+    try:
+        subprocess.run(["gunzip", "-t", str(archive_path)], check=True, capture_output=True, text=True)
+        result["gzip_test"] = True
+        listing = subprocess.run(["tar", "-tzf", str(archive_path)], check=True, capture_output=True, text=True)
+        entries = [line for line in listing.stdout.splitlines() if line.strip() and not line.endswith("/")]
+        result["archive_listing_count"] = len(entries)
+        if len(entries) != expected_file_count:
+            result["verification_error"] = (
+                f"tar listing count mismatch: expected={expected_file_count} actual={len(entries)}"
+            )
+            return result
+        result["verified"] = True
+    except Exception as exc:
+        result.setdefault("gzip_test", False)
+        result["verification_error"] = str(exc)
+    return result
+
+
+def _update_state_for_uploaded(state: dict[str, Any], candidates: list[JsonlCandidate]) -> dict[str, Any]:
+    files = dict(state.get("files") or {})
+    for candidate in candidates:
+        files[candidate.path.as_posix()] = {"mtime": candidate.mtime, "size": candidate.size}
+    return {"files": files, "updated_at": dt.datetime.now(dt.UTC).isoformat()}
+
+
+def _enqueue_run_summary(result: dict[str, Any], *, queue_dir: Path | None) -> None:
+    if result["status"] == "uploaded":
+        content = (
+            f"JSONL backup uploaded {result['bundled_file_count']} files to Drive; "
+            f"verified={result['verified']} archive={result.get('archive')}"
+        )
+        importance = 7 if result.get("verified") else 9
+    elif result["status"] == "created":
+        content = (
+            f"JSONL backup created local bundle with {result['bundled_file_count']} files; "
+            f"verified={result['verified']} archive={result.get('archive')}"
+        )
+        importance = 6 if result.get("verified") else 9
+    else:
+        content = f"JSONL backup {result['message']}"
+        importance = 5
+    enqueue_store(
+        content=content,
+        memory_type="milestone",
+        project="brainlayer",
+        tags=["backup", "jsonl"],
+        importance=importance,
+        source="jsonl_backup",
+        queue_dir=queue_dir,
+    )
+
+
+def run_backup(
+    *,
+    source_roots: list[Path] | None = None,
+    state_path: Path = DEFAULT_STATE_PATH,
+    staging_dir: Path = DEFAULT_STAGING_DIR,
+    log_path: Path = DEFAULT_LOG_PATH,
+    queue_dir: Path | None = None,
+    folder_parts: list[str] = DEFAULT_FOLDER_PARTS,
+    date_stamp: str | None = None,
+    now: float | None = None,
+    upload: bool = True,
+    active_skip_seconds: int = DEFAULT_ACTIVE_SKIP_SECONDS,
+) -> dict[str, Any]:
+    date_stamp = date_stamp or _today()
+    now = time.time() if now is None else now
+    roots = source_roots or DEFAULT_SOURCE_ROOTS
+    state_path = Path(state_path).expanduser()
+    state = _load_state(state_path)
+    candidates = _discover_jsonl_candidates(roots)
+
+    changed: list[JsonlCandidate] = []
+    active: list[JsonlCandidate] = []
+    covered = 0
+    for candidate in candidates:
+        if now - candidate.mtime < active_skip_seconds:
+            active.append(candidate)
+            continue
+        entry = state.get("files", {}).get(candidate.path.as_posix())
+        if _state_matches(entry, candidate):
+            covered += 1
+            continue
+        changed.append(candidate)
+
+    if not changed:
+        result: dict[str, Any] = {
+            "status": "no-op",
+            "uploaded": False,
+            "verified": True,
+            "already_covered_files": covered,
+            "discovered_file_count": len(candidates),
+            "skipped_active_count": len(active),
+            "message": f"no-op, {covered} files already covered",
+        }
+        _append_json_log(log_path, result)
+        _enqueue_run_summary(result, queue_dir=queue_dir)
+        return result
+
+    archive_path = create_jsonl_bundle(changed, staging_dir, date_stamp=date_stamp)
+    archive_size = archive_path.stat().st_size
+    result = {
+        "status": "uploaded" if upload else "created",
+        "archive": str(archive_path),
+        "bytes": archive_size,
+        "uploaded": False,
+        "verified": False,
+        "bundled_file_count": len(changed),
+        "skipped_active_count": len(active),
+        "already_covered_files": covered,
+        "source_file_count": len(candidates),
+        "retention_deleted": [],
+    }
+
+    if upload:
+        credentials = backup_daily.get_drive_credentials()
+        service = backup_daily.build_drive_service()
+        folder_id = backup_daily.ensure_drive_folder_chain(service, folder_parts)
+        uploaded = backup_daily.upload_file_to_drive_raw(archive_path, folder_id, credentials)
+        file_id = uploaded.get("id")
+        if not file_id:
+            raise RuntimeError(f"Drive upload response missing file id: {uploaded!r}")
+        backup_daily.verify_drive_upload(
+            service,
+            file_id=file_id,
+            expected_name=archive_path.name,
+            expected_size=archive_size,
+        )
+        result.update({"uploaded": True, "drive_file": uploaded})
+
+    result.update(verify_jsonl_bundle(archive_path, expected_file_count=len(changed)))
+    if result["verified"]:
+        _atomic_write_json(state_path, _update_state_for_uploaded(state, changed))
+        if upload:
+            deleted = backup_daily.prune_drive_backups(
+                service,
+                folder_parts=folder_parts,
+                retention_policy=JSONL_RETENTION,
+            )
+            result["retention_deleted"] = deleted
+
+    _append_json_log(log_path, result)
+    _enqueue_run_summary(result, queue_dir=queue_dir)
+    return result
+
+
+def _raise_backup_timeout(signum, frame) -> None:  # noqa: ARG001
+    raise backup_daily.BackupTimeoutError("jsonl backup exceeded configured wall-clock timeout")
+
+
+def main() -> int:
+    timeout_seconds = _configured_backup_timeout_seconds()
+    previous_alarm_handler = None
+    if timeout_seconds is not None:
+        previous_alarm_handler = signal.getsignal(signal.SIGALRM)
+        signal.signal(signal.SIGALRM, _raise_backup_timeout)
+        signal.setitimer(signal.ITIMER_REAL, timeout_seconds)
+    try:
+        result = run_backup(
+            staging_dir=Path(os.environ.get("BRAINLAYER_JSONL_BACKUP_STAGING_DIR", str(DEFAULT_STAGING_DIR))),
+            state_path=Path(os.environ.get("BRAINLAYER_JSONL_BACKUP_STATE_PATH", str(DEFAULT_STATE_PATH))),
+            log_path=Path(os.environ.get("BRAINLAYER_JSONL_BACKUP_LOG_PATH", str(DEFAULT_LOG_PATH))),
+            folder_parts=os.environ.get("BRAINLAYER_JSONL_BACKUP_DRIVE_FOLDER", "/".join(DEFAULT_FOLDER_PARTS)).split(
+                "/"
+            ),
+        )
+    except backup_daily.BackupTimeoutError:
+        result = {
+            "status": "failed",
+            "uploaded": False,
+            "verified": False,
+            "error": f"timed out after {timeout_seconds}s",
+        }
+        print(json.dumps(result, sort_keys=True), flush=True)
+        return 124
+    except Exception as exc:
+        result = {
+            "status": "failed",
+            "uploaded": False,
+            "verified": False,
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        print(json.dumps(result, sort_keys=True), flush=True)
+        return 1
+    finally:
+        if timeout_seconds is not None:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, previous_alarm_handler)
+    print(json.dumps(result, sort_keys=True), flush=True)
+    return 0 if result.get("verified", True) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -193,6 +193,36 @@ def test_prune_local_uncompressed_snapshots_keeps_two_newest(tmp_path):
     assert (tmp_path / "not-a-snapshot.db").exists()
 
 
+def test_create_snapshot_reports_no_uncompressed_path_when_current_raw_is_pruned(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    source = tmp_path / "brainlayer.db"
+    _create_source_db(source, chunk_count=2)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "2026-06-05.db").write_bytes(b"newer")
+    (out_dir / "2026-06-04.db").write_bytes(b"also-newer")
+
+    def fake_vacuum_into(target_path, **kwargs):  # noqa: ARG001
+        with sqlite3.connect(source) as db:
+            db.execute("VACUUM INTO ?", (str(target_path),))
+
+    monkeypatch.setattr(backup_daily, "request_brainbar_vacuum_into", fake_vacuum_into)
+
+    artifact = backup_daily.create_sqlite_backup_artifact(
+        source,
+        out_dir,
+        date_stamp="2026-06-03",
+        keep_uncompressed=True,
+        local_uncompressed_keep=2,
+    )
+
+    assert artifact.uncompressed_path is None
+    assert artifact.local_retention_deleted == ["2026-06-03.db"]
+    assert not (out_dir / "2026-06-03.db").exists()
+    assert sorted(path.name for path in out_dir.glob("*.db")) == ["2026-06-04.db", "2026-06-05.db"]
+
+
 def test_create_snapshot_routes_vacuum_into_over_brainbar_socket(tmp_path):
     from brainlayer.backup_daily import create_sqlite_backup_gzip
 

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -295,6 +295,77 @@ def test_brainbar_vacuum_request_fails_loud_after_retry_budget(tmp_path, monkeyp
     assert not target.exists()
 
 
+def test_brainbar_vacuum_request_does_not_retry_global_backup_timeout(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    target = tmp_path / "snapshot.db"
+    calls = []
+    sleeps = []
+
+    def timed_out(socket_path, request, timeout_seconds):  # noqa: ARG001
+        calls.append(request["params"]["name"])
+        raise backup_daily.BackupTimeoutError("backup exceeded configured wall-clock timeout")
+
+    monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", timed_out)
+    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    with pytest.raises(backup_daily.BackupTimeoutError):
+        backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
+
+    assert calls == ["brain_backup_vacuum_into"]
+    assert sleeps == []
+
+
+def test_brainbar_vacuum_request_accepts_valid_target_after_lost_response(tmp_path, monkeypatch, capsys):
+    from brainlayer import backup_daily
+
+    target = tmp_path / "snapshot.db"
+    calls = []
+    sleeps = []
+
+    def closed_after_success(socket_path, request, timeout_seconds):  # noqa: ARG001
+        calls.append(request["params"]["name"])
+        _create_source_db(target, chunk_count=2)
+        raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
+
+    monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", closed_after_success)
+    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
+
+    assert calls == ["brain_backup_vacuum_into"]
+    assert sleeps == []
+    assert "target exists and passed quick_check" in capsys.readouterr().out
+
+
+def test_brainbar_vacuum_request_removes_invalid_target_before_retry(tmp_path, monkeypatch, capsys):
+    from brainlayer import backup_daily
+
+    target = tmp_path / "snapshot.db"
+    calls = []
+    sleeps = []
+
+    def invalid_then_success(socket_path, request, timeout_seconds):  # noqa: ARG001
+        calls.append(request["params"]["name"])
+        if len(calls) == 1:
+            target.write_bytes(b"not sqlite")
+            raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
+        assert not target.exists()
+        _create_source_db(target, chunk_count=2)
+        return {"result": {"content": [{"type": "text", "text": '{"status":"ok"}'}]}}
+
+    monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", invalid_then_success)
+    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
+
+    assert calls == ["brain_backup_vacuum_into", "brain_backup_vacuum_into"]
+    assert sleeps == [60]
+    output = capsys.readouterr().out
+    assert "removing invalid existing target" in output
+    assert "retrying in 60s" in output
+
+
 def test_create_snapshot_rejects_low_disk_space(tmp_path, monkeypatch):
     from brainlayer import backup_daily
 

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -51,12 +51,14 @@ def _start_fake_brainbar_vacuum_server(socket_path: Path, source_db: Path):
     return received, thread
 
 
-def _create_source_db(path: Path) -> None:
+def _create_source_db(path: Path, *, chunk_count: int = 1) -> None:
     conn = sqlite3.connect(path)
     journal_mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
     assert journal_mode.upper() == "WAL"
     conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, content TEXT)")
     conn.execute("INSERT INTO chunks VALUES ('c1', 'hello')")
+    for idx in range(2, chunk_count + 1):
+        conn.execute("INSERT INTO chunks VALUES (?, ?)", (f"c{idx}", f"hello-{idx}"))
     conn.commit()
     conn.close()
 
@@ -87,6 +89,110 @@ def test_create_snapshot_gzip_is_restorable(tmp_path):
         restored_conn.close()
 
 
+def test_run_backup_verifies_gzip_with_snapshot_sentinel_and_keeps_raw_snapshot(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    source = tmp_path / "brainlayer.db"
+    _create_source_db(source, chunk_count=3)
+    socket_path = Path(f"/tmp/bb-{os.getpid()}-{uuid.uuid4().hex}.sock")
+    _start_fake_brainbar_vacuum_server(socket_path, source)
+    staging_dir = tmp_path / "out"
+    uploads: list[Path] = []
+
+    monkeypatch.setenv("BRAINBAR_SOCKET_PATH", str(socket_path))
+    monkeypatch.setattr(backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id")
+    monkeypatch.setattr(backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(backup_daily, "prune_drive_backups", lambda *args, **kwargs: [])
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        uploads.append(Path(file_path))
+        return {"id": "drive-file-id", "name": Path(file_path).name, "size": str(Path(file_path).stat().st_size)}
+
+    monkeypatch.setattr(backup_daily, "upload_file_to_drive_raw", fake_upload)
+
+    result = backup_daily.run_backup(
+        db_path=source,
+        staging_dir=staging_dir,
+        date_stamp="2026-06-05",
+        upload=True,
+        remove_local_after_upload=True,
+    )
+
+    assert uploads == [staging_dir / "2026-06-05.db.gz"]
+    assert result["verified"] is True
+    assert result["verification_mode"] == "quick"
+    assert result["sentinel_snapshot_chunks"] == 3
+    assert result["sentinel_verified_chunks"] == 3
+    assert result["local_removed"] is True
+    assert not (staging_dir / "2026-06-05.db.gz").exists()
+    assert (staging_dir / "2026-06-05.db").exists()
+
+
+def test_run_backup_full_verify_downloads_drive_copy_and_md5_compares(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    source = tmp_path / "brainlayer.db"
+    _create_source_db(source, chunk_count=2)
+    socket_path = Path(f"/tmp/bb-{os.getpid()}-{uuid.uuid4().hex}.sock")
+    _start_fake_brainbar_vacuum_server(socket_path, source)
+    uploaded_bytes: dict[str, bytes] = {}
+    downloads: list[str] = []
+
+    monkeypatch.setenv("BRAINBAR_SOCKET_PATH", str(socket_path))
+    monkeypatch.setenv("BRAINLAYER_BACKUP_FULL_VERIFY", "1")
+    monkeypatch.setattr(backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id")
+    monkeypatch.setattr(backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(backup_daily, "prune_drive_backups", lambda *args, **kwargs: [])
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        uploaded_bytes["drive-file-id"] = Path(file_path).read_bytes()
+        return {"id": "drive-file-id", "name": Path(file_path).name, "size": str(Path(file_path).stat().st_size)}
+
+    def fake_download(service, *, file_id: str, destination: Path) -> Path:  # noqa: ARG001
+        downloads.append(file_id)
+        destination.write_bytes(uploaded_bytes[file_id])
+        return destination
+
+    monkeypatch.setattr(backup_daily, "upload_file_to_drive_raw", fake_upload)
+    monkeypatch.setattr(backup_daily, "download_drive_file_raw", fake_download)
+
+    result = backup_daily.run_backup(
+        db_path=source,
+        staging_dir=tmp_path / "out",
+        date_stamp="2026-06-05",
+        upload=True,
+        remove_local_after_upload=True,
+    )
+
+    assert downloads == ["drive-file-id"]
+    assert result["verified"] is True
+    assert result["verification_mode"] == "full"
+    assert result["drive_md5_match"] is True
+    assert result["local_md5"] == result["drive_md5"]
+    assert result["sentinel_snapshot_chunks"] == 2
+    assert result["sentinel_verified_chunks"] == 2
+
+
+def test_prune_local_uncompressed_snapshots_keeps_two_newest(tmp_path):
+    from brainlayer.backup_daily import prune_local_uncompressed_snapshots
+
+    for day in range(1, 5):
+        (tmp_path / f"2026-06-0{day}.db").write_bytes(f"db-{day}".encode())
+    (tmp_path / "2026-06-04.db.gz").write_bytes(b"drive-only")
+    (tmp_path / "not-a-snapshot.db").write_bytes(b"ignore")
+
+    deleted = prune_local_uncompressed_snapshots(tmp_path, keep_latest=2)
+
+    assert deleted == ["2026-06-02.db", "2026-06-01.db"]
+    assert sorted(path.name for path in tmp_path.glob("2026-06-*.db")) == ["2026-06-03.db", "2026-06-04.db"]
+    assert (tmp_path / "2026-06-04.db.gz").exists()
+    assert (tmp_path / "not-a-snapshot.db").exists()
+
+
 def test_create_snapshot_routes_vacuum_into_over_brainbar_socket(tmp_path):
     from brainlayer.backup_daily import create_sqlite_backup_gzip
 
@@ -103,6 +209,60 @@ def test_create_snapshot_routes_vacuum_into_over_brainbar_socket(tmp_path):
     assert request["params"]["name"] == "brain_backup_vacuum_into"
     assert request["params"]["arguments"]["target_path"].endswith("/2026-05-13.db")
     assert snapshot.name == "2026-05-13.db.gz"
+
+
+def test_brainbar_vacuum_request_retries_closed_socket_with_backoff(tmp_path, monkeypatch, capsys):
+    from brainlayer import backup_daily
+
+    target = tmp_path / "snapshot.db"
+    calls = []
+    sleeps = []
+
+    def flaky_send(socket_path, request, timeout_seconds):  # noqa: ARG001
+        calls.append((socket_path, request["params"]["name"], timeout_seconds))
+        if len(calls) < 3:
+            raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
+        target.write_bytes(b"ok")
+        return {"result": {"content": [{"type": "text", "text": '{"status":"ok"}'}]}}
+
+    monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", flaky_send)
+    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
+
+    assert len(calls) == 3
+    assert sleeps == [60, 60]
+    output = capsys.readouterr().out
+    assert "BrainBar vacuum snapshot attempt 1/3 failed" in output
+    assert "BrainBar vacuum snapshot attempt 2/3 failed" in output
+    assert "retrying in 60s" in output
+
+
+def test_brainbar_vacuum_request_fails_loud_after_retry_budget(tmp_path, monkeypatch, capsys):
+    from brainlayer import backup_daily
+
+    target = tmp_path / "snapshot.db"
+    calls = []
+    sleeps = []
+
+    def closed_socket(socket_path, request, timeout_seconds):  # noqa: ARG001
+        calls.append(request["params"]["name"])
+        raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
+
+    monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", closed_socket)
+    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    with pytest.raises(RuntimeError, match="BrainBar socket closed without response"):
+        backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
+
+    assert calls == ["brain_backup_vacuum_into", "brain_backup_vacuum_into", "brain_backup_vacuum_into"]
+    assert sleeps == [60, 60]
+    output = capsys.readouterr().out
+    assert "BrainBar vacuum snapshot attempt 1/3 failed" in output
+    assert "BrainBar vacuum snapshot attempt 2/3 failed" in output
+    assert "BrainBar vacuum snapshot attempt 3/3 failed" in output
+    assert "retrying in 60s" in output
+    assert not target.exists()
 
 
 def test_create_snapshot_rejects_low_disk_space(tmp_path, monkeypatch):
@@ -176,10 +336,26 @@ def test_run_backup_verifies_upload_removes_local_and_rotates_last_n(tmp_path, m
     verified: list[tuple[str, str, int]] = []
     pruned: list[backup_daily.DriveRetentionPolicy] = []
 
-    monkeypatch.setattr(backup_daily, "create_sqlite_backup_gzip", lambda *args, **kwargs: snapshot)
+    class FakeArtifact:
+        gzip_path = snapshot
+        uncompressed_path = None
+        sentinel_chunks = 1
+        local_retention_deleted: list[str] = []
+
+    monkeypatch.setattr(backup_daily, "create_sqlite_backup_artifact", lambda *args, **kwargs: FakeArtifact())
     monkeypatch.setattr(backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
     monkeypatch.setattr(backup_daily, "build_drive_service", lambda *args, **kwargs: object())
     monkeypatch.setattr(backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id")
+    monkeypatch.setattr(
+        backup_daily,
+        "verify_sqlite_backup_artifact",
+        lambda *args, **kwargs: {
+            "verified": True,
+            "verification_mode": "quick",
+            "sentinel_snapshot_chunks": 1,
+            "sentinel_verified_chunks": 1,
+        },
+    )
     monkeypatch.setattr(
         backup_daily,
         "upload_file_to_drive_raw",

--- a/tests/test_jsonl_backup.py
+++ b/tests/test_jsonl_backup.py
@@ -125,6 +125,70 @@ def test_run_jsonl_backup_second_run_noops_when_state_covers_files(tmp_path, mon
     assert len((tmp_path / "jsonl-backup.log").read_text().strip().splitlines()) == 2
 
 
+def test_local_only_jsonl_bundle_does_not_advance_upload_state(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    source_root = tmp_path / "sessions"
+    _write_jsonl(source_root / "changed.jsonl", mtime=now - 3600)
+    state_path = tmp_path / "state.json"
+    uploads: list[Path] = []
+
+    local = jsonl_backup.run_backup(
+        source_roots=[source_root],
+        state_path=state_path,
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-05",
+        now=now,
+        upload=False,
+    )
+
+    assert local["status"] == "created"
+    assert local["verified"] is True
+    assert not state_path.exists()
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        jsonl_backup.backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id"
+    )
+    monkeypatch.setattr(jsonl_backup.backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "prune_drive_backups", lambda *args, **kwargs: [])
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        uploads.append(Path(file_path))
+        return {"id": "drive-jsonl-id", "name": Path(file_path).name, "size": str(Path(file_path).stat().st_size)}
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "upload_file_to_drive_raw", fake_upload)
+
+    uploaded = jsonl_backup.run_backup(
+        source_roots=[source_root],
+        state_path=state_path,
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-05",
+        now=now,
+        upload=True,
+    )
+
+    assert uploaded["status"] == "uploaded"
+    assert uploaded["bundled_file_count"] == 1
+    assert len(uploads) == 1
+    assert source_root.joinpath("changed.jsonl").as_posix() in state_path.read_text()
+
+
+def test_load_jsonl_backup_state_ignores_non_dict_json(tmp_path):
+    from brainlayer import jsonl_backup
+
+    state_path = tmp_path / "state.json"
+    state_path.write_text("[]", encoding="utf-8")
+
+    assert jsonl_backup._load_state(state_path) == {"files": {}}
+
+
 def test_run_jsonl_backup_upload_failure_is_loud(tmp_path, monkeypatch):
     from brainlayer import jsonl_backup
 
@@ -180,17 +244,41 @@ def test_corrupt_jsonl_bundle_verifies_false_and_main_returns_nonzero(tmp_path, 
 def test_jsonl_backup_launchd_plist_and_docstring_install_note_are_committed():
     module_path = Path("src/brainlayer/jsonl_backup.py")
     plist_path = Path("launchd/com.brainlayer.jsonl-backup.plist")
+    script_plist_path = Path("scripts/launchd/com.brainlayer.jsonl-backup.plist")
+    wrapper_path = Path("scripts/launchd/jsonl-backup.sh")
+    install_path = Path("scripts/launchd/install.sh")
 
     assert module_path.is_file()
     assert plist_path.is_file()
+    assert script_plist_path.is_file()
+    assert wrapper_path.is_file()
 
     module = module_path.read_text()
     plist = plist_path.read_text()
+    script_plist = script_plist_path.read_text()
+    wrapper = wrapper_path.read_text()
+    install = install_path.read_text()
 
     assert "Install note" in module
     assert "com.brainlayer.jsonl-backup" in plist
+    assert "com.brainlayer.jsonl-backup" in script_plist
     assert "<integer>5</integer>" in plist
+    assert "<integer>5</integer>" in script_plist
     assert "<integer>0</integer>" in plist
+    assert "<integer>0</integer>" in script_plist
     assert "BRAINLAYER_BACKUP_TIMEOUT_SECONDS" in plist
+    assert "BRAINLAYER_BACKUP_TIMEOUT_SECONDS" in wrapper
     assert "1800" in plist
+    assert "1800" in wrapper
     assert ".local/share/brainlayer/logs/jsonl-backup.log" in plist
+    assert "jsonl-backup" in install
+    assert "install_jsonl_backup_script" in install
+    assert "__BRAINLAYER_DIR_VALUE__" in wrapper
+    assert "PYTHONPATH" in wrapper
+    assert "__HOME__/.local/lib/brainlayer/jsonl-backup.sh" in script_plist
+    assert "<key>SoftResourceLimits</key>" in plist
+    assert "<key>SoftResourceLimits</key>" in script_plist
+    assert "<key>NumberOfFiles</key>" in plist
+    assert "<key>NumberOfFiles</key>" in script_plist
+    assert "<integer>4096</integer>" in plist
+    assert "<integer>4096</integer>" in script_plist

--- a/tests/test_jsonl_backup.py
+++ b/tests/test_jsonl_backup.py
@@ -1,0 +1,196 @@
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _write_jsonl(path: Path, line: str = '{"type":"message"}\n', *, mtime: float) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(line, encoding="utf-8")
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_run_jsonl_backup_uploads_incremental_bundle_verifies_and_enqueues_summary(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    claude_root = tmp_path / "home" / ".claude" / "projects"
+    archive_root = tmp_path / "home" / ".claude-archive"
+    codex_root = tmp_path / "home" / ".codex" / "sessions"
+    old_files = [
+        _write_jsonl(claude_root / "project-a" / "session-a.jsonl", mtime=now - 3600),
+        _write_jsonl(archive_root / "project-b" / "session-b.jsonl", mtime=now - 3600),
+        _write_jsonl(codex_root / "2026" / "06" / "05" / "rollout.jsonl", mtime=now - 3600),
+    ]
+    active = _write_jsonl(claude_root / "project-a" / "active.jsonl", mtime=now - 60)
+    uploads: list[Path] = []
+    pruned = []
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        jsonl_backup.backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id"
+    )
+    monkeypatch.setattr(jsonl_backup.backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        uploads.append(Path(file_path))
+        return {"id": "drive-jsonl-id", "name": Path(file_path).name, "size": str(Path(file_path).stat().st_size)}
+
+    def fake_prune(service, *, folder_parts, retention_policy):  # noqa: ARG001
+        pruned.append(retention_policy.keep_latest)
+        return ["claude-jsonl-2026-05-01.tar.gz"]
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "upload_file_to_drive_raw", fake_upload)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "prune_drive_backups", fake_prune)
+
+    result = jsonl_backup.run_backup(
+        source_roots=[claude_root, archive_root, codex_root],
+        state_path=tmp_path / "state.json",
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-05",
+        now=now,
+        upload=True,
+    )
+
+    assert uploads == [tmp_path / "staging" / "claude-jsonl-2026-06-05.tar.gz"]
+    assert pruned == [30]
+    assert result["status"] == "uploaded"
+    assert result["uploaded"] is True
+    assert result["verified"] is True
+    assert result["bundled_file_count"] == 3
+    assert result["archive_listing_count"] == 3
+    assert result["skipped_active_count"] == 1
+    assert active.as_posix() not in (tmp_path / "state.json").read_text()
+    state = json.loads((tmp_path / "state.json").read_text())
+    assert sorted(state["files"]) == sorted(path.as_posix() for path in old_files)
+    assert len((tmp_path / "jsonl-backup.log").read_text().strip().splitlines()) == 1
+    queued = list((tmp_path / "queue").glob("jsonl_backup-*.jsonl"))
+    assert len(queued) == 1
+    assert "JSONL backup uploaded 3 files" in queued[0].read_text()
+
+
+def test_run_jsonl_backup_second_run_noops_when_state_covers_files(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    source_root = tmp_path / "sessions"
+    _write_jsonl(source_root / "covered.jsonl", mtime=now - 3600)
+    uploads: list[Path] = []
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        jsonl_backup.backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id"
+    )
+    monkeypatch.setattr(jsonl_backup.backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "prune_drive_backups", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        jsonl_backup.backup_daily,
+        "upload_file_to_drive_raw",
+        lambda file_path, folder_id, credentials: (
+            uploads.append(Path(file_path))  # noqa: ARG005
+            or {
+                "id": f"drive-{len(uploads)}",
+                "name": Path(file_path).name,
+                "size": str(Path(file_path).stat().st_size),
+            }
+        ),
+    )
+
+    kwargs = {
+        "source_roots": [source_root],
+        "state_path": tmp_path / "state.json",
+        "staging_dir": tmp_path / "staging",
+        "log_path": tmp_path / "jsonl-backup.log",
+        "queue_dir": tmp_path / "queue",
+        "date_stamp": "2026-06-05",
+        "now": now,
+        "upload": True,
+    }
+    first = jsonl_backup.run_backup(**kwargs)
+    second = jsonl_backup.run_backup(**kwargs)
+
+    assert first["status"] == "uploaded"
+    assert second["status"] == "no-op"
+    assert second["uploaded"] is False
+    assert second["already_covered_files"] == 1
+    assert second["message"] == "no-op, 1 files already covered"
+    assert len(uploads) == 1
+    assert len((tmp_path / "jsonl-backup.log").read_text().strip().splitlines()) == 2
+
+
+def test_run_jsonl_backup_upload_failure_is_loud(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    source_root = tmp_path / "sessions"
+    _write_jsonl(source_root / "changed.jsonl", mtime=now - 3600)
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        jsonl_backup.backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id"
+    )
+    monkeypatch.setattr(
+        jsonl_backup.backup_daily,
+        "upload_file_to_drive_raw",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("upload failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        jsonl_backup.run_backup(
+            source_roots=[source_root],
+            state_path=tmp_path / "state.json",
+            staging_dir=tmp_path / "staging",
+            log_path=tmp_path / "jsonl-backup.log",
+            queue_dir=tmp_path / "queue",
+            date_stamp="2026-06-05",
+            now=now,
+            upload=True,
+        )
+
+    assert not (tmp_path / "state.json").exists()
+
+
+def test_corrupt_jsonl_bundle_verifies_false_and_main_returns_nonzero(tmp_path, monkeypatch, capsys):
+    from brainlayer import jsonl_backup
+
+    corrupt = tmp_path / "claude-jsonl-2026-06-05.tar.gz"
+    corrupt.write_bytes(b"not a gzip")
+    verification = jsonl_backup.verify_jsonl_bundle(corrupt, expected_file_count=1)
+    assert verification["verified"] is False
+
+    def fake_run_backup(**kwargs):  # noqa: ARG001
+        return {"status": "uploaded", "archive": str(corrupt), "uploaded": True, **verification}
+
+    monkeypatch.setattr(jsonl_backup, "run_backup", fake_run_backup)
+    monkeypatch.setattr(jsonl_backup, "_configured_backup_timeout_seconds", lambda: None)
+
+    assert jsonl_backup.main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verified"] is False
+
+
+def test_jsonl_backup_launchd_plist_and_docstring_install_note_are_committed():
+    module_path = Path("src/brainlayer/jsonl_backup.py")
+    plist_path = Path("launchd/com.brainlayer.jsonl-backup.plist")
+
+    assert module_path.is_file()
+    assert plist_path.is_file()
+
+    module = module_path.read_text()
+    plist = plist_path.read_text()
+
+    assert "Install note" in module
+    assert "com.brainlayer.jsonl-backup" in plist
+    assert "<integer>5</integer>" in plist
+    assert "<integer>0</integer>" in plist
+    assert "BRAINLAYER_BACKUP_TIMEOUT_SECONDS" in plist
+    assert "1800" in plist
+    assert ".local/share/brainlayer/logs/jsonl-backup.log" in plist


### PR DESCRIPTION
## Summary
- Add `python -m brainlayer.jsonl_backup` for incremental Claude/Codex JSONL transcript bundles uploaded to Brain Drive with 30-bundle Drive retention.
- Extend DB backup restore verification with `gunzip -t`, restored SQLite checks, chunks sentinel counts, full Drive download/md5 verification, raw local snapshot retention, and bounded BrainBar socket retry.
- Add launchd template for the 05:00 JSONL backup job and TDD coverage for mocked Drive, fixture DBs, corrupt archives, no-op incremental state, active-file skip, upload failure, and retry exhaustion.

## Test plan
- `uv run ruff check src/brainlayer/backup_daily.py src/brainlayer/jsonl_backup.py tests/test_backup_daily.py tests/test_jsonl_backup.py`
- `uv run pytest tests/test_backup_daily.py tests/test_jsonl_backup.py`
- `uv run pytest` → 2572 passed, 48 skipped, 5 xfailed, 328 warnings
- `cr review --plain` → no findings
- pre-push hook: pytest unit suite, MCP tool registration, isolated eval/hook routing, bun test, regression shell test all passed

## Notes
- `jsonl_backup.py` has no socket call sites; the bounded retry applies to the BrainBar vacuum snapshot socket path in `backup_daily.py`.
- Repository-wide `ruff check .` still reports pre-existing script lint/format issues outside this PR; change-scoped Ruff is clean.

Co-Authored-By: OpenAI Codex <noreply@openai.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add verified JSONL Drive backups with integrity checks and retry logic
> - Adds [`jsonl_backup.py`](https://github.com/EtanHey/brainlayer/pull/457/files#diff-c5b78e64594580d3a2299fadd7bf59feaf58c16fd96a4608d713bf5672af30e4) implementing an incremental backup workflow: discovers `*.jsonl` files across configured roots, bundles changed files into a `tar.gz`, uploads to Google Drive, verifies the bundle, and maintains local state to skip unchanged files on subsequent runs.
> - Extends [`backup_daily.py`](https://github.com/EtanHey/brainlayer/pull/457/files#diff-7478d7f165ea261a3912ebf2e9fb51ab469e9e8d211be7aa70cc123b4c9b97b8) with post-upload verification (`verify_sqlite_backup_artifact`) that checks MD5 against the Drive copy (on Sundays or via env flag), validates gzip integrity, runs SQLite PRAGMA checks, and compares a sentinel row count; local gzip and Drive pruning only proceed after passing verification.
> - Adds retry logic to `request_brainbar_vacuum_into` (up to 3 attempts, 60s backoff) with acceptance of an already-valid snapshot when the response is lost.
> - Adds a macOS launchd job ([`scripts/launchd/com.brainlayer.jsonl-backup.plist`](https://github.com/EtanHey/brainlayer/pull/457/files#diff-78da7d7d5f9be1ff6ac11689435a6c4510e6bf0becf219bb7968cc6e8808e79b)) and installer support to run the JSONL backup daily at 05:00.
> - Behavioral Change: `main()` in both backup modules now exits with code 1 when verification fails, and Drive pruning is skipped on unverified runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3453221.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches backup/restore and Google Drive upload paths; failed verification now fails the job and leaves local artifacts, and SQLite staging needs more disk (3× DB + 512MB).
> 
> **Overview**
> Adds **incremental JSONL transcript backups** via `python -m brainlayer.jsonl_backup`: discovers changed `.jsonl` files under Claude/Codex roots, skips recently modified files, bundles deltas into `claude-jsonl-YYYY-MM-DD.tar.gz`, uploads to Brain Drive, verifies the archive, prunes to 30 bundles, and tracks mtime/size state only after a verified upload. Run summaries go to the memory queue; launchd wiring (`jsonl-backup` target, wrapper script, 05:00 agent) is included.
> 
> **Daily SQLite backups** in `backup_daily.py` now build a `SQLiteBackupArtifact` (gzip plus optional local `.db`, chunk-count sentinel), run post-upload restore verification (`gunzip -t`, PRAGMA check, chunk sentinel; Sunday or `BRAINLAYER_BACKUP_FULL_VERIFY=1` adds Drive re-download + MD5), keep the two newest raw snapshots locally, and **skip** local gzip removal and Drive pruning when verification fails. `main()` exits non-zero on failed verification. BrainBar `vacuum_into` calls retry up to three times with backoff and can accept a valid on-disk target after a lost socket response. Drive retention parsing supports configurable filename prefix/suffix for JSONL archives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34532215b0994025b8e32a64fe0acded17982374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated JSONL transcript backup service with daily scheduling and Drive upload capability
  * Enhanced SQLite backup verification with gzip integrity checks and optional full verification mode
  * Improved backup retention policies with configurable naming patterns

* **Tests**
  * Added comprehensive test coverage for JSONL backup workflows and enhanced verification logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->