### PR TITLE
chore: release brainlayer 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.0.0"
+version = "1.1.0"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents — local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -1,0 +1,22 @@
+"""Release metadata version consistency checks."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+from brainlayer import __version__
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_versions_stay_in_sync() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    package_version = pyproject["project"]["version"]
+
+    server_manifest = json.loads((REPO_ROOT / "server.json").read_text(encoding="utf-8"))
+
+    assert __version__ == package_version
+    assert server_manifest["version"] == package_version
+    assert server_manifest["packages"][0]["version"] == package_version


### PR DESCRIPTION
## Summary
- Bump `brainlayer` package version from `1.0.0` to `1.1.0` so the trusted-publishing tag release publishes a fresh artifact containing recent main merges, including #494/#495.

## Verification
- `pytest -q` on Python 3.13 before edit: 3018 passed, 49 skipped, 5 xfailed, 328 warnings in 353.65s.
- `python3 -m build`: successfully built `brainlayer-1.1.0.tar.gz` and `brainlayer-1.1.0-py3-none-any.whl`.
- `pytest -q` on Python 3.13 after edit: 3018 passed, 49 skipped, 5 xfailed, 328 warnings in 327.87s.
- Push hook on Python 3.12.12: BrainLayer test gate passed, including 2917 passed / 9 skipped / 61 deselected / 1 xfailed, MCP registration 3 passed, isolated eval/hook routing 40 passed, Bun stale-index test 1 passed, and regression shell `test_fts5_determinism.sh` passed.

## Notes
- Local `coderabbit review --agent` was attempted before commit and interrupted after the bounded review window; it produced setup/status messages only and no findings. PR-level bot review is requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump plus a consistency test; no runtime or security behavior changes.
> 
> **Overview**
> **Release 1.1.0** — bumps the package version from `1.0.0` to `1.1.0` in `pyproject.toml`, `src/brainlayer/__init__.py` (`__version__`), and `server.json` (top-level and PyPI package entry) so PyPI/trusted publishing and the MCP manifest match.
> 
> Adds **`tests/test_release_version_sync.py`**, which asserts `__version__`, `pyproject` project version, and both `server.json` version fields stay aligned on future releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab968d0cc9d3d4323a88155c2a3d6fdbab6df8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release brainlayer 1.1.0
> Bumps the version from `1.0.0` to `1.1.0` across [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/497/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/497/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/497/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954). Adds [test_release_version_sync.py](https://github.com/EtanHey/brainlayer/pull/497/files#diff-5e66af398368d3d4dc61606a6fe72a134d441da71761dfe725e9405cd8ee8d75) to enforce that all four version fields stay in sync going forward.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aab968d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->