### PR TITLE
chore: add BrainLayer stability health check

### DIFF
--- a/docs/operations/brainlayer-health-check.md
+++ b/docs/operations/brainlayer-health-check.md
@@ -1,0 +1,38 @@
+# BrainLayer Health Check
+
+`brainlayer health-check` is a lightweight launchd tick for live BrainLayer stability.
+
+The scheduled LaunchAgent is `scripts/launchd/com.brainlayer.health-check.plist`. It runs every 300 seconds, at load, through the standard `brainlayer-env-run.sh` wrapper:
+
+```bash
+brainlayer health-check --json --heal
+```
+
+## Checks
+
+- Hotlane BrainBar embedding daemon is running.
+- Hotlane command line is not disabling the embedding backlog with `--backlog-batch 0`.
+- Active chunks missing semantic vectors are decreasing across ticks. One unchanged tick is tolerated; the second unchanged tick alarms.
+- BrainBar's served MCP socket can answer a `brain_search` canary with at least one result.
+
+## Self-Heal
+
+With `--heal`, the check uses `launchctl kickstart -k` for cheap recovery:
+
+- `com.brainlayer.hotlane-brainbar` when hotlane is dead, backlog is disabled, or missing vectors are climbing/stalled.
+- `com.brainlayer.brainbar` when the BrainBar MCP canary fails or returns zero results.
+
+The command always writes the latest missing-vector count to `~/.local/share/brainlayer/health-check-state.json`.
+
+## Logs
+
+Launchd output goes to:
+
+- `~/Library/Logs/brainlayer/health-check.out.log`
+- `~/Library/Logs/brainlayer/health-check.err.log`
+
+Manual dry run:
+
+```bash
+brainlayer health-check --json --no-heal
+```

--- a/docs/operations/brainlayer-health-check.md
+++ b/docs/operations/brainlayer-health-check.md
@@ -11,7 +11,7 @@ brainlayer health-check --json --heal
 ## Checks
 
 - Hotlane BrainBar embedding daemon is running.
-- Hotlane command line is not disabling the embedding backlog with `--backlog-batch 0`.
+- No running hotlane command line is disabling the embedding backlog with `--backlog-batch 0`.
 - Active chunks missing semantic vectors are decreasing across ticks. One unchanged tick is tolerated; the second unchanged tick alarms.
 - BrainBar's served MCP socket can answer a `brain_search` canary with at least one result.
 
@@ -20,7 +20,7 @@ brainlayer health-check --json --heal
 With `--heal`, the check uses `launchctl kickstart -k` for cheap recovery:
 
 - `com.brainlayer.hotlane-brainbar` when hotlane is dead, backlog is disabled, or missing vectors are climbing/stalled.
-- `com.brainlayer.brainbar` when the BrainBar MCP canary fails or returns zero results.
+- `com.brainlayer.brainbar-daemon` when the BrainBar MCP canary fails or returns zero results.
 
 The command always writes the latest missing-vector count to `~/.local/share/brainlayer/health-check-state.json`.
 

--- a/scripts/launchd/com.brainlayer.health-check.plist
+++ b/scripts/launchd/com.brainlayer.health-check.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.brainlayer.health-check</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__BRAINLAYER_ENV_RUN__</string>
+		<string>__BRAINLAYER_BIN__</string>
+		<string>health-check</string>
+		<string>--json</string>
+		<string>--heal</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+		<key>PYTHONUNBUFFERED</key>
+		<string>1</string>
+		<key>BRAINLAYER_REPO_ROOT</key>
+		<string>__BRAINLAYER_DIR__</string>
+		<key>BRAINLAYER_ENV_FILE</key>
+		<string>__BRAINLAYER_ENV_FILE__</string>
+		<key>BRAINLAYER_LAUNCHD_SERVICE</key>
+		<string>health-check</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/health-check.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/health-check.err.log</string>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ExitTimeOut</key>
+	<integer>45</integer>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>SoftResourceLimits</key>
+	<dict>
+		<key>NumberOfFiles</key>
+		<integer>4096</integer>
+	</dict>
+</dict>
+</plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -15,6 +15,7 @@
 #   ./scripts/launchd/install.sh backup       # Install daily DB backup only
 #   ./scripts/launchd/install.sh jsonl-backup # Install daily JSONL backup only
 #   ./scripts/launchd/install.sh maintenance  # Install recurring maintenance jobs
+#   ./scripts/launchd/install.sh health-check # Install stability health check only
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
 set -euo pipefail
 
@@ -248,6 +249,9 @@ case "${1:-all}" in
         install_plist maintenance-nightly
         install_plist maintenance-weekly
         ;;
+    health-check)
+        install_plist health-check
+        ;;
     all)
         install_env_runner
         verify_config_file
@@ -265,6 +269,7 @@ case "${1:-all}" in
         install_plist jsonl-backup
         install_plist maintenance-nightly
         install_plist maintenance-weekly
+        install_plist health-check
         # Remove old enrich plist if present
         remove_plist enrich 2>/dev/null || true
         ;;
@@ -281,11 +286,12 @@ case "${1:-all}" in
         remove_plist jsonl-backup 2>/dev/null || true
         remove_plist maintenance-nightly 2>/dev/null || true
         remove_plist maintenance-weekly 2>/dev/null || true
+        remove_plist health-check 2>/dev/null || true
         rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
         rm -f "$BRAINLAYER_LIB_DIR/jsonl-backup.sh"
         ;;
     *)
-        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|all|remove]"
+        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|all|remove]"
         exit 1
         ;;
 esac

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -359,6 +359,58 @@ def context(
         raise typer.Exit(1)
 
 
+@app.command("health-check")
+def health_check_command(
+    db: Optional[Path] = typer.Option(None, "--db", help="Path to brainlayer.db"),
+    state_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/health-check-state.json"),
+        "--state-path",
+        help="State file used to compare missing-vector progress between ticks.",
+    ),
+    socket_path: Path = typer.Option(Path("/tmp/brainbar.sock"), "--socket-path", help="BrainBar MCP socket path."),
+    canary_query: str = typer.Option("agentopology", "--canary-query", help="brain_search canary query."),
+    max_stalled_ticks: int = typer.Option(
+        2,
+        "--max-stalled-ticks",
+        min=1,
+        help="Number of unchanged missing-vector checks before alerting.",
+    ),
+    socket_timeout_seconds: float = typer.Option(
+        5.0,
+        "--socket-timeout",
+        min=0.5,
+        help="Seconds to wait for the BrainBar socket canary.",
+    ),
+    heal: bool = typer.Option(False, "--heal/--no-heal", help="Kickstart launchd services for cheap self-heals."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Run the lightweight BrainLayer stability health-check."""
+    from ..health_check import HealthCheckConfig, run_health_check
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db or get_db_path(),
+            state_path=state_path.expanduser(),
+            socket_path=socket_path.expanduser(),
+            canary_query=canary_query,
+            heal=heal,
+            socket_timeout_seconds=socket_timeout_seconds,
+            max_stalled_ticks=max_stalled_ticks,
+        )
+    )
+    payload = result.to_dict()
+    if json_output:
+        typer.echo(json.dumps(payload, sort_keys=True))
+    else:
+        status = "ok" if result.ok else "unhealthy"
+        rprint(f"[bold]{status}[/] missing_vectors={result.missing_vectors} canary_ok={result.canary_ok}")
+        for issue in result.issues:
+            rprint(f"[red]{issue.severity}[/] {issue.code}: {issue.message}")
+        for action in result.actions:
+            rprint(f"[yellow]action[/] {action}")
+    raise typer.Exit(0 if result.ok else 1)
+
+
 @app.command("reembed-backfill")
 def reembed_backfill_command(
     db: Optional[Path] = typer.Option(None, "--db", help="Path to brainlayer.db"),

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -1,0 +1,333 @@
+"""Lightweight stability health-check for live BrainLayer services."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import socket
+import sqlite3
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from .paths import get_db_path
+
+DEFAULT_SOCKET_PATH = Path("/tmp/brainbar.sock")
+DEFAULT_STATE_PATH = Path("~/.local/share/brainlayer/health-check-state.json").expanduser()
+DEFAULT_CANARY_QUERY = "agentopology"
+DEFAULT_HOTLANE_LABEL = "com.brainlayer.hotlane-brainbar"
+DEFAULT_BRAINBAR_LABEL = "com.brainlayer.brainbar"
+DEFAULT_BACKLOG_BATCH = 128
+
+
+@dataclass(frozen=True)
+class HealthIssue:
+    code: str
+    severity: str
+    message: str
+
+
+@dataclass
+class HealthCheckConfig:
+    db_path: Path = field(default_factory=get_db_path)
+    state_path: Path = field(default_factory=lambda: DEFAULT_STATE_PATH)
+    socket_path: Path = DEFAULT_SOCKET_PATH
+    canary_query: str = DEFAULT_CANARY_QUERY
+    hotlane_label: str = DEFAULT_HOTLANE_LABEL
+    brainbar_label: str = DEFAULT_BRAINBAR_LABEL
+    heal: bool = False
+    socket_timeout_seconds: float = 5.0
+    max_stalled_ticks: int = 2
+
+
+@dataclass
+class HotlaneProcess:
+    pid: int
+    command: str
+    backlog_batch: int
+
+
+@dataclass
+class HealthCheckResult:
+    checked_at: str
+    ok: bool
+    issues: list[HealthIssue] = field(default_factory=list)
+    actions: list[str] = field(default_factory=list)
+    hotlane_running: bool = False
+    backlog_batch: int | None = None
+    missing_vectors: int | None = None
+    previous_missing_vectors: int | None = None
+    stalled_ticks: int = 0
+    canary_ok: bool = False
+    canary_result_count: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+CommandRunner = Callable[[list[str]], Any]
+SocketRequestFn = Callable[[Path, str, float], dict[str, Any]]
+
+
+def _default_ps_output() -> str:
+    result = subprocess.run(["ps", "axo", "pid=,command="], text=True, capture_output=True, check=False)
+    return result.stdout
+
+
+def _default_command_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, text=True, capture_output=True, check=False)
+
+
+def _parse_backlog_batch(command: str) -> int:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+    for index, part in enumerate(parts):
+        if part == "--backlog-batch" and index + 1 < len(parts):
+            try:
+                return int(parts[index + 1])
+            except ValueError:
+                return 0
+        if part.startswith("--backlog-batch="):
+            try:
+                return int(part.split("=", 1)[1])
+            except ValueError:
+                return 0
+    return DEFAULT_BACKLOG_BATCH
+
+
+def parse_hotlane_processes(ps_output: str) -> list[HotlaneProcess]:
+    processes: list[HotlaneProcess] = []
+    for line in ps_output.splitlines():
+        stripped = line.strip()
+        if "hotlane_brainbar_daemon.py" not in stripped:
+            continue
+        if " rg " in stripped or "ripgrep" in stripped:
+            continue
+        match = re.match(r"(?P<pid>\d+)\s+(?P<command>.+)", stripped)
+        if not match:
+            continue
+        command = match.group("command")
+        processes.append(
+            HotlaneProcess(
+                pid=int(match.group("pid")),
+                command=command,
+                backlog_batch=_parse_backlog_batch(command),
+            )
+        )
+    return processes
+
+
+def count_missing_embeddings(db_path: Path) -> int:
+    uri = f"file:{db_path.expanduser()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=5)
+    try:
+        conn.execute("PRAGMA query_only = ON")
+        row = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM chunks c
+            LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
+            WHERE r.id IS NULL
+              AND c.content IS NOT NULL
+              AND c.content != ''
+              AND c.archived_at IS NULL
+              AND c.superseded_by IS NULL
+              AND c.aggregated_into IS NULL
+              AND COALESCE(c.archived, 0) = 0
+              AND COALESCE(c.status, 'active') = 'active'
+            """
+        ).fetchone()
+        return int(row[0] if row else 0)
+    finally:
+        conn.close()
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_state(path: Path, payload: dict[str, Any]) -> None:
+    resolved = path.expanduser()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    tmp = resolved.with_name(f".{resolved.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, resolved)
+
+
+def send_brainbar_search_canary(socket_path: Path, query: str, timeout_seconds: float) -> dict[str, Any]:
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "brain_search",
+            "arguments": {"query": query, "num_results": 1},
+        },
+    }
+    payload = json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n"
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout_seconds)
+        client.connect(str(socket_path.expanduser()))
+        client.sendall(payload)
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = client.recv(65_536)
+            if not chunk:
+                break
+            data += chunk
+    if not data:
+        raise RuntimeError(f"BrainBar socket closed without response: {socket_path}")
+    return json.loads(data.decode("utf-8"))
+
+
+def _canary_text(response: dict[str, Any]) -> tuple[bool, str]:
+    if response.get("error"):
+        return False, str(response["error"])
+    result = response.get("result") or {}
+    content = result.get("content") or []
+    text = "\n".join(str(item.get("text", "")) for item in content if isinstance(item, dict))
+    if result.get("isError"):
+        return False, text or "BrainBar returned isError=true"
+    return True, text
+
+
+def _canary_count(text: str) -> int | None:
+    match = re.search(r"-\s*(\d+)\s+of\s+(\d+)\s+shown", text)
+    if match:
+        return int(match.group(1))
+    match = re.search(r"Found\s+(\d+)\s+results?", text)
+    if match:
+        return int(match.group(1))
+    return 1 if text.strip() else 0
+
+
+def _kickstart(label: str, command_runner: CommandRunner) -> str:
+    target = f"gui/{os.getuid()}/{label}"
+    command_runner(["launchctl", "kickstart", "-k", target])
+    return f"kickstart:{label}"
+
+
+def _kickstart_once(result: HealthCheckResult, label: str, command_runner: CommandRunner) -> None:
+    action = f"kickstart:{label}"
+    if action in result.actions:
+        return
+    result.actions.append(_kickstart(label, command_runner))
+
+
+def run_health_check(
+    config: HealthCheckConfig,
+    *,
+    ps_output_fn: Callable[[], str] = _default_ps_output,
+    socket_request_fn: SocketRequestFn = send_brainbar_search_canary,
+    command_runner: CommandRunner = _default_command_runner,
+    now_fn: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> HealthCheckResult:
+    now = now_fn()
+    result = HealthCheckResult(checked_at=now.isoformat(), ok=True)
+
+    hotlane_processes = parse_hotlane_processes(ps_output_fn())
+    result.hotlane_running = bool(hotlane_processes)
+    if not hotlane_processes:
+        result.issues.append(
+            HealthIssue("hotlane_dead", "critical", "hotlane BrainBar embedding daemon is not running")
+        )
+        if config.heal:
+            _kickstart_once(result, config.hotlane_label, command_runner)
+    else:
+        result.backlog_batch = max(process.backlog_batch for process in hotlane_processes)
+        if result.backlog_batch <= 0:
+            result.issues.append(
+                HealthIssue("hotlane_backlog_disabled", "critical", "--backlog-batch is 0; embeddings will not drain")
+            )
+            if config.heal:
+                _kickstart_once(result, config.hotlane_label, command_runner)
+
+    state = _load_state(config.state_path)
+    previous_missing = state.get("missing_vectors")
+    result.previous_missing_vectors = int(previous_missing) if isinstance(previous_missing, int) else None
+    try:
+        result.missing_vectors = count_missing_embeddings(config.db_path)
+    except Exception as exc:
+        result.issues.append(
+            HealthIssue(
+                "missing_embeddings_count_failed",
+                "critical",
+                f"could not count missing embeddings: {exc}",
+            )
+        )
+
+    stalled_ticks = 0
+    if result.missing_vectors is not None:
+        if result.previous_missing_vectors is not None:
+            prior_stalled_ticks = int(state.get("stalled_ticks", 0) or 0)
+            if result.missing_vectors > result.previous_missing_vectors:
+                result.issues.append(
+                    HealthIssue(
+                        "missing_embeddings_climbing",
+                        "warning",
+                        f"missing embeddings increased {result.previous_missing_vectors} -> {result.missing_vectors}",
+                    )
+                )
+                stalled_ticks = prior_stalled_ticks + 1
+                if config.heal:
+                    _kickstart_once(result, config.hotlane_label, command_runner)
+            elif result.missing_vectors == result.previous_missing_vectors and result.missing_vectors > 0:
+                stalled_ticks = prior_stalled_ticks + 1
+                if stalled_ticks >= config.max_stalled_ticks:
+                    result.issues.append(
+                        HealthIssue(
+                            "missing_embeddings_not_draining",
+                            "warning",
+                            f"missing embeddings stayed at {result.missing_vectors} for {stalled_ticks} checks",
+                        )
+                    )
+                    if config.heal:
+                        _kickstart_once(result, config.hotlane_label, command_runner)
+    result.stalled_ticks = stalled_ticks
+    if result.missing_vectors is not None:
+        _write_state(
+            config.state_path,
+            {
+                "missing_vectors": result.missing_vectors,
+                "stalled_ticks": result.stalled_ticks,
+                "ts": now.isoformat(),
+            },
+        )
+
+    try:
+        response = socket_request_fn(config.socket_path, config.canary_query, config.socket_timeout_seconds)
+        canary_success, text = _canary_text(response)
+        result.canary_result_count = _canary_count(text) if canary_success else 0
+        result.canary_ok = canary_success and (result.canary_result_count or 0) > 0
+        if not result.canary_ok:
+            code = "brain_search_canary_failed" if not canary_success else "brain_search_canary_empty"
+            result.issues.append(
+                HealthIssue(
+                    code,
+                    "critical",
+                    f"BrainBar brain_search canary returned no usable results: {text[:240]}",
+                )
+            )
+            if config.heal:
+                _kickstart_once(result, config.brainbar_label, command_runner)
+    except Exception as exc:
+        result.canary_ok = False
+        result.issues.append(
+            HealthIssue("brain_search_canary_failed", "critical", f"BrainBar brain_search canary failed: {exc}")
+        )
+        if config.heal:
+            _kickstart_once(result, config.brainbar_label, command_runner)
+
+    result.ok = not result.issues
+    return result

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -20,7 +20,7 @@ DEFAULT_SOCKET_PATH = Path("/tmp/brainbar.sock")
 DEFAULT_STATE_PATH = Path("~/.local/share/brainlayer/health-check-state.json").expanduser()
 DEFAULT_CANARY_QUERY = "agentopology"
 DEFAULT_HOTLANE_LABEL = "com.brainlayer.hotlane-brainbar"
-DEFAULT_BRAINBAR_LABEL = "com.brainlayer.brainbar"
+DEFAULT_BRAINBAR_DAEMON_LABEL = "com.brainlayer.brainbar-daemon"
 DEFAULT_BACKLOG_BATCH = 128
 
 
@@ -38,7 +38,7 @@ class HealthCheckConfig:
     socket_path: Path = DEFAULT_SOCKET_PATH
     canary_query: str = DEFAULT_CANARY_QUERY
     hotlane_label: str = DEFAULT_HOTLANE_LABEL
-    brainbar_label: str = DEFAULT_BRAINBAR_LABEL
+    brainbar_daemon_label: str = DEFAULT_BRAINBAR_DAEMON_LABEL
     heal: bool = False
     socket_timeout_seconds: float = 5.0
     max_stalled_ticks: int = 2
@@ -245,8 +245,8 @@ def run_health_check(
         if config.heal:
             _kickstart_once(result, config.hotlane_label, command_runner)
     else:
-        result.backlog_batch = max(process.backlog_batch for process in hotlane_processes)
-        if result.backlog_batch <= 0:
+        result.backlog_batch = min(process.backlog_batch for process in hotlane_processes)
+        if any(process.backlog_batch <= 0 for process in hotlane_processes):
             result.issues.append(
                 HealthIssue("hotlane_backlog_disabled", "critical", "--backlog-batch is 0; embeddings will not drain")
             )
@@ -279,7 +279,7 @@ def run_health_check(
                         f"missing embeddings increased {result.previous_missing_vectors} -> {result.missing_vectors}",
                     )
                 )
-                stalled_ticks = prior_stalled_ticks + 1
+                stalled_ticks = 0
                 if config.heal:
                     _kickstart_once(result, config.hotlane_label, command_runner)
             elif result.missing_vectors == result.previous_missing_vectors and result.missing_vectors > 0:
@@ -320,14 +320,14 @@ def run_health_check(
                 )
             )
             if config.heal:
-                _kickstart_once(result, config.brainbar_label, command_runner)
+                _kickstart_once(result, config.brainbar_daemon_label, command_runner)
     except Exception as exc:
         result.canary_ok = False
         result.issues.append(
             HealthIssue("brain_search_canary_failed", "critical", f"BrainBar brain_search canary failed: {exc}")
         )
         if config.heal:
-            _kickstart_once(result, config.brainbar_label, command_runner)
+            _kickstart_once(result, config.brainbar_daemon_label, command_runner)
 
     result.ok = not result.issues
     return result

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -317,3 +317,12 @@ def test_launchd_installer_rejects_key_only_enrichment_config(tmp_path):
     assert result.returncode != 0
     assert "missing BRAINLAYER_ENRICH_ENABLED" in result.stderr
     assert "missing required enrichment config keys" in result.stdout
+
+
+def test_launchd_installer_wires_health_check_target():
+    install_source = (REPO_ROOT / "scripts/launchd/install.sh").read_text(encoding="utf-8")
+
+    assert "./scripts/launchd/install.sh health-check" in install_source
+    assert "health-check)" in install_source
+    assert "install_plist health-check" in install_source
+    assert "remove_plist health-check" in install_source

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import plistlib
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brainlayer.health_check import HealthCheckConfig, run_health_check
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_db(path: Path, *, total: int, vector_rows: int) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE chunks (
+                id TEXT PRIMARY KEY,
+                content TEXT,
+                archived_at TEXT,
+                superseded_by TEXT,
+                aggregated_into TEXT,
+                archived INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'active'
+            );
+            CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+            """
+        )
+        for index in range(total):
+            conn.execute(
+                "INSERT INTO chunks (id, content) VALUES (?, ?)",
+                (f"chunk-{index}", f"content {index}"),
+            )
+        for index in range(vector_rows):
+            conn.execute("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", (f"chunk-{index}",))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _ok_canary(_socket_path: Path, _query: str, _timeout_seconds: float) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": '## Search results for "agentopology" - 1 of 1 shown\n\n### 1. relevant result',
+                }
+            ]
+        },
+    }
+
+
+def test_backlog_batch_zero_alarms_and_kickstarts_hotlane(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=4, vector_rows=3)
+    commands: list[list[str]] = []
+
+    result = run_health_check(
+        HealthCheckConfig(db_path=db_path, state_path=state_path, heal=True),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 0 --enrich-limit 25\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda args: commands.append(args),
+        now_fn=lambda: datetime(2026, 6, 19, 4, 30, tzinfo=UTC),
+    )
+
+    assert result.ok is False
+    assert "hotlane_backlog_disabled" in [issue.code for issue in result.issues]
+    assert result.backlog_batch == 0
+    assert any("com.brainlayer.hotlane-brainbar" in " ".join(command) for command in commands)
+
+
+def test_missing_embeddings_not_draining_after_two_ticks(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=5, vector_rows=3)
+    state_path.write_text(
+        json.dumps(
+            {
+                "missing_vectors": 2,
+                "stalled_ticks": 1,
+                "ts": "2026-06-19T04:25:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(db_path=db_path, state_path=state_path, max_stalled_ticks=2),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py "
+            "--interval 1 --backlog-batch 128 --enrich-limit 25\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: None,
+        now_fn=lambda: datetime(2026, 6, 19, 4, 30, tzinfo=UTC),
+    )
+
+    assert result.ok is False
+    assert "missing_embeddings_not_draining" in [issue.code for issue in result.issues]
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    assert saved["missing_vectors"] == 2
+    assert saved["stalled_ticks"] == 2
+
+
+def test_brainbar_canary_error_alarms_and_kickstarts_brainbar(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=3, vector_rows=3)
+    commands: list[list[str]] = []
+
+    def failed_canary(_socket_path: Path, _query: str, _timeout_seconds: float) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [{"type": "text", "text": "Error: Database not available"}],
+                "isError": True,
+            },
+        }
+
+    result = run_health_check(
+        HealthCheckConfig(db_path=db_path, state_path=state_path, heal=True),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py "
+            "--interval 1 --backlog-batch 128 --enrich-limit 25\n"
+        ),
+        socket_request_fn=failed_canary,
+        command_runner=lambda args: commands.append(args),
+        now_fn=lambda: datetime(2026, 6, 19, 4, 30, tzinfo=UTC),
+    )
+
+    assert result.ok is False
+    assert "brain_search_canary_failed" in [issue.code for issue in result.issues]
+    assert any("com.brainlayer.brainbar" in " ".join(command) for command in commands)
+
+
+def test_health_check_launchagent_runs_every_five_minutes_and_heals():
+    plist_path = REPO_ROOT / "scripts/launchd/com.brainlayer.health-check.plist"
+    plist = plistlib.loads(plist_path.read_bytes())
+
+    assert plist["Label"] == "com.brainlayer.health-check"
+    assert plist["StartInterval"] == 300
+    assert plist["RunAtLoad"] is True
+    assert plist["ProgramArguments"][:3] == [
+        "__BRAINLAYER_ENV_RUN__",
+        "__BRAINLAYER_BIN__",
+        "health-check",
+    ]
+    assert "--heal" in plist["ProgramArguments"]

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -77,6 +77,30 @@ def test_backlog_batch_zero_alarms_and_kickstarts_hotlane(tmp_path):
     assert any("com.brainlayer.hotlane-brainbar" in " ".join(command) for command in commands)
 
 
+def test_any_zero_backlog_batch_alarms_when_multiple_hotlanes_are_running(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=4, vector_rows=3)
+    commands: list[list[str]] = []
+
+    result = run_health_check(
+        HealthCheckConfig(db_path=db_path, state_path=state_path, heal=True),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 128\n"
+            "456 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 0\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda args: commands.append(args),
+        now_fn=lambda: datetime(2026, 6, 19, 4, 30, tzinfo=UTC),
+    )
+
+    assert result.ok is False
+    assert "hotlane_backlog_disabled" in [issue.code for issue in result.issues]
+    assert result.backlog_batch == 0
+    assert len(commands) == 1
+    assert "com.brainlayer.hotlane-brainbar" in " ".join(commands[0])
+
+
 def test_missing_embeddings_not_draining_after_two_ticks(tmp_path):
     db_path = tmp_path / "brainlayer.db"
     state_path = tmp_path / "health-state.json"
@@ -110,6 +134,41 @@ def test_missing_embeddings_not_draining_after_two_ticks(tmp_path):
     assert saved["stalled_ticks"] == 2
 
 
+def test_missing_embeddings_climb_resets_stall_counter(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=5, vector_rows=2)
+    state_path.write_text(
+        json.dumps(
+            {
+                "missing_vectors": 2,
+                "stalled_ticks": 1,
+                "ts": "2026-06-19T04:25:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(db_path=db_path, state_path=state_path, max_stalled_ticks=2),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py "
+            "--interval 1 --backlog-batch 128 --enrich-limit 25\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: None,
+        now_fn=lambda: datetime(2026, 6, 19, 4, 30, tzinfo=UTC),
+    )
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert "missing_embeddings_climbing" in issue_codes
+    assert "missing_embeddings_not_draining" not in issue_codes
+    assert result.stalled_ticks == 0
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    assert saved["missing_vectors"] == 3
+    assert saved["stalled_ticks"] == 0
+
+
 def test_brainbar_canary_error_alarms_and_kickstarts_brainbar(tmp_path):
     db_path = tmp_path / "brainlayer.db"
     state_path = tmp_path / "health-state.json"
@@ -139,7 +198,7 @@ def test_brainbar_canary_error_alarms_and_kickstarts_brainbar(tmp_path):
 
     assert result.ok is False
     assert "brain_search_canary_failed" in [issue.code for issue in result.issues]
-    assert any("com.brainlayer.brainbar" in " ".join(command) for command in commands)
+    assert any("com.brainlayer.brainbar-daemon" in " ".join(command) for command in commands)
 
 
 def test_health_check_launchagent_runs_every_five_minutes_and_heals():


### PR DESCRIPTION
## Summary
- adds `brainlayer health-check` for launchd-run stability checks
- adds a 300s `com.brainlayer.health-check` LaunchAgent with `--json --heal`
- checks hotlane liveness, `--backlog-batch`, missing-vector drain trend, and BrainBar MCP `brain_search` canary
- documents state/log paths and self-heal behavior

## Verification
- RED first: `pytest tests/test_stability_health_check.py -q` failed on missing `brainlayer.health_check` module.
- `pytest tests/test_stability_health_check.py tests/test_launchd_hygiene.py -q` -> 17 passed.
- `ruff check src/brainlayer/health_check.py src/brainlayer/cli/__init__.py tests/test_stability_health_check.py` -> all checks passed.
- `ruff format --check src/brainlayer/health_check.py src/brainlayer/cli/__init__.py tests/test_stability_health_check.py` -> 3 files already formatted.
- `brainlayer health-check --help` rendered expected CLI options.
- Live no-heal smoke: `brainlayer health-check --json --no-heal --state-path /tmp/brainlayer-health-check-smoke.json` exited unhealthy without restarting services; detected hotlane running with `backlog_batch=128`, `missing_vectors=55757`, and BrainBar MCP canary failure: `Error: Database not available`.
- Pre-push gate: 2968 passed, 9 skipped, 61 deselected, 1 xfailed; MCP tool registration 3 passed; isolated eval/hook routing 40 passed; bun stale-index 1 passed; FTS5 determinism shell passed.

## Review
Review-required. Do not auto-merge.

## Operational note
The live no-heal smoke intentionally did not use `--heal`; it captured the current served-MCP failure safely. The scheduled LaunchAgent uses `--heal` and would kickstart the relevant launchd label when installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scheduled `--heal` can restart production launchd services on false positives; logic is well-tested but affects live hotlane/BrainBar uptime.
> 
> **Overview**
> Adds **`brainlayer health-check`** as a periodic stability probe for live BrainLayer: hotlane process presence, **`--backlog-batch 0`**, active chunks missing vectors (with cross-run stall detection via state file), and a BrainBar MCP **`brain_search`** canary over the UNIX socket. Optional **`--heal`** runs **`launchctl kickstart -k`** on **`com.brainlayer.hotlane-brainbar`** or **`com.brainlayer.brainbar-daemon`** when matching failures fire; **`--json`** and non-zero exit when unhealthy.
> 
> Wires **`com.brainlayer.health-check`** LaunchAgent (300s interval, **`--json --heal`**) into **`install.sh`** for **`health-check`**, **`all`**, and **`remove`**, plus ops doc and tests for backlog/stall/canary/installer wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4e404c7aa310c01dbdee01bec9965a3abdec9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add BrainLayer stability health check with self-heal via launchctl
> - Adds a new `brainlayer health-check` CLI command in [`src/brainlayer/cli/__init__.py`](https://github.com/EtanHey/brainlayer/pull/513/files#diff-e66ce4ea8b0cf3331154cb15181cb09a7c593566e36380fd9215ff29d24ffd02) that checks hotlane process backlog batch, counts missing embeddings (tracking stalled ticks across runs), and sends a UNIX socket canary query to BrainBar.
> - Implements the full health-check pipeline in [`src/brainlayer/health_check.py`](https://github.com/EtanHey/brainlayer/pull/513/files#diff-02ee89f403d662ff87be28bc3f25fb618f788bc46a8ea0cc752df6b38268671a) with structured `HealthCheckResult` output, JSON or human-readable output modes, and exit code 1 on unhealthy status.
> - When `--heal` is passed, automatically kickstarts the relevant launchd service (`hotlane` or `brainbar`) on specific failures using `launchctl kickstart`.
> - Adds a LaunchAgent plist ([`scripts/launchd/com.brainlayer.health-check.plist`](https://github.com/EtanHey/brainlayer/pull/513/files#diff-92e7bddfde15cb82ab689c8e9e8ffe0e9f522fb0c7e05326a6885684a2ffd63a)) that runs the check every 300 seconds with `--json --heal`, and extends the installer ([`scripts/launchd/install.sh`](https://github.com/EtanHey/brainlayer/pull/513/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756)) to support the `health-check` target.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f4e404.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->