### PR TITLE
fix(mcp): make BrainLayer tool surface trustable (pre-move gen16)

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -1149,7 +1149,7 @@ final class MCPRouter: @unchecked Sendable {
     nonisolated(unsafe) static let toolDefinitions: [[String: Any]] = [
         [
             "name": "brain_search",
-            "description": "Search BrainLayer's memory (past decisions, learnings, notes, project history) with hybrid semantic + keyword ranking. Pass a natural-language query; narrow with project, tag, source, or importance_min. Returns ranked chunks with snippets and a chunk_id — pass that chunk_id to brain_expand for full content.",
+            "description": "Search BrainLayer's memory (past decisions, learnings, notes, project history) with hybrid semantic + keyword ranking. Pass a natural-language query; narrow with project, tag, source, or importance_min. Returns ranked snippets (title, source, date, preview).",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -10,8 +10,17 @@
 import Foundation
 
 final class MCPRouter: @unchecked Sendable {
-    private static let mcpStoreBusyTimeoutMillis: Int32 = 250
-    private static let mcpStoreRetries = 1
+    // Budget tuned so an interactive brain_store can win the single-writer lock
+    // in the gaps between drain batches instead of fast-failing to the pending
+    // queue on the first contested attempt. 1500ms is well under agent-perceptible
+    // round-trip latency and far below the legacy 30s block (a1bceb01) that PR #475
+    // removed; the pending-queue fallback remains the safety net beyond this budget.
+    // NOTE: this raises the latency bound PR #475 (a6991478) deliberately lowered —
+    // it trades up to ~1.5s tail latency for immediate round-trip reliability under
+    // contention. The systemic fix (drain backlog/backpressure + single-writer) is
+    // tracked separately for orc review.
+    private static let mcpStoreBusyTimeoutMillis: Int32 = 1500
+    private static let mcpStoreRetries = 2
 
     private struct ToolOutput {
         let text: String

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -316,7 +316,10 @@ final class MCPRouter: @unchecked Sendable {
         if unreadOnly && subscriberID == nil {
             throw ToolError.missingParameter("agent_id")
         }
-        let db = try readDB()
+        // Unread search marks messages delivered (a write), so it must run on the
+        // writable connection. Plain reads stay on the read-only connection to
+        // avoid contending for the single-writer lock.
+        let db = unreadOnly ? try writeDB() : try readDB()
         SearchProfileLogger.log(
             scope: "search.brainbar",
             step: "router_dispatch",
@@ -1137,7 +1140,7 @@ final class MCPRouter: @unchecked Sendable {
     nonisolated(unsafe) static let toolDefinitions: [[String: Any]] = [
         [
             "name": "brain_search",
-            "description": "Search through past conversations and learnings. Hybrid semantic + keyword search.",
+            "description": "Search BrainLayer's memory (past decisions, learnings, notes, project history) with hybrid semantic + keyword ranking. Pass a natural-language query; narrow with project, tag, source, or importance_min. Returns ranked chunks with snippets and a chunk_id — pass that chunk_id to brain_expand for full content.",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1157,7 +1160,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_store",
-            "description": "Save decisions, learnings, mistakes, ideas, todos to memory.",
+            "description": "Save a decision, learning, mistake, idea, or todo to durable memory so future sessions can retrieve it with brain_search. Returns the new chunk_id. Add tags, importance (1-10), and project to improve later retrieval. For digesting long raw text use brain_digest instead.",
             "annotations": MCPRouter.writeAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1172,7 +1175,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_recall",
-            "description": "Get current working context, browse sessions, or inspect session details.",
+            "description": "Get session-level context, not topical search. Modes: context = what you're working on now; sessions = recent session history; operations/summary = details for one session_id; plan = plan linkage; stats = knowledge-base health stats. For looking up facts or past decisions by topic, use brain_search.",
             "annotations": MCPRouter.recallAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1184,7 +1187,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_entity",
-            "description": "Look up a known entity in the knowledge graph.",
+            "description": "Look up a named entity (person, project, company, tool) in the knowledge graph and return its profile and graph relations. Returns 'No entity found' if the name isn't in the graph yet — for fuzzy topical recall across memories use brain_search instead.",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1210,27 +1213,28 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_digest",
-            "description": "Ingest raw content (transcripts, docs, articles). Extracts entities, relations, action items.",
+            "description": "Digest a large block of raw text (transcript, doc, article) into one durable, enriched memory chunk that brain_search can find. Entity and relation extraction is attempted and returned as counts, but extracted entities are indexed asynchronously and may not be immediately resolvable via brain_entity. Takes only `content` (no project/title scoping here); for a short scoped note use brain_store with a project instead.",
             "annotations": MCPRouter.writeAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
-                    "content": ["type": "string", "description": "Raw content to digest"],
+                    "content": ["type": "string", "description": "Raw text to digest into memory"],
                 ] as [String: Any],
                 "required": ["content"]
             ] as [String: Any])
         ],
         [
             "name": "brain_update",
-            "description": "Update, archive, or merge existing memories.",
+            "description": "Update the importance and/or tags of an existing memory chunk in place. Provide chunk_id plus at least one of importance or tags (tags replace the chunk's existing tag list). This does NOT edit content — to replace content store a new memory with brain_store, to hide a chunk use brain_archive, to mark a replacement use brain_supersede.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
-                    "action": ["type": "string", "enum": ["update", "archive", "merge"], "description": "Action to perform"],
-                    "chunk_id": ["type": "string", "description": "Chunk ID to update"],
+                    "chunk_id": ["type": "string", "description": "ID of the chunk to update (from a brain_search or brain_store result)"],
+                    "importance": ["type": "integer", "description": "New importance score, 1-10"],
+                    "tags": ["type": "array", "items": ["type": "string"], "description": "New tag list — replaces the chunk's existing tags"],
                 ] as [String: Any],
-                "required": ["action", "chunk_id"]
+                "required": ["chunk_id"]
             ] as [String: Any])
         ],
         [
@@ -1249,7 +1253,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_tags",
-            "description": "List, search, or suggest tags across the knowledge base.",
+            "description": "List tags used across the knowledge base, each with its usage count. Pass an optional query to filter to tags containing that substring.",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -614,6 +614,56 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertTrue(tagsText.contains("readonly-route"), tagsText)
     }
 
+    /// Regression: brain_search(unread_only) marks messages delivered (a write).
+    /// It must run on the writable connection, not the read-only read handle —
+    /// otherwise markDelivered fails with `SQLite step failed: 8` (SQLITE_READONLY).
+    func testUnreadSearchUsesWritableConnectionForMarkDelivered() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-unread-route-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let setupDB = BrainDatabase(path: tempDB)
+        try setupDB.insertChunk(
+            id: "unread-route-target",
+            content: "Unread route target content about sockets",
+            sessionId: "unread-session",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 6,
+            tags: "[\"unread-route\"]"
+        )
+        setupDB.close()
+
+        let writeDB = BrainDatabase(path: tempDB)
+        let readDB = BrainDatabase(
+            path: tempDB,
+            openConfiguration: .init(busyTimeoutMillis: 250, readOnly: true)
+        )
+        defer { writeDB.close() }
+        defer { readDB.close() }
+
+        // Read handle is genuinely read-only; the old path attempted markDelivered
+        // here and failed with SQLITE_READONLY.
+        XCTAssertEqual(try sqlitePragma(handle: readDB.dbHandle, name: "query_only"), "1")
+
+        let router = MCPRouter()
+        router.setDatabases(write: writeDB, read: readDB)
+
+        let response = router.handle(toolCall(id: 401, name: "brain_search", arguments: [
+            "query": "sockets",
+            "num_results": 5,
+            "agent_id": "unread-route-agent",
+            "unread_only": true,
+        ]))
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertNil(result["isError"] as? Bool, "unread search must not error on a read-only read handle")
+        let text = try toolText(response)
+        XCTAssertFalse(text.contains("SQLite step failed"), text)
+        XCTAssertTrue(text.contains("Unread route target content"), text)
+
+        // markDelivered must have written through the writable connection.
+        XCTAssertNotNil(try writeDB.subscription(agentID: "unread-route-agent"))
+    }
+
     func testBrainSearchFallsBackToReadDatabaseWhenHybridHelperExceedsBudget() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-hybrid-budget-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }


### PR DESCRIPTION
## Why
Pre-move tool-trustability fix (gen16). A fresh round-trip of the live MCP/CLI surface found tools whose **schemas/descriptions don't match real behavior**, so agents can't call them correctly or trust the results. The live surface is `brain-bar/Sources/BrainBar/MCPRouter.swift` (served by BrainBarDaemon). All findings reproduced live before fixing (`/never-fabricate`).

## Interface layer — descriptions + schemas (`MCPRouter.swift` toolDefinitions)
- **brain_update** (headline bug): exposed schema was `{action, chunk_id}` with both required, but the handler **ignores `action`** and actually requires `chunk_id` + at least one of `importance`/`tags` — *neither was in the schema*. A no-field call errored `Missing required parameter: importance or tags`. Now exposes `importance` + `tags`, requires only `chunk_id`, drops the misleading `action`, and the description states the real contract (and that it does not edit content).
- **brain_digest**: described as synchronously extracting entities/relations into the KG, but the handler only takes `content` and entities are indexed **asynchronously** (not immediately resolvable via `brain_entity`); no project scoping. Description now matches real behavior.
- **brain_tags**: dropped "suggest" (not implemented) — now describes list+filter+counts.
- **brain_search / brain_store / brain_recall / brain_entity**: tightened to state what they return and when to use them vs each other (clear enough for a zero-context agent).

## Behavior fixes
- **brain_search(unread_only=true)** returned `SQLite step failed: 8` (SQLITE_READONLY): the unread path calls `markDelivered` (a write) but ran on the read-only connection. Now routes unread searches to the writable connection; plain reads stay read-only. New regression test with a genuinely read-only read handle.
- **brain_store "DB busy → queued"**: raised the MCP store busy budget (`mcpStoreBusyTimeoutMillis` 250→1500, retries 1→2) so an interactive store can win the single-writer lock between drain batches instead of fast-failing to the pending queue. Queue fallback unchanged. **⚠️ This raises the latency bound PR #475 (a6991478) deliberately lowered** — trades ≤~1.5s tail latency for immediate round-trip reliability. The *systemic* root cause (drain saturated by a ~29k-file watcher backlog; multiple write owners on one WAL DB) is an orc-level decision (single-writer consolidation / drain backpressure) and is **not** addressed here.

## Tests
`swift test --filter MCPRouterTests` → **61/61 pass**, incl. new `testUnreadSearchUsesWritableConnectionForMarkDelivered`. No live daemon touched (PR-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP contract (especially brain_update schema) and DB routing for unread search plus longer brain_store lock waits; behavior is regression-tested but agents relying on the old schema could break until they adapt.
> 
> **Overview**
> Aligns the live MCP **tool definitions** in `MCPRouter` with what handlers actually do, and fixes two reliability bugs agents hit in production.
> 
> **`brain_update`** — The advertised schema required misleading `action` + `chunk_id` while the handler only accepts `chunk_id` plus at least one of **`importance`** or **`tags`**. The schema now exposes those fields, drops `action`, and the description clarifies in-place metadata updates vs `brain_store` / `brain_archive` / `brain_supersede`.
> 
> **Other tools** — Descriptions for **`brain_search`**, **`brain_store`**, **`brain_recall`**, **`brain_entity`**, **`brain_digest`**, and **`brain_tags`** are rewritten so agents know return shapes, when to use each tool, and async KG indexing limits on digest.
> 
> **`brain_search(unread_only)`** — Unread filtering calls **`markDelivered`** (a write) but previously used the read-only handle, causing **`SQLITE_READONLY`**. Unread searches now use the **writable** connection; ordinary searches stay read-only. Regression test added with a genuine read-only read handle.
> 
> **`brain_store` under lock** — Raises MCP store busy wait (**250ms → 1500ms**) and retries (**1 → 2**) so interactive stores can acquire the single-writer lock between drain batches instead of immediately deferring to the pending queue; queue fallback is unchanged. This intentionally increases tail latency vs PR #475’s tighter bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 827d47f8c07db044c3aabf02a0a886d2d78ec2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `brain_search` with `unread_only` to use a writable DB connection and update `brain_update` tool schema
> - Fixes `brain_search` with `unread_only=true` failing with `SQLITE_READONLY` by switching to the writable DB handle when `unread_only` is true, allowing `markDelivered` to succeed
> - Updates `brain_update` tool schema: removes the `action` field, adds optional `importance` and `tags` fields, and reduces `required` to just `['chunk_id']`
> - Increases the `brain_store` single-writer lock busy timeout from 250ms to 1500ms and retry count from 1 to 2
> - Adds a test in [MCPRouterTests.swift](https://github.com/EtanHey/brainlayer/pull/504/files#diff-6a1a5be7d76811bedc4d3f0ebcb2043c90a2a0119ea214a29764bcd53b19af15) verifying `unread_only` searches use the writable connection
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 827d47f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->