### PR TITLE
fix: durable JSONL-watcher reliability (never-starve + resilient + self-heal)

### DIFF
--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -28,8 +28,8 @@ from brainlayer.vector_store import VectorStore
 
 LOGGER = logging.getLogger("brainlayer.hotlane_brainbar")
 STOP = False
-DEFAULT_HOTLANE_ENRICH_LIMIT = 25
-DEFAULT_BACKLOG_BATCH = 128
+DEFAULT_HOTLANE_ENRICH_LIMIT = 5
+DEFAULT_BACKLOG_BATCH = 4
 
 
 class CycleResult(NamedTuple):
@@ -68,6 +68,19 @@ def _candidate_chunk_ids(store: VectorStore, *, limit: int) -> list[str]:
         (limit,),
     )
     return [str(row[0]) for row in rows]
+
+
+def _default_queue_dir() -> Path:
+    import os
+
+    return Path(os.environ.get("BRAINLAYER_QUEUE_DIR", str(Path.home() / ".brainlayer" / "queue"))).expanduser()
+
+
+def _queue_depth(queue_dir: Path) -> int:
+    try:
+        return sum(1 for _path in queue_dir.glob("*.jsonl"))
+    except OSError:
+        return 0
 
 
 def run_cycle(
@@ -128,43 +141,49 @@ def run(
     time_fn: Callable[[], float] = time.monotonic,
     sleep_fn: Callable[[float], None] = time.sleep,
     max_cycles: int | None = None,
+    queue_dir: Path | None = None,
+    queue_depth_fn: Callable[[Path], int] = _queue_depth,
 ) -> None:
-    store = vector_store_cls(db_path)
-    try:
-        model = model_factory()
-        embed_batch_fn = getattr(model, "embed_texts", None)
-        if embed_batch_fn is not None:
+    model = model_factory()
+    embed_batch_fn = getattr(model, "embed_texts", None)
+    if embed_batch_fn is not None:
 
-            def embed_fn(text: str) -> list[float]:
-                embeddings = embed_batch_fn([text])
-                if len(embeddings) != 1:
-                    raise RuntimeError(f"single text embedder returned {len(embeddings)} embeddings")
-                return embeddings[0]
+        def embed_fn(text: str) -> list[float]:
+            embeddings = embed_batch_fn([text])
+            if len(embeddings) != 1:
+                raise RuntimeError(f"single text embedder returned {len(embeddings)} embeddings")
+            return embeddings[0]
 
-        else:
-            embed_fn = model.embed_query
-        last_backlog = time_fn() - backlog_interval
-        last_enrich = 0.0
-        enrich_disabled = False
-        cycles = 0
-        LOGGER.info("hotlane adapter started db=%s", db_path)
-        while not STOP:
-            if max_cycles is not None and cycles >= max_cycles:
-                break
+    else:
+        embed_fn = model.embed_query
+    queue_dir_was_explicit = queue_dir is not None
+    queue_dir = queue_dir or _default_queue_dir()
+    last_backlog = time_fn() - backlog_interval
+    last_enrich = 0.0
+    enrich_disabled = False
+    cycles = 0
+    LOGGER.info("hotlane adapter started db=%s", db_path)
+    while not STOP:
+        if max_cycles is not None and cycles >= max_cycles:
+            break
+        try:
+            now = time_fn()
+            queue_has_backlog = queue_depth_fn(queue_dir) > 0
+            if queue_has_backlog:
+                LOGGER.info("durable queue has backlog; yielding writer slot to drain")
+            cycle_backlog_batch = backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
+            cycle_enrich_limit = (
+                enrich_limit if not enrich_disabled and enrich_limit > 0 and now - last_enrich >= enrich_interval else 0
+            )
+            if queue_has_backlog:
+                cycle_backlog_batch = 0
+                cycle_enrich_limit = 0
+            if cycle_backlog_batch > 0:
+                last_backlog = now
+            if cycle_enrich_limit > 0:
+                last_enrich = now
+            store = vector_store_cls(db_path)
             try:
-                now = time_fn()
-                cycle_backlog_batch = (
-                    backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
-                )
-                cycle_enrich_limit = (
-                    enrich_limit
-                    if not enrich_disabled and enrich_limit > 0 and now - last_enrich >= enrich_interval
-                    else 0
-                )
-                if cycle_backlog_batch > 0:
-                    last_backlog = now
-                if cycle_enrich_limit > 0:
-                    last_enrich = now
                 result = cycle_fn(
                     store=store,
                     embed_fn=embed_fn,
@@ -174,25 +193,25 @@ def run(
                     enrich_limit=cycle_enrich_limit,
                     enrich_since_hours=enrich_since_hours,
                 )
-                if result.enrich_daily_cap_reached:
-                    enrich_disabled = True
-                    LOGGER.warning("enrichment daily cap reached; disabling hotlane enrichment until restart")
-                if result.embedded or result.enrich_attempted:
-                    LOGGER.info(
-                        "embedded=%d enrich_attempted=%d enriched=%d skipped=%d failed=%d",
-                        result.embedded,
-                        result.enrich_attempted,
-                        result.enriched,
-                        result.enrich_skipped,
-                        result.enrich_failed,
-                    )
-            except Exception:
-                LOGGER.exception("hotlane adapter cycle failed")
-                sleep_fn(min(interval * 2, 5.0))
-            cycles += 1
-            sleep_fn(interval)
-    finally:
-        store.close()
+            finally:
+                store.close()
+            if result.enrich_daily_cap_reached:
+                enrich_disabled = True
+                LOGGER.warning("enrichment daily cap reached; disabling hotlane enrichment until restart")
+            if result.embedded or result.enrich_attempted:
+                LOGGER.info(
+                    "embedded=%d enrich_attempted=%d enriched=%d skipped=%d failed=%d",
+                    result.embedded,
+                    result.enrich_attempted,
+                    result.enriched,
+                    result.enrich_skipped,
+                    result.enrich_failed,
+                )
+        except Exception:
+            LOGGER.exception("hotlane adapter cycle failed")
+            sleep_fn(min(interval * 2, 5.0))
+        cycles += 1
+        sleep_fn(interval)
 
 
 def main() -> None:

--- a/scripts/launchd/com.brainlayer.drain.plist
+++ b/scripts/launchd/com.brainlayer.drain.plist
@@ -10,9 +10,8 @@
 		<string>__PYTHON_BIN__</string>
 		<string>-m</string>
 		<string>brainlayer.drain</string>
-		<string>--once</string>
 		<string>--batch-size</string>
-		<string>250</string>
+		<string>50</string>
 	</array>
 	<key>EnvironmentVariables</key>
 	<dict>
@@ -31,20 +30,16 @@
 	<string>__HOME__/Library/Logs/brainlayer/drain.out.log</string>
 	<key>StandardErrorPath</key>
 	<string>__HOME__/Library/Logs/brainlayer/drain.err.log</string>
-	<key>WatchPaths</key>
-	<array>
-		<string>__HOME__/.brainlayer/queue</string>
-	</array>
-	<key>QueueDirectories</key>
-	<array>
-		<string>__HOME__/.brainlayer/queue</string>
-	</array>
+	<key>KeepAlive</key>
+	<true/>
 	<key>RunAtLoad</key>
 	<true/>
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
 	<key>Nice</key>
 	<integer>10</integer>
 	<key>ProcessType</key>
-	<string>Adaptive</string>
+	<string>Background</string>
 	<key>ExitTimeOut</key>
 	<integer>60</integer>
 	<key>LowPriorityIO</key>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -106,8 +106,11 @@ verify_config_file() {
 load_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
-    launchctl unload "$dst" 2>/dev/null || true
-    launchctl load "$dst"
+    local label="com.brainlayer.${name}"
+    launchctl enable "gui/$UID/$label"
+    launchctl bootout "gui/$UID/$label" 2>/dev/null || true
+    launchctl bootstrap "gui/$UID" "$dst"
+    launchctl print "gui/$UID/$label" >/dev/null
     echo "  Loaded: com.brainlayer.${name}"
 }
 

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -591,7 +591,9 @@ def health_check_command(
             watch_plist_path=watch_plist_path.expanduser(),
             drain_plist_path=drain_plist_path.expanduser(),
             health_check_plist_path=health_check_plist_path.expanduser(),
-            source_jsonl_globs=source_jsonl_globs if source_jsonl_globs is not None else HealthCheckConfig().source_jsonl_globs,
+            source_jsonl_globs=source_jsonl_globs
+            if source_jsonl_globs is not None
+            else HealthCheckConfig().source_jsonl_globs,
             pause_sentinel_path=pause_sentinel_path.expanduser(),
             drain_health_path=drain_health_path.expanduser(),
             queue_dir=queue_dir.expanduser(),

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -3,9 +3,12 @@
 import hashlib
 import json
 import logging
+import os
 import re as _re
+import subprocess
 import sys
 import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -37,6 +40,149 @@ agent_profile_app = typer.Typer(help="Manage per-agent search ranking profiles")
 app.add_typer(agent_profile_app, name="agent-profile")
 provenance_app = typer.Typer(help="Resolve provenance conflicts and pending confirmations")
 app.add_typer(provenance_app, name="provenance")
+
+
+def _launchd_target(label: str) -> str:
+    return f"gui/{os.getuid()}/{label}"
+
+
+def _run_launchctl(args: list[str]) -> int:
+    result = subprocess.run(args, text=True, capture_output=True, check=False)
+    if result.returncode != 0 and result.stderr:
+        typer.echo(result.stderr.strip(), err=True)
+    return int(result.returncode)
+
+
+def _plist_for_launchd_label(label: str, *, watch: Path, drain: Path, health_check: Path) -> Path:
+    if label == "com.brainlayer.watch":
+        return watch.expanduser()
+    if label == "com.brainlayer.drain":
+        return drain.expanduser()
+    if label == "com.brainlayer.health-check":
+        return health_check.expanduser()
+    return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
+
+
+def _bootstrap_label(label: str, plist_path: Path) -> None:
+    target = _launchd_target(label)
+    _run_launchctl(["launchctl", "enable", target])
+    _run_launchctl(["launchctl", "bootout", target])
+    _run_launchctl(["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path.expanduser())])
+    _run_launchctl(["launchctl", "print", target])
+
+
+def _bootout_label(label: str) -> None:
+    _run_launchctl(["launchctl", "bootout", _launchd_target(label)])
+
+
+def _default_pause_labels() -> list[str]:
+    return ["com.brainlayer.watch", "com.brainlayer.drain", "com.brainlayer.health-check"]
+
+
+@app.command("pause")
+def pause_command(
+    labels: list[str] | None = typer.Option(None, "--label", help="launchd label to pause; repeatable."),
+    pause_sentinel_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/pause.sentinel"),
+        "--pause-sentinel-path",
+        help="Pause sentinel path.",
+    ),
+    ttl_seconds: int = typer.Option(3600, "--ttl-seconds", min=1, help="Pause expiry in seconds."),
+) -> None:
+    """Record an intentional pause and bootout BrainLayer launchd labels."""
+    selected_labels = labels or _default_pause_labels()
+    now = datetime.now(UTC)
+    resolved = pause_sentinel_path.expanduser()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_text(
+        json.dumps(
+            {
+                "labels": selected_labels,
+                "created_at": now.isoformat(),
+                "expires_at": (now + timedelta(seconds=ttl_seconds)).isoformat(),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    for label in selected_labels:
+        _bootout_label(label)
+    typer.echo(f"paused labels={','.join(selected_labels)} sentinel={resolved}")
+
+
+@app.command("resume")
+def resume_command(
+    pause_sentinel_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/pause.sentinel"),
+        "--pause-sentinel-path",
+        help="Pause sentinel path.",
+    ),
+    watch_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.watch.plist"),
+        "--watch-plist-path",
+    ),
+    drain_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.drain.plist"),
+        "--drain-plist-path",
+    ),
+    health_check_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist"),
+        "--health-check-plist-path",
+    ),
+) -> None:
+    """Remove an intentional pause and bootstrap recorded launchd labels."""
+    resolved = pause_sentinel_path.expanduser()
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        payload = {}
+    labels = payload.get("labels") if isinstance(payload, dict) else None
+    selected_labels = [str(label) for label in labels] if isinstance(labels, list) else _default_pause_labels()
+    for label in selected_labels:
+        _bootstrap_label(
+            label,
+            _plist_for_launchd_label(
+                label,
+                watch=watch_plist_path,
+                drain=drain_plist_path,
+                health_check=health_check_plist_path,
+            ),
+        )
+    try:
+        resolved.unlink()
+    except FileNotFoundError:
+        pass
+    typer.echo(f"resumed labels={','.join(selected_labels)}")
+
+
+@app.command("reconcile-launchd")
+def reconcile_launchd_command(
+    watch_label: str = typer.Option("com.brainlayer.watch", "--watch-label"),
+    drain_label: str = typer.Option("com.brainlayer.drain", "--drain-label"),
+    health_check_label: str = typer.Option("com.brainlayer.health-check", "--health-check-label"),
+    watch_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.watch.plist"),
+        "--watch-plist-path",
+    ),
+    drain_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.drain.plist"),
+        "--drain-plist-path",
+    ),
+    health_check_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist"),
+        "--health-check-plist-path",
+    ),
+) -> None:
+    """Bootstrap the watcher, drain, and health-check launchd labels if absent."""
+    for label, plist_path in (
+        (watch_label, watch_plist_path),
+        (drain_label, drain_plist_path),
+        (health_check_label, health_check_plist_path),
+    ):
+        if label:
+            _bootstrap_label(label, plist_path)
+    typer.echo("reconciled launchd labels")
 
 
 @app.command()
@@ -382,6 +528,52 @@ def health_check_command(
         help="Seconds to wait for the BrainBar socket canary.",
     ),
     heal: bool = typer.Option(False, "--heal/--no-heal", help="Kickstart launchd services for cheap self-heals."),
+    watch_label: str = typer.Option("com.brainlayer.watch", "--watch-label", help="watch launchd label."),
+    drain_label: str = typer.Option("com.brainlayer.drain", "--drain-label", help="drain launchd label."),
+    health_check_label: str = typer.Option(
+        "com.brainlayer.health-check", "--health-check-label", help="health-check launchd label."
+    ),
+    watch_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.watch.plist"),
+        "--watch-plist-path",
+        help="watch LaunchAgent plist path.",
+    ),
+    drain_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.drain.plist"),
+        "--drain-plist-path",
+        help="drain LaunchAgent plist path.",
+    ),
+    health_check_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist"),
+        "--health-check-plist-path",
+        help="health-check LaunchAgent plist path.",
+    ),
+    source_jsonl_globs: list[str] | None = typer.Option(
+        None,
+        "--source-jsonl-glob",
+        help="Source JSONL glob used to detect active writes; repeatable.",
+    ),
+    pause_sentinel_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/pause.sentinel"),
+        "--pause-sentinel-path",
+        help="Pause sentinel path.",
+    ),
+    drain_health_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/drain-health.json"),
+        "--drain-health-path",
+        help="Drain health JSON path.",
+    ),
+    queue_dir: Path = typer.Option(Path("~/.brainlayer/queue"), "--queue-dir", help="Durable queue directory."),
+    offsets_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/offsets.json"),
+        "--offsets-path",
+        help="Watcher offsets JSON path.",
+    ),
+    watcher_health_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/watcher-health.json"),
+        "--watcher-health-path",
+        help="Watcher health JSON path.",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
     """Run the lightweight BrainLayer stability health-check."""
@@ -393,6 +585,18 @@ def health_check_command(
             state_path=state_path.expanduser(),
             socket_path=socket_path.expanduser(),
             canary_query=canary_query,
+            watch_label=watch_label,
+            drain_label=drain_label,
+            health_check_label=health_check_label,
+            watch_plist_path=watch_plist_path.expanduser(),
+            drain_plist_path=drain_plist_path.expanduser(),
+            health_check_plist_path=health_check_plist_path.expanduser(),
+            source_jsonl_globs=source_jsonl_globs if source_jsonl_globs is not None else HealthCheckConfig().source_jsonl_globs,
+            pause_sentinel_path=pause_sentinel_path.expanduser(),
+            drain_health_path=drain_health_path.expanduser(),
+            queue_dir=queue_dir.expanduser(),
+            offsets_path=offsets_path.expanduser(),
+            watcher_health_path=watcher_health_path.expanduser(),
             heal=heal,
             socket_timeout_seconds=socket_timeout_seconds,
             max_stalled_ticks=max_stalled_ticks,

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -141,6 +141,10 @@ def _default_log_path() -> Path:
     return Path.home() / ".brainlayer" / "logs" / "drain.log"
 
 
+def _default_drain_health_path() -> Path:
+    return Path.home() / ".local" / "share" / "brainlayer" / "drain-health.json"
+
+
 def _log(path: Path, message: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     stamp = datetime.now(timezone.utc).isoformat()
@@ -847,6 +851,45 @@ def _embed_store_chunks(
             logger.warning("Failed to embed drained chunk %s: %s", chunk_id, exc)
 
 
+def _precompute_event_embeddings(
+    events: list[dict[str, Any]],
+    embed_fn: Callable[[str], list[float]] | None,
+) -> dict[str, bytes]:
+    if not _embedding_enabled():
+        return {}
+    contents = []
+    for event in events:
+        payload = _event_payload(event)
+        if payload.get("kind") not in {"store_memory", "hook_chunk"}:
+            continue
+        content = str(payload.get("content") or "").strip()
+        if content:
+            contents.append(content)
+    if not contents:
+        return {}
+    resolved_embed_fn = embed_fn or _default_embed_fn()
+    precomputed: dict[str, bytes] = {}
+    for content in dict.fromkeys(contents):
+        try:
+            precomputed[content] = serialize_f32(resolved_embed_fn(content))
+        except Exception as exc:
+            logger.warning("Failed to precompute drained embedding: %s", exc)
+    return precomputed
+
+
+def _insert_precomputed_embedding(conn: apsw.Connection, chunk_id: str, embedding_bytes: bytes) -> None:
+    if "chunk_vectors" not in _table_names(conn):
+        return
+    conn.execute("DELETE FROM chunk_vectors WHERE chunk_id = ?", (chunk_id,))
+    conn.execute("INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)", (chunk_id, embedding_bytes))
+    if "chunk_vectors_binary" in _table_names(conn):
+        conn.execute("DELETE FROM chunk_vectors_binary WHERE chunk_id = ?", (chunk_id,))
+        conn.execute(
+            "INSERT INTO chunk_vectors_binary (chunk_id, embedding) VALUES (?, vec_quantize_binary(?))",
+            (chunk_id, embedding_bytes),
+        )
+
+
 def _quarantine_file(path: Path, log_path: Path, reason: BaseException) -> None:
     target = path.with_name(f"{path.name}.bad")
     if target.exists():
@@ -1144,7 +1187,6 @@ def drain_once(
 
         drained = 0
         collisions_dropped = 0
-        should_embed = _embedding_enabled()
         for path in files:
             try:
                 events = _read_events(path)
@@ -1165,6 +1207,7 @@ def drain_once(
                 break
 
             stop_draining = False
+            precomputed_embeddings = _precompute_event_embeddings(events_to_apply, embed_fn)
             for attempt in range(5):
                 conn: apsw.Connection | None = None
                 attempt_drained = 0
@@ -1179,11 +1222,13 @@ def drain_once(
                         result = _apply_event(conn, event)
                         if result.chunk_id:
                             store_chunk_ids.append(result.chunk_id)
+                            content = str(_event_payload(event).get("content") or "").strip()
+                            embedding_bytes = precomputed_embeddings.get(content)
+                            if embedding_bytes:
+                                _insert_precomputed_embedding(conn, result.chunk_id, embedding_bytes)
                         if result.collision_chunk_id:
                             collision_ids.append(result.collision_chunk_id)
                         attempt_drained += 1
-                    if should_embed:
-                        _embed_store_chunks(conn, store_chunk_ids, embed_fn)
                     conn.execute("COMMIT")
                     # Best-effort WAL reclaim. The truncating checkpoint (not PASSIVE)
                     # shrinks the WAL file after each drained batch — PASSIVE leaves
@@ -1253,10 +1298,40 @@ def drain_once(
     return drained
 
 
-def run_daemon(interval: float, batch_size: int) -> None:
+def _write_drain_health(path: Path, *, drain_cycles: int, drained_total: int) -> None:
+    payload = {
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "drain_cycles": drain_cycles,
+        "drained_total": drained_total,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def run_daemon(
+    interval: float,
+    batch_size: int,
+    *,
+    health_path: Path | None = None,
+    drain_once_fn: Callable[..., int] = drain_once,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    max_cycles: int | None = None,
+) -> None:
+    health_path = health_path or Path(os.environ.get("BRAINLAYER_DRAIN_HEALTH_PATH", str(_default_drain_health_path())))
+    drain_cycles = 0
+    drained_total = 0
     while True:
-        drain_once(batch_size=batch_size)
-        time.sleep(interval)
+        if max_cycles is not None and drain_cycles >= max_cycles:
+            return
+        drained_total += int(drain_once_fn(batch_size=batch_size) or 0)
+        drain_cycles += 1
+        try:
+            _write_drain_health(health_path, drain_cycles=drain_cycles, drained_total=drained_total)
+        except OSError:
+            logger.debug("Failed to write drain health snapshot", exc_info=True)
+        sleep_fn(interval)
 
 
 def main() -> int:

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -16,14 +16,19 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .paths import get_db_path
+from .watcher import default_watch_roots
 
 DEFAULT_SOCKET_PATH = Path("/tmp/brainbar.sock")
 DEFAULT_STATE_PATH = Path("~/.local/share/brainlayer/health-check-state.json").expanduser()
 DEFAULT_CANARY_QUERY = "agentopology"
 DEFAULT_HOTLANE_LABEL = "com.brainlayer.hotlane-brainbar"
 DEFAULT_BRAINBAR_DAEMON_LABEL = "com.brainlayer.brainbar-daemon"
-DEFAULT_BACKLOG_BATCH = 128
+DEFAULT_WATCH_LABEL = "com.brainlayer.watch"
+DEFAULT_DRAIN_LABEL = "com.brainlayer.drain"
+DEFAULT_HEALTH_CHECK_LABEL = "com.brainlayer.health-check"
+DEFAULT_BACKLOG_BATCH = 4
 DEFAULT_HEAL_MIN_CONSECUTIVE_FAILURES = 2
+DEFAULT_HEAL_CIRCUIT_BREAKER_LIMIT = 3
 HEAL_MIN_CONSECUTIVE_FAILURES_ENV = "BRAINLAYER_HEAL_MIN_CONSECUTIVE_FAILURES"
 
 
@@ -53,6 +58,38 @@ class HealthCheckConfig:
     canary_query: str = DEFAULT_CANARY_QUERY
     hotlane_label: str = DEFAULT_HOTLANE_LABEL
     brainbar_daemon_label: str = DEFAULT_BRAINBAR_DAEMON_LABEL
+    watch_label: str = DEFAULT_WATCH_LABEL
+    drain_label: str = DEFAULT_DRAIN_LABEL
+    health_check_label: str = DEFAULT_HEALTH_CHECK_LABEL
+    watch_plist_path: Path = field(
+        default_factory=lambda: Path("~/Library/LaunchAgents/com.brainlayer.watch.plist").expanduser()
+    )
+    drain_plist_path: Path = field(
+        default_factory=lambda: Path("~/Library/LaunchAgents/com.brainlayer.drain.plist").expanduser()
+    )
+    health_check_plist_path: Path = field(
+        default_factory=lambda: Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist").expanduser()
+    )
+    offsets_path: Path = field(default_factory=lambda: Path("~/.local/share/brainlayer/offsets.json").expanduser())
+    watcher_health_path: Path = field(
+        default_factory=lambda: Path("~/.local/share/brainlayer/watcher-health.json").expanduser()
+    )
+    drain_health_path: Path = field(
+        default_factory=lambda: Path("~/.local/share/brainlayer/drain-health.json").expanduser()
+    )
+    queue_dir: Path = field(default_factory=lambda: Path("~/.brainlayer/queue").expanduser())
+    source_jsonl_globs: list[str] = field(
+        default_factory=lambda: [str(root.resolved_path / "**" / "*.jsonl") for root in default_watch_roots()]
+    )
+    pause_sentinel_path: Path = field(
+        default_factory=lambda: Path("~/.local/share/brainlayer/pause.sentinel").expanduser()
+    )
+    max_offsets_age_seconds: int = 900
+    queue_auto_heal_count: int = 25
+    queue_page_count: int = 200
+    queue_page_oldest_seconds: int = 4 * 60 * 60
+    queue_page_bytes: int = 2 * 1024 * 1024 * 1024
+    heal_circuit_breaker_limit: int = DEFAULT_HEAL_CIRCUIT_BREAKER_LIMIT
     heal: bool = False
     socket_timeout_seconds: float = 5.0
     max_stalled_ticks: int = 2
@@ -99,7 +136,89 @@ def _default_ps_output() -> str:
 
 
 def _default_command_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, text=True, capture_output=True, check=False)
+    try:
+        return subprocess.run(args, text=True, capture_output=True, check=False)
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(args=args, returncode=127, stdout="", stderr=str(exc))
+
+
+def _command_returncode(result: Any) -> int:
+    return int(getattr(result, "returncode", 0) or 0)
+
+
+def _command_stdout(result: Any) -> str:
+    return str(getattr(result, "stdout", "") or "")
+
+
+def _launchd_target(label: str) -> str:
+    return f"gui/{os.getuid()}/{label}"
+
+
+def _launchd_label_loaded(label: str, command_runner: CommandRunner) -> bool | None:
+    if not label:
+        return True
+    result = command_runner(["launchctl", "print", _launchd_target(label)])
+    returncode = _command_returncode(result)
+    stderr = str(getattr(result, "stderr", "") or "")
+    stdout = _command_stdout(result)
+    if returncode == 0:
+        return True
+    if returncode == 127:
+        return None
+    output = f"{stdout}\n{stderr}".lower()
+    if "operation not permitted" in output or "permission" in output or "input/output error" in output:
+        return None
+    if "could not find service" in output or "service is not loaded" in output or returncode in {3, 36, 113}:
+        return False
+    return None
+
+
+def _kickstart(label: str, command_runner: CommandRunner) -> str:
+    target = _launchd_target(label)
+    command_runner(["launchctl", "kickstart", "-k", target])
+    return f"kickstart:{label}"
+
+
+def _bootstrap_if_absent(label: str, plist_path: Path, command_runner: CommandRunner) -> str:
+    loaded = _launchd_label_loaded(label, command_runner)
+    if loaded is True:
+        return f"loaded:{label}"
+    if loaded is None:
+        return f"launchctl-unavailable:{label}"
+    target = _launchd_target(label)
+    command_runner(["launchctl", "enable", target])
+    command_runner(["launchctl", "bootout", target])
+    command_runner(["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path.expanduser())])
+    verified = _launchd_label_loaded(label, command_runner)
+    if verified is True:
+        return f"bootstrap:{label}"
+    return f"bootstrap_failed:{label}"
+
+
+def _emit_heal_event(event: dict[str, Any]) -> None:
+    try:
+        from .telemetry import emit
+
+        emit("brainlayer-watcher", event)
+    except Exception:
+        pass
+
+
+def _push_notification(title: str, message: str) -> None:
+    try:
+        subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'display notification "{message[:180]}" with title "{title[:80]}"',
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=2,
+        )
+    except Exception:
+        pass
 
 
 def _parse_backlog_batch(command: str) -> int:
@@ -232,66 +351,180 @@ def _canary_count(text: str) -> int | None:
     return 1 if text.strip() else 0
 
 
-def _kickstart(label: str, command_runner: CommandRunner) -> str:
-    target = f"gui/{os.getuid()}/{label}"
-    command_runner(["launchctl", "kickstart", "-k", target])
-    return f"kickstart:{label}"
-
-
-def _kickstart_once(
-    result: HealthCheckResult,
-    label: str,
-    issue_code: str,
-    consecutive_failures: int,
-    command_runner: CommandRunner,
-) -> None:
-    action = f"kickstart:{label}"
-    if action in result.actions:
-        return
-    print(
-        f"heal action label={label} issue={issue_code} consecutive_failures={consecutive_failures} action={action}",
-        file=sys.stderr,
-    )
-    result.actions.append(_kickstart(label, command_runner))
-
-
 def _previous_heal_failures(state: dict[str, Any]) -> dict[str, int]:
     raw_failures = state.get("heal_failures")
     if not isinstance(raw_failures, dict):
         return {}
     failures: dict[str, int] = {}
-    for issue_code, count in raw_failures.items():
-        if not isinstance(issue_code, str) or not isinstance(count, int):
+    for key, count in raw_failures.items():
+        if not isinstance(key, str):
             continue
-        failures[issue_code] = max(0, count)
+        if isinstance(count, dict):
+            raw_count = count.get("count")
+        else:
+            raw_count = count
+        if not isinstance(raw_count, int):
+            continue
+        failures[key] = max(0, raw_count)
     return failures
 
 
-def _updated_heal_failures(
-    previous_failures: dict[str, int],
-    current_issue_codes: set[str],
-) -> dict[str, int]:
-    return {issue_code: previous_failures.get(issue_code, 0) + 1 for issue_code in sorted(current_issue_codes)}
+def _previous_tripped_heals(state: dict[str, Any]) -> set[str]:
+    raw = state.get("heal_tripped")
+    return {str(item) for item in raw} if isinstance(raw, list) else set()
+
+
+def _heal_key(label: str, issue_code: str) -> str:
+    return f"{label}:{issue_code}"
 
 
 def _apply_heals(
     *,
     result: HealthCheckResult,
-    issue_labels: dict[str, str],
+    issue_labels: dict[str, tuple[str, Path]],
     previous_failures: dict[str, int],
+    previous_tripped: set[str],
     config: HealthCheckConfig,
     command_runner: CommandRunner,
-) -> dict[str, int]:
+) -> tuple[dict[str, int], set[str]]:
     current_issue_codes = {issue.code for issue in result.issues}
-    heal_failures = _updated_heal_failures(previous_failures, current_issue_codes)
+    heal_failures: dict[str, int] = {}
+    tripped = set(previous_tripped)
+    for issue_code, (label, _plist_path) in issue_labels.items():
+        if issue_code in current_issue_codes:
+            key = _heal_key(label, issue_code)
+            heal_failures[key] = previous_failures.get(key, 0) + 1
+        else:
+            tripped.discard(_heal_key(label, issue_code))
     if not config.heal:
-        return heal_failures
+        return heal_failures, tripped
     threshold = max(1, config.heal_min_consecutive_failures)
-    for issue_code, label in issue_labels.items():
-        consecutive_failures = heal_failures.get(issue_code, 0)
+    breaker_limit = max(threshold, config.heal_circuit_breaker_limit)
+    for issue_code, (label, plist_path) in issue_labels.items():
+        key = _heal_key(label, issue_code)
+        consecutive_failures = heal_failures.get(key, 0)
+        if consecutive_failures >= breaker_limit:
+            if key not in tripped:
+                tripped.add(key)
+                result.actions.append(f"heal_escalation:{label}:{issue_code}")
+                _emit_heal_event(
+                    {
+                        "_type": "heal_escalation",
+                        "label": label,
+                        "issue_code": issue_code,
+                        "consecutive_failures": consecutive_failures,
+                    }
+                )
+                _push_notification("BrainLayer heal escalation", f"{label} {issue_code} failed repeatedly")
+            continue
         if consecutive_failures >= threshold:
-            _kickstart_once(result, label, issue_code, consecutive_failures, command_runner)
-    return heal_failures
+            action = (
+                _bootstrap_if_absent(label, plist_path, command_runner)
+                if issue_code in {"watch_unloaded", "drain_unloaded", "health_check_unloaded"}
+                else _kickstart(label, command_runner)
+            )
+            if action not in result.actions:
+                print(
+                    f"heal action label={label} issue={issue_code} "
+                    f"consecutive_failures={consecutive_failures} action={action}",
+                    file=sys.stderr,
+                )
+                result.actions.append(action)
+                _emit_heal_event(
+                    {
+                        "_type": "heal",
+                        "label": label,
+                        "issue_code": issue_code,
+                        "action": action,
+                        "consecutive_failures": consecutive_failures,
+                    }
+                )
+                _push_notification("BrainLayer heal action", f"{action} for {issue_code}")
+    return heal_failures, tripped
+
+
+def _path_age_seconds(path: Path, now: datetime) -> float | None:
+    try:
+        return max(0.0, now.timestamp() - path.expanduser().stat().st_mtime)
+    except OSError:
+        return None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _pause_sentinel_state(config: HealthCheckConfig, now: datetime) -> tuple[dict[str, Any], bool, bool]:
+    payload = _load_json(config.pause_sentinel_path)
+    if not payload:
+        return {}, False, False
+    expires_at = _parse_iso_datetime(payload.get("expires_at"))
+    stale = expires_at is not None and now > expires_at
+    return payload, not stale, stale
+
+
+def _source_recent(config: HealthCheckConfig, now: datetime, window_seconds: int) -> bool:
+    import glob
+
+    cutoff = now.timestamp() - window_seconds
+    for pattern in config.source_jsonl_globs:
+        for raw_path in glob.iglob(str(Path(pattern).expanduser()), recursive=True):
+            try:
+                if Path(raw_path).stat().st_mtime >= cutoff:
+                    return True
+            except OSError:
+                continue
+    return False
+
+
+def _queue_stats(queue_dir: Path, now: datetime) -> tuple[int, int, float | None]:
+    count = 0
+    total_bytes = 0
+    oldest: float | None = None
+    try:
+        paths = list(queue_dir.expanduser().glob("*.jsonl"))
+    except OSError:
+        return 0, 0, None
+    for path in paths:
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        count += 1
+        total_bytes += stat.st_size
+        age = max(0.0, now.timestamp() - stat.st_mtime)
+        oldest = age if oldest is None else max(oldest, age)
+    return count, total_bytes, oldest
+
+
+def _plist_for_label(config: HealthCheckConfig, label: str) -> Path:
+    if label == config.watch_label:
+        return config.watch_plist_path
+    if label == config.drain_label:
+        return config.drain_plist_path
+    if label == config.health_check_label:
+        return config.health_check_plist_path
+    if label == config.hotlane_label:
+        return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
+    if label == config.brainbar_daemon_label:
+        return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
+    return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
 
 
 def run_health_check(
@@ -306,36 +539,43 @@ def run_health_check(
     result = HealthCheckResult(checked_at=now.isoformat(), ok=True)
     state = _load_state(config.state_path)
     previous_heal_failures = _previous_heal_failures(state)
-    heal_issue_labels: dict[str, str] = {}
+    previous_tripped = _previous_tripped_heals(state)
+    heal_issue_labels: dict[str, tuple[str, Path]] = {}
+
+    def add_issue(code: str, severity: str, message: str) -> None:
+        result.issues.append(HealthIssue(code, severity, message))
+        _emit_heal_event(
+            {
+                "_type": "health_issue_detected",
+                "issue_code": code,
+                "severity": severity,
+                "message": message[:500],
+            }
+        )
 
     hotlane_processes = parse_hotlane_processes(ps_output_fn())
     result.hotlane_running = bool(hotlane_processes)
     if not hotlane_processes:
-        result.issues.append(
-            HealthIssue("hotlane_dead", "critical", "hotlane BrainBar embedding daemon is not running")
-        )
-        if config.heal:
-            heal_issue_labels["hotlane_dead"] = config.hotlane_label
+        add_issue("hotlane_dead", "critical", "hotlane BrainBar embedding daemon is not running")
+        heal_issue_labels["hotlane_dead"] = (config.hotlane_label, _plist_for_label(config, config.hotlane_label))
     else:
         result.backlog_batch = min(process.backlog_batch for process in hotlane_processes)
         if any(process.backlog_batch <= 0 for process in hotlane_processes):
-            result.issues.append(
-                HealthIssue("hotlane_backlog_disabled", "critical", "--backlog-batch is 0; embeddings will not drain")
+            add_issue("hotlane_backlog_disabled", "critical", "--backlog-batch is 0; embeddings will not drain")
+            heal_issue_labels["hotlane_backlog_disabled"] = (
+                config.hotlane_label,
+                _plist_for_label(config, config.hotlane_label),
             )
-            if config.heal:
-                heal_issue_labels["hotlane_backlog_disabled"] = config.hotlane_label
 
     previous_missing = state.get("missing_vectors")
     result.previous_missing_vectors = int(previous_missing) if isinstance(previous_missing, int) else None
     try:
         result.missing_vectors = count_missing_embeddings(config.db_path)
     except Exception as exc:
-        result.issues.append(
-            HealthIssue(
-                "missing_embeddings_count_failed",
-                "critical",
-                f"could not count missing embeddings: {exc}",
-            )
+        add_issue(
+            "missing_embeddings_count_failed",
+            "critical",
+            f"could not count missing embeddings: {exc}",
         )
 
     stalled_ticks = 0
@@ -343,28 +583,28 @@ def run_health_check(
         if result.previous_missing_vectors is not None:
             prior_stalled_ticks = int(state.get("stalled_ticks", 0) or 0)
             if result.missing_vectors > result.previous_missing_vectors:
-                result.issues.append(
-                    HealthIssue(
-                        "missing_embeddings_climbing",
-                        "warning",
-                        f"missing embeddings increased {result.previous_missing_vectors} -> {result.missing_vectors}",
-                    )
+                add_issue(
+                    "missing_embeddings_climbing",
+                    "warning",
+                    f"missing embeddings increased {result.previous_missing_vectors} -> {result.missing_vectors}",
                 )
                 stalled_ticks = 0
-                if config.heal:
-                    heal_issue_labels["missing_embeddings_climbing"] = config.hotlane_label
+                heal_issue_labels["missing_embeddings_climbing"] = (
+                    config.hotlane_label,
+                    _plist_for_label(config, config.hotlane_label),
+                )
             elif result.missing_vectors == result.previous_missing_vectors and result.missing_vectors > 0:
                 stalled_ticks = prior_stalled_ticks + 1
                 if stalled_ticks >= config.max_stalled_ticks:
-                    result.issues.append(
-                        HealthIssue(
-                            "missing_embeddings_not_draining",
-                            "warning",
-                            f"missing embeddings stayed at {result.missing_vectors} for {stalled_ticks} checks",
-                        )
+                    add_issue(
+                        "missing_embeddings_not_draining",
+                        "warning",
+                        f"missing embeddings stayed at {result.missing_vectors} for {stalled_ticks} checks",
                     )
-                    if config.heal:
-                        heal_issue_labels["missing_embeddings_not_draining"] = config.hotlane_label
+                    heal_issue_labels["missing_embeddings_not_draining"] = (
+                        config.hotlane_label,
+                        _plist_for_label(config, config.hotlane_label),
+                    )
     result.stalled_ticks = stalled_ticks
 
     try:
@@ -374,37 +614,127 @@ def run_health_check(
         result.canary_ok = canary_success and (result.canary_result_count or 0) > 0
         if not result.canary_ok:
             code = "brain_search_canary_failed" if not canary_success else "brain_search_canary_empty"
-            result.issues.append(
-                HealthIssue(
-                    code,
-                    "critical",
-                    f"BrainBar brain_search canary returned no usable results: {text[:240]}",
-                )
+            add_issue(
+                code,
+                "critical",
+                f"BrainBar brain_search canary returned no usable results: {text[:240]}",
             )
-            if config.heal:
-                heal_issue_labels[code] = config.brainbar_daemon_label
+            heal_issue_labels[code] = (
+                config.brainbar_daemon_label,
+                _plist_for_label(config, config.brainbar_daemon_label),
+            )
     except Exception as exc:
         result.canary_ok = False
-        result.issues.append(
-            HealthIssue("brain_search_canary_failed", "critical", f"BrainBar brain_search canary failed: {exc}")
+        add_issue("brain_search_canary_failed", "critical", f"BrainBar brain_search canary failed: {exc}")
+        heal_issue_labels["brain_search_canary_failed"] = (
+            config.brainbar_daemon_label,
+            _plist_for_label(config, config.brainbar_daemon_label),
         )
-        if config.heal:
-            heal_issue_labels["brain_search_canary_failed"] = config.brainbar_daemon_label
 
-    heal_failures = _apply_heals(
+    if config.heal:
+        for label in (config.watch_label, config.drain_label, config.health_check_label):
+            if label:
+                action = _bootstrap_if_absent(label, _plist_for_label(config, label), command_runner)
+                if action.startswith(("bootstrap:", "bootstrap_failed:", "launchctl-unavailable:")):
+                    result.actions.append(action)
+
+    for label, issue_code, message in (
+        (config.watch_label, "watch_unloaded", "watch launchd label is not loaded"),
+        (config.drain_label, "drain_unloaded", "drain launchd label is not loaded"),
+        (config.health_check_label, "health_check_unloaded", "health-check launchd label is not loaded"),
+    ):
+        if not label:
+            continue
+        loaded = _launchd_label_loaded(label, command_runner)
+        if loaded is False:
+            add_issue(issue_code, "critical", message)
+            heal_issue_labels[issue_code] = (label, _plist_for_label(config, label))
+
+    pause_payload, pause_active, pause_stale = _pause_sentinel_state(config, now)
+    if pause_stale:
+        add_issue("pause_sentinel_stale", "critical", "pause sentinel is expired; launchd resume may have been forgotten")
+        _push_notification("BrainLayer pause expired", "pause.sentinel is stale")
+        if config.heal:
+            try:
+                config.pause_sentinel_path.expanduser().unlink()
+                result.actions.append("resume:stale-pause-sentinel")
+            except OSError:
+                result.actions.append("resume_failed:stale-pause-sentinel")
+
+    queue_count, queue_bytes, queue_oldest_age = _queue_stats(config.queue_dir, now)
+    if queue_count >= config.queue_auto_heal_count:
+        severity = "critical" if queue_count >= config.queue_page_count else "warning"
+        add_issue(
+            "queue_backed_up",
+            severity,
+            f"durable queue backlog count={queue_count} bytes={queue_bytes} oldest_age={queue_oldest_age}",
+        )
+        heal_issue_labels["queue_backed_up"] = (config.drain_label, _plist_for_label(config, config.drain_label))
+    if (
+        queue_count > 0
+        and (
+            queue_count >= config.queue_page_count
+            or queue_bytes >= config.queue_page_bytes
+            or (queue_oldest_age is not None and queue_oldest_age >= config.queue_page_oldest_seconds)
+        )
+    ):
+        _push_notification("BrainLayer queue backlog", f"queue_count={queue_count} queue_bytes={queue_bytes}")
+
+    watcher_health = _load_json(config.watcher_health_path)
+    watcher_poll_count = watcher_health.get("poll_count")
+    previous_watcher_poll_count = state.get("watcher_poll_count")
+    source_recent = _source_recent(config, now, config.max_offsets_age_seconds)
+    offsets_age = _path_age_seconds(config.offsets_path, now)
+    watcher_health_age = _path_age_seconds(config.watcher_health_path, now)
+    if (
+        not pause_active
+        and source_recent
+        and isinstance(watcher_poll_count, int)
+        and watcher_poll_count == previous_watcher_poll_count
+        and offsets_age is not None
+        and offsets_age >= config.max_offsets_age_seconds
+        and watcher_health_age is not None
+        and watcher_health_age >= config.max_offsets_age_seconds
+    ):
+        add_issue(
+            "watcher_stalled",
+            "critical",
+            f"watcher poll_count flat at {watcher_poll_count}; offsets_age={offsets_age:.0f}s",
+        )
+        heal_issue_labels["watcher_stalled"] = (config.watch_label, config.watch_plist_path)
+
+    drain_health = _load_json(config.drain_health_path)
+    drain_total = drain_health.get("drained_total")
+    previous_drain_total = state.get("drain_drained_total")
+    if queue_count > 0 and isinstance(drain_total, int) and drain_total == previous_drain_total:
+        add_issue(
+            "drain_no_progress",
+            "critical",
+            f"drain drained_total flat at {drain_total} while queue_count={queue_count}",
+        )
+        heal_issue_labels["drain_no_progress"] = (config.drain_label, config.drain_plist_path)
+
+    heal_failures, heal_tripped = _apply_heals(
         result=result,
         issue_labels=heal_issue_labels,
         previous_failures=previous_heal_failures,
+        previous_tripped=previous_tripped,
         config=config,
         command_runner=command_runner,
     )
-    if result.missing_vectors is not None or heal_failures:
-        state_payload: dict[str, Any] = dict(state)
-        state_payload["heal_failures"] = heal_failures
-        state_payload["ts"] = now.isoformat()
-        if result.missing_vectors is not None:
-            state_payload["missing_vectors"] = result.missing_vectors
-            state_payload["stalled_ticks"] = result.stalled_ticks
-        _write_state(config.state_path, state_payload)
+    state_payload: dict[str, Any] = dict(state)
+    state_payload["heal_failures"] = heal_failures
+    state_payload["heal_tripped"] = sorted(heal_tripped) if result.issues else []
+    state_payload["ts"] = now.isoformat()
+    if result.missing_vectors is not None:
+        state_payload["missing_vectors"] = result.missing_vectors
+        state_payload["stalled_ticks"] = result.stalled_ticks
+    if isinstance(watcher_poll_count, int):
+        state_payload["watcher_poll_count"] = watcher_poll_count
+    if isinstance(drain_total, int):
+        state_payload["drain_drained_total"] = drain_total
+    if pause_payload:
+        state_payload["pause_sentinel"] = pause_payload
+    _write_state(config.state_path, state_payload)
     result.ok = not result.issues
     return result

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -652,7 +652,9 @@ def run_health_check(
 
     pause_payload, pause_active, pause_stale = _pause_sentinel_state(config, now)
     if pause_stale:
-        add_issue("pause_sentinel_stale", "critical", "pause sentinel is expired; launchd resume may have been forgotten")
+        add_issue(
+            "pause_sentinel_stale", "critical", "pause sentinel is expired; launchd resume may have been forgotten"
+        )
         _push_notification("BrainLayer pause expired", "pause.sentinel is stale")
         if config.heal:
             try:
@@ -670,13 +672,10 @@ def run_health_check(
             f"durable queue backlog count={queue_count} bytes={queue_bytes} oldest_age={queue_oldest_age}",
         )
         heal_issue_labels["queue_backed_up"] = (config.drain_label, _plist_for_label(config, config.drain_label))
-    if (
-        queue_count > 0
-        and (
-            queue_count >= config.queue_page_count
-            or queue_bytes >= config.queue_page_bytes
-            or (queue_oldest_age is not None and queue_oldest_age >= config.queue_page_oldest_seconds)
-        )
+    if queue_count > 0 and (
+        queue_count >= config.queue_page_count
+        or queue_bytes >= config.queue_page_bytes
+        or (queue_oldest_age is not None and queue_oldest_age >= config.queue_page_oldest_seconds)
     ):
         _push_notification("BrainLayer queue backlog", f"queue_count={queue_count} queue_bytes={queue_bytes}")
 

--- a/src/brainlayer/pipeline/classify.py
+++ b/src/brainlayer/pipeline/classify.py
@@ -385,7 +385,13 @@ def classify_content(entry: dict) -> ClassifiedContent | None:
     base_meta = _extract_entry_metadata(entry)
 
     if entry_type == "user":
-        raw_content = entry.get("message", {}).get("content", "")
+        msg = entry.get("message")
+        if isinstance(msg, str):
+            raw_content = msg
+        elif isinstance(msg, dict):
+            raw_content = msg.get("content", "")
+        else:
+            raw_content = ""
         content = _extract_text_content(raw_content)
         task_result = _extract_task_notification_result(content)
         if task_result is not None:
@@ -419,8 +425,15 @@ def classify_content(entry: dict) -> ClassifiedContent | None:
         )
 
     if entry_type == "assistant":
-        message = entry.get("message", {})
-        content_blocks = message.get("content", [])
+        message = entry.get("message")
+        if isinstance(message, str):
+            content_blocks = [{"type": "text", "text": message}]
+        elif isinstance(message, dict):
+            content_blocks = message.get("content", [])
+        else:
+            content_blocks = []
+        if isinstance(content_blocks, str):
+            content_blocks = [{"type": "text", "text": content_blocks}]
 
         # Process each content block
         results = []

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -408,7 +408,9 @@ class BatchIndexer:
             return 3
 
     def _quarantine_entries(self, entries: list[dict], reason: Exception) -> None:
-        quarantine_dir = Path(os.environ.get("BRAINLAYER_WATCHER_QUARANTINE_DIR", "~/.brainlayer/quarantine")).expanduser()
+        quarantine_dir = Path(
+            os.environ.get("BRAINLAYER_WATCHER_QUARANTINE_DIR", "~/.brainlayer/quarantine")
+        ).expanduser()
         quarantine_dir.mkdir(parents=True, exist_ok=True)
         path = quarantine_dir / f"watcher-flush-{int(time.time() * 1000)}.jsonl"
         with path.open("w", encoding="utf-8") as handle:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -309,6 +309,7 @@ class JSONLTailer:
             try:
                 parsed = json.loads(line_data)
                 if isinstance(parsed, dict):
+                    parsed["_line_end_offset"] = self.offset + nl_idx + 1
                     lines.append(parsed)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 logger.debug("Skipping corrupt JSONL line at offset %d", self.offset)
@@ -337,18 +338,21 @@ class BatchIndexer:
 
     def __init__(
         self,
-        on_flush: Callable[[list[dict]], int | None],
+        on_flush: Callable[[list[dict]], dict[str, int] | None],
         batch_size: int = 10,
         flush_interval_ms: int = 100,
+        on_confirm_offsets: Callable[[dict[str, int]], None] | None = None,
     ):
         self.on_flush = on_flush
         self.batch_size = batch_size
         self.flush_interval_ms = flush_interval_ms
+        self.on_confirm_offsets = on_confirm_offsets
         self._buffer: list[dict] = []
         self._lock = threading.Lock()
         self._last_flush = time.monotonic()
         self.total_flushed = 0
         self.total_outputs = 0
+        self._flush_failures = 0
 
     def add(self, items: list[dict]):
         """Add parsed lines to the buffer."""
@@ -381,11 +385,66 @@ class BatchIndexer:
         count = len(batch)
         try:
             result = self.on_flush(batch)
+            watermarks = self._confirmed_watermarks(batch, result)
+            if watermarks and self.on_confirm_offsets:
+                self.on_confirm_offsets(watermarks)
             self._buffer = []  # Clear only after successful flush
+            self._flush_failures = 0
             self.total_flushed += count
-            self.total_outputs += result if isinstance(result, int) else count
+            self.total_outputs += getattr(result, "inserted", count)
         except Exception as e:
             logger.error("Batch flush failed (%d items), retaining in buffer: %s", count, e)
+            self._isolate_failed_flush(batch, e)
+
+    def _confirmed_watermarks(self, batch: list[dict], result: dict[str, int] | None) -> dict[str, int]:
+        if isinstance(result, dict):
+            return {str(source_file): int(offset) for source_file, offset in result.items()}
+        return {}
+
+    def _flush_retain_limit(self) -> int:
+        try:
+            return max(1, int(os.environ.get("BRAINLAYER_WATCHER_FLUSH_RETAIN_LIMIT", "3")))
+        except ValueError:
+            return 3
+
+    def _quarantine_entries(self, entries: list[dict], reason: Exception) -> None:
+        quarantine_dir = Path(os.environ.get("BRAINLAYER_WATCHER_QUARANTINE_DIR", "~/.brainlayer/quarantine")).expanduser()
+        quarantine_dir.mkdir(parents=True, exist_ok=True)
+        path = quarantine_dir / f"watcher-flush-{int(time.time() * 1000)}.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for entry in entries:
+                handle.write(json.dumps({"reason": str(reason), "entry": entry}, sort_keys=True) + "\n")
+        logger.critical("Quarantined %d watcher flush entries at %s after repeated failures", len(entries), path)
+
+    def _isolate_failed_flush(self, batch: list[dict], reason: Exception) -> None:
+        if len(batch) <= 1:
+            self._flush_failures += 1
+            if self._flush_failures >= self._flush_retain_limit():
+                self._quarantine_entries(batch, reason)
+                self._buffer = []
+                self._flush_failures = 0
+            return
+
+        retained: list[dict] = []
+        confirmed: dict[str, int] = {}
+        outputs = 0
+        for item in batch:
+            try:
+                result = self.on_flush([item])
+            except Exception:
+                retained.append(item)
+                continue
+            item_watermarks = self._confirmed_watermarks([item], result)
+            for source_file, offset in item_watermarks.items():
+                confirmed[source_file] = max(confirmed.get(source_file, 0), offset)
+            outputs += getattr(result, "inserted", 1)
+
+        if confirmed and self.on_confirm_offsets:
+            self.on_confirm_offsets(confirmed)
+        self.total_outputs += outputs
+        self.total_flushed += len(batch) - len(retained)
+        self._buffer = retained
+        self._flush_failures = self._flush_failures + 1 if retained else 0
 
 
 # ── JSONL Watcher ────────────────────────────────────────────────────────────
@@ -411,7 +470,7 @@ class JSONLWatcher:
         self,
         watch_dir: str | Path | None = None,
         registry_path: str | Path | None = None,
-        on_flush: Callable[[list[dict]], None] | None = None,
+        on_flush: Callable[[list[dict]], dict[str, int] | None] | None = None,
         on_rewind: Callable[[str, str, int, int], None] | None = None,
         watch_roots: list[WatchRoot] | None = None,
         db_path: str | Path | None = None,
@@ -439,6 +498,7 @@ class JSONLWatcher:
             on_flush=on_flush or (lambda _items: None),
             batch_size=batch_size,
             flush_interval_ms=flush_interval_ms,
+            on_confirm_offsets=self._advance_confirmed_offsets,
         )
         self.poll_interval_s = poll_interval_s
         self.registry_flush_interval_s = registry_flush_interval_s
@@ -454,9 +514,27 @@ class JSONLWatcher:
         self._health_window_started_epoch = time.time()
         self._health_entries_seen = 0
         self._health_output_at_start = 0
+        self.poll_count = 0
+
+    def _advance_confirmed_offsets(self, watermarks: dict[str, int]) -> None:
+        for filepath, offset in watermarks.items():
+            tailer = self._tailers.get(filepath)
+            inode = tailer.get_inode() if tailer else self.registry.get(filepath)[1]
+            current_offset, _current_inode = self.registry.get(filepath)
+            if offset >= current_offset:
+                self.registry.set(filepath, offset, inode)
 
     def provider_for_file(self, filepath: str) -> str:
-        return self._file_providers.get(filepath, "unknown")
+        provider = self._file_providers.get(filepath)
+        if provider:
+            return provider
+
+        path = Path(filepath).expanduser().resolve(strict=False)
+        for root in self.watch_roots:
+            root_path = root.resolved_path.resolve(strict=False)
+            if path == root_path or path.is_relative_to(root_path):
+                return root.provider
+        return "unknown"
 
     def _discover_jsonl_files(self) -> list[str]:
         """Find all .jsonl files under each watched project, including nested session artifacts."""
@@ -498,6 +576,8 @@ class JSONLWatcher:
                 continue
             entry["_source_file"] = filepath
             entry["_provider"] = provider
+            if isinstance(line.get("_line_end_offset"), int):
+                entry["_line_end_offset"] = line["_line_end_offset"]
             normalized.append(entry)
         return normalized
 
@@ -551,6 +631,7 @@ class JSONLWatcher:
         )
         payload = {
             "updated_at": datetime.now(timezone.utc).isoformat(),
+            "poll_count": self.poll_count,
             "providers": sorted({root.provider for root in self.watch_roots}),
             "files_tracked": len(files),
             "active_jsonl_entries_per_minute": entries_per_min,
@@ -600,69 +681,74 @@ class JSONLWatcher:
     def poll_once(self) -> int:
         """Run one poll cycle. Returns number of new lines found."""
         total_new = 0
-        files = self._discover_jsonl_files()
+        files: list[str] = []
+        self.poll_count += 1
 
-        for filepath in files:
-            tailer = self._ensure_tailer(filepath)
-            new_lines = tailer.read_new_lines(max_lines=self.max_lines_per_file)
+        try:
+            files = self._discover_jsonl_files()
 
-            # Handle rewind detection (checkpoint restore)
-            if tailer.rewound:
-                session_id = Path(filepath).stem
-                logger.warning(
-                    "Checkpoint restore: %s (offset %d → %d)",
-                    session_id,
-                    tailer.rewind_old_offset,
-                    tailer.rewind_new_offset,
-                )
+            for filepath in files:
                 try:
-                    from .telemetry import emit
+                    tailer = self._ensure_tailer(filepath)
+                    new_lines = tailer.read_new_lines(max_lines=self.max_lines_per_file)
 
-                    emit(
-                        "brainlayer-watcher",
-                        {
-                            "_type": "rewind_detected",
-                            "session_id": session_id,
-                            "file_path": filepath,
-                            "old_offset": tailer.rewind_old_offset,
-                            "new_offset": tailer.rewind_new_offset,
-                        },
-                    )
-                except Exception:
-                    pass
-
-                # Call rewind callback if set
-                if self.on_rewind:
-                    try:
-                        self.on_rewind(
-                            filepath,
+                    # Handle rewind detection (checkpoint restore)
+                    if tailer.rewound:
+                        session_id = Path(filepath).stem
+                        logger.warning(
+                            "Checkpoint restore: %s (offset %d → %d)",
                             session_id,
                             tailer.rewind_old_offset,
                             tailer.rewind_new_offset,
                         )
-                    except Exception as e:
-                        logger.error("Rewind callback failed: %s", e)
+                        try:
+                            from .telemetry import emit
 
-                tailer.rewound = False  # Reset flag
+                            emit(
+                                "brainlayer-watcher",
+                                {
+                                    "_type": "rewind_detected",
+                                    "session_id": session_id,
+                                    "file_path": filepath,
+                                    "old_offset": tailer.rewind_old_offset,
+                                    "new_offset": tailer.rewind_new_offset,
+                                },
+                            )
+                        except Exception:
+                            pass
 
-            if new_lines:
-                normalized_lines = self._normalize_lines(filepath, new_lines)
-                self.indexer.add(normalized_lines)
-                self.registry.set(filepath, tailer.offset, tailer.get_inode())
-                self._health_entries_seen += len(normalized_lines)
-                total_new += len(normalized_lines)
+                        # Call rewind callback if set
+                        if self.on_rewind:
+                            try:
+                                self.on_rewind(
+                                    filepath,
+                                    session_id,
+                                    tailer.rewind_old_offset,
+                                    tailer.rewind_new_offset,
+                                )
+                            except Exception as e:
+                                logger.error("Rewind callback failed: %s", e)
 
-        self.indexer.tick()
+                        tailer.rewound = False  # Reset flag
 
-        # Periodic registry flush
-        now = time.monotonic()
-        if now - self._last_registry_flush >= self.registry_flush_interval_s:
-            self.registry.flush()
-            self._last_registry_flush = now
+                    if new_lines:
+                        normalized_lines = self._normalize_lines(filepath, new_lines)
+                        self.indexer.add(normalized_lines)
+                        self._health_entries_seen += len(normalized_lines)
+                        total_new += len(normalized_lines)
+                except Exception:
+                    logger.exception("Poll file error: %s", filepath)
 
-        self._write_health_snapshot(files)
+            self.indexer.tick()
+            return total_new
+        finally:
+            # Periodic registry flush
+            now = time.monotonic()
+            if now - self._last_registry_flush >= self.registry_flush_interval_s:
+                self.registry.flush()
+                self._last_registry_flush = now
 
-        return total_new
+            self._write_health_snapshot(files)
 
     def start(self):
         """Start the watcher loop (blocking). Call stop() from another thread."""
@@ -683,16 +769,49 @@ class JSONLWatcher:
 
         heartbeat_interval_s = 60.0
         last_heartbeat = time.monotonic()
+        last_error_fingerprint: str | None = None
+        repeated_error_count = 0
+        try:
+            livelock_threshold = int(os.environ.get("BRAINLAYER_WATCHER_LIVELOCK_ERROR_THRESHOLD", "5"))
+        except ValueError:
+            livelock_threshold = 5
 
         while not self._stop.is_set():
             try:
                 self.poll_once()
+                last_error_fingerprint = None
+                repeated_error_count = 0
             except Exception as e:
                 logger.error("Poll cycle error: %s", e)
+                fingerprint = f"{type(e).__name__}:{e}"
+                if fingerprint == last_error_fingerprint:
+                    repeated_error_count += 1
+                else:
+                    last_error_fingerprint = fingerprint
+                    repeated_error_count = 1
                 try:
                     emit_watcher_error("poll_cycle", str(e))
                 except Exception:
                     pass
+                if repeated_error_count > livelock_threshold:
+                    logger.critical(
+                        "Watcher live-locked on repeated poll error (%d): %s",
+                        repeated_error_count,
+                        fingerprint,
+                    )
+                    try:
+                        from .telemetry import emit
+
+                        emit(
+                            "brainlayer-watcher",
+                            {
+                                "_type": "watcher_live_locked",
+                                "error": fingerprint,
+                                "repeated_error_count": repeated_error_count,
+                            },
+                        )
+                    except Exception:
+                        pass
 
             # Periodic heartbeat
             now = time.monotonic()

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -13,6 +13,7 @@ Filtering layers:
 import json
 import logging
 import os
+import random
 import re
 import time
 from datetime import datetime, timezone
@@ -67,6 +68,28 @@ _SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.D
 _PURE_DELETION_DIFF_RE = re.compile(r"^```(?:diff)?\n(?:-[^\n]*\n)+```$", re.MULTILINE)
 
 
+class FlushWatermarks(dict[str, int]):
+    """Confirmed per-source offsets returned by watcher flushes."""
+
+    def __init__(self, *args: Any, inserted: int = 0, skipped: int = 0, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.inserted = inserted
+        self.skipped = skipped
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, int):
+            return self.inserted == other
+        return super().__eq__(other)
+
+
+def _nonnegative_float_env(name: str, default: float) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return value if value >= 0 else default
+
+
 def _strip_system_reminders(text: str) -> str:
     """Remove system-reminder XML blocks from text content."""
     return _SYSTEM_REMINDER_RE.sub("", text).strip()
@@ -91,7 +114,8 @@ def _extract_raw_text(entry: dict) -> str:
     """Extract the raw text content from any JSONL entry type."""
     entry_type = entry.get("type", "")
     if entry_type == "user":
-        raw = entry.get("message", {}).get("content", "")
+        msg = entry.get("message")
+        raw = msg if isinstance(msg, str) else (msg.get("content", "") if isinstance(msg, dict) else "")
         if isinstance(raw, str):
             return raw
         if isinstance(raw, list):
@@ -102,7 +126,10 @@ def _extract_raw_text(entry: dict) -> str:
             return " ".join(parts)
         return ""
     if entry_type == "assistant":
-        blocks = entry.get("message", {}).get("content", [])
+        msg = entry.get("message")
+        blocks = msg if isinstance(msg, str) else (msg.get("content", []) if isinstance(msg, dict) else [])
+        if isinstance(blocks, str):
+            return blocks
         parts = []
         for block in blocks:
             if isinstance(block, dict) and block.get("type") == "text":
@@ -226,7 +253,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         arbitrated = os.environ.get("BRAINLAYER_ARBITRATED") == "1"
     store = None if arbitrated else VectorStore(db_path or get_db_path())
 
-    def flush_to_db(entries: list[dict[str, Any]]) -> int:
+    def flush_to_db(entries: list[dict[str, Any]]) -> FlushWatermarks:
         """Process raw JSONL entries through pipeline and insert into DB."""
         import time as _time
 
@@ -235,6 +262,42 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         inserted = 0
         skipped = 0
         source_files_seen: set[str] = set()
+        confirmed_offsets: dict[str, int] = {}
+
+        def confirm_entry(entry: dict[str, Any], source_file: str) -> None:
+            raw_offset = entry.get("_line_end_offset")
+            if isinstance(raw_offset, int):
+                confirmed_offsets[source_file] = max(confirmed_offsets.get(source_file, 0), raw_offset)
+
+        def enqueue_chunk(
+            *,
+            chunk_id: str,
+            clean_content: str,
+            metadata: dict[str, Any],
+            source_file: str,
+            project: str | None,
+            content_type: str,
+            value_type: str,
+            created_at: str,
+            conversation_id: str,
+            sender: Any,
+            tags: str | None,
+            chunk_origin: str | None,
+        ) -> None:
+            enqueue_watcher_chunk(
+                chunk_id=chunk_id,
+                content=clean_content,
+                metadata=metadata,
+                source_file=source_file,
+                project=project,
+                content_type=content_type,
+                value_type=value_type,
+                created_at=created_at,
+                conversation_id=conversation_id,
+                sender=sender,
+                tags=json.loads(tags) if tags else None,
+                chunk_origin=chunk_origin,
+            )
 
         for entry in entries:
             source_file = entry.get("_source_file", "unknown")
@@ -246,25 +309,33 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
             skip_reason = should_skip_entry(entry, source_file=source_file)
             if skip_reason:
                 skipped += 1
+                confirm_entry(entry, source_file)
                 continue
 
             # Layer 2: Pipeline classify
             try:
                 classified = classify_content(entry)
             except Exception:
+                logger.exception("Classification failed for watcher entry from %s", source_file)
                 skipped += 1
+                confirm_entry(entry, source_file)
                 continue
 
             if classified is None:
                 skipped += 1
+                confirm_entry(entry, source_file)
                 continue
 
             # Layer 3: Pipeline chunk
             try:
                 chunks = chunk_content(classified)
             except Exception:
+                logger.exception("Chunking failed for watcher entry from %s", source_file)
                 skipped += 1
+                confirm_entry(entry, source_file)
                 continue
+
+            entry_confirmed = True
 
             for chunk in chunks:
                 clean_content = _strip_system_reminders(chunk.content)
@@ -293,11 +364,11 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                         tags = json.dumps(correction_tags)
                 chunk_origin = detect_chunk_origin(clean_content)
 
-                try:
-                    if arbitrated:
-                        enqueue_watcher_chunk(
+                if arbitrated:
+                    try:
+                        enqueue_chunk(
                             chunk_id=chunk_id,
-                            content=clean_content,
+                            clean_content=clean_content,
                             metadata=metadata,
                             source_file=source_file,
                             project=project,
@@ -306,47 +377,36 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                             created_at=created_at,
                             conversation_id=conversation_id,
                             sender=metadata.get("sender"),
-                            tags=json.loads(tags) if tags else None,
+                            tags=tags,
                             chunk_origin=chunk_origin,
                         )
-                        inserted += 1
-                    else:
-                        assert cursor is not None and store is not None
-                        for attempt in range(5):
-                            transaction_started = False
-                            try:
-                                cursor.execute("BEGIN IMMEDIATE")
-                                transaction_started = True
-                                duplicate, dedupe_fields = find_duplicate(
+                    except Exception:
+                        entry_confirmed = False
+                        raise
+                    inserted += 1
+                else:
+                    assert cursor is not None and store is not None
+                    deadline_s = _nonnegative_float_env("BRAINLAYER_WATCHER_WRITE_DEADLINE_S", 15.0)
+                    deadline = time.monotonic() + deadline_s
+                    attempt = 0
+                    while True:
+                        transaction_started = False
+                        try:
+                            cursor.execute("BEGIN IMMEDIATE")
+                            transaction_started = True
+                            duplicate, dedupe_fields = find_duplicate(
+                                store.conn,
+                                chunk_id=chunk_id,
+                                content=clean_content,
+                                created_at=created_at,
+                                project=project,
+                                content_type=chunk.content_type.value,
+                            )
+                            if duplicate is not None:
+                                merge_duplicate_chunk(
                                     store.conn,
-                                    chunk_id=chunk_id,
-                                    content=clean_content,
-                                    created_at=created_at,
-                                    project=project,
-                                    content_type=chunk.content_type.value,
-                                )
-                                if duplicate is not None:
-                                    merge_duplicate_chunk(
-                                        store.conn,
-                                        canonical_id=duplicate.canonical_chunk_id,
-                                        duplicate_id=chunk_id,
-                                        incoming={
-                                            "id": chunk_id,
-                                            "content": clean_content,
-                                            "tags": tags,
-                                            "created_at": created_at,
-                                            "last_seen_at": created_at,
-                                        },
-                                        mechanism=duplicate.mechanism,
-                                        hamming_distance_value=duplicate.hamming_distance,
-                                    )
-                                    cursor.execute("COMMIT")
-                                    transaction_started = False
-                                    inserted += 1
-                                    break
-                                if merge_existing_chunk_seen(
-                                    store.conn,
-                                    chunk_id=chunk_id,
+                                    canonical_id=duplicate.canonical_chunk_id,
+                                    duplicate_id=chunk_id,
                                     incoming={
                                         "id": chunk_id,
                                         "content": clean_content,
@@ -354,67 +414,111 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                         "created_at": created_at,
                                         "last_seen_at": created_at,
                                     },
-                                ):
-                                    cursor.execute("COMMIT")
-                                    transaction_started = False
-                                    inserted += 1
-                                    break
-                                cursor.execute(
-                                    """INSERT OR IGNORE INTO chunks
-                                       (id, content, metadata, source_file, project,
-                                        content_type, value_type, char_count, source,
-                                        created_at, conversation_id, sender, tags, chunk_origin,
-                                        seen_count, last_seen_at, dedupe_hash, simhash,
-                                        simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
-                                        ingested_at)
-                                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                                               CAST(strftime('%s', 'now') AS INTEGER))""",
-                                    (
-                                        chunk_id,
-                                        clean_content,
-                                        json.dumps(metadata),
-                                        source_file,
-                                        project,
-                                        chunk.content_type.value,
-                                        chunk.value.value,
-                                        len(clean_content),
-                                        "realtime_watcher",
-                                        created_at,
-                                        conversation_id,
-                                        metadata.get("sender"),
-                                        tags,
-                                        chunk_origin,
-                                        1,
-                                        created_at,
-                                        dedupe_fields.dedupe_hash,
-                                        dedupe_fields.simhash,
-                                        dedupe_fields.bands[0],
-                                        dedupe_fields.bands[1],
-                                        dedupe_fields.bands[2],
-                                        dedupe_fields.bands[3],
-                                    ),
+                                    mechanism=duplicate.mechanism,
+                                    hamming_distance_value=duplicate.hamming_distance,
                                 )
-                                changed = store.conn.changes() > 0
                                 cursor.execute("COMMIT")
                                 transaction_started = False
-                                if changed:
-                                    inserted += 1
-                                else:
-                                    skipped += 1
+                                inserted += 1
                                 break
-                            except apsw.BusyError:
-                                if transaction_started:
-                                    cursor.execute("ROLLBACK")
-                                if attempt == 4:
+                            if merge_existing_chunk_seen(
+                                store.conn,
+                                chunk_id=chunk_id,
+                                incoming={
+                                    "id": chunk_id,
+                                    "content": clean_content,
+                                    "tags": tags,
+                                    "created_at": created_at,
+                                    "last_seen_at": created_at,
+                                },
+                            ):
+                                cursor.execute("COMMIT")
+                                transaction_started = False
+                                inserted += 1
+                                break
+                            cursor.execute(
+                                """INSERT OR IGNORE INTO chunks
+                                   (id, content, metadata, source_file, project,
+                                    content_type, value_type, char_count, source,
+                                    created_at, conversation_id, sender, tags, chunk_origin,
+                                    seen_count, last_seen_at, dedupe_hash, simhash,
+                                    simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
+                                    ingested_at)
+                                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                                           CAST(strftime('%s', 'now') AS INTEGER))""",
+                                (
+                                    chunk_id,
+                                    clean_content,
+                                    json.dumps(metadata),
+                                    source_file,
+                                    project,
+                                    chunk.content_type.value,
+                                    chunk.value.value,
+                                    len(clean_content),
+                                    "realtime_watcher",
+                                    created_at,
+                                    conversation_id,
+                                    metadata.get("sender"),
+                                    tags,
+                                    chunk_origin,
+                                    1,
+                                    created_at,
+                                    dedupe_fields.dedupe_hash,
+                                    dedupe_fields.simhash,
+                                    dedupe_fields.bands[0],
+                                    dedupe_fields.bands[1],
+                                    dedupe_fields.bands[2],
+                                    dedupe_fields.bands[3],
+                                ),
+                            )
+                            changed = store.conn.changes() > 0
+                            cursor.execute("COMMIT")
+                            transaction_started = False
+                            if changed:
+                                inserted += 1
+                            else:
+                                skipped += 1
+                            break
+                        except apsw.BusyError:
+                            if transaction_started:
+                                cursor.execute("ROLLBACK")
+                            if time.monotonic() >= deadline:
+                                try:
+                                    enqueue_chunk(
+                                        chunk_id=chunk_id,
+                                        clean_content=clean_content,
+                                        metadata=metadata,
+                                        source_file=source_file,
+                                        project=project,
+                                        content_type=chunk.content_type.value,
+                                        value_type=chunk.value.value,
+                                        created_at=created_at,
+                                        conversation_id=conversation_id,
+                                        sender=metadata.get("sender"),
+                                        tags=tags,
+                                        chunk_origin=chunk_origin,
+                                    )
+                                except Exception:
+                                    logger.exception("spill_failed chunk_id=%s source_file=%s", chunk_id, source_file)
+                                    entry_confirmed = False
                                     raise
-                                time.sleep(0.05 * (2**attempt))
+                                inserted += 1
+                                logger.warning("Direct watcher write busy for %s; spilled to queue", chunk_id)
+                                break
+                            delay = min(0.05 * (2**attempt), 1.0) * random.uniform(0.8, 1.2)
+                            attempt += 1
+                            time.sleep(delay)
+                        except Exception:
+                            transaction_started = False
+                            try:
+                                cursor.execute("ROLLBACK")
                             except Exception:
-                                if transaction_started:
-                                    cursor.execute("ROLLBACK")
-                                raise
-                except Exception as e:
-                    logger.warning("Queue/write failed for %s: %s", chunk_id, e)
-                    skipped += 1
+                                pass
+                            entry_confirmed = False
+                            raise
+
+            if entry_confirmed:
+                confirm_entry(entry, source_file)
 
         latency_ms = (_time.monotonic() - flush_start) * 1000
 
@@ -438,6 +542,6 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         except Exception:
             pass
 
-        return inserted
+        return FlushWatermarks(confirmed_offsets, inserted=inserted, skipped=skipped)
 
     return flush_to_db

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -128,3 +128,38 @@ class TestSystemPromptDetection:
     def test_does_not_flag_normal_user_question(self):
         content = "You are using SQLite here, right? Why does the lock happen?"
         assert looks_like_system_prompt(content) is False
+
+
+class TestBareStringMessageDoesNotCrash:
+    """Regression: classify_content must not raise AttributeError on bare-string messages.
+
+    Watcher Mode-D live-lock: a JSONL entry whose `message` is a bare string
+    (not a dict) caused `entry.get("message", {}).get("content", "")` to raise
+    `'str' object has no attribute 'get'`, aborting the poll cycle and freezing
+    offsets. See watcher-durable-fix-spec.md Mode D.
+    """
+
+    def test_user_bare_string_message(self):
+        entry = {"type": "user", "message": "a plain user string long enough to keep around"}
+        # Must not raise; should classify as user content.
+        result = classify_content(entry)
+        assert result is not None
+        assert result.content_type == ContentType.USER_MESSAGE
+
+    def test_assistant_bare_string_message(self):
+        entry = {"type": "assistant", "message": "a plain assistant string long enough to retain"}
+        # Must not raise AttributeError (the Mode-D crash). Retention is a
+        # separate content-filtering concern; the guarantee here is no crash.
+        result = classify_content(entry)
+        assert result is None or result.content_type is not None
+
+    def test_user_dict_message_still_works(self):
+        entry = {"type": "user", "message": {"content": "dict user content kept around for testing"}}
+        result = classify_content(entry)
+        assert result is not None
+        assert result.content_type == ContentType.USER_MESSAGE
+
+    def test_non_str_non_dict_message_returns_safely(self):
+        # Weird shapes must not raise.
+        assert classify_content({"type": "user", "message": 123}) is None
+        assert classify_content({"type": "assistant", "message": None}) is None

--- a/tests/test_cli_launchd_mode_a.py
+++ b/tests/test_cli_launchd_mode_a.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from brainlayer.cli import app
+from brainlayer.health_check import HealthCheckResult
+
+
+def test_health_check_cli_forwards_mode_a_config_fields(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run_health_check(config):
+        captured["config"] = config
+        return HealthCheckResult(checked_at="2026-06-20T10:00:00+00:00", ok=True)
+
+    monkeypatch.setattr("brainlayer.health_check.run_health_check", fake_run_health_check)
+    result = CliRunner().invoke(
+        app,
+        [
+            "health-check",
+            "--db",
+            str(tmp_path / "brainlayer.db"),
+            "--state-path",
+            str(tmp_path / "state.json"),
+            "--watch-label",
+            "com.test.watch",
+            "--drain-label",
+            "com.test.drain",
+            "--health-check-label",
+            "com.test.health",
+            "--watch-plist-path",
+            str(tmp_path / "watch.plist"),
+            "--drain-plist-path",
+            str(tmp_path / "drain.plist"),
+            "--health-check-plist-path",
+            str(tmp_path / "health.plist"),
+            "--source-jsonl-glob",
+            str(tmp_path / "projects/**/*.jsonl"),
+            "--pause-sentinel-path",
+            str(tmp_path / "pause.sentinel"),
+            "--drain-health-path",
+            str(tmp_path / "drain-health.json"),
+            "--queue-dir",
+            str(tmp_path / "queue"),
+            "--offsets-path",
+            str(tmp_path / "offsets.json"),
+            "--watcher-health-path",
+            str(tmp_path / "watcher-health.json"),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config = captured["config"]
+    assert config.watch_label == "com.test.watch"
+    assert config.drain_label == "com.test.drain"
+    assert config.health_check_label == "com.test.health"
+    assert config.watch_plist_path == tmp_path / "watch.plist"
+    assert config.drain_plist_path == tmp_path / "drain.plist"
+    assert config.health_check_plist_path == tmp_path / "health.plist"
+    assert config.source_jsonl_globs == [str(tmp_path / "projects/**/*.jsonl")]
+    assert config.pause_sentinel_path == tmp_path / "pause.sentinel"
+    assert config.drain_health_path == tmp_path / "drain-health.json"
+    assert config.queue_dir == tmp_path / "queue"
+    assert config.offsets_path == tmp_path / "offsets.json"
+    assert config.watcher_health_path == tmp_path / "watcher-health.json"
+
+
+def test_pause_and_resume_record_labels_and_call_launchctl(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+    monkeypatch.setattr("brainlayer.cli._run_launchctl", lambda args: commands.append(args) or 0)
+
+    pause_path = tmp_path / "pause.sentinel"
+    pause_result = CliRunner().invoke(
+        app,
+        [
+            "pause",
+            "--pause-sentinel-path",
+            str(pause_path),
+            "--label",
+            "com.test.watch",
+            "--label",
+            "com.test.drain",
+            "--ttl-seconds",
+            "60",
+        ],
+    )
+
+    assert pause_result.exit_code == 0, pause_result.output
+    payload = json.loads(pause_path.read_text(encoding="utf-8"))
+    assert payload["labels"] == ["com.test.watch", "com.test.drain"]
+    assert ["launchctl", "bootout", f"gui/{os.getuid()}/com.test.watch"] in commands
+    assert ["launchctl", "bootout", f"gui/{os.getuid()}/com.test.drain"] in commands
+
+    resume_result = CliRunner().invoke(app, ["resume", "--pause-sentinel-path", str(pause_path)])
+
+    assert resume_result.exit_code == 0, resume_result.output
+    assert not pause_path.exists()
+    assert any(command[:2] == ["launchctl", "bootstrap"] for command in commands)
+
+
+def test_reconcile_launchd_bootstraps_all_mode_a_labels(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+    monkeypatch.setattr("brainlayer.cli._run_launchctl", lambda args: commands.append(args) or 0)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "reconcile-launchd",
+            "--watch-plist-path",
+            str(tmp_path / "watch.plist"),
+            "--drain-plist-path",
+            str(tmp_path / "drain.plist"),
+            "--health-check-plist-path",
+            str(tmp_path / "health.plist"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    command_text = "\n".join(" ".join(command) for command in commands)
+    assert "com.brainlayer.watch" in command_text
+    assert "com.brainlayer.drain" in command_text
+    assert "com.brainlayer.health-check" in command_text

--- a/tests/test_cli_launchd_mode_a.py
+++ b/tests/test_cli_launchd_mode_a.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 
 from typer.testing import CliRunner
 

--- a/tests/test_drain_health.py
+++ b/tests/test_drain_health.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+
+from brainlayer.drain import run_daemon
+
+
+def test_run_daemon_writes_progress_heartbeat(tmp_path):
+    health_path = tmp_path / "drain-health.json"
+    drained_values = iter([2, 0])
+
+    run_daemon(
+        interval=0,
+        batch_size=10,
+        health_path=health_path,
+        drain_once_fn=lambda **_kwargs: next(drained_values),
+        sleep_fn=lambda _seconds: None,
+        max_cycles=2,
+    )
+
+    payload = json.loads(health_path.read_text(encoding="utf-8"))
+    assert payload["drain_cycles"] == 2
+    assert payload["drained_total"] == 2
+    assert payload["updated_at"]

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -74,7 +74,7 @@ def test_hotlane_cycle_can_disable_enrichment():
 def test_hotlane_default_backlog_batch_drains_pending_embeddings():
     hotlane = _load_hotlane_module()
 
-    assert hotlane.DEFAULT_BACKLOG_BATCH >= 64
+    assert hotlane.DEFAULT_BACKLOG_BATCH == 4
 
 
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
@@ -181,6 +181,7 @@ def test_hotlane_run_schedules_backlog_on_first_cycle():
         vector_store_cls=lambda _path: FakeStore(),
         model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
         cycle_fn=fake_cycle,
+        queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([100.0, 100.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=1,
@@ -215,6 +216,7 @@ def test_hotlane_run_advances_enrich_timer_before_failed_cycle():
         vector_store_cls=lambda _path: FakeStore(),
         model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
         cycle_fn=fake_cycle,
+        queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([0.0, 100.0, 101.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=2,
@@ -249,9 +251,81 @@ def test_hotlane_run_disables_enrichment_after_daily_cap():
         vector_store_cls=lambda _path: FakeStore(),
         model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
         cycle_fn=fake_cycle,
+        queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([0.0, 100.0, 111.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=2,
     )
 
     assert scheduled_enrich_limits == [25, 0]
+
+
+def test_hotlane_run_opens_and_closes_writer_store_each_cycle(tmp_path):
+    hotlane = _load_hotlane_module()
+    events = []
+
+    class FakeStore:
+        def __init__(self, path):
+            events.append(("open", path))
+
+        def close(self):
+            events.append(("close", None))
+
+    def fake_cycle(**_kwargs):
+        return hotlane.CycleResult()
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=0,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        vector_store_cls=FakeStore,
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=fake_cycle,
+        time_fn=iter([0.0, 100.0, 101.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=2,
+    )
+
+    assert [event[0] for event in events] == ["open", "close", "open", "close"]
+
+
+def test_hotlane_run_keeps_recent_cycle_while_queue_is_backlogged(tmp_path):
+    hotlane = _load_hotlane_module()
+    opened = []
+    cycle_calls = []
+
+    class FakeStore:
+        def __init__(self, path):
+            opened.append(path)
+
+        def close(self):
+            pass
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=hotlane.DEFAULT_HOTLANE_ENRICH_LIMIT,
+        enrich_since_hours=8760,
+        vector_store_cls=FakeStore,
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=lambda **kwargs: cycle_calls.append(kwargs) or hotlane.CycleResult(),
+        time_fn=iter([0.0, 100.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=1,
+        queue_depth_fn=lambda _queue_dir: 3,
+    )
+
+    assert opened == [tmp_path / "brainlayer.db"]
+    assert len(cycle_calls) == 1
+    assert cycle_calls[0]["backlog_batch"] == 0
+    assert cycle_calls[0]["enrich_limit"] == 0
+    assert cycle_calls[0]["recent_limit"] == 5

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -375,8 +375,11 @@ class TestJSONLWatcher:
         watcher = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",
-            on_flush=lambda items: flushed.extend(items)
-            or {str(healthy): len(b'{"id":"healthy"}\n')} if items and items[0].get("id") == "healthy" else {},
+            on_flush=lambda items: (
+                flushed.extend(items) or {str(healthy): len(b'{"id":"healthy"}\n')}
+                if items and items[0].get("id") == "healthy"
+                else {}
+            ),
             batch_size=1,
             health_path=health_path,
         )
@@ -406,8 +409,7 @@ class TestJSONLWatcher:
         w1 = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",
-            on_flush=lambda items: flushed1.extend(items)
-            or {str(f): max(item["_line_end_offset"] for item in items)},
+            on_flush=lambda items: flushed1.extend(items) or {str(f): max(item["_line_end_offset"] for item in items)},
             batch_size=1,
         )
         w1.poll_once()
@@ -422,8 +424,7 @@ class TestJSONLWatcher:
         w2 = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",
-            on_flush=lambda items: flushed2.extend(items)
-            or {str(f): max(item["_line_end_offset"] for item in items)},
+            on_flush=lambda items: flushed2.extend(items) or {str(f): max(item["_line_end_offset"] for item in items)},
             batch_size=1,
         )
         w2.poll_once()

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -201,6 +201,23 @@ class TestBatchIndexer:
         indexer.add([{"c": 3}, {"d": 4}])
         assert indexer.total_flushed == 4
 
+    def test_flush_callback_watermark_is_forwarded_to_offset_callback(self):
+        confirmed = []
+        indexer = BatchIndexer(
+            on_flush=lambda items: {"/tmp/source.jsonl": items[-1]["_line_end_offset"]},
+            batch_size=2,
+            on_confirm_offsets=confirmed.append,
+        )
+
+        indexer.add(
+            [
+                {"_source_file": "/tmp/source.jsonl", "_line_end_offset": 10},
+                {"_source_file": "/tmp/source.jsonl", "_line_end_offset": 20},
+            ]
+        )
+
+        assert confirmed == [{"/tmp/source.jsonl": 20}]
+
     def test_flush_error_retains_buffer(self):
         def bad_flush(items):
             raise RuntimeError("flush failed")
@@ -320,6 +337,65 @@ class TestJSONLWatcher:
         watcher.poll_once()
         assert "_source_file" in flushed[0]
         assert flushed[0]["_source_file"].endswith("s1.jsonl")
+        assert flushed[0]["_line_end_offset"] == len(b'{"id":"1"}\n')
+
+    def test_offsets_advance_only_to_flush_confirmed_watermark(self, tmp_path):
+        project = self._make_project_dir(tmp_path)
+        f = project / "s1.jsonl"
+        first_line = b'{"id":"1"}\n'
+        second_line = b'{"id":"2"}\n'
+        f.write_bytes(first_line + second_line)
+
+        def partial_flush(items):
+            return {items[0]["_source_file"]: items[0]["_line_end_offset"]}
+
+        watcher = JSONLWatcher(
+            watch_dir=tmp_path / "projects",
+            registry_path=tmp_path / "offsets.json",
+            on_flush=partial_flush,
+            batch_size=100,
+            flush_interval_ms=0,
+        )
+
+        assert watcher.poll_once() == 2
+
+        offset, _inode = watcher.registry.get(str(f))
+        assert offset == len(first_line)
+        assert watcher._tailers[str(f)].offset == len(first_line + second_line)
+
+    def test_poll_once_isolates_file_crashes_and_still_flushes_health(self, tmp_path):
+        project = self._make_project_dir(tmp_path)
+        poison = project / "poison.jsonl"
+        healthy = project / "healthy.jsonl"
+        poison.write_text('{"id":"poison"}\n')
+        healthy.write_text('{"id":"healthy"}\n')
+        flushed = []
+        health_path = tmp_path / "watcher-health.json"
+
+        watcher = JSONLWatcher(
+            watch_dir=tmp_path / "projects",
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items)
+            or {str(healthy): len(b'{"id":"healthy"}\n')} if items and items[0].get("id") == "healthy" else {},
+            batch_size=1,
+            health_path=health_path,
+        )
+        watcher._discover_jsonl_files = lambda: [str(poison), str(healthy)]
+        original_normalize = watcher._normalize_lines
+
+        def crash_one_file(filepath, new_lines):
+            if filepath == str(poison):
+                raise AttributeError("poison parse failure")
+            return original_normalize(filepath, new_lines)
+
+        watcher._normalize_lines = crash_one_file
+
+        assert watcher.poll_once() == 1
+        assert [item["id"] for item in flushed] == ["healthy"]
+        assert watcher.registry.get(str(poison))[0] == 0
+        assert watcher.registry.get(str(healthy))[0] == len(b'{"id":"healthy"}\n')
+        payload = json.loads(health_path.read_text())
+        assert payload["poll_count"] == 1
 
     def test_offset_survives_restart(self, tmp_path):
         project = self._make_project_dir(tmp_path)
@@ -330,7 +406,8 @@ class TestJSONLWatcher:
         w1 = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",
-            on_flush=lambda items: flushed1.extend(items),
+            on_flush=lambda items: flushed1.extend(items)
+            or {str(f): max(item["_line_end_offset"] for item in items)},
             batch_size=1,
         )
         w1.poll_once()
@@ -345,7 +422,8 @@ class TestJSONLWatcher:
         w2 = JSONLWatcher(
             watch_dir=tmp_path / "projects",
             registry_path=tmp_path / "offsets.json",
-            on_flush=lambda items: flushed2.extend(items),
+            on_flush=lambda items: flushed2.extend(items)
+            or {str(f): max(item["_line_end_offset"] for item in items)},
             batch_size=1,
         )
         w2.poll_once()

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -79,9 +79,11 @@ def test_active_daemon_launchd_hygiene_matrix():
             "KeepAlive": True,
         },
         "scripts/launchd/com.brainlayer.drain.plist": {
-            "ProcessType": "Adaptive",
+            "ProcessType": "Background",
             "ExitTimeOut": 60,
             "LowPriorityIO": True,
+            "KeepAlive": True,
+            "ThrottleInterval": 10,
         },
         "scripts/launchd/com.brainlayer.backup-daily.plist": {
             "ProcessType": "Background",
@@ -97,10 +99,9 @@ def test_active_daemon_launchd_hygiene_matrix():
             assert plist.get(key) == value, path
 
     drain = _load("scripts/launchd/com.brainlayer.drain.plist")
-    assert "KeepAlive" not in drain
-    assert drain["WatchPaths"] == ["__HOME__/.brainlayer/queue"]
-    assert drain["QueueDirectories"] == ["__HOME__/.brainlayer/queue"]
-    assert "--once" in drain["ProgramArguments"]
+    assert "WatchPaths" not in drain
+    assert "QueueDirectories" not in drain
+    assert "--once" not in drain["ProgramArguments"]
 
     backup = _load("scripts/launchd/com.brainlayer.backup-daily.plist")
     assert "KeepAlive" not in backup
@@ -326,3 +327,15 @@ def test_launchd_installer_wires_health_check_target():
     assert "health-check)" in install_source
     assert "install_plist health-check" in install_source
     assert "remove_plist health-check" in install_source
+
+
+def test_launchd_installer_uses_bootstrap_not_legacy_load_unload():
+    install_source = (REPO_ROOT / "scripts/launchd/install.sh").read_text(encoding="utf-8")
+    load_plist_body = install_source.split("load_plist() {", 1)[1].split("\nunload_plist() {", 1)[0]
+
+    assert "launchctl enable" in load_plist_body
+    assert "launchctl bootout" in load_plist_body
+    assert "launchctl bootstrap" in load_plist_body
+    assert "launchctl print" in load_plist_body
+    assert "launchctl load" not in load_plist_body
+    assert "launchctl unload" not in load_plist_body

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -9,10 +9,35 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import brainlayer.health_check as health_check
 from brainlayer.health_check import HealthCheckConfig, run_health_check
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_default_queue_dir(tmp_path_factory, monkeypatch):
+    """Isolate the default HealthCheckConfig queue_dir from the live queue.
+
+    Tests that build HealthCheckConfig without an explicit queue_dir otherwise
+    read the developer's real ~/.brainlayer/queue; a populated live queue then
+    makes them spuriously report `queue_backed_up`. We redirect _queue_stats
+    so the live default path is treated as the empty isolated dir, while tests
+    that pass an explicit queue_dir are honored unchanged.
+    """
+    empty_queue = tmp_path_factory.mktemp("hc-queue")
+    live_default = Path("~/.brainlayer/queue").expanduser()
+    real_queue_stats = health_check._queue_stats
+
+    def _isolated_queue_stats(queue_dir, now):
+        if queue_dir.expanduser() == live_default:
+            queue_dir = empty_queue
+        return real_queue_stats(queue_dir, now)
+
+    monkeypatch.setattr(health_check, "_queue_stats", _isolated_queue_stats)
+    yield
 
 
 def _make_db(path: Path, *, total: int, vector_rows: int) -> None:

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import inspect
 import json
+import os
 import plistlib
 import sqlite3
-import inspect
-import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -348,8 +348,7 @@ def test_health_check_bootstraps_absent_default_launchd_labels_instead_of_kickst
             heal_min_consecutive_failures=1,
         ),
         ps_output_fn=lambda: (
-            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py "
-            "--interval 1 --backlog-batch 4 --enrich-limit 5\n"
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4 --enrich-limit 5\n"
         ),
         socket_request_fn=_ok_canary,
         command_runner=command_runner,
@@ -422,9 +421,7 @@ def test_health_check_reports_watcher_stalled_drain_no_progress_and_queue_backed
             queue_auto_heal_count=1,
             queue_page_count=1,
         ),
-        ps_output_fn=lambda: (
-            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
-        ),
+        ps_output_fn=lambda: "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n",
         socket_request_fn=_ok_canary,
         command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
         now_fn=lambda: now,
@@ -453,9 +450,7 @@ def test_success_tick_clears_heal_breaker_state(tmp_path):
 
     result = run_health_check(
         HealthCheckConfig(db_path=db_path, state_path=state_path),
-        ps_output_fn=lambda: (
-            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
-        ),
+        ps_output_fn=lambda: "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n",
         socket_request_fn=_ok_canary,
         command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
         now_fn=lambda: datetime(2026, 6, 20, 10, 0, tzinfo=UTC),

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import json
 import plistlib
 import sqlite3
-from datetime import UTC, datetime
+import inspect
+import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
+import brainlayer.health_check as health_check
 from brainlayer.health_check import HealthCheckConfig, run_health_check
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -75,7 +79,7 @@ def test_backlog_batch_zero_alarms_but_waits_until_repeated_failure_to_kickstart
     assert first_result.ok is False
     assert "hotlane_backlog_disabled" in [issue.code for issue in first_result.issues]
     assert first_result.backlog_batch == 0
-    assert commands == []
+    assert not any(command[:3] == ["launchctl", "kickstart", "-k"] for command in commands)
     assert "kickstart" not in capsys.readouterr().err
 
     second_result = run_health_check(
@@ -91,8 +95,9 @@ def test_backlog_batch_zero_alarms_but_waits_until_repeated_failure_to_kickstart
     assert second_result.ok is False
     assert "hotlane_backlog_disabled" in [issue.code for issue in second_result.issues]
     assert second_result.backlog_batch == 0
-    assert len(commands) == 1
-    assert "com.brainlayer.hotlane-brainbar" in " ".join(commands[0])
+    kickstarts = [command for command in commands if command[:3] == ["launchctl", "kickstart", "-k"]]
+    assert len(kickstarts) == 1
+    assert "com.brainlayer.hotlane-brainbar" in " ".join(kickstarts[0])
     stderr = capsys.readouterr().err
     assert "heal action" in stderr
     assert "label=com.brainlayer.hotlane-brainbar" in stderr
@@ -120,8 +125,9 @@ def test_any_zero_backlog_batch_alarms_when_multiple_hotlanes_are_running(tmp_pa
     assert result.ok is False
     assert "hotlane_backlog_disabled" in [issue.code for issue in result.issues]
     assert result.backlog_batch == 0
-    assert len(commands) == 1
-    assert "com.brainlayer.hotlane-brainbar" in " ".join(commands[0])
+    kickstarts = [command for command in commands if command[:3] == ["launchctl", "kickstart", "-k"]]
+    assert len(kickstarts) == 1
+    assert "com.brainlayer.hotlane-brainbar" in " ".join(kickstarts[0])
 
 
 def test_missing_embeddings_not_draining_after_two_ticks(tmp_path):
@@ -224,7 +230,7 @@ def test_heal_state_write_preserves_missing_vector_history_when_count_fails(tmp_
     saved = json.loads(state_path.read_text(encoding="utf-8"))
     assert saved["missing_vectors"] == 7
     assert saved["stalled_ticks"] == 1
-    assert saved["heal_failures"]["hotlane_backlog_disabled"] == 1
+    assert saved["heal_failures"]["com.brainlayer.hotlane-brainbar:hotlane_backlog_disabled"] == 1
 
 
 def test_brainbar_canary_error_waits_until_repeated_failure_to_kickstart_brainbar(tmp_path):
@@ -257,7 +263,7 @@ def test_brainbar_canary_error_waits_until_repeated_failure_to_kickstart_brainba
 
     assert first_result.ok is False
     assert "brain_search_canary_failed" in [issue.code for issue in first_result.issues]
-    assert commands == []
+    assert not any(command[:3] == ["launchctl", "kickstart", "-k"] for command in commands)
 
     second_result = run_health_check(
         config,
@@ -294,3 +300,156 @@ def test_health_check_launchagent_runs_every_five_minutes_and_heals():
         "health-check",
     ]
     assert "--heal" in plist["ProgramArguments"]
+    assert "KeepAlive" not in plist
+
+
+def test_health_check_bootstraps_absent_default_launchd_labels_instead_of_kickstart_only(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=1, vector_rows=1)
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]):
+        commands.append(args)
+        if args[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            heal=True,
+            heal_min_consecutive_failures=1,
+        ),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py "
+            "--interval 1 --backlog-batch 4 --enrich-limit 5\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=command_runner,
+        now_fn=lambda: datetime(2026, 6, 20, 10, 0, tzinfo=UTC),
+    )
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert {"watch_unloaded", "drain_unloaded", "health_check_unloaded"} <= set(issue_codes)
+    assert ["launchctl", "enable", f"gui/{__import__('os').getuid()}/com.brainlayer.watch"] in commands
+    assert ["launchctl", "enable", f"gui/{__import__('os').getuid()}/com.brainlayer.drain"] in commands
+    assert ["launchctl", "enable", f"gui/{__import__('os').getuid()}/com.brainlayer.health-check"] in commands
+    assert [
+        "launchctl",
+        "bootstrap",
+        f"gui/{__import__('os').getuid()}",
+        str(Path("~/Library/LaunchAgents/com.brainlayer.watch.plist").expanduser()),
+    ] in commands
+    assert not any(command[:3] == ["launchctl", "kickstart", "-k"] for command in commands)
+
+
+def test_run_health_check_references_mode_d_detector_helpers():
+    source = inspect.getsource(health_check.run_health_check)
+
+    for helper_name in ("_pause_sentinel_state", "_source_recent", "_queue_stats", "_path_age_seconds"):
+        assert helper_name in source
+
+
+def test_health_check_reports_watcher_stalled_drain_no_progress_and_queue_backed_up(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    offsets_path = tmp_path / "offsets.json"
+    watcher_health_path = tmp_path / "watcher-health.json"
+    drain_health_path = tmp_path / "drain-health.json"
+    queue_dir = tmp_path / "queue"
+    source_dir = tmp_path / "source"
+    queue_dir.mkdir()
+    source_dir.mkdir()
+    _make_db(db_path, total=1, vector_rows=1)
+
+    now = datetime(2026, 6, 20, 10, 0, tzinfo=UTC)
+    offsets_path.write_text("{}", encoding="utf-8")
+    watcher_health_path.write_text(json.dumps({"poll_count": 5}), encoding="utf-8")
+    drain_health_path.write_text(json.dumps({"drained_total": 10}), encoding="utf-8")
+    queue_file = queue_dir / "watcher-test.jsonl"
+    queue_file.write_text("{}\n", encoding="utf-8")
+    source_file = source_dir / "session.jsonl"
+    source_file.write_text("{}\n", encoding="utf-8")
+    old_mtime = (now - timedelta(seconds=1000)).timestamp()
+    recent_mtime = (now - timedelta(seconds=30)).timestamp()
+    os.utime(offsets_path, (old_mtime, old_mtime))
+    os.utime(watcher_health_path, (old_mtime, old_mtime))
+    os.utime(drain_health_path, (old_mtime, old_mtime))
+    os.utime(queue_file, (old_mtime, old_mtime))
+    os.utime(source_file, (recent_mtime, recent_mtime))
+    state_path.write_text(
+        json.dumps({"watcher_poll_count": 5, "drain_drained_total": 10}),
+        encoding="utf-8",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            offsets_path=offsets_path,
+            watcher_health_path=watcher_health_path,
+            drain_health_path=drain_health_path,
+            queue_dir=queue_dir,
+            source_jsonl_globs=[str(source_dir / "*.jsonl")],
+            max_offsets_age_seconds=300,
+            queue_auto_heal_count=1,
+            queue_page_count=1,
+        ),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        now_fn=lambda: now,
+    )
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert "watcher_stalled" in issue_codes
+    assert "drain_no_progress" in issue_codes
+    assert "queue_backed_up" in issue_codes
+
+
+def test_success_tick_clears_heal_breaker_state(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=1, vector_rows=1)
+    state_path.write_text(
+        json.dumps(
+            {
+                "heal_failures": {"com.brainlayer.watch:watch_unloaded": 3},
+                "heal_tripped": ["com.brainlayer.watch:watch_unloaded"],
+                "missing_vectors": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(db_path=db_path, state_path=state_path),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        now_fn=lambda: datetime(2026, 6, 20, 10, 0, tzinfo=UTC),
+    )
+
+    assert result.ok is True
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    assert saved["heal_failures"] == {}
+    assert saved["heal_tripped"] == []
+
+
+def test_drain_launchagent_is_long_lived_keepalive_daemon():
+    plist_path = REPO_ROOT / "scripts/launchd/com.brainlayer.drain.plist"
+    plist = plistlib.loads(plist_path.read_bytes())
+
+    assert plist["Label"] == "com.brainlayer.drain"
+    assert plist["KeepAlive"] is True
+    assert plist["RunAtLoad"] is True
+    assert plist["ThrottleInterval"] == 10
+    assert "--once" not in plist["ProgramArguments"]
+    assert "WatchPaths" not in plist
+    assert "QueueDirectories" not in plist

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -98,9 +98,10 @@ class TestPreClassifyFilters:
         assert _extract_raw_text({"type": "user", "message": long_text}) == long_text
         assert _extract_raw_text({"type": "assistant", "message": long_text}) == long_text
         assert _extract_raw_text({"type": "user", "message": {"content": long_text}}) == long_text
-        assert _extract_raw_text(
-            {"type": "assistant", "message": {"content": [{"type": "text", "text": long_text}]}}
-        ) == long_text
+        assert (
+            _extract_raw_text({"type": "assistant", "message": {"content": [{"type": "text", "text": long_text}]}})
+            == long_text
+        )
 
 
 # ── Post-Chunk Filters ───────────────────────────────────────────────────────
@@ -212,7 +213,9 @@ class TestFlushCallback:
         conn.close()
         assert rows == (0,)
 
-    def test_classification_poison_entry_confirms_its_offset_and_does_not_block_later_entries(self, tmp_path, monkeypatch):
+    def test_classification_poison_entry_confirms_its_offset_and_does_not_block_later_entries(
+        self, tmp_path, monkeypatch
+    ):
         import brainlayer.watcher_bridge as bridge
 
         db_path = tmp_path / "test.db"

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -14,11 +14,14 @@ import json
 import sqlite3
 import time
 
+import apsw
+
 from brainlayer.vector_store import VectorStore
 from brainlayer.watcher import JSONLTailer, JSONLWatcher
 from brainlayer.watcher_bridge import (
     _extract_claude_conversation_id,
     _extract_project_from_source,
+    _extract_raw_text,
     _normalize_project_name,
     _strip_system_reminders,
     create_flush_callback,
@@ -88,6 +91,16 @@ class TestPreClassifyFilters:
 
     def test_skip_unknown_type(self):
         assert should_skip_entry({"type": "unknown-new-type"}) is not None
+
+    def test_extract_raw_text_accepts_bare_string_messages_for_user_and_assistant(self):
+        long_text = "Bare string messages should not crash the watcher bridge extraction path."
+
+        assert _extract_raw_text({"type": "user", "message": long_text}) == long_text
+        assert _extract_raw_text({"type": "assistant", "message": long_text}) == long_text
+        assert _extract_raw_text({"type": "user", "message": {"content": long_text}}) == long_text
+        assert _extract_raw_text(
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": long_text}]}}
+        ) == long_text
 
 
 # ── Post-Chunk Filters ───────────────────────────────────────────────────────
@@ -174,6 +187,61 @@ class TestFlushCallback:
         assert inserted == 1
         assert len(queued_files) == 1
         assert rows == (0,)
+
+    def test_direct_write_busy_spills_to_queue_instead_of_silently_dropping(self, tmp_path, monkeypatch):
+        import brainlayer.watcher_bridge as bridge
+
+        db_path = tmp_path / "test.db"
+        queue_dir = tmp_path / "queue"
+        VectorStore(db_path).close()
+        monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setenv("BRAINLAYER_WATCHER_WRITE_DEADLINE_S", "0")
+        monkeypatch.setattr(bridge, "find_duplicate", lambda *_args, **_kwargs: (_ for _ in ()).throw(apsw.BusyError()))
+
+        flush = create_flush_callback(db_path, arbitrated=False)
+        entry = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant")
+        entry["_source_file"] = str(tmp_path / "projects" / "test-project" / "session.jsonl")
+        entry["_line_end_offset"] = 123
+
+        result = flush([entry])
+
+        assert result[str(entry["_source_file"])] == 123
+        assert len(list(queue_dir.glob("watcher-*.jsonl"))) == 1
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT COUNT(*) FROM chunks WHERE source = 'realtime_watcher'").fetchone()
+        conn.close()
+        assert rows == (0,)
+
+    def test_classification_poison_entry_confirms_its_offset_and_does_not_block_later_entries(self, tmp_path, monkeypatch):
+        import brainlayer.watcher_bridge as bridge
+
+        db_path = tmp_path / "test.db"
+        VectorStore(db_path).close()
+        original_classify = bridge.classify_content
+
+        def classify_or_poison(entry):
+            if entry.get("poison"):
+                raise ValueError("deterministic bad entry")
+            return original_classify(entry)
+
+        monkeypatch.setattr(bridge, "classify_content", classify_or_poison)
+        flush = create_flush_callback(db_path, arbitrated=False)
+        source_file = str(tmp_path / "projects" / "test-project" / "session.jsonl")
+        poison = _make_jsonl_entry(text=_LONG_TEXT, entry_type="assistant", poison=True)
+        poison["_source_file"] = source_file
+        poison["_line_end_offset"] = 10
+        healthy = _make_jsonl_entry(text=_LONG_TEXT + " healthy", entry_type="assistant")
+        healthy["_source_file"] = source_file
+        healthy["_line_end_offset"] = 30
+
+        result = flush([poison, healthy])
+
+        assert result[source_file] == 30
+        assert result.skipped == 1
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT COUNT(*) FROM chunks WHERE source = 'realtime_watcher'").fetchone()
+        conn.close()
+        assert rows[0] >= 1
 
     def test_inserts_valid_entry(self, tmp_path):
         db_path = tmp_path / "test.db"


### PR DESCRIPTION
## Why

The JSONL watcher had been silently indexing **nothing for ~2 days** (offsets frozen Jun 18 03:52). Root cause was the convergence of **four independent, language-agnostic death-modes** plus a split-brain deployment (live launchd plists pointed at `brainlayer-prod` while hotlane ran `/Gits/brainlayer`), and a self-heal monitor that was merged but never loaded. Verified live before the fix.

## Four death-modes closed

- **Mode A — bootout-without-rebootstrap (the dominant recurrence vector).** `watch`/`drain`/`health-check` were enabled-but-NOT-loaded (absent from `launchctl list`). `KeepAlive=true` is inert on an unloaded label, and `launchctl kickstart -k` *errors* on an unloaded label, so the existing self-heal could not recover it. **Fix:** `health_check.py` gains `_bootstrap_if_absent` (enable + bootout + bootstrap — NOT kickstart) plus symmetric `watch/drain/health-check` absent detectors; `install.sh load_plist` moved off legacy `launchctl load/unload` to the idempotent enable+bootout+bootstrap path.

- **Mode B — drain death-at-open / hotlane writer starvation.** hotlane opened `VectorStore` once and held the writer pidfile + WAL lock continuously; the `--once` drain (QueueDirectories + WatchPaths) exhausted its open-retry budget and froze the backlog the moment the watcher stopped enqueuing. **Fix:** hotlane opens-write-closes per cycle and yields the writer entirely while the durable queue is non-empty; drain becomes a long-lived `KeepAlive` daemon that retries the backlog on a timer regardless of new queue writes; embeddings are computed *before* `BEGIN IMMEDIATE` to shrink lock-hold.

- **Mode C — silent drop + offset-past-undelivered race.** On busy-budget exhaustion the bridge dropped the chunk and `flush_to_db` returned normally while the watcher had already advanced the offset. **Fix:** the bridge **spills to the durable queue** instead of dropping; `flush_to_db` returns per-source-file **confirmed watermarks**; the watcher advances offsets only to the confirmed watermark (each line carries its source-file + end-offset through the buffer), so a buffered-then-dropped chunk can never commit its offset.

- **Mode D — poll-cycle live-lock.** A JSONL entry whose `message` is a **bare string** (not a dict) raised `'str' object has no attribute 'get'`, aborting `poll_once` and freezing offsets + health while the process stayed alive (KeepAlive never fires; process-presence monitors stay green). **Fix:** `_extract_raw_text` **and** `classify.py` (both the user and assistant branches — the second site was the follow-on commit found live during deploy) tolerate bare-string messages; `poll_once` is per-file crash-isolated with flush + health snapshot in `finally`; a monotonic `poll_count` heartbeat (plus a symmetric drain-progress heartbeat) lets the monitor distinguish alive-but-stuck from healthy-idle without trusting the broken `*_per_minute` fields.

## New durability layer

- `brainlayer pause` / `resume` — the sanctioned bulk-op stop now records the labels it boots out in a pause-sentinel and restores exactly them; a stale sentinel auto-resumes + escalates loudly (closes the dominant recurrence vector by construction).
- `brainlayer reconcile-launchd` — bootstrap-if-absent `{watch, drain, health-check}`; anchorable from the always-loaded BrainBar daemon (watcher-of-the-watcher).
- `com.brainlayer.health-check` installed as a `StartInterval=300` poller running `health-check --json --heal`.
- Persistent per-`(label, issue)` circuit breaker in `health-check-state.json` with mandatory **success-reset**, so a heal target that re-dies trips and escalates after K attempts instead of flapping (no 288-restarts/day), and a recovered service can be healed again.
- Axiom telemetry + best-effort PushNotification on every heal / escalation — never silent.

## Catch-up (deployed alongside this PR)

Freed the writer (hotlane lowered to `--backlog-batch 4 --enrich-limit 5`, open-write-close), `PRAGMA wal_checkpoint(TRUNCATE)`, drained the stranded queue files in bounded `--once --batch-size 50` passes (no `attempt-N/41` storm — drain recovered within ~12 attempts), then re-bootstrapped the repointed watcher/drain and installed the health-check poller. After deploy: poll-cycle errors → **0**, offsets advanced Jun18 → Jun20, `max_offset_lag_bytes` 7M → **0**, DB chunk count climbing well above the prior ~35/hr floor.

## Tests

`139` targeted tests pass (full pre-push unit gate green). New coverage:
- `tests/test_classify.py::TestBareStringMessageDoesNotCrash` — bare-string user/assistant + dict + non-str/non-dict shapes don't raise.
- `tests/test_stability_health_check.py` — autouse fixture isolates the default `queue_dir` from the live `~/.brainlayer/queue` so a populated local queue can't spuriously fail the suite.
- Mode-A heal, drain-liveness, circuit-breaker, pause-sentinel suppression/escalation, hotlane open-write-close + queue-yield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqgSTrcnkHocz2rfLrveXK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core indexing durability, SQLite write coordination, and always-on drain behavior; misconfiguration could affect live indexing or increase background load.
> 
> **Overview**
> This PR closes several failure modes that left JSONL indexing stalled for days: unloaded launchd labels, writer lock contention, offsets advancing past undelivered data, and poll-cycle crashes on malformed entries.
> 
> **Watcher and bridge:** Flushes return **confirmed byte watermarks**; offsets advance only after successful processing. On SQLite busy, the bridge **spills to the durable queue** instead of dropping. `classify`/`watcher_bridge` accept bare-string `message` fields. The indexer quarantines poison batches; `poll_once` isolates per-file errors and tracks **`poll_count`** for stall detection.
> 
> **Drain and hotlane:** Drain runs as a **KeepAlive** daemon (no `--once`/queue triggers), writes **`drain-health.json`**, and **precomputes embeddings before transactions**. Hotlane uses smaller default batches, **opens/closes the DB each cycle**, and **skips backlog/enrich when the queue has files**.
> 
> **Ops:** `install.sh` uses **enable/bootout/bootstrap**; CLI adds **`pause`**, **`resume`**, and **`reconcile-launchd`**. Health check gains bootstrap-for-unloaded services, queue/watcher/drain stall detectors, heal **circuit breaker**, and notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6817683c4cf958c0dad634290dd4ff9e964be0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the JSONL watcher durable with offset confirmation, DB-busy spill-to-queue, per-file error isolation, and self-healing health checks
> - Offsets now advance only after a successful flush; `BatchIndexer` reports confirmed per-source watermarks via an `on_confirm_offsets` callback, and `JSONLWatcher` stores them only when the flush confirms them, preventing data loss on crash.
> - On sustained `BusyError` during DB writes, chunks are spilled to the durable queue and counted as inserted rather than dropped; exponential backoff with a configurable deadline (`BRAINLAYER_WATCHER_WRITE_DEADLINE_S`) replaces a fixed retry loop.
> - Per-file polling errors are caught and logged in isolation so one bad file does not stop other files from being processed or the health snapshot from being written.
> - Repeated identical poll errors beyond `BRAINLAYER_WATCHER_LIVELOCK_ERROR_THRESHOLD` emit a critical telemetry event.
> - The drain LaunchAgent is converted from a one-shot WatchPaths-triggered agent to a long-lived `KeepAlive`/`Background` daemon with `ThrottleInterval 10` and batch size 50; the install script switches from legacy `launchctl load/unload` to `enable`/`bootout`/`bootstrap`.
> - The health check gains launchd load-state detection, pause-sentinel handling, queue-backlog detection, watcher-stall and drain-progress checks, and a circuit-breaker for repeated heal failures with telemetry escalation and macOS notifications.
> - New CLI subcommands `pause`, `resume`, and `reconcile-launchd` manage BrainLayer LaunchAgents.
> - `classify_content` and `_extract_raw_text` now accept bare-string `message` fields for user and assistant entries instead of crashing.
> - Risk: the drain plist change (removing `--once`, adding `KeepAlive`) requires reloading the LaunchAgent; the hotlane daemon now opens and closes the `VectorStore` every cycle and throttles to batch/enrich size 0 when the queue has backlog.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5d64ad6. 9 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->