### PR TITLE
feat: add BrainBar signal coverage observability

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -66,7 +66,7 @@ final class BrainBarDashboardPanelController {
         panel.titlebarAppearsTransparent = true
         panel.isReleasedWhenClosed = false
         panel.isFloatingPanel = true
-        panel.hidesOnDeactivate = true
+        panel.hidesOnDeactivate = false
         panel.level = .statusBar
         panel.minSize = minSize
         panel.maxSize = maxSize

--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -11,12 +11,13 @@ final class BrainBarDashboardPanelController {
         width: BrainBarWindowPlacement.minimumSize.width,
         height: BrainBarWindowPlacement.minimumSize.height
     )
+    static let maxSize = NSSize(width: 1_600, height: 1_200)
 
-    let popoverForTesting: NSPopover
+    let panelForTesting: NSPanel
     let contentViewControllerForTesting: NSViewController
-    var isShownForTesting: Bool { popover.isShown }
+    var isShownForTesting: Bool { panel.isVisible }
 
-    private let popover: NSPopover
+    private let panel: NSPanel
 
     init(runtime: BrainBarRuntime) {
         let hostingController = NSHostingController(
@@ -27,15 +28,14 @@ final class BrainBarDashboardPanelController {
         hostingController.view.frame = NSRect(origin: .zero, size: Self.defaultSize)
         hostingController.view.autoresizingMask = [.width, .height]
 
-        popover = NSPopover()
-        popoverForTesting = popover
         contentViewControllerForTesting = hostingController
+        panel = Self.makePanel(contentViewController: hostingController)
+        panelForTesting = panel
 
-        configurePopover(contentViewController: hostingController)
     }
 
     func toggle(anchoredTo anchorView: NSView? = nil) {
-        if popover.isShown {
+        if panel.isVisible {
             dismiss()
         } else {
             show(anchoredTo: anchorView)
@@ -44,22 +44,58 @@ final class BrainBarDashboardPanelController {
 
     func show(anchoredTo anchorView: NSView? = nil) {
         guard let anchorView else { return }
-
-        popover.show(
-            relativeTo: anchorView.bounds,
-            of: anchorView,
-            preferredEdge: .minY
-        )
+        positionPanel(below: anchorView)
+        NSApp.activate(ignoringOtherApps: true)
+        panel.makeKeyAndOrderFront(nil)
+        panel.orderFrontRegardless()
     }
 
     func dismiss() {
-        popover.performClose(nil)
+        panel.orderOut(nil)
     }
 
-    private func configurePopover(contentViewController: NSViewController) {
-        popover.behavior = .transient
-        popover.animates = true
-        popover.contentSize = Self.defaultSize
-        popover.contentViewController = contentViewController
+    private static func makePanel(contentViewController: NSViewController) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: defaultSize),
+            styleMask: [.titled, .fullSizeContentView, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "BrainBar"
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isReleasedWhenClosed = false
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = true
+        panel.level = .statusBar
+        panel.minSize = minSize
+        panel.maxSize = maxSize
+        panel.contentViewController = contentViewController
+        panel.contentMinSize = minSize
+        panel.setContentSize(defaultSize)
+        return panel
+    }
+
+    private func positionPanel(below anchorView: NSView) {
+        guard let anchorWindow = anchorView.window,
+              let screen = anchorWindow.screen ?? NSScreen.screens.first else {
+            panel.setFrame(NSRect(origin: .zero, size: panel.frame.size), display: false)
+            return
+        }
+
+        let anchorRectInWindow = anchorView.convert(anchorView.bounds, to: nil)
+        let anchorRect = anchorWindow.convertToScreen(anchorRectInWindow)
+        let visibleFrame = screen.visibleFrame
+        let panelSize = panel.frame.size
+        let gap = BrainBarWindowPlacement.menuBarIconGap
+        let targetX = min(
+            max(anchorRect.maxX - panelSize.width, visibleFrame.minX),
+            visibleFrame.maxX - panelSize.width
+        )
+        let targetY = max(
+            min(anchorRect.minY - gap - panelSize.height, visibleFrame.maxY - panelSize.height),
+            visibleFrame.minY
+        )
+        panel.setFrameOrigin(NSPoint(x: targetX, y: targetY))
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -336,6 +336,7 @@ private struct BrainBarDashboardView: View {
                     overviewCard(layout: layout)
                     freshnessLine
                     pipelinePanel(layout: layout)
+                    signalCoveragePanel(layout: layout)
                     diagnostics(layout: layout)
                 }
                 .padding(layout.outerPadding)
@@ -545,6 +546,13 @@ private struct BrainBarDashboardView: View {
         )
     }
 
+    private func signalCoveragePanel(layout: BrainBarDashboardLayout) -> some View {
+        BrainBarSignalCoveragePanel(
+            stats: collector.stats,
+            compact: layout.compactCards
+        )
+    }
+
     @ViewBuilder
     private func diagnostics(layout: BrainBarDashboardLayout) -> some View {
         let flowCard = BrainBarDiagnosticCard(
@@ -558,6 +566,7 @@ private struct BrainBarDashboardView: View {
                     fromByteCount: collector.stats.databaseSizeBytes,
                     countStyle: .file
                 )),
+                ("Vector", vectorSummary),
             ],
             columns: layout.diagnosticItemColumns
         )
@@ -569,6 +578,7 @@ private struct BrainBarDashboardView: View {
                 ("Daemon", daemonSummary),
                 ("Agents", collector.agentActivity.summaryText),
                 ("State", collector.state.label),
+                ("FTS", ftsSummary),
                 ("Trigram", trigramSummary),
                 ("Last seen", daemonLastSeenSummary),
             ],
@@ -629,9 +639,34 @@ private struct BrainBarDashboardView: View {
         )
     }
 
+    private var vectorSummary: String {
+        signalSummary(
+            indexedCount: collector.stats.vectorIndexedChunkCount,
+            backlogCount: collector.stats.vectorBacklogCount,
+            coveragePercent: collector.stats.vectorCoveragePercent
+        )
+    }
+
+    private var ftsSummary: String {
+        signalSummary(
+            indexedCount: collector.stats.ftsIndexedChunkCount,
+            backlogCount: collector.stats.ftsBacklogCount,
+            coveragePercent: collector.stats.ftsCoveragePercent
+        )
+    }
+
     private var trigramSummary: String {
-        "\(collector.stats.trigramIndexedChunkCount)/\(collector.stats.chunkCount) · " +
-            String(format: "%.0f%%", collector.stats.trigramCoveragePercent)
+        signalSummary(
+            indexedCount: collector.stats.trigramIndexedChunkCount,
+            backlogCount: collector.stats.trigramBacklogCount,
+            coveragePercent: collector.stats.trigramCoveragePercent
+        )
+    }
+
+    private func signalSummary(indexedCount: Int, backlogCount: Int, coveragePercent: Double) -> String {
+        "\(indexedCount)/\(collector.stats.chunkCount) · " +
+            String(format: "%.0f%%", coveragePercent) +
+            " · backlog \(backlogCount)"
     }
 }
 
@@ -651,6 +686,138 @@ private struct BrainBarTrigramProgress: View {
             }
             ProgressView(value: min(stats.trigramCoveragePercent, 100), total: 100)
         }
+    }
+}
+
+private struct BrainBarSignalCoveragePanel: View {
+    let stats: BrainDatabase.DashboardStats
+    let compact: Bool
+
+    private var signals: [BrainBarSignalCoverage] {
+        [
+            BrainBarSignalCoverage(
+                name: "Vector",
+                indexedCount: stats.vectorIndexedChunkCount,
+                totalCount: stats.chunkCount,
+                backlogCount: stats.vectorBacklogCount,
+                coveragePercent: stats.vectorCoveragePercent,
+                accentColor: .brainBarAccent
+            ),
+            BrainBarSignalCoverage(
+                name: "FTS",
+                indexedCount: stats.ftsIndexedChunkCount,
+                totalCount: stats.chunkCount,
+                backlogCount: stats.ftsBacklogCount,
+                coveragePercent: stats.ftsCoveragePercent,
+                accentColor: .brainBarAccentBright
+            ),
+            BrainBarSignalCoverage(
+                name: "Trigram",
+                indexedCount: stats.trigramIndexedChunkCount,
+                totalCount: stats.chunkCount,
+                backlogCount: stats.trigramBacklogCount,
+                coveragePercent: stats.trigramCoveragePercent,
+                accentColor: .brainBarAccentViolet
+            ),
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 12 : 16) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .firstTextBaseline, spacing: 12) {
+                    BrainBarSectionLabel("Signal Coverage")
+                    Text("Coverage is counted per retrieval signal; backlogs stay separate.")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    BrainBarSectionLabel("Signal Coverage")
+                    Text("Coverage is counted per retrieval signal; backlogs stay separate.")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            if compact {
+                VStack(spacing: 10) {
+                    ForEach(signals) { signal in
+                        BrainBarSignalCoverageRow(signal: signal, compact: true)
+                    }
+                }
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    ForEach(signals) { signal in
+                        BrainBarSignalCoverageRow(signal: signal, compact: false)
+                    }
+                }
+            }
+        }
+        .padding(compact ? 18 : 22)
+        .background(
+            BrainBarGlassPanel(cornerRadius: BrainBarDesignTokens.Radius.lg, tint: .brainBarAccentBright)
+        )
+    }
+}
+
+private struct BrainBarSignalCoverage: Identifiable {
+    let name: String
+    let indexedCount: Int
+    let totalCount: Int
+    let backlogCount: Int
+    let coveragePercent: Double
+    let accentColor: Color
+
+    var id: String { name }
+
+    var countText: String {
+        "\(indexedCount)/\(totalCount)"
+    }
+
+    var percentText: String {
+        String(format: "%.0f%%", coveragePercent)
+    }
+
+    var backlogText: String {
+        "backlog \(backlogCount)"
+    }
+}
+
+private struct BrainBarSignalCoverageRow: View {
+    let signal: BrainBarSignalCoverage
+    let compact: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 8 : 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(signal.name)
+                    .font(.system(size: compact ? 13 : 14, weight: .semibold))
+                Spacer(minLength: 8)
+                Text(signal.percentText)
+                    .font(.system(size: compact ? 16 : 18, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+            }
+
+            ProgressView(value: min(max(signal.coveragePercent, 0), 100), total: 100)
+                .tint(signal.accentColor)
+
+            HStack(spacing: 10) {
+                BrainBarLaneMetric(label: "Indexed", value: signal.countText)
+                BrainBarLaneMetric(label: "Backlog", value: "\(signal.backlogCount)")
+                Spacer(minLength: 0)
+            }
+
+            Text(signal.backlogText)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(compact ? 12 : 14)
+        .background(BrainBarDashboardCardStyle())
     }
 }
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -664,7 +664,7 @@ private struct BrainBarDashboardView: View {
     }
 
     private func signalSummary(indexedCount: Int, backlogCount: Int, coveragePercent: Double) -> String {
-        "\(indexedCount)/\(collector.stats.chunkCount) · " +
+        "\(indexedCount)/\(collector.stats.signalEligibleChunkCount) · " +
             String(format: "%.0f%%", coveragePercent) +
             " · backlog \(backlogCount)"
     }
@@ -679,7 +679,7 @@ private struct BrainBarTrigramProgress: View {
                 Text("Trigram maintenance")
                     .font(.system(size: 11, weight: .semibold))
                 Spacer(minLength: 8)
-                Text("\(stats.trigramIndexedChunkCount)/\(stats.chunkCount)")
+                Text("\(stats.trigramIndexedChunkCount)/\(stats.signalEligibleChunkCount)")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
@@ -698,7 +698,7 @@ private struct BrainBarSignalCoveragePanel: View {
             BrainBarSignalCoverage(
                 name: "Vector",
                 indexedCount: stats.vectorIndexedChunkCount,
-                totalCount: stats.chunkCount,
+                totalCount: stats.signalEligibleChunkCount,
                 backlogCount: stats.vectorBacklogCount,
                 coveragePercent: stats.vectorCoveragePercent,
                 accentColor: .brainBarAccent
@@ -706,7 +706,7 @@ private struct BrainBarSignalCoveragePanel: View {
             BrainBarSignalCoverage(
                 name: "FTS",
                 indexedCount: stats.ftsIndexedChunkCount,
-                totalCount: stats.chunkCount,
+                totalCount: stats.signalEligibleChunkCount,
                 backlogCount: stats.ftsBacklogCount,
                 coveragePercent: stats.ftsCoveragePercent,
                 accentColor: .brainBarAccentBright
@@ -714,7 +714,7 @@ private struct BrainBarSignalCoveragePanel: View {
             BrainBarSignalCoverage(
                 name: "Trigram",
                 indexedCount: stats.trigramIndexedChunkCount,
-                totalCount: stats.chunkCount,
+                totalCount: stats.signalEligibleChunkCount,
                 backlogCount: stats.trigramBacklogCount,
                 coveragePercent: stats.trigramCoveragePercent,
                 accentColor: .brainBarAccentViolet

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -103,6 +103,8 @@ final class BrainDatabase: @unchecked Sendable {
         let liveWindowMinutes: Int
         let lastWriteAt: Date?
         let lastEnrichedAt: Date?
+        let vectorIndexedChunkCount: Int
+        let ftsIndexedChunkCount: Int
         let trigramIndexedChunkCount: Int
         let pendingStoreQueueDepth: Int
         let pendingStoreOldestQueuedAt: Date?
@@ -125,6 +127,8 @@ final class BrainDatabase: @unchecked Sendable {
             liveWindowMinutes: Int = 1,
             lastWriteAt: Date? = nil,
             lastEnrichedAt: Date? = nil,
+            vectorIndexedChunkCount: Int = 0,
+            ftsIndexedChunkCount: Int = 0,
             trigramIndexedChunkCount: Int = 0,
             pendingStoreQueueDepth: Int = 0,
             pendingStoreOldestQueuedAt: Date? = nil,
@@ -146,6 +150,8 @@ final class BrainDatabase: @unchecked Sendable {
             self.liveWindowMinutes = liveWindowMinutes
             self.lastWriteAt = lastWriteAt
             self.lastEnrichedAt = lastEnrichedAt
+            self.vectorIndexedChunkCount = vectorIndexedChunkCount
+            self.ftsIndexedChunkCount = ftsIndexedChunkCount
             self.trigramIndexedChunkCount = trigramIndexedChunkCount
             self.pendingStoreQueueDepth = pendingStoreQueueDepth
             self.pendingStoreOldestQueuedAt = pendingStoreOldestQueuedAt
@@ -180,9 +186,33 @@ final class BrainDatabase: @unchecked Sendable {
             eventIsLive(lastEnrichedAt, now: now) || recentEnrichmentCount > 0
         }
 
+        var vectorBacklogCount: Int {
+            max(chunkCount - vectorIndexedChunkCount, 0)
+        }
+
+        var ftsBacklogCount: Int {
+            max(chunkCount - ftsIndexedChunkCount, 0)
+        }
+
+        var trigramBacklogCount: Int {
+            max(chunkCount - trigramIndexedChunkCount, 0)
+        }
+
+        var vectorCoveragePercent: Double {
+            coveragePercent(indexedCount: vectorIndexedChunkCount)
+        }
+
+        var ftsCoveragePercent: Double {
+            coveragePercent(indexedCount: ftsIndexedChunkCount)
+        }
+
         var trigramCoveragePercent: Double {
+            coveragePercent(indexedCount: trigramIndexedChunkCount)
+        }
+
+        private func coveragePercent(indexedCount: Int) -> Double {
             guard chunkCount > 0 else { return 100 }
-            return (Double(trigramIndexedChunkCount) / Double(chunkCount)) * 100
+            return (Double(indexedCount) / Double(chunkCount)) * 100
         }
 
         func withPendingStoreFlushRate(_ rate: Double) -> DashboardStats {
@@ -202,6 +232,8 @@ final class BrainDatabase: @unchecked Sendable {
                 liveWindowMinutes: liveWindowMinutes,
                 lastWriteAt: lastWriteAt,
                 lastEnrichedAt: lastEnrichedAt,
+                vectorIndexedChunkCount: vectorIndexedChunkCount,
+                ftsIndexedChunkCount: ftsIndexedChunkCount,
                 trigramIndexedChunkCount: trigramIndexedChunkCount,
                 pendingStoreQueueDepth: pendingStoreQueueDepth,
                 pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
@@ -1597,6 +1629,7 @@ final class BrainDatabase: @unchecked Sendable {
             }
 
             let counts = try dashboardCounts()
+            let signalCounts = try dashboardSignalCoverageCounts()
             let lastEvents = try dashboardLastEvents(now: now)
             let chunkCount = counts.chunkCount
             let enrichedChunkCount = counts.enrichedChunkCount
@@ -1632,7 +1665,9 @@ final class BrainDatabase: @unchecked Sendable {
                 liveWindowMinutes: liveWindowMinutes,
                 lastWriteAt: lastEvents.lastWriteAt,
                 lastEnrichedAt: lastEvents.lastEnrichedAt,
-                trigramIndexedChunkCount: (try? countRows(in: "chunks_fts_trigram")) ?? 0,
+                vectorIndexedChunkCount: signalCounts.vectorIndexedChunkCount,
+                ftsIndexedChunkCount: signalCounts.ftsIndexedChunkCount,
+                trigramIndexedChunkCount: signalCounts.trigramIndexedChunkCount,
                 pendingStoreQueueDepth: pendingStoreQueue.depth,
                 pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt,
                 watcherHealth: watcherHealth
@@ -1707,6 +1742,35 @@ final class BrainDatabase: @unchecked Sendable {
             enrichedChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL"),
             pendingEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NULL AND enriched_at IS NULL")
         )
+    }
+
+    private func dashboardSignalCoverageCounts() throws -> (
+        vectorIndexedChunkCount: Int,
+        ftsIndexedChunkCount: Int,
+        trigramIndexedChunkCount: Int
+    ) {
+        (
+            vectorIndexedChunkCount: try joinedCoverageCount(tableName: "chunk_vectors_rowids", idColumn: "id"),
+            ftsIndexedChunkCount: try joinedCoverageCount(tableName: "chunks_fts", idColumn: "chunk_id"),
+            trigramIndexedChunkCount: try joinedCoverageCount(tableName: "chunks_fts_trigram", idColumn: "chunk_id")
+        )
+    }
+
+    private func joinedCoverageCount(tableName: String, idColumn: String) throws -> Int {
+        let allowedTables = [
+            "chunk_vectors_rowids": "id",
+            "chunks_fts": "chunk_id",
+            "chunks_fts_trigram": "chunk_id",
+        ]
+        guard allowedTables[tableName] == idColumn else {
+            throw DBError.exec(SQLITE_ERROR, "invalid coverage table")
+        }
+        guard (try? tableExists(tableName)) == true else { return 0 }
+        return try scalarInt("""
+            SELECT COUNT(DISTINCT signal.\(idColumn))
+            FROM \(tableName) AS signal
+            INNER JOIN chunks AS c ON c.id = signal.\(idColumn)
+        """)
     }
 
     private func dashboardLastEvents(now: Date) throws -> (lastWriteAt: Date?, lastEnrichedAt: Date?) {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -103,6 +103,7 @@ final class BrainDatabase: @unchecked Sendable {
         let liveWindowMinutes: Int
         let lastWriteAt: Date?
         let lastEnrichedAt: Date?
+        let signalEligibleChunkCount: Int
         let vectorIndexedChunkCount: Int
         let ftsIndexedChunkCount: Int
         let trigramIndexedChunkCount: Int
@@ -127,6 +128,7 @@ final class BrainDatabase: @unchecked Sendable {
             liveWindowMinutes: Int = 1,
             lastWriteAt: Date? = nil,
             lastEnrichedAt: Date? = nil,
+            signalEligibleChunkCount: Int? = nil,
             vectorIndexedChunkCount: Int = 0,
             ftsIndexedChunkCount: Int = 0,
             trigramIndexedChunkCount: Int = 0,
@@ -150,6 +152,7 @@ final class BrainDatabase: @unchecked Sendable {
             self.liveWindowMinutes = liveWindowMinutes
             self.lastWriteAt = lastWriteAt
             self.lastEnrichedAt = lastEnrichedAt
+            self.signalEligibleChunkCount = signalEligibleChunkCount ?? chunkCount
             self.vectorIndexedChunkCount = vectorIndexedChunkCount
             self.ftsIndexedChunkCount = ftsIndexedChunkCount
             self.trigramIndexedChunkCount = trigramIndexedChunkCount
@@ -187,15 +190,15 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         var vectorBacklogCount: Int {
-            max(chunkCount - vectorIndexedChunkCount, 0)
+            max(signalEligibleChunkCount - vectorIndexedChunkCount, 0)
         }
 
         var ftsBacklogCount: Int {
-            max(chunkCount - ftsIndexedChunkCount, 0)
+            max(signalEligibleChunkCount - ftsIndexedChunkCount, 0)
         }
 
         var trigramBacklogCount: Int {
-            max(chunkCount - trigramIndexedChunkCount, 0)
+            max(signalEligibleChunkCount - trigramIndexedChunkCount, 0)
         }
 
         var vectorCoveragePercent: Double {
@@ -211,8 +214,8 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         private func coveragePercent(indexedCount: Int) -> Double {
-            guard chunkCount > 0 else { return 100 }
-            return (Double(indexedCount) / Double(chunkCount)) * 100
+            guard signalEligibleChunkCount > 0 else { return 100 }
+            return (Double(indexedCount) / Double(signalEligibleChunkCount)) * 100
         }
 
         func withPendingStoreFlushRate(_ rate: Double) -> DashboardStats {
@@ -232,6 +235,7 @@ final class BrainDatabase: @unchecked Sendable {
                 liveWindowMinutes: liveWindowMinutes,
                 lastWriteAt: lastWriteAt,
                 lastEnrichedAt: lastEnrichedAt,
+                signalEligibleChunkCount: signalEligibleChunkCount,
                 vectorIndexedChunkCount: vectorIndexedChunkCount,
                 ftsIndexedChunkCount: ftsIndexedChunkCount,
                 trigramIndexedChunkCount: trigramIndexedChunkCount,
@@ -1665,6 +1669,7 @@ final class BrainDatabase: @unchecked Sendable {
                 liveWindowMinutes: liveWindowMinutes,
                 lastWriteAt: lastEvents.lastWriteAt,
                 lastEnrichedAt: lastEvents.lastEnrichedAt,
+                signalEligibleChunkCount: signalCounts.eligibleChunkCount,
                 vectorIndexedChunkCount: signalCounts.vectorIndexedChunkCount,
                 ftsIndexedChunkCount: signalCounts.ftsIndexedChunkCount,
                 trigramIndexedChunkCount: signalCounts.trigramIndexedChunkCount,
@@ -1745,18 +1750,33 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     private func dashboardSignalCoverageCounts() throws -> (
+        eligibleChunkCount: Int,
         vectorIndexedChunkCount: Int,
         ftsIndexedChunkCount: Int,
         trigramIndexedChunkCount: Int
     ) {
-        (
-            vectorIndexedChunkCount: try joinedCoverageCount(tableName: "chunk_vectors_rowids", idColumn: "id"),
-            ftsIndexedChunkCount: try joinedCoverageCount(tableName: "chunks_fts", idColumn: "chunk_id"),
-            trigramIndexedChunkCount: try joinedCoverageCount(tableName: "chunks_fts_trigram", idColumn: "chunk_id")
+        let searchableWhereClause = try searchableChunkWhereClause(alias: "c")
+        return (
+            eligibleChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks AS c WHERE \(searchableWhereClause)"),
+            vectorIndexedChunkCount: try joinedCoverageCount(
+                tableName: "chunk_vectors_rowids",
+                idColumn: "id",
+                searchableWhereClause: searchableWhereClause
+            ),
+            ftsIndexedChunkCount: try joinedCoverageCount(
+                tableName: "chunks_fts",
+                idColumn: "chunk_id",
+                searchableWhereClause: searchableWhereClause
+            ),
+            trigramIndexedChunkCount: try joinedCoverageCount(
+                tableName: "chunks_fts_trigram",
+                idColumn: "chunk_id",
+                searchableWhereClause: searchableWhereClause
+            )
         )
     }
 
-    private func joinedCoverageCount(tableName: String, idColumn: String) throws -> Int {
+    private func joinedCoverageCount(tableName: String, idColumn: String, searchableWhereClause: String) throws -> Int {
         let allowedTables = [
             "chunk_vectors_rowids": "id",
             "chunks_fts": "chunk_id",
@@ -1765,12 +1785,41 @@ final class BrainDatabase: @unchecked Sendable {
         guard allowedTables[tableName] == idColumn else {
             throw DBError.exec(SQLITE_ERROR, "invalid coverage table")
         }
-        guard (try? tableExists(tableName)) == true else { return 0 }
+        guard let db else { throw DBError.notOpen }
+        guard try tableExists(tableName) else { return 0 }
+        guard try tableColumns(name: tableName, on: db).contains(idColumn) else { return 0 }
         return try scalarInt("""
             SELECT COUNT(DISTINCT signal.\(idColumn))
             FROM \(tableName) AS signal
             INNER JOIN chunks AS c ON c.id = signal.\(idColumn)
+            WHERE \(searchableWhereClause)
         """)
+    }
+
+    private func searchableChunkWhereClause(alias: String) throws -> String {
+        guard let db else { throw DBError.notOpen }
+        let columns = try tableColumns(name: "chunks", on: db)
+        var clauses: [String] = []
+        if columns.contains("content") {
+            clauses.append("\(alias).content IS NOT NULL")
+            clauses.append("\(alias).content != ''")
+        }
+        if columns.contains("superseded_by") {
+            clauses.append("\(alias).superseded_by IS NULL")
+        }
+        if columns.contains("aggregated_into") {
+            clauses.append("\(alias).aggregated_into IS NULL")
+        }
+        if columns.contains("archived_at") {
+            clauses.append("\(alias).archived_at IS NULL")
+        }
+        if columns.contains("archived") {
+            clauses.append("COALESCE(\(alias).archived, 0) = 0")
+        }
+        if columns.contains("status") {
+            clauses.append("COALESCE(\(alias).status, 'active') = 'active'")
+        }
+        return clauses.isEmpty ? "1 = 1" : clauses.joined(separator: " AND ")
     }
 
     private func dashboardLastEvents(now: Date) throws -> (lastWriteAt: Date?, lastEnrichedAt: Date?) {

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
@@ -14,6 +14,7 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
         XCTAssertGreaterThan(panel.maxSize.height, BrainBarDashboardPanelController.defaultSize.height)
         XCTAssertEqual(panel.minSize, BrainBarDashboardPanelController.minSize)
         XCTAssertTrue(panel.styleMask.contains(.resizable))
+        XCTAssertFalse(panel.hidesOnDeactivate)
         XCTAssertEqual(panel.contentViewController, controller.contentViewControllerForTesting)
         XCTAssertEqual(controller.contentViewControllerForTesting.view.frame.size, BrainBarDashboardPanelController.defaultSize)
     }
@@ -83,7 +84,7 @@ final class BrainBarDashboardPanelControllerTests: XCTestCase {
         )
         XCTAssertNotNil(
             field,
-            "Command bar should create its ready text field when runtime.database was installed before the popover became visible."
+            "Command bar should create its ready text field when runtime.database was installed before the panel became visible."
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardPanelControllerTests.swift
@@ -4,17 +4,21 @@ import XCTest
 
 @MainActor
 final class BrainBarDashboardPanelControllerTests: XCTestCase {
-    func testDashboardPopoverUsesTransientMenuBarMountedContract() {
+    func testDashboardPanelUsesResizableMenuBarWindowContract() {
         let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
+        let panel = controller.panelForTesting
 
-        XCTAssertEqual(controller.popoverForTesting.behavior, .transient)
         XCTAssertEqual(BrainBarDashboardPanelController.defaultSize, NSSize(width: 900, height: 640))
         XCTAssertEqual(BrainBarDashboardPanelController.minSize, NSSize(width: 760, height: 560))
-        XCTAssertEqual(controller.popoverForTesting.contentSize, NSSize(width: 900, height: 640))
-        XCTAssertNotNil(controller.popoverForTesting.contentViewController)
+        XCTAssertGreaterThan(panel.maxSize.width, BrainBarDashboardPanelController.defaultSize.width)
+        XCTAssertGreaterThan(panel.maxSize.height, BrainBarDashboardPanelController.defaultSize.height)
+        XCTAssertEqual(panel.minSize, BrainBarDashboardPanelController.minSize)
+        XCTAssertTrue(panel.styleMask.contains(.resizable))
+        XCTAssertEqual(panel.contentViewController, controller.contentViewControllerForTesting)
+        XCTAssertEqual(controller.contentViewControllerForTesting.view.frame.size, BrainBarDashboardPanelController.defaultSize)
     }
 
-    func testDashboardPopoverDoesNotOpenWithoutStatusItemAnchor() {
+    func testDashboardPanelDoesNotOpenWithoutStatusItemAnchor() {
         let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
 
         controller.toggle()

--- a/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarStatusPopoverControllerTests.swift
@@ -4,21 +4,21 @@ import XCTest
 
 @MainActor
 final class BrainBarStatusPopoverControllerTests: XCTestCase {
-    func testControllerWiresVariableLengthStatusItemToMenuBarPopover() {
+    func testControllerWiresVariableLengthStatusItemToMenuBarPanel() {
         let runtime = BrainBarRuntime(launchMode: .menuItemDaemon)
-        let popoverController = BrainBarDashboardPanelController(runtime: runtime)
+        let panelController = BrainBarDashboardPanelController(runtime: runtime)
         let controller = BrainBarStatusPopoverController(
             runtime: runtime,
-            dashboardPanelController: popoverController
+            dashboardPanelController: panelController
         )
         defer { controller.stop() }
 
         XCTAssertEqual(controller.statusItemForTesting.length, NSStatusItem.variableLength)
         XCTAssertEqual(controller.statusItemForTesting.button?.target as? BrainBarStatusPopoverController, controller)
         XCTAssertTrue(BrainBarStatusPopoverController.statusItemEventMask.contains(.rightMouseUp))
-        XCTAssertEqual(popoverController.popoverForTesting.behavior, .transient)
-        XCTAssertNotNil(popoverController.popoverForTesting.contentViewController)
-        XCTAssertEqual(popoverController.popoverForTesting.contentSize, NSSize(width: 900, height: 640))
+        XCTAssertEqual(panelController.panelForTesting.contentViewController, panelController.contentViewControllerForTesting)
+        XCTAssertEqual(panelController.panelForTesting.contentViewController?.view.frame.size, NSSize(width: 900, height: 640))
+        XCTAssertTrue(panelController.panelForTesting.styleMask.contains(.resizable))
     }
 
     func testStatusItemContextMenuContainsNoLaunchModeSwitchingChoices() {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -85,6 +85,36 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
     }
 
+    func testDashboardStatsReportsPerSignalCoverageAndBacklogs() throws {
+        for id in ["signal-1", "signal-2", "signal-3"] {
+            try db.insertChunk(
+                id: id,
+                content: "Signal coverage fixture \(id)",
+                sessionId: "dashboard",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 5
+            )
+        }
+        db.exec("CREATE TABLE IF NOT EXISTS chunk_vectors_rowids(id TEXT PRIMARY KEY)")
+        db.exec("INSERT INTO chunk_vectors_rowids(id) VALUES ('signal-1'), ('signal-2')")
+        db.exec("DELETE FROM chunks_fts WHERE chunk_id = 'signal-3'")
+        db.exec("DELETE FROM chunks_fts_trigram WHERE chunk_id = 'signal-2'")
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.chunkCount, 3)
+        XCTAssertEqual(stats.vectorIndexedChunkCount, 2)
+        XCTAssertEqual(stats.ftsIndexedChunkCount, 2)
+        XCTAssertEqual(stats.trigramIndexedChunkCount, 2)
+        XCTAssertEqual(stats.vectorBacklogCount, 1)
+        XCTAssertEqual(stats.ftsBacklogCount, 1)
+        XCTAssertEqual(stats.trigramBacklogCount, 1)
+        XCTAssertEqual(stats.vectorCoveragePercent, 66.666, accuracy: 0.01)
+        XCTAssertEqual(stats.ftsCoveragePercent, 66.666, accuracy: 0.01)
+        XCTAssertEqual(stats.trigramCoveragePercent, 66.666, accuracy: 0.01)
+    }
+
     func testDashboardStatsReadsWatcherHealthSnapshot() throws {
         let healthURL = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("watcher-health-\(UUID().uuidString).json")
@@ -236,6 +266,19 @@ final class DashboardTests: XCTestCase {
 
         XCTAssertTrue(source.contains("collector.lastDataFetchedAt == nil"))
         XCTAssertTrue(source.contains("Connecting to daemon and loading dashboard data"))
+    }
+
+    func testDashboardRendersPerSignalCoverageSection() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertTrue(source.contains("BrainBarSignalCoveragePanel"))
+        XCTAssertTrue(source.contains("Signal Coverage"))
+        XCTAssertTrue(source.contains("Vector"))
+        XCTAssertTrue(source.contains("FTS"))
+        XCTAssertTrue(source.contains("Trigram"))
+        XCTAssertTrue(source.contains("vectorBacklogCount"))
+        XCTAssertTrue(source.contains("ftsBacklogCount"))
+        XCTAssertTrue(source.contains("trigramBacklogCount"))
     }
 
     func testBrainBarHeaderExposesRestartAndQuitControls() throws {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -86,7 +86,7 @@ final class DashboardTests: XCTestCase {
     }
 
     func testDashboardStatsReportsPerSignalCoverageAndBacklogs() throws {
-        for id in ["signal-1", "signal-2", "signal-3"] {
+        for id in ["signal-1", "signal-2", "signal-3", "signal-archived"] {
             try db.insertChunk(
                 id: id,
                 content: "Signal coverage fixture \(id)",
@@ -96,6 +96,7 @@ final class DashboardTests: XCTestCase {
                 importance: 5
             )
         }
+        db.exec("UPDATE chunks SET archived = 1, archived_at = '2026-06-19T00:00:00Z', status = 'archived' WHERE id = 'signal-archived'")
         db.exec("CREATE TABLE IF NOT EXISTS chunk_vectors_rowids(id TEXT PRIMARY KEY)")
         db.exec("INSERT INTO chunk_vectors_rowids(id) VALUES ('signal-1'), ('signal-2')")
         db.exec("DELETE FROM chunks_fts WHERE chunk_id = 'signal-3'")
@@ -103,7 +104,8 @@ final class DashboardTests: XCTestCase {
 
         let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
 
-        XCTAssertEqual(stats.chunkCount, 3)
+        XCTAssertEqual(stats.chunkCount, 4)
+        XCTAssertEqual(stats.signalEligibleChunkCount, 3)
         XCTAssertEqual(stats.vectorIndexedChunkCount, 2)
         XCTAssertEqual(stats.ftsIndexedChunkCount, 2)
         XCTAssertEqual(stats.trigramIndexedChunkCount, 2)
@@ -113,6 +115,26 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.vectorCoveragePercent, 66.666, accuracy: 0.01)
         XCTAssertEqual(stats.ftsCoveragePercent, 66.666, accuracy: 0.01)
         XCTAssertEqual(stats.trigramCoveragePercent, 66.666, accuracy: 0.01)
+    }
+
+    func testDashboardStatsTreatsLegacyFtsTableWithoutChunkIdAsUnknownCoverage() throws {
+        try db.insertChunk(
+            id: "legacy-fts-1",
+            content: "Legacy FTS fixture",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        db.exec("DROP TABLE chunks_fts")
+        db.exec("CREATE VIRTUAL TABLE chunks_fts USING fts5(content)")
+        db.exec("INSERT INTO chunks_fts(content) VALUES ('Legacy FTS fixture')")
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.signalEligibleChunkCount, 1)
+        XCTAssertEqual(stats.ftsIndexedChunkCount, 0)
+        XCTAssertEqual(stats.ftsBacklogCount, 1)
     }
 
     func testDashboardStatsReadsWatcherHealthSnapshot() throws {
@@ -276,6 +298,7 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(source.contains("Vector"))
         XCTAssertTrue(source.contains("FTS"))
         XCTAssertTrue(source.contains("Trigram"))
+        XCTAssertTrue(source.contains("signalEligibleChunkCount"))
         XCTAssertTrue(source.contains("vectorBacklogCount"))
         XCTAssertTrue(source.contains("ftsBacklogCount"))
         XCTAssertTrue(source.contains("trigramBacklogCount"))


### PR DESCRIPTION
## Summary
- Replace the BrainBar menu dashboard popover with a resizable `NSPanel` while keeping the default `900x640` size and `760x560` minimum.
- Add per-signal dashboard stats for vector embeddings, FTS, and trigram coverage, including separate indexed counts, percentages, and backlogs.
- Surface the new signal coverage section in the BrainBar dashboard and add Vector/FTS/Trigram details to diagnostics.

## Test plan
- [x] `swift test --filter 'DashboardTests|BrainBarDashboardPanelControllerTests|BrainBarStatusPopoverControllerTests'` -> 68 tests, 0 failures
- [x] `swift build` -> build complete
- [x] `git diff --check` -> no output
- [x] Pre-push gate -> `2964 passed, 9 skipped, 61 deselected, 1 xfailed, 103 warnings`; MCP registration `3 passed`; isolated eval/hook routing `40 passed`; bun stale-index `1 pass`; FTS5 determinism passed
- [x] Visual receipt: offscreen SwiftUI render `/tmp/brainbar-dashboard-qa.png` showed the expanded dashboard with Signal Coverage cards: Vector 92% / backlog 1, FTS 100% / backlog 0, Trigram 100% / backlog 0, with no obvious text overlap

## Review notes
- Review required; do not merge this PR until review is clean.
- Local `coderabbit review --agent` was attempted before commit and hit the 180s timeout without returning findings; PR-level bots should review the pushed branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI shell change (popover → panel) affects menu-bar interaction and window lifecycle; dashboard stats add dynamic SQL joins and schema-aware eligibility that must stay aligned with retrieval indexing.
> 
> **Overview**
> Replaces the menu-bar **NSPopover** dashboard with a floating, **resizable NSPanel** (same default/min sizes, new max 1600×1200), positioned below the status item, kept visible on deactivate, and activated when opened.
> 
> Adds **retrieval signal observability**: `DashboardStats` now tracks **signal-eligible** chunks (searchable, non-archived) and joined indexed counts for **Vector**, **FTS**, and **Trigram**, with per-signal coverage % and backlog. The dashboard gets a **Signal Coverage** section and diagnostics rows use the same indexed/backlog formatting (trigram no longer uses raw chunk totals).
> 
> Tests updated for the panel contract and new DB coverage queries (including legacy FTS without `chunk_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413ac55a6a024da591e5f272742ad71f29f19e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-signal coverage observability (Vector, FTS, Trigram) to BrainBar dashboard
> - Adds a Signal Coverage panel to the BrainBar dashboard showing indexed count, backlog, and coverage percent for Vector, FTS, and Trigram signals via new `BrainBarSignalCoveragePanel` and `BrainBarSignalCoverageRow` views.
> - Extends `BrainDatabase.DashboardStats` with `signalEligibleChunkCount`, per-signal indexed counts, backlog counts, and coverage percents; all percentages are now relative to signal-eligible chunks rather than total chunk count.
> - Adds `dashboardSignalCoverageCounts` to compute per-signal coverage via joins against signal tables, with `joinedCoverageCount` safely handling missing or legacy tables (returns 0 if table or expected column is absent).
> - Replaces the `NSPopover`-based dashboard with a floating `NSPanel` anchored below the status item, with configurable min/max sizes and resizable style.
> - Behavioral Change: trigram coverage denominator changes from `chunkCount` to `signalEligibleChunkCount`, which may lower reported coverage percent for existing databases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 413ac55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Signal Coverage panel to the dashboard displaying indexed chunk coverage metrics for Vector, FTS, and Trigram signals
  * Dashboard diagnostic cards now include additional signal coverage information (Vector and FTS metrics)
  * Improved signal coverage and backlog statistics formatting for consistency

* **Tests**
  * Expanded test coverage for signal coverage reporting and dashboard panel functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->