### PR TITLE
fix(mcp): scope brain_digest and persist digest entities

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -5166,6 +5166,52 @@ final class BrainDatabase: @unchecked Sendable {
         return "digest-entity-\(trimmed.isEmpty ? "unknown" : trimmed)"
     }
 
+    private func entityIDForDigestEntity(name: String) throws -> String? {
+        guard let db else { throw DBError.notOpen }
+
+        let existingSQL = """
+            SELECT id
+            FROM kg_entities
+            WHERE name = ?
+            ORDER BY CASE entity_type
+                WHEN 'person' THEN 0
+                WHEN 'project' THEN 1
+                WHEN 'company' THEN 2
+                WHEN 'tool' THEN 3
+                WHEN 'concept' THEN 4
+                ELSE 5
+            END, id
+            LIMIT 1
+        """
+        var existingStmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, existingSQL, -1, &existingStmt, nil) == SQLITE_OK else {
+            throw DBError.prepare(sqlite3_errcode(db))
+        }
+        bindText(name, to: existingStmt, index: 1)
+        if sqlite3_step(existingStmt) == SQLITE_ROW {
+            let existingID = columnText(existingStmt, 0)
+            sqlite3_finalize(existingStmt)
+            return existingID
+        }
+        sqlite3_finalize(existingStmt)
+
+        let entityID = Self.digestEntityID(name: name)
+        let insertSQL = "INSERT OR IGNORE INTO kg_entities (id, entity_type, name, metadata) VALUES (?, 'concept', ?, '{}')"
+        try runWriteStatement(on: db, sql: insertSQL, retries: 3) { stmt in
+            bindText(entityID, to: stmt, index: 1)
+            bindText(name, to: stmt, index: 2)
+        }
+
+        var insertedStmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, existingSQL, -1, &insertedStmt, nil) == SQLITE_OK else {
+            throw DBError.prepare(sqlite3_errcode(db))
+        }
+        defer { sqlite3_finalize(insertedStmt) }
+        bindText(name, to: insertedStmt, index: 1)
+        guard sqlite3_step(insertedStmt) == SQLITE_ROW else { return nil }
+        return columnText(insertedStmt, 0)
+    }
+
     func digest(content: String, project: String? = nil, title: String? = nil) throws -> [String: Any] {
         guard db != nil else { throw DBError.notOpen }
 
@@ -5235,9 +5281,8 @@ final class BrainDatabase: @unchecked Sendable {
             // each to the digested chunk so brain_entity surfaces its memories.
             var entitiesPersisted = 0
             for name in entities {
-                let entityID = Self.digestEntityID(name: name)
                 do {
-                    try insertEntity(id: entityID, type: "concept", name: name)
+                    guard let entityID = try entityIDForDigestEntity(name: name) else { continue }
                     try linkEntityChunk(entityId: entityID, chunkId: stored.chunkID, relevance: 1.0)
                     entitiesPersisted += 1
                 } catch {
@@ -5260,7 +5305,7 @@ final class BrainDatabase: @unchecked Sendable {
             return [
                 "mode": "digest",
                 "entities": entities,
-                "entities_created": entities.count,
+                "entities_created": 0,
                 "urls": urls,
                 "code_identifiers": codeIds,
                 "chunks_created": 0,

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -5151,7 +5151,22 @@ final class BrainDatabase: @unchecked Sendable {
 
     // MARK: - brain_digest: rule-based entity extraction
 
-    func digest(content: String) throws -> [String: Any] {
+    /// Build a deterministic, KG-resolvable entity ID from an entity name.
+    /// Format mirrors the existing `<type>-<slug>` convention so repeated digests
+    /// upsert the same entity (via INSERT OR REPLACE) instead of duplicating.
+    static func digestEntityID(name: String) -> String {
+        let slug = name
+            .lowercased()
+            .map { $0.isLetter || $0.isNumber ? $0 : "-" }
+            .reduce(into: "") { acc, ch in
+                if ch == "-" && acc.hasSuffix("-") { return }
+                acc.append(ch)
+            }
+        let trimmed = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return "digest-entity-\(trimmed.isEmpty ? "unknown" : trimmed)"
+    }
+
+    func digest(content: String, project: String? = nil, title: String? = nil) throws -> [String: Any] {
         guard db != nil else { throw DBError.notOpen }
 
         // Rule-based entity extraction
@@ -5200,19 +5215,40 @@ final class BrainDatabase: @unchecked Sendable {
 
         // Store the digest as a chunk
         let digestSummary = "Digest: \(entities.count) entities, \(urls.count) URLs, \(codeIds.count) code refs"
-        
+        let titledContent: String = {
+            let body = String(content.prefix(500)) + (content.count > 500 ? "..." : "")
+            if let title, !title.isEmpty { return "\(title)\n\n\(body)" }
+            return body
+        }()
+
         do {
             let stored = try store(
-                content: content.prefix(500) + (content.count > 500 ? "..." : ""),
+                content: titledContent,
                 tags: ["digest"] + entities.prefix(5).map { $0 },
                 importance: 5,
-                source: "digest"
+                source: "digest",
+                project: project
             )
-            
+
+            // Persist extracted entities to the knowledge graph so they are
+            // immediately resolvable via brain_entity (lookupEntity), and link
+            // each to the digested chunk so brain_entity surfaces its memories.
+            var entitiesPersisted = 0
+            for name in entities {
+                let entityID = Self.digestEntityID(name: name)
+                do {
+                    try insertEntity(id: entityID, type: "concept", name: name)
+                    try linkEntityChunk(entityId: entityID, chunkId: stored.chunkID, relevance: 1.0)
+                    entitiesPersisted += 1
+                } catch {
+                    // Best-effort: a single failed entity write must not fail the digest.
+                }
+            }
+
             return [
                 "mode": "digest",
                 "entities": entities,
-                "entities_created": entities.count,
+                "entities_created": entitiesPersisted,
                 "urls": urls,
                 "code_identifiers": codeIds,
                 "chunks_created": 1,

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -686,8 +686,10 @@ final class MCPRouter: @unchecked Sendable {
         guard let content = args["content"] as? String else {
             throw ToolError.missingParameter("content")
         }
+        let project = (args["project"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let title = (args["title"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         let db = try writeDB()
-        let result = try db.digest(content: content)
+        let result = try db.digest(content: content, project: project, title: title)
         return ToolOutput(text: TextFormatter.formatDigestResult(DigestResult(payload: result)))
     }
 
@@ -1222,12 +1224,14 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_digest",
-            "description": "Digest a large block of raw text (transcript, doc, article) into one durable, enriched memory chunk that brain_search can find. Entity and relation extraction is attempted and returned as counts, but extracted entities are indexed asynchronously and may not be immediately resolvable via brain_entity. Takes only `content` (no project/title scoping here); for a short scoped note use brain_store with a project instead.",
+            "description": "Digest a large block of raw text (transcript, doc, article) into one durable, enriched memory chunk that brain_search can find. Pass `project` to scope the chunk so brain_search(project=...) finds it, and an optional `title` to label the digest. Extracted entities are written to the knowledge graph and become resolvable via brain_entity. For a short scoped note use brain_store with a project instead.",
             "annotations": MCPRouter.writeAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [
                     "content": ["type": "string", "description": "Raw text to digest into memory"],
+                    "project": ["type": "string", "description": "Project context for the digested chunk (enables brain_search project scoping)"],
+                    "title": ["type": "string", "description": "Optional short title/label for the digest"],
                 ] as [String: Any],
                 "required": ["content"]
             ] as [String: Any])

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -1735,6 +1735,62 @@ final class DatabaseTests: XCTestCase {
                       "Digested chunk should be linked to its extracted entity")
     }
 
+    func testDigestReusesExistingConceptEntityWithoutReplacingMetadata() throws {
+        try db.insertEntity(
+            id: "concept-existing-brainlayer",
+            type: "concept",
+            name: "BrainLayer",
+            metadata: "{\"description\":\"enriched concept\"}"
+        )
+
+        let result = try db.digest(content: "BrainLayer architecture uses SQLite and Swift for local retrieval.")
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+
+        let entity = try XCTUnwrap(try db.lookupEntity(query: "BrainLayer"))
+        let entityID = try XCTUnwrap(entity["entity_id"] as? String)
+        XCTAssertEqual(entityID, "concept-existing-brainlayer")
+        XCTAssertEqual(entity["metadata"] as? String, "{\"description\":\"enriched concept\"}")
+
+        let matchingRows = try sqliteScalarInt(path: tempDBPath, sql: "SELECT COUNT(*) FROM kg_entities WHERE name = 'BrainLayer'")
+        XCTAssertEqual(matchingRows, 1, "Digest should not create a duplicate concept row for an existing name")
+
+        let linkedChunks = try db.fetchEntityChunks(entityId: entityID, limit: 10)
+        XCTAssertTrue(linkedChunks.contains(where: { $0.chunkID == chunkID }))
+    }
+
+    func testDigestReusesExistingCrossTypeEntityInsteadOfCreatingConceptDuplicate() throws {
+        try db.insertEntity(
+            id: "project-brainlayer",
+            type: "project",
+            name: "BrainLayer",
+            metadata: "{\"description\":\"canonical project\"}"
+        )
+
+        let result = try db.digest(content: "BrainLayer architecture uses SQLite and Swift for local retrieval.")
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+
+        let entity = try XCTUnwrap(try db.lookupEntity(query: "BrainLayer"))
+        let entityID = try XCTUnwrap(entity["entity_id"] as? String)
+        XCTAssertEqual(entityID, "project-brainlayer")
+        XCTAssertEqual(entity["entity_type"] as? String, "project")
+
+        let conceptRows = try sqliteScalarInt(path: tempDBPath, sql: "SELECT COUNT(*) FROM kg_entities WHERE name = 'BrainLayer' AND entity_type = 'concept'")
+        XCTAssertEqual(conceptRows, 0, "Digest should link the canonical entity instead of creating an ambiguous concept duplicate")
+
+        let linkedChunks = try db.fetchEntityChunks(entityId: entityID, limit: 10)
+        XCTAssertTrue(linkedChunks.contains(where: { $0.chunkID == chunkID }))
+    }
+
+    func testDigestStorageFailureReportsZeroPersistedEntities() throws {
+        db.failNextStoreAfterInsertForTesting = true
+
+        let result = try db.digest(content: "Etan Heyman discussed BrainLayer architecture with Claude.")
+
+        XCTAssertEqual(result["chunks_created"] as? Int, 0)
+        XCTAssertEqual(result["entities_created"] as? Int, 0)
+        XCTAssertNotNil(result["error"])
+    }
+
     func testDigestTitlePrependedToChunk() throws {
         let content = "The pipeline ingests raw transcripts and produces durable memory chunks for retrieval."
         let result = try db.digest(content: content, title: "Gen16 Digest Title")
@@ -1886,6 +1942,16 @@ private func sqliteCount(path: String, sql: String) throws -> Int {
 private func sqliteScalarString(path: String, sql: String) throws -> String? {
     try withSQLiteConnection(path: path) { db in
         try scalarString(
+            db: db,
+            sql: sql,
+            bind: { _ in }
+        )
+    }
+}
+
+private func sqliteScalarInt(path: String, sql: String) throws -> Int {
+    try withSQLiteConnection(path: path) { db in
+        try scalarInt(
             db: db,
             sql: sql,
             bind: { _ in }

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -1704,6 +1704,47 @@ final class DatabaseTests: XCTestCase {
         XCTAssertNotNil(result["chunks_created"])
     }
 
+    func testDigestScopesChunkToProject() throws {
+        let content = "Etan Heyman discussed BrainLayer architecture. The project uses SQLite and Swift to ship a fast retrieval pipeline for memories."
+        let result = try db.digest(content: content, project: "gen16-scope")
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+
+        let scoped = try db.search(query: "BrainLayer architecture", limit: 10, project: "gen16-scope")
+        XCTAssertTrue(scoped.contains(where: { ($0["chunk_id"] as? String) == chunkID }),
+                      "Digested chunk should be findable via search scoped to its project")
+
+        let otherProject = try db.search(query: "BrainLayer architecture", limit: 10, project: "some-other-project")
+        XCTAssertFalse(otherProject.contains(where: { ($0["chunk_id"] as? String) == chunkID }),
+                       "Digested chunk should NOT appear under a different project scope")
+    }
+
+    func testDigestEntitiesResolvableViaLookup() throws {
+        let content = "Etan Heyman discussed BrainLayer architecture with Claude. The project uses SQLite and Swift."
+        let result = try db.digest(content: content)
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+        let entities = result["entities"] as? [String] ?? []
+        let name = try XCTUnwrap(entities.first(where: { $0.contains("BrainLayer") }))
+
+        let entity = try XCTUnwrap(try db.lookupEntity(query: name),
+                                   "Digest-extracted entity should be resolvable via lookupEntity")
+        let entityID = try XCTUnwrap(entity["entity_id"] as? String)
+        XCTAssertEqual(entity["name"] as? String, name)
+
+        let linkedChunks = try db.fetchEntityChunks(entityId: entityID, limit: 10)
+        XCTAssertTrue(linkedChunks.contains(where: { $0.chunkID == chunkID }),
+                      "Digested chunk should be linked to its extracted entity")
+    }
+
+    func testDigestTitlePrependedToChunk() throws {
+        let content = "The pipeline ingests raw transcripts and produces durable memory chunks for retrieval."
+        let result = try db.digest(content: content, title: "Gen16 Digest Title")
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+        let chunk = try XCTUnwrap(try db.getChunk(id: chunkID))
+        let storedContent = try XCTUnwrap(chunk["content"] as? String)
+        XCTAssertTrue(storedContent.hasPrefix("Gen16 Digest Title"),
+                      "Title should be prepended to the digested chunk content")
+    }
+
     private func seedTrigramMaintenanceRows(count: Int) throws {
         for index in 0..<count {
             try db.insertChunk(

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -893,6 +893,56 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertTrue(text.contains("content length 200001 exceeds maxLength 200000"))
     }
 
+    func testBrainDigestSchemaExposesProjectAndTitle() throws {
+        let router = MCPRouter()
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/list"
+        ])
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        let tools = try XCTUnwrap(result["tools"] as? [[String: Any]])
+        let digest = try XCTUnwrap(tools.first(where: { $0["name"] as? String == "brain_digest" }))
+        let schema = try XCTUnwrap(digest["inputSchema"] as? [String: Any])
+        let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
+        XCTAssertNotNil(properties["content"], "digest schema must expose content")
+        XCTAssertNotNil(properties["project"], "digest schema must expose project")
+        XCTAssertNotNil(properties["title"], "digest schema must expose title")
+        let required = schema["required"] as? [String] ?? []
+        XCTAssertEqual(required, ["content"], "only content should be required")
+    }
+
+    func testBrainDigestHandlerScopesChunkToProject() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-digest-scope-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_digest",
+                "arguments": [
+                    "content": "Etan Heyman discussed BrainLayer architecture. The project uses SQLite and Swift for a fast retrieval pipeline.",
+                    "project": "gen16-router-scope"
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertNil(result["isError"] as? Bool)
+
+        let scoped = try db.search(query: "BrainLayer architecture", limit: 10, project: "gen16-router-scope")
+        XCTAssertFalse(scoped.isEmpty, "Digested chunk should be findable under the project passed to brain_digest")
+
+        // And the extracted entity should now resolve via the KG lookup.
+        let entity = try db.lookupEntity(query: "BrainLayer")
+        XCTAssertNotNil(entity, "Digest-extracted entity should resolve via brain_entity lookup")
+    }
+
     func testBrainSubscribeToolIsServerHandled() throws {
         let router = MCPRouter()
         let request: [String: Any] = [


### PR DESCRIPTION
## Summary
- Adds `project` and `title` to the BrainBar `brain_digest` MCP schema and handler.
- Persists digest chunks with `chunks.project`, allowing `brain_search(project=...)` scoping via the existing search filter path.
- Writes digest-extracted entities to `kg_entities` with deterministic `digest-entity-<slug>` IDs and links them through `kg_entity_chunks` so `brain_entity` can resolve them.

## Audit Notes
- Branch ancestry verified: `6c90e0be` is on top of `f8a1ff54` (#504).
- Project scoping is not accepted-and-dropped: `MCPRouter.handleBrainDigest` passes `project` to `BrainDatabase.digest`, which calls `store(... project: project)`, and `store` binds it into `chunks.project`; `search` filters on `c.project = ?`.
- KG resolvability is real: `digest` calls `insertEntity(id: digest-entity-<slug>, type: "concept", name: ...)` and `linkEntityChunk`; `brain_entity` calls `lookupEntity`, which reads the same `kg_entities` table by name/LIKE and then related rows.
- Follow-up noted: digest entity type is hardcoded as `concept`.

## Test Plan
- `cd brain-bar && swift test --filter 'DatabaseTests.testDigest|MCPRouterTests.testBrainDigest'`
  - Passed: 8 tests, 0 failures.
- `cd brain-bar && swift build`
  - Passed: build complete.
- `pytest`
  - Passed: 3044 passed, 49 skipped, 5 xfailed, 328 warnings in 452.79s.

## Known Verification Caveat
- Full `cd brain-bar && swift test` did not complete in this environment; I interrupted after the `xctest` process ran for more than five minutes with no summary.
- Broader touched-class run `cd brain-bar && swift test --filter 'DatabaseTests|MCPRouterTests'` found one unrelated failure: `MCPRouterTests.testBrainStoreMCPWriteBudgetQueuesPromptlyUnderSQLiteLock` took about 5.30s against a `<1.0s` assertion.
- The same single test fails on `main` (`/Users/etanheyman/Gits/brainlayer-prod`) with about 5.28s against the same assertion, so this is inherited and not introduced by this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes digest storage semantics and KG writes (`entities_created` meaning, new concept rows); behavior is covered by tests but touches core memory/search/entity paths.
> 
> **Overview**
> **`brain_digest`** now accepts optional **`project`** and **`title`**: digested chunks are stored with `chunks.project` for `brain_search(project=...)`, and a non-empty title is prepended to the stored snippet.
> 
> After rule-based extraction, entities are written to **`kg_entities`** (stable `digest-entity-<slug>` IDs, reuse existing rows by name with type priority) and linked via **`kg_entity_chunks`** so **`brain_entity`** can resolve them immediately. **`entities_created`** counts successful KG writes, not raw extractions; failed chunk storage reports **`entities_created: 0`**.
> 
> The MCP tool schema, handler, and tool description are updated to match (empty `project`/`title` normalized to `nil`). Tests cover project scoping, entity lookup/linking, deduplication, storage failure, and schema exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547a24ab3161ae48ab8e39cd3bf1d1f03c32b18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope `brain_digest` chunks to a project and persist extracted entities to the knowledge graph
> - `brain_digest` now accepts optional `project` and `title` arguments; `project` scopes chunk storage and retrieval, and `title` is prepended to stored chunk content.
> - Extracted entity names are upserted into `kg_entities` as concept entities (reusing existing rows by name regardless of type) and linked to the digest chunk via `linkEntityChunk`.
> - `digestEntityID` generates stable, slug-based entity IDs prefixed with `digest-entity-` for deterministic insertion.
> - The `entities_created` field in the digest response now reflects successfully persisted entity–chunk links rather than raw extraction count.
> - Behavioral Change: digests that previously stored chunks without a project scope now support scoped search; existing calls without `project`/`title` are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 547a24a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->