### PR TITLE
fix: gate correction detection false fires

### DIFF
--- a/src/brainlayer/pipeline/correction_detection.py
+++ b/src/brainlayer/pipeline/correction_detection.py
@@ -44,9 +44,9 @@ _HARNESS_MARKERS = (
     '"operation": "enqueue"',
 )
 _ENTITY_CONTEXT_MARKERS = ("[entity:",)
-_TASK_NOTIFICATION_WRAPPER = re.compile(
-    r"^\s*<task-notification\b|\"commandmode\"\s*:\s*\"task-notification\"",
-    re.IGNORECASE,
+_TASK_NOTIFICATION_JSON_WRAPPER = re.compile(
+    r"^\s*\{.*\"commandmode\"\s*:\s*\"task-notification\"",
+    re.IGNORECASE | re.DOTALL,
 )
 
 _DISPATCH_MARKERS = (
@@ -130,6 +130,11 @@ def looks_like_live_correction(prompt: str) -> bool:
     return bool(_LIVE_CORRECTION_CUES.search(prompt))
 
 
+def has_correction_signal(prompt: str) -> bool:
+    """Return True when the prompt matches any correction category pattern."""
+    return any(pattern.search(prompt) for pattern, _category in CORRECTION_PATTERNS)
+
+
 def has_strong_live_correction_cue(prompt: str) -> bool:
     """Return True for live cues strong enough to override relay/dispatch markers."""
     return bool(_STRONG_LIVE_CORRECTION_CUES.search(prompt))
@@ -147,7 +152,10 @@ def has_standing_rule_live_correction(prompt: str) -> bool:
 
 def is_wrapped_task_notification(prompt: str) -> bool:
     """Return True for task-notification envelopes, not mentions of the token."""
-    return bool(_TASK_NOTIFICATION_WRAPPER.search(prompt))
+    lowered = prompt.lstrip().lower()
+    return (lowered.startswith("<task-notification") and "</task-notification>" in lowered) or bool(
+        _TASK_NOTIFICATION_JSON_WRAPPER.search(prompt)
+    )
 
 
 def should_suppress_correction_detection(prompt: str) -> tuple[bool, str]:
@@ -169,6 +177,12 @@ def should_suppress_correction_detection(prompt: str) -> tuple[bool, str]:
 
     lowered = prompt.lower()
     for marker in _HARNESS_MARKERS:
+        if (
+            marker in {"<task-notification", "</task-notification>"}
+            and marker in lowered
+            and has_correction_signal(prompt)
+        ):
+            continue
         if marker in lowered and not has_direct_live_correction_line(prompt):
             return (True, f"harness marker: {marker!r}")
 

--- a/src/brainlayer/pipeline/correction_detection.py
+++ b/src/brainlayer/pipeline/correction_detection.py
@@ -44,6 +44,10 @@ _HARNESS_MARKERS = (
     '"operation": "enqueue"',
 )
 _ENTITY_CONTEXT_MARKERS = ("[entity:",)
+_TASK_NOTIFICATION_WRAPPER = re.compile(
+    r"^\s*<task-notification\b|\"commandmode\"\s*:\s*\"task-notification\"",
+    re.IGNORECASE,
+)
 
 _DISPATCH_MARKERS = (
     "dispatch brief",
@@ -141,6 +145,11 @@ def has_standing_rule_live_correction(prompt: str) -> bool:
     return bool(_STANDING_RULE_LIVE_CORRECTION.search(prompt))
 
 
+def is_wrapped_task_notification(prompt: str) -> bool:
+    """Return True for task-notification envelopes, not mentions of the token."""
+    return bool(_TASK_NOTIFICATION_WRAPPER.search(prompt))
+
+
 def should_suppress_correction_detection(prompt: str) -> tuple[bool, str]:
     """Return (suppress, reason) for prompts that are confidently non-user payloads.
 
@@ -155,6 +164,8 @@ def should_suppress_correction_detection(prompt: str) -> tuple[bool, str]:
         return (True, "agent-relay header")
     if _FLEET_TICK.search(prompt):
         return (True, "fleet tick")
+    if is_wrapped_task_notification(prompt):
+        return (True, "task-notification wrapper")
 
     lowered = prompt.lower()
     for marker in _HARNESS_MARKERS:

--- a/src/brainlayer/pipeline/correction_detection.py
+++ b/src/brainlayer/pipeline/correction_detection.py
@@ -2,33 +2,114 @@
 
 from __future__ import annotations
 
+import os
 import re
+
+_RELAY_HEADER = re.compile(
+    r"^\s*\[(?=[^\]\n]{0,80}\b(?:agent|brainlayer|claude|codex|cursor|golem|lead|orc|worker)\b)"
+    r"[^\]\n]{0,80}?(?:→|->)[^\]\n]{0,80}?\]",
+    re.IGNORECASE,
+)
+_FLEET_TICK = re.compile(r"^\s*FLEET\s+TICK\b", re.IGNORECASE)
+_STANDING_RULE_MARKER = re.compile(r"\bstanding\b", re.IGNORECASE)
+_STANDING_RULE_LIVE_CORRECTION = re.compile(
+    r"\bstanding\b.*\b(?:wrong|incorrect)\b|\b(?:wrong|incorrect)\b.*\bstanding\b",
+    re.IGNORECASE,
+)
+
+_HARNESS_MARKERS = (
+    "<system-reminder>",
+    "userpromptsubmit hook additional context",
+    "important: after completing your current task",
+    "# autonomous loop",
+    "autonomous loop tick",
+    "<<autonomous-loop",
+    "[frustration signal detected",
+    "[brainlayer auto]",
+    "[brainlayer deep]",
+    "this is ambient context",
+    "the user sent a new message while you were working",
+    "silent orchestrator-monitor",
+    "stay silent unless a real event",
+    "# autonomous loop tick",
+    "run the autonomous check",
+    "<task-notification",
+    "</task-notification>",
+    '"commandmode":"task-notification"',
+    '"commandmode": "task-notification"',
+    "queued_command",
+    '"type":"queue-operation"',
+    '"type": "queue-operation"',
+    '"operation":"enqueue"',
+    '"operation": "enqueue"',
+)
+_ENTITY_CONTEXT_MARKERS = ("[entity:",)
+
+_DISPATCH_MARKERS = (
+    "dispatch brief",
+    "worker brief",
+    "dispatched by:",
+    "quoted in dispatch",
+    "brief quoting",
+    "you are the new brainlayer",
+    "outgoing lead",
+    "grill answer",
+)
+_QUOTED_DISPATCH_MARKERS = (
+    "quoted in dispatch",
+    "brief quoting",
+)
+
+_STANDING_RULE_TERMS = (
+    "no --print",
+    "no -p",
+    "--print/-p",
+    "no source ~/.zshrc",
+    "do not use source ~/.zshrc",
+)
+
+_LIVE_CORRECTION_CUES = re.compile(
+    r"^\s*(no\b|stop\b|wait\b|why\b|what\b|are you\b)|"
+    r"\b(i told you|as i said|we spoke about|this is live)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_STRONG_LIVE_CORRECTION_CUES = re.compile(
+    r"\b(i told you|as i said|we spoke about|this is live)\b",
+    re.IGNORECASE,
+)
+_DIRECT_LIVE_CORRECTION_LINE = re.compile(
+    r"^\s*(?:no\b\s*(?:[,.:;]|\s-\s)|nope\b\s*(?:[,.:;]|\s-\s)|"
+    r"that'?s?\s+wrong\b|stop\b\s*[.!?:;-]|לא\s+נכון\b)",
+    re.IGNORECASE,
+)
 
 CORRECTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(
-            r"(?:^|\b)(?:no|nope|wrong|incorrect|that'?s?\s+(?:not|wrong|incorrect))",
+            r"\b(?:no|nope|wrong|incorrect)\b|\bthat'?s?\s+(?:not|wrong|incorrect)\b",
             re.IGNORECASE,
         ),
         "factual",
     ),
     (
         re.compile(
-            r"(?:^|\b)(?:don'?t|do\s+not|stop|never|please\s+don'?t|i\s+(?:don'?t\s+)?(?:want|like|prefer))",
+            r"\b(?:don'?t|do\s+not|stop|never)\b|"
+            r"\bplease\s+don'?t\b|"
+            r"\bi\s+(?:don'?t\s+)?(?:want|like|prefer)\b",
             re.IGNORECASE,
         ),
         "preference",
     ),
     (
         re.compile(
-            r"(?:^|\b)(?:actually|i\s+meant|i\s+said|not\s+[\w]+[,]\s+(?:it'?s|but))",
+            r"\b(?:actually|i\s+meant|i\s+said)\b|\bnot\s+[\w]+,\s+(?:it'?s|but)\b",
             re.IGNORECASE,
         ),
         "factual",
     ),
     (
         re.compile(
-            r"(?:^|\b)(?:too\s+(?:long|short|verbose|brief)|format|style|tone)",
+            r"\btoo\s+(?:long|short|verbose|brief)\b|\b(?:format(?:ting)?|styl(?:e|ing)|tone)\b",
             re.IGNORECASE,
         ),
         "style",
@@ -40,10 +121,77 @@ CORRECTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 ]
 
 
+def looks_like_live_correction(prompt: str) -> bool:
+    """Return True when a prompt has explicit live user-correction cues."""
+    return bool(_LIVE_CORRECTION_CUES.search(prompt))
+
+
+def has_strong_live_correction_cue(prompt: str) -> bool:
+    """Return True for live cues strong enough to override relay/dispatch markers."""
+    return bool(_STRONG_LIVE_CORRECTION_CUES.search(prompt))
+
+
+def has_direct_live_correction_line(prompt: str) -> bool:
+    """Return True when any line starts like a direct user correction."""
+    return any(_DIRECT_LIVE_CORRECTION_LINE.search(line) for line in prompt.splitlines())
+
+
+def has_standing_rule_live_correction(prompt: str) -> bool:
+    """Return True when standing-rule text is itself being corrected."""
+    return bool(_STANDING_RULE_LIVE_CORRECTION.search(prompt))
+
+
+def should_suppress_correction_detection(prompt: str) -> tuple[bool, str]:
+    """Return (suppress, reason) for prompts that are confidently non-user payloads.
+
+    The gate is intentionally conservative: relay, harness, cron, and dispatch
+    markers suppress false fires, but ambiguous prompts still pass to regexes.
+    """
+    if os.environ.get("BRAINLAYER_CORRECTION_STAGE_A_DISABLED") == "1":
+        return (False, "")
+    if not prompt:
+        return (False, "")
+    if _RELAY_HEADER.search(prompt):
+        return (True, "agent-relay header")
+    if _FLEET_TICK.search(prompt):
+        return (True, "fleet tick")
+
+    lowered = prompt.lower()
+    for marker in _HARNESS_MARKERS:
+        if marker in lowered:
+            return (True, f"harness marker: {marker!r}")
+
+    if any(marker in lowered for marker in _ENTITY_CONTEXT_MARKERS) and not (
+        looks_like_live_correction(prompt) or has_direct_live_correction_line(prompt)
+    ):
+        return (True, "entity context marker")
+
+    if any(marker in lowered for marker in _QUOTED_DISPATCH_MARKERS):
+        return (True, "quoted dispatch marker")
+
+    if any(marker in lowered for marker in _DISPATCH_MARKERS) and not (
+        has_strong_live_correction_cue(prompt) or has_direct_live_correction_line(prompt)
+    ):
+        return (True, "dispatch marker")
+
+    if _STANDING_RULE_MARKER.search(prompt) and any(term in lowered for term in _STANDING_RULE_TERMS):
+        if not (
+            has_strong_live_correction_cue(prompt)
+            or has_direct_live_correction_line(prompt)
+            or has_standing_rule_live_correction(prompt)
+        ):
+            return (True, "relayed standing-rules block")
+
+    return (False, "")
+
+
 def detect_correction(prompt: str) -> str | None:
     """Detect whether text looks like a user correction and return its category."""
     stripped = prompt.strip()
     if len(stripped) < 5:
+        return None
+    suppress, _reason = should_suppress_correction_detection(stripped)
+    if suppress:
         return None
     for pattern, category in CORRECTION_PATTERNS:
         if pattern.search(stripped):

--- a/src/brainlayer/pipeline/correction_detection.py
+++ b/src/brainlayer/pipeline/correction_detection.py
@@ -2,33 +2,114 @@
 
 from __future__ import annotations
 
+import os
 import re
+
+_RELAY_HEADER = re.compile(
+    r"^\s*\[(?=[^\]\n]{0,80}\b(?:agent|brainlayer|claude|codex|cursor|golem|lead|orc|worker)\b)"
+    r"[^\]\n]{0,80}?(?:→|->)[^\]\n]{0,80}?\]",
+    re.IGNORECASE,
+)
+_FLEET_TICK = re.compile(r"^\s*FLEET\s+TICK\b", re.IGNORECASE)
+_STANDING_RULE_MARKER = re.compile(r"\bstanding\b", re.IGNORECASE)
+_STANDING_RULE_LIVE_CORRECTION = re.compile(
+    r"\bstanding\b.*\b(?:wrong|incorrect)\b|\b(?:wrong|incorrect)\b.*\bstanding\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_HARNESS_MARKERS = (
+    "<system-reminder>",
+    "userpromptsubmit hook additional context",
+    "important: after completing your current task",
+    "# autonomous loop",
+    "autonomous loop tick",
+    "<<autonomous-loop",
+    "[frustration signal detected",
+    "[brainlayer auto]",
+    "[brainlayer deep]",
+    "this is ambient context",
+    "the user sent a new message while you were working",
+    "silent orchestrator-monitor",
+    "stay silent unless a real event",
+    "# autonomous loop tick",
+    "run the autonomous check",
+    "<task-notification",
+    "</task-notification>",
+    '"commandmode":"task-notification"',
+    '"commandmode": "task-notification"',
+    "queued_command",
+    '"type":"queue-operation"',
+    '"type": "queue-operation"',
+    '"operation":"enqueue"',
+    '"operation": "enqueue"',
+)
+_ENTITY_CONTEXT_MARKERS = ("[entity:",)
+
+_DISPATCH_MARKERS = (
+    "dispatch brief",
+    "worker brief",
+    "dispatched by:",
+    "quoted in dispatch",
+    "brief quoting",
+    "you are the new brainlayer",
+    "outgoing lead",
+    "grill answer",
+)
+_QUOTED_DISPATCH_MARKERS = (
+    "quoted in dispatch",
+    "brief quoting",
+)
+
+_STANDING_RULE_TERMS = (
+    "no --print",
+    "no -p",
+    "--print/-p",
+    "no source ~/.zshrc",
+    "do not use source ~/.zshrc",
+)
+
+_LIVE_CORRECTION_CUES = re.compile(
+    r"^\s*(no\b|stop\b|wait\b|why\b|what\b|are you\b)|"
+    r"\b(i told you|as i said|we spoke about|this is live)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_STRONG_LIVE_CORRECTION_CUES = re.compile(
+    r"\b(i told you|as i said|we spoke about|this is live)\b",
+    re.IGNORECASE,
+)
+_DIRECT_LIVE_CORRECTION_LINE = re.compile(
+    r"^\s*(?:no\b\s*(?:[,.:;]|\s-\s)|nope\b\s*(?:[,.:;]|\s-\s)|"
+    r"that'?s?\s+wrong\b|stop\b\s*[.!?:;-]|לא\s+נכון\b)",
+    re.IGNORECASE,
+)
 
 CORRECTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(
-            r"(?:^|\b)(?:no|nope|wrong|incorrect|that'?s?\s+(?:not|wrong|incorrect))",
+            r"\b(?:no|nope|wrong|incorrect)\b|\bthat'?s?\s+(?:not|wrong|incorrect)\b",
             re.IGNORECASE,
         ),
         "factual",
     ),
     (
         re.compile(
-            r"(?:^|\b)(?:don'?t|do\s+not|stop|never|please\s+don'?t|i\s+(?:don'?t\s+)?(?:want|like|prefer))",
+            r"\b(?:don'?t|do\s+not|stop|never)\b|"
+            r"\bplease\s+don'?t\b|"
+            r"\bi\s+(?:don'?t\s+)?(?:want|like|prefer)\b",
             re.IGNORECASE,
         ),
         "preference",
     ),
     (
         re.compile(
-            r"(?:^|\b)(?:actually|i\s+meant|i\s+said|not\s+[\w]+[,]\s+(?:it'?s|but))",
+            r"\b(?:actually|i\s+meant|i\s+said)\b|\bnot\s+[\w]+,\s+(?:it'?s|but)\b",
             re.IGNORECASE,
         ),
         "factual",
     ),
     (
         re.compile(
-            r"(?:^|\b)(?:too\s+(?:long|short|verbose|brief)|format|style|tone)",
+            r"\btoo\s+(?:long|short|verbose|brief)\b|\b(?:format(?:ting)?|styl(?:e|ing)|tone)\b",
             re.IGNORECASE,
         ),
         "style",
@@ -40,10 +121,77 @@ CORRECTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 ]
 
 
+def looks_like_live_correction(prompt: str) -> bool:
+    """Return True when a prompt has explicit live user-correction cues."""
+    return bool(_LIVE_CORRECTION_CUES.search(prompt))
+
+
+def has_strong_live_correction_cue(prompt: str) -> bool:
+    """Return True for live cues strong enough to override relay/dispatch markers."""
+    return bool(_STRONG_LIVE_CORRECTION_CUES.search(prompt))
+
+
+def has_direct_live_correction_line(prompt: str) -> bool:
+    """Return True when any line starts like a direct user correction."""
+    return any(_DIRECT_LIVE_CORRECTION_LINE.search(line) for line in prompt.splitlines())
+
+
+def has_standing_rule_live_correction(prompt: str) -> bool:
+    """Return True when standing-rule text is itself being corrected."""
+    return bool(_STANDING_RULE_LIVE_CORRECTION.search(prompt))
+
+
+def should_suppress_correction_detection(prompt: str) -> tuple[bool, str]:
+    """Return (suppress, reason) for prompts that are confidently non-user payloads.
+
+    The gate is intentionally conservative: relay, harness, cron, and dispatch
+    markers suppress false fires, but ambiguous prompts still pass to regexes.
+    """
+    if os.environ.get("BRAINLAYER_CORRECTION_STAGE_A_DISABLED") == "1":
+        return (False, "")
+    if not prompt:
+        return (False, "")
+    if _RELAY_HEADER.search(prompt):
+        return (True, "agent-relay header")
+    if _FLEET_TICK.search(prompt):
+        return (True, "fleet tick")
+
+    lowered = prompt.lower()
+    for marker in _HARNESS_MARKERS:
+        if marker in lowered and not _DIRECT_LIVE_CORRECTION_LINE.search(prompt):
+            return (True, f"harness marker: {marker!r}")
+
+    if any(marker in lowered for marker in _ENTITY_CONTEXT_MARKERS) and not (
+        looks_like_live_correction(prompt) or has_direct_live_correction_line(prompt)
+    ):
+        return (True, "entity context marker")
+
+    if any(marker in lowered for marker in _QUOTED_DISPATCH_MARKERS):
+        return (True, "quoted dispatch marker")
+
+    if any(marker in lowered for marker in _DISPATCH_MARKERS) and not (
+        has_strong_live_correction_cue(prompt) or has_direct_live_correction_line(prompt)
+    ):
+        return (True, "dispatch marker")
+
+    if _STANDING_RULE_MARKER.search(prompt) and any(term in lowered for term in _STANDING_RULE_TERMS):
+        if not (
+            has_strong_live_correction_cue(prompt)
+            or has_direct_live_correction_line(prompt)
+            or has_standing_rule_live_correction(prompt)
+        ):
+            return (True, "relayed standing-rules block")
+
+    return (False, "")
+
+
 def detect_correction(prompt: str) -> str | None:
     """Detect whether text looks like a user correction and return its category."""
     stripped = prompt.strip()
     if len(stripped) < 5:
+        return None
+    suppress, _reason = should_suppress_correction_detection(stripped)
+    if suppress:
         return None
     for pattern, category in CORRECTION_PATTERNS:
         if pattern.search(stripped):

--- a/src/brainlayer/pipeline/correction_detection.py
+++ b/src/brainlayer/pipeline/correction_detection.py
@@ -158,7 +158,7 @@ def should_suppress_correction_detection(prompt: str) -> tuple[bool, str]:
 
     lowered = prompt.lower()
     for marker in _HARNESS_MARKERS:
-        if marker in lowered and not _DIRECT_LIVE_CORRECTION_LINE.search(prompt):
+        if marker in lowered and not has_direct_live_correction_line(prompt):
             return (True, f"harness marker: {marker!r}")
 
     if any(marker in lowered for marker in _ENTITY_CONTEXT_MARKERS) and not (

--- a/tests/test_conditional_hooks.py
+++ b/tests/test_conditional_hooks.py
@@ -13,6 +13,7 @@ Env vars tested:
 
 import importlib.util
 import io
+import json
 import os
 import sqlite3
 from pathlib import Path
@@ -662,6 +663,46 @@ class TestPromptSearchConditional:
         assert prompt_search.detect_correction("This response is too verbose.") == "style"
         assert prompt_search.detect_correction("לא נכון, תתקן את זה") == "factual"
         assert prompt_search.detect_correction("ok") is None
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "[orc gen-12 -> brainlayerCodex] No need to escalate; the worker is still running.",
+            "FLEET TICK (gen-12 orc, R5/R6.5/R8)\n"
+            "Codex s:13 working, no PR yet; do not narrate and do not stop the loop.",
+            "<task-notification>\n"
+            "<summary>Worker completed</summary>\n"
+            '<result>Historical Etan quote: "No, use the launcher."</result>\n'
+            "</task-notification>",
+            "You are the NEW brainlayerClaude-LEAD. The outgoing answer said to run "
+            "nohup ./scripts/worker.sh > /tmp/worker.log 2>&1 &.",
+        ],
+    )
+    def test_main_suppresses_correction_nudge_for_non_user_payloads(self, prompt_search, monkeypatch, capsys, prompt):
+        fake_conn = FakeConn()
+
+        monkeypatch.setattr(prompt_search, "get_db_path", lambda: "/tmp/brainlayer.db")
+        monkeypatch.setattr(
+            prompt_search, "classify_prompt", lambda prompt, detected_entities=None: "knowledge_question"
+        )
+        monkeypatch.setattr(prompt_search, "record_prompt_classification", lambda **kwargs: None)
+        monkeypatch.setattr(prompt_search, "record_injection_event", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            prompt_search.sqlite3,
+            "connect",
+            lambda *args, **kwargs: fake_conn,
+        )
+        monkeypatch.setattr(
+            prompt_search.sys,
+            "stdin",
+            io.StringIO('{"prompt":' + json.dumps(prompt) + ',"session_id":"sess-1"}'),
+        )
+
+        with pytest.raises(SystemExit):
+            prompt_search.main()
+
+        output = capsys.readouterr().out
+        assert "Correction detected:" not in output
 
     def test_main_prints_correction_store_nudge(self, prompt_search, monkeypatch, capsys):
         fake_conn = FakeConn()

--- a/tests/test_correction_detection_gate.py
+++ b/tests/test_correction_detection_gate.py
@@ -1,0 +1,101 @@
+"""Regression tests for correction-detection false-fire gates."""
+
+from __future__ import annotations
+
+import pytest
+
+from brainlayer.pipeline.correction_detection import (
+    build_correction_tags,
+    detect_correction,
+    looks_like_live_correction,
+)
+
+FALSE_FIRE_PROMPTS = [
+    pytest.param(
+        "[orc gen-12 -> brainlayerCodex] No need to escalate; the worker is still running.",
+        id="agent-relay-header",
+    ),
+    pytest.param(
+        "FLEET TICK (gen-12 orc, R5/R6.5/R8)\nCodex s:13 working, no PR yet; do not narrate and do not stop the loop.",
+        id="fleet-tick-cron",
+    ),
+    pytest.param(
+        "<task-notification>\n"
+        "<summary>Worker completed</summary>\n"
+        '<result>Historical Etan quote: "No, use the launcher."</result>\n'
+        "</task-notification>",
+        id="task-notification",
+    ),
+    pytest.param(
+        "Worker Brief - Correction-Detection Gate Port\n"
+        "Mission: port the gate. No PR exists yet; do not use the real DB in tests.",
+        id="worker-dispatch-brief",
+    ),
+    pytest.param(
+        "Worker Brief\nQuoted in dispatch:\nNo, use the launcher.",
+        id="quoted-dispatch-correction",
+    ),
+    pytest.param(
+        "Worker Brief\nQuoted in dispatch:\nI told you, no -- use the launcher.",
+        id="quoted-dispatch-strong-cue",
+    ),
+    pytest.param(
+        "No PR exists yet.\n"
+        "Worker Brief - Correction-Detection Gate Port\n"
+        "Dispatch this to a worker; do not use the real DB in tests.",
+        id="leading-no-worker-brief",
+    ),
+    pytest.param(
+        "No --print/-p mode ever.\nStanding rules block for worker dispatch; do not use source ~/.zshrc.",
+        id="leading-no-standing-rules",
+    ),
+    pytest.param(
+        "You are the NEW brainlayerClaude-LEAD. Read the outgoing lead's grill answer: "
+        "run nohup ./scripts/worker.sh > /tmp/worker.log 2>&1 &.",
+        id="boot-grill-answer-with-nohup",
+    ),
+    pytest.param(
+        "The note now describes normal startup behavior and should not be tagged.",
+        id="no-substrings",
+    ),
+    pytest.param("The stopper process stayed healthy during the run.", id="stop-substring"),
+    pytest.param("Nevermind the previous timing estimate; this is neutral.", id="never-substring"),
+    pytest.param("Wrongness scoring belongs to the eval, not the hook.", id="wrong-substring"),
+    pytest.param("The answer was incorrectly routed by a different tool.", id="incorrect-substring"),
+    pytest.param("Formatters and stylelint ran before the tonearm calibration note.", id="style-substrings"),
+]
+
+
+@pytest.mark.parametrize("prompt", FALSE_FIRE_PROMPTS)
+def test_detect_correction_suppresses_non_user_payloads(prompt: str):
+    assert detect_correction(prompt) is None
+
+
+@pytest.mark.parametrize("prompt", FALSE_FIRE_PROMPTS)
+def test_build_correction_tags_suppresses_non_user_payloads(prompt: str):
+    assert build_correction_tags(prompt) == []
+
+
+@pytest.mark.parametrize(
+    ("prompt", "category"),
+    [
+        ("No - I told you, use the launcher", "factual"),
+        ("that's wrong, the DB is at ~/.local/share", "factual"),
+        ("stop. you keep doing this", "preference"),
+        ("Worker Brief\nNo, that's wrong - use the launcher", "factual"),
+        ("I have no understanding of no --print; that's wrong, use the launcher", "factual"),
+        ("Please fix the formatting", "style"),
+        ("Please change the styling", "style"),
+        ("Some context.\nNo, that's wrong - use the launcher", "factual"),
+        ("No, [Entity: Avi Simon -- person] is wrong; Avi works at Lightricks.", "factual"),
+        ("[old -> new] is wrong; it should be old -> newer", "factual"),
+        ("No --print/-p standing rule is wrong; allow -p for debug.", "factual"),
+        ("לא נכון", "factual"),
+    ],
+)
+def test_detect_correction_keeps_true_positives(prompt: str, category: str):
+    assert detect_correction(prompt) == category
+
+
+def test_live_correction_cues_match_multiline_direct_correction():
+    assert looks_like_live_correction("Some context.\nNo, that's wrong - use the launcher")

--- a/tests/test_correction_detection_gate.py
+++ b/tests/test_correction_detection_gate.py
@@ -89,6 +89,7 @@ def test_build_correction_tags_suppresses_non_user_payloads(prompt: str):
         ("Some context.\nNo, that's wrong - use the launcher", "factual"),
         ("No, [Entity: Avi Simon -- person] is wrong; Avi works at Lightricks.", "factual"),
         ("No, the <task-notification> watcher is wrong; do not store those chunks.", "factual"),
+        ("Some context\nNo, the <task-notification> watcher is wrong; do not store those chunks.", "factual"),
         ("[old -> new] is wrong; it should be old -> newer", "factual"),
         ("No --print/-p standing rule is wrong; allow -p for debug.", "factual"),
         ("No --print/-p standing rule\nis wrong; allow -p for debug.", "factual"),

--- a/tests/test_correction_detection_gate.py
+++ b/tests/test_correction_detection_gate.py
@@ -1,0 +1,103 @@
+"""Regression tests for correction-detection false-fire gates."""
+
+from __future__ import annotations
+
+import pytest
+
+from brainlayer.pipeline.correction_detection import (
+    build_correction_tags,
+    detect_correction,
+    looks_like_live_correction,
+)
+
+FALSE_FIRE_PROMPTS = [
+    pytest.param(
+        "[orc gen-12 -> brainlayerCodex] No need to escalate; the worker is still running.",
+        id="agent-relay-header",
+    ),
+    pytest.param(
+        "FLEET TICK (gen-12 orc, R5/R6.5/R8)\nCodex s:13 working, no PR yet; do not narrate and do not stop the loop.",
+        id="fleet-tick-cron",
+    ),
+    pytest.param(
+        "<task-notification>\n"
+        "<summary>Worker completed</summary>\n"
+        '<result>Historical Etan quote: "No, use the launcher."</result>\n'
+        "</task-notification>",
+        id="task-notification",
+    ),
+    pytest.param(
+        "Worker Brief - Correction-Detection Gate Port\n"
+        "Mission: port the gate. No PR exists yet; do not use the real DB in tests.",
+        id="worker-dispatch-brief",
+    ),
+    pytest.param(
+        "Worker Brief\nQuoted in dispatch:\nNo, use the launcher.",
+        id="quoted-dispatch-correction",
+    ),
+    pytest.param(
+        "Worker Brief\nQuoted in dispatch:\nI told you, no -- use the launcher.",
+        id="quoted-dispatch-strong-cue",
+    ),
+    pytest.param(
+        "No PR exists yet.\n"
+        "Worker Brief - Correction-Detection Gate Port\n"
+        "Dispatch this to a worker; do not use the real DB in tests.",
+        id="leading-no-worker-brief",
+    ),
+    pytest.param(
+        "No --print/-p mode ever.\nStanding rules block for worker dispatch; do not use source ~/.zshrc.",
+        id="leading-no-standing-rules",
+    ),
+    pytest.param(
+        "You are the NEW brainlayerClaude-LEAD. Read the outgoing lead's grill answer: "
+        "run nohup ./scripts/worker.sh > /tmp/worker.log 2>&1 &.",
+        id="boot-grill-answer-with-nohup",
+    ),
+    pytest.param(
+        "The note now describes normal startup behavior and should not be tagged.",
+        id="no-substrings",
+    ),
+    pytest.param("The stopper process stayed healthy during the run.", id="stop-substring"),
+    pytest.param("Nevermind the previous timing estimate; this is neutral.", id="never-substring"),
+    pytest.param("Wrongness scoring belongs to the eval, not the hook.", id="wrong-substring"),
+    pytest.param("The answer was incorrectly routed by a different tool.", id="incorrect-substring"),
+    pytest.param("Formatters and stylelint ran before the tonearm calibration note.", id="style-substrings"),
+]
+
+
+@pytest.mark.parametrize("prompt", FALSE_FIRE_PROMPTS)
+def test_detect_correction_suppresses_non_user_payloads(prompt: str):
+    assert detect_correction(prompt) is None
+
+
+@pytest.mark.parametrize("prompt", FALSE_FIRE_PROMPTS)
+def test_build_correction_tags_suppresses_non_user_payloads(prompt: str):
+    assert build_correction_tags(prompt) == []
+
+
+@pytest.mark.parametrize(
+    ("prompt", "category"),
+    [
+        ("No - I told you, use the launcher", "factual"),
+        ("that's wrong, the DB is at ~/.local/share", "factual"),
+        ("stop. you keep doing this", "preference"),
+        ("Worker Brief\nNo, that's wrong - use the launcher", "factual"),
+        ("I have no understanding of no --print; that's wrong, use the launcher", "factual"),
+        ("Please fix the formatting", "style"),
+        ("Please change the styling", "style"),
+        ("Some context.\nNo, that's wrong - use the launcher", "factual"),
+        ("No, [Entity: Avi Simon -- person] is wrong; Avi works at Lightricks.", "factual"),
+        ("No, the <task-notification> watcher is wrong; do not store those chunks.", "factual"),
+        ("[old -> new] is wrong; it should be old -> newer", "factual"),
+        ("No --print/-p standing rule is wrong; allow -p for debug.", "factual"),
+        ("No --print/-p standing rule\nis wrong; allow -p for debug.", "factual"),
+        ("לא נכון", "factual"),
+    ],
+)
+def test_detect_correction_keeps_true_positives(prompt: str, category: str):
+    assert detect_correction(prompt) == category
+
+
+def test_live_correction_cues_match_multiline_direct_correction():
+    assert looks_like_live_correction("Some context.\nNo, that's wrong - use the launcher")

--- a/tests/test_correction_detection_gate.py
+++ b/tests/test_correction_detection_gate.py
@@ -97,6 +97,8 @@ def test_build_correction_tags_suppresses_non_user_payloads(prompt: str):
         ("No, [Entity: Avi Simon -- person] is wrong; Avi works at Lightricks.", "factual"),
         ("No, the <task-notification> watcher is wrong; do not store those chunks.", "factual"),
         ("Some context\nNo, the <task-notification> watcher is wrong; do not store those chunks.", "factual"),
+        ('No, "commandMode": "task-notification" is wrong; keep user corrections.', "factual"),
+        ("<task-notification> is wrong; do not treat this user correction as a wrapper.", "factual"),
         ("[old -> new] is wrong; it should be old -> newer", "factual"),
         ("No --print/-p standing rule is wrong; allow -p for debug.", "factual"),
         ("No --print/-p standing rule\nis wrong; allow -p for debug.", "factual"),

--- a/tests/test_correction_detection_gate.py
+++ b/tests/test_correction_detection_gate.py
@@ -27,6 +27,13 @@ FALSE_FIRE_PROMPTS = [
         id="task-notification",
     ),
     pytest.param(
+        "<task-notification>\n"
+        "<summary>Worker completed</summary>\n"
+        "<result>No, the watcher should skip this quoted worker result.</result>\n"
+        "</task-notification>",
+        id="wrapped-task-notification-correction-looking-line",
+    ),
+    pytest.param(
         "Worker Brief - Correction-Detection Gate Port\n"
         "Mission: port the gate. No PR exists yet; do not use the real DB in tests.",
         id="worker-dispatch-brief",


### PR DESCRIPTION
## Summary
- Ported the conservative Stage A relay/harness/cron/dispatch gate into `brainlayer.pipeline.correction_detection` so prompt-search and watcher auto-tags share it.
- Tightened correction regexes with trailing word boundaries so `no` no longer matches inside words like `nohup`, `note`, `now`, or `normal`.
- Added regression tests for agent relays, task notifications, FLEET TICK cron payloads, boot/grill/nohup text, substring false positives, and true Etan corrections including Hebrew.

## Test plan
- [x] RED: `uv run pytest tests/test_correction_detection_gate.py tests/test_conditional_hooks.py::TestPromptSearchConditional::test_main_suppresses_correction_nudge_for_non_user_payloads -q` failed 16 cases before implementation.
- [x] `uv run pytest tests/test_correction_detection_gate.py tests/test_conditional_hooks.py -q` → 69 passed.
- [x] Installed hook smoke with temp DB: false_orc_dispatch/false_fleet_tick/false_nohup_sentence/false_task_notification each `correction_fires=0`; true_launcher/true_db_path/true_stop/true_hebrew each `correction_fires=1`.
- [x] `uv run ruff check src/ && uv run ruff format src/` → All checks passed, 131 files left unchanged.
- [x] `uv run pytest tests/` → 2629 passed, 48 skipped, 5 xfailed.
- [x] Pre-push hook: Python gate 2555 passed, 9 skipped, 77 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun suite passed; FTS5 determinism shell regression passed.

## Local review gate
- `timeout 180 coderabbit review --agent` reached the timeout while still reviewing and emitted no findings before timeout. Proceeding on the fresh local verification evidence; PR-level reviewers requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior of user-correction detection for prompt-search nudges and watcher auto-tags; false negatives on real corrections are possible despite escape hatches, but scope is limited to heuristics and tests are extensive.
> 
> **Overview**
> Adds a **Stage A suppression gate** in `correction_detection` so `detect_correction` and `build_correction_tags` skip agent relays, FLEET TICK cron text, task-notification wrappers, harness/dispatch/standing-rule payloads, and similar non-user content before regex matching. Live user corrections can still pass via helpers (`has_direct_live_correction_line`, strong live cues, standing-rule corrections). Suppression is opt-out with `BRAINLAYER_CORRECTION_STAGE_A_DISABLED=1`.
> 
> **Correction regexes** now use word boundaries and clearer phrase splits so tokens like `no`/`stop`/`wrong`/`format`/`style` no longer match inside words such as `nohup`, `note`, or `normal`.
> 
> Regression coverage lands in `test_correction_detection_gate.py` plus a hook test ensuring prompt-search does not emit **Correction detected** for representative false-fire payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64f6c04ef228439ef0df03d8901e53ae4cc3f09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix false-positive correction detection for system and relay payloads
> - Adds `should_suppress_correction_detection` to [correction_detection.py](https://github.com/EtanHey/brainlayer/pull/462/files#diff-88043da2d91b362207109d756a32439388e2514eabd03b1a4ad46c2562ddbbb9), which gates `detect_correction` before pattern matching and returns `None` for agent-relay headers, fleet ticks, task-notification wrappers, harness markers, dispatch markers, and standing-rule blocks.
> - Adds several helper functions (`looks_like_live_correction`, `has_strong_live_correction_cue`, `has_direct_live_correction_line`, `has_standing_rule_live_correction`, `is_wrapped_task_notification`) to let suppression logic be overridden when genuine live-correction intent is present.
> - Suppression can be disabled entirely via the `BRAINLAYER_CORRECTION_STAGE_A_DISABLED=1` env var.
> - New parametrized tests in [test_correction_detection_gate.py](https://github.com/EtanHey/brainlayer/pull/462/files#diff-357bee5e6b7bbee0579185992d2c77d66d1c49e9b110b89bc3c926a9c3a44b74) cover both suppressed system payloads and retained true-positive correction prompts.
> - Behavioral Change: `detect_correction` now returns `None` for payloads previously classified as corrections; downstream callers consuming its return value may be affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a64f6c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined correction detection to reduce false positives by implementing enhanced heuristics for distinguishing user corrections from automated system messages and payloads.
  * Strengthened suppression gates for non-user payload types, including relay headers, task notifications, and environment-controlled scenarios.

* **Tests**
  * Added comprehensive regression test suite validating correction detection accuracy and false-positive suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->