### PR TITLE
fix(brainbar): suppress noisy injection events

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4871,7 +4871,9 @@ final class BrainDatabase: @unchecked Sendable {
 
     func listInjectionEvents(sessionID: String? = nil, limit: Int = 20) throws -> [InjectionEvent] {
         guard let db else { throw DBError.notOpen }
-        var sql = "SELECT id, session_id, timestamp, query, chunk_ids, token_count, mode FROM injection_events"
+        let hasModeColumn = try tableColumns(name: "injection_events", on: db).contains("mode")
+        let modeSelect = hasModeColumn ? "mode" : "'normal'"
+        var sql = "SELECT id, session_id, timestamp, query, chunk_ids, token_count, \(modeSelect) AS mode FROM injection_events"
         var conditions: [String] = []
         if sessionID != nil { conditions.append("session_id = ?") }
         conditions.append(Self.liveInjectionEventSQLPredicate(eventTable: "injection_events"))
@@ -5027,6 +5029,7 @@ final class BrainDatabase: @unchecked Sendable {
             query: event.query,
             chunkIDs: scopedChunkIDs,
             tokenCount: event.tokenCount,
+            mode: event.mode,
             chunks: liveChunks,
             claudeConversationID: event.claudeConversationID
         )

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -545,7 +545,8 @@ final class BrainDatabase: @unchecked Sendable {
                 timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 query TEXT NOT NULL,
                 chunk_ids TEXT NOT NULL DEFAULT '[]',
-                token_count INTEGER NOT NULL DEFAULT 0
+                token_count INTEGER NOT NULL DEFAULT 0,
+                mode TEXT NOT NULL DEFAULT 'normal'
             )
         """)
 
@@ -553,6 +554,7 @@ final class BrainDatabase: @unchecked Sendable {
             CREATE INDEX IF NOT EXISTS idx_injection_events_session_timestamp
             ON injection_events(session_id, timestamp DESC)
         """)
+        try ensureInjectionEventColumns()
 
         // Filtered VIEW excludes co_occurs_with noise from KG queries
         try execute("""
@@ -583,6 +585,7 @@ final class BrainDatabase: @unchecked Sendable {
         try ensureKGEntityColumns()
         try ensureKGRelationColumns()
         try ensureKGEntityAliasTable()
+        try ensureInjectionEventColumns()
         try rebuildFTSTableIfNeeded()
         try rebuildTrigramFTSTableIfNeeded()
     }
@@ -2384,6 +2387,15 @@ final class BrainDatabase: @unchecked Sendable {
             "source": columnText(stmt, 11) as Any,
             "score": score
         ]
+    }
+
+    private func ensureInjectionEventColumns() throws {
+        guard let db else { throw DBError.notOpen }
+        guard (try? tableExists("injection_events")) == true else { return }
+        let existingColumns = try tableColumns(name: "injection_events", on: db)
+        if !existingColumns.contains("mode") {
+            try execute("ALTER TABLE injection_events ADD COLUMN mode TEXT NOT NULL DEFAULT 'normal'")
+        }
     }
 
     private func ensureChunkColumns() throws {
@@ -4859,7 +4871,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     func listInjectionEvents(sessionID: String? = nil, limit: Int = 20) throws -> [InjectionEvent] {
         guard let db else { throw DBError.notOpen }
-        var sql = "SELECT id, session_id, timestamp, query, chunk_ids, token_count FROM injection_events"
+        var sql = "SELECT id, session_id, timestamp, query, chunk_ids, token_count, mode FROM injection_events"
         var conditions: [String] = []
         if sessionID != nil { conditions.append("session_id = ?") }
         conditions.append(Self.liveInjectionEventSQLPredicate(eventTable: "injection_events"))
@@ -4885,7 +4897,8 @@ final class BrainDatabase: @unchecked Sendable {
                 "timestamp": columnText(stmt, 2) as Any,
                 "query": columnText(stmt, 3) as Any,
                 "chunk_ids": columnText(stmt, 4) as Any,
-                "token_count": Int(sqlite3_column_int(stmt, 5))
+                "token_count": Int(sqlite3_column_int(stmt, 5)),
+                "mode": columnText(stmt, 6) as Any
             ]
             if let event = try? InjectionEvent(row: row) {
                 let details = (try? injectionChunkDetails(ids: event.chunkIDs)) ?? []
@@ -4901,6 +4914,7 @@ final class BrainDatabase: @unchecked Sendable {
                         query: scopedEvent.query,
                         chunkIDs: scopedEvent.chunkIDs,
                         tokenCount: scopedEvent.tokenCount,
+                        mode: scopedEvent.mode,
                         chunks: scopedEvent.chunks,
                         claudeConversationID: resumableID
                     )

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -292,6 +292,16 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         "\(query) • \(chunkCount) chunks • \(tokenCount) tok"
     }
 
+    var chunkRibbonStatusText: String? {
+        if !chunks.isEmpty {
+            return nil
+        }
+        if chunkIDs.isEmpty {
+            return "No memories surfaced."
+        }
+        return "Hit bars show retrieved chunk IDs; source metadata was unavailable."
+    }
+
     private static func normalizedForDedupe(_ text: String) -> String {
         text.trimmingCharacters(in: .whitespacesAndNewlines)
             .components(separatedBy: .whitespacesAndNewlines)

--- a/brain-bar/Sources/BrainBar/InjectionEvent.swift
+++ b/brain-bar/Sources/BrainBar/InjectionEvent.swift
@@ -225,6 +225,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
     let query: String
     let chunkIDs: [String]
     let tokenCount: Int
+    let mode: String
     let chunks: [InjectionChunk]
     let claudeConversationID: String
 
@@ -296,6 +297,9 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         if !chunks.isEmpty {
             return nil
         }
+        if mode == "degraded" {
+            return "BrainLayer degraded; source metadata unavailable."
+        }
         if chunkIDs.isEmpty {
             return "No memories surfaced."
         }
@@ -317,6 +321,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         query: String,
         chunkIDs: [String],
         tokenCount: Int,
+        mode: String = "normal",
         chunks: [InjectionChunk] = [],
         claudeConversationID: String = ""
     ) {
@@ -326,6 +331,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         self.query = query
         self.chunkIDs = chunkIDs
         self.tokenCount = tokenCount
+        self.mode = mode
         self.chunks = chunks
         self.claudeConversationID = claudeConversationID
     }
@@ -342,6 +348,7 @@ struct InjectionEvent: Equatable, Identifiable, Sendable {
         timestamp = row["timestamp"] as? String ?? ""
         query = row["query"] as? String ?? ""
         tokenCount = row["token_count"] as? Int ?? 0
+        mode = row["mode"] as? String ?? "normal"
         claudeConversationID = row["claude_conversation_id"] as? String ?? ""
 
         if let rawChunkIDs = row["chunk_ids"] as? [String] {

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -505,8 +505,8 @@ struct InjectionFeedView: View {
                             .font(.system(size: 10, weight: .medium))
                     }
                 }
-                if event.chunks.isEmpty {
-                    Text("Hit bars show retrieved chunk IDs; source metadata was unavailable.")
+                if let statusText = event.chunkRibbonStatusText {
+                    Text(statusText)
                         .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(.secondary)
                         .lineLimit(2)

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -1274,6 +1274,77 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(event.chunks.map(\.id), ["live-hook"])
     }
 
+    func testListInjectionEventsPreservesModeAfterFeedScoping() throws {
+        try db.insertChunk(
+            id: "live-hook-mode",
+            content: "Injected project context for degraded hook session.",
+            sessionId: "session-live",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        db.exec("""
+            UPDATE chunks
+            SET source = 'mcp',
+                source_file = 'precompact:live-hook-mode',
+                tags = '["hook-injection"]'
+            WHERE id = 'live-hook-mode'
+        """)
+
+        db.recordInjectionEvent(
+            sessionID: "claude-session-1",
+            query: "degraded mode survives scoping",
+            chunkIDs: ["live-hook-mode"],
+            tokenCount: 24,
+            timestamp: "2026-05-29T00:01:00.000Z"
+        )
+        db.exec("UPDATE injection_events SET mode = 'degraded' WHERE query = 'degraded mode survives scoping'")
+
+        let event = try XCTUnwrap(db.listInjectionEvents(sessionID: "claude-session-1", limit: 1).first)
+
+        XCTAssertEqual(event.mode, "degraded")
+        XCTAssertEqual(event.chunkRibbonStatusText, nil)
+    }
+
+    func testListInjectionEventsReadOnlyLegacyDBWithoutModeFallsBackToNormal() throws {
+        let legacyPath = NSTemporaryDirectory() + "brainbar-legacy-injection-events-\(UUID().uuidString).db"
+        try sqliteExecWrite(
+            path: legacyPath,
+            sql: """
+                CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL DEFAULT '',
+                    source_file TEXT NOT NULL DEFAULT '',
+                    content_type TEXT NOT NULL DEFAULT '',
+                    tags TEXT NOT NULL DEFAULT '[]'
+                );
+                CREATE TABLE injection_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+                    query TEXT NOT NULL,
+                    chunk_ids TEXT NOT NULL,
+                    token_count INTEGER NOT NULL DEFAULT 0
+                );
+                INSERT INTO injection_events (session_id, timestamp, query, chunk_ids, token_count)
+                VALUES ('legacy-session', '2026-05-29T00:01:00.000Z', 'legacy no mode', '[]', 0);
+            """
+        )
+        defer {
+            try? FileManager.default.removeItem(atPath: legacyPath)
+            try? FileManager.default.removeItem(atPath: legacyPath + "-wal")
+            try? FileManager.default.removeItem(atPath: legacyPath + "-shm")
+        }
+
+        let legacyDB = BrainDatabase(path: legacyPath, openConfiguration: .init(readOnly: true))
+        defer { legacyDB.close() }
+
+        let event = try XCTUnwrap(legacyDB.listInjectionEvents(sessionID: "legacy-session", limit: 1).first)
+
+        XCTAssertEqual(event.query, "legacy no mode")
+        XCTAssertEqual(event.mode, "normal")
+    }
+
     func testListInjectionEventsFiltersBySessionAndNewestFirst() throws {
         try db.recordInjectionEvent(
             sessionID: "session-a",

--- a/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
@@ -274,6 +274,38 @@ final class InjectionEventTests: XCTestCase {
         XCTAssertEqual(event.chunkRibbonStatusText, "No memories surfaced.")
     }
 
+    func testDegradedEventReportsInfrastructureStatus() {
+        let event = InjectionEvent(
+            id: 9,
+            sessionID: "s9",
+            timestamp: "2026-03-31T04:50:00.000Z",
+            query: "database unavailable",
+            chunkIDs: [],
+            tokenCount: 0,
+            mode: "degraded",
+            chunks: []
+        )
+
+        XCTAssertEqual(event.chunkRibbonStatusText, "BrainLayer degraded; source metadata unavailable.")
+    }
+
+    func testRowDecodesInjectionMode() throws {
+        let event = try InjectionEvent(
+            row: [
+                "id": 10,
+                "session_id": "sess-10",
+                "timestamp": "2026-03-31T04:50:00.000Z",
+                "query": "degraded event",
+                "chunk_ids": "[]",
+                "token_count": 0,
+                "mode": "degraded"
+            ]
+        )
+
+        XCTAssertEqual(event.mode, "degraded")
+        XCTAssertEqual(event.chunkRibbonStatusText, "BrainLayer degraded; source metadata unavailable.")
+    }
+
     func testMissingChunkRowsReportMetadataUnavailable() {
         let event = InjectionEvent(
             id: 8,

--- a/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionEventTests.swift
@@ -259,4 +259,32 @@ final class InjectionEventTests: XCTestCase {
         XCTAssertEqual(event.primaryKind, .other)
         XCTAssertEqual(event.displayTitle, "lead chunk metadata missing")
     }
+
+    func testEmptyChunkIDsReportNoMemoriesSurfaced() {
+        let event = InjectionEvent(
+            id: 7,
+            sessionID: "s7",
+            timestamp: "2026-03-31T04:50:00.000Z",
+            query: "zero result prompt",
+            chunkIDs: [],
+            tokenCount: 0,
+            chunks: []
+        )
+
+        XCTAssertEqual(event.chunkRibbonStatusText, "No memories surfaced.")
+    }
+
+    func testMissingChunkRowsReportMetadataUnavailable() {
+        let event = InjectionEvent(
+            id: 8,
+            sessionID: "s8",
+            timestamp: "2026-03-31T04:50:00.000Z",
+            query: "missing chunk metadata",
+            chunkIDs: ["missing"],
+            tokenCount: 12,
+            chunks: []
+        )
+
+        XCTAssertEqual(event.chunkRibbonStatusText, "Hit bars show retrieved chunk IDs; source metadata was unavailable.")
+    }
 }

--- a/hooks/brainlayer-prompt-search.py
+++ b/hooks/brainlayer-prompt-search.py
@@ -43,6 +43,7 @@ def degraded_notice(reason):
 def emit_degraded(reason):
     print(degraded_notice(reason))
 
+
 # Prompts shorter than this are probably greetings/commands — skip search
 MIN_PROMPT_LENGTH = 15
 HEBREW_CANDIDATE_RE = re.compile(r"[\u0590-\u05FF]{2,}")
@@ -63,7 +64,7 @@ OPERATIONAL_NOISE_MARKERS = (
     '"tool_use_id"',
     "'tool_use_id'",
 )
-MONITOR_TICK_RE = re.compile(r"\b(fleet|monitor|cron|loop)\s+tick\b", re.IGNORECASE)
+MONITOR_TICK_RE = re.compile(r"^\s*(fleet|monitor|cron|loop)\s+tick\b.*$", re.IGNORECASE | re.DOTALL)
 OUTPUT_FILE_ONLY_RE = re.compile(
     r"^\s*(?:output[-_ ]?file|output_path|artifact_path)\s*[:=]\s*\S+\s*$",
     re.IGNORECASE,
@@ -79,10 +80,11 @@ def is_operational_noise_prompt(prompt: str) -> bool:
     if not normalized:
         return False
 
-    if any(marker in normalized for marker in OPERATIONAL_NOISE_MARKERS):
+    starts_like_envelope = normalized.startswith(("<task-notification", "<tool-result", "<tool-use-id"))
+    if starts_like_envelope and any(marker in normalized for marker in OPERATIONAL_NOISE_MARKERS):
         return True
 
-    if MONITOR_TICK_RE.search(prompt):
+    if MONITOR_TICK_RE.fullmatch(normalized):
         return True
 
     if OUTPUT_FILE_ONLY_RE.match(prompt):

--- a/hooks/brainlayer-prompt-search.py
+++ b/hooks/brainlayer-prompt-search.py
@@ -53,6 +53,42 @@ LOW_CONFIDENCE_FALLBACK_THRESHOLD = 0.30
 LOW_CONFIDENCE_FALLBACK_MESSAGE = "No high-confidence memories found. Use brain_search() for deeper retrieval."
 _KG_ENTITY_CHUNKS_RELATION_TYPE_CACHE = {}
 AMBIGUOUS_SINGLE_TOKEN_ENTITY_TYPES = {"technology", "tool"}
+OPERATIONAL_NOISE_MARKERS = (
+    "<task-notification",
+    "<tool-use-id",
+    "<tool-result",
+    "</tool-result",
+    "toolu_",
+    "tool_result",
+    '"tool_use_id"',
+    "'tool_use_id'",
+)
+MONITOR_TICK_RE = re.compile(r"\b(fleet|monitor|cron|loop)\s+tick\b", re.IGNORECASE)
+OUTPUT_FILE_ONLY_RE = re.compile(
+    r"^\s*(?:output[-_ ]?file|output_path|artifact_path)\s*[:=]\s*\S+\s*$",
+    re.IGNORECASE,
+)
+
+
+def is_operational_noise_prompt(prompt: str) -> bool:
+    """Return True for hook payloads that are operational envelopes, not user prompts."""
+    if not prompt:
+        return False
+
+    normalized = prompt.strip().lower()
+    if not normalized:
+        return False
+
+    if any(marker in normalized for marker in OPERATIONAL_NOISE_MARKERS):
+        return True
+
+    if MONITOR_TICK_RE.search(prompt):
+        return True
+
+    if OUTPUT_FILE_ONLY_RE.match(prompt):
+        return True
+
+    return False
 
 
 def get_session_context(conn, session_id: str, limit: int = 3) -> list[str]:
@@ -1070,7 +1106,8 @@ def main():
 
     def finalize_and_exit(*, mode=None):
         final_mode = mode or telemetry_mode
-        if session_id and prompt and db_path:
+        should_record = bool(new_chunk_ids) or final_mode == "degraded"
+        if should_record and session_id and prompt and db_path:
             token_estimate = sum(len(b) // 4 for b in new_briefs)
             record_injection_event(
                 db_path=db_path,
@@ -1099,6 +1136,9 @@ def main():
 
     if not prompt:
         finalize_and_exit(mode="skip")
+
+    if is_operational_noise_prompt(prompt):
+        sys.exit(0)
 
     classification = classify_prompt(prompt)
     record_prompt_classification(session_id=session_id, prompt=prompt, classification=classification)

--- a/tests/test_conditional_hooks.py
+++ b/tests/test_conditional_hooks.py
@@ -261,6 +261,27 @@ class TestPromptSearchConditional:
         assert activate is True
         assert light is True
 
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "<task-notification>\n<summary>Worker completed</summary>\n</task-notification>",
+            "<task-notification><tool-use-id>toolu_123</tool-use-id></task-notification>",
+            "<tool-result tool_use_id=\"toolu_123\">ok</tool-result>",
+            "FLEET TICK gen16: monitor heartbeat only",
+            "output_file=/tmp/worker.out",
+        ],
+    )
+    def test_operational_noise_prompts_are_detected(self, prompt_search, prompt):
+        assert prompt_search.is_operational_noise_prompt(prompt) is True
+
+    def test_real_user_prompt_is_not_operational_noise(self, prompt_search):
+        assert (
+            prompt_search.is_operational_noise_prompt(
+                "What did we decide about restoring the BrainLayer watcher?"
+            )
+            is False
+        )
+
     def test_extract_keywords_keeps_short_meaningful_terms(self, prompt_search):
         keywords = prompt_search.extract_keywords("T3 Code AI PR review")
 
@@ -509,7 +530,7 @@ class TestPromptSearchConditional:
         row = sqlite3.connect(db_path).execute("SELECT mode FROM injection_events").fetchone()
         assert row == ("entity",)
 
-    def test_injection_event_skip_logged(self, prompt_search, tmp_path, monkeypatch, capsys):
+    def test_injection_event_skip_not_logged(self, prompt_search, tmp_path, monkeypatch, capsys):
         db_path = tmp_path / "hook-events.db"
         conn = sqlite3.connect(db_path)
         conn.execute(
@@ -539,10 +560,81 @@ class TestPromptSearchConditional:
         assert capsys.readouterr().out == ""
         row = (
             sqlite3.connect(db_path)
-            .execute("SELECT session_id, chunk_ids, token_count, mode FROM injection_events")
+            .execute("SELECT COUNT(*) FROM injection_events")
             .fetchone()
         )
-        assert row == ("sess-skip", "[]", 0, "skip")
+        assert row == (0,)
+
+    def test_operational_noise_prompt_exits_before_classification_and_event(
+        self, prompt_search, monkeypatch, capsys
+    ):
+        calls = []
+
+        def classify_spy(*args, **kwargs):
+            calls.append((args, kwargs))
+            return "knowledge_question"
+
+        monkeypatch.setattr(prompt_search, "get_db_path", lambda: "/tmp/brainlayer.db")
+        monkeypatch.setattr(prompt_search, "classify_prompt", classify_spy)
+        monkeypatch.setattr(
+            prompt_search,
+            "record_injection_event",
+            lambda *args, **kwargs: calls.append(("event", args, kwargs)),
+        )
+        monkeypatch.setattr(
+            prompt_search.sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "prompt": "<task-notification><tool-use-id>toolu_abc</tool-use-id></task-notification>",
+                        "session_id": "sess-noise",
+                    }
+                )
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            prompt_search.main()
+
+        assert exc_info.value.code == 0
+        assert capsys.readouterr().out == ""
+        assert calls == []
+
+    def test_zero_result_real_prompt_stays_out_of_visible_injection_events(
+        self, prompt_search, monkeypatch, capsys
+    ):
+        fake_conn = FakeConn()
+        events = []
+
+        monkeypatch.setattr(prompt_search, "get_db_path", lambda: "/tmp/brainlayer.db")
+        monkeypatch.setattr(
+            prompt_search, "classify_prompt", lambda prompt, detected_entities=None: "knowledge_question"
+        )
+        monkeypatch.setattr(prompt_search, "record_prompt_classification", lambda **kwargs: None)
+        monkeypatch.setattr(prompt_search, "record_injection_event", lambda *args, **kwargs: events.append(kwargs))
+        monkeypatch.setattr(prompt_search, "detect_entities_in_prompt", lambda *args, **kwargs: [])
+        monkeypatch.setattr(prompt_search, "detect_correction", lambda prompt: None)
+        monkeypatch.setattr(prompt_search.sqlite3, "connect", lambda *args, **kwargs: fake_conn)
+        monkeypatch.setattr(
+            prompt_search.sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "prompt": "What did we decide about a term that has no indexed memories?",
+                        "session_id": "sess-zero",
+                    }
+                )
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            prompt_search.main()
+
+        assert exc_info.value.code == 0
+        assert "No high-confidence memories found" in capsys.readouterr().out
+        assert events == []
 
     def test_main_prints_search_before_assume_warning(self, prompt_search, monkeypatch, capsys):
         fake_conn = FakeConn()

--- a/tests/test_conditional_hooks.py
+++ b/tests/test_conditional_hooks.py
@@ -266,7 +266,7 @@ class TestPromptSearchConditional:
         [
             "<task-notification>\n<summary>Worker completed</summary>\n</task-notification>",
             "<task-notification><tool-use-id>toolu_123</tool-use-id></task-notification>",
-            "<tool-result tool_use_id=\"toolu_123\">ok</tool-result>",
+            '<tool-result tool_use_id="toolu_123">ok</tool-result>',
             "FLEET TICK gen16: monitor heartbeat only",
             "output_file=/tmp/worker.out",
         ],
@@ -276,11 +276,20 @@ class TestPromptSearchConditional:
 
     def test_real_user_prompt_is_not_operational_noise(self, prompt_search):
         assert (
+            prompt_search.is_operational_noise_prompt("What did we decide about restoring the BrainLayer watcher?")
+            is False
+        )
+
+    def test_real_user_prompt_with_pasted_tool_result_is_not_operational_noise(self, prompt_search):
+        assert (
             prompt_search.is_operational_noise_prompt(
-                "What did we decide about restoring the BrainLayer watcher?"
+                'What did we decide about <tool-result tool_use_id="toolu_123"> output in prompts?'
             )
             is False
         )
+
+    def test_real_user_prompt_with_monitor_tick_phrase_is_not_operational_noise(self, prompt_search):
+        assert prompt_search.is_operational_noise_prompt("Why did the fleet tick monitor fail?") is False
 
     def test_extract_keywords_keeps_short_meaningful_terms(self, prompt_search):
         keywords = prompt_search.extract_keywords("T3 Code AI PR review")
@@ -558,16 +567,10 @@ class TestPromptSearchConditional:
             prompt_search.main()
 
         assert capsys.readouterr().out == ""
-        row = (
-            sqlite3.connect(db_path)
-            .execute("SELECT COUNT(*) FROM injection_events")
-            .fetchone()
-        )
+        row = sqlite3.connect(db_path).execute("SELECT COUNT(*) FROM injection_events").fetchone()
         assert row == (0,)
 
-    def test_operational_noise_prompt_exits_before_classification_and_event(
-        self, prompt_search, monkeypatch, capsys
-    ):
+    def test_operational_noise_prompt_exits_before_classification_and_event(self, prompt_search, monkeypatch, capsys):
         calls = []
 
         def classify_spy(*args, **kwargs):
@@ -601,9 +604,7 @@ class TestPromptSearchConditional:
         assert capsys.readouterr().out == ""
         assert calls == []
 
-    def test_zero_result_real_prompt_stays_out_of_visible_injection_events(
-        self, prompt_search, monkeypatch, capsys
-    ):
+    def test_zero_result_real_prompt_stays_out_of_visible_injection_events(self, prompt_search, monkeypatch, capsys):
         fake_conn = FakeConn()
         events = []
 


### PR DESCRIPTION
## Summary
- add an early operational-noise prompt gate for task/tool payloads, monitor ticks, tool IDs, and output-file-only payloads
- stop writing visible injection_events for meaningful real prompts that return zero chunks; only meaningful retrievals with chunk IDs (and degraded telemetry) are recorded
- fix BrainBar injection feed copy so empty chunk_ids says "No memories surfaced" and metadata warnings are reserved for non-empty chunk_ids with missing chunk rows

## Evidence
Before, from `### gen16-brainlayer-health-diag`:
- latest injection_events included task-notification noise with `chunk_ids=[]`, token_count=0, mode=entity
- DB totals: 3,281 empty events; 1,172 empty task/tool-noise events
- recent 2h sample: 150 events, 135 empty, 59 task/tool noise
- positive control real prompt event 15111 injected 3 chunks / 56 tokens

After, PR-local verification:
- operational-noise hook regression exits before prompt classification and before `record_injection_event`
- zero-result real prompt regression leaves visible injection_events empty
- BrainBar copy regression distinguishes empty chunk_ids from missing chunk rows

## Verification
- `pytest tests/test_conditional_hooks.py tests/test_adaptive_injection.py -q && python3 -m py_compile hooks/brainlayer-prompt-search.py` -> 64 passed
- `swift test --package-path brain-bar --filter InjectionEventTests` -> 14 tests, 0 failures
- `pytest -q` -> 3032 passed, 49 skipped, 5 xfailed
- pre-push gate -> 2931 passed, 9 skipped, 61 deselected, 1 xfailed; MCP tool registration 3 passed; isolated eval/hook routing 40 passed; bun/regression shell passed

## Notes
- No running daemon was edited or restarted.
- Local `coderabbit review --agent` was attempted and timed out after 180s with no actionable output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hook exit paths and injection event persistence (observability/feed behavior); DB migration is additive with safe defaults, but fewer events are stored than before.
> 
> **Overview**
> Reduces clutter in the **injection feed** and `injection_events` table by tightening when the prompt-search hook writes rows and when BrainBar shows status copy.
> 
> The hook adds **`is_operational_noise_prompt()`** and exits early (no classification, no DB write) for task/tool envelopes, monitor/cron tick lines, and output-file-only payloads. **`finalize_and_exit`** now records events only when there are retrieved chunk IDs or **`mode == "degraded"`**—skips and zero-hit real prompts no longer create visible rows.
> 
> BrainBar gains a persisted **`mode`** column on `injection_events` (with migration and legacy read fallback to `'normal'`), threads **`mode`** through listing/scoping, and uses **`chunkRibbonStatusText`** in the feed: empty hits show *"No memories surfaced."*, degraded shows infrastructure copy, and missing chunk metadata is only shown when chunk IDs exist without rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280156b3cc24bcdd74e691ca1876da8cf0ca9087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress noisy injection events and add mode-aware status in BrainBar feed
> - Adds a `mode` field (default `'normal'`) to `injection_events` in [BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/498/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc), with an in-place migration for existing databases missing the column.
> - Extends `InjectionEvent` in [InjectionEvent.swift](https://github.com/EtanHey/brainlayer/pull/498/files#diff-daa55ed5cef065accc4cc9a964997dc043576bfafc6a245d302675c4bea1f962) with a `mode` property and a `chunkRibbonStatusText` computed property that surfaces contextual messages (e.g. degraded infrastructure, no memories surfaced, metadata unavailable).
> - Updates [InjectionFeedView.swift](https://github.com/EtanHey/brainlayer/pull/498/files#diff-6332189fd07a82bbf0d03eba69489afb10493291f2ed71f888c418002b6e54f2) to show mode-aware status text per event instead of a fixed message.
> - Modifies [brainlayer-prompt-search.py](https://github.com/EtanHey/brainlayer/pull/498/files#diff-337bf7c8c2cbf907be6bc00e08029e422d8a2b9d2947392655ff795e0df36e15) to skip recording injection events entirely for operational noise prompts (task envelopes, tool-result wrappers, monitor ticks), and to only record events when there are new chunk IDs or mode is `'degraded'`.
> - Behavioral Change: `brainlayer-prompt-search.py` no longer records `skip` events with no chunks; operational envelope prompts produce no `injection_events` row at all.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 280156b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added degraded mode tracking to distinguish normal vs. impaired operation states.
  * Implemented automatic filtering of operational noise to reduce unnecessary processing.
  * Enhanced status messaging for memory retrieval (clearer "no memories" and unavailability indicators).

* **Tests**
  * Expanded test coverage for mode detection and operational noise filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->