### PR TITLE
Fix #455 forward-stamp queued stores

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -224,8 +224,10 @@ final class BrainDatabase: @unchecked Sendable {
         let tags: [String]
         let importance: Int
         let source: String
+        let project: String?
         let queueID: String?
         let queuedAt: String?
+        let createdAt: String?
         let chunkID: String?
 
         enum CodingKeys: String, CodingKey {
@@ -233,8 +235,10 @@ final class BrainDatabase: @unchecked Sendable {
             case tags
             case importance
             case source
+            case project
             case queueID = "queue_id"
             case queuedAt = "queued_at"
+            case createdAt = "created_at"
             case chunkID = "chunk_id"
         }
 
@@ -243,16 +247,20 @@ final class BrainDatabase: @unchecked Sendable {
             tags: [String],
             importance: Int,
             source: String,
+            project: String? = nil,
             queueID: String? = nil,
             queuedAt: String? = nil,
+            createdAt: String? = nil,
             chunkID: String? = nil
         ) {
             self.content = content
             self.tags = tags
             self.importance = importance
             self.source = source
+            self.project = project
             self.queueID = queueID
             self.queuedAt = queuedAt
+            self.createdAt = createdAt
             self.chunkID = chunkID
         }
 
@@ -262,8 +270,10 @@ final class BrainDatabase: @unchecked Sendable {
             tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
             importance = try container.decodeIfPresent(Int.self, forKey: .importance) ?? 5
             source = try container.decodeIfPresent(String.self, forKey: .source) ?? "mcp"
+            project = try container.decodeIfPresent(String.self, forKey: .project)
             queueID = try container.decodeIfPresent(String.self, forKey: .queueID)
             queuedAt = try container.decodeIfPresent(String.self, forKey: .queuedAt)
+            createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
             chunkID = try container.decodeIfPresent(String.self, forKey: .chunkID)
         }
     }
@@ -653,19 +663,21 @@ final class BrainDatabase: @unchecked Sendable {
         contentType: String,
         importance: Int,
         sender: String? = nil,
-        tags: String = "[]"
+        tags: String = "[]",
+        createdAt: String? = nil
     ) throws {
         guard let db else { throw DBError.notOpen }
         if (try? tableExists("chunks")) != true {
             try ensureSchema()
         }
+        let createdAt = createdAt ?? Self.timestamp()
         let sql = """
             INSERT OR REPLACE INTO chunks (
                 id, content, metadata, source_file, project, content_type,
                 importance, conversation_id, sender, char_count, tags, summary,
-                preview_text, brick_id, source_uri, status, ingested_at
+                preview_text, created_at, brick_id, source_uri, status, ingested_at
             )
-            VALUES (?, ?, '{}', 'brainbar', ?, ?, ?, ?, ?, ?, ?, '', ?, ?, 'brainbar', 'active', CAST(strftime('%s', 'now') AS INTEGER))
+            VALUES (?, ?, '{}', 'brainbar', ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, 'brainbar', 'active', CAST(strftime('%s', 'now') AS INTEGER))
         """
         try runWriteStatement(on: db, sql: sql, retries: 3) { stmt in
             bindText(id, to: stmt, index: 1)
@@ -682,7 +694,8 @@ final class BrainDatabase: @unchecked Sendable {
             sqlite3_bind_int(stmt, 8, Int32(content.count))
             bindText(tags, to: stmt, index: 9)
             bindText(Self.previewText(summary: "", content: content), to: stmt, index: 10)
-            bindText(id, to: stmt, index: 11)
+            bindText(createdAt, to: stmt, index: 11)
+            bindText(id, to: stmt, index: 12)
         }
         try refreshSearchStatistics()
     }
@@ -880,19 +893,22 @@ final class BrainDatabase: @unchecked Sendable {
         tags: [String],
         importance: Int,
         source: String,
+        project: String? = nil,
         chunkID: String? = nil,
         queueID: String? = nil,
+        createdAt: String? = nil,
         refreshStatistics: Bool = true,
         retries: Int = 3,
         busyTimeoutMillis: Int32? = nil
     ) throws -> StoredChunk {
         guard let db else { throw DBError.notOpen }
         let chunkID = chunkID ?? Self.makeChunkID()
+        let createdAt = createdAt ?? Self.timestamp()
         let tagsJSON = (try? encodeJSON(tags)) ?? "[]"
         let metadataJSON = Self.storeMetadataJSON(queueID: queueID)
         let sql = """
-            INSERT INTO chunks (id, content, metadata, source_file, tags, importance, source, content_type, char_count, preview_text)
-            VALUES (?, ?, ?, 'brainbar-store', ?, ?, ?, 'user_message', ?, ?)
+            INSERT INTO chunks (id, content, metadata, source_file, project, tags, importance, source, content_type, char_count, created_at, preview_text)
+            VALUES (?, ?, ?, 'brainbar-store', ?, ?, ?, ?, 'user_message', ?, ?, ?)
         """
         let previousBusyTimeout = busyTimeoutMillis.flatMap { _ in queryPragma(db, name: "busy_timeout") }
         if let busyTimeoutMillis {
@@ -909,11 +925,17 @@ final class BrainDatabase: @unchecked Sendable {
                 bindText(chunkID, to: stmt, index: 1)
                 bindText(content, to: stmt, index: 2)
                 bindText(metadataJSON, to: stmt, index: 3)
-                bindText(tagsJSON, to: stmt, index: 4)
-                sqlite3_bind_int(stmt, 5, Int32(importance))
-                bindText(source, to: stmt, index: 6)
-                sqlite3_bind_int(stmt, 7, Int32(content.count))
-                bindText(Self.previewText(summary: "", content: content), to: stmt, index: 8)
+                if let project {
+                    bindText(project, to: stmt, index: 4)
+                } else {
+                    sqlite3_bind_null(stmt, 4)
+                }
+                bindText(tagsJSON, to: stmt, index: 5)
+                sqlite3_bind_int(stmt, 6, Int32(importance))
+                bindText(source, to: stmt, index: 7)
+                sqlite3_bind_int(stmt, 8, Int32(content.count))
+                bindText(createdAt, to: stmt, index: 9)
+                bindText(Self.previewText(summary: "", content: content), to: stmt, index: 10)
             }
             if failNextStoreAfterInsertForTesting {
                 failNextStoreAfterInsertForTesting = false
@@ -934,16 +956,20 @@ final class BrainDatabase: @unchecked Sendable {
         tags: [String],
         importance: Int,
         source: String,
+        project: String? = nil,
         busyTimeoutMillis: Int32 = 50
     ) throws -> StoreWriteOutcome {
         let chunkID = Self.makeChunkID()
+        let createdAt = Self.timestamp()
         do {
             let stored = try store(
                 content: content,
                 tags: tags,
                 importance: importance,
                 source: source,
+                project: project,
                 chunkID: chunkID,
+                createdAt: createdAt,
                 refreshStatistics: true,
                 retries: 0,
                 busyTimeoutMillis: busyTimeoutMillis
@@ -958,6 +984,8 @@ final class BrainDatabase: @unchecked Sendable {
                 tags: tags,
                 importance: importance,
                 source: source,
+                project: project,
+                createdAt: createdAt,
                 chunkID: chunkID
             )
             return .queued(queueID: queued.queueID, queuedAt: queued.queuedAt, chunkID: queued.chunkID)
@@ -965,11 +993,25 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     /// Async wrapper for store() — runs DB write off the main thread.
-    func storeAsync(content: String, tags: [String], importance: Int, source: String) async throws -> StoredChunk {
+    func storeAsync(
+        content: String,
+        tags: [String],
+        importance: Int,
+        source: String,
+        project: String? = nil,
+        createdAt: String? = nil
+    ) async throws -> StoredChunk {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async { [self] in
                 do {
-                    let result = try self.store(content: content, tags: tags, importance: importance, source: source)
+                    let result = try self.store(
+                        content: content,
+                        tags: tags,
+                        importance: importance,
+                        source: source,
+                        project: project,
+                        createdAt: createdAt
+                    )
                     continuation.resume(returning: result)
                 } catch {
                     continuation.resume(throwing: error)
@@ -996,6 +1038,8 @@ final class BrainDatabase: @unchecked Sendable {
         tags: [String],
         importance: Int,
         source: String,
+        project: String? = nil,
+        createdAt: String? = nil,
         chunkID: String? = nil
     ) throws -> (queueID: String, queuedAt: String, chunkID: String) {
         try Self.queuePendingStore(
@@ -1004,6 +1048,8 @@ final class BrainDatabase: @unchecked Sendable {
             tags: tags,
             importance: importance,
             source: source,
+            project: project,
+            createdAt: createdAt,
             chunkID: chunkID
         )
     }
@@ -1015,6 +1061,8 @@ final class BrainDatabase: @unchecked Sendable {
         tags: [String],
         importance: Int,
         source: String,
+        project: String? = nil,
+        createdAt: String? = nil,
         chunkID: String? = nil
     ) throws -> (queueID: String, queuedAt: String, chunkID: String) {
         Self.pendingStoreFileLock.lock()
@@ -1027,14 +1075,17 @@ final class BrainDatabase: @unchecked Sendable {
         )
         let queueID = UUID().uuidString.lowercased()
         let queuedAt = Self.timestamp()
+        let createdAt = createdAt ?? queuedAt
         let chunkID = chunkID ?? Self.makeChunkID()
         let item = PendingStoreItem(
             content: content,
             tags: tags,
             importance: importance,
             source: source,
+            project: project,
             queueID: queueID,
             queuedAt: queuedAt,
+            createdAt: createdAt,
             chunkID: chunkID
         )
         var line = try JSONEncoder().encode(item)
@@ -1091,8 +1142,10 @@ final class BrainDatabase: @unchecked Sendable {
                             tags: item.tags,
                             importance: item.importance,
                             source: item.source,
+                            project: item.project,
                             chunkID: chunkID,
                             queueID: queueID,
+                            createdAt: item.createdAt ?? item.queuedAt,
                             refreshStatistics: false
                         )
                         flushed.append(
@@ -3181,8 +3234,10 @@ final class BrainDatabase: @unchecked Sendable {
             tags: item.tags,
             importance: item.importance,
             source: item.source,
+            project: item.project,
             queueID: queueID,
             queuedAt: item.queuedAt,
+            createdAt: item.createdAt ?? item.queuedAt,
             chunkID: chunkID
         )
         return try? JSONEncoder().encode(replayItem)

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -473,11 +473,12 @@ final class MCPRouter: @unchecked Sendable {
         }
         let tags = args["tags"] as? [String] ?? []
         let importance = args["importance"] as? Int ?? 5
+        let project = args["project"] as? String
         guard let db = database else {
-            return try queueBrainStore(content: content, tags: tags, importance: importance, source: "mcp")
+            return try queueBrainStore(content: content, tags: tags, importance: importance, source: "mcp", project: project)
         }
         do {
-            switch try db.storeOrQueueWithinBudget(content: content, tags: tags, importance: importance, source: "mcp") {
+            switch try db.storeOrQueueWithinBudget(content: content, tags: tags, importance: importance, source: "mcp", project: project) {
             case .stored(let stored):
                 let flushedStores = db.flushPendingStores()
                 return ToolOutput(
@@ -504,11 +505,11 @@ final class MCPRouter: @unchecked Sendable {
                 return queuedBrainStoreOutput(queueID: queueID, queuedAt: queuedAt, chunkID: chunkID)
             }
         } catch BrainDatabase.DBError.notOpen {
-            return try queueBrainStore(content: content, tags: tags, importance: importance, source: "mcp")
+            return try queueBrainStore(content: content, tags: tags, importance: importance, source: "mcp", project: project)
         }
     }
 
-    private func queueBrainStore(content: String, tags: [String], importance: Int, source: String) throws -> ToolOutput {
+    private func queueBrainStore(content: String, tags: [String], importance: Int, source: String, project: String?) throws -> ToolOutput {
         guard let dbPath else {
             throw ToolError.noDatabase
         }
@@ -517,7 +518,8 @@ final class MCPRouter: @unchecked Sendable {
             content: content,
             tags: tags,
             importance: importance,
-            source: source
+            source: source,
+            project: project
         )
         return queuedBrainStoreOutput(queueID: queued.queueID, queuedAt: queued.queuedAt, chunkID: queued.chunkID)
     }
@@ -1088,6 +1090,7 @@ final class MCPRouter: @unchecked Sendable {
                     "content": ["type": "string", "description": "Content to store"],
                     "tags": ["type": "array", "items": ["type": "string"], "description": "Tags for categorization"],
                     "importance": ["type": "integer", "description": "Importance score (1-10)"],
+                    "project": ["type": "string", "description": "Project context for the stored memory"],
                 ] as [String: Any],
                 "required": ["content"]
             ] as [String: Any])

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -483,6 +483,44 @@ final class DatabaseTests: XCTestCase {
         )
     }
 
+    func testFlushPendingStoresUsesQueuedAtAsCreatedAtAndPreservesProject() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("brainbar-stamping-queue-\(UUID().uuidString).jsonl")
+        setenv("BRAINBAR_PENDING_STORES_PATH", queuePath.path, 1)
+        defer {
+            unsetenv("BRAINBAR_PENDING_STORES_PATH")
+            try? FileManager.default.removeItem(at: queuePath)
+        }
+
+        let queuedAt = "2026-06-06T18:45:12Z"
+        let chunkID = "brainbar-queuedstamp1"
+        let payload: [String: Any] = [
+            "content": "Queued BrainBar store must keep reservation metadata",
+            "tags": ["brainbar", "queue"],
+            "importance": 8,
+            "source": "mcp",
+            "queue_id": "queue-stamp-test",
+            "queued_at": queuedAt,
+            "chunk_id": chunkID,
+            "project": "brainlayer"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        try (data + Data([0x0A])).write(to: queuePath)
+
+        let flushed = db.flushPendingStores()
+
+        XCTAssertEqual(flushed.count, 1)
+        XCTAssertEqual(flushed.first?.storedChunk.chunkID, chunkID)
+        XCTAssertEqual(
+            try sqliteScalarString(path: tempDBPath, sql: "SELECT created_at FROM chunks WHERE id = '\(chunkID)'"),
+            queuedAt
+        )
+        XCTAssertEqual(
+            try sqliteScalarString(path: tempDBPath, sql: "SELECT project FROM chunks WHERE id = '\(chunkID)'"),
+            "brainlayer"
+        )
+    }
+
     func testInjectionEventsTableExists() throws {
         let exists = try db.tableExists("injection_events")
         XCTAssertTrue(exists, "injection_events table must exist")

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -33,6 +33,7 @@ DEFAULT_TOKEN_PATH = Path.home() / ".config" / "google-drive-mcp" / "tokens.json
 DEFAULT_CLIENT_PATH = Path.home() / ".config" / "google-drive-mcp" / "gcp-oauth.keys.json"
 DEFAULT_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"]
 DEFAULT_STAGING_DIR = Path.home() / ".local" / "share" / "brainlayer" / "backups"
+DEFAULT_LOG_PATH = Path.home() / ".local" / "share" / "brainlayer" / "logs" / "backup-daily.log"
 DEFAULT_BRAINBAR_SOCKET_PATH = "/tmp/brainbar.sock"
 BACKUP_TIMEOUT_ENV = "BRAINLAYER_BACKUP_TIMEOUT_SECONDS"
 BACKUP_FULL_VERIFY_ENV = "BRAINLAYER_BACKUP_FULL_VERIFY"
@@ -68,6 +69,13 @@ class SQLiteBackupArtifact:
 
 def _today() -> str:
     return dt.datetime.now(dt.UTC).date().isoformat()
+
+
+def _append_json_log(path: Path, payload: dict[str, Any]) -> None:
+    path = Path(path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
 
 
 def _escape_drive_query_value(value: str) -> str:
@@ -669,6 +677,7 @@ def run_backup(
     db_path: Path | None = None,
     staging_dir: Path = DEFAULT_STAGING_DIR,
     folder_parts: list[str] = DEFAULT_FOLDER_PARTS,
+    log_path: Path = DEFAULT_LOG_PATH,
     date_stamp: str | None = None,
     upload: bool = True,
     retention_policy: DriveRetentionPolicy = DAILY_RETENTION,
@@ -723,6 +732,7 @@ def run_backup(
         else:
             deleted = []
         result.update({"uploaded": True, "drive_file": uploaded, "retention_deleted": deleted})
+    _append_json_log(log_path, result)
     return result
 
 
@@ -741,6 +751,7 @@ def main() -> int:
                 "BRAINLAYER_BACKUP_DRIVE_FOLDER",
                 os.environ.get("BRAINLAYER_BACKUP_DRIVE_PATH", "/".join(DEFAULT_FOLDER_PARTS)),
             ).split("/"),
+            log_path=Path(os.environ.get("BRAINLAYER_BACKUP_LOG_PATH", str(DEFAULT_LOG_PATH))),
         )
     except BackupTimeoutError:
         print(f"brainlayer backup timed out after {timeout_seconds}s", flush=True)

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -698,41 +698,46 @@ def run_backup(
         "local_removed": False,
         "verified": False,
     }
-    if upload:
-        credentials = get_drive_credentials()
-        service = build_drive_service()
-        folder_id = ensure_drive_folder_chain(service, folder_parts)
-        uploaded = upload_file_to_drive_raw(snapshot, folder_id, credentials)
-        file_id = uploaded.get("id")
-        if not file_id:
-            raise RuntimeError(f"Drive upload response missing file id: {uploaded!r}")
-        verify_drive_upload(
-            service,
-            file_id=file_id,
-            expected_name=snapshot.name,
-            expected_size=snapshot_size,
-        )
-        result.update(
-            verify_sqlite_backup_artifact(
-                artifact,
-                full=_should_run_full_verify(resolved_date_stamp),
-                service=service,
-                file_id=file_id,
-            )
-        )
-        if result["verified"]:
-            if remove_local_after_upload:
-                snapshot.unlink()
-                result["local_removed"] = True
-            deleted = prune_drive_backups(
+    try:
+        if upload:
+            credentials = get_drive_credentials()
+            service = build_drive_service()
+            folder_id = ensure_drive_folder_chain(service, folder_parts)
+            uploaded = upload_file_to_drive_raw(snapshot, folder_id, credentials)
+            file_id = uploaded.get("id")
+            if not file_id:
+                raise RuntimeError(f"Drive upload response missing file id: {uploaded!r}")
+            verify_drive_upload(
                 service,
-                folder_parts=folder_parts,
-                retention_policy=retention_policy,
+                file_id=file_id,
+                expected_name=snapshot.name,
+                expected_size=snapshot_size,
             )
-        else:
-            deleted = []
-        result.update({"uploaded": True, "drive_file": uploaded, "retention_deleted": deleted})
-    _append_json_log(log_path, result)
+            result.update(
+                verify_sqlite_backup_artifact(
+                    artifact,
+                    full=_should_run_full_verify(resolved_date_stamp),
+                    service=service,
+                    file_id=file_id,
+                )
+            )
+            if result["verified"]:
+                if remove_local_after_upload:
+                    snapshot.unlink()
+                    result["local_removed"] = True
+                deleted = prune_drive_backups(
+                    service,
+                    folder_parts=folder_parts,
+                    retention_policy=retention_policy,
+                )
+            else:
+                deleted = []
+            result.update({"uploaded": True, "drive_file": uploaded, "retention_deleted": deleted})
+    except Exception as exc:
+        result.update({"error_type": type(exc).__name__, "error": str(exc)})
+        raise
+    finally:
+        _append_json_log(log_path, result)
     return result
 
 

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -2251,6 +2251,7 @@ def flush() -> None:
                     project=item.get("project"),
                     tags=item.get("tags"),
                     importance=item.get("importance"),
+                    created_at=item.get("created_at") or item.get("queued_at"),
                     source="pending",
                     confidence_score=item.get("confidence_score"),
                     outcome=item.get("outcome"),

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -290,6 +290,18 @@ def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
     return {"kind": "unknown", **event}
 
 
+def _event_created_at(event: dict[str, Any]) -> str:
+    raw_created_at = event.get("created_at")
+    if raw_created_at:
+        return str(raw_created_at)
+    raw_queued_at = event.get("queued_at")
+    if isinstance(raw_queued_at, int | float):
+        return datetime.fromtimestamp(float(raw_queued_at), timezone.utc).isoformat()
+    if raw_queued_at:
+        return str(raw_queued_at)
+    return datetime.now(timezone.utc).isoformat()
+
+
 def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     raw_content = event.get("content")
     if raw_content is None:
@@ -310,6 +322,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         logger.warning("Skipping recursive MCP store event: %s", recursive_reason)
         return ApplyResult()
     now = datetime.now(timezone.utc).isoformat()
+    created_at = _event_created_at(event)
     metadata = {"memory_type": event.get("memory_type", "note")}
     raw_metadata = event.get("metadata")
     if isinstance(raw_metadata, dict):
@@ -328,7 +341,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
                     "content": content,
                     "tags": json.dumps(tags) if tags else None,
                     "importance": float(event["importance"]) if event.get("importance") is not None else None,
-                    "created_at": now,
+                    "created_at": created_at,
                     "last_seen_at": now,
                 },
             )
@@ -346,7 +359,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "value_type": "HIGH",
             "char_count": len(content),
             "source": event.get("source") or "manual",
-            "created_at": now,
+            "created_at": created_at,
             "enriched_at": now,
             "enrich_status": "success",
             "summary": content[:200],

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -5,6 +5,7 @@ import json
 import os
 import threading
 import uuid
+from datetime import datetime, timezone
 
 import apsw
 from mcp.types import CallToolResult, TextContent
@@ -41,6 +42,18 @@ def _is_lock_error(exc: BaseException) -> bool:
 
 def _new_manual_chunk_id() -> str:
     return f"manual-{uuid.uuid4().hex[:16]}"
+
+
+def _reservation_created_at(item: dict) -> str | None:
+    raw_created_at = item.get("created_at")
+    if raw_created_at:
+        return str(raw_created_at)
+    raw_queued_at = item.get("queued_at")
+    if raw_queued_at is None:
+        return None
+    if isinstance(raw_queued_at, int | float):
+        return datetime.fromtimestamp(float(raw_queued_at), timezone.utc).isoformat()
+    return str(raw_queued_at)
 
 
 async def _brain_digest(
@@ -407,6 +420,8 @@ def _queue_store(item: dict) -> None:
     Enforces _QUEUE_MAX_SIZE: if the file exceeds the limit, oldest lines
     are dropped to make room.
     """
+    item = dict(item)
+    item["created_at"] = _reservation_created_at(item) or datetime.now(timezone.utc).isoformat()
     try:
         from ..queue_io import enqueue_store
 
@@ -481,6 +496,7 @@ def _flush_pending_stores(store, embed_fn) -> int:
                 function_name=item.get("function_name"),
                 line_number=item.get("line_number"),
                 chunk_id=item.get("chunk_id"),
+                created_at=_reservation_created_at(item),
             )
             if item.get("supersedes"):
                 if not store.supersede_chunk(item["supersedes"], result["id"]):
@@ -542,6 +558,7 @@ async def _store(
     A background task embeds pending chunks after the response is sent.
     """
     promised_chunk_id = _new_manual_chunk_id()
+    reservation_created_at = datetime.now(timezone.utc).isoformat()
     try:
         if os.environ.get("BRAINLAYER_ARBITRATED") == "1":
             from ..ingest_guard import reject_recursive_mcp_output
@@ -576,6 +593,7 @@ async def _store(
                     "function_name": function_name,
                     "line_number": line_number,
                     "supersedes": supersedes,
+                    "created_at": reservation_created_at,
                 }
             )
             clear_hybrid_search_cache()
@@ -608,6 +626,7 @@ async def _store(
             function_name=function_name,
             line_number=line_number,
             chunk_id=promised_chunk_id,
+            created_at=reservation_created_at,
         )
 
         chunk_id = result["id"]
@@ -691,6 +710,7 @@ async def _store(
                     "function_name": function_name,
                     "line_number": line_number,
                     "supersedes": supersedes,
+                    "created_at": reservation_created_at,
                 }
             )
             structured = {"chunk_id": promised_chunk_id, "queued": True, "related": []}

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -6,6 +6,7 @@ import json
 import os
 import time
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -61,12 +62,14 @@ def enqueue_store(
     project: str | None = None,
     tags: list[str] | None = None,
     importance: int | None = None,
+    created_at: str | None = None,
     source: str = "mcp",
     queue_dir: Path | None = None,
     **metadata: Any,
 ) -> Path:
     supersedes = metadata.pop("supersedes", None)
     chunk_id = metadata.pop("chunk_id", None) or f"manual-{uuid.uuid4().hex[:16]}"
+    created_at = created_at or datetime.now(timezone.utc).isoformat()
     return enqueue_jsonl(
         {
             "kind": "store_memory",
@@ -76,6 +79,7 @@ def enqueue_store(
             "project": project,
             "tags": tags,
             "importance": importance,
+            "created_at": created_at,
             "supersedes": supersedes,
             "metadata": {key: value for key, value in metadata.items() if value is not None},
         },

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -122,7 +122,8 @@ def store_memory(
 
     # Generate chunk ID and timestamps
     chunk_id = chunk_id or f"manual-{uuid.uuid4().hex[:16]}"
-    now = created_at or datetime.now(timezone.utc).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
+    effective_created_at = created_at or now
 
     # Embed at write time (if embed_fn provided), otherwise defer
     embedding = None
@@ -165,7 +166,7 @@ def store_memory(
         "tags": tags_json,
         "importance": float(importance) if importance is not None else None,
         "content_class": content_class,
-        "created_at": now,
+        "created_at": effective_created_at,
         "last_seen_at": now,
     }
     for attempt in range(5):
@@ -199,7 +200,7 @@ def store_memory(
                     store.conn,
                     chunk_id=incoming_chunk_id,
                     content=content,
-                    created_at=now,
+                    created_at=effective_created_at,
                     project=project,
                     content_type=memory_type,
                 )
@@ -247,7 +248,7 @@ def store_memory(
                             "HIGH",
                             len(content),
                             "manual",
-                            now,
+                            effective_created_at,
                             now,
                             "success",
                             content[:200],

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -70,6 +70,7 @@ def store_memory(
     function_name: Optional[str] = None,
     line_number: Optional[int] = None,
     chunk_id: Optional[str] = None,
+    created_at: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Persistently store a memory into BrainLayer.
 
@@ -96,6 +97,7 @@ def store_memory(
         function_name: Optional function reference. Only for type=issue.
         line_number: Optional line number reference. Only for type=issue.
         chunk_id: Optional caller-supplied chunk ID for durable queued writes.
+        created_at: Optional caller-supplied reservation timestamp for queued writes.
 
     Returns:
         Dict with 'id' (chunk ID) and 'related' (list of similar existing memories).
@@ -120,7 +122,7 @@ def store_memory(
 
     # Generate chunk ID and timestamps
     chunk_id = chunk_id or f"manual-{uuid.uuid4().hex[:16]}"
-    now = datetime.now(timezone.utc).isoformat()
+    now = created_at or datetime.now(timezone.utc).isoformat()
 
     # Embed at write time (if embed_fn provided), otherwise defer
     embedding = None

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -585,6 +585,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 conversation_id TEXT,
                 position INTEGER,
                 context_summary TEXT,
+                created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 chunk_origin TEXT DEFAULT 'unknown',
                 content_class TEXT DEFAULT 'knowledge'
             )
@@ -1969,7 +1970,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 transaction_started = True
                 for chunk, embedding in valid_pairs:
                     chunk_id = chunk["id"]
-                    created_at = chunk.get("created_at")
+                    created_at = chunk.get("created_at") or datetime.now(timezone.utc).isoformat()
+                    chunk = {**chunk, "created_at": created_at}
                     tags_value = chunk.get("tags")
                     tags_json = json.dumps(tags_value) if isinstance(tags_value, (list, dict)) else tags_value
                     duplicate, dedupe_fields = find_duplicate(

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -549,6 +549,48 @@ def test_run_backup_appends_result_to_file_log(tmp_path, monkeypatch):
     assert logged == result
 
 
+def test_run_backup_appends_file_log_when_upload_fails(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    snapshot = tmp_path / "2026-05-30.db.gz"
+    snapshot.write_bytes(b"backup-bytes")
+    log_path = tmp_path / "backup-daily.log"
+
+    class FakeArtifact:
+        gzip_path = snapshot
+        uncompressed_path = None
+        sentinel_chunks = 1
+        local_retention_deleted: list[str] = []
+
+    monkeypatch.setattr(backup_daily, "create_sqlite_backup_artifact", lambda *args, **kwargs: FakeArtifact())
+    monkeypatch.setattr(backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id")
+    monkeypatch.setattr(
+        backup_daily,
+        "upload_file_to_drive_raw",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("drive unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="drive unavailable"):
+        backup_daily.run_backup(
+            db_path=tmp_path / "brainlayer.db",
+            staging_dir=tmp_path,
+            date_stamp="2026-05-30",
+            upload=True,
+            log_path=log_path,
+        )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    logged = json.loads(lines[0])
+    assert logged["snapshot"] == str(snapshot)
+    assert logged["uploaded"] is False
+    assert logged["verified"] is False
+    assert logged["error_type"] == "RuntimeError"
+    assert logged["error"] == "drive unavailable"
+
+
 def test_prune_drive_backups_keeps_only_latest_n_snapshots():
     from brainlayer.backup_daily import DriveRetentionPolicy, prune_drive_backups
 

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -493,6 +493,62 @@ def test_run_backup_verifies_upload_removes_local_and_rotates_last_n(tmp_path, m
     assert not snapshot.exists()
 
 
+def test_run_backup_appends_result_to_file_log(tmp_path, monkeypatch):
+    from brainlayer import backup_daily
+
+    snapshot = tmp_path / "2026-05-30.db.gz"
+    snapshot.write_bytes(b"backup-bytes")
+    log_path = tmp_path / "backup-daily.log"
+
+    class FakeArtifact:
+        gzip_path = snapshot
+        uncompressed_path = None
+        sentinel_chunks = 1
+        local_retention_deleted: list[str] = []
+
+    monkeypatch.setattr(backup_daily, "create_sqlite_backup_artifact", lambda *args, **kwargs: FakeArtifact())
+    monkeypatch.setattr(backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(backup_daily, "ensure_drive_folder_chain", lambda service, folder_parts: "folder-id")
+    monkeypatch.setattr(
+        backup_daily,
+        "verify_sqlite_backup_artifact",
+        lambda *args, **kwargs: {
+            "verified": True,
+            "verification_mode": "quick",
+            "sentinel_snapshot_chunks": 1,
+            "sentinel_verified_chunks": 1,
+        },
+    )
+    monkeypatch.setattr(
+        backup_daily,
+        "upload_file_to_drive_raw",
+        lambda file_path, folder_id, credentials: {
+            "id": "drive-file-id",
+            "name": Path(file_path).name,
+            "size": str(Path(file_path).stat().st_size),
+        },
+    )
+    monkeypatch.setattr(backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(backup_daily, "prune_drive_backups", lambda *args, **kwargs: [])
+
+    result = backup_daily.run_backup(
+        db_path=tmp_path / "brainlayer.db",
+        staging_dir=tmp_path,
+        date_stamp="2026-05-30",
+        upload=True,
+        log_path=log_path,
+    )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    logged = json.loads(lines[0])
+    assert logged["snapshot"] == str(snapshot)
+    assert logged["drive_file"]["id"] == "drive-file-id"
+    assert logged["verified"] is True
+    assert logged == result
+
+
 def test_prune_drive_backups_keeps_only_latest_n_snapshots():
     from brainlayer.backup_daily import DriveRetentionPolicy, prune_drive_backups
 

--- a/tests/test_brainstore.py
+++ b/tests/test_brainstore.py
@@ -184,6 +184,33 @@ class TestStoreMemory:
         assert created_at >= before
         assert created_at <= after
 
+    def test_store_created_at_override_does_not_backdate_write_timestamps(self, store, mock_embed):
+        """Queued replay created_at stays separate from write-time timestamps."""
+        from brainlayer.store import store_memory
+
+        reservation_created_at = "2026-01-01T00:00:00+00:00"
+        before = datetime.now(timezone.utc).isoformat()
+        result = store_memory(
+            store=store,
+            embed_fn=mock_embed,
+            content="Replay timestamp separation matters",
+            memory_type="note",
+            project="test",
+            created_at=reservation_created_at,
+        )
+        after = datetime.now(timezone.utc).isoformat()
+
+        cursor = store.conn.cursor()
+        row = cursor.execute(
+            "SELECT created_at, enriched_at, last_seen_at FROM chunks WHERE id = ?",
+            (result["id"],),
+        ).fetchone()
+
+        assert row is not None
+        assert row[0] == reservation_created_at
+        assert before <= row[1] <= after
+        assert before <= row[2] <= after
+
     def test_store_sets_ingested_at(self, store, mock_embed):
         """Stored memory has a fresh Unix ingested_at timestamp."""
         from brainlayer.store import store_memory

--- a/tests/test_phase3_qa.py
+++ b/tests/test_phase3_qa.py
@@ -9,6 +9,7 @@ Tests cover:
 """
 
 import os
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -364,8 +365,8 @@ class TestCreatedAtUpsert:
         row = list(cursor.execute("SELECT created_at FROM chunks WHERE id = 'dated-chunk'"))
         assert row[0][0] == "2026-02-19T10:00:00+00:00"
 
-    def test_created_at_null_when_missing(self, tmp_path):
-        """Chunks without created_at should have NULL in the DB."""
+    def test_created_at_stamped_when_missing(self, tmp_path):
+        """Chunks without created_at should be forward-stamped at write time."""
         store = VectorStore(tmp_path / "test.db")
         chunks = [
             {
@@ -383,4 +384,5 @@ class TestCreatedAtUpsert:
 
         cursor = store.conn.cursor()
         row = list(cursor.execute("SELECT created_at FROM chunks WHERE id = 'undated-chunk'"))
-        assert row[0][0] is None
+        assert row[0][0] is not None
+        datetime.fromisoformat(row[0][0])

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -119,6 +119,61 @@ async def test_busy_queue_fallback_flushes_promised_chunk_id(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_busy_queue_fallback_flushes_reservation_timestamp_and_project(tmp_path, monkeypatch):
+    """Queued stores persist the reservation-time created_at and queued project."""
+    from brainlayer.drain import drain_once
+    from brainlayer.mcp.store_handler import _store
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    store = VectorStore(db_path)
+    store.close()
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store"),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="brainlayer"),
+        patch("brainlayer.store.store_memory", side_effect=apsw.BusyError("locked")),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        monkeypatch.setattr("brainlayer.mcp.store_handler._retry_delay", 0.001)
+        texts, structured = await _store(
+            content="queued flush must keep reservation metadata",
+            memory_type="note",
+            project="brainlayer",
+        )
+
+    queued_files = list(queue_dir.glob("mcp-*.jsonl"))
+    assert len(queued_files) == 1
+    queued_event = json.loads(queued_files[0].read_text())
+    promised_chunk_id = structured["chunk_id"]
+    reservation_created_at = queued_event["created_at"]
+
+    assert promised_chunk_id == queued_event["chunk_id"]
+    assert queued_event["project"] == "brainlayer"
+    assert structured["queued"] is True
+    assert any(promised_chunk_id in item.text for item in texts)
+
+    assert drain_once(db_path=db_path, queue_dir=queue_dir, log_path=tmp_path / "drain.log") == 1
+
+    conn = apsw.Connection(str(db_path))
+    try:
+        row = (
+            conn.cursor()
+            .execute(
+                "SELECT created_at, project FROM chunks WHERE id = ?",
+                (promised_chunk_id,),
+            )
+            .fetchone()
+        )
+    finally:
+        conn.close()
+
+    assert row == (reservation_created_at, "brainlayer")
+
+
+@pytest.mark.asyncio
 async def test_writer_in_use_error_queues_instead_of_erroring(tmp_path):
     """Writer pidfile contention queues the store instead of returning an MCP error."""
     from brainlayer.mcp.store_handler import _store

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -199,6 +199,35 @@ class TestFlushPendingStores:
         assert flushed == 1
         assert mock_store_memory.call_args.kwargs["chunk_id"] == "manual-promised1234"
 
+    def test_flush_preserves_legacy_pending_created_at_and_project(self, tmp_path):
+        """Legacy pending-stores flush must replay reservation metadata."""
+        pending_path = tmp_path / "pending-stores.jsonl"
+        pending_path.write_text(
+            json.dumps(
+                {
+                    "chunk_id": "manual-promised5678",
+                    "content": "queued item",
+                    "memory_type": "note",
+                    "project": "brainlayer",
+                    "created_at": "2026-06-06T18:45:12Z",
+                }
+            )
+            + "\n"
+        )
+
+        with patch(
+            "brainlayer.mcp.store_handler._get_pending_store_path",
+            return_value=pending_path,
+        ):
+            with patch("brainlayer.store.store_memory") as mock_store_memory:
+                mock_store_memory.return_value = {"id": "manual-promised5678", "related": []}
+                flushed = _flush_pending_stores(MagicMock(), MagicMock())
+
+        assert flushed == 1
+        assert mock_store_memory.call_args.kwargs["chunk_id"] == "manual-promised5678"
+        assert mock_store_memory.call_args.kwargs["project"] == "brainlayer"
+        assert mock_store_memory.call_args.kwargs["created_at"] == "2026-06-06T18:45:12Z"
+
     def test_flush_preserves_legacy_pending_supersedes(self, tmp_path):
         """Legacy pending-stores flush must apply queued supersedes metadata."""
         pending_path = tmp_path / "pending-stores.jsonl"


### PR DESCRIPTION
## Summary
- Stamp `created_at` at store reservation time for Python and Swift queued paths, preserve that value through flush/drain, and carry caller `project` context instead of guessing at flush time.
- Stamp direct non-queued store paths too, including a DB-level default for Python `chunks` inserts and explicit Swift/Python insert parameters.
- Restore `backup_daily` JSONL file appends at `~/.local/share/brainlayer/logs/backup-daily.log`, with an env override for tests/operators.

## Verification
- `pytest -q tests/test_store_handler.py::test_busy_queue_fallback_flushes_reservation_timestamp_and_project`
- `pytest -q tests/test_backup_daily.py::test_run_backup_appends_result_to_file_log`
- `swift test --filter DatabaseTests.testFlushPendingStoresUsesQueuedAtAsCreatedAtAndPreservesProject`
- `pytest -q tests/test_store_handler.py tests/test_backup_daily.py tests/test_write_queue.py`
- `pytest -q tests/test_brainstore.py tests/test_vector_store.py tests/test_store_handler.py tests/test_write_queue.py tests/test_backup_daily.py`
- `pytest -q tests/test_phase3_qa.py::TestCreatedAtUpsert`
- `pytest` (2602 passed, 48 skipped, 5 xfailed)
- `ruff format src/ tests/test_phase3_qa.py tests/test_write_queue.py tests/test_store_handler.py tests/test_backup_daily.py`
- `ruff check src/ tests/test_phase3_qa.py tests/test_write_queue.py tests/test_store_handler.py tests/test_backup_daily.py`
- `swift test --filter 'DatabaseTests|AsyncStoreTests'` (106 tests, 0 failures)
- `swift test` (613 tests, 0 failures)
- Pre-push gate: pytest unit suite (2528 passed, 9 skipped, 77 deselected, 1 xfailed), MCP registration (3 passed), isolated eval/hook routing (40 passed), bun suite, `test_fts5_determinism.sh`

## Remaining
- Existing production NULL backlog still needs one lead-gated backfill after this forward-stamping fix lands. This PR does not run bulk DB operations.

Refs #455

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chunk write paths, queue replay, and timestamp semantics used for search/dedup; behavior change for previously NULL created_at on new writes, but scoped with tests and no bulk backfill in this PR.
> 
> **Overview**
> **Queued and direct store paths** now set **`created_at` at reservation time** and keep that value through queue, flush, and drain instead of stamping again when the DB finally accepts the write. **`project`** is captured on enqueue and replayed on flush (Python unified queue, legacy pending JSONL, CLI pending replay, BrainBar pending stores, and MCP **`brain_store`**).
> 
> Python **`store_memory`**, **`enqueue_store`**, **`drain`**, and **`vector_store.upsert_chunks`** accept or default **`created_at`**; the **`chunks`** schema adds a column default so inserts without an explicit timestamp still get one. Swift **`BrainDatabase`** writes **`created_at`** and **`project`** on **`store`**, **`insertChunk`**, and pending-store JSONL items.
> 
> **`backup_daily`** appends one JSON line per run to **`~/.local/share/brainlayer/logs/backup-daily.log`** (override via env), restoring operator-visible backup history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dcdb1e16e5b41469d0df9c3fdc77d75c8160da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward-stamp reservation `created_at` through queued brain stores on flush
> - Captures a `created_at` timestamp at the time a `brain_store` request is received and threads it through the queue, flush, and drain paths so chunks retain their original reservation time rather than being stamped at write time.
> - Extends `store_memory`, `enqueue_store`, `_apply_store`, and the Swift `BrainDatabase.store`/`queuePendingStore` methods to accept and persist `created_at` without backdating `enriched_at` or `last_seen_at`.
> - Adds an optional `project` field to the `brain_store` MCP tool schema and propagates it through the same queue/flush pipeline.
> - Adds a `DEFAULT` of current UTC time to the `chunks` table `created_at` column so rows written without an explicit value are still stamped.
> - Behavioral Change: previously queued stores were stamped with the flush-time timestamp; they now use the earlier reservation timestamp from when the request was first received.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 648d0ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->