### PR TITLE
fix(watcher): prioritize active JSONL files

### DIFF
--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -455,7 +455,7 @@ class JSONLWatcher:
 
     def _discover_jsonl_files(self) -> list[str]:
         """Find all .jsonl files under each watched project, including nested session artifacts."""
-        files = []
+        discovered: list[tuple[float, str, str]] = []
         self._file_providers = {}
         for root in self.watch_roots:
             root_path = root.resolved_path
@@ -469,10 +469,16 @@ class JSONLWatcher:
                     for f in base.rglob("*.jsonl"):
                         if f.is_file():
                             path = str(f)
-                            files.append(path)
-                            self._file_providers[path] = root.provider
+                            try:
+                                mtime = f.stat().st_mtime
+                            except OSError:
+                                continue
+                            discovered.append((mtime, path, root.provider))
             except OSError:
                 continue
+        discovered.sort(key=lambda item: item[0], reverse=True)
+        files = [path for _mtime, path, provider in discovered]
+        self._file_providers = {path: provider for _mtime, path, provider in discovered}
         return files
 
     def _normalize_lines(self, filepath: str, new_lines: list[dict]) -> list[dict]:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -471,7 +471,8 @@ class JSONLWatcher:
                             path = str(f)
                             try:
                                 mtime = f.stat().st_mtime
-                            except OSError:
+                            except OSError as e:
+                                logger.debug("Skipping JSONL file during discovery after stat failure: %s: %s", path, e)
                                 continue
                             discovered.append((mtime, path, root.provider))
             except OSError:

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -8,6 +8,7 @@ Covers:
 """
 
 import json
+import os
 import sqlite3
 import threading
 import time
@@ -412,6 +413,33 @@ class TestJSONLWatcher:
 
         assert len(files) == 4
         assert {watcher.provider_for_file(path) for path in files} == {"claude", "codex", "cursor", "gemini"}
+
+    def test_multi_root_discovers_newest_jsonl_files_first(self, tmp_path):
+        codex_sessions = tmp_path / "codex" / "sessions"
+        cursor_sessions = tmp_path / "cursor" / "sessions"
+        codex_sessions.mkdir(parents=True)
+        cursor_sessions.mkdir(parents=True)
+        old_codex = codex_sessions / "old.jsonl"
+        fresh_cursor = cursor_sessions / "fresh.jsonl"
+        old_codex.write_text('{"id":"old"}\n')
+        fresh_cursor.write_text('{"id":"fresh"}\n')
+        os.utime(old_codex, (1000, 1000))
+        os.utime(fresh_cursor, (2000, 2000))
+
+        watcher = JSONLWatcher(
+            watch_roots=[
+                WatchRoot("codex", codex_sessions),
+                WatchRoot("cursor", cursor_sessions),
+            ],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda x: None,
+        )
+
+        files = watcher._discover_jsonl_files()
+
+        assert files == [str(fresh_cursor), str(old_codex)]
+        assert watcher.provider_for_file(str(fresh_cursor)) == "cursor"
+        assert watcher.provider_for_file(str(old_codex)) == "codex"
 
     def test_codex_root_normalizes_role_content_entries(self, tmp_path):
         sessions = tmp_path / "codex" / "sessions"


### PR DESCRIPTION
## Summary\n- Sort multi-root JSONL discovery by newest mtime first so active Codex/Cursor/Gemini files are not buried behind historical backlog.\n- Preserve provider attribution after sorting.\n- Add regression coverage for newest-file-first discovery across providers.\n\n## Verification\n- ruff check src/ tests/\n- ruff format --check src/ tests/\n- pytest tests/test_jsonl_watcher.py -q => 39 passed\n- pytest -q => 3043 passed, 49 skipped, 5 xfailed\n- pre-push gate => 2942 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun stale-index 1 passed; FTS determinism PASS\n\n## Reviews\n@codex review\n@cursor @bugbot review\n@coderabbitai review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change to discovery/poll iteration order in the realtime watcher; covered by a focused unit test with no auth or data-schema impact.
> 
> **Overview**
> **JSONL discovery now returns newest files first** so each `poll_once` cycle tails recently modified Codex/Cursor/Gemini (and other) session logs before older backlog, instead of an arbitrary walk order that could starve active sessions.
> 
> `_discover_jsonl_files` records `(mtime, path, provider)` per file, sorts by **mtime descending**, and rebuilds `_file_providers` from that sorted list. Files that fail `stat()` are skipped with a debug log rather than breaking discovery.
> 
> A regression test asserts cross-provider ordering (newer Cursor file before older Codex) and that provider attribution stays correct after sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636db361b3590fbf830feb94c729e108a7fd8fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prioritize active JSONL files by sorting `JSONLWatcher._discover_jsonl_files` by newest modification time first
> - [watcher.py](https://github.com/EtanHey/brainlayer/pull/501/files#diff-b79db8c32ce15bfa265ba7d0c665c7439dbdf270c58f05156abec78694c7bde5): `_discover_jsonl_files` now stats each file to get `st_mtime`, sorts results descending by modification time, and rebuilds `_file_providers` in the same order.
> - Files whose `stat` call raises `OSError` are skipped with a debug log instead of causing an error.
> - A new test in [test_jsonl_watcher.py](https://github.com/EtanHey/brainlayer/pull/501/files#diff-bbee3d4b88b3c25e7192b08307a2551963fb8d068f8f289536f7235abf5bedf5) verifies newest-first ordering and correct provider mapping across multiple roots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 636db36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSONL files discovered during watching are now consistently ordered by modification time, with the newest files returned first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->