### PR TITLE
fix(search): expose chunk_id in full brain_search output

### DIFF
--- a/brain-bar/Sources/BrainBar/Formatting/TextFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Formatting/TextFormatter.swift
@@ -7,7 +7,7 @@ enum TextFormatter {
         case center
     }
 
-    static func formatSearchResults(query: String, results: [SearchResult], total: Int) -> String {
+    static func formatSearchResults(query: String, results: [SearchResult], total: Int, detail: String = "compact") -> String {
         let truncatedQuery = truncate(query, maxLen: 50)
 
         if total == 0 {
@@ -18,6 +18,11 @@ enum TextFormatter {
             ].joined(separator: "\n")
         }
 
+        // Only the explicit "full" detail level exposes chunk IDs, so they can be
+        // chained into brain_update/brain_expand/brain_supersede/brain_archive.
+        // Compact (the default) intentionally hides them.
+        let includeChunkID = detail == "full"
+
         var lines = ["## Search results for \"\(truncatedQuery)\" - \(results.count) of \(total) shown"]
 
         for (index, result) in results.enumerated() {
@@ -27,6 +32,9 @@ enum TextFormatter {
             let datePart = formattedDate(result.date)
             lines.append("")
             lines.append("### \(index + 1). \(title)")
+            if includeChunkID && !result.chunkID.isEmpty {
+                lines.append("- ID: \(result.chunkID)")
+            }
             lines.append("- Source: \(source.isEmpty ? "unknown" : source)")
             lines.append("- Date: \(datePart.isEmpty ? "unknown" : datePart)")
             lines.append("- Preview: \(preview)")

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -365,7 +365,12 @@ final class MCPRouter: @unchecked Sendable {
             )
             let typedResults = results.map(SearchResult.init(payload:))
             return (
-                TextFormatter.formatSearchResults(query: query, results: typedResults, total: typedResults.count),
+                TextFormatter.formatSearchResults(
+                    query: query,
+                    results: typedResults,
+                    total: typedResults.count,
+                    detail: args["detail"] as? String ?? "compact"
+                ),
                 [:]
             )
         }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -1003,6 +1003,35 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertFalse(text.contains("f-1"), "Compact labeled markdown should not expose chunk_id by default")
     }
 
+    func testBrainSearchFullDetailExposesChunkID() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-detail-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        try db.insertChunk(id: "detail-1", content: "Socket handling code", sessionId: "s1", project: "brainbar", contentType: "assistant_text", importance: 5)
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_search",
+                "arguments": ["query": "socket", "project": "brainbar", "detail": "full"] as [String: Any]
+            ] as [String: Any]
+        ])
+
+        let result = response["result"] as? [String: Any]
+        let content = result?["content"] as? [[String: Any]]
+        let text = content?.first?["text"] as? String ?? ""
+
+        XCTAssertTrue(text.contains("## Search results"), "Should contain markdown header")
+        XCTAssertTrue(text.contains("Socket handling code"), "Should contain chunk content")
+        XCTAssertTrue(text.contains("- ID: detail-1"), "full detail must expose chunk_id for chaining")
+    }
+
     func testBrainSearchPassesImportanceMinFilter() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-imp-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }

--- a/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
+++ b/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
@@ -39,6 +39,62 @@ final class TextFormatterParityTests: XCTestCase {
         XCTAssertFalse(output.contains("rt-abc123def"))
     }
 
+    func testSearchResultsFullDetailExposesChunkID() {
+        let results = [
+            SearchResult(
+                chunkID: "rt-abc123def4567890",
+                score: 0.87,
+                project: "brainlayer",
+                date: "2026-03-29T19:30:00Z",
+                summary: "BrainBar is a native macOS daemon for BrainLayer MCP routing.",
+                snippet: "BrainBar is a native macOS daemon for BrainLayer MCP routing.",
+                importance: 8,
+                tags: ["swift", "macos", "mcp"],
+                sourceFile: "/Users/etanheyman/Gits/brainlayer/brain-bar/Sources/BrainBar/MCPRouter.swift"
+            )
+        ]
+
+        let output = TextFormatter.formatSearchResults(
+            query: "brainbar",
+            results: results,
+            total: results.count,
+            detail: "full"
+        )
+
+        XCTAssertTrue(output.contains("- ID: rt-abc123def4567890"), "full detail must expose chunk_id for chaining")
+        // Sanity: the ID line should sit under the result header, before Source.
+        XCTAssertTrue(
+            output.contains("### 1. BrainBar is a native macOS daemon for BrainLayer MCP routing.\n- ID: rt-abc123def4567890\n- Source:"),
+            "ID line must precede Source line"
+        )
+    }
+
+    func testSearchResultsCompactDetailHidesChunkID() {
+        let results = [
+            SearchResult(
+                chunkID: "rt-abc123def4567890",
+                score: 0.87,
+                project: "brainlayer",
+                date: "2026-03-29T19:30:00Z",
+                summary: "BrainBar is a native macOS daemon for BrainLayer MCP routing.",
+                snippet: "BrainBar is a native macOS daemon for BrainLayer MCP routing.",
+                importance: 8,
+                sourceFile: "/Users/etanheyman/Gits/brainlayer/brain-bar/Sources/BrainBar/MCPRouter.swift"
+            )
+        ]
+
+        // Explicit compact and the default must both hide the chunk_id.
+        let explicitCompact = TextFormatter.formatSearchResults(
+            query: "brainbar", results: results, total: 1, detail: "compact"
+        )
+        let defaultDetail = TextFormatter.formatSearchResults(query: "brainbar", results: results, total: 1)
+
+        XCTAssertFalse(explicitCompact.contains("rt-abc123def"), "compact must not expose chunk_id")
+        XCTAssertFalse(explicitCompact.contains("- ID:"))
+        XCTAssertFalse(defaultDetail.contains("rt-abc123def"), "default detail must not expose chunk_id")
+        XCTAssertFalse(defaultDetail.contains("- ID:"))
+    }
+
     func testSearchResultSourceBasenameHandlesWindowsPaths() {
         let results = [
             SearchResult(

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -70,13 +70,19 @@ def _append_kv_section(lines: list[str], title: str, values: dict | None, *, ski
         lines.append(f"- {key}: {value}")
 
 
-def format_search_results(query: str, results: list[dict], total: int) -> str:
+def format_search_results(query: str, results: list[dict], total: int, detail: str = "compact") -> str:
     """Format search results as labeled-field markdown.
 
     Each result dict should have: chunk_id, score, project, date, snippet, summary, importance.
+
+    Only detail="full" exposes the chunk_id (as a "- ID:" line) so it can be chained
+    into brain_update/brain_expand/brain_supersede/brain_archive. Compact (the default)
+    intentionally hides it.
     """
     if total == 0:
         return f'## Search results for "{_truncate(query, 50)}" - 0 of 0 shown\n\nNo results found.'
+
+    include_chunk_id = detail == "full"
 
     lines = []
     lines.append(f'## Search results for "{_truncate(query, 50)}" - {len(results)} of {total} shown')
@@ -91,6 +97,9 @@ def format_search_results(query: str, results: list[dict], total: int) -> str:
 
         lines.append("")
         lines.append(f"### {i + 1}. {title}")
+        chunk_id = r.get("chunk_id")
+        if include_chunk_id and chunk_id:
+            lines.append(f"- ID: {chunk_id}")
         lines.append(f"- Source: {source}")
         lines.append(f"- Date: {date}")
         lines.append(f"- Preview: {preview}")

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -1846,6 +1846,9 @@ async def _search(
             structured_results.append(item)
 
             output_parts.append(f"\n### Result {i + 1} (score: {score:.3f})")
+            # full detail exposes the chunk_id so it can be chained into
+            # brain_update/brain_expand/brain_supersede/brain_archive.
+            output_parts.append(f"- ID: {cid}")
             enrichment_parts = []
             if meta.get("intent"):
                 enrichment_parts.append(f"Intent: {meta['intent']}")

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -522,7 +522,7 @@ def _exact_chunk_lookup_result(
         structured_results = [item]
 
     structured = {"query": query, "total": 1, "results": structured_results}
-    formatted_text = format_search_results(query, structured_results, 1)
+    formatted_text = format_search_results(query, structured_results, 1, detail=detail)
     return ([TextContent(type="text", text=formatted_text)], structured)
 
 

--- a/tests/test_mcp_format.py
+++ b/tests/test_mcp_format.py
@@ -155,6 +155,20 @@ class TestFormatSearchResults:
         # Query should be truncated in header
         assert len(output.split("\n")[0]) < 250
 
+    def test_compact_hides_chunk_id(self):
+        results = [self._make_result(chunk_id="hide-me-123")]
+        # Default and explicit compact must both hide the chunk_id.
+        assert "hide-me-123" not in format_search_results("q", results, 1)
+        assert "hide-me-123" not in format_search_results("q", results, 1, detail="compact")
+        assert "- ID:" not in format_search_results("q", results, 1, detail="compact")
+
+    def test_full_detail_exposes_chunk_id(self):
+        results = [self._make_result(chunk_id="show-me-456")]
+        output = format_search_results("q", results, 1, detail="full")
+        assert "- ID: show-me-456" in output
+        # ID line sits under the result header.
+        assert "### 1." in output
+
 
 # --- format_store_result ---
 

--- a/tests/test_search_chunk_id.py
+++ b/tests/test_search_chunk_id.py
@@ -157,6 +157,41 @@ class TestSearchReturnsChunkId:
             assert full["results"][0]["chunk_id"] == "real-chunk-id-001"
 
     @pytest.mark.asyncio
+    async def test_full_text_output_exposes_chunk_id(self, mock_store, mock_model):
+        """Full detail rendered TEXT must include the chunk_id so it can be chained
+        into brain_update/brain_expand/brain_supersede/brain_archive from a search hit."""
+        chunk_ids = ["text-id-001", "text-id-002"]
+        documents = ["First document content", "Second document content"]
+        mock_store.hybrid_search.return_value = _make_search_results(chunk_ids, documents)
+
+        with (
+            patch("brainlayer.mcp.search_handler._get_vector_store", return_value=mock_store),
+            patch("brainlayer.mcp.search_handler._get_embedding_model", return_value=mock_model),
+        ):
+            content, _ = await _search(query="test query", detail="full")
+
+        text = "\n".join(getattr(c, "text", "") for c in content)
+        assert "- ID: text-id-001" in text
+        assert "- ID: text-id-002" in text
+
+    @pytest.mark.asyncio
+    async def test_compact_text_output_hides_chunk_id(self, mock_store, mock_model):
+        """Compact rendered TEXT must NOT expose the chunk_id."""
+        chunk_ids = ["hidden-id-001"]
+        documents = ["Some content"]
+        mock_store.hybrid_search.return_value = _make_search_results(chunk_ids, documents)
+
+        with (
+            patch("brainlayer.mcp.search_handler._get_vector_store", return_value=mock_store),
+            patch("brainlayer.mcp.search_handler._get_embedding_model", return_value=mock_model),
+        ):
+            content, _ = await _search(query="test query", detail="compact")
+
+        text = "\n".join(getattr(c, "text", "") for c in content)
+        assert "hidden-id-001" not in text
+        assert "- ID:" not in text
+
+    @pytest.mark.asyncio
     async def test_empty_results_no_crash(self, mock_store, mock_model):
         """Empty result set should not crash."""
         mock_store.hybrid_search.return_value = {

--- a/tests/test_search_chunk_id.py
+++ b/tests/test_search_chunk_id.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from brainlayer.mcp.search_handler import _search
+from brainlayer.mcp.search_handler import _exact_chunk_lookup_result, _search
 
 
 def _make_search_results(chunk_ids, documents, metadatas=None, distances=None):
@@ -190,6 +190,25 @@ class TestSearchReturnsChunkId:
         text = "\n".join(getattr(c, "text", "") for c in content)
         assert "hidden-id-001" not in text
         assert "- ID:" not in text
+
+    @pytest.mark.asyncio
+    async def test_exact_lookup_full_text_output_exposes_chunk_id(self, mock_store, mock_model):
+        """Exact chunk-id lookup must honor detail=full in rendered text."""
+        mock_store.get_chunk.return_value = {
+            "id": "exact-id-001",
+            "content": "Exact document content",
+            "source_file": "session.jsonl",
+            "project": "test-project",
+            "created_at": "2026-03-01T12:00:00",
+            "importance": 5,
+            "summary": "Exact summary",
+        }
+
+        content, structured = _exact_chunk_lookup_result("exact-id-001", mock_store, detail="full")
+
+        text = "\n".join(getattr(c, "text", "") for c in content)
+        assert structured["results"][0]["chunk_id"] == "exact-id-001"
+        assert "- ID: exact-id-001" in text
 
     @pytest.mark.asyncio
     async def test_empty_results_no_crash(self, mock_store, mock_model):


### PR DESCRIPTION
## Summary
- Exposes the real search result `chunk_id` in rendered `brain_search` text when `detail='full'`.
- Threads `detail` into the Swift BrainBar DB fallback formatter path.
- Keeps compact/default rendered text hiding chunk IDs, with code comments and tests documenting that choice.

## Audit Notes
- Branch base verified against `main` at `f8a1ff54` (#504).
- Swift DB path emits `SearchResult.chunkID`, sourced from `BrainDatabase.searchRow` `chunk_id` (`chunks.id`).
- Python full path emits `cid` from `results["ids"][0]`, the same value stored in structured `chunk_id`.
- Swift BrainBar `brain_expand`, `brain_update`, `brain_supersede`, and `brain_archive` accept that chunk ID string.

## Test Plan
- `cd brain-bar && swift build` -> Build complete.
- `cd brain-bar && swift test --filter 'MCPRouterTests/testBrainSearchFullDetailExposesChunkID|TextFormatterParityTests/testSearchResults'` -> Executed 4 tests, 0 failures.
- `cd brain-bar && swift test --filter 'MCPRouterTests/testReadToolsUseReadonlyReadDatabaseWhenWriteHandleIsUnavailable|MCPRouterTests/testBrainArchiveHidesChunkFromDefaultSearch|MCPRouterTests/testBrainSupersedeHidesOldChunkAndKeepsReplacement|DatabaseTests/testUpdateChunkImportance|DatabaseTests/testExpandChunkReturnsSurroundingContext'` -> Executed 5 tests, 0 failures.
- `pytest tests/test_mcp_format.py tests/test_search_chunk_id.py` -> 53 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path formatting and MCP text output only; default behavior unchanged and covered by new tests on both stacks.
> 
> **Overview**
> **`brain_search` rendered text now respects `detail` for chunk IDs** across Python MCP and Swift BrainBar. Both formatters take a `detail` argument (default **`compact`**) and only add a **`- ID: <chunk_id>`** line under each hit when **`detail=full`**, so agents can copy IDs into `brain_update`, `brain_expand`, `brain_supersede`, and `brain_archive` without changing default, quieter output.
> 
> On the **Python** side, `format_search_results` gates the ID line; `search_handler` passes `detail` through for exact chunk lookup and the full-detail hybrid path adds **`- ID: {cid}`** in rendered output. On **BrainBar**, the DB fallback in `MCPRouter` forwards the tool’s `detail` into `TextFormatter.formatSearchResults`.
> 
> Tests in Python and Swift lock in **full exposes / compact (and default) hides** for both structured results and rendered markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f96eba8a1f43dc14a1753ae98f9d17c52c73c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `chunk_id` in `brain_search` output when `detail='full'` is requested
> - Adds a `detail` parameter (default `'compact'`) to `format_search_results` in [_format.py](https://github.com/EtanHey/brainlayer/pull/505/files#diff-620f1b58e5c06f4a3deffae64c1f9ae5a2889d8ae71386fe2251340fb17c6644) and [`TextFormatter.formatSearchResults`](https://github.com/EtanHey/brainlayer/pull/505/files#diff-406b80db55df7e19ce43d88956585835fe258751b47822c353015f921c3d092c); when set to `'full'`, a `- ID: <chunk_id>` line is appended under each result header.
> - Threads the `detail` argument through the MCP routers in both the Python ([search_handler.py](https://github.com/EtanHey/brainlayer/pull/505/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0)) and Swift ([MCPRouter.swift](https://github.com/EtanHey/brainlayer/pull/505/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f)) implementations so callers can opt in via the `brain_search` tool args.
> - Adds tests in both codebases covering `full` (ID line present) and `compact` (ID line absent) behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f96eba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now support optional chunk ID visibility via a `detail` parameter (`"full"` mode displays IDs; `"compact"` mode hides them by default).

* **Tests**
  * Added comprehensive tests to verify chunk ID display behavior across detail modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->