### PR TITLE
fix(watcher): restore multi-root queued ingestion

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -533,6 +533,7 @@ private struct BrainBarDashboardView: View {
         BrainBarQueueRail(
             summary: flowSummary.queue,
             coverageText: "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched",
+            watcherText: collector.stats.watcherHealth?.summaryText ?? "unknown",
             compact: layout.compactCards
         )
     }
@@ -722,6 +723,7 @@ private struct BrainBarFlowLaneCard: View {
 private struct BrainBarQueueRail: View {
     let summary: DashboardQueueSummary
     let coverageText: String
+    let watcherText: String
     let compact: Bool
 
     var body: some View {
@@ -768,11 +770,13 @@ private struct BrainBarQueueRail: View {
             HStack(spacing: 14) {
                 BrainBarLaneMetric(label: "Backlog", value: "\(summary.backlogCount)")
                 BrainBarLaneMetric(label: "Coverage", value: coverageText)
+                BrainBarLaneMetric(label: "Watcher", value: watcherText)
             }
 
             VStack(alignment: .leading, spacing: 8) {
                 BrainBarLaneMetric(label: "Backlog", value: "\(summary.backlogCount)")
                 BrainBarLaneMetric(label: "Coverage", value: coverageText)
+                BrainBarLaneMetric(label: "Watcher", value: watcherText)
             }
         }
     }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -67,6 +67,27 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     struct DashboardStats: Sendable, Equatable {
+        struct WatcherHealth: Sendable, Equatable {
+            let alerting: Bool
+            let filesTracked: Int
+            let maxOffsetLagBytes: Int
+            let activeEntriesPerMinute: Double
+            let realtimeInsertsPerMinute: Double
+
+            var summaryText: String {
+                if alerting {
+                    if maxOffsetLagBytes >= 1_048_576 {
+                        return "lag \(Int((Double(maxOffsetLagBytes) / 1_048_576.0).rounded())) MB"
+                    }
+                    return "coverage alert"
+                }
+                if filesTracked > 0 {
+                    return "\(filesTracked) files"
+                }
+                return "idle"
+            }
+        }
+
         let chunkCount: Int
         let enrichedChunkCount: Int
         let pendingEnrichmentCount: Int
@@ -86,6 +107,7 @@ final class BrainDatabase: @unchecked Sendable {
         let pendingStoreQueueDepth: Int
         let pendingStoreOldestQueuedAt: Date?
         let pendingStoreFlushRatePerMinute: Double
+        let watcherHealth: WatcherHealth?
 
         init(
             chunkCount: Int,
@@ -106,7 +128,8 @@ final class BrainDatabase: @unchecked Sendable {
             trigramIndexedChunkCount: Int = 0,
             pendingStoreQueueDepth: Int = 0,
             pendingStoreOldestQueuedAt: Date? = nil,
-            pendingStoreFlushRatePerMinute: Double = 0
+            pendingStoreFlushRatePerMinute: Double = 0,
+            watcherHealth: WatcherHealth? = nil
         ) {
             self.chunkCount = chunkCount
             self.enrichedChunkCount = enrichedChunkCount
@@ -127,6 +150,7 @@ final class BrainDatabase: @unchecked Sendable {
             self.pendingStoreQueueDepth = pendingStoreQueueDepth
             self.pendingStoreOldestQueuedAt = pendingStoreOldestQueuedAt
             self.pendingStoreFlushRatePerMinute = pendingStoreFlushRatePerMinute
+            self.watcherHealth = watcherHealth
         }
 
         var recentWriteCount: Int {
@@ -181,7 +205,8 @@ final class BrainDatabase: @unchecked Sendable {
                 trigramIndexedChunkCount: trigramIndexedChunkCount,
                 pendingStoreQueueDepth: pendingStoreQueueDepth,
                 pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
-                pendingStoreFlushRatePerMinute: rate
+                pendingStoreFlushRatePerMinute: rate,
+                watcherHealth: watcherHealth
             )
         }
     }
@@ -1545,6 +1570,7 @@ final class BrainDatabase: @unchecked Sendable {
 
     func dashboardStats(activityWindowMinutes: Int = 30, bucketCount: Int = 12) throws -> DashboardStats {
         let pendingStoreQueue = pendingStoreQueueSnapshot()
+        let watcherHealth = watcherHealthSnapshot()
         return try withReadTransaction {
             let liveWindowMinutes = 1
             let now = Date()
@@ -1562,7 +1588,8 @@ final class BrainDatabase: @unchecked Sendable {
                     recentEnrichmentFiveMinuteCount: 0,
                     activityWindowMinutes: activityWindowMinutes,
                     bucketCount: bucketCount,
-                    liveWindowMinutes: liveWindowMinutes
+                    liveWindowMinutes: liveWindowMinutes,
+                    watcherHealth: watcherHealth
                 )
             }
 
@@ -1604,9 +1631,29 @@ final class BrainDatabase: @unchecked Sendable {
                 lastEnrichedAt: lastEvents.lastEnrichedAt,
                 trigramIndexedChunkCount: (try? countRows(in: "chunks_fts_trigram")) ?? 0,
                 pendingStoreQueueDepth: pendingStoreQueue.depth,
-                pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt
+                pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt,
+                watcherHealth: watcherHealth
             )
         }
+    }
+
+    private func watcherHealthSnapshot() -> DashboardStats.WatcherHealth? {
+        let envPath = ProcessInfo.processInfo.environment["BRAINLAYER_WATCHER_HEALTH_PATH"]
+        let healthPath = envPath ?? URL(fileURLWithPath: path)
+            .deletingLastPathComponent()
+            .appendingPathComponent("watcher-health.json")
+            .path
+        guard let data = FileManager.default.contents(atPath: healthPath),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return DashboardStats.WatcherHealth(
+            alerting: payload["alerting"] as? Bool ?? false,
+            filesTracked: payload["files_tracked"] as? Int ?? 0,
+            maxOffsetLagBytes: payload["max_offset_lag_bytes"] as? Int ?? 0,
+            activeEntriesPerMinute: payload["active_jsonl_entries_per_minute"] as? Double ?? 0,
+            realtimeInsertsPerMinute: payload["db_realtime_inserts_per_minute"] as? Double ?? 0
+        )
     }
 
     func dataVersion() throws -> Int {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -85,6 +85,31 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
     }
 
+    func testDashboardStatsReadsWatcherHealthSnapshot() throws {
+        let healthURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("watcher-health-\(UUID().uuidString).json")
+        try """
+        {
+          "alerting": true,
+          "files_tracked": 7,
+          "max_offset_lag_bytes": 2097152,
+          "active_jsonl_entries_per_minute": 44.0,
+          "db_realtime_inserts_per_minute": 3.0
+        }
+        """.write(to: healthURL, atomically: true, encoding: .utf8)
+        let restoreHealthPath = setDashboardWatcherHealthPath(healthURL)
+        defer {
+            restoreHealthPath()
+            try? FileManager.default.removeItem(at: healthURL)
+        }
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.watcherHealth?.filesTracked, 7)
+        XCTAssertEqual(stats.watcherHealth?.alerting, true)
+        XCTAssertEqual(stats.watcherHealth?.summaryText, "lag 2 MB")
+    }
+
     func testDashboardStatsRecentEnrichmentCountSharesBucketSource() {
         let stats = DashboardStats(
             chunkCount: 12,
@@ -1536,6 +1561,18 @@ private func setDashboardPendingStoreQueuePath(_ path: URL) -> () -> Void {
             setenv("BRAINBAR_PENDING_STORES_PATH", previous, 1)
         } else {
             unsetenv("BRAINBAR_PENDING_STORES_PATH")
+        }
+    }
+}
+
+private func setDashboardWatcherHealthPath(_ path: URL) -> () -> Void {
+    let previous = ProcessInfo.processInfo.environment["BRAINLAYER_WATCHER_HEALTH_PATH"]
+    setenv("BRAINLAYER_WATCHER_HEALTH_PATH", path.path, 1)
+    return {
+        if let previous {
+            setenv("BRAINLAYER_WATCHER_HEALTH_PATH", previous, 1)
+        } else {
+            unsetenv("BRAINLAYER_WATCHER_HEALTH_PATH")
         }
     }
 }

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -1959,11 +1959,11 @@ def export_obsidian(
 
 @app.command()
 def watch(
-    source: Path = typer.Option(
-        Path.home() / ".claude" / "projects",
+    source: Optional[list[Path]] = typer.Option(
+        None,
         "--source",
         "-s",
-        help="Directory to watch for .jsonl files",
+        help="Directory to watch for .jsonl files. Repeat to override default multi-provider roots.",
     ),
     poll_interval: float = typer.Option(1.0, "--poll", help="Poll interval in seconds"),
     batch_size: int = typer.Option(10, "--batch-size", help="Flush after this many lines"),
@@ -1971,32 +1971,39 @@ def watch(
 ) -> None:
     """Watch for new JSONL conversations and index in real-time.
 
-    Tail-follows .jsonl files under ~/.claude/projects/, processes new lines
-    through the classification/chunking pipeline, and inserts into BrainLayer
-    with deferred embedding. Chunks are immediately searchable via FTS5.
+    Tail-follows Claude, Codex, Cursor, and Gemini JSONL roots by default,
+    processes new lines through the classification/chunking pipeline, and
+    enqueues chunks for the single-writer drain.
 
     This is a persistent process — run it as a LaunchAgent or in a terminal.
     """
+    import os
     import signal
 
     from ..parent_death import install_parent_death_watcher
     from ..paths import get_db_path
-    from ..watcher import JSONLWatcher
+    from ..watcher import JSONLWatcher, WatchRoot, default_watch_roots
     from ..watcher_bridge import create_flush_callback
 
     install_parent_death_watcher()
+    os.environ.setdefault("BRAINLAYER_ARBITRATED", "1")
 
     db_path = get_db_path()
     offsets_path = db_path.parent / "offsets.json"
+    health_path = Path(os.environ.get("BRAINLAYER_WATCHER_HEALTH_PATH", str(db_path.parent / "watcher-health.json")))
+    watch_roots = [WatchRoot("custom", item) for item in source] if source else default_watch_roots()
 
     rprint("[bold blue]זיכרון[/] Real-time JSONL watcher")
-    rprint(f"  Watching: [bold]{source}[/]")
+    for root in watch_roots:
+        rprint(f"  Watching {root.provider}: [bold]{root.resolved_path}[/]")
     rprint(f"  Database: [bold]{db_path}[/]")
     rprint(f"  Offsets:  [bold]{offsets_path}[/]")
+    rprint(f"  Health:   [bold]{health_path}[/]")
     rprint(f"  Poll: {poll_interval}s | Batch: {batch_size} | Flush: {flush_interval}ms")
+    rprint("  Writer:   queue arbitration (drain owns DB writes)")
     rprint()
 
-    on_flush = create_flush_callback(db_path)
+    on_flush = create_flush_callback(db_path, arbitrated=True)
 
     def on_rewind(filepath: str, session_id: str, old_offset: int, new_offset: int):
         """Handle checkpoint restore — soft-archive chunks from reverted timeline."""
@@ -2025,13 +2032,14 @@ def watch(
             rprint(f"  [red]Failed to archive reverted chunks: {e}[/]")
 
     watcher = JSONLWatcher(
-        watch_dir=source,
+        watch_roots=watch_roots,
         registry_path=offsets_path,
         on_flush=on_flush,
         on_rewind=on_rewind,
         poll_interval_s=poll_interval,
         batch_size=batch_size,
         flush_interval_ms=flush_interval,
+        health_path=health_path,
     )
 
     def handle_signal(signum, frame):

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -2036,6 +2036,7 @@ def watch(
         registry_path=offsets_path,
         on_flush=on_flush,
         on_rewind=on_rewind,
+        db_path=db_path,
         poll_interval_s=poll_interval,
         batch_size=batch_size,
         flush_interval_ms=flush_interval,

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -17,6 +17,7 @@ Swift DispatchSource kqueue in BrainBar for sub-1ms notification latency.
 import json
 import logging
 import os
+import sqlite3
 import tempfile
 import threading
 import time
@@ -60,7 +61,7 @@ def _content_to_text(content: Any) -> str:
     if isinstance(content, list):
         parts = []
         for item in content:
-            if isinstance(item, dict) and item.get("type") not in {None, "text", "output_text"}:
+            if isinstance(item, dict) and item.get("type") not in {None, "text", "input_text", "output_text"}:
                 continue
             text = _content_to_text(item)
             if text:
@@ -79,12 +80,23 @@ def normalize_provider_entry(entry: dict[str, Any], provider: str) -> dict[str, 
         normalized["_provider"] = provider
         return normalized
 
+    payload = entry.get("payload")
+    payload_entry = payload if isinstance(payload, dict) else None
+    if provider == "codex" and entry_type == "response_item":
+        if not payload_entry or payload_entry.get("type") != "message":
+            return None
+        candidate = {**payload_entry, "timestamp": entry.get("timestamp")}
+    elif payload_entry:
+        candidate = {**payload_entry, "timestamp": entry.get("timestamp") or payload_entry.get("timestamp")}
+    else:
+        candidate = entry
+
     role = (
-        entry.get("role")
-        or entry.get("sender")
-        or entry.get("speaker")
-        or (entry.get("author") or {}).get("role")
-        or (entry.get("message") or {}).get("role")
+        candidate.get("role")
+        or candidate.get("sender")
+        or candidate.get("speaker")
+        or (candidate.get("author") or {}).get("role")
+        or (candidate.get("message") or {}).get("role")
     )
     role = str(role or "").lower()
     if role in {"model", "gemini", "ai", "bot"}:
@@ -92,14 +104,16 @@ def normalize_provider_entry(entry: dict[str, Any], provider: str) -> dict[str, 
     if role not in {"user", "assistant"}:
         return None
 
-    text = _content_to_text(entry.get("content") or entry.get("text") or entry.get("message"))
+    text = _content_to_text(candidate.get("content") or candidate.get("text") or candidate.get("message"))
     if not text:
         return None
 
     return {
         "type": role,
         "message": {"role": role, "content": [{"type": "text", "text": text}]},
-        "timestamp": entry.get("timestamp") or entry.get("created_at") or datetime.now(timezone.utc).isoformat(),
+        "timestamp": candidate.get("timestamp")
+        or candidate.get("created_at")
+        or datetime.now(timezone.utc).isoformat(),
         "_provider": provider,
     }
 
@@ -149,6 +163,7 @@ class CoverageWatchdog:
             self._lag_bad_since = None
 
         return {"alerting": bool(reasons), "alert_reasons": reasons}
+
 
 # ── Offset Registry ──────────────────────────────────────────────────────────
 
@@ -315,7 +330,7 @@ class BatchIndexer:
 
     def __init__(
         self,
-        on_flush: Callable[[list[dict]], None],
+        on_flush: Callable[[list[dict]], int | None],
         batch_size: int = 10,
         flush_interval_ms: int = 100,
     ):
@@ -326,6 +341,7 @@ class BatchIndexer:
         self._lock = threading.Lock()
         self._last_flush = time.monotonic()
         self.total_flushed = 0
+        self.total_outputs = 0
 
     def add(self, items: list[dict]):
         """Add parsed lines to the buffer."""
@@ -357,9 +373,10 @@ class BatchIndexer:
         self._last_flush = time.monotonic()
         count = len(batch)
         try:
-            self.on_flush(batch)
+            result = self.on_flush(batch)
             self._buffer = []  # Clear only after successful flush
             self.total_flushed += count
+            self.total_outputs += result if isinstance(result, int) else count
         except Exception as e:
             logger.error("Batch flush failed (%d items), retaining in buffer: %s", count, e)
 
@@ -390,6 +407,7 @@ class JSONLWatcher:
         on_flush: Callable[[list[dict]], None] | None = None,
         on_rewind: Callable[[str, str, int, int], None] | None = None,
         watch_roots: list[WatchRoot] | None = None,
+        db_path: str | Path | None = None,
         poll_interval_s: float = 1.0,
         batch_size: int = 10,
         flush_interval_ms: int = 100,
@@ -405,7 +423,9 @@ class JSONLWatcher:
             self.watch_roots = default_watch_roots()
         self.watch_dir = self.watch_roots[0].resolved_path if self.watch_roots else Path(".")
         self.on_rewind = on_rewind
-        registry = Path(registry_path).expanduser() if registry_path else Path.home() / ".local/share/brainlayer/offsets.json"
+        registry = (
+            Path(registry_path).expanduser() if registry_path else Path.home() / ".local/share/brainlayer/offsets.json"
+        )
         self.registry = OffsetRegistry(registry)
         self.indexer = BatchIndexer(
             on_flush=on_flush or (lambda _items: None),
@@ -419,10 +439,12 @@ class JSONLWatcher:
         self._stop = threading.Event()
         self._last_registry_flush = time.monotonic()
         self.health_path = Path(health_path).expanduser() if health_path else None
+        self.db_path = Path(db_path).expanduser() if db_path else None
         self.coverage_watchdog = coverage_watchdog or CoverageWatchdog()
         self._health_window_started = time.monotonic()
+        self._health_window_started_epoch = time.time()
         self._health_entries_seen = 0
-        self._health_flushed_at_start = 0
+        self._health_output_at_start = 0
 
     def provider_for_file(self, filepath: str) -> str:
         return self._file_providers.get(filepath, "unknown")
@@ -475,6 +497,26 @@ class JSONLWatcher:
             max_lag = max(max_lag, max(size - offset, 0))
         return max_lag
 
+    def _db_realtime_inserts_since_window_start(self) -> int | None:
+        if not self.db_path:
+            return None
+        try:
+            conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True, timeout=1)
+            try:
+                row = conn.execute(
+                    """
+                    SELECT COUNT(*) FROM chunks
+                    WHERE source = 'realtime_watcher'
+                      AND COALESCE(ingested_at, strftime('%s', created_at)) >= ?
+                    """,
+                    (int(self._health_window_started_epoch),),
+                ).fetchone()
+                return int(row[0]) if row else 0
+            finally:
+                conn.close()
+        except sqlite3.Error:
+            return None
+
     def _write_health_snapshot(self, files: list[str]):
         if not self.health_path:
             return
@@ -482,7 +524,9 @@ class JSONLWatcher:
         now = time.monotonic()
         elapsed = max(now - self._health_window_started, 1.0)
         entries_per_min = self._health_entries_seen / elapsed * 60.0
-        inserts_per_min = (self.indexer.total_flushed - self._health_flushed_at_start) / elapsed * 60.0
+        outputs_per_min = (self.indexer.total_outputs - self._health_output_at_start) / elapsed * 60.0
+        db_inserts = self._db_realtime_inserts_since_window_start()
+        inserts_per_min = (db_inserts / elapsed * 60.0) if db_inserts is not None else outputs_per_min
         max_lag = self._max_offset_lag_bytes(files)
         watchdog = self.coverage_watchdog.evaluate(
             active_entries_per_minute=entries_per_min,
@@ -495,6 +539,7 @@ class JSONLWatcher:
             "files_tracked": len(files),
             "active_jsonl_entries_per_minute": entries_per_min,
             "db_realtime_inserts_per_minute": inserts_per_min,
+            "watcher_chunks_output_per_minute": outputs_per_min,
             "max_offset_lag_bytes": max_lag,
             **watchdog,
         }
@@ -508,8 +553,9 @@ class JSONLWatcher:
 
         if elapsed >= 60.0:
             self._health_window_started = now
+            self._health_window_started_epoch = time.time()
             self._health_entries_seen = 0
-            self._health_flushed_at_start = self.indexer.total_flushed
+            self._health_output_at_start = self.indexer.total_outputs
 
     def _ensure_tailer(self, filepath: str) -> JSONLTailer:
         """Get or create a tailer for a file, respecting stored offsets."""

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -20,10 +20,135 @@ import os
 import tempfile
 import threading
 import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WatchRoot:
+    provider: str
+    path: Path | str
+
+    @property
+    def resolved_path(self) -> Path:
+        return Path(self.path).expanduser()
+
+
+def default_watch_roots(home: Path | None = None) -> list[WatchRoot]:
+    root = home or Path.home()
+    return [
+        WatchRoot("claude", root / ".claude" / "projects"),
+        WatchRoot("codex", root / ".codex" / "sessions"),
+        WatchRoot("cursor", root / ".cursor" / "sessions"),
+        WatchRoot("gemini", root / ".gemini" / "sessions"),
+    ]
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        for key in ("text", "content", "message"):
+            text = _content_to_text(content.get(key))
+            if text:
+                return text
+        return ""
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") not in {None, "text", "output_text"}:
+                continue
+            text = _content_to_text(item)
+            if text:
+                parts.append(text)
+        return " ".join(parts)
+    return ""
+
+
+def normalize_provider_entry(entry: dict[str, Any], provider: str) -> dict[str, Any] | None:
+    if not isinstance(entry, dict):
+        return None
+
+    entry_type = entry.get("type")
+    if entry_type in {"user", "assistant"} and isinstance(entry.get("message"), dict):
+        normalized = dict(entry)
+        normalized["_provider"] = provider
+        return normalized
+
+    role = (
+        entry.get("role")
+        or entry.get("sender")
+        or entry.get("speaker")
+        or (entry.get("author") or {}).get("role")
+        or (entry.get("message") or {}).get("role")
+    )
+    role = str(role or "").lower()
+    if role in {"model", "gemini", "ai", "bot"}:
+        role = "assistant"
+    if role not in {"user", "assistant"}:
+        return None
+
+    text = _content_to_text(entry.get("content") or entry.get("text") or entry.get("message"))
+    if not text:
+        return None
+
+    return {
+        "type": role,
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+        "timestamp": entry.get("timestamp") or entry.get("created_at") or datetime.now(timezone.utc).isoformat(),
+        "_provider": provider,
+    }
+
+
+class CoverageWatchdog:
+    def __init__(
+        self,
+        *,
+        coverage_ratio_threshold: float = 0.25,
+        lag_threshold_bytes: int = 1_048_576,
+        alert_after_s: float = 300.0,
+        now_fn: Callable[[], float] = time.monotonic,
+    ):
+        self.coverage_ratio_threshold = coverage_ratio_threshold
+        self.lag_threshold_bytes = lag_threshold_bytes
+        self.alert_after_s = alert_after_s
+        self.now_fn = now_fn
+        self._coverage_bad_since: float | None = None
+        self._lag_bad_since: float | None = None
+
+    def evaluate(
+        self,
+        *,
+        active_entries_per_minute: float,
+        realtime_inserts_per_minute: float,
+        max_offset_lag_bytes: int,
+    ) -> dict[str, Any]:
+        now = self.now_fn()
+        reasons = []
+        coverage_bad = (
+            active_entries_per_minute > 0
+            and realtime_inserts_per_minute / active_entries_per_minute < self.coverage_ratio_threshold
+        )
+        if coverage_bad:
+            self._coverage_bad_since = now if self._coverage_bad_since is None else self._coverage_bad_since
+            if now - self._coverage_bad_since >= self.alert_after_s:
+                reasons.append("coverage_drop")
+        else:
+            self._coverage_bad_since = None
+
+        lag_bad = max_offset_lag_bytes > self.lag_threshold_bytes
+        if lag_bad:
+            self._lag_bad_since = now if self._lag_bad_since is None else self._lag_bad_since
+            if now - self._lag_bad_since >= self.alert_after_s:
+                reasons.append("offset_lag")
+        else:
+            self._lag_bad_since = None
+
+        return {"alerting": bool(reasons), "alert_reasons": reasons}
 
 # ── Offset Registry ──────────────────────────────────────────────────────────
 
@@ -260,46 +385,131 @@ class JSONLWatcher:
 
     def __init__(
         self,
-        watch_dir: str | Path,
-        registry_path: str | Path,
-        on_flush: Callable[[list[dict]], None],
+        watch_dir: str | Path | None = None,
+        registry_path: str | Path | None = None,
+        on_flush: Callable[[list[dict]], None] | None = None,
         on_rewind: Callable[[str, str, int, int], None] | None = None,
+        watch_roots: list[WatchRoot] | None = None,
         poll_interval_s: float = 1.0,
         batch_size: int = 10,
         flush_interval_ms: int = 100,
         registry_flush_interval_s: float = 5.0,
+        health_path: str | Path | None = None,
+        coverage_watchdog: CoverageWatchdog | None = None,
     ):
-        self.watch_dir = Path(watch_dir).expanduser()
+        if watch_roots is not None:
+            self.watch_roots = [WatchRoot(root.provider, root.path) for root in watch_roots]
+        elif watch_dir is not None:
+            self.watch_roots = [WatchRoot("claude", Path(watch_dir).expanduser())]
+        else:
+            self.watch_roots = default_watch_roots()
+        self.watch_dir = self.watch_roots[0].resolved_path if self.watch_roots else Path(".")
         self.on_rewind = on_rewind
-        self.registry = OffsetRegistry(Path(registry_path).expanduser())
+        registry = Path(registry_path).expanduser() if registry_path else Path.home() / ".local/share/brainlayer/offsets.json"
+        self.registry = OffsetRegistry(registry)
         self.indexer = BatchIndexer(
-            on_flush=on_flush,
+            on_flush=on_flush or (lambda _items: None),
             batch_size=batch_size,
             flush_interval_ms=flush_interval_ms,
         )
         self.poll_interval_s = poll_interval_s
         self.registry_flush_interval_s = registry_flush_interval_s
         self._tailers: dict[str, JSONLTailer] = {}
+        self._file_providers: dict[str, str] = {}
         self._stop = threading.Event()
         self._last_registry_flush = time.monotonic()
+        self.health_path = Path(health_path).expanduser() if health_path else None
+        self.coverage_watchdog = coverage_watchdog or CoverageWatchdog()
+        self._health_window_started = time.monotonic()
+        self._health_entries_seen = 0
+        self._health_flushed_at_start = 0
+
+    def provider_for_file(self, filepath: str) -> str:
+        return self._file_providers.get(filepath, "unknown")
 
     def _discover_jsonl_files(self) -> list[str]:
         """Find all .jsonl files under each watched project, including nested session artifacts."""
         files = []
-        try:
-            dirs = list(self.watch_dir.iterdir())
-        except OSError:
-            return files
-        for project_dir in dirs:
-            if not project_dir.is_dir():
+        self._file_providers = {}
+        for root in self.watch_roots:
+            root_path = root.resolved_path
+            if not root_path.exists():
                 continue
             try:
-                for f in project_dir.rglob("*.jsonl"):
-                    if f.is_file():
-                        files.append(str(f))
+                bases = [root_path]
+                if root.provider == "claude":
+                    bases = [path for path in root_path.iterdir() if path.is_dir()]
+                for base in bases:
+                    for f in base.rglob("*.jsonl"):
+                        if f.is_file():
+                            path = str(f)
+                            files.append(path)
+                            self._file_providers[path] = root.provider
             except OSError:
                 continue
         return files
+
+    def _normalize_lines(self, filepath: str, new_lines: list[dict]) -> list[dict]:
+        provider = self.provider_for_file(filepath)
+        normalized = []
+        for line in new_lines:
+            entry = normalize_provider_entry(line, provider)
+            if not entry and provider == "claude":
+                entry = dict(line)
+            if not entry:
+                continue
+            entry["_source_file"] = filepath
+            entry["_provider"] = provider
+            normalized.append(entry)
+        return normalized
+
+    def _max_offset_lag_bytes(self, files: list[str]) -> int:
+        max_lag = 0
+        for filepath in files:
+            try:
+                size = os.path.getsize(filepath)
+            except OSError:
+                continue
+            tailer = self._tailers.get(filepath)
+            offset = tailer.offset if tailer else self.registry.get(filepath)[0]
+            max_lag = max(max_lag, max(size - offset, 0))
+        return max_lag
+
+    def _write_health_snapshot(self, files: list[str]):
+        if not self.health_path:
+            return
+
+        now = time.monotonic()
+        elapsed = max(now - self._health_window_started, 1.0)
+        entries_per_min = self._health_entries_seen / elapsed * 60.0
+        inserts_per_min = (self.indexer.total_flushed - self._health_flushed_at_start) / elapsed * 60.0
+        max_lag = self._max_offset_lag_bytes(files)
+        watchdog = self.coverage_watchdog.evaluate(
+            active_entries_per_minute=entries_per_min,
+            realtime_inserts_per_minute=inserts_per_min,
+            max_offset_lag_bytes=max_lag,
+        )
+        payload = {
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "providers": sorted({root.provider for root in self.watch_roots}),
+            "files_tracked": len(files),
+            "active_jsonl_entries_per_minute": entries_per_min,
+            "db_realtime_inserts_per_minute": inserts_per_min,
+            "max_offset_lag_bytes": max_lag,
+            **watchdog,
+        }
+        try:
+            self.health_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self.health_path.with_suffix(".tmp")
+            tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+            tmp_path.replace(self.health_path)
+        except OSError:
+            logger.debug("Failed to write watcher health snapshot", exc_info=True)
+
+        if elapsed >= 60.0:
+            self._health_window_started = now
+            self._health_entries_seen = 0
+            self._health_flushed_at_start = self.indexer.total_flushed
 
     def _ensure_tailer(self, filepath: str) -> JSONLTailer:
         """Get or create a tailer for a file, respecting stored offsets."""
@@ -374,12 +584,11 @@ class JSONLWatcher:
                 tailer.rewound = False  # Reset flag
 
             if new_lines:
-                # Tag each line with source metadata
-                for line in new_lines:
-                    line.setdefault("_source_file", filepath)
-                self.indexer.add(new_lines)
+                normalized_lines = self._normalize_lines(filepath, new_lines)
+                self.indexer.add(normalized_lines)
                 self.registry.set(filepath, tailer.offset, tailer.get_inode())
-                total_new += len(new_lines)
+                self._health_entries_seen += len(normalized_lines)
+                total_new += len(normalized_lines)
 
         self.indexer.tick()
 
@@ -388,6 +597,8 @@ class JSONLWatcher:
         if now - self._last_registry_flush >= self.registry_flush_interval_s:
             self.registry.flush()
             self._last_registry_flush = now
+
+        self._write_health_snapshot(files)
 
         return total_new
 

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -216,13 +216,14 @@ def _extract_project_from_source(source_file: str) -> str | None:
 # ── Flush callback ───────────────────────────────────────────────────────────
 
 
-def create_flush_callback(db_path: Path | None = None) -> callable:
+def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | None = None) -> callable:
     """Create an on_flush callback that processes JSONL lines into BrainLayer.
 
     Returns a callable that takes a list[dict] of raw JSONL entries and
     inserts them as chunks into the database (deferred embedding).
     """
-    arbitrated = os.environ.get("BRAINLAYER_ARBITRATED") == "1"
+    if arbitrated is None:
+        arbitrated = os.environ.get("BRAINLAYER_ARBITRATED") == "1"
     store = None if arbitrated else VectorStore(db_path or get_db_path())
 
     def flush_to_db(entries: list[dict[str, Any]]) -> None:

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -226,7 +226,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         arbitrated = os.environ.get("BRAINLAYER_ARBITRATED") == "1"
     store = None if arbitrated else VectorStore(db_path or get_db_path())
 
-    def flush_to_db(entries: list[dict[str, Any]]) -> None:
+    def flush_to_db(entries: list[dict[str, Any]]) -> int:
         """Process raw JSONL entries through pipeline and insert into DB."""
         import time as _time
 
@@ -437,5 +437,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
             )
         except Exception:
             pass
+
+        return inserted
 
     return flush_to_db

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -7,10 +7,11 @@ Covers:
 - JSONLWatcher: file discovery, poll cycle, end-to-end integration
 """
 
+import json
 import threading
 import time
 
-from brainlayer.watcher import BatchIndexer, JSONLTailer, JSONLWatcher, OffsetRegistry
+from brainlayer.watcher import BatchIndexer, CoverageWatchdog, JSONLTailer, JSONLWatcher, OffsetRegistry, WatchRoot
 
 # ── OffsetRegistry Tests ─────────────────────────────────────────────────────
 
@@ -385,3 +386,97 @@ class TestJSONLWatcher:
         watcher.poll_once()
         projects = {f["project"] for f in flushed}
         assert projects == {"a", "b"}
+
+    def test_multi_root_discovers_claude_codex_cursor_and_gemini_files(self, tmp_path):
+        claude_project = tmp_path / "claude" / "projects" / "proj"
+        codex_sessions = tmp_path / "codex" / "sessions"
+        cursor_sessions = tmp_path / "cursor" / "sessions"
+        gemini_sessions = tmp_path / "gemini" / "sessions"
+        for root in (claude_project, codex_sessions, cursor_sessions, gemini_sessions):
+            root.mkdir(parents=True)
+            (root / f"{root.parent.name}.jsonl").write_text('{"id":"1"}\n')
+
+        watcher = JSONLWatcher(
+            watch_roots=[
+                WatchRoot("claude", tmp_path / "claude" / "projects"),
+                WatchRoot("codex", codex_sessions),
+                WatchRoot("cursor", cursor_sessions),
+                WatchRoot("gemini", gemini_sessions),
+            ],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda x: None,
+        )
+
+        files = watcher._discover_jsonl_files()
+
+        assert len(files) == 4
+        assert {watcher.provider_for_file(path) for path in files} == {"claude", "codex", "cursor", "gemini"}
+
+    def test_codex_root_normalizes_role_content_entries(self, tmp_path):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "session.jsonl").write_text(
+            json.dumps(
+                {
+                    "role": "user",
+                    "content": "Explain the watcher arbitration design with enough detail to index.",
+                    "timestamp": "2026-06-17T10:00:00Z",
+                }
+            )
+            + "\n"
+        )
+
+        flushed = []
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items),
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 1
+        assert flushed[0]["type"] == "user"
+        assert flushed[0]["message"]["content"][0]["text"].startswith("Explain the watcher")
+        assert flushed[0]["_provider"] == "codex"
+
+    def test_health_snapshot_alerts_on_coverage_drop_and_offset_lag(self, tmp_path):
+        now = [0.0]
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A substantive assistant response that should be observed by the watcher.",
+                }
+            )
+            + "\n"
+        )
+        health_path = tmp_path / "watcher-health.json"
+        watchdog = CoverageWatchdog(
+            lag_threshold_bytes=1,
+            alert_after_s=5,
+            now_fn=lambda: now[0],
+        )
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: None,
+            batch_size=100,
+            health_path=health_path,
+            coverage_watchdog=watchdog,
+        )
+
+        watcher.poll_once()
+        transcript.write_text(transcript.read_text() + (" " * 2048))
+        watcher.poll_once()
+        now[0] = 6.0
+        watcher.poll_once()
+
+        payload = json.loads(health_path.read_text())
+        assert payload["providers"] == ["codex"]
+        assert payload["max_offset_lag_bytes"] > 1
+        assert payload["alerting"] is True
+        assert "offset_lag" in payload["alert_reasons"]

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -8,6 +8,7 @@ Covers:
 """
 
 import json
+import sqlite3
 import threading
 import time
 
@@ -438,6 +439,78 @@ class TestJSONLWatcher:
         assert flushed[0]["type"] == "user"
         assert flushed[0]["message"]["content"][0]["text"].startswith("Explain the watcher")
         assert flushed[0]["_provider"] == "codex"
+
+    def test_codex_root_normalizes_real_response_item_payload_entries(self, tmp_path):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "session.jsonl").write_text(
+            json.dumps(
+                {
+                    "timestamp": "2026-06-17T10:00:00Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "Explain the watcher arbitration design with enough detail to index.",
+                            }
+                        ],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+        flushed = []
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items),
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 1
+        assert flushed[0]["type"] == "user"
+        assert flushed[0]["message"]["content"][0]["text"].startswith("Explain the watcher")
+        assert flushed[0]["_provider"] == "codex"
+
+    def test_health_snapshot_uses_db_realtime_insert_rate_when_db_path_is_available(self, tmp_path):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A substantive assistant response that should be observed by the watcher.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.commit()
+        conn.close()
+
+        health_path = tmp_path / "watcher-health.json"
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: len(items),
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+        )
+
+        watcher.poll_once()
+
+        payload = json.loads(health_path.read_text())
+        assert payload["active_jsonl_entries_per_minute"] > 0
+        assert payload["watcher_chunks_output_per_minute"] > 0
+        assert payload["db_realtime_inserts_per_minute"] == 0
 
     def test_health_snapshot_alerts_on_coverage_drop_and_offset_lag(self, tmp_path):
         now = [0.0]

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -155,11 +155,30 @@ class TestProjectExtraction:
 
 
 class TestFlushCallback:
+    def test_arbitrated_flush_enqueues_watcher_chunks_without_db_write(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "test.db"
+        queue_dir = tmp_path / "queue"
+        VectorStore(db_path).close()
+        monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+
+        flush = create_flush_callback(db_path, arbitrated=True)
+        entry = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant")
+        entry["_source_file"] = str(tmp_path / "projects" / "-Users-test-Gits-myproject" / "session.jsonl")
+
+        flush([entry])
+
+        queued_files = list(queue_dir.glob("watcher-*.jsonl"))
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT COUNT(*) FROM chunks WHERE source = 'realtime_watcher'").fetchone()
+        conn.close()
+        assert len(queued_files) == 1
+        assert rows == (0,)
+
     def test_inserts_valid_entry(self, tmp_path):
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         entry = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant")
         entry["_source_file"] = str(tmp_path / "projects" / "-Users-test-Gits-myproject" / "session.jsonl")
 
@@ -174,7 +193,7 @@ class TestFlushCallback:
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         conversation_id = "3679128a-f371-445f-82ba-b3946e2f20b6"
         entry = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant", sessionId="brainlayer-session-9")
         entry["_source_file"] = str(tmp_path / "projects" / "-Users-test-Gits-myproject" / f"{conversation_id}.jsonl")
@@ -194,7 +213,7 @@ class TestFlushCallback:
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         entry = _make_jsonl_entry(
             text=(
                 "Watcher ingested_at regression coverage should store a fresh unix timestamp "
@@ -221,7 +240,7 @@ class TestFlushCallback:
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         entry = _make_jsonl_entry(text="ok", entry_type="assistant")
         entry["_source_file"] = "/tmp/test.jsonl"
 
@@ -236,7 +255,7 @@ class TestFlushCallback:
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         flush([{"type": "progress", "_source_file": "/tmp/test.jsonl", "data": {}}])
 
         conn = sqlite3.connect(str(db_path))
@@ -248,7 +267,7 @@ class TestFlushCallback:
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         entry = _make_jsonl_entry(
             text="This exact same content should only appear once in the database even when flushed twice",
             entry_type="assistant",
@@ -270,7 +289,7 @@ class TestFlushCallback:
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         content = "This exact same content should merge even when it appears in a different session file"
         first = _make_jsonl_entry(text=content, entry_type="assistant", timestamp="2026-05-16T09:00:00Z")
         second = _make_jsonl_entry(text=content, entry_type="assistant", timestamp="2026-05-16T10:00:00Z")
@@ -297,7 +316,7 @@ class TestFlushCallback:
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         entry = _make_jsonl_entry(
             role="user",
             text="No, that's wrong. Avi works at Lightricks.",
@@ -341,7 +360,7 @@ class TestFullPipeline:
         )
         jsonl_file.write_text(json.dumps(entry) + "\n")
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         watcher = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",
@@ -370,7 +389,7 @@ class TestFullPipeline:
         )
         jsonl_file.write_text(json.dumps(entry) + "\n")
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         watcher = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",
@@ -404,7 +423,7 @@ class TestFullPipeline:
         )
         jsonl_file.write_text(json.dumps(entry) + "\n")
 
-        flush = create_flush_callback(db_path)
+        flush = create_flush_callback(db_path, arbitrated=False)
         watcher = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -165,12 +165,13 @@ class TestFlushCallback:
         entry = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant")
         entry["_source_file"] = str(tmp_path / "projects" / "-Users-test-Gits-myproject" / "session.jsonl")
 
-        flush([entry])
+        inserted = flush([entry])
 
         queued_files = list(queue_dir.glob("watcher-*.jsonl"))
         conn = sqlite3.connect(str(db_path))
         rows = conn.execute("SELECT COUNT(*) FROM chunks WHERE source = 'realtime_watcher'").fetchone()
         conn.close()
+        assert inserted == 1
         assert len(queued_files) == 1
         assert rows == (0,)
 


### PR DESCRIPTION
## Summary
- make `brainlayer watch` multi-root across Claude, Codex, Cursor, and Gemini session JSONL trees with provider parser adapters
- default the watcher to queue arbitration so watcher ingestion enqueues and the drain owns DB writes
- add watcher coverage health snapshots for active JSONL rate, realtime DB insert rate, offset lag, and alert reasons surfaced in BrainBar

## Evidence
Before, from `### gen16-brainlayer-health-diag`:
- `com.brainlayer.watch` was not loaded
- live rate probe at 2026-06-17T13:49:48Z found 2,047 JSONL entries/hour but only 66 DB chunks/hour, only 20 realtime chunks/hour
- Codex had 727 JSONL entries/hour and 0 realtime DB source files
- active Claude file offset lag was 5,701,430 bytes

After, PR-local verification:
- multi-root watcher regression discovers Claude, Codex, Cursor, and Gemini files
- Codex role/content JSONL regression normalizes and flushes 1/1 entries through the watcher path
- queue arbitration regression writes one watcher queue file and 0 direct realtime DB rows from the watcher
- coverage watchdog regression alerts on sustained >1MB offset lag / coverage drop and BrainBar reads the watcher health snapshot

## Verification
- `pytest tests/test_jsonl_watcher.py tests/test_watcher_bridge.py -q && python3 -m py_compile src/brainlayer/watcher.py src/brainlayer/watcher_bridge.py src/brainlayer/cli/__init__.py` -> 69 passed
- `swift test --package-path brain-bar --filter DashboardTests/testDashboardStatsReadsWatcherHealthSnapshot` -> 1 test, 0 failures
- `pytest -q` -> 3028 passed, 49 skipped, 5 xfailed
- pre-push gate completed and branch is pushed/tracking origin

## Notes
- No launchctl load/unload or live daemon edits were performed.
- Full production after-rate requires orc review/merge and supervised service deployment.
- Local `coderabbit review --agent` was attempted and timed out after 180s with no actionable output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Default watch behavior now enqueues instead of direct DB writes and expands ingestion across four provider roots—core realtime indexing path with operational visibility tied to a sidecar JSON file.
> 
> **Overview**
> Restores **multi-provider JSONL watching** and switches the default **`brainlayer watch`** path to **queued ingestion** so the drain owns DB writes, plus **watcher health** surfaced in BrainBar.
> 
> The watcher now accepts multiple **`WatchRoot`** trees (Claude, Codex, Cursor, Gemini by default) with **provider-specific normalization** before flush. **`create_flush_callback(..., arbitrated=True)`** is the CLI default (`BRAINLAYER_ARBITRATED=1`); flushes **enqueue** chunks and return insert counts instead of writing SQLite directly. Each poll writes **`watcher-health.json`** (rates, offset lag, **`CoverageWatchdog`** alerts). **`BrainDatabase.dashboardStats`** reads that file (override via **`BRAINLAYER_WATCHER_HEALTH_PATH`**) and the dashboard **Queue** rail shows a **Watcher** metric from **`summaryText`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88862d9c3ef099cac152f8892f2f04c51136ebcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore multi-root queued ingestion in the watcher with health snapshot reporting
> - Extends `JSONLWatcher` to discover and normalize JSONL files across multiple provider roots (Claude, Codex, Cursor, Gemini) and tag each entry with its provider.
> - Adds `_write_health_snapshot` to periodically write a JSON health file tracking coverage, offset lag, and DB insert rate; a `CoverageWatchdog` class detects sustained coverage drops.
> - The `watch` CLI command now defaults to all provider roots when `--source` is omitted, runs in arbitrated mode (`BRAINLAYER_ARBITRATED=1`), and passes `health_path` to the watcher.
> - `create_flush_callback` gains an `arbitrated` parameter; in arbitrated mode it enqueues chunks without writing to the DB and returns an inserted count.
> - The BrainBar queue rail UI gains a 'Watcher' metric column sourced from `DashboardStats.WatcherHealth`, which is populated by reading `watcher-health.json` alongside the database.
> - Behavioral Change: `watch` now monitors four provider roots by default instead of a single `--source` path, and DB writes are owned by the drain process in arbitrated mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88862d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->