### PR TITLE
fix: scope dedupe simhash by week

### DIFF
--- a/scripts/resimhash_dedupe.py
+++ b/scripts/resimhash_dedupe.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Recompute stored dedupe simhashes after the content-only SimHash migration."""
+
+import os
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from brainlayer.dedupe import resimhash_main
+
+
+if __name__ == "__main__":
+    if hasattr(os, "nice"):
+        try:
+            os.nice(5)
+        except OSError:
+            pass
+    raise SystemExit(resimhash_main())

--- a/src/brainlayer/dedupe.py
+++ b/src/brainlayer/dedupe.py
@@ -83,6 +83,14 @@ class BackfillResult:
     hashed: int
 
 
+@dataclass(frozen=True)
+class ResimhashResult:
+    scanned: int
+    updated: int
+    last_id: str | None
+    complete: bool
+
+
 def normalize_for_dedupe(content: str) -> str:
     """Normalize text before SimHash tokenization."""
     without_timestamps = _ISO_TIMESTAMP_RE.sub(" ", content.lower())
@@ -144,17 +152,11 @@ def _weighted_features(content: str, created_at: str | None = None) -> Iterable[
     if not tokens:
         return []
     if len(tokens) < SHINGLE_WIDTH:
-        features = [(f"tok:{token}", 1.0) for token in tokens]
-    else:
-        features = [
-            (f"sh:{' '.join(tokens[index : index + SHINGLE_WIDTH])}", 1.0)
-            for index in range(0, len(tokens) - SHINGLE_WIDTH + 1)
-        ]
-    bucket = _week_bucket(created_at)
-    if bucket is not None:
-        # Low relative to long chunks, but strong enough to separate short weekly milestones.
-        features.extend((f"week:{bucket}:{bit}", 2.0) for bit in range(2))
-    return features
+        return [(f"tok:{token}", 1.0) for token in tokens]
+    return [
+        (f"sh:{' '.join(tokens[index : index + SHINGLE_WIDTH])}", 1.0)
+        for index in range(0, len(tokens) - SHINGLE_WIDTH + 1)
+    ]
 
 
 def simhash64(content: str, *, created_at: str | None = None) -> int:
@@ -335,7 +337,7 @@ def find_duplicate(
 
     candidates = cursor.execute(
         f"""
-        SELECT id, simhash, content FROM chunks
+        SELECT id, simhash, content, created_at FROM chunks
         WHERE id != ?
           AND {_active_clause()}
           AND {scope_sql}
@@ -349,7 +351,10 @@ def find_duplicate(
         (chunk_id, *scope_params, *fields.bands),
     ).fetchall()
     best: DuplicateHit | None = None
-    for candidate_id, candidate_simhash, candidate_content in candidates:
+    incoming_week = _week_bucket(created_at)
+    for candidate_id, candidate_simhash, candidate_content, candidate_created_at in candidates:
+        if _week_bucket(candidate_created_at) != incoming_week:
+            continue
         if _numeric_tokens_conflict(content, str(candidate_content)):
             continue
         distance = hamming_distance(fields.simhash, candidate_simhash)
@@ -784,7 +789,7 @@ def _drop_backfill_index(
     chunk_id: str,
     *,
     seen_hashes: dict[tuple[str | None, str | None, str], str],
-    band_index: dict[tuple[str | None, str | None, str], set[str]],
+    band_index: dict[tuple[str | None, str | None, str | None, str], set[str]],
     fingerprints: dict[str, str],
     numeric_index: dict[str, set[str]],
 ) -> None:
@@ -805,7 +810,7 @@ def _add_backfill_index(
     project: Any,
     content_type: Any,
     seen_hashes: dict[tuple[str | None, str | None, str], str],
-    band_index: dict[tuple[str | None, str | None, str], set[str]],
+    band_index: dict[tuple[str | None, str | None, str | None, str], set[str]],
     fingerprints: dict[str, str],
     numeric_index: dict[str, set[str]],
 ) -> DedupeFields:
@@ -814,8 +819,9 @@ def _add_backfill_index(
     seen_hashes[(*scope, fields.dedupe_hash)] = chunk_id
     fingerprints[chunk_id] = fields.simhash
     numeric_index[chunk_id] = _numeric_tokens(content)
+    week_bucket = _week_bucket(created_at)
     for band in fields.bands:
-        band_index.setdefault((*scope, band), set()).add(chunk_id)
+        band_index.setdefault((*scope, week_bucket, band), set()).add(chunk_id)
     return fields
 
 
@@ -844,7 +850,7 @@ def backfill_dedupe_database(
         cursor.execute("PRAGMA wal_checkpoint(FULL)")
         total = cursor.execute(f"SELECT COUNT(*) FROM chunks WHERE {_active_clause()}").fetchone()[0]
         seen_hashes: dict[tuple[str | None, str | None, str], str] = {}
-        band_index: dict[tuple[str | None, str | None, str], set[str]] = {}
+        band_index: dict[tuple[str | None, str | None, str | None, str], set[str]] = {}
         fingerprints: dict[str, str] = {}
         numeric_index: dict[str, set[str]] = {}
         merged = 0
@@ -901,8 +907,9 @@ def backfill_dedupe_database(
                     hit = DuplicateHit(seen_hashes[hash_key], "sha256", 0)
                 elif len(normalize_for_dedupe(str(incoming["content"])).split()) >= MIN_SIMHASH_TOKENS:
                     candidate_ids: set[str] = set()
+                    week_bucket = _week_bucket(incoming.get("created_at"))
                     for band in fields.bands:
-                        candidate_ids.update(band_index.get((*scope, band), set()))
+                        candidate_ids.update(band_index.get((*scope, week_bucket, band), set()))
                     best_id = None
                     best_distance = SIMHASH_BITS
                     for candidate_id in candidate_ids:
@@ -1000,6 +1007,163 @@ def backfill_dedupe_database(
         return BackfillResult(scanned=scanned, merged=merged, hashed=hashed)
     finally:
         conn.close()
+
+
+RESIMHASH_MIGRATION_NAME = "2026_06_11_content_only_simhash_v1"
+
+
+def _ensure_resimhash_progress_schema(cursor: Any) -> None:
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dedupe_resimhash_progress (
+            migration_name TEXT PRIMARY KEY,
+            last_id TEXT,
+            scanned INTEGER NOT NULL DEFAULT 0,
+            updated INTEGER NOT NULL DEFAULT 0,
+            started_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT
+        )
+        """
+    )
+
+
+def resimhash_dedupe_database(
+    db_path: str | Path,
+    *,
+    batch_size: int = 5000,
+    checkpoint_every: int = 3,
+    allow_live: bool = False,
+    migration_name: str = RESIMHASH_MIGRATION_NAME,
+) -> ResimhashResult:
+    if batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+    if checkpoint_every <= 0:
+        raise ValueError("checkpoint_every must be a positive integer")
+    path = Path(db_path).expanduser().resolve()
+    if path == Path(get_db_path()).expanduser().resolve() and not allow_live:
+        raise ValueError(
+            "Refusing to re-simhash the default live DB; stop enrichment and pass allow_live=True"
+        )
+
+    conn = apsw.Connection(str(path))
+    conn.setbusytimeout(30_000)
+    try:
+        cursor = conn.cursor()
+        ensure_dedupe_schema(conn)
+        _ensure_resimhash_progress_schema(cursor)
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        now = datetime.now(timezone.utc).isoformat()
+        row = cursor.execute(
+            """
+            SELECT last_id, scanned, updated, completed_at
+            FROM dedupe_resimhash_progress
+            WHERE migration_name = ?
+            """,
+            (migration_name,),
+        ).fetchone()
+        if row and row[3]:
+            return ResimhashResult(scanned=int(row[1]), updated=int(row[2]), last_id=row[0], complete=True)
+        if row:
+            last_id = str(row[0] or "")
+            scanned = int(row[1] or 0)
+            updated = int(row[2] or 0)
+        else:
+            last_id = ""
+            scanned = 0
+            updated = 0
+            cursor.execute(
+                """
+                INSERT INTO dedupe_resimhash_progress(
+                    migration_name, last_id, scanned, updated, started_at, updated_at
+                )
+                VALUES (?, '', 0, 0, ?, ?)
+                """,
+                (migration_name, now, now),
+            )
+
+        batches = 0
+        while True:
+            rows = cursor.execute(
+                """
+                SELECT id, content, created_at
+                FROM chunks
+                WHERE id > ?
+                  AND content IS NOT NULL
+                  AND simhash IS NOT NULL
+                ORDER BY id ASC
+                LIMIT ?
+                """,
+                (last_id, batch_size),
+            ).fetchall()
+            if not rows:
+                break
+            cursor.execute("BEGIN IMMEDIATE")
+            try:
+                for chunk_id, content, created_at in rows:
+                    fields = compute_dedupe_fields(str(content), created_at)
+                    cursor.execute(
+                        """
+                        UPDATE chunks
+                        SET simhash = ?,
+                            simhash_band_0 = ?,
+                            simhash_band_1 = ?,
+                            simhash_band_2 = ?,
+                            simhash_band_3 = ?
+                        WHERE id = ?
+                        """,
+                        (fields.simhash, *fields.bands, chunk_id),
+                    )
+                last_id = str(rows[-1][0])
+                scanned += len(rows)
+                updated += len(rows)
+                cursor.execute(
+                    """
+                    UPDATE dedupe_resimhash_progress
+                    SET last_id = ?, scanned = ?, updated = ?, updated_at = ?
+                    WHERE migration_name = ?
+                    """,
+                    (last_id, scanned, updated, datetime.now(timezone.utc).isoformat(), migration_name),
+                )
+                cursor.execute("COMMIT")
+            except Exception:
+                cursor.execute("ROLLBACK")
+                raise
+            batches += 1
+            logger.info("dedupe re-simhash progress: scanned=%d updated=%d last_id=%s", scanned, updated, last_id)
+            if batches % checkpoint_every == 0:
+                cursor.execute("PRAGMA wal_checkpoint(FULL)")
+
+        completed_at = datetime.now(timezone.utc).isoformat()
+        cursor.execute(
+            """
+            UPDATE dedupe_resimhash_progress
+            SET completed_at = ?, updated_at = ?
+            WHERE migration_name = ?
+            """,
+            (completed_at, completed_at, migration_name),
+        )
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        return ResimhashResult(scanned=scanned, updated=updated, last_id=last_id or None, complete=True)
+    finally:
+        conn.close()
+
+
+def resimhash_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Recompute BrainLayer stored simhashes with content-only fingerprints.")
+    parser.add_argument("--db", default=get_db_path(), help="SQLite DB path to process")
+    parser.add_argument("--batch-size", type=int, default=5000)
+    parser.add_argument("--checkpoint-every", type=int, default=3, help="WAL checkpoint every N batches")
+    parser.add_argument("--allow-live", action="store_true", help="Allow processing the canonical live DB")
+    args = parser.parse_args(argv)
+    result = resimhash_dedupe_database(
+        args.db,
+        batch_size=args.batch_size,
+        checkpoint_every=args.checkpoint_every,
+        allow_live=args.allow_live,
+    )
+    print(json.dumps(result.__dict__, sort_keys=True))
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/brainlayer/dedupe.py
+++ b/src/brainlayer/dedupe.py
@@ -1042,9 +1042,7 @@ def resimhash_dedupe_database(
         raise ValueError("checkpoint_every must be a positive integer")
     path = Path(db_path).expanduser().resolve()
     if path == Path(get_db_path()).expanduser().resolve() and not allow_live:
-        raise ValueError(
-            "Refusing to re-simhash the default live DB; stop enrichment and pass allow_live=True"
-        )
+        raise ValueError("Refusing to re-simhash the default live DB; stop enrichment and pass allow_live=True")
 
     conn = apsw.Connection(str(path))
     conn.setbusytimeout(30_000)
@@ -1150,7 +1148,9 @@ def resimhash_dedupe_database(
 
 
 def resimhash_main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Recompute BrainLayer stored simhashes with content-only fingerprints.")
+    parser = argparse.ArgumentParser(
+        description="Recompute BrainLayer stored simhashes with content-only fingerprints."
+    )
     parser.add_argument("--db", default=get_db_path(), help="SQLite DB path to process")
     parser.add_argument("--batch-size", type=int, default=5000)
     parser.add_argument("--checkpoint-every", type=int, default=3, help="WAL checkpoint every N batches")

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -266,6 +266,89 @@ def test_weekly_standups_remain_distinct_chunks(tmp_path):
     store.close()
 
 
+def test_simhash_scope_allows_unknown_week_to_unknown_week(tmp_path):
+    from brainlayer.dedupe import compute_dedupe_fields, find_duplicate
+
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    first_words = [f"token{i}" for i in range(100)]
+    second_words = first_words.copy()
+    second_words[0] = "changed0"
+    candidate_content = " ".join(first_words)
+    incoming_content = " ".join(second_words)
+    fields = compute_dedupe_fields(candidate_content, None)
+
+    store.conn.cursor().execute(
+        """
+        INSERT INTO chunks(id, content, metadata, source_file, project, content_type, created_at,
+                           dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3)
+        VALUES (?, ?, '{}', 'seed', 'brainlayer', 'note', NULL, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "unknown-week",
+            candidate_content,
+            fields.dedupe_hash,
+            fields.simhash,
+            *fields.bands,
+        ),
+    )
+
+    hit, _ = find_duplicate(
+        store.conn,
+        chunk_id="incoming",
+        content=incoming_content,
+        created_at=None,
+        project="brainlayer",
+        content_type="note",
+    )
+
+    assert hit is not None
+    assert hit.canonical_chunk_id == "unknown-week"
+    assert hit.mechanism == "simhash"
+    store.close()
+
+
+def test_simhash_scope_blocks_unknown_week_to_dated_week(tmp_path):
+    from brainlayer.dedupe import compute_dedupe_fields, find_duplicate
+
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    first_words = [f"token{i}" for i in range(100)]
+    second_words = first_words.copy()
+    second_words[0] = "changed0"
+    candidate_content = " ".join(first_words)
+    incoming_content = " ".join(second_words)
+    fields = compute_dedupe_fields(candidate_content, "2026-05-11T09:00:00Z")
+
+    store.conn.cursor().execute(
+        """
+        INSERT INTO chunks(id, content, metadata, source_file, project, content_type, created_at,
+                           dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3)
+        VALUES (?, ?, '{}', 'seed', 'brainlayer', 'note', ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "dated-week",
+            candidate_content,
+            "2026-05-11T09:00:00Z",
+            fields.dedupe_hash,
+            fields.simhash,
+            *fields.bands,
+        ),
+    )
+
+    hit, _ = find_duplicate(
+        store.conn,
+        chunk_id="incoming",
+        content=incoming_content,
+        created_at=None,
+        project="brainlayer",
+        content_type="note",
+    )
+
+    assert hit is None
+    store.close()
+
+
 def test_timestamp_only_changes_remain_distinct_chunks(tmp_path):
     db_path = tmp_path / "brainlayer.db"
     store = VectorStore(db_path)

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -51,19 +51,18 @@ def test_normalized_exact_hash_preserves_timestamps_but_ignores_stopwords_and_wh
     assert normalized_exact_hash(first_deadline) != normalized_exact_hash(second_deadline)
 
 
-def test_simhash_week_bucket_prevents_weekly_milestone_collapse():
+def test_simhash_is_content_only_across_week_buckets():
     from brainlayer.dedupe import hamming_distance, is_near_duplicate, simhash64
 
-    week_1 = "Week 1 standup: shipped ingest dedupe tests and opened the review loop"
-    week_2 = "Week 2 standup: shipped ingest dedupe tests and opened the review loop"
+    content = "Weekly standup shipped ingest dedupe tests and opened the review loop"
 
-    left = simhash64(week_1, created_at="2026-05-04T09:00:00Z")
-    right = simhash64(week_2, created_at="2026-05-11T09:00:00Z")
+    left = simhash64(content, created_at="2026-05-04T09:00:00Z")
+    right = simhash64(content, created_at="2026-05-11T09:00:00Z")
 
-    assert hamming_distance(left, right) > 3
-    assert not is_near_duplicate(
-        week_1,
-        week_2,
+    assert hamming_distance(left, right) == 0
+    assert is_near_duplicate(
+        content,
+        content,
         created_at_a="2026-05-04T09:00:00Z",
         created_at_b="2026-05-11T09:00:00Z",
     )
@@ -238,17 +237,20 @@ def test_merged_content_list_does_not_double_number_existing_items():
 def test_weekly_standups_remain_distinct_chunks(tmp_path):
     db_path = tmp_path / "brainlayer.db"
     store = VectorStore(db_path)
+    first_words = [f"token{i}" for i in range(100)]
+    second_words = first_words.copy()
+    second_words[0] = "changed0"
 
     store.upsert_chunks(
         [
             _chunk(
                 "week-1",
-                "Week 1 standup: shipped ingest dedupe tests and opened the review loop",
+                " ".join(first_words),
                 created_at="2026-05-04T09:00:00Z",
             ),
             _chunk(
                 "week-2",
-                "Week 2 standup: shipped ingest dedupe tests and opened the review loop",
+                " ".join(second_words),
                 created_at="2026-05-11T09:00:00Z",
             ),
         ],
@@ -486,6 +488,113 @@ def test_backfill_refuses_default_live_db_without_explicit_allow(monkeypatch, tm
         assert "snapshot" in str(exc)
     else:
         raise AssertionError("live default DB backfill should require allow_live=True")
+
+
+def test_resimhash_recomputes_stored_simhashes_without_merging(tmp_path):
+    from brainlayer.dedupe import compute_dedupe_fields, resimhash_dedupe_database
+
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    content = "Resimhash migration should recompute stale simhash fields only"
+    expected_fields = compute_dedupe_fields(content, "2026-05-11T09:00:00Z")
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO chunks(id, content, metadata, source_file, created_at,
+                           dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3)
+        VALUES (?, ?, '{}', 'seed', ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "stale-row",
+            content,
+            "2026-05-11T09:00:00Z",
+            expected_fields.dedupe_hash,
+            "0000000000000000",
+            "0000",
+            "0000",
+            "0000",
+            "0000",
+        ),
+    )
+    store.close()
+
+    result = resimhash_dedupe_database(db_path, batch_size=1, checkpoint_every=1)
+
+    checked = VectorStore(db_path)
+    row = (
+        checked.conn.cursor()
+        .execute(
+            """
+            SELECT simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3
+            FROM chunks
+            WHERE id = 'stale-row'
+            """
+        )
+        .fetchone()
+    )
+    aliases = checked.conn.cursor().execute("SELECT COUNT(*) FROM chunk_id_alias").fetchone()[0]
+
+    assert result.scanned == 1
+    assert result.updated == 1
+    assert row == (expected_fields.simhash, *expected_fields.bands)
+    assert aliases == 0
+    checked.close()
+
+
+def test_resimhash_resumes_after_recorded_last_id(tmp_path):
+    from brainlayer.dedupe import compute_dedupe_fields, resimhash_dedupe_database
+
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    cursor = store.conn.cursor()
+    new_fields = compute_dedupe_fields("second migration resume row", "2026-05-11T09:00:00Z")
+    stale_simhash = "0000000000000000"
+    stale_bands = ("0000", "0000", "0000", "0000")
+    for chunk_id, content in [
+        ("a-first", "first migration resume row"),
+        ("b-second", "second migration resume row"),
+    ]:
+        fields = compute_dedupe_fields(content, "2026-05-11T09:00:00Z")
+        cursor.execute(
+            """
+            INSERT INTO chunks(id, content, metadata, source_file, created_at,
+                               dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3)
+            VALUES (?, ?, '{}', 'seed', '2026-05-11T09:00:00Z', ?, ?, ?, ?, ?, ?)
+            """,
+            (chunk_id, content, fields.dedupe_hash, stale_simhash, *stale_bands),
+        )
+    cursor.execute(
+        """
+        CREATE TABLE dedupe_resimhash_progress (
+            migration_name TEXT PRIMARY KEY,
+            last_id TEXT,
+            scanned INTEGER NOT NULL DEFAULT 0,
+            updated INTEGER NOT NULL DEFAULT 0,
+            started_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+        INSERT INTO dedupe_resimhash_progress(migration_name, last_id, scanned, updated, started_at, updated_at)
+        VALUES ('test-resume', 'a-first', 1, 1, '2026-06-11T00:00:00Z', '2026-06-11T00:00:00Z')
+        """
+    )
+    store.close()
+
+    result = resimhash_dedupe_database(db_path, batch_size=1, checkpoint_every=1, migration_name="test-resume")
+
+    checked = VectorStore(db_path)
+    rows = dict(
+        checked.conn.cursor().execute(
+            "SELECT id, simhash FROM chunks WHERE id IN ('a-first', 'b-second') ORDER BY id"
+        )
+    )
+    assert result.scanned == 2
+    assert rows == {"a-first": stale_simhash, "b-second": new_fields.simhash}
+    checked.close()
 
 
 def test_alias_resolution_expires_after_grace_period(tmp_path):

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -588,9 +588,7 @@ def test_resimhash_resumes_after_recorded_last_id(tmp_path):
 
     checked = VectorStore(db_path)
     rows = dict(
-        checked.conn.cursor().execute(
-            "SELECT id, simhash FROM chunks WHERE id IN ('a-first', 'b-second') ORDER BY id"
-        )
+        checked.conn.cursor().execute("SELECT id, simhash FROM chunks WHERE id IN ('a-first', 'b-second') ORDER BY id")
     )
     assert result.scanned == 2
     assert rows == {"a-first": stale_simhash, "b-second": new_fields.simhash}


### PR DESCRIPTION
## Summary
- Makes `simhash64` content-only by removing the week-bucket feature from the fingerprint.
- Preserves temporal dedupe safety by enforcing week-bucket equality separately for simhash duplicate candidates.
- Adds a resumable batched `scripts/resimhash_dedupe.py` migration with progress tracking and WAL checkpoints.
- Adds/updates regression tests for content-only simhash, same-week near-dup merge, cross-week non-merge, and migration resume behavior.

## RED -> GREEN evidence
- RED before implementation:
  - `pytest tests/test_dedupe.py::test_simhash_is_content_only_across_week_buckets tests/test_dedupe.py::test_weekly_standups_remain_distinct_chunks tests/test_brainstore.py::TestStoreMemory::test_changed_duplicate_embedding_runs_after_write_transaction -q`
  - Result: `2 failed, 1 passed`; content-only simhash failed with hamming `25`, and the main blocker gave a new chunk id for the one-word near-duplicate.
- GREEN focused after implementation:
  - `pytest tests/test_dedupe.py::test_resimhash_recomputes_stored_simhashes_without_merging tests/test_dedupe.py::test_resimhash_resumes_after_recorded_last_id tests/test_dedupe.py::test_simhash_is_content_only_across_week_buckets tests/test_dedupe.py::test_weekly_standups_remain_distinct_chunks tests/test_brainstore.py::TestStoreMemory::test_changed_duplicate_embedding_runs_after_write_transaction -q`
  - Result: `5 passed in 1.26s`.
- Affected files:
  - `pytest tests/test_dedupe.py tests/test_brainstore.py -q`
  - Result: `46 passed in 3.69s`.
- Final gate before commit:
  - `bash scripts/run_tests.sh`
  - Result: `BrainLayer test gate passed`; unit summary `2636 passed, 9 skipped, 77 deselected, 1 xfailed`, MCP registration `3 passed`, isolated eval/hook routing `40 passed`, Bun `1 pass`, regression shell passed.
- Pre-push gate on push:
  - `git push -u origin engine/dedup-simhash-week-scope`
  - Result: `BrainLayer test gate passed`; unit summary `2606 passed, 9 skipped, 61 deselected, 1 xfailed`, MCP registration `3 passed`, isolated eval/hook routing `40 passed`, Bun `1 pass`, regression shell passed.

## Live DB migration / safety evidence
- Checked enrichment launchd state before migration: no `brainlayer.enrichment` job listed.
- Pre/post WAL checkpoint ran with `busy=0`.
- Live migration command:
  - `scripts/resimhash_dedupe.py --allow-live --batch-size 10000 --checkpoint-every 2`
  - Result: `{"complete": true, "last_id": "rt-sess-pro-6f0fe85db352d4ef", "scanned": 65669, "updated": 65669}`.
- Read-only live DB verification after migration:
  - `chunks_total=451619`, `with_simhash=65669`, `migratable=65669`, progress row complete for `2026_06_11_content_only_simhash_v1`.
- Read-only collision spot check on 2,000 recent active live rows:
  - unique candidate pairs: `6171`
  - distinct near-candidate pairs: `101`
  - all distinct near-candidates had token Jaccard `>=0.958`; no low-overlap collision bucket.

## Notes
- Local `coderabbit review --agent` was run with a 180s bound and timed out while heartbeating, with no findings returned.
- The pre-push hook printed linked-worktree cache warnings because `.git` is a file in this worktree, but the gate completed green and the push succeeded.
- Merge method requested by dispatch: merge commit, never squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes ingest dedupe merge rules and invalidates stored simhashes until migration; incorrect rollout could mis-merge or fail to dedupe across large live datasets.
> 
> **Overview**
> **SimHash fingerprints are now content-only** — week-bucket tokens are removed from `_weighted_features`, so identical text hashes the same regardless of `created_at`.
> 
> **Temporal separation moves to candidate filtering:** `find_duplicate` and dedupe backfill only treat simhash matches within the same ISO week bucket (including `NULL`↔`NULL`); cross-week near-dups no longer merge.
> 
> Adds a **resumable batched migration** (`resimhash_dedupe_database`, `scripts/resimhash_dedupe.py`, `dedupe_resimhash_progress`) to rewrite stored `simhash` and band columns without merging chunks. Existing rows need this run before ingest-time band lookup aligns with newly computed hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f6837cf7b393755d30d5aa8fad8bfcbcd8db7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope dedupe simhash candidates by week bucket and add resumable resimhash migration
> - Removes `created_at`-based features from `_weighted_features` in [dedupe.py](https://github.com/EtanHey/brainlayer/pull/471/files#diff-64cae90f5e9689d4e6ba0a957e885ff704eb5efd9ad42ec0ae4bed7653d5f5f5), making simhash fingerprints content-only.
> - Adds week-bucket scoping to `find_duplicate` and `_add_backfill_index` so cross-week candidates are never considered matches.
> - Introduces `resimhash_dedupe_database`, a resumable batch workflow that rewrites existing `simhash` and band columns using the new content-only fingerprint, tracking progress in a new `dedupe_resimhash_progress` table.
> - Adds a `resimhash` CLI subcommand via [scripts/resimhash_dedupe.py](https://github.com/EtanHey/brainlayer/pull/471/files#diff-74ad51fa1f7d1d26c296eac4540cbdd6cb0e19a26a8c265d184d944c16bf1638) with `--batch-size`, `--checkpoint-every`, and `--allow-live` options.
> - Behavioral Change: existing simhash values computed with week-weighted features will differ from newly computed ones until the resimhash migration completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9f6837.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->