### PR TITLE
WI-4 hot embedding lane

### DIFF
--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -663,7 +663,7 @@ async def _store(
             structured = _deferred_store_receipt(promised_chunk_id, queue_path, reason="ARBITRATED")
             return ([TextContent(type="text", text=format_store_result(promised_chunk_id, queued=True))], structured)
 
-        from ..store import embed_pending_chunks, store_memory
+        from ..store import embed_hot_chunk, embed_pending_chunks, store_memory
 
         store = _get_vector_store()
         normalized_project = _normalize_project_name(project)
@@ -712,6 +712,8 @@ async def _store(
                 bg_store = _VS(db_path)
                 model = _get_embedding_model()
                 embed_fn = model.embed_query
+                if embed_hot_chunk(store=bg_store, embed_fn=embed_fn, chunk_id=chunk_id):
+                    logger.info("Hot-embedded chunk %s", chunk_id)
                 count = embed_pending_chunks(
                     store=bg_store,
                     embed_fn=embed_fn,

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -380,6 +380,8 @@ def embed_pending_chunks(
               AND c.archived_at IS NULL
               AND c.superseded_by IS NULL
               AND c.aggregated_into IS NULL
+              AND COALESCE(c.archived, 0) = 0
+              AND COALESCE(c.status, 'active') = 'active'
             ORDER BY c.created_at ASC
             LIMIT ?
             """,
@@ -397,8 +399,11 @@ def embed_pending_chunks(
             if len(embeddings) != len(rows):
                 raise ValueError(f"batch embedder returned {len(embeddings)} embeddings for {len(rows)} chunks")
             for (chunk_id, _), embedding in zip(rows, embeddings):
-                store._upsert_chunk_vector(cursor, chunk_id, embedding)
-                count += 1
+                try:
+                    store._upsert_chunk_vector(cursor, chunk_id, embedding)
+                    count += 1
+                except Exception as e:
+                    logger.warning("Failed to write pending chunk %s: %s", chunk_id, e)
         except Exception as e:
             logger.warning("Failed to embed pending chunk batch: %s", e)
     else:
@@ -414,6 +419,51 @@ def embed_pending_chunks(
 
     clear_hybrid_search_cache(getattr(store, "db_path", None))
     return count
+
+
+def embed_hot_chunk(
+    store: VectorStore,
+    embed_fn: Callable[[str], List[float]],
+    chunk_id: str,
+) -> bool:
+    """Embed one just-stored active chunk without disturbing the FIFO backlog drain.
+
+    Returns True only when this call writes a vector. Missing, inactive, empty,
+    already-embedded, or failed chunks return False so callers can safely fall
+    through to deferred backlog processing.
+    """
+    cursor = store.conn.cursor()
+    row = cursor.execute(
+        """
+        SELECT c.content
+        FROM chunks c
+        LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
+        WHERE c.id = ?
+          AND v.chunk_id IS NULL
+          AND c.content IS NOT NULL
+          AND c.content != ''
+          AND c.archived_at IS NULL
+          AND c.superseded_by IS NULL
+          AND c.aggregated_into IS NULL
+          AND COALESCE(c.archived, 0) = 0
+          AND COALESCE(c.status, 'active') = 'active'
+        """,
+        (chunk_id,),
+    ).fetchone()
+    if row is None:
+        return False
+
+    try:
+        embedding = embed_fn(row[0])
+        store._upsert_chunk_vector(cursor, chunk_id, embedding)
+    except Exception as e:
+        logger.warning("Failed to hot-embed chunk %s: %s", chunk_id, e)
+        return False
+
+    from .search_repo import clear_hybrid_search_cache
+
+    clear_hybrid_search_cache(getattr(store, "db_path", None))
+    return True
 
 
 def _find_related(

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -6,6 +6,7 @@ Goal: brain_store returns immediately without blocking on embedding generation.
 Embeddings are generated in the background and backfilled.
 """
 
+import threading
 import time
 
 import pytest
@@ -45,7 +46,14 @@ def fast_embed():
     return _embed
 
 
-def _insert_pending_chunk(store: VectorStore, *, chunk_id: str, source: str, content: str | None = None) -> None:
+def _insert_pending_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    source: str,
+    content: str | None = None,
+    created_at: str = "2026-06-14T00:00:00+00:00",
+) -> None:
     cursor = store.conn.cursor()
     text = content or f"Pending content for {chunk_id}"
     cursor.execute(
@@ -55,11 +63,41 @@ def _insert_pending_chunk(store: VectorStore, *, chunk_id: str, source: str, con
             summary, tags, importance, chunk_origin, seen_count, last_seen_at,
             content_class
         ) VALUES (?, ?, '{}', 'test.jsonl', 'test', 'note',
-            'HIGH', ?, ?, '2026-06-14T00:00:00+00:00', NULL, NULL,
-            NULL, NULL, NULL, 'raw', 1, '2026-06-14T00:00:00+00:00',
+            'HIGH', ?, ?, ?, NULL, NULL,
+            NULL, NULL, NULL, 'raw', 1, ?,
             'human-authored')""",
-        (chunk_id, text, len(text), source),
+        (chunk_id, text, len(text), source, created_at, created_at),
     )
+
+
+def _has_vector(store: VectorStore, chunk_id: str) -> bool:
+    cursor = store.conn.cursor()
+    return (
+        cursor.execute(
+            "SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?",
+            (chunk_id,),
+        ).fetchone()[0]
+        == 1
+    )
+
+
+def _pending_active_count(store: VectorStore) -> int:
+    cursor = store.conn.cursor()
+    return cursor.execute(
+        """
+        SELECT COUNT(*)
+        FROM chunks c
+        LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
+        WHERE v.chunk_id IS NULL
+          AND c.content IS NOT NULL
+          AND c.content != ''
+          AND c.archived_at IS NULL
+          AND c.superseded_by IS NULL
+          AND c.aggregated_into IS NULL
+          AND COALESCE(c.archived, 0) = 0
+          AND COALESCE(c.status, 'active') = 'active'
+        """
+    ).fetchone()[0]
 
 
 class TestDeferredStore:
@@ -259,11 +297,15 @@ class TestBackgroundEmbedder:
         _insert_pending_chunk(store, chunk_id="archived-pending", source="claude_code")
         _insert_pending_chunk(store, chunk_id="superseded-pending", source="claude_code")
         _insert_pending_chunk(store, chunk_id="aggregated-pending", source="claude_code")
+        _insert_pending_chunk(store, chunk_id="archived-flag-pending", source="claude_code")
+        _insert_pending_chunk(store, chunk_id="inactive-pending", source="claude_code")
 
         cursor = store.conn.cursor()
         cursor.execute("UPDATE chunks SET archived_at = '2026-06-14T00:00:00+00:00' WHERE id = 'archived-pending'")
         cursor.execute("UPDATE chunks SET superseded_by = 'replacement' WHERE id = 'superseded-pending'")
         cursor.execute("UPDATE chunks SET aggregated_into = 'aggregate' WHERE id = 'aggregated-pending'")
+        cursor.execute("UPDATE chunks SET archived = 1 WHERE id = 'archived-flag-pending'")
+        cursor.execute("UPDATE chunks SET status = 'inactive' WHERE id = 'inactive-pending'")
 
         count = embed_pending_chunks(store=store, embed_fn=fast_embed, batch_size=20)
 
@@ -305,6 +347,233 @@ class TestBackgroundEmbedder:
         assert single_calls == []
         assert len(batch_calls) == 1
         assert len(batch_calls[0]) == 4
+
+    def test_g1_fifo_reproduction_new_chunk_waits_behind_old_backlog(self, store, fast_embed):
+        """G1 RED proof: oldest-first drain alone starves a just-stored chunk for one pass."""
+        from brainlayer.store import embed_pending_chunks, store_memory
+
+        for i in range(60):
+            _insert_pending_chunk(
+                store,
+                chunk_id=f"old-backlog-{i:03d}",
+                source="claude_code",
+                created_at=f"2026-06-13T00:{i:02d}:00+00:00",
+            )
+
+        result = store_memory(
+            store=store,
+            embed_fn=None,
+            content="fresh hot lane candidate should not wait",
+            memory_type="note",
+            project="test",
+            created_at="2026-06-14T00:00:00+00:00",
+        )
+
+        count = embed_pending_chunks(store=store, embed_fn=fast_embed, batch_size=50)
+
+        assert count == 50
+        assert not _has_vector(store, result["id"])
+        assert all(_has_vector(store, f"old-backlog-{i:03d}") for i in range(50))
+
+    def test_embed_hot_chunk_embeds_new_chunk_before_oldest_drain(self, store, fast_embed):
+        """G2: hot lane fast-tracks the just-stored chunk without consuming drain slots."""
+        from brainlayer.store import embed_hot_chunk, embed_pending_chunks, store_memory
+
+        def lane_embed(text: str) -> list[float]:
+            if "g2 hot chunk" in text:
+                return [1.0] + [0.0] * 1023
+            return [0.0, 1.0] + [0.0] * 1022
+
+        for i in range(60):
+            _insert_pending_chunk(
+                store,
+                chunk_id=f"g2-old-backlog-{i:03d}",
+                source="claude_code",
+                created_at=f"2026-06-13T00:{i:02d}:00+00:00",
+            )
+
+        result = store_memory(
+            store=store,
+            embed_fn=None,
+            content="g2 hot chunk vector-only proof",
+            memory_type="note",
+            project="test",
+            created_at="2026-06-14T00:00:00+00:00",
+        )
+
+        assert embed_hot_chunk(store=store, embed_fn=lane_embed, chunk_id=result["id"]) is True
+        assert _has_vector(store, result["id"])
+
+        drain_count = embed_pending_chunks(store=store, embed_fn=lane_embed, batch_size=50)
+
+        assert drain_count == 50
+        assert _has_vector(store, result["id"])
+        assert all(_has_vector(store, f"g2-old-backlog-{i:03d}") for i in range(50))
+
+        results = store.hybrid_search(
+            query_embedding=lane_embed("g2 hot chunk vector-only proof"),
+            query_text="no_keyword_match_for_g2_hot_lane",
+            n_results=1,
+            project_filter="test",
+        )
+        assert results["ids"][0][0] == result["id"]
+
+    def test_embed_hot_chunk_is_idempotent_and_does_not_double_embed(self, store, fast_embed):
+        """G2/G3: already-vectorized chunks are skipped instead of embedded again."""
+        from brainlayer.store import embed_hot_chunk, store_memory
+
+        calls = []
+
+        def recording_embed(text: str) -> list[float]:
+            calls.append(text)
+            return fast_embed(text)
+
+        result = store_memory(
+            store=store,
+            embed_fn=None,
+            content="hot idempotency proof",
+            memory_type="note",
+            project="test",
+        )
+
+        assert embed_hot_chunk(store=store, embed_fn=recording_embed, chunk_id=result["id"]) is True
+        assert embed_hot_chunk(store=store, embed_fn=recording_embed, chunk_id=result["id"]) is False
+
+        duplicate_count = (
+            store.conn.cursor()
+            .execute(
+                """
+            SELECT COUNT(*)
+            FROM (
+                SELECT chunk_id
+                FROM chunk_vectors
+                GROUP BY chunk_id
+                HAVING COUNT(*) > 1
+            )
+            """
+            )
+            .fetchone()[0]
+        )
+        assert calls == ["hot idempotency proof"]
+        assert duplicate_count == 0
+
+    def test_g3_hot_lane_preserves_monotonic_shrink_and_oldest_tail(self, store, fast_embed):
+        """G3: hot lane plus FIFO drain shrinks old backlog and clears the oldest tail."""
+        from brainlayer.store import embed_hot_chunk, embed_pending_chunks, store_memory
+
+        def lane_embed(text: str) -> list[float]:
+            if "g3 fresh hot lane candidate" in text:
+                return [1.0] + [0.0] * 1023
+            return [0.0, 1.0] + [0.0] * 1022
+
+        for i in range(120):
+            _insert_pending_chunk(
+                store,
+                chunk_id=f"g3-old-backlog-{i:03d}",
+                source="claude_code",
+                created_at=f"2026-06-13T{i // 60:02d}:{i % 60:02d}:00+00:00",
+            )
+
+        oldest_50 = [f"g3-old-backlog-{i:03d}" for i in range(50)]
+        pending_counts = [_pending_active_count(store)]
+
+        for i in range(4):
+            content = f"g3 fresh hot lane candidate {i}"
+            result = store_memory(
+                store=store,
+                embed_fn=None,
+                content=content,
+                memory_type="note",
+                project="test",
+                created_at=f"2026-06-14T00:0{i}:00+00:00",
+            )
+
+            assert embed_hot_chunk(store=store, embed_fn=lane_embed, chunk_id=result["id"]) is True
+            assert _has_vector(store, result["id"])
+
+            results = store.hybrid_search(
+                query_embedding=lane_embed(content),
+                query_text=f"no_keyword_match_for_g3_hot_lane_{i}",
+                n_results=1,
+                project_filter="test",
+            )
+            assert results["ids"][0][0] == result["id"]
+
+            embed_pending_chunks(store=store, embed_fn=lane_embed, batch_size=30)
+            pending_counts.append(_pending_active_count(store))
+
+        assert all(after < before for before, after in zip(pending_counts, pending_counts[1:]))
+        assert all(_has_vector(store, chunk_id) for chunk_id in oldest_50)
+
+        duplicate_count = (
+            store.conn.cursor()
+            .execute(
+                """
+            SELECT COUNT(*)
+            FROM (
+                SELECT chunk_id
+                FROM chunk_vectors
+                GROUP BY chunk_id
+                HAVING COUNT(*) > 1
+            )
+            """
+            )
+            .fetchone()[0]
+        )
+        assert duplicate_count == 0
+
+    def test_embed_hot_chunk_failure_is_deferred_safe(self, store):
+        """G4: hot embed failure does not remove or strand the stored row."""
+        from brainlayer.store import embed_hot_chunk, store_memory
+
+        result = store_memory(
+            store=store,
+            embed_fn=None,
+            content="hot lane fallback remains text searchable",
+            memory_type="note",
+            project="test",
+        )
+
+        def failing_embed(_text: str) -> list[float]:
+            raise RuntimeError("model unavailable")
+
+        assert embed_hot_chunk(store=store, embed_fn=failing_embed, chunk_id=result["id"]) is False
+        assert not _has_vector(store, result["id"])
+        fts_results = store.hybrid_search(
+            query_embedding=[0.0] * 1024,
+            query_text="hot lane fallback remains text searchable",
+            n_results=1,
+            project_filter="test",
+        )
+        assert fts_results["ids"][0][0] == result["id"]
+
+    def test_embed_pending_batch_write_failure_continues_remainder(self, store):
+        """CodeRabbit #483: one failed vector write must not abort the rest of the batch."""
+        from brainlayer.store import embed_pending_chunks
+
+        for i in range(3):
+            _insert_pending_chunk(store, chunk_id=f"batch-write-{i}", source="claude_code")
+
+        original_upsert = store._upsert_chunk_vector
+
+        def flaky_upsert(cursor, chunk_id, embedding):
+            if chunk_id == "batch-write-1":
+                raise RuntimeError("simulated write failure")
+            original_upsert(cursor, chunk_id, embedding)
+
+        store._upsert_chunk_vector = flaky_upsert
+
+        count = embed_pending_chunks(
+            store=store,
+            embed_fn=lambda _text: [0.0] * 1024,
+            batch_size=3,
+            embed_batch_fn=lambda texts: [[float(i)] * 1024 for i, _ in enumerate(texts)],
+        )
+
+        assert count == 2
+        assert _has_vector(store, "batch-write-0")
+        assert not _has_vector(store, "batch-write-1")
+        assert _has_vector(store, "batch-write-2")
 
 
 class TestMCPStoreDeferred:
@@ -353,3 +622,60 @@ class TestMCPStoreDeferred:
                 tmp_store.close()
             except Exception:
                 pass  # Daemon thread may still hold the connection
+
+    @pytest.mark.asyncio
+    async def test_mcp_background_hot_embeds_new_chunk_and_drains_oldest_backlog(self, tmp_path, monkeypatch):
+        """G7: real MCP background thread hot-embeds the stored chunk before FIFO drain."""
+        from unittest.mock import patch
+
+        from brainlayer.mcp.store_handler import _store_new
+
+        monkeypatch.delenv("BRAINLAYER_ARBITRATED", raising=False)
+
+        db_path = tmp_path / "test.db"
+        tmp_store = VectorStore(db_path)
+        for i in range(70):
+            _insert_pending_chunk(
+                tmp_store,
+                chunk_id=f"g7-old-backlog-{i:03d}",
+                source="claude_code",
+                created_at=f"2026-06-13T00:{i:02d}:00+00:00",
+            )
+
+        class FastModel:
+            def embed_query(self, text):
+                seed = sum(ord(c) for c in text[:50]) % 100
+                return [float(seed + i) / 1000.0 for i in range(1024)]
+
+            def embed_texts(self, texts, batch_size=64):
+                return [self.embed_query(text) for text in texts]
+
+        try:
+            with (
+                patch("brainlayer.mcp.store_handler._get_vector_store", return_value=tmp_store),
+                patch("brainlayer.mcp.store_handler._get_embedding_model", return_value=FastModel()),
+                patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+                patch("brainlayer.enrichment_controller.enrich_single", return_value={"summary": "skipped"}),
+            ):
+                _content, structured = await _store_new(
+                    content="g7 hot mcp lane searchable",
+                    memory_type="note",
+                    project="test",
+                )
+
+                chunk_id = structured["chunk_id"]
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    drained_old = sum(_has_vector(tmp_store, f"g7-old-backlog-{i:03d}") for i in range(64))
+                    if _has_vector(tmp_store, chunk_id) and drained_old == 64:
+                        break
+                    time.sleep(0.05)
+
+            assert _has_vector(tmp_store, chunk_id)
+            assert all(_has_vector(tmp_store, f"g7-old-backlog-{i:03d}") for i in range(64))
+            assert not _has_vector(tmp_store, "g7-old-backlog-064")
+        finally:
+            for thread in threading.enumerate():
+                if thread.daemon and thread.name != "MainThread":
+                    thread.join(timeout=0.1)
+            tmp_store.close()


### PR DESCRIPTION
## Summary
- add embed_hot_chunk to hot-embed the just-stored active chunk before the FIFO backlog drain
- keep embed_pending_chunks oldest-first with ORDER BY c.created_at ASC
- make pending query match active lifecycle exclusions and keep batch write failures from aborting the remainder
- wire MCP background store thread to hot-embed on its separate VectorStore connection before draining backlog

## Evidence
- RED: G1 FIFO reproduction passed and desired hot-lane test failed before implementation with missing embed_hot_chunk
- G1-G4/G7 named gate tests: PYTHONPATH=src python3 -m pytest tests/test_deferred_embedding.py -vv -k "g1_fifo or embeds_new_chunk_before_oldest_drain or idempotent or g3_hot_lane or failure_is_deferred_safe or batch_write_failure or mcp_background_hot" -> 8 passed
- G3 included monotonic shrink across K=4, oldest-50-tail embedded, duplicate vector rows = 0
- G5: BRAINLAYER_ENRICH_DAILY_USD_CAP=100000 PYTHONPATH=src python3 -m pytest tests/test_provenance*.py tests/test_deferred_embedding.py tests/test_store_handler.py -q -> 136 passed
- lint changed files: PYTHONPATH=src python3 -m ruff check src/brainlayer/store.py src/brainlayer/mcp/store_handler.py tests/test_deferred_embedding.py -> All checks passed
- ORDER gate: rg found ORDER BY c.created_at ASC in src/brainlayer/store.py and no DESC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deferred embedding and hybrid search cache invalidation on the write path; behavior is well-tested but affects when new memories become vector-searchable relative to backlog processing.
> 
> **Overview**
> Adds a **hot embedding lane** so a just-stored memory can get a vector immediately instead of waiting behind a large oldest-first pending backlog.
> 
> **`embed_hot_chunk`** in `store.py` embeds one active, pending chunk by ID, clears the hybrid search cache on success, and returns false when the row is ineligible, already vectorized, or embed/write fails—so normal FIFO backfill can still run.
> 
> **`embed_pending_chunks`** now excludes inactive rows via `archived` and `status`, and in batch mode a failed per-row vector upsert no longer aborts the whole batch; remaining rows still get written.
> 
> The MCP store **background thread** calls `embed_hot_chunk` for the new chunk on its separate DB connection before `embed_pending_chunks`, so the latest store is vector-searchable sooner while backlog drain stays `ORDER BY created_at ASC`.
> 
> Tests cover FIFO starvation, hot-lane behavior, idempotency, failure deferral, batch partial failure, and MCP background integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a20b5f9c10488958350cf8eec185c320e04868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hot embedding lane to make newly stored chunks vector-searchable before backlog drain
> - The background task in [`store_handler.py`](https://github.com/EtanHey/brainlayer/pull/484/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263) now calls the new `embed_hot_chunk` function immediately after storing a chunk, before draining the pending backlog via `embed_pending_chunks`.
> - [`embed_hot_chunk`](https://github.com/EtanHey/brainlayer/pull/484/files#diff-3f4ff41bcf437c9376f0c0bc397eca30e1b05c0d75d4e95ef1579366d7c4c707) looks up a chunk by ID, computes its embedding, writes the vector, clears the hybrid search cache, and returns `True` on success or `False` on failure.
> - Batch upserts in `embed_pending_chunks` now wrap each `_upsert_chunk_vector` call in a try/except, so a single failing write no longer aborts the rest of the batch.
> - Comprehensive tests in [`test_deferred_embedding.py`](https://github.com/EtanHey/brainlayer/pull/484/files#diff-f66ffc4c31d4822ce8ce764de7d3b1c2722d02e89f035f21a07d41c0c46f78ee) cover FIFO starvation, hot-embed idempotency, backlog ordering, and failure resilience.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0a20b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Newly stored content receives priority embedding, improving response times.

* **Bug Fixes**
  * Enhanced eligibility checks for content embedding based on active status.
  * Individual embedding failures no longer prevent remaining batch items from being processed.
  * Improved error logging for failed embedding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->