### PR TITLE
fix(transport): preserve original chunk attribution through fallback replay (WI-3)

### DIFF
--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -331,6 +331,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     elif raw_metadata:
         logger.warning("Skipping non-object store metadata for chunk_id=%s", event.get("chunk_id"))
     tags = event.get("tags")
+    explicit_chunk_origin = event.get("chunk_origin") or metadata.get("chunk_origin")
     existing = conn.execute("SELECT content FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
     if existing:
         if str(existing[0]).strip() == content:
@@ -367,7 +368,7 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "tags": json.dumps(tags) if tags else None,
             "importance": float(event["importance"]) if event.get("importance") is not None else None,
             "content_hash": _content_hash(content),
-            "chunk_origin": detect_chunk_origin(content, event.get("chunk_origin")),
+            "chunk_origin": detect_chunk_origin(content, explicit_chunk_origin),
         },
     )
     supersedes = event.get("supersedes") or metadata.get("supersedes")

--- a/src/brainlayer/fallback_replay.py
+++ b/src/brainlayer/fallback_replay.py
@@ -77,6 +77,7 @@ def replay_entry(
             fallback_source_path=str(entry.path),
             origin_repo_path=str(entry.origin_repo_path),
             replayed_by=replayed_by,
+            chunk_origin=entry.frontmatter.get("chunk_origin"),
         )
     except Exception as exc:
         try:

--- a/src/brainlayer/fallback_replay.py
+++ b/src/brainlayer/fallback_replay.py
@@ -67,18 +67,20 @@ def replay_entry(
     replayed_by: str,
 ) -> ReplayResult:
     try:
-        result = store_func(
-            content=entry.body,
-            memory_type=str(entry.frontmatter.get("memory_type") or "note"),
-            project=entry.project,
-            tags=_normalize_tags(entry.frontmatter.get("tags")),
-            importance=entry.frontmatter.get("importance"),
-            created_at=str(entry.frontmatter.get("timestamp") or ""),
-            fallback_source_path=str(entry.path),
-            origin_repo_path=str(entry.origin_repo_path),
-            replayed_by=replayed_by,
-            chunk_origin=entry.frontmatter.get("chunk_origin"),
-        )
+        store_kwargs = {
+            "content": entry.body,
+            "memory_type": str(entry.frontmatter.get("memory_type") or "note"),
+            "project": entry.project,
+            "tags": _normalize_tags(entry.frontmatter.get("tags")),
+            "importance": entry.frontmatter.get("importance"),
+            "created_at": str(entry.frontmatter.get("timestamp") or ""),
+            "fallback_source_path": str(entry.path),
+            "origin_repo_path": str(entry.origin_repo_path),
+            "replayed_by": replayed_by,
+        }
+        if entry.frontmatter.get("chunk_origin"):
+            store_kwargs["chunk_origin"] = entry.frontmatter["chunk_origin"]
+        result = store_func(**store_kwargs)
     except Exception as exc:
         try:
             _write_replay_attempt(entry, chunk_id=entry.frontmatter.get("chunk_id") or None)

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -533,6 +533,7 @@ def _flush_pending_stores(store, embed_fn) -> int:
         for line in lines:
             try:
                 item = json.loads(line)
+                item_metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
                 result = store_memory(
                     store=store,
                     embed_fn=embed_fn,
@@ -553,6 +554,7 @@ def _flush_pending_stores(store, embed_fn) -> int:
                     line_number=item.get("line_number"),
                     chunk_id=item.get("chunk_id"),
                     created_at=_reservation_created_at(item),
+                    chunk_origin=item.get("chunk_origin") or item_metadata.get("chunk_origin"),
                 )
                 if item.get("supersedes"):
                     if not store.supersede_chunk(item["supersedes"], result["id"]):

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -68,6 +68,7 @@ def enqueue_store(
     **metadata: Any,
 ) -> Path:
     supersedes = metadata.pop("supersedes", None)
+    chunk_origin = metadata.pop("chunk_origin", None)
     chunk_id = metadata.pop("chunk_id", None) or f"manual-{uuid.uuid4().hex[:16]}"
     created_at = created_at or datetime.now(timezone.utc).isoformat()
     return enqueue_jsonl(
@@ -80,6 +81,7 @@ def enqueue_store(
             "tags": tags,
             "importance": importance,
             "created_at": created_at,
+            "chunk_origin": chunk_origin,
             "supersedes": supersedes,
             "metadata": {key: value for key, value in metadata.items() if value is not None},
         },

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -74,6 +74,7 @@ def store_memory(
     fallback_source_path: Optional[str] = None,
     origin_repo_path: Optional[str] = None,
     replayed_by: Optional[str] = None,
+    chunk_origin: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Persistently store a memory into BrainLayer.
 
@@ -104,6 +105,7 @@ def store_memory(
         fallback_source_path: Optional path to a local fallback file being replayed.
         origin_repo_path: Optional git root for the fallback's originating repo.
         replayed_by: Optional replay worker identifier.
+        chunk_origin: Optional explicit origin classification preserved from queued fallback metadata.
 
     Returns:
         Dict with 'id' (chunk ID) and 'related' (list of similar existing memories).
@@ -166,7 +168,7 @@ def store_memory(
     if replayed_by is not None:
         meta["replayed_by"] = replayed_by
 
-    chunk_origin = detect_chunk_origin(content)
+    resolved_chunk_origin = detect_chunk_origin(content, chunk_origin)
     content_class = classify_content_class(content, content_type=memory_type, tags=tags, source="manual")
     tags_json = json.dumps(tags) if tags else None
     incoming_chunk_id = chunk_id
@@ -266,7 +268,7 @@ def store_memory(
                             content[:200],
                             tags_json,
                             float(importance) if importance is not None else None,
-                            chunk_origin,
+                            resolved_chunk_origin,
                             1,
                             now,
                             dedupe_fields.dedupe_hash,
@@ -333,7 +335,7 @@ def store_memory(
 
     clear_hybrid_search_cache(getattr(store, "db_path", None))
     store._invalidate_audit_recursion_count_cache()
-    if chunk_origin == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT:
+    if resolved_chunk_origin == CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT:
         store._invalidate_checkpoint_count_cache()
 
     return {

--- a/tests/test_transport_replay_attribution.py
+++ b/tests/test_transport_replay_attribution.py
@@ -1,0 +1,278 @@
+"""WI-3 fallback replay attribution smoke tests.
+
+These tests exercise the durable write paths directly. They intentionally do not
+kill an MCP child process; transport-close is represented by a queued write file
+that the replay/drain path must handle with its original attribution intact.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import apsw
+import pytest
+
+from brainlayer.chunk_origin import CHUNK_ORIGIN_AGENT_EXPLICIT, CHUNK_ORIGIN_USER_EXPLICIT
+
+
+def _git_env() -> dict[str, str]:
+    import os
+
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
+def _git_init(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(("git", "init", "-q"), cwd=path, env=_git_env(), check=True)
+
+
+def _write_markdown_fallback(repo: Path, *, chunk_origin: str, project: str = "systems") -> Path:
+    path = repo / "docs.local" / "brain-store-fallback" / "pending.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        "intended_brain_store: true\n"
+        "memory_type: note\n"
+        f"project: {project}\n"
+        "importance: 8\n"
+        "tags: [wi3, fallback]\n"
+        "timestamp: 2026-06-14T06:00:00+00:00\n"
+        "reason: transport_closed\n"
+        "retry_attempted: true\n"
+        f"chunk_origin: {chunk_origin}\n"
+        "chunk_id:\n"
+        "---\n"
+        "WI3_MARKDOWN_REPLAY_TOKEN originating systems repo fallback body\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.mark.asyncio
+async def test_db_busy_fallback_returns_deferred_receipt_and_durable_queue(tmp_path):
+    """DB-busy is a real fallback condition: brain_store returns a loud queue receipt."""
+    from brainlayer.mcp.store_handler import _store
+
+    queue_dir = tmp_path / "queue"
+
+    with (
+        patch("brainlayer.mcp.store_handler._get_vector_store", return_value=MagicMock()),
+        patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="systems"),
+        patch("brainlayer.store.store_memory", side_effect=apsw.BusyError("database is locked")),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+    ):
+        texts, structured = await _store(
+            content="WI3_DB_BUSY_QUEUE_TOKEN systems fallback write",
+            memory_type="note",
+            project="systems",
+            tags=["wi3", "db-busy"],
+        )
+
+    queue_files = list(queue_dir.glob("mcp-*.jsonl"))
+    event = json.loads(queue_files[0].read_text(encoding="utf-8"))
+
+    assert structured["status"] == "DEFERRED"
+    assert structured["deferred"]["reason"] == "DB_BUSY"
+    assert structured["deferred"]["action"] == "queued_for_drain"
+    assert structured["chunk_id"] == event["chunk_id"]
+    assert event["project"] == "systems"
+    assert event["source"] == "mcp"
+    assert any("queued" in text.text.lower() for text in texts)
+
+
+def test_transport_closed_jsonl_replay_preserves_original_chunk_origin(tmp_path, monkeypatch):
+    """A queued transport fallback must land with BEFORE chunk_origin preserved AFTER drain."""
+    from brainlayer.drain import drain_once
+    from brainlayer.queue_io import enqueue_store
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    VectorStore(db_path).close()
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    queue_file = enqueue_store(
+        chunk_id="manual-wi3-jsonl-origin",
+        content="WI3_JSONL_REPLAY_TOKEN originating systems repo queued write",
+        memory_type="note",
+        project="systems",
+        tags=["wi3", "transport-closed"],
+        importance=7,
+        chunk_origin=CHUNK_ORIGIN_USER_EXPLICIT,
+        queue_dir=queue_dir,
+    )
+    before_event = json.loads(queue_file.read_text(encoding="utf-8"))
+
+    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log")
+
+    with VectorStore(db_path) as store:
+        row = store.conn.cursor().execute(
+            "SELECT project, source, source_file, chunk_origin FROM chunks WHERE id = ?",
+            ("manual-wi3-jsonl-origin",),
+        ).fetchone()
+
+    assert before_event["project"] == "systems"
+    assert before_event["chunk_origin"] == CHUNK_ORIGIN_USER_EXPLICIT
+    assert drained == 1
+    assert row == ("systems", "mcp", "brainlayer-queue", CHUNK_ORIGIN_USER_EXPLICIT)
+
+
+def test_markdown_fallback_replay_preserves_origin_repo_and_chunk_origin(tmp_path):
+    """Markdown fallback replay must not re-stamp originating repo attribution to unknown."""
+    from brainlayer.fallback_replay import parse_fallback_file, replay_entry
+    from brainlayer.store import store_memory
+    from brainlayer.vector_store import VectorStore
+
+    repo = tmp_path / "systems"
+    _git_init(repo)
+    fallback_path = _write_markdown_fallback(repo, chunk_origin=CHUNK_ORIGIN_AGENT_EXPLICIT)
+    db_path = tmp_path / "brainlayer.db"
+
+    entry = parse_fallback_file(fallback_path)
+    with VectorStore(db_path) as store:
+        result = replay_entry(
+            entry,
+            store_func=lambda **kwargs: store_memory(store=store, embed_fn=None, **kwargs),
+            replayed_by="wi3-test",
+        )
+        row = store.conn.cursor().execute(
+            "SELECT project, chunk_origin, metadata FROM chunks WHERE id = ?",
+            (result.chunk_id,),
+        ).fetchone()
+
+    metadata = json.loads(row[2])
+    assert result.error is None
+    assert row[0] == "systems"
+    assert row[1] == CHUNK_ORIGIN_AGENT_EXPLICIT
+    assert metadata["origin_repo_path"] == str(repo.resolve())
+    assert metadata["fallback_source_path"] == str(fallback_path)
+    assert metadata["replayed_by"] == "wi3-test"
+
+
+def test_legacy_pending_store_empty_chunk_id_lands_with_origin_and_is_queryable(tmp_path):
+    """Legacy pending-stores lines with empty chunk_id still replay to a searchable row."""
+    from brainlayer.mcp.store_handler import _flush_pending_stores
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    pending_path = tmp_path / "pending-stores.jsonl"
+    token = "WI3_EMPTY_CHUNK_ID_QUERYABLE_TOKEN"
+    pending_path.write_text(
+        json.dumps(
+            {
+                "chunk_id": "",
+                "content": f"{token} originating systems repo legacy fallback",
+                "memory_type": "note",
+                "project": "systems",
+                "tags": ["wi3", "empty-chunk-id"],
+                "chunk_origin": CHUNK_ORIGIN_USER_EXPLICIT,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with VectorStore(db_path) as store:
+        with patch("brainlayer.mcp.store_handler._get_pending_store_path", return_value=pending_path):
+            flushed = _flush_pending_stores(store, None)
+        row = store.conn.cursor().execute(
+            "SELECT id, project, chunk_origin FROM chunks WHERE content LIKE ?",
+            (f"%{token}%",),
+        ).fetchone()
+        results = store.search(query_text=token, n_results=5)
+
+    assert flushed == 1
+    assert row[0].startswith("manual-")
+    assert row[1:] == ("systems", CHUNK_ORIGIN_USER_EXPLICIT)
+    assert row[0] in results["ids"][0]
+
+
+def test_metadata_only_queued_origin_is_preserved_for_old_fallback_events(tmp_path, monkeypatch):
+    """Old queued files may only have metadata.chunk_origin; drain must still preserve it."""
+    from brainlayer.drain import drain_once
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    VectorStore(db_path).close()
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    (queue_dir / "mcp-metadata-origin.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "store_memory",
+                "chunk_id": "manual-wi3-metadata-origin",
+                "content": "WI3_METADATA_ONLY_ORIGIN_TOKEN originating systems repo queued write",
+                "memory_type": "note",
+                "project": "systems",
+                "metadata": {"chunk_origin": CHUNK_ORIGIN_USER_EXPLICIT},
+                "source": "mcp",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log")
+
+    with VectorStore(db_path) as store:
+        row = store.conn.cursor().execute(
+            "SELECT project, chunk_origin FROM chunks WHERE id = ?",
+            ("manual-wi3-metadata-origin",),
+        ).fetchone()
+
+    assert drained == 1
+    assert row == ("systems", CHUNK_ORIGIN_USER_EXPLICIT)
+
+
+def test_deferred_mcp_row_stays_raw_etan_direct_with_high_enrichment_cap(tmp_path, monkeypatch):
+    """Deferred MCP queue rows remain direct user-authored provenance after enrichment."""
+    from brainlayer import enrichment_controller as controller
+    from brainlayer.provenance_integration import resolve_entity_conflicts
+    from brainlayer.vector_store import VectorStore
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "100000")
+    db_path = tmp_path / "brainlayer.db"
+    chunk = {
+        "id": "chunk-wi3-deferred-mcp-queue",
+        "content": "WI3_PRIMARY_BACKEND: Groq",
+        "metadata": {},
+        "source_file": "brainlayer-queue",
+        "project": "brainlayer",
+        "content_type": "note",
+        "value_type": "HIGH",
+        "char_count": len("WI3_PRIMARY_BACKEND: Groq"),
+        "source": "mcp",
+        "sender": None,
+        "created_at": "2026-06-14T00:00:00Z",
+    }
+
+    with VectorStore(db_path) as store:
+        store.upsert_chunks([chunk], [[0.01] * 1024])
+        controller._apply_enrichment(store, chunk, {"summary": "queued MCP store", "entities": []})
+        store.upsert_entity("e-wi3-enrichment", "concept", "enrichment", canonical_name="enrichment")
+        store.link_entity_chunk(
+            "e-wi3-enrichment",
+            chunk["id"],
+            context="WI3_PRIMARY_BACKEND: Groq",
+            mention_type="explicit",
+        )
+
+        row = store.conn.cursor().execute(
+            "SELECT source, source_file, provenance_class FROM chunks WHERE id = ?",
+            (chunk["id"],),
+        ).fetchone()
+        report = resolve_entity_conflicts(store, "enrichment", dry_run=True)
+        results = store.search(query_text="WI3_PRIMARY_BACKEND", n_results=5, source_filter="mcp")
+
+    authoritative = report.resolutions["WI3_PRIMARY_BACKEND"].authoritative
+    assert row == ("mcp", "brainlayer-queue", "RAW-ETAN-DIRECT")
+    assert authoritative is not None
+    assert authoritative.id == chunk["id"]
+    assert authoritative.provenance_class == "RAW-ETAN-DIRECT"
+    assert authoritative.user_anchored is True
+    assert results["ids"] == [[chunk["id"]]]
+    assert results["metadatas"][0][0]["provenance_class"] == "RAW-ETAN-DIRECT"


### PR DESCRIPTION
Fallback/queue replay now preserves the ORIGINAL chunk_origin instead of re-detecting from content (prevents attribution loss / stranded writes). Rebased onto merged WI-1+WI-2; coexistence suite 126 passed. Happy Camper gen-16 step 3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provenance fields on durable write/replay paths; scope is narrow and well-tested, but wrong attribution would affect search and conflict resolution downstream.
> 
> **Overview**
> Queued and replayed memory writes now **keep the original `chunk_origin`** instead of re-deriving it from body text at drain/replay time, so transport-close, DB-busy, and markdown fallback paths do not lose user/agent explicit attribution.
> 
> **`chunk_origin`** is threaded end-to-end: optional on `store_memory`, serialized on `enqueue_store`, read from queue events (top-level or `metadata.chunk_origin`) in **drain** and **`_flush_pending_stores`**, and forwarded from markdown fallback frontmatter in **`replay_entry`**. **`detect_chunk_origin(content, explicit)`** still applies when no explicit value is present.
> 
> Adds **WI-3 smoke tests** covering JSONL drain, markdown replay, legacy `pending-stores.jsonl`, metadata-only queued origin, and deferred MCP provenance after enrichment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526724c130ff58e1261b0118cc97c8dad608fa97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve original chunk attribution through fallback replay and store pipeline
> - [`store_memory`](https://github.com/EtanHey/brainlayer/pull/482/files#diff-3f4ff41bcf437c9376f0c0bc397eca30e1b05c0d75d4e95ef1579366d7c4c707) now accepts an explicit `chunk_origin` parameter, passing it to `detect_chunk_origin` instead of always auto-detecting from content.
> - [`replay_entry`](https://github.com/EtanHey/brainlayer/pull/482/files#diff-59dfac125f20ef3cc711ac4bb09b2ae4821c87807166b698ea0ef9babddcf115) propagates `chunk_origin` from markdown frontmatter to the store function during fallback replay.
> - [`enqueue_store`](https://github.com/EtanHey/brainlayer/pull/482/files#diff-2867bea29e6832d2011b2e5f6e00fa8212abf0e059278a6cb08fda52bdae2de6) extracts `chunk_origin` from metadata and promotes it to a top-level field in the queued JSON payload.
> - [`_flush_pending_stores`](https://github.com/EtanHey/brainlayer/pull/482/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263) and [`_apply_store`](https://github.com/EtanHey/brainlayer/pull/482/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) resolve `chunk_origin` from both top-level and nested metadata fields when processing queued events.
> - New test module [`test_transport_replay_attribution.py`](https://github.com/EtanHey/brainlayer/pull/482/files#diff-3ff37d68e176d1f4ce9e9e7dee405e678009b2b5dc8f686f509a519e7aab80f8) covers queue receipts, JSONL origin preservation, markdown fallback attribution, and legacy replay edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 526724c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->