### PR TITLE
fix(brain-graph): shim umap sklearn finite kwarg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Free runner disk
+        run: |
+          df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          df -h
+
       - name: Cache pip
         uses: actions/cache@v4
         with:

--- a/src/brainlayer/pipeline/brain_graph.py
+++ b/src/brainlayer/pipeline/brain_graph.py
@@ -624,8 +624,49 @@ def label_communities(
 # ─── UMAP 3D Layout ────────────────────────────────────────────────
 
 
+def _ensure_umap_sklearn_compat() -> None:
+    """Bridge umap-learn (>=0.5.7) against scikit-learn <1.6.
+
+    umap calls ``check_array(..., ensure_all_finite=...)``, a kwarg that only
+    exists in scikit-learn >=1.6 (it replaced ``force_all_finite``). When the
+    installed sklearn predates 1.6 — e.g. when another dependency pins
+    ``scikit-learn<1.6`` (category-encoders) — that call raises
+    ``TypeError: unexpected keyword argument 'ensure_all_finite'`` and the
+    export crashes for any layout with >=4096 nodes. Translate the kwarg in
+    place (idempotent; no-op on sklearn>=1.6) so brain-export is robust to the
+    resolved sklearn version.
+    """
+    import inspect
+
+    import sklearn.utils as sk_utils
+
+    if "ensure_all_finite" in inspect.signature(sk_utils.check_array).parameters:
+        return  # sklearn>=1.6 — native support, nothing to do
+    if getattr(sk_utils.check_array, "_brainlayer_finite_shim", False):
+        return  # already patched
+
+    _orig = sk_utils.check_array
+
+    def _check_array_compat(*args, **kwargs):
+        if "ensure_all_finite" in kwargs:
+            kwargs["force_all_finite"] = kwargs.pop("ensure_all_finite")
+        return _orig(*args, **kwargs)
+
+    _check_array_compat._brainlayer_finite_shim = True
+    sk_utils.check_array = _check_array_compat
+    try:
+        import sklearn.utils.validation as sk_val
+
+        sk_val.check_array = _check_array_compat
+    except Exception as exc:
+        logger.debug("Could not patch sklearn.utils.validation.check_array: %s", exc)
+    logger.info("Applied sklearn<1.6 check_array(ensure_all_finite) compat shim for umap")
+
+
 def compute_layout(sessions: list[dict]) -> np.ndarray:
     """Compute 3D positions via UMAP on session embeddings."""
+    _ensure_umap_sklearn_compat()
+    # Keep this lazy import below the sklearn shim so umap binds the patched check_array.
     import umap
 
     embeddings = np.array([s["embedding"] for s in sessions])

--- a/tests/test_brain_graph_compat.py
+++ b/tests/test_brain_graph_compat.py
@@ -1,0 +1,40 @@
+"""brain-export umap/sklearn compatibility shim.
+
+Regression guard for the env where scikit-learn is pinned <1.6 (e.g. by
+category-encoders) while umap-learn calls check_array(ensure_all_finite=...),
+which only exists in sklearn>=1.6 — crashing brain-export for >=4096 nodes.
+"""
+
+import numpy as np
+import pytest
+
+from brainlayer.pipeline.brain_graph import _ensure_umap_sklearn_compat, compute_layout
+
+
+def test_check_array_tolerates_ensure_all_finite_after_shim():
+    import sklearn.utils as sk_utils
+
+    _ensure_umap_sklearn_compat()
+    # After the shim, check_array must accept the >=1.6 kwarg regardless of the
+    # installed sklearn version (native on >=1.6, translated on <1.6).
+    arr = sk_utils.check_array([[1.0, 2.0], [3.0, 4.0]], ensure_all_finite=True)
+    assert arr.shape == (2, 2)
+
+
+def test_shim_is_idempotent():
+    _ensure_umap_sklearn_compat()
+    _ensure_umap_sklearn_compat()  # second call must be a no-op, not double-wrap
+    import sklearn.utils as sk_utils
+
+    sk_utils.check_array([[1.0]], ensure_all_finite=True)  # still works
+
+
+def test_compute_layout_runs_under_pinned_sklearn():
+    pytest.importorskip("umap")
+    rng = np.random.default_rng(0)
+    sessions = [{"embedding": list(rng.random(16))} for _ in range(120)]
+    coords = compute_layout(sessions)
+    assert coords.shape == (120, 3)
+    # normalized into the Three.js [-50, 50] box
+    assert coords.min() >= -50.0001, f"min out of bounds: {coords.min()}"
+    assert coords.max() <= 50.0001, f"max out of bounds: {coords.max()}"


### PR DESCRIPTION
## Summary
- Adds `_ensure_umap_sklearn_compat()` before UMAP layout so `ensure_all_finite` is translated to `force_all_finite` under scikit-learn <1.6.
- Adds regression coverage for the shim and marks the compute-layout integration check as requiring optional `umap`/`brain` dependencies.

## Test plan
- `pytest tests/test_brain_graph_compat.py -q` -> 3 passed, 1 warning in local environment with `umap`
- `uv run --extra dev pytest tests/test_brain_graph_compat.py -q` -> 2 passed, 1 skipped in default dev environment without optional `umap`
- Pre-push `scripts/run_tests.sh` -> BrainLayer test gate passed; unit suite `2610 passed, 10 skipped, 61 deselected, 1 xfailed`

WHY admin merge: one-EtanHey-account cannot self-approve; option-B requires CI green + review evidence + admin merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runtime monkeypatch of sklearn is localized to UMAP layout and is idempotent; CI change only removes unused hosted-toolcache paths on runners.
> 
> **Overview**
> Fixes **brain-export** crashes when **umap-learn** calls `sklearn.utils.check_array(..., ensure_all_finite=...)` on environments where **scikit-learn &lt;1.6** still exposes only `force_all_finite` (e.g. pins from **category-encoders**).
> 
> Adds **`_ensure_umap_sklearn_compat()`** in `brain_graph.py`: no-op on sklearn ≥1.6; otherwise wraps `check_array` to translate the kwarg and patches both `sklearn.utils` and `sklearn.utils.validation`. **`compute_layout`** runs the shim **before** the lazy `umap` import so UMAP binds the patched function.
> 
> Adds **`tests/test_brain_graph_compat.py`** for shim behavior, idempotency, and a **`compute_layout`** smoke test (skipped when optional `umap` is missing).
> 
> CI adds a **Free runner disk** step on the test matrix job (removes preinstalled Android/dotnet/GHC/CodeQL) to reduce out-of-disk failures before installs and HF model caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9826893a2256b8bc50497b0cfe5506103021287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `compute_layout` compatibility with scikit-learn <1.6 by shimming `ensure_all_finite` kwarg
> - Adds `_ensure_umap_sklearn_compat()` in [brain_graph.py](https://github.com/EtanHey/brainlayer/pull/472/files#diff-4b94d85f681916f6f322161b8f6c08538260d38a0fc86bae2fe7dba28c0790d3) that patches `sklearn.utils.check_array` to translate the `ensure_all_finite` kwarg (introduced in sklearn 1.6) to `force_all_finite` when running on older versions.
> - `compute_layout` calls the shim before importing umap so umap binds to the patched `check_array`, preventing a `TypeError` during layout computation on sklearn <1.6.
> - The shim is idempotent (guarded by a sentinel attribute) and covered by new tests in [test_brain_graph_compat.py](https://github.com/EtanHey/brainlayer/pull/472/files#diff-e1aa9e1b1e6ccfccfb7a26fdeac94d0e272ad6c86f775e7cbb0dbe898b2e7b88).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e982689.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->