### PR TITLE
fix: preserve owner/tool names in redaction

### DIFF
--- a/src/brainlayer/cloud_backfill.py
+++ b/src/brainlayer/cloud_backfill.py
@@ -27,6 +27,7 @@ import json
 import os
 import sqlite3
 import time
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -40,7 +41,7 @@ from .pipeline.enrichment import (
     build_prompt,
     parse_enrichment,
 )
-from .pipeline.sanitize import SanitizeConfig, Sanitizer
+from .pipeline.sanitize import Sanitizer
 from .vector_store import VectorStore
 
 # ── Config ──────────────────────────────────────────────────────────────
@@ -486,17 +487,9 @@ def _init_sanitizer(store: VectorStore) -> Sanitizer:
     if known_names:
         print(f"  Built name dictionary: {len(known_names)} names from WhatsApp contacts")
         # Rebuild sanitizer with the full name dictionary
-        new_config = SanitizeConfig(
-            owner_names=sanitizer.config.owner_names,
-            owner_emails=sanitizer.config.owner_emails,
-            owner_paths=sanitizer.config.owner_paths,
+        new_config = replace(
+            sanitizer.config,
             known_names=frozenset(known_names) | sanitizer.config.known_names,
-            strip_emails=sanitizer.config.strip_emails,
-            strip_ips=sanitizer.config.strip_ips,
-            strip_jwts=sanitizer.config.strip_jwts,
-            strip_op_refs=sanitizer.config.strip_op_refs,
-            strip_phone_numbers=sanitizer.config.strip_phone_numbers,
-            use_spacy_ner=sanitizer.config.use_spacy_ner,
         )
         sanitizer = Sanitizer(new_config)
 

--- a/src/brainlayer/cloud_backfill.py
+++ b/src/brainlayer/cloud_backfill.py
@@ -489,7 +489,7 @@ def _init_sanitizer(store: VectorStore) -> Sanitizer:
         # Rebuild sanitizer with the full name dictionary
         new_config = replace(
             sanitizer.config,
-            known_names=frozenset(known_names) | sanitizer.config.known_names,
+            confirmed_person_names=frozenset(known_names) | sanitizer.config.confirmed_person_names,
         )
         sanitizer = Sanitizer(new_config)
 

--- a/src/brainlayer/pipeline/sanitize.py
+++ b/src/brainlayer/pipeline/sanitize.py
@@ -213,9 +213,12 @@ class Sanitizer:
             )
             if normalized
         )
-        self._person_redaction_allowlist_tokens = frozenset(
-            token for name in self.config.person_redaction_allowlist for token in _person_allowlist_tokens(name)
-        )
+        single_token_allowlist: set[str] = set()
+        for name in self.config.person_redaction_allowlist:
+            tokens = _person_allowlist_tokens(name)
+            if len(tokens) == 1:
+                single_token_allowlist.update(tokens)
+        self._person_redaction_allowlist_tokens = frozenset(single_token_allowlist)
 
         self._build_owner_regex()
         self._build_known_names_regex()
@@ -298,9 +301,7 @@ class Sanitizer:
         tokens = _person_allowlist_tokens(name)
         if not tokens or not (tokens & self._person_redaction_allowlist_tokens):
             return False
-        allowed_mixed_span_tokens = (
-            self._person_redaction_allowlist_tokens | _PERSON_ALLOWLIST_TOOL_DESCRIPTOR_TOKENS
-        )
+        allowed_mixed_span_tokens = self._person_redaction_allowlist_tokens | _PERSON_ALLOWLIST_TOOL_DESCRIPTOR_TOKENS
         return tokens <= allowed_mixed_span_tokens
 
     def sanitize(

--- a/src/brainlayer/pipeline/sanitize.py
+++ b/src/brainlayer/pipeline/sanitize.py
@@ -40,6 +40,50 @@ from typing import Any, Optional
 
 # ── Types ──────────────────────────────────────────────────────────────
 
+DEFAULT_PERSON_REDACTION_ALLOWLIST = frozenset(
+    {
+        # Owner identity and handles that must remain searchable in first-party memory.
+        "Etan",
+        "Etan Heyman",
+        "EtanHey",
+        "etanheyman",
+        # AI tools, agents, and vendors that NER can misclassify as PERSON.
+        "Claude",
+        "Codex",
+        "Cursor",
+        "Gemini",
+        "ChatGPT",
+        "Anthropic",
+        "OpenAI",
+        "Copilot",
+        "Llama",
+        "Mistral",
+    }
+)
+
+_PERSON_ALLOWLIST_TOOL_DESCRIPTOR_TOKENS = frozenset(
+    {
+        "agent",
+        "agents",
+        "ai",
+        "api",
+        "app",
+        "assistant",
+        "bot",
+        "chat",
+        "cli",
+        "cloud",
+        "code",
+        "desktop",
+        "llm",
+        "mcp",
+        "model",
+        "models",
+        "tool",
+        "tools",
+    }
+)
+
 
 @dataclass(frozen=True)
 class Replacement:
@@ -77,17 +121,33 @@ class SanitizeConfig:
     strip_op_refs: bool = True
     strip_phone_numbers: bool = True
     use_spacy_ner: bool = True
+    person_redaction_allowlist: frozenset[str] = DEFAULT_PERSON_REDACTION_ALLOWLIST
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────
 
 # Hebrew nikud (diacritics) range: U+0591 to U+05C7
 _NIKUD_RE = re.compile(r"[\u0591-\u05c7]")
+_ALLOWLIST_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*|[\u0590-\u05ff]+")
 
 
 def _strip_nikud(text: str) -> str:
     """Remove Hebrew nikud (diacritical marks) for fuzzy name matching."""
     return _NIKUD_RE.sub("", text)
+
+
+def _normalize_person_allowlist_value(text: str) -> str:
+    """Normalize a PERSON allowlist value for case-insensitive matching."""
+    return " ".join(_strip_nikud(text).casefold().split())
+
+
+def _person_allowlist_tokens(text: str) -> frozenset[str]:
+    """Return normalized tokens so allowlisted tools inside NER spans survive."""
+    return frozenset(
+        token
+        for token in (_normalize_person_allowlist_value(match.group(0)) for match in _ALLOWLIST_TOKEN_RE.finditer(text))
+        if token
+    )
 
 
 def _nikud_offset_map(original: str) -> list[int]:
@@ -146,6 +206,16 @@ class Sanitizer:
         self._pseudo_lock = threading.Lock()  # Thread-safe pseudonym access
         self._owner_re: Optional[re.Pattern[str]] = None
         self._known_names_re: Optional[re.Pattern[str]] = None
+        self._person_redaction_allowlist = frozenset(
+            normalized
+            for normalized in (
+                _normalize_person_allowlist_value(name) for name in self.config.person_redaction_allowlist
+            )
+            if normalized
+        )
+        self._person_redaction_allowlist_tokens = frozenset(
+            token for name in self.config.person_redaction_allowlist for token in _person_allowlist_tokens(name)
+        )
 
         self._build_owner_regex()
         self._build_known_names_regex()
@@ -219,6 +289,19 @@ class Sanitizer:
                 h = hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
                 self._name_to_pseudo[key] = f"[PERSON_{h}]"
             return self._name_to_pseudo[key]
+
+    def _is_person_redaction_allowlisted(self, name: str) -> bool:
+        """Return True when a PERSON span should remain verbatim."""
+        normalized = _normalize_person_allowlist_value(name)
+        if normalized in self._person_redaction_allowlist:
+            return True
+        tokens = _person_allowlist_tokens(name)
+        if not tokens or not (tokens & self._person_redaction_allowlist_tokens):
+            return False
+        allowed_mixed_span_tokens = (
+            self._person_redaction_allowlist_tokens | _PERSON_ALLOWLIST_TOOL_DESCRIPTOR_TOKENS
+        )
+        return tokens <= allowed_mixed_span_tokens
 
     def sanitize(
         self,
@@ -362,11 +445,13 @@ class Sanitizer:
                         "name_dict",
                     )
                     for m in self._known_names_re.finditer(text_no_nikud)
+                    if not self._is_person_redaction_allowlisted(m.group(0))
                 ]
             else:
                 name_matches = [
                     (m.start(), m.end(), self._pseudonym(m.group(0)), "person_name", "name_dict")
                     for m in self._known_names_re.finditer(text)
+                    if not self._is_person_redaction_allowlisted(m.group(0))
                 ]
             text = _apply_replacements(text, name_matches)
 
@@ -389,6 +474,9 @@ class Sanitizer:
                     continue
                 # Skip very short entities (likely false positives)
                 if len(ent.text.strip()) < 3:
+                    continue
+                # Skip owner/tool/agent names that must remain searchable.
+                if self._is_person_redaction_allowlisted(ent.text):
                     continue
                 # Skip if already replaced
                 if any(s <= ent.start_char < e for s, e in replaced_spans):
@@ -533,6 +621,9 @@ class Sanitizer:
         extra_names = frozenset(
             n.strip() for n in os.environ.get("BRAINLAYER_SANITIZE_EXTRA_NAMES", "").split(",") if n.strip()
         )
+        person_redaction_allowlist = DEFAULT_PERSON_REDACTION_ALLOWLIST | frozenset(
+            n.strip() for n in os.environ.get("BRAINLAYER_REDACTION_ALLOWLIST", "").split(",") if n.strip()
+        )
         use_spacy = os.environ.get("BRAINLAYER_SANITIZE_USE_SPACY", "true").lower() in (
             "true",
             "1",
@@ -545,5 +636,6 @@ class Sanitizer:
             owner_paths=owner_paths,
             known_names=extra_names,
             use_spacy_ner=use_spacy,
+            person_redaction_allowlist=person_redaction_allowlist,
         )
         return cls(config)

--- a/src/brainlayer/pipeline/sanitize.py
+++ b/src/brainlayer/pipeline/sanitize.py
@@ -115,6 +115,7 @@ class SanitizeConfig:
     owner_emails: tuple[str, ...] = ()
     owner_paths: tuple[str, ...] = ()
     known_names: frozenset[str] = frozenset()
+    confirmed_person_names: frozenset[str] = frozenset()
     strip_emails: bool = True
     strip_ips: bool = True
     strip_jwts: bool = True
@@ -206,6 +207,7 @@ class Sanitizer:
         self._pseudo_lock = threading.Lock()  # Thread-safe pseudonym access
         self._owner_re: Optional[re.Pattern[str]] = None
         self._known_names_re: Optional[re.Pattern[str]] = None
+        self._confirmed_person_names_re: Optional[re.Pattern[str]] = None
         self._person_redaction_allowlist = frozenset(
             normalized
             for normalized in (
@@ -242,13 +244,18 @@ class Sanitizer:
         Hebrew Unicode chars), uses lookahead/lookbehind on whitespace since
         \\b doesn't work reliably with Hebrew script.
         """
-        if not self.config.known_names:
+        self._known_names_re = self._compile_name_regex(self.config.known_names)
+        self._confirmed_person_names_re = self._compile_name_regex(self.config.confirmed_person_names)
+
+    def _compile_name_regex(self, names: frozenset[str]) -> Optional[re.Pattern[str]]:
+        """Build a compiled regex for a set of personal names."""
+        if not names:
             return
 
         latin_names: list[str] = []
         hebrew_names: list[str] = []
 
-        for name in sorted(self.config.known_names, key=len, reverse=True):
+        for name in sorted(names, key=len, reverse=True):
             name = name.strip()
             if not name or len(name) < 2:
                 continue
@@ -268,7 +275,8 @@ class Sanitizer:
             parts.append(r"(?:^|(?<=\s))(?:" + "|".join(hebrew_names) + r")(?=\s|$)")
 
         if parts:
-            self._known_names_re = re.compile("|".join(parts), re.IGNORECASE | re.MULTILINE)
+            return re.compile("|".join(parts), re.IGNORECASE | re.MULTILINE)
+        return None
 
     def _get_nlp(self):
         """Lazy-load spaCy model on first use."""
@@ -431,13 +439,17 @@ class Sanitizer:
 
         # ── Layer 2: Known names dictionary ──
 
-        if self._known_names_re:
+        def _collect_name_dict_matches(
+            pattern: re.Pattern[str],
+            *,
+            allow_allowlist_skip: bool,
+        ) -> list[tuple[int, int, str, str, str]]:
             # Match against nikud-stripped text but replace in original
             text_no_nikud = _strip_nikud(text)
             if text_no_nikud != text:
                 # Hebrew text with nikud — match on stripped version, map positions back
                 omap = _nikud_offset_map(text)
-                name_matches = [
+                return [
                     (
                         omap[m.start()],
                         omap[m.end()],
@@ -445,15 +457,27 @@ class Sanitizer:
                         "person_name",
                         "name_dict",
                     )
-                    for m in self._known_names_re.finditer(text_no_nikud)
-                    if not self._is_person_redaction_allowlisted(m.group(0))
+                    for m in pattern.finditer(text_no_nikud)
+                    if not (allow_allowlist_skip and self._is_person_redaction_allowlisted(m.group(0)))
                 ]
-            else:
-                name_matches = [
-                    (m.start(), m.end(), self._pseudonym(m.group(0)), "person_name", "name_dict")
-                    for m in self._known_names_re.finditer(text)
-                    if not self._is_person_redaction_allowlisted(m.group(0))
-                ]
+            return [
+                (m.start(), m.end(), self._pseudonym(m.group(0)), "person_name", "name_dict")
+                for m in pattern.finditer(text)
+                if not (allow_allowlist_skip and self._is_person_redaction_allowlisted(m.group(0)))
+            ]
+
+        if self._confirmed_person_names_re:
+            name_matches = _collect_name_dict_matches(
+                self._confirmed_person_names_re,
+                allow_allowlist_skip=False,
+            )
+            text = _apply_replacements(text, name_matches)
+
+        if self._known_names_re:
+            name_matches = _collect_name_dict_matches(
+                self._known_names_re,
+                allow_allowlist_skip=True,
+            )
             text = _apply_replacements(text, name_matches)
 
         # ── Layer 3: spaCy NER (English names only) ──
@@ -556,7 +580,7 @@ class Sanitizer:
         """Extract unique sender names from WhatsApp chunks in the DB.
 
         Queries the chunks table for distinct sender values where source='whatsapp'.
-        Returns the set of names found (can be passed to SanitizeConfig.known_names).
+        Returns the set of names found (can be passed to SanitizeConfig.confirmed_person_names).
         """
         cursor = store.conn.cursor()
         rows = list(

--- a/tests/test_cloud_backfill.py
+++ b/tests/test_cloud_backfill.py
@@ -68,31 +68,57 @@ def test_init_sanitizer_preserves_env_allowlist_when_adding_whatsapp_names(tmp_p
     """DB-derived contact names should not discard env-extended redaction allowlist entries."""
     export_dir = tmp_path / "exports"
     monkeypatch.setattr(cloud_backfill, "EXPORT_DIR", export_dir)
+    monkeypatch.setenv("BRAINLAYER_SANITIZE_USE_SPACY", "false")
     monkeypatch.setenv("BRAINLAYER_REDACTION_ALLOWLIST", "BrainLayerBot")
 
     store = VectorStore(tmp_path / "backfill.db")
     try:
         cursor = store.conn.cursor()
-        for chunk_id, sender in [("contact-tool", "BrainLayerBot"), ("contact-person", "John Smith")]:
-            cursor.execute(
-                """
-                INSERT INTO chunks (id, content, metadata, source_file, project, content_type, char_count, source, sender)
-                VALUES (?, ?, '{}', 'whatsapp.jsonl', 'test-project', 'message', ?, 'whatsapp', ?)
-                """,
-                (
-                    chunk_id,
-                    f"{sender} sent a long enough WhatsApp message to populate sanitizer contacts.",
-                    70,
-                    sender,
-                ),
-            )
+        cursor.execute(
+            """
+            INSERT INTO chunks (id, content, metadata, source_file, project, content_type, char_count, source, sender)
+            VALUES (?, ?, '{}', 'whatsapp.jsonl', 'test-project', 'message', ?, 'whatsapp', ?)
+            """,
+            (
+                "contact-person",
+                "John Smith sent a long enough WhatsApp message to populate sanitizer contacts.",
+                70,
+                "John Smith",
+            ),
+        )
 
         sanitizer = cloud_backfill._init_sanitizer(store)
         result = sanitizer.sanitize("BrainLayerBot coordinated with John Smith.")
 
+        assert "BrainLayerBot" in sanitizer.config.person_redaction_allowlist
         assert "BrainLayerBot" in result.sanitized
         assert "John Smith" not in result.sanitized
         assert "[PERSON_" in result.sanitized
+    finally:
+        store.close()
+
+
+def test_init_sanitizer_redacts_allowlisted_whatsapp_contact_names(tmp_path, monkeypatch):
+    """Confirmed DB contact names should redact even if their text matches a tool allowlist entry."""
+    export_dir = tmp_path / "exports"
+    monkeypatch.setattr(cloud_backfill, "EXPORT_DIR", export_dir)
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        store.conn.cursor().execute(
+            """
+            INSERT INTO chunks (id, content, metadata, source_file, project, content_type, char_count, source, sender)
+            VALUES ('contact-claude', 'Claude sent a long enough WhatsApp message.', '{}',
+                    'whatsapp.jsonl', 'test-project', 'message', 43, 'whatsapp', 'Claude')
+            """
+        )
+
+        sanitizer = cloud_backfill._init_sanitizer(store)
+        result = sanitizer.sanitize("Claude sent a message.")
+
+        assert "Claude" not in result.sanitized
+        assert "[PERSON_" in result.sanitized
+        assert any(replacement.source == "name_dict" for replacement in result.replacements)
     finally:
         store.close()
 

--- a/tests/test_cloud_backfill.py
+++ b/tests/test_cloud_backfill.py
@@ -64,6 +64,39 @@ def test_export_unenriched_chunks_disables_thinking(tmp_path, monkeypatch):
         store.close()
 
 
+def test_init_sanitizer_preserves_env_allowlist_when_adding_whatsapp_names(tmp_path, monkeypatch):
+    """DB-derived contact names should not discard env-extended redaction allowlist entries."""
+    export_dir = tmp_path / "exports"
+    monkeypatch.setattr(cloud_backfill, "EXPORT_DIR", export_dir)
+    monkeypatch.setenv("BRAINLAYER_REDACTION_ALLOWLIST", "BrainLayerBot")
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        cursor = store.conn.cursor()
+        for chunk_id, sender in [("contact-tool", "BrainLayerBot"), ("contact-person", "John Smith")]:
+            cursor.execute(
+                """
+                INSERT INTO chunks (id, content, metadata, source_file, project, content_type, char_count, source, sender)
+                VALUES (?, ?, '{}', 'whatsapp.jsonl', 'test-project', 'message', ?, 'whatsapp', ?)
+                """,
+                (
+                    chunk_id,
+                    f"{sender} sent a long enough WhatsApp message to populate sanitizer contacts.",
+                    70,
+                    sender,
+                ),
+            )
+
+        sanitizer = cloud_backfill._init_sanitizer(store)
+        result = sanitizer.sanitize("BrainLayerBot coordinated with John Smith.")
+
+        assert "BrainLayerBot" in result.sanitized
+        assert "John Smith" not in result.sanitized
+        assert "[PERSON_" in result.sanitized
+    finally:
+        store.close()
+
+
 def test_estimate_batch_cost_uses_discounted_batch_rates():
     """Batch usage cost helper should apply the documented 50% discount."""
     cost = cloud_backfill.estimate_batch_cost_usd(1_000_000, 2_000_000)

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -184,6 +184,20 @@ class TestNameDictionary:
         assert "John Smith" not in result.sanitized
         assert {replacement.original for replacement in result.replacements} == {"Claude Shannon", "John Smith"}
 
+    def test_single_token_from_multiword_allowlist_still_pseudonymizes(self):
+        s = Sanitizer(
+            SanitizeConfig(
+                known_names=frozenset({"Heyman"}),
+                use_spacy_ner=False,
+            )
+        )
+
+        result = s.sanitize("Heyman joined the thread")
+
+        assert "Heyman" not in result.sanitized
+        assert "[PERSON_" in result.sanitized
+        assert any(replacement.original == "Heyman" for replacement in result.replacements)
+
     def test_english_name_replaced(self, full_sanitizer):
         result = full_sanitizer.sanitize("David Cohen joined the meeting")
         assert "David Cohen" not in result.sanitized

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -129,6 +129,61 @@ class TestRegexSanitization:
 class TestNameDictionary:
     """Test known-names dictionary matching (Layer 2)."""
 
+    def test_owner_and_tool_names_preserved_from_person_pseudonyms(self):
+        s = Sanitizer(
+            SanitizeConfig(
+                known_names=frozenset(
+                    {
+                        "Etan",
+                        "EtanHey",
+                        "Claude",
+                        "Codex",
+                        "Cursor",
+                        "Gemini",
+                        "John Smith",
+                    }
+                ),
+                use_spacy_ner=False,
+            )
+        )
+
+        result = s.sanitize("Etan EtanHey Claude Codex Cursor Gemini discussed it with John Smith")
+
+        for allowed_name in ("Etan", "EtanHey", "Claude", "Codex", "Cursor", "Gemini"):
+            assert allowed_name in result.sanitized
+            assert allowed_name not in {replacement.original for replacement in result.replacements}
+
+        assert "John Smith" not in result.sanitized
+        assert "[PERSON_" in result.sanitized
+        assert any(replacement.original == "John Smith" for replacement in result.replacements)
+
+    def test_env_redaction_allowlist_extends_person_pseudonym_exclusions(self, monkeypatch):
+        monkeypatch.setenv("BRAINLAYER_SANITIZE_USE_SPACY", "false")
+        monkeypatch.setenv("BRAINLAYER_SANITIZE_EXTRA_NAMES", "BrainLayerBot,John Smith")
+        monkeypatch.setenv("BRAINLAYER_REDACTION_ALLOWLIST", "BrainLayerBot")
+
+        s = Sanitizer.from_env()
+        result = s.sanitize("BrainLayerBot discussed it with John Smith")
+
+        assert "BrainLayerBot" in result.sanitized
+        assert "John Smith" not in result.sanitized
+        assert "[PERSON_" in result.sanitized
+
+    def test_allowlisted_token_in_span_preserves_tool_spans_not_people(self):
+        s = Sanitizer(
+            SanitizeConfig(
+                known_names=frozenset({"Claude Code", "Claude Shannon", "John Smith"}),
+                use_spacy_ner=False,
+            )
+        )
+
+        result = s.sanitize("Claude Code discussed Claude Shannon with John Smith")
+
+        assert "Claude Code" in result.sanitized
+        assert "Claude Shannon" not in result.sanitized
+        assert "John Smith" not in result.sanitized
+        assert {replacement.original for replacement in result.replacements} == {"Claude Shannon", "John Smith"}
+
     def test_english_name_replaced(self, full_sanitizer):
         result = full_sanitizer.sanitize("David Cohen joined the meeting")
         assert "David Cohen" not in result.sanitized


### PR DESCRIPTION
## Summary
- Add a documented default PERSON redaction allowlist for Etan identity variants and common AI tool/agent/vendor names.
- Extend the allowlist through `BRAINLAYER_REDACTION_ALLOWLIST` in `Sanitizer.from_env()`.
- Skip PERSON pseudonymization for allowlisted spans while still pseudonymizing real third-party people, including mixed spans like `Claude Shannon`.

## Test plan
- `pytest tests/test_sanitize.py::TestNameDictionary::test_owner_and_tool_names_preserved_from_person_pseudonyms tests/test_sanitize.py::TestNameDictionary::test_env_redaction_allowlist_extends_person_pseudonym_exclusions -q` — RED before implementation: 2 failed as expected.
- `pytest tests/test_sanitize.py::TestNameDictionary::test_allowlisted_token_in_span_preserves_tool_spans_not_people -q` — RED before mixed-span tightening: 1 failed as expected.
- `pytest tests/test_sanitize.py -q` — 45 passed, 1 warning.
- `ruff check src/brainlayer/pipeline/sanitize.py tests/test_sanitize.py` — all checks passed.
- `BRAINLAYER_PREPUSH=1 BRAINLAYER_PREPUSH_SCOPE=changed-only scripts/run_tests.sh` — pre-push gate passed locally before commit.
- `git push -u origin fix/redaction-owner-tool-allowlist` — push hook passed: unit suite 2974 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook 40 passed; Bun 1 passed; regression shell passed.

## Review notes
- Local `coderabbit review --agent` was attempted before commit but hit free OSS rate limit: wait time reported as 7 minutes 52 seconds.
- Do not merge here; orc/Etan owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PII redaction rules on content sent to external LLM APIs; misconfiguration could leak names or strip searchable terms, though confirmed WhatsApp contacts are explicitly prioritized over allowlist skips.
> 
> **Overview**
> Adds a **person redaction allowlist** so owner handles and common AI tool/vendor names stay verbatim in sanitized text while real people still get pseudonymized. Defaults cover Etan identity variants and names like Claude, Cursor, and Gemini; **`BRAINLAYER_REDACTION_ALLOWLIST`** extends that set at runtime.
> 
> **Sanitizer** now applies allowlist checks in the name-dictionary layer (optional skip for `known_names` only) and in spaCy PERSON detection, with token-level rules so spans like **Claude Code** can stay while **Claude Shannon** is still replaced. WhatsApp-derived contacts are merged into new **`confirmed_person_names`**, which always redact even when the string matches an allowlisted tool name (e.g. a contact named Claude).
> 
> **Cloud backfill** rebuilds config with **`dataclasses.replace`** when attaching DB contact names, so env allowlist and other fields are not dropped. Tests cover allowlist behavior, mixed spans, and backfill sanitizer init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40494818532a46254b5e66e56045e755eb735c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve owner and tool names from PERSON redaction in sanitizer
> - Adds a `person_redaction_allowlist` to `SanitizeConfig` (defaulting to `DEFAULT_PERSON_REDACTION_ALLOWLIST`) and a `confirmed_person_names` field for names that must always be redacted regardless of the allowlist.
> - Introduces `Sanitizer._is_person_redaction_allowlisted` in [sanitize.py](https://github.com/EtanHey/brainlayer/pull/515/files#diff-6f4959611cf51ef4443a3db74e57c92f64c8dd67ace33d90cf1520d291fa5e20) to exempt PERSON spans from pseudonymization when they match the allowlist by full value or by token intersection with tool/agent descriptor tokens.
> - Updates [cloud_backfill.py](https://github.com/EtanHey/brainlayer/pull/515/files#diff-fb56f065e2009656ecba034f8387c5d1e24b2a548452961ccf4668f25b4d5d37) to store WhatsApp-derived contact names in `confirmed_person_names` (via `dataclasses.replace`) so they are always redacted even if their text overlaps with allowlisted tokens.
> - The `from_env` factory merges `DEFAULT_PERSON_REDACTION_ALLOWLIST` with `BRAINLAYER_REDACTION_ALLOWLIST` env var entries at construction time.
> - Behavioral Change: PERSON spans matching the allowlist are no longer pseudonymized; confirmed names take priority and are still redacted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4049481.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->