### PR TITLE
fix(hooks): Stop-hook indexer stamps created_at (the fleet-wide realtime NULL source)

### DIFF
--- a/hooks/brainbar-stop-index.py
+++ b/hooks/brainbar-stop-index.py
@@ -15,6 +15,7 @@ import os
 import sqlite3
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 PENDING_DIR = Path.home() / ".brainlayer" / "pending"
@@ -103,10 +104,11 @@ def main():
         cursor = conn.execute(
             """INSERT OR IGNORE INTO chunks
                (id, content, metadata, source_file, source, project, content_type,
-                char_count, conversation_id, importance)
+                char_count, conversation_id, importance, created_at)
                VALUES (?, ?, ?, ?, 'realtime', ?, 'assistant_text',
-                ?, ?, 5)""",
-            (chunk_id, content, metadata, transcript, project, len(content), session_id),
+                ?, ?, 5, ?)""",
+            (chunk_id, content, metadata, transcript, project, len(content), session_id,
+             datetime.now(timezone.utc).isoformat()),
         )
 
         if cursor.rowcount > 0:
@@ -124,6 +126,7 @@ def main():
             "content_hash": content_hash,
             "project": project,
             "timestamp": time.time(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
         queue_file = QUEUE_DIR / f"{session_id}.jsonl"
         with open(queue_file, "a") as f:

--- a/hooks/brainbar-stop-index.py
+++ b/hooks/brainbar-stop-index.py
@@ -107,8 +107,16 @@ def main():
                 char_count, conversation_id, importance, created_at)
                VALUES (?, ?, ?, ?, 'realtime', ?, 'assistant_text',
                 ?, ?, 5, ?)""",
-            (chunk_id, content, metadata, transcript, project, len(content), session_id,
-             datetime.now(timezone.utc).isoformat()),
+            (
+                chunk_id,
+                content,
+                metadata,
+                transcript,
+                project,
+                len(content),
+                session_id,
+                datetime.now(timezone.utc).isoformat(),
+            ),
         )
 
         if cursor.rowcount > 0:

--- a/tests/test_stop_hook_created_at.py
+++ b/tests/test_stop_hook_created_at.py
@@ -1,0 +1,43 @@
+"""Stop hook must stamp created_at on realtime chunk inserts (the #455 fleet-wide NULL source)."""
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parents[1] / "hooks" / "brainbar-stop-index.py"
+
+
+def _mk_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE chunks (
+            id TEXT PRIMARY KEY, content TEXT, metadata TEXT, source_file TEXT,
+            source TEXT, project TEXT, content_type TEXT, char_count INTEGER,
+            conversation_id TEXT, importance REAL, created_at TEXT)"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_stop_hook_stamps_created_at(tmp_path, monkeypatch):
+    db = tmp_path / "t.db"
+    _mk_db(db)
+    payload = {
+        "session_id": "deadbeef-0000-0000-0000-000000000000",
+        "last_assistant_message": "x" * 64,
+        "cwd": str(tmp_path),
+        "transcript_path": "t.jsonl",
+    }
+    env = {"BRAINLAYER_DB": str(db), "PATH": "/usr/bin:/bin", "HOME": str(tmp_path)}
+    r = subprocess.run(
+        [sys.executable, str(HOOK)], input=json.dumps(payload), text=True,
+        capture_output=True, env=env, timeout=15,
+    )
+    assert r.returncode == 0, r.stderr
+    conn = sqlite3.connect(db)
+    row = conn.execute("SELECT created_at FROM chunks").fetchone()
+    conn.close()
+    assert row is not None, "no chunk inserted"
+    assert row[0], "created_at is NULL — the regression this test guards"
+    assert "T" in row[0] and row[0].endswith(("Z", "+00:00")), f"non-canonical stamp: {row[0]}"

--- a/tests/test_stop_hook_created_at.py
+++ b/tests/test_stop_hook_created_at.py
@@ -1,4 +1,5 @@
 """Stop hook must stamp created_at on realtime chunk inserts (the #455 fleet-wide NULL source)."""
+
 import json
 import sqlite3
 import subprocess
@@ -31,8 +32,12 @@ def test_stop_hook_stamps_created_at(tmp_path, monkeypatch):
     }
     env = {"BRAINLAYER_DB": str(db), "PATH": "/usr/bin:/bin", "HOME": str(tmp_path)}
     r = subprocess.run(
-        [sys.executable, str(HOOK)], input=json.dumps(payload), text=True,
-        capture_output=True, env=env, timeout=15,
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=15,
     )
     assert r.returncode == 0, r.stderr
     conn = sqlite3.connect(db)


### PR DESCRIPTION
Found by LEAD systematic debugging after #464+#466 both deployed and realtime chunks STILL landed NULL: the Stop hook (`hooks/brainbar-stop-index.py`, wired in settings.json, runs on every Stop in every session) does a **raw sqlite3 INSERT that omits created_at** — standalone script, no package imports, so neither #464 nor #466 could reach it.

- Stamp at insert: canonical UTC ISO (the #455 format convention)
- Fallback queue entry carries created_at too
- TDD: subprocess test vs tmp DB — RED on old script (created_at NULL), GREEN with fix

Refs #455 (closes the created_at arc) · live repro rows 736416/733397/733392. 🤖 brainlayerClaude-LEAD-v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized hook change plus test; only affects timestamp population on realtime indexing, no auth or schema migration.
> 
> **Overview**
> The **Stop hook** (`brainbar-stop-index.py`) was inserting realtime chunks without **`created_at`**, leaving a fleet-wide NULL gap that earlier package-level fixes did not cover because this path uses a raw standalone SQLite insert.
> 
> The INSERT now includes **`created_at`** set to canonical UTC ISO via `datetime.now(timezone.utc).isoformat()`, and the DB-failure **JSONL queue fallback** adds the same field. A subprocess integration test asserts the inserted row has a non-null, ISO-shaped timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167a6fec7cc3239f6985d11c06ac9defbef8e321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stamp `created_at` with a UTC ISO 8601 timestamp in the stop-hook indexer
> - Updates [brainbar-stop-index.py](https://github.com/EtanHey/brainlayer/pull/468/files#diff-33edfa3eb92c0890de9bc98fe089af9febbb5a6d86878d39bda44635689848c0) to include `created_at` in the `chunks` table INSERT, set to the current UTC time in ISO 8601 format at insertion time.
> - Fallback queue entries also receive the same `created_at` field so the value is consistent across both paths.
> - Adds [test_stop_hook_created_at.py](https://github.com/EtanHey/brainlayer/pull/468/files#diff-89ee9a30ff56206775f11bd81e87b82a85414faff527ef3e02594fc962db74f1) to verify that `created_at` is non-null and correctly formatted on insert.
> - Behavioral Change: `chunks` rows inserted by the stop hook will now have a populated `created_at`; rows previously inserted will remain NULL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 167a6fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chunk records now automatically capture and store creation timestamps in ISO 8601 UTC format, improving audit trail and tracking capabilities for newly recorded entries.

* **Tests**
  * Added test coverage to verify that chunk records correctly record timestamps with proper formatting during data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->