### PR TITLE
fix(watcher): prevent hot JSONL starvation

### DIFF
--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -276,7 +276,7 @@ class JSONLTailer:
             return True
         return False
 
-    def read_new_lines(self) -> list[dict]:
+    def read_new_lines(self, max_lines: int | None = None) -> list[dict]:
         """Read any new complete lines since last call. Returns parsed JSON dicts."""
         # Check for rewind before reading
         self.check_rewind()
@@ -295,6 +295,8 @@ class JSONLTailer:
         lines = []
 
         while b"\n" in self._buffer:
+            if max_lines is not None and len(lines) >= max_lines:
+                break
             nl_idx = self._buffer.index(b"\n")
             line_data = self._buffer[:nl_idx]
             self._buffer = self._buffer[nl_idx + 1 :]
@@ -418,6 +420,7 @@ class JSONLWatcher:
         registry_flush_interval_s: float = 5.0,
         health_path: str | Path | None = None,
         coverage_watchdog: CoverageWatchdog | None = None,
+        max_lines_per_file: int = 100,
     ):
         if watch_roots is not None:
             self.watch_roots = [WatchRoot(root.provider, root.path) for root in watch_roots]
@@ -438,6 +441,7 @@ class JSONLWatcher:
         )
         self.poll_interval_s = poll_interval_s
         self.registry_flush_interval_s = registry_flush_interval_s
+        self.max_lines_per_file = max(1, max_lines_per_file)
         self._tailers: dict[str, JSONLTailer] = {}
         self._file_providers: dict[str, str] = {}
         self._stop = threading.Event()
@@ -599,7 +603,7 @@ class JSONLWatcher:
 
         for filepath in files:
             tailer = self._ensure_tailer(filepath)
-            new_lines = tailer.read_new_lines()
+            new_lines = tailer.read_new_lines(max_lines=self.max_lines_per_file)
 
             # Handle rewind detection (checkpoint restore)
             if tailer.rewound:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -288,10 +288,11 @@ class JSONLTailer:
         except OSError:
             return []
 
-        if not new_data:
+        if not new_data and b"\n" not in self._buffer:
             return []
 
-        self._buffer += new_data
+        if new_data:
+            self._buffer += new_data
         lines = []
 
         while b"\n" in self._buffer:

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -480,6 +480,10 @@ class TestJSONLWatcher:
         assert [item["_provider"] for item in flushed] == ["codex", "cursor"]
         assert watcher._tailers[str(hot_codex)].offset < hot_codex.stat().st_size
 
+        flushed.clear()
+        assert watcher.poll_once() == 1
+        assert [item["_provider"] for item in flushed] == ["codex"]
+
     def test_codex_root_normalizes_role_content_entries(self, tmp_path):
         sessions = tmp_path / "codex" / "sessions"
         sessions.mkdir(parents=True)

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -441,6 +441,45 @@ class TestJSONLWatcher:
         assert watcher.provider_for_file(str(fresh_cursor)) == "cursor"
         assert watcher.provider_for_file(str(old_codex)) == "codex"
 
+    def test_poll_once_limits_each_file_so_active_roots_do_not_starve(self, tmp_path):
+        codex_sessions = tmp_path / "codex" / "sessions"
+        cursor_sessions = tmp_path / "cursor" / "sessions"
+        codex_sessions.mkdir(parents=True)
+        cursor_sessions.mkdir(parents=True)
+        hot_codex = codex_sessions / "hot.jsonl"
+        fresh_cursor = cursor_sessions / "fresh.jsonl"
+        hot_codex.write_text(
+            "\n".join(
+                json.dumps({"role": "user", "content": f"codex active line {idx} with enough content"})
+                for idx in range(3)
+            )
+            + "\n"
+        )
+        fresh_cursor.write_text(
+            json.dumps(
+                {"type": "message", "payload": {"role": "user", "content": "cursor active line with enough content"}}
+            )
+            + "\n"
+        )
+        os.utime(hot_codex, (3000, 3000))
+        os.utime(fresh_cursor, (2000, 2000))
+
+        flushed = []
+        watcher = JSONLWatcher(
+            watch_roots=[
+                WatchRoot("codex", codex_sessions),
+                WatchRoot("cursor", cursor_sessions),
+            ],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items),
+            batch_size=1,
+            max_lines_per_file=1,
+        )
+
+        assert watcher.poll_once() == 2
+        assert [item["_provider"] for item in flushed] == ["codex", "cursor"]
+        assert watcher._tailers[str(hot_codex)].offset < hot_codex.stat().st_size
+
     def test_codex_root_normalizes_role_content_entries(self, tmp_path):
         sessions = tmp_path / "codex" / "sessions"
         sessions.mkdir(parents=True)


### PR DESCRIPTION
## Summary\n- Add a per-file line cap to JSONL tailing so one large active file cannot monopolize a poll cycle.\n- Keep unread buffered bytes for the next poll, preserving offsets and partial-line behavior.\n- Add regression coverage proving a hot Codex file does not starve an active Cursor root in the same poll.\n\n## Verification\n- ruff format src/brainlayer/watcher.py tests/test_jsonl_watcher.py\n- ruff check src/brainlayer/watcher.py tests/test_jsonl_watcher.py\n- pytest tests/test_jsonl_watcher.py -q => 40 passed\n- pre-push gate => 2943 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun stale-index 1 passed; FTS determinism PASS\n\n## Reviews\n@codex review\n@cursor @bugbot review\n@coderabbitai review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is a bounded read per poll with buffered remainder preserved; default cap is generous and covered by a targeted regression test.
> 
> **Overview**
> **Per-file read cap** stops one high-volume JSONL from consuming an entire poll cycle when multiple watch roots are active.
> 
> `JSONLTailer.read_new_lines` accepts optional `max_lines` and stops after that many complete lines, leaving unread bytes in the internal buffer for the next read. The early-exit when no new file data arrives now still allows draining a buffered partial line once a newline is present.
> 
> `JSONLWatcher` adds **`max_lines_per_file`** (default **100**, minimum **1**) and passes it from `poll_once` into each tailer. A regression test asserts that with `max_lines_per_file=1`, a hot Codex file and a Cursor file both get one line in the same poll, with remaining Codex data picked up on the next cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4fba7e9ee7dee58b2d17a1398140d57efc3e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix JSONL watcher starvation by capping lines read per file per poll cycle
> - Adds `max_lines_per_file` (default 100) to `JSONLWatcher` and passes it to `JSONLTailer.read_new_lines` as a per-call cap, preventing a single high-volume file from monopolizing a poll cycle.
> - Updates `JSONLTailer.read_new_lines` to accept an optional `max_lines` limit and to still return buffered complete lines even when no new file data is read.
> - A new test in [test_jsonl_watcher.py](https://github.com/EtanHey/brainlayer/pull/502/files#diff-bbee3d4b88b3c25e7192b08307a2551963fb8d068f8f289536f7235abf5bedf5) verifies that two competing providers each get at least one line processed in the first poll cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd4fba7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->