### PR TITLE
Prep BrainBar notarization and socket MCP configs

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -6,10 +6,6 @@
       "command": "socat",
       "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"]
     },
-    "brainlayer-legacy": {
-      "_comment": "Fallback: original Python MCP server (remove after BrainBar is stable)",
-      "command": "brainlayer-mcp"
-    },
     "voicelayer": {
       "command": "voicelayer-mcp"
     },

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -50,7 +50,14 @@ done
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PACKAGE_DIR="$SCRIPT_DIR"
 BUNDLE_DIR="$SCRIPT_DIR/bundle"
-SIGN_IDENTITY="${BRAINBAR_CODESIGN_IDENTITY:-Apple Development: Etan Heyman (DXHB5E7P2D)}"
+SIGN_IDENTITY="${BRAINBAR_CODESIGN_IDENTITY:-Developer ID Application: Etan Heyman (PPN23G925Y)}"
+BRAINBAR_NOTARY_PROFILE="${BRAINBAR_NOTARY_PROFILE:-${BRAINBAR_NOTARY_KEYCHAIN_PROFILE:-}}"
+BRAINBAR_NOTARY_APPLE_ID="${BRAINBAR_NOTARY_APPLE_ID:-}"
+BRAINBAR_NOTARY_PASSWORD="${BRAINBAR_NOTARY_PASSWORD:-}"
+BRAINBAR_NOTARY_TEAM_ID="${BRAINBAR_NOTARY_TEAM_ID:-PPN23G925Y}"
+BRAINBAR_NOTARY_KEY="${BRAINBAR_NOTARY_KEY:-}"
+BRAINBAR_NOTARY_KEY_ID="${BRAINBAR_NOTARY_KEY_ID:-}"
+BRAINBAR_NOTARY_ISSUER="${BRAINBAR_NOTARY_ISSUER:-}"
 UI_PLIST_LABEL="com.brainlayer.brainbar"
 DAEMON_PLIST_LABEL="com.brainlayer.brainbar-daemon"
 UI_PLIST_FILENAME="$UI_PLIST_LABEL.plist"
@@ -435,6 +442,90 @@ wait_for_socket() {
     return 1
 }
 
+notary_credentials_available() {
+    if [ -n "$BRAINBAR_NOTARY_PROFILE" ]; then
+        return 0
+    fi
+    if [ -n "$BRAINBAR_NOTARY_APPLE_ID" ] && [ -n "$BRAINBAR_NOTARY_PASSWORD" ] && [ -n "$BRAINBAR_NOTARY_TEAM_ID" ]; then
+        return 0
+    fi
+    if [ -n "$BRAINBAR_NOTARY_KEY" ] && [ -n "$BRAINBAR_NOTARY_KEY_ID" ] && [ -n "$BRAINBAR_NOTARY_ISSUER" ]; then
+        return 0
+    fi
+    return 1
+}
+
+notarytool_auth_args() {
+    if [ -n "$BRAINBAR_NOTARY_PROFILE" ]; then
+        printf '%s\0%s\0' "--keychain-profile" "$BRAINBAR_NOTARY_PROFILE"
+        return 0
+    fi
+    if [ -n "$BRAINBAR_NOTARY_APPLE_ID" ] && [ -n "$BRAINBAR_NOTARY_PASSWORD" ] && [ -n "$BRAINBAR_NOTARY_TEAM_ID" ]; then
+        printf '%s\0%s\0%s\0%s\0%s\0%s\0' \
+            "--apple-id" "$BRAINBAR_NOTARY_APPLE_ID" \
+            "--password" "$BRAINBAR_NOTARY_PASSWORD" \
+            "--team-id" "$BRAINBAR_NOTARY_TEAM_ID"
+        return 0
+    fi
+    if [ -n "$BRAINBAR_NOTARY_KEY" ] && [ -n "$BRAINBAR_NOTARY_KEY_ID" ] && [ -n "$BRAINBAR_NOTARY_ISSUER" ]; then
+        printf '%s\0%s\0%s\0%s\0%s\0%s\0' \
+            "--key" "$BRAINBAR_NOTARY_KEY" \
+            "--key-id" "$BRAINBAR_NOTARY_KEY_ID" \
+            "--issuer" "$BRAINBAR_NOTARY_ISSUER"
+        return 0
+    fi
+    return 1
+}
+
+verify_spctl_assessment() {
+    local phase="$1"
+    local required="${2:-0}"
+    if spctl -a -vvv "$APP_DIR"; then
+        return 0
+    fi
+    if [ "$required" -eq 1 ]; then
+        echo "[build-app] ERROR: spctl assessment failed after $phase" >&2
+        return 1
+    fi
+    echo "[build-app] WARNING: spctl assessment failed before notarization; continuing to notary readiness/submit" >&2
+    return 0
+}
+
+notarize_and_staple() {
+    if ! notary_credentials_available; then
+        echo "[build-app] Notary credentials not configured; skipping notarytool submit."
+        echo "[build-app] Ready to submit with one of:"
+        echo "  BRAINBAR_NOTARY_PROFILE=<keychain-profile>"
+        echo "  BRAINBAR_NOTARY_APPLE_ID=<apple-id> BRAINBAR_NOTARY_PASSWORD=<app-specific-password> BRAINBAR_NOTARY_TEAM_ID=<team-id>"
+        echo "  BRAINBAR_NOTARY_KEY=<api-key.p8> BRAINBAR_NOTARY_KEY_ID=<key-id> BRAINBAR_NOTARY_ISSUER=<issuer-id>"
+        return 0
+    fi
+
+    local auth_args=()
+    while IFS= read -r -d '' arg; do
+        auth_args+=("$arg")
+    done < <(notarytool_auth_args)
+
+    local notary_zip_base
+    local notary_zip
+    notary_zip_base="$(mktemp -t brainbar-notary)"
+    notary_zip="$notary_zip_base.zip"
+    rm -f "$notary_zip_base"
+    ditto -c -k --keepParent "$APP_DIR" "$notary_zip"
+
+    echo "[build-app] Submitting for notarization..."
+    if xcrun notarytool submit "$notary_zip" "${auth_args[@]}" --wait; then
+        rm -f "$notary_zip"
+    else
+        local submit_status=$?
+        rm -f "$notary_zip"
+        return "$submit_status"
+    fi
+    echo "[build-app] Stapling notarization ticket..."
+    xcrun stapler staple "$APP_DIR"
+    verify_spctl_assessment "notarization" 1
+}
+
 if [ "$DEV_BUNDLE_BUILD" -eq 0 ]; then
     # Stop LaunchAgents first so KeepAlive cannot race the rebuild and unlink the
     # freshly rebound socket from an older instance that is still terminating.
@@ -509,7 +600,7 @@ echo "  BuildTimeUTC=$BUILD_UTC"
 
 # Developer signing keeps TCC permissions stable across rebuilds.
 echo "[build-app] Signing..."
-codesign --force --deep --sign "$SIGN_IDENTITY" --timestamp=none "$APP_DIR"
+codesign --force --deep --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP_DIR"
 
 echo "[build-app] Verifying signature..."
 if ! codesign -dv --verbose=4 "$APP_DIR" 2>&1 | grep -F "Authority=$SIGN_IDENTITY" >/dev/null; then
@@ -517,6 +608,8 @@ if ! codesign -dv --verbose=4 "$APP_DIR" 2>&1 | grep -F "Authority=$SIGN_IDENTIT
     codesign -dv --verbose=4 "$APP_DIR" 2>&1
     exit 1
 fi
+verify_spctl_assessment "Developer ID signing"
+notarize_and_staple
 
 # Register URL scheme with Launch Services (ensures brainbar:// works after rebuild)
 "$LSREGISTER" -R "$APP_DIR"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -508,7 +508,9 @@ notarize_and_staple() {
 
     local notary_zip_base
     local notary_zip
-    notary_zip_base="$(mktemp -t brainbar-notary)"
+    local tmp_parent
+    tmp_parent="${TMPDIR:-/tmp}"
+    notary_zip_base="$(mktemp "${tmp_parent%/}/brainbar-notary.XXXXXX")"
     notary_zip="$notary_zip_base.zip"
     rm -f "$notary_zip_base"
     ditto -c -k --keepParent "$APP_DIR" "$notary_zip"

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,8 @@ Add to Claude Code (`~/.claude.json`):
 {
   "mcpServers": {
     "brainlayer": {
-      "command": "brainlayer-mcp"
+      "command": "socat",
+      "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"]
     }
   }
 }

--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -1,39 +1,35 @@
 # MCP Configuration for BrainLayer
 
-Add this to `~/.claude/settings.json` under `mcpServers`:
+Use the BrainBar socket bridge for agent MCP wiring. This avoids GUI `PATH`
+drift in Finder-launched apps because agents connect to the already-running
+BrainBar daemon instead of spawning a Python MCP process.
+
+Add this to Claude, Codex, Cursor, or Gemini MCP settings under `mcpServers`:
 
 ```json
 {
   "mcpServers": {
     "brainlayer": {
-      "command": "python",
-      "args": ["-m", "brainlayer.mcp"],
-      "cwd": "/path/to/brainlayer"
+      "command": "socat",
+      "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"]
     }
   }
 }
 ```
 
-Or if you have brainlayer installed globally:
+If a GUI app cannot find `socat`, use the absolute Homebrew path in `command`
+(`/opt/homebrew/bin/socat` on Apple Silicon, `/usr/local/bin/socat` on Intel).
 
-```json
-{
-  "mcpServers": {
-    "brainlayer": {
-      "command": "brainlayer-mcp",
-      "args": []
-    }
-  }
-}
-```
+The Python `brainlayer-mcp` entrypoint is still packaged for development and
+formula installs, but it is not the recommended agent wiring path.
 
 ## Testing the MCP Server
 
-1. Start the server manually to test:
+1. Confirm BrainBar owns the MCP socket:
    ```bash
-   cd /path/to/brainlayer
-   source .venv/bin/activate
-   python -m brainlayer.mcp
+   test -S /tmp/brainbar.sock
+   printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
+     | socat - UNIX-CONNECT:/tmp/brainbar.sock
    ```
 
 2. In Claude Code, the tools should appear:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,43 +46,37 @@ This parses your Claude Code conversations (JSONL files), classifies content, ch
 
 ## Connect to Your Editor
 
-### Claude Code
+### Claude Code, Codex, Cursor, and Gemini
 
-Add to `~/.claude.json`:
-
-```json
-{
-  "mcpServers": {
-    "brainlayer": {
-      "command": "brainlayer-mcp"
-    }
-  }
-}
-```
-
-### Cursor
-
-Add in Cursor's MCP settings:
+Add to each agent's MCP settings under `mcpServers`:
 
 ```json
 {
   "mcpServers": {
     "brainlayer": {
-      "command": "brainlayer-mcp"
+      "command": "socat",
+      "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"]
     }
   }
 }
 ```
+
+If a Finder-launched GUI app cannot resolve `socat`, set `command` to the
+absolute Homebrew path: `/opt/homebrew/bin/socat` on Apple Silicon or
+`/usr/local/bin/socat` on Intel.
 
 ### Zed
 
-Add to `settings.json`:
+Add the same socket command to `settings.json`:
 
 ```json
 {
   "context_servers": {
     "brainlayer": {
-      "command": { "path": "brainlayer-mcp" }
+      "command": {
+        "path": "socat",
+        "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"]
+      }
     }
   }
 }
@@ -96,7 +90,8 @@ Add to `.vscode/mcp.json`:
 {
   "servers": {
     "brainlayer": {
-      "command": "brainlayer-mcp"
+      "command": "socat",
+      "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"]
     }
   }
 }

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -362,6 +362,8 @@ def test_build_app_script_is_notarization_ready_for_developer_id() -> None:
     assert "--wait" in script
     assert "stapler" in script
     assert "staple" in script
+    assert "mktemp -t brainbar-notary" not in script
+    assert "brainbar-notary.XXXXXX" in script
 
 
 def test_build_app_runs_hardened_codesign_and_notarization_when_profile_is_available(tmp_path: Path) -> None:

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -166,8 +166,33 @@ exit 0
     )
     (tool_dir / "codesign").write_text(
         """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${BRAINBAR_FAKE_CODESIGN_LOG:-/dev/null}"
 if [[ "$*" == *"-dv"* ]]; then
-  printf 'Authority=%s\n' "$BRAINBAR_CODESIGN_IDENTITY"
+  printf 'Authority=%s\n' "${BRAINBAR_CODESIGN_IDENTITY:-Developer ID Application: Etan Heyman (PPN23G925Y)}"
+fi
+exit 0
+"""
+    )
+    (tool_dir / "xcrun").write_text(
+        """#!/usr/bin/env bash
+tool="${1:-}"
+shift || true
+case "$tool" in
+  notarytool)
+    printf '%s\n' "$*" >> "${BRAINBAR_FAKE_NOTARYTOOL_LOG:-/dev/null}"
+    ;;
+  stapler)
+    printf '%s\n' "$*" >> "${BRAINBAR_FAKE_STAPLER_LOG:-/dev/null}"
+    ;;
+esac
+exit 0
+"""
+    )
+    (tool_dir / "spctl").write_text(
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${BRAINBAR_FAKE_SPCTL_LOG:-/dev/null}"
+if [[ "${BRAINBAR_FAKE_SPCTL_FAIL:-0}" == "1" ]]; then
+  exit 1
 fi
 exit 0
 """
@@ -225,7 +250,7 @@ exit 0
     (tool_dir / "lsregister").write_text("#!/usr/bin/env bash\nexit 0\n")
     (tool_dir / "pgrep").write_text("#!/usr/bin/env bash\nexit 1\n")
     (tool_dir / "killall").write_text("#!/usr/bin/env bash\nexit 0\n")
-    for tool in ("swift", "codesign", "plistbuddy", "launchctl", "lsregister", "pgrep", "killall"):
+    for tool in ("swift", "codesign", "xcrun", "spctl", "plistbuddy", "launchctl", "lsregister", "pgrep", "killall"):
         os.chmod(tool_dir / tool, 0o755)
     return tool_dir, bin_dir
 
@@ -323,6 +348,101 @@ def test_canonical_build_allows_launchagent_install_when_brainlayer_package_is_i
 
     assert result.returncode == 0, result.stderr
     assert "[build-app] brainlayer package is installed" in result.stdout
+
+
+def test_build_app_script_is_notarization_ready_for_developer_id() -> None:
+    script = (Path(__file__).resolve().parents[1] / "brain-bar" / "build-app.sh").read_text()
+
+    assert "Developer ID Application: Etan Heyman (PPN23G925Y)" in script
+    assert "Apple Development: Etan Heyman" not in script
+    assert "--options runtime" in script
+    assert "--timestamp=none" not in script
+    assert "notarytool" in script
+    assert "submit" in script
+    assert "--wait" in script
+    assert "stapler" in script
+    assert "staple" in script
+
+
+def test_build_app_runs_hardened_codesign_and_notarization_when_profile_is_available(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-dev-worktree")
+    home = tmp_path / "home"
+    home.mkdir()
+    _prepare_bundle_inputs(repo)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+    codesign_log = tmp_path / "codesign.log"
+    notarytool_log = tmp_path / "notarytool.log"
+    stapler_log = tmp_path / "stapler.log"
+    spctl_log = tmp_path / "spctl.log"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=tmp_path / "canonical",
+        home=home,
+        dry_run=False,
+        extra_args=["--force-worktree-build"],
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_FAKE_CODESIGN_LOG": str(codesign_log),
+            "BRAINBAR_FAKE_NOTARYTOOL_LOG": str(notarytool_log),
+            "BRAINBAR_FAKE_STAPLER_LOG": str(stapler_log),
+            "BRAINBAR_FAKE_SPCTL_LOG": str(spctl_log),
+            "BRAINBAR_NOTARY_PROFILE": "brainbar-notary-test",
+            "BRAINBAR_CODESIGN_IDENTITY": "Developer ID Application: Etan Heyman (PPN23G925Y)",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    codesign_calls = codesign_log.read_text(encoding="utf-8")
+    assert "--sign Developer ID Application: Etan Heyman (PPN23G925Y)" in codesign_calls
+    assert "--options runtime" in codesign_calls
+    assert "--timestamp " in codesign_calls or codesign_calls.rstrip().endswith("--timestamp")
+    assert "--timestamp=none" not in codesign_calls
+    notarytool_call = notarytool_log.read_text(encoding="utf-8")
+    notarytool_parts = notarytool_call.split()
+    assert notarytool_parts[0] == "submit"
+    assert notarytool_parts[1].endswith(".zip")
+    assert not notarytool_parts[1].endswith(".app")
+    assert "--keychain-profile brainbar-notary-test" in notarytool_call
+    assert "--wait" in notarytool_call
+    assert stapler_log.read_text(encoding="utf-8").startswith("staple ")
+    assert "-a -vvv" in spctl_log.read_text(encoding="utf-8")
+
+
+def test_build_app_submits_before_requiring_post_notary_spctl_acceptance(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-dev-worktree")
+    home = tmp_path / "home"
+    home.mkdir()
+    _prepare_bundle_inputs(repo)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+    notarytool_log = tmp_path / "notarytool.log"
+    stapler_log = tmp_path / "stapler.log"
+    spctl_log = tmp_path / "spctl.log"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=tmp_path / "canonical",
+        home=home,
+        dry_run=False,
+        extra_args=["--force-worktree-build"],
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_FAKE_NOTARYTOOL_LOG": str(notarytool_log),
+            "BRAINBAR_FAKE_STAPLER_LOG": str(stapler_log),
+            "BRAINBAR_FAKE_SPCTL_LOG": str(spctl_log),
+            "BRAINBAR_FAKE_SPCTL_FAIL": "1",
+            "BRAINBAR_NOTARY_PROFILE": "brainbar-notary-test",
+            "BRAINBAR_CODESIGN_IDENTITY": "Developer ID Application: Etan Heyman (PPN23G925Y)",
+        },
+    )
+
+    assert result.returncode != 0
+    assert notarytool_log.read_text(encoding="utf-8").startswith("submit ")
+    assert stapler_log.read_text(encoding="utf-8").startswith("staple ")
+    assert spctl_log.read_text(encoding="utf-8").count("-a -vvv") >= 2
+    assert "spctl assessment failed after notarization" in result.stderr
 
 
 def test_canonical_build_removes_only_stale_dev_bundles(tmp_path: Path) -> None:

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -197,6 +197,14 @@ fi
 exit 0
 """
     )
+    (tool_dir / "ditto").write_text(
+        """#!/usr/bin/env bash
+out="${@: -1}"
+mkdir -p "$(dirname "$out")"
+: > "$out"
+exit 0
+"""
+    )
     (tool_dir / "plistbuddy").write_text(
         """#!/usr/bin/env bash
 if [[ "$2" == "Print :GitCommit" && -f "$3" ]]; then
@@ -250,7 +258,18 @@ exit 0
     (tool_dir / "lsregister").write_text("#!/usr/bin/env bash\nexit 0\n")
     (tool_dir / "pgrep").write_text("#!/usr/bin/env bash\nexit 1\n")
     (tool_dir / "killall").write_text("#!/usr/bin/env bash\nexit 0\n")
-    for tool in ("swift", "codesign", "xcrun", "spctl", "plistbuddy", "launchctl", "lsregister", "pgrep", "killall"):
+    for tool in (
+        "swift",
+        "codesign",
+        "xcrun",
+        "spctl",
+        "ditto",
+        "plistbuddy",
+        "launchctl",
+        "lsregister",
+        "pgrep",
+        "killall",
+    ):
         os.chmod(tool_dir / tool, 0o755)
     return tool_dir, bin_dir
 

--- a/tests/test_mcp_socket_config_templates.py
+++ b/tests/test_mcp_socket_config_templates.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOCKET_ARGS = ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"]
+
+
+def test_agent_mcp_templates_use_brainbar_socket_bridge() -> None:
+    root_config = json.loads((REPO_ROOT / ".mcp.json.example").read_text(encoding="utf-8"))
+    plugin_config = json.loads((REPO_ROOT / "extensions/brainlayer-plugin/.mcp.json").read_text(encoding="utf-8"))
+
+    for config in (root_config, plugin_config):
+        brainlayer = config["mcpServers"]["brainlayer"]
+        assert brainlayer == {"command": "socat", "args": SOCKET_ARGS}
+
+    for config in (root_config, plugin_config):
+        serialized = json.dumps(config)
+        assert "brainlayer-legacy" not in serialized
+        assert "brainlayer-mcp" not in serialized
+
+
+def test_agent_mcp_docs_do_not_teach_direct_brainlayer_mcp_spawn() -> None:
+    docs = [
+        REPO_ROOT / "docs/mcp-config.md",
+        REPO_ROOT / "docs/quickstart.md",
+        REPO_ROOT / "docs/index.md",
+    ]
+
+    for path in docs:
+        content = path.read_text(encoding="utf-8")
+        assert '"command": "brainlayer-mcp"' not in content, str(path)
+        assert '"command": "socat"' in content, str(path)
+        assert '"UNIX-CONNECT:/tmp/brainbar.sock"' in content, str(path)


### PR DESCRIPTION
## Summary
- sign BrainBar with `Developer ID Application: Etan Heyman (PPN23G925Y)`, hardened runtime, real timestamp
- add notarytool `submit --wait` support, stapler wiring, and credential-gated readiness output
- keep pre-notary `spctl` rejection non-fatal, then require Gatekeeper acceptance after stapling
- migrate Claude/Codex/Cursor/Gemini docs/templates to the BrainBar `socat STDIO UNIX-CONNECT:/tmp/brainbar.sock` MCP bridge

## Verification
- `uv run pytest tests/test_brainbar_build_app_guards.py tests/test_mcp_socket_config_templates.py tests/test_phase2_plugin_manifest.py -q` -> `38 passed`
- `uv run ruff check tests/test_brainbar_build_app_guards.py tests/test_mcp_socket_config_templates.py` -> `All checks passed!`
- `uv run ruff format --check tests/test_brainbar_build_app_guards.py tests/test_mcp_socket_config_templates.py` -> `2 files already formatted`
- `bash -n brain-bar/build-app.sh && shellcheck --severity=warning brain-bar/build-app.sh`
- Real dev app build, without touching live LaunchAgents: `bash brain-bar/build-app.sh --force-worktree-build --force-dirty`
  - built `/Users/etanheyman/Applications/BrainBar-DEV-brainlayer-homebrew-gates-codex.app`
  - `codesign -dv --verbose=4` shows `flags=0x10000(runtime)`, `Authority=Developer ID Application: Etan Heyman (PPN23G925Y)`, real `Timestamp=Jun 17, 2026`, `TeamIdentifier=PPN23G925Y`
  - `spctl -a -vvv` reports `source=Unnotarized Developer ID`, expected until Apple notary credentials are configured
- TCC persistence proxy: designated requirement unchanged across re-sign and includes `identifier "com.brainlayer.brainbar"` and `certificate leaf[subject.OU] = PPN23G925Y`
- Pre-push hook: `2922 passed, 9 skipped, 61 deselected, 1 xfailed`, MCP registration `3 passed`, isolated eval/hook routing `40 passed`, bun suite `1 pass`, `test_fts5_determinism.sh` PASS

## Credential boundary
The script is ready to submit with `BRAINBAR_NOTARY_PROFILE`, Apple ID/app-specific password, or ASC API key env vars. The actual Apple notary submit was intentionally not run because this machine has no stored notary credentials.

@codex review
@cursor @bugbot review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/release behavior changes (signing identity, notarization when credentials exist) affect macOS distribution and Gatekeeper; MCP doc changes shift the recommended integration path away from spawning Python MCP.
> 
> **Overview**
> **BrainBar macOS release pipeline** now targets **Developer ID** distribution: default signing identity switches from Apple Development to **Developer ID Application**, with **hardened runtime** (`--options runtime`) and a real **timestamp** instead of `--timestamp=none`. After sign verification, the script runs a **credential-gated notarization** path—`notarytool submit --wait` on a zipped app, **stapler staple**, and **`spctl`** checks (pre-notary failure is a warning; post-staple failure aborts). Notary auth supports keychain profile, Apple ID/password, or ASC API key env vars; without credentials it prints readiness instructions and skips submit.
> 
> **Agent MCP wiring** is standardized on the **BrainBar Unix socket**: `.mcp.json.example` drops the legacy `brainlayer-legacy` / `brainlayer-mcp` server entries; docs (`index`, `quickstart`, `mcp-config`) now teach **`socat` + `UNIX-CONNECT:/tmp/brainbar.sock`** for Claude/Codex/Cursor/Gemini (plus Zed/VS Code variants), with notes on absolute Homebrew `socat` paths for GUI apps.
> 
> **Tests** assert the build script’s notarization/codesign contract and fake-tool integration for submit/staple/spctl, plus template/doc consistency for the socket bridge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028c446994079a671e67b74ef967f4416f0f981a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add macOS notarization support and switch MCP configs to BrainBar socket bridge
> - Updates [brain-bar/build-app.sh](https://github.com/EtanHey/brainlayer/pull/496/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb) to sign with a Developer ID Application identity, enable hardened runtime (`--options runtime --timestamp`), and run a full notarization workflow via `xcrun notarytool submit --wait` + `xcrun stapler staple` when credentials are available.
> - Adds helpers to detect credential sets (keychain profile, Apple ID/password, or App Store Connect API key) and run `spctl` Gatekeeper assessment before and after notarization.
> - Replaces direct `brainlayer-mcp` spawn instructions in [.mcp.json.example](https://github.com/EtanHey/brainlayer/pull/496/files#diff-10d24da47aee675a2661e4db4a87340e5608a4276612b4939e982b15c5a94cc8), docs, and quickstart with a `socat STDIO UNIX-CONNECT:/tmp/brainbar.sock` socket bridge config.
> - Adds tests in [tests/test_brainbar_build_app_guards.py](https://github.com/EtanHey/brainlayer/pull/496/files#diff-55ab4f81b7c4728e3996f37748109685b4424032a223b6ffa23835b7c4de25b6) and [tests/test_mcp_socket_config_templates.py](https://github.com/EtanHey/brainlayer/pull/496/files#diff-ba3fa426039f97acadbbf2d2df796eaa3b52d1eeeeae3fa118b5204855d87c86) covering notarization flow, codesign flags, and socket config correctness.
> - Behavioral Change: notarization runs unconditionally after signing if any credential set is detected; `spctl` assessment failure after stapling is a hard error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 028c446.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the build process with improved Apple Developer ID signing and notarization (including hardened runtime, notarization submission with waiting, stapling, and post-notary verification).
  * Updated BrainLayer agent connectivity to use a socket-based `socat` bridge to `/tmp/brainbar.sock` instead of legacy MCP server commands.
* **Documentation**
  * Refreshed MCP setup guides and quickstart instructions for Claude, Cursor, Zed, VS Code, and Gemini to use the socket bridge configuration.
* **Chores**
  * Removed legacy `brainlayer-mcp` / `brainlayer-legacy` command references from configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->