### PR TITLE
fix(brainbar): clamp Vector popover within window so it pops over, not clipped

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -633,20 +633,17 @@ private struct BrainBarDashboardView: View {
     }
 
     private var vectorDetailTransition: AnyTransition {
+        // NOTE: deliberately NOT using RevealClip here. RevealClip masks the popover
+        // to height*progress; the height-measurement re-render (BrainBarVectorDetailHeightKey)
+        // interrupts the insertion animation, leaving progress < 1 → the popover renders
+        // CLIPPED to a partial height with empty space below it (Etan live-QA 2026-06-20).
+        // A plain opacity (+ subtle slide on removal) can never clip the content height.
         if reduceMotion {
             .opacity
         } else {
             .asymmetric(
-            insertion: .opacity.combined(with: .modifier(
-                active: RevealClip(progress: 0),
-                identity: RevealClip(progress: 1)
-            )),
-            removal: .opacity
-                .combined(with: .modifier(
-                    active: RevealClip(progress: 0),
-                    identity: RevealClip(progress: 1)
-                ))
-                .combined(with: .offset(y: -6))
+                insertion: .opacity,
+                removal: .opacity.combined(with: .offset(y: -6))
             )
         }
     }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -324,6 +324,7 @@ private struct BrainBarDashboardView: View {
     @State private var vectorSignalDetailExpanded = false
     @State private var vectorSignalRowFrame: CGRect = .zero
     @State private var vectorSignalRootFrame: CGRect = .zero
+    @State private var vectorDetailHeight: CGFloat = 0
 
     private var flowSummary: DashboardFlowSummary {
         DashboardFlowSummary.derive(daemon: collector.daemon, stats: collector.stats)
@@ -370,11 +371,27 @@ private struct BrainBarDashboardView: View {
                     BrainBarVectorSignalDetail(signal: vectorSignal, compact: layout.compactCards)
                         .frame(width: vectorDetailWidth(layout: layout), alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
-                        .offset(x: vectorDetailXOffset(layout: layout), y: vectorDetailYOffset(layout: layout))
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: BrainBarVectorDetailHeightKey.self,
+                                    value: geo.size.height
+                                )
+                            }
+                        )
+                        .offset(
+                            x: vectorDetailXOffset(layout: layout),
+                            y: vectorDetailYOffset(layout: layout, containerHeight: proxy.size.height)
+                        )
                         .shadow(color: .brainBarBlack.opacity(0.55), radius: 22, y: 12)
                         .shadow(color: .brainBarBlack.opacity(0.30), radius: 6, y: 2)
                         .transition(vectorDetailTransition)
                         .zIndex(vectorSignalDetailExpanded ? 30 : 0)
+                }
+            }
+            .onPreferenceChange(BrainBarVectorDetailHeightKey.self) { height in
+                if height > 0 {
+                    vectorDetailHeight = height
                 }
             }
         }
@@ -600,8 +617,14 @@ private struct BrainBarDashboardView: View {
         max(layout.outerPadding, vectorSignalRootFrame.minX)
     }
 
-    private func vectorDetailYOffset(layout: BrainBarDashboardLayout) -> CGFloat {
-        vectorSignalRootFrame.maxY + (layout.compactCards ? 8 : 10)
+    private func vectorDetailYOffset(layout: BrainBarDashboardLayout, containerHeight: CGFloat) -> CGFloat {
+        BrainBarVectorDetailLayout.yOffset(
+            anchorMaxY: vectorSignalRootFrame.maxY,
+            gap: layout.compactCards ? 8 : 10,
+            detailHeight: vectorDetailHeight,
+            containerHeight: containerHeight,
+            padding: layout.outerPadding
+        )
     }
 
     private func vectorDetailWidth(layout: BrainBarDashboardLayout) -> CGFloat {
@@ -749,6 +772,39 @@ private struct BrainBarVectorSignalRootFrameKey: PreferenceKey {
         if next != .zero {
             value = next
         }
+    }
+}
+
+private struct BrainBarVectorDetailHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let next = nextValue()
+        if next > 0 {
+            value = next
+        }
+    }
+}
+
+/// Positioning math for the Vector "see under the hood" popover. Kept as a pure,
+/// testable function so the clamp logic can't silently regress to clipping.
+enum BrainBarVectorDetailLayout {
+    /// Y offset for the popover within the dashboard container. Prefers sitting just
+    /// below the anchor (`anchorMaxY + gap`), but clamps upward so the full popover
+    /// height stays within `containerHeight - padding` — it pops OVER the content
+    /// above rather than overflowing and clipping at the bottom edge. Falls back to
+    /// the preferred offset until the popover height has been measured.
+    static func yOffset(
+        anchorMaxY: CGFloat,
+        gap: CGFloat,
+        detailHeight: CGFloat,
+        containerHeight: CGFloat,
+        padding: CGFloat
+    ) -> CGFloat {
+        let preferred = anchorMaxY + gap
+        guard detailHeight > 0, containerHeight > 0 else { return preferred }
+        let highestTop = max(padding, containerHeight - padding - detailHeight)
+        return min(preferred, highestTop)
     }
 }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarWindowRootViewVectorDetailLayoutTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarWindowRootViewVectorDetailLayoutTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import BrainBar
+
+/// Guards the Vector "see under the hood" popover positioning.
+///
+/// Regression (Etan live-QA 2026-06-20): the popover anchored at
+/// `anchor.maxY + gap` with no clamp, so when the signal panel sat low in the
+/// window the popover overflowed the bottom edge and was CLIPPED. The fix clamps
+/// the Y so the full popover height stays within the container — it pops OVER the
+/// content above rather than clipping below.
+final class BrainBarWindowRootViewVectorDetailLayoutTests: XCTestCase {
+    func testSitsBelowAnchorWhenThereIsRoom() {
+        let y = BrainBarVectorDetailLayout.yOffset(
+            anchorMaxY: 100, gap: 10, detailHeight: 50, containerHeight: 400, padding: 16
+        )
+        XCTAssertEqual(y, 110, accuracy: 0.001, "should sit just below the anchor when it fits")
+    }
+
+    func testClampsUpwardSoBottomStaysInBounds() {
+        // anchor low in the window: below-offset would clip.
+        let container: CGFloat = 400
+        let detail: CGFloat = 120
+        let padding: CGFloat = 16
+        let y = BrainBarVectorDetailLayout.yOffset(
+            anchorMaxY: 380, gap: 10, detailHeight: detail, containerHeight: container, padding: padding
+        )
+        // clamped so the bottom (y + detail) stays within container - padding.
+        XCTAssertLessThanOrEqual(y + detail, container - padding + 0.001)
+        XCTAssertEqual(y, container - padding - detail, accuracy: 0.001)
+    }
+
+    func testTopAlignsWhenTallerThanContainer() {
+        let y = BrainBarVectorDetailLayout.yOffset(
+            anchorMaxY: 380, gap: 10, detailHeight: 500, containerHeight: 400, padding: 16
+        )
+        XCTAssertEqual(y, 16, accuracy: 0.001, "falls back to padding when it cannot fully fit")
+    }
+
+    func testUnmeasuredHeightUsesPreferredBelowOffset() {
+        // Before the popover height is measured (height == 0), use the preferred offset.
+        let y = BrainBarVectorDetailLayout.yOffset(
+            anchorMaxY: 200, gap: 8, detailHeight: 0, containerHeight: 400, padding: 16
+        )
+        XCTAssertEqual(y, 208, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## What
The Vector "see under the hood" detail popover is an `.overlay` positioned at `anchor.maxY + gap` with **no clamp**, so when the SIGNAL COVERAGE panel sits low in the window the popover overflows and **clips at the bottom edge** (Etan live-QA). This measures the popover height and clamps its Y (`BrainBarVectorDetailLayout.yOffset`) so the full popover stays within `containerHeight - padding` — it pops OVER the content above instead of clipping below.

## Test
`BrainBarWindowRootViewVectorDetailLayoutTests` (4 cases: sits-below-when-room, clamps-up-to-stay-in-bounds, top-aligns-when-taller-than-window, unmeasured-uses-preferred). `swift build` + `swift test` green.

## Verification status (honest)
Clamp math is unit-tested and the build is deployed to the live ~/Applications/BrainBar.app. Automated visual confirmation of the popover-open state is hard (the SwiftUI Vector toggle is finicky to trigger programmatically via screencapture/cliclick at Retina scale) — **final visual confirm pending a human click**. Inherent limit: at a window shorter than the popover itself, it top-aligns (can't fully fit); the common/normal-height clipping case is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard UI positioning and animation only; clamp logic is covered by unit tests with no auth, data, or API changes.
> 
> **Overview**
> Fixes the Vector **“see under the hood”** detail popover clipping at the bottom of the BrainBar dashboard when Signal Coverage sits low in the window.
> 
> The overlay now **measures popover height** (`BrainBarVectorDetailHeightKey`) and positions it with **`BrainBarVectorDetailLayout.yOffset`**, which keeps the full panel inside the dashboard (`containerHeight` minus padding) by shifting upward over content above instead of overflowing below. Until height is measured, placement still uses the preferred below-anchor offset.
> 
> **Show/hide animation** drops `RevealClip` in favor of opacity (and a small slide on dismiss) so the height-measurement re-render does not interrupt the reveal and leave the popover partially masked.
> 
> Four unit tests lock in preferred placement, upward clamping, oversized popover top-align, and the unmeasured-height fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd276272612222eeaea278fcecb63a9cf7cdf57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clamp Vector detail popover Y offset within the window to prevent clipping
> - Adds `BrainBarVectorDetailLayout.yOffset` to compute the popover's Y position, preferring below the anchor but clamping upward so the bottom edge stays within the container bounds.
> - Measures the popover height at runtime via a `GeometryReader` and `BrainBarVectorDetailHeightKey` preference key, feeding the result into the layout calculation.
> - Replaces the `RevealClip` insertion/removal transition with a simple opacity fade (plus slight upward slide on removal) to avoid partial-height clipping during measurement re-renders.
> - Adds unit tests in `BrainBarWindowRootViewVectorDetailLayoutTests` covering the clamping, anchor-below, and unmeasured-height cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd27627.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->