### PR TITLE
fix: interleave enrichment in hotlane writer

### DIFF
--- a/docs/enrichment-provider-agnostic-design.md
+++ b/docs/enrichment-provider-agnostic-design.md
@@ -1,0 +1,52 @@
+# Enrichment Provider-Agnostic Design
+
+## Scope
+
+This note documents the provider seam for cloud enrichment. It does not implement
+additional providers. The current realtime path is Gemini-specific, while the
+local enrichment backend already uses `BRAINLAYER_ENRICH_BACKEND` for `mlx` and
+`ollama`, and `build_external_prompt()` already produces a provider-neutral
+prompt plus sanitized chunk context.
+
+## Provider Selector
+
+Use `BRAINLAYER_ENRICH_PROVIDER` as the cloud provider selector. The current
+default should remain `gemini` for backwards compatibility. Keep
+`BRAINLAYER_ENRICH_BACKEND` for the existing local backend selector; do not
+reuse it for cloud provider choice.
+
+Related launchd config should use `BRAINLAYER_LAUNCHD_DRAIN_ENABLED` for the
+drain service gate, matching the unified config-file worker's key namespace.
+
+## Provider Interface
+
+Add one narrow adapter seam behind realtime enrichment:
+
+- client factory: create the provider client from environment/config
+- request adapter: map the `build_external_prompt()` output to provider request
+  fields
+- response adapter: normalize provider output into the existing enrichment JSON
+  shape consumed by `parse_enrichment()`
+- error adapter: normalize rate-limit, daily-cap, timeout, and retryable errors
+
+The enrichment controller should keep owning candidate selection, duplicate
+marking, rate limiting, telemetry, and database writes. Provider adapters should
+not know about SQLite rows or write queues.
+
+## Adding a Provider
+
+A new provider needs:
+
+- a client factory keyed by `BRAINLAYER_ENRICH_PROVIDER`
+- model/config environment keys under a provider-specific prefix
+- a prompt/request adapter that accepts the provider-neutral prompt
+- a response parser that returns the same JSON fields used today
+- retry/cap error mapping compatible with the existing supervisor behavior
+
+## Current Blockers
+
+The realtime path still names Gemini-specific helpers and config builders
+directly. Before adding OpenAI, Anthropic, or another cloud provider, split those
+helpers into a small provider module and leave `enrich_realtime()` calling only
+the provider interface. Keep the first refactor provider-preserving so Gemini
+behavior remains unchanged.

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Hot-embed recent BrainBar MCP writes and interleave realtime enrichment.
+
+BrainBar owns the live MCP socket and stores ``brain_store`` rows directly in
+SQLite. This adapter owns the single BrainLayer writer slot and must therefore
+perform all write-side background work that needs steady progress: hot embedding,
+optional embedding backlog, and enrichment backlog.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import signal
+import time
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+from brainlayer.embeddings import get_embedding_model
+from brainlayer.enrichment_controller import (
+    DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS,
+    _result_hit_daily_cap,
+    enrich_realtime,
+)
+from brainlayer.paths import get_db_path
+from brainlayer.store import embed_hot_chunk, embed_pending_chunks
+from brainlayer.vector_store import VectorStore
+
+LOGGER = logging.getLogger("brainlayer.hotlane_brainbar")
+STOP = False
+DEFAULT_HOTLANE_ENRICH_LIMIT = 25
+
+
+class CycleResult(NamedTuple):
+    embedded: int = 0
+    enrich_attempted: int = 0
+    enriched: int = 0
+    enrich_skipped: int = 0
+    enrich_failed: int = 0
+    enrich_daily_cap_reached: bool = False
+
+
+def _stop(_signum: int, _frame: object) -> None:
+    global STOP
+    STOP = True
+
+
+def _candidate_chunk_ids(store: VectorStore, *, limit: int) -> list[str]:
+    rows = store.conn.cursor().execute(
+        """
+        SELECT c.id
+        FROM chunks c
+        LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
+        WHERE r.id IS NULL
+          AND c.source_file = 'brainbar-store'
+          AND c.source = 'mcp'
+          AND c.content IS NOT NULL
+          AND c.content != ''
+          AND c.archived_at IS NULL
+          AND c.superseded_by IS NULL
+          AND c.aggregated_into IS NULL
+          AND COALESCE(c.archived, 0) = 0
+          AND COALESCE(c.status, 'active') = 'active'
+        ORDER BY c.created_at DESC
+        LIMIT ?
+        """,
+        (limit,),
+    )
+    return [str(row[0]) for row in rows]
+
+
+def run_cycle(
+    *,
+    store: VectorStore,
+    embed_fn: Callable[[str], list[float]],
+    recent_limit: int,
+    backlog_batch: int,
+    enrich_limit: int,
+    enrich_since_hours: int,
+    candidate_chunk_ids_fn: Callable[..., list[str]] = _candidate_chunk_ids,
+    hot_embed_fn: Callable[..., bool] = embed_hot_chunk,
+    pending_embed_fn: Callable[..., int] = embed_pending_chunks,
+    enrich_fn: Callable[..., object] = enrich_realtime,
+) -> CycleResult:
+    embedded = 0
+    for chunk_id in candidate_chunk_ids_fn(store, limit=recent_limit):
+        if hot_embed_fn(store=store, embed_fn=embed_fn, chunk_id=chunk_id):
+            embedded += 1
+            break
+
+    if backlog_batch > 0:
+        embedded += pending_embed_fn(store=store, embed_fn=embed_fn, batch_size=backlog_batch)
+
+    if enrich_limit <= 0:
+        return CycleResult(embedded=embedded)
+
+    enrich_result = enrich_fn(store, limit=enrich_limit, since_hours=enrich_since_hours)
+    return CycleResult(
+        embedded=embedded,
+        enrich_attempted=int(getattr(enrich_result, "attempted", 0) or 0),
+        enriched=int(getattr(enrich_result, "enriched", 0) or 0),
+        enrich_skipped=int(getattr(enrich_result, "skipped", 0) or 0),
+        enrich_failed=int(getattr(enrich_result, "failed", 0) or 0),
+        enrich_daily_cap_reached=hasattr(enrich_result, "errors") and _result_hit_daily_cap(enrich_result),
+    )
+
+
+def run(
+    *,
+    db_path: Path,
+    interval: float,
+    recent_limit: int,
+    backlog_interval: float,
+    backlog_batch: int,
+    enrich_interval: float,
+    enrich_limit: int,
+    enrich_since_hours: int,
+    vector_store_cls: Callable[[Path], VectorStore] = VectorStore,
+    model_factory: Callable[[], object] = get_embedding_model,
+    cycle_fn: Callable[..., CycleResult] = run_cycle,
+    time_fn: Callable[[], float] = time.monotonic,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    max_cycles: int | None = None,
+) -> None:
+    store = vector_store_cls(db_path)
+    try:
+        model = model_factory()
+        embed_fn = model.embed_query
+        last_backlog = time_fn()
+        last_enrich = 0.0
+        enrich_disabled = False
+        cycles = 0
+        LOGGER.info("hotlane adapter started db=%s", db_path)
+        while not STOP:
+            if max_cycles is not None and cycles >= max_cycles:
+                break
+            try:
+                now = time_fn()
+                cycle_backlog_batch = (
+                    backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
+                )
+                cycle_enrich_limit = (
+                    enrich_limit
+                    if not enrich_disabled and enrich_limit > 0 and now - last_enrich >= enrich_interval
+                    else 0
+                )
+                if cycle_backlog_batch > 0:
+                    last_backlog = now
+                if cycle_enrich_limit > 0:
+                    last_enrich = now
+                result = cycle_fn(
+                    store=store,
+                    embed_fn=embed_fn,
+                    recent_limit=recent_limit,
+                    backlog_batch=cycle_backlog_batch,
+                    enrich_limit=cycle_enrich_limit,
+                    enrich_since_hours=enrich_since_hours,
+                )
+                if result.enrich_daily_cap_reached:
+                    enrich_disabled = True
+                    LOGGER.warning("enrichment daily cap reached; disabling hotlane enrichment until restart")
+                if result.embedded or result.enrich_attempted:
+                    LOGGER.info(
+                        "embedded=%d enrich_attempted=%d enriched=%d skipped=%d failed=%d",
+                        result.embedded,
+                        result.enrich_attempted,
+                        result.enriched,
+                        result.enrich_skipped,
+                        result.enrich_failed,
+                    )
+            except Exception:
+                LOGGER.exception("hotlane adapter cycle failed")
+                sleep_fn(min(interval * 2, 5.0))
+            cycles += 1
+            sleep_fn(interval)
+    finally:
+        store.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=get_db_path())
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("--recent-limit", type=int, default=5)
+    parser.add_argument("--backlog-interval", type=float, default=10.0)
+    parser.add_argument("--backlog-batch", type=int, default=0)
+    parser.add_argument("--enrich-interval", type=float, default=10.0)
+    parser.add_argument("--enrich-limit", type=int, default=DEFAULT_HOTLANE_ENRICH_LIMIT)
+    parser.add_argument("--enrich-since-hours", type=int, default=DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    run(
+        db_path=args.db,
+        interval=max(args.interval, 0.25),
+        recent_limit=max(args.recent_limit, 1),
+        backlog_interval=max(args.backlog_interval, 1.0),
+        backlog_batch=max(args.backlog_batch, 0),
+        enrich_interval=max(args.enrich_interval, 1.0),
+        enrich_limit=max(args.enrich_limit, 0),
+        enrich_since_hours=max(args.enrich_since_hours, 0),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -1150,6 +1150,23 @@ def _mark_meta_research(store, chunk: dict[str, Any]) -> None:
             pass
 
 
+def _mark_duplicate_content(store, chunk: dict[str, Any]) -> None:
+    cursor = store.conn.cursor()
+    now = datetime.now(timezone.utc).isoformat()
+    content = chunk.get("content", "")
+    content_hash = _content_hash(content) if content else None
+    if content_hash:
+        cursor.execute(
+            "UPDATE chunks SET enriched_at = ?, enrich_status = 'duplicate', content_hash = ? WHERE id = ?",
+            (now, content_hash, chunk["id"]),
+        )
+    else:
+        cursor.execute(
+            "UPDATE chunks SET enriched_at = ?, enrich_status = 'duplicate' WHERE id = ?",
+            (now, chunk["id"]),
+        )
+
+
 def _backfill_content_hashes(store, limit: int = 1000) -> int:
     """Backfill content_hash for chunks that don't have one yet. Returns count updated."""
     try:
@@ -1552,6 +1569,13 @@ def enrich_realtime(
                             pending.cancel()
                         break
                     if status == "skip":
+                        if write_batcher is None:
+                            _submit_write(
+                                store,
+                                f"mark-duplicate:{chunk['id']}",
+                                lambda chunk=chunk: _mark_duplicate_content(store, chunk),
+                                yield_after=rate_per_second > 0,
+                            )
                         result.skipped += 1
                         continue
                     if status == "meta":
@@ -1646,6 +1670,12 @@ def enrich_batch(
                     result.skipped += 1
                     continue
                 if _is_duplicate_content(store, chunk.get("content", "")):
+                    if write_batcher is None:
+                        _submit_write(
+                            store,
+                            f"mark-duplicate:{chunk['id']}",
+                            lambda chunk=chunk: _mark_duplicate_content(store, chunk),
+                        )
                     result.skipped += 1
                     continue
 

--- a/src/brainlayer/session_repo.py
+++ b/src/brainlayer/session_repo.py
@@ -80,21 +80,58 @@ class SessionMixin:
 
         prev_assistant_expr = self._previous_assistant_text_candidate_expr(cols)
 
-        results = list(
-            cursor.execute(
-                f"""
-                SELECT c.id, c.content, c.source_file, c.project, c.content_type,
-                       c.conversation_id, c.position, c.char_count, c.source, c.created_at,
-                       {"c.sender" if "sender" in cols else "NULL AS sender"},
-                       {prev_assistant_expr}
-                FROM chunks c
-                WHERE {" AND ".join(where)}
-                ORDER BY c.rowid {order_clause}
-                LIMIT ?
-                """,
-                params,
+        if "content_hash" in cols:
+            results = list(
+                cursor.execute(
+                    f"""
+                    WITH ranked AS (
+                        SELECT c.id, c.content, c.source_file, c.project, c.content_type,
+                               c.conversation_id, c.position, c.char_count, c.source, c.created_at,
+                               {"c.sender" if "sender" in cols else "NULL AS sender"},
+                               {prev_assistant_expr},
+                               c.rowid AS candidate_rowid,
+                               EXISTS (
+                                   SELECT 1
+                                   FROM chunks e
+                                   WHERE e.content_hash = c.content_hash
+                                     AND e.id != c.id
+                                     AND e.enriched_at IS NOT NULL
+                                     AND e.summary IS NOT NULL
+                               ) AS has_enriched_twin,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY COALESCE(c.content_hash, c.id)
+                                   ORDER BY c.rowid {order_clause}
+                               ) AS hash_rank
+                        FROM chunks c
+                        WHERE {" AND ".join(where)}
+                    )
+                    SELECT id, content, source_file, project, content_type,
+                           conversation_id, position, char_count, source, created_at,
+                           sender, prev_assistant_text
+                    FROM ranked
+                    WHERE hash_rank = 1
+                    ORDER BY has_enriched_twin ASC, candidate_rowid {order_clause}
+                    LIMIT ?
+                    """,
+                    params,
+                )
             )
-        )
+        else:
+            results = list(
+                cursor.execute(
+                    f"""
+                    SELECT c.id, c.content, c.source_file, c.project, c.content_type,
+                           c.conversation_id, c.position, c.char_count, c.source, c.created_at,
+                           {"c.sender" if "sender" in cols else "NULL AS sender"},
+                           {prev_assistant_expr}
+                    FROM chunks c
+                    WHERE {" AND ".join(where)}
+                    ORDER BY c.rowid {order_clause}
+                    LIMIT ?
+                    """,
+                    params,
+                )
+            )
 
         candidates = [
             {

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -529,6 +529,31 @@ def test_realtime_skips_duplicate_content(monkeypatch):
     assert result.enriched == 1
 
 
+def test_realtime_persists_duplicate_skip_status(monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    store = MagicMock()
+    store.get_enrichment_candidates.return_value = [_candidate("c1", "dup"), _candidate("c2", "unique")]
+    submitted_labels = []
+    _patch_realtime_deps(monkeypatch, controller, store)
+    monkeypatch.setattr(controller, "_is_duplicate_content", lambda s, c: c == "dup")
+
+    def capture_submit(_store, label, operation, **_kwargs):
+        submitted_labels.append(label)
+        operation()
+
+    monkeypatch.setattr(controller, "_submit_write", capture_submit)
+    mark_duplicate = MagicMock()
+    monkeypatch.setattr(controller, "_mark_duplicate_content", mark_duplicate, raising=False)
+
+    result = controller.enrich_realtime(store, limit=2)
+
+    assert result.skipped == 1
+    assert result.enriched == 1
+    assert "mark-duplicate:c1" in submitted_labels
+    mark_duplicate.assert_called_once_with(store, store.get_enrichment_candidates.return_value[0])
+
+
 def test_local_enrichment_stays_disabled_even_with_duplicates(monkeypatch):
     from brainlayer import enrichment_controller as controller
 

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_hotlane_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "hotlane_brainbar_daemon.py"
+    spec = importlib.util.spec_from_file_location("hotlane_brainbar_daemon", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _raise_if_called(message: str):
+    def inner(**_kwargs):
+        raise AssertionError(message)
+
+    return inner
+
+
+def test_hotlane_cycle_runs_enrichment_through_same_writer_store():
+    hotlane = _load_hotlane_module()
+    writer_store = object()
+    calls = []
+
+    result = hotlane.run_cycle(
+        store=writer_store,
+        embed_fn=lambda _text: [0.0],
+        recent_limit=5,
+        backlog_batch=0,
+        enrich_limit=25,
+        enrich_since_hours=8760,
+        candidate_chunk_ids_fn=lambda store, *, limit: calls.append(("candidates", store, limit)) or [],
+        hot_embed_fn=_raise_if_called("no hot candidates"),
+        pending_embed_fn=_raise_if_called("backlog disabled"),
+        enrich_fn=lambda store, **kwargs: (
+            calls.append(("enrich", store, kwargs)) or SimpleNamespace(attempted=2, enriched=1, skipped=0, failed=0)
+        ),
+    )
+
+    assert result.embedded == 0
+    assert result.enrich_attempted == 2
+    assert result.enriched == 1
+    assert calls == [
+        ("candidates", writer_store, 5),
+        ("enrich", writer_store, {"limit": 25, "since_hours": 8760}),
+    ]
+
+
+def test_hotlane_cycle_can_disable_enrichment():
+    hotlane = _load_hotlane_module()
+
+    result = hotlane.run_cycle(
+        store=object(),
+        embed_fn=lambda _text: [0.0],
+        recent_limit=5,
+        backlog_batch=0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        candidate_chunk_ids_fn=lambda _store, *, limit: [],
+        hot_embed_fn=lambda **_kwargs: False,
+        pending_embed_fn=lambda **_kwargs: 0,
+        enrich_fn=_raise_if_called("enrichment disabled"),
+    )
+
+    assert result.enrich_attempted == 0
+    assert result.enriched == 0
+
+
+def test_hotlane_run_advances_enrich_timer_before_failed_cycle():
+    hotlane = _load_hotlane_module()
+    scheduled_enrich_limits = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    def fake_cycle(**kwargs):
+        scheduled_enrich_limits.append(kwargs["enrich_limit"])
+        if len(scheduled_enrich_limits) == 1:
+            raise RuntimeError("gemini transient failure")
+        return hotlane.CycleResult()
+
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=0,
+        enrich_interval=10.0,
+        enrich_limit=25,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=fake_cycle,
+        time_fn=iter([0.0, 100.0, 101.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=2,
+    )
+
+    assert scheduled_enrich_limits == [25, 0]
+
+
+def test_hotlane_run_disables_enrichment_after_daily_cap():
+    hotlane = _load_hotlane_module()
+    scheduled_enrich_limits = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    def fake_cycle(**kwargs):
+        scheduled_enrich_limits.append(kwargs["enrich_limit"])
+        if len(scheduled_enrich_limits) == 1:
+            return hotlane.CycleResult(enrich_attempted=1, enrich_failed=1, enrich_daily_cap_reached=True)
+        return hotlane.CycleResult()
+
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=0,
+        enrich_interval=10.0,
+        enrich_limit=25,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=fake_cycle,
+        time_fn=iter([0.0, 100.0, 111.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=2,
+    )
+
+    assert scheduled_enrich_limits == [25, 0]

--- a/tests/test_session_enrichment_candidates.py
+++ b/tests/test_session_enrichment_candidates.py
@@ -117,6 +117,26 @@ def test_get_enrichment_candidates_respects_limit(tmp_path):
     assert len(results) == 2
 
 
+def test_get_enrichment_candidates_uses_one_candidate_per_content_hash(tmp_path):
+    from brainlayer.enrichment_controller import _content_hash
+
+    store = VectorStore(tmp_path / "test.db")
+    duplicate_hash = _content_hash("canonical duplicate content")
+    _insert_chunk(store, "duplicate-old", "older duplicate row " + "x" * 80)
+    _insert_chunk(store, "duplicate-new", "newer duplicate row " + "x" * 80)
+    _insert_chunk(store, "unique", "unique candidate " + "y" * 80)
+    store.conn.cursor().execute(
+        "UPDATE chunks SET content_hash = ? WHERE id IN ('duplicate-old', 'duplicate-new')",
+        (duplicate_hash,),
+    )
+
+    results = store.get_enrichment_candidates(limit=10)
+
+    assert len(results) == 2
+    assert "unique" in {row["id"] for row in results}
+    assert len({"duplicate-old", "duplicate-new"} & {row["id"] for row in results}) == 1
+
+
 def test_get_enrichment_candidates_returns_empty_list_when_nothing_needs_enrichment(tmp_path):
     store = VectorStore(tmp_path / "test.db")
     _insert_chunk(store, "c1", "a" * 80)


### PR DESCRIPTION
## Summary
- Track the BrainBar hotlane daemon in-repo.
- Interleave realtime enrichment through the same long-lived `VectorStore` writer that already hot-embeds BrainBar MCP rows.
- Add a focused regression test proving the enrichment pass receives the same writer store and can be disabled.

## Root Cause
The live WI-4 hotlane daemon held the BrainLayer writer pidfile and only embedded (`embed_hot_chunk` / optional `embed_pending_chunks`). `brainlayer enrich --mode realtime` could not acquire the writer, so the enrichment backlog starved.

`src/brainlayer/drain.py` is the queue drain/apply path: it applies queued `enrichment_update` events and embeds chunks from queued store events, but it does not generate Gemini enrichment for the unenriched backlog. For the deployed blocker, the minimal one-writer fix is to make the existing hotlane writer do both embed and enrich.

## Verification
- RED: `PYTHONPATH=src python3 -m pytest tests/test_hotlane_brainbar_daemon.py -q` initially failed because `scripts/hotlane_brainbar_daemon.py` was missing.
- GREEN: `PYTHONPATH=src python3 -m pytest tests/test_hotlane_brainbar_daemon.py tests/test_enrich_supervisor.py tests/test_deferred_embedding.py -q` -> `32 passed in 3.67s`.
- Ruff: `python3 -m ruff check scripts/hotlane_brainbar_daemon.py tests/test_hotlane_brainbar_daemon.py` -> `All checks passed!`.
- Copy DB verification only, no prod mutation during test:
  - `/tmp/hc-enrich-fix.db` copied via sqlite `.backup` from `~/.local/share/brainlayer/brainlayer.db`.
  - Hot embed copy test: synthetic BrainBar row vector count `0 -> 1`, `cycle_embedded=1`.
  - Enrichment copy test: `copy_immediate_before_unenriched=67793`, `copy_immediate_after_unenriched=67792`, `cycle_enriched=1`.
- Live scheduled job verification after updating the deployed hotlane service:
  - `com.brainlayer.hotlane-brainbar` running pid `17149` with `--enrich-interval 10.0 --enrich-limit 25 --enrich-since-hours 87600`.
  - Prod un-enriched count dropped from `67793` before service restart to `67689` after verification window.
  - Logs show successful cycles: `embedded=0 enrich_attempted=25 enriched=25 skipped=0 failed=0`.
- Full suite note: `PYTHONPATH=src python3 -m pytest -q` is blocked during collection by `tests/regression/test_drift_detection.py`: Deepchecks imports sklearn scorer `max_error`, but this sklearn install rejects that scorer.

## Security Follow-Up
The existing live enrichment LaunchAgent contains a raw `GOOGLE_API_KEY`. I did not print it in this PR body and did not commit it. The deployed hotlane plist reads the existing value at process start instead of duplicating the raw key into another plist. Move this secret to 1Password/secret-backed launch at the next hygiene pass.

Co-Authored-By: Codex <codex@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live writer path and enrichment candidate selection/writes; behavior is covered by tests but affects backlog draining and SQLite updates in production.
> 
> **Overview**
> Fixes enrichment backlog starvation when the hotlane process already holds the sole BrainLayer writer: a new **`hotlane_brainbar_daemon`** runs hot embedding, optional backlog embedding, and periodic **`enrich_realtime`** on one long-lived **`VectorStore`**, with CLI-tunable intervals, daily-cap shutdown, and tests for shared-store enrichment and timer behavior.
> 
> **Enrichment dedup** is tightened end-to-end: **`get_enrichment_candidates`** returns at most one row per **`content_hash`** and prefers hashes without an already-enriched twin; realtime/batch now **persist** duplicate skips via **`_mark_duplicate_content`** (`enrich_status = 'duplicate'`) instead of only counting them as skipped.
> 
> Adds a short **provider-agnostic enrichment** design note (no new providers in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b3a4081ae692ff477330968dcc1ac63cf48fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Interleave enrichment into the hotlane writer daemon
> - Adds [hotlane_brainbar_daemon.py](https://github.com/EtanHey/brainlayer/pull/489/files#diff-a6f55cd2d945568d3534e21b0c40cf5a431cb8287640870ba7b2a6149ac2c0d9) with a main loop that runs hot embedding, backlog embedding, and enrichment on independent timers, with CLI arguments for all pacing and limit parameters.
> - `run_cycle` returns a structured `CycleResult` and disables enrichment for the remainder of the process when a provider daily cap is detected.
> - Fixes `enrich_realtime` and `enrich_batch` in [enrichment_controller.py](https://github.com/EtanHey/brainlayer/pull/489/files#diff-026585aba924166a0b476c6d49978052feec275fe24d58eb945516c2627eeebb) to immediately persist `duplicate` status (with timestamp and content hash) for skipped chunks when no write batcher is active.
> - Updates `get_enrichment_candidates` in [session_repo.py](https://github.com/EtanHey/brainlayer/pull/489/files#diff-8869d9906ebb24eac961fec78a69eeaa3e285f2c046d3ed306f2d8c812fc58a7) to return at most one candidate per `content_hash` when that column exists, avoiding redundant enrichment of identical content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96b3a40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daemon service that continuously hot-embeds recent content into the vector store
  * Supports processing embedding backlogs and optional real-time enrichment
  * Configurable intervals, batch sizes, and enrichment limits for tuning behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->