### PR TITLE
test: add hot hybrid currentness benchmark

### DIFF
--- a/scripts/hot_currentness_benchmark.py
+++ b/scripts/hot_currentness_benchmark.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""Measure BrainLayer hot store-to-search currentness.
+
+This script intentionally separates durable row visibility, lexical FTS/trigram
+visibility, embedding availability, and hybrid/RRF visibility. It can run
+against the canonical DB or a caller-supplied test DB.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+# isort: off
+from brainlayer._helpers import _escape_fts5_query
+from brainlayer.drain import drain_once
+from brainlayer.fallback_replay import load_scope_map, parse_fallback_file, replay_entry
+from brainlayer.paths import DEFAULT_DB_PATH
+from brainlayer.queue_io import enqueue_store, get_queue_dir
+from brainlayer.store import embed_pending_chunks, store_memory
+from brainlayer.vector_store import VectorStore
+# isort: on
+
+
+EmbedFn = Callable[[str], list[float]]
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _latency_ms(start: float) -> float:
+    return round((_now() - start) * 1000.0, 3)
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return round(values[0], 3)
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * percentile
+    lower = int(index)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = index - lower
+    return round(ordered[lower] * (1 - fraction) + ordered[upper] * fraction, 3)
+
+
+def summarize_latencies(values: list[float]) -> dict[str, float | None]:
+    return {
+        "count": len(values),
+        "p50_ms": _percentile(values, 0.50),
+        "p95_ms": _percentile(values, 0.95),
+        "max_ms": round(max(values), 3) if values else None,
+    }
+
+
+def drain_throughput(*, events: int, elapsed_s: float) -> float | None:
+    if elapsed_s <= 0:
+        return None
+    return round(events / elapsed_s, 3)
+
+
+def queue_metrics(*, queue_dir: Path, now: float | None = None) -> dict[str, float | int | None]:
+    now = time.time() if now is None else now
+    files = sorted(queue_dir.glob("*.jsonl")) if queue_dir.exists() else []
+    event_count = 0
+    oldest_queued_at: float | None = None
+    for path in files:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            event_count += 1
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            queued_at = event.get("queued_at")
+            if isinstance(queued_at, int | float):
+                oldest_queued_at = (
+                    float(queued_at) if oldest_queued_at is None else min(oldest_queued_at, float(queued_at))
+                )
+    oldest_age = round(now - oldest_queued_at, 3) if oldest_queued_at is not None else None
+    return {
+        "queue_depth_files": len(files),
+        "queue_depth_events": event_count,
+        "oldest_queued_age_s": oldest_age,
+    }
+
+
+def embedding_backlog_metrics(*, db_path: Path) -> dict[str, Any]:
+    store = VectorStore(db_path, readonly=True)
+    try:
+        row = (
+            store.conn.cursor()
+            .execute(
+                """
+            SELECT COUNT(*), MIN(c.created_at)
+            FROM chunks c
+            LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
+            WHERE v.chunk_id IS NULL
+              AND c.source IN ('manual', 'mcp')
+            """
+            )
+            .fetchone()
+        )
+        return {
+            "pending_manual_mcp_embeddings": int(row[0] or 0),
+            "oldest_pending_manual_mcp_created_at": row[1],
+        }
+    finally:
+        store.close()
+
+
+def _poll(timeout_s: float, poll_interval_s: float, predicate: Callable[[], bool]) -> float | None:
+    start = _now()
+    deadline = start + timeout_s
+    while _now() <= deadline:
+        if predicate():
+            return _latency_ms(start)
+        time.sleep(poll_interval_s)
+    return None
+
+
+def _row_exists(store: VectorStore, sql: str, params: tuple[Any, ...]) -> bool:
+    return bool(store.conn.cursor().execute(sql, params).fetchone())
+
+
+def _fts_visible(store: VectorStore, table_name: str, chunk_id: str, query_text: str) -> bool:
+    query = _escape_fts5_query(query_text)
+    if not query:
+        return False
+    sql = f"SELECT 1 FROM {table_name} WHERE {table_name} MATCH ? AND chunk_id = ? LIMIT 1"
+    return _row_exists(store, sql, (query, chunk_id))
+
+
+def _embedding_visible(store: VectorStore, chunk_id: str) -> bool:
+    return _row_exists(store, "SELECT 1 FROM chunk_vectors WHERE chunk_id = ? LIMIT 1", (chunk_id,))
+
+
+def _hybrid_visible(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    query_text: str,
+    query_embedding: list[float],
+    project: str | None,
+) -> bool:
+    result = store.hybrid_search(
+        query_embedding=query_embedding,
+        query_text=query_text,
+        n_results=10,
+        project_filter=project,
+        include_audit=True,
+        include_operational=True,
+        filter_meta_noise=False,
+    )
+    ids = result.get("ids") or []
+    return bool(ids and ids[0] and chunk_id in ids[0])
+
+
+def run_store_probe(
+    *,
+    db_path: Path,
+    content: str,
+    project: str | None,
+    embed_fn: EmbedFn | None,
+    embed_after_store: bool,
+    timeout_s: float = 30.0,
+    poll_interval_s: float = 0.05,
+) -> dict[str, Any]:
+    store = VectorStore(db_path)
+    try:
+        call_start = _now()
+        stored = store_memory(
+            store=store,
+            embed_fn=None,
+            content=content,
+            memory_type="note",
+            project=project,
+            tags=["hot-currentness-benchmark"],
+            importance=5,
+        )
+        call_latency_ms = _latency_ms(call_start)
+        chunk_id = stored["id"]
+
+        durable_latency = _poll(
+            timeout_s,
+            poll_interval_s,
+            lambda: _row_exists(store, "SELECT 1 FROM chunks WHERE id = ? LIMIT 1", (chunk_id,)),
+        )
+        fts_latency = _poll(timeout_s, poll_interval_s, lambda: _fts_visible(store, "chunks_fts", chunk_id, content))
+        trigram_latency = _poll(
+            timeout_s,
+            poll_interval_s,
+            lambda: _fts_visible(store, "chunks_fts_trigram", chunk_id, content),
+        )
+
+        embedding_latency = None
+        hybrid_latency = None
+        hybrid_visible_with_embedding = False
+        query_embedding = embed_fn(content) if embed_fn is not None else None
+        if embed_after_store and embed_fn is not None:
+            embed_start = _now()
+            embed_pending_chunks(store=store, embed_fn=embed_fn, batch_size=1)
+            embedding_latency = _poll(
+                timeout_s,
+                poll_interval_s,
+                lambda: _embedding_visible(store, chunk_id),
+            )
+            if embedding_latency is not None:
+                embedding_latency = round((_now() - embed_start) * 1000.0, 3)
+
+        if query_embedding is not None:
+            hybrid_latency = _poll(
+                timeout_s,
+                poll_interval_s,
+                lambda: (
+                    _embedding_visible(store, chunk_id)
+                    and _hybrid_visible(
+                        store,
+                        chunk_id=chunk_id,
+                        query_text=content,
+                        query_embedding=query_embedding,
+                        project=project,
+                    )
+                ),
+            )
+            hybrid_visible_with_embedding = hybrid_latency is not None and _embedding_visible(store, chunk_id)
+
+        return {
+            "chunk_id": chunk_id,
+            "brain_store_call_latency_ms": call_latency_ms,
+            "durable_row_latency_ms": durable_latency,
+            "fts_visibility_latency_ms": fts_latency,
+            "trigram_visibility_latency_ms": trigram_latency,
+            "embedding_availability_latency_ms": embedding_latency,
+            "hybrid_rrf_visibility_latency_ms": hybrid_latency,
+            "hybrid_rrf_visible_with_embedding": hybrid_visible_with_embedding,
+        }
+    finally:
+        store.close()
+
+
+def run_store_scenario(
+    *,
+    db_path: Path,
+    project: str,
+    count: int,
+    embed_fn: EmbedFn | None,
+    embed_after_store: bool,
+    label: str,
+    timeout_s: float,
+) -> dict[str, Any]:
+    probes = []
+    for index in range(count):
+        marker = f"hcphase1b-{label}-{uuid.uuid4().hex[:12]}-{index}"
+        probes.append(
+            run_store_probe(
+                db_path=db_path,
+                content=f"{marker} hot hybrid currentness benchmark marker",
+                project=project,
+                embed_fn=embed_fn,
+                embed_after_store=embed_after_store,
+                timeout_s=timeout_s,
+            )
+        )
+    return _summarize_probe_set(label, probes)
+
+
+def run_fake_load_scenario(
+    *,
+    db_path: Path,
+    project: str,
+    count: int,
+    workers: int,
+    label: str,
+    timeout_s: float,
+) -> dict[str, Any]:
+    probes: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = []
+        for index in range(count):
+            marker = f"hcphase1b-{label}-{uuid.uuid4().hex[:12]}-{index}"
+            futures.append(
+                executor.submit(
+                    run_store_probe,
+                    db_path=db_path,
+                    content=f"{marker} fake concurrent Codex load currentness marker",
+                    project=project,
+                    embed_fn=None,
+                    embed_after_store=False,
+                    timeout_s=timeout_s,
+                )
+            )
+        for future in as_completed(futures):
+            probes.append(future.result())
+    result = _summarize_probe_set(label, probes)
+    result["workers"] = workers
+    return result
+
+
+def run_queue_drain_scenario(
+    *,
+    db_path: Path,
+    queue_dir: Path,
+    project: str,
+    count: int,
+    embed_fn: EmbedFn | None,
+    label: str,
+) -> dict[str, Any]:
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    before = queue_metrics(queue_dir=queue_dir)
+    expected_ids: list[str] = []
+    for index in range(count):
+        chunk_id = f"manual-{uuid.uuid4().hex[:16]}"
+        expected_ids.append(chunk_id)
+        enqueue_store(
+            content=f"hcphase1b-{label}-{uuid.uuid4().hex[:12]} queued drain hot currentness marker {index}",
+            memory_type="note",
+            project=project,
+            tags=["hot-currentness-benchmark", "queue-drain"],
+            importance=5,
+            chunk_id=chunk_id,
+            source=label,
+            queue_dir=queue_dir,
+        )
+    queued = queue_metrics(queue_dir=queue_dir)
+    start = _now()
+    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=count, embed_fn=embed_fn)
+    elapsed = _now() - start
+    after = queue_metrics(queue_dir=queue_dir)
+    store = VectorStore(db_path)
+    try:
+        durable = sum(
+            1
+            for chunk_id in expected_ids
+            if _row_exists(store, "SELECT 1 FROM chunks WHERE id = ? LIMIT 1", (chunk_id,))
+        )
+        embedded = sum(1 for chunk_id in expected_ids if _embedding_visible(store, chunk_id))
+    finally:
+        store.close()
+    return {
+        "label": label,
+        "queued_ids": expected_ids,
+        "queue_before": before,
+        "queue_after_enqueue": queued,
+        "queue_after_drain": after,
+        "drained_events": drained,
+        "drain_elapsed_s": round(elapsed, 3),
+        "drain_throughput_events_s": drain_throughput(events=drained, elapsed_s=elapsed),
+        "durable_rows": durable,
+        "embedded_rows": embedded,
+    }
+
+
+def run_fallback_replay_scenario(
+    *,
+    db_path: Path,
+    project: str,
+    count: int,
+    label: str,
+) -> dict[str, Any]:
+    replayed: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="brainlayer-hc-fallback-") as tmp:
+        root = Path(tmp) / "sample-repo"
+        decisions = root / "docs.local" / "decisions"
+        decisions.mkdir(parents=True)
+        scope_map = load_scope_map()
+        store = VectorStore(db_path)
+        try:
+            for index in range(count):
+                path = decisions / f"hcphase1b-{index}.md"
+                path.write_text(
+                    "---\n"
+                    "intended_brain_store: true\n"
+                    "memory_type: note\n"
+                    f"project: {project}\n"
+                    "tags:\n"
+                    "  - hot-currentness-benchmark\n"
+                    "  - fallback-replay\n"
+                    "importance: 5\n"
+                    "timestamp: '2026-06-13T00:00:00+00:00'\n"
+                    "chunk_id:\n"
+                    "---\n"
+                    f"hcphase1b-{label}-{uuid.uuid4().hex[:12]} fallback replay marker {index}\n",
+                    encoding="utf-8",
+                )
+                entry = parse_fallback_file(path, scope_map=scope_map)
+                start = _now()
+                result = replay_entry(
+                    entry,
+                    store_func=lambda **kwargs: store_memory(store=store, embed_fn=None, **kwargs),
+                    replayed_by="hot-currentness-benchmark",
+                )
+                replayed.append(
+                    {
+                        "path": str(path),
+                        "chunk_id": result.chunk_id,
+                        "error": result.error,
+                        "replay_latency_ms": _latency_ms(start),
+                    }
+                )
+        finally:
+            store.close()
+    return {"label": label, "replayed": replayed}
+
+
+def _summarize_probe_set(label: str, probes: list[dict[str, Any]]) -> dict[str, Any]:
+    fields = [
+        "brain_store_call_latency_ms",
+        "durable_row_latency_ms",
+        "fts_visibility_latency_ms",
+        "trigram_visibility_latency_ms",
+        "embedding_availability_latency_ms",
+        "hybrid_rrf_visibility_latency_ms",
+    ]
+    return {
+        "label": label,
+        "probes": probes,
+        "summary": {
+            field: summarize_latencies([probe[field] for probe in probes if probe.get(field) is not None])
+            for field in fields
+        },
+    }
+
+
+def _load_default_embed_fn() -> EmbedFn:
+    from brainlayer.embeddings import get_embedding_model
+
+    model = get_embedding_model()
+    return model.embed_query
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Measure BrainLayer hot hybrid currentness.")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    parser.add_argument("--queue-dir", type=Path, default=get_queue_dir())
+    parser.add_argument("--project", default="brainlayer")
+    parser.add_argument("--count", type=int, default=3)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--timeout-s", type=float, default=30.0)
+    parser.add_argument(
+        "--scenario",
+        choices=["store-no-embed", "store-with-embed", "fake-load", "queue-drain", "fallback-replay", "all"],
+        default="store-with-embed",
+    )
+    parser.add_argument("--no-real-embed", action="store_true", help="Skip loading the real embedding model.")
+    args = parser.parse_args()
+
+    embed_fn = None if args.no_real_embed else _load_default_embed_fn()
+    output: dict[str, Any] = {
+        "db_path": str(args.db),
+        "queue_dir": str(args.queue_dir),
+        "project": args.project,
+        "count": args.count,
+        "started_at_epoch": time.time(),
+        "embedding_backlog_before": embedding_backlog_metrics(db_path=args.db),
+        "queue_before": queue_metrics(queue_dir=args.queue_dir),
+        "scenarios": [],
+    }
+
+    if args.scenario in {"store-no-embed", "all"}:
+        output["scenarios"].append(
+            run_store_scenario(
+                db_path=args.db,
+                project=args.project,
+                count=args.count,
+                embed_fn=embed_fn,
+                embed_after_store=False,
+                label="store-no-embed",
+                timeout_s=args.timeout_s,
+            )
+        )
+    if args.scenario in {"store-with-embed", "all"}:
+        output["scenarios"].append(
+            run_store_scenario(
+                db_path=args.db,
+                project=args.project,
+                count=args.count,
+                embed_fn=embed_fn,
+                embed_after_store=embed_fn is not None,
+                label="store-with-embed",
+                timeout_s=args.timeout_s,
+            )
+        )
+    if args.scenario in {"queue-drain", "all"}:
+        output["scenarios"].append(
+            run_queue_drain_scenario(
+                db_path=args.db,
+                queue_dir=args.queue_dir,
+                project=args.project,
+                count=args.count,
+                embed_fn=embed_fn,
+                label="queue-drain",
+            )
+        )
+    if args.scenario in {"fallback-replay", "all"}:
+        output["scenarios"].append(
+            run_fallback_replay_scenario(
+                db_path=args.db,
+                project=args.project,
+                count=args.count,
+                label="fallback-replay",
+            )
+        )
+
+    if args.scenario in {"fake-load", "all"}:
+        output["scenarios"].append(
+            run_fake_load_scenario(
+                db_path=args.db,
+                project=args.project,
+                count=args.count,
+                workers=args.workers,
+                label="fake-load",
+                timeout_s=args.timeout_s,
+            )
+        )
+
+    output["embedding_backlog_after"] = embedding_backlog_metrics(db_path=args.db)
+    output["queue_after"] = queue_metrics(queue_dir=args.queue_dir)
+    output["finished_at_epoch"] = time.time()
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hot_currentness_benchmark.py
+++ b/scripts/hot_currentness_benchmark.py
@@ -81,8 +81,7 @@ def _ensure_db_initialized(db_path: Path) -> None:
 
 def _set_drain_embed_env(enabled: bool) -> str | None:
     previous = os.environ.get("BRAINLAYER_DRAIN_EMBED")
-    if not enabled:
-        os.environ["BRAINLAYER_DRAIN_EMBED"] = "0"
+    os.environ["BRAINLAYER_DRAIN_EMBED"] = "1" if enabled else "0"
     return previous
 
 
@@ -106,11 +105,11 @@ def queue_metrics(*, queue_dir: Path, now: float | None = None) -> dict[str, flo
         for line in lines:
             if not line.strip():
                 continue
-            event_count += 1
             try:
                 event = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            event_count += 1
             queued_at = event.get("queued_at")
             if isinstance(queued_at, int | float):
                 oldest_queued_at = (
@@ -150,6 +149,20 @@ def embedding_backlog_metrics(*, db_path: Path) -> dict[str, Any]:
 
 def _poll(timeout_s: float, poll_interval_s: float, predicate: Callable[[], bool]) -> float | None:
     start = _now()
+    deadline = start + timeout_s
+    while _now() <= deadline:
+        if predicate():
+            return _latency_ms(start)
+        time.sleep(poll_interval_s)
+    return None
+
+
+def _poll_from(
+    start: float,
+    timeout_s: float,
+    poll_interval_s: float,
+    predicate: Callable[[], bool],
+) -> float | None:
     deadline = start + timeout_s
     while _now() <= deadline:
         if predicate():
@@ -248,7 +261,8 @@ def run_store_probe(
                 embedding_latency = round((_now() - embed_start) * 1000.0, 3)
 
         if query_embedding is not None:
-            hybrid_latency = _poll(
+            hybrid_latency = _poll_from(
+                call_start,
                 timeout_s,
                 poll_interval_s,
                 lambda: (
@@ -363,7 +377,8 @@ def run_queue_drain_scenario(
             tags=["hot-currentness-benchmark", "queue-drain"],
             importance=5,
             chunk_id=chunk_id,
-            source=label,
+            benchmark_label=label,
+            source="mcp",
             queue_dir=benchmark_queue_dir,
         )
     queued = queue_metrics(queue_dir=benchmark_queue_dir)

--- a/scripts/hot_currentness_benchmark.py
+++ b/scripts/hot_currentness_benchmark.py
@@ -30,7 +30,7 @@ from brainlayer.drain import drain_once
 from brainlayer.fallback_replay import load_scope_map, parse_fallback_file, replay_entry
 from brainlayer.paths import DEFAULT_DB_PATH
 from brainlayer.queue_io import enqueue_store, get_queue_dir
-from brainlayer.store import embed_pending_chunks, store_memory
+from brainlayer.store import embed_hot_chunk, embed_pending_chunks, store_memory
 from brainlayer.vector_store import VectorStore
 # isort: on
 
@@ -208,6 +208,10 @@ def _hybrid_visible(
     return bool(ids and ids[0] and chunk_id in ids[0])
 
 
+def _vector_only_query_text(chunk_id: str) -> str:
+    return f"vector_only_currentness_probe_{chunk_id.replace('-', '_')}"
+
+
 def run_store_probe(
     *,
     db_path: Path,
@@ -247,10 +251,13 @@ def run_store_probe(
 
         embedding_latency = None
         hybrid_latency = None
+        hybrid_vector_latency = None
         hybrid_visible_with_embedding = False
+        hybrid_vector_visible_with_embedding = False
         query_embedding = embed_fn(content) if embed_fn is not None else None
         if embed_after_store and embed_fn is not None:
             embed_start = _now()
+            embed_hot_chunk(store=store, embed_fn=embed_fn, chunk_id=chunk_id)
             embed_pending_chunks(store=store, embed_fn=embed_fn, batch_size=1)
             embedding_latency = _poll(
                 timeout_s,
@@ -277,6 +284,24 @@ def run_store_probe(
                 ),
             )
             hybrid_visible_with_embedding = hybrid_latency is not None and _embedding_visible(store, chunk_id)
+            hybrid_vector_latency = _poll_from(
+                call_start,
+                timeout_s,
+                poll_interval_s,
+                lambda: (
+                    _embedding_visible(store, chunk_id)
+                    and _hybrid_visible(
+                        store,
+                        chunk_id=chunk_id,
+                        query_text=_vector_only_query_text(chunk_id),
+                        query_embedding=query_embedding,
+                        project=project,
+                    )
+                ),
+            )
+            hybrid_vector_visible_with_embedding = hybrid_vector_latency is not None and _embedding_visible(
+                store, chunk_id
+            )
 
         return {
             "chunk_id": chunk_id,
@@ -287,6 +312,8 @@ def run_store_probe(
             "embedding_availability_latency_ms": embedding_latency,
             "hybrid_rrf_visibility_latency_ms": hybrid_latency,
             "hybrid_rrf_visible_with_embedding": hybrid_visible_with_embedding,
+            "hybrid_vector_arm_visibility_latency_ms": hybrid_vector_latency,
+            "hybrid_vector_arm_visible_with_embedding": hybrid_vector_visible_with_embedding,
         }
     finally:
         store.close()
@@ -475,6 +502,7 @@ def _summarize_probe_set(label: str, probes: list[dict[str, Any]]) -> dict[str, 
         "trigram_visibility_latency_ms",
         "embedding_availability_latency_ms",
         "hybrid_rrf_visibility_latency_ms",
+        "hybrid_vector_arm_visibility_latency_ms",
     ]
     return {
         "label": label,

--- a/scripts/hot_currentness_benchmark.py
+++ b/scripts/hot_currentness_benchmark.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import tempfile
 import time
@@ -71,6 +72,25 @@ def drain_throughput(*, events: int, elapsed_s: float) -> float | None:
     if elapsed_s <= 0:
         return None
     return round(events / elapsed_s, 3)
+
+
+def _ensure_db_initialized(db_path: Path) -> None:
+    store = VectorStore(db_path)
+    store.close()
+
+
+def _set_drain_embed_env(enabled: bool) -> str | None:
+    previous = os.environ.get("BRAINLAYER_DRAIN_EMBED")
+    if not enabled:
+        os.environ["BRAINLAYER_DRAIN_EMBED"] = "0"
+    return previous
+
+
+def _restore_drain_embed_env(previous: str | None) -> None:
+    if previous is None:
+        os.environ.pop("BRAINLAYER_DRAIN_EMBED", None)
+    else:
+        os.environ["BRAINLAYER_DRAIN_EMBED"] = previous
 
 
 def queue_metrics(*, queue_dir: Path, now: float | None = None) -> dict[str, float | int | None]:
@@ -293,6 +313,7 @@ def run_fake_load_scenario(
     label: str,
     timeout_s: float,
 ) -> dict[str, Any]:
+    """Issue concurrent stores; SQLite still serializes writes through BEGIN IMMEDIATE."""
     probes: list[dict[str, Any]] = []
     with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = []
@@ -323,10 +344,14 @@ def run_queue_drain_scenario(
     project: str,
     count: int,
     embed_fn: EmbedFn | None,
+    embed_after_drain: bool = True,
     label: str,
 ) -> dict[str, Any]:
     queue_dir.mkdir(parents=True, exist_ok=True)
-    before = queue_metrics(queue_dir=queue_dir)
+    _ensure_db_initialized(db_path)
+    benchmark_queue_dir = queue_dir / f"{label}-{uuid.uuid4().hex[:12]}"
+    benchmark_queue_dir.mkdir(parents=True, exist_ok=True)
+    before = queue_metrics(queue_dir=benchmark_queue_dir)
     expected_ids: list[str] = []
     for index in range(count):
         chunk_id = f"manual-{uuid.uuid4().hex[:16]}"
@@ -339,13 +364,17 @@ def run_queue_drain_scenario(
             importance=5,
             chunk_id=chunk_id,
             source=label,
-            queue_dir=queue_dir,
+            queue_dir=benchmark_queue_dir,
         )
-    queued = queue_metrics(queue_dir=queue_dir)
+    queued = queue_metrics(queue_dir=benchmark_queue_dir)
     start = _now()
-    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=count, embed_fn=embed_fn)
+    previous_drain_embed = _set_drain_embed_env(embed_after_drain)
+    try:
+        drained = drain_once(db_path=db_path, queue_dir=benchmark_queue_dir, batch_size=count, embed_fn=embed_fn)
+    finally:
+        _restore_drain_embed_env(previous_drain_embed)
     elapsed = _now() - start
-    after = queue_metrics(queue_dir=queue_dir)
+    after = queue_metrics(queue_dir=benchmark_queue_dir)
     store = VectorStore(db_path)
     try:
         durable = sum(
@@ -358,6 +387,7 @@ def run_queue_drain_scenario(
         store.close()
     return {
         "label": label,
+        "benchmark_queue_dir": str(benchmark_queue_dir),
         "queued_ids": expected_ids,
         "queue_before": before,
         "queue_after_enqueue": queued,
@@ -465,6 +495,7 @@ def main() -> int:
     args = parser.parse_args()
 
     embed_fn = None if args.no_real_embed else _load_default_embed_fn()
+    _ensure_db_initialized(args.db)
     output: dict[str, Any] = {
         "db_path": str(args.db),
         "queue_dir": str(args.queue_dir),
@@ -508,6 +539,7 @@ def main() -> int:
                 project=args.project,
                 count=args.count,
                 embed_fn=embed_fn,
+                embed_after_drain=embed_fn is not None,
                 label="queue-drain",
             )
         )

--- a/tests/test_hot_currentness_benchmark.py
+++ b/tests/test_hot_currentness_benchmark.py
@@ -1,6 +1,9 @@
 import importlib.util
 import json
+import os
+import sqlite3
 import sys
+import time
 from pathlib import Path
 
 
@@ -59,15 +62,38 @@ def test_queue_metrics_report_depth_oldest_age_and_throughput(tmp_path):
         + "\n",
         encoding="utf-8",
     )
+    (queue_dir / "bad.jsonl").write_text("{not-json}\n", encoding="utf-8")
 
     metrics = benchmark.queue_metrics(queue_dir=queue_dir, now=110.0)
 
     assert metrics == {
-        "queue_depth_files": 1,
+        "queue_depth_files": 2,
         "queue_depth_events": 1,
         "oldest_queued_age_s": 10.0,
     }
     assert benchmark.drain_throughput(events=5, elapsed_s=2.0) == 2.5
+
+
+def test_store_probe_measures_hybrid_latency_from_original_write(tmp_path):
+    benchmark = _load_benchmark_module()
+    db_path = tmp_path / "hot-currentness.db"
+
+    def slow_embed(text: str) -> list[float]:
+        time.sleep(0.05)
+        return _fake_embed(text)
+
+    result = benchmark.run_store_probe(
+        db_path=db_path,
+        content="hybrid latency should include embedding work from write time",
+        project="brainlayer-test",
+        embed_fn=slow_embed,
+        embed_after_store=True,
+        timeout_s=3.0,
+        poll_interval_s=0.01,
+    )
+
+    assert result["hybrid_rrf_visible_with_embedding"] is True
+    assert result["hybrid_rrf_visibility_latency_ms"] >= 100.0
 
 
 def test_queue_drain_scenario_uses_isolated_queue_when_parent_has_backlog(tmp_path):
@@ -98,6 +124,9 @@ def test_queue_drain_scenario_uses_isolated_queue_when_parent_has_backlog(tmp_pa
     assert result["drained_events"] == 1
     assert (queue_dir / "aaa-backlog.jsonl").exists()
     assert Path(result["benchmark_queue_dir"]).parent == queue_dir
+    with sqlite3.connect(db_path) as conn:
+        source = conn.execute("SELECT source FROM chunks WHERE id = ?", (result["queued_ids"][0],)).fetchone()
+    assert source == ("mcp",)
 
 
 def test_queue_drain_scenario_can_disable_real_drain_embeddings(tmp_path, monkeypatch):
@@ -125,6 +154,27 @@ def test_queue_drain_scenario_can_disable_real_drain_embeddings(tmp_path, monkey
 
     assert result["durable_rows"] == 1
     assert result["embedded_rows"] == 0
+
+
+def test_queue_drain_scenario_enables_embeddings_even_when_env_disables_drain(tmp_path, monkeypatch):
+    benchmark = _load_benchmark_module()
+    db_path = tmp_path / "hot-currentness.db"
+    queue_dir = tmp_path / "queue"
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    result = benchmark.run_queue_drain_scenario(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        project="brainlayer-test",
+        count=1,
+        embed_fn=_fake_embed,
+        embed_after_drain=True,
+        label="queue-drain",
+    )
+
+    assert result["durable_rows"] == 1
+    assert result["embedded_rows"] == 1
+    assert os.environ["BRAINLAYER_DRAIN_EMBED"] == "0"
 
 
 def test_main_accepts_fresh_database_for_backlog_metrics(tmp_path, monkeypatch, capsys):

--- a/tests/test_hot_currentness_benchmark.py
+++ b/tests/test_hot_currentness_benchmark.py
@@ -1,0 +1,69 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_benchmark_module():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "hot_currentness_benchmark.py"
+    spec = importlib.util.spec_from_file_location("hot_currentness_benchmark_test", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_embed(text: str) -> list[float]:
+    seed = sum(ord(char) for char in text) % 17
+    return [float(seed + idx) / 1000.0 for idx in range(1024)]
+
+
+def test_store_probe_separates_durable_lexical_embedding_and_hybrid_visibility(tmp_path):
+    benchmark = _load_benchmark_module()
+    db_path = tmp_path / "hot-currentness.db"
+    marker = "hcprobealpha unique currentness marker"
+
+    result = benchmark.run_store_probe(
+        db_path=db_path,
+        content=f"{marker} should become hybrid visible after embedding",
+        project="brainlayer-test",
+        embed_fn=_fake_embed,
+        embed_after_store=True,
+        timeout_s=3.0,
+        poll_interval_s=0.01,
+    )
+
+    assert result["chunk_id"].startswith("manual-")
+    assert result["brain_store_call_latency_ms"] >= 0
+    assert result["durable_row_latency_ms"] >= 0
+    assert result["fts_visibility_latency_ms"] >= 0
+    assert result["trigram_visibility_latency_ms"] >= 0
+    assert result["embedding_availability_latency_ms"] >= 0
+    assert result["hybrid_rrf_visibility_latency_ms"] >= 0
+    assert result["hybrid_rrf_visible_with_embedding"] is True
+
+
+def test_queue_metrics_report_depth_oldest_age_and_throughput(tmp_path):
+    benchmark = _load_benchmark_module()
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    (queue_dir / "mcp-test.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "store_memory",
+                "content": "queued content",
+                "queued_at": 100.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    metrics = benchmark.queue_metrics(queue_dir=queue_dir, now=110.0)
+
+    assert metrics == {
+        "queue_depth_files": 1,
+        "queue_depth_events": 1,
+        "oldest_queued_age_s": 10.0,
+    }
+    assert benchmark.drain_throughput(events=5, elapsed_s=2.0) == 2.5

--- a/tests/test_hot_currentness_benchmark.py
+++ b/tests/test_hot_currentness_benchmark.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 
@@ -67,3 +68,90 @@ def test_queue_metrics_report_depth_oldest_age_and_throughput(tmp_path):
         "oldest_queued_age_s": 10.0,
     }
     assert benchmark.drain_throughput(events=5, elapsed_s=2.0) == 2.5
+
+
+def test_queue_drain_scenario_uses_isolated_queue_when_parent_has_backlog(tmp_path):
+    benchmark = _load_benchmark_module()
+    db_path = tmp_path / "hot-currentness.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    backlog = {
+        "kind": "store_memory",
+        "chunk_id": "manual-backlog",
+        "content": "older unrelated backlog should not be drained by benchmark",
+        "project": "brainlayer-test",
+        "source": "mcp",
+    }
+    (queue_dir / "aaa-backlog.jsonl").write_text(json.dumps(backlog) + "\n", encoding="utf-8")
+
+    result = benchmark.run_queue_drain_scenario(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        project="brainlayer-test",
+        count=1,
+        embed_fn=_fake_embed,
+        label="queue-drain",
+    )
+
+    assert result["durable_rows"] == 1
+    assert result["embedded_rows"] == 1
+    assert result["drained_events"] == 1
+    assert (queue_dir / "aaa-backlog.jsonl").exists()
+    assert Path(result["benchmark_queue_dir"]).parent == queue_dir
+
+
+def test_queue_drain_scenario_can_disable_real_drain_embeddings(tmp_path, monkeypatch):
+    benchmark = _load_benchmark_module()
+    db_path = tmp_path / "hot-currentness.db"
+    queue_dir = tmp_path / "queue"
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "1")
+
+    def fail_if_loaded():
+        raise AssertionError("real embedding model should not be loaded")
+
+    import brainlayer.drain as drain
+
+    monkeypatch.setattr(drain, "_default_embed_fn", fail_if_loaded)
+
+    result = benchmark.run_queue_drain_scenario(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        project="brainlayer-test",
+        count=1,
+        embed_fn=None,
+        embed_after_drain=False,
+        label="queue-drain",
+    )
+
+    assert result["durable_rows"] == 1
+    assert result["embedded_rows"] == 0
+
+
+def test_main_accepts_fresh_database_for_backlog_metrics(tmp_path, monkeypatch, capsys):
+    benchmark = _load_benchmark_module()
+    db_path = tmp_path / "fresh.db"
+    queue_dir = tmp_path / "queue"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hot_currentness_benchmark.py",
+            "--db",
+            str(db_path),
+            "--queue-dir",
+            str(queue_dir),
+            "--scenario",
+            "store-no-embed",
+            "--count",
+            "0",
+            "--timeout-s",
+            "0.01",
+            "--no-real-embed",
+        ],
+    )
+
+    assert benchmark.main() == 0
+    output = json.loads(capsys.readouterr().out)
+
+    assert db_path.exists()
+    assert output["embedding_backlog_before"]["pending_manual_mcp_embeddings"] == 0

--- a/tests/test_hot_currentness_benchmark.py
+++ b/tests/test_hot_currentness_benchmark.py
@@ -22,6 +22,65 @@ def _fake_embed(text: str) -> list[float]:
     return [float(seed + idx) / 1000.0 for idx in range(1024)]
 
 
+def _has_vector(db_path: Path, chunk_id: str) -> bool:
+    with sqlite3.connect(db_path) as conn:
+        return (
+            conn.execute(
+                "SELECT COUNT(*) FROM chunk_vectors_rowids WHERE id = ?",
+                (chunk_id,),
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_store_probe_hot_embeds_fresh_chunk_and_still_drains_old_backlog(tmp_path):
+    benchmark = _load_benchmark_module()
+    from brainlayer.store import store_memory
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "hot-currentness.db"
+    store = VectorStore(db_path)
+    old_ids = []
+    try:
+        for index in range(3):
+            old = store_memory(
+                store=store,
+                embed_fn=None,
+                content=f"old backlog currentness drain marker {index}",
+                memory_type="note",
+                project="brainlayer-test",
+                created_at=f"2026-06-13T00:0{index}:00+00:00",
+            )
+            old_ids.append(old["id"])
+    finally:
+        store.close()
+
+    fresh_content = "fresh vector currentness marker should hot embed before backlog"
+
+    def lane_embed(text: str) -> list[float]:
+        if text == fresh_content:
+            return [1.0] + [0.0] * 1023
+        return [0.0, 1.0] + [0.0] * 1022
+
+    before_pending = benchmark.embedding_backlog_metrics(db_path=db_path)["pending_manual_mcp_embeddings"]
+    result = benchmark.run_store_probe(
+        db_path=db_path,
+        content=fresh_content,
+        project="brainlayer-test",
+        embed_fn=lane_embed,
+        embed_after_store=True,
+        timeout_s=3.0,
+        poll_interval_s=0.01,
+    )
+    after_pending = benchmark.embedding_backlog_metrics(db_path=db_path)["pending_manual_mcp_embeddings"]
+
+    assert result["hybrid_vector_arm_visible_with_embedding"] is True
+    assert result["hybrid_vector_arm_visibility_latency_ms"] >= 0
+    assert _has_vector(db_path, result["chunk_id"])
+    assert _has_vector(db_path, old_ids[0])
+    assert after_pending < before_pending
+
+
 def test_store_probe_separates_durable_lexical_embedding_and_hybrid_visibility(tmp_path):
     benchmark = _load_benchmark_module()
     db_path = tmp_path / "hot-currentness.db"


### PR DESCRIPTION
## Summary

Adds a repeatable Phase 1B benchmark harness for hot hybrid currentness and focused test coverage around the probe behavior. This PR is measurement/tooling plus evidence only; it does not implement the hot embedding queue.

## Measured Evidence

- Pass: durable write visibility is immediate enough for the 30s Phase 1B target.
- Pass: FTS visibility is immediate enough for the 30s Phase 1B target.
- Pass: trigram visibility is immediate enough for the 30s Phase 1B target.
- Fail: embedding availability did not become visible within 30s.
- Fail: hybrid/RRF retrieval did not surface the new chunk within 30s because embeddings were not available.

## Live Backlog

- Pending manual/MCP embeddings: 760.
- Oldest pending timestamp observed in findings: 2026-04-05T00:00:00+00:00.

## Recommendation

Add a hot embedding queue/lane with a small microbatch worker so new writes can become vector-visible quickly. Keep LLM enrichment separate from the hot embedding path so currentness is not blocked by enrichment latency or backlog.

## Phase Gate

Phase 2 remains blocked until hot hybrid currentness passes: new writes must become visible through hybrid/RRF retrieval within 30s.

## Verification

- `python3 -m py_compile scripts/hot_currentness_benchmark.py` -> passed
- `python3 -m ruff check scripts/hot_currentness_benchmark.py tests/test_hot_currentness_benchmark.py` -> `All checks passed!`
- `python3 -m ruff format --check scripts/hot_currentness_benchmark.py tests/test_hot_currentness_benchmark.py` -> `2 files already formatted`
- `python3 -m pytest tests/test_hot_currentness_benchmark.py tests/test_deferred_embedding.py tests/test_write_queue.py -q` -> `52 passed in 4.48s`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New scripts and tests only; no changes to MCP, drain, or store runtime paths beyond invoking existing APIs in benchmarks.
> 
> **Overview**
> Adds **measurement-only** tooling for Phase 1B: a CLI script and pytest suite that quantify how quickly new writes become visible through each layer of the hot path (durable row, FTS, trigram, embeddings, hybrid/RRF), without changing production embedding or queue behavior.
> 
> **`scripts/hot_currentness_benchmark.py`** runs selectable scenarios against a configurable DB and prints JSON with p50/p95 latency summaries, queue depth/age, and manual/MCP embedding backlog. Store probes poll until each visibility stage succeeds (or timeout). Scenarios include direct store (with optional post-store `embed_hot_chunk` / `embed_pending_chunks`), concurrent fake load, isolated queue drain via `drain_once` (with temporary `BRAINLAYER_DRAIN_EMBED` override), and fallback replay from synthetic decision files.
> 
> **`tests/test_hot_currentness_benchmark.py`** loads the script dynamically and asserts probe stage separation, hybrid latency measured from write time, queue metric parsing, drain isolation from parent backlog, and drain embed env toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221f5ee9deb97ba2d37e082675b865834870e0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmarking tool to measure content visibility latency across storage, full-text search, embeddings, and hybrid search stages.

* **Tests**
  * Added test suite validating benchmark measurement accuracy and queue metrics reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hot hybrid currentness benchmark script and tests
> - Adds [scripts/hot_currentness_benchmark.py](https://github.com/EtanHey/brainlayer/pull/479/files#diff-f674f372e86ceb9c3b3520a67720ce54fc1969a4428cfa159b5a7aa0315dca23), a CLI that runs configurable benchmark scenarios (store, fake concurrent load, queue drain, fallback replay) and outputs a structured JSON report with latency percentiles, queue metrics, and embedding backlog metrics.
> - Core probe logic in `run_store_probe` measures per-chunk latencies for durable write, FTS/trigram visibility, embedding availability, and hybrid RRF search visibility (lexical+vector and vector-only).
> - `run_queue_drain_scenario` isolates benchmark queue I/O in a dedicated subdirectory to avoid interfering with existing backlogs.
> - Adds [tests/test_hot_currentness_benchmark.py](https://github.com/EtanHey/brainlayer/pull/479/files#diff-7d1cd813401b0f411ff2998e6493da90620eda005aeb513b16294d25b15333b3) covering probe latency separation, hybrid visibility, queue metrics, drain isolation, env var restore, and the main CLI entrypoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 221f5ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->