### PR TITLE
fix: honor explicit redaction names

### DIFF
--- a/src/brainlayer/pipeline/sanitize.py
+++ b/src/brainlayer/pipeline/sanitize.py
@@ -114,7 +114,9 @@ class SanitizeConfig:
     owner_names: tuple[str, ...] = ()
     owner_emails: tuple[str, ...] = ()
     owner_paths: tuple[str, ...] = ()
+    # General dictionaries may include tool/agent false positives and honor the PERSON allowlist.
     known_names: frozenset[str] = frozenset()
+    # Explicit PII dictionaries always redact, even when a name collides with the allowlist.
     confirmed_person_names: frozenset[str] = frozenset()
     strip_emails: bool = True
     strip_ips: bool = True
@@ -659,7 +661,7 @@ class Sanitizer:
             owner_names=owner_names,
             owner_emails=owner_emails,
             owner_paths=owner_paths,
-            known_names=extra_names,
+            confirmed_person_names=extra_names,
             use_spacy_ner=use_spacy,
             person_redaction_allowlist=person_redaction_allowlist,
         )

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -159,15 +159,27 @@ class TestNameDictionary:
 
     def test_env_redaction_allowlist_extends_person_pseudonym_exclusions(self, monkeypatch):
         monkeypatch.setenv("BRAINLAYER_SANITIZE_USE_SPACY", "false")
-        monkeypatch.setenv("BRAINLAYER_SANITIZE_EXTRA_NAMES", "BrainLayerBot,John Smith")
+        monkeypatch.setenv("BRAINLAYER_SANITIZE_EXTRA_NAMES", "John Smith")
         monkeypatch.setenv("BRAINLAYER_REDACTION_ALLOWLIST", "BrainLayerBot")
 
         s = Sanitizer.from_env()
         result = s.sanitize("BrainLayerBot discussed it with John Smith")
 
+        assert "BrainLayerBot" in s.config.person_redaction_allowlist
         assert "BrainLayerBot" in result.sanitized
         assert "John Smith" not in result.sanitized
         assert "[PERSON_" in result.sanitized
+
+    def test_env_extra_names_redact_even_when_default_allowlisted(self, monkeypatch):
+        monkeypatch.setenv("BRAINLAYER_SANITIZE_USE_SPACY", "false")
+        monkeypatch.setenv("BRAINLAYER_SANITIZE_EXTRA_NAMES", "Claude")
+
+        s = Sanitizer.from_env()
+        result = s.sanitize("Claude joined the thread")
+
+        assert "Claude" not in result.sanitized
+        assert "[PERSON_" in result.sanitized
+        assert any(replacement.original == "Claude" for replacement in result.replacements)
 
     def test_allowlisted_token_in_span_preserves_tool_spans_not_people(self):
         s = Sanitizer(


### PR DESCRIPTION
Follow-up to #515 after Codex found a P1: env-provided `BRAINLAYER_SANITIZE_EXTRA_NAMES` entries are explicit PII redactions and must not be skipped when they collide with the owner/tool PERSON allowlist.

Changes:
- Route `BRAINLAYER_SANITIZE_EXTRA_NAMES` into `confirmed_person_names`.
- Keep generic `known_names` allowlist behavior for tool/agent false-positive dictionaries.
- Add regression for `BRAINLAYER_SANITIZE_EXTRA_NAMES=Claude` redacting `Claude`.

Verification:
- RED: `pytest tests/test_sanitize.py::TestNameDictionary::test_env_extra_names_redact_even_when_default_allowlisted -q` failed before the fix.
- `pytest tests/test_sanitize.py::TestNameDictionary::test_env_redaction_allowlist_extends_person_pseudonym_exclusions tests/test_sanitize.py::TestNameDictionary::test_env_extra_names_redact_even_when_default_allowlisted -q`
- `pytest tests/test_sanitize.py tests/test_cloud_backfill.py -q`
- `ruff format --check src/brainlayer/pipeline/sanitize.py tests/test_sanitize.py`
- `ruff check src/brainlayer/pipeline/sanitize.py tests/test_sanitize.py`
- `git push` pre-push BrainLayer test gate: 2978 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration, isolated eval/hook routing, Bun stale-index test, and `test_fts5_determinism.sh` passed.

Note: #515 was squash-merged by Etan while this worker was handling the late P1. A same-branch follow-up PR would duplicate the squash-merged diff, so this clean branch contains only the P1 fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PII redaction behavior for env-configured names before external LLM calls; fix is narrow and covered by new tests, but misconfiguration could still leak or over-redact names.
> 
> **Overview**
> Fixes a bug where **`BRAINLAYER_SANITIZE_EXTRA_NAMES`** was loaded into **`known_names`**, so entries that overlap the default PERSON allowlist (e.g. **`Claude`**) could be left unredacted.
> 
> **`Sanitizer.from_env()`** now maps those env values to **`confirmed_person_names`**, which always pseudonymizes dictionary matches and does not skip allowlisted tokens. Comments on **`SanitizeConfig`** clarify that **`known_names`** is for general/tool false positives (allowlist applies), while **`confirmed_person_names`** is for explicit PII (always redact).
> 
> Tests split allowlist vs extra-name behavior and add a regression that **`EXTRA_NAMES=Claude`** still redacts **`Claude`** when spaCy is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 242c1b4a15435ebf340786906967704a764a06d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Sanitizer.from_env` to always redact explicitly provided names regardless of allowlist
> Names supplied via `BRAINLAYER_SANITIZE_EXTRA_NAMES` were previously assigned to `config.known_names`, which respects the PERSON allowlist and could be skipped if a name collided with it. They are now assigned to `config.confirmed_person_names`, which bypasses the allowlist and always redacts. Clarifying comments were added to [sanitize.py](https://github.com/EtanHey/brainlayer/pull/517/files#diff-6f4959611cf51ef4443a3db74e57c92f64c8dd67ace33d90cf1520d291fa5e20) to document the distinction between the two fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 242c1b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->