### PR TITLE
fix: stop drain after schema contention

### DIFF
--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -1043,6 +1043,8 @@ def burn_drain_once(
                 conn.execute("BEGIN IMMEDIATE")
                 prefetched_state = _prefetch_enrichment_state(conn, all_events)
                 store_chunk_ids: list[str] = []
+                attempt_applied_events = 0
+                attempt_skipped_verified_stale = 0
                 for _, events in batch:
                     for event in events:
                         if _is_verified_redundant_enrichment(event, prefetched_state):
@@ -1053,15 +1055,17 @@ def burn_drain_once(
                                 chunk_id=payload.get("chunk_id"),
                                 commit=False,
                             )
-                            result.skipped_verified_stale += 1
+                            attempt_skipped_verified_stale += 1
                             continue
                         applied = _apply_event(conn, event)
-                        result.applied_events += 1
+                        attempt_applied_events += 1
                         if applied.chunk_id:
                             store_chunk_ids.append(applied.chunk_id)
                 if _embedding_enabled():
                     _embed_store_chunks(conn, store_chunk_ids, embed_fn)
                 conn.execute("COMMIT")
+                result.applied_events += attempt_applied_events
+                result.skipped_verified_stale += attempt_skipped_verified_stale
                 conn.setbusytimeout(_checkpoint_busy_timeout_ms())
                 try:
                     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
@@ -1160,6 +1164,7 @@ def drain_once(
             ):
                 break
 
+            stop_draining = False
             for attempt in range(5):
                 conn: apsw.Connection | None = None
                 attempt_drained = 0
@@ -1229,6 +1234,7 @@ def drain_once(
                             context=f"drain failed for {path.name}",
                             force=True,
                         ):
+                            stop_draining = True
                             break
                         continue
                     _log(log_path, f"drain failed for {path.name}: {exc}")
@@ -1236,6 +1242,8 @@ def drain_once(
                 finally:
                     if conn is not None:
                         conn.close()
+            if stop_draining:
+                break
     finally:
         fcntl.flock(lock_fd, fcntl.LOCK_UN)
         os.close(lock_fd)

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -354,6 +354,50 @@ class TestFlushPendingStores:
         assert queued.exists()
         assert "batch preserved" in log_path.read_text()
 
+    def test_drain_stops_after_forced_schema_bootstrap_writer_in_use(self, tmp_path, monkeypatch):
+        """A schema-blocked store file must stop later queue files from draining."""
+        from brainlayer.vector_store import WriterInUseError
+
+        db_path = tmp_path / "brainlayer.db"
+        queue_dir = tmp_path / "queue"
+        log_path = tmp_path / "drain.log"
+        queue_dir.mkdir()
+        monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("CREATE TABLE marker(id TEXT)")
+
+        first = queue_dir / "a-store-schema-contended.jsonl"
+        second = queue_dir / "b-store-must-wait.jsonl"
+        first_payload = {
+            "kind": "store_memory",
+            "chunk_id": "manual-schema-contended-1",
+            "content": "first store should preserve queue order",
+            "memory_type": "note",
+            "project": "test",
+        }
+        second_payload = {
+            "kind": "store_memory",
+            "chunk_id": "manual-schema-contended-2",
+            "content": "second store must not be attempted after first schema block",
+            "memory_type": "note",
+            "project": "test",
+        }
+        first.write_text(json.dumps(first_payload) + "\n")
+        second.write_text(json.dumps(second_payload) + "\n")
+        first_before = first.read_text()
+        second_before = second.read_text()
+
+        with patch(
+            "brainlayer.drain._ensure_drain_db_schema",
+            side_effect=WriterInUseError("another writer is using brainlayer.db (pid 123)"),
+        ) as ensure_schema:
+            drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=2, log_path=log_path)
+
+        assert drained == 0
+        assert ensure_schema.call_count == 1
+        assert first.read_text() == first_before
+        assert second.read_text() == second_before
+
     def test_burn_drain_preserves_store_queue_when_schema_bootstrap_writer_in_use(self, tmp_path, monkeypatch):
         """Burn drain must preserve store files if first-run schema init is contended."""
         from brainlayer.vector_store import WriterInUseError
@@ -393,6 +437,50 @@ class TestFlushPendingStores:
         assert result.files_deleted == 0
         assert queued.exists()
         assert "batch preserved" in log_path.read_text()
+
+    def test_burn_drain_missing_chunks_retry_counts_events_once(self, tmp_path, monkeypatch):
+        """A failed first schema attempt must not inflate committed event counts."""
+        db_path = tmp_path / "brainlayer.db"
+        queue_dir = tmp_path / "queue"
+        log_path = tmp_path / "drain.log"
+        queue_dir.mkdir()
+        monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("CREATE TABLE marker(id TEXT)")
+
+        queued = queue_dir / "store-missing-chunks-retry.jsonl"
+        queued.write_text(
+            json.dumps({"kind": "unknown", "content": "noop counted only after commit"})
+            + "\n"
+            + json.dumps(
+                {
+                    "kind": "store_memory",
+                    "chunk_id": "manual-missing-chunks-retry",
+                    "content": "burn drain retry should count committed events once",
+                    "memory_type": "note",
+                    "project": "test",
+                }
+            )
+            + "\n"
+        )
+
+        result = burn_drain_once(
+            db_path=db_path,
+            queue_dir=queue_dir,
+            batch_size=1,
+            log_path=log_path,
+        )
+
+        assert result.applied_events == 2
+        assert result.failed_files == 0
+        assert result.files_deleted == 1
+        assert not queued.exists()
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT id FROM chunks WHERE id = ?",
+                ("manual-missing-chunks-retry",),
+            ).fetchone()
+        assert row == ("manual-missing-chunks-retry",)
 
     def test_flush_preserves_legacy_pending_chunk_id(self, tmp_path):
         """Legacy pending-stores flush must persist the caller-visible queued ID."""


### PR DESCRIPTION
## Summary

Follow-up to #516, which Etan squash-merged while the final review-response commit was still running local pre-push.

This PR carries only that final small fix:
- stop `drain_once` after forced schema bootstrap contention so later queue files are not applied or unlinked while an earlier store file remains queued
- count `burn_drain_once` applied/skipped events only after the transaction commits, so missing-chunks retry does not double-count rolled-back work
- add regressions that preserve queued payload contents and verify burn-drain result counters

## Verification

Red/green before the fix:
- `test_drain_stops_after_forced_schema_bootstrap_writer_in_use` failed because `drain_once` advanced to the second queue file after forced schema bootstrap contention.
- `test_burn_drain_missing_chunks_retry_counts_events_once` failed with `applied_events == 3` before counters were moved behind COMMIT.

Current local verification:
- `pytest tests/test_write_queue.py::TestFlushPendingStores::test_drain_stops_after_forced_schema_bootstrap_writer_in_use tests/test_write_queue.py::TestFlushPendingStores::test_burn_drain_missing_chunks_retry_counts_events_once -q` -> 2 passed
- `ruff check src/brainlayer/drain.py tests/test_write_queue.py` -> passed
- `ruff format --check src/brainlayer/drain.py tests/test_write_queue.py` -> 2 files already formatted
- pre-push: `3012 passed, 9 skipped, 61 deselected, 1 xfailed, 103 warnings`, MCP registration 3 passed, isolated eval/hook routing 40 passed, Bun 1 pass, FTS determinism passed

@codex review
@cursor @bugbot re-review
@coderabbitai review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and metrics in the durable JSONL drain path; mistakes could skip or reorder queued writes, but scope is small and covered by new tests.
> 
> **Overview**
> Fixes two queue-drain edge cases in **`drain_once`** and **`burn_drain_once`**.
> 
> **`drain_once`:** When a store file hits a missing-`chunks` error and **forced** schema bootstrap fails (e.g. another writer holds the DB), the loop now sets **`stop_draining`** and exits instead of moving on to the next JSONL file. That keeps FIFO order: later files are not drained or unlinked while an earlier store file is still blocked on schema init.
> 
> **`burn_drain_once`:** **`applied_events`** and **`skipped_verified_stale`** are accumulated only **after** `COMMIT`, using per-attempt counters. Rolled-back work from a failed first attempt (e.g. missing `chunks` then successful retry) no longer inflates reported counts.
> 
> Regressions cover stopping after contended forced bootstrap (both queue files unchanged, schema helper called once) and burn-drain counting exactly two committed events after a missing-chunks retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245a7445270b5569d1d89ab2b416e4ce49646556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix drain to stop processing queue files after schema contention
> - When forced schema bootstrap fails (e.g. `WriterInUseError`) in the missing-chunks retry path of `drain_once`, processing now stops immediately rather than continuing to later queue files, preserving queue order.
> - In `burn_drain_once`, event counts (`applied_events`, `skipped_verified_stale`) are now accumulated into per-attempt local counters and only added to the result after a successful `COMMIT`, preventing double-counting on retries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 245a744.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->