### PR TITLE
fix(drain): default BRAINLAYER_DRAIN_EMBED=0 in launchd template (write-throughput)

### DIFF
--- a/scripts/launchd/com.brainlayer.drain.plist
+++ b/scripts/launchd/com.brainlayer.drain.plist
@@ -25,6 +25,13 @@
 		<string>__BRAINLAYER_ENV_FILE__</string>
 		<key>BRAINLAYER_LAUNCHD_SERVICE</key>
 		<string>drain</string>
+		<!-- Write chunks WITHOUT computing embeddings inside the drain's write
+		     transaction. Inline embedding lengthens the write-lock hold time and,
+		     under multi-writer contention (BrainBar/daemon/hybrid/watcher), starves
+		     the drain on SQLITE_BUSY so the realtime queue backs up. Vectors are
+		     backfilled out-of-band by enrichment/hotlane. (M1/throughput fix.) -->
+		<key>BRAINLAYER_DRAIN_EMBED</key>
+		<string>0</string>
 	</dict>
 	<key>StandardOutPath</key>
 	<string>__HOME__/Library/Logs/brainlayer/drain.out.log</string>


### PR DESCRIPTION
## What
Set `BRAINLAYER_DRAIN_EMBED=0` in `scripts/launchd/com.brainlayer.drain.plist` so the drain writes chunks **without** computing embeddings inside the write transaction. Vectors backfill out-of-band via enrichment/hotlane.

## Why
Diagnosed by the write-throughput root-cause workflow (2026-06-20): under multi-writer contention (BrainBar + BrainBarDaemon + brainbar_hybrid + watcher all hold the DB), inline embedding lengthened the drain's write-lock hold time and starved it on SQLITE_BUSY at DB open — the realtime queue backed up to ~8.7K files while only ~27 chunks/hr landed (vs ~9/min produced). Etan observed the dashboard JSONL-watcher series stuck at ~6-7/bucket.

## Verified live
Applied to the installed plist + kickstarted the drain: queue 6.4K → 4.0K and `drained_total` 50 → 2100 within minutes; the realtime write path recovered.

## Follow-ups (not in this PR)
- watcher process at 87% CPU (re-rglob storm) — separate fix.
- stale `ingested_at` on the drain realtime insert (dashboard undercount) — separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational default in a plist template only; vectors rely on existing backfill paths, with no auth or schema changes in this diff.
> 
> **Overview**
> The launchd template for **com.brainlayer.drain** now sets **`BRAINLAYER_DRAIN_EMBED=0`**, so the drain persists chunks **without** running embedding inside the SQLite write transaction. Embeddings are expected to be filled later via enrichment/hotlane.
> 
> An inline comment documents the motivation: inline embedding held the write lock longer; with several writers on the same DB, the drain hit **SQLITE_BUSY**, throughput collapsed, and the realtime queue grew. Disabling embed-on-drain shortens lock time so the drain can keep up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a72f5bcbd753e0fa4709d8f165de79bba2f3d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `BRAINLAYER_DRAIN_EMBED=0` in the launchd drain plist to improve write throughput
> Sets `BRAINLAYER_DRAIN_EMBED=0` in [com.brainlayer.drain.plist](https://github.com/EtanHey/brainlayer/pull/529/files#diff-70207bc8c3e8d94c42e40498a2f1427b0f6d179630f181dd836398cbfd3fa751) so the drain process skips computing embeddings during the write transaction. Embeddings are backfilled out-of-band instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a72f5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->