### PR TITLE
feat: add db shrink tooling

### DIFF
--- a/scripts/db_shrink_eval.py
+++ b/scripts/db_shrink_eval.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Benchmark before/after DB-shrink snapshots and persist the gate result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from brainlayer.db_shrink import dbstat_sizes
+from brainlayer.eval.benchmark import (
+    DEFAULT_QUERY_SUITE,
+    ReadOnlyBenchmarkStore,
+    SearchBenchmark,
+    _run_from_dict,
+    canonical_eval_doc_id,
+    pipeline_fts5_only,
+    prewarm_benchmark_embedder,
+)
+from brainlayer.vector_store import VectorStore
+
+
+def _run_pipeline(
+    db_path: Path,
+    qrels_path: str,
+    pipeline: str,
+    n_results: int,
+    *,
+    query_timeout_ms: int,
+) -> dict[str, Any]:
+    benchmark = SearchBenchmark(qrels_path)
+    queries = benchmark.queries_in_qrels(DEFAULT_QUERY_SUITE)
+    if not queries:
+        raise SystemExit("No benchmark queries have both qrels and query text.")
+
+    timed_out_queries: list[str] = []
+
+    def _run_with_progress(pipeline_fn):
+        run_dict: dict[str, dict[str, float]] = {}
+        total = len(queries)
+        for index, (query_id, query_text) in enumerate(queries, start=1):
+            print(f"[{pipeline}] {db_path.name} query {index}/{total}: {query_id}", flush=True)
+            results = pipeline_fn(query_id, query_text)
+            run_dict[query_id] = {}
+            for chunk_id, score in results:
+                normalized_id = canonical_eval_doc_id(str(chunk_id))
+                run_dict[query_id][normalized_id] = max(float(score), run_dict[query_id].get(normalized_id, 0.0))
+        return _run_from_dict(run_dict)
+
+    if pipeline == "fts5":
+        with ReadOnlyBenchmarkStore(db_path) as store:
+            def _fts_query(query_id: str, query_text: str):
+                deadline = time.monotonic() + (query_timeout_ms / 1000.0)
+                store.conn.set_progress_handler(lambda: 1 if time.monotonic() >= deadline else 0, 1000)
+                try:
+                    return pipeline_fts5_only(store, query_text, n_results=n_results)
+                except sqlite3.OperationalError as exc:
+                    if "interrupted" not in str(exc).lower():
+                        raise
+                    timed_out_queries.append(query_id)
+                    return []
+                finally:
+                    store.conn.set_progress_handler(None, 0)
+
+            run = _run_with_progress(_fts_query)
+    elif pipeline == "hybrid_rrf":
+        embed_fn = prewarm_benchmark_embedder()
+        with VectorStore(db_path, readonly=True) as store:
+            run = _run_with_progress(
+                lambda _query_id, query_text: [
+                    (chunk_id, 1.0 / (rank + 1))
+                    for rank, chunk_id in enumerate(
+                        store.hybrid_search(
+                            query_embedding=embed_fn(query_text),
+                            query_text=query_text,
+                            n_results=n_results,
+                            brainbar_helper_fast_profile=True,
+                        ).get("ids", [[]])[0]
+                    )
+                ]
+            )
+    else:
+        raise ValueError(f"Unsupported pipeline: {pipeline}")
+
+    return {
+        "metrics": benchmark.evaluate_pipeline(run),
+        "query_count": len(queries),
+        "query_timeout_ms": query_timeout_ms,
+        "timed_out_queries": timed_out_queries,
+    }
+
+
+def _gate(before: dict[str, Any], after: dict[str, Any], *, max_regression: float) -> dict[str, Any]:
+    gated_metrics = ("ndcg@3", "ndcg@10", "recall@20")
+    regressions: list[dict[str, Any]] = []
+    for pipeline, before_result in before.items():
+        after_result = after[pipeline]
+        for metric in gated_metrics:
+            before_value = float(before_result["metrics"].get(metric, 0.0))
+            after_value = float(after_result["metrics"].get(metric, 0.0))
+            delta = after_value - before_value
+            if delta < -max_regression:
+                regressions.append(
+                    {
+                        "pipeline": pipeline,
+                        "metric": metric,
+                        "before": before_value,
+                        "after": after_value,
+                        "delta": delta,
+                    }
+                )
+    return {
+        "verdict": "pass" if not regressions else "fail",
+        "max_regression": max_regression,
+        "regressions": regressions,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before-db", required=True)
+    parser.add_argument("--after-db", required=True)
+    parser.add_argument("--qrels-path", default="tests/eval_qrels.json")
+    parser.add_argument("--pipeline", action="append", choices=["fts5", "hybrid_rrf"], dest="pipelines")
+    parser.add_argument("--n-results", type=int, default=20)
+    parser.add_argument("--max-regression", type=float, default=0.005)
+    parser.add_argument("--query-timeout-ms", type=int, default=10_000)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    pipelines = args.pipelines or ["fts5", "hybrid_rrf"]
+    before_db = Path(args.before_db).expanduser().resolve()
+    after_db = Path(args.after_db).expanduser().resolve()
+    before_results = {
+        pipeline: _run_pipeline(
+            before_db,
+            args.qrels_path,
+            pipeline,
+            args.n_results,
+            query_timeout_ms=args.query_timeout_ms,
+        )
+        for pipeline in pipelines
+    }
+    after_results = {
+        pipeline: _run_pipeline(
+            after_db,
+            args.qrels_path,
+            pipeline,
+            args.n_results,
+            query_timeout_ms=args.query_timeout_ms,
+        )
+        for pipeline in pipelines
+    }
+    gate = _gate(before_results, after_results, max_regression=args.max_regression)
+    before_bytes = before_db.stat().st_size
+    after_bytes = after_db.stat().st_size
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_path = Path(args.output) if args.output else Path("eval_results") / "db-shrink-2026-06-01.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp": timestamp,
+        "before_db": str(before_db),
+        "after_db": str(after_db),
+        "before_bytes": before_bytes,
+        "after_bytes": after_bytes,
+        "reclaimed_bytes": max(0, before_bytes - after_bytes),
+        "pipelines": pipelines,
+        "before": before_results,
+        "after": after_results,
+        "gate": gate,
+        "dbstat_top_before": dict(list(dbstat_sizes(before_db).items())[:20]),
+        "dbstat_top_after": dict(list(dbstat_sizes(after_db).items())[:20]),
+    }
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    print(f"Saved DB-shrink eval to {output_path}")
+    return 0 if gate["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/db_shrink_migrate.py
+++ b/scripts/db_shrink_migrate.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Run offline DB shrink migrations against a snapshot path."""
+
+from brainlayer.db_shrink import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/db_shrink.py
+++ b/src/brainlayer/db_shrink.py
@@ -461,6 +461,22 @@ def _delete_by_chunk_id(cursor: Any, schema: dict[str, list[str]], table_name: s
         cursor.execute(f"DELETE FROM {table_name} WHERE chunk_id = ?", (duplicate_id,))
 
 
+def _delete_fts_rows_for_chunk(cursor: Any, schema: dict[str, list[str]], duplicate_id: str) -> None:
+    if "chunk_fts_rowids" not in schema:
+        return
+    row = cursor.execute(
+        "SELECT fts_rowid, trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = ?",
+        (duplicate_id,),
+    ).fetchone()
+    if row is None:
+        return
+    fts_rowid, trigram_rowid = row
+    if fts_rowid is not None and "chunks_fts" in schema:
+        cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (fts_rowid,))
+    if trigram_rowid is not None and "chunks_fts_trigram" in schema:
+        cursor.execute("DELETE FROM chunks_fts_trigram WHERE rowid = ?", (trigram_rowid,))
+
+
 def _record_alias(cursor: Any, duplicate_id: str, canonical_id: str) -> None:
     cursor.execute(
         """
@@ -486,6 +502,8 @@ def _merge_duplicate_references(
     schema: dict[str, list[str]],
     duplicate_id: str,
     canonical_id: str,
+    *,
+    delete_fts_rows: bool = False,
 ) -> None:
     for table_name in ("chunk_tags", "kg_entity_chunks", "chunk_clusters", "agent_reads"):
         if table_name in schema:
@@ -496,6 +514,8 @@ def _merge_duplicate_references(
     for table_name in ("chunk_vectors", "chunk_vectors_binary"):
         _delete_by_chunk_id(cursor, schema, table_name, duplicate_id)
 
+    if delete_fts_rows:
+        _delete_fts_rows_for_chunk(cursor, schema, duplicate_id)
     _delete_by_chunk_id(cursor, schema, "chunk_fts_rowids", duplicate_id)
     _record_alias(cursor, duplicate_id, canonical_id)
     cursor.execute("DELETE FROM chunks WHERE id = ?", (duplicate_id,))
@@ -567,7 +587,8 @@ def apply_content_dedup(
     try:
         cursor = conn.cursor()
         ensure_dedupe_schema(conn)
-        drop_fts_triggers(cursor)
+        if rebuild_fts:
+            drop_fts_triggers(cursor)
         schema = _schema_columns(cursor)
         cursor.execute("PRAGMA wal_checkpoint(FULL)")
         for offset in range(0, len(duplicates), batch_size):
@@ -578,7 +599,13 @@ def apply_content_dedup(
                         continue
                     if cursor.execute("SELECT 1 FROM chunks WHERE id = ?", (canonical_id,)).fetchone() is None:
                         continue
-                    _merge_duplicate_references(cursor, schema, duplicate_id, canonical_id)
+                    _merge_duplicate_references(
+                        cursor,
+                        schema,
+                        duplicate_id,
+                        canonical_id,
+                        delete_fts_rows=not rebuild_fts,
+                    )
                     deleted += 1
                 cursor.execute("COMMIT")
             except Exception:

--- a/src/brainlayer/db_shrink.py
+++ b/src/brainlayer/db_shrink.py
@@ -1,0 +1,682 @@
+"""Offline BrainLayer DB shrink migrations.
+
+These helpers are intentionally path-parameterized. They are for snapshot
+maintenance first; the canonical live DB requires an explicit guard override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import apsw
+import sqlite_vec
+
+from brainlayer.dedupe import ensure_dedupe_schema, normalized_exact_hash
+from brainlayer.paths import get_db_path
+
+FTS_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED"
+FTS_VALUE_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, id"
+FTS_TRIGGER_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries"
+FTS_MODE_SINGLE_TRIGRAM = "single_trigram"
+FTS_MODE_COMPACT_DUAL = "compact_dual"
+LIVE_REFUSAL = "Refusing to write to the canonical live DB"
+
+
+@dataclass(frozen=True)
+class FtsMigrationResult:
+    db_path: str
+    mode: str
+    chunk_count: int
+    fts_count: int
+    before_bytes: int
+    after_bytes: int
+    reclaimed_bytes: int
+
+
+@dataclass(frozen=True)
+class DedupResult:
+    db_path: str
+    scanned_rows: int
+    duplicate_groups: int
+    duplicate_rows: int
+    deleted_rows: int
+    protected_chunk_ids: int
+
+
+@dataclass(frozen=True)
+class VacuumResult:
+    db_path: str
+    before_bytes: int
+    after_bytes: int
+    reclaimed_bytes: int
+
+
+def _resolve(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def assert_not_live_db(db_path: str | Path, *, allow_live: bool = False) -> None:
+    """Refuse writes to the canonical live DB unless explicitly overridden."""
+    path = _resolve(db_path)
+    live_path = _resolve(get_db_path())
+    if path == live_path and not allow_live:
+        raise ValueError(f"{LIVE_REFUSAL}; run against a snapshot or pass --i-know-this-is-live")
+
+
+def _connect(db_path: str | Path) -> apsw.Connection:
+    conn = apsw.Connection(str(_resolve(db_path)))
+    conn.setbusytimeout(30_000)
+    conn.enableloadextension(True)
+    conn.loadextension(sqlite_vec.loadable_path())
+    conn.enableloadextension(False)
+    return conn
+
+
+def _table_exists(cursor: Any, table_name: str) -> bool:
+    return (
+        cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?",
+            (table_name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _columns(cursor: Any, table_name: str) -> list[str]:
+    return [str(row[1]) for row in cursor.execute(f"PRAGMA table_info({table_name})")]
+
+
+def _schema_columns(cursor: Any) -> dict[str, list[str]]:
+    tables = [
+        str(row[0])
+        for row in cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'"
+        )
+    ]
+    return {table_name: _columns(cursor, table_name) for table_name in tables}
+
+
+def _db_file_bytes(db_path: str | Path) -> int:
+    return _resolve(db_path).stat().st_size
+
+
+def dbstat_sizes(db_path: str | Path, *, allow_live: bool = False) -> dict[str, int]:
+    """Return per-object byte sizes from SQLite dbstat."""
+    assert_not_live_db(db_path, allow_live=allow_live)
+    conn = _connect(db_path)
+    try:
+        return {
+            str(name): int(size)
+            for name, size in conn.cursor().execute(
+                "SELECT name, SUM(pgsize) FROM dbstat GROUP BY name ORDER BY SUM(pgsize) DESC"
+            )
+        }
+    finally:
+        conn.close()
+
+
+def _ensure_meta(cursor: Any) -> None:
+    cursor.execute("CREATE TABLE IF NOT EXISTS brainlayer_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+
+
+def set_fts_mode(cursor: Any, mode: str) -> None:
+    _ensure_meta(cursor)
+    cursor.execute(
+        "INSERT INTO brainlayer_meta(key, value) VALUES ('fts_mode', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (mode,),
+    )
+
+
+def get_fts_mode(cursor: Any) -> str | None:
+    if not _table_exists(cursor, "brainlayer_meta"):
+        return None
+    row = cursor.execute("SELECT value FROM brainlayer_meta WHERE key = 'fts_mode'").fetchone()
+    return str(row[0]) if row else None
+
+
+def drop_fts_triggers(cursor: Any) -> None:
+    for name in (
+        "chunks_fts_insert",
+        "chunks_fts_delete",
+        "chunks_fts_update",
+        "chunks_fts_trigram_insert",
+        "chunks_fts_trigram_delete",
+        "chunks_fts_trigram_update",
+    ):
+        cursor.execute(f"DROP TRIGGER IF EXISTS {name}")
+
+
+def create_single_trigram_fts_schema(cursor: Any) -> None:
+    """Create the compact FTS schema and triggers used by the migration."""
+    cursor.execute(f"""
+        CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+            {FTS_COLUMNS},
+            tokenize='trigram'
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS chunk_fts_rowids (
+            chunk_id TEXT PRIMARY KEY,
+            fts_rowid INTEGER,
+            trigram_rowid INTEGER
+        )
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_insert")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_insert AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (
+                new.content,
+                new.summary,
+                new.tags,
+                new.resolved_query,
+                new.key_facts,
+                new.resolved_queries,
+                new.id
+            );
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid)
+            VALUES (new.id, last_insert_rowid(), NULL)
+            ON CONFLICT(chunk_id) DO UPDATE SET
+                fts_rowid = excluded.fts_rowid,
+                trigram_rowid = NULL;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_delete")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_delete AFTER DELETE ON chunks BEGIN
+            DELETE FROM chunks_fts
+            WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_update")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_update
+        AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries ON chunks BEGIN
+            DELETE FROM chunks_fts
+            WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (
+                new.content,
+                new.summary,
+                new.tags,
+                new.resolved_query,
+                new.key_facts,
+                new.resolved_queries,
+                new.id
+            );
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid)
+            VALUES (new.id, last_insert_rowid(), NULL)
+            ON CONFLICT(chunk_id) DO UPDATE SET
+                fts_rowid = excluded.fts_rowid,
+                trigram_rowid = NULL;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_insert")
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_delete")
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_update")
+
+
+def create_compact_dual_fts_schema(cursor: Any) -> None:
+    """Create current compact dual FTS schema: default FTS plus trigram FTS."""
+    cursor.execute(f"""
+        CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+            {FTS_COLUMNS}
+        )
+    """)
+    cursor.execute(f"""
+        CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts_trigram USING fts5(
+            {FTS_COLUMNS},
+            tokenize='trigram'
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS chunk_fts_rowids (
+            chunk_id TEXT PRIMARY KEY,
+            fts_rowid INTEGER,
+            trigram_rowid INTEGER
+        )
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_insert")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_insert AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+            VALUES (new.id, last_insert_rowid())
+            ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_insert")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_insert AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
+            INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
+            VALUES (new.id, last_insert_rowid())
+            ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_delete")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_delete AFTER DELETE ON chunks BEGIN
+            DELETE FROM chunks_fts
+            WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            DELETE FROM chunks_fts_trigram
+            WHERE rowid = (SELECT trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_delete")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_delete AFTER DELETE ON chunks BEGIN
+            DELETE FROM chunks_fts
+            WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            DELETE FROM chunks_fts_trigram
+            WHERE rowid = (SELECT trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_update")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_update
+        AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries ON chunks BEGIN
+            DELETE FROM chunks_fts
+            WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+            VALUES (new.id, last_insert_rowid())
+            ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid;
+        END
+    """)
+    cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_update")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_update
+        AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries ON chunks BEGIN
+            DELETE FROM chunks_fts_trigram
+            WHERE rowid = (SELECT trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (new.content, new.summary, new.tags, new.resolved_query, new.key_facts, new.resolved_queries, new.id);
+            INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
+            VALUES (new.id, last_insert_rowid())
+            ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid;
+        END
+    """)
+
+
+def _rebuild_fts(
+    db_path: str | Path,
+    *,
+    mode: str,
+    allow_live: bool = False,
+) -> FtsMigrationResult:
+    assert_not_live_db(db_path, allow_live=allow_live)
+    path = _resolve(db_path)
+    before_bytes = _db_file_bytes(path)
+    conn = _connect(path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            drop_fts_triggers(cursor)
+            cursor.execute("DROP TABLE IF EXISTS chunks_fts")
+            cursor.execute("DROP TABLE IF EXISTS chunks_fts_trigram")
+            cursor.execute("DELETE FROM chunk_fts_rowids")
+            if mode == FTS_MODE_SINGLE_TRIGRAM:
+                create_single_trigram_fts_schema(cursor)
+            elif mode == FTS_MODE_COMPACT_DUAL:
+                create_compact_dual_fts_schema(cursor)
+            else:
+                raise ValueError(f"Unsupported FTS mode: {mode}")
+            cursor.execute(f"""
+                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                SELECT {FTS_VALUE_COLUMNS} FROM chunks
+            """)
+            if mode == FTS_MODE_COMPACT_DUAL:
+                cursor.execute(f"""
+                    INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                    SELECT {FTS_VALUE_COLUMNS} FROM chunks
+                """)
+                cursor.execute("""
+                    INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+                    SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
+                    ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid
+                """)
+                cursor.execute("""
+                    INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
+                    SELECT chunk_id, rowid FROM chunks_fts_trigram WHERE chunk_id IS NOT NULL
+                    ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid
+                """)
+            else:
+                cursor.execute("""
+                    INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid)
+                    SELECT chunk_id, rowid, NULL FROM chunks_fts WHERE chunk_id IS NOT NULL
+                    ON CONFLICT(chunk_id) DO UPDATE SET
+                        fts_rowid = excluded.fts_rowid,
+                        trigram_rowid = NULL
+                """)
+            set_fts_mode(cursor, mode)
+            chunk_count = int(cursor.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+            fts_count = int(cursor.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0])
+            cursor.execute("COMMIT")
+        except Exception:
+            cursor.execute("ROLLBACK")
+            raise
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+    finally:
+        conn.close()
+    after_bytes = _db_file_bytes(path)
+    return FtsMigrationResult(
+        db_path=str(path),
+        mode=mode,
+        chunk_count=chunk_count,
+        fts_count=fts_count,
+        before_bytes=before_bytes,
+        after_bytes=after_bytes,
+        reclaimed_bytes=max(0, before_bytes - after_bytes),
+    )
+
+
+def migrate_fts_single_trigram(db_path: str | Path, *, allow_live: bool = False) -> FtsMigrationResult:
+    """Replace dual/prefix FTS tables with one compact trigram FTS table."""
+    return _rebuild_fts(db_path, mode=FTS_MODE_SINGLE_TRIGRAM, allow_live=allow_live)
+
+
+def migrate_fts_compact_dual(db_path: str | Path, *, allow_live: bool = False) -> FtsMigrationResult:
+    """Rebuild FTS without legacy prefix bloat while preserving trigram search."""
+    return _rebuild_fts(db_path, mode=FTS_MODE_COMPACT_DUAL, allow_live=allow_live)
+
+
+def _canonical_for_group(rows: list[tuple[str, str | None]], protected_chunk_ids: set[str]) -> str:
+    ordered = sorted(rows, key=lambda row: (row[0] not in protected_chunk_ids, row[1] or "", row[0]))
+    return ordered[0][0]
+
+
+def analyze_content_duplicates(
+    db_path: str | Path, *, allow_live: bool = False
+) -> tuple[int, dict[str, list[tuple[str, str | None]]]]:
+    """Return scanned row count and exact normalized-content duplicate groups."""
+    assert_not_live_db(db_path, allow_live=allow_live)
+    conn = _connect(db_path)
+    groups: dict[str, list[tuple[str, str | None]]] = defaultdict(list)
+    scanned = 0
+    try:
+        for chunk_id, content, created_at in conn.cursor().execute("SELECT id, content, created_at FROM chunks"):
+            scanned += 1
+            if content is None:
+                continue
+            content_hash = normalized_exact_hash(str(content))
+            groups[content_hash].append((str(chunk_id), str(created_at) if created_at is not None else None))
+    finally:
+        conn.close()
+    return scanned, {content_hash: rows for content_hash, rows in groups.items() if len(rows) > 1}
+
+
+def _insert_or_ignore_repoint(
+    cursor: Any,
+    schema: dict[str, list[str]],
+    table_name: str,
+    duplicate_id: str,
+    canonical_id: str,
+) -> None:
+    cols = schema.get(table_name, [])
+    if "chunk_id" not in cols:
+        return
+    column_sql = ", ".join(cols)
+    select_sql = ", ".join("? AS chunk_id" if col == "chunk_id" else col for col in cols)
+    cursor.execute(
+        f"INSERT OR IGNORE INTO {table_name} ({column_sql}) SELECT {select_sql} FROM {table_name} WHERE chunk_id = ?",
+        (canonical_id, duplicate_id),
+    )
+    cursor.execute(f"DELETE FROM {table_name} WHERE chunk_id = ?", (duplicate_id,))
+
+
+def _update_or_ignore(
+    cursor: Any,
+    schema: dict[str, list[str]],
+    table_name: str,
+    column_name: str,
+    duplicate_id: str,
+    canonical_id: str,
+) -> None:
+    if column_name not in schema.get(table_name, []):
+        return
+    cursor.execute(
+        f"UPDATE OR IGNORE {table_name} SET {column_name} = ? WHERE {column_name} = ?",
+        (canonical_id, duplicate_id),
+    )
+
+
+def _delete_by_chunk_id(cursor: Any, schema: dict[str, list[str]], table_name: str, duplicate_id: str) -> None:
+    if "chunk_id" in schema.get(table_name, []):
+        cursor.execute(f"DELETE FROM {table_name} WHERE chunk_id = ?", (duplicate_id,))
+
+
+def _record_alias(cursor: Any, duplicate_id: str, canonical_id: str) -> None:
+    cursor.execute(
+        """
+        INSERT INTO chunk_id_alias(old_chunk_id, canonical_chunk_id, deprecated_at)
+        VALUES (?, ?, datetime('now'))
+        ON CONFLICT(old_chunk_id) DO UPDATE SET
+            canonical_chunk_id = excluded.canonical_chunk_id,
+            deprecated_at = excluded.deprecated_at
+        """,
+        (duplicate_id, canonical_id),
+    )
+    cursor.execute(
+        """
+        INSERT INTO dedupe_audit(chunk_id_dropped, chunk_id_kept, mechanism, hamming_distance, ts)
+        VALUES (?, ?, 'normalized_content_physical_delete', 0, datetime('now'))
+        """,
+        (duplicate_id, canonical_id),
+    )
+
+
+def _merge_duplicate_references(
+    cursor: Any,
+    schema: dict[str, list[str]],
+    duplicate_id: str,
+    canonical_id: str,
+) -> None:
+    for table_name in ("chunk_tags", "kg_entity_chunks", "chunk_clusters", "agent_reads"):
+        if table_name in schema:
+            _insert_or_ignore_repoint(cursor, schema, table_name, duplicate_id, canonical_id)
+
+    # sqlite-vec virtual tables can raise a primary-key error even with
+    # INSERT OR IGNORE. Duplicate chunks do not need duplicate vectors.
+    for table_name in ("chunk_vectors", "chunk_vectors_binary"):
+        _delete_by_chunk_id(cursor, schema, table_name, duplicate_id)
+
+    _delete_by_chunk_id(cursor, schema, "chunk_fts_rowids", duplicate_id)
+    _record_alias(cursor, duplicate_id, canonical_id)
+    cursor.execute("DELETE FROM chunks WHERE id = ?", (duplicate_id,))
+
+
+def _bulk_update_alias_refs(
+    cursor: Any,
+    schema: dict[str, list[str]],
+    table_name: str,
+    column_name: str,
+) -> None:
+    if column_name not in schema.get(table_name, []):
+        return
+    cursor.execute(f"""
+        UPDATE OR IGNORE {table_name}
+        SET {column_name} = (
+            SELECT canonical_chunk_id
+            FROM chunk_id_alias
+            WHERE old_chunk_id = {table_name}.{column_name}
+        )
+        WHERE {column_name} IN (SELECT old_chunk_id FROM chunk_id_alias)
+    """)
+
+
+def _bulk_repoint_direct_refs(cursor: Any, schema: dict[str, list[str]]) -> None:
+    for table_name in ("chunk_events", "correction_pairs", "file_interactions"):
+        _bulk_update_alias_refs(cursor, schema, table_name, "chunk_id")
+    _bulk_update_alias_refs(cursor, schema, "kg_relations", "source_chunk_id")
+
+
+def _bulk_repoint_chunk_self_refs(cursor: Any, schema: dict[str, list[str]]) -> None:
+    for column_name in ("superseded_by", "aggregated_into", "consolidated_into"):
+        if column_name not in schema.get("chunks", []):
+            continue
+        cursor.execute(f"""
+            UPDATE OR IGNORE chunks
+            SET {column_name} = (
+                SELECT canonical_chunk_id
+                FROM chunk_id_alias
+                WHERE old_chunk_id = chunks.{column_name}
+            )
+            WHERE {column_name} IN (SELECT old_chunk_id FROM chunk_id_alias)
+        """)
+
+
+def apply_content_dedup(
+    db_path: str | Path,
+    *,
+    protected_chunk_ids: Iterable[str] = (),
+    batch_size: int = 1000,
+    allow_live: bool = False,
+    rebuild_fts: bool = True,
+    fts_mode: str = FTS_MODE_COMPACT_DUAL,
+) -> DedupResult:
+    """Physically delete exact normalized-content duplicates from a snapshot DB."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+    assert_not_live_db(db_path, allow_live=allow_live)
+    protected = {str(chunk_id) for chunk_id in protected_chunk_ids}
+    scanned, groups = analyze_content_duplicates(db_path, allow_live=allow_live)
+    duplicates: list[tuple[str, str]] = []
+    for rows in groups.values():
+        canonical_id = _canonical_for_group(rows, protected)
+        duplicates.extend((chunk_id, canonical_id) for chunk_id, _created_at in rows if chunk_id != canonical_id)
+
+    path = _resolve(db_path)
+    conn = _connect(path)
+    deleted = 0
+    try:
+        cursor = conn.cursor()
+        ensure_dedupe_schema(conn)
+        drop_fts_triggers(cursor)
+        schema = _schema_columns(cursor)
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        for offset in range(0, len(duplicates), batch_size):
+            cursor.execute("BEGIN IMMEDIATE")
+            try:
+                for duplicate_id, canonical_id in duplicates[offset : offset + batch_size]:
+                    if cursor.execute("SELECT 1 FROM chunks WHERE id = ?", (duplicate_id,)).fetchone() is None:
+                        continue
+                    if cursor.execute("SELECT 1 FROM chunks WHERE id = ?", (canonical_id,)).fetchone() is None:
+                        continue
+                    _merge_duplicate_references(cursor, schema, duplicate_id, canonical_id)
+                    deleted += 1
+                cursor.execute("COMMIT")
+            except Exception:
+                cursor.execute("ROLLBACK")
+                raise
+            cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            _bulk_repoint_direct_refs(cursor, schema)
+            _bulk_repoint_chunk_self_refs(cursor, schema)
+            cursor.execute("COMMIT")
+        except Exception:
+            cursor.execute("ROLLBACK")
+            raise
+    finally:
+        conn.close()
+    if rebuild_fts:
+        _rebuild_fts(path, mode=fts_mode, allow_live=allow_live)
+    return DedupResult(
+        db_path=str(path),
+        scanned_rows=scanned,
+        duplicate_groups=len(groups),
+        duplicate_rows=len(duplicates),
+        deleted_rows=deleted,
+        protected_chunk_ids=len(protected),
+    )
+
+
+def vacuum_database(db_path: str | Path, *, allow_live: bool = False) -> VacuumResult:
+    """Physically compact a snapshot DB after logical shrink operations."""
+    assert_not_live_db(db_path, allow_live=allow_live)
+    path = _resolve(db_path)
+    before_bytes = _db_file_bytes(path)
+    conn = _connect(path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        cursor.execute("VACUUM")
+        cursor.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        conn.close()
+    after_bytes = _db_file_bytes(path)
+    return VacuumResult(
+        db_path=str(path),
+        before_bytes=before_bytes,
+        after_bytes=after_bytes,
+        reclaimed_bytes=max(0, before_bytes - after_bytes),
+    )
+
+
+def load_protected_qrel_ids(qrels_path: str | Path | None) -> set[str]:
+    if qrels_path is None:
+        return set()
+    payload = json.loads(Path(qrels_path).read_text())
+    protected: set[str] = set()
+    for judgments in payload.values():
+        if isinstance(judgments, dict):
+            protected.update(str(doc_id) for doc_id in judgments)
+    return protected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", required=True)
+    parser.add_argument("--batch-size", type=int, default=1000)
+    parser.add_argument("--qrels-path")
+    parser.add_argument("--skip-fts", action="store_true")
+    parser.add_argument("--skip-dedup", action="store_true")
+    parser.add_argument("--fts-mode", choices=["compact-dual", "single-trigram"], default="compact-dual")
+    parser.add_argument("--vacuum", action="store_true", help="Physically compact the snapshot after migrations")
+    parser.add_argument("--i-know-this-is-live", action="store_true")
+    args = parser.parse_args(argv)
+
+    allow_live = bool(args.i_know_this_is_live)
+    assert_not_live_db(args.db_path, allow_live=allow_live)
+    started = time.time()
+    results: dict[str, Any] = {"db_path": str(_resolve(args.db_path))}
+    fts_mode = FTS_MODE_SINGLE_TRIGRAM if args.fts_mode == "single-trigram" else FTS_MODE_COMPACT_DUAL
+    if not args.skip_dedup:
+        protected = load_protected_qrel_ids(args.qrels_path)
+        results["dedup"] = asdict(
+            apply_content_dedup(
+                args.db_path,
+                protected_chunk_ids=protected,
+                batch_size=args.batch_size,
+                allow_live=allow_live,
+                rebuild_fts=not args.skip_fts,
+                fts_mode=fts_mode,
+            )
+        )
+    elif not args.skip_fts:
+        results["fts"] = asdict(_rebuild_fts(args.db_path, mode=fts_mode, allow_live=allow_live))
+    if args.vacuum:
+        results["vacuum"] = asdict(vacuum_database(args.db_path, allow_live=allow_live))
+    results["elapsed_seconds"] = round(time.time() - started, 3)
+    print(json.dumps(results, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_db_shrink.py
+++ b/tests/test_db_shrink.py
@@ -247,3 +247,89 @@ def test_dedupe_deletes_duplicates_and_repoints_refs(tmp_path):
     assert interaction == "qrel-id"
     assert relation == "qrel-id"
     assert vector is None
+
+
+def test_dedupe_without_fts_rebuild_preserves_fts_consistency(tmp_path):
+    from brainlayer.db_shrink import apply_content_dedup
+
+    db_path = tmp_path / "dedup-skip-fts.db"
+    conn = sqlite3.connect(db_path)
+    _init_chunks(conn)
+    conn.executescript(
+        """
+        CREATE TABLE chunk_id_alias (
+            old_chunk_id TEXT PRIMARY KEY,
+            canonical_chunk_id TEXT NOT NULL,
+            deprecated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE dedupe_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chunk_id_dropped TEXT NOT NULL,
+            chunk_id_kept TEXT NOT NULL,
+            mechanism TEXT NOT NULL,
+            hamming_distance INTEGER,
+            ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
+        );
+        CREATE TRIGGER chunks_fts_insert AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            VALUES (
+                new.content,
+                new.summary,
+                new.tags,
+                new.resolved_query,
+                new.key_facts,
+                new.resolved_queries,
+                new.id
+            );
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid)
+            VALUES (new.id, last_insert_rowid(), NULL)
+            ON CONFLICT(chunk_id) DO UPDATE SET
+                fts_rowid = excluded.fts_rowid,
+                trigram_rowid = NULL;
+        END;
+        CREATE TRIGGER chunks_fts_delete AFTER DELETE ON chunks BEGIN
+            DELETE FROM chunks_fts
+            WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+            DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
+        END;
+        """
+    )
+    rows = [
+        ("canonical-id", "Duplicate content that should collapse", "2026-01-01"),
+        ("dupe-id", "duplicate   content that should collapse", "2026-01-02"),
+    ]
+    conn.executemany(
+        """
+        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
+        VALUES (?, ?, '', '', '', '', '', ?)
+        """,
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+    result = apply_content_dedup(db_path, rebuild_fts=False)
+
+    checked = sqlite3.connect(db_path)
+    remaining_fts_ids = {
+        row[0] for row in checked.execute("SELECT chunk_id FROM chunks_fts WHERE chunk_id IS NOT NULL")
+    }
+    delete_trigger = checked.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'chunks_fts_delete'"
+    ).fetchone()
+    checked.execute(
+        """
+        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
+        VALUES ('fresh-id', 'Fresh searchable note', '', '', '', '', '', '2026-01-03')
+        """
+    )
+    fresh_fts = checked.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'fresh-id'").fetchone()[0]
+    checked.close()
+
+    assert result.deleted_rows == 1
+    assert remaining_fts_ids == {"canonical-id"}
+    assert delete_trigger is not None
+    assert fresh_fts == 1

--- a/tests/test_db_shrink.py
+++ b/tests/test_db_shrink.py
@@ -1,0 +1,249 @@
+import sqlite3
+
+import pytest
+
+
+def _init_chunks(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            summary TEXT,
+            tags TEXT,
+            resolved_query TEXT,
+            key_facts TEXT,
+            resolved_queries TEXT,
+            created_at TEXT,
+            project TEXT,
+            content_type TEXT
+        );
+        CREATE TABLE chunk_fts_rowids (
+            chunk_id TEXT PRIMARY KEY,
+            fts_rowid INTEGER,
+            trigram_rowid INTEGER
+        );
+        """
+    )
+
+
+def test_guard_refuses_live_path_without_explicit_override(tmp_path, monkeypatch):
+    from brainlayer import db_shrink
+
+    live_path = tmp_path / "brainlayer.db"
+    live_path.touch()
+    monkeypatch.setattr(db_shrink, "get_db_path", lambda: live_path)
+
+    with pytest.raises(ValueError, match="Refusing to write to the canonical live DB"):
+        db_shrink.assert_not_live_db(live_path)
+
+    db_shrink.assert_not_live_db(live_path, allow_live=True)
+
+
+def test_migrate_fts_single_trigram_drops_redundant_table(tmp_path):
+    from brainlayer.db_shrink import migrate_fts_single_trigram
+
+    db_path = tmp_path / "fts.db"
+    conn = sqlite3.connect(db_path)
+    _init_chunks(conn)
+    conn.executescript(
+        """
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED,
+            prefix='2 3 4', tokenize='unicode61 remove_diacritics 2'
+        );
+        CREATE VIRTUAL TABLE chunks_fts_trigram USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED,
+            tokenize='trigram'
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
+        VALUES ('c1', 'searchable abcdef memory', '', '', '', '', '', '2026-01-01')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+        SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+        SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    result = migrate_fts_single_trigram(db_path)
+
+    checked = sqlite3.connect(db_path)
+    schema = checked.execute("SELECT sql FROM sqlite_master WHERE name = 'chunks_fts'").fetchone()[0]
+    trigram_table = checked.execute("SELECT 1 FROM sqlite_master WHERE name = 'chunks_fts_trigram'").fetchone()
+    fts_count = checked.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0]
+    meta_mode = checked.execute("SELECT value FROM brainlayer_meta WHERE key = 'fts_mode'").fetchone()[0]
+    checked.close()
+
+    assert result.chunk_count == 1
+    assert result.fts_count == 1
+    assert "tokenize='trigram'" in schema
+    assert trigram_table is None
+    assert fts_count == 1
+    assert meta_mode == "single_trigram"
+
+
+def test_migrate_fts_compact_dual_preserves_trigram_table(tmp_path):
+    from brainlayer.db_shrink import migrate_fts_compact_dual
+
+    db_path = tmp_path / "fts-dual.db"
+    conn = sqlite3.connect(db_path)
+    _init_chunks(conn)
+    conn.executescript(
+        """
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED,
+            prefix='2 3 4', tokenize='unicode61 remove_diacritics 2'
+        );
+        CREATE VIRTUAL TABLE chunks_fts_trigram USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED,
+            tokenize='trigram'
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
+        VALUES ('c1', 'searchable abcdef memory', '', '', '', '', '', '2026-01-01')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    result = migrate_fts_compact_dual(db_path)
+
+    checked = sqlite3.connect(db_path)
+    schema = checked.execute("SELECT sql FROM sqlite_master WHERE name = 'chunks_fts'").fetchone()[0]
+    trigram_schema = checked.execute("SELECT sql FROM sqlite_master WHERE name = 'chunks_fts_trigram'").fetchone()[0]
+    counts = checked.execute(
+        "SELECT (SELECT COUNT(*) FROM chunks_fts), (SELECT COUNT(*) FROM chunks_fts_trigram)"
+    ).fetchone()
+    checked.close()
+
+    assert result.mode == "compact_dual"
+    assert "prefix=" not in schema
+    assert "tokenize='trigram'" in trigram_schema
+    assert counts == (1, 1)
+
+
+def test_dedupe_deletes_duplicates_and_repoints_refs(tmp_path):
+    from brainlayer.db_shrink import apply_content_dedup
+
+    db_path = tmp_path / "dedup.db"
+    conn = sqlite3.connect(db_path)
+    _init_chunks(conn)
+    conn.executescript(
+        """
+        CREATE TABLE chunk_id_alias (
+            old_chunk_id TEXT PRIMARY KEY,
+            canonical_chunk_id TEXT NOT NULL,
+            deprecated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE dedupe_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chunk_id_dropped TEXT NOT NULL,
+            chunk_id_kept TEXT NOT NULL,
+            mechanism TEXT NOT NULL,
+            hamming_distance INTEGER,
+            ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE chunk_tags (
+            chunk_id TEXT NOT NULL,
+            tag TEXT NOT NULL,
+            PRIMARY KEY (chunk_id, tag)
+        );
+        CREATE TABLE kg_entity_chunks (
+            entity_id TEXT NOT NULL,
+            chunk_id TEXT NOT NULL,
+            relevance REAL,
+            context TEXT,
+            PRIMARY KEY (entity_id, chunk_id)
+        );
+        CREATE TABLE chunk_vectors (
+            chunk_id TEXT PRIMARY KEY,
+            embedding BLOB
+        );
+        CREATE TABLE correction_pairs (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT
+        );
+        CREATE TABLE file_interactions (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT
+        );
+        CREATE TABLE kg_relations (
+            id TEXT PRIMARY KEY,
+            source_chunk_id TEXT
+        );
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
+        );
+        """
+    )
+    rows = [
+        ("qrel-id", "Duplicate content for the eval target", "2026-01-02"),
+        ("dupe-id", "duplicate   content for the eval target", "2026-01-01"),
+        ("old-id", "Another duplicate memory", "2026-01-01"),
+        ("new-id", "another duplicate memory", "2026-01-03"),
+        ("unique-id", "Unique memory", "2026-01-04"),
+    ]
+    conn.executemany(
+        """
+        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
+        VALUES (?, ?, '', '', '', '', '', ?)
+        """,
+        rows,
+    )
+    conn.executemany(
+        "INSERT INTO chunk_tags(chunk_id, tag) VALUES (?, ?)", [("dupe-id", "dupe-tag"), ("qrel-id", "qrel-tag")]
+    )
+    conn.execute(
+        "INSERT INTO kg_entity_chunks(entity_id, chunk_id, relevance, context) VALUES ('e1', 'dupe-id', 0.7, 'ctx')"
+    )
+    conn.execute("INSERT INTO chunk_vectors(chunk_id, embedding) VALUES ('dupe-id', X'00')")
+    conn.execute("INSERT INTO correction_pairs(id, chunk_id) VALUES (1, 'dupe-id')")
+    conn.execute("INSERT INTO file_interactions(id, chunk_id) VALUES (1, 'dupe-id')")
+    conn.execute("INSERT INTO kg_relations(id, source_chunk_id) VALUES ('r1', 'dupe-id')")
+    conn.commit()
+    conn.close()
+
+    result = apply_content_dedup(db_path, protected_chunk_ids={"qrel-id"}, batch_size=2)
+
+    checked = sqlite3.connect(db_path)
+    chunk_ids = {row[0] for row in checked.execute("SELECT id FROM chunks")}
+    alias = dict(checked.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias"))
+    tags = set(checked.execute("SELECT chunk_id, tag FROM chunk_tags"))
+    entity_link = checked.execute("SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = 'e1'").fetchone()[0]
+    correction = checked.execute("SELECT chunk_id FROM correction_pairs WHERE id = 1").fetchone()[0]
+    interaction = checked.execute("SELECT chunk_id FROM file_interactions WHERE id = 1").fetchone()[0]
+    relation = checked.execute("SELECT source_chunk_id FROM kg_relations WHERE id = 'r1'").fetchone()[0]
+    vector = checked.execute("SELECT 1 FROM chunk_vectors WHERE chunk_id = 'dupe-id'").fetchone()
+    checked.close()
+
+    assert result.duplicate_rows == 2
+    assert result.deleted_rows == 2
+    assert "dupe-id" not in chunk_ids
+    assert "new-id" not in chunk_ids
+    assert "qrel-id" in chunk_ids
+    assert "old-id" in chunk_ids
+    assert alias["dupe-id"] == "qrel-id"
+    assert alias["new-id"] == "old-id"
+    assert ("qrel-id", "dupe-tag") in tags
+    assert entity_link == "qrel-id"
+    assert correction == "qrel-id"
+    assert interaction == "qrel-id"
+    assert relation == "qrel-id"
+    assert vector is None


### PR DESCRIPTION
## Summary
- add offline DB shrink helpers for FTS schema rebuilds, exact-content deduplication, and vacuuming snapshots
- add migration/evaluation scripts for snapshot shrink workflows
- add fixture coverage for live DB refusal, FTS migration modes, and duplicate repointing

## Test plan
- `uv run pytest -q tests/test_db_shrink.py` (4 passed)
- `uv run python scripts/db_shrink_migrate.py --help`
- `uv run python scripts/db_shrink_eval.py --help` (help passes; third-party ranx emits SyntaxWarnings during import)
- local CodeRabbit pre-commit review timed out at 180s after reaching reviewing heartbeat; no findings emitted before timeout

Co-Authored-By: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Destructive snapshot migrations delete chunks and rebuild FTS while repointing many related tables; misuse of `--i-know-this-is-live` could corrupt the production DB.
> 
> **Overview**
> Adds **offline snapshot maintenance** for BrainLayer SQLite DBs: compact FTS rebuilds, exact-content deduplication, optional `VACUUM`, plus CLIs to migrate and to **gate** shrink work on search quality.
> 
> **`brainlayer.db_shrink`** refuses writes to the canonical live DB unless `--i-know-this-is-live` is set. It can rebuild FTS in **`single_trigram`** (one trigram table, drops legacy prefix/dual bloat) or **`compact_dual`** (default + trigram without prefix indexes), record `fts_mode` in `brainlayer_meta`, and report sizes via **`dbstat_sizes`**. **`apply_content_dedup`** finds duplicates via existing **`normalized_exact_hash`**, picks a canonical row (qrel IDs protected when `--qrels-path` is passed), physically deletes dupes, merges tags/KG links, drops duplicate vector rows, writes **`chunk_id_alias`** / audit rows, bulk-repoints refs in events/corrections/files/relations and chunk self-refs, then optionally rebuilds FTS.
> 
> **`scripts/db_shrink_migrate.py`** runs the migrate CLI (dedup, FTS-only, vacuum flags). **`scripts/db_shrink_eval.py`** benchmarks **before/after** snapshots with **fts5** and **hybrid_rrf**, compares **ndcg@3/10** and **recall@20** against a max regression threshold, and writes a JSON report (bytes reclaimed, dbstat top objects, pass/fail exit code).
> 
> **`tests/test_db_shrink.py`** covers the live-path guard, both FTS modes, dedup repointing with protected qrel IDs, and dedup with incremental FTS cleanup when FTS rebuild is skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07d18bfecf82e60ad9df4b9d9b1ed03b0a33eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DB shrink tooling for FTS rebuild, content deduplication, and vacuuming
> - Adds [`db_shrink.py`](https://github.com/EtanHey/brainlayer/pull/510/files#diff-d5715496341129821ad2d0f0431216640c88fecc4ca343a1a20787bf76662476) with programmatic and CLI operations to rebuild FTS schemas (single-trigram or compact-dual), deduplicate chunks by normalized content hash with reference repointing across related tables, and vacuum the DB to reclaim disk space.
> - Adds [`db_shrink_eval.py`](https://github.com/EtanHey/brainlayer/pull/510/files#diff-bc92945cecef67170a234c7b725ce45608607c535c1fc729ebc0529eb4bf58de), a CLI benchmark script that runs FTS5 and hybrid RRF pipelines against before/after DB snapshots, computes NDCG/recall metrics, gates regressions, and writes a timestamped JSON report.
> - Adds [`db_shrink_migrate.py`](https://github.com/EtanHey/brainlayer/pull/510/files#diff-c1cc9a67db17d3fafd8502a3599cf413fb1f9422b9be6a907859cf35f818e015) as a thin CLI entrypoint that calls `brainlayer.db_shrink.main()`.
> - Deduplication repoints references in `chunk_events`, `correction_pairs`, `file_interactions`, `kg_relations`, and sqlite-vec tables to the canonical chunk, records aliases, and optionally rebuilds or incrementally cleans up FTS rows.
> - Risk: all write operations refuse to run against the live canonical DB unless `allow_live=True` is explicitly passed; misuse of that override could corrupt production data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c07d18b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->