### PR TITLE
chore: release brainlayer 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.1.0"
+version = "1.2.0"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents — local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
## Summary
- Bump BrainLayer package metadata from 1.1.0 to 1.2.0 in `pyproject.toml`, `src/brainlayer/__init__.py`, and `server.json`.
- Release main's multi-root watcher fixes to PyPI so packaged installs no longer get the old Claude-only watcher from v1.1.0.

## Verification
- `pytest tests/test_release_version_sync.py tests/test_jsonl_watcher.py tests/test_watcher_bridge.py` — 76 passed
- `python3 -m build --sdist --wheel` — built `brainlayer-1.2.0.tar.gz` and `brainlayer-1.2.0-py3-none-any.whl`
- `pytest` — 3044 passed, 49 skipped, 5 xfailed
- `PYTHONPATH=src python3 - <<'PY' ... default_watch_roots()` — returns claude, codex, cursor, gemini roots
- `coderabbit review --agent` — findings: 0

Co-Authored-By: OpenAI Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version alignment with no runtime logic changes in the diff; release risk is limited to packaging/registry consistency.
> 
> **Overview**
> **Version-only release** that bumps BrainLayer from **1.1.0** to **1.2.0** everywhere packaging and MCP registry metadata must agree: `pyproject.toml`, `src/brainlayer/__init__.py` (`__version__`), and `server.json` (top-level and PyPI package entry).
> 
> This tags a PyPI/MCP publish so installs pick up **main’s multi-root JSONL watcher behavior** (Claude, Codex, Cursor, Gemini roots) instead of the older Claude-only watcher shipped in 1.1.0. No functional code changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caaddf290b73a0a0dc4667549026f67cb29a3b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release brainlayer 1.2.0
> Bumps the version from 1.1.0 to 1.2.0 in [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/503/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/503/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [src/brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/503/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized caaddf2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->