### PR TITLE
test(provenance): RED-first deferred-MCP guard + both-copies-in-sync (WI-2)

### DIFF
--- a/tests/test_deferred_mcp_provenance_guard.py
+++ b/tests/test_deferred_mcp_provenance_guard.py
@@ -1,0 +1,114 @@
+"""Regression guard for deferred MCP queue provenance.
+
+The deferred-MCP provenance rule is intentionally duplicated in
+enrichment_controller.py and provenance_integration.py. These tests fail if
+either copy stops treating source='mcp' + source_file='brainlayer-queue' as
+Etan-authored direct input.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+DIRECT_QUEUE_CASES = [
+    pytest.param("manual", "brainlayer-store", "RAW-ETAN-DIRECT", id="manual-brainlayer-store"),
+    pytest.param("manual", "brainbar-store", "RAW-ETAN-DIRECT", id="manual-brainbar-store"),
+    pytest.param("manual", "brainlayer-queue", "RAW-ETAN-DIRECT", id="manual-brainlayer-queue"),
+    pytest.param("mcp", "brainlayer-queue", "RAW-ETAN-DIRECT", id="deferred-mcp-brainlayer-queue"),
+    pytest.param("mcp", "other-queue", "AGENT-INFERENCE", id="mcp-other-source-file"),
+    pytest.param("claude_code", "brainlayer-queue", "AGENT-INFERENCE", id="claude-code-brainlayer-queue"),
+]
+
+
+def _row(source: str, source_file: str) -> dict[str, Any]:
+    return {
+        "id": f"chunk-{source}-{source_file}",
+        "content": "PRIMARY_BACKEND: Groq",
+        "content_type": "note",
+        "sender": None,
+        "created_at": "2026-06-14T00:00:00Z",
+        "provenance_class": None,
+        "source": source,
+        "source_file": source_file,
+    }
+
+
+def _enrichment_controller_class(source: str, source_file: str) -> str:
+    from brainlayer.enrichment_controller import _derive_chunk_provenance_class
+
+    return _derive_chunk_provenance_class(_row(source, source_file))
+
+
+def _provenance_integration_claim(source: str, source_file: str):
+    from brainlayer.provenance_integration import _row_to_claim
+
+    return _row_to_claim(_row(source, source_file), "enrichment")
+
+
+@pytest.mark.parametrize(("source", "source_file", "expected"), DIRECT_QUEUE_CASES)
+def test_deferred_mcp_queue_rows_classify_as_user_anchored_in_both_paths(source, source_file, expected):
+    claim = _provenance_integration_claim(source, source_file)
+
+    assert _enrichment_controller_class(source, source_file) == expected
+    assert claim.provenance_class == expected
+    assert claim.user_anchored is (expected != "AGENT-INFERENCE")
+
+
+@pytest.mark.parametrize(("source", "source_file", "_expected"), DIRECT_QUEUE_CASES)
+def test_duplicate_deferred_queue_predicates_stay_logically_in_sync(source, source_file, _expected):
+    controller_class = _enrichment_controller_class(source, source_file)
+    integration_claim = _provenance_integration_claim(source, source_file)
+
+    assert integration_claim.provenance_class == controller_class
+    assert integration_claim.user_anchored is (controller_class != "AGENT-INFERENCE")
+
+
+def test_on_disk_deferred_mcp_row_resolves_direct_and_remains_queryable(tmp_path):
+    from brainlayer import enrichment_controller as controller
+    from brainlayer.provenance_integration import resolve_entity_conflicts
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    chunk = {
+        "id": "chunk-deferred-mcp-queue",
+        "content": "PRIMARY_BACKEND: Groq",
+        "metadata": {},
+        "source_file": "brainlayer-queue",
+        "project": "brainlayer",
+        "content_type": "note",
+        "value_type": "HIGH",
+        "char_count": len("PRIMARY_BACKEND: Groq"),
+        "source": "mcp",
+        "sender": None,
+        "created_at": "2026-06-14T00:00:00Z",
+    }
+
+    store = VectorStore(db_path)
+    try:
+        store.upsert_chunks([chunk], [[0.01] * 1024])
+        controller._apply_enrichment(store, chunk, {"summary": "queued MCP store", "entities": []})
+        store.upsert_entity("e-enrichment", "concept", "enrichment", canonical_name="enrichment")
+        store.link_entity_chunk("e-enrichment", chunk["id"], context="PRIMARY_BACKEND: Groq", mention_type="explicit")
+
+        row = (
+            store.conn.cursor()
+            .execute("SELECT source, source_file, provenance_class FROM chunks WHERE id = ?", (chunk["id"],))
+            .fetchone()
+        )
+        assert row == ("mcp", "brainlayer-queue", "RAW-ETAN-DIRECT")
+
+        report = resolve_entity_conflicts(store, "enrichment", dry_run=True)
+        primary_backend = report.resolutions["PRIMARY_BACKEND"].authoritative
+        assert primary_backend is not None
+        assert primary_backend.id == chunk["id"]
+        assert primary_backend.provenance_class == "RAW-ETAN-DIRECT"
+        assert primary_backend.user_anchored is True
+
+        results = store.search(query_text="PRIMARY_BACKEND", n_results=5, source_filter="mcp")
+        assert results["ids"] == [[chunk["id"]]]
+        assert results["metadatas"][0][0]["provenance_class"] == "RAW-ETAN-DIRECT"
+    finally:
+        store.close()


### PR DESCRIPTION
Guard: deferred-MCP rows (source=mcp + source_file=brainlayer-queue) stay RAW-ETAN-DIRECT; the two duplicated predicate copies stay in sync. Test-only. 13 passed. Happy Camper gen-16 WI-2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no runtime or schema changes; low risk aside from future CI time from the new integration test.
> 
> **Overview**
> Adds **`tests/test_deferred_mcp_provenance_guard.py`** as a test-only regression guard for deferred MCP queue provenance. No production code changes.
> 
> The new suite locks in that rows with **`source='mcp'`** and **`source_file='brainlayer-queue'`** are treated as **`RAW-ETAN-DIRECT`** (user-anchored), matching the duplicated predicates in **`enrichment_controller._derive_chunk_provenance_class`** and **`provenance_integration._row_to_claim`**. Parametrized cases cover manual store/queue paths, deferred MCP on **`brainlayer-queue`**, and negative cases (**`mcp`** on other queues, **`claude_code`** on the queue → **`AGENT-INFERENCE`**).
> 
> A dedicated test asserts the two code paths stay logically in sync, and an integration test writes a deferred MCP chunk through enrichment into a temp **`VectorStore`**, checks persisted **`provenance_class`**, **`resolve_entity_conflicts`** authority, and MCP-filtered search metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99f27f721cc3bd185b816ca3b31302e7b3470e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RED-first tests for deferred MCP provenance guard across both classification paths
> - Adds parametrized tests in [test_deferred_mcp_provenance_guard.py](https://github.com/EtanHey/brainlayer/pull/481/files#diff-135e0ec0e6b76ab5da1594c18e4cf5ca45c948c6c8450d1fcbea459023d6c24f) asserting that `enrichment_controller._derive_chunk_provenance_class` and `provenance_integration._row_to_claim` independently classify deferred MCP `brainlayer-queue` rows as `RAW-ETAN-DIRECT` with `user_anchored=True`.
> - Adds a sync-check test ensuring both code paths never diverge in `provenance_class` or `user_anchored` for the covered `(source, source_file)` inputs.
> - Adds an end-to-end integration test that inserts a deferred MCP chunk into a real `VectorStore` DB, runs enrichment, resolves entity conflicts, and asserts the chunk surfaces with the expected provenance metadata in search results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a99f27f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added regression tests to ensure consistent provenance classification for MCP-sourced data
* Tests verify correct labeling, user anchoring logic, and search filtering behavior for deferred MCP chunks
* Includes integration testing to confirm proper conflict resolution in the vector store

<!-- end of auto-generated comment: release notes by coderabbit.ai -->