### PR TITLE
fix: preserve deferred MCP store provenance

### DIFF
--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -1106,7 +1106,9 @@ def _ensure_provenance_class_column(store) -> bool:
 def _derive_chunk_provenance_class(chunk: dict[str, Any], content: str | None = None) -> str:
     source = str(chunk.get("source") or "").strip().lower()
     source_file = str(chunk.get("source_file") or "").strip().lower()
-    if source == "manual" and source_file in {"brainlayer-store", "brainbar-store", "brainlayer-queue"}:
+    if (source == "manual" and source_file in {"brainlayer-store", "brainbar-store", "brainlayer-queue"}) or (
+        source == "mcp" and source_file == "brainlayer-queue"
+    ):
         return "RAW-ETAN-DIRECT"
     text = (chunk.get("content") or "") if content is None else (content or "")
     return derive_provenance_class(

--- a/src/brainlayer/provenance_integration.py
+++ b/src/brainlayer/provenance_integration.py
@@ -630,7 +630,9 @@ def _row_to_claim(row: dict[str, Any], entity: str) -> Claim:
     if not provenance_class:
         source = str(row.get("source") or "").strip().lower()
         source_file = str(row.get("source_file") or "").strip().lower()
-        if source == "manual" and source_file in {"brainlayer-store", "brainbar-store", "brainlayer-queue"}:
+        if (source == "manual" and source_file in {"brainlayer-store", "brainbar-store", "brainlayer-queue"}) or (
+            source == "mcp" and source_file == "brainlayer-queue"
+        ):
             provenance_class = RAW_ETAN_DIRECT
         else:
             provenance_class = derive_provenance_class(

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -1993,6 +1993,80 @@ def test_queued_brain_store_note_without_provenance_class_is_user_anchored(con):
     )
 
 
+def test_deferred_mcp_store_note_without_provenance_class_is_user_anchored(con):
+    from brainlayer.provenance_integration import (
+        enqueue_provenance_resolution,
+        list_pending_confirm,
+        sweep_provenance_queue,
+    )
+
+    con.execute("INSERT INTO kg_entities (id, name) VALUES ('e-enrichment', 'enrichment')")
+    con.execute("ALTER TABLE chunks ADD COLUMN provenance_class TEXT")
+    con.execute("ALTER TABLE chunks ADD COLUMN source TEXT")
+    con.execute("ALTER TABLE chunks ADD COLUMN source_file TEXT")
+    con.executemany(
+        """
+        INSERT INTO chunks (id, content, content_type, sender, source, source_file, created_at, provenance_class)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                "c-brain-queue-mcp-old",
+                "PRIMARY_BACKEND: Groq",
+                "note",
+                None,
+                "mcp",
+                "brainlayer-queue",
+                "2026-03-26T00:00:00Z",
+                None,
+            ),
+            (
+                "c-direct-new",
+                "PRIMARY_BACKEND: Gemini",
+                "user_message",
+                "user",
+                "claude_code",
+                "session.jsonl",
+                "2026-06-09T00:00:00Z",
+                "RAW-ETAN-DIRECT",
+            ),
+        ],
+    )
+    con.executemany(
+        "INSERT INTO kg_entity_chunks (entity_id, chunk_id) VALUES ('e-enrichment', ?)",
+        [("c-brain-queue-mcp-old",), ("c-direct-new",)],
+    )
+
+    enqueue_provenance_resolution(con, "enrichment", chunk_id="c-direct-new")
+    result = sweep_provenance_queue(con)
+
+    assert result.superseded_count == 1
+    assert list_pending_confirm(con) == []
+    assert tuple(
+        con.execute("SELECT status, superseded_by FROM chunks WHERE id = 'c-brain-queue-mcp-old'").fetchone()
+    ) == (
+        "superseded",
+        "c-direct-new",
+    )
+
+
+def test_deferred_mcp_store_enrichment_derives_direct_provenance():
+    from brainlayer.enrichment_controller import _derive_chunk_provenance_class
+
+    assert (
+        _derive_chunk_provenance_class(
+            {
+                "content": "PRIMARY_BACKEND: Gemini",
+                "content_type": "note",
+                "sender": None,
+                "source": "mcp",
+                "source_file": "brainlayer-queue",
+            }
+        )
+        == "RAW-ETAN-DIRECT"
+    )
+
+
 def test_derive_chunk_provenance_class_tolerates_null_content():
     from brainlayer.enrichment_controller import _derive_chunk_provenance_class
 


### PR DESCRIPTION
## Summary
- Treat deferred MCP queued brain_store rows (`source="mcp"`, `source_file="brainlayer-queue"`) as `RAW-ETAN-DIRECT` evidence.
- Keep queued/deferred store authority consistent with immediate/manual brain_store writes.
- Add focused regressions for enrichment-time provenance derivation and sweep-time queued-store conflict resolution.

## Verification
- `git diff --stat`
- `python3 -m pytest tests/test_provenance_integration.py -q` -> 50 passed
- `ruff format --check src/brainlayer/enrichment_controller.py src/brainlayer/provenance_integration.py tests/test_provenance_integration.py` -> clean
- `ruff check src/brainlayer/enrichment_controller.py src/brainlayer/provenance_integration.py tests/test_provenance_integration.py` -> clean
- pre-push BrainLayer gate -> passed: 2753 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook 40 passed; Bun 1 passed; shell regression passed

Scope: narrow post-merge hotfix only. No Phase 1A/1B/2 work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow provenance-class heuristic change with mirrored logic in two helpers and focused tests; no auth or schema changes.
> 
> **Overview**
> Extends the existing **brain_store / queue** user-authority rule so deferred MCP writes (`source="mcp"`, `source_file="brainlayer-queue"`) get **`RAW-ETAN-DIRECT`** the same way manual queued store notes already do.
> 
> The same condition is applied in **`_derive_chunk_provenance_class`** (enrichment-time persistence) and **`_row_to_claim`** (fallback when `provenance_class` is missing during provenance sweeps), so MCP-queued notes are not misclassified as agent inference and can supersede conflicting claims correctly.
> 
> Adds regressions for sweep-time conflict resolution and enrichment-time derivation for the MCP queue path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3433b05d51f1d3e27045bb0ad0da50aa69fee7e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provenance class for deferred MCP `brainlayer-queue` chunks and claims
> - In [`enrichment_controller.py`](https://github.com/EtanHey/brainlayer/pull/476/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb), `_derive_chunk_provenance_class` now returns `RAW-ETAN-DIRECT` when `source == "mcp"` and `source_file == "brainlayer-queue"`, matching the existing logic for manual store sources.
> - In [`provenance_integration.py`](https://github.com/EtanHey/brainlayer/pull/476/files#diff-fc190ea6f5cd124c6cd9537ed16739b91fbed204da874a871f294ac3dccb7dde), `_row_to_claim` applies the same condition so claims built from rows without a stored `provenance_class` also get `RAW_ETAN_DIRECT` instead of a derived fallback.
> - Two new tests cover the corrected derivation and verify that an MCP brainlayer-queue note is correctly superseded during the provenance resolution sweep.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3433b05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provenance classification for MCP store queue data to correctly identify user-direct submissions, ensuring accurate data origin tracking.

* **Tests**
  * Added test coverage for deferred MCP store provenance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->