### PR TITLE
fix: fall back when hybrid search returns empty

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -386,9 +386,17 @@ final class MCPRouter: @unchecked Sendable {
                     profileQueryID: profileQueryID
                 ))
                 if let response {
-                    textSection = response.text
-                    metadata = sanitizedHybridMetadata(response.metadata)
-                    kgSection = ""
+                    if hybridSearchResponseIsEmpty(response) {
+                        NSLog("[BrainBar] Hybrid search helper returned empty results, falling back to BrainBar database search")
+                        let fallback = try searchViaBrainBarDatabase()
+                        textSection = fallback.text
+                        metadata = fallback.metadata
+                        kgSection = localKGSection()
+                    } else {
+                        textSection = response.text
+                        metadata = sanitizedHybridMetadata(response.metadata)
+                        kgSection = ""
+                    }
                 } else {
                     NSLog("[BrainBar] Hybrid search helper exceeded %.3fs budget, falling back to BrainBar database search", hybridSearchBudget)
                     let fallback = try searchViaBrainBarDatabase()
@@ -415,6 +423,22 @@ final class MCPRouter: @unchecked Sendable {
             return ToolOutput(text: textSection, metadata: metadata)
         }
         return ToolOutput(text: kgSection + "\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n" + textSection, metadata: metadata)
+    }
+
+    private func hybridSearchResponseIsEmpty(_ response: HybridSearchResponse) -> Bool {
+        if let structured = response.metadata["structuredContent"] as? [String: Any] {
+            if let total = structured["total"] as? Int {
+                return total == 0
+            }
+            if let total = structured["total"] as? NSNumber {
+                return total.intValue == 0
+            }
+            if let results = structured["results"] as? [Any] {
+                return results.isEmpty
+            }
+        }
+
+        return response.text.contains(" - 0 of 0 shown")
     }
 
     private func hybridSearchWithinBudget(arguments: [String: Any]) throws -> HybridSearchResponse? {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -474,6 +474,44 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertNil(result["structuredContent"])
     }
 
+    func testBrainSearchFallsBackToBrainBarDatabaseWhenHybridHelperReturnsEmptyResults() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-hybrid-empty-fallback-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try db.insertChunk(
+            id: "empty-helper-fallback-result",
+            content: "brainlayer live search fallback result from Swift database",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 8
+        )
+
+        let helper = RecordingHybridSearchClient(
+            response: HybridSearchResponse(
+                text: """
+## Search results for "brainlayer" - 0 of 0 shown
+
+No results found.
+"""
+            )
+        )
+        let router = MCPRouter(hybridSearchClient: helper)
+        router.setDatabase(db)
+
+        let response = router.handle(toolCall(id: 179, name: "brain_search", arguments: [
+            "query": "brainlayer",
+            "num_results": 3,
+            "project": "brainlayer"
+        ]))
+
+        XCTAssertEqual(helper.requests.count, 1)
+        let text = try toolText(response)
+        XCTAssertTrue(text.contains("brainlayer live search fallback result from Swift database"), text)
+        XCTAssertFalse(text.contains("No results found."), text)
+    }
+
     func testBrainStoreMCPResultIsPlainAndShowsTagsWithoutContent() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-store-output-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }


### PR DESCRIPTION
## Summary
- Fall back to the local BrainBar Swift database search when the hybrid helper returns an empty/zero-result response.
- Keep normal successful helper responses on the helper path.
- Add a regression test for helper `0 of 0 shown` returning the Swift FTS hit.

## Test plan
- `swift test --package-path brain-bar --filter MCPRouterTests/testBrainSearchFallsBackToBrainBarDatabaseWhenHybridHelperReturnsEmptyResults`
- `swift test --package-path brain-bar --filter MCPRouterTests`
- Pre-push BrainLayer test gate: pytest unit suite, MCP tool registration, isolated eval/hook routing, bun test suite, FTS determinism shell test

## Notes
- Full unfiltered `swift test --package-path brain-bar` was attempted but stalled with no test output after several minutes and was interrupted; targeted Swift router coverage passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized routing change in MCP search with an existing fallback path and a new regression test; no auth or data-model changes.
> 
> **Overview**
> **`brain_search`** now treats a successful hybrid helper response with **zero hits** like a failed or timed-out call: it runs the local Swift database search and can prepend Swift KG facts, instead of returning the helper’s empty “0 of 0 shown” payload.
> 
> Empty detection uses **`hybridSearchResponseIsEmpty`**, which checks `structuredContent` (`total` / `results`) and a fallback match on the helper text pattern ` - 0 of 0 shown`. Non-empty helper responses are unchanged.
> 
> A regression test covers helper empty markdown returning a local FTS hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64d7b032139692c9b680592bed6abf5a8196114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to BrainBar database search when hybrid search returns empty results
> - Adds `hybridSearchResponseIsEmpty` helper in [MCPRouter.swift](https://github.com/EtanHey/brainlayer/pull/508/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f) that detects empty hybrid responses via `structuredContent` total count or a "0 of 0 shown" text substring.
> - When the hybrid search returns within budget but is empty, the `brain_search` handler now falls back to the BrainBar database, uses the local KG section, and logs the fallback.
> - Adds a test in [MCPRouterTests.swift](https://github.com/EtanHey/brainlayer/pull/508/files#diff-6a1a5be7d76811bedc4d3f0ebcb2043c90a2a0119ea214a29764bcd53b19af15) covering the fallback path with a recording hybrid client returning zero results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c64d7b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search functionality to gracefully handle empty results from the primary search service by automatically falling back to database results, ensuring users continue to find relevant content even when external search returns no matches.

* **Tests**
  * Added regression test to validate the search fallback mechanism works correctly when the primary search returns no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->