### PR TITLE
fix: drain BrainLayer embeddings and recover FTS search

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -845,7 +845,7 @@ final class BrainDatabase: @unchecked Sendable {
             "COALESCE(c.archived, 0) = 0",
             "COALESCE(c.status, 'active') = 'active'"
         ]
-        if project != nil { conditions.append("c.project = ?") }
+        if project != nil { conditions.append("(c.project = ? OR c.project IS NULL)") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
         if let explicitTag = tag {
             conditions.append("c.tags LIKE ?")
@@ -1255,7 +1255,7 @@ final class BrainDatabase: @unchecked Sendable {
             "COALESCE(c.archived, 0) = 0",
             "COALESCE(c.status, 'active') = 'active'"
         ]
-        if project != nil { conditions.append("c.project = ?") }
+        if project != nil { conditions.append("(c.project = ? OR c.project IS NULL)") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
         if let explicitTag = tag {
             conditions.append("c.tags LIKE ?")
@@ -2231,8 +2231,10 @@ final class BrainDatabase: @unchecked Sendable {
         }
         guard !tokens.isEmpty else { return "\"\"" }
         // Prefix search keeps typeahead fast while the reranker narrows the
-        // bounded candidate set later in the search pipeline.
-        return tokens.joined(separator: " ")
+        // bounded candidate set later in the search pipeline. Keep short
+        // queries precise, but avoid over-constraining longer natural-language
+        // queries into zero-result intersections.
+        return tokens.joined(separator: tokens.count >= 4 ? " OR " : " ")
     }
 
     private func sanitizeTrigramFTS5Query(_ query: String) -> String {
@@ -2361,7 +2363,7 @@ final class BrainDatabase: @unchecked Sendable {
             "COALESCE(c.archived, 0) = 0",
             "COALESCE(c.status, 'active') = 'active'"
         ]
-        if project != nil { conditions.append("c.project = ?") }
+        if project != nil { conditions.append("(c.project = ? OR c.project IS NULL)") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
         if tag != nil { conditions.append("c.tags LIKE ?") }
         if importanceMin != nil { conditions.append("c.importance >= ?") }

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -869,6 +869,43 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(results.first?["chunk_id"] as? String, "test-chunk-1")
     }
 
+    func testFTSSearchLongNaturalLanguageQueryUsesRecallMode() throws {
+        try db.insertChunk(
+            id: "sonnet-role-rule",
+            content: "CURSOR SPAWN RULE: repoGolem launcher Cursor workers must pin model:sonnet with explicit role contracts.",
+            sessionId: "session-sonnet-rule",
+            project: "golems",
+            contentType: "assistant_text",
+            importance: 9
+        )
+
+        let results = try db.search(
+            query: "cursor spawned with model sonnet model not pinned repoGolem under specification",
+            limit: 10,
+            project: "golems"
+        )
+        let resultIDs = results.compactMap { $0["chunk_id"] as? String }
+
+        XCTAssertTrue(resultIDs.contains("sonnet-role-rule"))
+    }
+
+    func testProjectScopedSearchIncludesGlobalChunks() throws {
+        try db.insertChunk(
+            id: "global-role-contract",
+            content: "GlobalRoleContractNeedle applies to every repoGolem worker role.",
+            sessionId: "session-global-role",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 8
+        )
+        db.exec("UPDATE chunks SET project = NULL WHERE id = 'global-role-contract'")
+
+        let results = try db.search(query: "GlobalRoleContractNeedle", limit: 10, project: "golems")
+        let resultIDs = results.compactMap { $0["chunk_id"] as? String }
+
+        XCTAssertTrue(resultIDs.contains("global-role-contract"))
+    }
+
     func testSearchReturnsEmptyForNoMatch() throws {
         let results = try db.search(query: "xyznonexistent123", limit: 10)
         XCTAssertTrue(results.isEmpty)

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -29,6 +29,7 @@ from brainlayer.vector_store import VectorStore
 LOGGER = logging.getLogger("brainlayer.hotlane_brainbar")
 STOP = False
 DEFAULT_HOTLANE_ENRICH_LIMIT = 25
+DEFAULT_BACKLOG_BATCH = 128
 
 
 class CycleResult(NamedTuple):
@@ -80,6 +81,7 @@ def run_cycle(
     candidate_chunk_ids_fn: Callable[..., list[str]] = _candidate_chunk_ids,
     hot_embed_fn: Callable[..., bool] = embed_hot_chunk,
     pending_embed_fn: Callable[..., int] = embed_pending_chunks,
+    embed_batch_fn: Callable[[list[str]], list[list[float]]] | None = None,
     enrich_fn: Callable[..., object] = enrich_realtime,
 ) -> CycleResult:
     embedded = 0
@@ -89,7 +91,12 @@ def run_cycle(
             break
 
     if backlog_batch > 0:
-        embedded += pending_embed_fn(store=store, embed_fn=embed_fn, batch_size=backlog_batch)
+        embedded += pending_embed_fn(
+            store=store,
+            embed_fn=embed_fn,
+            batch_size=backlog_batch,
+            embed_batch_fn=embed_batch_fn,
+        )
 
     if enrich_limit <= 0:
         return CycleResult(embedded=embedded)
@@ -126,7 +133,8 @@ def run(
     try:
         model = model_factory()
         embed_fn = model.embed_query
-        last_backlog = time_fn()
+        embed_batch_fn = getattr(model, "embed_texts", None)
+        last_backlog = time_fn() - backlog_interval
         last_enrich = 0.0
         enrich_disabled = False
         cycles = 0
@@ -153,6 +161,7 @@ def run(
                     embed_fn=embed_fn,
                     recent_limit=recent_limit,
                     backlog_batch=cycle_backlog_batch,
+                    embed_batch_fn=embed_batch_fn,
                     enrich_limit=cycle_enrich_limit,
                     enrich_since_hours=enrich_since_hours,
                 )
@@ -183,7 +192,7 @@ def main() -> None:
     parser.add_argument("--interval", type=float, default=1.0)
     parser.add_argument("--recent-limit", type=int, default=5)
     parser.add_argument("--backlog-interval", type=float, default=10.0)
-    parser.add_argument("--backlog-batch", type=int, default=0)
+    parser.add_argument("--backlog-batch", type=int, default=DEFAULT_BACKLOG_BATCH)
     parser.add_argument("--enrich-interval", type=float, default=10.0)
     parser.add_argument("--enrich-limit", type=int, default=DEFAULT_HOTLANE_ENRICH_LIMIT)
     parser.add_argument("--enrich-since-hours", type=int, default=DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS)

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -132,8 +132,17 @@ def run(
     store = vector_store_cls(db_path)
     try:
         model = model_factory()
-        embed_fn = model.embed_query
         embed_batch_fn = getattr(model, "embed_texts", None)
+        if embed_batch_fn is not None:
+
+            def embed_fn(text: str) -> list[float]:
+                embeddings = embed_batch_fn([text])
+                if len(embeddings) != 1:
+                    raise RuntimeError(f"single text embedder returned {len(embeddings)} embeddings")
+                return embeddings[0]
+
+        else:
+            embed_fn = model.embed_query
         last_backlog = time_fn() - backlog_interval
         last_enrich = 0.0
         enrich_disabled = False

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -411,8 +411,8 @@ def embed_pending_chunks(
         cursor.execute(
             """
             SELECT c.id, c.content FROM chunks c
-            LEFT JOIN chunk_vectors v ON c.id = v.chunk_id
-            WHERE v.chunk_id IS NULL
+            LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
+            WHERE r.id IS NULL
               AND c.content IS NOT NULL
               AND c.content != ''
               AND c.archived_at IS NULL

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -444,6 +444,13 @@ def embed_pending_chunks(
                     logger.warning("Failed to write pending chunk %s: %s", chunk_id, e)
         except Exception as e:
             logger.warning("Failed to embed pending chunk batch: %s", e)
+            for chunk_id, content in rows:
+                try:
+                    embedding = embed_fn(content)
+                    store._upsert_chunk_vector(cursor, chunk_id, embedding)
+                    count += 1
+                except Exception as row_error:
+                    logger.warning("Failed to embed chunk %s: %s", chunk_id, row_error)
     else:
         for chunk_id, content in rows:
             try:

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -623,6 +623,31 @@ class TestBackgroundEmbedder:
         assert not _has_vector(store, "batch-write-1")
         assert _has_vector(store, "batch-write-2")
 
+    def test_embed_pending_batch_embed_failure_falls_back_per_row(self, store):
+        """Batch embed failure should not let one bad row block newer pending chunks."""
+        from brainlayer.store import embed_pending_chunks
+
+        _insert_pending_chunk(store, chunk_id="batch-fallback-good-0", source="claude_code", content="good zero")
+        _insert_pending_chunk(store, chunk_id="batch-fallback-bad-1", source="claude_code", content="bad one")
+        _insert_pending_chunk(store, chunk_id="batch-fallback-good-2", source="claude_code", content="good two")
+
+        def row_embed(text: str) -> list[float]:
+            if "bad" in text:
+                raise RuntimeError("simulated bad row")
+            return [0.25] * 1024
+
+        count = embed_pending_chunks(
+            store=store,
+            embed_fn=row_embed,
+            batch_size=3,
+            embed_batch_fn=lambda _texts: (_ for _ in ()).throw(RuntimeError("simulated batch failure")),
+        )
+
+        assert count == 2
+        assert _has_vector(store, "batch-fallback-good-0")
+        assert not _has_vector(store, "batch-fallback-bad-1")
+        assert _has_vector(store, "batch-fallback-good-2")
+
 
 class TestMCPStoreDeferred:
     """MCP _store handler uses deferred embedding."""

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -348,6 +348,54 @@ class TestBackgroundEmbedder:
         assert len(batch_calls) == 1
         assert len(batch_calls[0]) == 4
 
+    def test_embed_pending_chunks_selects_pending_rows_from_rowid_support_table(self):
+        """Backlog selection must avoid scanning the vec0 virtual table."""
+        from brainlayer.store import embed_pending_chunks
+
+        class FakeCursor:
+            def __init__(self):
+                self.queries = []
+                self.params = []
+
+            def execute(self, sql, params=()):
+                self.queries.append(sql)
+                self.params.append(params)
+                if "SELECT c.id, c.content FROM chunks c" in sql:
+                    return [("pending-rowid", "Needs vector")]
+                raise AssertionError(f"unexpected SQL: {sql}")
+
+        class FakeConn:
+            def __init__(self, cursor):
+                self._cursor = cursor
+
+            def cursor(self):
+                return self._cursor
+
+        class FakeStore:
+            db_path = None
+
+            def __init__(self):
+                self.cursor = FakeCursor()
+                self.conn = FakeConn(self.cursor)
+                self.upserts = []
+
+            def _upsert_chunk_vector(self, cursor, chunk_id, embedding):
+                self.upserts.append((cursor, chunk_id, embedding))
+
+        fake_store = FakeStore()
+        count = embed_pending_chunks(
+            store=fake_store,
+            embed_fn=lambda _text: [1.0] * 1024,
+            batch_size=7,
+        )
+
+        selection_sql = fake_store.cursor.queries[0]
+        assert count == 1
+        assert "chunk_vectors_rowids r ON c.id = r.id" in selection_sql
+        assert "LEFT JOIN chunk_vectors v" not in selection_sql
+        assert fake_store.cursor.params[0] == (7,)
+        assert fake_store.upserts == [(fake_store.cursor, "pending-rowid", [1.0] * 1024)]
+
     def test_g1_fifo_reproduction_new_chunk_waits_behind_old_backlog(self, store, fast_embed):
         """G1 RED proof: oldest-first drain alone starves a just-stored chunk for one pass."""
         from brainlayer.store import embed_pending_chunks, store_memory

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -117,6 +117,46 @@ def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
     assert received_batch_fns[0].__func__ is FakeModel.embed_texts
 
 
+def test_hotlane_run_uses_document_embeddings_for_stored_chunks():
+    hotlane = _load_hotlane_module()
+    received_embed_fns = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    class FakeModel:
+        def embed_query(self, _text):
+            return [1.0]
+
+        def embed_texts(self, texts):
+            return [[2.0] for _text in texts]
+
+    def fake_cycle(**kwargs):
+        received_embed_fns.append(kwargs["embed_fn"])
+        return hotlane.CycleResult()
+
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=FakeModel,
+        cycle_fn=fake_cycle,
+        time_fn=iter([0.0, 100.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=1,
+    )
+
+    assert len(received_embed_fns) == 1
+    assert received_embed_fns[0]("stored chunk text") == [2.0]
+
+
 def test_hotlane_run_schedules_backlog_on_first_cycle():
     hotlane = _load_hotlane_module()
     scheduled_backlog_batches = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -71,6 +71,84 @@ def test_hotlane_cycle_can_disable_enrichment():
     assert result.enriched == 0
 
 
+def test_hotlane_default_backlog_batch_drains_pending_embeddings():
+    hotlane = _load_hotlane_module()
+
+    assert hotlane.DEFAULT_BACKLOG_BATCH >= 64
+
+
+def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
+    hotlane = _load_hotlane_module()
+    received_batch_fns = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    class FakeModel:
+        def embed_query(self, _text):
+            return [0.0]
+
+        def embed_texts(self, texts):
+            return [[0.0] * 1024 for _text in texts]
+
+    def fake_cycle(**kwargs):
+        received_batch_fns.append(kwargs.get("embed_batch_fn"))
+        return hotlane.CycleResult()
+
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=FakeModel,
+        cycle_fn=fake_cycle,
+        time_fn=iter([0.0, 100.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=1,
+    )
+
+    assert len(received_batch_fns) == 1
+    assert received_batch_fns[0].__func__ is FakeModel.embed_texts
+
+
+def test_hotlane_run_schedules_backlog_on_first_cycle():
+    hotlane = _load_hotlane_module()
+    scheduled_backlog_batches = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    def fake_cycle(**kwargs):
+        scheduled_backlog_batches.append(kwargs["backlog_batch"])
+        return hotlane.CycleResult()
+
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=fake_cycle,
+        time_fn=iter([100.0, 100.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=1,
+    )
+
+    assert scheduled_backlog_batches == [hotlane.DEFAULT_BACKLOG_BATCH]
+
+
 def test_hotlane_run_advances_enrich_timer_before_failed_cycle():
     hotlane = _load_hotlane_module()
     scheduled_enrich_limits = []


### PR DESCRIPTION
## Summary

- Enables hotlane embedding backlog draining by default (`DEFAULT_BACKLOG_BATCH = 128`) and schedules the backlog on the first daemon cycle instead of waiting for the first interval.
- Threads the model batch embedder into `embed_pending_chunks` and changes pending-row selection to use `chunk_vectors_rowids` instead of scanning the vec0 virtual table.
- Fixes BrainBar fallback FTS for long natural-language queries by using OR recall mode for 4+ tokens, and lets project-scoped search include global (`project IS NULL`) chunks.

## Live verification

- LaunchAgent before fix had `--backlog-batch 0`; live plist is now running `--backlog-batch 128` from this branch.
- One-off live drain against the real DB wrote 128 vectors without deleting/rebuilding data:
  - before: `vectors=463875`, lifecycle active missing `83242`
  - after: `vectors=464003`, lifecycle active missing `83114`
  - elapsed `154.94s`, throughput `49.57 embeddings/min`
- Latest post-restart sample: `2026-06-18 22:13:11 | chunks=547963 | chunk_vectors_rowids=464005 | lifecycle active missing=83122`.
- Live `brain_search("cursor spawned with model sonnet model not pinned repoGolem under specification", project="golems")` before BrainBar search fix returned `0 of 0`.
- After installing the fixed BrainBar app from this branch, the same query returns `5 of 5`; result #1 is the repoGolem/Cursor model-pinning memory.
- Additional live probes also return 5/5 for `repoGolem launcher model not pinned Cursor sonnet` and `BrainLayer embedder backlog launchd backlog batch`.

## Tests

- `pytest -q`: `3063 passed, 49 skipped, 5 xfailed`.
- Pre-push gate: `2962 passed, 9 skipped, 61 deselected, 1 xfailed`, plus MCP registration, isolated eval/hook routing, bun stale-index test, and `test_fts5_determinism.sh` all passed.
- Focused Swift tests passed:
  - `DatabaseTests/testFTSSearchLongNaturalLanguageQueryUsesRecallMode`
  - `DatabaseTests/testProjectScopedSearchIncludesGlobalChunks`
  - `DatabaseTests/testSearchExactChunkIDRespectsProjectScope`
- Full `swift test --package-path brain-bar` was attempted and interrupted after sampling an existing unrelated hang in `BrainBarReliabilityTests.testQueuedWriteBurstDoesNotTakeReadPathDown`, blocked in pending-store busy retry under the test's intentional write lock.

## Review

Review required. Do not merge automatically; orc should merge after review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core search SQL and embedding backlog behavior at scale; changes are targeted with tests but affect live recall semantics and daemon throughput on production DBs.
> 
> **Overview**
> **Embedding pipeline:** The hotlane daemon now defaults to a **128-chunk backlog batch** (was effectively off at `0`) and runs backlog work on the **first cycle** instead of waiting one interval. When the model exposes `embed_texts`, that batch path is wired through the cycle. Pending-chunk selection in `embed_pending_chunks` joins **`chunk_vectors_rowids`** instead of the vec0 `chunk_vectors` table, with **per-row fallback** if a batch embed fails.
> 
> **BrainBar search:** Project-scoped FTS/SQL filters use **`(c.project = ? OR c.project IS NULL)`** so global chunks appear in project searches. **`sanitizeFTS5Query`** joins token clauses with **`OR`** when there are **4+ tokens** (AND/space for shorter queries) to improve recall on long natural-language queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7335dfe48e3e473be38c811900ab820e7dcd4097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix FTS search recall and drain BrainLayer pending embeddings
> - Project-scoped searches in [BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/512/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc) now include chunks with `NULL` project, fixing searches that excluded globally-scoped chunks.
> - FTS5 queries with 4 or more tokens now join tokens with `OR` instead of `AND`, improving recall for long natural-language queries.
> - The daemon in [hotlane_brainbar_daemon.py](https://github.com/EtanHey/brainlayer/pull/512/files#diff-a6f55cd2d945568d3534e21b0c40cf5a431cb8287640870ba7b2a6149ac2c0d9) now uses the model's `embed_texts` batch API for stored chunk embeddings and schedules backlog processing on the first cycle (previously required an explicit trigger).
> - Batch embedding failures in [store.py](https://github.com/EtanHey/brainlayer/pull/512/files#diff-3f4ff41bcf437c9376f0c0bc397eca30e1b05c0d75d4e95ef1579366d7c4c707) now fall back to per-row embedding, so a single bad row no longer blocks the rest of the batch.
> - Behavioral Change: FTS5 queries of ≥4 tokens switch from implicit AND to OR semantics, which increases recall but may reduce precision.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7335dfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long natural language queries now benefit from improved search recall logic.
  * Project-scoped searches now include shared global content.
  * Batch embedding support for background processing pipelines.

* **Bug Fixes**
  * Batch embedding failures now gracefully fall back to per-item processing for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->