### PR TITLE
feat: Aldante-grade BrainBar graphs (gradient fill, point-anchored hover, hero cards)

### DIFF
--- a/brain-bar/Package.swift
+++ b/brain-bar/Package.swift
@@ -21,6 +21,9 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Sources/BrainBar",
+            swiftSettings: [
+                .define("BRAINBAR_UI"),
+            ],
             linkerSettings: [
                 .linkedLibrary("sqlite3"),
             ]

--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -88,11 +88,13 @@ final class BrainBarDashboardPanelController: NSObject, NSWindowDelegate {
 
     private func dismissIfClickOutside() {
         guard panel.isVisible, Date().timeIntervalSince(shownAt) > 0.20 else { return }
+        guard !BrainBarSettingsActions.suppressDashboardResignDismiss else { return }
         dismiss()
     }
 
     private func dismissIfLocalClickOutside(_ event: NSEvent) {
         guard panel.isVisible, Date().timeIntervalSince(shownAt) > 0.20 else { return }
+        guard !BrainBarSettingsActions.suppressDashboardResignDismiss else { return }
         if event.window === panel { return }
         if let button = statusItemButton, event.window === button.window { return }   // let toggle() own the menubar click
         dismiss()

--- a/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarDashboardPanelController.swift
@@ -1,8 +1,13 @@
 import AppKit
 import SwiftUI
 
+final class BrainBarDashboardPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
 @MainActor
-final class BrainBarDashboardPanelController {
+final class BrainBarDashboardPanelController: NSObject, NSWindowDelegate {
     static let defaultSize = NSSize(
         width: BrainBarWindowPlacement.defaultSize.width,
         height: BrainBarWindowPlacement.defaultSize.height
@@ -18,6 +23,10 @@ final class BrainBarDashboardPanelController {
     var isShownForTesting: Bool { panel.isVisible }
 
     private let panel: NSPanel
+    private var clickOutsideMonitor: Any?
+    private var localClickMonitor: Any?
+    private var shownAt: Date = .distantPast
+    weak var statusItemButton: NSView?
 
     init(runtime: BrainBarRuntime) {
         let hostingController = NSHostingController(
@@ -31,7 +40,8 @@ final class BrainBarDashboardPanelController {
         contentViewControllerForTesting = hostingController
         panel = Self.makePanel(contentViewController: hostingController)
         panelForTesting = panel
-
+        super.init()
+        panel.delegate = self
     }
 
     func toggle(anchoredTo anchorView: NSView? = nil) {
@@ -48,14 +58,58 @@ final class BrainBarDashboardPanelController {
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
+        shownAt = Date()
+        installClickOutsideMonitor()
     }
 
     func dismiss() {
+        removeClickOutsideMonitor()
         panel.orderOut(nil)
     }
 
+    private func installClickOutsideMonitor() {
+        removeClickOutsideMonitor()
+        let mask: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        clickOutsideMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { [weak self] _ in
+            Task { @MainActor in self?.dismissIfClickOutside() }
+        }
+        localClickMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+            Task { @MainActor in self?.dismissIfLocalClickOutside(event) }
+            return event
+        }
+    }
+
+    private func removeClickOutsideMonitor() {
+        if let clickOutsideMonitor { NSEvent.removeMonitor(clickOutsideMonitor) }
+        if let localClickMonitor { NSEvent.removeMonitor(localClickMonitor) }
+        clickOutsideMonitor = nil
+        localClickMonitor = nil
+    }
+
+    private func dismissIfClickOutside() {
+        guard panel.isVisible, Date().timeIntervalSince(shownAt) > 0.20 else { return }
+        dismiss()
+    }
+
+    private func dismissIfLocalClickOutside(_ event: NSEvent) {
+        guard panel.isVisible, Date().timeIntervalSince(shownAt) > 0.20 else { return }
+        if event.window === panel { return }
+        if let button = statusItemButton, event.window === button.window { return }   // let toggle() own the menubar click
+        dismiss()
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        guard panel.isVisible, Date().timeIntervalSince(shownAt) > 0.20 else { return }
+        guard !BrainBarSettingsActions.suppressDashboardResignDismiss else { return }
+        dismiss()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        removeClickOutsideMonitor()
+    }
+
     private static func makePanel(contentViewController: NSViewController) -> NSPanel {
-        let panel = NSPanel(
+        let panel = BrainBarDashboardPanel(
             contentRect: NSRect(origin: .zero, size: defaultSize),
             styleMask: [.titled, .fullSizeContentView, .closable, .resizable],
             backing: .buffered,
@@ -68,6 +122,7 @@ final class BrainBarDashboardPanelController {
         panel.isFloatingPanel = true
         panel.hidesOnDeactivate = false
         panel.level = .statusBar
+        panel.becomesKeyOnlyIfNeeded = false
         panel.minSize = minSize
         panel.maxSize = maxSize
         panel.contentViewController = contentViewController

--- a/brain-bar/Sources/BrainBar/BrainBarSettingsActions.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarSettingsActions.swift
@@ -1,9 +1,72 @@
 import AppKit
+#if BRAINBAR_UI
+import SwiftUI
+#endif
 
+@MainActor
 enum BrainBarSettingsActions {
-    @MainActor
+    private(set) static var suppressDashboardResignDismiss = false
+
+#if BRAINBAR_UI
+    private static var windowController: NSWindowController?
+    private static var closeObserver: NSObjectProtocol?
+
+    static func openSettingsWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let controller = windowController {
+            promoteForSettings()
+            controller.window?.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let hosting = NSHostingController(rootView: BrainBarSettingsView())
+        let window = NSWindow(contentViewController: hosting)
+        window.title = "BrainLayer Settings"
+        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.isReleasedWhenClosed = false
+        window.titlebarAppearsTransparent = false
+        window.level = .normal
+        window.center()
+
+        let controller = NSWindowController(window: window)
+        windowController = controller
+
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in demoteAfterSettings() }
+        }
+
+        promoteForSettings()
+        controller.showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private static func promoteForSettings() {
+        suppressDashboardResignDismiss = true
+        if NSApp.activationPolicy() != .regular {
+            NSApp.setActivationPolicy(.regular)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private static func demoteAfterSettings() {
+        suppressDashboardResignDismiss = false
+        if let closeObserver { NotificationCenter.default.removeObserver(closeObserver) }
+        closeObserver = nil
+        windowController = nil
+        NSApp.setActivationPolicy(.accessory)
+    }
+#else
+    // BrainBarDaemon target is headless and never opens Settings (the file is shared
+    // via symlink, but BrainBarSettingsView + its deps live only in the BrainBar target).
+    // Keep the original no-op so the daemon target compiles.
     static func openSettingsWindow() {
         NSApp.activate(ignoringOtherApps: true)
         NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
     }
+#endif
 }

--- a/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
@@ -24,6 +24,7 @@ final class BrainBarStatusPopoverController: NSObject {
         configureContextMenu()
         configureStatusItem()
         bindRuntime()
+        dashboardPanelController.statusItemButton = statusItemForTesting.button
     }
 
     func toggle(_ sender: Any?) {

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -103,14 +103,10 @@ struct BrainBarWindowRootView: View {
     @ViewBuilder
     private var dashboardContent: some View {
         if let collector = runtime.collector {
-            if collector.lastDataFetchedAt == nil {
-                BrainBarLoadingView(title: "BrainBar", subtitle: "Connecting to daemon and loading dashboard data...")
-            } else {
-                BrainBarDashboardView(
-                    collector: collector,
-                    hotkeyStatus: runtime.hotkeyStatus.statusLine
-                )
-            }
+            BrainBarDashboardContent(
+                collector: collector,
+                hotkeyStatus: runtime.hotkeyStatus.statusLine
+            )
         } else {
             BrainBarLoadingView(title: "BrainBar", subtitle: "Opening database and warming the dashboard...")
         }
@@ -161,6 +157,22 @@ struct BrainBarWindowRootView: View {
     }
 }
 
+private struct BrainBarDashboardContent: View {
+    @ObservedObject var collector: StatsCollector
+    let hotkeyStatus: String
+
+    var body: some View {
+        if collector.lastDataFetchedAt == nil {
+            BrainBarLoadingView(title: "BrainBar", subtitle: "Connecting to daemon and loading dashboard data...")
+        } else {
+            BrainBarDashboardView(
+                collector: collector,
+                hotkeyStatus: hotkeyStatus
+            )
+        }
+    }
+}
+
 @MainActor
 private final class BrainBarCommandBarViewModelProvider {
     private let panelState = QuickCapturePanelState()
@@ -193,31 +205,16 @@ private struct BrainBarWindowHeader: View {
 
     var body: some View {
         VStack(spacing: 10) {
-            ViewThatFits(in: .horizontal) {
-                HStack(alignment: .center, spacing: 16) {
-                    brand
-                    Spacer(minLength: 16)
-                    sectionPicker(maxWidth: 280)
-                    refreshControls
-                    BrainBarAppControlMenu()
-                    Spacer(minLength: 12)
-                    hotkeyLabel
-                }
-
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(alignment: .center, spacing: 12) {
-                        brand
-                        Spacer(minLength: 12)
-                        BrainBarAppControlMenu()
-                        hotkeyLabel
-                            .frame(maxWidth: 180, alignment: .trailing)
-                    }
-
-                    HStack(alignment: .center, spacing: 10) {
-                        sectionPicker(maxWidth: .infinity)
-                        refreshControls
-                    }
-                }
+            HStack(alignment: .center, spacing: 12) {
+                brand
+                Spacer(minLength: 12)
+                BrainBarAppControlMenu()
+                hotkeyLabel
+                    .frame(maxWidth: 200, alignment: .trailing)
+            }
+            HStack(alignment: .center, spacing: 10) {
+                sectionPicker(maxWidth: .infinity)
+                refreshControls
             }
 
             BrainBarCommandBar(viewModel: commandBarViewModel)
@@ -317,6 +314,7 @@ private struct BrainBarDashboardView: View {
     @ObservedObject var collector: StatsCollector
     let hotkeyStatus: String
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var previousWriteBuckets: [Int] = []
     @State private var previousEnrichmentBuckets: [Int] = []
     @State private var writePulseRevision = 0
@@ -324,26 +322,61 @@ private struct BrainBarDashboardView: View {
     @State private var detailsExpanded = false
     @State private var signalCoverageExpanded = false
     @State private var vectorSignalDetailExpanded = false
+    @State private var vectorSignalRowFrame: CGRect = .zero
+    @State private var vectorSignalRootFrame: CGRect = .zero
 
     private var flowSummary: DashboardFlowSummary {
         DashboardFlowSummary.derive(daemon: collector.daemon, stats: collector.stats)
+    }
+
+    private var vectorSignal: BrainBarSignalCoverage {
+        BrainBarSignalCoverage(
+            name: "Vector",
+            indexedCount: collector.stats.vectorIndexedChunkCount,
+            totalCount: collector.stats.signalEligibleChunkCount,
+            backlogCount: collector.stats.vectorBacklogCount,
+            coveragePercent: collector.stats.vectorCoveragePercent,
+            accentColor: .brainBarSignalVector,
+            showsDetail: true,
+            vectorNetDrainRatePerHour: collector.stats.vectorNetDrainRatePerHour,
+            vectorBacklogETAHours: collector.stats.vectorBacklogETAHours
+        )
     }
 
     var body: some View {
         GeometryReader { proxy in
             let layout = BrainBarDashboardLayout(containerSize: proxy.size)
 
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(alignment: .leading, spacing: layout.sectionSpacing) {
-                    overviewCard(layout: layout)
-                    freshnessLine
-                    pipelinePanel(layout: layout)
-                    diagnostics(layout: layout)
+            ZStack(alignment: .topLeading) {
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: layout.sectionSpacing) {
+                        overviewCard(layout: layout)
+                        freshnessLine
+                        pipelinePanel(layout: layout)
+                        diagnostics(layout: layout)
+                    }
+                    .padding(layout.outerPadding)
+                    .frame(maxWidth: layout.maxContentWidth, alignment: .topLeading)
+                    .frame(maxWidth: .infinity, alignment: .top)
                 }
-                .padding(layout.outerPadding)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .coordinateSpace(name: BrainBarVectorSignalCoordinateSpace.root)
+            .onPreferenceChange(BrainBarVectorSignalRootFrameKey.self) { frame in
+                vectorSignalRootFrame = frame
+            }
+            .overlay(alignment: .topLeading) {
+                if signalCoverageExpanded, vectorSignalDetailExpanded, vectorSignalRootFrame != .zero {
+                    BrainBarVectorSignalDetail(signal: vectorSignal, compact: layout.compactCards)
+                        .frame(width: vectorDetailWidth(layout: layout), alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .offset(x: vectorDetailXOffset(layout: layout), y: vectorDetailYOffset(layout: layout))
+                        .shadow(color: .brainBarBlack.opacity(0.55), radius: 22, y: 12)
+                        .shadow(color: .brainBarBlack.opacity(0.30), radius: 6, y: 2)
+                        .transition(vectorDetailTransition)
+                        .zIndex(vectorSignalDetailExpanded ? 30 : 0)
+                }
+            }
         }
         .onAppear {
             previousWriteBuckets = collector.stats.recentActivityBuckets
@@ -491,7 +524,6 @@ private struct BrainBarDashboardView: View {
             writesCard(layout: layout)
 
             signalCoveragePanel(layout: layout)
-                .padding(.top, max(0, 20 - layout.gridSpacing))
 
             if layout.chartColumns == 2 {
                 HStack(alignment: .top, spacing: layout.gridSpacing) {
@@ -511,6 +543,10 @@ private struct BrainBarDashboardView: View {
         .background(
             BrainBarGlassPanel(cornerRadius: layout.panelCornerRadius, tint: .brainBarAccent)
         )
+        .coordinateSpace(name: BrainBarVectorSignalCoordinateSpace.pipelinePanel)
+        .onPreferenceChange(BrainBarVectorSignalFrameKey.self) { frame in
+            vectorSignalRowFrame = frame
+        }
     }
 
     private func writesCard(layout: BrainBarDashboardLayout) -> some View {
@@ -560,6 +596,38 @@ private struct BrainBarDashboardView: View {
         )
     }
 
+    private func vectorDetailXOffset(layout: BrainBarDashboardLayout) -> CGFloat {
+        max(layout.outerPadding, vectorSignalRootFrame.minX)
+    }
+
+    private func vectorDetailYOffset(layout: BrainBarDashboardLayout) -> CGFloat {
+        vectorSignalRootFrame.maxY + (layout.compactCards ? 8 : 10)
+    }
+
+    private func vectorDetailWidth(layout: BrainBarDashboardLayout) -> CGFloat {
+        let measuredWidth = vectorSignalRootFrame == .zero ? vectorSignalRowFrame.width : vectorSignalRootFrame.width
+        return max(layout.compactCards ? 150 : 170, measuredWidth)
+    }
+
+    private var vectorDetailTransition: AnyTransition {
+        if reduceMotion {
+            .opacity
+        } else {
+            .asymmetric(
+            insertion: .opacity.combined(with: .modifier(
+                active: RevealClip(progress: 0),
+                identity: RevealClip(progress: 1)
+            )),
+            removal: .opacity
+                .combined(with: .modifier(
+                    active: RevealClip(progress: 0),
+                    identity: RevealClip(progress: 1)
+                ))
+                .combined(with: .offset(y: -6))
+            )
+        }
+    }
+
     @ViewBuilder
     private func diagnostics(layout: BrainBarDashboardLayout) -> some View {
         let flowCard = BrainBarDiagnosticCard(
@@ -573,7 +641,6 @@ private struct BrainBarDashboardView: View {
                     fromByteCount: collector.stats.databaseSizeBytes,
                     countStyle: .file
                 )),
-                ("Vector", vectorSummary),
             ],
             columns: layout.diagnosticItemColumns
         )
@@ -585,8 +652,6 @@ private struct BrainBarDashboardView: View {
                 ("Daemon", daemonSummary),
                 ("Agents", collector.agentActivity.summaryText),
                 ("State", collector.state.label),
-                ("FTS", ftsSummary),
-                ("Trigram", trigramSummary),
                 ("Last seen", daemonLastSeenSummary),
             ],
             columns: layout.diagnosticItemColumns
@@ -606,7 +671,6 @@ private struct BrainBarDashboardView: View {
                             runtimeCard
                         }
                     }
-                    BrainBarTrigramProgress(stats: collector.stats)
                 }
                 .padding(.top, 4)
             } label: {
@@ -645,57 +709,45 @@ private struct BrainBarDashboardView: View {
             activityWindowMinutes: collector.stats.activityWindowMinutes
         )
     }
+}
 
-    private var vectorSummary: String {
-        signalSummary(
-            indexedCount: collector.stats.vectorIndexedChunkCount,
-            backlogCount: collector.stats.vectorBacklogCount,
-            coveragePercent: collector.stats.vectorCoveragePercent
-        )
-    }
-
-    private var ftsSummary: String {
-        signalSummary(
-            indexedCount: collector.stats.ftsIndexedChunkCount,
-            backlogCount: collector.stats.ftsBacklogCount,
-            coveragePercent: collector.stats.ftsCoveragePercent
-        )
-    }
-
-    private var trigramSummary: String {
-        signalSummary(
-            indexedCount: collector.stats.trigramIndexedChunkCount,
-            backlogCount: collector.stats.trigramBacklogCount,
-            coveragePercent: collector.stats.trigramCoveragePercent
-        )
-    }
-
-    private func signalSummary(indexedCount: Int, backlogCount: Int, coveragePercent: Double) -> String {
-        "\(indexedCount)/\(collector.stats.signalEligibleChunkCount) · " +
-            String(format: "%.0f%%", coveragePercent) +
-            " · backlog \(backlogCount)"
+private struct RevealClip: ViewModifier, Animatable {
+    var progress: CGFloat          // 0 = collapsed, 1 = full height
+    nonisolated var animatableData: CGFloat { get { progress } set { progress = newValue } }
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .top)
+            .mask(alignment: .top) {
+                GeometryReader { geo in
+                    Color.black.frame(height: geo.size.height * max(0, min(progress, 1)), alignment: .top)
+                }
+            }
     }
 }
 
-private struct BrainBarTrigramProgress: View {
-    let stats: BrainDatabase.DashboardStats
+private enum BrainBarVectorSignalCoordinateSpace {
+    static let pipelinePanel = "BrainBarPipelinePanel"
+    static let root = "BrainBarRoot"
+}
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text("Trigram maintenance")
-                    .font(.system(size: 11, weight: .semibold))
-                Spacer(minLength: 8)
-                Text("\(stats.trigramIndexedChunkCount)/\(stats.signalEligibleChunkCount)")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-            }
-            BrainBarAnimatedCoverageBar(
-                percent: min(stats.trigramCoveragePercent, 100),
-                accentColor: .brainBarSignalTrigram
-            )
-            .frame(height: 6)
+private struct BrainBarVectorSignalFrameKey: PreferenceKey {
+    static let defaultValue: CGRect = .zero
+
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        let next = nextValue()
+        if next != .zero {
+            value = next
+        }
+    }
+}
+
+private struct BrainBarVectorSignalRootFrameKey: PreferenceKey {
+    static let defaultValue: CGRect = .zero
+
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        let next = nextValue()
+        if next != .zero {
+            value = next
         }
     }
 }
@@ -746,6 +798,12 @@ private struct BrainBarSignalCoveragePanel: View {
         ]
     }
 
+    private func setVectorDetail(_ open: Bool) {
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.25)) {
+            isVectorDetailExpanded = open
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 10 : 12) {
             Text("SIGNAL COVERAGE")
@@ -756,16 +814,16 @@ private struct BrainBarSignalCoveragePanel: View {
 
             if isExpanded {
                 signalBars
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .frame(maxWidth: .infinity, alignment: .top)
+                    .transition(.opacity)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .onAppear {
-            updateRevealedSignals(animated: false)
+        .onExitCommand {
+            if isVectorDetailExpanded { setVectorDetail(false) }
         }
-        .onChange(of: isExpanded) { _, _ in
-            updateRevealedSignals(animated: true)
-        }
+        .onAppear { updateRevealedSignals(animated: false) }
+        .onChange(of: isExpanded) { _, _ in updateRevealedSignals(animated: true) }
     }
 
     private var disclosureButton: some View {
@@ -818,30 +876,38 @@ private struct BrainBarSignalCoveragePanel: View {
         VStack(alignment: .leading, spacing: compact ? 8 : 10) {
             if signal.showsDetail {
                 Button {
-                    withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.25)) {
-                        isVectorDetailExpanded.toggle()
-                    }
+                    setVectorDetail(!isVectorDetailExpanded)
                 } label: {
                     BrainBarSignalCoverageRow(
                         signal: signal,
                         compact: compact,
                         isSelected: isVectorDetailExpanded
                     )
+                    .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.plain)
                 .help("Show Vector backlog details")
-
-                if isVectorDetailExpanded {
-                    BrainBarVectorSignalDetail(signal: signal, compact: compact)
-                        .transition(.opacity.combined(with: .move(edge: .top)))
-                }
             } else {
                 BrainBarSignalCoverageRow(signal: signal, compact: compact, isSelected: false)
             }
         }
         .frame(minWidth: compact ? 150 : 170, maxWidth: .infinity, alignment: .topLeading)
         .opacity(isExpanded ? (revealedSignalIDs.contains(signal.id) ? 1 : 0) : 1)
-        .offset(y: isExpanded && !revealedSignalIDs.contains(signal.id) ? 8 : 0)
+        .background {
+            if signal.showsDetail {
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(
+                            key: BrainBarVectorSignalFrameKey.self,
+                            value: proxy.frame(in: .named(BrainBarVectorSignalCoordinateSpace.pipelinePanel))
+                        )
+                        .preference(
+                            key: BrainBarVectorSignalRootFrameKey.self,
+                            value: proxy.frame(in: .named(BrainBarVectorSignalCoordinateSpace.root))
+                        )
+                }
+            }
+        }
     }
 
     private func updateRevealedSignals(animated: Bool) {
@@ -992,12 +1058,23 @@ private struct BrainBarVectorSignalDetail: View {
         .padding(.horizontal, compact ? 12 : 16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
-                .fill(signal.accentColor.opacity(0.08))
-                .overlay(
-                    RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
-                        .stroke(signal.accentColor.opacity(0.28), lineWidth: 1)
-                )
+            ZStack {
+                RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                    .fill(Color.brainBarBackgroundRaised)
+                RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                    .fill(signal.accentColor.opacity(0.10))
+                RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                    .stroke(
+                        LinearGradient(colors: [Color.brainBarWhite.opacity(0.08), .clear],
+                                       startPoint: .top, endPoint: .bottom),
+                        lineWidth: 1
+                    )
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                    .stroke(signal.accentColor.opacity(0.45), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous))
         )
     }
 
@@ -1087,14 +1164,17 @@ private struct BrainBarFlowLaneCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 10 : 12) {
             HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 3) {
                     Text(lane.name.uppercased())
-                        .font(.system(size: 11, weight: .semibold))
-                        .tracking(0.88)
+                        .font(.system(size: 10, weight: .semibold))
+                        .tracking(0.80)
                         .foregroundStyle(Color.brainBarTextSecondary.opacity(0.60))
-                    Text(lane.windowLabel)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.secondary)
+                    Text(lane.rateText)
+                        .font(.system(size: compact ? 22 : 26, weight: .bold))
+                        .monospacedDigit()
+                        .foregroundStyle(Color.brainBarTextPrimary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
                 }
                 Spacer(minLength: 12)
                 BrainBarFlowStatusPill(
@@ -1117,7 +1197,8 @@ private struct BrainBarFlowLaneCard: View {
                 tertiaryAccentColor: lane.tertiaryAccentColor,
                 activityWindowMinutes: lane.activityWindowMinutes,
                 fetchedAt: fetchedAt,
-                pulseRevision: pulseRevision
+                pulseRevision: pulseRevision,
+                referenceValue: sparklineReferenceValue
             )
             .frame(height: chartHeight)
 
@@ -1137,23 +1218,11 @@ private struct BrainBarFlowLaneCard: View {
                 )
             }
 
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 12) {
-                    BrainBarLaneMetric(label: "Rate", value: lane.rateText)
-                    BrainBarLaneMetric(label: "Volume", value: lane.volumeText)
-                    BrainBarLaneMetric(label: "Last event", value: lane.lastEventText)
-                    Spacer(minLength: 0)
-                }
-
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(spacing: 12) {
-                        BrainBarLaneMetric(label: "Rate", value: lane.rateText)
-                        BrainBarLaneMetric(label: "Volume", value: lane.volumeText)
-                        Spacer(minLength: 0)
-                    }
-                    BrainBarLaneMetric(label: "Last event", value: lane.lastEventText)
-                }
-            }
+            Text("\(lane.volumeText) · \(lane.lastEventText)")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color.brainBarTextSecondary.opacity(0.70))
+                .lineLimit(1)
+                .truncationMode(.tail)
 
             Text(lane.statusText)
                 .font(.system(size: 11, weight: .medium))
@@ -1164,6 +1233,33 @@ private struct BrainBarFlowLaneCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(compact ? 16 : 18)
         .background(BrainBarDashboardCardStyle(emphasized: emphasize))
+    }
+
+    private var sparklineReferenceValue: Int? {
+        guard lane.name.localizedCaseInsensitiveContains("enrichment") else { return nil }
+        return max(lane.values.max() ?? 0, lane.secondaryValues.max() ?? 0, lane.tertiaryValues.max() ?? 0, 1)
+    }
+}
+
+/// Test/preview seam: render the (private) number-first flow lane card for visual QA.
+@MainActor
+enum BrainBarFlowLaneCardPreview {
+    static func make(
+        lane: DashboardFlowLane,
+        compact: Bool = false,
+        chartHeight: CGFloat = 170,
+        fetchedAt: Date = Date()
+    ) -> AnyView {
+        AnyView(
+            BrainBarFlowLaneCard(
+                lane: lane,
+                pulseRevision: 0,
+                compact: compact,
+                chartHeight: chartHeight,
+                fetchedAt: fetchedAt,
+                emphasize: true
+            )
+        )
     }
 }
 
@@ -1345,28 +1441,30 @@ struct BrainBarDashboardLayout {
     let metricValueFontSize: CGFloat
     let sparklineHeight: CGFloat
     let panelCornerRadius: CGFloat
+    let maxContentWidth: CGFloat
 
     init(containerSize: CGSize) {
         let compactHeight = containerSize.height < 620
         let compactWidth = containerSize.width < 920
 
-        chartColumns = containerSize.width >= 1_200 ? 2 : 1
-        overviewMetricColumns = containerSize.width >= 980 ? 4 : 2
-        diagnosticColumns = containerSize.width >= 960 ? 2 : 1
-        diagnosticItemColumns = containerSize.width >= 820 ? 2 : 1
+        chartColumns = containerSize.width >= 1_040 ? 2 : 1
+        overviewMetricColumns = containerSize.width >= 900 ? 4 : 2
+        diagnosticColumns = containerSize.width >= 880 ? 2 : 1
+        diagnosticItemColumns = containerSize.width >= 760 ? 2 : 1
 
         compactCards = compactWidth || compactHeight
-        outerPadding = compactCards ? 28 : 48
-        sectionSpacing = compactCards ? 22 : 34
-        gridSpacing = compactCards ? 18 : 24
-        cardPadding = compactCards ? 28 : 44
+        outerPadding = compactCards ? 24 : 32
+        sectionSpacing = compactCards ? 20 : 28
+        gridSpacing = compactCards ? 16 : 22
+        cardPadding = compactCards ? 22 : 32
         overviewTitleFontSize = compactCards ? BrainBarDesignTokens.TypeScale.title : BrainBarDesignTokens.TypeScale.display
         overviewSubtitleFontSize = BrainBarDesignTokens.TypeScale.body
         overviewStatsWidth = compactCards ? 310 : 420
         metricCardMinHeight = compactCards ? 96 : 128
         metricValueFontSize = compactCards ? 48 : BrainBarDesignTokens.TypeScale.hero
-        sparklineHeight = compactCards ? 118 : 150
+        sparklineHeight = compactCards ? 140 : 170
         panelCornerRadius = BrainBarDesignTokens.Radius.xl
+        maxContentWidth = 1_280
     }
 }
 
@@ -1685,14 +1783,15 @@ private struct BrainBarDashboardCardStyle: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .stroke(Color.brainBarBorderSoft, lineWidth: 1)
+                    .strokeBorder(Color.brainBarBorderSoft, lineWidth: 1)
             )
             .overlay(alignment: .top) {
-                Rectangle()
+                Capsule(style: .continuous)
                     .fill(Color.brainBarWhite.opacity(0.06))
                     .frame(height: 1)
-                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                    .padding(.horizontal, max(10, cornerRadius * 0.70))
             }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .shadow(color: Color.brainBarBlack.opacity(0.30), radius: 8, y: 2)
     }
 }
@@ -1733,6 +1832,7 @@ private struct BrainBarHeroSparkline: View {
     let activityWindowMinutes: Int
     let fetchedAt: Date
     let pulseRevision: Int
+    let referenceValue: Int?
 
     var body: some View {
         GeometryReader { proxy in
@@ -1757,7 +1857,8 @@ private struct BrainBarHeroSparkline: View {
                 accentColor: accentColor,
                 secondaryAccentColor: secondaryAccentColor,
                 tertiaryAccentColor: tertiaryAccentColor,
-                compact: SparklineRenderer.isCompact(size: renderSize)
+                compact: SparklineRenderer.isCompact(size: renderSize),
+                referenceValue: referenceValue
             )
             .id(pulseRevision)
             .frame(width: proxy.size.width, height: proxy.size.height)

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -1241,7 +1241,9 @@ private struct BrainBarFlowLaneCard: View {
     }
 }
 
-/// Test/preview seam: render the (private) number-first flow lane card for visual QA.
+#if DEBUG
+/// Debug-only seam: render the (private) number-first flow lane card for visual QA.
+/// Never compiled into a release build.
 @MainActor
 enum BrainBarFlowLaneCardPreview {
     static func make(
@@ -1262,6 +1264,7 @@ enum BrainBarFlowLaneCardPreview {
         )
     }
 }
+#endif
 
 private struct BrainBarQueueRail: View {
     let summary: DashboardQueueSummary

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -1237,7 +1237,9 @@ private struct BrainBarFlowLaneCard: View {
 
     private var sparklineReferenceValue: Int? {
         guard lane.name.localizedCaseInsensitiveContains("enrichment") else { return nil }
-        return max(lane.values.max() ?? 0, lane.secondaryValues.max() ?? 0, lane.tertiaryValues.max() ?? 0, 1)
+        let peak = max(lane.values.max() ?? 0, lane.secondaryValues.max() ?? 0, lane.tertiaryValues.max() ?? 0)
+        // No benchmark line on a completely empty chart — it would imply a phantom target.
+        return peak > 0 ? peak : nil
     }
 }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/DashboardMetricFormatter.swift
@@ -7,6 +7,14 @@ enum DashboardMetricFormatter {
         return formatter
     }()
 
+    static func axisTickString(_ value: Int) -> String {
+        if value >= 1000 {
+            let thousands = Double(value) / 1000
+            return thousands >= 10 ? "\(Int(thousands.rounded()))k" : String(format: "%.1fk", thousands)
+        }
+        return "\(value)"
+    }
+
     private static let shortAbsoluteTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm"

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -394,7 +394,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
                 sparklineLabel: "Enrichment completions over \(windowLabel)",
                 latestBucketName: "latest enrichment bucket",
                 accentColor: enrichmentColor,
-                primarySeriesLabel: nil,
+                primarySeriesLabel: "Enrichments",
                 secondaryValues: [],
                 secondarySeriesLabel: nil,
                 secondaryAccentColor: nil,

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -119,7 +119,9 @@ struct SparklineChartPresentation: Equatable, Sendable {
     }
 
     var primaryLegendLabel: String {
-        primarySeriesLabel ?? "Primary"
+        if let primarySeriesLabel, !primarySeriesLabel.isEmpty { return primarySeriesLabel }
+        let trimmed = label.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? "Activity" : trimmed
     }
 
     var secondaryLegendLabel: String {
@@ -150,6 +152,34 @@ struct SparklineChartPresentation: Equatable, Sendable {
 
     var maxValue: Int {
         max(values.max() ?? 0, secondaryValues.max() ?? 0, tertiaryValues.max() ?? 0, 1)
+    }
+
+    var tightAxisMax: Int {
+        maxValue <= 5 ? max(maxValue, 1) : axisMax
+    }
+
+    /// Rounds the raw peak up to a glanceable 1/2/5 x 10^n tick so y-axis labels are round.
+    var axisMax: Int {
+        let raw = maxValue
+        guard raw > 1 else { return 1 }
+        let exponent = floor(log10(Double(raw)))
+        let base = pow(10, exponent)
+        let fraction = Double(raw) / base
+        let niceFraction: Double = fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10
+        return max(Int((niceFraction * base).rounded(.up)), 1)
+    }
+    /// Tick values bottom->top: always includes 0 (baseline) and axisMax (peak).
+    var yAxisTicks: [Int] {
+        let top = axisMax
+        if top <= 2 { return Array(0...top) }
+        let mid = Int((Double(top) / 2).rounded())
+        return Array(Set([0, mid, top])).sorted()
+    }
+
+    var tightYAxisTicks: [Int] {
+        let top = tightAxisMax
+        if top <= 2 { return Array(0...top) }
+        return Array(Set([0, Int(ceil(Double(top) / 2)), top])).sorted()
     }
 
     func points(for role: SparklineSeriesRole) -> [SparklineChartPoint] {
@@ -199,6 +229,16 @@ struct SparklineChartPresentation: Equatable, Sendable {
         return (1...2).contains(total)
     }
 
+    func nonZeroFraction(_ role: SparklineSeriesRole) -> Double {
+        let rolePoints = points(for: role)
+        guard !rolePoints.isEmpty else { return 0 }
+        return Double(rolePoints.filter { $0.value > 0 }.count) / Double(rolePoints.count)
+    }
+
+    func isDense(_ role: SparklineSeriesRole) -> Bool {
+        nonZeroFraction(role) >= 0.5
+    }
+
     var xAxisDomainStart: Date {
         fetchedAt.addingTimeInterval(-Double(max(activityWindowMinutes * 60, 1)))
     }
@@ -228,25 +268,6 @@ struct SparklineChartPresentation: Equatable, Sendable {
             return "last \(Self.durationLabel(seconds: olderSecondsAgo))"
         }
         return "\(Self.durationLabel(seconds: olderSecondsAgo))-\(Self.durationLabel(seconds: newerSecondsAgo)) ago"
-    }
-
-    func tooltipText(forBucket bucket: Int) -> String {
-        let clampedBucket = min(max(bucket, 0), max(values.count - 1, 0))
-        let primaryValue = values.indices.contains(clampedBucket) ? values[clampedBucket] : 0
-        guard hasMultipleSeries else {
-            return "\(bucketLabel(for: clampedBucket)) (\(relativeBucketLabel(for: clampedBucket))): \(primaryValue)"
-        }
-
-        var seriesComponents = ["\(primarySeriesLabel ?? "Primary") \(primaryValue)"]
-        if let secondarySeriesLabel, hasSecondarySeries {
-            let value = secondaryValues.indices.contains(clampedBucket) ? secondaryValues[clampedBucket] : 0
-            seriesComponents.append("\(secondarySeriesLabel) \(value)")
-        }
-        if let tertiarySeriesLabel, hasTertiarySeries {
-            let value = tertiaryValues.indices.contains(clampedBucket) ? tertiaryValues[clampedBucket] : 0
-            seriesComponents.append("\(tertiarySeriesLabel) \(value)")
-        }
-        return "\(bucketLabel(for: clampedBucket)) (\(relativeBucketLabel(for: clampedBucket))): \(seriesComponents.joined(separator: ", "))"
     }
 
     private func bucketRange(for bucket: Int) -> (start: Date, end: Date) {
@@ -295,29 +316,44 @@ struct SparklineChartPresentation: Equatable, Sendable {
     }
 }
 
+enum SparklineSmoothing {
+    case linear
+    case monotone
+    case catmullRom
+}
+
 struct SparklineChart: View {
     let presentation: SparklineChartPresentation
     let accentColor: NSColor
     let secondaryAccentColor: NSColor?
     let tertiaryAccentColor: NSColor?
     let compact: Bool
+    let referenceValue: Int?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var hoveredBucket: Int?
     @State private var hoverLocation: CGPoint?
-    @State private var lineRevealProgress: CGFloat = 1
 
     init(
         presentation: SparklineChartPresentation,
         accentColor: NSColor,
         secondaryAccentColor: NSColor? = nil,
         tertiaryAccentColor: NSColor? = nil,
-        compact: Bool = false
+        compact: Bool = false,
+        referenceValue: Int? = nil,
+        previewHoveredBucket: Int? = nil,
+        previewHoverX: CGFloat? = nil
     ) {
         self.presentation = presentation
         self.accentColor = accentColor
         self.secondaryAccentColor = secondaryAccentColor
         self.tertiaryAccentColor = tertiaryAccentColor
         self.compact = compact
+        self.referenceValue = referenceValue
+        // Test/preview seam: render a fixed hover state without a live cursor.
+        _hoveredBucket = State(initialValue: previewHoveredBucket)
+        if previewHoveredBucket != nil {
+            _hoverLocation = State(initialValue: CGPoint(x: previewHoverX ?? 0, y: 0))
+        }
     }
 
     var body: some View {
@@ -346,51 +382,150 @@ struct SparklineChart: View {
                 }
                 .frame(height: 12)
                 .padding(.horizontal, 16)
+                .opacity(hoveredBucket == nil ? 0 : 1)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.15), value: hoveredBucket)
             }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(presentation.accessibilityLabel))
         .accessibilityValue(Text(presentation.accessibilityValue))
-        .onAppear {
-            if reduceMotion {
-                lineRevealProgress = 1
-            } else {
-                lineRevealProgress = 0
-                withAnimation(.easeOut(duration: 0.6)) {
-                    lineRevealProgress = 1
-                }
-            }
-        }
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: presentation)
     }
 
     private var chartBody: some View {
         GeometryReader { geometry in
             let plotFrame = plotFrame(in: geometry.size)
+            let isHovering = hoveredBucket != nil
 
             ZStack(alignment: .topLeading) {
+                if !compact {
+                    ForEach(presentation.tightYAxisTicks, id: \.self) { tick in
+                        let y = yPosition(forValue: tick, in: plotFrame)
+                        if tick == 0 || isHovering {
+                            Path { p in
+                                p.move(to: CGPoint(x: plotFrame.minX, y: y))
+                                p.addLine(to: CGPoint(x: plotFrame.maxX, y: y))
+                            }
+                            .stroke(
+                                Color.brainBarBorderSoft.opacity(tick == 0 ? 0.55 : 0.22),
+                                style: StrokeStyle(lineWidth: tick == 0 ? 1 : 0.75,
+                                                   dash: tick == 0 ? [] : [2, 3])
+                            )
+                            .transition(.opacity)
+
+                            if tick != 0 {
+                                Text(DashboardMetricFormatter.axisTickString(tick))
+                                    .font(.system(size: 9, weight: .medium))
+                                    .monospacedDigit()
+                                    .foregroundStyle(Color.brainBarTextMuted)
+                                    .frame(width: yAxisGutter - 4, alignment: .trailing)
+                                    .position(x: (yAxisGutter - 4) / 2, y: y)
+                                    .transition(.opacity)
+                            }
+                        }
+                    }
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.15), value: hoveredBucket)
+                }
+
+                ForEach(SparklineSeriesRole.allCases, id: \.self) { role in
+                    if !compact, presentation.shouldPlotSeries(role) {
+                        SparklineSeriesAreaShape(
+                            points: presentation.points(for: role),
+                            maxValue: plotMax,
+                            plotFrame: plotFrame,
+                            baselineY: baselineY(for: role, in: plotFrame),
+                            smoothing: smoothing(for: role)
+                        )
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    color(for: role).opacity(role == .primary ? 0.34 : 0.16),
+                                    color(for: role).opacity(0.0),
+                                ],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                    }
+                }
+
+                if !compact, let referenceValue {
+                    let clampedReference = min(max(referenceValue, 0), plotMax)
+                    let y = yPosition(forValue: clampedReference, in: plotFrame)
+                    Path { p in
+                        p.move(to: CGPoint(x: plotFrame.minX, y: y))
+                        p.addLine(to: CGPoint(x: plotFrame.maxX, y: y))
+                    }
+                    .stroke(
+                        color(for: .primary).opacity(0.4),
+                        style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [4, 4])
+                    )
+                }
+
+                if let hoveredBucket, !compact, !presentation.points.isEmpty {
+                    let clampedBucket = min(max(hoveredBucket, 0), presentation.values.count - 1)
+                    let anchorPoint = point(
+                        for: presentation.points[clampedBucket],
+                        bucketCount: presentation.points.count,
+                        in: plotFrame
+                    )
+                    Path { p in
+                        p.move(to: CGPoint(x: anchorPoint.x, y: plotFrame.minY))
+                        p.addLine(to: CGPoint(x: anchorPoint.x, y: plotFrame.maxY))
+                    }
+                    .stroke(
+                        color(for: .primary).opacity(0.3),
+                        style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [3, 3])
+                    )
+                }
+
                 ForEach(SparklineSeriesRole.allCases, id: \.self) { role in
                     if presentation.shouldPlotSeries(role) {
                         SparklineSeriesPathShape(
                             points: presentation.points(for: role),
-                            maxValue: presentation.maxValue,
-                            plotFrame: plotFrame
+                            maxValue: plotMax,
+                            plotFrame: plotFrame,
+                            smoothing: smoothing(for: role)
                         )
                         .stroke(color(for: role), style: lineStyle(for: role))
+                        .shadow(
+                            color: !compact && role == .primary ? color(for: role).opacity(0.25) : .clear,
+                            radius: !compact && role == .primary ? 4 : 0,
+                            y: !compact && role == .primary ? 1 : 0
+                        )
 
-                        ForEach(visiblePointMarkers(for: role)) { point in
-                            Circle()
-                                .fill(color(for: role))
-                                .frame(width: compact ? 4.4 : 9, height: compact ? 4.4 : 9)
-                                .position(
-                                    self.point(
-                                        for: point,
-                                        bucketCount: presentation.points(for: role).count,
-                                        in: plotFrame
+                        if compact {
+                            ForEach(visiblePointMarkers(for: role)) { point in
+                                Circle()
+                                    .fill(color(for: role))
+                                    .frame(width: 4.4, height: 4.4)
+                                    .position(
+                                        self.point(
+                                            for: point,
+                                            bucketCount: presentation.points(for: role).count,
+                                            in: plotFrame
+                                        )
                                     )
-                                )
+                            }
                         }
                     }
+                }
+
+                if let hoveredBucket, !compact, !presentation.points.isEmpty {
+                    let clampedBucket = min(max(hoveredBucket, 0), presentation.values.count - 1)
+                    let anchorPoint = point(
+                        for: presentation.points[clampedBucket],
+                        bucketCount: presentation.points.count,
+                        in: plotFrame
+                    )
+                    Circle()
+                        .fill(color(for: .primary))
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.brainBarBackgroundRaised, lineWidth: 1.5)
+                        )
+                        .position(anchorPoint)
                 }
 
                 Rectangle()
@@ -409,14 +544,25 @@ struct SparklineChart: View {
 
                 if let hoveredBucket,
                    let hoverLocation,
-                   !compact {
-                    let tooltipSize = SparklineTooltipPlacement.tooltipSize(in: geometry.size)
-                    sparklineTooltip(forBucket: hoveredBucket)
-                        .frame(width: tooltipSize.width, alignment: .leading)
+                   !compact,
+                   !presentation.points.isEmpty {
+                    let clampedBucket = min(max(hoveredBucket, 0), max(presentation.values.count - 1, 0))
+                    let anchorPoint = point(
+                        for: presentation.points[clampedBucket],
+                        bucketCount: presentation.points.count,
+                        in: plotFrame
+                    )
+                    let tooltipSize = SparklineTooltipPlacement.tooltipSize(
+                        in: geometry.size,
+                        seriesCount: tooltipRows(forBucket: clampedBucket).count
+                    )
+                    sparklineTooltip(forBucket: clampedBucket, size: tooltipSize)
                         .position(
                             SparklineTooltipPlacement.position(
-                                near: hoverLocation,
-                                in: geometry.size,
+                                near: CGPoint(x: hoverLocation.x, y: anchorPoint.y),
+                                anchorY: anchorPoint.y,
+                                hoveredX: anchorPoint.x,
+                                containerBounds: geometry.size,
                                 tooltipSize: tooltipSize
                             )
                         )
@@ -442,16 +588,34 @@ struct SparklineChart: View {
         } else {
             x = plotFrame.minX + CGFloat(point.bucket) * (plotFrame.width / CGFloat(bucketCount - 1))
         }
-        let normalizedValue = CGFloat(point.value) / CGFloat(max(presentation.maxValue, 1))
+        let normalizedValue = CGFloat(point.value) / CGFloat(max(plotMax, 1))
         return CGPoint(x: x, y: plotFrame.maxY - (normalizedValue * plotFrame.height))
+    }
+
+    private func yPosition(forValue value: Int, in plotFrame: CGRect) -> CGFloat {
+        let normalized = CGFloat(value) / CGFloat(max(plotMax, 1))
+        return plotFrame.maxY - normalized * plotFrame.height
+    }
+
+    private var yAxisGutter: CGFloat { compact ? 0 : 30 }
+    private var plotMax: Int { compact ? presentation.maxValue : presentation.tightAxisMax }
+
+    private func smoothing(for role: SparklineSeriesRole) -> SparklineSmoothing {
+        guard !compact else { return .linear }
+        return presentation.isDense(role) ? .catmullRom : .monotone
+    }
+
+    private func baselineY(for role: SparklineSeriesRole, in plotFrame: CGRect) -> CGFloat {
+        presentation.isDense(role) ? plotFrame.maxY : plotFrame.maxY - plotFrame.height * 0.10
     }
 
     private func plotFrame(in size: CGSize) -> CGRect {
         let inset: CGFloat = compact ? 2 : 10
+        let leftInset = inset + yAxisGutter
         return CGRect(
-            x: inset,
+            x: leftInset,
             y: inset,
-            width: max(size.width - inset * 2, 1),
+            width: max(size.width - leftInset - inset, 1),
             height: max(size.height - inset * 2, 1)
         )
     }
@@ -542,22 +706,76 @@ struct SparklineChart: View {
         }
     }
 
+    private func tooltipRows(forBucket bucket: Int) -> [(role: SparklineSeriesRole, label: String, value: Int)] {
+        return SparklineSeriesRole.allCases.compactMap { role in
+            guard presentation.shouldPlotSeries(role),
+                  let label = presentation.label(for: role) else { return nil }
+            let series: [Int]
+            switch role {
+            case .primary:   series = presentation.values
+            case .secondary: series = presentation.secondaryValues
+            case .tertiary:  series = presentation.tertiaryValues
+            }
+            let value = series.indices.contains(bucket) ? series[bucket] : 0
+            return (role, label, value)
+        }
+    }
+
     @ViewBuilder
-    private func sparklineTooltip(forBucket bucket: Int) -> some View {
-        Text(presentation.tooltipText(forBucket: bucket))
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(.primary)
-            .lineLimit(2)
-            .truncationMode(.tail)
+    private func sparklineTooltip(forBucket bucket: Int, size: CGSize) -> some View {
+        let rows = tooltipRows(forBucket: bucket)
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(presentation.bucketLabel(for: bucket))
+                    .font(.system(size: 11, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(Color.brainBarTextPrimary)
+                Text(presentation.relativeBucketLabel(for: bucket))
+                    .font(.system(size: 9.5, weight: .medium))
+                    .foregroundStyle(Color.brainBarTextSecondary.opacity(0.70))
+            }
+            .lineLimit(1)
             .fixedSize(horizontal: false, vertical: true)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(Color.brainBar(nsColor: accentColor).opacity(0.35), lineWidth: 1)
-            )
-            .shadow(color: .black.opacity(0.14), radius: 8, y: 3)
+
+            if !rows.isEmpty {
+                Rectangle()
+                    .fill(Color.brainBarBorderSoft)
+                    .frame(height: 1)
+                    .padding(.horizontal, 2)
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(rows, id: \.role) { row in
+                        HStack(spacing: 6) {
+                            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                                .fill(color(for: row.role))
+                                .frame(width: 7, height: 7)
+                            Text(row.label)
+                                .font(.system(size: 10.5, weight: .medium))
+                                .foregroundStyle(Color.brainBarTextSecondary)
+                                .lineLimit(1).truncationMode(.tail)
+                            Spacer(minLength: 8)
+                            Text("\(row.value)")
+                                .font(.system(size: 11, weight: .semibold))
+                                .monospacedDigit()
+                                .foregroundStyle(Color.brainBarTextPrimary)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(width: size.width, height: size.height, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Color.brainBarBackgroundRaised)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .strokeBorder(Color.brainBar(nsColor: accentColor).opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.28), radius: 9, y: 3)
+        .accessibilityHidden(true)
     }
 }
 
@@ -565,29 +783,193 @@ private struct SparklineSeriesPathShape: Shape {
     let points: [SparklineChartPoint]
     let maxValue: Int
     let plotFrame: CGRect
+    let smoothing: SparklineSmoothing
 
     func path(in rect: CGRect) -> Path {
+        SparklineSeriesPathBuilder.topPath(
+            for: points,
+            maxValue: maxValue,
+            plotFrame: plotFrame,
+            smoothing: smoothing
+        )
+    }
+}
+
+private struct SparklineSeriesAreaShape: Shape {
+    let points: [SparklineChartPoint]
+    let maxValue: Int
+    let plotFrame: CGRect
+    let baselineY: CGFloat
+    let smoothing: SparklineSmoothing
+
+    func path(in rect: CGRect) -> Path {
+        let renderedPoints = SparklineSeriesPathBuilder.renderedPoints(
+            for: points,
+            maxValue: maxValue,
+            plotFrame: plotFrame
+        )
+        guard let first = renderedPoints.first, let last = renderedPoints.last else {
+            return Path()
+        }
+
+        var path = SparklineSeriesPathBuilder.topPath(
+            for: renderedPoints,
+            plotFrame: plotFrame,
+            smoothing: smoothing
+        )
+        let clampedBaseline = min(max(baselineY, plotFrame.minY), plotFrame.maxY)
+        path.addLine(to: CGPoint(x: last.x, y: clampedBaseline))
+        path.addLine(to: CGPoint(x: first.x, y: clampedBaseline))
+        path.closeSubpath()
+        return path
+    }
+}
+
+private enum SparklineSeriesPathBuilder {
+    static func topPath(
+        for points: [SparklineChartPoint],
+        maxValue: Int,
+        plotFrame: CGRect,
+        smoothing: SparklineSmoothing
+    ) -> Path {
+        topPath(
+            for: renderedPoints(for: points, maxValue: maxValue, plotFrame: plotFrame),
+            plotFrame: plotFrame,
+            smoothing: smoothing
+        )
+    }
+
+    static func renderedPoints(
+        for points: [SparklineChartPoint],
+        maxValue: Int,
+        plotFrame: CGRect
+    ) -> [CGPoint] {
+        points.map { point in
+            let x: CGFloat
+            if points.count <= 1 {
+                x = plotFrame.midX
+            } else {
+                x = plotFrame.minX + CGFloat(point.bucket) * (plotFrame.width / CGFloat(points.count - 1))
+            }
+            let normalizedValue = CGFloat(point.value) / CGFloat(max(maxValue, 1))
+            return CGPoint(x: x, y: plotFrame.maxY - (normalizedValue * plotFrame.height))
+        }
+    }
+
+    static func topPath(
+        for renderedPoints: [CGPoint],
+        plotFrame: CGRect,
+        smoothing: SparklineSmoothing
+    ) -> Path {
+        guard let first = renderedPoints.first else { return Path() }
+        guard renderedPoints.count > 1 else {
+            var path = Path()
+            path.move(to: first)
+            return path
+        }
+
+        switch smoothing {
+        case .linear:
+            return linearPath(for: renderedPoints)
+        case .monotone:
+            return monotonePath(for: renderedPoints, plotFrame: plotFrame)
+        case .catmullRom:
+            return catmullRomPath(for: renderedPoints, plotFrame: plotFrame)
+        }
+    }
+
+    private static func linearPath(for points: [CGPoint]) -> Path {
         var path = Path()
         for (index, point) in points.enumerated() {
-            let renderedPoint = renderedPoint(for: point, bucketCount: points.count)
             if index == 0 {
-                path.move(to: renderedPoint)
+                path.move(to: point)
             } else {
-                path.addLine(to: renderedPoint)
+                path.addLine(to: point)
             }
         }
         return path
     }
 
-    private func renderedPoint(for point: SparklineChartPoint, bucketCount: Int) -> CGPoint {
-        let x: CGFloat
-        if bucketCount <= 1 {
-            x = plotFrame.midX
-        } else {
-            x = plotFrame.minX + CGFloat(point.bucket) * (plotFrame.width / CGFloat(bucketCount - 1))
+    private static func monotonePath(for points: [CGPoint], plotFrame: CGRect) -> Path {
+        let count = points.count
+        var secants = Array(repeating: CGFloat.zero, count: count - 1)
+        for index in 0..<(count - 1) {
+            let dx = points[index + 1].x - points[index].x
+            secants[index] = dx == 0 ? 0 : (points[index + 1].y - points[index].y) / dx
         }
-        let normalizedValue = CGFloat(point.value) / CGFloat(max(maxValue, 1))
-        return CGPoint(x: x, y: plotFrame.maxY - (normalizedValue * plotFrame.height))
+
+        var tangents = Array(repeating: CGFloat.zero, count: count)
+        tangents[0] = secants[0]
+        tangents[count - 1] = secants[count - 2]
+        if count > 2 {
+            for index in 1..<(count - 1) {
+                let previous = secants[index - 1]
+                let next = secants[index]
+                if previous == 0 || next == 0 || (previous > 0) != (next > 0) {
+                    tangents[index] = 0
+                } else {
+                    tangents[index] = (previous + next) / 2
+                }
+            }
+        }
+
+        for index in 0..<(count - 1) {
+            let secant = secants[index]
+            guard secant != 0 else {
+                tangents[index] = 0
+                tangents[index + 1] = 0
+                continue
+            }
+            let alpha = tangents[index] / secant
+            let beta = tangents[index + 1] / secant
+            let magnitude = alpha * alpha + beta * beta
+            if magnitude > 9 {
+                let scale = 3 / sqrt(magnitude)
+                tangents[index] = scale * alpha * secant
+                tangents[index + 1] = scale * beta * secant
+            }
+        }
+
+        var path = Path()
+        path.move(to: points[0])
+        for index in 0..<(count - 1) {
+            let dx = points[index + 1].x - points[index].x
+            let control1 = CGPoint(
+                x: points[index].x + dx / 3,
+                y: clampY(points[index].y + tangents[index] * dx / 3, in: plotFrame)
+            )
+            let control2 = CGPoint(
+                x: points[index + 1].x - dx / 3,
+                y: clampY(points[index + 1].y - tangents[index + 1] * dx / 3, in: plotFrame)
+            )
+            path.addCurve(to: points[index + 1], control1: control1, control2: control2)
+        }
+        return path
+    }
+
+    private static func catmullRomPath(for points: [CGPoint], plotFrame: CGRect) -> Path {
+        var path = Path()
+        path.move(to: points[0])
+        for index in 0..<(points.count - 1) {
+            let p0 = points[max(index - 1, 0)]
+            let p1 = points[index]
+            let p2 = points[index + 1]
+            let p3 = points[min(index + 2, points.count - 1)]
+            let control1 = CGPoint(
+                x: p1.x + (p2.x - p0.x) / 6,
+                y: clampY(p1.y + (p2.y - p0.y) / 6, in: plotFrame)
+            )
+            let control2 = CGPoint(
+                x: p2.x - (p3.x - p1.x) / 6,
+                y: clampY(p2.y - (p3.y - p1.y) / 6, in: plotFrame)
+            )
+            path.addCurve(to: p2, control1: control1, control2: control2)
+        }
+        return path
+    }
+
+    private static func clampY(_ y: CGFloat, in plotFrame: CGRect) -> CGFloat {
+        min(max(y, plotFrame.minY), plotFrame.maxY)
     }
 }
 
@@ -595,36 +977,61 @@ enum SparklineTooltipPlacement {
     private static let margin: CGFloat = 8
     private static let preferredWidth: CGFloat = 260
     private static let minimumWidth: CGFloat = 112
-    private static let estimatedHeight: CGFloat = 44
     private static let cursorGap: CGFloat = 12
+    // Structured-card metrics = the PINNED card height (matches sparklineTooltip's paddings/spacing).
+    private static let verticalPadding: CGFloat = 9
+    private static let headerHeight: CGFloat = 24
+    private static let dividerBlock: CGFloat = 14
+    private static let rowHeight: CGFloat = 16
 
-    static func tooltipSize(in containerSize: CGSize) -> CGSize {
+    static func tooltipSize(in containerSize: CGSize, seriesCount: Int = 1) -> CGSize {
         let availableWidth = max(containerSize.width - margin * 2, minimumWidth)
-        return CGSize(
-            width: min(preferredWidth, availableWidth),
-            height: estimatedHeight
-        )
+        let rows = max(seriesCount, 0)
+        let rowsBlock = rows > 0 ? dividerBlock + CGFloat(rows) * rowHeight : 0
+        let height = verticalPadding * 2 + headerHeight + rowsBlock
+        let availableHeight = max(containerSize.height - margin * 2, height)
+        return CGSize(width: min(preferredWidth, availableWidth),
+                      height: min(height, availableHeight))
     }
 
     static func position(
         near location: CGPoint,
-        in containerSize: CGSize,
+        anchorY: CGFloat,
+        hoveredX: CGFloat,
+        containerBounds: CGSize,
         tooltipSize: CGSize
     ) -> CGPoint {
         let halfWidth = tooltipSize.width / 2
         let halfHeight = tooltipSize.height / 2
         let minX = margin + halfWidth
-        let maxX = max(containerSize.width - margin - halfWidth, minX)
+        let maxX = max(containerBounds.width - margin - halfWidth, minX)
         let x = min(max(location.x, minX), maxX)
-
-        let yAbove = location.y - cursorGap - halfHeight
-        let yBelow = location.y + cursorGap + halfHeight
         let minY = margin + halfHeight
-        let maxY = max(containerSize.height - margin - halfHeight, minY)
-        let preferredY = yAbove >= minY ? yAbove : yBelow
-        let y = min(max(preferredY, minY), maxY)
+        let maxY = max(containerBounds.height - margin - halfHeight, minY)
 
-        return CGPoint(x: x, y: y)
+        let yAbove = anchorY - cursorGap - halfHeight
+        if yAbove >= minY {
+            return CGPoint(x: x, y: yAbove)
+        }
+
+        let yBelow = anchorY + cursorGap + halfHeight
+        if yBelow <= maxY {
+            return CGPoint(x: x, y: yBelow)
+        }
+
+        let rightX = hoveredX + halfWidth + cursorGap
+        let leftX = hoveredX - halfWidth - cursorGap
+        let sideX: CGFloat
+        if rightX >= minX, rightX <= maxX {
+            sideX = rightX
+        } else if leftX >= minX, leftX <= maxX {
+            sideX = leftX
+        } else {
+            sideX = x
+        }
+        let y = min(max(anchorY, minY), maxY)
+
+        return CGPoint(x: sideX, y: y)
     }
 }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -339,9 +339,7 @@ struct SparklineChart: View {
         secondaryAccentColor: NSColor? = nil,
         tertiaryAccentColor: NSColor? = nil,
         compact: Bool = false,
-        referenceValue: Int? = nil,
-        previewHoveredBucket: Int? = nil,
-        previewHoverX: CGFloat? = nil
+        referenceValue: Int? = nil
     ) {
         self.presentation = presentation
         self.accentColor = accentColor
@@ -349,12 +347,33 @@ struct SparklineChart: View {
         self.tertiaryAccentColor = tertiaryAccentColor
         self.compact = compact
         self.referenceValue = referenceValue
-        // Test/preview seam: render a fixed hover state without a live cursor.
+    }
+
+#if DEBUG
+    /// Debug-only seam: render a fixed hover state (dot + crosshair + tooltip) without
+    /// a live cursor, for snapshot/visual QA. Never compiled into a release build.
+    init(
+        presentation: SparklineChartPresentation,
+        accentColor: NSColor,
+        secondaryAccentColor: NSColor? = nil,
+        tertiaryAccentColor: NSColor? = nil,
+        compact: Bool = false,
+        referenceValue: Int? = nil,
+        previewHoveredBucket: Int?,
+        previewHoverX: CGFloat
+    ) {
+        self.presentation = presentation
+        self.accentColor = accentColor
+        self.secondaryAccentColor = secondaryAccentColor
+        self.tertiaryAccentColor = tertiaryAccentColor
+        self.compact = compact
+        self.referenceValue = referenceValue
         _hoveredBucket = State(initialValue: previewHoveredBucket)
         if previewHoveredBucket != nil {
-            _hoverLocation = State(initialValue: CGPoint(x: previewHoverX ?? 0, y: 0))
+            _hoverLocation = State(initialValue: CGPoint(x: previewHoverX, y: 0))
         }
     }
+#endif
 
     var body: some View {
         VStack(spacing: 2) {
@@ -1027,7 +1046,11 @@ enum SparklineTooltipPlacement {
         } else if leftX >= minX, leftX <= maxX {
             sideX = leftX
         } else {
-            sideX = x
+            // No clean side fits at the anchor column — pin to whichever edge has
+            // more room so the card still clears the on-curve dot instead of
+            // landing on the anchor column and overlapping the curve (a top-edge
+            // spike in a narrow / tall-tooltip container).
+            sideX = (hoveredX - minX) >= (maxX - hoveredX) ? minX : maxX
         }
         let y = min(max(anchorY, minY), maxY)
 

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -322,6 +322,31 @@ enum SparklineSmoothing {
     case catmullRom
 }
 
+/// Picks which plotted series the hover indicator rides. Pure + testable.
+enum SparklineHoverAnchor {
+    /// Among the plotted series, return the one with the highest value at the hovered
+    /// bucket; ties keep declaration order (primary first). Falls back to the first
+    /// plotted series, then `.primary` when nothing is plotted — so the dot, crosshair,
+    /// and tooltip never anchor to an empty baseline on a multi-series chart where only
+    /// a secondary/tertiary lane has data.
+    static func dominantRole(
+        plotted: [SparklineSeriesRole],
+        valueAtBucket: [SparklineSeriesRole: Int]
+    ) -> SparklineSeriesRole {
+        guard let first = plotted.first else { return .primary }
+        var best = first
+        var bestValue = valueAtBucket[first] ?? 0
+        for role in plotted.dropFirst() {
+            let value = valueAtBucket[role] ?? 0
+            if value > bestValue {
+                best = role
+                bestValue = value
+            }
+        }
+        return best
+    }
+}
+
 struct SparklineChart: View {
     let presentation: SparklineChartPresentation
     let accentColor: NSColor
@@ -483,17 +508,14 @@ struct SparklineChart: View {
 
                 if let hoveredBucket, !compact, !presentation.points.isEmpty {
                     let clampedBucket = min(max(hoveredBucket, 0), presentation.values.count - 1)
-                    let anchorPoint = point(
-                        for: presentation.points[clampedBucket],
-                        bucketCount: presentation.points.count,
-                        in: plotFrame
-                    )
+                    let anchorRole = hoverAnchorRole(forBucket: clampedBucket)
+                    let anchorPoint = hoverAnchorPoint(forBucket: clampedBucket, in: plotFrame)
                     Path { p in
                         p.move(to: CGPoint(x: anchorPoint.x, y: plotFrame.minY))
                         p.addLine(to: CGPoint(x: anchorPoint.x, y: plotFrame.maxY))
                     }
                     .stroke(
-                        color(for: .primary).opacity(0.3),
+                        color(for: anchorRole).opacity(0.3),
                         style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [3, 3])
                     )
                 }
@@ -532,13 +554,10 @@ struct SparklineChart: View {
 
                 if let hoveredBucket, !compact, !presentation.points.isEmpty {
                     let clampedBucket = min(max(hoveredBucket, 0), presentation.values.count - 1)
-                    let anchorPoint = point(
-                        for: presentation.points[clampedBucket],
-                        bucketCount: presentation.points.count,
-                        in: plotFrame
-                    )
+                    let anchorRole = hoverAnchorRole(forBucket: clampedBucket)
+                    let anchorPoint = hoverAnchorPoint(forBucket: clampedBucket, in: plotFrame)
                     Circle()
-                        .fill(color(for: .primary))
+                        .fill(color(for: anchorRole))
                         .frame(width: 8, height: 8)
                         .overlay(
                             Circle()
@@ -566,11 +585,7 @@ struct SparklineChart: View {
                    !compact,
                    !presentation.points.isEmpty {
                     let clampedBucket = min(max(hoveredBucket, 0), max(presentation.values.count - 1, 0))
-                    let anchorPoint = point(
-                        for: presentation.points[clampedBucket],
-                        bucketCount: presentation.points.count,
-                        in: plotFrame
-                    )
+                    let anchorPoint = hoverAnchorPoint(forBucket: clampedBucket, in: plotFrame)
                     let tooltipSize = SparklineTooltipPlacement.tooltipSize(
                         in: geometry.size,
                         seriesCount: tooltipRows(forBucket: clampedBucket).count
@@ -609,6 +624,29 @@ struct SparklineChart: View {
         }
         let normalizedValue = CGFloat(point.value) / CGFloat(max(plotMax, 1))
         return CGPoint(x: x, y: plotFrame.maxY - (normalizedValue * plotFrame.height))
+    }
+
+    /// The plotted series the hover indicator should ride at the given bucket (the
+    /// visible spike may be on a secondary/tertiary lane, not the primary).
+    private func hoverAnchorRole(forBucket bucket: Int) -> SparklineSeriesRole {
+        let plotted = SparklineSeriesRole.allCases.filter { presentation.shouldPlotSeries($0) }
+        let values = Dictionary(uniqueKeysWithValues: plotted.map { role -> (SparklineSeriesRole, Int) in
+            let pts = presentation.points(for: role)
+            return (role, pts.indices.contains(bucket) ? pts[bucket].value : 0)
+        })
+        return SparklineHoverAnchor.dominantRole(plotted: plotted, valueAtBucket: values)
+    }
+
+    /// On-curve anchor point (x = bucket position, y = dominant plotted series' value
+    /// at that bucket) for the crosshair, ring dot, and tooltip vertical placement.
+    private func hoverAnchorPoint(forBucket bucket: Int, in plotFrame: CGRect) -> CGPoint {
+        let role = hoverAnchorRole(forBucket: bucket)
+        let pts = presentation.points(for: role)
+        let clamped = min(max(bucket, 0), max(pts.count - 1, 0))
+        guard pts.indices.contains(clamped) else {
+            return CGPoint(x: plotFrame.midX, y: plotFrame.maxY)
+        }
+        return point(for: pts[clamped], bucketCount: pts.count, in: plotFrame)
     }
 
     private func yPosition(forValue value: Int, in plotFrame: CGRect) -> CGFloat {

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -322,6 +322,17 @@ enum SparklineSmoothing {
     case catmullRom
 }
 
+/// Decides the area-fill floor for a series. Pure + testable.
+enum SparklineBaseline {
+    /// Sparse series with at least one nonzero bucket get a lifted soft floor so their
+    /// runs of zeros read as a designed band around the spike. Dense series fill to the
+    /// true zero baseline, and a series with NO data at all also stays on the true
+    /// baseline so it never implies a phantom band of activity.
+    static func usesSoftFloor(isDense: Bool, nonZeroFraction: Double) -> Bool {
+        !isDense && nonZeroFraction > 0
+    }
+}
+
 /// Picks which plotted series the hover indicator rides. Pure + testable.
 enum SparklineHoverAnchor {
     /// Among the plotted series, return the one with the highest value at the hovered
@@ -663,7 +674,11 @@ struct SparklineChart: View {
     }
 
     private func baselineY(for role: SparklineSeriesRole, in plotFrame: CGRect) -> CGFloat {
-        presentation.isDense(role) ? plotFrame.maxY : plotFrame.maxY - plotFrame.height * 0.10
+        let softFloor = SparklineBaseline.usesSoftFloor(
+            isDense: presentation.isDense(role),
+            nonZeroFraction: presentation.nonZeroFraction(role)
+        )
+        return softFloor ? plotFrame.maxY - plotFrame.height * 0.10 : plotFrame.maxY
     }
 
     private func plotFrame(in size: CGSize) -> CGRect {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -387,6 +387,9 @@ final class DashboardTests: XCTestCase {
     func testDashboardShowsLoadingUntilFirstStatsFetchCompletes() throws {
         let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
 
+        XCTAssertTrue(source.contains("private struct BrainBarDashboardContent: View"))
+        XCTAssertTrue(source.contains("@ObservedObject var collector: StatsCollector"))
+        XCTAssertTrue(source.contains("BrainBarDashboardContent("))
         XCTAssertTrue(source.contains("collector.lastDataFetchedAt == nil"))
         XCTAssertTrue(source.contains("Connecting to daemon and loading dashboard data"))
     }
@@ -409,6 +412,91 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(source.contains("trigramBacklogCount"))
     }
 
+    func testVectorSignalDetailMountsAtRootToEscapePipelineAndScrollClips() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+        let bodyRange = try XCTUnwrap(source.range(of: "var body: some View"))
+        let pipelinePanelRange = try XCTUnwrap(source.range(of: "private func pipelinePanel"))
+        let writesCardRange = try XCTUnwrap(source[pipelinePanelRange.upperBound...].range(of: "private func writesCard"))
+        let bodySource = String(source[bodyRange.lowerBound..<pipelinePanelRange.lowerBound])
+        let pipelinePanelSource = String(source[pipelinePanelRange.lowerBound..<writesCardRange.lowerBound])
+        let signalColumnRange = try XCTUnwrap(source.range(of: "private func signalColumn"))
+        let coverageModelRange = try XCTUnwrap(source[signalColumnRange.upperBound...].range(of: "private struct BrainBarSignalCoverage"))
+        let signalColumnSource = String(source[signalColumnRange.lowerBound..<coverageModelRange.lowerBound])
+
+        XCTAssertFalse(
+            source.contains("overlayPreferenceValue(VectorRowAnchorKey.self)"),
+            "Vector detail should not depend on a preference anchor that can fail to resolve while the selected row styling still changes."
+        )
+        XCTAssertFalse(
+            source.contains("anchorPreference(key: VectorRowAnchorKey.self"),
+            "The Vector row click path should mount the detail directly instead of only emitting an anchor preference."
+        )
+        XCTAssertTrue(
+            bodySource.contains(".coordinateSpace(name: BrainBarVectorSignalCoordinateSpace.root)"),
+            "The root GeometryReader should define the coordinate space used to position the unclipped Vector detail."
+        )
+        XCTAssertTrue(
+            bodySource.contains(".overlay(alignment: .topLeading)"),
+            "The Vector detail must be hoisted to a root overlay so the pipeline panel and ScrollView cannot clip it."
+        )
+        XCTAssertTrue(
+            bodySource.contains("BrainBarVectorSignalDetail(signal: vectorSignal, compact: layout.compactCards)"),
+            "The root overlay should own the Vector detail float."
+        )
+        XCTAssertTrue(
+            bodySource.contains(".zIndex(vectorSignalDetailExpanded ? 30 : 0)"),
+            "The hoisted Vector detail needs a high zIndex above every sibling pipeline card."
+        )
+        XCTAssertFalse(
+            pipelinePanelSource.contains("BrainBarVectorSignalDetail(signal: vectorSignal, compact: layout.compactCards)"),
+            "The Vector detail cannot remain inside the pipeline panel overlay because that panel clips the float."
+        )
+        XCTAssertFalse(
+            pipelinePanelSource.contains(".zIndex(vectorSignalDetailExpanded ? 1 : 0)"),
+            "The old in-panel zIndex workaround should be removed once the float lives at root level."
+        )
+        XCTAssertFalse(
+            pipelinePanelSource.contains(".padding(.top, max(0, 20 - layout.gridSpacing))"),
+            "The old in-panel spacing workaround should be removed once the float lives at root level."
+        )
+        XCTAssertFalse(
+            signalColumnSource.contains("BrainBarVectorSignalDetail"),
+            "The Vector detail cannot live in the signal column overlay because later pipeline siblings paint over that layer."
+        )
+        XCTAssertTrue(
+            signalColumnSource.contains("BrainBarVectorSignalRootFrameKey"),
+            "The Vector signal row should emit a root-space frame for the unclipped overlay."
+        )
+    }
+
+    func testVectorSignalDetailUsesDerivedZLiftNotHeldState() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertFalse(source.contains("@State private var isFloatLifted"))
+        XCTAssertFalse(source.contains("DispatchQueue.main.asyncAfter(deadline: .now() + 0.27)"))
+        XCTAssertTrue(source.contains(".zIndex(vectorSignalDetailExpanded ? 30 : 0)"))
+    }
+
+    func testDashboardCardTopHighlightIsClippedInsideRoundedCorners() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+        let styleRange = try XCTUnwrap(source.range(of: "private struct BrainBarDashboardCardStyle"))
+        let nextStructRange = try XCTUnwrap(source[styleRange.upperBound...].range(of: "private struct BrainBarFlowStatusPill"))
+        let styleSource = String(source[styleRange.lowerBound..<nextStructRange.lowerBound])
+
+        XCTAssertFalse(
+            styleSource.contains(".overlay(alignment: .top) {\n                Rectangle()"),
+            "A full-width top Rectangle creates the flat divider hat across rounded card corners."
+        )
+        XCTAssertTrue(
+            styleSource.contains(".strokeBorder(Color.brainBarBorderSoft, lineWidth: 1)"),
+            "The card border should use strokeBorder so it remains correct after clipping."
+        )
+        XCTAssertTrue(
+            styleSource.contains(".padding(.horizontal, max(10, cornerRadius * 0.70))\n            }\n            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))\n            .shadow"),
+            "The shared card top highlight should be inset clear of rounded corners."
+        )
+    }
+
     func testBrainBarHeaderExposesRestartAndQuitControls() throws {
         let rootSource = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
         let processSource = try brainBarSourceFile("Sources/BrainBar/BrainBarProcessControl.swift")
@@ -423,6 +511,23 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(processSource.contains("FileManager.default.fileExists"))
         XCTAssertTrue(processSource.contains("URL(fileURLWithPath: \"/usr/bin/open\")"))
         XCTAssertFalse(processSource.contains("URL(fileURLWithPath: \"/bin/sh\")"))
+    }
+
+    @MainActor
+    func testDashboardPanelUsesKeyWindowContractAndSettingsDismissSuppression() throws {
+        let controller = BrainBarDashboardPanelController(runtime: BrainBarRuntime())
+        let panel = controller.panelForTesting
+        let panelSource = try brainBarSourceFile("Sources/BrainBar/BrainBarDashboardPanelController.swift")
+        let settingsSource = try brainBarSourceFile("Sources/BrainBar/BrainBarSettingsActions.swift")
+
+        XCTAssertTrue(panel.canBecomeKey)
+        XCTAssertFalse(panel.canBecomeMain)
+        XCTAssertFalse(panel.becomesKeyOnlyIfNeeded)
+        XCTAssertTrue(panelSource.contains("func windowWillClose(_ notification: Notification)"))
+        XCTAssertTrue(panelSource.contains("BrainBarSettingsActions.suppressDashboardResignDismiss"))
+        XCTAssertTrue(settingsSource.contains("private(set) static var suppressDashboardResignDismiss"))
+        XCTAssertTrue(settingsSource.contains("suppressDashboardResignDismiss = true"))
+        XCTAssertTrue(settingsSource.contains("suppressDashboardResignDismiss = false"))
     }
 
     func testRestartHandoffAllowsOnlyMatchingFreshExistingInstance() throws {
@@ -736,10 +841,7 @@ final class DashboardTests: XCTestCase {
             presentation.bucketLabel(for: 3),
             "\(Self.shortTime(now.addingTimeInterval(-5 * 60)))-\(Self.shortTime(now))"
         )
-        XCTAssertEqual(
-            presentation.tooltipText(forBucket: 2),
-            "\(Self.shortTime(now.addingTimeInterval(-10 * 60)))-\(Self.shortTime(now.addingTimeInterval(-5 * 60))) (10m-5m ago): 5"
-        )
+        XCTAssertEqual(presentation.relativeBucketLabel(for: 2), "10m-5m ago")
     }
 
     func testSparklineChartPresentationLabelsPartialMinuteBucketsLikeDatabase() {
@@ -815,23 +917,78 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(presentation.legendEntries.allSatisfy { !$0.isActive })
     }
 
+    func testSparklinePresentationClassifiesDensityAndUsesTightTicksForSmallPeaks() {
+        let sparse = SparklineChartPresentation(
+            label: "Enrichments over 30m",
+            values: [0, 0, 3, 0, 0],
+            secondaryValues: [1, 1, 0, 1, 1],
+            activityWindowMinutes: 30,
+            fetchedAt: Date(timeIntervalSince1970: 1_764_236_400)
+        )
+
+        XCTAssertEqual(sparse.nonZeroFraction(.primary), 0.2, accuracy: 0.001)
+        XCTAssertFalse(sparse.isDense(.primary))
+        XCTAssertTrue(sparse.isDense(.secondary))
+        XCTAssertEqual(sparse.axisMax, 5)
+        XCTAssertEqual(sparse.tightAxisMax, 3)
+        XCTAssertEqual(sparse.tightYAxisTicks, [0, 2, 3])
+
+        let larger = SparklineChartPresentation(
+            label: "Writes over 30m",
+            values: [0, 9],
+            activityWindowMinutes: 30,
+            fetchedAt: Date(timeIntervalSince1970: 1_764_236_400)
+        )
+
+        XCTAssertEqual(larger.tightAxisMax, larger.axisMax)
+        XCTAssertEqual(larger.axisMax, 10)
+    }
+
     func testSparklineTooltipPlacementClampsHorizontally() {
         let container = CGSize(width: 160, height: 100)
         let tooltip = SparklineTooltipPlacement.tooltipSize(in: container)
 
         let left = SparklineTooltipPlacement.position(
             near: CGPoint(x: 0, y: 80),
-            in: container,
+            anchorY: 80,
+            hoveredX: 0,
+            containerBounds: container,
             tooltipSize: tooltip
         )
         let right = SparklineTooltipPlacement.position(
             near: CGPoint(x: 220, y: 80),
-            in: container,
+            anchorY: 80,
+            hoveredX: 220,
+            containerBounds: container,
             tooltipSize: tooltip
         )
 
         XCTAssertGreaterThanOrEqual(left.x - tooltip.width / 2, 8)
         XCTAssertLessThanOrEqual(right.x + tooltip.width / 2, container.width - 8)
+    }
+
+    func testSparklineTooltipPlacementAnchorsToPointAndFallsBackSidewaysNearTopSpike() {
+        let container = CGSize(width: 420, height: 96)
+        let tooltip = SparklineTooltipPlacement.tooltipSize(in: container)
+
+        let topSpike = SparklineTooltipPlacement.position(
+            near: CGPoint(x: 35, y: 12),
+            anchorY: 12,
+            hoveredX: 35,
+            containerBounds: container,
+            tooltipSize: tooltip
+        )
+        let roomy = SparklineTooltipPlacement.position(
+            near: CGPoint(x: 220, y: 86),
+            anchorY: 86,
+            hoveredX: 220,
+            containerBounds: container,
+            tooltipSize: tooltip
+        )
+
+        XCTAssertGreaterThan(topSpike.x, 35, "Top spikes should side-place instead of pinning the tooltip to the bottom.")
+        XCTAssertLessThanOrEqual(topSpike.y + tooltip.height / 2, container.height - 8)
+        XCTAssertLessThan(roomy.y, 86, "Roomy lower points should place the tooltip above the on-curve anchor.")
     }
 
     func testSparklineTooltipPlacementFlipsBelowNearTopEdge() {
@@ -840,17 +997,47 @@ final class DashboardTests: XCTestCase {
 
         let top = SparklineTooltipPlacement.position(
             near: CGPoint(x: 130, y: 4),
-            in: container,
+            anchorY: 4,
+            hoveredX: 130,
+            containerBounds: container,
             tooltipSize: tooltip
         )
         let lower = SparklineTooltipPlacement.position(
             near: CGPoint(x: 130, y: 90),
-            in: container,
+            anchorY: 90,
+            hoveredX: 130,
+            containerBounds: container,
             tooltipSize: tooltip
         )
 
         XCTAssertGreaterThan(top.y, 4)
         XCTAssertLessThan(lower.y, 90)
+    }
+
+    func testSparklineTooltipUsesRoundedUpMetricsAndSingleOpaqueBackground() throws {
+        let compactContainer = CGSize(width: 260, height: 90)
+        let tooltip = SparklineTooltipPlacement.tooltipSize(in: compactContainer, seriesCount: 3)
+        let source = try brainBarSourceFile("Sources/BrainBar/Dashboard/SparklineRenderer.swift")
+
+        XCTAssertEqual(tooltip.height, 104)
+        XCTAssertTrue(source.contains("private static let headerHeight: CGFloat = 24"))
+        XCTAssertTrue(source.contains("private static let dividerBlock: CGFloat = 14"))
+        XCTAssertTrue(source.contains("private static let rowHeight: CGFloat = 16"))
+        XCTAssertFalse(source.contains(".background(.regularMaterial"))
+        XCTAssertTrue(source.contains(".fill(Color.brainBarBackgroundRaised)"))
+    }
+
+    func testSparklineRendererSimplifiesStructuredTooltipHelpers() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/Dashboard/SparklineRenderer.swift")
+
+        XCTAssertFalse(source.contains("func tooltipText(forBucket"))
+        XCTAssertTrue(source.contains("let clampedBucket = min(max(hoveredBucket, 0), max(presentation.values.count - 1, 0))"))
+        XCTAssertTrue(source.contains("private var plotMax: Int { compact ? presentation.maxValue : presentation.tightAxisMax }"))
+        XCTAssertFalse(source.contains("line 523"))
+        XCTAssertFalse(source.contains("(G3)"))
+        XCTAssertFalse(source.contains("(G4)"))
+        XCTAssertFalse(source.contains("(G5)"))
+        XCTAssertFalse(source.contains("(I1)"))
     }
 
     func testDashboardMetricFormatterRequiresAbsoluteLastEventText() {
@@ -886,6 +1073,19 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(SparklineRenderer.isCompact(size: NSSize(width: 52, height: 116)))
         XCTAssertTrue(SparklineRenderer.isCompact(size: NSSize(width: 300, height: 20)))
         XCTAssertFalse(SparklineRenderer.isCompact(size: NSSize(width: 53, height: 21)))
+    }
+
+    func testSparklineChartOmitsCurrentValueEndpointAnnotation() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/Dashboard/SparklineRenderer.swift")
+
+        XCTAssertFalse(
+            source.contains("currentValueLabelPosition"),
+            "Dashboard sparklines should keep endpoint markers but not render the floating current-value pill."
+        )
+        XCTAssertFalse(
+            source.contains("Text(\"\\(last.value)\")"),
+            "The confusing numeric endpoint pill should be removed from Writes and Enrichments charts."
+        )
     }
 
     func testDashboardStatsCountsRecentISO8601Timestamps() throws {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -991,6 +991,38 @@ final class DashboardTests: XCTestCase {
         XCTAssertLessThan(roomy.y, 86, "Roomy lower points should place the tooltip above the on-curve anchor.")
     }
 
+    // Degenerate case: a top-edge spike in a container so narrow that NEITHER side
+    // candidate fits at the anchor column. The card must still clear the dot by
+    // pinning to the edge with more room — never land on the anchor column and
+    // overlap the curve. (Reviewer M1, PR #526.)
+    func testSparklineTooltipPlacementSidePinsToEdgeWhenNoSideRoomAtAnchor() {
+        // 300 wide so minX (138) < maxX (162): the edge is distinct from the
+        // horizontally-clamped anchor column, yet the tooltip (260 wide) is wide
+        // enough that NEITHER side candidate fits at the anchor.
+        let container = CGSize(width: 300, height: 96)
+        let tooltip = SparklineTooltipPlacement.tooltipSize(in: container)
+        let halfWidth = tooltip.width / 2
+        let minX = 8 + halfWidth
+        let maxX = max(container.width - 8 - halfWidth, minX)
+        XCTAssertLessThan(minX, maxX, "Test geometry must keep the edges distinct from the anchor column.")
+
+        // Top spike right-of-center: rightX and leftX both fall outside [minX, maxX],
+        // so the SIDE fallback must pin to the roomier (left) edge, not the anchor column.
+        let anchorX: CGFloat = 175
+        let topSpike = SparklineTooltipPlacement.position(
+            near: CGPoint(x: anchorX, y: 8),
+            anchorY: 8,
+            hoveredX: anchorX,
+            containerBounds: container,
+            tooltipSize: tooltip
+        )
+        let clampedAnchorColumn = min(max(anchorX, minX), maxX)
+        XCTAssertEqual(topSpike.x, minX, accuracy: 0.5,
+                       "No side room at the anchor column should pin to the roomier (left) edge.")
+        XCTAssertNotEqual(topSpike.x, clampedAnchorColumn, accuracy: 0.5,
+                          "The card must not sit on the anchor column overlapping the curve.")
+    }
+
     func testSparklineTooltipPlacementFlipsBelowNearTopEdge() {
         let container = CGSize(width: 260, height: 120)
         let tooltip = SparklineTooltipPlacement.tooltipSize(in: container)

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -1023,6 +1023,18 @@ final class DashboardTests: XCTestCase {
                           "The card must not sit on the anchor column overlapping the curve.")
     }
 
+    // A sparse series with a spike gets the lifted soft floor (so its zeros read as a
+    // designed band), but a series with NO data at all stays on the true zero baseline
+    // so it never implies a phantom band of activity. (Reviewer Codex P2, PR #526.)
+    func testSparkBaselineUsesSoftFloorOnlyForSparseSeriesWithData() {
+        // Sparse but has a spike -> soft floor.
+        XCTAssertTrue(SparklineBaseline.usesSoftFloor(isDense: false, nonZeroFraction: 0.2))
+        // Completely empty -> true baseline (no soft floor).
+        XCTAssertFalse(SparklineBaseline.usesSoftFloor(isDense: false, nonZeroFraction: 0.0))
+        // Dense -> true baseline.
+        XCTAssertFalse(SparklineBaseline.usesSoftFloor(isDense: true, nonZeroFraction: 0.8))
+    }
+
     // The hover indicator must ride the PLOTTED series with the visible spike at the
     // hovered bucket, not always the primary — otherwise a Writes chart fed only by
     // the watcher lane (primary all-zero) anchors the dot/tooltip to the baseline.

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -1023,6 +1023,50 @@ final class DashboardTests: XCTestCase {
                           "The card must not sit on the anchor column overlapping the curve.")
     }
 
+    // The hover indicator must ride the PLOTTED series with the visible spike at the
+    // hovered bucket, not always the primary — otherwise a Writes chart fed only by
+    // the watcher lane (primary all-zero) anchors the dot/tooltip to the baseline.
+    // (Reviewers: Cursor Bugbot Medium / Codex P2, PR #526.)
+    func testHoverAnchorPicksDominantPlottedSeries() {
+        // Only secondary plotted, secondary has the value at this bucket.
+        XCTAssertEqual(
+            SparklineHoverAnchor.dominantRole(
+                plotted: [.secondary],
+                valueAtBucket: [.secondary: 4]
+            ),
+            .secondary
+        )
+        // Both plotted; secondary spikes while primary is zero -> ride secondary.
+        XCTAssertEqual(
+            SparklineHoverAnchor.dominantRole(
+                plotted: [.primary, .secondary],
+                valueAtBucket: [.primary: 0, .secondary: 5]
+            ),
+            .secondary
+        )
+        // Tie favors primary (declaration order).
+        XCTAssertEqual(
+            SparklineHoverAnchor.dominantRole(
+                plotted: [.primary, .secondary],
+                valueAtBucket: [.primary: 3, .secondary: 3]
+            ),
+            .primary
+        )
+        // Primary dominates.
+        XCTAssertEqual(
+            SparklineHoverAnchor.dominantRole(
+                plotted: [.primary, .secondary, .tertiary],
+                valueAtBucket: [.primary: 6, .secondary: 2, .tertiary: 1]
+            ),
+            .primary
+        )
+        // Nothing plotted -> safe fallback to primary.
+        XCTAssertEqual(
+            SparklineHoverAnchor.dominantRole(plotted: [], valueAtBucket: [:]),
+            .primary
+        )
+    }
+
     func testSparklineTooltipPlacementFlipsBelowNearTopEdge() {
         let container = CGSize(width: 260, height: 120)
         let tooltip = SparklineTooltipPlacement.tooltipSize(in: container)

--- a/brain-bar/Tests/BrainBarTests/SparklineSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SparklineSnapshotTests.swift
@@ -149,5 +149,22 @@ final class SparklineSnapshotTests: XCTestCase {
         )
         save(BrainBarFlowLaneCardPreview.make(lane: writesLane),
              "card-writes", size: CGSize(width: 380, height: 320))
+
+        // HOVER where ONLY the secondary (rose) series has the spike and primary is
+        // zero at that bucket: the dot/crosshair/tooltip must ride the ROSE curve, not
+        // the green baseline. (Reviewer multi-series anchor fix.) Bucket 4 -> secondary=3.
+        let secondaryOnly = SparklineChartPresentation(
+            label: "Writes",
+            values: [0, 0, 0, 0, 0, 0, 0, 0],
+            secondaryValues: [0, 1, 0, 2, 3, 0, 1, 0],
+            primarySeriesLabel: "Agent",
+            secondarySeriesLabel: "Watcher"
+        )
+        save(
+            SparklineChart(presentation: secondaryOnly, accentColor: accent,
+                           secondaryAccentColor: watcher,
+                           previewHoveredBucket: 4, previewHoverX: 160),
+            "secondary-spike-hover"
+        )
     }
 }

--- a/brain-bar/Tests/BrainBarTests/SparklineSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SparklineSnapshotTests.swift
@@ -1,0 +1,153 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BrainBar
+
+/// Renders the real SparklineChart views to PNGs for visual QA against the Aldante
+/// reference frames. Not an assertion test — it produces images in the qa dir.
+/// Run with: swift test --filter SparklineSnapshotTests
+@MainActor
+final class SparklineSnapshotTests: XCTestCase {
+    // Opt-in only: set BRAINBAR_SNAPSHOT_DIR to render the QA PNGs. Skipped in CI by default.
+    private var outDir: String? { ProcessInfo.processInfo.environment["BRAINBAR_SNAPSHOT_DIR"] }
+
+    private func save<V: View>(_ view: V, _ name: String, size: CGSize = CGSize(width: 360, height: 200)) {
+        guard let outDir else { return }
+        let renderer = ImageRenderer(content:
+            view
+                .frame(width: size.width, height: size.height)
+                .padding(18)
+                .background(Color(nsColor: NSColor(calibratedRed: 0.07, green: 0.08, blue: 0.10, alpha: 1)))
+        )
+        renderer.scale = 2
+        guard let image = renderer.nsImage,
+              let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            XCTFail("render failed for \(name)")
+            return
+        }
+        try? FileManager.default.createDirectory(atPath: outDir, withIntermediateDirectories: true)
+        let path = "\(outDir)/\(name).png"
+        try? png.write(to: URL(fileURLWithPath: path))
+        print("SNAPSHOT \(path)")
+    }
+
+    func testRenderSparklines() throws {
+        try XCTSkipIf(outDir == nil, "Set BRAINBAR_SNAPSHOT_DIR to render QA snapshots")
+        let accent = BrainBarDesignTokens.Colors.signalFTS5 // green-ish, like Aldante battery card
+        let watcher = BrainBarDesignTokens.Colors.seriesWatcher
+
+        // SPARSE: the [0,0,3,0,0] trap — must show a soft-floor lit band + spike mass, no overshoot.
+        let sparse = SparklineChartPresentation(
+            label: "Enrichments",
+            values: [0, 0, 3, 0, 0, 1, 0, 0],
+            primarySeriesLabel: "Enrichments"
+        )
+        save(SparklineChart(presentation: sparse, accentColor: accent), "sparse-rest")
+
+        // DENSE: continuous-ish signal — full gradient mass + catmull smoothing.
+        let dense = SparklineChartPresentation(
+            label: "Coverage",
+            values: [42, 48, 55, 53, 60, 66, 71, 69, 74, 80],
+            primarySeriesLabel: "Coverage"
+        )
+        save(SparklineChart(presentation: dense, accentColor: accent), "dense-rest")
+
+        // LOW-VALUE tight scale: peak of 3 should fill toward the TOP, not pin at 60%.
+        let low = SparklineChartPresentation(
+            label: "Writes",
+            values: [0, 1, 2, 3, 2, 1, 0, 1],
+            primarySeriesLabel: "Writes"
+        )
+        save(SparklineChart(presentation: low, accentColor: accent), "low-tight")
+
+        // DUAL series: green primary + rose secondary, each its own faint fill.
+        let dual = SparklineChartPresentation(
+            label: "Writes",
+            values: [0, 2, 0, 4, 1, 3, 0, 2],
+            secondaryValues: [1, 0, 2, 0, 3, 0, 1, 0],
+            primarySeriesLabel: "Agent",
+            secondarySeriesLabel: "Watcher"
+        )
+        save(SparklineChart(presentation: dual, accentColor: accent, secondaryAccentColor: watcher), "dual-rest")
+
+        // COMPACT (menubar) regression: must stay a clean stroke, no fill/chrome.
+        save(
+            SparklineChart(presentation: sparse, accentColor: accent, compact: true),
+            "sparse-compact",
+            size: CGSize(width: 44, height: 18)
+        )
+
+        // HOVER over a mid bucket: crosshair + on-curve dot + tooltip + revealed axes.
+        save(
+            SparklineChart(presentation: dense, accentColor: accent,
+                           previewHoveredBucket: 5, previewHoverX: 190),
+            "dense-hover-mid"
+        )
+
+        // HOVER DIRECTLY ON THE TOP SPIKE (the reviewer-flagged failure):
+        // the card must NOT collapse to the bottom — it should ride above/beside the dot.
+        save(
+            SparklineChart(presentation: sparse, accentColor: accent,
+                           previewHoveredBucket: 2, previewHoverX: 110),
+            "sparse-hover-spike"
+        )
+
+        // REFERENCE LINE (Aldante signature dashed benchmark).
+        save(
+            SparklineChart(presentation: low, accentColor: accent, referenceValue: 3),
+            "low-reference"
+        )
+
+        // FULL NUMBER-FIRST CARD (the defining Aldante trait): caption + hero number,
+        // status pill, graph as evidence, single muted caption at the bottom.
+        let enrichLane = DashboardFlowLane(
+            name: "Enrichments",
+            status: .live,
+            statusText: "Enrichment is draining backlog steadily.",
+            windowLabel: "Last 30m",
+            activityWindowMinutes: 30,
+            rateText: "0.5/min",
+            volumeText: "14 enriched",
+            lastEventText: "1m ago",
+            values: [0, 0, 3, 0, 0, 1, 0, 2],
+            sparklineLabel: "Enrichments",
+            latestBucketName: "latest bucket count",
+            accentColor: BrainBarDesignTokens.Colors.signalFTS5,
+            primarySeriesLabel: "Enrichments",
+            secondaryValues: [],
+            secondarySeriesLabel: nil,
+            secondaryAccentColor: nil,
+            tertiaryValues: [],
+            tertiarySeriesLabel: nil,
+            tertiaryAccentColor: nil
+        )
+        save(BrainBarFlowLaneCardPreview.make(lane: enrichLane),
+             "card-enrichments", size: CGSize(width: 380, height: 300))
+
+        let writesLane = DashboardFlowLane(
+            name: "Writes",
+            status: .live,
+            statusText: "Writes are landing across agent + watcher.",
+            windowLabel: "Last 30m",
+            activityWindowMinutes: 30,
+            rateText: "1.2/min",
+            volumeText: "37 writes",
+            lastEventText: "just now",
+            values: [0, 2, 0, 4, 1, 3, 0, 2],
+            sparklineLabel: "Writes",
+            latestBucketName: "latest bucket count",
+            accentColor: BrainBarDesignTokens.Colors.signalFTS5,
+            primarySeriesLabel: "Agent",
+            secondaryValues: [1, 0, 2, 0, 3, 0, 1, 0],
+            secondarySeriesLabel: "Watcher",
+            secondaryAccentColor: BrainBarDesignTokens.Colors.seriesWatcher,
+            tertiaryValues: [],
+            tertiarySeriesLabel: nil,
+            tertiaryAccentColor: nil
+        )
+        save(BrainBarFlowLaneCardPreview.make(lane: writesLane),
+             "card-writes", size: CGSize(width: 380, height: 320))
+    }
+}


### PR DESCRIPTION
## Summary

Turns the BrainBar telemetry-strip sparklines into Aldante-style cards and fixes Etan's three literal bugs:
1. **Flat graphs** → density-gated gradient AREA fill + tight scale + overshoot-free smoothing.
2. **Tooltip stuck at the bottom** → point-anchored placement allowed to live in the whole card body (incl. on top spikes).
3. **Vector detail float clipped** → lifted above the panel + ScrollView clip.

Built to visual-diff against the Aldante reference frames (`docs.local/handoffs/2026-06-20/aldante-ref/frames`, vid2_26 rest / vid2_30 hover).

### SparklineRenderer.swift
- **Density classifier** (`nonZeroFraction` / `isDense`) — every treatment branches on it.
- **Gradient area fill** behind the stroke: dense series fill to a true zero baseline; sparse series (e.g. `[0,0,3,0,0]`) use a ~10% soft floor so a run of zeros shows a lit band instead of an empty card. Primary fill 0.34, secondary 0.16 so dual-series Writes (green + rose) stay distinct.
- **Tight Y-scale** (`tightAxisMax`): a peak of 3 fills toward the top instead of dying against axisMax 5.
- **Overshoot-free smoothing**: Fritsch–Carlson monotone cubic for sparse/default (tangent = 0 at extrema/zeros, magnitude-clamped); Catmull–Rom only for dense series. Fill top edge shares the path builder so fill and stroke align.
- **Calm at rest**: only the solid 0-baseline. Gridlines, y-tick labels, and the x-axis time row fade in on hover (0.15s; instant under Reduce Motion). Resting endpoint dot removed (kept the 4.4px compact menubar dot).
- **Point-anchored hover**: dashed vertical crosshair + ringed on-curve dot at the hovered bucket; tooltip anchored to the on-curve point and allowed to occupy the whole chart body (ABOVE → BELOW → SIDE) so a hover on a top spike rides up into the header band instead of collapsing low. **Tooltip card content is unchanged** — only placement + size metrics moved.
- Optional dashed **reference line** (wired to the enrichments card).
- **Compact menubar path hard-skips** fill/shadow/crosshair/hover/reference/axis reveal.

### BrainBarWindowRootView.swift
- **Number-first flow lane cards**: muted caption above a bold hero value, status pill top-right, graph as evidence, single muted caption at the bottom.
- **Vector detail float** lifted to a root-level overlay (new root coordinate space + `BrainBarVectorSignalRootFrameKey`) so it escapes the ScrollView and glass-panel clips; removed the in-panel zIndex/padding workarounds.

## Test plan
- [x] `swift build -j 4` green, no new warnings
- [x] `swift test --filter DashboardTests` — 77 tests pass
- [x] Visual QA via a headless `ImageRenderer` snapshot harness (`SparklineSnapshotTests.swift`, env-gated by `BRAINBAR_SNAPSHOT_DIR`) rendering the **actual** views and diffing against the Aldante reference frames: rest (sparse/dense/low/dual), compact menubar, hover-mid, hover-on-top-spike (card rode up, not bottom-pinned), reference line, full number-first cards.
- [x] Deployed to `~/Applications/BrainBar.app` (re-signed, UI restarted, daemon untouched) — new binary running stably.

Note: the BrainBar dashboard is an `NSPanel` that dismisses on resign-key, so scripted live screenshots of the menu-bar panel are unreliable; the headless snapshot of the real SwiftUI views is the robust visual-QA path used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqgSTrcnkHocz2rfLrveXK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large SwiftUI rendering and panel/window lifecycle changes can alter dashboard appearance and dismiss timing; Settings activation-policy toggles affect macOS app behavior but are scoped to the UI target.
> 
> **Overview**
> **Dashboard sparklines and flow cards** get a major visual/interaction overhaul in `SparklineRenderer.swift`: gradient area fills with density-aware baselines and smoothing (linear / monotone / Catmull–Rom), **tight Y-axis scaling**, hover-revealed grid and ticks, optional **reference lines** on enrichment lanes, and **on-curve** crosshair + multi-row tooltips anchored to the dominant plotted series (not always primary). Flow lane cards lead with a **hero rate**, slim the header, and trim runtime diagnostics (vector/FTS/trigram summaries and trigram progress UI removed from the disclosure section).
> 
> **Vector signal detail** no longer expands inline under the row—it is **hoisted to a root overlay** positioned via preference keys and coordinate spaces so ScrollView/pipeline clipping cannot cut it off; Escape dismisses it.
> 
> **Menu-bar dashboard panel** (`BrainBarDashboardPanelController`): custom keyable `NSPanel`, click-outside + resign-key dismiss after ~200ms, menubar button exempt from outside-click dismiss, and **`suppressDashboardResignDismiss`** while Settings is open. **Settings** (`BrainBarSettingsActions`, gated by new `BRAINBAR_UI` in `Package.swift`) opens a dedicated SwiftUI window, temporarily promotes activation policy to `.regular`, and restores `.accessory` on close; daemon target keeps the legacy no-op path.
> 
> Tests expand `DashboardTests` for the new layout/hover/placement rules; optional **`SparklineSnapshotTests`** renders PNGs when `BRAINBAR_SNAPSHOT_DIR` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632f3bb65644e43de371d8dca2b3f81b50283f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add gradient-fill sparklines, point-anchored hover tooltips, and hero cards to BrainBar dashboard
> - [SparklineChart](https://github.com/EtanHey/brainlayer/pull/526/files#diff-27c132f6a3e15acfd5900246f3fc1e277502117e1e22c5b47ee78581e8e13a02) gains gradient area fills under curves with monotone/Catmull-Rom smoothing, y-axis grid lines with compact tick labels, and a crosshair+ring hover indicator anchored to the dominant plotted series at the hovered bucket.
> - Tooltip placement is now content-aware and anchor-relative, preferring above/below the curve point and falling back to a side pin near top-edge spikes.
> - [BrainBarFlowLaneCard](https://github.com/EtanHey/brainlayer/pull/526/files#diff-57c1c80423a80417b3f4cbc4e6a402907ac480e6e897bd8e05eb027d49d3d7de) is reworked to show the current rate as a large monospaced figure with volume and last-event on a single secondary line; enrichment charts receive a reference/benchmark line.
> - The Vector signal detail is lifted from an inline panel to a root-level floating overlay, positioned relative to the Vector row via named coordinate spaces and preference keys to escape scroll and pipeline clip regions; a `RevealClip` modifier animates the reveal when Reduce Motion is off.
> - [BrainBarDashboardPanelController](https://github.com/EtanHey/brainlayer/pull/526/files#diff-b36f4fce51ecc22a410f32c4624d10afdb3c3a4585a79e4323cef34aa04898da) now installs global and local click monitors so the panel dismisses on outside clicks, with a 0.2s grace period and suppression while the Settings window is open.
> - A SwiftUI-backed Settings window is added in [BrainBarSettingsActions](https://github.com/EtanHey/brainlayer/pull/526/files#diff-4e9afcccdc8505530616627cf9d01dafd68780e0e2183fd8812c79586f8b9228), promoting activation policy to `.regular` while open and demoting back to `.accessory` on close.
> - Snapshot tests in [SparklineSnapshotTests](https://github.com/EtanHey/brainlayer/pull/526/files#diff-87cc5eadb9343fe966db227ae2a2e1ab3513a6909b28610eb2c0a1707be0f817) render charts to PNG when `BRAINBAR_SNAPSHOT_DIR` is set, covering sparse, dense, hover, reference-line, and card preview scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 632f3bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->