### PR TITLE
fix(reembed): backfill ~118.5K unvectored chunks (keyset-paginated MPS bge-large) [AT-RISK: live drain, do-not-merge-yet]

### DIFF
--- a/docs/plans/2026-06-14-reembed-unvectored-backlog.md
+++ b/docs/plans/2026-06-14-reembed-unvectored-backlog.md
@@ -1,0 +1,61 @@
+# Reembed Unvectored Backlog Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Clear the cold semantic backlog by embedding every active chunk that has no vector, regardless of source.
+
+**Architecture:** Add a reusable pending-vector backfill module that counts/selects active unvectored chunks, batch-encodes content with the local BGE model, and writes both float and binary vector rows through the existing vector upsert path. Update the daemon backfill to use the same all-source pending selection and batch embedding adapter.
+
+**Tech Stack:** Python, APSW/sqlite-vec, Typer CLI, sentence-transformers `BAAI/bge-large-en-v1.5`, pytest.
+
+---
+
+### Task 1: Daemon Backfill Widening
+
+**Files:**
+- Modify: `src/brainlayer/store.py`
+- Test: `tests/test_deferred_embedding.py`
+
+**Steps:**
+1. Write a failing test proving `embed_pending_chunks()` embeds unvectored `claude_code` and `realtime_watcher` chunks, not just `manual`/`mcp`.
+2. Write a failing test proving archived/superseded/aggregated chunks are skipped.
+3. Write a failing test proving a batch-capable embedder receives one list call rather than per-row calls.
+4. Update `embed_pending_chunks()` to select all active sources and use batch encoding when the supplied embedder supports it.
+5. Run the focused deferred embedding tests.
+
+### Task 2: One-Time Backfill CLI
+
+**Files:**
+- Create: `src/brainlayer/reembed_backfill.py`
+- Modify: `src/brainlayer/cli/__init__.py`
+- Test: `tests/test_reembed_backfill.py`
+
+**Steps:**
+1. Write failing tests for active unvectored chunk counting, batch selection, idempotent skip behavior, and both vector table writes.
+2. Implement count/select/write helpers around `VectorStore`.
+3. Implement `run_reembed_backfill()` with dry-run/test-limit support, progress logging, throughput, and resumability by querying only missing vectors.
+4. Add `brainlayer reembed-backfill` CLI command.
+5. Run focused backfill tests and CLI help/import checks.
+
+### Task 3: Live Backfill Run
+
+**Files:**
+- No code changes expected.
+
+**Steps:**
+1. Verify the heavy-ML mutex by checking for `llama-server`, `ollama`, `whisper`, `mlx`, and enrichment processes.
+2. Count active unvectored chunks before the run.
+3. Run the backfill with conservative batch size on MPS when available.
+4. Monitor RAM/swap and lower batch size if memory pressure rises.
+5. Count active unvectored chunks after the run and spot-check semantic retrieval.
+
+### Task 4: Completion
+
+**Files:**
+- Commit all changes on `fix/reembed-unvectored-backlog`.
+
+**Steps:**
+1. Run relevant focused tests, then `pytest` if feasible.
+2. Store the implementation decision and measured outcome in BrainLayer.
+3. Post DONE/BLOCKED evidence to gen-16 if cmux is reachable.
+4. Commit and push with `--no-verify` only; do not merge.

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -289,6 +289,62 @@ def context(
         raise typer.Exit(1)
 
 
+@app.command("reembed-backfill")
+def reembed_backfill_command(
+    db: Optional[Path] = typer.Option(None, "--db", help="Path to brainlayer.db"),
+    batch_size: int = typer.Option(64, "--batch-size", help="Model encode batch size", min=1),
+    limit: Optional[int] = typer.Option(None, "--limit", help="Maximum chunks to embed in this run", min=1),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Count pending chunks without loading the model"),
+    include_inactive: bool = typer.Option(
+        False,
+        "--include-inactive",
+        help="Also embed archived, superseded, and aggregated chunks",
+    ),
+    progress_every: int = typer.Option(10, "--progress-every", help="Log progress every N batches", min=1),
+    model_name: str = typer.Option("BAAI/bge-large-en-v1.5", "--model", help="Sentence-transformers model name"),
+    skip_heavy_ml_check: bool = typer.Option(
+        False,
+        "--skip-heavy-ml-check",
+        help="Bypass the local heavy-ML process mutex check",
+    ),
+) -> None:
+    """Batch-embed active chunks that are missing semantic vectors."""
+    from ..reembed_backfill import find_heavy_ml_processes, run_reembed_backfill
+
+    db_path = db or get_db_path()
+
+    if not dry_run and not skip_heavy_ml_check:
+        conflicts = find_heavy_ml_processes()
+        if conflicts:
+            rprint("[red]Heavy-ML mutex blocked reembed-backfill.[/]")
+            rprint("[yellow]Stop these processes or rerun only when they are idle:[/]")
+            for conflict in conflicts:
+                rprint(f"  {conflict}")
+            raise typer.Exit(2)
+
+    result = run_reembed_backfill(
+        db_path=db_path,
+        model_name=model_name,
+        batch_size=batch_size,
+        limit=limit,
+        dry_run=dry_run,
+        include_inactive=include_inactive,
+        progress_every=progress_every,
+    )
+
+    scope = "all chunks" if include_inactive else "active chunks"
+    if dry_run:
+        rprint(f"Unvectored {scope}: {result.before_count}")
+        return
+
+    rprint(f"Before unvectored {scope}: {result.before_count}")
+    rprint(f"After unvectored {scope}: {result.after_count}")
+    rprint(f"Processed: {result.processed}")
+    rprint(f"Failed: {result.failed}")
+    rprint(f"Throughput: {result.chunks_per_second:.1f} chunks/sec")
+    rprint(f"Wall-clock: {result.elapsed_seconds:.1f}s")
+
+
 # Known project renames/aliases - map old names to canonical names
 # Example: pre-monorepo standalone repos → monorepo
 PROJECT_ALIASES: dict[str, str] = {

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import logging
 import re as _re
 import sys
 import time
@@ -312,6 +313,8 @@ def reembed_backfill_command(
     from ..reembed_backfill import find_heavy_ml_processes, run_reembed_backfill
 
     db_path = db or get_db_path()
+    if not dry_run:
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     if not dry_run and not skip_heavy_ml_check:
         conflicts = find_heavy_ml_processes()

--- a/src/brainlayer/embeddings.py
+++ b/src/brainlayer/embeddings.py
@@ -115,6 +115,23 @@ class EmbeddingModel:
         except Exception as e:
             raise RuntimeError(f"Failed to embed query: {e}") from e
 
+    def embed_texts(self, texts: List[str], batch_size: int = 64) -> List[List[float]]:
+        """Generate passage embeddings for stored chunk content in batches."""
+        if not texts:
+            return []
+
+        model = self._load_model()
+        try:
+            embeddings = model.encode(
+                texts,
+                batch_size=batch_size,
+                convert_to_numpy=True,
+                show_progress_bar=False,
+            )
+            return [embedding.tolist() for embedding in embeddings]
+        except Exception as e:
+            raise RuntimeError(f"Failed to embed text batch: {e}") from e
+
 
 # Global model instance
 _embedding_model: Optional[EmbeddingModel] = None

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -712,7 +712,12 @@ async def _store(
                 bg_store = _VS(db_path)
                 model = _get_embedding_model()
                 embed_fn = model.embed_query
-                count = embed_pending_chunks(store=bg_store, embed_fn=embed_fn)
+                count = embed_pending_chunks(
+                    store=bg_store,
+                    embed_fn=embed_fn,
+                    batch_size=64,
+                    embed_batch_fn=lambda texts: model.embed_texts(texts, batch_size=64),
+                )
                 if count > 0:
                     logger.info("Embedded %d pending chunks", count)
                 _flush_pending_stores(bg_store, embed_fn)

--- a/src/brainlayer/reembed_backfill.py
+++ b/src/brainlayer/reembed_backfill.py
@@ -187,9 +187,7 @@ def find_heavy_ml_processes() -> list[str]:
         executable_name = Path(executable).name.lower()
         argv0_name = Path(argv0).name.lower()
         lower = command.lower()
-        executable_match = any(
-            pattern in executable_name or pattern in argv0_name for pattern in HEAVY_ML_EXECUTABLES
-        )
+        executable_match = any(pattern in executable_name or pattern in argv0_name for pattern in HEAVY_ML_EXECUTABLES)
         python_executable = "python" in executable_name or "python" in argv0_name
         python_mlx = python_executable and any(marker in lower for marker in HEAVY_ML_PYTHON_MARKERS)
         python_entrypoint = ""

--- a/src/brainlayer/reembed_backfill.py
+++ b/src/brainlayer/reembed_backfill.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shlex
 import subprocess
 import time
 from dataclasses import dataclass
@@ -181,7 +182,17 @@ def find_heavy_ml_processes() -> list[str]:
         )
         python_executable = "python" in executable_name or "python" in argv0_name
         python_mlx = python_executable and any(marker in lower for marker in HEAVY_ML_PYTHON_MARKERS)
-        python_embed = python_executable and "embed" in lower
+        python_entrypoint = ""
+        if python_executable:
+            try:
+                tokens = shlex.split(command)
+            except ValueError:
+                tokens = command.split()
+            if len(tokens) >= 3 and tokens[1] == "-m":
+                python_entrypoint = tokens[2]
+            elif len(tokens) >= 2:
+                python_entrypoint = Path(tokens[1]).name
+        python_embed = python_executable and "embed" in python_entrypoint.lower()
         if executable_match or python_mlx or python_embed:
             matches.append(stripped)
     return matches

--- a/src/brainlayer/reembed_backfill.py
+++ b/src/brainlayer/reembed_backfill.py
@@ -26,7 +26,6 @@ HEAVY_ML_PYTHON_MARKERS = (
     "mlx_audio.tts.generate",
     "mlx_lm.server",
     "brainlayer.reembed_backfill",
-    "python.*embed",
 )
 
 
@@ -173,11 +172,16 @@ def find_heavy_ml_processes() -> list[str]:
         pid, executable, command = parts
         if pid == current_pid:
             continue
+        argv0 = command.split(None, 1)[0] if command else ""
         executable_name = Path(executable).name.lower()
+        argv0_name = Path(argv0).name.lower()
         lower = command.lower()
-        executable_match = any(pattern in executable_name for pattern in HEAVY_ML_EXECUTABLES)
-        python_mlx = "python" in executable_name and any(marker in lower for marker in HEAVY_ML_PYTHON_MARKERS)
-        python_embed = "python" in executable_name and "embed" in lower
+        executable_match = any(
+            pattern in executable_name or pattern in argv0_name for pattern in HEAVY_ML_EXECUTABLES
+        )
+        python_executable = "python" in executable_name or "python" in argv0_name
+        python_mlx = python_executable and any(marker in lower for marker in HEAVY_ML_PYTHON_MARKERS)
+        python_embed = python_executable and "embed" in lower
         if executable_match or python_mlx or python_embed:
             matches.append(stripped)
     return matches

--- a/src/brainlayer/reembed_backfill.py
+++ b/src/brainlayer/reembed_backfill.py
@@ -1,0 +1,255 @@
+"""Batch re-embed active chunks that are missing semantic vectors."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+
+from .embeddings import DEFAULT_MODEL
+from .vector_store import VectorStore
+
+logger = logging.getLogger(__name__)
+
+HEAVY_ML_PATTERNS = (
+    "llama-server",
+    "ollama",
+    "whisper",
+    "mlx",
+    "brainlayer enrich",
+    "enrichment",
+)
+
+
+class BatchEmbeddingModel(Protocol):
+    def encode(self, texts: list[str], **kwargs: Any) -> Iterable[Any]:
+        """Return one embedding per input text."""
+
+
+@dataclass(frozen=True)
+class PendingChunk:
+    chunk_id: str
+    content: str
+
+
+@dataclass(frozen=True)
+class BackfillResult:
+    before_count: int
+    after_count: int
+    processed: int
+    failed: int
+    elapsed_seconds: float
+
+    @property
+    def chunks_per_second(self) -> float:
+        return self.processed / self.elapsed_seconds if self.elapsed_seconds > 0 else 0.0
+
+
+def _chunk_columns(store: VectorStore) -> set[str]:
+    return {row[1] for row in store.conn.cursor().execute("PRAGMA table_info(chunks)")}
+
+
+def _active_lifecycle_clauses(store: VectorStore) -> list[str]:
+    columns = _chunk_columns(store)
+    clauses = []
+    if "archived_at" in columns:
+        clauses.append("c.archived_at IS NULL")
+    if "superseded_by" in columns:
+        clauses.append("c.superseded_by IS NULL")
+    if "aggregated_into" in columns:
+        clauses.append("c.aggregated_into IS NULL")
+    return clauses
+
+
+def _pending_where_sql(store: VectorStore, *, include_inactive: bool) -> str:
+    clauses = [
+        "v.chunk_id IS NULL",
+        "c.content IS NOT NULL",
+        "c.content != ''",
+    ]
+    if not include_inactive:
+        clauses.extend(_active_lifecycle_clauses(store))
+    return " AND ".join(clauses)
+
+
+def count_unvectored_chunks(store: VectorStore, *, include_inactive: bool = False) -> int:
+    """Count chunks with no float vector row.
+
+    By default this matches normal semantic search eligibility and skips
+    archived, superseded, and aggregated lifecycle rows.
+    """
+    where_sql = _pending_where_sql(store, include_inactive=include_inactive)
+    return int(
+        store.conn.cursor()
+        .execute(
+            f"""
+            SELECT COUNT(*)
+            FROM chunks c
+            LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
+            WHERE {where_sql}
+            """
+        )
+        .fetchone()[0]
+    )
+
+
+def fetch_unvectored_batch(
+    store: VectorStore,
+    *,
+    batch_size: int,
+    include_inactive: bool = False,
+) -> list[PendingChunk]:
+    """Fetch the next resumable batch of active chunks missing vectors."""
+    where_sql = _pending_where_sql(store, include_inactive=include_inactive)
+    rows = store.conn.cursor().execute(
+        f"""
+        SELECT c.id, c.content
+        FROM chunks c
+        LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
+        WHERE {where_sql}
+        ORDER BY c.created_at ASC, c.id ASC
+        LIMIT ?
+        """,
+        (batch_size,),
+    )
+    return [PendingChunk(chunk_id=str(chunk_id), content=str(content)) for chunk_id, content in rows]
+
+
+def _to_float_list(embedding: Any) -> list[float]:
+    if hasattr(embedding, "tolist"):
+        embedding = embedding.tolist()
+    return [float(value) for value in embedding]
+
+
+def write_chunk_embeddings(store: VectorStore, chunks: list[PendingChunk], embeddings: Iterable[Any]) -> int:
+    """Write float and binary vectors for a batch, returning successful rows."""
+    cursor = store.conn.cursor()
+    written = 0
+    for chunk, embedding in zip(chunks, embeddings):
+        try:
+            store._upsert_chunk_vector(cursor, chunk.chunk_id, _to_float_list(embedding))
+            written += 1
+        except Exception as exc:
+            logger.warning("Failed to write embedding for %s: %s", chunk.chunk_id, exc)
+    return written
+
+
+def load_embedding_model(model_name: str = DEFAULT_MODEL):
+    """Load the sentence-transformers model on MPS when available."""
+    import torch
+    from sentence_transformers import SentenceTransformer
+
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    logger.info("Loading %s on %s", model_name, device)
+    return SentenceTransformer(model_name, device=device)
+
+
+def find_heavy_ml_processes() -> list[str]:
+    """Return running heavy-ML process command lines that should block this job."""
+    try:
+        result = subprocess.run(["ps", "-axo", "pid=,command="], capture_output=True, text=True, check=True)
+    except Exception as exc:
+        logger.warning("Unable to inspect process list for heavy-ML mutex: %s", exc)
+        return []
+
+    current_pid = str(os.getpid())
+    matches = []
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        pid, _, command = stripped.partition(" ")
+        if pid == current_pid:
+            continue
+        lower = command.lower()
+        if any(pattern in lower for pattern in HEAVY_ML_PATTERNS):
+            matches.append(stripped)
+    return matches
+
+
+def run_reembed_backfill(
+    *,
+    db_path: str | Path,
+    model: BatchEmbeddingModel | None = None,
+    model_name: str = DEFAULT_MODEL,
+    batch_size: int = 64,
+    limit: int | None = None,
+    dry_run: bool = False,
+    include_inactive: bool = False,
+    progress_every: int = 10,
+) -> BackfillResult:
+    """Batch-embed all chunks missing vectors.
+
+    The run is resumable because each batch is selected with a LEFT JOIN against
+    `chunk_vectors`; reruns skip rows that already received vectors.
+    """
+    store = VectorStore(db_path)
+    start = time.monotonic()
+    processed = 0
+    failed = 0
+    before_count = count_unvectored_chunks(store, include_inactive=include_inactive)
+
+    try:
+        if dry_run or before_count == 0:
+            elapsed = time.monotonic() - start
+            return BackfillResult(
+                before_count=before_count,
+                after_count=before_count,
+                processed=0,
+                failed=0,
+                elapsed_seconds=elapsed,
+            )
+
+        active_model = model or load_embedding_model(model_name)
+        batch_number = 0
+        while True:
+            remaining_limit = None if limit is None else max(limit - processed, 0)
+            if remaining_limit == 0:
+                break
+            effective_batch_size = batch_size if remaining_limit is None else min(batch_size, remaining_limit)
+            chunks = fetch_unvectored_batch(
+                store,
+                batch_size=effective_batch_size,
+                include_inactive=include_inactive,
+            )
+            if not chunks:
+                break
+
+            texts = [chunk.content for chunk in chunks]
+            embeddings = active_model.encode(
+                texts,
+                batch_size=effective_batch_size,
+                convert_to_numpy=True,
+                show_progress_bar=False,
+            )
+            written = write_chunk_embeddings(store, chunks, embeddings)
+            processed += written
+            failed += len(chunks) - written
+            batch_number += 1
+
+            if batch_number % progress_every == 0:
+                elapsed = time.monotonic() - start
+                rate = processed / elapsed if elapsed > 0 else 0.0
+                logger.info(
+                    "Reembed backfill progress: processed=%d failed=%d remaining=%d rate=%.1f chunks/s",
+                    processed,
+                    failed,
+                    count_unvectored_chunks(store, include_inactive=include_inactive),
+                    rate,
+                )
+
+        after_count = count_unvectored_chunks(store, include_inactive=include_inactive)
+        elapsed = time.monotonic() - start
+        return BackfillResult(
+            before_count=before_count,
+            after_count=after_count,
+            processed=processed,
+            failed=failed,
+            elapsed_seconds=elapsed,
+        )
+    finally:
+        store.close()

--- a/src/brainlayer/reembed_backfill.py
+++ b/src/brainlayer/reembed_backfill.py
@@ -15,13 +15,18 @@ from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
 
-HEAVY_ML_PATTERNS = (
+HEAVY_ML_EXECUTABLES = (
     "llama-server",
     "ollama",
     "whisper",
-    "mlx",
-    "brainlayer enrich",
-    "enrichment",
+    "whisper-server",
+    "mlx_lm.server",
+)
+HEAVY_ML_PYTHON_MARKERS = (
+    "mlx_audio.tts.generate",
+    "mlx_lm.server",
+    "brainlayer.reembed_backfill",
+    "python.*embed",
 )
 
 
@@ -151,7 +156,7 @@ def load_embedding_model(model_name: str = DEFAULT_MODEL):
 def find_heavy_ml_processes() -> list[str]:
     """Return running heavy-ML process command lines that should block this job."""
     try:
-        result = subprocess.run(["ps", "-axo", "pid=,command="], capture_output=True, text=True, check=True)
+        result = subprocess.run(["ps", "-axo", "pid=,comm=,args="], capture_output=True, text=True, check=True)
     except Exception as exc:
         logger.warning("Unable to inspect process list for heavy-ML mutex: %s", exc)
         return []
@@ -162,11 +167,18 @@ def find_heavy_ml_processes() -> list[str]:
         stripped = line.strip()
         if not stripped:
             continue
-        pid, _, command = stripped.partition(" ")
+        parts = stripped.split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid, executable, command = parts
         if pid == current_pid:
             continue
+        executable_name = Path(executable).name.lower()
         lower = command.lower()
-        if any(pattern in lower for pattern in HEAVY_ML_PATTERNS):
+        executable_match = any(pattern in executable_name for pattern in HEAVY_ML_EXECUTABLES)
+        python_mlx = "python" in executable_name and any(marker in lower for marker in HEAVY_ML_PYTHON_MARKERS)
+        python_embed = "python" in executable_name and "embed" in lower
+        if executable_match or python_mlx or python_embed:
             matches.append(stripped)
     return matches
 

--- a/src/brainlayer/reembed_backfill.py
+++ b/src/brainlayer/reembed_backfill.py
@@ -72,7 +72,7 @@ def _active_lifecycle_clauses(store: VectorStore) -> list[str]:
 
 def _pending_where_sql(store: VectorStore, *, include_inactive: bool) -> str:
     clauses = [
-        "v.chunk_id IS NULL",
+        "r.id IS NULL",
         "c.content IS NOT NULL",
         "c.content != ''",
     ]
@@ -94,7 +94,7 @@ def count_unvectored_chunks(store: VectorStore, *, include_inactive: bool = Fals
             f"""
             SELECT COUNT(*)
             FROM chunks c
-            LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
+            LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
             WHERE {where_sql}
             """
         )
@@ -114,7 +114,7 @@ def fetch_unvectored_batch(
         f"""
         SELECT c.id, c.content
         FROM chunks c
-        LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
+        LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
         WHERE {where_sql}
         ORDER BY c.created_at ASC, c.id ASC
         LIMIT ?
@@ -134,13 +134,23 @@ def write_chunk_embeddings(store: VectorStore, chunks: list[PendingChunk], embed
     """Write float and binary vectors for a batch, returning successful rows."""
     cursor = store.conn.cursor()
     written = 0
-    for chunk, embedding in zip(chunks, embeddings):
-        try:
-            store._upsert_chunk_vector(cursor, chunk.chunk_id, _to_float_list(embedding))
-            written += 1
-        except Exception as exc:
-            logger.warning("Failed to write embedding for %s: %s", chunk.chunk_id, exc)
-    return written
+    transaction_started = False
+    try:
+        cursor.execute("BEGIN IMMEDIATE")
+        transaction_started = True
+        for chunk, embedding in zip(chunks, embeddings):
+            try:
+                store._upsert_chunk_vector(cursor, chunk.chunk_id, _to_float_list(embedding))
+                written += 1
+            except Exception as exc:
+                logger.warning("Failed to write embedding for %s: %s", chunk.chunk_id, exc)
+        cursor.execute("COMMIT")
+        transaction_started = False
+        return written
+    except Exception:
+        if transaction_started:
+            cursor.execute("ROLLBACK")
+        raise
 
 
 def load_embedding_model(model_name: str = DEFAULT_MODEL):
@@ -208,6 +218,7 @@ def run_reembed_backfill(
     dry_run: bool = False,
     include_inactive: bool = False,
     progress_every: int = 10,
+    candidate_page_size: int | None = None,
 ) -> BackfillResult:
     """Batch-embed all chunks missing vectors.
 
@@ -233,39 +244,64 @@ def run_reembed_backfill(
 
         active_model = model or load_embedding_model(model_name)
         batch_number = 0
+        page_size = candidate_page_size or max(batch_size * 64, 4096)
         while True:
             remaining_limit = None if limit is None else max(limit - processed, 0)
             if remaining_limit == 0:
                 break
-            effective_batch_size = batch_size if remaining_limit is None else min(batch_size, remaining_limit)
-            chunks = fetch_unvectored_batch(
+            effective_page_size = page_size if remaining_limit is None else min(page_size, remaining_limit)
+            candidate_start = time.monotonic()
+            candidates = fetch_unvectored_batch(
                 store,
-                batch_size=effective_batch_size,
+                batch_size=effective_page_size,
                 include_inactive=include_inactive,
             )
-            if not chunks:
+            candidate_query_ms = (time.monotonic() - candidate_start) * 1000
+            if not candidates:
                 break
 
-            texts = [chunk.content for chunk in chunks]
-            embeddings = active_model.encode(
-                texts,
-                batch_size=effective_batch_size,
-                convert_to_numpy=True,
-                show_progress_bar=False,
-            )
-            written = write_chunk_embeddings(store, chunks, embeddings)
-            processed += written
-            failed += len(chunks) - written
-            batch_number += 1
+            for offset in range(0, len(candidates), batch_size):
+                remaining_limit = None if limit is None else max(limit - processed, 0)
+                if remaining_limit == 0:
+                    break
+                effective_batch_size = batch_size if remaining_limit is None else min(batch_size, remaining_limit)
+                chunks = candidates[offset : offset + effective_batch_size]
+                if not chunks:
+                    break
 
-            if batch_number % progress_every == 0:
+                texts = [chunk.content for chunk in chunks]
+                encode_start = time.monotonic()
+                embeddings = active_model.encode(
+                    texts,
+                    batch_size=len(chunks),
+                    convert_to_numpy=True,
+                    show_progress_bar=False,
+                )
+                encode_ms = (time.monotonic() - encode_start) * 1000
+
+                write_start = time.monotonic()
+                written = write_chunk_embeddings(store, chunks, embeddings)
+                vector_write_ms = (time.monotonic() - write_start) * 1000
+
+                processed += written
+                failed += len(chunks) - written
+                batch_number += 1
                 elapsed = time.monotonic() - start
                 rate = processed / elapsed if elapsed > 0 else 0.0
                 logger.info(
-                    "Reembed backfill progress: processed=%d failed=%d remaining=%d rate=%.1f chunks/s",
+                    (
+                        "Reembed backfill batch: batch=%d size=%d written=%d "
+                        "candidate_query_ms=%.1f encode_ms=%.1f vector_write_ms=%.1f "
+                        "processed=%d failed=%d rate=%.1f chunks/s"
+                    ),
+                    batch_number,
+                    len(chunks),
+                    written,
+                    candidate_query_ms if offset == 0 else 0.0,
+                    encode_ms,
+                    vector_write_ms,
                     processed,
                     failed,
-                    count_unvectored_chunks(store, include_inactive=include_inactive),
                     rate,
                 )
 

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -348,16 +348,22 @@ def embed_pending_chunks(
     store: VectorStore,
     embed_fn: Callable[[str], List[float]],
     batch_size: int = 50,
+    embed_batch_fn: Optional[Callable[[List[str]], List[List[float]]]] = None,
 ) -> int:
     """Backfill embeddings for chunks stored without them.
 
     Finds chunks in the chunks table that have no corresponding row in
-    chunk_vectors and generates embeddings for them.
+    chunk_vectors and generates embeddings for them. Only active lifecycle
+    rows are eligible; archived, superseded, and aggregated chunks are
+    intentionally skipped because normal semantic search excludes them.
 
     Args:
         store: VectorStore instance.
         embed_fn: Function that takes text and returns a 1024-dim embedding vector.
         batch_size: Max chunks to process in one call.
+        embed_batch_fn: Optional function that takes a list of texts and returns
+            one 1024-dim embedding vector per text. When provided, the daemon
+            embeds the selected rows in one model batch instead of one row at a time.
 
     Returns:
         Number of chunks embedded.
@@ -368,7 +374,12 @@ def embed_pending_chunks(
             """
             SELECT c.id, c.content FROM chunks c
             LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
-            WHERE v.chunk_id IS NULL AND c.source IN ('manual', 'mcp')
+            WHERE v.chunk_id IS NULL
+              AND c.content IS NOT NULL
+              AND c.content != ''
+              AND c.archived_at IS NULL
+              AND c.superseded_by IS NULL
+              AND c.aggregated_into IS NULL
             ORDER BY c.created_at ASC
             LIMIT ?
             """,
@@ -380,13 +391,24 @@ def embed_pending_chunks(
         return 0
 
     count = 0
-    for chunk_id, content in rows:
+    if embed_batch_fn is not None:
         try:
-            embedding = embed_fn(content)
-            store._upsert_chunk_vector(cursor, chunk_id, embedding)
-            count += 1
+            embeddings = embed_batch_fn([content for _, content in rows])
+            if len(embeddings) != len(rows):
+                raise ValueError(f"batch embedder returned {len(embeddings)} embeddings for {len(rows)} chunks")
+            for (chunk_id, _), embedding in zip(rows, embeddings):
+                store._upsert_chunk_vector(cursor, chunk_id, embedding)
+                count += 1
         except Exception as e:
-            logger.warning("Failed to embed chunk %s: %s", chunk_id, e)
+            logger.warning("Failed to embed pending chunk batch: %s", e)
+    else:
+        for chunk_id, content in rows:
+            try:
+                embedding = embed_fn(content)
+                store._upsert_chunk_vector(cursor, chunk_id, embedding)
+                count += 1
+            except Exception as e:
+                logger.warning("Failed to embed chunk %s: %s", chunk_id, e)
 
     from .search_repo import clear_hybrid_search_cache
 

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -45,6 +45,23 @@ def fast_embed():
     return _embed
 
 
+def _insert_pending_chunk(store: VectorStore, *, chunk_id: str, source: str, content: str | None = None) -> None:
+    cursor = store.conn.cursor()
+    text = content or f"Pending content for {chunk_id}"
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            value_type, char_count, source, created_at, enriched_at, enrich_status,
+            summary, tags, importance, chunk_origin, seen_count, last_seen_at,
+            content_class
+        ) VALUES (?, ?, '{}', 'test.jsonl', 'test', 'note',
+            'HIGH', ?, ?, '2026-06-14T00:00:00+00:00', NULL, NULL,
+            NULL, NULL, NULL, 'raw', 1, '2026-06-14T00:00:00+00:00',
+            'human-authored')""",
+        (chunk_id, text, len(text), source),
+    )
+
+
 class TestDeferredStore:
     """store_memory with embed_fn=None stores without embedding."""
 
@@ -214,6 +231,80 @@ class TestBackgroundEmbedder:
 
         count = embed_pending_chunks(store=store, embed_fn=fast_embed, batch_size=3)
         assert count == 3  # Only processes batch_size items
+
+    def test_embed_pending_chunks_embeds_all_active_sources(self, store, fast_embed):
+        """embed_pending_chunks self-heals active unvectored chunks regardless of source."""
+        from brainlayer.store import embed_pending_chunks
+
+        sources = ["manual", "mcp", "claude_code", "realtime_watcher", "youtube", "whatsapp"]
+        for source in sources:
+            _insert_pending_chunk(store, chunk_id=f"{source}-pending", source=source)
+
+        count = embed_pending_chunks(store=store, embed_fn=fast_embed, batch_size=20)
+
+        assert count == len(sources)
+        cursor = store.conn.cursor()
+        for source in sources:
+            vector_count = cursor.execute(
+                "SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?",
+                (f"{source}-pending",),
+            ).fetchone()[0]
+            assert vector_count == 1, f"{source} chunk was not embedded"
+
+    def test_embed_pending_chunks_skips_inactive_lifecycle_rows(self, store, fast_embed):
+        """Archived, superseded, and aggregated chunks are intentional exclusions."""
+        from brainlayer.store import embed_pending_chunks
+
+        _insert_pending_chunk(store, chunk_id="active-pending", source="claude_code")
+        _insert_pending_chunk(store, chunk_id="archived-pending", source="claude_code")
+        _insert_pending_chunk(store, chunk_id="superseded-pending", source="claude_code")
+        _insert_pending_chunk(store, chunk_id="aggregated-pending", source="claude_code")
+
+        cursor = store.conn.cursor()
+        cursor.execute("UPDATE chunks SET archived_at = '2026-06-14T00:00:00+00:00' WHERE id = 'archived-pending'")
+        cursor.execute("UPDATE chunks SET superseded_by = 'replacement' WHERE id = 'superseded-pending'")
+        cursor.execute("UPDATE chunks SET aggregated_into = 'aggregate' WHERE id = 'aggregated-pending'")
+
+        count = embed_pending_chunks(store=store, embed_fn=fast_embed, batch_size=20)
+
+        assert count == 1
+        embedded_ids = {
+            row[0]
+            for row in cursor.execute(
+                "SELECT chunk_id FROM chunk_vectors WHERE chunk_id LIKE '%-pending' ORDER BY chunk_id"
+            )
+        }
+        assert embedded_ids == {"active-pending"}
+
+    def test_embed_pending_chunks_uses_batch_embedder_when_available(self, store):
+        """Batch-capable callers can avoid per-row model.encode calls."""
+        from brainlayer.store import embed_pending_chunks
+
+        for i in range(4):
+            _insert_pending_chunk(store, chunk_id=f"batch-pending-{i}", source="realtime_watcher")
+
+        single_calls = []
+        batch_calls = []
+
+        def single_embed(text: str) -> list[float]:
+            single_calls.append(text)
+            return [0.0] * 1024
+
+        def batch_embed(texts: list[str]) -> list[list[float]]:
+            batch_calls.append(list(texts))
+            return [[float(i + 1)] * 1024 for i, _ in enumerate(texts)]
+
+        count = embed_pending_chunks(
+            store=store,
+            embed_fn=single_embed,
+            batch_size=4,
+            embed_batch_fn=batch_embed,
+        )
+
+        assert count == 4
+        assert single_calls == []
+        assert len(batch_calls) == 1
+        assert len(batch_calls[0]) == 4
 
 
 class TestMCPStoreDeferred:

--- a/tests/test_deferred_mcp_provenance_guard.py
+++ b/tests/test_deferred_mcp_provenance_guard.py
@@ -12,7 +12,6 @@ from typing import Any
 
 import pytest
 
-
 DIRECT_QUEUE_CASES = [
     pytest.param("manual", "brainlayer-store", "RAW-ETAN-DIRECT", id="manual-brainlayer-store"),
     pytest.param("manual", "brainbar-store", "RAW-ETAN-DIRECT", id="manual-brainbar-store"),

--- a/tests/test_reembed_backfill.py
+++ b/tests/test_reembed_backfill.py
@@ -175,6 +175,9 @@ def test_heavy_ml_mutex_ignores_agent_prompt_text(monkeypatch):
                 "222 /opt/homebrew/bin/llama-server /opt/homebrew/bin/llama-server --model local.gguf",
                 "333 /usr/bin/python3 python -m mlx_audio.tts.generate --model voice",
                 "444 /usr/bin/python3 python scripts/embed_backfill.py",
+                "555 /opt/homebrew/bi /opt/homebrew/bin/whisper-server -m ggml-large-v3-turbo.bin",
+                "666 /Library/Framewo /Library/Frameworks/Python.framework/Versions/3.13/Resources/Python.app/Contents/MacOS/Python /Library/Frameworks/Python.framework/Versions/3.13/bin/mlx_lm.server --model local",
+                "777 /usr/bin/python3 python -m pytest tests/test_deferred_embedding.py -q",
             ]
         )
 
@@ -183,8 +186,10 @@ def test_heavy_ml_mutex_ignores_agent_prompt_text(monkeypatch):
 
     matches = reembed_backfill.find_heavy_ml_processes()
 
-    assert len(matches) == 3
+    assert len(matches) == 5
     assert not any("claude --append-system-prompt" in match for match in matches)
     assert any("llama-server" in match for match in matches)
     assert any("mlx_audio.tts.generate" in match for match in matches)
     assert any("embed_backfill.py" in match for match in matches)
+    assert any("whisper-server" in match for match in matches)
+    assert any("mlx_lm.server" in match for match in matches)

--- a/tests/test_reembed_backfill.py
+++ b/tests/test_reembed_backfill.py
@@ -1,0 +1,165 @@
+"""Tests for the one-time unvectored chunk re-embedding backfill."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from brainlayer._helpers import serialize_f32
+from brainlayer.vector_store import VectorStore
+
+
+def _embed(seed: float) -> list[float]:
+    return [seed + (i / 10000.0) for i in range(1024)]
+
+
+def _insert_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    source: str = "claude_code",
+    content: str | None = None,
+    created_at: str = "2026-06-14T00:00:00+00:00",
+) -> None:
+    text = content or f"Backfill content for {chunk_id}"
+    store.conn.cursor().execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            value_type, char_count, source, created_at, enriched_at, enrich_status,
+            summary, tags, importance, chunk_origin, seen_count, last_seen_at,
+            content_class
+        ) VALUES (?, ?, '{}', 'test.jsonl', 'test', 'note',
+            'HIGH', ?, ?, ?, NULL, NULL,
+            NULL, NULL, NULL, 'raw', 1, ?,
+            'human-authored')""",
+        (chunk_id, text, len(text), source, created_at, created_at),
+    )
+
+
+class FakeBatchModel:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def encode(self, texts, **kwargs):
+        self.calls.append(list(texts))
+        return [_embed(float(i + 1)) for i, _ in enumerate(texts)]
+
+
+def test_count_unvectored_chunks_counts_all_active_sources(tmp_path):
+    from brainlayer.reembed_backfill import count_unvectored_chunks
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        _insert_chunk(store, chunk_id="manual-missing", source="manual")
+        _insert_chunk(store, chunk_id="claude-missing", source="claude_code")
+        _insert_chunk(store, chunk_id="watcher-missing", source="realtime_watcher")
+        _insert_chunk(store, chunk_id="already-vectored", source="youtube")
+        store._upsert_chunk_vector(store.conn.cursor(), "already-vectored", _embed(0.5))
+
+        assert count_unvectored_chunks(store) == 3
+    finally:
+        store.close()
+
+
+def test_count_unvectored_chunks_excludes_inactive_by_default(tmp_path):
+    from brainlayer.reembed_backfill import count_unvectored_chunks
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        _insert_chunk(store, chunk_id="active")
+        _insert_chunk(store, chunk_id="archived")
+        _insert_chunk(store, chunk_id="superseded")
+        _insert_chunk(store, chunk_id="aggregated")
+        cursor = store.conn.cursor()
+        cursor.execute("UPDATE chunks SET archived_at = '2026-06-14T00:00:00+00:00' WHERE id = 'archived'")
+        cursor.execute("UPDATE chunks SET superseded_by = 'replacement' WHERE id = 'superseded'")
+        cursor.execute("UPDATE chunks SET aggregated_into = 'aggregate' WHERE id = 'aggregated'")
+
+        assert count_unvectored_chunks(store) == 1
+        assert count_unvectored_chunks(store, include_inactive=True) == 4
+    finally:
+        store.close()
+
+
+def test_fetch_unvectored_batch_is_resumable_and_ordered(tmp_path):
+    from brainlayer.reembed_backfill import fetch_unvectored_batch
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        _insert_chunk(store, chunk_id="later", created_at="2026-06-14T00:00:03+00:00")
+        _insert_chunk(store, chunk_id="earlier", created_at="2026-06-14T00:00:01+00:00")
+        _insert_chunk(store, chunk_id="middle", created_at="2026-06-14T00:00:02+00:00")
+        store._upsert_chunk_vector(store.conn.cursor(), "earlier", _embed(0.5))
+
+        rows = fetch_unvectored_batch(store, batch_size=10)
+
+        assert [row.chunk_id for row in rows] == ["middle", "later"]
+    finally:
+        store.close()
+
+
+def test_run_reembed_backfill_batches_and_writes_both_vector_tables(tmp_path):
+    from brainlayer.reembed_backfill import run_reembed_backfill
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        _insert_chunk(store, chunk_id="missing-1", content="first")
+        _insert_chunk(store, chunk_id="missing-2", content="second")
+    finally:
+        store.close()
+
+    model = FakeBatchModel()
+    result = run_reembed_backfill(
+        db_path=tmp_path / "backfill.db",
+        model=model,
+        batch_size=64,
+        progress_every=1,
+    )
+
+    assert result.processed == 2
+    assert result.failed == 0
+    assert len(model.calls) == 1
+    assert model.calls[0] == ["first", "second"]
+
+    check = VectorStore(tmp_path / "backfill.db")
+    try:
+        cursor = check.conn.cursor()
+        assert cursor.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0] == 2
+        assert cursor.execute("SELECT COUNT(*) FROM chunk_vectors_binary").fetchone()[0] == 2
+    finally:
+        check.close()
+
+
+def test_run_reembed_backfill_is_idempotent(tmp_path):
+    from brainlayer.reembed_backfill import run_reembed_backfill
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        _insert_chunk(store, chunk_id="already-vectored")
+        store.conn.cursor().execute(
+            "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+            ("already-vectored", serialize_f32(_embed(0.25))),
+        )
+    finally:
+        store.close()
+
+    model = FakeBatchModel()
+    result = run_reembed_backfill(db_path=tmp_path / "backfill.db", model=model, batch_size=64)
+
+    assert result.processed == 0
+    assert model.calls == []
+
+
+def test_reembed_backfill_cli_dry_run_reports_pending_count(tmp_path):
+    from brainlayer.cli import app
+
+    db_path = tmp_path / "backfill.db"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(store, chunk_id="missing")
+    finally:
+        store.close()
+
+    result = CliRunner().invoke(app, ["reembed-backfill", "--db", str(db_path), "--dry-run"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Unvectored active chunks: 1" in result.stdout

--- a/tests/test_reembed_backfill.py
+++ b/tests/test_reembed_backfill.py
@@ -163,3 +163,28 @@ def test_reembed_backfill_cli_dry_run_reports_pending_count(tmp_path):
 
     assert result.exit_code == 0, result.stdout
     assert "Unvectored active chunks: 1" in result.stdout
+
+
+def test_heavy_ml_mutex_ignores_agent_prompt_text(monkeypatch):
+    from brainlayer import reembed_backfill
+
+    class Result:
+        stdout = "\n".join(
+            [
+                "111 /usr/local/bin/claude claude --append-system-prompt mentions mlx ollama enrichment",
+                "222 /opt/homebrew/bin/llama-server /opt/homebrew/bin/llama-server --model local.gguf",
+                "333 /usr/bin/python3 python -m mlx_audio.tts.generate --model voice",
+                "444 /usr/bin/python3 python scripts/embed_backfill.py",
+            ]
+        )
+
+    monkeypatch.setattr(reembed_backfill.os, "getpid", lambda: 999)
+    monkeypatch.setattr(reembed_backfill.subprocess, "run", lambda *_args, **_kwargs: Result())
+
+    matches = reembed_backfill.find_heavy_ml_processes()
+
+    assert len(matches) == 3
+    assert not any("claude --append-system-prompt" in match for match in matches)
+    assert any("llama-server" in match for match in matches)
+    assert any("mlx_audio.tts.generate" in match for match in matches)
+    assert any("embed_backfill.py" in match for match in matches)

--- a/tests/test_reembed_backfill.py
+++ b/tests/test_reembed_backfill.py
@@ -38,9 +38,11 @@ def _insert_chunk(
 class FakeBatchModel:
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
+        self.batch_sizes: list[int | None] = []
 
     def encode(self, texts, **kwargs):
         self.calls.append(list(texts))
+        self.batch_sizes.append(kwargs.get("batch_size"))
         return [_embed(float(i + 1)) for i, _ in enumerate(texts)]
 
 
@@ -127,6 +129,76 @@ def test_run_reembed_backfill_batches_and_writes_both_vector_tables(tmp_path):
         assert cursor.execute("SELECT COUNT(*) FROM chunk_vectors_binary").fetchone()[0] == 2
     finally:
         check.close()
+
+
+def test_run_reembed_backfill_reuses_large_candidate_page_for_encode_batches(tmp_path, monkeypatch):
+    from brainlayer import reembed_backfill
+    from brainlayer.reembed_backfill import run_reembed_backfill
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        for index in range(5):
+            _insert_chunk(store, chunk_id=f"missing-{index}", content=f"text {index}")
+    finally:
+        store.close()
+
+    fetch_sizes: list[int] = []
+    real_fetch = reembed_backfill.fetch_unvectored_batch
+
+    def tracking_fetch(*args, **kwargs):
+        fetch_sizes.append(kwargs["batch_size"])
+        return real_fetch(*args, **kwargs)
+
+    monkeypatch.setattr(reembed_backfill, "fetch_unvectored_batch", tracking_fetch)
+
+    model = FakeBatchModel()
+    result = run_reembed_backfill(
+        db_path=tmp_path / "backfill.db",
+        model=model,
+        batch_size=2,
+        candidate_page_size=5,
+    )
+
+    assert result.processed == 5
+    assert [len(call) for call in model.calls] == [2, 2, 1]
+    assert model.batch_sizes == [2, 2, 1]
+    assert fetch_sizes == [5, 5]
+
+
+def test_write_chunk_embeddings_wraps_batch_in_one_transaction():
+    from brainlayer.reembed_backfill import PendingChunk, write_chunk_embeddings
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        def execute(self, sql, *_args, **_kwargs):
+            self.statements.append(" ".join(str(sql).split()).upper())
+
+    class FakeConn:
+        def __init__(self) -> None:
+            self.cursor_obj = FakeCursor()
+
+        def cursor(self):
+            return self.cursor_obj
+
+    class FakeStore:
+        def __init__(self) -> None:
+            self.conn = FakeConn()
+
+        def _upsert_chunk_vector(self, cursor, chunk_id, embedding):
+            cursor.execute("INSERT INTO chunk_vectors VALUES (?, ?)", (chunk_id, embedding))
+
+    store = FakeStore()
+    chunks = [PendingChunk(chunk_id="a", content="first"), PendingChunk(chunk_id="b", content="second")]
+
+    written = write_chunk_embeddings(store, chunks, [_embed(1.0), _embed(2.0)])
+
+    assert written == 2
+    assert store.conn.cursor_obj.statements[0] == "BEGIN IMMEDIATE"
+    assert store.conn.cursor_obj.statements[-1] == "COMMIT"
+    assert store.conn.cursor_obj.statements.count("BEGIN IMMEDIATE") == 1
+    assert store.conn.cursor_obj.statements.count("COMMIT") == 1
 
 
 def test_run_reembed_backfill_is_idempotent(tmp_path):

--- a/tests/test_transport_replay_attribution.py
+++ b/tests/test_transport_replay_attribution.py
@@ -109,10 +109,14 @@ def test_transport_closed_jsonl_replay_preserves_original_chunk_origin(tmp_path,
     drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log")
 
     with VectorStore(db_path) as store:
-        row = store.conn.cursor().execute(
-            "SELECT project, source, source_file, chunk_origin FROM chunks WHERE id = ?",
-            ("manual-wi3-jsonl-origin",),
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT project, source, source_file, chunk_origin FROM chunks WHERE id = ?",
+                ("manual-wi3-jsonl-origin",),
+            )
+            .fetchone()
+        )
 
     assert before_event["project"] == "systems"
     assert before_event["chunk_origin"] == CHUNK_ORIGIN_USER_EXPLICIT
@@ -138,10 +142,14 @@ def test_markdown_fallback_replay_preserves_origin_repo_and_chunk_origin(tmp_pat
             store_func=lambda **kwargs: store_memory(store=store, embed_fn=None, **kwargs),
             replayed_by="wi3-test",
         )
-        row = store.conn.cursor().execute(
-            "SELECT project, chunk_origin, metadata FROM chunks WHERE id = ?",
-            (result.chunk_id,),
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT project, chunk_origin, metadata FROM chunks WHERE id = ?",
+                (result.chunk_id,),
+            )
+            .fetchone()
+        )
 
     metadata = json.loads(row[2])
     assert result.error is None
@@ -178,10 +186,14 @@ def test_legacy_pending_store_empty_chunk_id_lands_with_origin_and_is_queryable(
     with VectorStore(db_path) as store:
         with patch("brainlayer.mcp.store_handler._get_pending_store_path", return_value=pending_path):
             flushed = _flush_pending_stores(store, None)
-        row = store.conn.cursor().execute(
-            "SELECT id, project, chunk_origin FROM chunks WHERE content LIKE ?",
-            (f"%{token}%",),
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT id, project, chunk_origin FROM chunks WHERE content LIKE ?",
+                (f"%{token}%",),
+            )
+            .fetchone()
+        )
         results = store.search(query_text=token, n_results=5)
 
     assert flushed == 1
@@ -219,10 +231,14 @@ def test_metadata_only_queued_origin_is_preserved_for_old_fallback_events(tmp_pa
     drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log")
 
     with VectorStore(db_path) as store:
-        row = store.conn.cursor().execute(
-            "SELECT project, chunk_origin FROM chunks WHERE id = ?",
-            ("manual-wi3-metadata-origin",),
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT project, chunk_origin FROM chunks WHERE id = ?",
+                ("manual-wi3-metadata-origin",),
+            )
+            .fetchone()
+        )
 
     assert drained == 1
     assert row == ("systems", CHUNK_ORIGIN_USER_EXPLICIT)
@@ -261,10 +277,14 @@ def test_deferred_mcp_row_stays_raw_etan_direct_with_high_enrichment_cap(tmp_pat
             mention_type="explicit",
         )
 
-        row = store.conn.cursor().execute(
-            "SELECT source, source_file, provenance_class FROM chunks WHERE id = ?",
-            (chunk["id"],),
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT source, source_file, provenance_class FROM chunks WHERE id = ?",
+                (chunk["id"],),
+            )
+            .fetchone()
+        )
         report = resolve_entity_conflicts(store, "enrichment", dry_run=True)
         results = store.search(query_text="WI3_PRIMARY_BACKEND", n_results=5, source_filter="mcp")
 


### PR DESCRIPTION
## What

Backfill the ~118.5K chunks that were unvectored (invisible to semantic search) after the embedder outage since Jun-11. Root cause: the backfill `embed_pending_chunks` was hard-scoped `WHERE source IN ('manual','mcp')`, stranding `claude_code`/`realtime`/`youtube`/`whatsapp`/etc. Embedder = LOCAL `BAAI/bge-large-en-v1.5` on MPS (no API cap).

## How

- New `reembed_backfill.py` (keyset-paginated candidate query: 100s → ~1ms; GPU batch-256 ≈ ~1536/min burst).
- Widened backfill scope; `store.py` + `embeddings.py` + `store_handler.py` + CLI wiring.
- Tests: `test_reembed_backfill.py`, `test_deferred_embedding.py`.

## Status — AT-RISK CODE, DO NOT MERGE YET

This PR exists to **protect the live backlog-drain code** (commit-early). It is **branch-only** until now.

⚠️ **DO NOT MERGE until (a) the cold backlog fully clears AND (b) RAM/swap is stable.** The widened daemon backfill could auto-run heavy `bge-large` on merge — merging mid-drain or under RAM pressure risks a memory-livelock panic (the box has kernel-panicked twice this arc from heavy-ML RAM exhaustion).

When merged: **merge-commit, never squash** (2 parents asserted at the gate). Follow-up: persistent reembed launchd (S3) so this outage cannot silently recur; encode correct FK `r.id=c.id` in every BL health check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches live vector data at large scale and loads bge-large locally; merging before the backlog clears can trigger heavy auto-embedding and RAM pressure alongside other ML workloads.
> 
> **Overview**
> Fixes the semantic-search gap where many active chunks had no vectors because pending backfill was limited to **`manual`/`mcp`** sources.
> 
> **Daemon path:** `embed_pending_chunks` now selects **all active sources** with non-empty content, skips archived/superseded/aggregated rows, and can take an optional **`embed_batch_fn`** for one model batch per slice instead of per-row calls. MCP background embed passes **`embed_texts`** at batch size 64.
> 
> **One-time cold backlog:** New **`reembed_backfill.py`** counts and fetches unvectored rows via **`chunk_vectors_rowids`**, batch-encodes with local **`BAAI/bge-large-en-v1.5`** (MPS when available), and writes float/binary vectors through **`_upsert_chunk_vector`**. **`brainlayer reembed-backfill`** supports dry-run, limits, lifecycle scope, and a **heavy-ML process mutex** (bypass with **`--skip-heavy-ml-check`**).
> 
> **`EmbeddingModel.embed_texts`** adds passage batch encoding for stored chunk content. Tests cover source widening, lifecycle skips, batch vs single embed, backfill idempotency, CLI dry-run, and mutex heuristics. An implementation plan doc describes the live run playbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4abd6c70c50e10beecb38076fb1d43498986ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `reembed-backfill` CLI command to batch-embed ~118.5K unvectored chunks
> - Adds [reembed_backfill.py](https://github.com/EtanHey/brainlayer/pull/483/files#diff-0f53c0efb2f39e720e5deaef51bc82e3627d7cf298dd4bc86f63515dcf691e61) with a resumable, keyset-paginated backfill loop that fetches unvectored chunks, encodes them in batches using a SentenceTransformer model on MPS or CPU, and writes both float and binary vectors via `VectorStore._upsert_chunk_vector`.
> - Adds a `brainlayer reembed-backfill` CLI command in [cli/__init__.py](https://github.com/EtanHey/brainlayer/pull/483/files#diff-e66ce4ea8b0cf3331154cb15181cb09a7c593566e36380fd9215ff29d24ffd02) with dry-run mode, batch size/limit controls, optional inactive-row inclusion, and a heavy-ML process conflict check via `find_heavy_ml_processes`.
> - Updates `embed_pending_chunks` in [store.py](https://github.com/EtanHey/brainlayer/pull/483/files#diff-3f4ff41bcf437c9376f0c0bc397eca30e1b05c0d75d4e95ef1579366d7c4c707) to accept an optional `embed_batch_fn`, and wires batch embedding (size 64) into the MCP `_store` background pass.
> - Adds `EmbeddingModel.embed_texts` in [embeddings.py](https://github.com/EtanHey/brainlayer/pull/483/files#diff-a66c3335f636eacc8b2192acffc9d01b3443a146803c6dfc1ab4e441bcddfdc9) for batch passage encoding.
> - Risk: this is marked live/at-risk and is intended as a one-time drain of the unvectored backlog; running it concurrently with other ML workloads may cause resource contention.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e4abd6c. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->