### PR TITLE
fix(brainlayer): restore prompt brain_store queue budget

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -10,17 +10,12 @@
 import Foundation
 
 final class MCPRouter: @unchecked Sendable {
-    // Budget tuned so an interactive brain_store can win the single-writer lock
-    // in the gaps between drain batches instead of fast-failing to the pending
-    // queue on the first contested attempt. 1500ms is well under agent-perceptible
-    // round-trip latency and far below the legacy 30s block (a1bceb01) that PR #475
-    // removed; the pending-queue fallback remains the safety net beyond this budget.
-    // NOTE: this raises the latency bound PR #475 (a6991478) deliberately lowered —
-    // it trades up to ~1.5s tail latency for immediate round-trip reliability under
-    // contention. The systemic fix (drain backlog/backpressure + single-writer) is
-    // tracked separately for orc review.
-    private static let mcpStoreBusyTimeoutMillis: Int32 = 1500
-    private static let mcpStoreRetries = 2
+    // Keep contested MCP writes interactive: make one short attempt, then queue
+    // for replay so brain_store returns well under the 1s prompt-queue budget.
+    // Longer contention handling belongs in the deferred single-writer/backpressure
+    // path, not in the synchronous MCP response.
+    private static let mcpStoreBusyTimeoutMillis: Int32 = 250
+    private static let mcpStoreRetries = 1
 
     private struct ToolOutput {
         let text: String


### PR DESCRIPTION
## Summary
- Reverts the #504 synchronous `brain_store` contention budget from `1500ms / 2 attempts` back to the #475 prompt-queue bound of `250ms / 1 attempt`.
- Keeps the rest of #504 intact; only the MCP store busy-budget comment and constants changed.
- Restores the contract that contested MCP writes queue promptly under SQLite lock contention instead of blocking beyond the 1s prompt budget.

## RED
`cd brain-bar && swift test --filter testBrainStoreMCPWriteBudgetQueuesPromptlyUnderSQLiteLock`

```text
/Users/etanheyman/Gits/brainlayer.wt/gen16-busy-budget-revert/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift:1742: error: -[BrainBarTests.MCPRouterTests testBrainStoreMCPWriteBudgetQueuesPromptlyUnderSQLiteLock] : XCTAssertLessThan failed: ("5.311346054077148") is not less than ("1.0")
Test Case '-[BrainBarTests.MCPRouterTests testBrainStoreMCPWriteBudgetQueuesPromptlyUnderSQLiteLock]' failed (5.513 seconds).
Test Suite 'MCPRouterTests' failed at 2026-06-18 01:16:07.604.
	 Executed 1 test, with 1 failure (0 unexpected) in 5.513 (5.513) seconds
```

## GREEN
`cd brain-bar && swift test --filter MCPRouterTests`

```text
Test Case '-[BrainBarTests.MCPRouterTests testBrainStoreMCPWriteBudgetQueuesPromptlyUnderSQLiteLock]' passed (0.903 seconds).
Test Suite 'MCPRouterTests' passed at 2026-06-18 01:16:55.924.
	 Executed 61 tests, with 0 failures (0 unexpected) in 1.486 (1.491) seconds
Test Suite 'BrainBarPackageTests.xctest' passed at 2026-06-18 01:16:55.924.
	 Executed 61 tests, with 0 failures (0 unexpected) in 1.486 (1.491) seconds
Test Suite 'Selected tests' passed at 2026-06-18 01:16:55.924.
	 Executed 61 tests, with 0 failures (0 unexpected) in 1.486 (1.492) seconds
```

## Review
- Pre-commit `coderabbit review --agent`: `findings: 0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only MCP `brain_store` busy-wait/retry constants and comments change; behavior under contention shifts toward faster queueing, which is covered by existing tests.
> 
> **Overview**
> Restores the **synchronous `brain_store` contention budget** in `MCPRouter` after a prior increase: **`mcpStoreBusyTimeoutMillis` goes from 1500ms to 250ms** and **`mcpStoreRetries` from 2 to 1**, matching the ~1s prompt-queue contract.
> 
> Under SQLite lock contention, contested MCP writes should **fail fast and queue for replay** instead of blocking the JSON-RPC response for up to ~1.5s across retries. Comments are updated to state that longer contention handling stays on the deferred single-writer/backpressure path, not the synchronous MCP path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7fd07fce713eda87da51817ceeb074fad56ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce `MCPRouter` store busy timeout from 1500ms to 250ms and retries from 2 to 1
> Restores the prompt brain_store queue budget by tightening contention tuning in [MCPRouter.swift](https://github.com/EtanHey/brainlayer/pull/506/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f). The router now makes a single short attempt before deferring, rather than holding longer with multiple retries.
>
> Behavioral Change: MCP store busy conditions will now time out ~6x faster and no longer retry, which may increase deferral rate under contention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc7fd07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->