### PR TITLE
Add BrainBar config settings UI

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarApp.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarApp.swift
@@ -273,10 +273,14 @@ struct BrainBarApp: App {
 
     var body: some Scene {
         Settings {
-            EmptyView()
+            BrainBarSettingsView()
         }
         .commands {
             CommandGroup(after: .appInfo) {
+                Button("Settings...") {
+                    BrainBarSettingsActions.openSettingsWindow()
+                }
+
                 Button("Toggle BrainBar") {
                     appDelegate.runtime.handleToggleRequest()
                 }

--- a/brain-bar/Sources/BrainBar/BrainBarSettingsActions.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarSettingsActions.swift
@@ -1,0 +1,9 @@
+import AppKit
+
+enum BrainBarSettingsActions {
+    @MainActor
+    static func openSettingsWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+}

--- a/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
@@ -1,0 +1,366 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class BrainBarSettingsViewModel: ObservableObject {
+    @Published var config: BrainLayerConfig
+    @Published var pendingPlainAPIKey = ""
+    @Published var onePasswordReference: String
+    @Published var errorMessage: String?
+
+    private let store: BrainLayerConfigStore
+    private let launchdStatusProvider: any BrainLayerLaunchdStatusSampling
+
+    init(
+        store: BrainLayerConfigStore = BrainLayerConfigStore(),
+        launchdStatusProvider: any BrainLayerLaunchdStatusSampling = BrainLayerLaunchdStatusProvider(),
+        refreshStatusOnLoad: Bool = true
+    ) {
+        self.store = store
+        self.launchdStatusProvider = launchdStatusProvider
+        do {
+            let document = try store.loadDocument()
+            config = document.config
+            onePasswordReference = document.config.googleAPIKey.opReference
+        } catch {
+            config = .defaultConfig
+            onePasswordReference = BrainLayerConfig.defaultConfig.googleAPIKey.opReference
+            errorMessage = error.localizedDescription
+        }
+        if refreshStatusOnLoad {
+            refreshLaunchdStatus()
+        }
+    }
+
+    func setEnrichmentEnabled(_ enabled: Bool) {
+        config.enrichmentEnabled = enabled
+        save()
+    }
+
+    func setSystemEnabled(_ enabled: Bool) {
+        config.systemEnabled = enabled
+        save()
+    }
+
+    func setEnrichmentMode(_ mode: BrainLayerEnrichmentMode) {
+        config.enrichmentMode = mode
+        save()
+    }
+
+    func setEnrichmentProvider(_ provider: BrainLayerEnrichmentProvider) {
+        config.enrichmentProvider = provider
+        if provider == .gemini, config.enrichmentBackend.isEmpty {
+            config.enrichmentBackend = "gemini"
+        }
+        save()
+    }
+
+    func setEnrichmentBackend(_ backend: String) {
+        config.enrichmentBackend = backend.trimmingCharacters(in: .whitespacesAndNewlines)
+        save()
+    }
+
+    func storePlainAPIKey() {
+        let value = pendingPlainAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        guard confirmGoogleAPIKeyOverwriteIfNeeded() else { return }
+        config.googleAPIKey = .plain(value)
+        pendingPlainAPIKey = ""
+        save()
+    }
+
+    func storeOnePasswordReference() {
+        let reference = onePasswordReference.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !reference.isEmpty else { return }
+        if config.googleAPIKey != .onePasswordReference(reference) {
+            guard confirmGoogleAPIKeyOverwriteIfNeeded() else { return }
+        }
+        config.googleAPIKey = .onePasswordReference(reference)
+        save()
+    }
+
+    func clearGoogleAPIKey() {
+        config.googleAPIKey = .missing
+        save()
+    }
+
+    func setJob(_ job: BrainLayerLaunchdJob, enabled: Bool) {
+        config.launchdJobs[job, default: BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown)].enabled = enabled
+        save()
+    }
+
+    func refreshLaunchdStatus() {
+        let states = launchdStatusProvider.sample()
+        for (job, state) in states {
+            config.launchdJobs[job, default: BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown)].loadState = state
+        }
+    }
+
+    private func save() {
+        do {
+            try store.save(config)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func confirmGoogleAPIKeyOverwriteIfNeeded() -> Bool {
+        guard config.googleAPIKey.kind != .missing else { return true }
+        let alert = NSAlert()
+        alert.messageText = "Replace existing Gemini API key?"
+        alert.informativeText = "BrainBar will update the BrainLayer config file without displaying the current value."
+        alert.addButton(withTitle: "Replace")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+}
+
+struct BrainBarSettingsView: View {
+    @StateObject var viewModel: BrainBarSettingsViewModel
+    @FocusState private var focusedField: Field?
+
+    enum Field {
+        case plainKey
+        case opReference
+        case backend
+    }
+
+    init(viewModel: BrainBarSettingsViewModel = BrainBarSettingsViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                header
+                if let errorMessage = viewModel.errorMessage {
+                    errorBanner(errorMessage)
+                }
+                BrainBarSettingsPanel(title: "Enrichment") {
+                    enrichmentControls
+                }
+                BrainBarSettingsPanel(title: "Gemini API Key") {
+                    secretControls
+                }
+                BrainBarSettingsPanel(title: "System Jobs") {
+                    jobsGrid
+                }
+            }
+            .padding(22)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .frame(width: 700)
+        .frame(minHeight: 640)
+        .background(Color.brainBarBackgroundBase)
+        .foregroundStyle(Color.brainBarTextPrimary)
+        .environment(\.colorScheme, .dark)
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "gearshape.2")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(Color.brainBarAccentBright)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("BrainLayer Settings")
+                    .font(.system(size: 22, weight: .semibold))
+                Text(BrainLayerConfigStore.defaultConfigURL().path)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(Color.brainBarTextMuted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Button {
+                viewModel.refreshLaunchdStatus()
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private var enrichmentControls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(
+                "Enable enrichment",
+                isOn: Binding(
+                    get: { viewModel.config.enrichmentEnabled },
+                    set: { viewModel.setEnrichmentEnabled($0) }
+                )
+            )
+            Toggle(
+                "Enable BrainLayer jobs",
+                isOn: Binding(
+                    get: { viewModel.config.systemEnabled },
+                    set: { viewModel.setSystemEnabled($0) }
+                )
+            )
+
+            Picker(
+                "Mode",
+                selection: Binding(
+                    get: { viewModel.config.enrichmentMode },
+                    set: { viewModel.setEnrichmentMode($0) }
+                )
+            ) {
+                ForEach(BrainLayerEnrichmentMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Picker(
+                "Provider",
+                selection: Binding(
+                    get: { viewModel.config.enrichmentProvider },
+                    set: { viewModel.setEnrichmentProvider($0) }
+                )
+            ) {
+                ForEach(BrainLayerEnrichmentProvider.allCases) { provider in
+                    Text(provider.title)
+                        .tag(provider)
+                }
+            }
+
+            HStack {
+                Text("Backend")
+                    .foregroundStyle(Color.brainBarTextSecondary)
+                    .frame(width: 110, alignment: .leading)
+                TextField(
+                    "gemini",
+                    text: Binding(
+                        get: { viewModel.config.enrichmentBackend },
+                        set: { viewModel.setEnrichmentBackend($0) }
+                    )
+                )
+                .focused($focusedField, equals: .backend)
+                .textFieldStyle(.roundedBorder)
+            }
+        }
+    }
+
+    private var secretControls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label(viewModel.config.googleAPIKey.displayText, systemImage: "key")
+                    .foregroundStyle(Color.brainBarTextSecondary)
+                Spacer()
+                Button("Clear") {
+                    viewModel.clearGoogleAPIKey()
+                }
+                .disabled(viewModel.config.googleAPIKey.kind == .missing)
+            }
+
+            HStack {
+                Text("1Password")
+                    .foregroundStyle(Color.brainBarTextSecondary)
+                    .frame(width: 110, alignment: .leading)
+                TextField("op://Private/Google AI/Gemini API key", text: $viewModel.onePasswordReference)
+                    .focused($focusedField, equals: .opReference)
+                    .textFieldStyle(.roundedBorder)
+                Button("Use") {
+                    viewModel.storeOnePasswordReference()
+                }
+            }
+
+            HStack {
+                Text("Plain key")
+                    .foregroundStyle(Color.brainBarTextSecondary)
+                    .frame(width: 110, alignment: .leading)
+                SecureField("Paste new key", text: $viewModel.pendingPlainAPIKey)
+                    .focused($focusedField, equals: .plainKey)
+                    .textFieldStyle(.roundedBorder)
+                Button("Store") {
+                    viewModel.storePlainAPIKey()
+                }
+                .disabled(viewModel.pendingPlainAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    private var jobsGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 205), spacing: 12)], alignment: .leading, spacing: 12) {
+            ForEach(BrainLayerLaunchdJob.allCases) { job in
+                BrainBarJobToggle(job: job, viewModel: viewModel)
+            }
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(Color(nsColor: BrainBarStateTheme.error.theme.color))
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(nsColor: BrainBarStateTheme.error.theme.glow))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+}
+
+private struct BrainBarSettingsPanel<Content: View>: View {
+    let title: String
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color.brainBarTextPrimary)
+            VStack(alignment: .leading, spacing: 12) {
+                content
+            }
+        }
+        .padding(16)
+        .background(Color.brainBarGlassPrimary)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.brainBarBorderEdge, lineWidth: 1)
+        )
+    }
+}
+
+private struct BrainBarJobToggle: View {
+    let job: BrainLayerLaunchdJob
+    @ObservedObject var viewModel: BrainBarSettingsViewModel
+
+    var body: some View {
+        let setting = viewModel.config.launchdJobs[job] ?? BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown)
+        VStack(alignment: .leading, spacing: 7) {
+            Toggle(
+                job.title,
+                isOn: Binding(
+                    get: { viewModel.config.launchdJobs[job]?.enabled ?? true },
+                    set: { viewModel.setJob(job, enabled: $0) }
+                )
+            )
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(loadStateColor(setting.loadState))
+                    .frame(width: 7, height: 7)
+                Text(setting.loadState.title)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.brainBarTextMuted)
+            }
+        }
+        .padding(12)
+        .background(Color.brainBarGlassSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.brainBarBorderSoft, lineWidth: 1)
+        )
+    }
+
+    private func loadStateColor(_ state: BrainLayerLaunchdLoadState) -> Color {
+        switch state {
+        case .running: BrainBarStateTheme.active.theme.swiftUIColor
+        case .loaded: BrainBarStateTheme.loading.theme.swiftUIColor
+        case .unloaded: BrainBarStateTheme.idle.theme.swiftUIColor
+        case .unknown: BrainBarStateTheme.degraded.theme.swiftUIColor
+        }
+    }
+}

--- a/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
@@ -6,7 +6,9 @@ final class BrainBarSettingsViewModel: ObservableObject {
     @Published var config: BrainLayerConfig
     @Published var pendingPlainAPIKey = ""
     @Published var onePasswordReference: String
+    @Published var backendDraft: String
     @Published var errorMessage: String?
+    @Published var isRefreshingLaunchdStatus = false
 
     private let store: BrainLayerConfigStore
     private let launchdStatusProvider: any BrainLayerLaunchdStatusSampling
@@ -14,6 +16,7 @@ final class BrainBarSettingsViewModel: ObservableObject {
     init(
         store: BrainLayerConfigStore = BrainLayerConfigStore(),
         launchdStatusProvider: any BrainLayerLaunchdStatusSampling = BrainLayerLaunchdStatusProvider(),
+        initialLaunchdStates: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] = [:],
         refreshStatusOnLoad: Bool = true
     ) {
         self.store = store
@@ -22,51 +25,56 @@ final class BrainBarSettingsViewModel: ObservableObject {
             let document = try store.loadDocument()
             config = document.config
             onePasswordReference = document.config.googleAPIKey.opReference
+            backendDraft = document.config.enrichmentBackend
         } catch {
             config = .defaultConfig
             onePasswordReference = BrainLayerConfig.defaultConfig.googleAPIKey.opReference
+            backendDraft = BrainLayerConfig.defaultConfig.enrichmentBackend
             errorMessage = error.localizedDescription
         }
+        applyLaunchdStates(initialLaunchdStates)
         if refreshStatusOnLoad {
             refreshLaunchdStatus()
         }
     }
 
     func setEnrichmentEnabled(_ enabled: Bool) {
-        config.enrichmentEnabled = enabled
-        save()
+        updateConfig { $0.enrichmentEnabled = enabled }
     }
 
     func setSystemEnabled(_ enabled: Bool) {
-        config.systemEnabled = enabled
-        save()
+        updateConfig { $0.systemEnabled = enabled }
     }
 
     func setEnrichmentMode(_ mode: BrainLayerEnrichmentMode) {
-        config.enrichmentMode = mode
-        save()
+        updateConfig { $0.enrichmentMode = mode }
     }
 
     func setEnrichmentProvider(_ provider: BrainLayerEnrichmentProvider) {
-        config.enrichmentProvider = provider
-        if provider == .gemini, config.enrichmentBackend.isEmpty {
-            config.enrichmentBackend = "gemini"
+        updateConfig { nextConfig in
+            nextConfig.enrichmentProvider = provider
+            if provider == .gemini, nextConfig.enrichmentBackend.isEmpty {
+                nextConfig.enrichmentBackend = "gemini"
+            }
         }
-        save()
     }
 
-    func setEnrichmentBackend(_ backend: String) {
-        config.enrichmentBackend = backend.trimmingCharacters(in: .whitespacesAndNewlines)
-        save()
+    func commitBackendDraft() {
+        let backend = backendDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !backend.isEmpty, backend != config.enrichmentBackend else {
+            backendDraft = config.enrichmentBackend
+            return
+        }
+        updateConfig { $0.enrichmentBackend = backend }
     }
 
     func storePlainAPIKey() {
         let value = pendingPlainAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty else { return }
         guard confirmGoogleAPIKeyOverwriteIfNeeded() else { return }
-        config.googleAPIKey = .plain(value)
-        pendingPlainAPIKey = ""
-        save()
+        if updateConfig({ $0.googleAPIKey = .plain(value) }) {
+            pendingPlainAPIKey = ""
+        }
     }
 
     func storeOnePasswordReference() {
@@ -75,33 +83,50 @@ final class BrainBarSettingsViewModel: ObservableObject {
         if config.googleAPIKey != .onePasswordReference(reference) {
             guard confirmGoogleAPIKeyOverwriteIfNeeded() else { return }
         }
-        config.googleAPIKey = .onePasswordReference(reference)
-        save()
+        _ = updateConfig { $0.googleAPIKey = .onePasswordReference(reference) }
     }
 
     func clearGoogleAPIKey() {
-        config.googleAPIKey = .missing
-        save()
+        _ = updateConfig { $0.googleAPIKey = .missing }
     }
 
     func setJob(_ job: BrainLayerLaunchdJob, enabled: Bool) {
-        config.launchdJobs[job, default: BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown)].enabled = enabled
-        save()
+        updateConfig {
+            $0.launchdJobs[job, default: BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown)].enabled = enabled
+        }
     }
 
     func refreshLaunchdStatus() {
-        let states = launchdStatusProvider.sample()
+        isRefreshingLaunchdStatus = true
+        let provider = launchdStatusProvider
+        Task {
+            let states = await Task.detached {
+                provider.sample()
+            }.value
+            applyLaunchdStates(states)
+            isRefreshingLaunchdStatus = false
+        }
+    }
+
+    private func applyLaunchdStates(_ states: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]) {
         for (job, state) in states {
             config.launchdJobs[job, default: BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown)].loadState = state
         }
     }
 
-    private func save() {
+    @discardableResult
+    private func updateConfig(_ apply: (inout BrainLayerConfig) -> Void) -> Bool {
+        var nextConfig = config
+        apply(&nextConfig)
         do {
-            try store.save(config)
+            try store.save(nextConfig)
+            config = nextConfig
+            backendDraft = nextConfig.enrichmentBackend
             errorMessage = nil
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -178,6 +203,7 @@ struct BrainBarSettingsView: View {
                 Label("Refresh", systemImage: "arrow.clockwise")
             }
             .controlSize(.small)
+            .disabled(viewModel.isRefreshingLaunchdStatus)
         }
     }
 
@@ -230,13 +256,20 @@ struct BrainBarSettingsView: View {
                     .frame(width: 110, alignment: .leading)
                 TextField(
                     "gemini",
-                    text: Binding(
-                        get: { viewModel.config.enrichmentBackend },
-                        set: { viewModel.setEnrichmentBackend($0) }
-                    )
+                    text: $viewModel.backendDraft
                 )
                 .focused($focusedField, equals: .backend)
                 .textFieldStyle(.roundedBorder)
+                .onSubmit {
+                    viewModel.commitBackendDraft()
+                }
+                Button("Save") {
+                    viewModel.commitBackendDraft()
+                }
+                .disabled(
+                    viewModel.backendDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                        viewModel.backendDraft.trimmingCharacters(in: .whitespacesAndNewlines) == viewModel.config.enrichmentBackend
+                )
             }
         }
     }

--- a/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
@@ -96,6 +96,14 @@ final class BrainBarStatusPopoverController: NSObject {
     private func configureContextMenu() {
         contextMenuForTesting.addItem(
             NSMenuItem(
+                title: "Settings...",
+                action: #selector(openSettings(_:)),
+                keyEquivalent: ""
+            )
+        )
+        contextMenuForTesting.addItem(NSMenuItem.separator())
+        contextMenuForTesting.addItem(
+            NSMenuItem(
                 title: "Restart BrainBar",
                 action: #selector(restartBrainBar(_:)),
                 keyEquivalent: ""
@@ -117,6 +125,10 @@ final class BrainBarStatusPopoverController: NSObject {
 
     @objc private func restartBrainBar(_ sender: Any?) {
         BrainBarProcessControl.restart()
+    }
+
+    @objc private func openSettings(_ sender: Any?) {
+        BrainBarSettingsActions.openSettingsWindow()
     }
 
     @objc private func quitBrainBar(_ sender: Any?) {

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -293,6 +293,10 @@ private struct BrainBarHeaderRefreshControls: View {
 private struct BrainBarAppControlMenu: View {
     var body: some View {
         Menu {
+            Button("Settings...") {
+                BrainBarSettingsActions.openSettingsWindow()
+            }
+            Divider()
             Button("Restart BrainBar") {
                 BrainBarProcessControl.restart()
             }

--- a/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
+++ b/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
@@ -1,0 +1,450 @@
+import Foundation
+
+enum BrainLayerEnrichmentMode: String, CaseIterable, Identifiable {
+    case remote
+    case local
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .remote: "Remote"
+        case .local: "Local"
+        }
+    }
+}
+
+enum BrainLayerEnrichmentProvider: String, CaseIterable, Identifiable {
+    case gemini
+    case openai
+    case anthropic
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .gemini: "Gemini"
+        case .openai: "OpenAI"
+        case .anthropic: "Anthropic"
+        }
+    }
+
+    var isWiredToday: Bool {
+        self == .gemini
+    }
+}
+
+enum BrainLayerGoogleAPIKey: Equatable {
+    enum Kind: Equatable {
+        case missing
+        case plainPresent
+        case onePasswordReference
+    }
+
+    case missing
+    case plain(String)
+    case onePasswordReference(String)
+
+    var kind: Kind {
+        switch self {
+        case .missing: .missing
+        case .plain: .plainPresent
+        case .onePasswordReference: .onePasswordReference
+        }
+    }
+
+    var displayText: String {
+        switch self {
+        case .missing: "Not configured"
+        case .plain: "Stored in config file"
+        case .onePasswordReference: "1Password reference"
+        }
+    }
+
+    var opReference: String {
+        if case let .onePasswordReference(reference) = self {
+            return reference
+        }
+        return "op://Private/Google AI/Gemini API key"
+    }
+
+    fileprivate var renderedValue: String {
+        switch self {
+        case .missing:
+            ""
+        case let .plain(value):
+            Self.shellSingleQuoted(value)
+        case let .onePasswordReference(reference):
+            "\"$(op read \(Self.shellSingleQuoted(reference)))\""
+        }
+    }
+
+    private static func shellSingleQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+}
+
+enum BrainLayerLaunchdLoadState: Equatable {
+    case running
+    case loaded
+    case unloaded
+    case unknown
+
+    var title: String {
+        switch self {
+        case .running: "Running"
+        case .loaded: "Loaded"
+        case .unloaded: "Unloaded"
+        case .unknown: "Unknown"
+        }
+    }
+}
+
+enum BrainLayerLaunchdJob: String, CaseIterable, Identifiable {
+    case enrichment
+    case hotlane
+    case decay
+    case drain
+    case watch
+    case index
+    case backupDaily
+    case jsonlBackup
+    case maintenanceNightly
+    case maintenanceWeekly
+    case repairFTS
+    case walCheckpoint
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .enrichment: "Enrichment"
+        case .hotlane: "Hotlane"
+        case .decay: "Decay"
+        case .drain: "Drain"
+        case .watch: "Watch"
+        case .index: "Index"
+        case .backupDaily: "Backup Daily"
+        case .jsonlBackup: "JSONL Backup"
+        case .maintenanceNightly: "Maintenance Nightly"
+        case .maintenanceWeekly: "Maintenance Weekly"
+        case .repairFTS: "Repair FTS"
+        case .walCheckpoint: "WAL Checkpoint"
+        }
+    }
+
+    var configKey: String {
+        switch self {
+        case .enrichment: "BRAINLAYER_LAUNCHD_ENRICHMENT_ENABLED"
+        case .hotlane: "BRAINLAYER_LAUNCHD_HOTLANE_ENABLED"
+        case .decay: "BRAINLAYER_LAUNCHD_DECAY_ENABLED"
+        case .drain: "BRAINLAYER_LAUNCHD_DRAIN_ENABLED"
+        case .watch: "BRAINLAYER_LAUNCHD_WATCH_ENABLED"
+        case .index: "BRAINLAYER_LAUNCHD_INDEX_ENABLED"
+        case .backupDaily: "BRAINLAYER_LAUNCHD_BACKUP_DAILY_ENABLED"
+        case .jsonlBackup: "BRAINLAYER_LAUNCHD_JSONL_BACKUP_ENABLED"
+        case .maintenanceNightly: "BRAINLAYER_LAUNCHD_MAINTENANCE_NIGHTLY_ENABLED"
+        case .maintenanceWeekly: "BRAINLAYER_LAUNCHD_MAINTENANCE_WEEKLY_ENABLED"
+        case .repairFTS: "BRAINLAYER_LAUNCHD_REPAIR_FTS_ENABLED"
+        case .walCheckpoint: "BRAINLAYER_LAUNCHD_WAL_CHECKPOINT_ENABLED"
+        }
+    }
+
+    var launchdLabel: String {
+        switch self {
+        case .backupDaily: "com.brainlayer.backup-daily"
+        case .jsonlBackup: "com.brainlayer.jsonl-backup"
+        case .maintenanceNightly: "com.brainlayer.maintenance-nightly"
+        case .maintenanceWeekly: "com.brainlayer.maintenance-weekly"
+        case .repairFTS: "com.brainlayer.repair-fts"
+        case .walCheckpoint: "com.brainlayer.wal-checkpoint"
+        default: "com.brainlayer.\(rawValue)"
+        }
+    }
+}
+
+struct BrainLayerLaunchdJobSetting: Equatable {
+    var enabled: Bool
+    var loadState: BrainLayerLaunchdLoadState
+}
+
+struct BrainLayerConfig: Equatable {
+    var googleAPIKey: BrainLayerGoogleAPIKey
+    var systemEnabled: Bool
+    var enrichmentEnabled: Bool
+    var enrichmentMode: BrainLayerEnrichmentMode
+    var enrichmentProvider: BrainLayerEnrichmentProvider
+    var enrichmentBackend: String
+    var launchdJobs: [BrainLayerLaunchdJob: BrainLayerLaunchdJobSetting]
+
+    static let defaultConfig = BrainLayerConfig(
+        googleAPIKey: .missing,
+        systemEnabled: true,
+        enrichmentEnabled: true,
+        enrichmentMode: .remote,
+        enrichmentProvider: .gemini,
+        enrichmentBackend: "gemini",
+        launchdJobs: Dictionary(
+            uniqueKeysWithValues: BrainLayerLaunchdJob.allCases.map {
+                ($0, BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown))
+            }
+        )
+    )
+}
+
+struct BrainLayerEnvDocument {
+    private var originalLines: [String]
+    private(set) var config: BrainLayerConfig
+
+    init(text: String) throws {
+        originalLines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        config = Self.parse(lines: originalLines)
+    }
+
+    init(config: BrainLayerConfig) {
+        originalLines = []
+        self.config = config
+    }
+
+    mutating func update(_ apply: (inout BrainLayerConfig) -> Void) {
+        apply(&config)
+    }
+
+    func rendered() -> String {
+        let managedValues = Self.managedValues(for: config)
+        var emitted = Set<String>()
+        var output: [String] = []
+
+        for line in originalLines {
+            guard let key = Self.assignmentKey(line), managedValues[key] != nil else {
+                output.append(line)
+                continue
+            }
+            guard !emitted.contains(key), let value = managedValues[key] else {
+                continue
+            }
+            output.append("\(key)=\(value)")
+            emitted.insert(key)
+        }
+
+        if output.isEmpty {
+            output.append("# BrainLayer private config.")
+        }
+        if !output.isEmpty, output.last != "" {
+            output.append("")
+        }
+
+        for key in Self.managedKeyOrder where !emitted.contains(key) {
+            guard let value = managedValues[key] else { continue }
+            output.append("\(key)=\(value)")
+            emitted.insert(key)
+        }
+
+        return output.joined(separator: "\n") + "\n"
+    }
+
+    private static let managedKeyOrder: [String] = [
+        "GOOGLE_API_KEY",
+        "BRAINLAYER_SYSTEM_ENABLED",
+        "BRAINLAYER_ENRICH_ENABLED",
+        "BRAINLAYER_ENRICH_MODE",
+        "BRAINLAYER_ENRICH_PROVIDER",
+        "BRAINLAYER_ENRICH_BACKEND",
+        "BRAINLAYER_ENRICH_RATE",
+        "BRAINLAYER_ENRICH_CONCURRENCY",
+        "BRAINLAYER_MAX_COMMIT_BATCH",
+        "BRAINLAYER_GEMINI_SERVICE_TIER",
+        "BRAINLAYER_DISABLED_SLEEP_SECONDS",
+        "BRAINLAYER_LAUNCHD_ENRICHMENT_ENABLED",
+        "BRAINLAYER_LAUNCHD_HOTLANE_ENABLED",
+        "BRAINLAYER_LAUNCHD_DECAY_ENABLED",
+        "BRAINLAYER_LAUNCHD_DRAIN_ENABLED",
+        "BRAINLAYER_LAUNCHD_WATCH_ENABLED",
+        "BRAINLAYER_LAUNCHD_INDEX_ENABLED",
+        "BRAINLAYER_LAUNCHD_BACKUP_DAILY_ENABLED",
+        "BRAINLAYER_LAUNCHD_JSONL_BACKUP_ENABLED",
+        "BRAINLAYER_LAUNCHD_MAINTENANCE_NIGHTLY_ENABLED",
+        "BRAINLAYER_LAUNCHD_MAINTENANCE_WEEKLY_ENABLED",
+        "BRAINLAYER_LAUNCHD_REPAIR_FTS_ENABLED",
+        "BRAINLAYER_LAUNCHD_WAL_CHECKPOINT_ENABLED",
+    ]
+
+    private static func managedValues(for config: BrainLayerConfig) -> [String: String] {
+        var values: [String: String] = [
+            "GOOGLE_API_KEY": config.googleAPIKey.renderedValue,
+            "BRAINLAYER_SYSTEM_ENABLED": config.systemEnabled ? "1" : "0",
+            "BRAINLAYER_ENRICH_ENABLED": config.enrichmentEnabled ? "1" : "0",
+            "BRAINLAYER_ENRICH_MODE": config.enrichmentMode.rawValue,
+            "BRAINLAYER_ENRICH_PROVIDER": config.enrichmentProvider.rawValue,
+            "BRAINLAYER_ENRICH_BACKEND": config.enrichmentBackend,
+            "BRAINLAYER_ENRICH_RATE": "15",
+            "BRAINLAYER_ENRICH_CONCURRENCY": "4",
+            "BRAINLAYER_MAX_COMMIT_BATCH": "25",
+            "BRAINLAYER_GEMINI_SERVICE_TIER": "flex",
+            "BRAINLAYER_DISABLED_SLEEP_SECONDS": "3600",
+        ]
+        for job in BrainLayerLaunchdJob.allCases {
+            values[job.configKey] = config.launchdJobs[job]?.enabled == false ? "0" : "1"
+        }
+        return values
+    }
+
+    private static func parse(lines: [String]) -> BrainLayerConfig {
+        var config = BrainLayerConfig.defaultConfig
+        let assignments = Dictionary(lines.compactMap(Self.assignment), uniquingKeysWith: { _, new in new })
+
+        if let rawKey = assignments["GOOGLE_API_KEY"] ?? assignments["GOOGLE_GENERATIVE_AI_API_KEY"] {
+            config.googleAPIKey = parseGoogleKey(rawKey)
+        }
+        if let raw = assignments["BRAINLAYER_SYSTEM_ENABLED"] {
+            config.systemEnabled = !isFalse(raw)
+        }
+        if let raw = assignments["BRAINLAYER_ENRICH_ENABLED"] {
+            config.enrichmentEnabled = !isFalse(raw)
+        }
+        if let raw = assignments["BRAINLAYER_ENRICH_MODE"],
+           let mode = BrainLayerEnrichmentMode(rawValue: normalized(raw)) {
+            config.enrichmentMode = mode
+        }
+        if let raw = assignments["BRAINLAYER_ENRICH_PROVIDER"],
+           let provider = BrainLayerEnrichmentProvider(rawValue: normalized(raw)) {
+            config.enrichmentProvider = provider
+        }
+        if let raw = assignments["BRAINLAYER_ENRICH_BACKEND"], !normalized(raw).isEmpty {
+            config.enrichmentBackend = normalized(raw)
+        }
+        for job in BrainLayerLaunchdJob.allCases {
+            guard let raw = assignments[job.configKey] else { continue }
+            config.launchdJobs[job]?.enabled = !isFalse(raw)
+        }
+        return config
+    }
+
+    private static func parseGoogleKey(_ raw: String) -> BrainLayerGoogleAPIKey {
+        let value = strippedValue(raw)
+        guard !value.isEmpty else { return .missing }
+        if value.contains("op read") {
+            return .onePasswordReference(extractOpReference(from: value) ?? "op://Private/Google AI/Gemini API key")
+        }
+        return .plain(value)
+    }
+
+    private static func extractOpReference(from value: String) -> String? {
+        guard let range = value.range(of: "op://") else { return nil }
+        let suffix = value[range.lowerBound...]
+        let terminators = CharacterSet(charactersIn: "'\")")
+        if let end = suffix.unicodeScalars.firstIndex(where: { terminators.contains($0) }) {
+            return String(String.UnicodeScalarView(suffix.unicodeScalars[..<end]))
+        }
+        return String(suffix)
+    }
+
+    private static func assignment(_ line: String) -> (String, String)? {
+        guard let key = assignmentKey(line) else { return nil }
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let withoutExport = trimmed.hasPrefix("export ") ? String(trimmed.dropFirst("export ".count)) : trimmed
+        let parts = withoutExport.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        return (key, String(parts[1]).trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func assignmentKey(_ line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return nil }
+        let withoutExport = trimmed.hasPrefix("export ") ? String(trimmed.dropFirst("export ".count)) : trimmed
+        guard let equals = withoutExport.firstIndex(of: "=") else { return nil }
+        return String(withoutExport[..<equals]).trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func isFalse(_ value: String) -> Bool {
+        ["0", "false", "no", "off", "disabled"].contains(normalized(value))
+    }
+
+    private static func normalized(_ value: String) -> String {
+        strippedValue(value).lowercased()
+    }
+
+    private static func strippedValue(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        if trimmed.count >= 2,
+           let first = trimmed.first,
+           let last = trimmed.last,
+           (first == "'" && last == "'") || (first == "\"" && last == "\"") {
+            return String(trimmed.dropFirst().dropLast())
+        }
+        return trimmed
+    }
+}
+
+struct BrainLayerConfigStore {
+    let configURL: URL
+    var fileManager: FileManager = .default
+
+    static func defaultConfigURL(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        homeDirectory
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("brainlayer", isDirectory: true)
+            .appendingPathComponent("brainlayer.env", isDirectory: false)
+    }
+
+    init(configURL: URL = BrainLayerConfigStore.defaultConfigURL()) {
+        self.configURL = configURL
+    }
+
+    func loadDocument() throws -> BrainLayerEnvDocument {
+        guard fileManager.fileExists(atPath: configURL.path) else {
+            return BrainLayerEnvDocument(config: .defaultConfig)
+        }
+        let text = try String(contentsOf: configURL, encoding: .utf8)
+        return try BrainLayerEnvDocument(text: text)
+    }
+
+    func save(_ config: BrainLayerConfig) throws {
+        var document = try loadDocument()
+        document.update { $0 = config }
+        try fileManager.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try document.rendered().write(to: configURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
+    }
+}
+
+protocol BrainLayerLaunchdStatusSampling {
+    func sample() -> [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]
+}
+
+struct BrainLayerLaunchdStatusProvider: BrainLayerLaunchdStatusSampling {
+    func sample() -> [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] {
+        Dictionary(
+            uniqueKeysWithValues: BrainLayerLaunchdJob.allCases.map { job in
+                (job, state(for: job.launchdLabel))
+            }
+        )
+    }
+
+    private func state(for label: String) -> BrainLayerLaunchdLoadState {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["print", "gui/\(getuid())/\(label)"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return .unloaded }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? ""
+            return output.contains("pid =") ? .running : .loaded
+        } catch {
+            return .unknown
+        }
+    }
+}
+
+struct StaticBrainLayerLaunchdStatusProvider: BrainLayerLaunchdStatusSampling {
+    let states: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]
+
+    func sample() -> [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] {
+        states
+    }
+}

--- a/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
+++ b/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
@@ -175,6 +175,7 @@ struct BrainLayerConfig: Equatable {
     var enrichmentMode: BrainLayerEnrichmentMode
     var enrichmentProvider: BrainLayerEnrichmentProvider
     var enrichmentBackend: String
+    var tuningValues: [String: String]
     var launchdJobs: [BrainLayerLaunchdJob: BrainLayerLaunchdJobSetting]
 
     static let defaultConfig = BrainLayerConfig(
@@ -184,6 +185,7 @@ struct BrainLayerConfig: Equatable {
         enrichmentMode: .remote,
         enrichmentProvider: .gemini,
         enrichmentBackend: "gemini",
+        tuningValues: BrainLayerEnvDocument.tuningDefaults,
         launchdJobs: Dictionary(
             uniqueKeysWithValues: BrainLayerLaunchdJob.allCases.map {
                 ($0, BrainLayerLaunchdJobSetting(enabled: true, loadState: .unknown))
@@ -211,7 +213,10 @@ struct BrainLayerEnvDocument {
     }
 
     func rendered() -> String {
-        let managedValues = Self.managedValues(for: config)
+        let includeLegacyGoogleKey = originalLines.contains {
+            Self.assignmentKey($0) == "GOOGLE_GENERATIVE_AI_API_KEY"
+        }
+        let managedValues = Self.managedValues(for: config, includeLegacyGoogleKey: includeLegacyGoogleKey)
         var emitted = Set<String>()
         var output: [String] = []
 
@@ -243,8 +248,17 @@ struct BrainLayerEnvDocument {
         return output.joined(separator: "\n") + "\n"
     }
 
+    static let tuningDefaults: [String: String] = [
+        "BRAINLAYER_ENRICH_RATE": "15",
+        "BRAINLAYER_ENRICH_CONCURRENCY": "4",
+        "BRAINLAYER_MAX_COMMIT_BATCH": "25",
+        "BRAINLAYER_GEMINI_SERVICE_TIER": "flex",
+        "BRAINLAYER_DISABLED_SLEEP_SECONDS": "3600",
+    ]
+
     private static let managedKeyOrder: [String] = [
         "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
         "BRAINLAYER_SYSTEM_ENABLED",
         "BRAINLAYER_ENRICH_ENABLED",
         "BRAINLAYER_ENRICH_MODE",
@@ -269,7 +283,18 @@ struct BrainLayerEnvDocument {
         "BRAINLAYER_LAUNCHD_WAL_CHECKPOINT_ENABLED",
     ]
 
-    private static func managedValues(for config: BrainLayerConfig) -> [String: String] {
+    private static let tuningKeyOrder: [String] = [
+        "BRAINLAYER_ENRICH_RATE",
+        "BRAINLAYER_ENRICH_CONCURRENCY",
+        "BRAINLAYER_MAX_COMMIT_BATCH",
+        "BRAINLAYER_GEMINI_SERVICE_TIER",
+        "BRAINLAYER_DISABLED_SLEEP_SECONDS",
+    ]
+
+    private static func managedValues(
+        for config: BrainLayerConfig,
+        includeLegacyGoogleKey: Bool
+    ) -> [String: String] {
         var values: [String: String] = [
             "GOOGLE_API_KEY": config.googleAPIKey.renderedValue,
             "BRAINLAYER_SYSTEM_ENABLED": config.systemEnabled ? "1" : "0",
@@ -277,12 +302,13 @@ struct BrainLayerEnvDocument {
             "BRAINLAYER_ENRICH_MODE": config.enrichmentMode.rawValue,
             "BRAINLAYER_ENRICH_PROVIDER": config.enrichmentProvider.rawValue,
             "BRAINLAYER_ENRICH_BACKEND": config.enrichmentBackend,
-            "BRAINLAYER_ENRICH_RATE": "15",
-            "BRAINLAYER_ENRICH_CONCURRENCY": "4",
-            "BRAINLAYER_MAX_COMMIT_BATCH": "25",
-            "BRAINLAYER_GEMINI_SERVICE_TIER": "flex",
-            "BRAINLAYER_DISABLED_SLEEP_SECONDS": "3600",
         ]
+        if includeLegacyGoogleKey {
+            values["GOOGLE_GENERATIVE_AI_API_KEY"] = ""
+        }
+        for key in tuningKeyOrder {
+            values[key] = config.tuningValues[key] ?? tuningDefaults[key] ?? ""
+        }
         for job in BrainLayerLaunchdJob.allCases {
             values[job.configKey] = config.launchdJobs[job]?.enabled == false ? "0" : "1"
         }
@@ -312,6 +338,10 @@ struct BrainLayerEnvDocument {
         }
         if let raw = assignments["BRAINLAYER_ENRICH_BACKEND"], !normalized(raw).isEmpty {
             config.enrichmentBackend = normalized(raw)
+        }
+        for key in tuningKeyOrder {
+            guard let raw = assignments[key] else { continue }
+            config.tuningValues[key] = raw
         }
         for job in BrainLayerLaunchdJob.allCases {
             guard let raw = assignments[job.configKey] else { continue }
@@ -408,7 +438,7 @@ struct BrainLayerConfigStore {
     }
 }
 
-protocol BrainLayerLaunchdStatusSampling {
+protocol BrainLayerLaunchdStatusSampling: Sendable {
     func sample() -> [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]
 }
 

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarSettingsActions.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarSettingsActions.swift
@@ -1,0 +1,1 @@
+../BrainBar/BrainBarSettingsActions.swift

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
@@ -1,0 +1,85 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BrainBar
+
+final class BrainBarSettingsSnapshotTests: XCTestCase {
+    @MainActor
+    func testSettingsViewRendersConfigBackedPanelScreenshot() throws {
+        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-settings-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("brainlayer", isDirectory: true)
+            .appendingPathComponent("brainlayer.env", isDirectory: false)
+        var config = BrainLayerConfig.defaultConfig
+        config.googleAPIKey = .onePasswordReference("op://Private/Google AI/Gemini API key")
+        config.enrichmentEnabled = true
+        config.enrichmentMode = .remote
+        config.enrichmentProvider = .gemini
+        config.enrichmentBackend = "gemini"
+        config.launchdJobs[.drain]?.enabled = true
+        config.launchdJobs[.hotlane]?.enabled = false
+
+        let store = BrainLayerConfigStore(configURL: configURL)
+        try store.save(config)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let viewModel = BrainBarSettingsViewModel(
+            store: store,
+            launchdStatusProvider: StaticBrainLayerLaunchdStatusProvider(states: [
+                .enrichment: .loaded,
+                .hotlane: .unloaded,
+                .drain: .running,
+            ])
+        )
+        let view = NSHostingView(rootView: BrainBarSettingsView(viewModel: viewModel))
+        view.frame = NSRect(x: 0, y: 0, width: 700, height: 1_080)
+        view.layoutSubtreeIfNeeded()
+
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            XCTFail("Expected hosting view to produce a bitmap")
+            return
+        }
+        view.cacheDisplay(in: view.bounds, to: bitmap)
+
+        guard let png = bitmap.representation(using: .png, properties: [:]) else {
+            XCTFail("Expected renderer to produce a PNG")
+            return
+        }
+
+        let url = screenshotURL()
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try png.write(to: url)
+        XCTAssertGreaterThan(png.count, 1_000)
+        XCTAssertGreaterThan(distinctSampledColorCount(in: bitmap), 8)
+    }
+
+    private func screenshotURL() -> URL {
+        if let override = ProcessInfo.processInfo.environment["BRAINBAR_SETTINGS_SCREENSHOT_PATH"],
+           !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        return URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("docs.local/brainbar-settings-ui-phase2/brainbar-settings.png")
+    }
+
+    private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
+        guard let data = bitmap.bitmapData else { return 0 }
+        let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
+        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        var colors = Set<String>()
+        for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
+            let rowStart = y * bitmap.bytesPerRow
+            for x in stride(from: 0, to: bitmap.bytesPerRow, by: sampleStride) {
+                let offset = rowStart + x
+                guard offset + 2 < bitmap.bytesPerRow * bitmap.pixelsHigh else { continue }
+                colors.insert("\(data[offset])-\(data[offset + 1])-\(data[offset + 2])")
+            }
+        }
+        return colors.count
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
@@ -31,7 +31,13 @@ final class BrainBarSettingsSnapshotTests: XCTestCase {
                 .enrichment: .loaded,
                 .hotlane: .unloaded,
                 .drain: .running,
-            ])
+            ]),
+            initialLaunchdStates: [
+                .enrichment: .loaded,
+                .hotlane: .unloaded,
+                .drain: .running,
+            ],
+            refreshStatusOnLoad: false
         )
         let view = NSHostingView(rootView: BrainBarSettingsView(viewModel: viewModel))
         view.frame = NSRect(x: 0, y: 0, width: 700, height: 1_080)

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import BrainBar
+
+final class BrainBarSettingsViewModelTests: XCTestCase {
+    @MainActor
+    func testFailedSaveLeavesDisplayedConfigAtLastPersistedValue() throws {
+        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-settings-model-\(UUID().uuidString)", isDirectory: false)
+        try "not a directory".write(to: tempRoot, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let store = BrainLayerConfigStore(configURL: tempRoot.appendingPathComponent("brainlayer.env"))
+        let viewModel = BrainBarSettingsViewModel(
+            store: store,
+            launchdStatusProvider: StaticBrainLayerLaunchdStatusProvider(states: [:]),
+            refreshStatusOnLoad: false
+        )
+
+        XCTAssertTrue(viewModel.config.enrichmentEnabled)
+        viewModel.setEnrichmentEnabled(false)
+
+        XCTAssertTrue(viewModel.config.enrichmentEnabled)
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testBackendDraftDoesNotPersistUntilCommitted() throws {
+        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-settings-model-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot.appendingPathComponent("brainlayer.env")
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let store = BrainLayerConfigStore(configURL: configURL)
+        try store.save(BrainLayerConfig.defaultConfig)
+        let viewModel = BrainBarSettingsViewModel(
+            store: store,
+            launchdStatusProvider: StaticBrainLayerLaunchdStatusProvider(states: [:]),
+            refreshStatusOnLoad: false
+        )
+
+        viewModel.backendDraft = "mlx"
+        var document = try store.loadDocument()
+        XCTAssertEqual(document.config.enrichmentBackend, "gemini")
+
+        viewModel.commitBackendDraft()
+        document = try store.loadDocument()
+        XCTAssertEqual(document.config.enrichmentBackend, "mlx")
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
@@ -32,6 +32,7 @@ final class BrainBarStatusPopoverControllerTests: XCTestCase {
 
         let itemTitles = controller.contextMenuForTesting.items.map(\.title)
 
+        XCTAssertTrue(itemTitles.contains("Settings..."))
         XCTAssertTrue(itemTitles.contains("Restart BrainBar"))
         XCTAssertFalse(itemTitles.contains("Run as App Window"))
         XCTAssertFalse(itemTitles.contains("Run as Menu Item Daemon"))

--- a/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import BrainBar
+
+final class BrainLayerConfigTests: XCTestCase {
+    func testDefaultConfigURLUsesUnifiedBrainLayerEnvPath() {
+        let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+
+        XCTAssertEqual(
+            BrainLayerConfigStore.defaultConfigURL(homeDirectory: home).path,
+            "/Users/example/.config/brainlayer/brainlayer.env"
+        )
+    }
+
+    func testParsesUnifiedConfigWithoutLeakingPlainSecret() throws {
+        let document = try BrainLayerEnvDocument(
+            text: """
+            # BrainLayer private config.
+            GOOGLE_API_KEY='plain-secret'
+            BRAINLAYER_SYSTEM_ENABLED=1
+            BRAINLAYER_ENRICH_ENABLED=off
+            BRAINLAYER_ENRICH_MODE=local
+            BRAINLAYER_ENRICH_PROVIDER=gemini
+            BRAINLAYER_ENRICH_BACKEND=ollama
+            BRAINLAYER_LAUNCHD_DRAIN_ENABLED=0
+            """
+        )
+
+        XCTAssertEqual(document.config.googleAPIKey.kind, .plainPresent)
+        XCTAssertEqual(document.config.googleAPIKey.displayText, "Stored in config file")
+        XCTAssertEqual(document.config.enrichmentEnabled, false)
+        XCTAssertEqual(document.config.enrichmentMode, .local)
+        XCTAssertEqual(document.config.enrichmentProvider, .gemini)
+        XCTAssertEqual(document.config.enrichmentBackend, "ollama")
+        XCTAssertEqual(document.config.launchdJobs[.drain]?.enabled, false)
+        XCTAssertFalse(document.config.googleAPIKey.displayText.contains("plain-secret"))
+    }
+
+    func testParsesOnePasswordGoogleKeyReference() throws {
+        let document = try BrainLayerEnvDocument(
+            text: """
+            GOOGLE_API_KEY="$(op read 'op://Private/Google AI/Gemini API key')"
+            BRAINLAYER_ENRICH_PROVIDER=gemini
+            BRAINLAYER_ENRICH_BACKEND=gemini
+            """
+        )
+
+        XCTAssertEqual(document.config.googleAPIKey.kind, .onePasswordReference)
+        XCTAssertEqual(document.config.googleAPIKey.displayText, "1Password reference")
+    }
+
+    func testUpdatingConfigPreservesCommentsAndUnmanagedKeys() throws {
+        var document = try BrainLayerEnvDocument(
+            text: """
+            # keep this
+            CUSTOM_FLAG=keep
+            GOOGLE_API_KEY='old-secret'
+            BRAINLAYER_ENRICH_ENABLED=1
+            BRAINLAYER_ENRICH_MODE=remote
+            BRAINLAYER_ENRICH_PROVIDER=gemini
+            BRAINLAYER_ENRICH_BACKEND=gemini
+            BRAINLAYER_LAUNCHD_DRAIN_ENABLED=1
+            """
+        )
+
+        document.update { config in
+            config.googleAPIKey = .onePasswordReference("op://Private/Google AI/Gemini API key")
+            config.enrichmentEnabled = false
+            config.enrichmentMode = .local
+            config.enrichmentBackend = "mlx"
+            config.launchdJobs[.drain]?.enabled = false
+        }
+
+        let rendered = document.rendered()
+        XCTAssertTrue(rendered.contains("# keep this"))
+        XCTAssertTrue(rendered.contains("CUSTOM_FLAG=keep"))
+        XCTAssertTrue(rendered.contains("GOOGLE_API_KEY=\"$(op read 'op://Private/Google AI/Gemini API key')\""))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_ENABLED=0"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_MODE=local"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_BACKEND=mlx"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_LAUNCHD_DRAIN_ENABLED=0"))
+        XCTAssertFalse(rendered.contains("old-secret"))
+    }
+
+    func testWritesMissingConfigWithFullSchemaDefaults() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-config-\(UUID().uuidString)", isDirectory: true)
+        let configURL = directory.appendingPathComponent("brainlayer.env")
+        let store = BrainLayerConfigStore(configURL: configURL)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try store.save(BrainLayerConfig.defaultConfig)
+
+        let content = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertTrue(content.contains("BRAINLAYER_ENRICH_ENABLED=1"))
+        XCTAssertTrue(content.contains("BRAINLAYER_ENRICH_MODE=remote"))
+        XCTAssertTrue(content.contains("BRAINLAYER_ENRICH_PROVIDER=gemini"))
+        XCTAssertTrue(content.contains("BRAINLAYER_ENRICH_BACKEND=gemini"))
+        XCTAssertTrue(content.contains("BRAINLAYER_LAUNCHD_ENRICHMENT_ENABLED=1"))
+        XCTAssertTrue(content.contains("BRAINLAYER_LAUNCHD_DRAIN_ENABLED=1"))
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
@@ -58,6 +58,11 @@ final class BrainLayerConfigTests: XCTestCase {
             BRAINLAYER_ENRICH_MODE=remote
             BRAINLAYER_ENRICH_PROVIDER=gemini
             BRAINLAYER_ENRICH_BACKEND=gemini
+            BRAINLAYER_ENRICH_RATE=99
+            BRAINLAYER_ENRICH_CONCURRENCY=7
+            BRAINLAYER_MAX_COMMIT_BATCH=88
+            BRAINLAYER_GEMINI_SERVICE_TIER=standard
+            BRAINLAYER_DISABLED_SLEEP_SECONDS=42
             BRAINLAYER_LAUNCHD_DRAIN_ENABLED=1
             """
         )
@@ -77,8 +82,33 @@ final class BrainLayerConfigTests: XCTestCase {
         XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_ENABLED=0"))
         XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_MODE=local"))
         XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_BACKEND=mlx"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_RATE=99"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_ENRICH_CONCURRENCY=7"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_MAX_COMMIT_BATCH=88"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_GEMINI_SERVICE_TIER=standard"))
+        XCTAssertTrue(rendered.contains("BRAINLAYER_DISABLED_SLEEP_SECONDS=42"))
         XCTAssertTrue(rendered.contains("BRAINLAYER_LAUNCHD_DRAIN_ENABLED=0"))
         XCTAssertFalse(rendered.contains("old-secret"))
+    }
+
+    func testSaveMigratesLegacyGoogleKeyAliasToCanonicalKeyAndClearsAlias() throws {
+        var document = try BrainLayerEnvDocument(
+            text: """
+            GOOGLE_GENERATIVE_AI_API_KEY='legacy-secret'
+            BRAINLAYER_ENRICH_PROVIDER=gemini
+            """
+        )
+
+        XCTAssertEqual(document.config.googleAPIKey.kind, .plainPresent)
+
+        document.update { config in
+            config.googleAPIKey = .missing
+        }
+
+        let rendered = document.rendered()
+        XCTAssertTrue(rendered.contains("GOOGLE_API_KEY="))
+        XCTAssertTrue(rendered.contains("GOOGLE_GENERATIVE_AI_API_KEY="))
+        XCTAssertFalse(rendered.contains("legacy-secret"))
     }
 
     func testWritesMissingConfigWithFullSchemaDefaults() throws {


### PR DESCRIPTION
## Summary
- Adds a BrainBar Settings scene and menu entries for opening it from the app command menu, header menu, and status context menu.
- Adds config-file backed parsing/writing for ~/.config/brainlayer/brainlayer.env, covering GOOGLE_API_KEY, BRAINLAYER_ENRICH_ENABLED, BRAINLAYER_ENRICH_MODE, BRAINLAYER_ENRICH_PROVIDER, BRAINLAYER_ENRICH_BACKEND, BRAINLAYER_SYSTEM_ENABLED, and all BRAINLAYER_LAUNCHD_*_ENABLED job gates.
- Keeps 1Password as the preferred API-key path while allowing a secure plain-env fallback; existing configured keys require confirmation before replacement and are never displayed raw.
- Shows non-destructive launchd load state via launchctl print only; this PR does not edit installed plists, load/unload jobs, or restart daemons.

## Verification
- swift build --product BrainBar
- swift build --product BrainBarDaemon
- swift test --filter "BrainLayerConfigTests|BrainBarSettingsSnapshotTests|BrainBarStatusPopoverControllerTests/testStatusItemContextMenuContainsNoLaunchModeSwitchingChoices"
- Screenshot generated and visually checked: brain-bar/docs.local/brainbar-settings-ui-phase2/brainbar-settings.png

## Notes
- Full `swift test` still hangs after build with no test output, matching the baseline behavior observed before the change; I killed only that swift-test/xctest runner after confirming the hang.

@codex review
@cursor @bugbot review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The PR writes secrets and operational flags to a user config file (including optional plain API keys) and can disable enrichment or launchd job gates, which affects background BrainLayer behavior even though it does not load/unload launchd directly.
> 
> **Overview**
> Replaces the empty **Settings** scene with **`BrainBarSettingsView`**, wired through **`BrainBarSettingsActions.openSettingsWindow()`** from the app menu, dashboard power menu, and status-bar context menu.
> 
> Adds **`BrainLayerConfig` / `BrainLayerEnvDocument` / `BrainLayerConfigStore`** to read and write `~/.config/brainlayer/brainlayer.env` while preserving comments and unmanaged keys. The UI edits enrichment toggles, mode/provider/backend, Gemini key handling (1Password reference or plain with overwrite confirmation, never shown raw), and per-job **`BRAINLAYER_LAUNCHD_*_ENABLED`** flags. **`launchctl print`** supplies read-only job load/running indicators; toggles only change env gates, not plists or daemons.
> 
> Tests cover env parse/render, view-model save failures and backend draft commit, settings snapshot PNG, and the new context-menu item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c406087a4335565597da4a91c3ceebe92994f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings window for configuring enrichment mode, API key management (including 1Password integration), and system service enablement
  * Added "Settings..." menu items in the app menu and status bar for quick access to preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add BrainBar settings UI with config persistence and launchd job controls
> - Adds `BrainBarSettingsView`, a full SwiftUI settings panel for configuring enrichment options (mode, provider, backend), Google API key (plain or 1Password reference), and launchd job toggles with live load state indicators.
> - Introduces `BrainLayerConfig`, `BrainLayerEnvDocument`, and `BrainLayerConfigStore` to parse, mutate, and round-trip persist a `~/.config/brainlayer/brainlayer.env` file while preserving comments and unmanaged keys; file is written with 0600 permissions.
> - Adds `BrainLayerLaunchdStatusProvider` which shells out to `launchctl` per job to classify load state as running, loaded, unloaded, or unknown.
> - Exposes the settings window via a `Settings...` entry in the status item context menu, the in-app control menu, and a new macOS `Settings` scene command using `BrainBarSettingsActions.openSettingsWindow()`.
> - Adds snapshot and config round-trip tests covering parsing, rendering, and default file creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1a0a5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->