### PR TITLE
fix(brainlayer): preserve exact entity and provenance queue guards

### DIFF
--- a/src/brainlayer/maintenance.py
+++ b/src/brainlayer/maintenance.py
@@ -284,7 +284,7 @@ def _file_is_redundant_enrichment(conn: apsw.Connection, events: list[dict[str, 
         return False
     states = _chunk_states(conn, chunk_ids)
     for event in events:
-        if "entities" in event:
+        if "entities" in event or str(event.get("provenance_class") or "").strip():
             return False
         chunk_id = str(event["chunk_id"])
         expected_hash = event.get("content_hash")

--- a/src/brainlayer/provenance_integration.py
+++ b/src/brainlayer/provenance_integration.py
@@ -433,14 +433,23 @@ def _single_entity_match(rows: list[Any], entity: str, source: str) -> tuple[lis
 
 
 def _entity_ids(conn, entity: str) -> tuple[list[str], str]:
-    rows = list(
+    id_rows = list(
         conn.execute(
-            "SELECT id, name FROM kg_entities WHERE id = ? OR lower(name) = lower(?) ORDER BY id ASC",
-            (entity, entity),
+            "SELECT id, name FROM kg_entities WHERE id = ? ORDER BY id ASC",
+            (entity,),
         )
     )
-    if rows:
-        return _single_entity_match(rows, entity, "id/name")
+    if id_rows:
+        return _single_entity_match(id_rows, entity, "id")
+
+    name_rows = list(
+        conn.execute(
+            "SELECT id, name FROM kg_entities WHERE lower(name) = lower(?) ORDER BY id ASC",
+            (entity,),
+        )
+    )
+    if name_rows:
+        return _single_entity_match(name_rows, entity, "name")
 
     if "kg_entity_aliases" in _tables(conn):
         alias_rows = list(

--- a/tests/test_maintenance_routine.py
+++ b/tests/test_maintenance_routine.py
@@ -287,6 +287,42 @@ def test_stale_queue_quarantine_preserves_empty_entity_redundant_enrichment(tmp_
     assert not quarantine_root.exists()
 
 
+def test_stale_queue_quarantine_preserves_provenance_class_redundant_enrichment(tmp_path):
+    from brainlayer.maintenance import quarantine_stale_queue_files
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    quarantine_root = tmp_path / "quarantine"
+    _create_enrichment_db(db_path)
+    provenance_only = queue_dir / "enrichment-provenance-class.jsonl"
+    _write_jsonl(
+        provenance_only,
+        [
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "already-done",
+                "content_hash": "hash-ok",
+                "enrichment": {"summary": "redundant summary"},
+                "provenance_class": "RAW-ETAN-DIRECT",
+            }
+        ],
+    )
+
+    result = quarantine_stale_queue_files(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        quarantine_root=quarantine_root,
+        dry_run=False,
+        now=dt.datetime(2026, 5, 30, 4, 10, tzinfo=dt.timezone.utc),
+    )
+
+    assert result.scanned_files == 1
+    assert result.candidate_files == 0
+    assert result.quarantined_files == 0
+    assert provenance_only.exists()
+    assert not quarantine_root.exists()
+
+
 def test_maintenance_launchd_plists_and_installer_wiring():
     nightly_path = REPO_ROOT / "scripts/launchd/com.brainlayer.maintenance-nightly.plist"
     weekly_path = REPO_ROOT / "scripts/launchd/com.brainlayer.maintenance-weekly.plist"

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -1426,8 +1426,7 @@ def test_provenance_sweep_drops_ambiguous_entity_instead_of_requeueing_forever(c
     assert result.swept == 1
     assert result.entities == ["controlLayer"]
     assert result.notes == [
-        "Ambiguous entity lookup for 'controlLayer' via id/name: e-control:controlLayer, "
-        "e-control-duplicate:controlLayer"
+        "Ambiguous entity lookup for 'controlLayer' via name: e-control:controlLayer, e-control-duplicate:controlLayer"
     ]
     assert con.execute("SELECT COUNT(*) FROM provenance_resolve_queue WHERE entity = 'controlLayer'").fetchone()[0] == 0
 
@@ -1554,8 +1553,7 @@ def test_resolver_skips_writes_when_entity_lookup_is_ambiguous(con):
     assert result.superseded_count == 0
     assert result.pending_confirm_count == 0
     assert result.notes == [
-        "Ambiguous entity lookup for 'controlLayer' via id/name: e-control:controlLayer, "
-        "e-control-duplicate:controlLayer"
+        "Ambiguous entity lookup for 'controlLayer' via name: e-control:controlLayer, e-control-duplicate:controlLayer"
     ]
 
 
@@ -2065,6 +2063,18 @@ def test_deferred_mcp_store_enrichment_derives_direct_provenance():
         )
         == "RAW-ETAN-DIRECT"
     )
+
+
+def test_entity_lookup_prefers_exact_id_before_exact_name_collision(con):
+    from brainlayer.provenance_integration import _entity_ids
+
+    con.execute("INSERT INTO kg_entities (id, name) VALUES ('controllayer', 'Control Layer ID')")
+    con.execute("INSERT INTO kg_entities (id, name) VALUES ('e-control-name', 'controlLayer')")
+
+    entity_ids, canonical_name = _entity_ids(con, "controllayer")
+
+    assert entity_ids == ["controllayer"]
+    assert canonical_name == "Control Layer ID"
 
 
 def test_derive_chunk_provenance_class_tolerates_null_content():


### PR DESCRIPTION
## Summary
- keep exact entity id/name/alias matches isolated before normalized fan-out
- treat ambiguous normalized fan-out as no-op via existing ambiguity handling
- preserve redundant enrichment updates that carry provenance or entity data so drain can enqueue provenance resolution

## Test plan
- `pytest tests/test_provenance_integration.py::test_entity_lookup_prefers_exact_id_before_exact_name_collision tests/test_provenance_autosupersede.py::test_gather_same_entity_keeps_exact_entity_match_isolated_from_normalized_fanout tests/test_provenance_autosupersede.py::test_gather_same_entity_treats_ambiguous_normalized_fanout_as_noop tests/test_maintenance_routine.py::test_stale_queue_quarantine_preserves_provenance_class_redundant_enrichment tests/test_maintenance_routine.py::test_stale_queue_quarantine_preserves_entity_bearing_redundant_enrichment tests/test_write_queue.py::test_burn_drain_redundant_enrichment_preserves_provenance_enqueue -q`
- `BRAINLAYER_PREPUSH=1 BRAINLAYER_PREPUSH_SCOPE=changed-only bash scripts/run_tests.sh`
- pre-push gate on branch push

## Notes
- PR #475 was already merged before this blocking P2 fix could land on that branch. PR #476 was a narrow deferred MCP store provenance hotfix; it did not cover exact entity id/name lookup isolation or stale queue preservation for provenance-class-only enrichment updates. This PR is the clean follow-up branch from current `main` containing only the remaining P2 guard fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provenance entity resolution and maintenance quarantine behavior; wrong lookup order could affect supersede/sweep, but scope is narrow and well covered by tests.
> 
> **Overview**
> Tightens **brainlayer** guards so stale-queue maintenance and provenance resolution do not drop work or merge the wrong KG rows.
> 
> **Stale queue:** `_file_is_redundant_enrichment` no longer treats an `enrichment_update` as fully redundant when the event carries a non-empty **`provenance_class`** (same idea as events with **`entities`**). Those files stay in the queue instead of being quarantined as stale duplicates.
> 
> **Entity lookup:** `_entity_ids` resolves in order—exact **`kg_entities.id`**, then case-insensitive **name**, then aliases/normalized fan-out. A lookup string that matches an id is not merged with a separate row that only shares the name, so resolution and sweep use the intended entity. Ambiguity notes now say **`via name`** (or **`via id`**) instead of **`via id/name`**.
> 
> Tests cover provenance-class-only redundant enrichment preservation and id-before-name collision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8f114065bd6e097860d8a93a00ffc49f4f53b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix entity and provenance queue guards in brainlayer maintenance and provenance integration
> - [`maintenance._file_is_redundant_enrichment`](https://github.com/EtanHey/brainlayer/pull/477/files#diff-5623eb0b0ddbc791b2b25c828a74927787f1cf710501ff90555ebf92981b041d) now treats `enrichment_update` files with a non-empty `provenance_class` as non-redundant, preventing them from being quarantined.
> - [`provenance_integration._entity_ids`](https://github.com/EtanHey/brainlayer/pull/477/files#diff-fc190ea6f5cd124c6cd9537ed16739b91fbed204da874a871f294ac3dccb7dde) splits entity lookup into two sequential queries: exact ID match first, then case-insensitive name match. Ambiguity notes now report `via id` or `via name` instead of `via id/name`.
> - Behavioral Change: entity inputs that match both an ID and another entity's name now resolve to the ID match rather than potentially colliding with the name match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af8f114.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
