### PR TITLE
fix(brain_store): drain pending queue on the .queued path (WI-1)

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -512,11 +512,17 @@ final class MCPRouter: @unchecked Sendable {
                     ]
                 )
             case .queued(let queueID, let queuedAt, let chunkID):
+                // Mirror the .stored path: even when the current store queues under a
+                // busy DB, drain the existing backlog so prior writes are not stranded.
+                // Exclude the just-queued chunk so it is not immediately re-replayed /
+                // double-stored before its own deferred drain runs.
+                let flushedStores = db.flushPendingStores(excludingChunkIDs: [chunkID])
                 return queuedBrainStoreOutput(
                     queueID: queueID,
                     queuedAt: queuedAt,
                     chunkID: chunkID,
-                    queuePath: db.pendingStoreQueuePathForReceipt()
+                    queuePath: db.pendingStoreQueuePathForReceipt(),
+                    flushedStores: flushedStores
                 )
             }
         } catch BrainDatabase.DBError.notOpen {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -1790,18 +1790,30 @@ final class MCPRouterTests: XCTestCase {
 
         let result = response["result"] as? [String: Any]
         XCTAssertNil(result?["isError"])
+        // The live write queued (busy DB), but the existing backlog must still drain.
         XCTAssertEqual(result?["queued"] as? Bool, true)
-        XCTAssertEqual(result?["flushed_count"] as? Int, 0)
+        XCTAssertEqual(result?["flushed_count"] as? Int, 1)
         let flushed = result?["_brainbarFlushedQueuedChunks"] as? [[String: Any]]
-        XCTAssertEqual(flushed?.count, 0)
+        XCTAssertEqual(flushed?.count, 1)
+        // Receipts stay privacy-stripped (chunk_id + rowid only), matching the .stored path.
+        XCTAssertNotNil(flushed?.first?["chunk_id"] as? String)
+        XCTAssertNotNil(flushed?.first?["rowid"])
+        XCTAssertNil(flushed?.first?["content"])
+        XCTAssertNil(flushed?.first?["tags"])
+        XCTAssertNil(flushed?.first?["importance"])
 
+        // Only the just-queued LIVE chunk remains queued (the seeded backlog item was drained).
+        let queuedPayloadAfterFlush = try XCTUnwrap(readSinglePendingStorePayload(queuePath: queuePath))
+        XCTAssertEqual(queuedPayloadAfterFlush["content"] as? String, "Live write queues but still triggers flush")
+
+        // The pre-seeded backlog item flushed to the DB exactly once; the live chunk did not.
         let contents = try chunkContents(path: dbPath)
-        XCTAssertFalse(contents.contains("Queued item should flush even when live write queues"))
+        XCTAssertEqual(
+            contents.filter { $0 == "Queued item should flush even when live write queues" }.count,
+            1,
+            "the seeded backlog item should be stored exactly once"
+        )
         XCTAssertFalse(contents.contains("Live write queues but still triggers flush"))
-
-        let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
-        XCTAssertTrue(queuedText.contains("Queued item should flush even when live write queues"))
-        XCTAssertTrue(queuedText.contains("Live write queues but still triggers flush"))
     }
 
     func testBrainStoreFlushKeepsMalformedQueueLines() throws {


### PR DESCRIPTION
When a store queues under a busy DB, drain the pending backlog (mirror the .stored path) excluding the just-queued chunk. Fixes stranded queued writes. RED->GREEN verified; targeted MCPRouterTests passes. Happy Camper gen-16 WI-1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP write persistence and queue replay ordering; wrong exclusion could double-store or leave backlog stranded, but scope is narrow and covered by targeted tests.
> 
> **Overview**
> When **`brain_store`** hits a busy DB and returns a **DEFERRED/queued** response, it now **drains older `pending-stores.jsonl` backlog** the same way the successful **`.stored`** path already did—so earlier queued writes are not left stranded while only the new chunk stays queued.
> 
> The drain **skips the chunk ID just written to the queue** so that entry is not replayed immediately (avoiding double-store before its normal deferred drain). The deferred MCP metadata still reports **`flushed_count`** and privacy-stripped **`_brainbarFlushedQueuedChunks`** receipts.
> 
> **`MCPRouterTests`** now assert that a live busy write still flushes a pre-seeded queue line once, leaves only the live payload on disk, and does not persist the live content until a later drain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41a03b4cb5a79334b3f2e92e7e217de292aa2cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drain pending store backlog on the `.queued` path in brain-store handler
> - In [MCPRouter.swift](https://github.com/EtanHey/brainlayer/pull/480/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f), the `.queued` branch now calls `db.flushPendingStores(excludingChunkIDs: [chunkID])` to drain the existing backlog before returning, mirroring the `.stored` path's behavior.
> - The response now includes `flushed_count` and `_brainbarFlushedQueuedChunks` (with `chunk_id` and `rowid` only, no content/tags/importance) when a live write is queued.
> - Tests in [MCPRouterTests.swift](https://github.com/EtanHey/brainlayer/pull/480/files#diff-6a1a5be7d76811bedc4d3f0ebcb2043c90a2a0119ea214a29764bcd53b19af15) are updated to assert the new flush metadata and verify only the live chunk remains in the queue after the drain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c41a03b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->