### PR TITLE
feat(kg): harvest Etan's voice-session decisions (ctx-strip + question split)

### DIFF
--- a/scripts/kg_session_harvest.py
+++ b/scripts/kg_session_harvest.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""CLI wrapper for brainlayer.kg_session_harvest."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from brainlayer.kg_session_harvest import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -195,7 +195,7 @@ def _build_clean_decisions(
     questions: list[dict[str, Any]],
     decisions: dict[str, Any],
 ) -> dict[str, Any]:
-    question_keys = {_cluster_key(cluster) for cluster in questions}
+    question_keys = _question_keys(clusters, questions)
     clusters_by_key = _clusters_by_key(clusters)
 
     merge = []
@@ -232,6 +232,12 @@ def _build_clean_decisions(
     if _contains_ctx(clean):
         raise ValueError("ctx- member leaked into clean decisions")
     return clean
+
+
+def _question_keys(clusters: list[dict[str, Any]], questions: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    keys = {_cluster_key(cluster) for cluster in questions}
+    keys.update(_cluster_key(cluster) for cluster in clusters if QUESTION_STEM_RE.match(cluster["stem"]))
+    return keys
 
 
 def _clusters_by_key(clusters: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -217,11 +217,12 @@ def _build_clean_decisions(
             needs.append(_clean_needs_item(item, clusters_by_key[key]))
     needs = [item for item in needs if item is not None]
 
+    rules: dict[str, Any] = {}
     clean: dict[str, Any] = {
         "schema": DECISIONS_SCHEMA,
         "source": decisions.get("source"),
-        "rules": {},
-        "per_category": _per_category(merge, keep),
+        "rules": rules,
+        "per_category": _per_category(clusters, question_keys, merge, keep, rules),
         "counts": _counts(merge, keep),
         "merge": merge,
         "keep": keep,
@@ -397,16 +398,55 @@ def _counts(merge: list[dict[str, Any]], keep: list[dict[str, Any]]) -> dict[str
     }
 
 
-def _per_category(merge: list[dict[str, Any]], keep: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+def _per_category(
+    clusters: list[dict[str, Any]],
+    question_keys: set[tuple[str, str]],
+    merge: list[dict[str, Any]],
+    keep: list[dict[str, Any]],
+    rules: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
     per_category: dict[str, dict[str, Any]] = {}
-    for item in merge + keep:
-        category = item["category"]
-        row = per_category.setdefault(category, {"total": 0, "explicit": 0, "by_rule": 0, "undecided": 0, "rule": None})
+    cluster_keys = set()
+    for cluster in clusters:
+        key = _cluster_key(cluster)
+        if key in question_keys:
+            continue
+        cluster_keys.add(key)
+        category = cluster["category"]
+        row = per_category.setdefault(
+            category,
+            {"total": 0, "explicit": 0, "by_rule": 0, "undecided": 0, "rule": rules.get(category)},
+        )
         row["total"] += 1
+
+    seen: set[tuple[str, str]] = set()
+    for item in merge + keep:
+        key = _decision_key(item, "exported")
+        if key in seen:
+            category, stem = key
+            raise ValueError(f"duplicate decision for {category}:{stem}")
+        seen.add(key)
+        if key not in cluster_keys:
+            category, stem = key
+            raise ValueError(f"decision references unknown non-question cluster {category}:{stem}")
+        category = item["category"]
+        row = per_category[category]
         if item.get("source") in RULE_SOURCES:
             row["by_rule"] += 1
         else:
             row["explicit"] += 1
+
+    for category, rule in rules.items():
+        per_category.setdefault(
+            category,
+            {"total": 0, "explicit": 0, "by_rule": 0, "undecided": 0, "rule": rule},
+        )
+        per_category[category]["rule"] = rule
+
+    for row in per_category.values():
+        row["undecided"] = row["total"] - row["explicit"] - row["by_rule"]
+        if row["undecided"] < 0:
+            raise ValueError("decision counts exceed category total")
     return per_category
 
 

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -87,13 +87,12 @@ def _load_decisions(path: str | Path) -> dict[str, Any]:
     decisions = json.loads(Path(path).read_text(encoding="utf-8"))
     if decisions.get("schema") != DECISIONS_SCHEMA:
         raise ValueError(f"session decisions schema must be {DECISIONS_SCHEMA!r}; got {decisions.get('schema')!r}")
-    for field in ("merge", "keep"):
+    for field in ("merge", "keep", "skipped", "needs_v1_1"):
         if not isinstance(decisions.get(field, []), list):
             raise ValueError(f"session decisions field {field!r} must be a list")
-    if "skipped" in decisions and not isinstance(decisions["skipped"], list):
-        raise ValueError("session decisions field 'skipped' must be a list")
-    if "needs_v1_1" in decisions and not isinstance(decisions["needs_v1_1"], list):
-        raise ValueError("session decisions field 'needs_v1_1' must be a list")
+        for item in decisions.get(field, []):
+            if not isinstance(item, dict):
+                raise ValueError(f"decision item in {field!r} must be an object, got {type(item).__name__}")
     return decisions
 
 
@@ -432,7 +431,7 @@ def _contains_ctx(value: Any) -> bool:
         return any(_contains_ctx(key) or _contains_ctx(val) for key, val in value.items())
     if isinstance(value, list):
         return any(_contains_ctx(item) for item in value)
-    return isinstance(value, str) and "ctx-" in value
+    return _is_ctx_id(value)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -252,10 +252,12 @@ def _clean_merge_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str
         raise ValueError(f"cluster {cluster['stem']!r} has no real members after ctx-strip")
 
     canonical = item.get("canonical")
-    canonical_id = canonical.get("id") if isinstance(canonical, dict) else None
+    if not isinstance(canonical, dict) or not isinstance(canonical.get("id"), str):
+        raise ValueError(f"merge decision for {cluster['stem']!r} must include a canonical object with a string id")
+    canonical_id = canonical["id"]
     if canonical_id in members_by_id:
         clean_canonical = _member_ref(members_by_id[canonical_id])
-    elif canonical_id is None or _is_ctx_id(canonical_id):
+    elif _is_ctx_id(canonical_id):
         clean_canonical = _member_ref(_canonical_by_chunks(real_members))
     else:
         raise ValueError(f"canonical {canonical_id!r} is not a real member of {cluster['stem']!r}")

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -500,6 +500,8 @@ def _render_answers_markdown(answers: list[dict[str, Any]]) -> str:
 
 
 def _load_apply_decisions(path: Path) -> dict[str, Any]:
+    # This harvester is repo-local tooling: it intentionally validates against
+    # the sibling cleanup script instead of duplicating its decisions schema.
     root = Path(__file__).resolve().parents[2]
     validator_path = root / "scripts" / "kg_cleanup_apply.py"
     spec = importlib.util.spec_from_file_location("brainlayer_kg_cleanup_apply_validator", validator_path)

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -85,6 +85,8 @@ def _validate_members(stem: str, members: list[Any]) -> None:
 
 def _load_decisions(path: str | Path) -> dict[str, Any]:
     decisions = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(decisions, dict):
+        raise ValueError(f"session decisions must be a JSON object, got {type(decisions).__name__}")
     if decisions.get("schema") != DECISIONS_SCHEMA:
         raise ValueError(f"session decisions schema must be {DECISIONS_SCHEMA!r}; got {decisions.get('schema')!r}")
     for field in ("merge", "keep", "skipped", "needs_v1_1"):
@@ -118,21 +120,35 @@ def _question_clusters(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [by_number[number] for number in range(1, 7)]
 
 
+def _cluster_key(cluster: dict[str, Any]) -> tuple[str, str]:
+    return cluster["category"], cluster["stem"]
+
+
+def _decision_key(item: dict[str, Any], field: str) -> tuple[str, str]:
+    stem = item.get("stem")
+    if not isinstance(stem, str):
+        raise ValueError(f"decision in {field} is missing a string stem")
+    category = item.get("category")
+    if not isinstance(category, str):
+        raise ValueError(f"decision in {field} is missing a string category")
+    return category, stem
+
+
 def _validate_decision_stems(decisions: dict[str, Any], clusters: list[dict[str, Any]]) -> None:
-    stems = {cluster["stem"] for cluster in clusters}
+    cluster_keys = {_cluster_key(cluster) for cluster in clusters}
     for field in ("merge", "keep", "skipped", "needs_v1_1"):
         for item in decisions.get(field, []):
-            stem = item.get("stem")
-            if stem not in stems:
-                raise ValueError(f"unknown decision stem {stem!r} in {field}")
+            category, stem = _decision_key(item, field)
+            if (category, stem) not in cluster_keys:
+                raise ValueError(f"unknown decision stem {stem!r} in category {category!r} for {field}")
 
 
 def _build_answers(questions: list[dict[str, Any]], decisions: dict[str, Any]) -> list[dict[str, Any]]:
-    decisions_by_stem = _decision_items_by_stem(decisions)
+    decisions_by_key = _decision_items_by_key(decisions)
     answers = []
     for question in questions:
         stem = question["stem"]
-        decision = decisions_by_stem.get(stem)
+        decision = decisions_by_key.get(_cluster_key(question))
         if decision is None:
             raise ValueError(f"missing dictionary answer decision for {stem!r}")
         note = decision.get("note")
@@ -149,17 +165,16 @@ def _build_answers(questions: list[dict[str, Any]], decisions: dict[str, Any]) -
     return answers
 
 
-def _decision_items_by_stem(decisions: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    by_stem: dict[str, dict[str, Any]] = {}
+def _decision_items_by_key(decisions: dict[str, Any]) -> dict[tuple[str, str], dict[str, Any]]:
+    by_key: dict[tuple[str, str], dict[str, Any]] = {}
     for field in ("merge", "keep", "skipped"):
         for item in decisions.get(field, []):
-            stem = item.get("stem")
-            if not isinstance(stem, str):
-                raise ValueError(f"decision in {field} is missing a string stem")
-            if stem in by_stem:
-                raise ValueError(f"duplicate exported decision for stem {stem!r}")
-            by_stem[stem] = item
-    return by_stem
+            key = _decision_key(item, field)
+            if key in by_key:
+                category, stem = key
+                raise ValueError(f"duplicate exported decision for stem {stem!r} in category {category!r}")
+            by_key[key] = item
+    return by_key
 
 
 def _question_text(cluster: dict[str, Any]) -> str:
@@ -180,24 +195,26 @@ def _build_clean_decisions(
     questions: list[dict[str, Any]],
     decisions: dict[str, Any],
 ) -> dict[str, Any]:
-    question_stems = {cluster["stem"] for cluster in questions}
-    clusters_by_stem = _clusters_by_stem(clusters)
+    question_keys = {_cluster_key(cluster) for cluster in questions}
+    clusters_by_key = _clusters_by_key(clusters)
 
-    merge = [
-        _clean_merge_item(item, clusters_by_stem[item["stem"]])
-        for item in decisions.get("merge", [])
-        if item.get("stem") not in question_stems
-    ]
-    keep = [
-        _clean_keep_item(item, clusters_by_stem[item["stem"]])
-        for item in decisions.get("keep", [])
-        if item.get("stem") not in question_stems
-    ]
-    needs = [
-        _clean_needs_item(item, clusters_by_stem[item["stem"]])
-        for item in decisions.get("needs_v1_1", [])
-        if item.get("stem") not in question_stems
-    ]
+    merge = []
+    for item in decisions.get("merge", []):
+        key = _decision_key(item, "merge")
+        if key not in question_keys:
+            merge.append(_clean_merge_item(item, clusters_by_key[key]))
+
+    keep = []
+    for item in decisions.get("keep", []):
+        key = _decision_key(item, "keep")
+        if key not in question_keys:
+            keep.append(_clean_keep_item(item, clusters_by_key[key]))
+
+    needs = []
+    for item in decisions.get("needs_v1_1", []):
+        key = _decision_key(item, "needs_v1_1")
+        if key not in question_keys:
+            needs.append(_clean_needs_item(item, clusters_by_key[key]))
     needs = [item for item in needs if item is not None]
 
     clean: dict[str, Any] = {
@@ -216,14 +233,15 @@ def _build_clean_decisions(
     return clean
 
 
-def _clusters_by_stem(clusters: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    by_stem: dict[str, dict[str, Any]] = {}
+def _clusters_by_key(clusters: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    by_key: dict[tuple[str, str], dict[str, Any]] = {}
     for cluster in clusters:
-        stem = cluster["stem"]
-        if stem in by_stem:
-            raise ValueError(f"duplicate cluster stem {stem!r}")
-        by_stem[stem] = cluster
-    return by_stem
+        key = _cluster_key(cluster)
+        if key in by_key:
+            category, stem = key
+            raise ValueError(f"duplicate cluster stem {stem!r} in category {category!r}")
+        by_key[key] = cluster
+    return by_key
 
 
 def _clean_merge_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str, Any]:
@@ -241,7 +259,14 @@ def _clean_merge_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str
     else:
         raise ValueError(f"canonical {canonical_id!r} is not a real member of {cluster['stem']!r}")
 
-    original_loser_ids = [member.get("id") for member in item.get("members", []) if isinstance(member, dict)]
+    selected_members = item.get("members")
+    if not isinstance(selected_members, list):
+        raise ValueError(f"merge decision for {cluster['stem']!r} must include a members list")
+    original_loser_ids = []
+    for member in selected_members:
+        if not isinstance(member, dict) or not isinstance(member.get("id"), str):
+            raise ValueError(f"merge member for {cluster['stem']!r} must be an object with a string id")
+        original_loser_ids.append(member["id"])
     unknown_loser_ids = [
         member_id for member_id in original_loser_ids if member_id not in members_by_id and not _is_ctx_id(member_id)
     ]
@@ -249,12 +274,14 @@ def _clean_merge_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str
         raise ValueError(f"merge members {unknown_loser_ids!r} are not real members of {cluster['stem']!r}")
     clean_member_ids = _dedupe([member_id for member_id in original_loser_ids if member_id in members_by_id])
     if not clean_member_ids:
-        clean_member_ids = [member["id"] for member in real_members]
+        raise ValueError(f"merge decision for {cluster['stem']!r} selects no real members after ctx-strip")
     members = [
         _member_ref(members_by_id[member_id])
         for member_id in clean_member_ids
         if member_id != clean_canonical["id"]
     ]
+    if not members:
+        raise ValueError(f"merge decision for {cluster['stem']!r} selects no real loser members")
 
     clean: dict[str, Any] = {
         "stem": cluster["stem"],
@@ -348,10 +375,10 @@ def _clean_mixed_note(note: str) -> str:
     payload, separator, suffix = note[len(prefix) :].partition("; ")
     try:
         member_map = json.loads(payload)
-    except json.JSONDecodeError:
-        return note
+    except json.JSONDecodeError as exc:
+        raise ValueError("MIXED note payload must be valid JSON object") from exc
     if not isinstance(member_map, dict):
-        return note
+        raise ValueError("MIXED note payload must be a JSON object")
     filtered = {member_id: action for member_id, action in member_map.items() if not _is_ctx_id(member_id)}
     clean = f"{prefix}{json.dumps(filtered, sort_keys=True, ensure_ascii=False)}"
     if separator:

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -1,0 +1,462 @@
+"""Harvest Etan voice-session answers and apply-safe KG decisions.
+
+The live review batch includes six dictionary questions followed by contested
+KG clusters whose first member is synthetic context (`ctx-*`). This module
+splits question notes into dictionary answers and emits a clean decisions file
+that `scripts/kg_cleanup_apply.py --decisions` can validate without ever
+touching the BrainLayer DB.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+DECISIONS_SCHEMA = "kg-flag-decisions-v1"
+QUESTION_STEM_RE = re.compile(r"^Q([1-6]) of 6\b")
+RULE_SOURCES = {"rule", "voice-rule"}
+
+
+def harvest_session(
+    batch_path: str | Path,
+    session_decisions_path: str | Path,
+    *,
+    answers_path: str | Path,
+    decisions_path: str | Path,
+) -> dict[str, Any]:
+    """Write dictionary answers and ctx-free cleanup decisions.
+
+    The output decisions file is validated by importing
+    `scripts/kg_cleanup_apply.py::load_decisions`; this function never opens the
+    BrainLayer SQLite database.
+    """
+    clusters = _load_batch(batch_path)
+    decisions = _load_decisions(session_decisions_path)
+    _validate_decision_stems(decisions, clusters)
+
+    questions = _question_clusters(clusters)
+    answers = _build_answers(questions, decisions)
+    clean = _build_clean_decisions(clusters, questions, decisions)
+
+    answers_outputs = _write_answers(Path(answers_path), answers)
+    decisions_out = Path(decisions_path)
+    decisions_out.parent.mkdir(parents=True, exist_ok=True)
+    decisions_out.write_text(json.dumps(clean, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    _load_apply_decisions(decisions_out)
+
+    return {
+        "answers_count": len(answers),
+        "answers_json": str(answers_outputs["json"]),
+        "answers_markdown": str(answers_outputs["markdown"]),
+        "decisions": str(decisions_out),
+        "decision_counts": clean["counts"],
+    }
+
+
+def _load_batch(path: str | Path) -> list[dict[str, Any]]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("session batch must be a category object")
+
+    clusters: list[dict[str, Any]] = []
+    for category, rows in raw.items():
+        if not isinstance(rows, list):
+            raise ValueError(f"session batch category {category!r} must be a list")
+        for row in rows:
+            if not isinstance(row, dict) or not isinstance(row.get("stem"), str):
+                raise ValueError(f"invalid cluster in category {category!r}")
+            members = row.get("members", [])
+            if not isinstance(members, list):
+                raise ValueError(f"cluster {row.get('stem')!r} members must be a list")
+            _validate_members(row["stem"], members)
+            clusters.append({**row, "category": category, "members": members})
+    return clusters
+
+
+def _validate_members(stem: str, members: list[Any]) -> None:
+    for member in members:
+        if not isinstance(member, dict) or not all(isinstance(member.get(key), str) for key in ("id", "name", "type")):
+            raise ValueError(f"invalid member in cluster {stem!r}: {member!r}")
+
+
+def _load_decisions(path: str | Path) -> dict[str, Any]:
+    decisions = json.loads(Path(path).read_text(encoding="utf-8"))
+    if decisions.get("schema") != DECISIONS_SCHEMA:
+        raise ValueError(f"session decisions schema must be {DECISIONS_SCHEMA!r}; got {decisions.get('schema')!r}")
+    for field in ("merge", "keep"):
+        if not isinstance(decisions.get(field, []), list):
+            raise ValueError(f"session decisions field {field!r} must be a list")
+    if "skipped" in decisions and not isinstance(decisions["skipped"], list):
+        raise ValueError("session decisions field 'skipped' must be a list")
+    if "needs_v1_1" in decisions and not isinstance(decisions["needs_v1_1"], list):
+        raise ValueError("session decisions field 'needs_v1_1' must be a list")
+    return decisions
+
+
+def _question_clusters(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    dictionary_category = [cluster for cluster in clusters if cluster["category"] == "dictionary-questions"]
+    questions = dictionary_category or [cluster for cluster in clusters if QUESTION_STEM_RE.match(cluster["stem"])]
+    if len(questions) != 6:
+        raise ValueError(f"expected exactly 6 dictionary question stems, found {len(questions)}")
+
+    by_number: dict[int, dict[str, Any]] = {}
+    for cluster in questions:
+        match = QUESTION_STEM_RE.match(cluster["stem"])
+        if match is None:
+            raise ValueError(f"question stem must start with Qn of 6: {cluster['stem']!r}")
+        number = int(match.group(1))
+        if number in by_number:
+            raise ValueError(f"duplicate question stem number Q{number}")
+        by_number[number] = cluster
+
+    expected = set(range(1, 7))
+    if set(by_number) != expected:
+        raise ValueError(f"question stems must cover Q1-Q6, got {sorted(by_number)}")
+    return [by_number[number] for number in range(1, 7)]
+
+
+def _validate_decision_stems(decisions: dict[str, Any], clusters: list[dict[str, Any]]) -> None:
+    stems = {cluster["stem"] for cluster in clusters}
+    for field in ("merge", "keep", "skipped", "needs_v1_1"):
+        for item in decisions.get(field, []):
+            stem = item.get("stem")
+            if stem not in stems:
+                raise ValueError(f"unknown decision stem {stem!r} in {field}")
+
+
+def _build_answers(questions: list[dict[str, Any]], decisions: dict[str, Any]) -> list[dict[str, Any]]:
+    decisions_by_stem = _decision_items_by_stem(decisions)
+    answers = []
+    for question in questions:
+        stem = question["stem"]
+        decision = decisions_by_stem.get(stem)
+        if decision is None:
+            raise ValueError(f"missing dictionary answer decision for {stem!r}")
+        note = decision.get("note")
+        if not isinstance(note, str) or not note.strip():
+            raise ValueError(f"dictionary answer for {stem!r} must be a non-empty note")
+        answers.append(
+            {
+                "stem": stem,
+                "question": _question_text(question),
+                "answer": note,
+                "decided_at": decision.get("decided_at"),
+            }
+        )
+    return answers
+
+
+def _decision_items_by_stem(decisions: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    by_stem: dict[str, dict[str, Any]] = {}
+    for field in ("merge", "keep", "skipped"):
+        for item in decisions.get(field, []):
+            stem = item.get("stem")
+            if not isinstance(stem, str):
+                raise ValueError(f"decision in {field} is missing a string stem")
+            if stem in by_stem:
+                raise ValueError(f"duplicate exported decision for stem {stem!r}")
+            by_stem[stem] = item
+    return by_stem
+
+
+def _question_text(cluster: dict[str, Any]) -> str:
+    members = cluster.get("members", [])
+    if len(members) != 1:
+        raise ValueError(f"question cluster {cluster['stem']!r} must have exactly one member")
+    member = members[0]
+    if member.get("type") != "question":
+        raise ValueError(f"question cluster {cluster['stem']!r} first member must have type 'question'")
+    name = member.get("name")
+    if not isinstance(name, str):
+        raise ValueError(f"question cluster {cluster['stem']!r} member name must be a string")
+    return name
+
+
+def _build_clean_decisions(
+    clusters: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    decisions: dict[str, Any],
+) -> dict[str, Any]:
+    question_stems = {cluster["stem"] for cluster in questions}
+    clusters_by_stem = _clusters_by_stem(clusters)
+
+    merge = [
+        _clean_merge_item(item, clusters_by_stem[item["stem"]])
+        for item in decisions.get("merge", [])
+        if item.get("stem") not in question_stems
+    ]
+    keep = [
+        _clean_keep_item(item, clusters_by_stem[item["stem"]])
+        for item in decisions.get("keep", [])
+        if item.get("stem") not in question_stems
+    ]
+    needs = [
+        _clean_needs_item(item, clusters_by_stem[item["stem"]])
+        for item in decisions.get("needs_v1_1", [])
+        if item.get("stem") not in question_stems
+    ]
+    needs = [item for item in needs if item is not None]
+
+    clean: dict[str, Any] = {
+        "schema": DECISIONS_SCHEMA,
+        "source": decisions.get("source"),
+        "rules": {},
+        "per_category": _per_category(merge, keep),
+        "counts": _counts(merge, keep),
+        "merge": merge,
+        "keep": keep,
+    }
+    if needs:
+        clean["needs_v1_1"] = needs
+    if _contains_ctx(clean):
+        raise ValueError("ctx- member leaked into clean decisions")
+    return clean
+
+
+def _clusters_by_stem(clusters: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_stem: dict[str, dict[str, Any]] = {}
+    for cluster in clusters:
+        stem = cluster["stem"]
+        if stem in by_stem:
+            raise ValueError(f"duplicate cluster stem {stem!r}")
+        by_stem[stem] = cluster
+    return by_stem
+
+
+def _clean_merge_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str, Any]:
+    real_members = _real_members(cluster)
+    members_by_id = {member["id"]: member for member in real_members}
+    if not real_members:
+        raise ValueError(f"cluster {cluster['stem']!r} has no real members after ctx-strip")
+
+    canonical = item.get("canonical")
+    canonical_id = canonical.get("id") if isinstance(canonical, dict) else None
+    if canonical_id in members_by_id:
+        clean_canonical = _member_ref(members_by_id[canonical_id])
+    elif canonical_id is None or _is_ctx_id(canonical_id):
+        clean_canonical = _member_ref(_canonical_by_chunks(real_members))
+    else:
+        raise ValueError(f"canonical {canonical_id!r} is not a real member of {cluster['stem']!r}")
+
+    original_loser_ids = [member.get("id") for member in item.get("members", []) if isinstance(member, dict)]
+    unknown_loser_ids = [
+        member_id for member_id in original_loser_ids if member_id not in members_by_id and not _is_ctx_id(member_id)
+    ]
+    if unknown_loser_ids:
+        raise ValueError(f"merge members {unknown_loser_ids!r} are not real members of {cluster['stem']!r}")
+    clean_member_ids = _dedupe([member_id for member_id in original_loser_ids if member_id in members_by_id])
+    if not clean_member_ids:
+        clean_member_ids = [member["id"] for member in real_members]
+    members = [
+        _member_ref(members_by_id[member_id])
+        for member_id in clean_member_ids
+        if member_id != clean_canonical["id"]
+    ]
+
+    clean: dict[str, Any] = {
+        "stem": cluster["stem"],
+        "category": cluster["category"],
+        "source": item.get("source", "voice"),
+        "canonical": clean_canonical,
+        "members": members,
+    }
+    _copy_optional_item_fields(item, clean)
+    return clean
+
+
+def _clean_keep_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str, Any]:
+    clean: dict[str, Any] = {
+        "stem": cluster["stem"],
+        "category": cluster["category"],
+        "source": item.get("source", "voice"),
+    }
+    _copy_optional_item_fields(item, clean)
+    if isinstance(clean.get("note"), str):
+        clean["note"] = _clean_mixed_note(clean["note"])
+    return clean
+
+
+def _clean_needs_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str, Any] | None:
+    members = item.get("members")
+    if not isinstance(members, dict):
+        raise ValueError(f"needs_v1_1 item for {cluster['stem']!r} must include a member map")
+    real_member_ids = {member["id"] for member in _real_members(cluster)}
+    unknown_member_ids = [
+        member_id for member_id in members if member_id not in real_member_ids and not _is_ctx_id(member_id)
+    ]
+    if unknown_member_ids:
+        raise ValueError(f"mixed members {unknown_member_ids!r} are not real members of {cluster['stem']!r}")
+    filtered_members = {member_id: action for member_id, action in members.items() if not _is_ctx_id(member_id)}
+    if not filtered_members:
+        return None
+    clean: dict[str, Any] = {
+        "stem": cluster["stem"],
+        "category": cluster["category"],
+        "source": item.get("source", "voice"),
+        "members": filtered_members,
+    }
+    _copy_optional_item_fields(item, clean)
+    if isinstance(clean.get("note"), str):
+        clean["note"] = _clean_mixed_note(clean["note"])
+    return clean
+
+
+def _copy_optional_item_fields(source: dict[str, Any], target: dict[str, Any]) -> None:
+    for field in ("note", "decided_at"):
+        if field in source:
+            target[field] = source[field]
+
+
+def _real_members(cluster: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        member
+        for member in cluster.get("members", [])
+        if isinstance(member, dict) and not _is_ctx_id(member.get("id")) and member.get("type") != "context"
+    ]
+
+
+def _member_ref(member: dict[str, Any]) -> dict[str, Any]:
+    return {"id": member["id"], "name": member["name"], "type": member["type"]}
+
+
+def _canonical_by_chunks(members: list[dict[str, Any]]) -> dict[str, Any]:
+    return max(members, key=lambda member: int(member.get("chunks") or 0))
+
+
+def _is_ctx_id(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith("ctx-")
+
+
+def _dedupe(values: list[Any]) -> list[Any]:
+    seen = set()
+    out = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def _clean_mixed_note(note: str) -> str:
+    prefix = "MIXED: "
+    if not note.startswith(prefix):
+        return note
+    payload, separator, suffix = note[len(prefix) :].partition("; ")
+    try:
+        member_map = json.loads(payload)
+    except json.JSONDecodeError:
+        return note
+    if not isinstance(member_map, dict):
+        return note
+    filtered = {member_id: action for member_id, action in member_map.items() if not _is_ctx_id(member_id)}
+    clean = f"{prefix}{json.dumps(filtered, sort_keys=True, ensure_ascii=False)}"
+    if separator:
+        clean = f"{clean}; {suffix}"
+    return clean
+
+
+def _counts(merge: list[dict[str, Any]], keep: list[dict[str, Any]]) -> dict[str, int]:
+    exported = merge + keep
+    return {
+        "merge_clusters": len(merge),
+        "rows_merged_away": sum(len(item["members"]) for item in merge),
+        "keep": len(keep),
+        "explicit": sum(1 for item in exported if item.get("source") not in RULE_SOURCES),
+        "by_rule": sum(1 for item in exported if item.get("source") in RULE_SOURCES),
+    }
+
+
+def _per_category(merge: list[dict[str, Any]], keep: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    per_category: dict[str, dict[str, Any]] = {}
+    for item in merge + keep:
+        category = item["category"]
+        row = per_category.setdefault(category, {"total": 0, "explicit": 0, "by_rule": 0, "undecided": 0, "rule": None})
+        row["total"] += 1
+        if item.get("source") in RULE_SOURCES:
+            row["by_rule"] += 1
+        else:
+            row["explicit"] += 1
+    return per_category
+
+
+def _write_answers(path: Path, answers: list[dict[str, Any]]) -> dict[str, Path]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix == ".json":
+        json_path = path
+        markdown_path = path.with_suffix(".md")
+    else:
+        markdown_path = path
+        json_path = path.with_suffix(".json")
+
+    json_path.write_text(json.dumps(answers, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    markdown_path.write_text(_render_answers_markdown(answers), encoding="utf-8")
+    return {"json": json_path, "markdown": markdown_path}
+
+
+def _render_answers_markdown(answers: list[dict[str, Any]]) -> str:
+    lines = ["# Dictionary Answers", ""]
+    for answer in answers:
+        lines.extend(
+            [
+                f"## {answer['stem']}",
+                "",
+                f"Question: {answer['question']}",
+                "",
+                f"Answer: {answer['answer']}",
+                "",
+                f"Decided at: {answer.get('decided_at') or ''}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _load_apply_decisions(path: Path) -> dict[str, Any]:
+    root = Path(__file__).resolve().parents[2]
+    validator_path = root / "scripts" / "kg_cleanup_apply.py"
+    spec = importlib.util.spec_from_file_location("brainlayer_kg_cleanup_apply_validator", validator_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not import kg cleanup validator from {validator_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.load_decisions(path)
+
+
+def _contains_ctx(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(_contains_ctx(key) or _contains_ctx(val) for key, val in value.items())
+    if isinstance(value, list):
+        return any(_contains_ctx(item) for item in value)
+    return isinstance(value, str) and "ctx-" in value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Harvest Etan KG voice-session answers and clean decisions.")
+    parser.add_argument("--batch", required=True, help="Session batch JSON path")
+    parser.add_argument(
+        "--session-decisions",
+        "--input-decisions",
+        dest="session_decisions",
+        required=True,
+        help="Raw session decisions JSON path",
+    )
+    parser.add_argument("--answers", required=True, help="Answers output path; JSON/Markdown sidecar is also written")
+    parser.add_argument("--decisions", required=True, help="Clean kg-flag-decisions-v1 output path")
+    args = parser.parse_args(argv)
+
+    result = harvest_session(
+        args.batch,
+        args.session_decisions,
+        answers_path=args.answers,
+        decisions_path=args.decisions,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = ["harvest_session", "main"]

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -292,6 +292,8 @@ def _clean_merge_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str
         "members": members,
     }
     _copy_optional_item_fields(item, clean)
+    if isinstance(clean.get("note"), str):
+        clean["note"] = _clean_note(clean["note"], cluster)
     return clean
 
 
@@ -303,7 +305,7 @@ def _clean_keep_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str,
     }
     _copy_optional_item_fields(item, clean)
     if isinstance(clean.get("note"), str):
-        clean["note"] = _clean_mixed_note(clean["note"])
+        clean["note"] = _clean_note(clean["note"], cluster)
     return clean
 
 
@@ -328,7 +330,7 @@ def _clean_needs_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str
     }
     _copy_optional_item_fields(item, clean)
     if isinstance(clean.get("note"), str):
-        clean["note"] = _clean_mixed_note(clean["note"])
+        clean["note"] = _clean_note(clean["note"], cluster)
     return clean
 
 
@@ -385,6 +387,21 @@ def _clean_mixed_note(note: str) -> str:
     if separator:
         clean = f"{clean}; {suffix}"
     return clean
+
+
+def _clean_note(note: str, cluster: dict[str, Any]) -> str:
+    clean = _clean_mixed_note(note)
+    for ctx_id in sorted(_ctx_member_ids(cluster), key=len, reverse=True):
+        clean = re.sub(rf"(?<![\w-]){re.escape(ctx_id)}(?![\w-])", "synthetic context", clean)
+    return clean
+
+
+def _ctx_member_ids(cluster: dict[str, Any]) -> list[str]:
+    return [
+        member["id"]
+        for member in cluster.get("members", [])
+        if isinstance(member, dict) and _is_ctx_id(member.get("id"))
+    ]
 
 
 def _counts(merge: list[dict[str, Any]], keep: list[dict[str, Any]]) -> dict[str, int]:

--- a/src/brainlayer/kg_session_harvest.py
+++ b/src/brainlayer/kg_session_harvest.py
@@ -277,9 +277,7 @@ def _clean_merge_item(item: dict[str, Any], cluster: dict[str, Any]) -> dict[str
     if not clean_member_ids:
         raise ValueError(f"merge decision for {cluster['stem']!r} selects no real members after ctx-strip")
     members = [
-        _member_ref(members_by_id[member_id])
-        for member_id in clean_member_ids
-        if member_id != clean_canonical["id"]
+        _member_ref(members_by_id[member_id]) for member_id in clean_member_ids if member_id != clean_canonical["id"]
     ]
     if not members:
         raise ValueError(f"merge decision for {cluster['stem']!r} selects no real loser members")

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -385,6 +385,38 @@ def test_harvest_fails_loud_when_merge_selects_no_real_losers(batch_file: Path, 
         )
 
 
+def test_harvest_fails_loud_when_merge_canonical_is_missing(batch_file: Path, decisions_file: Path, tmp_path: Path):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    for item in data["merge"]:
+        if item["stem"] == "android eas":
+            item.pop("canonical")
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must include a canonical object"):
+        harvest_session(
+            batch_file,
+            decisions_file,
+            answers_path=tmp_path / "answers.md",
+            decisions_path=tmp_path / "clean.json",
+        )
+
+
+def test_harvest_fails_loud_when_merge_canonical_is_malformed(batch_file: Path, decisions_file: Path, tmp_path: Path):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    for item in data["merge"]:
+        if item["stem"] == "android eas":
+            item["canonical"] = "tool-android"
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must include a canonical object"):
+        harvest_session(
+            batch_file,
+            decisions_file,
+            answers_path=tmp_path / "answers.md",
+            decisions_path=tmp_path / "clean.json",
+        )
+
+
 def test_harvest_keys_clusters_by_category_and_stem(decisions_file: Path, tmp_path: Path):
     batch = deepcopy(SESSION_BATCH)
     batch["other-queue"] = [

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -212,6 +212,23 @@ def test_harvest_filters_mixed_member_maps(batch_file: Path, decisions_file: Pat
     assert not _contains_ctx(clean["needs_v1_1"])
 
 
+def test_harvest_allows_non_id_note_text_containing_ctx_token(
+    batch_file: Path, decisions_file: Path, tmp_path: Path
+):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    for item in data["keep"]:
+        if item["stem"] == "agent mix":
+            item["note"] = "MIXED: {\"agent-concept\": \"keep\", \"agent-tool\": \"merge\"}; compare ctx-local wording"
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+
+    harvest_session(
+        batch_file,
+        decisions_file,
+        answers_path=tmp_path / "answers.md",
+        decisions_path=tmp_path / "clean.json",
+    )
+
+
 def test_harvest_clean_decisions_round_trip_through_apply_validator(
     batch_file: Path, decisions_file: Path, tmp_path: Path
 ):
@@ -238,6 +255,22 @@ def test_harvest_fails_loud_on_unknown_decision_stem(batch_file: Path, decisions
 
     with pytest.raises(ValueError, match="unknown decision stem"):
         harvest_session(batch_file, decisions_file, answers_path=tmp_path / "answers.md", decisions_path=tmp_path / "clean.json")
+
+
+def test_harvest_fails_loud_on_non_object_decision_item(
+    batch_file: Path, decisions_file: Path, tmp_path: Path
+):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    data["merge"].append("not an object")
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="decision item in 'merge'"):
+        harvest_session(
+            batch_file,
+            decisions_file,
+            answers_path=tmp_path / "answers.md",
+            decisions_path=tmp_path / "clean.json",
+        )
 
 
 def test_harvest_fails_loud_on_malformed_batch_member(decisions_file: Path, tmp_path: Path):

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -96,12 +96,48 @@ def batch_file(tmp_path: Path) -> Path:
 @pytest.fixture
 def decisions_file(tmp_path: Path) -> Path:
     answers = [
-        {"stem": "Q1 of 6 - invocable substrates", "category": "etan-queue", "source": "voice", "note": "widen Technology", "decided_at": "2026-06-06T01:00:00Z"},
-        {"stem": "Q2 of 6 - sprints and QA rounds", "category": "etan-queue", "source": "voice", "note": "process vocabulary", "decided_at": "2026-06-06T01:01:00Z"},
-        {"stem": "Q3 of 6 - external media", "category": "etan-queue", "source": "voice", "note": "external-source", "decided_at": "2026-06-06T01:02:00Z"},
-        {"stem": "Q4 of 6 - agents as subtype", "category": "etan-queue", "source": "voice", "note": "agent subtype", "decided_at": "2026-06-06T01:03:00Z"},
-        {"stem": "Q5 of 6 - orphaned persons", "category": "etan-queue", "source": "voice", "note": "do not invent people", "decided_at": "2026-06-06T01:04:00Z"},
-        {"stem": "Q6 of 6 - concept demotion method", "category": "etan-queue", "source": "voice", "note": "demote by evidence", "decided_at": "2026-06-06T01:05:00Z"},
+        {
+            "stem": "Q1 of 6 - invocable substrates",
+            "category": "etan-queue",
+            "source": "voice",
+            "note": "widen Technology",
+            "decided_at": "2026-06-06T01:00:00Z",
+        },
+        {
+            "stem": "Q2 of 6 - sprints and QA rounds",
+            "category": "etan-queue",
+            "source": "voice",
+            "note": "process vocabulary",
+            "decided_at": "2026-06-06T01:01:00Z",
+        },
+        {
+            "stem": "Q3 of 6 - external media",
+            "category": "etan-queue",
+            "source": "voice",
+            "note": "external-source",
+            "decided_at": "2026-06-06T01:02:00Z",
+        },
+        {
+            "stem": "Q4 of 6 - agents as subtype",
+            "category": "etan-queue",
+            "source": "voice",
+            "note": "agent subtype",
+            "decided_at": "2026-06-06T01:03:00Z",
+        },
+        {
+            "stem": "Q5 of 6 - orphaned persons",
+            "category": "etan-queue",
+            "source": "voice",
+            "note": "do not invent people",
+            "decided_at": "2026-06-06T01:04:00Z",
+        },
+        {
+            "stem": "Q6 of 6 - concept demotion method",
+            "category": "etan-queue",
+            "source": "voice",
+            "note": "demote by evidence",
+            "decided_at": "2026-06-06T01:05:00Z",
+        },
     ]
     payload = {
         "schema": "kg-flag-decisions-v1",
@@ -212,13 +248,11 @@ def test_harvest_filters_mixed_member_maps(batch_file: Path, decisions_file: Pat
     assert not _contains_ctx(clean["needs_v1_1"])
 
 
-def test_harvest_allows_non_id_note_text_containing_ctx_token(
-    batch_file: Path, decisions_file: Path, tmp_path: Path
-):
+def test_harvest_allows_non_id_note_text_containing_ctx_token(batch_file: Path, decisions_file: Path, tmp_path: Path):
     data = json.loads(decisions_file.read_text(encoding="utf-8"))
     for item in data["keep"]:
         if item["stem"] == "agent mix":
-            item["note"] = "MIXED: {\"agent-concept\": \"keep\", \"agent-tool\": \"merge\"}; compare ctx-local wording"
+            item["note"] = 'MIXED: {"agent-concept": "keep", "agent-tool": "merge"}; compare ctx-local wording'
     decisions_file.write_text(json.dumps(data), encoding="utf-8")
 
     harvest_session(
@@ -229,9 +263,7 @@ def test_harvest_allows_non_id_note_text_containing_ctx_token(
     )
 
 
-def test_harvest_strips_embedded_ctx_member_ids_from_notes(
-    batch_file: Path, decisions_file: Path, tmp_path: Path
-):
+def test_harvest_strips_embedded_ctx_member_ids_from_notes(batch_file: Path, decisions_file: Path, tmp_path: Path):
     data = json.loads(decisions_file.read_text(encoding="utf-8"))
     data["source"] = "etan-ctx-strip-session"
     for item in data["merge"]:
@@ -285,12 +317,12 @@ def test_harvest_fails_loud_on_unknown_decision_stem(batch_file: Path, decisions
     decisions_file.write_text(json.dumps(data), encoding="utf-8")
 
     with pytest.raises(ValueError, match="unknown decision stem"):
-        harvest_session(batch_file, decisions_file, answers_path=tmp_path / "answers.md", decisions_path=tmp_path / "clean.json")
+        harvest_session(
+            batch_file, decisions_file, answers_path=tmp_path / "answers.md", decisions_path=tmp_path / "clean.json"
+        )
 
 
-def test_harvest_fails_loud_on_non_object_decision_item(
-    batch_file: Path, decisions_file: Path, tmp_path: Path
-):
+def test_harvest_fails_loud_on_non_object_decision_item(batch_file: Path, decisions_file: Path, tmp_path: Path):
     data = json.loads(decisions_file.read_text(encoding="utf-8"))
     data["merge"].append("not an object")
     decisions_file.write_text(json.dumps(data), encoding="utf-8")
@@ -304,9 +336,7 @@ def test_harvest_fails_loud_on_non_object_decision_item(
         )
 
 
-def test_harvest_fails_loud_on_non_object_decisions_file(
-    batch_file: Path, tmp_path: Path
-):
+def test_harvest_fails_loud_on_non_object_decisions_file(batch_file: Path, tmp_path: Path):
     decisions_path = tmp_path / "bad-decisions.json"
     decisions_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
 
@@ -337,9 +367,7 @@ def test_harvest_fails_loud_on_malformed_mixed_note_with_ctx_member(
         )
 
 
-def test_harvest_fails_loud_when_merge_selects_no_real_losers(
-    batch_file: Path, decisions_file: Path, tmp_path: Path
-):
+def test_harvest_fails_loud_when_merge_selects_no_real_losers(batch_file: Path, decisions_file: Path, tmp_path: Path):
     data = json.loads(decisions_file.read_text(encoding="utf-8"))
     for item in data["merge"]:
         if item["stem"] == "android eas":
@@ -357,9 +385,7 @@ def test_harvest_fails_loud_when_merge_selects_no_real_losers(
         )
 
 
-def test_harvest_keys_clusters_by_category_and_stem(
-    decisions_file: Path, tmp_path: Path
-):
+def test_harvest_keys_clusters_by_category_and_stem(decisions_file: Path, tmp_path: Path):
     batch = deepcopy(SESSION_BATCH)
     batch["other-queue"] = [
         {
@@ -387,9 +413,7 @@ def test_harvest_keys_clusters_by_category_and_stem(
     assert all(member["id"] != "other-android" for member in clean["merge"][0]["members"])
 
 
-def test_harvest_per_category_counts_skipped_and_undecided_non_question_clusters(
-    decisions_file: Path, tmp_path: Path
-):
+def test_harvest_per_category_counts_skipped_and_undecided_non_question_clusters(decisions_file: Path, tmp_path: Path):
     batch = deepcopy(SESSION_BATCH)
     batch["etan-queue"].extend(
         [

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -519,24 +519,28 @@ def test_cli_runs_from_plain_checkout_without_pythonpath(batch_file: Path, decis
     clean_path = tmp_path / "clean-decisions.json"
     env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(script),
-            "--batch",
-            str(batch_file),
-            "--session-decisions",
-            str(decisions_file),
-            "--answers",
-            str(answers_path),
-            "--decisions",
-            str(clean_path),
-        ],
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--batch",
+                str(batch_file),
+                "--session-decisions",
+                str(decisions_file),
+                "--answers",
+                str(answers_path),
+                "--decisions",
+                str(clean_path),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(f"kg_session_harvest CLI timed out after {exc.timeout} seconds")
 
     assert result.returncode == 0, result.stderr
     assert json.loads(clean_path.read_text(encoding="utf-8"))["counts"]["merge_clusters"] == 1

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -229,6 +229,37 @@ def test_harvest_allows_non_id_note_text_containing_ctx_token(
     )
 
 
+def test_harvest_strips_embedded_ctx_member_ids_from_notes(
+    batch_file: Path, decisions_file: Path, tmp_path: Path
+):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    data["source"] = "etan-ctx-strip-session"
+    for item in data["merge"]:
+        if item["stem"] == "android eas":
+            item["note"] = "merge ctx-android eas into the real Android EAS entries"
+    for item in data["keep"]:
+        if item["stem"] == "agent mix":
+            item["note"] = (
+                'MIXED: {"agent-concept": "keep", "agent-tool": "merge", "ctx-agent mix": "keep"}; '
+                "ctx-agent mix is only review context; keep ctx-local wording"
+            )
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+    clean_path = tmp_path / "clean.json"
+
+    harvest_session(
+        batch_file,
+        decisions_file,
+        answers_path=tmp_path / "answers.md",
+        decisions_path=clean_path,
+    )
+
+    clean = json.loads(clean_path.read_text(encoding="utf-8"))
+    assert clean["source"] == "etan-ctx-strip-session"
+    assert "ctx-android eas" not in clean["merge"][0]["note"]
+    assert "ctx-agent mix" not in clean["keep"][0]["note"]
+    assert "ctx-local" in clean["keep"][0]["note"]
+
+
 def test_harvest_clean_decisions_round_trip_through_apply_validator(
     batch_file: Path, decisions_file: Path, tmp_path: Path
 ):

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -273,6 +273,89 @@ def test_harvest_fails_loud_on_non_object_decision_item(
         )
 
 
+def test_harvest_fails_loud_on_non_object_decisions_file(
+    batch_file: Path, tmp_path: Path
+):
+    decisions_path = tmp_path / "bad-decisions.json"
+    decisions_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="session decisions must be a JSON object"):
+        harvest_session(
+            batch_file,
+            decisions_path,
+            answers_path=tmp_path / "answers.md",
+            decisions_path=tmp_path / "clean.json",
+        )
+
+
+def test_harvest_fails_loud_on_malformed_mixed_note_with_ctx_member(
+    batch_file: Path, decisions_file: Path, tmp_path: Path
+):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    for item in data["keep"]:
+        if item["stem"] == "agent mix":
+            item["note"] = 'MIXED: {"ctx-agent mix": "keep"'
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="MIXED note payload must be valid JSON"):
+        harvest_session(
+            batch_file,
+            decisions_file,
+            answers_path=tmp_path / "answers.md",
+            decisions_path=tmp_path / "clean.json",
+        )
+
+
+def test_harvest_fails_loud_when_merge_selects_no_real_losers(
+    batch_file: Path, decisions_file: Path, tmp_path: Path
+):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    for item in data["merge"]:
+        if item["stem"] == "android eas":
+            item["members"] = [
+                {"id": "ctx-android eas", "name": "CONTESTED - judge said Technology", "type": "context"}
+            ]
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="selects no real members"):
+        harvest_session(
+            batch_file,
+            decisions_file,
+            answers_path=tmp_path / "answers.md",
+            decisions_path=tmp_path / "clean.json",
+        )
+
+
+def test_harvest_keys_clusters_by_category_and_stem(
+    decisions_file: Path, tmp_path: Path
+):
+    batch = deepcopy(SESSION_BATCH)
+    batch["other-queue"] = [
+        {
+            "stem": "android eas",
+            "size": 2,
+            "members": [
+                {"id": "ctx-other android eas", "name": "Other contested context", "type": "context", "chunks": 0},
+                {"id": "other-android", "name": "Android EAS", "type": "project", "chunks": 9},
+            ],
+        }
+    ]
+    batch_path = _write_json(tmp_path / "duplicate-stems.json", batch)
+    clean_path = tmp_path / "clean.json"
+
+    harvest_session(
+        batch_path,
+        decisions_file,
+        answers_path=tmp_path / "answers.md",
+        decisions_path=clean_path,
+    )
+
+    clean = json.loads(clean_path.read_text(encoding="utf-8"))
+    assert clean["merge"][0]["category"] == "etan-queue"
+    assert clean["merge"][0]["canonical"]["id"] == "tool-android"
+    assert all(member["id"] != "other-android" for member in clean["merge"][0]["members"])
+
+
 def test_harvest_fails_loud_on_malformed_batch_member(decisions_file: Path, tmp_path: Path):
     batch = deepcopy(SESSION_BATCH)
     del batch["etan-queue"][6]["members"][2]["type"]

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -1,0 +1,283 @@
+import json
+import os
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from brainlayer.kg_session_harvest import harvest_session
+
+SESSION_BATCH = {
+    "etan-queue": [
+        {
+            "stem": "Q1 of 6 - invocable substrates",
+            "size": 1,
+            "members": [
+                {
+                    "id": "q1",
+                    "name": "DICTIONARY QUESTION: Tools or widen Technology?",
+                    "type": "question",
+                    "chunks": 0,
+                }
+            ],
+        },
+        {
+            "stem": "Q2 of 6 - sprints and QA rounds",
+            "size": 1,
+            "members": [
+                {
+                    "id": "q2",
+                    "name": "DICTIONARY QUESTION: Sprint, QA pass, or process?",
+                    "type": "question",
+                    "chunks": 0,
+                }
+            ],
+        },
+        {
+            "stem": "Q3 of 6 - external media",
+            "size": 1,
+            "members": [{"id": "q3", "name": "DICTIONARY QUESTION: Media source?", "type": "question", "chunks": 0}],
+        },
+        {
+            "stem": "Q4 of 6 - agents as subtype",
+            "size": 1,
+            "members": [{"id": "q4", "name": "DICTIONARY QUESTION: Agent subtype?", "type": "question", "chunks": 0}],
+        },
+        {
+            "stem": "Q5 of 6 - orphaned persons",
+            "size": 1,
+            "members": [{"id": "q5", "name": "DICTIONARY QUESTION: Person fallback?", "type": "question", "chunks": 0}],
+        },
+        {
+            "stem": "Q6 of 6 - concept demotion method",
+            "size": 1,
+            "members": [{"id": "q6", "name": "DICTIONARY QUESTION: Demote how?", "type": "question", "chunks": 0}],
+        },
+        {
+            "stem": "android eas",
+            "size": 4,
+            "members": [
+                {
+                    "id": "ctx-android eas",
+                    "name": "CONTESTED - judge said Technology; red-team refuted.",
+                    "type": "context",
+                    "chunks": 0,
+                },
+                {"id": "project-android", "name": "Android EAS", "type": "project", "chunks": 1},
+                {"id": "tool-android", "name": "Android EAS", "type": "tool", "chunks": 7},
+                {"id": "tech-android", "name": "Android EAS", "type": "technology", "chunks": 3},
+            ],
+        },
+        {
+            "stem": "agent mix",
+            "size": 3,
+            "members": [
+                {"id": "ctx-agent mix", "name": "CONTESTED - mixed case.", "type": "context", "chunks": 0},
+                {"id": "agent-tool", "name": "Agent Mix", "type": "tool", "chunks": 4},
+                {"id": "agent-concept", "name": "Agent Mix", "type": "concept", "chunks": 2},
+            ],
+        },
+    ]
+}
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def batch_file(tmp_path: Path) -> Path:
+    return _write_json(tmp_path / "etan-session.json", SESSION_BATCH)
+
+
+@pytest.fixture
+def decisions_file(tmp_path: Path) -> Path:
+    answers = [
+        {"stem": "Q1 of 6 - invocable substrates", "category": "etan-queue", "source": "voice", "note": "widen Technology", "decided_at": "2026-06-06T01:00:00Z"},
+        {"stem": "Q2 of 6 - sprints and QA rounds", "category": "etan-queue", "source": "voice", "note": "process vocabulary", "decided_at": "2026-06-06T01:01:00Z"},
+        {"stem": "Q3 of 6 - external media", "category": "etan-queue", "source": "voice", "note": "external-source", "decided_at": "2026-06-06T01:02:00Z"},
+        {"stem": "Q4 of 6 - agents as subtype", "category": "etan-queue", "source": "voice", "note": "agent subtype", "decided_at": "2026-06-06T01:03:00Z"},
+        {"stem": "Q5 of 6 - orphaned persons", "category": "etan-queue", "source": "voice", "note": "do not invent people", "decided_at": "2026-06-06T01:04:00Z"},
+        {"stem": "Q6 of 6 - concept demotion method", "category": "etan-queue", "source": "voice", "note": "demote by evidence", "decided_at": "2026-06-06T01:05:00Z"},
+    ]
+    payload = {
+        "schema": "kg-flag-decisions-v1",
+        "source": "etan-session-2026-06-06",
+        "rules": {},
+        "per_category": {},
+        "counts": {"merge_clusters": 3, "rows_merged_away": 6, "keep": 2, "explicit": 5, "by_rule": 0},
+        "merge": [
+            answers[1],
+            {
+                "stem": "android eas",
+                "category": "etan-queue",
+                "source": "voice",
+                "canonical": {"id": "ctx-android eas", "name": "CONTESTED - judge said Technology", "type": "context"},
+                "members": [
+                    {"id": "project-android", "name": "Android EAS", "type": "project"},
+                    {"id": "tool-android", "name": "Android EAS", "type": "tool"},
+                    {"id": "tech-android", "name": "Android EAS", "type": "technology"},
+                    {"id": "ctx-android eas", "name": "CONTESTED - judge said Technology", "type": "context"},
+                ],
+                "note": "merge the real Android EAS entries",
+                "decided_at": "2026-06-06T01:06:00Z",
+            },
+        ],
+        "keep": [
+            answers[0],
+            answers[2],
+            answers[3],
+            answers[4],
+            answers[5],
+            {
+                "stem": "agent mix",
+                "category": "etan-queue",
+                "source": "voice",
+                "note": 'MIXED: {"agent-concept": "keep", "agent-tool": "merge", "ctx-agent mix": "keep"}; split tool from concept',
+                "decided_at": "2026-06-06T01:07:00Z",
+            },
+        ],
+        "needs_v1_1": [
+            {
+                "stem": "agent mix",
+                "category": "etan-queue",
+                "source": "voice",
+                "members": {"ctx-agent mix": "keep", "agent-tool": "merge", "agent-concept": "keep"},
+                "note": "split tool from concept",
+                "decided_at": "2026-06-06T01:07:00Z",
+            }
+        ],
+    }
+    return _write_json(tmp_path / "session-decisions.json", payload)
+
+
+def _contains_ctx(value: object) -> bool:
+    if isinstance(value, dict):
+        return any(_contains_ctx(k) or _contains_ctx(v) for k, v in value.items())
+    if isinstance(value, list):
+        return any(_contains_ctx(item) for item in value)
+    return isinstance(value, str) and value.startswith("ctx-")
+
+
+def test_harvest_splits_question_answers_by_stem_not_action(batch_file: Path, decisions_file: Path, tmp_path: Path):
+    answers_path = tmp_path / "answers.md"
+    clean_path = tmp_path / "clean-decisions.json"
+
+    result = harvest_session(batch_file, decisions_file, answers_path=answers_path, decisions_path=clean_path)
+
+    answers_json = json.loads((tmp_path / "answers.json").read_text(encoding="utf-8"))
+    assert [row["stem"] for row in answers_json] == [
+        "Q1 of 6 - invocable substrates",
+        "Q2 of 6 - sprints and QA rounds",
+        "Q3 of 6 - external media",
+        "Q4 of 6 - agents as subtype",
+        "Q5 of 6 - orphaned persons",
+        "Q6 of 6 - concept demotion method",
+    ]
+    assert answers_json[1]["question"] == "DICTIONARY QUESTION: Sprint, QA pass, or process?"
+    assert answers_json[1]["answer"] == "process vocabulary"
+    assert result["answers_count"] == 6
+
+    clean = json.loads(clean_path.read_text(encoding="utf-8"))
+    clean_stems = {item["stem"] for item in clean["merge"] + clean["keep"]}
+    assert "Q1 of 6 - invocable substrates" not in clean_stems
+    assert "Q2 of 6 - sprints and QA rounds" not in clean_stems
+    assert "android eas" in clean_stems
+
+
+def test_harvest_strips_ctx_members_and_rederives_canonical_from_chunk_count(
+    batch_file: Path, decisions_file: Path, tmp_path: Path
+):
+    clean_path = tmp_path / "clean-decisions.json"
+
+    harvest_session(batch_file, decisions_file, answers_path=tmp_path / "answers.md", decisions_path=clean_path)
+
+    clean = json.loads(clean_path.read_text(encoding="utf-8"))
+    android = clean["merge"][0]
+    assert android["canonical"] == {"id": "tool-android", "name": "Android EAS", "type": "tool"}
+    assert [member["id"] for member in android["members"]] == ["project-android", "tech-android"]
+    assert not _contains_ctx(clean)
+
+
+def test_harvest_filters_mixed_member_maps(batch_file: Path, decisions_file: Path, tmp_path: Path):
+    clean_path = tmp_path / "clean-decisions.json"
+
+    harvest_session(batch_file, decisions_file, answers_path=tmp_path / "answers.md", decisions_path=clean_path)
+
+    clean = json.loads(clean_path.read_text(encoding="utf-8"))
+    assert clean["needs_v1_1"][0]["members"] == {"agent-tool": "merge", "agent-concept": "keep"}
+    assert not _contains_ctx(clean["needs_v1_1"])
+
+
+def test_harvest_clean_decisions_round_trip_through_apply_validator(
+    batch_file: Path, decisions_file: Path, tmp_path: Path
+):
+    from scripts.kg_cleanup_apply import load_decisions
+
+    clean_path = tmp_path / "clean-decisions.json"
+
+    harvest_session(batch_file, decisions_file, answers_path=tmp_path / "answers.md", decisions_path=clean_path)
+
+    clean = load_decisions(clean_path)
+    assert clean["counts"] == {
+        "merge_clusters": 1,
+        "rows_merged_away": 2,
+        "keep": 1,
+        "explicit": 2,
+        "by_rule": 0,
+    }
+
+
+def test_harvest_fails_loud_on_unknown_decision_stem(batch_file: Path, decisions_file: Path, tmp_path: Path):
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    data["keep"].append({"stem": "missing stem", "category": "etan-queue", "source": "voice"})
+    decisions_file.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown decision stem"):
+        harvest_session(batch_file, decisions_file, answers_path=tmp_path / "answers.md", decisions_path=tmp_path / "clean.json")
+
+
+def test_harvest_fails_loud_on_malformed_batch_member(decisions_file: Path, tmp_path: Path):
+    batch = deepcopy(SESSION_BATCH)
+    del batch["etan-queue"][6]["members"][2]["type"]
+    batch_path = _write_json(tmp_path / "bad-batch.json", batch)
+
+    with pytest.raises(ValueError, match="invalid member.*android eas"):
+        harvest_session(
+            batch_path,
+            decisions_file,
+            answers_path=tmp_path / "answers.md",
+            decisions_path=tmp_path / "clean.json",
+        )
+
+
+def test_cli_runs_from_plain_checkout_without_pythonpath(batch_file: Path, decisions_file: Path, tmp_path: Path):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "kg_session_harvest.py"
+    answers_path = tmp_path / "answers.md"
+    clean_path = tmp_path / "clean-decisions.json"
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--batch",
+            str(batch_file),
+            "--session-decisions",
+            str(decisions_file),
+            "--answers",
+            str(answers_path),
+            "--decisions",
+            str(clean_path),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(clean_path.read_text(encoding="utf-8"))["counts"]["merge_clusters"] == 1

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -224,6 +224,55 @@ def test_harvest_splits_question_answers_by_stem_not_action(batch_file: Path, de
     assert "android eas" in clean_stems
 
 
+def test_harvest_excludes_question_stems_outside_dictionary_category(decisions_file: Path, tmp_path: Path):
+    batch = deepcopy(SESSION_BATCH)
+    questions = batch["etan-queue"][:6]
+    batch = {
+        "dictionary-questions": questions,
+        "etan-queue": batch["etan-queue"][6:],
+        "contested": [
+            {
+                "stem": questions[0]["stem"],
+                "size": 2,
+                "members": [
+                    {"id": "ctx-duplicate q1", "name": "Duplicate question context", "type": "context", "chunks": 0},
+                    {"id": "duplicate-q1-real", "name": "Duplicate Q1", "type": "concept", "chunks": 1},
+                ],
+            }
+        ],
+    }
+    question_stems = {question["stem"] for question in questions}
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    for field in ("merge", "keep", "skipped", "needs_v1_1"):
+        for item in data.get(field, []):
+            if item["stem"] in question_stems:
+                item["category"] = "dictionary-questions"
+    data["keep"].append(
+        {
+            "stem": questions[0]["stem"],
+            "category": "contested",
+            "source": "voice",
+            "note": "duplicate question-shaped cluster",
+            "decided_at": "2026-06-06T01:08:00Z",
+        }
+    )
+    batch_path = _write_json(tmp_path / "dictionary-questions.json", batch)
+    decisions_path = _write_json(tmp_path / "dictionary-decisions.json", data)
+    clean_path = tmp_path / "clean.json"
+
+    harvest_session(
+        batch_path,
+        decisions_path,
+        answers_path=tmp_path / "answers.md",
+        decisions_path=clean_path,
+    )
+
+    clean = json.loads(clean_path.read_text(encoding="utf-8"))
+    clean_keys = {(item["category"], item["stem"]) for item in clean["merge"] + clean["keep"]}
+    assert ("contested", questions[0]["stem"]) not in clean_keys
+    assert "contested" not in clean["per_category"]
+
+
 def test_harvest_strips_ctx_members_and_rederives_canonical_from_chunk_count(
     batch_file: Path, decisions_file: Path, tmp_path: Path
 ):

--- a/tests/test_kg_session_harvest.py
+++ b/tests/test_kg_session_harvest.py
@@ -356,6 +356,62 @@ def test_harvest_keys_clusters_by_category_and_stem(
     assert all(member["id"] != "other-android" for member in clean["merge"][0]["members"])
 
 
+def test_harvest_per_category_counts_skipped_and_undecided_non_question_clusters(
+    decisions_file: Path, tmp_path: Path
+):
+    batch = deepcopy(SESSION_BATCH)
+    batch["etan-queue"].extend(
+        [
+            {
+                "stem": "manual skip",
+                "size": 2,
+                "members": [
+                    {"id": "ctx-manual skip", "name": "Skip context", "type": "context", "chunks": 0},
+                    {"id": "skip-real", "name": "Manual Skip", "type": "concept", "chunks": 1},
+                ],
+            },
+            {
+                "stem": "still undecided",
+                "size": 2,
+                "members": [
+                    {"id": "ctx-still undecided", "name": "Undecided context", "type": "context", "chunks": 0},
+                    {"id": "undecided-real", "name": "Still Undecided", "type": "concept", "chunks": 1},
+                ],
+            },
+        ]
+    )
+    data = json.loads(decisions_file.read_text(encoding="utf-8"))
+    data["skipped"] = [
+        {"stem": "manual skip", "category": "etan-queue", "source": "voice", "decided_at": "2026-06-06T01:08:00Z"}
+    ]
+    batch_path = _write_json(tmp_path / "partial-session.json", batch)
+    decisions_path = _write_json(tmp_path / "partial-decisions.json", data)
+    clean_path = tmp_path / "clean.json"
+
+    harvest_session(
+        batch_path,
+        decisions_path,
+        answers_path=tmp_path / "answers.md",
+        decisions_path=clean_path,
+    )
+
+    clean = json.loads(clean_path.read_text(encoding="utf-8"))
+    assert clean["per_category"]["etan-queue"] == {
+        "total": 4,
+        "explicit": 2,
+        "by_rule": 0,
+        "undecided": 2,
+        "rule": None,
+    }
+    assert clean["counts"] == {
+        "merge_clusters": 1,
+        "rows_merged_away": 2,
+        "keep": 1,
+        "explicit": 2,
+        "by_rule": 0,
+    }
+
+
 def test_harvest_fails_loud_on_malformed_batch_member(decisions_file: Path, tmp_path: Path):
     batch = deepcopy(SESSION_BATCH)
     del batch["etan-queue"][6]["members"][2]["type"]


### PR DESCRIPTION
## Summary
- Add `brainlayer.kg_session_harvest` plus `scripts/kg_session_harvest.py` to harvest raw voice-session decisions into dictionary answers and apply-safe KG decisions.
- Split Q1-Q6 dictionary answers by batch stem/order regardless of recorded action, preserving verbatim notes as answers.
- Strip `ctx-*` synthetic members from canonical suggestions, merge member lists, mixed maps, and notes; rederive a real canonical by chunk count when the recorded canonical is synthetic.
- Validate the clean output by importing `scripts/kg_cleanup_apply.py::load_decisions`; the harvester does not open or write the BrainLayer DB.

## Test plan
- [x] `python3 -m pytest tests/test_kg_session_harvest.py` — 7 passed
- [x] `python3 -m pytest tests/test_kg_session_harvest.py tests/test_kg_review_session.py tests/test_kg_cleanup.py` — 34 passed before review fix; harvester suite rerun after fix
- [x] `python3 -m ruff check src/brainlayer/kg_session_harvest.py scripts/kg_session_harvest.py tests/test_kg_session_harvest.py` — all checks passed
- [x] `python3 -m pytest` — 2585 passed, 48 skipped, 5 xfailed, 328 warnings in 265.12s
- [x] pre-push hook gate — pytest unit suite 2511 passed, 9 skipped, 77 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; Bun stale-index test passed; FTS5 determinism shell regression passed

## Notes
- `python3 -m ruff check .` currently fails on 56 pre-existing lint issues in unrelated scripts; this branch's changed files are Ruff-clean.
- Pre-commit `coderabbit review --agent` hit the 180s timeout after emitting one minor finding about malformed batch-member errors. Fixed with explicit member validation plus a regression test.
- Review required; do not merge this PR yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect ctx stripping or canonical re-derivation could produce wrong merge/keep payloads for downstream KG apply, though the harvester never writes the DB and round-trips through the apply validator.
> 
> **Overview**
> Adds **`brainlayer.kg_session_harvest`** and **`scripts/kg_session_harvest.py`** to turn raw Etan voice-session batch + decisions JSON into dictionary Q1–Q6 answers (JSON/Markdown) and a **`kg-flag-decisions-v1`** file safe for **`kg_cleanup_apply`**.
> 
> Answers are taken from decision **notes** keyed by question stem/order, not from whether the row was merge/keep; those question clusters are **dropped** from the exported cleanup decisions. Contested-cluster decisions are scrubbed of **`ctx-*`** synthetic members (canonical, merge losers, `needs_v1_1` maps, and `MIXED:` note JSON); when the recorded canonical is synthetic, the real canonical is **re-picked by highest chunk count**. Output is checked by dynamically calling **`scripts/kg_cleanup_apply.load_decisions`**—no BrainLayer DB access.
> 
> **`tests/test_kg_session_harvest.py`** covers happy paths, ctx/note edge cases, validation failures, and CLI execution without `PYTHONPATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07dd8e00ee6fe82507fc199ecba4774000a1f8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `kg_session_harvest` pipeline to strip ctx-members and extract question-split decisions
> - Adds [`src/brainlayer/kg_session_harvest.py`](https://github.com/EtanHey/brainlayer/pull/460/files#diff-8c999acb7618c5cc1a9ac15c8d9519c92d4e4bbb3d66c6916137b7f4d96662e5) with a `harvest_session` function that loads a session batch and raw decisions, extracts six dictionary questions, builds answers, strips `ctx-` members from merge/keep/needs_v1_1 items, sanitizes notes, and writes JSON and Markdown artifacts to disk.
> - Adds a [`scripts/kg_session_harvest.py`](https://github.com/EtanHey/brainlayer/pull/460/files#diff-eac6e189021172386d18c4f8295c8f7559d1d5e19bcd47bde5d748a4795ac0af) CLI wrapper that invokes `main` and exits with its status code.
> - Validates clean decisions by dynamically importing the sibling `scripts/kg_cleanup_apply.py` loader, reusing its schema check instead of duplicating it.
> - Adds a comprehensive test suite in [`tests/test_kg_session_harvest.py`](https://github.com/EtanHey/brainlayer/pull/460/files#diff-06b18c93d266fcdbdefb24a974e8f3d02542870d91c7447f418388452155ad4d) covering ctx stripping, note sanitization, per-category counts, error cases, and a CLI invocation test without `PYTHONPATH`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07dd8e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session harvesting functionality with automatic data cleaning and validation.
  * Generates cleaned decision outputs and corresponding metadata exports.
  * Includes comprehensive input validation and error handling for malformed data.
  * CLI tool now available for session processing workflows.

* **Tests**
  * Added extensive test coverage for harvesting workflows, validation scenarios, and CLI execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->