### PR TITLE
fix(brainbar): report live agent and write signals

### DIFF
--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -242,10 +242,24 @@ final class AgentActivityMonitor {
         if commandHasCursorAgentSession(command) {
             return .cursor
         }
-        if command.contains(" gemini") {
+        if commandHasExecutableToken(command, executableName: "gemini") {
             return .gemini
         }
         return nil
+    }
+
+    private static func commandHasExecutableToken(_ command: String, executableName: String) -> Bool {
+        let tokens = command.split(whereSeparator: \.isWhitespace).map(String.init)
+        let promptFlags = ["--prompt", "--prompt-interactive", "--message", "-p", "-i"]
+        for token in tokens {
+            if promptFlags.contains(token) {
+                return false
+            }
+            if token == executableName || token.hasSuffix("/\(executableName)") {
+                return true
+            }
+        }
+        return false
     }
 
     private static func commandHasCursorAgentSession(_ command: String) -> Bool {

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -179,7 +179,6 @@ final class AgentActivityMonitor {
             return true
         }
         if command.contains("/.bun/bin/codex")
-            || command.contains("cursor agent")
             || commandHasCursorAgentSession(command) {
             return true
         }
@@ -199,7 +198,7 @@ final class AgentActivityMonitor {
             || command.contains(" brainlayercodex") {
             return .codex
         }
-        if command.hasPrefix("cursor ") || command.contains("cursor agent") || command.contains(" brainlayercursor") {
+        if command.hasPrefix("cursor ") || command.contains(" brainlayercursor") {
             return .cursor
         }
         if command.hasPrefix("gemini ")
@@ -214,7 +213,7 @@ final class AgentActivityMonitor {
         let tokens = command.split { character in
             character.isWhitespace || character == "="
         }
-        let promptFlags = ["--prompt", "--prompt-interactive", "--message"]
+        let promptFlags = ["--prompt", "--prompt-interactive", "--message", "-p", "-i"]
         for index in tokens.indices {
             if promptFlags.contains(String(tokens[index])) {
                 return false
@@ -236,9 +235,6 @@ final class AgentActivityMonitor {
         }
         if command.contains("/.bun/bin/codex") {
             return .codex
-        }
-        if command.contains("cursor agent") {
-            return .cursor
         }
         if commandHasCursorAgentSession(command) {
             return .cursor

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -192,7 +192,14 @@ final class AgentActivityMonitor {
         let tokens = command.split { character in
             character.isWhitespace || character == "="
         }
-        for index in tokens.indices where tokens[index] == "--model" && index + 1 < tokens.endIndex {
+        let promptFlags = ["--prompt", "--prompt-interactive", "--message"]
+        for index in tokens.indices {
+            if promptFlags.contains(String(tokens[index])) {
+                return false
+            }
+            guard tokens[index] == "--model" && index + 1 < tokens.endIndex else {
+                continue
+            }
             let model = tokens[index + 1]
             if model == familyToken || model.hasPrefix("\(familyToken)-") {
                 return true

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -201,6 +201,7 @@ final class AgentActivityMonitor {
             return .codex
         }
         if commandHasCursorCLIEntryPoint(command)
+            || commandHasCursorAgentSession(command)
             || command.contains(" brainlayercursor") {
             return .cursor
         }
@@ -266,6 +267,13 @@ final class AgentActivityMonitor {
         guard command.contains("cursor-agent") else { return false }
 
         let tokens = command.split(whereSeparator: \.isWhitespace).map(String.init)
+        if tokens.contains("worker-server") {
+            return false
+        }
+        if let launcher = tokens.first,
+           launcher == "cursor-agent" || launcher.hasSuffix("/cursor-agent") {
+            return true
+        }
         for index in tokens.indices where tokens[index] == "agent" {
             guard index > tokens.startIndex else { continue }
             let launcher = tokens[tokens.index(before: index)]

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -169,7 +169,7 @@ final class AgentActivityMonitor {
     }
 
     private static func isAgentEntrypoint(executable: String, command: String) -> Bool {
-        if executable == "agy" || executable == "codex" {
+        if executable == "agy" || executable == "codex" || executable == "cursor" {
             return true
         }
         if command.hasPrefix("claude ")
@@ -198,7 +198,9 @@ final class AgentActivityMonitor {
             || command.contains(" brainlayercodex") {
             return .codex
         }
-        if command.hasPrefix("cursor ") || command.contains(" brainlayercursor") {
+        if command.hasPrefix("cursor ")
+            || (executable == "cursor" && command.contains("/cursor "))
+            || command.contains(" brainlayercursor") {
             return .cursor
         }
         if command.hasPrefix("gemini ")

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -174,8 +174,10 @@ final class AgentActivityMonitor {
         }
         if command.hasPrefix("claude ")
             || command.hasPrefix("codex ")
-            || command.hasPrefix("cursor ")
             || command.hasPrefix("gemini ") {
+            return true
+        }
+        if commandHasCursorCLIEntryPoint(command) {
             return true
         }
         if command.contains("/.bun/bin/codex")
@@ -198,8 +200,7 @@ final class AgentActivityMonitor {
             || command.contains(" brainlayercodex") {
             return .codex
         }
-        if command.hasPrefix("cursor ")
-            || (executable == "cursor" && command.contains("/cursor "))
+        if commandHasCursorCLIEntryPoint(command)
             || command.contains(" brainlayercursor") {
             return .cursor
         }
@@ -262,5 +263,13 @@ final class AgentActivityMonitor {
             }
         }
         return false
+    }
+
+    private static func commandHasCursorCLIEntryPoint(_ command: String) -> Bool {
+        let tokens = command.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard tokens.count >= 2 else { return false }
+
+        let launcher = tokens[0]
+        return (launcher == "cursor" || launcher.hasSuffix("/cursor")) && tokens[1] == "agent"
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -218,9 +218,29 @@ final class AgentActivityMonitor {
         if command.contains("cursor agent") {
             return .cursor
         }
+        if commandHasCursorAgentSession(command) {
+            return .cursor
+        }
         if command.contains(" gemini") {
             return .gemini
         }
         return nil
+    }
+
+    private static func commandHasCursorAgentSession(_ command: String) -> Bool {
+        guard command.contains("cursor-agent") else { return false }
+
+        let tokens = command.split(whereSeparator: \.isWhitespace).map(String.init)
+        for index in tokens.indices where tokens[index] == "agent" {
+            guard index > tokens.startIndex else { continue }
+            let launcher = tokens[tokens.index(before: index)]
+            if launcher == "index.js"
+                || launcher.hasSuffix("/index.js")
+                || launcher == "cursor-agent"
+                || launcher.hasSuffix("/cursor-agent") {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -96,7 +96,7 @@ final class AgentActivityMonitor {
 
             guard !isIgnoredProcess(executable: executable, command: lowerCommand) else { continue }
 
-            if let family = detectActualFamily(command: lowerCommand) {
+            if let family = detectActualFamily(executable: executable, command: lowerCommand) {
                 actualCounts[family, default: 0] += 1
                 continue
             }
@@ -164,13 +164,13 @@ final class AgentActivityMonitor {
         return false
     }
 
-    private static func detectActualFamily(command: String) -> AgentFamily? {
+    private static func detectActualFamily(executable: String, command: String) -> AgentFamily? {
         if command.hasPrefix("claude ") || command.contains("/claude ") || command.contains(" brainlayerclaude") {
             return .claude
         }
         if command.hasPrefix("codex ")
             || command.contains("/codex/codex ")
-            || (command.contains("/bin/codex ") && !command.contains("/.bun/bin/codex "))
+            || (executable == "codex" && command.contains("/bin/codex "))
             || command.contains(" brainlayercodex") {
             return .codex
         }

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -168,13 +168,19 @@ final class AgentActivityMonitor {
         if command.hasPrefix("claude ") || command.contains("/claude ") || command.contains(" brainlayerclaude") {
             return .claude
         }
-        if command.hasPrefix("codex ") || command.contains("/codex/codex ") || command.contains(" brainlayercodex") {
+        if command.hasPrefix("codex ")
+            || command.contains("/codex/codex ")
+            || (command.contains("/bin/codex ") && !command.contains("/.bun/bin/codex "))
+            || command.contains(" brainlayercodex") {
             return .codex
         }
         if command.hasPrefix("cursor ") || command.contains("cursor agent") || command.contains(" brainlayercursor") {
             return .cursor
         }
-        if command.hasPrefix("gemini ") || command.contains("/gemini ") || command.contains(" brainlayergemini") {
+        if command.hasPrefix("gemini ")
+            || command.contains("/gemini ")
+            || command.contains(" brainlayergemini")
+            || (command.hasPrefix("agy ") && command.contains("gemini")) {
             return .gemini
         }
         return nil

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -145,6 +145,10 @@ final class AgentActivityMonitor {
     }
 
     private static func isIgnoredProcess(executable: String, command: String) -> Bool {
+        if isAgentEntrypoint(executable: executable, command: command) {
+            return false
+        }
+
         let noiseTokens = [
             "/applications/claude.app",
             "claude helper",
@@ -159,6 +163,24 @@ final class AgentActivityMonitor {
             return true
         }
         if executable == "rg" || executable == "awk" || executable == "grep" {
+            return true
+        }
+        return false
+    }
+
+    private static func isAgentEntrypoint(executable: String, command: String) -> Bool {
+        if executable == "agy" || executable == "codex" {
+            return true
+        }
+        if command.hasPrefix("claude ")
+            || command.hasPrefix("codex ")
+            || command.hasPrefix("cursor ")
+            || command.hasPrefix("gemini ") {
+            return true
+        }
+        if command.contains("/.bun/bin/codex")
+            || command.contains("cursor agent")
+            || commandHasCursorAgentSession(command) {
             return true
         }
         return false

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -180,7 +180,7 @@ final class AgentActivityMonitor {
         if command.hasPrefix("gemini ")
             || command.contains("/gemini ")
             || command.contains(" brainlayergemini")
-            || (command.hasPrefix("agy ") && command.contains("gemini")) {
+            || (executable == "agy" && command.contains("gemini")) {
             return .gemini
         }
         return nil

--- a/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/AgentActivityMonitor.swift
@@ -165,6 +165,9 @@ final class AgentActivityMonitor {
     }
 
     private static func detectActualFamily(executable: String, command: String) -> AgentFamily? {
+        if executable == "agy" && commandHasModelToken(command, familyToken: "gemini") {
+            return .gemini
+        }
         if command.hasPrefix("claude ") || command.contains("/claude ") || command.contains(" brainlayerclaude") {
             return .claude
         }
@@ -179,11 +182,23 @@ final class AgentActivityMonitor {
         }
         if command.hasPrefix("gemini ")
             || command.contains("/gemini ")
-            || command.contains(" brainlayergemini")
-            || (executable == "agy" && command.contains("gemini")) {
+            || command.contains(" brainlayergemini") {
             return .gemini
         }
         return nil
+    }
+
+    private static func commandHasModelToken(_ command: String, familyToken: String) -> Bool {
+        let tokens = command.split { character in
+            character.isWhitespace || character == "="
+        }
+        for index in tokens.indices where tokens[index] == "--model" && index + 1 < tokens.endIndex {
+            let model = tokens[index + 1]
+            if model == familyToken || model.hasPrefix("\(familyToken)-") {
+                return true
+            }
+        }
+        return false
     }
 
     private static func detectWrapperFamily(executable: String, command: String) -> AgentFamily? {

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -58,6 +58,29 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 1)
     }
 
+    func testParseSnapshotClassifiesAgyGeminiByExecutableBeforePromptMentionsClaude() {
+        let snapshot = """
+        19004 agy /Users/etanheyman/.local/bin/agy --dangerously-skip-permissions --model Gemini 3.1 Pro --prompt-interactive Adopt brainlayerClaude context for orchestration
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .claude), 0)
+        XCTAssertEqual(activity.count(for: .gemini), 1)
+        XCTAssertEqual(activity.totalActiveAgents, 1)
+    }
+
+    func testParseSnapshotDoesNotClassifyAgyByGeminiSubstringInsideArgument() {
+        let snapshot = """
+        19005 agy /Users/etanheyman/.local/bin/agy --config mygeminiconfig --prompt-interactive ordinary task
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .gemini), 0)
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+    }
+
     func testRunSnapshotCommandDrainsLargeStdoutWithoutDeadlocking() {
         let script = "python3 -c \"print('codex ' * 20000)\""
 

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -81,6 +81,17 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 0)
     }
 
+    func testParseSnapshotDoesNotClassifyAgyByPromptMentioningModelFlag() {
+        let snapshot = """
+        19006 agy /Users/etanheyman/.local/bin/agy --prompt-interactive Please document why --model gemini should not be parsed from prompt text
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .gemini), 0)
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+    }
+
     func testRunSnapshotCommandDrainsLargeStdoutWithoutDeadlocking() {
         let script = "python3 -c \"print('codex ' * 20000)\""
 

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -10,6 +10,7 @@ final class AgentActivityMonitorTests: XCTestCase {
         18001 cursor cursor agent --resume session-123
         19001 gemini gemini --model gemini-2.5-pro
         19002 agy agy --dangerously-skip-permissions --model Gemini 3.1 Pro (High)
+        19003 agy /Users/etanheyman/.local/bin/agy --dangerously-skip-permissions --model Gemini 3.1 Pro (High)
          1355 Electron /Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler --monitor-self-annotation=ptype=crashpad-handler
          1588 Claude\\ Helper /Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper --type=gpu-process
         """
@@ -19,8 +20,8 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.count(for: .claude), 1)
         XCTAssertEqual(activity.count(for: .codex), 1)
         XCTAssertEqual(activity.count(for: .cursor), 1)
-        XCTAssertEqual(activity.count(for: .gemini), 2)
-        XCTAssertEqual(activity.totalActiveAgents, 5)
+        XCTAssertEqual(activity.count(for: .gemini), 3)
+        XCTAssertEqual(activity.totalActiveAgents, 6)
     }
 
     func testParseSnapshotRetainsFamiliesWithZeroCounts() {

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -92,6 +92,18 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 0)
     }
 
+    func testParseSnapshotClassifiesCursorAgentNodeLauncherAndSkipsWorkerServer() {
+        let snapshot = """
+        50008 node /Users/etanheyman/.local/bin/cursor-agent --use-system-ca /Users/etanheyman/.local/share/cursor-agent/versions/2026.06.12-01-15-52-7244546/index.js agent
+        52858 node /Users/etanheyman/.local/share/cursor-agent/versions/2026.06.12-01-15-52-7244546/node /Users/etanheyman/.local/share/cursor-agent/versions/2026.06.12-01-15-52-7244546/index.js worker-server
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .cursor), 1)
+        XCTAssertEqual(activity.totalActiveAgents, 1)
+    }
+
     func testRunSnapshotCommandDrainsLargeStdoutWithoutDeadlocking() {
         let script = "python3 -c \"print('codex ' * 20000)\""
 

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -45,6 +45,18 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 0)
     }
 
+    func testParseSnapshotDoesNotTreatNonCodexLauncherAsActualCodex() {
+        let snapshot = """
+        13908 node node /opt/homebrew/bin/codex --model gpt-5.4
+        13909 codex /Users/etanheyman/.bun/install/global/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex --model gpt-5.4
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .codex), 1)
+        XCTAssertEqual(activity.totalActiveAgents, 1)
+    }
+
     func testRunSnapshotCommandDrainsLargeStdoutWithoutDeadlocking() {
         let script = "python3 -c \"print('codex ' * 20000)\""
 

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -9,6 +9,7 @@ final class AgentActivityMonitorTests: XCTestCase {
         13909 codex /Users/etanheyman/.bun/install/global/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex --model gpt-5.4 --dangerously-bypass-approvals-and-sandbox
         18001 cursor cursor agent --resume session-123
         19001 gemini gemini --model gemini-2.5-pro
+        19002 agy agy --dangerously-skip-permissions --model Gemini 3.1 Pro (High)
          1355 Electron /Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler --monitor-self-annotation=ptype=crashpad-handler
          1588 Claude\\ Helper /Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper --type=gpu-process
         """
@@ -18,8 +19,8 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.count(for: .claude), 1)
         XCTAssertEqual(activity.count(for: .codex), 1)
         XCTAssertEqual(activity.count(for: .cursor), 1)
-        XCTAssertEqual(activity.count(for: .gemini), 1)
-        XCTAssertEqual(activity.totalActiveAgents, 4)
+        XCTAssertEqual(activity.count(for: .gemini), 2)
+        XCTAssertEqual(activity.totalActiveAgents, 5)
     }
 
     func testParseSnapshotRetainsFamiliesWithZeroCounts() {

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -139,6 +139,17 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 1)
     }
 
+    func testParseSnapshotClassifiesCursorCliLaunchedByFullPath() {
+        let snapshot = """
+        50100 cursor /Users/etanheyman/.local/bin/cursor agent --resume session-456
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .cursor), 1)
+        XCTAssertEqual(activity.totalActiveAgents, 1)
+    }
+
     func testRunSnapshotCommandDrainsLargeStdoutWithoutDeadlocking() {
         let script = "python3 -c \"print('codex ' * 20000)\""
 

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -46,6 +46,17 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 0)
     }
 
+    func testParseSnapshotCountsClaudeCliWhenPromptMentionsSearchCommands() {
+        let snapshot = """
+        13303 2.1.175 claude --dangerously-skip-permissions --append-system-prompt Use grep and ps -axo only as debugging examples
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .claude), 1)
+        XCTAssertEqual(activity.totalActiveAgents, 1)
+    }
+
     func testParseSnapshotDoesNotTreatNonCodexLauncherAsActualCodex() {
         let snapshot = """
         13908 node node /opt/homebrew/bin/codex --model gpt-5.4

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -150,6 +150,17 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 1)
     }
 
+    func testParseSnapshotDoesNotClassifyCursorDesktopAppAsAgent() {
+        let snapshot = """
+        50101 Cursor /Applications/Cursor.app/Contents/MacOS/Cursor --type=renderer
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .cursor), 0)
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+    }
+
     func testRunSnapshotCommandDrainsLargeStdoutWithoutDeadlocking() {
         let script = "python3 -c \"print('codex ' * 20000)\""
 

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -150,6 +150,17 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 1)
     }
 
+    func testParseSnapshotClassifiesRootCursorAgentSession() {
+        let snapshot = """
+        50009 cursor-agent cursor-agent --yolo -p investigate live agent signals
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .cursor), 1)
+        XCTAssertEqual(activity.totalActiveAgents, 1)
+    }
+
     func testParseSnapshotClassifiesCursorCliLaunchedByFullPath() {
         let snapshot = """
         50100 cursor /Users/etanheyman/.local/bin/cursor agent --resume session-456

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -127,6 +127,17 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 0)
     }
 
+    func testParseSnapshotDoesNotClassifyWrapperByPromptMentioningGemini() {
+        let snapshot = """
+        19009 node node /Users/etanheyman/tmp/helper.js --prompt Please explain gemini launcher behavior
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .gemini), 0)
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+    }
+
     func testParseSnapshotClassifiesCursorAgentNodeLauncherAndSkipsWorkerServer() {
         let snapshot = """
         50008 node /Users/etanheyman/.local/bin/cursor-agent --use-system-ca /Users/etanheyman/.local/share/cursor-agent/versions/2026.06.12-01-15-52-7244546/index.js agent

--- a/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/AgentActivityMonitorTests.swift
@@ -46,6 +46,18 @@ final class AgentActivityMonitorTests: XCTestCase {
         XCTAssertEqual(activity.totalActiveAgents, 0)
     }
 
+    func testParseSnapshotSkipsSearchCommandsThatMentionCursorAgentPhrase() {
+        let snapshot = """
+        42031 rg rg -n cursor agent /Users/etanheyman/Gits
+        42032 zsh /bin/zsh -lc ps -axo pid=,ucomm=,args= | rg cursor agent
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .cursor), 0)
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+    }
+
     func testParseSnapshotCountsClaudeCliWhenPromptMentionsSearchCommands() {
         let snapshot = """
         13303 2.1.175 claude --dangerously-skip-permissions --append-system-prompt Use grep and ps -axo only as debugging examples
@@ -95,6 +107,18 @@ final class AgentActivityMonitorTests: XCTestCase {
     func testParseSnapshotDoesNotClassifyAgyByPromptMentioningModelFlag() {
         let snapshot = """
         19006 agy /Users/etanheyman/.local/bin/agy --prompt-interactive Please document why --model gemini should not be parsed from prompt text
+        """
+
+        let activity = AgentActivityMonitor.parse(snapshot)
+
+        XCTAssertEqual(activity.count(for: .gemini), 0)
+        XCTAssertEqual(activity.totalActiveAgents, 0)
+    }
+
+    func testParseSnapshotDoesNotClassifyAgyByPromptAliasMentioningModelFlag() {
+        let snapshot = """
+        19007 agy /Users/etanheyman/.local/bin/agy -i Please document why --model gemini should not be parsed from prompt text
+        19008 agy /Users/etanheyman/.local/bin/agy -p Please document why --model gemini should not be parsed from prompt text
         """
 
         let activity = AgentActivityMonitor.parse(snapshot)

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -1008,6 +1008,15 @@ final class DatabaseTests: XCTestCase {
         // Verify it's searchable
         let results = try db.search(query: "GRDB SQLite", limit: 10)
         XCTAssertFalse(results.isEmpty)
+
+        let createdAt = try XCTUnwrap(sqliteScalarString(
+            path: tempDBPath,
+            sql: "SELECT created_at FROM chunks WHERE id = '\(stored.chunkID)'"
+        ))
+        XCTAssertNotNil(ISO8601DateFormatter().date(from: createdAt))
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 5, bucketCount: 5)
+        XCTAssertGreaterThan(stats.recentWriteFiveMinuteCount, 0)
     }
 
     func testAnalyzePopulatesStatsForSearchIndexes() throws {


### PR DESCRIPTION
## Summary
- Count Codex vendor binaries as live Codex agents without double-counting launcher wrappers.
- Count Gemini sessions launched through `gemini ...` and `agy --model Gemini...`, including full-path `agy` argv shapes.
- Fix the live bug where `agy --model Gemini...` was counted as Claude when the prompt mentioned Claude launcher names.
- Keep `agy` Gemini detection narrow: only `--model gemini` / `--model gemini-*` before prompt text qualifies, not arbitrary `gemini` substrings or prompt examples.
- Add regression coverage that BrainBar stores populate `created_at` and appear in recent write dashboard stats.

## Review fixes
- `854f89de`: require `ucomm == codex` before `/bin/codex` contributes an actual Codex count.
- `f10c4ecc`: detect `agy`/Gemini from `ucomm == agy` even when argv starts with a full path.
- `54428013`: classify `agy --model Gemini...` before Claude prompt markers, then narrow matching to real model tokens.
- `005d9d92`: stop `agy` model-token scanning at prompt-bearing flags so prompt text containing `--model gemini` cannot classify the process as Gemini.

## Test plan
- [x] RED: `swift test --filter BrainBarTests.AgentActivityMonitorTests/testParseSnapshotClassifiesAgyGeminiByExecutableBeforePromptMentionsClaude` failed before the fix with Claude 1 / Gemini 0.
- [x] RED: `swift test --filter BrainBarTests.AgentActivityMonitorTests/testParseSnapshotDoesNotClassifyAgyByGeminiSubstringInsideArgument` failed before narrowing with Gemini 1.
- [x] RED: `swift test --filter BrainBarTests.AgentActivityMonitorTests/testParseSnapshotDoesNotClassifyAgyByPromptMentioningModelFlag` failed before the prompt-boundary fix with Gemini 1.
- [x] `swift test --filter BrainBarTests.AgentActivityMonitorTests/testParseSnapshotClassifiesAgyGeminiByExecutableBeforePromptMentionsClaude --filter BrainBarTests.AgentActivityMonitorTests/testParseSnapshotDoesNotClassifyAgyByPromptMentioningModelFlag` — 2 tests, 0 failures.
- [x] `swift test --filter BrainBarTests.AgentActivityMonitorTests` — 8 tests, 0 failures.
- [x] `swift test --skip BrainBarTests.BrainBarReliabilityTests/testBrainStoreQueuesWithinBudgetWhenDatabaseWriteLockIsHeld` — 616 tests, 0 failures.
- [x] `git diff --check` — passed.
- [x] `coderabbit review --agent` local bounded pre-commit review before `54428013` — 0 findings.
- [x] pre-push `scripts/run_tests.sh` gate after `005d9d92` — 2610 passed, 10 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun 1 passed; FTS5 determinism shell test passed.

## Notes
- Full unskipped BrainBar Swift suite was previously observed hanging in `BrainBarReliabilityTests.testBrainStoreQueuesWithinBudgetWhenDatabaseWriteLockIsHeld`; this PR therefore uses SwiftPM `--skip` for that known hanging test while running the rest of the suite.
- Pre-push emits a non-fatal cache-path warning in this git worktree because `.git` is a file, not a directory. The hook still completes and pushes successfully.
- Greptile is unavailable: its review bot reports the free trial ended / payment required.
- This PR does not run local enrichment. It only fixes BrainBar live-agent classification and write-signal dashboard tests.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix live agent and write signal reporting in BrainBar's `AgentActivityMonitor`
> - Improves agent family classification in [`AgentActivityMonitor`](https://github.com/EtanHey/brainlayer/pull/474/files#diff-7217db9383909eaa194bc60de17f2c7e375a04736e78fb59b176e93b22dc2c3b) by passing the executable name alongside the command string, enabling executable-aware detection for `agy` (Gemini), `codex`, and Cursor.
> - Adds `isAgentEntrypoint` to prevent known agent launchers from being filtered out by noise-token heuristics.
> - Replaces substring-based wrapper detection with structured helpers (`commandHasExecutableToken`, `commandHasCursorAgentSession`, `commandHasCursorCLIEntryPoint`) to avoid false positives when agent names appear in prompt text.
> - Adds `commandHasModelToken` to classify `agy` processes by `--model` flag without misclassifying when model names appear in prompt arguments.
> - Extends tests with 12 new cases covering false-positive and false-negative classification scenarios; updates expected Gemini count from 1 to 3 and `totalActiveAgents` from 4 to 6.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8e84c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only process parsing and test assertions; no auth, persistence schema, or write-path logic changes beyond new coverage.
> 
> **Overview**
> **Live agent CLI counts** in `AgentActivityMonitor` are reworked so `ps` snapshots classify real sessions more accurately and ignore search/noise.
> 
> Classification now uses **executable (`ucomm`) plus argv**, not command text alone. **`agy`** with a real **`--model gemini`** token counts as Gemini (including full-path argv) and is checked **before** Claude heuristics, fixing mislabels when prompts mention Claude. Model/executable parsing **stops at prompt flags** (`--prompt`, `-p`, etc.) so prompt examples mentioning `gemini` or `--model gemini` do not flip family. **Codex** vendor binaries count only when **`ucomm == codex`** and the path looks like the real binary; **node** launchers to unrelated `codex` paths no longer double-count. **Cursor** detection adds **`cursor agent`**, **`cursor-agent`** sessions (including node/`index.js` launchers), and excludes **`worker-server`** and the desktop app.
> 
> **Noise filtering** adds an **`isAgentEntrypoint`** allow-list so known agent processes are not dropped when argv looks like `rg`, `grep`, or `ps`.
> 
> **Tests:** many new `AgentActivityMonitorTests` snapshot cases; **`testStoreCreatesChunk`** also asserts **`created_at`** and **`dashboardStats.recentWriteFiveMinuteCount`** after store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e84c5b673b94c7bf897ba67bda6f687b3b7836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved AI agent detection by using both process executable and command details for more accurate family classification.
  * Prevented agent entrypoint processes from being incorrectly filtered from activity monitoring.
  * Refined recognition of Gemini, Codex, Claude, and Cursor agent/launcher patterns to reduce miscounts and misclassification.

* **Tests**
  * Expanded activity-monitoring snapshot coverage to validate skipping of irrelevant command noise and correct agent counting.
  * Added database assertions for stored chunk timestamps and recent write activity stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->