### PR TITLE
feat(brainbar): 3-line always-visible menu-bar status icon

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarStatusPopoverController.swift
@@ -75,12 +75,14 @@ final class BrainBarStatusPopoverController: NSObject {
     }
 
     private func renderStatusIcon(stats: BrainDatabase.DashboardStats, state: PipelineState) {
-        let livePresentation = BrainBarLivePresentation.derive(stats: stats)
-        statusItemForTesting.button?.image = SparklineRenderer.render(
-            state: state,
-            values: stats.recentEnrichmentBuckets,
-            size: NSSize(width: 22, height: 12),
-            accentColor: livePresentation.accentColor
+        // Three overlapping pipeline lines (Agent stores / JSONL watcher / Enrichment)
+        // with an always-visible baseline so the icon stays legible on a dark
+        // fullscreen menu bar instead of the old single gray line that vanished.
+        statusItemForTesting.button?.image = SparklineRenderer.renderStatusBarIcon(
+            agent: stats.recentAgentWriteBuckets,
+            watcher: stats.recentWatcherWriteBuckets,
+            enrichment: stats.recentEnrichmentBuckets,
+            size: NSSize(width: 26, height: 14)
         )
     }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -1111,6 +1111,60 @@ enum SparklineTooltipPlacement {
     }
 }
 
+/// The menu-bar status icon: three overlapping pipeline sparklines (Agent stores /
+/// JSONL watcher / Enrichment) over an always-visible baseline. Bright colors on a
+/// transparent ground (isTemplate=false) keep it visible on a dark fullscreen menu
+/// bar — where the old single gray line vanished. Even when every series is idle,
+/// the baseline keeps the icon on screen.
+struct MenuBarSparklineIcon: View {
+    struct Series: Equatable {
+        let values: [Int]
+        let color: Color
+    }
+
+    let series: [Series]
+
+    var body: some View {
+        Canvas { ctx, size in
+            let inset: CGFloat = 1.5
+            let rect = CGRect(
+                x: inset,
+                y: inset,
+                width: max(size.width - inset * 2, 1),
+                height: max(size.height - inset * 2, 1)
+            )
+
+            // Always-visible baseline so the icon never disappears on any background.
+            var baseline = Path()
+            baseline.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+            baseline.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            ctx.stroke(baseline, with: .color(.white.opacity(0.28)), lineWidth: 0.75)
+
+            // Shared scale across series so relative activity reads at a glance.
+            let globalMax = max(series.flatMap { $0.values }.max() ?? 0, 1)
+            for s in series {
+                guard s.values.count > 1 else { continue }
+                var path = Path()
+                for (index, value) in s.values.enumerated() {
+                    let x = rect.minX + CGFloat(index) * (rect.width / CGFloat(s.values.count - 1))
+                    let normalized = CGFloat(value) / CGFloat(globalMax)
+                    let y = rect.maxY - normalized * rect.height
+                    if index == 0 {
+                        path.move(to: CGPoint(x: x, y: y))
+                    } else {
+                        path.addLine(to: CGPoint(x: x, y: y))
+                    }
+                }
+                ctx.stroke(
+                    path,
+                    with: .color(s.color),
+                    style: StrokeStyle(lineWidth: 1.2, lineCap: .round, lineJoin: .round)
+                )
+            }
+        }
+    }
+}
+
 enum SparklineRenderer {
     static func isCompact(size: NSSize) -> Bool {
         let width = max(size.width.rounded(.up), 1)
@@ -1167,6 +1221,34 @@ enum SparklineRenderer {
         .frame(width: width, height: height)
 
         let renderer = ImageRenderer(content: chart)
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
+        if let image = renderer.nsImage {
+            image.isTemplate = false
+            return image
+        }
+        return NSImage(size: NSSize(width: width, height: height))
+    }
+
+    /// Render the three-line pipeline status-bar icon (Agent / Watcher / Enrichment).
+    /// isTemplate=false: we want the bright colors, and the baseline guarantees the
+    /// icon stays visible on a dark fullscreen menu bar even when all series are idle.
+    @MainActor
+    static func renderStatusBarIcon(
+        agent: [Int],
+        watcher: [Int],
+        enrichment: [Int],
+        size: NSSize = NSSize(width: 26, height: 14)
+    ) -> NSImage {
+        let width = max(size.width.rounded(.up), 1)
+        let height = max(size.height.rounded(.up), 1)
+        let icon = MenuBarSparklineIcon(series: [
+            .init(values: agent, color: Color(nsColor: BrainBarDesignTokens.Colors.seriesAgent)),
+            .init(values: watcher, color: Color(nsColor: BrainBarDesignTokens.Colors.seriesWatcher)),
+            .init(values: enrichment, color: Color(nsColor: BrainBarDesignTokens.Colors.signalFTS5)),
+        ])
+        .frame(width: width, height: height)
+
+        let renderer = ImageRenderer(content: icon)
         renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
         if let image = renderer.nsImage {
             image.isTemplate = false

--- a/brain-bar/Tests/BrainBarTests/SparklineRendererIconTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SparklineRendererIconTests.swift
@@ -1,0 +1,44 @@
+import AppKit
+import XCTest
+@testable import BrainBar
+
+/// Guards the menu-bar status icon: it must (1) render a non-empty image even when
+/// ALL series are idle/zero (so it never vanishes on a dark fullscreen menu bar —
+/// Etan 2026-06-20), and (2) draw the three overlapping pipeline lines.
+@MainActor
+final class SparklineRendererIconTests: XCTestCase {
+    private var outDir: String? { ProcessInfo.processInfo.environment["BRAINBAR_SNAPSHOT_DIR"] }
+
+    private func save(_ image: NSImage, _ name: String) {
+        guard let dir = outDir,
+              let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else { return }
+        try? png.write(to: URL(fileURLWithPath: "\(dir)/\(name).png"))
+    }
+
+    func testStatusIconRendersWhenAllSeriesIdle() throws {
+        // The regression: gray single line on a dark bar = invisible. The icon must
+        // still produce a real (non-zero-size) image when nothing is happening.
+        let image = SparklineRenderer.renderStatusBarIcon(
+            agent: Array(repeating: 0, count: 12),
+            watcher: Array(repeating: 0, count: 12),
+            enrichment: Array(repeating: 0, count: 12),
+            size: NSSize(width: 26, height: 14)
+        )
+        XCTAssertGreaterThan(image.size.width, 0)
+        XCTAssertGreaterThan(image.size.height, 0)
+        save(image, "status-icon-idle")
+    }
+
+    func testStatusIconRendersThreeActiveSeries() throws {
+        let image = SparklineRenderer.renderStatusBarIcon(
+            agent: [0, 1, 0, 2, 1, 0, 1, 0, 2, 1, 0, 1],
+            watcher: [3, 5, 4, 7, 6, 5, 8, 6, 5, 7, 6, 9],
+            enrichment: [1, 0, 2, 1, 3, 2, 1, 2, 0, 1, 2, 1],
+            size: NSSize(width: 26, height: 14)
+        )
+        XCTAssertGreaterThan(image.size.width, 0)
+        save(image, "status-icon-active")
+    }
+}


### PR DESCRIPTION
## What
Menu-bar status icon now draws **three overlapping pipeline sparklines** (Agent stores=cyan, JSONL watcher=rose, Enrichment=green) over an **always-visible baseline**.

## Why (Etan 2026-06-20)
1. The old icon was a single sparkline tinted with a state-derived color that goes **gray when idle**, with `isTemplate=false` → **invisible on a dark fullscreen menu bar**. The baseline guarantees it never disappears (even when all series are zero).
2. He wanted 3 lines (one per pipeline) overlapping for a more telling at-a-glance icon.

## Verified
Rendered the actual icon to PNG (idle = visible baseline; active = 3 distinct colored lines) — `SparklineRendererIconTests` (2 cases, green). Will go live in the unified build alongside the dashboard redesign + QA fixes (not deployed standalone, to avoid reverting the dashboard branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only menu bar rendering with no auth, data, or pipeline logic changes; existing dashboard stats fields are reused.
> 
> **Overview**
> Replaces the menu-bar status image: instead of one enrichment sparkline tinted by **live/idle** state (gray when idle, often invisible on a dark menu bar), it now renders **three overlapping pipeline series**—Agent writes, JSONL watcher writes, and enrichment—from `DashboardStats` bucket arrays, at a slightly larger **26×14** size.
> 
> Adds **`MenuBarSparklineIcon`** (SwiftUI `Canvas`) with a fixed **baseline** plus shared-scale colored strokes using existing design-token series colors, and **`SparklineRenderer.renderStatusBarIcon`** with **`isTemplate = false`** so colors and the baseline stay visible when all buckets are zero.
> 
> **`SparklineRendererIconTests`** locks in non-empty renders for all-idle and active data, with optional PNG snapshots when `BRAINBAR_SNAPSHOT_DIR` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bfcbc273a68113de27075aec43778305a524bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace single-line sparkline with 3-line always-visible menu-bar status icon
> - Replaces the single accent-colored sparkline in `BrainBarStatusPopoverController.renderStatusIcon` with a three-series icon showing agent, watcher, and enrichment activity as distinct colored lines.
> - Adds `MenuBarSparklineIcon`, a SwiftUI `Canvas`-based view in [SparklineRenderer.swift](https://github.com/EtanHey/brainlayer/pull/531/files#diff-27c132f6a3e15acfd5900246f3fc1e277502117e1e22c5b47ee78581e8e13a02) that draws a persistent baseline at the bottom so the icon remains visible even when all series are zero.
> - Adds `SparklineRenderer.renderStatusBarIcon`, a `@MainActor` static function that renders the three series to a non-template 26×14 `NSImage` (up from 22×12).
> - Adds tests in [SparklineRendererIconTests.swift](https://github.com/EtanHey/brainlayer/pull/531/files#diff-afadcce0f96c566f98cdf875576b041f75a912b89ed9065fb50c34fdfd69365b) for both idle (all-zero) and active series, with optional PNG snapshot output via `BRAINBAR_SNAPSHOT_DIR`.
> - Behavioral Change: the icon is no longer a template image, so it renders in color rather than adapting to the system appearance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98bfcbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->