### PR TITLE
fix(brainbar): daemon resolves brainlayer venv python, not bare python3.14 (M1 #7b)

### DIFF
--- a/brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift
+++ b/brain-bar/Sources/BrainBar/HybridSearchHelperClient.swift
@@ -86,6 +86,13 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, HybridSearchRe
                 return candidate
             }
         }
+        // On a Homebrew install with no repo checkout, the bare `python3`/`python`
+        // on PATH is the system interpreter (e.g. python3.14) that lacks the
+        // `brainlayer` module — using it yields ModuleNotFoundError at warmup.
+        // Prefer the formula venv, which has the package installed.
+        if let venvPython = resolveHomebrewVenvPython(environment: environment) {
+            return venvPython
+        }
         if let python3 = findExecutable(named: "python3", path: environment["PATH"]) {
             return python3
         }
@@ -110,6 +117,26 @@ final class HybridSearchHelperClient: HybridSearchClientProtocol, HybridSearchRe
             return nil
         }
         return sourcePath
+    }
+
+    /// Resolve the brainlayer Homebrew formula venv python, which has the
+    /// `brainlayer` package installed. Probes `$HOMEBREW_PREFIX` first (set in
+    /// Homebrew shells / launchd plists), then the canonical Apple-Silicon and
+    /// Intel prefixes so a clone works even when HOMEBREW_PREFIX is unset.
+    static func resolveHomebrewVenvPython(environment: [String: String]) -> String? {
+        var prefixes: [String] = []
+        if let prefix = environment["HOMEBREW_PREFIX"],
+           !prefix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            prefixes.append(prefix)
+        }
+        prefixes.append(contentsOf: ["/opt/homebrew", "/usr/local"])
+        for prefix in prefixes {
+            let candidate = "\(prefix)/opt/brainlayer/libexec/venv/bin/python"
+            if FileManager.default.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+        return nil
     }
 
     private static func normalizedRepoRoot(environment: [String: String]) -> String? {

--- a/brain-bar/Tests/BrainBarTests/HybridSearchHelperClientTests.swift
+++ b/brain-bar/Tests/BrainBarTests/HybridSearchHelperClientTests.swift
@@ -24,6 +24,38 @@ final class HybridSearchHelperClientTests: XCTestCase {
         XCTAssertEqual(resolved, pythonPath)
     }
 
+    func testResolvePythonExecutablePrefersHomebrewVenvOverBarePython3() throws {
+        // On a Homebrew clone with no repo checkout, bare `python3` on PATH is the
+        // system interpreter (e.g. python3.14) that lacks the `brainlayer` module.
+        // The formula venv at <prefix>/opt/brainlayer/libexec/venv/bin/python MUST win.
+        let prefix = NSTemporaryDirectory() + "brainbar-brew-\(UUID().uuidString)"
+        let venvPython = "\(prefix)/opt/brainlayer/libexec/venv/bin/python"
+        try FileManager.default.createDirectory(
+            atPath: "\(prefix)/opt/brainlayer/libexec/venv/bin",
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: venvPython, contents: Data("#!/bin/sh\n".utf8))
+        chmod(venvPython, 0o755)
+
+        let pathDir = NSTemporaryDirectory() + "brainbar-brew-path-\(UUID().uuidString)"
+        let barePython3 = "\(pathDir)/python3"
+        try FileManager.default.createDirectory(atPath: pathDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: barePython3, contents: Data("#!/bin/sh\n".utf8))
+        chmod(barePython3, 0o755)
+
+        defer {
+            try? FileManager.default.removeItem(atPath: prefix)
+            try? FileManager.default.removeItem(atPath: pathDir)
+        }
+
+        let resolved = HybridSearchHelperClient.resolvePythonExecutable(environment: [
+            "HOMEBREW_PREFIX": prefix,
+            "PATH": pathDir
+        ])
+
+        XCTAssertEqual(resolved, venvPython)
+    }
+
     func testResolvePythonPathPrefersInstalledPackageWhenUnset() throws {
         let repoRoot = NSTemporaryDirectory() + "brainbar-helper-src-\(UUID().uuidString)"
         try FileManager.default.createDirectory(


### PR DESCRIPTION
## What
`HybridSearchHelperClient.resolvePythonExecutable` now probes the Homebrew formula venv (`<prefix>/opt/brainlayer/libexec/venv/bin/python`, from $HOMEBREW_PREFIX then /opt/homebrew, /usr/local) **before** the bare `python3`/`python` PATH fallback.

## Why
On a Homebrew clone with no repo checkout, bare `python3` on PATH is the system interpreter (e.g. python3.14) that lacks the `brainlayer` module → `ModuleNotFoundError` at hybrid-helper warmup ("notReady"), so BrainBar fleet brain_search silently degrades. (M1-clone friction #7b; same class as the hook bug #3.)

## Test
New `testResolvePythonExecutablePrefersHomebrewVenvOverBarePython3` (decoy python3 on PATH must lose to the venv). Existing repo-root test still passes. `swift build` + `swift test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Python executable resolution order plus a unit test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes hybrid search helper warmup on **Homebrew-only installs** (no repo checkout) by choosing the formula venv interpreter before falling back to `python3`/`python` on `PATH`.
> 
> `HybridSearchHelperClient.resolvePythonExecutable` now calls new **`resolveHomebrewVenvPython`**, which looks for `<prefix>/opt/brainlayer/libexec/venv/bin/python` using `$HOMEBREW_PREFIX`, then `/opt/homebrew` and `/usr/local`. That ordering runs **after** explicit overrides, `VIRTUAL_ENV`, and repo `.venv`, but **before** generic PATH lookup—so the system `python3` without `brainlayer` is no longer used and `ModuleNotFoundError` / `notReady` degradation is avoided.
> 
> Adds **`testResolvePythonExecutablePrefersHomebrewVenvOverBarePython3`** to assert the venv wins when a decoy `python3` is on `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a2fa473f03a6303b981f517c1ff7505c92f98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolvePythonExecutable` to prefer brainlayer Homebrew formula venv Python over bare `python3`
> - Adds `resolveHomebrewVenvPython` in [`HybridSearchHelperClient.swift`](https://github.com/EtanHey/brainlayer/pull/528/files#diff-c005f2849273dedb87dbd8219bb3e7268f67871c6cd44f0eaa0c69d4b4c8c40a) to locate the brainlayer formula venv interpreter at `opt/brainlayer/libexec/venv/bin/python` under `HOMEBREW_PREFIX` (or canonical `/opt/homebrew`/`/usr/local` fallbacks).
> - Updates `resolvePythonExecutable` to try the venv interpreter first, falling back to bare `python3`/`python` on PATH only when no venv is found.
> - Adds a test verifying that a mock Homebrew prefix with a venv python is preferred over a bare `python3` on PATH.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50a2fa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->