### PR TITLE
chore: release 1.2.2 (durable JSONL-watcher reliability)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.2.0"
+version = "1.2.2"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents — local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.2"

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -18,25 +18,43 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(autouse=True)
-def _isolate_default_queue_dir(tmp_path_factory, monkeypatch):
-    """Isolate the default HealthCheckConfig queue_dir from the live queue.
+def _isolate_default_live_paths(tmp_path_factory, monkeypatch):
+    """Isolate HealthCheckConfig defaults that point at live developer state.
 
-    Tests that build HealthCheckConfig without an explicit queue_dir otherwise
-    read the developer's real ~/.brainlayer/queue; a populated live queue then
-    makes them spuriously report `queue_backed_up`. We redirect _queue_stats
-    so the live default path is treated as the empty isolated dir, while tests
-    that pass an explicit queue_dir are honored unchanged.
+    Several tests build HealthCheckConfig without overriding every path, so they
+    inherit the developer's real ~/.brainlayer/queue and
+    ~/.local/share/brainlayer/pause.sentinel. A populated live queue then makes
+    them spuriously report `queue_backed_up`, and a live pause sentinel
+    suppresses `watcher_stalled`. We redirect the queue-stats and
+    pause-sentinel readers so the live default paths resolve to empty/absent
+    isolated locations, while tests that pass explicit paths are honored.
     """
     empty_queue = tmp_path_factory.mktemp("hc-queue")
-    live_default = Path("~/.brainlayer/queue").expanduser()
+    live_queue_default = Path("~/.brainlayer/queue").expanduser()
     real_queue_stats = health_check._queue_stats
 
     def _isolated_queue_stats(queue_dir, now):
-        if queue_dir.expanduser() == live_default:
+        if queue_dir.expanduser() == live_queue_default:
             queue_dir = empty_queue
         return real_queue_stats(queue_dir, now)
 
     monkeypatch.setattr(health_check, "_queue_stats", _isolated_queue_stats)
+
+    # Redirect the live default pause-sentinel path to an absent tmp file so a
+    # real `brainlayer pause` sentinel cannot leak into tests that don't
+    # override pause_sentinel_path.
+    absent_sentinel = tmp_path_factory.mktemp("hc-sentinel") / "pause.sentinel"
+    live_sentinel_default = Path("~/.local/share/brainlayer/pause.sentinel").expanduser()
+    real_pause_state = health_check._pause_sentinel_state
+
+    def _isolated_pause_state(config, now):
+        if config.pause_sentinel_path.expanduser() == live_sentinel_default:
+            from dataclasses import replace
+
+            config = replace(config, pause_sentinel_path=absent_sentinel)
+        return real_pause_state(config, now)
+
+    monkeypatch.setattr(health_check, "_pause_sentinel_state", _isolated_pause_state)
     yield
 
 


### PR DESCRIPTION
Bumps the package to **1.2.2** so the durable JSONL-watcher fix (#525) is publishable to PyPI and installable via the `homebrew-layers` tap.

## Why a new version
- PyPI's `1.2.0` predates the watcher fix.
- The existing `v1.2.1` git tag was created on code where `pyproject.toml` still read `1.2.0`, so its publish workflow built `brainlayer-1.2.0` (already on PyPI) and **failed** — `v1.2.1` was never published.
- This bump syncs `pyproject.toml`, `src/brainlayer/__init__.py`, and `server.json` (both `version` and `packages[0].version`) to `1.2.2` so `test_release_version_sync` passes and the `Publish to PyPI` workflow can build+upload cleanly on the `v1.2.2` tag.

## Also included
A test-isolation fix in `test_stability_health_check.py`: the autouse fixture now redirects the default `pause_sentinel_path` (and, as before, `queue_dir`) away from live developer state. Without it, a real `brainlayer pause` sentinel on the dev machine suppresses `watcher_stalled` and breaks `test_health_check_reports_watcher_stalled_drain_no_progress_and_queue_backed_up`. Full unit gate green (3042 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata and test-only changes; no production runtime behavior in this diff.
> 
> **Overview**
> **Release 1.2.2** — bumps `version` from `1.2.0` to `1.2.2` in `pyproject.toml`, `src/brainlayer/__init__.py`, and `server.json` (top-level and `packages[0].version`) so release/version-sync checks and the PyPI publish workflow can ship the durable JSONL-watcher fix that was not cleanly publishable on prior tags.
> 
> **Test isolation** — renames and broadens the autouse fixture in `test_stability_health_check.py`: it still redirects the default `~/.brainlayer/queue` for `_queue_stats`, and now also swaps the default `~/.local/share/brainlayer/pause.sentinel` to an absent temp path via `_pause_sentinel_state`, preventing a real `brainlayer pause` on a dev machine from suppressing `watcher_stalled` in tests that rely on default `HealthCheckConfig` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3791e814d10f1e008716bc1d0d627f1556be844d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 1.2.2 with improved health check test isolation
> - Bumps version to 1.2.2 in [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/527/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/527/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [`__version__`](https://github.com/EtanHey/brainlayer/pull/527/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954)
> - Expands the autouse fixture in [test_stability_health_check.py](https://github.com/EtanHey/brainlayer/pull/527/files#diff-1e1847cfcf0367700d03d50d1ada976cb14799056dbfc8d380b3b3f5ba7c6ae3) to also isolate the default `pause_sentinel_path` by monkeypatching `_pause_sentinel_state`, preventing tests from touching `~/.local/share/brainlayer/pause.sentinel`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3791e81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->