### PR TITLE
fix(kg): speak_text v2 — question items + TTS noise (Etan-session unblock)

### DIFF
--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -537,14 +537,20 @@ def apply_rule(
 def speak_text(cluster: dict[str, Any]) -> str:
     """Spoken summary of a cluster, optimized for TTS (short, concrete)."""
     members = cluster["members"]
+    if any(m.get("type") == "question" for m in members):
+        # Dictionary-question pseudo-cluster: the member name IS the question.
+        question = next(m["name"] for m in members if m.get("type") == "question")
+        return f"{question} Answer in your own words; I will capture it verbatim and mark this item handled."
     names = sorted({m["name"] for m in members})
     parts = [f"Cluster {cluster['stem']!r}, category {cluster['category']}, {len(members)} entries."]
     if len(names) == 1:
-        parts.append(f"All named {names[0]}.")
+        # Single shared name: say it once, with the type spread only.
+        types = ", ".join(sorted({m["type"] for m in members}))
+        parts.append(f"All named {names[0]}, typed {types}.")
     else:
         parts.append("Name variants: " + ", ".join(names) + ".")
-    by_member = ", ".join(f"{m['name']} as {m['type']} with {m.get('chunks', 0)} chunks" for m in members)
-    parts.append(by_member + ".")
+        by_member = ", ".join(f"{m['name']} as {m['type']}" for m in members)
+        parts.append(by_member + ".")
     parts.append("Merge, keep separate, mixed, or skip?")
     return " ".join(parts)
 

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -399,3 +399,49 @@ def test_voice_rewrite_preserves_unknown_dashboard_fields(batch_file, decisions_
     assert data["keep"][0]["note"] == "non-deterministic voice answer"
     assert data["keep"][0]["dashboard_row_id"] == "row-17"
     assert_v1(data)
+
+
+# --- speak_text v2: question items + TTS noise fixes (Etan session blockers) ---
+
+
+def _q_cluster():
+    return {
+        "stem": "Q1 of 6 — invocable substrates",
+        "category": "etan-queue",
+        "members": [{"id": "q1", "name": "DICTIONARY QUESTION: are languages Tools?", "type": "question", "chunks": 0}],
+    }
+
+
+def _tool_cluster():
+    return {
+        "stem": "github",
+        "category": "etan-queue",
+        "members": [
+            {"id": "a", "name": "github", "type": "tool", "chunks": 4},
+            {"id": "b", "name": "GitHub", "type": "technology", "chunks": 2},
+        ],
+    }
+
+
+def test_speak_question_item_uses_capture_verbatim_prompt():
+    from brainlayer.kg_review_session import speak_text
+
+    s = speak_text(_q_cluster())
+    assert "Merge, keep separate" not in s
+    assert "DICTIONARY QUESTION: are languages Tools?" in s
+    assert "capture" in s.lower() and "verbatim" in s.lower()
+
+
+def test_speak_does_not_respeak_identical_single_name():
+    from brainlayer.kg_review_session import speak_text
+
+    s = speak_text(_q_cluster())
+    assert s.count("DICTIONARY QUESTION: are languages Tools?") == 1
+
+
+def test_speak_drops_chunk_counts():
+    from brainlayer.kg_review_session import speak_text
+
+    s = speak_text(_tool_cluster())
+    assert "chunks" not in s
+    assert "Merge, keep separate, mixed, or skip?" in s


### PR DESCRIPTION
## Summary
- `type:"question"` members: speak the question text + 'Answer in your own words; I will capture it verbatim and mark this item handled' — replaces the unconditional merge menu (kg_review_session.py:548)
- Single-name clusters: name spoken once with type spread (no per-member re-speak)
- Chunk-count metadata dropped from TTS (vl-v2 asks)

## Context
Last blocker for Etan's 40-item voice session re-invite (engine side deployed per orc). Live :8849 server reads this worktree — verified live: Q1 speaks the pure question + capture-verbatim terminal.

## Test plan
- [x] TDD: 3 RED→GREEN tests; full module 17/17 (W2's suite intact); ruff clean
- [x] Live /api/next verification on the running session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only spoken prompt strings change; no decision file schema, persistence, or API contract updates.
> 
> **Overview**
> Updates **`speak_text`** in the KG flag-batch review driver so voice/TTS prompts match dictionary questions and read more cleanly.
> 
> Clusters with a member whose **`type` is `"question"`** now speak the question text once and instruct the user to answer in their own words for verbatim capture—instead of the usual merge/keep/mixed/skip menu. For normal duplicate-name clusters, a single shared name is spoken once with a combined type list, and **chunk counts are omitted** from per-member lines to reduce TTS clutter.
> 
> Three tests lock in the question prompt, no duplicate question text, and absence of chunk wording on tool clusters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab684bbd4f13de6cee095aacb4ce77d0d22b7060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `speak_text` to handle question items with verbatim-capture TTS prompts and drop chunk counts
> - When a knowledge graph cluster contains a member of type `question`, `speak_text` now returns a verbatim-capture prompt using the question text instead of the standard merge/keep prompt.
> - For clusters where all members share a single name, the output now states the name once with a comma-separated list of types rather than enumerating each member.
> - Chunk counts are removed from all `speak_text` output.
> - New tests in [test_kg_review_session.py](https://github.com/EtanHey/brainlayer/pull/461/files#diff-f3e0a580e40f8225f12f8dc5d29235b330a08652d7b7fd3f5ed13cb38af85b87) cover the question-item prompt, single-name deduplication, and absence of chunk count language.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab684bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->