### PR TITLE
chore: ignore generated local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,16 @@ tests/eval_results/
 # Aggregate metrics go in results/ instead; raw rows archived to Brain Drive.
 eval_results/*.jsonl
 
+# Generated local eval/graph outputs
+eval_results/
+graphify-out/
+*.bak-*
+*.json.lock
+
+# Local agent/graph tooling state
+.agents/
+.graphifyignore
+
 # Progress trackers (ephemeral)
 scripts/.kg_rebuild_progress.json
 


### PR DESCRIPTION
## Summary
- ignore generated local eval and graphify outputs
- ignore JSON lock files, backup suffixes, local agent state, and local graphify scan config

## Test plan
- `printf '%s\n' eval_results/etan-session-decisions-2026-06-06.json.lock graphify-out/example .agents/mcp_config.json .graphifyignore eval_results/kg-phase1-decisions-2026-06-05.json.bak-web-v0 | git check-ignore -v --stdin`
- `coderabbit review --agent` (0 findings)

Co-Authored-By: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ignore rules with no runtime or deployment impact; note that newly ignored paths under `eval_results/` will no longer appear in future commits unless force-added.
> 
> **Overview**
> Expands **`.gitignore`** so local-only outputs and tooling state do not get committed accidentally.
> 
> **Generated eval/graph outputs:** ignores the whole **`eval_results/`** tree (in addition to the existing **`eval_results/*.jsonl`** privacy rule), plus **`graphify-out/`**, **`*.bak-*`**, and **`*.json.lock`**.
> 
> **Local agent/graph config:** ignores **`.agents/`** and **`.graphifyignore`**.
> 
> No application or CI behavior changes—only what Git treats as untracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f2fbd2d18470101cdba1ac99ac18588ac896d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add gitignore rules for generated eval, graph, and agent artifacts
> Adds ignore rules to [.gitignore](.gitignore) for locally generated outputs and tooling state: `eval_results/` (full directory), `graphify-out/`, `*.bak-*`, `*.json.lock`, `.agents/`, and `.graphifyignore`. An existing entry for `eval_results/*.jsonl` is retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f2fbd2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->