### PR TITLE
fix(watcher): tolerate string provider metadata

### DIFF
--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -70,6 +70,10 @@ def _content_to_text(content: Any) -> str:
     return ""
 
 
+def _mapping_value(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 def normalize_provider_entry(entry: dict[str, Any], provider: str) -> dict[str, Any] | None:
     if not isinstance(entry, dict):
         return None
@@ -95,8 +99,8 @@ def normalize_provider_entry(entry: dict[str, Any], provider: str) -> dict[str, 
         candidate.get("role")
         or candidate.get("sender")
         or candidate.get("speaker")
-        or (candidate.get("author") or {}).get("role")
-        or (candidate.get("message") or {}).get("role")
+        or _mapping_value(candidate.get("author")).get("role")
+        or _mapping_value(candidate.get("message")).get("role")
     )
     role = str(role or "").lower()
     if role in {"model", "gemini", "ai", "bot"}:

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -476,6 +476,57 @@ class TestJSONLWatcher:
         assert flushed[0]["message"]["content"][0]["text"].startswith("Explain the watcher")
         assert flushed[0]["_provider"] == "codex"
 
+    def test_normalizer_ignores_string_author_without_poll_failure(self, tmp_path):
+        sessions = tmp_path / "cursor" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "session.jsonl").write_text(
+            json.dumps(
+                {
+                    "timestamp": "2026-06-17T10:00:00Z",
+                    "author": "user",
+                    "content": "This row lacks a structured role and should be skipped without crashing.",
+                }
+            )
+            + "\n"
+        )
+
+        flushed = []
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("cursor", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items),
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 0
+        assert flushed == []
+
+    def test_normalizer_uses_text_message_without_dict_role_lookup_failure(self, tmp_path):
+        sessions = tmp_path / "gemini" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "session.jsonl").write_text(
+            json.dumps(
+                {
+                    "timestamp": "2026-06-17T10:00:00Z",
+                    "role": "model",
+                    "message": "Gemini live adapter verification text should normalize cleanly.",
+                }
+            )
+            + "\n"
+        )
+
+        flushed = []
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("gemini", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items),
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 1
+        assert flushed[0]["type"] == "assistant"
+        assert flushed[0]["message"]["content"][0]["text"].startswith("Gemini live adapter")
+
     def test_health_snapshot_uses_db_realtime_insert_rate_when_db_path_is_available(self, tmp_path):
         sessions = tmp_path / "codex" / "sessions"
         sessions.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Prevent multi-root watcher normalization from crashing when real provider rows use string-valued author/message metadata.
- Add regressions for string author rows and string message rows.

## Verification
- ruff format src/brainlayer/watcher.py tests/test_jsonl_watcher.py
- ruff check src/brainlayer/watcher.py tests/test_jsonl_watcher.py
- pytest tests/test_jsonl_watcher.py -q
- full pre-push gate: 2941 passed, 9 skipped, 61 deselected, 1 xfailed; MCP/eval/bun/FTS shell gates passed

@codex review
@cursor @bugbot review
@coderabbitai review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9e8e74f2d5ab7412659c140a05fb05d05ef2fca4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `normalize_provider_entry` to tolerate non-dict `author` and `message` values
> Adds a `_mapping_value` helper in [watcher.py](https://github.com/EtanHey/brainlayer/pull/500/files#diff-b79db8c32ce15bfa265ba7d0c665c7439dbdf270c58f05156abec78694c7bde5) that returns the input if it is a dict, otherwise returns an empty dict. This replaces the `(value or {}).get(...)` pattern used to extract role fields, which failed when `author` or `message` were non-empty strings (truthy but not dicts). Two tests are added to cover string `author` and string `message` cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e8e74f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->