### PR TITLE
Add consumer-aware retrieval scoping

### DIFF
--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -20,7 +20,7 @@ from .._helpers import _escape_fts5_query, _is_sqlite_busy_error
 from ..chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_checkpoint_content
 from ..content_class import content_class_is_default_hidden, normalize_content_class, query_signals_operational_intent
 from ..lexical_defense import _normalize_surface, load_lexical_defense_dictionary
-from ..search_repo import _is_audit_recursion_metadata
+from ..search_repo import _is_audit_recursion_metadata, _metadata_matches_project_scope
 
 # Retry settings for DB lock resilience on reads
 _RETRY_MAX_ATTEMPTS = 3
@@ -331,6 +331,7 @@ def _exact_chunk_lookup_result(
     include_audit: bool = False,
     include_operational: bool = False,
     content_class_filter: str | None = None,
+    consumer_scope: Any | None = None,
 ) -> tuple[list[TextContent], dict] | None:
     """Return an exact chunk hit for chunk-id shaped queries, or None on miss."""
     candidate = query.strip()
@@ -352,7 +353,10 @@ def _exact_chunk_lookup_result(
     effective_source = None if source == "all" else source
     if any(value is not None for value in (effective_source, intent, sentiment, source_filter, correction_category)):
         return None
-    if project is not None:
+    if consumer_scope is not None:
+        if not _metadata_matches_project_scope({"project": chunk.get("project")}, project, consumer_scope):
+            return _empty_exact_chunk_lookup_result(query)
+    elif project is not None:
         chunk_project = _normalize_project_name(chunk.get("project")) or chunk.get("project")
         normalized_project = _normalize_project_name(project) or project
         if chunk_project not in (normalized_project, None):
@@ -757,13 +761,19 @@ async def _brain_search_dispatch(
             f"num_results={num_results} must be between {_MIN_PUBLIC_NUM_RESULTS} and {_MAX_PUBLIC_NUM_RESULTS}"
         )
 
-    if project is None and entity_id is None and source not in ("youtube", "whatsapp", "telegram", "all"):
+    consumer_scope = None
+    if project is None and entity_id is None:
         try:
             from ..scoping import resolve_project_scope
 
             project = resolve_project_scope()
         except Exception:
             logger.debug("Project auto-scope failed, proceeding without scope")
+    from ..scoping import resolve_consumer_scope
+
+    consumer_scope = resolve_consumer_scope(project=project, include_checkpoints=include_checkpoints)
+    project = consumer_scope.project_filter
+    include_checkpoints = consumer_scope.include_checkpoints
 
     if entity_id is not None:
         return await _search(
@@ -790,11 +800,19 @@ async def _brain_search_dispatch(
             profile_query_id=profile_query_id,
             profile_scope=profile_scope,
             brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+            consumer_scope=consumer_scope,
         )
 
     if chunk_id is not None:
         store = _get_vector_store()
         chunk = store.get_chunk(chunk_id)
+        if isinstance(chunk, dict) and not _metadata_matches_project_scope(
+            {"project": chunk.get("project")},
+            project,
+            consumer_scope,
+        ):
+            empty = {"query": query, "total": 0, "results": []}
+            return ([TextContent(type="text", text="No results found.")], empty)
         if (
             not include_checkpoints
             and isinstance(chunk, dict)
@@ -957,6 +975,7 @@ async def _brain_search_dispatch(
         include_audit=include_audit,
         include_operational=include_operational,
         content_class_filter=content_class_filter,
+        consumer_scope=consumer_scope,
     )
     if exact_chunk_hit is not None:
         return exact_chunk_hit
@@ -1156,6 +1175,7 @@ async def _brain_search_dispatch(
         profile_query_id=profile_query_id,
         profile_scope=profile_scope,
         brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+        consumer_scope=consumer_scope,
     )
     return result
 
@@ -1488,6 +1508,7 @@ async def _search(
     profile_query_id: str | None = None,
     profile_scope: str = "search.mcp",
     brainbar_helper_fast_profile: bool = False,
+    consumer_scope: Any | None = None,
 ):
     """Execute a hybrid search query (semantic + keyword via RRF). Retries on BusyError."""
     try:
@@ -1572,6 +1593,7 @@ async def _search(
                         profile_query_id=profile_query_id,
                         profile_scope=profile_scope,
                         brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+                        consumer_scope=consumer_scope,
                     )
                     break
                 except Exception as e:

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -64,6 +64,48 @@ def _is_sqlite_vec_knn_error(exc: Exception) -> bool:
     return "sqlite-vec" in message or ("knn" in message and ("limit" in message or "too large" in message))
 
 
+def _row_matches_consumer_scope(row: dict[str, Any], project: str | None, consumer_scope: Any | None) -> bool:
+    return _metadata_matches_project_scope({"project": row.get("project")}, project, consumer_scope)
+
+
+def _filter_rows_for_consumer_scope(
+    rows: list[dict[str, Any]],
+    project: str | None,
+    consumer_scope: Any | None,
+) -> list[dict[str, Any]]:
+    return [row for row in rows if _row_matches_consumer_scope(row, project, consumer_scope)]
+
+
+def _filter_recall_result_for_consumer_scope(result: Any, project: str | None, consumer_scope: Any | None) -> Any:
+    if consumer_scope is None:
+        return result
+    if hasattr(result, "file_history"):
+        result.file_history = _filter_rows_for_consumer_scope(result.file_history, project, consumer_scope)
+    if hasattr(result, "related_chunks"):
+        result.related_chunks = _filter_rows_for_consumer_scope(result.related_chunks, project, consumer_scope)
+    if hasattr(result, "session_summaries"):
+        result.session_summaries = _filter_rows_for_consumer_scope(result.session_summaries, project, consumer_scope)
+    return result
+
+
+def _filter_regression_for_consumer_scope(result: dict[str, Any], project: str | None, consumer_scope: Any | None) -> dict[str, Any]:
+    if consumer_scope is None:
+        return result
+    filtered = dict(result)
+    timeline = _filter_rows_for_consumer_scope(list(result.get("timeline") or []), project, consumer_scope)
+    filtered["timeline"] = timeline
+    last_success = result.get("last_success")
+    filtered["last_success"] = (
+        last_success if isinstance(last_success, dict) and _row_matches_consumer_scope(last_success, project, consumer_scope) else None
+    )
+    filtered["changes_after"] = _filter_rows_for_consumer_scope(
+        list(result.get("changes_after") or []),
+        project,
+        consumer_scope,
+    )
+    return filtered
+
+
 def _helper_sentinel_path() -> Path:
     return Path("~/.local/share/brainlayer/use-helper-socket").expanduser()
 
@@ -762,7 +804,7 @@ async def _brain_search_dispatch(
         )
 
     consumer_scope = None
-    if project is None and entity_id is None:
+    if project is None:
         try:
             from ..scoping import resolve_project_scope
 
@@ -849,16 +891,18 @@ async def _brain_search_dispatch(
             after=after,
             include_checkpoints=include_checkpoints,
             include_audit=include_audit,
+            consumer_scope=consumer_scope,
         )
 
     if file_path is not None and _query_has_regression_signal(query):
-        regression_result = await _regression(file_path=file_path, project=project)
+        regression_result = await _regression(file_path=file_path, project=project, consumer_scope=consumer_scope)
         recall_result = await _recall(
             file_path=file_path,
             project=project,
             max_results=max_results,
             include_audit=include_audit,
             agent_id=agent_id,
+            consumer_scope=consumer_scope,
         )
         merged_text = []
         if isinstance(regression_result, list):
@@ -870,13 +914,14 @@ async def _brain_search_dispatch(
         return merged_text
 
     if file_path is not None:
-        timeline = await _file_timeline(file_path=file_path, project=project, limit=50)
+        timeline = await _file_timeline(file_path=file_path, project=project, limit=50, consumer_scope=consumer_scope)
         recall_result = await _recall(
             file_path=file_path,
             project=project,
             max_results=max_results,
             include_audit=include_audit,
             agent_id=agent_id,
+            consumer_scope=consumer_scope,
         )
         merged_text = []
         if isinstance(timeline, list):
@@ -1774,6 +1819,7 @@ async def _context(
     *,
     include_checkpoints: bool = False,
     include_audit: bool = False,
+    consumer_scope: Any | None = None,
 ) -> list[TextContent]:
     """Get surrounding conversation context for a chunk."""
     try:
@@ -1784,6 +1830,7 @@ async def _context(
             after=after,
             include_checkpoints=include_checkpoints,
             include_audit=include_audit,
+            consumer_scope=consumer_scope,
         )
         if result.get("error"):
             return _error_result(f"Unknown chunk_id '{chunk_id[:20]}...'. Use chunk_id from brainlayer_search results.")
@@ -1807,11 +1854,17 @@ async def _context(
         return _error_result(f"Context error: {str(e)}")
 
 
-async def _file_timeline(file_path: str, project: str | None = None, limit: int = 50) -> list[TextContent]:
+async def _file_timeline(
+    file_path: str,
+    project: str | None = None,
+    limit: int = 50,
+    consumer_scope: Any | None = None,
+) -> list[TextContent]:
     """Get interaction timeline for a file."""
     try:
         store = _get_vector_store()
         interactions = store.get_file_timeline(file_path, project=project, limit=limit)
+        interactions = _filter_rows_for_consumer_scope(interactions, project, consumer_scope)
         if not interactions:
             return [TextContent(type="text", text=f"No interactions found for '{file_path}'.")]
         output_parts = [f"## File Timeline: {file_path}\n", f"Found {len(interactions)} interactions:\n"]
@@ -1846,11 +1899,16 @@ async def _operations(session_id: str) -> list[TextContent]:
         return _error_result(f"Operations error: {str(e)}")
 
 
-async def _regression(file_path: str, project: str | None = None) -> list[TextContent]:
+async def _regression(
+    file_path: str,
+    project: str | None = None,
+    consumer_scope: Any | None = None,
+) -> list[TextContent]:
     """Analyze a file for regressions."""
     try:
         store = _get_vector_store()
         result = store.get_file_regression(file_path, project=project)
+        result = _filter_regression_for_consumer_scope(result, project, consumer_scope)
         if not result["timeline"]:
             return [TextContent(type="text", text=f"No interactions found for '{file_path}'.")]
         parts = [f"## Regression Analysis: {file_path}\n", f"Timeline: {len(result['timeline'])} interactions\n"]
@@ -1965,6 +2023,7 @@ async def _recall(
     max_results: int = 10,
     include_audit: bool = False,
     agent_id: str | None = None,
+    consumer_scope: Any | None = None,
 ):
     """Execute recall -- proactive context retrieval."""
     try:
@@ -1991,6 +2050,7 @@ async def _recall(
                 agent_id=agent_id,
             ),
         )
+        result = _filter_recall_result_for_consumer_scope(result, normalized_project, consumer_scope)
         structured = {
             "target": result.target,
             "file_history": [

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -88,7 +88,9 @@ def _filter_recall_result_for_consumer_scope(result: Any, project: str | None, c
     return result
 
 
-def _filter_regression_for_consumer_scope(result: dict[str, Any], project: str | None, consumer_scope: Any | None) -> dict[str, Any]:
+def _filter_regression_for_consumer_scope(
+    result: dict[str, Any], project: str | None, consumer_scope: Any | None
+) -> dict[str, Any]:
     if consumer_scope is None:
         return result
     filtered = dict(result)
@@ -96,7 +98,9 @@ def _filter_regression_for_consumer_scope(result: dict[str, Any], project: str |
     filtered["timeline"] = timeline
     last_success = result.get("last_success")
     filtered["last_success"] = (
-        last_success if isinstance(last_success, dict) and _row_matches_consumer_scope(last_success, project, consumer_scope) else None
+        last_success
+        if isinstance(last_success, dict) and _row_matches_consumer_scope(last_success, project, consumer_scope)
+        else None
     )
     filtered["changes_after"] = _filter_rows_for_consumer_scope(
         list(result.get("changes_after") or []),

--- a/src/brainlayer/scoping.py
+++ b/src/brainlayer/scoping.py
@@ -6,6 +6,7 @@ Falls back to parsing CWD if no config exists.
 
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -16,6 +17,9 @@ _SCOPES_PATH = Path.home() / ".config" / "brainlayer" / "scopes.yaml"
 # Cache parsed config
 _cached_scopes: Optional[dict] = None
 _cached_mtime: float = 0.0
+_VALID_CONSUMERS = frozenset({"orchestrator", "worker", "coach"})
+_DEFAULT_CONSUMER = "worker"
+_COACH_PROJECT = "personal"
 
 
 def _load_scopes() -> dict:
@@ -109,6 +113,113 @@ def resolve_project_scope() -> Optional[str]:
         return matches[0][1]
 
     return None if default == "all" else default
+
+
+@dataclass(frozen=True)
+class ConsumerScope:
+    """Retrieval-time visibility policy for a BrainLayer consumer role."""
+
+    role: str
+    project_filter: Optional[str]
+    source_filter: Optional[str] = None
+    include_checkpoints: bool = False
+    allow_null_project: bool = False
+    deny_all: bool = False
+
+    @classmethod
+    def for_worker(
+        cls,
+        project: Optional[str],
+        *,
+        source_filter: Optional[str] = None,
+        include_checkpoints: bool = False,
+    ) -> "ConsumerScope":
+        return cls(
+            role="worker",
+            project_filter=project,
+            source_filter=source_filter,
+            include_checkpoints=include_checkpoints,
+            allow_null_project=False,
+            deny_all=project is None,
+        )
+
+    @classmethod
+    def for_orchestrator(
+        cls,
+        *,
+        source_filter: Optional[str] = None,
+        include_checkpoints: bool = False,
+    ) -> "ConsumerScope":
+        return cls(
+            role="orchestrator",
+            project_filter=None,
+            source_filter=source_filter,
+            include_checkpoints=include_checkpoints,
+            allow_null_project=True,
+            deny_all=False,
+        )
+
+    @classmethod
+    def for_coach(
+        cls,
+        *,
+        source_filter: Optional[str] = None,
+        include_checkpoints: bool = True,
+    ) -> "ConsumerScope":
+        return cls(
+            role="coach",
+            project_filter=_COACH_PROJECT,
+            source_filter=source_filter,
+            include_checkpoints=include_checkpoints,
+            allow_null_project=True,
+            deny_all=False,
+        )
+
+    def cache_key(self) -> tuple:
+        return (
+            self.role,
+            self.project_filter,
+            self.source_filter,
+            self.include_checkpoints,
+            self.allow_null_project,
+            self.deny_all,
+        )
+
+
+def resolve_consumer_role(consumer: Optional[str] = None) -> str:
+    """Resolve consumer role from explicit value or BRAINLAYER_CONSUMER.
+
+    Missing or invalid values fail closed to worker, the most restrictive role.
+    """
+    raw = consumer if consumer is not None else os.environ.get("BRAINLAYER_CONSUMER")
+    role = (raw or _DEFAULT_CONSUMER).strip().casefold()
+    if role not in _VALID_CONSUMERS:
+        logger.warning("Invalid BRAINLAYER_CONSUMER=%r; defaulting to worker", raw)
+        return _DEFAULT_CONSUMER
+    return role
+
+
+def resolve_consumer_scope(
+    *,
+    project: Optional[str] = None,
+    consumer: Optional[str] = None,
+    source_filter: Optional[str] = None,
+    include_checkpoints: bool = False,
+) -> ConsumerScope:
+    """Resolve the retrieval-time policy for the current BrainLayer consumer."""
+    role = resolve_consumer_role(consumer)
+    if role == "orchestrator":
+        return ConsumerScope.for_orchestrator(
+            source_filter=source_filter,
+            include_checkpoints=include_checkpoints,
+        )
+    if role == "coach":
+        return ConsumerScope.for_coach(source_filter=source_filter, include_checkpoints=True)
+    return ConsumerScope.for_worker(
+        project,
+        source_filter=source_filter,
+        include_checkpoints=include_checkpoints,
+    )
 
 
 def _cwd_heuristic() -> Optional[str]:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -22,6 +22,7 @@ from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_chec
 from .content_class import DEFAULT_CONTENT_CLASS, normalize_content_class, query_signals_operational_intent
 from .dedupe import resolve_chunk_id
 from .ingest_guard import recursive_mcp_output_reason
+from .scoping import ConsumerScope
 
 # ── hybrid_search result cache ───────────────────────────────────────────────
 # Caches identical (store, query_text, filters) → results for 60s.
@@ -356,6 +357,61 @@ def _content_class_expr(store: Any, alias: str | None = None) -> str:
     if getattr(store, "_has_content_class", True):
         return f"{alias}.content_class" if alias else "content_class"
     return f"'{DEFAULT_CONTENT_CLASS}'"
+
+
+def _effective_project_filter(project_filter: Optional[str], consumer_scope: ConsumerScope | None) -> Optional[str]:
+    if consumer_scope is not None:
+        return consumer_scope.project_filter
+    return project_filter
+
+
+def _effective_source_filter(source_filter: Optional[str], consumer_scope: ConsumerScope | None) -> Optional[str]:
+    if consumer_scope is not None and consumer_scope.source_filter is not None:
+        return consumer_scope.source_filter
+    return source_filter
+
+
+def _effective_include_checkpoints(include_checkpoints: bool, consumer_scope: ConsumerScope | None) -> bool:
+    if consumer_scope is not None:
+        return include_checkpoints or consumer_scope.include_checkpoints
+    return include_checkpoints
+
+
+def _project_scope_where(
+    column_expr: str,
+    project_filter: Optional[str],
+    consumer_scope: ConsumerScope | None,
+) -> tuple[str | None, list[Any]]:
+    if consumer_scope is not None and consumer_scope.deny_all:
+        return "0 = 1", []
+
+    effective_project = _effective_project_filter(project_filter, consumer_scope)
+    if not effective_project:
+        return None, []
+
+    if consumer_scope is not None and not consumer_scope.allow_null_project:
+        return f"{column_expr} = ?", [effective_project]
+    return f"({column_expr} = ? OR {column_expr} IS NULL)", [effective_project]
+
+
+def _metadata_matches_project_scope(
+    metadata: dict[str, Any],
+    project_filter: Optional[str],
+    consumer_scope: ConsumerScope | None,
+) -> bool:
+    if consumer_scope is not None and consumer_scope.deny_all:
+        return False
+
+    effective_project = _effective_project_filter(project_filter, consumer_scope)
+    if not effective_project:
+        return True
+
+    project = metadata.get("project")
+    if project == effective_project:
+        return True
+    if project is None:
+        return consumer_scope is None or consumer_scope.allow_null_project
+    return False
 
 
 def _optional_chunk_expr(store: Any, column: str, alias: str | None = None, fallback: str = "NULL") -> str:
@@ -965,6 +1021,7 @@ class SearchMixin:
         include_audit: bool = False,
         include_operational: bool = False,
         content_class_filter: Optional[str] = None,
+        consumer_scope: ConsumerScope | None = None,
     ) -> Dict[str, List]:
         """Search chunks by embedding or text.
 
@@ -976,6 +1033,9 @@ class SearchMixin:
         """
 
         cursor = self._read_cursor()
+        project_filter = _effective_project_filter(project_filter, consumer_scope)
+        source_filter = _effective_source_filter(source_filter, consumer_scope)
+        include_checkpoints = _effective_include_checkpoints(include_checkpoints, consumer_scope)
 
         if query_embedding is not None:
             # Vector similarity search
@@ -987,9 +1047,10 @@ class SearchMixin:
             if entity_id:
                 where_clauses.append("c.id IN (SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = ?)")
                 filter_params.append(entity_id)
-            if project_filter:
-                where_clauses.append("(c.project = ? OR c.project IS NULL)")
-                filter_params.append(project_filter)
+            project_clause, project_params = _project_scope_where("c.project", project_filter, consumer_scope)
+            if project_clause:
+                where_clauses.append(project_clause)
+                filter_params.extend(project_params)
             if content_type_filter:
                 where_clauses.append("c.content_type = ?")
                 filter_params.append(content_type_filter)
@@ -1106,9 +1167,10 @@ class SearchMixin:
             if entity_id:
                 where_clauses.append("id IN (SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = ?)")
                 params.append(entity_id)
-            if project_filter:
-                where_clauses.append("(project = ? OR project IS NULL)")
-                params.append(project_filter)
+            project_clause, project_params = _project_scope_where("project", project_filter, consumer_scope)
+            if project_clause:
+                where_clauses.append(project_clause)
+                params.extend(project_params)
             if content_type_filter:
                 where_clauses.append("content_type = ?")
                 params.append(content_type_filter)
@@ -1389,10 +1451,14 @@ class SearchMixin:
         include_operational: bool = False,
         content_class_filter: Optional[str] = None,
         brainbar_helper_fast_profile: bool = False,
+        consumer_scope: ConsumerScope | None = None,
     ) -> Dict[str, List]:
         """Run KNN search against binary-quantized vectors."""
         cursor = self._read_cursor()
         query_bytes = serialize_f32(query_embedding)
+        project_filter = _effective_project_filter(project_filter, consumer_scope)
+        source_filter = _effective_source_filter(source_filter, consumer_scope)
+        include_checkpoints = _effective_include_checkpoints(include_checkpoints, consumer_scope)
 
         where_clauses = []
         filter_params: list = []
@@ -1400,9 +1466,10 @@ class SearchMixin:
         if entity_id:
             where_clauses.append("c.id IN (SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = ?)")
             filter_params.append(entity_id)
-        if project_filter:
-            where_clauses.append("(c.project = ? OR c.project IS NULL)")
-            filter_params.append(project_filter)
+        project_clause, project_params = _project_scope_where("c.project", project_filter, consumer_scope)
+        if project_clause:
+            where_clauses.append(project_clause)
+            filter_params.extend(project_params)
         if content_type_filter:
             where_clauses.append("c.content_type = ?")
             filter_params.append(content_type_filter)
@@ -1647,6 +1714,7 @@ class SearchMixin:
         profile_query_id: str | None = None,
         profile_scope: str = "search.repo",
         brainbar_helper_fast_profile: bool = False,
+        consumer_scope: ConsumerScope | None = None,
     ) -> Dict[str, List]:
         """Hybrid search combining semantic (vector) + keyword (FTS5) via Reciprocal Rank Fusion.
 
@@ -1658,6 +1726,12 @@ class SearchMixin:
         return cached results, avoiding repeated brute-force 303K-vector scans.
         Cache is module-level LRU (128 entries) with defensive copy-on-read.
         """
+
+        project_filter = _effective_project_filter(project_filter, consumer_scope)
+        source_filter = _effective_source_filter(source_filter, consumer_scope)
+        include_checkpoints = _effective_include_checkpoints(include_checkpoints, consumer_scope)
+        if consumer_scope is not None and consumer_scope.deny_all:
+            return {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]}
 
         # ── Cache lookup ─────────────────────────────────────────────────────
         store_key = os.fspath(getattr(self, "db_path", "<unknown-db>"))
@@ -1692,6 +1766,7 @@ class SearchMixin:
             correction_category,
             filter_meta_noise,
             brainbar_helper_fast_profile,
+            consumer_scope.cache_key() if consumer_scope is not None else None,
         )
         now = time.monotonic()
         if cache_key in _hybrid_cache:
@@ -1733,6 +1808,7 @@ class SearchMixin:
                 include_operational=include_operational,
                 content_class_filter=content_class_filter,
                 brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+                consumer_scope=consumer_scope,
             )
             search_profile.emit(
                 profile_scope,
@@ -1776,6 +1852,7 @@ class SearchMixin:
                 include_audit=include_audit,
                 include_operational=include_operational,
                 content_class_filter=content_class_filter,
+                consumer_scope=consumer_scope,
             )
             search_profile.emit(
                 profile_scope,
@@ -1810,9 +1887,10 @@ class SearchMixin:
                 entity_join = "JOIN kg_entity_chunks ec ON c.id = ec.chunk_id"
                 fts_extra.append("AND ec.entity_id = ?")
                 fts_filter_params.append(entity_id)
-            if project_filter:
-                fts_extra.append("AND (c.project = ? OR c.project IS NULL)")
-                fts_filter_params.append(project_filter)
+            project_clause, project_params = _project_scope_where("c.project", project_filter, consumer_scope)
+            if project_clause:
+                fts_extra.append(f"AND {project_clause}")
+                fts_filter_params.extend(project_params)
             if source_filter:
                 fts_extra.append("AND c.source = ?")
                 fts_filter_params.append(source_filter)
@@ -1994,9 +2072,10 @@ class SearchMixin:
         if recency_intent and not date_from:
             recent_extra = []
             recent_params: list = []
-            if project_filter:
-                recent_extra.append("AND (project = ? OR project IS NULL)")
-                recent_params.append(project_filter)
+            project_clause, project_params = _project_scope_where("project", project_filter, consumer_scope)
+            if project_clause:
+                recent_extra.append(f"AND {project_clause}")
+                recent_params.extend(project_params)
             if source_filter:
                 recent_extra.append("AND source = ?")
                 recent_params.append(source_filter)
@@ -2204,12 +2283,12 @@ class SearchMixin:
                 continue
             if not include_audit and _is_audit_recursion_metadata(meta, doc):
                 continue
+            if not _metadata_matches_project_scope(meta, project_filter, consumer_scope):
+                continue
 
             # Apply filters to FTS-only results
             if fts_rank is not None and sem_entry is None:
                 if source_filter and meta.get("source") != source_filter:
-                    continue
-                if project_filter and meta.get("project") not in (project_filter, None):
                     continue
                 if content_type_filter and meta.get("content_type") != content_type_filter:
                     continue

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -2431,6 +2431,7 @@ class SearchMixin:
         *,
         include_checkpoints: bool = False,
         include_audit: bool = False,
+        consumer_scope: ConsumerScope | None = None,
     ) -> Dict[str, Any]:
         """Get surrounding chunks from the same conversation."""
         read_conn = self._get_read_conn()
@@ -2441,7 +2442,7 @@ class SearchMixin:
         target = list(
             cursor.execute(
                 """
-            SELECT conversation_id, position, content, metadata, content_type, tags, chunk_origin
+            SELECT conversation_id, position, content, metadata, content_type, tags, chunk_origin, project, source_file
             FROM chunks WHERE id = ?
         """,
                 (chunk_id,),
@@ -2451,7 +2452,9 @@ class SearchMixin:
         if not target:
             return {"target": None, "context": [], "error": "Chunk not found"}
 
-        conv_id, position, content, metadata, content_type, tags, chunk_origin = target[0]
+        conv_id, position, content, metadata, content_type, tags, chunk_origin, project, source_file = target[0]
+        if not _metadata_matches_project_scope({"project": project}, None, consumer_scope):
+            return {"target": None, "context": [], "error": "Chunk not found"}
         if self._context_chunk_is_filtered(
             content=content,
             tags=tags,
@@ -2466,13 +2469,21 @@ class SearchMixin:
             # have no conversation_id/position. They should still be expandable as a
             # single target chunk instead of being treated as missing.
             return {
-                "target": {"id": chunk_id, "content": content, "position": None},
+                "target": {
+                    "id": chunk_id,
+                    "content": content,
+                    "position": None,
+                    "project": project,
+                    "source_file": source_file,
+                },
                 "context": [
                     {
                         "id": chunk_id,
                         "content": content,
                         "position": None,
                         "content_type": content_type,
+                        "project": project,
+                        "source_file": source_file,
                         "is_target": True,
                     }
                 ],
@@ -2482,7 +2493,7 @@ class SearchMixin:
         context_rows = list(
             cursor.execute(
                 """
-            SELECT id, content, position, content_type, tags, chunk_origin
+            SELECT id, content, position, content_type, tags, chunk_origin, project, source_file
             FROM chunks
             WHERE conversation_id = ?
               AND position BETWEEN ? AND ?
@@ -2494,6 +2505,9 @@ class SearchMixin:
 
         context = []
         for row in context_rows:
+            row_project = row[6]
+            if not _metadata_matches_project_scope({"project": row_project}, None, consumer_scope):
+                continue
             if self._context_chunk_is_filtered(
                 content=row[1],
                 tags=row[4],
@@ -2508,11 +2522,19 @@ class SearchMixin:
                     "content": row[1],
                     "position": row[2],
                     "content_type": row[3],
+                    "project": row_project,
+                    "source_file": row[7],
                     "is_target": row[0] == chunk_id,
                 }
             )
 
         return {
-            "target": {"id": chunk_id, "content": content, "position": position},
+            "target": {
+                "id": chunk_id,
+                "content": content,
+                "position": position,
+                "project": project,
+                "source_file": source_file,
+            },
             "context": context,
         }

--- a/tests/test_audit_recursion_filter.py
+++ b/tests/test_audit_recursion_filter.py
@@ -639,6 +639,7 @@ def test_entity_chunks_exclude_audit_evidence_by_default(tmp_path):
 
 @pytest.mark.asyncio
 async def test_chunk_context_filters_audit_neighbors_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
     store = VectorStore(tmp_path / "audit-context-filter.db")
     try:
         recursive_content = 'MCP BrainLayer Memory: Invalid JSON-RPC message: {"jsonrpc":"2.0"}'

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -487,8 +487,18 @@ async def test_worker_recall_filters_foreign_and_null_rows(monkeypatch):
     def fake_recall(**_kwargs):
         return _FakeRecallResult(
             file_history=[
-                {"timestamp": "2026-06-01T00:00:00Z", "session_id": "repo-a-session", "action": "edit", "project": "repo-a"},
-                {"timestamp": "2026-06-01T01:00:00Z", "session_id": "repo-b-session", "action": "edit", "project": "repo-b"},
+                {
+                    "timestamp": "2026-06-01T00:00:00Z",
+                    "session_id": "repo-a-session",
+                    "action": "edit",
+                    "project": "repo-a",
+                },
+                {
+                    "timestamp": "2026-06-01T01:00:00Z",
+                    "session_id": "repo-b-session",
+                    "action": "edit",
+                    "project": "repo-b",
+                },
                 {"timestamp": "2026-06-01T02:00:00Z", "session_id": "null-session", "action": "read", "project": None},
             ],
             related_chunks=[

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -1,0 +1,303 @@
+"""Consumer-role scoping guards for retrieval-time BrainLayer search."""
+
+import json
+
+import pytest
+
+from brainlayer._helpers import serialize_f32
+from brainlayer.chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+from brainlayer.scoping import ConsumerScope, resolve_consumer_scope
+from brainlayer.search_repo import _hybrid_cache
+from brainlayer.vector_store import VectorStore
+
+
+@pytest.fixture(autouse=True)
+def clear_hybrid_cache():
+    _hybrid_cache.clear()
+    yield
+    _hybrid_cache.clear()
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = VectorStore(tmp_path / "consumer-scope.db")
+    s._binary_index_available = False
+    yield s
+    s.close()
+
+
+def _embed(text: str) -> list[float]:
+    seed = (sum(ord(c) for c in text[:40]) % 97) / 1000.0
+    return [seed + (i / 10000.0) for i in range(1024)]
+
+
+def _insert_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    content: str,
+    embedding: list[float],
+    project: str | None,
+    created_at: str = "2026-06-01T00:00:00Z",
+    chunk_origin: str | None = None,
+) -> None:
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, created_at, chunk_origin
+        ) VALUES (?, ?, ?, 'scope-test.jsonl', ?, 'assistant_text', ?, 'claude_code', ?, ?)""",
+        (
+            chunk_id,
+            content,
+            json.dumps({}),
+            project,
+            len(content),
+            created_at,
+            chunk_origin,
+        ),
+    )
+    cursor.execute(
+        "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+        (chunk_id, serialize_f32(embedding)),
+    )
+
+
+def _ids(results: dict) -> list[str]:
+    return results["ids"][0]
+
+
+def _projects(results: dict) -> list[str | None]:
+    return [meta.get("project") for meta in results["metadatas"][0]]
+
+
+class _ScopedEmbeddingModel:
+    def embed_query(self, query: str) -> list[float]:
+        return _embed(query)
+
+
+def test_resolve_consumer_scope_defaults_to_worker_fail_closed(monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_CONSUMER", raising=False)
+
+    scope = resolve_consumer_scope(project="brainlayer")
+
+    assert scope.role == "worker"
+    assert scope.project_filter == "brainlayer"
+    assert scope.allow_null_project is False
+    assert scope.deny_all is False
+
+
+def test_worker_without_project_denies_all(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "worker")
+
+    scope = resolve_consumer_scope(project=None)
+
+    assert scope.role == "worker"
+    assert scope.deny_all is True
+    assert scope.allow_null_project is False
+
+
+def test_worker_consumer_scope_blocks_foreign_and_null_projects_across_rrf(store):
+    query_embedding = _embed("repo b semantic target")
+    _insert_chunk(
+        store,
+        chunk_id="repo-a-allowed",
+        content="repo scoped allowed memory",
+        embedding=_embed("distant repo a"),
+        project="repo-a",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="repo-b-vector-and-fts",
+        content="scope leak sentinel foreign repo",
+        embedding=query_embedding,
+        project="repo-b",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="null-vector-and-fts",
+        content="scope leak sentinel user local",
+        embedding=[value + 0.00001 for value in query_embedding],
+        project=None,
+    )
+
+    results = store.hybrid_search(
+        query_embedding=query_embedding,
+        query_text="scope leak sentinel",
+        n_results=10,
+        consumer_scope=ConsumerScope.for_worker("repo-a"),
+    )
+
+    assert "repo-b-vector-and-fts" not in _ids(results)
+    assert "null-vector-and-fts" not in _ids(results)
+    assert set(_projects(results)) <= {"repo-a"}
+
+
+def test_worker_consumer_scope_closes_null_project_fts_only_leak(store):
+    _insert_chunk(
+        store,
+        chunk_id="null-fts-leak",
+        content="fts only leak sentinel",
+        embedding=_embed("unrelated null vector"),
+        project=None,
+    )
+    store.conn.cursor().execute("DELETE FROM chunk_vectors")
+
+    results = store.hybrid_search(
+        query_embedding=_embed("nothing close"),
+        query_text="fts only leak sentinel",
+        n_results=5,
+        consumer_scope=ConsumerScope.for_worker("repo-a"),
+    )
+
+    assert _ids(results) == []
+
+
+def test_orchestrator_consumer_scope_preserves_cross_repo_and_null_visibility(store):
+    _insert_chunk(
+        store,
+        chunk_id="repo-a",
+        content="orchestrator full context sentinel repo a",
+        embedding=_embed("repo a"),
+        project="repo-a",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="repo-b",
+        content="orchestrator full context sentinel repo b",
+        embedding=_embed("repo b"),
+        project="repo-b",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="null-user-local",
+        content="orchestrator full context sentinel user local",
+        embedding=_embed("user local"),
+        project=None,
+    )
+
+    results = store.hybrid_search(
+        query_embedding=_embed("repo a"),
+        query_text="orchestrator full context sentinel",
+        n_results=10,
+        consumer_scope=ConsumerScope.for_orchestrator(),
+    )
+
+    assert {"repo-a", "repo-b", "null-user-local"} <= set(_ids(results))
+    assert {"repo-a", "repo-b", None} <= set(_projects(results))
+
+
+def test_coach_consumer_scope_uses_personal_lane_and_recency_checkpoints(store):
+    _insert_chunk(
+        store,
+        chunk_id="old-personal-checkpoint",
+        content="[precompact checkpoint] coach personal checkpoint status",
+        embedding=_embed("coach checkpoint"),
+        project="personal",
+        created_at="2026-05-01T00:00:00Z",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    )
+    _insert_chunk(
+        store,
+        chunk_id="new-personal-checkpoint",
+        content="[precompact checkpoint] coach personal checkpoint status",
+        embedding=_embed("coach checkpoint"),
+        project="personal",
+        created_at="2026-06-10T00:00:00Z",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    )
+    _insert_chunk(
+        store,
+        chunk_id="foreign-code-checkpoint",
+        content="[precompact checkpoint] coach personal checkpoint status",
+        embedding=_embed("coach checkpoint"),
+        project="brainlayer",
+        created_at="2026-06-12T00:00:00Z",
+        chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+    )
+
+    results = store.hybrid_search(
+        query_embedding=_embed("coach checkpoint"),
+        query_text="latest coach personal checkpoint",
+        n_results=5,
+        consumer_scope=ConsumerScope.for_coach(),
+    )
+
+    assert _ids(results)[:2] == ["new-personal-checkpoint", "old-personal-checkpoint"]
+    assert "foreign-code-checkpoint" not in _ids(results)
+    assert set(_projects(results)) <= {"personal", None}
+
+
+@pytest.mark.asyncio
+async def test_mcp_roundtrip_applies_worker_and_orchestrator_scopes_on_seeded_store(store, monkeypatch):
+    from brainlayer.mcp.search_handler import _brain_search
+
+    _insert_chunk(
+        store,
+        chunk_id="repo-a-handler",
+        content="handler scope sentinel repo a",
+        embedding=_embed("handler scope sentinel"),
+        project="repo-a",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="repo-b-handler",
+        content="handler scope sentinel repo b",
+        embedding=_embed("handler scope sentinel"),
+        project="repo-b",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="null-handler",
+        content="handler scope sentinel user local",
+        embedding=_embed("handler scope sentinel"),
+        project=None,
+    )
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: _ScopedEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._detect_entities", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+    monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "repo-a")
+
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "worker")
+    _content, worker_structured = await _brain_search(
+        query="handler scope sentinel",
+        source="all",
+        num_results=10,
+        allow_helper_route=False,
+    )
+
+    worker_projects = {result["project"] for result in worker_structured["results"]}
+    assert worker_projects == {"repo-a"}
+
+    _content, worker_exact_structured = await _brain_search(
+        query="null-handler",
+        source="all",
+        num_results=10,
+        allow_helper_route=False,
+    )
+    assert worker_exact_structured["results"] == []
+
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
+    _content, orchestrator_structured = await _brain_search(
+        query="handler scope sentinel",
+        source="all",
+        num_results=10,
+        allow_helper_route=False,
+    )
+
+    orchestrator_ids = {result["chunk_id"] for result in orchestrator_structured["results"]}
+    orchestrator_projects = {result.get("project") for result in orchestrator_structured["results"]}
+    assert {"repo-a-handler", "repo-b-handler", "null-handler"} <= orchestrator_ids
+    assert {"repo-a", "repo-b", None} <= orchestrator_projects
+
+    _content, orchestrator_exact_structured = await _brain_search(
+        query="null-handler",
+        source="all",
+        num_results=10,
+        allow_helper_route=False,
+    )
+    assert orchestrator_exact_structured["results"][0]["chunk_id"] == "null-handler"

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -1,6 +1,8 @@
 """Consumer-role scoping guards for retrieval-time BrainLayer search."""
 
 import json
+from dataclasses import dataclass, field
+from typing import Any
 
 import pytest
 
@@ -63,6 +65,32 @@ def _insert_chunk(
     )
 
 
+def _insert_context_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    content: str,
+    project: str | None,
+    conversation_id: str,
+    position: int,
+) -> None:
+    store.conn.cursor().execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, conversation_id, position
+        ) VALUES (?, ?, ?, 'scope-context.jsonl', ?, 'assistant_text', ?, 'claude_code', ?, ?)""",
+        (
+            chunk_id,
+            content,
+            json.dumps({}),
+            project,
+            len(content),
+            conversation_id,
+            position,
+        ),
+    )
+
+
 def _ids(results: dict) -> list[str]:
     return results["ids"][0]
 
@@ -71,9 +99,29 @@ def _projects(results: dict) -> list[str | None]:
     return [meta.get("project") for meta in results["metadatas"][0]]
 
 
+def _text_parts(parts: list[Any]) -> str:
+    return "\n".join(getattr(part, "text", str(part)) for part in parts)
+
+
 class _ScopedEmbeddingModel:
     def embed_query(self, query: str) -> list[float]:
         return _embed(query)
+
+
+@dataclass
+class _FakeRecallResult:
+    target: str = "src/app.py"
+    file_history: list[dict[str, Any]] = field(default_factory=list)
+    related_chunks: list[dict[str, Any]] = field(default_factory=list)
+    session_summaries: list[dict[str, Any]] = field(default_factory=list)
+
+    def format(self) -> str:
+        parts = [f"## Recall: {self.target}"]
+        for row in self.file_history:
+            parts.append(f"{row.get('project')}:{row.get('action')}:{row.get('session_id')}")
+        for row in self.related_chunks:
+            parts.append(f"{row.get('project')}:{row.get('content')}")
+        return "\n".join(parts)
 
 
 def test_resolve_consumer_scope_defaults_to_worker_fail_closed(monkeypatch):
@@ -228,6 +276,252 @@ def test_coach_consumer_scope_uses_personal_lane_and_recency_checkpoints(store):
     assert set(_projects(results)) <= {"personal", None}
 
 
+def test_worker_direct_context_filters_foreign_and_null_neighbors(store):
+    conversation_id = "mixed-session"
+    _insert_context_chunk(
+        store,
+        chunk_id="repo-b-before",
+        content="foreign repo neighbor must not leak",
+        project="repo-b",
+        conversation_id=conversation_id,
+        position=1,
+    )
+    _insert_context_chunk(
+        store,
+        chunk_id="repo-a-target",
+        content="allowed repo target",
+        project="repo-a",
+        conversation_id=conversation_id,
+        position=2,
+    )
+    _insert_context_chunk(
+        store,
+        chunk_id="null-after",
+        content="user-local neighbor must not leak",
+        project=None,
+        conversation_id=conversation_id,
+        position=3,
+    )
+    _insert_context_chunk(
+        store,
+        chunk_id="repo-a-after",
+        content="allowed repo neighbor",
+        project="repo-a",
+        conversation_id=conversation_id,
+        position=4,
+    )
+
+    worker_context = store.get_context(
+        "repo-a-target",
+        before=3,
+        after=3,
+        consumer_scope=ConsumerScope.for_worker("repo-a"),
+    )
+
+    assert worker_context["target"]["id"] == "repo-a-target"
+    assert [chunk["id"] for chunk in worker_context["context"]] == ["repo-a-target", "repo-a-after"]
+
+
+def test_orchestrator_direct_context_preserves_mixed_project_neighbors(store):
+    conversation_id = "mixed-session"
+    _insert_context_chunk(
+        store,
+        chunk_id="repo-b-before",
+        content="foreign repo neighbor is visible to orchestrator",
+        project="repo-b",
+        conversation_id=conversation_id,
+        position=1,
+    )
+    _insert_context_chunk(
+        store,
+        chunk_id="repo-a-target",
+        content="allowed repo target",
+        project="repo-a",
+        conversation_id=conversation_id,
+        position=2,
+    )
+    _insert_context_chunk(
+        store,
+        chunk_id="null-after",
+        content="user-local neighbor is visible to orchestrator",
+        project=None,
+        conversation_id=conversation_id,
+        position=3,
+    )
+
+    orchestrator_context = store.get_context(
+        "repo-a-target",
+        before=3,
+        after=3,
+        consumer_scope=ConsumerScope.for_orchestrator(),
+    )
+
+    assert [chunk["id"] for chunk in orchestrator_context["context"]] == [
+        "repo-b-before",
+        "repo-a-target",
+        "null-after",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_worker_file_timeline_filters_foreign_and_null_rows(monkeypatch):
+    from brainlayer.mcp.search_handler import _file_timeline
+
+    class FakeStore:
+        def get_file_timeline(self, file_path, project=None, limit=50):  # noqa: ANN001, ARG002
+            return [
+                {
+                    "file_path": "src/app.py",
+                    "timestamp": "2026-06-01T00:00:00Z",
+                    "session_id": "repo-a-session",
+                    "action": "edit",
+                    "project": "repo-a",
+                },
+                {
+                    "file_path": "src/app.py",
+                    "timestamp": "2026-06-01T01:00:00Z",
+                    "session_id": "repo-b-session",
+                    "action": "edit",
+                    "project": "repo-b",
+                },
+                {
+                    "file_path": "src/app.py",
+                    "timestamp": "2026-06-01T02:00:00Z",
+                    "session_id": "null-session",
+                    "action": "read",
+                    "project": None,
+                },
+            ]
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: FakeStore())
+
+    parts = await _file_timeline(
+        file_path="src/app.py",
+        project="repo-a",
+        consumer_scope=ConsumerScope.for_worker("repo-a"),
+    )
+
+    text = _text_parts(parts)
+    assert "Found 1 interactions" in text
+    assert "repo-a-session"[:8] in text
+    assert "repo-b" not in text
+    assert "null-session"[:8] not in text
+
+
+@pytest.mark.asyncio
+async def test_worker_regression_filters_foreign_and_null_rows(monkeypatch):
+    from brainlayer.mcp.search_handler import _regression
+
+    class FakeStore:
+        def get_file_regression(self, file_path, project=None):  # noqa: ANN001, ARG002
+            return {
+                "timeline": [
+                    {
+                        "file_path": "src/app.py",
+                        "timestamp": "2026-06-01T00:00:00Z",
+                        "session_id": "repo-a-session",
+                        "action": "test-pass",
+                        "project": "repo-a",
+                        "branch": "main",
+                    },
+                    {
+                        "file_path": "src/app.py",
+                        "timestamp": "2026-06-01T01:00:00Z",
+                        "session_id": "repo-b-session",
+                        "action": "edit",
+                        "project": "repo-b",
+                        "branch": "foreign",
+                    },
+                    {
+                        "file_path": "src/app.py",
+                        "timestamp": "2026-06-01T02:00:00Z",
+                        "session_id": "null-session",
+                        "action": "edit",
+                        "project": None,
+                        "branch": "local",
+                    },
+                ],
+                "last_success": {
+                    "timestamp": "2026-06-01T00:00:00Z",
+                    "session_id": "repo-a-session",
+                    "branch": "main",
+                    "project": "repo-a",
+                },
+                "changes_after": [
+                    {
+                        "timestamp": "2026-06-01T01:00:00Z",
+                        "session_id": "repo-b-session",
+                        "action": "edit",
+                        "project": "repo-b",
+                        "branch": "foreign",
+                    },
+                    {
+                        "timestamp": "2026-06-01T02:00:00Z",
+                        "session_id": "null-session",
+                        "action": "edit",
+                        "project": None,
+                        "branch": "local",
+                    },
+                ],
+            }
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: FakeStore())
+
+    parts = await _regression(
+        file_path="src/app.py",
+        project="repo-a",
+        consumer_scope=ConsumerScope.for_worker("repo-a"),
+    )
+
+    text = _text_parts(parts)
+    assert "Timeline: 1 interactions" in text
+    assert "repo-a-s" in text
+    assert "repo-b" not in text
+    assert "null-session"[:8] not in text
+
+
+@pytest.mark.asyncio
+async def test_worker_recall_filters_foreign_and_null_rows(monkeypatch):
+    from brainlayer.mcp.search_handler import _recall
+
+    def fake_recall(**_kwargs):
+        return _FakeRecallResult(
+            file_history=[
+                {"timestamp": "2026-06-01T00:00:00Z", "session_id": "repo-a-session", "action": "edit", "project": "repo-a"},
+                {"timestamp": "2026-06-01T01:00:00Z", "session_id": "repo-b-session", "action": "edit", "project": "repo-b"},
+                {"timestamp": "2026-06-01T02:00:00Z", "session_id": "null-session", "action": "read", "project": None},
+            ],
+            related_chunks=[
+                {"content": "allowed related", "project": "repo-a"},
+                {"content": "foreign related", "project": "repo-b"},
+                {"content": "null related", "project": None},
+            ],
+        )
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: _ScopedEmbeddingModel())
+    monkeypatch.setattr("brainlayer.engine.recall", fake_recall)
+
+    parts, structured = await _recall(
+        file_path="src/app.py",
+        project="repo-a",
+        consumer_scope=ConsumerScope.for_worker("repo-a"),
+    )
+
+    text = _text_parts(parts)
+    assert structured["file_history"] == [
+        {
+            "timestamp": "2026-06-01T00:00:00",
+            "action": "edit",
+            "session_id": "repo-a-session",
+            "file_path": "",
+        }
+    ]
+    assert [chunk["project"] for chunk in structured["related_chunks"]] == ["repo-a"]
+    assert "repo-b" not in text
+    assert "null related" not in text
+
+
 @pytest.mark.asyncio
 async def test_mcp_roundtrip_applies_worker_and_orchestrator_scopes_on_seeded_store(store, monkeypatch):
     from brainlayer.mcp.search_handler import _brain_search
@@ -301,3 +595,21 @@ async def test_mcp_roundtrip_applies_worker_and_orchestrator_scopes_on_seeded_st
         allow_helper_route=False,
     )
     assert orchestrator_exact_structured["results"][0]["chunk_id"] == "null-handler"
+
+
+@pytest.mark.asyncio
+async def test_entity_id_search_resolves_project_before_worker_scope(monkeypatch):
+    from brainlayer.mcp.search_handler import _brain_search
+
+    async def fake_search(**kwargs):
+        return ([], kwargs)
+
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "worker")
+    monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "repo-a")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._search", fake_search)
+
+    _content, kwargs = await _brain_search(query="entity lookup", entity_id="entity-1")
+
+    assert kwargs["project"] == "repo-a"
+    assert kwargs["consumer_scope"].project_filter == "repo-a"
+    assert kwargs["consumer_scope"].deny_all is False

--- a/tests/test_phase6_critical.py
+++ b/tests/test_phase6_critical.py
@@ -13,7 +13,7 @@ Covers:
 import asyncio
 import json
 import threading
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import apsw
 import pytest
@@ -159,6 +159,7 @@ class TestSearchRouting:
             after=3,
             include_checkpoints=False,
             include_audit=False,
+            consumer_scope=ANY,
         )
 
     def test_search_routing_file_path(self):

--- a/tests/test_search_exact_chunk_id.py
+++ b/tests/test_search_exact_chunk_id.py
@@ -258,7 +258,9 @@ async def test_brain_search_chunk_id_context_blocks_audit_recursion_by_default(m
             new=AsyncMock(side_effect=AssertionError("audit-recursive chunk_id must not route to context")),
         ),
     ):
-        content, structured = await _brain_search(query="ignored", chunk_id=chunk_id, project="brainlayer", detail="compact")
+        content, structured = await _brain_search(
+            query="ignored", chunk_id=chunk_id, project="brainlayer", detail="compact"
+        )
 
     assert "No results found." in content[0].text
     assert structured == {"query": "ignored", "total": 0, "results": []}

--- a/tests/test_search_exact_chunk_id.py
+++ b/tests/test_search_exact_chunk_id.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -7,8 +7,9 @@ from brainlayer.mcp.search_handler import _brain_search, _exact_chunk_lookup_res
 
 
 @pytest.mark.asyncio
-async def test_brain_search_exact_chunk_id_query_bypasses_hybrid_search():
+async def test_brain_search_exact_chunk_id_query_bypasses_hybrid_search(monkeypatch):
     """Free-text chunk IDs should short-circuit to an exact chunk lookup."""
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
     chunk_id = "brainbar-ddf12232"
     mock_store = MagicMock()
     mock_store.get_chunk.return_value = {
@@ -100,8 +101,9 @@ async def test_brain_search_exact_chunk_id_orchestrator_defaults_missing_project
 
 
 @pytest.mark.asyncio
-async def test_brain_search_exact_chunk_id_treats_source_all_as_unfiltered():
+async def test_brain_search_exact_chunk_id_treats_source_all_as_unfiltered(monkeypatch):
     """BrainBar forwards source='all'; exact chunk-id lookup must still short-circuit."""
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
     chunk_id = "brainbar-sourceall01"
     mock_store = MagicMock()
     mock_store.get_chunk.return_value = {
@@ -201,8 +203,9 @@ def test_exact_chunk_lookup_skips_status_archived_chunks():
 
 
 @pytest.mark.asyncio
-async def test_brain_search_chunk_id_context_routing_wins_over_exact_lookup():
+async def test_brain_search_chunk_id_context_routing_wins_over_exact_lookup(monkeypatch):
     """Explicit chunk_id context expansion should run before exact-id short-circuiting."""
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "worker")
     chunk_id = "brainbar-ddf12232"
     mock_store = MagicMock()
     mock_store.get_chunk.return_value = {
@@ -221,7 +224,7 @@ async def test_brain_search_chunk_id_context_routing_wins_over_exact_lookup():
             new=AsyncMock(side_effect=AssertionError("chunk_id routing should bypass hybrid search")),
         ),
     ):
-        result = await _brain_search(query=chunk_id, chunk_id=chunk_id, detail="compact")
+        result = await _brain_search(query=chunk_id, chunk_id=chunk_id, project="brainlayer", detail="compact")
 
     assert result == ["context window"]
     context_mock.assert_awaited_once_with(
@@ -230,11 +233,13 @@ async def test_brain_search_chunk_id_context_routing_wins_over_exact_lookup():
         after=3,
         include_checkpoints=False,
         include_audit=False,
+        consumer_scope=ANY,
     )
 
 
 @pytest.mark.asyncio
-async def test_brain_search_chunk_id_context_blocks_audit_recursion_by_default():
+async def test_brain_search_chunk_id_context_blocks_audit_recursion_by_default(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "worker")
     chunk_id = "rt-33abe108-recursive"
     mock_store = MagicMock()
     mock_store.get_chunk.return_value = {
@@ -253,14 +258,15 @@ async def test_brain_search_chunk_id_context_blocks_audit_recursion_by_default()
             new=AsyncMock(side_effect=AssertionError("audit-recursive chunk_id must not route to context")),
         ),
     ):
-        content, structured = await _brain_search(query="ignored", chunk_id=chunk_id, detail="compact")
+        content, structured = await _brain_search(query="ignored", chunk_id=chunk_id, project="brainlayer", detail="compact")
 
     assert "No results found." in content[0].text
     assert structured == {"query": "ignored", "total": 0, "results": []}
 
 
 @pytest.mark.asyncio
-async def test_brain_search_chunk_id_context_allows_audit_when_requested():
+async def test_brain_search_chunk_id_context_allows_audit_when_requested(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "worker")
     chunk_id = "rt-33abe108-recursive"
     mock_store = MagicMock()
     mock_store.get_chunk.return_value = {
@@ -276,7 +282,13 @@ async def test_brain_search_chunk_id_context_allows_audit_when_requested():
         patch("brainlayer.mcp.search_handler._get_vector_store", return_value=mock_store),
         patch("brainlayer.mcp.search_handler._context", new=AsyncMock(return_value=["context window"])) as context_mock,
     ):
-        result = await _brain_search(query="ignored", chunk_id=chunk_id, detail="compact", include_audit=True)
+        result = await _brain_search(
+            query="ignored",
+            chunk_id=chunk_id,
+            project="brainlayer",
+            detail="compact",
+            include_audit=True,
+        )
 
     assert result == ["context window"]
     context_mock.assert_awaited_once_with(
@@ -285,6 +297,7 @@ async def test_brain_search_chunk_id_context_allows_audit_when_requested():
         after=3,
         include_checkpoints=False,
         include_audit=True,
+        consumer_scope=ANY,
     )
 
 
@@ -320,8 +333,9 @@ async def test_brain_search_exact_chunk_id_respects_project_scope():
 
 
 @pytest.mark.asyncio
-async def test_brain_search_exact_chunk_id_resolves_recent_alias():
+async def test_brain_search_exact_chunk_id_resolves_recent_alias(monkeypatch):
     """Old duplicate chunk IDs should resolve through chunk_id_alias during grace period."""
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
     old_chunk_id = "brainbar-olddup01"
     canonical_id = "brainbar-canon01"
     mock_store = MagicMock()

--- a/tests/test_search_exact_chunk_id.py
+++ b/tests/test_search_exact_chunk_id.py
@@ -40,8 +40,8 @@ async def test_brain_search_exact_chunk_id_query_bypasses_hybrid_search():
 
 
 @pytest.mark.asyncio
-async def test_brain_search_exact_chunk_id_defaults_missing_project_to_unknown():
-    """Exact chunk lookup should keep compact results stable when project is null."""
+async def test_brain_search_exact_chunk_id_default_worker_hides_missing_project(monkeypatch):
+    """Default worker scope must not expose null-project exact chunk hits."""
     chunk_id = "brainbar-nullproj01"
     mock_store = MagicMock()
     mock_store.get_chunk.return_value = {
@@ -55,6 +55,37 @@ async def test_brain_search_exact_chunk_id_defaults_missing_project_to_unknown()
         "summary": "Null project repro",
         "tags": '["fts"]',
     }
+    monkeypatch.delenv("BRAINLAYER_CONSUMER", raising=False)
+
+    with (
+        patch("brainlayer.mcp.search_handler._get_vector_store", return_value=mock_store),
+        patch(
+            "brainlayer.mcp.search_handler._search",
+            new=AsyncMock(side_effect=AssertionError("exact chunk-id query should bypass hybrid search")),
+        ),
+    ):
+        _, structured = await _brain_search(query=chunk_id, detail="compact")
+
+    assert structured["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_brain_search_exact_chunk_id_orchestrator_defaults_missing_project_to_unknown(monkeypatch):
+    """Orchestrator scope keeps compact results stable when project is null."""
+    chunk_id = "brainbar-nullproj01"
+    mock_store = MagicMock()
+    mock_store.get_chunk.return_value = {
+        "id": chunk_id,
+        "content": "Chunk without project metadata",
+        "source_file": "docs/repro.md",
+        "project": None,
+        "content_type": "note",
+        "importance": 3,
+        "created_at": "2026-04-30T09:15:00Z",
+        "summary": "Null project repro",
+        "tags": '["fts"]',
+    }
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
 
     with (
         patch("brainlayer.mcp.search_handler._get_vector_store", return_value=mock_store),

--- a/tests/test_search_handler.py
+++ b/tests/test_search_handler.py
@@ -73,6 +73,60 @@ async def test_brain_search_mcp_threads_agent_id_to_hybrid_search(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_brain_search_threads_fail_closed_worker_consumer_scope_when_env_unset(monkeypatch):
+    store = RecordingSearchStore()
+
+    monkeypatch.delenv("BRAINLAYER_CONSUMER", raising=False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: FakeEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._exact_chunk_lookup_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._detect_entities", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+    monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "brainlayer")
+
+    await _brain_search(
+        query="auth implementation",
+        source="all",
+        allow_helper_route=False,
+    )
+
+    scope = store.hybrid_kwargs["consumer_scope"]
+    assert scope.role == "worker"
+    assert scope.project_filter == "brainlayer"
+    assert scope.allow_null_project is False
+    assert store.hybrid_kwargs["project_filter"] == "brainlayer"
+
+
+@pytest.mark.asyncio
+async def test_brain_search_threads_orchestrator_consumer_scope(monkeypatch):
+    store = RecordingSearchStore()
+
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: FakeEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._exact_chunk_lookup_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._detect_entities", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+    monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "brainlayer")
+
+    await _brain_search(
+        query="auth implementation",
+        source="all",
+        allow_helper_route=False,
+    )
+
+    scope = store.hybrid_kwargs["consumer_scope"]
+    assert scope.role == "orchestrator"
+    assert scope.project_filter is None
+    assert scope.allow_null_project is True
+    assert store.hybrid_kwargs["project_filter"] is None
+
+
+@pytest.mark.asyncio
 async def test_brain_search_threads_helper_fast_profile_to_hybrid_search(monkeypatch):
     store = RecordingSearchStore()
 

--- a/tests/test_smart_search_entity_dedup.py
+++ b/tests/test_smart_search_entity_dedup.py
@@ -202,11 +202,12 @@ class TestBrainExpand:
         text = result.content[0].text if hasattr(result, "content") else result[0].text
         assert "Unknown tool" not in text
 
-    def test_brain_expand_manual_chunk_id_returns_target_content(self, tmp_path):
+    def test_brain_expand_manual_chunk_id_returns_target_content(self, tmp_path, monkeypatch):
         """brain_expand should expand manual-* chunk IDs created via brain_store."""
         from brainlayer.mcp import call_tool
         from brainlayer.store import store_memory
 
+        monkeypatch.setenv("BRAINLAYER_CONSUMER", "orchestrator")
         store = VectorStore(tmp_path / "test.db")
 
         with patch(


### PR DESCRIPTION
## Summary
- Add `ConsumerScope` retrieval-time policy for `BRAINLAYER_CONSUMER=worker|orchestrator|coach`, defaulting unset/invalid consumers to worker.
- Thread one `consumer_scope` object through MCP search and hybrid search instead of adding more separate filter knobs.
- Close NULL-project leakage for worker-scoped vector, binary, FTS, recency, RRF/post-merge, exact chunk-ID, and direct chunk context paths while preserving orchestrator NULL/cross-repo visibility.
- Add seeded ranking/MCP tests for worker isolation, orchestrator context, coach checkpoint recency, fail-closed default, and exact chunk-ID policy behavior.

## Verification
- RED first: `pytest tests/test_consumer_scoping.py tests/test_search_handler.py -q` initially failed on missing `ConsumerScope` import.
- G2 RED→GREEN replay: legacy `project_filter='repo-a'` returned `['null-leak', 'repo-a-ok']` with projects `[None, 'repo-a']`; worker `ConsumerScope.for_worker('repo-a')` returned `['repo-a-ok']` with projects `['repo-a']`.
- Focused WI-6/MCP: `pytest tests/test_consumer_scoping.py tests/test_search_handler.py -q` → 15 passed.
- Exact-ID regression: `pytest tests/test_search_exact_chunk_id.py tests/test_consumer_scoping.py tests/test_search_handler.py -q` → 28 passed.
- Search/provenance slice: `pytest tests/test_consumer_scoping.py tests/test_search_handler.py tests/test_search_exact_chunk_id.py tests/test_hybrid_search.py tests/test_search_filter_params.py tests/test_provenance.py tests/test_deferred_mcp_provenance_guard.py -q` → 135 passed.
- Lint: `ruff check src/brainlayer/scoping.py src/brainlayer/search_repo.py src/brainlayer/mcp/search_handler.py tests/test_consumer_scoping.py tests/test_search_handler.py tests/test_search_exact_chunk_id.py` → all checks passed.
- Full regression excluding known dependency collection failure: `pytest --ignore=tests/regression/test_drift_detection.py -q` → 2919 passed, 48 skipped, 5 xfailed, 326 warnings in 401.15s.
- Known blocker for raw full `pytest`: `tests/regression/test_drift_detection.py` fails during collection because `deepchecks` calls `sklearn.metrics.get_scorer("max_error")`, which raises `ValueError: 'max_error' is not a valid scoring value` in this environment.
- G6 physical layer: `find . -name '*.db' -o -name '*.sqlite' -o -name '*.sqlite3'` returned no files; git diff is limited to `scoping.py`, `search_repo.py`, MCP search handler, and tests. No schema/storage migration files changed.

## Boundary Notes
- Worker isolation is logical retrieval-time policy on the one per-account DB, not a physical DB boundary.
- OF-3 remains Etan's ruling: this PR closes observed retrieval-time leaks, but shared physical storage/embedding surfaces are still a policy boundary decision.
- This worker PR should not be merged by me; UG-1 says Etan/orc watcher owns merge approval.

Co-Authored-By: Claude Opus 4.8 (1M context)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default retrieval behavior for unset consumers (fail-closed worker) and touch many search paths; incorrect scope wiring could hide legitimate results or leak cross-project chunks, though coverage is extensive.
> 
> **Overview**
> Introduces **`ConsumerScope`** and **`resolve_consumer_scope`** in `scoping.py`, driven by **`BRAINLAYER_CONSUMER`** (`worker` | `orchestrator` | `coach`) with missing/invalid values defaulting to the restrictive **worker** role. Workers require a resolved project, exclude **NULL**-project chunks, and **`deny_all`** when no project is set; orchestrator keeps cross-repo and null-project visibility; coach scopes to **`personal`** and enables checkpoint retrieval.
> 
> MCP **`_brain_search_dispatch`** now resolves scope once, overrides **`project`** / **`include_checkpoints`** from it, and passes **`consumer_scope`** into hybrid search, exact chunk-ID lookup, chunk context, recall, regression, and file timeline. Post-query filters trim recall/regression/timeline rows that fail scope checks.
> 
> **`search_repo`** centralizes scope in SQL via **`_project_scope_where`** and **`_metadata_matches_project_scope`** across vector, binary KNN, FTS, recency, RRF merge, and **`get_context`**, and includes scope in the hybrid result cache key. Tests cover worker isolation, orchestrator visibility, coach checkpoints, and MCP roundtrips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b84b6be0612ca1a7adbebd666674c0b9df8594a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add consumer-aware retrieval scoping to brain search across all search paths
> - Introduces a `ConsumerScope` dataclass in [scoping.py](https://github.com/EtanHey/brainlayer/pull/486/files#diff-e4550f64ac5b6346b3a2871191256d540d0ac40c01e764f90752f9129f652a63) with factory methods for three roles: `worker` (scoped to a single project, deny-all when project is None), `orchestrator` (cross-project, allows null-project rows), and `coach` (personal project lane with checkpoints enabled).
> - Adds `resolve_consumer_scope` and `resolve_consumer_role` utilities that read the `BRAINLAYER_CONSUMER` env var and construct the appropriate scope, defaulting to `worker` on invalid values.
> - Threads `consumer_scope` through all search paths in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/486/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472): `hybrid_search`, float/LIKE search, `binary_knn`, and `get_context` now apply SQL-level project filtering, post-query metadata filtering, and scope-segmented cache keys.
> - Applies scope filtering in [search_handler.py](https://github.com/EtanHey/brainlayer/pull/486/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) to exact chunk lookups, file timeline, regression, and recall results, stripping rows whose project doesn't match the active consumer scope.
> - Risk: Workers with no project set now receive empty results (`deny_all`); orchestrator tests required `BRAINLAYER_CONSUMER=orchestrator` to preserve existing behavior, indicating a breaking default for callers that don't set the env var.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b84b6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-based search result filtering with support for worker, orchestrator, and coach roles
  * Search queries now support project and source filtering based on consumer scope
  * Implemented configurable checkpoint visibility based on consumer role assignment
  * Search results are now filtered according to environment-based consumer configuration with fail-safe defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->