### PR TITLE
fix(provenance): harden PR 470 regression assertions

### DIFF
--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -1015,8 +1015,14 @@ def test_apply_enrichment_sets_content_hash():
     _apply_enrichment(store, chunk, {"summary": "s"})
 
     expected_hash = _content_hash("test content")
-    args = cursor.execute.call_args_list[-1][0]
-    assert args[1] == (expected_hash, "c1")
+    # _apply_enrichment issues several UPDATEs (raw_entities, content_hash,
+    # provenance_class); assert on the content_hash write specifically rather
+    # than relying on it being the last execute call.
+    content_hash_calls = [
+        call.args for call in cursor.execute.call_args_list if call.args and "content_hash" in call.args[0]
+    ]
+    assert content_hash_calls, "expected a content_hash UPDATE"
+    assert content_hash_calls[-1][1] == (expected_hash, "c1")
 
 
 def test_apply_enrichment_persists_raw_entities():


### PR DESCRIPTION
## Summary
- Hardens `test_apply_enrichment_sets_content_hash` to assert on the `content_hash` UPDATE instead of relying on execute-call ordering.
- Resolved the cherry-pick conflict by preserving `origin/main`'s deletion of `src/brainlayer/provenance_integration.py`; the requested MENTION-skip target no longer exists on main.

## Test plan
- `pytest tests/test_enrichment_controller.py tests/test_entity_fact_correction_judge.py tests/test_mcp_labeled_field_output.py -q` -> 94 passed
- Pre-push `scripts/run_tests.sh` -> BrainLayer test gate passed; unit suite `2608 passed, 9 skipped, 61 deselected, 1 xfailed`

WHY admin merge: one-EtanHey-account cannot self-approve; option-B requires CI green + review evidence + admin merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior affected.
> 
> **Overview**
> **Hardens** `test_apply_enrichment_sets_content_hash` so it no longer assumes the `content_hash` write is the final `cursor.execute` on the mock.
> 
> The test now collects every `execute` call whose SQL includes `content_hash`, requires at least one match, and checks that the **last** such call uses `(_content_hash("test content"), "c1")`. That keeps the regression check tied to the dedup hash write even when `_apply_enrichment` runs additional UPDATEs (e.g. `raw_entities_json`) before or after it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9e83e70c88f21e37b1c5436f9cb85ffac3e9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `test_apply_enrichment_sets_content_hash` regression assertions
> The test previously assumed the `content_hash` UPDATE was the last `cursor.execute` call, which made it fragile to execution order changes. It now filters all `cursor.execute` calls for those whose SQL contains `content_hash`, asserts at least one such call exists, and checks the parameters of the last matching call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e9e83e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved test stability for content hash validation by enhancing assertion logic to account for varying execution sequence patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->