### PR TITLE
fix: add ORQI batch item_kind contract

### DIFF
--- a/docs/orqi-batch-contract.md
+++ b/docs/orqi-batch-contract.md
@@ -13,7 +13,7 @@ Batches are JSON objects keyed by queue/category name:
   "<queue-name>": [
     {
       "stem": "<stable item label>",
-      "size": 2,
+      "size": 1,
       "item_kind": "question",
       "members": [
         {"id": "q1", "name": "Question text", "type": "question", "chunks": 0}

--- a/docs/orqi-batch-contract.md
+++ b/docs/orqi-batch-contract.md
@@ -1,0 +1,73 @@
+# ORQI Batch Contract
+
+This contract covers KG flag-review batches consumed by ORQI/voice review
+surfaces and produced by BrainLayer batch tooling. The canonical in-repo
+location for batch and decisions artifacts is `eval_results/`.
+
+## Batch Shape
+
+Batches are JSON objects keyed by queue/category name:
+
+```json
+{
+  "<queue-name>": [
+    {
+      "stem": "<stable item label>",
+      "size": 2,
+      "item_kind": "question",
+      "members": [
+        {"id": "q1", "name": "Question text", "type": "question", "chunks": 0}
+      ]
+    }
+  ]
+}
+```
+
+`item_kind` is required on newly emitted items. Older batches may omit it;
+readers may derive it from `members` for backward compatibility.
+
+## Item Kinds
+
+`item_kind` is a string and is intentionally extensible.
+
+- `question`: any member has `type: "question"`.
+- `cluster`: no member has `type: "question"`.
+
+Question items are note-only decisions. They must not expose member-mapping or
+merge/keep/split cluster controls. Cluster items use the full decision menu.
+
+## Member Types
+
+Known member types in the 2026-06-06 Etan session batch:
+
+| type | count |
+| --- | ---: |
+| company | 3 |
+| concept | 24 |
+| context | 34 |
+| person | 2 |
+| project | 19 |
+| question | 6 |
+| technology | 12 |
+| tool | 14 |
+
+`context` members are synthetic review context. They are useful for UI
+presentation but must not be treated as real KG entities by cleanup appliers.
+
+## Decisions Schema
+
+Decision files use top-level schema id:
+
+```json
+{
+  "schema": "kg-flag-decisions-v1"
+}
+```
+
+Every writer must stamp `"schema": "kg-flag-decisions-v1"` when creating or
+updating a decisions file that lacks the field. A file declaring another schema
+must fail validation instead of being silently rewritten.
+
+Versioning rule: breaking changes require a new schema id, starting with
+`kg-flag-decisions-v2`, plus a migration note explaining how `v1` files are
+converted or intentionally rejected.

--- a/scripts/kg_flag_batch.py
+++ b/scripts/kg_flag_batch.py
@@ -57,6 +57,10 @@ def categorize(stem: str, names: list[str]) -> str:
     return "sep-variants"
 
 
+def item_kind_from_members(members: list[dict]) -> str:
+    return "question" if any(member.get("type") == "question" for member in members) else "cluster"
+
+
 def load_keep_separate_decisions(con: sqlite3.Connection) -> set[tuple[str, str]]:
     try:
         rows = con.execute(
@@ -125,6 +129,7 @@ def main() -> None:
                 for m in sorted(members, key=lambda m: -m["n_chunks"])
             ],
         }
+        cluster["item_kind"] = item_kind_from_members(cluster["members"])
         cats[category].append(cluster)
 
     out_json = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("eval_results/kg-phase1-flag-batch-2026-06-05.json")

--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -245,8 +245,8 @@ def _member_ref(member: dict[str, Any]) -> dict[str, Any]:
 
 def _real_merge_members(cluster: dict[str, Any]) -> list[dict[str, Any]]:
     members = [member for member in cluster["members"] if member.get("type") != "context"]
-    if not members:
-        raise ValueError(f"cluster {cluster['cluster_id']!r} has no real merge members")
+    if len(members) < 2:
+        raise ValueError(f"cluster {cluster['cluster_id']!r} needs at least two real merge members")
     return sorted(members, key=lambda member: member.get("chunks", 0), reverse=True)
 
 

--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -247,7 +247,7 @@ def _real_merge_members(cluster: dict[str, Any]) -> list[dict[str, Any]]:
     members = [member for member in cluster["members"] if member.get("type") != "context"]
     if len(members) < 2:
         raise ValueError(f"cluster {cluster['cluster_id']!r} needs at least two real merge members")
-    return sorted(members, key=lambda member: member.get("chunks", 0), reverse=True)
+    return sorted(members, key=lambda member: member.get("chunks") or 0, reverse=True)
 
 
 def _canonical_override(decision: dict[str, Any]) -> tuple[str | None, str | None]:

--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -243,6 +243,13 @@ def _member_ref(member: dict[str, Any]) -> dict[str, Any]:
     return {"id": member["id"], "name": member["name"], "type": member["type"]}
 
 
+def _real_merge_members(cluster: dict[str, Any]) -> list[dict[str, Any]]:
+    members = [member for member in cluster["members"] if member.get("type") != "context"]
+    if not members:
+        raise ValueError(f"cluster {cluster['cluster_id']!r} has no real merge members")
+    return sorted(members, key=lambda member: member.get("chunks", 0), reverse=True)
+
+
 def _canonical_override(decision: dict[str, Any]) -> tuple[str | None, str | None]:
     canonical = decision.get("canonical")
     canonical_id = decision.get("canonical_id")
@@ -257,9 +264,7 @@ def _canonical_override(decision: dict[str, Any]) -> tuple[str | None, str | Non
 
 
 def _select_canonical(cluster: dict[str, Any], decision: dict[str, Any] | None = None) -> dict[str, Any]:
-    members = cluster["members"]
-    if not members:
-        raise ValueError(f"cluster {cluster['cluster_id']!r} has no members")
+    members = _real_merge_members(cluster)
     if not decision:
         return members[0]
     canonical_id, canonical_name = _canonical_override(decision)
@@ -270,6 +275,14 @@ def _select_canonical(cluster: dict[str, Any], decision: dict[str, Any] | None =
             return member
         if canonical_name and member["name"] == canonical_name:
             return member
+    for member in cluster["members"]:
+        if member.get("type") != "context":
+            continue
+        if (canonical_id and member["id"] == canonical_id) or (canonical_name and member["name"] == canonical_name):
+            raise ValueError(
+                f"canonical override {canonical_id or canonical_name!r} is not a real merge member "
+                f"in cluster {cluster['cluster_id']!r}"
+            )
     raise ValueError(
         f"canonical override {canonical_id or canonical_name!r} is not in cluster {cluster['cluster_id']!r}"
     )
@@ -288,7 +301,7 @@ def _merge_item(
         "category": cluster["category"],
         "source": source,
         "canonical": _member_ref(canonical),
-        "members": [_member_ref(member) for member in cluster["members"] if member["id"] != canonical["id"]],
+        "members": [_member_ref(member) for member in _real_merge_members(cluster) if member["id"] != canonical["id"]],
         "decided_at": decided_at,
     }
     if note:

--- a/src/brainlayer/kg_review_session.py
+++ b/src/brainlayer/kg_review_session.py
@@ -76,16 +76,22 @@ def load_flag_batch(batch_path: str | Path) -> list[dict[str, Any]]:
     clusters: list[dict[str, Any]] = []
     for category in raw:
         for cluster in raw[category]:
+            members = cluster.get("members", [])
             clusters.append(
                 {
                     "cluster_id": cluster_id(category, cluster["stem"]),
                     "category": category,
                     "stem": cluster["stem"],
-                    "size": cluster.get("size", len(cluster.get("members", []))),
-                    "members": cluster.get("members", []),
+                    "size": cluster.get("size", len(members)),
+                    "members": members,
+                    "item_kind": cluster.get("item_kind") or _item_kind_from_members(members),
                 }
             )
     return clusters
+
+
+def _item_kind_from_members(members: list[dict[str, Any]]) -> str:
+    return "question" if any(member.get("type") == "question" for member in members) else "cluster"
 
 
 def _source_from_batch(batch_path: str | Path) -> str:
@@ -106,6 +112,8 @@ def _empty_decisions(source: str = DEFAULT_SOURCE) -> dict[str, Any]:
 
 
 def _ensure_v1_shape(data: dict[str, Any], source: str) -> dict[str, Any]:
+    if "schema" not in data:
+        data["schema"] = DECISIONS_SCHEMA
     if data.get("schema") != DECISIONS_SCHEMA:
         raise ValueError(f"decisions file must use schema {DECISIONS_SCHEMA!r}; got {data.get('schema')!r}")
     data.setdefault("source", source)

--- a/tests/test_kg_cleanup.py
+++ b/tests/test_kg_cleanup.py
@@ -318,3 +318,30 @@ def test_flag_batch_skips_logged_keep_separate_clusters(con, tmp_path):
 
     assert kg_flag_batch.should_skip_keep_separate("prefix-variants", "codex", keep_decisions)
     assert not kg_flag_batch.should_skip_keep_separate("case-only", "codex", keep_decisions)
+
+
+def test_flag_batch_item_kind_derives_from_question_members():
+    assert (
+        kg_flag_batch.item_kind_from_members(
+            [{"id": "q1", "name": "DICTIONARY QUESTION: classify languages?", "type": "question", "chunks": 0}]
+        )
+        == "question"
+    )
+    assert (
+        kg_flag_batch.item_kind_from_members(
+            [
+                {"id": "ctx-q", "name": "Context", "type": "context", "chunks": 0},
+                {"id": "q2", "name": "DICTIONARY QUESTION: mixed item?", "type": "question", "chunks": 0},
+            ]
+        )
+        == "question"
+    )
+    assert (
+        kg_flag_batch.item_kind_from_members(
+            [
+                {"id": "ctx-github", "name": "CONTESTED - type split", "type": "context", "chunks": 0},
+                {"id": "tool-github", "name": "GitHub", "type": "tool", "chunks": 7},
+            ]
+        )
+        == "cluster"
+    )

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -180,6 +180,74 @@ def test_record_decision_is_merge_safe_and_stamped(batch_file, decisions_file):
     assert_v1(data)
 
 
+def test_record_merge_excludes_context_members_from_canonical_and_losers(tmp_path, decisions_file):
+    batch = {
+        "contested": [
+            {
+                "stem": "android eas",
+                "size": 4,
+                "members": [
+                    {
+                        "id": "ctx-android eas",
+                        "name": "CONTESTED - judge said Technology",
+                        "type": "context",
+                        "chunks": 0,
+                    },
+                    {"id": "project-android", "name": "Android EAS", "type": "project", "chunks": 1},
+                    {"id": "tool-android", "name": "Android EAS", "type": "tool", "chunks": 7},
+                    {"id": "tech-android", "name": "Android EAS", "type": "technology", "chunks": 3},
+                ],
+            }
+        ]
+    }
+    batch_file = tmp_path / "context-batch.json"
+    batch_file.write_text(json.dumps(batch))
+
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="contested:android eas",
+        decision={"action": "merge", "source": "voice"},
+    )
+
+    data = json.loads(decisions_file.read_text())
+    merge = data["merge"][0]
+    assert merge["canonical"] == {"id": "tool-android", "name": "Android EAS", "type": "tool"}
+    assert [member["id"] for member in merge["members"]] == ["tech-android", "project-android"]
+    assert "ctx-android eas" not in json.dumps(merge)
+    assert_v1(data)
+
+
+def test_record_merge_rejects_context_canonical_override(tmp_path, decisions_file):
+    batch = {
+        "contested": [
+            {
+                "stem": "android eas",
+                "size": 2,
+                "members": [
+                    {
+                        "id": "ctx-android eas",
+                        "name": "CONTESTED - judge said Technology",
+                        "type": "context",
+                        "chunks": 0,
+                    },
+                    {"id": "tool-android", "name": "Android EAS", "type": "tool", "chunks": 7},
+                ],
+            }
+        ]
+    }
+    batch_file = tmp_path / "context-batch.json"
+    batch_file.write_text(json.dumps(batch))
+
+    with pytest.raises(ValueError, match="canonical override .* is not a real merge member"):
+        record_decision(
+            batch_file,
+            decisions_file,
+            cluster_id="contested:android eas",
+            decision={"action": "merge", "source": "voice", "canonical_id": "ctx-android eas"},
+        )
+
+
 def test_record_decision_validates_action(batch_file, decisions_file):
     with pytest.raises(ValueError):
         record_decision(

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -223,6 +223,37 @@ def test_record_merge_rejects_context_canonical_override(tmp_path, decisions_fil
         "contested": [
             {
                 "stem": "android eas",
+                "size": 3,
+                "members": [
+                    {
+                        "id": "ctx-android eas",
+                        "name": "CONTESTED - judge said Technology",
+                        "type": "context",
+                        "chunks": 0,
+                    },
+                    {"id": "tool-android", "name": "Android EAS", "type": "tool", "chunks": 7},
+                    {"id": "tech-android", "name": "Android EAS", "type": "technology", "chunks": 3},
+                ],
+            }
+        ]
+    }
+    batch_file = tmp_path / "context-batch.json"
+    batch_file.write_text(json.dumps(batch))
+
+    with pytest.raises(ValueError, match="canonical override .* is not a real merge member"):
+        record_decision(
+            batch_file,
+            decisions_file,
+            cluster_id="contested:android eas",
+            decision={"action": "merge", "source": "voice", "canonical_id": "ctx-android eas"},
+        )
+
+
+def test_record_merge_rejects_fewer_than_two_real_members(tmp_path, decisions_file):
+    batch = {
+        "contested": [
+            {
+                "stem": "android eas",
                 "size": 2,
                 "members": [
                     {
@@ -239,13 +270,15 @@ def test_record_merge_rejects_context_canonical_override(tmp_path, decisions_fil
     batch_file = tmp_path / "context-batch.json"
     batch_file.write_text(json.dumps(batch))
 
-    with pytest.raises(ValueError, match="canonical override .* is not a real merge member"):
+    with pytest.raises(ValueError, match="needs at least two real merge members"):
         record_decision(
             batch_file,
             decisions_file,
             cluster_id="contested:android eas",
-            decision={"action": "merge", "source": "voice", "canonical_id": "ctx-android eas"},
+            decision={"action": "merge", "source": "voice"},
         )
+
+    assert not decisions_file.exists()
 
 
 def test_record_decision_validates_action(batch_file, decisions_file):

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -95,6 +95,11 @@ def test_load_flag_batch_flattens_with_ids(batch_file):
     assert "diagnosis-flag:agent c" in ids
     assert "case-only:docker" in ids
     assert all("category" in c and "members" in c for c in clusters)
+    assert {c["cluster_id"]: c["item_kind"] for c in clusters} == {
+        "diagnosis-flag:agent c": "cluster",
+        "case-only:agent": "cluster",
+        "case-only:docker": "cluster",
+    }
 
 
 def test_next_undecided_is_idempotent_until_decision_or_skip(batch_file, decisions_file):
@@ -398,6 +403,33 @@ def test_voice_rewrite_preserves_unknown_dashboard_fields(batch_file, decisions_
     assert data["keep"][0]["source"] == "voice"
     assert data["keep"][0]["note"] == "non-deterministic voice answer"
     assert data["keep"][0]["dashboard_row_id"] == "row-17"
+    assert_v1(data)
+
+
+def test_record_decision_stamps_schema_on_legacy_decisions_file(batch_file, decisions_file):
+    decisions_file.write_text(
+        json.dumps(
+            {
+                "source": "kg-phase1-flag-batch-2026-06-05",
+                "rules": {},
+                "per_category": {},
+                "counts": {},
+                "merge": [],
+                "keep": [],
+            }
+        )
+    )
+
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="case-only:agent",
+        decision={"action": "keep", "note": "legacy file upgrade", "source": "voice"},
+    )
+
+    data = json.loads(decisions_file.read_text())
+    assert data["schema"] == DECISIONS_SCHEMA
+    assert data["keep"][0]["note"] == "legacy file upgrade"
     assert_v1(data)
 
 

--- a/tests/test_kg_review_session.py
+++ b/tests/test_kg_review_session.py
@@ -281,6 +281,36 @@ def test_record_merge_rejects_fewer_than_two_real_members(tmp_path, decisions_fi
     assert not decisions_file.exists()
 
 
+def test_record_merge_treats_null_chunks_as_zero(tmp_path, decisions_file):
+    batch = {
+        "contested": [
+            {
+                "stem": "android eas",
+                "size": 2,
+                "members": [
+                    {"id": "tool-android", "name": "Android EAS", "type": "tool", "chunks": None},
+                    {"id": "tech-android", "name": "Android EAS", "type": "technology", "chunks": 3},
+                ],
+            }
+        ]
+    }
+    batch_file = tmp_path / "null-chunks-batch.json"
+    batch_file.write_text(json.dumps(batch))
+
+    record_decision(
+        batch_file,
+        decisions_file,
+        cluster_id="contested:android eas",
+        decision={"action": "merge", "source": "voice"},
+    )
+
+    data = json.loads(decisions_file.read_text())
+    merge = data["merge"][0]
+    assert merge["canonical"] == {"id": "tech-android", "name": "Android EAS", "type": "technology"}
+    assert [member["id"] for member in merge["members"]] == ["tool-android"]
+    assert_v1(data)
+
+
 def test_record_decision_validates_action(batch_file, decisions_file):
     with pytest.raises(ValueError):
         record_decision(


### PR DESCRIPTION
## Summary
- add producer-side `item_kind` derivation for KG flag-batch items (`question` when any member has `type: question`, otherwise `cluster`)
- preserve/backfill `item_kind` in the shared KG review-session loader for older batches
- stamp missing `schema: kg-flag-decisions-v1` on existing decisions files while still rejecting explicit schema mismatches
- document the ORQI batch/decisions contract in `docs/orqi-batch-contract.md`

## Sample batch items

Question item:
```json
{
  "etan-queue": [
    {
      "stem": "Q1 of 6 — invocable substrates",
      "size": 1,
      "members": [
        {
          "id": "q1",
          "name": "TypeScript, Python, AI models like Qwen and Kokoro, frameworks like MLX — the test says build-WITH means Tool, but most people call these Technology. One ruling for all three families: Tools, or widen Technology?",
          "type": "question",
          "chunks": 0
        }
      ],
      "item_kind": "question"
    }
  ]
}
```

Cluster item:
```json
{
  "etan-queue": [
    {
      "stem": "android eas",
      "size": 4,
      "members": [
        {"id": "ctx-android eas", "name": "CONTESTED — judge said Technology/merge...", "type": "context", "chunks": 0},
        {"id": "317840eb-1fed-5d95-b0d8-88c2567049f0", "name": "Android EAS", "type": "project", "chunks": 1},
        {"id": "3edf8f9e-bbae-5a9a-ba73-36b18707eae1", "name": "Android EAS", "type": "tool", "chunks": 1},
        {"id": "acd548d5-b218-5506-9b58-f09e2f3ac233", "name": "Android EAS", "type": "technology", "chunks": 1}
      ],
      "item_kind": "cluster"
    }
  ]
}
```

## Test plan
- [x] RED: `pytest tests/test_kg_cleanup.py::test_flag_batch_item_kind_derives_from_question_members tests/test_kg_review_session.py::test_record_decision_stamps_schema_on_legacy_decisions_file` failed before implementation for missing helper/schema stamping
- [x] `pytest tests/test_kg_review_session.py tests/test_kg_session_harvest.py tests/test_kg_cleanup.py` — 51 passed
- [x] `ruff check src/ scripts/kg_flag_batch.py tests/test_kg_cleanup.py tests/test_kg_review_session.py`
- [x] `ruff format src/ scripts/kg_flag_batch.py tests/test_kg_cleanup.py tests/test_kg_review_session.py` — 134 files left unchanged
- [x] `pytest` — 2601 passed, 48 skipped, 5 xfailed, 328 warnings
- [x] pre-push gate — 2527 passed, 9 skipped, 77 deselected, 1 xfailed, 107 warnings; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun 1 pass; regression shell passed

## Review notes
- Local `coderabbit review --agent` attempted before commit and hit CLI rate limit (recoverable; waitTime 6m28s). Proceeded per PR-loop guidance on fresh local verification evidence; PR-level bot review requested after PR creation.

Co-Authored-By: Codex <codex@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Merge validation is stricter: clusters with only one real entity plus context, or merges that treated context as canonical, will now raise ValueError instead of producing invalid apply payloads.
> 
> **Overview**
> Introduces the **ORQI batch contract** in `docs/orqi-batch-contract.md`: batch items carry **`item_kind`** (`question` vs `cluster`), **`context` members are UI-only**, and decisions files must use **`kg-flag-decisions-v1`**.
> 
> **Batch production:** `kg_flag_batch.py` now stamps **`item_kind`** on each emitted cluster (`question` when any member has `type: question`, else `cluster`).
> 
> **Review session:** `load_flag_batch` reads or **backfills `item_kind`** for legacy batches. Merge recording **ignores `context` members** for canonical/loser selection, **rejects context as canonical**, and **requires at least two non-context members** before a merge is allowed. Legacy decisions files **missing `schema` get auto-stamped** with `kg-flag-decisions-v1`; explicit schema mismatches still fail.
> 
> Tests cover `item_kind` derivation, schema stamping, and context-aware merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9017fac575e4ecf274bc27624c89e9ac5912480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `item_kind` field to ORQI batch clusters and harden merge member handling
> - Adds `item_kind` to each cluster in the batch script ([kg_flag_batch.py](https://github.com/EtanHey/brainlayer/pull/463/files#diff-f808a65e85e8fc5a4186fb434ec9f53711684cc1763bed901c5c7267abced3c1)) and loader ([kg_review_session.py](https://github.com/EtanHey/brainlayer/pull/463/files#diff-a3ec1e9b0f8f2c609df6eec2ed276fc4776b5e0df1f6532ff43950b785cc9a1c)), derived from member types: `'question'` if any member is a question, otherwise `'cluster'`.
> - Introduces `_real_merge_members` to exclude `context`-type members from canonical selection and losers list, requiring at least two real members or raising.
> - Fixes canonical override validation to reject context members and absent members with a specific error.
> - Legacy decisions files missing a `schema` field are now stamped with `DECISIONS_SCHEMA` instead of being rejected.
> - Adds a [contract document](https://github.com/EtanHey/brainlayer/pull/463/files#diff-a43ac0fe63910d13ff149ab40b313ebc7f81618de1b384fbf0c534cff46a2d6f) describing batch shape, `item_kind` semantics, and decisions schema versioning rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9017fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->