### PR TITLE
fix: add Happy Camper isolation proof and request-scoped roles

### DIFF
--- a/docs.local/gen16-happy-camper/wi8-runbook-DRAFT.md
+++ b/docs.local/gen16-happy-camper/wi8-runbook-DRAFT.md
@@ -1,0 +1,125 @@
+# Happy Camper 2nd Account Runbook Draft
+
+Status: DRAFT - depends on PR #487 deployment plus a real-cmux BASIC split re-run.
+
+## Purpose
+
+Set up the Happy Camper macOS account so BrainLayer memory is isolated by the account's own database, then apply within-DB role scoping for day-to-day agents.
+
+Etan's OF-3 ruling: cross-account isolation is physical. The new macOS account gets its own BrainLayer DB and MCP wiring, so it cannot reach the current user's DB unless explicitly pointed at it.
+
+## Hard Gates
+
+1. Do not point the Happy Camper account at `~/.local/share/brainlayer/brainlayer.db` from the main account.
+2. Do not share the main account's MCP socket path with the Happy Camper account.
+3. Load a BrainLayer build that includes request-scoped `consumer` support before relying on role separation inside one DB.
+4. Run the real-cmux BASIC split gate after loading that build:
+   - Orchestrator call with `consumer="orchestrator"` sees repo A, repo B, and null-project user-local rows.
+   - Worker call with `consumer="worker"` and its project sees only its allowed project set.
+5. Only after BASIC passes, run the lead/worktree gate:
+   - Lead sees its main repo plus all configured worktrees, plus configured parallel repos.
+   - Worker on main sees main only.
+   - Worker on a worktree sees that worktree plus main.
+
+## Account Setup
+
+1. Create the second macOS account through System Settings.
+2. Log into the new account directly, not through the existing account's shell.
+3. Install or link the needed repos inside the new account home.
+4. Confirm the new account resolves its BrainLayer DB independently:
+   ```bash
+   python3 - <<'PY'
+   from brainlayer.paths import get_db_path
+   print(get_db_path())
+   PY
+   ```
+   Expected shape: `/Users/<happy-camper-user>/.local/share/brainlayer/brainlayer.db`.
+5. Initialize/index only the Happy Camper account's intended data.
+6. Confirm the main account's DB is not referenced by environment:
+   ```bash
+   env | grep -E '^BRAINLAYER_DB=|mcplayer|brainlayer'
+   ```
+
+## Role Wiring
+
+Every shared-socket BrainLayer search call must carry the role explicitly. Process-level `BRAINLAYER_CONSUMER` is a fallback only; it cannot differentiate multiple agents sharing one MCP server.
+
+Required request roles:
+
+- Orchestrator: pass `consumer="orchestrator"`.
+- Lead: pass `consumer="lead"` plus the lead repo project.
+- Worker on main: pass `consumer="worker"` plus the main repo project.
+- Worker on worktree: pass `consumer="worker"` plus the worktree project.
+- Coach/personal lane: pass `consumer="coach"`.
+
+Until an automatic injection layer exists, put this in each agent boot brief and role-specific MCP wrapper:
+
+```text
+When calling BrainLayer search/recall, always include consumer="<role>".
+For workers and leads, include the current project name.
+```
+
+## Worktree Config
+
+Configure worktree relationships in `~/.config/brainlayer/scopes.yaml`:
+
+```yaml
+scopes:
+  ~/Gits/repo-a: repo-a
+  ~/Gits/repo-a.wt/feature-x: repo-a.worktree.feature-x
+  ~/Gits/repo-b: repo-b
+
+worktrees:
+  repo-a.worktree.feature-x: repo-a
+
+lead_parallel_projects:
+  repo-a:
+    - repo-b
+```
+
+Semantics:
+
+- `worktrees` maps worktree project IDs to their main repo project ID.
+- A lead scoped to `repo-a` sees `repo-a` plus all worktrees mapped to `repo-a`.
+- If `lead_parallel_projects.repo-a` includes `repo-b`, the lead also sees `repo-b` and worktrees mapped to `repo-b`.
+- A worker scoped to `repo-a.worktree.feature-x` sees `repo-a.worktree.feature-x` and `repo-a`.
+- A worker scoped to `repo-a` sees `repo-a` only.
+
+## Born-Bitemporal Check
+
+After the new account starts writing memories, sample recent rows and confirm bitemporal fields are present where the schema supports them:
+
+```bash
+sqlite3 ~/.local/share/brainlayer/brainlayer.db \
+  "SELECT id, project, created_at, valid_at, invalid_at FROM chunks ORDER BY rowid DESC LIMIT 10;"
+```
+
+Expected:
+
+- `created_at` is populated.
+- `valid_at` is populated for born-bitemporal writes after the bitemporal migration.
+- `invalid_at` is null for current facts.
+
+## Dry-Run Commands
+
+Run the deterministic proof harness on the target build:
+
+```bash
+PYTHONPATH=src python3 -m brainlayer.isolation_proof \
+  --db /tmp/happy-camper-isolation-proof.db \
+  --json
+```
+
+Expected BASIC output:
+
+- `worker-repo-a`: `repo-a-main-proof`
+- `orchestrator`: all seeded IDs
+- `coach`: `personal-checkpoint-proof`, `null-user-local-proof`
+
+Then run the real-cmux gate with the live MCP server loaded from the same build. Paste the observed `brain_search` outputs into the collab before merging.
+
+## Current Open Items
+
+1. PR #487 must be reviewed and loaded before live real-agent verification can be meaningful.
+2. The role injection is currently explicit per request. A future wrapper or launcher layer should auto-fill `consumer` so agents cannot forget it.
+3. The Happy Camper account can proceed because account-level isolation is physical, but within-DB role scoping should not be called fully live-green until the post-deploy real-cmux gates pass.

--- a/docs.local/gen16-happy-camper/wi8-runbook-DRAFT.md
+++ b/docs.local/gen16-happy-camper/wi8-runbook-DRAFT.md
@@ -110,11 +110,14 @@ PYTHONPATH=src python3 -m brainlayer.isolation_proof \
   --json
 ```
 
-Expected BASIC output:
+Expected output:
 
 - `worker-repo-a`: `repo-a-main-proof`
 - `orchestrator`: all seeded IDs
 - `coach`: `personal-checkpoint-proof`, `null-user-local-proof`
+- `lead-repo-a`: `repo-a-main-proof`, `repo-a-worktree-proof`, `repo-b-main-proof`, `repo-b-worktree-proof`
+- `worker-repo-a-main`: `repo-a-main-proof`
+- `worker-repo-a-worktree`: `repo-a-main-proof`, `repo-a-worktree-proof`
 
 Then run the real-cmux gate with the live MCP server loaded from the same build. Paste the observed `brain_search` outputs into the collab before merging.
 

--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -176,6 +176,8 @@ class HybridSearchHelper:
             "allow_helper_route": False,
             "brainbar_helper_fast_profile": True,
         }
+        if arguments.get("consumer"):
+            search_kwargs["consumer"] = arguments.get("consumer")
         if arguments.get("include_operational"):
             search_kwargs["include_operational"] = True
         if arguments.get("content_class"):

--- a/src/brainlayer/engine.py
+++ b/src/brainlayer/engine.py
@@ -180,6 +180,7 @@ def think(
     max_results: int = 10,
     include_audit: bool = False,
     agent_id: str | None = None,
+    consumer_scope: Any | None = None,
 ) -> ThinkResult:
     """Given current task context, retrieve relevant past knowledge.
 
@@ -210,6 +211,7 @@ def think(
         importance_min=3.0,  # Skip low-importance noise
         include_audit=include_audit,
         agent_id=agent_id,
+        consumer_scope=consumer_scope,
     )
 
     if not results["documents"][0]:
@@ -245,6 +247,7 @@ def recall(
     max_results: int = 10,
     include_audit: bool = False,
     agent_id: str | None = None,
+    consumer_scope: Any | None = None,
 ) -> RecallResult:
     """Proactive smart retrieval based on file or topic.
 
@@ -286,6 +289,7 @@ def recall(
                 project_filter=project,
                 include_audit=include_audit,
                 agent_id=agent_id,
+                consumer_scope=consumer_scope,
             )
             for doc, meta in zip(search_results["documents"][0], search_results["metadatas"][0]):
                 result.related_chunks.append(
@@ -309,6 +313,7 @@ def recall(
             project_filter=project,
             include_audit=include_audit,
             agent_id=agent_id,
+            consumer_scope=consumer_scope,
         )
         for doc, meta in zip(search_results["documents"][0], search_results["metadatas"][0]):
             result.related_chunks.append(

--- a/src/brainlayer/isolation_proof.py
+++ b/src/brainlayer/isolation_proof.py
@@ -1,0 +1,241 @@
+"""Seeded isolation-proof harness for BrainLayer consumer scoping.
+
+The harness deliberately uses deterministic local embeddings so it can run in
+tests, CI, and cmux smoke probes without starting an embedder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._helpers import serialize_f32
+from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
+from .scoping import resolve_consumer_scope
+from .search_repo import clear_hybrid_search_cache
+from .vector_store import VectorStore
+
+QUERY_TEXT = "happy camper isolation proof sentinel"
+
+BASIC_PROOF_EXPECTATIONS: dict[str, set[str]] = {
+    "worker-repo-a": {"repo-a-main-proof"},
+    "orchestrator": {
+        "repo-a-main-proof",
+        "repo-a-worktree-proof",
+        "repo-a-checkpoint-proof",
+        "repo-b-main-proof",
+        "repo-b-checkpoint-proof",
+        "personal-checkpoint-proof",
+        "null-user-local-proof",
+    },
+    "coach": {"personal-checkpoint-proof", "null-user-local-proof"},
+}
+
+
+@dataclass(frozen=True)
+class IsolationProofFixture:
+    db_path: Path
+    seeded_ids: set[str]
+
+
+@dataclass(frozen=True)
+class ScopeProbe:
+    name: str
+    consumer: str
+    project: str | None
+    include_checkpoints: bool = False
+
+
+@dataclass(frozen=True)
+class IsolationProofReport:
+    visible_ids_by_probe: dict[str, set[str]]
+    failures: list[str]
+
+    def as_jsonable(self) -> dict:
+        return {
+            "visible_ids_by_probe": {
+                name: sorted(visible_ids) for name, visible_ids in sorted(self.visible_ids_by_probe.items())
+            },
+            "failures": list(self.failures),
+        }
+
+
+def _embed(text: str) -> list[float]:
+    seed = (sum(ord(character) for character in text[:80]) % 97) / 1000.0
+    return [seed + (index / 10000.0) for index in range(1024)]
+
+
+def _insert_proof_chunk(
+    store: VectorStore,
+    *,
+    chunk_id: str,
+    project: str | None,
+    content: str,
+    created_at: str,
+    chunk_origin: str | None = None,
+) -> None:
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, created_at, chunk_origin
+        ) VALUES (?, ?, ?, 'happy-camper-isolation-proof.jsonl', ?, 'assistant_text', ?, 'claude_code', ?, ?)""",
+        (
+            chunk_id,
+            content,
+            json.dumps({"proof_fixture": "happy-camper-isolation"}),
+            project,
+            len(content),
+            created_at,
+            chunk_origin,
+        ),
+    )
+    cursor.execute(
+        "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+        (chunk_id, serialize_f32(_embed(QUERY_TEXT))),
+    )
+
+
+def seed_isolation_proof_db(db_path: str | Path) -> IsolationProofFixture:
+    """Create a self-contained DB with repo, worktree, local, and checkpoint rows."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+
+    seeded_ids = {
+        "repo-a-main-proof",
+        "repo-a-worktree-proof",
+        "repo-a-checkpoint-proof",
+        "repo-b-main-proof",
+        "repo-b-checkpoint-proof",
+        "personal-checkpoint-proof",
+        "null-user-local-proof",
+    }
+    store = VectorStore(path)
+    store._binary_index_available = False
+    try:
+        _insert_proof_chunk(
+            store,
+            chunk_id="repo-a-main-proof",
+            project="repo-a",
+            content=f"{QUERY_TEXT} repo A main branch memory",
+            created_at="2026-06-14T00:00:00Z",
+        )
+        _insert_proof_chunk(
+            store,
+            chunk_id="repo-a-worktree-proof",
+            project="repo-a.worktree.feature-x",
+            content=f"{QUERY_TEXT} repo A feature worktree memory",
+            created_at="2026-06-14T00:01:00Z",
+        )
+        _insert_proof_chunk(
+            store,
+            chunk_id="repo-a-checkpoint-proof",
+            project="repo-a",
+            content=f"[precompact checkpoint] {QUERY_TEXT} repo A checkpoint memory",
+            created_at="2026-06-14T00:02:00Z",
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+        _insert_proof_chunk(
+            store,
+            chunk_id="repo-b-main-proof",
+            project="repo-b",
+            content=f"{QUERY_TEXT} repo B main branch memory",
+            created_at="2026-06-14T00:03:00Z",
+        )
+        _insert_proof_chunk(
+            store,
+            chunk_id="repo-b-checkpoint-proof",
+            project="repo-b",
+            content=f"[precompact checkpoint] {QUERY_TEXT} repo B checkpoint memory",
+            created_at="2026-06-14T00:04:00Z",
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+        _insert_proof_chunk(
+            store,
+            chunk_id="personal-checkpoint-proof",
+            project="personal",
+            content=f"[precompact checkpoint] {QUERY_TEXT} personal coach checkpoint memory",
+            created_at="2026-06-14T00:05:00Z",
+            chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
+        )
+        _insert_proof_chunk(
+            store,
+            chunk_id="null-user-local-proof",
+            project=None,
+            content=f"{QUERY_TEXT} user-local null-project memory",
+            created_at="2026-06-14T00:06:00Z",
+        )
+    finally:
+        store.close()
+    clear_hybrid_search_cache(path)
+    return IsolationProofFixture(db_path=path, seeded_ids=seeded_ids)
+
+
+def run_basic_isolation_proof(db_path: str | Path, probes: list[ScopeProbe] | None = None) -> IsolationProofReport:
+    """Run role probes against the seeded DB and compare them with expected IDs."""
+    selected_probes = probes or [
+        ScopeProbe(name="worker-repo-a", consumer="worker", project="repo-a"),
+        ScopeProbe(name="orchestrator", consumer="orchestrator", project=None, include_checkpoints=True),
+        ScopeProbe(name="coach", consumer="coach", project=None),
+    ]
+    visible_ids_by_probe: dict[str, set[str]] = {}
+    failures: list[str] = []
+
+    store = VectorStore(Path(db_path), readonly=True)
+    store._binary_index_available = False
+    try:
+        for probe in selected_probes:
+            scope = resolve_consumer_scope(
+                project=probe.project,
+                consumer=probe.consumer,
+                include_checkpoints=probe.include_checkpoints,
+            )
+            results = store.hybrid_search(
+                query_embedding=_embed(QUERY_TEXT),
+                query_text=QUERY_TEXT,
+                n_results=20,
+                consumer_scope=scope,
+            )
+            visible_ids = set(results["ids"][0])
+            visible_ids_by_probe[probe.name] = visible_ids
+            expected = BASIC_PROOF_EXPECTATIONS.get(probe.name)
+            if expected is not None and visible_ids != expected:
+                failures.append(f"{probe.name}: expected {sorted(expected)}, got {sorted(visible_ids)}")
+    finally:
+        store.close()
+
+    return IsolationProofReport(visible_ids_by_probe=visible_ids_by_probe, failures=failures)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build and run the Happy Camper BrainLayer isolation proof DB.")
+    parser.add_argument("--db", type=Path, required=True, help="Path to write the seeded proof SQLite DB")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    fixture = seed_isolation_proof_db(args.db)
+    report = run_basic_isolation_proof(fixture.db_path)
+    payload = {
+        "db_path": str(fixture.db_path),
+        "seeded_ids": sorted(fixture.seeded_ids),
+        **report.as_jsonable(),
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"DB: {fixture.db_path}")
+        print(f"Seeded: {', '.join(payload['seeded_ids'])}")
+        for name, visible_ids in payload["visible_ids_by_probe"].items():
+            print(f"{name}: {', '.join(visible_ids)}")
+        print("PASS" if not report.failures else "FAIL")
+        for failure in report.failures:
+            print(f"- {failure}")
+    return 0 if not report.failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/isolation_proof.py
+++ b/src/brainlayer/isolation_proof.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from ._helpers import serialize_f32
 from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT
-from .scoping import resolve_consumer_scope
+from .scoping import ConsumerScope, resolve_consumer_scope
 from .search_repo import clear_hybrid_search_cache
 from .vector_store import VectorStore
 
@@ -26,11 +26,23 @@ BASIC_PROOF_EXPECTATIONS: dict[str, set[str]] = {
         "repo-a-worktree-proof",
         "repo-a-checkpoint-proof",
         "repo-b-main-proof",
+        "repo-b-worktree-proof",
         "repo-b-checkpoint-proof",
         "personal-checkpoint-proof",
         "null-user-local-proof",
     },
     "coach": {"personal-checkpoint-proof", "null-user-local-proof"},
+}
+
+EXTENSION_PROOF_EXPECTATIONS: dict[str, set[str]] = {
+    "lead-repo-a": {
+        "repo-a-main-proof",
+        "repo-a-worktree-proof",
+        "repo-b-main-proof",
+        "repo-b-worktree-proof",
+    },
+    "worker-repo-a-main": {"repo-a-main-proof"},
+    "worker-repo-a-worktree": {"repo-a-main-proof", "repo-a-worktree-proof"},
 }
 
 
@@ -46,6 +58,7 @@ class ScopeProbe:
     consumer: str
     project: str | None
     include_checkpoints: bool = False
+    project_filters: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -110,6 +123,7 @@ def seed_isolation_proof_db(db_path: str | Path) -> IsolationProofFixture:
         "repo-a-worktree-proof",
         "repo-a-checkpoint-proof",
         "repo-b-main-proof",
+        "repo-b-worktree-proof",
         "repo-b-checkpoint-proof",
         "personal-checkpoint-proof",
         "null-user-local-proof",
@@ -148,10 +162,17 @@ def seed_isolation_proof_db(db_path: str | Path) -> IsolationProofFixture:
         )
         _insert_proof_chunk(
             store,
+            chunk_id="repo-b-worktree-proof",
+            project="repo-b.worktree.parallel",
+            content=f"{QUERY_TEXT} repo B parallel worktree memory",
+            created_at="2026-06-14T00:04:00Z",
+        )
+        _insert_proof_chunk(
+            store,
             chunk_id="repo-b-checkpoint-proof",
             project="repo-b",
             content=f"[precompact checkpoint] {QUERY_TEXT} repo B checkpoint memory",
-            created_at="2026-06-14T00:04:00Z",
+            created_at="2026-06-14T00:05:00Z",
             chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
         )
         _insert_proof_chunk(
@@ -159,7 +180,7 @@ def seed_isolation_proof_db(db_path: str | Path) -> IsolationProofFixture:
             chunk_id="personal-checkpoint-proof",
             project="personal",
             content=f"[precompact checkpoint] {QUERY_TEXT} personal coach checkpoint memory",
-            created_at="2026-06-14T00:05:00Z",
+            created_at="2026-06-14T00:06:00Z",
             chunk_origin=CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
         )
         _insert_proof_chunk(
@@ -167,12 +188,29 @@ def seed_isolation_proof_db(db_path: str | Path) -> IsolationProofFixture:
             chunk_id="null-user-local-proof",
             project=None,
             content=f"{QUERY_TEXT} user-local null-project memory",
-            created_at="2026-06-14T00:06:00Z",
+            created_at="2026-06-14T00:07:00Z",
         )
     finally:
         store.close()
     clear_hybrid_search_cache(path)
     return IsolationProofFixture(db_path=path, seeded_ids=seeded_ids)
+
+
+def _scope_for_probe(probe: ScopeProbe) -> ConsumerScope:
+    if probe.project_filters:
+        return ConsumerScope(
+            role=probe.consumer,
+            project_filter=probe.project,
+            project_filters=probe.project_filters,
+            include_checkpoints=probe.include_checkpoints,
+            allow_null_project=False,
+            deny_all=probe.project is None,
+        )
+    return resolve_consumer_scope(
+        project=probe.project,
+        consumer=probe.consumer,
+        include_checkpoints=probe.include_checkpoints,
+    )
 
 
 def run_basic_isolation_proof(db_path: str | Path, probes: list[ScopeProbe] | None = None) -> IsolationProofReport:
@@ -189,11 +227,7 @@ def run_basic_isolation_proof(db_path: str | Path, probes: list[ScopeProbe] | No
     store._binary_index_available = False
     try:
         for probe in selected_probes:
-            scope = resolve_consumer_scope(
-                project=probe.project,
-                consumer=probe.consumer,
-                include_checkpoints=probe.include_checkpoints,
-            )
+            scope = _scope_for_probe(probe)
             results = store.hybrid_search(
                 query_embedding=_embed(QUERY_TEXT),
                 query_text=QUERY_TEXT,
@@ -211,6 +245,41 @@ def run_basic_isolation_proof(db_path: str | Path, probes: list[ScopeProbe] | No
     return IsolationProofReport(visible_ids_by_probe=visible_ids_by_probe, failures=failures)
 
 
+def run_extension_isolation_proof(db_path: str | Path) -> IsolationProofReport:
+    return run_basic_isolation_proof(
+        db_path,
+        probes=[
+            ScopeProbe(
+                name="lead-repo-a",
+                consumer="lead",
+                project="repo-a",
+                project_filters=(
+                    "repo-a",
+                    "repo-a.worktree.feature-x",
+                    "repo-b",
+                    "repo-b.worktree.parallel",
+                ),
+            ),
+            ScopeProbe(name="worker-repo-a-main", consumer="worker", project="repo-a"),
+            ScopeProbe(
+                name="worker-repo-a-worktree",
+                consumer="worker",
+                project="repo-a.worktree.feature-x",
+                project_filters=("repo-a.worktree.feature-x", "repo-a"),
+            ),
+        ],
+    )
+
+
+def run_full_isolation_proof(db_path: str | Path) -> IsolationProofReport:
+    basic = run_basic_isolation_proof(db_path)
+    extension = run_extension_isolation_proof(db_path)
+    return IsolationProofReport(
+        visible_ids_by_probe={**basic.visible_ids_by_probe, **extension.visible_ids_by_probe},
+        failures=[*basic.failures, *extension.failures],
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build and run the Happy Camper BrainLayer isolation proof DB.")
     parser.add_argument("--db", type=Path, required=True, help="Path to write the seeded proof SQLite DB")
@@ -218,7 +287,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     fixture = seed_isolation_proof_db(args.db)
-    report = run_basic_isolation_proof(fixture.db_path)
+    report = run_full_isolation_proof(fixture.db_path)
     payload = {
         "db_path": str(fixture.db_path),
         "seeded_ids": sorted(fixture.seeded_ids),

--- a/src/brainlayer/isolation_proof.py
+++ b/src/brainlayer/isolation_proof.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ._helpers import serialize_f32
@@ -197,20 +197,14 @@ def seed_isolation_proof_db(db_path: str | Path) -> IsolationProofFixture:
 
 
 def _scope_for_probe(probe: ScopeProbe) -> ConsumerScope:
-    if probe.project_filters:
-        return ConsumerScope(
-            role=probe.consumer,
-            project_filter=probe.project,
-            project_filters=probe.project_filters,
-            include_checkpoints=probe.include_checkpoints,
-            allow_null_project=False,
-            deny_all=probe.project is None,
-        )
-    return resolve_consumer_scope(
+    scope = resolve_consumer_scope(
         project=probe.project,
         consumer=probe.consumer,
         include_checkpoints=probe.include_checkpoints,
     )
+    if probe.project_filters:
+        return replace(scope, project_filters=probe.project_filters)
+    return scope
 
 
 def run_basic_isolation_proof(
@@ -224,7 +218,7 @@ def run_basic_isolation_proof(
         ScopeProbe(name="orchestrator", consumer="orchestrator", project=None, include_checkpoints=True),
         ScopeProbe(name="coach", consumer="coach", project=None),
     ]
-    expected_by_probe = expectations or {**BASIC_PROOF_EXPECTATIONS, **EXTENSION_PROOF_EXPECTATIONS}
+    expected_by_probe = expectations or BASIC_PROOF_EXPECTATIONS
     visible_ids_by_probe: dict[str, set[str]] = {}
     failures: list[str] = []
 
@@ -278,7 +272,9 @@ def run_extension_isolation_proof(db_path: str | Path) -> IsolationProofReport:
 
 
 def run_full_isolation_proof(db_path: str | Path) -> IsolationProofReport:
-    basic = run_basic_isolation_proof(db_path)
+    basic = run_basic_isolation_proof(
+        db_path, expectations={**BASIC_PROOF_EXPECTATIONS, **EXTENSION_PROOF_EXPECTATIONS}
+    )
     extension = run_extension_isolation_proof(db_path)
     return IsolationProofReport(
         visible_ids_by_probe={**basic.visible_ids_by_probe, **extension.visible_ids_by_probe},

--- a/src/brainlayer/isolation_proof.py
+++ b/src/brainlayer/isolation_proof.py
@@ -213,13 +213,18 @@ def _scope_for_probe(probe: ScopeProbe) -> ConsumerScope:
     )
 
 
-def run_basic_isolation_proof(db_path: str | Path, probes: list[ScopeProbe] | None = None) -> IsolationProofReport:
+def run_basic_isolation_proof(
+    db_path: str | Path,
+    probes: list[ScopeProbe] | None = None,
+    expectations: dict[str, set[str]] | None = None,
+) -> IsolationProofReport:
     """Run role probes against the seeded DB and compare them with expected IDs."""
     selected_probes = probes or [
         ScopeProbe(name="worker-repo-a", consumer="worker", project="repo-a"),
         ScopeProbe(name="orchestrator", consumer="orchestrator", project=None, include_checkpoints=True),
         ScopeProbe(name="coach", consumer="coach", project=None),
     ]
+    expected_by_probe = expectations or {**BASIC_PROOF_EXPECTATIONS, **EXTENSION_PROOF_EXPECTATIONS}
     visible_ids_by_probe: dict[str, set[str]] = {}
     failures: list[str] = []
 
@@ -236,7 +241,7 @@ def run_basic_isolation_proof(db_path: str | Path, probes: list[ScopeProbe] | No
             )
             visible_ids = set(results["ids"][0])
             visible_ids_by_probe[probe.name] = visible_ids
-            expected = BASIC_PROOF_EXPECTATIONS.get(probe.name)
+            expected = expected_by_probe.get(probe.name)
             if expected is not None and visible_ids != expected:
                 failures.append(f"{probe.name}: expected {sorted(expected)}, got {sorted(visible_ids)}")
     finally:
@@ -268,6 +273,7 @@ def run_extension_isolation_proof(db_path: str | Path) -> IsolationProofReport:
                 project_filters=("repo-a.worktree.feature-x", "repo-a"),
             ),
         ],
+        expectations=EXTENSION_PROOF_EXPECTATIONS,
     )
 
 

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -414,7 +414,7 @@ async def list_tools() -> list[Tool]:
                         },
                         "consumer": {
                             "type": "string",
-                            "enum": ["orchestrator", "worker", "coach"],
+                            "enum": ["orchestrator", "lead", "worker", "coach"],
                             "description": "Per-request consumer role for shared MCP servers. Overrides BRAINLAYER_CONSUMER for this search.",
                         },
                         "file_path": {
@@ -757,7 +757,7 @@ async def list_tools() -> list[Tool]:
                         },
                         "consumer": {
                             "type": "string",
-                            "enum": ["orchestrator", "worker", "coach"],
+                            "enum": ["orchestrator", "lead", "worker", "coach"],
                             "description": "Per-request consumer role for shared MCP servers in search mode. Overrides BRAINLAYER_CONSUMER for this request.",
                         },
                         "hours": {

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -163,6 +163,7 @@ _INPUT_STRING_MAX_LENGTHS = {
     "content_type": 64,
     "content_type_filter": 64,
     "context": 4_096,
+    "consumer": 32,
     "correction_category": 128,
     "date_from": 32,
     "date_to": 32,
@@ -410,6 +411,11 @@ async def list_tools() -> list[Tool]:
                         "project": {
                             "type": "string",
                             "description": "Filter by project name. Encoded/worktree names are auto-normalized.",
+                        },
+                        "consumer": {
+                            "type": "string",
+                            "enum": ["orchestrator", "worker", "coach"],
+                            "description": "Per-request consumer role for shared MCP servers. Overrides BRAINLAYER_CONSUMER for this search.",
                         },
                         "file_path": {
                             "type": "string",
@@ -748,6 +754,11 @@ async def list_tools() -> list[Tool]:
                         "project": {
                             "type": "string",
                             "description": "Filter by project name.",
+                        },
+                        "consumer": {
+                            "type": "string",
+                            "enum": ["orchestrator", "worker", "coach"],
+                            "description": "Per-request consumer role for shared MCP servers in search mode. Overrides BRAINLAYER_CONSUMER for this request.",
                         },
                         "hours": {
                             "type": "integer",
@@ -1300,6 +1311,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
                 mode="search",
                 query=arguments["query"],
                 project=arguments.get("project"),
+                consumer=arguments.get("consumer"),
                 file_path=arguments.get("file_path"),
                 chunk_id=arguments.get("chunk_id"),
                 content_type=resolved_content_type,
@@ -1387,6 +1399,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
             _brain_recall(
                 mode=arguments.get("mode"),
                 project=arguments.get("project"),
+                consumer=arguments.get("consumer"),
                 hours=arguments.get("hours", 24),
                 days=arguments.get("days", 7),
                 limit=arguments.get("limit", 20),

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -134,6 +134,7 @@ def _filter_think_result_for_consumer_scope(result: Any, project: str | None, co
 def _filter_current_context_for_consumer_scope(result: Any, project: str | None, consumer_scope: Any | None) -> Any:
     if consumer_scope is None:
         return result
+    filtered_sessions = []
     if hasattr(result, "recent_sessions"):
         filtered_sessions = [
             session
@@ -144,6 +145,13 @@ def _filter_current_context_for_consumer_scope(result: Any, project: str | None,
         result.active_branches = sorted(
             {session.branch for session in filtered_sessions if getattr(session, "branch", None)}
         )
+        scoped_files: list[str] = []
+        for session in filtered_sessions:
+            for file_path in getattr(session, "files_changed", []) or []:
+                if file_path and file_path not in scoped_files:
+                    scoped_files.append(file_path)
+        result.recent_files = scoped_files
+        result.active_plan = next((session.plan_name for session in filtered_sessions if session.plan_name), "")
     if hasattr(result, "active_projects"):
         result.active_projects = [
             active_project
@@ -151,6 +159,20 @@ def _filter_current_context_for_consumer_scope(result: Any, project: str | None,
             if _row_matches_consumer_scope({"project": active_project}, project, consumer_scope)
         ]
     return result
+
+
+def _filter_sessions_for_consumer_scope(
+    sessions: list[Any], project: str | None, consumer_scope: Any | None
+) -> list[Any]:
+    if consumer_scope is None:
+        return sessions
+    if getattr(consumer_scope, "deny_all", False):
+        return []
+    return [
+        session
+        for session in sessions
+        if _row_matches_consumer_scope({"project": getattr(session, "project", None)}, project, consumer_scope)
+    ]
 
 
 def _helper_sentinel_path() -> Path:
@@ -1568,7 +1590,12 @@ async def _brain_recall(
     if resolved_mode == "context":
         return await _current_context(hours=hours, project=project, consumer_scope=consumer_scope)
     elif resolved_mode == "sessions":
-        return await _sessions(project=project, days=max(1, min(days, 365)), limit=max(1, min(limit, 100)))
+        return await _sessions(
+            project=project,
+            days=max(1, min(days, 365)),
+            limit=max(1, min(limit, 100)),
+            consumer_scope=consumer_scope,
+        )
     elif resolved_mode == "operations":
         if not session_id:
             return _error_result("session_id required for mode=operations")
@@ -2153,14 +2180,21 @@ async def _recall(
         return _error_result(f"Recall error: {str(e)}")
 
 
-async def _sessions(project: str | None = None, days: int = 7, limit: int = 20) -> list[TextContent]:
+async def _sessions(
+    project: str | None = None,
+    days: int = 7,
+    limit: int = 20,
+    consumer_scope: Any | None = None,
+) -> list[TextContent]:
     """List recent sessions."""
     try:
         from ..engine import format_sessions, sessions
 
         store = _get_vector_store()
         normalized_project = _normalize_project_name(project)
-        result = sessions(store=store, project=normalized_project, days=days, limit=limit)
+        prefilter_project = _prefilter_project_for_consumer_scope(normalized_project, consumer_scope)
+        result = sessions(store=store, project=prefilter_project, days=days, limit=limit)
+        result = _filter_sessions_for_consumer_scope(result, normalized_project, consumer_scope)
         return [TextContent(type="text", text=format_sessions(result, days=days))]
     except Exception as e:
         return _error_result(f"Sessions error: {str(e)}")

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -111,7 +111,10 @@ def _filter_regression_for_consumer_scope(
 
 
 def _prefilter_project_for_consumer_scope(project: str | None, consumer_scope: Any | None) -> str | None:
-    if consumer_scope is not None and len(getattr(consumer_scope, "project_filters", ()) or ()) > 1:
+    if consumer_scope is not None and (
+        len(getattr(consumer_scope, "project_filters", ()) or ()) > 1
+        or getattr(consumer_scope, "allow_null_project", False)
+    ):
         return None
     return project
 
@@ -1172,6 +1175,7 @@ async def _brain_search_dispatch(
                 content_class_filter=content_class_filter,
                 agent_id=agent_id,
                 brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+                consumer_scope=consumer_scope,
             )
             chunk_results = kg_results.get("chunks", {})
 
@@ -1541,7 +1545,12 @@ async def _brain_recall(
             logger.debug("Project auto-scope failed, proceeding without scope")
     from ..scoping import resolve_consumer_scope
 
-    consumer_scope = resolve_consumer_scope(project=project, consumer=consumer, include_checkpoints=include_checkpoints)
+    consumer_scope = resolve_consumer_scope(
+        project=project,
+        consumer=consumer,
+        source_filter=source_filter,
+        include_checkpoints=include_checkpoints,
+    )
     project = consumer_scope.project_filter
 
     # --- New modes: search + entity ---
@@ -2101,6 +2110,7 @@ async def _think(
                 max_results=max_results,
                 include_audit=include_audit,
                 agent_id=agent_id,
+                consumer_scope=consumer_scope,
             ),
         )
         result = _filter_think_result_for_consumer_scope(result, normalized_project, consumer_scope)
@@ -2150,6 +2160,7 @@ async def _recall(
                 max_results=max_results,
                 include_audit=include_audit,
                 agent_id=agent_id,
+                consumer_scope=consumer_scope,
             ),
         )
         result = _filter_recall_result_for_consumer_scope(result, normalized_project, consumer_scope)

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -110,6 +110,49 @@ def _filter_regression_for_consumer_scope(
     return filtered
 
 
+def _prefilter_project_for_consumer_scope(project: str | None, consumer_scope: Any | None) -> str | None:
+    if consumer_scope is not None and len(getattr(consumer_scope, "project_filters", ()) or ()) > 1:
+        return None
+    return project
+
+
+def _filter_think_result_for_consumer_scope(result: Any, project: str | None, consumer_scope: Any | None) -> Any:
+    if consumer_scope is None:
+        return result
+    total = 0
+    for field_name in ("decisions", "patterns", "bugs", "context"):
+        if not hasattr(result, field_name):
+            continue
+        filtered = _filter_rows_for_consumer_scope(list(getattr(result, field_name) or []), project, consumer_scope)
+        setattr(result, field_name, filtered)
+        total += len(filtered)
+    if hasattr(result, "total"):
+        result.total = total
+    return result
+
+
+def _filter_current_context_for_consumer_scope(result: Any, project: str | None, consumer_scope: Any | None) -> Any:
+    if consumer_scope is None:
+        return result
+    if hasattr(result, "recent_sessions"):
+        filtered_sessions = [
+            session
+            for session in result.recent_sessions
+            if _row_matches_consumer_scope({"project": getattr(session, "project", None)}, project, consumer_scope)
+        ]
+        result.recent_sessions = filtered_sessions
+        result.active_branches = sorted(
+            {session.branch for session in filtered_sessions if getattr(session, "branch", None)}
+        )
+    if hasattr(result, "active_projects"):
+        result.active_projects = [
+            active_project
+            for active_project in result.active_projects
+            if _row_matches_consumer_scope({"project": active_project}, project, consumer_scope)
+        ]
+    return result
+
+
 def _helper_sentinel_path() -> Path:
     return Path("~/.local/share/brainlayer/use-helper-socket").expanduser()
 
@@ -971,13 +1014,14 @@ async def _brain_search_dispatch(
         )
 
     if _query_signals_current_context(query):
-        ctx = await _current_context(hours=24)
+        ctx = await _current_context(hours=24, project=project, consumer_scope=consumer_scope)
         think_result = await _think(
             context=query,
             project=project,
             max_results=max_results,
             include_audit=include_audit,
             agent_id=agent_id,
+            consumer_scope=consumer_scope,
         )
         merged_text = []
         if isinstance(ctx, tuple):
@@ -997,6 +1041,7 @@ async def _brain_search_dispatch(
             max_results=max_results,
             include_audit=include_audit,
             agent_id=agent_id,
+            consumer_scope=consumer_scope,
         )
 
     if _query_signals_recall(query):
@@ -1006,6 +1051,7 @@ async def _brain_search_dispatch(
             max_results=max_results,
             include_audit=include_audit,
             agent_id=agent_id,
+            consumer_scope=consumer_scope,
         )
 
     store = _get_vector_store()
@@ -1464,6 +1510,18 @@ async def _brain_recall(
             }
         )
 
+    if project is None:
+        try:
+            from ..scoping import resolve_project_scope
+
+            project = resolve_project_scope()
+        except Exception:
+            logger.debug("Project auto-scope failed, proceeding without scope")
+    from ..scoping import resolve_consumer_scope
+
+    consumer_scope = resolve_consumer_scope(project=project, consumer=consumer, include_checkpoints=include_checkpoints)
+    project = consumer_scope.project_filter
+
     # --- New modes: search + entity ---
 
     if resolved_mode == "search":
@@ -1508,7 +1566,7 @@ async def _brain_recall(
     # --- Original modes ---
 
     if resolved_mode == "context":
-        return await _current_context(hours=hours)
+        return await _current_context(hours=hours, project=project, consumer_scope=consumer_scope)
     elif resolved_mode == "sessions":
         return await _sessions(project=project, days=max(1, min(days, 365)), limit=max(1, min(limit, 100)))
     elif resolved_mode == "operations":
@@ -1874,7 +1932,8 @@ async def _file_timeline(
     """Get interaction timeline for a file."""
     try:
         store = _get_vector_store()
-        interactions = store.get_file_timeline(file_path, project=project, limit=limit)
+        prefilter_project = _prefilter_project_for_consumer_scope(project, consumer_scope)
+        interactions = store.get_file_timeline(file_path, project=prefilter_project, limit=limit)
         interactions = _filter_rows_for_consumer_scope(interactions, project, consumer_scope)
         if not interactions:
             return [TextContent(type="text", text=f"No interactions found for '{file_path}'.")]
@@ -1918,7 +1977,8 @@ async def _regression(
     """Analyze a file for regressions."""
     try:
         store = _get_vector_store()
-        result = store.get_file_regression(file_path, project=project)
+        prefilter_project = _prefilter_project_for_consumer_scope(project, consumer_scope)
+        result = store.get_file_regression(file_path, project=prefilter_project)
         result = _filter_regression_for_consumer_scope(result, project, consumer_scope)
         if not result["timeline"]:
             return [TextContent(type="text", text=f"No interactions found for '{file_path}'.")]
@@ -1989,6 +2049,7 @@ async def _think(
     max_results: int = 10,
     include_audit: bool = False,
     agent_id: str | None = None,
+    consumer_scope: Any | None = None,
 ):
     """Execute think -- retrieve relevant memories for current task."""
     try:
@@ -2002,18 +2063,20 @@ async def _think(
             return model.embed_query(text)
 
         normalized_project = _normalize_project_name(project)
+        prefilter_project = _prefilter_project_for_consumer_scope(normalized_project, consumer_scope)
         result = await loop.run_in_executor(
             None,
             lambda: think(
                 context=context,
                 store=store,
                 embed_fn=_embed,
-                project=normalized_project,
+                project=prefilter_project,
                 max_results=max_results,
                 include_audit=include_audit,
                 agent_id=agent_id,
             ),
         )
+        result = _filter_think_result_for_consumer_scope(result, normalized_project, consumer_scope)
         structured = {
             "query": result.query,
             "total": result.total,
@@ -2043,6 +2106,7 @@ async def _recall(
         store = _get_vector_store()
         model = _get_embedding_model()
         normalized_project = _normalize_project_name(project)
+        prefilter_project = _prefilter_project_for_consumer_scope(normalized_project, consumer_scope)
         loop = asyncio.get_running_loop()
 
         def _embed(text: str) -> list[float]:
@@ -2055,7 +2119,7 @@ async def _recall(
                 embed_fn=_embed,
                 file_path=file_path,
                 topic=topic,
-                project=normalized_project,
+                project=prefilter_project,
                 max_results=max_results,
                 include_audit=include_audit,
                 agent_id=agent_id,
@@ -2164,13 +2228,14 @@ async def _session_summary(session_id: str):
         return _error_result(f"Session summary error: {str(e)}")
 
 
-async def _current_context(hours: int = 24):
+async def _current_context(hours: int = 24, project: str | None = None, consumer_scope: Any | None = None):
     """Lightweight session awareness."""
     try:
         from ..engine import current_context
 
         store = _get_vector_store()
         result = current_context(store=store, hours=hours)
+        result = _filter_current_context_for_consumer_scope(result, project, consumer_scope)
         structured = {
             "active_projects": result.active_projects,
             "active_branches": result.active_branches,

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -652,6 +652,7 @@ def _kg_facts_sql(
 async def _brain_search(
     query: str,
     project: str | None = None,
+    consumer: str | None = None,
     file_path: str | None = None,
     chunk_id: str | None = None,
     content_type: str | None = None,
@@ -710,6 +711,7 @@ async def _brain_search(
                     helper_project = _resolve_helper_project(project, entity_id=entity_id, source=source)
                     helper_kwargs = {
                         "project": helper_project,
+                        "consumer": consumer,
                         "source": source,
                         "tag": tag,
                         "importance_min": importance_min,
@@ -739,6 +741,7 @@ async def _brain_search(
         return await _brain_search_dispatch(
             query=query,
             project=project,
+            consumer=consumer,
             file_path=file_path,
             chunk_id=chunk_id,
             content_type=content_type,
@@ -773,6 +776,7 @@ async def _brain_search(
 async def _brain_search_dispatch(
     query: str,
     project: str | None = None,
+    consumer: str | None = None,
     file_path: str | None = None,
     chunk_id: str | None = None,
     content_type: str | None = None,
@@ -817,7 +821,7 @@ async def _brain_search_dispatch(
             logger.debug("Project auto-scope failed, proceeding without scope")
     from ..scoping import resolve_consumer_scope
 
-    consumer_scope = resolve_consumer_scope(project=project, include_checkpoints=include_checkpoints)
+    consumer_scope = resolve_consumer_scope(project=project, consumer=consumer, include_checkpoints=include_checkpoints)
     project = consumer_scope.project_filter
     include_checkpoints = consumer_scope.include_checkpoints
 
@@ -941,6 +945,7 @@ async def _brain_search_dispatch(
         return await _brain_search(
             query=query,
             project=project,
+            consumer=consumer,
             file_path=extracted_file,
             content_type=content_type,
             source=source,
@@ -1395,6 +1400,7 @@ def _smart_detect_mode(query: str | None, mode: str | None) -> str:
 async def _brain_recall(
     mode: str | None = None,
     project: str | None = None,
+    consumer: str | None = None,
     hours: int = 24,
     days: int = 7,
     limit: int = 20,
@@ -1466,6 +1472,7 @@ async def _brain_recall(
         return await _brain_search(
             query=query,
             project=project,
+            consumer=consumer,
             file_path=file_path,
             chunk_id=chunk_id,
             content_type=content_type,

--- a/src/brainlayer/scoping.py
+++ b/src/brainlayer/scoping.py
@@ -17,7 +17,7 @@ _SCOPES_PATH = Path.home() / ".config" / "brainlayer" / "scopes.yaml"
 # Cache parsed config
 _cached_scopes: Optional[dict] = None
 _cached_mtime: float = 0.0
-_VALID_CONSUMERS = frozenset({"orchestrator", "worker", "coach"})
+_VALID_CONSUMERS = frozenset({"orchestrator", "lead", "worker", "coach"})
 _DEFAULT_CONSUMER = "worker"
 _COACH_PROJECT = "personal"
 
@@ -121,6 +121,7 @@ class ConsumerScope:
 
     role: str
     project_filter: Optional[str]
+    project_filters: tuple[str, ...] = ()
     source_filter: Optional[str] = None
     include_checkpoints: bool = False
     allow_null_project: bool = False
@@ -137,10 +138,30 @@ class ConsumerScope:
         return cls(
             role="worker",
             project_filter=project,
+            project_filters=_worker_project_filters(project),
             source_filter=source_filter,
             include_checkpoints=include_checkpoints,
             allow_null_project=False,
             deny_all=project is None,
+        )
+
+    @classmethod
+    def for_lead(
+        cls,
+        project: Optional[str],
+        *,
+        source_filter: Optional[str] = None,
+        include_checkpoints: bool = False,
+    ) -> "ConsumerScope":
+        root_project = _main_project_for(project)
+        return cls(
+            role="lead",
+            project_filter=root_project,
+            project_filters=_lead_project_filters(root_project),
+            source_filter=source_filter,
+            include_checkpoints=include_checkpoints,
+            allow_null_project=False,
+            deny_all=root_project is None,
         )
 
     @classmethod
@@ -179,6 +200,7 @@ class ConsumerScope:
         return (
             self.role,
             self.project_filter,
+            self.project_filters,
             self.source_filter,
             self.include_checkpoints,
             self.allow_null_project,
@@ -213,6 +235,12 @@ def resolve_consumer_scope(
             source_filter=source_filter,
             include_checkpoints=include_checkpoints,
         )
+    if role == "lead":
+        return ConsumerScope.for_lead(
+            project,
+            source_filter=source_filter,
+            include_checkpoints=include_checkpoints,
+        )
     if role == "coach":
         return ConsumerScope.for_coach(source_filter=source_filter, include_checkpoints=True)
     return ConsumerScope.for_worker(
@@ -220,6 +248,82 @@ def resolve_consumer_scope(
         source_filter=source_filter,
         include_checkpoints=include_checkpoints,
     )
+
+
+def _worktree_map(config: Optional[dict] = None) -> dict[str, str]:
+    """Return configured worktree-project -> main-project mappings."""
+    raw = (config or _load_scopes()).get("worktrees", {})
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, str] = {}
+    for worktree_project, main_project in raw.items():
+        if isinstance(worktree_project, str) and isinstance(main_project, str):
+            worktree = worktree_project.strip()
+            main = main_project.strip()
+            if worktree and main:
+                result[worktree] = main
+    return result
+
+
+def _main_project_for(project: Optional[str], config: Optional[dict] = None) -> Optional[str]:
+    if project is None:
+        return None
+    return _worktree_map(config).get(project, project)
+
+
+def _worktrees_for_main(main_project: Optional[str], config: Optional[dict] = None) -> tuple[str, ...]:
+    if main_project is None:
+        return ()
+    mapping = _worktree_map(config)
+    return tuple(sorted(worktree for worktree, main in mapping.items() if main == main_project))
+
+
+def _parallel_projects_for_lead(main_project: Optional[str], config: Optional[dict] = None) -> tuple[str, ...]:
+    if main_project is None:
+        return ()
+    cfg = config or _load_scopes()
+    raw = cfg.get("lead_parallel_projects", cfg.get("parallel_repos", {}))
+    if not isinstance(raw, dict):
+        return ()
+    configured = raw.get(main_project, ())
+    if isinstance(configured, str):
+        configured = [configured]
+    if not isinstance(configured, (list, tuple)):
+        return ()
+    projects: list[str] = []
+    for project in configured:
+        if isinstance(project, str) and project.strip():
+            projects.append(_main_project_for(project.strip(), cfg) or project.strip())
+    return tuple(projects)
+
+
+def _dedupe_projects(projects: list[str | None]) -> tuple[str, ...]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for project in projects:
+        if project is None or project in seen:
+            continue
+        seen.add(project)
+        deduped.append(project)
+    return tuple(deduped)
+
+
+def _worker_project_filters(project: Optional[str]) -> tuple[str, ...]:
+    if project is None:
+        return ()
+    main_project = _main_project_for(project)
+    if main_project and main_project != project:
+        return _dedupe_projects([project, main_project])
+    return (project,)
+
+
+def _lead_project_filters(main_project: Optional[str]) -> tuple[str, ...]:
+    if main_project is None:
+        return ()
+    projects: list[str | None] = [main_project, *_worktrees_for_main(main_project)]
+    for parallel_project in _parallel_projects_for_lead(main_project):
+        projects.extend([parallel_project, *_worktrees_for_main(parallel_project)])
+    return _dedupe_projects(projects)
 
 
 def _cwd_heuristic() -> Optional[str]:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -365,6 +365,16 @@ def _effective_project_filter(project_filter: Optional[str], consumer_scope: Con
     return project_filter
 
 
+def _effective_project_filters(project_filter: Optional[str], consumer_scope: ConsumerScope | None) -> tuple[str, ...]:
+    if consumer_scope is not None:
+        if consumer_scope.project_filters:
+            return consumer_scope.project_filters
+        if consumer_scope.project_filter:
+            return (consumer_scope.project_filter,)
+        return ()
+    return (project_filter,) if project_filter else ()
+
+
 def _effective_source_filter(source_filter: Optional[str], consumer_scope: ConsumerScope | None) -> Optional[str]:
     if consumer_scope is not None and consumer_scope.source_filter is not None:
         return consumer_scope.source_filter
@@ -385,13 +395,14 @@ def _project_scope_where(
     if consumer_scope is not None and consumer_scope.deny_all:
         return "0 = 1", []
 
-    effective_project = _effective_project_filter(project_filter, consumer_scope)
-    if not effective_project:
+    effective_projects = _effective_project_filters(project_filter, consumer_scope)
+    if not effective_projects:
         return None, []
 
+    placeholders = ", ".join("?" for _ in effective_projects)
     if consumer_scope is not None and not consumer_scope.allow_null_project:
-        return f"{column_expr} = ?", [effective_project]
-    return f"({column_expr} = ? OR {column_expr} IS NULL)", [effective_project]
+        return f"{column_expr} IN ({placeholders})", list(effective_projects)
+    return f"({column_expr} IN ({placeholders}) OR {column_expr} IS NULL)", list(effective_projects)
 
 
 def _metadata_matches_project_scope(
@@ -402,12 +413,12 @@ def _metadata_matches_project_scope(
     if consumer_scope is not None and consumer_scope.deny_all:
         return False
 
-    effective_project = _effective_project_filter(project_filter, consumer_scope)
-    if not effective_project:
+    effective_projects = _effective_project_filters(project_filter, consumer_scope)
+    if not effective_projects:
         return True
 
     project = metadata.get("project")
-    if project == effective_project:
+    if project in effective_projects:
         return True
     if project is None:
         return consumer_scope is None or consumer_scope.allow_null_project

--- a/tests/test_3tool_aliases.py
+++ b/tests/test_3tool_aliases.py
@@ -235,7 +235,11 @@ class TestBackwardCompatRecallModes:
         ) as mock_ctx:
             asyncio.run(_brain_recall(mode="context"))
 
-        mock_ctx.assert_called_once_with(hours=24)
+        mock_ctx.assert_called_once()
+        call_kwargs = mock_ctx.call_args.kwargs
+        assert call_kwargs["hours"] == 24
+        assert call_kwargs["consumer_scope"].role == "worker"
+        assert call_kwargs["consumer_scope"].allow_null_project is False
 
     def test_sessions_mode_still_works(self):
         """mode=sessions still routes to _sessions."""

--- a/tests/test_3tool_aliases.py
+++ b/tests/test_3tool_aliases.py
@@ -250,7 +250,13 @@ class TestBackwardCompatRecallModes:
         ) as mock_sessions:
             asyncio.run(_brain_recall(mode="sessions", days=14, limit=50))
 
-        mock_sessions.assert_called_once_with(project=None, days=14, limit=50)
+        mock_sessions.assert_called_once()
+        call_kwargs = mock_sessions.call_args.kwargs
+        assert call_kwargs["project"] is None
+        assert call_kwargs["days"] == 14
+        assert call_kwargs["limit"] == 50
+        assert call_kwargs["consumer_scope"].role == "worker"
+        assert call_kwargs["consumer_scope"].allow_null_project is False
 
     def test_stats_mode_still_works(self):
         """mode=stats still routes to _stats + _list_projects."""

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -764,9 +764,11 @@ async def test_think_filters_with_expanded_lead_scope(monkeypatch):
             total=4,
         )
 
-    consumer_scope = ConsumerScope.for_lead("repo-a")
-    object.__setattr__(consumer_scope, "project_filters", ("repo-a", "repo-a.worktree.feature-x"))
-
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {"worktrees": {"repo-a.worktree.feature-x": "repo-a"}},
+    )
+    consumer_scope = resolve_consumer_scope(project="repo-a", consumer="lead")
     monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
     monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: _ScopedEmbeddingModel())
     monkeypatch.setattr("brainlayer.engine.think", fake_think)
@@ -813,8 +815,11 @@ async def test_lead_file_timeline_skips_single_project_prefilter(monkeypatch):
                 },
             ]
 
-    consumer_scope = ConsumerScope.for_lead("repo-a")
-    object.__setattr__(consumer_scope, "project_filters", ("repo-a", "repo-a.worktree.feature-x"))
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {"worktrees": {"repo-a.worktree.feature-x": "repo-a"}},
+    )
+    consumer_scope = resolve_consumer_scope(project="repo-a", consumer="lead")
     monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: FakeStore())
 
     parts = await _file_timeline(
@@ -893,8 +898,11 @@ async def test_sessions_route_honors_deny_all_and_expanded_scope(monkeypatch):
     monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
     monkeypatch.setattr("brainlayer.engine.sessions", fake_sessions)
 
-    lead_scope = ConsumerScope.for_lead("repo-a")
-    object.__setattr__(lead_scope, "project_filters", ("repo-a", "repo-a.worktree.feature-x"))
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {"worktrees": {"repo-a.worktree.feature-x": "repo-a"}},
+    )
+    lead_scope = resolve_consumer_scope(project="repo-a", consumer="lead")
 
     parts = await _sessions(project="repo-a", consumer_scope=lead_scope)
     text = _text_parts(parts)

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -124,6 +124,20 @@ class _FakeRecallResult:
         return "\n".join(parts)
 
 
+@dataclass
+class _FakeThinkResult:
+    query: str = "scope"
+    decisions: list[dict[str, Any]] = field(default_factory=list)
+    patterns: list[dict[str, Any]] = field(default_factory=list)
+    bugs: list[dict[str, Any]] = field(default_factory=list)
+    context: list[dict[str, Any]] = field(default_factory=list)
+    total: int = 0
+
+    def format(self) -> str:
+        rows = [*self.decisions, *self.patterns, *self.bugs, *self.context]
+        return "\n".join(f"{row.get('project')}:{row.get('content')}" for row in rows)
+
+
 def test_resolve_consumer_scope_defaults_to_worker_fail_closed(monkeypatch):
     monkeypatch.delenv("BRAINLAYER_CONSUMER", raising=False)
 
@@ -676,6 +690,115 @@ async def test_worker_recall_filters_foreign_and_null_rows(monkeypatch):
     assert [chunk["project"] for chunk in structured["related_chunks"]] == ["repo-a"]
     assert "repo-b" not in text
     assert "null related" not in text
+
+
+@pytest.mark.asyncio
+async def test_recall_signal_route_passes_consumer_scope(monkeypatch):
+    from brainlayer.mcp.search_handler import _brain_search
+
+    calls = []
+
+    async def fake_recall(**kwargs):
+        calls.append(kwargs)
+        return ([], {"target": kwargs.get("topic")})
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._query_signals_recall", lambda _query: True)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._recall", fake_recall)
+
+    await _brain_search(
+        query="recall scoped work",
+        project="repo-a",
+        consumer="worker",
+        allow_helper_route=False,
+    )
+
+    assert calls[0]["consumer_scope"].project_filter == "repo-a"
+    assert calls[0]["consumer_scope"].allow_null_project is False
+
+
+@pytest.mark.asyncio
+async def test_think_filters_with_expanded_lead_scope(monkeypatch):
+    from brainlayer.mcp.search_handler import _think
+
+    captured = {}
+
+    def fake_think(**kwargs):
+        captured["project"] = kwargs.get("project")
+        return _FakeThinkResult(
+            decisions=[
+                {"content": "main allowed", "project": "repo-a"},
+                {"content": "worktree allowed", "project": "repo-a.worktree.feature-x"},
+                {"content": "foreign blocked", "project": "repo-c"},
+                {"content": "null blocked", "project": None},
+            ],
+            total=4,
+        )
+
+    consumer_scope = ConsumerScope.for_lead("repo-a")
+    object.__setattr__(consumer_scope, "project_filters", ("repo-a", "repo-a.worktree.feature-x"))
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: _ScopedEmbeddingModel())
+    monkeypatch.setattr("brainlayer.engine.think", fake_think)
+
+    parts, structured = await _think(
+        context="think scoped work",
+        project="repo-a",
+        consumer_scope=consumer_scope,
+    )
+
+    assert captured["project"] is None
+    assert [item["project"] for item in structured["decisions"]] == ["repo-a", "repo-a.worktree.feature-x"]
+    assert "foreign blocked" not in _text_parts(parts)
+
+
+@pytest.mark.asyncio
+async def test_lead_file_timeline_skips_single_project_prefilter(monkeypatch):
+    from brainlayer.mcp.search_handler import _file_timeline
+
+    class FakeStore:
+        def get_file_timeline(self, file_path, project=None, limit=50):  # noqa: ANN001, ARG002
+            assert project is None
+            return [
+                {
+                    "file_path": "src/app.py",
+                    "timestamp": "2026-06-01T00:00:00Z",
+                    "session_id": "main-session",
+                    "action": "edit",
+                    "project": "repo-a",
+                },
+                {
+                    "file_path": "src/app.py",
+                    "timestamp": "2026-06-01T01:00:00Z",
+                    "session_id": "worktree-session",
+                    "action": "edit",
+                    "project": "repo-a.worktree.feature-x",
+                },
+                {
+                    "file_path": "src/app.py",
+                    "timestamp": "2026-06-01T02:00:00Z",
+                    "session_id": "foreign-session",
+                    "action": "read",
+                    "project": "repo-c",
+                },
+            ]
+
+    consumer_scope = ConsumerScope.for_lead("repo-a")
+    object.__setattr__(consumer_scope, "project_filters", ("repo-a", "repo-a.worktree.feature-x"))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: FakeStore())
+
+    parts = await _file_timeline(
+        file_path="src/app.py",
+        project="repo-a",
+        consumer_scope=consumer_scope,
+    )
+
+    text = _text_parts(parts)
+    assert "Found 2 interactions" in text
+    assert "main-ses" in text
+    assert "worktree" in text
+    assert "foreign" not in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -232,6 +232,34 @@ def test_worker_on_main_sees_main_only(monkeypatch):
     assert scope.project_filters == ("repo-a",)
 
 
+def test_prefilter_project_skips_when_scope_allows_null_project():
+    from brainlayer.mcp.search_handler import _prefilter_project_for_consumer_scope
+
+    assert _prefilter_project_for_consumer_scope("personal", ConsumerScope.for_coach()) is None
+
+
+def test_engine_think_and_recall_pass_consumer_scope_to_hybrid_search():
+    from brainlayer.engine import recall, think
+
+    calls = []
+
+    class FakeStore:
+        def hybrid_search(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "documents": [["allowed memory"]],
+                "metadatas": [[{"project": "repo-a", "intent": "implementing"}]],
+            }
+
+    scope = ConsumerScope.for_worker("repo-a")
+
+    think("scoped work", store=FakeStore(), embed_fn=_embed, project=None, consumer_scope=scope)
+    recall(store=FakeStore(), embed_fn=_embed, topic="scoped work", project=None, consumer_scope=scope)
+
+    assert calls[0]["consumer_scope"] == scope
+    assert calls[1]["consumer_scope"] == scope
+
+
 def test_worker_consumer_scope_blocks_foreign_and_null_projects_across_rrf(store):
     query_embedding = _embed("repo b semantic target")
     _insert_chunk(
@@ -1021,3 +1049,57 @@ async def test_entity_id_search_resolves_project_before_worker_scope(monkeypatch
     assert kwargs["project"] == "repo-a"
     assert kwargs["consumer_scope"].project_filter == "repo-a"
     assert kwargs["consumer_scope"].deny_all is False
+
+
+@pytest.mark.asyncio
+async def test_recall_resolves_consumer_scope_with_source_filter(monkeypatch):
+    from brainlayer.mcp.search_handler import _brain_recall
+
+    calls = []
+
+    async def fake_current_context(**kwargs):
+        calls.append(kwargs)
+        return ([], {"context": "ok"})
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._current_context", fake_current_context)
+
+    await _brain_recall(
+        mode="context",
+        project="repo-a",
+        consumer="worker",
+        source_filter="%youtube%",
+    )
+
+    assert calls[0]["consumer_scope"].source_filter == "%youtube%"
+
+
+@pytest.mark.asyncio
+async def test_entity_kg_search_receives_consumer_scope(monkeypatch):
+    from brainlayer.mcp.search_handler import _brain_search
+
+    calls = []
+
+    class FakeStore:
+        def kg_hybrid_search(self, **kwargs):
+            calls.append(kwargs)
+            return {"chunks": {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]}}
+
+        def hybrid_search(self, **_kwargs):
+            return {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: FakeStore())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: _ScopedEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._detect_entities", lambda *_args, **_kwargs: [{"name": "RepoA"}])
+    monkeypatch.setattr("brainlayer.mcp.search_handler._kg_facts_sql", lambda *_args, **_kwargs: [])
+
+    await _brain_search(
+        query="RepoA",
+        project="repo-a",
+        consumer="worker",
+        allow_helper_route=False,
+    )
+
+    assert calls[0]["consumer_scope"].project_filter == "repo-a"
+    assert calls[0]["consumer_scope"].allow_null_project is False

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -145,6 +145,78 @@ def test_worker_without_project_denies_all(monkeypatch):
     assert scope.allow_null_project is False
 
 
+def test_lead_scope_expands_repo_to_all_configured_worktrees(monkeypatch):
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {
+            "worktrees": {
+                "repo-a.worktree.feature-x": "repo-a",
+                "repo-a.worktree.feature-y": "repo-a",
+                "repo-b.worktree.other": "repo-b",
+            }
+        },
+    )
+
+    scope = resolve_consumer_scope(project="repo-a", consumer="lead")
+
+    assert scope.role == "lead"
+    assert scope.project_filter == "repo-a"
+    assert scope.project_filters == (
+        "repo-a",
+        "repo-a.worktree.feature-x",
+        "repo-a.worktree.feature-y",
+    )
+    assert scope.allow_null_project is False
+
+
+def test_lead_scope_includes_user_configured_parallel_repos(monkeypatch):
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {
+            "worktrees": {
+                "repo-a.worktree.feature-x": "repo-a",
+                "repo-b.worktree.other": "repo-b",
+            },
+            "lead_parallel_projects": {"repo-a": ["repo-b"]},
+        },
+    )
+
+    scope = resolve_consumer_scope(project="repo-a.worktree.feature-x", consumer="lead")
+
+    assert scope.project_filter == "repo-a"
+    assert scope.project_filters == (
+        "repo-a",
+        "repo-a.worktree.feature-x",
+        "repo-b",
+        "repo-b.worktree.other",
+    )
+
+
+def test_worker_on_worktree_sees_worktree_and_main(monkeypatch):
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {"worktrees": {"repo-a.worktree.feature-x": "repo-a"}},
+    )
+
+    scope = resolve_consumer_scope(project="repo-a.worktree.feature-x", consumer="worker")
+
+    assert scope.role == "worker"
+    assert scope.project_filter == "repo-a.worktree.feature-x"
+    assert scope.project_filters == ("repo-a.worktree.feature-x", "repo-a")
+
+
+def test_worker_on_main_sees_main_only(monkeypatch):
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {"worktrees": {"repo-a.worktree.feature-x": "repo-a"}},
+    )
+
+    scope = resolve_consumer_scope(project="repo-a", consumer="worker")
+
+    assert scope.project_filter == "repo-a"
+    assert scope.project_filters == ("repo-a",)
+
+
 def test_worker_consumer_scope_blocks_foreign_and_null_projects_across_rrf(store):
     query_embedding = _embed("repo b semantic target")
     _insert_chunk(
@@ -179,6 +251,80 @@ def test_worker_consumer_scope_blocks_foreign_and_null_projects_across_rrf(store
     assert "repo-b-vector-and-fts" not in _ids(results)
     assert "null-vector-and-fts" not in _ids(results)
     assert set(_projects(results)) <= {"repo-a"}
+
+
+def test_lead_consumer_scope_includes_repo_worktrees_and_parallel_repos(store, monkeypatch):
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {
+            "worktrees": {
+                "repo-a.worktree.feature-x": "repo-a",
+                "repo-b.worktree.parallel": "repo-b",
+            },
+            "lead_parallel_projects": {"repo-a": ["repo-b"]},
+        },
+    )
+    for chunk_id, project in [
+        ("repo-a-main", "repo-a"),
+        ("repo-a-worktree", "repo-a.worktree.feature-x"),
+        ("repo-b-main", "repo-b"),
+        ("repo-b-worktree", "repo-b.worktree.parallel"),
+        ("repo-c-foreign", "repo-c"),
+        ("null-user-local", None),
+    ]:
+        _insert_chunk(
+            store,
+            chunk_id=chunk_id,
+            content="lead worktree visibility sentinel",
+            embedding=_embed("lead worktree visibility sentinel"),
+            project=project,
+        )
+
+    scope = resolve_consumer_scope(project="repo-a", consumer="lead")
+    results = store.hybrid_search(
+        query_embedding=_embed("lead worktree visibility sentinel"),
+        query_text="lead worktree visibility sentinel",
+        n_results=10,
+        consumer_scope=scope,
+    )
+
+    assert set(_ids(results)) == {
+        "repo-a-main",
+        "repo-a-worktree",
+        "repo-b-main",
+        "repo-b-worktree",
+    }
+
+
+def test_worker_worktree_consumer_scope_includes_worktree_and_main_only(store, monkeypatch):
+    monkeypatch.setattr(
+        "brainlayer.scoping._load_scopes",
+        lambda: {"worktrees": {"repo-a.worktree.feature-x": "repo-a"}},
+    )
+    for chunk_id, project in [
+        ("repo-a-main", "repo-a"),
+        ("repo-a-worktree", "repo-a.worktree.feature-x"),
+        ("repo-a-other-worktree", "repo-a.worktree.other"),
+        ("repo-b-main", "repo-b"),
+        ("null-user-local", None),
+    ]:
+        _insert_chunk(
+            store,
+            chunk_id=chunk_id,
+            content="worker worktree visibility sentinel",
+            embedding=_embed("worker worktree visibility sentinel"),
+            project=project,
+        )
+
+    scope = resolve_consumer_scope(project="repo-a.worktree.feature-x", consumer="worker")
+    results = store.hybrid_search(
+        query_embedding=_embed("worker worktree visibility sentinel"),
+        query_text="worker worktree visibility sentinel",
+        n_results=10,
+        consumer_scope=scope,
+    )
+
+    assert set(_ids(results)) == {"repo-a-main", "repo-a-worktree"}
 
 
 def test_worker_consumer_scope_closes_null_project_fts_only_leak(store):

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -608,6 +608,56 @@ async def test_mcp_roundtrip_applies_worker_and_orchestrator_scopes_on_seeded_st
 
 
 @pytest.mark.asyncio
+async def test_mcp_search_consumer_argument_overrides_shared_server_env(store, monkeypatch):
+    from brainlayer.mcp.search_handler import _brain_search
+
+    _insert_chunk(
+        store,
+        chunk_id="repo-a-explicit-consumer",
+        content="explicit consumer scope sentinel repo a",
+        embedding=_embed("explicit consumer"),
+        project="repo-a",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="repo-b-explicit-consumer",
+        content="explicit consumer scope sentinel repo b",
+        embedding=_embed("explicit consumer"),
+        project="repo-b",
+    )
+    _insert_chunk(
+        store,
+        chunk_id="null-explicit-consumer",
+        content="explicit consumer scope sentinel user local",
+        embedding=_embed("explicit consumer"),
+        project=None,
+    )
+
+    monkeypatch.setenv("BRAINLAYER_CONSUMER", "worker")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: _ScopedEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._detect_entities", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+    monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "repo-a")
+
+    _content, structured = await _brain_search(
+        query="explicit consumer scope sentinel",
+        source="all",
+        num_results=10,
+        consumer="orchestrator",
+        allow_helper_route=False,
+    )
+
+    assert {result["chunk_id"] for result in structured["results"]} == {
+        "repo-a-explicit-consumer",
+        "repo-b-explicit-consumer",
+        "null-explicit-consumer",
+    }
+
+
+@pytest.mark.asyncio
 async def test_entity_id_search_resolves_project_before_worker_scope(monkeypatch):
     from brainlayer.mcp.search_handler import _brain_search
 

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -2,6 +2,7 @@
 
 import json
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -799,6 +800,84 @@ async def test_lead_file_timeline_skips_single_project_prefilter(monkeypatch):
     assert "main-ses" in text
     assert "worktree" in text
     assert "foreign" not in text
+
+
+@pytest.mark.asyncio
+async def test_current_context_filters_files_and_plan_from_scoped_sessions(monkeypatch):
+    from brainlayer.engine import SessionInfo
+    from brainlayer.mcp.search_handler import _current_context
+
+    def fake_current_context(**_kwargs):
+        return SimpleNamespace(
+            active_projects=["repo-a", "repo-b"],
+            active_branches=["main", "foreign"],
+            active_plan="foreign-plan",
+            recent_files=["foreign.py"],
+            recent_sessions=[
+                SessionInfo(
+                    session_id="repo-a-session",
+                    project="repo-a",
+                    branch="main",
+                    plan_name="allowed-plan",
+                    files_changed=["allowed.py"],
+                ),
+                SessionInfo(
+                    session_id="repo-b-session",
+                    project="repo-b",
+                    branch="foreign",
+                    plan_name="foreign-plan",
+                    files_changed=["foreign.py"],
+                ),
+            ],
+            format=lambda: "context",
+        )
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.engine.current_context", fake_current_context)
+
+    _parts, structured = await _current_context(
+        project="repo-a",
+        consumer_scope=ConsumerScope.for_worker("repo-a"),
+    )
+
+    assert structured["active_projects"] == ["repo-a"]
+    assert structured["active_branches"] == ["main"]
+    assert structured["active_plan"] == "allowed-plan"
+    assert structured["recent_files"] == ["allowed.py"]
+    assert [session["project"] for session in structured["recent_sessions"]] == ["repo-a"]
+
+
+@pytest.mark.asyncio
+async def test_sessions_route_honors_deny_all_and_expanded_scope(monkeypatch):
+    from brainlayer.engine import SessionInfo
+    from brainlayer.mcp.search_handler import _sessions
+
+    captured_projects = []
+
+    def fake_sessions(**kwargs):
+        captured_projects.append(kwargs.get("project"))
+        return [
+            SessionInfo(session_id="main-session", project="repo-a", branch="main"),
+            SessionInfo(session_id="worktree-session", project="repo-a.worktree.feature-x", branch="feature-x"),
+            SessionInfo(session_id="foreign-session", project="repo-c", branch="foreign"),
+        ]
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.engine.sessions", fake_sessions)
+
+    lead_scope = ConsumerScope.for_lead("repo-a")
+    object.__setattr__(lead_scope, "project_filters", ("repo-a", "repo-a.worktree.feature-x"))
+
+    parts = await _sessions(project="repo-a", consumer_scope=lead_scope)
+    text = _text_parts(parts)
+
+    assert captured_projects[-1] is None
+    assert "main-ses" in text
+    assert "worktree" in text
+    assert "repo-c" not in text
+
+    parts = await _sessions(project=None, consumer_scope=ConsumerScope.for_worker(None))
+    assert "No sessions found" in _text_parts(parts)
 
 
 @pytest.mark.asyncio

--- a/tests/test_isolation_proof_harness.py
+++ b/tests/test_isolation_proof_harness.py
@@ -1,0 +1,34 @@
+"""Reusable isolation-proof harness for Happy Camper scoping."""
+
+from brainlayer.isolation_proof import (
+    BASIC_PROOF_EXPECTATIONS,
+    ScopeProbe,
+    run_basic_isolation_proof,
+    seed_isolation_proof_db,
+)
+
+
+def test_seeded_isolation_proof_db_exercises_basic_split(tmp_path):
+    db_path = tmp_path / "happy-camper-isolation-proof.db"
+
+    fixture = seed_isolation_proof_db(db_path)
+    report = run_basic_isolation_proof(
+        fixture.db_path,
+        probes=[
+            ScopeProbe(name="worker-repo-a", consumer="worker", project="repo-a"),
+            ScopeProbe(name="orchestrator", consumer="orchestrator", project=None, include_checkpoints=True),
+            ScopeProbe(name="coach", consumer="coach", project=None),
+        ],
+    )
+
+    assert fixture.seeded_ids == {
+        "repo-a-main-proof",
+        "repo-a-worktree-proof",
+        "repo-a-checkpoint-proof",
+        "repo-b-main-proof",
+        "repo-b-checkpoint-proof",
+        "personal-checkpoint-proof",
+        "null-user-local-proof",
+    }
+    assert report.visible_ids_by_probe == BASIC_PROOF_EXPECTATIONS
+    assert report.failures == []

--- a/tests/test_isolation_proof_harness.py
+++ b/tests/test_isolation_proof_harness.py
@@ -48,3 +48,25 @@ def test_full_isolation_proof_db_exercises_extension_roles(tmp_path):
         **EXTENSION_PROOF_EXPECTATIONS,
     }
     assert report.failures == []
+
+
+def test_extension_isolation_proof_reports_expectation_failures(tmp_path):
+    db_path = tmp_path / "happy-camper-extension-failure-proof.db"
+
+    fixture = seed_isolation_proof_db(db_path)
+    report = run_basic_isolation_proof(
+        fixture.db_path,
+        probes=[
+            ScopeProbe(
+                name="lead-repo-a",
+                consumer="lead",
+                project="repo-a",
+                project_filters=("repo-a",),
+            )
+        ],
+    )
+
+    assert report.failures == [
+        "lead-repo-a: expected ['repo-a-main-proof', 'repo-a-worktree-proof', "
+        "'repo-b-main-proof', 'repo-b-worktree-proof'], got ['repo-a-main-proof']"
+    ]

--- a/tests/test_isolation_proof_harness.py
+++ b/tests/test_isolation_proof_harness.py
@@ -2,8 +2,10 @@
 
 from brainlayer.isolation_proof import (
     BASIC_PROOF_EXPECTATIONS,
+    EXTENSION_PROOF_EXPECTATIONS,
     ScopeProbe,
     run_basic_isolation_proof,
+    run_full_isolation_proof,
     seed_isolation_proof_db,
 )
 
@@ -26,9 +28,23 @@ def test_seeded_isolation_proof_db_exercises_basic_split(tmp_path):
         "repo-a-worktree-proof",
         "repo-a-checkpoint-proof",
         "repo-b-main-proof",
+        "repo-b-worktree-proof",
         "repo-b-checkpoint-proof",
         "personal-checkpoint-proof",
         "null-user-local-proof",
     }
     assert report.visible_ids_by_probe == BASIC_PROOF_EXPECTATIONS
+    assert report.failures == []
+
+
+def test_full_isolation_proof_db_exercises_extension_roles(tmp_path):
+    db_path = tmp_path / "happy-camper-full-isolation-proof.db"
+
+    fixture = seed_isolation_proof_db(db_path)
+    report = run_full_isolation_proof(fixture.db_path)
+
+    assert report.visible_ids_by_probe == {
+        **BASIC_PROOF_EXPECTATIONS,
+        **EXTENSION_PROOF_EXPECTATIONS,
+    }
     assert report.failures == []

--- a/tests/test_isolation_proof_harness.py
+++ b/tests/test_isolation_proof_harness.py
@@ -64,6 +64,7 @@ def test_extension_isolation_proof_reports_expectation_failures(tmp_path):
                 project_filters=("repo-a",),
             )
         ],
+        expectations=EXTENSION_PROOF_EXPECTATIONS,
     )
 
     assert report.failures == [

--- a/tests/test_mcp_warm_route.py
+++ b/tests/test_mcp_warm_route.py
@@ -5,6 +5,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from mcp.types import TextContent
@@ -212,6 +213,19 @@ async def test_brain_search_helper_path_forwards_max_results(monkeypatch):
     await _brain_search(query="recall previous warm route decisions", project="brainlayer", max_results=17)
 
     assert calls[0]["max_results"] == 17
+
+
+@pytest.mark.asyncio
+async def test_warm_helper_search_passes_consumer_to_local_dispatch(monkeypatch):
+    from brainlayer.brainbar_hybrid_helper import HybridSearchHelper
+
+    helper = HybridSearchHelper(socket_path=Path("/tmp/unused.sock"), db_path=Path("/tmp/unused.db"))
+    mock_search = AsyncMock(return_value=([TextContent(type="text", text="ok")], {"total": 0}))
+    monkeypatch.setattr("brainlayer.mcp.search_handler._brain_search", mock_search)
+
+    await helper._search({"query": "scoped helper", "project": "repo-a", "consumer": "worker"})
+
+    assert mock_search.call_args.kwargs["consumer"] == "worker"
 
 
 @pytest.mark.asyncio

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -577,7 +577,7 @@ class TestInputSchemaPresence:
         consumer = props["consumer"]
 
         assert consumer["type"] == "string"
-        assert consumer["enum"] == ["orchestrator", "worker", "coach"]
+        assert consumer["enum"] == ["orchestrator", "lead", "worker", "coach"]
 
 
 # ── Alias resolution in call_tool ────────────────────────────────────────────

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -571,6 +571,14 @@ class TestInputSchemaPresence:
 
         assert cc["type"] == "string"
 
+    def test_consumer_role_is_exposed_for_shared_mcp_socket(self):
+        """brain_search exposes per-request consumer role for shared MCP servers."""
+        props = self._get_brain_search_props()
+        consumer = props["consumer"]
+
+        assert consumer["type"] == "string"
+        assert consumer["enum"] == ["orchestrator", "worker", "coach"]
+
 
 # ── Alias resolution in call_tool ────────────────────────────────────────────
 
@@ -713,6 +721,28 @@ class TestAliasResolution:
 
         call_kwargs = mock_recall.call_args[1]
         assert call_kwargs["include_checkpoints"] is True
+
+    def test_consumer_passes_from_call_tool(self):
+        """consumer is forwarded so shared MCP sockets can scope each request."""
+        from brainlayer.mcp import call_tool
+
+        with patch(
+            "brainlayer.mcp._brain_recall",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ) as mock_recall:
+            asyncio.run(
+                call_tool(
+                    "brain_search",
+                    {
+                        "query": "test",
+                        "consumer": "orchestrator",
+                    },
+                )
+            )
+
+        call_kwargs = mock_recall.call_args[1]
+        assert call_kwargs["consumer"] == "orchestrator"
 
 
 class TestBrainResumeSchema:

--- a/tests/test_search_filter_params.py
+++ b/tests/test_search_filter_params.py
@@ -744,6 +744,28 @@ class TestAliasResolution:
         call_kwargs = mock_recall.call_args[1]
         assert call_kwargs["consumer"] == "orchestrator"
 
+    def test_consumer_passes_from_direct_brain_recall_call_tool(self):
+        """consumer is forwarded through the direct brain_recall route too."""
+        from brainlayer.mcp import call_tool
+
+        with patch(
+            "brainlayer.mcp._brain_recall",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ) as mock_recall:
+            asyncio.run(
+                call_tool(
+                    "brain_recall",
+                    {
+                        "topic": "test",
+                        "consumer": "lead",
+                    },
+                )
+            )
+
+        call_kwargs = mock_recall.call_args[1]
+        assert call_kwargs["consumer"] == "lead"
+
 
 class TestBrainResumeSchema:
     """Verify the explicit checkpoint resume tool is exposed."""


### PR DESCRIPTION
## Summary
- add a deterministic Happy Camper isolation-proof harness that seeds repo-A, repo-B, repo-A worktree, repo-B worktree, null-project, and checkpoint rows without starting the embedder
- expose a per-request `consumer` argument on `brain_search` and `brain_recall(mode="search")` so shared MCP socket callers can pass role explicitly
- add the WI-6 extension: `lead` role, configured worktree expansion, worker-on-worktree visibility of worktree + main, worker-on-main main-only, and user-configurable lead parallel repos
- add the requested 2nd-account runbook draft at `docs.local/gen16-happy-camper/wi8-runbook-DRAFT.md` and force-track it even though `docs.local` is normally ignored
- review-response commits `a0c9e607`, `11a9a407`, and `64761dbc` close helper/smart-route/harness/context/session/KG/engine-scope gaps found by CodeRabbit/Codex/Cursor/Macroscope review

## Gate notes
- hc-iso-tester found current live main fails BASIC real-agent scoping because shared MCP wiring cannot differentiate roles.
- Commit `cc818917` fixes the branch mechanism with request-scoped `consumer`; tester gave a branch-aware conditional PASS on that mechanism.
- Commit `c7388ecc` adds lead/worktree scoping; tester gave a branch-aware conditional PASS on the extension and runbook.
- Commit `301aa3fe` extends the CLI harness to cover all roles in one command, per tester recommendation.
- Commit `a0c9e607` threads request `consumer` through the warm helper, passes `consumer_scope` through smart think/recall/current-context routes, avoids single-project prefiltering for expanded scopes, validates extension proof expectations, and adds direct `brain_recall` forwarding coverage.
- Commit `11a9a407` scopes current-context files/plans and `brain_recall(mode="sessions")`, including deny-all and expanded-scope behavior.
- Commit `64761dbc` threads `consumer_scope` into engine think/recall hybrid searches and KG hybrid search, preserves coach null-project visibility during prefilter selection, and forwards `source_filter` into recall scope resolution.
- True real-cmux GREEN still requires loading this branch/PR into the running shared server, then rerunning the live two-agent/four-role gate.
- The runbook calls out that `consumer` is currently explicit/manual per request; a wrapper/launcher layer should eventually auto-fill it so agents cannot forget.

## Test plan
- RED: harness/module, request consumer, lead/worktree, and review-regression tests failed before implementation/fixes
- GREEN focused latest: latest review-regression set -> `6 passed in 0.72s`
- GREEN touched latest: `pytest tests/test_3tool_aliases.py tests/test_brainbar_hybrid_helper.py tests/test_hybrid_helper_contract.py tests/test_mcp_warm_route.py tests/test_consumer_scoping.py tests/test_isolation_proof_harness.py tests/test_search_filter_params.py tests/test_engine.py -q` -> `158 passed in 2.53s`
- GREEN lint/format latest: `ruff check src/ ... && ruff format --check src/ ...` -> `All checks passed!` / `147 files already formatted`
- GREEN harness CLI latest: `PYTHONPATH=src python3 -m brainlayer.isolation_proof --db /tmp/happy-camper-full-isolation-proof.db --json` -> `failures: []`
- GREEN broad latest: `pytest --ignore=tests/regression/test_drift_detection.py` -> `2948 passed, 48 skipped, 5 xfailed in 278.41s`
- BLOCKED full-suite collection: `pytest tests/regression/test_drift_detection.py -q` still fails before branch tests because installed `deepchecks` imports `sklearn.metrics.get_scorer('max_error')`, which this sklearn install rejects

## Review gates
- CodeRabbit pre-commit on harness commit: `findings: 0`
- CodeRabbit pre-commit on later commits: bounded `timeout 180 coderabbit review --agent` runs timed out after heartbeat-only reviewing output; commits proceeded on fresh test evidence per PR-loop fallback
- Review comments addressed through `64761dbc`; re-review requested after push. CI/review checks may still be running on the latest commit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add request-scoped consumer roles and Happy Camper isolation proof harness
> - Adds a `lead` consumer role to [`scoping.py`](https://github.com/EtanHey/brainlayer/pull/487/files#diff-e4550f64ac5b6346b3a2871191256d540d0ac40c01e764f90752f9129f652a63) with multi-project visibility spanning main, worktrees, and configured parallel repos; worker scopes now also include the main repo when scoped to a worktree.
> - Extends [`search_repo.py`](https://github.com/EtanHey/brainlayer/pull/487/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) to filter hybrid search results against multiple projects via `ConsumerScope.project_filters` using SQL `IN` clauses instead of single equality.
> - Adds a `consumer` parameter to MCP tools `brain_search` and `brain_recall` in [`mcp/__init__.py`](https://github.com/EtanHey/brainlayer/pull/487/files#diff-b707fe059f28de703d53819bf809ca800bef866d46fac9f5867e52568026f686) and propagates it through [`search_handler.py`](https://github.com/EtanHey/brainlayer/pull/487/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) to scope all retrieval paths (think, recall, sessions, context, file timeline, regression).
> - Introduces [`isolation_proof.py`](https://github.com/EtanHey/brainlayer/pull/487/files#diff-11d0f15296d8ebb51328a34d6651ffe12adf801c94b98dbd952e618048bb2371) with a seeded SQLite fixture, role-based search probes, and a CLI to verify that consumer scoping yields exactly the expected chunk visibility across roles and projects.
> - Risk: all search results (think, recall, sessions, context) are now post-filtered by consumer scope, which will silently reduce output for callers that previously received cross-project results without specifying a consumer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36cece6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core retrieval authorization and SQL project predicates for all scoped searches; incorrect scoping could leak cross-repo memories on shared MCP servers until live real-cmux gates pass.
> 
> **Overview**
> Adds **per-request `consumer`** on MCP `brain_search` / `brain_recall` (orchestrator, lead, worker, coach) so multiple agents on one shared MCP socket can override process-level `BRAINLAYER_CONSUMER`.
> 
> **Scoping** gains a **`lead`** role, **`project_filters`** for multi-repo visibility, and **`scopes.yaml`**-driven worktree + `lead_parallel_projects` expansion; workers on a worktree see worktree + main only. Hybrid search SQL moves from single-project equality to **`IN (...)`** predicates when scopes span multiple projects.
> 
> **Retrieval paths** thread `consumer_scope` through engine `think`/`recall`, warm helper, KG hybrid search, and post-filters for context, sessions, think/recall, file timeline, and regression.
> 
> New **`brainlayer.isolation_proof`** CLI seeds a deterministic DB and asserts visible chunk IDs per role; a **Happy Camper 2nd-account runbook draft** documents account isolation gates and manual `consumer` wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36cece6a1adfa4c7a93b6acb13d2aa0d8f5a1846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->