### PR TITLE
feat: add opt-in bitemporal chunk ledger

### DIFF
--- a/src/brainlayer/bitemporal.py
+++ b/src/brainlayer/bitemporal.py
@@ -1,0 +1,183 @@
+"""Phase-1 bitemporal chunk schema and helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+SENTINEL_SYS_PERIOD_END = "9999-12-31T23:59:59.999999Z"
+LEGACY_SYS_PERIOD_START = "0001-01-01T00:00:00.000000Z"
+
+_TEMPORAL_COLUMNS = [
+    ("content_hash", "TEXT"),
+    ("valid_from", "TEXT"),
+    ("invalid_at", "TEXT"),
+    ("sys_period_start", f"TEXT DEFAULT '{LEGACY_SYS_PERIOD_START}'"),
+    ("sys_period_end", f"TEXT DEFAULT '{SENTINEL_SYS_PERIOD_END}'"),
+]
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _column_defs(cursor: Any, table: str) -> list[tuple[str, str]]:
+    return [(str(row[1]), str(row[2]) if row[2] else "TEXT") for row in cursor.execute(f"PRAGMA table_info({table})")]
+
+
+def _table_columns(cursor: Any, table: str) -> set[str]:
+    return {str(row[1]) for row in cursor.execute(f"PRAGMA table_info({table})")}
+
+
+def _ensure_temporal_columns(cursor: Any) -> None:
+    existing = _table_columns(cursor, "chunks")
+    for column, column_type in _TEMPORAL_COLUMNS:
+        if column not in existing:
+            cursor.execute(f"ALTER TABLE chunks ADD COLUMN {_quote_ident(column)} {column_type}")
+            existing.add(column)
+
+
+def _ensure_history_table(cursor: Any) -> None:
+    chunk_columns = _column_defs(cursor, "chunks")
+    column_sql = ", ".join(f"{_quote_ident(name)} {column_type}" for name, column_type in chunk_columns)
+    cursor.execute(f"CREATE TABLE IF NOT EXISTS _chunks_history ({column_sql})")
+
+    history_columns = _table_columns(cursor, "_chunks_history")
+    for name, column_type in chunk_columns:
+        if name not in history_columns:
+            cursor.execute(f"ALTER TABLE _chunks_history ADD COLUMN {_quote_ident(name)} {column_type}")
+            history_columns.add(name)
+
+
+def _ensure_clock_table(cursor: Any) -> None:
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS _brainlayer_bitemporal_clock (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            wall_second TEXT NOT NULL,
+            tick INTEGER NOT NULL
+        )
+        """
+    )
+    cursor.execute(
+        """
+        INSERT OR IGNORE INTO _brainlayer_bitemporal_clock(id, wall_second, tick)
+        VALUES (1, strftime('%Y-%m-%dT%H:%M:%S','now'), 0)
+        """
+    )
+
+
+def _history_insert_sql(cursor: Any) -> str:
+    columns = [name for name, _ in _column_defs(cursor, "chunks")]
+    column_sql = ", ".join(_quote_ident(name) for name in columns)
+    values = []
+    for name in columns:
+        if name == "sys_period_end":
+            values.append(
+                """
+                (
+                    SELECT wall_second || printf('.%06dZ', tick)
+                    FROM _brainlayer_bitemporal_clock
+                    WHERE id = 1
+                )
+                """
+            )
+        else:
+            values.append(f"OLD.{_quote_ident(name)}")
+    value_sql = ", ".join(values)
+    return f"INSERT INTO _chunks_history ({column_sql}) VALUES ({value_sql});"
+
+
+def _clock_tick_sql() -> str:
+    return """
+        UPDATE _brainlayer_bitemporal_clock
+        SET
+            tick = CASE
+                WHEN wall_second = strftime('%Y-%m-%dT%H:%M:%S','now') THEN tick + 1
+                ELSE 0
+            END,
+            wall_second = strftime('%Y-%m-%dT%H:%M:%S','now')
+        WHERE id = 1;
+    """
+
+
+def _install_triggers(cursor: Any) -> None:
+    history_insert = _history_insert_sql(cursor)
+    clock_tick = _clock_tick_sql()
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_bitemporal_update")
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_bitemporal_delete")
+    cursor.execute(
+        f"""
+        CREATE TRIGGER chunks_bitemporal_update
+        AFTER UPDATE ON chunks
+        BEGIN
+            {clock_tick}
+            {history_insert}
+        END
+        """
+    )
+    cursor.execute(
+        f"""
+        CREATE TRIGGER chunks_bitemporal_delete
+        AFTER DELETE ON chunks
+        BEGIN
+            {clock_tick}
+            {history_insert}
+        END
+        """
+    )
+
+
+def apply_bitemporal_migration(conn: Any) -> None:
+    """Idempotently install Phase-1 bitemporal schema on an existing DB.
+
+    The migration owns a short `BEGIN IMMEDIATE` write transaction. It adds only
+    nullable/defaulted columns and metadata tables; it does not backfill legacy
+    row hashes or migrate live data.
+    """
+    cursor = conn.cursor()
+    transaction_started = False
+    try:
+        cursor.execute("BEGIN IMMEDIATE")
+        transaction_started = True
+        _ensure_temporal_columns(cursor)
+        _ensure_history_table(cursor)
+        _ensure_clock_table(cursor)
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_chunks_current_active ON chunks(created_at, id) WHERE invalid_at IS NULL"
+        )
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_chunks_history_period
+            ON _chunks_history(id, sys_period_start, sys_period_end)
+            """
+        )
+        _install_triggers(cursor)
+        cursor.execute("COMMIT")
+        transaction_started = False
+    except Exception:
+        if transaction_started:
+            cursor.execute("ROLLBACK")
+        raise
+
+
+def supersede_chunk(conn: Any, chunk_id: str, *, invalid_at: str | None = None) -> bool:
+    """Mark a chunk invalid without deleting it.
+
+    The old row image is copied to `_chunks_history` by the UPDATE trigger.
+    """
+    now = invalid_at or datetime.now(timezone.utc).isoformat()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        UPDATE chunks
+        SET invalid_at = COALESCE(invalid_at, ?),
+            sys_period_end = CASE
+                WHEN sys_period_end IS NULL OR sys_period_end = ? THEN ?
+                ELSE sys_period_end
+            END
+        WHERE id = ?
+        """,
+        (now, SENTINEL_SYS_PERIOD_END, now, chunk_id),
+    )
+    return conn.changes() > 0

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -365,6 +365,12 @@ def _optional_chunk_expr(store: Any, column: str, alias: str | None = None, fall
     return f"{fallback} AS {column}"
 
 
+def _temporal_current_clause(store: Any, alias: str | None = None) -> str | None:
+    if not getattr(store, "_has_invalid_at", False):
+        return None
+    return f"{alias}.invalid_at IS NULL" if alias else "invalid_at IS NULL"
+
+
 def _clone_hybrid_result(result: Dict[str, List]) -> Dict[str, List]:
     """Return a defensive deep copy of cached hybrid_search results."""
     return copy.deepcopy(result)
@@ -1035,6 +1041,9 @@ class SearchMixin:
                 checkpoint_clause = self._checkpoint_exclusion_clause("c")
                 if checkpoint_clause:
                     where_clauses.append(checkpoint_clause)
+            temporal_clause = _temporal_current_clause(self, "c")
+            if temporal_clause:
+                where_clauses.append(temporal_clause)
             if not include_archived:
                 where_clauses.append("c.superseded_by IS NULL")
                 where_clauses.append("c.aggregated_into IS NULL")
@@ -1148,6 +1157,9 @@ class SearchMixin:
                 checkpoint_clause = self._checkpoint_exclusion_clause()
                 if checkpoint_clause:
                     where_clauses.append(checkpoint_clause)
+            temporal_clause = _temporal_current_clause(self)
+            if temporal_clause:
+                where_clauses.append(temporal_clause)
             if not include_archived:
                 where_clauses.append("superseded_by IS NULL")
                 where_clauses.append("aggregated_into IS NULL")
@@ -1442,6 +1454,9 @@ class SearchMixin:
             checkpoint_clause = self._checkpoint_exclusion_clause("c")
             if checkpoint_clause:
                 where_clauses.append(checkpoint_clause)
+        temporal_clause = _temporal_current_clause(self, "c")
+        if temporal_clause:
+            where_clauses.append(temporal_clause)
         if not include_archived:
             where_clauses.append("c.superseded_by IS NULL")
             where_clauses.append("c.aggregated_into IS NULL")
@@ -1846,6 +1861,9 @@ class SearchMixin:
                 checkpoint_clause = self._checkpoint_exclusion_clause("c")
                 if checkpoint_clause:
                     fts_extra.append(f"AND {checkpoint_clause}")
+            temporal_clause = _temporal_current_clause(self, "c")
+            if temporal_clause:
+                fts_extra.append(f"AND {temporal_clause}")
             if filter_meta_noise:
                 for pattern in META_NOISE_PATTERNS_CASEFOLDED:
                     fts_extra.append("AND LOWER(c.content) NOT LIKE ?")
@@ -2030,6 +2048,9 @@ class SearchMixin:
                 checkpoint_clause = self._checkpoint_exclusion_clause()
                 if checkpoint_clause:
                     recent_extra.append(f"AND {checkpoint_clause}")
+            temporal_clause = _temporal_current_clause(self)
+            if temporal_clause:
+                recent_extra.append(f"AND {temporal_clause}")
             if filter_meta_noise:
                 for pattern in META_NOISE_PATTERNS_CASEFOLDED:
                     recent_extra.append("AND LOWER(content) NOT LIKE ?")

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -30,6 +30,7 @@ Usage:
     )
 """
 
+import hashlib
 import json
 import logging
 import time
@@ -132,6 +133,7 @@ def store_memory(
     chunk_id = chunk_id or f"manual-{uuid.uuid4().hex[:16]}"
     now = datetime.now(timezone.utc).isoformat()
     effective_created_at = created_at or now
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
 
     # Embed at write time (if embed_fn provided), otherwise defer
     embedding = None
@@ -182,6 +184,7 @@ def store_memory(
         "content_class": content_class,
         "created_at": effective_created_at,
         "last_seen_at": now,
+        "content_hash": content_hash,
     }
     for attempt in range(5):
         cursor = store.conn.cursor()
@@ -240,45 +243,80 @@ def store_memory(
                             store._upsert_chunk_vector(cursor, stored_chunk_id, embedding)
                 else:
                     stored_chunk_id = incoming_chunk_id
+                    chunk_columns = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+                    insert_columns = [
+                        "id",
+                        "content",
+                        "metadata",
+                        "source_file",
+                        "project",
+                        "content_type",
+                        "value_type",
+                        "char_count",
+                        "source",
+                        "created_at",
+                        "enriched_at",
+                        "enrich_status",
+                        "summary",
+                        "tags",
+                        "importance",
+                        "chunk_origin",
+                        "seen_count",
+                        "last_seen_at",
+                        "dedupe_hash",
+                        "simhash",
+                        "simhash_band_0",
+                        "simhash_band_1",
+                        "simhash_band_2",
+                        "simhash_band_3",
+                        "content_class",
+                    ]
+                    insert_values = [
+                        incoming_chunk_id,
+                        content,
+                        json.dumps(meta),
+                        "brainlayer-store",
+                        project,
+                        memory_type,
+                        "HIGH",
+                        len(content),
+                        "manual",
+                        effective_created_at,
+                        now,
+                        "success",
+                        content[:200],
+                        tags_json,
+                        float(importance) if importance is not None else None,
+                        resolved_chunk_origin,
+                        1,
+                        now,
+                        dedupe_fields.dedupe_hash,
+                        dedupe_fields.simhash,
+                        dedupe_fields.bands[0],
+                        dedupe_fields.bands[1],
+                        dedupe_fields.bands[2],
+                        dedupe_fields.bands[3],
+                        content_class,
+                    ]
+                    optional_values = {
+                        "content_hash": content_hash,
+                        "valid_from": effective_created_at,
+                        "invalid_at": None,
+                        "sys_period_start": now,
+                        "sys_period_end": "9999-12-31T23:59:59.999999Z",
+                    }
+                    for column, value in optional_values.items():
+                        if column in chunk_columns:
+                            insert_columns.append(column)
+                            insert_values.append(value)
+                    column_sql = ", ".join(insert_columns)
+                    placeholders = ", ".join("?" for _ in insert_values)
                     cursor.execute(
-                        """
-                        INSERT INTO chunks
-                        (id, content, metadata, source_file, project, content_type,
-                         value_type, char_count, source, created_at, enriched_at, enrich_status,
-                         summary, tags, importance, chunk_origin, seen_count, last_seen_at,
-                         dedupe_hash, simhash, simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
-                         content_class, ingested_at)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                                ?,
-                                CAST(strftime('%s', 'now') AS INTEGER))
-                    """,
-                        (
-                            incoming_chunk_id,
-                            content,
-                            json.dumps(meta),
-                            "brainlayer-store",
-                            project,
-                            memory_type,
-                            "HIGH",
-                            len(content),
-                            "manual",
-                            effective_created_at,
-                            now,
-                            "success",
-                            content[:200],
-                            tags_json,
-                            float(importance) if importance is not None else None,
-                            resolved_chunk_origin,
-                            1,
-                            now,
-                            dedupe_fields.dedupe_hash,
-                            dedupe_fields.simhash,
-                            dedupe_fields.bands[0],
-                            dedupe_fields.bands[1],
-                            dedupe_fields.bands[2],
-                            dedupe_fields.bands[3],
-                            content_class,
-                        ),
+                        f"""
+                        INSERT INTO chunks ({column_sql}, ingested_at)
+                        VALUES ({placeholders}, CAST(strftime('%s', 'now') AS INTEGER))
+                        """,
+                        insert_values,
                     )
                     if embedding is not None:
                         store._upsert_chunk_vector(cursor, stored_chunk_id, embedding)

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -495,6 +495,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self._has_content_class = "content_class" in chunk_columns
         self._has_provenance_class = "provenance_class" in chunk_columns
         self._has_superseded_by = "superseded_by" in chunk_columns
+        self._has_invalid_at = "invalid_at" in chunk_columns
         self._binary_index_available = "chunk_vectors_binary" in existing_tables
         self._trigram_fts_available = "chunks_fts_trigram" in existing_tables
         self._chunk_tags_available = "chunk_tags" in existing_tables
@@ -590,7 +591,12 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 provenance_class TEXT,
                 chunk_origin TEXT DEFAULT 'unknown',
-                content_class TEXT DEFAULT 'knowledge'
+                content_class TEXT DEFAULT 'knowledge',
+                content_hash TEXT,
+                valid_from TEXT,
+                invalid_at TEXT,
+                sys_period_start TEXT DEFAULT '0001-01-01T00:00:00.000000Z',
+                sys_period_end TEXT DEFAULT '9999-12-31T23:59:59.999999Z'
             )
         """)
 
@@ -1587,6 +1593,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
             """)
 
+        existing_cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
+        self._has_invalid_at = "invalid_at" in existing_cols
+        if self._has_invalid_at:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_chunks_current_active ON chunks(created_at, id) WHERE invalid_at IS NULL"
+            )
+
         # Thread-local storage for per-thread read connections.
         # APSW connections are NOT thread-safe — each thread needs its own.
         # This prevents "Connection is busy in another thread" when parallel
@@ -2279,6 +2292,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 lifecycle_clauses.append("COALESCE(archived, 0) = 0")
             if "status" in cols:
                 lifecycle_clauses.append("COALESCE(status, 'active') = 'active'")
+        if "invalid_at" in cols:
+            lifecycle_clauses.append("invalid_at IS NULL")
         lifecycle_filter = "".join(f" AND {clause}" for clause in lifecycle_clauses)
         rows = list(
             cursor.execute(

--- a/tests/test_bitemporal_phase1.py
+++ b/tests/test_bitemporal_phase1.py
@@ -1,0 +1,210 @@
+import hashlib
+
+import apsw
+
+from brainlayer.vector_store import VectorStore
+
+SENTINEL_END = "9999-12-31T23:59:59.999999Z"
+
+
+def _legacy_conn(tmp_path):
+    conn = apsw.Connection(str(tmp_path / "legacy.db"))
+    conn.cursor().execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            metadata TEXT NOT NULL,
+            source_file TEXT NOT NULL,
+            created_at TEXT
+        )
+        """
+    )
+    return conn
+
+
+def _insert_chunk(conn, chunk_id: str, content: str, *, invalid_at: str | None = None) -> None:
+    conn.cursor().execute(
+        """
+        INSERT INTO chunks (
+            id, content, metadata, source_file, created_at, content_hash,
+            valid_from, invalid_at, sys_period_start, sys_period_end
+        )
+        VALUES (?, ?, '{}', 'fixture', '2026-06-14T00:00:00+00:00', ?, ?, ?, ?, ?)
+        """,
+        (
+            chunk_id,
+            content,
+            hashlib.sha256(content.strip().encode("utf-8")).hexdigest(),
+            "2026-06-14T00:00:00.000000Z",
+            invalid_at,
+            "2026-06-14T00:00:00.000000Z",
+            SENTINEL_END,
+        ),
+    )
+
+
+def test_migration_preserves_old_rows_on_update_and_delete(tmp_path):
+    from brainlayer.bitemporal import apply_bitemporal_migration
+
+    conn = _legacy_conn(tmp_path)
+    apply_bitemporal_migration(conn)
+    _insert_chunk(conn, "chunk-1", "original payload")
+
+    conn.cursor().execute("UPDATE chunks SET content = ? WHERE id = ?", ("updated payload", "chunk-1"))
+    conn.cursor().execute("DELETE FROM chunks WHERE id = ?", ("chunk-1",))
+
+    history = list(
+        conn.cursor().execute(
+            "SELECT id, content, sys_period_start, sys_period_end FROM _chunks_history WHERE id = ? ORDER BY rowid",
+            ("chunk-1",),
+        )
+    )
+
+    assert [row[1] for row in history] == ["original payload", "updated payload"]
+    assert history[0][2] == "2026-06-14T00:00:00.000000Z"
+    assert history[0][3] != SENTINEL_END
+    assert history[1][3] != SENTINEL_END
+    assert conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE id = 'chunk-1'").fetchone()[0] == 0
+
+
+def test_history_supports_as_of_queries_for_superseded_content(tmp_path):
+    from brainlayer.bitemporal import apply_bitemporal_migration
+
+    conn = _legacy_conn(tmp_path)
+    apply_bitemporal_migration(conn)
+    _insert_chunk(conn, "chunk-2", "before correction")
+
+    conn.cursor().execute("UPDATE chunks SET content = ? WHERE id = ?", ("after correction", "chunk-2"))
+    as_of_rows = list(
+        conn.cursor().execute(
+            """
+            SELECT content FROM _chunks_history
+            WHERE id = ?
+              AND sys_period_start <= ?
+              AND sys_period_end > ?
+            """,
+            ("chunk-2", "2026-06-14T00:00:01.000000Z", "2026-06-14T00:00:01.000000Z"),
+        )
+    )
+
+    assert as_of_rows == [("before correction",)]
+
+
+def test_current_view_uses_partial_invalid_at_index(tmp_path):
+    from brainlayer.bitemporal import apply_bitemporal_migration
+
+    conn = _legacy_conn(tmp_path)
+    apply_bitemporal_migration(conn)
+    _insert_chunk(conn, "active", "current")
+    _insert_chunk(conn, "inactive", "old", invalid_at="2026-06-14T01:00:00.000000Z")
+
+    current_ids = list(conn.cursor().execute("SELECT id FROM chunks WHERE invalid_at IS NULL ORDER BY id"))
+    plan = " ".join(
+        str(part)
+        for row in conn.cursor().execute("EXPLAIN QUERY PLAN SELECT id FROM chunks WHERE invalid_at IS NULL")
+        for part in row
+    )
+
+    assert current_ids == [("active",)]
+    assert "idx_chunks_current_active" in plan
+
+
+def test_supersede_updates_invalid_at_and_keeps_recoverable_history(tmp_path):
+    from brainlayer.bitemporal import apply_bitemporal_migration, supersede_chunk
+
+    conn = _legacy_conn(tmp_path)
+    apply_bitemporal_migration(conn)
+    _insert_chunk(conn, "chunk-3", "recover me")
+
+    assert supersede_chunk(conn, "chunk-3", invalid_at="2026-06-14T02:00:00.000000Z") is True
+
+    current_rows = list(conn.cursor().execute("SELECT id FROM chunks WHERE invalid_at IS NULL"))
+    history_rows = list(
+        conn.cursor().execute(
+            """
+            SELECT content FROM _chunks_history
+            WHERE id = ?
+              AND sys_period_start <= ?
+              AND sys_period_end > ?
+            """,
+            ("chunk-3", "2026-06-14T00:00:01.000000Z", "2026-06-14T00:00:01.000000Z"),
+        )
+    )
+
+    assert current_rows == []
+    assert history_rows == [("recover me",)]
+
+
+def test_bitemporal_migration_is_idempotent(tmp_path):
+    from brainlayer.bitemporal import apply_bitemporal_migration
+
+    conn = _legacy_conn(tmp_path)
+    apply_bitemporal_migration(conn)
+    first_columns = list(conn.cursor().execute("PRAGMA table_info(chunks)"))
+    first_history_columns = list(conn.cursor().execute("PRAGMA table_info(_chunks_history)"))
+    first_triggers = list(
+        conn.cursor().execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'chunks_bitemporal_%' ORDER BY name"
+        )
+    )
+
+    apply_bitemporal_migration(conn)
+
+    assert list(conn.cursor().execute("PRAGMA table_info(chunks)")) == first_columns
+    assert list(conn.cursor().execute("PRAGMA table_info(_chunks_history)")) == first_history_columns
+    assert (
+        list(
+            conn.cursor().execute(
+                "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'chunks_bitemporal_%' ORDER BY name"
+            )
+        )
+        == first_triggers
+    )
+
+
+def test_store_memory_populates_content_hash_and_temporal_columns(tmp_path):
+    from brainlayer.store import store_memory
+
+    store = VectorStore(tmp_path / "store.db")
+    try:
+        result = store_memory(
+            store=store,
+            embed_fn=None,
+            content="Temporal store write",
+            memory_type="note",
+            project="brainlayer",
+        )
+        row = store.conn.cursor().execute(
+            "SELECT content_hash, valid_from, invalid_at, sys_period_start, sys_period_end FROM chunks WHERE id = ?",
+            (result["id"],),
+        ).fetchone()
+    finally:
+        store.close()
+
+    assert row == (
+        hashlib.sha256("Temporal store write".encode("utf-8")).hexdigest(),
+        row[1],
+        None,
+        row[3],
+        SENTINEL_END,
+    )
+    assert row[1] is not None
+    assert row[3] is not None
+
+
+def test_vector_store_startup_does_not_install_history_triggers_without_opt_in(tmp_path):
+    store = VectorStore(tmp_path / "opt-in.db")
+    try:
+        cursor = store.conn.cursor()
+        history_table = cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '_chunks_history'"
+        ).fetchone()
+        bitemporal_triggers = list(
+            cursor.execute("SELECT name FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'chunks_bitemporal_%'")
+        )
+    finally:
+        store.close()
+
+    assert history_table is None
+    assert bitemporal_triggers == []

--- a/tests/test_bitemporal_phase1.py
+++ b/tests/test_bitemporal_phase1.py
@@ -175,10 +175,14 @@ def test_store_memory_populates_content_hash_and_temporal_columns(tmp_path):
             memory_type="note",
             project="brainlayer",
         )
-        row = store.conn.cursor().execute(
-            "SELECT content_hash, valid_from, invalid_at, sys_period_start, sys_period_end FROM chunks WHERE id = ?",
-            (result["id"],),
-        ).fetchone()
+        row = (
+            store.conn.cursor()
+            .execute(
+                "SELECT content_hash, valid_from, invalid_at, sys_period_start, sys_period_end FROM chunks WHERE id = ?",
+                (result["id"],),
+            )
+            .fetchone()
+        )
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary
- Adds Phase-1 bitemporal chunk schema support: temporal columns, `_chunks_history`, deterministic SQLite clock table, update/delete history triggers, and `supersede_chunk()` helper.
- Keeps migration opt-in via `apply_bitemporal_migration(conn)`; normal `VectorStore` startup does not install history triggers or force-migrate live rows.
- Populates `content_hash` and temporal fields on `store_memory` writes when the columns exist, and filters current search/read paths with `invalid_at IS NULL` when available.
- Merged current `origin/main` after WI-4 (#484); did not touch `embed_pending_chunks`, `_upsert_chunk_vector`, or hybrid fusion logic beyond preserving WI-4 merge content.

## Test plan / Gates
- B1 RED destructive reproduction: legacy fixture `DELETE` yielded `current_rows=0 history_exists=False recovered_rows=0`.
- B2-B4 + idempotency/write-path tests: `python3 -m pytest tests/test_bitemporal_phase1.py -q` -> `7 passed`.
- Lint: `python3 -m ruff check src/brainlayer/bitemporal.py src/brainlayer/store.py src/brainlayer/search_repo.py src/brainlayer/vector_store.py tests/test_bitemporal_phase1.py` -> `All checks passed!`.
- Targeted B5/WI regression set: `python3 -m pytest tests/test_bitemporal_phase1.py tests/test_deferred_embedding.py tests/test_brainstore.py tests/test_hybrid_search.py tests/test_search_handler.py tests/test_db_lock_resilience.py tests/test_provenance.py tests/test_transport_replay_attribution.py tests/test_mcp_timeout.py -q` -> `138 passed` on the merge commit.
- Broad non-live/non-slow suite: `python3 -m pytest -q -m "not live and not slow" --ignore=tests/regression/test_drift_detection.py` -> `2900 passed, 1 skipped, 52 deselected, 1 xfailed` on the merge commit.

## Known verification limitation
- Unignored full broad collection currently fails before tests run in `tests/regression/test_drift_detection.py`: `deepchecks` imports `get_scorer('max_error')`, but installed scikit-learn rejects that scorer name. This is environment/dependency collection failure, not from this diff; the same collector was excluded for broad regression coverage.

Co-Authored-By: Claude Opus 4.8 (1M context)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chunk persistence and all major search paths once migrated; behavior change is gated on opt-in migration and column presence, but mistaken migration or supersede use could hide or alter visible memories.
> 
> **Overview**
> Introduces **Phase-1 bitemporal chunk tracking** behind an explicit **`apply_bitemporal_migration(conn)`** call—normal **`VectorStore` startup does not** install history tables or update/delete triggers.
> 
> The migration adds temporal columns on **`chunks`**, a mirror **`_chunks_history`** table, a monotonic clock for **`sys_period_*`**, indexes, and **`AFTER UPDATE`/`AFTER DELETE`** triggers that snapshot the prior row. **`supersede_chunk`** soft-invalidates a chunk by setting **`invalid_at`** (and closing **`sys_period_end`**) without deleting it.
> 
> **Write path:** **`store_memory`** now sets SHA-256 **`content_hash`** and, when those columns exist, **`valid_from`**, **`invalid_at`**, and system-period fields on new inserts (dynamic column list vs a fixed INSERT).
> 
> **Read/search path:** When **`invalid_at`** is present on the schema, vector, FTS, hybrid, and lifecycle filters add **`invalid_at IS NULL`** so superseded rows drop out of default retrieval. Fresh DBs get the columns from **`vector_store`** DDL; history/triggers still require the opt-in migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b165432db66a76263523eda993e1baaef82862f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in bitemporal chunk ledger with history table, triggers, and temporal query filtering
> - Adds [bitemporal.py](https://github.com/EtanHey/brainlayer/pull/485/files#diff-60cc6149469a093cd319a52db8bc7766eaf21d63bfcda630ead7fcddc9865178) implementing a Phase-1 bitemporal schema: temporal columns (`content_hash`, `valid_from`, `invalid_at`, `sys_period_start`, `sys_period_end`) on `chunks`, a `_chunks_history` table, a monotonic clock table, and AFTER UPDATE/DELETE triggers that archive old row images.
> - `apply_bitemporal_migration` is an idempotent entrypoint that installs the full schema and trigger set in a single `BEGIN IMMEDIATE` transaction.
> - `supersede_chunk` soft-invalidates a chunk by setting `invalid_at` and closing `sys_period_end`, preserving the prior image in history via the UPDATE trigger.
> - Search queries in `SearchMixin` and lifecycle filters in `VectorStore` now exclude rows where `invalid_at IS NULL` is false when the column is present.
> - `store_memory` computes a SHA-256 `content_hash` and stamps all temporal columns on insert; `VectorStore.__init__` detects column presence and creates a partial index on current rows.
> - Risk: running `apply_bitemporal_migration` mutates the live database schema and trigger set; existing databases without temporal columns will have them added via `ALTER TABLE`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 144d43f. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->