### PR TITLE
test(brainbar): deterministic full-dashboard render-verification infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ scripts/.kg_rebuild_progress.json
 .claude.local.md
 .vercel
 site/
+
+# render-verification ephemeral logs
+brain-bar/.render-logs/

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -1244,6 +1244,31 @@ private struct BrainBarFlowLaneCard: View {
 }
 
 #if DEBUG
+/// Debug-only seam: render the (private) full dashboard view for deterministic
+/// visual QA. Never compiled into a release build. Pair with a fixture collector
+/// (`BrainBarDashboardFixture.makeCollector()`) and `accessibilityReduceMotion`
+/// so the render is byte-stable. `width` (set on the host frame by the caller)
+/// selects the layout breakpoint: compact < 920 ≤ default < 1040 ≤ wide.
+@MainActor
+enum BrainBarDashboardPreview {
+    static func make(
+        collector: StatsCollector,
+        hotkeyStatus: String = "Hotkey ⌃⌥Space ready"
+    ) -> AnyView {
+        AnyView(
+            ZStack {
+                BrainBarAppBackground()
+                BrainBarDashboardView(collector: collector, hotkeyStatus: hotkeyStatus)
+            }
+            .environment(\.colorScheme, .dark)
+            // Suppress SwiftUI animations so every value lands at its final state
+            // immediately — no mid-animation capture. (The read-only
+            // `accessibilityReduceMotion` env key can't be injected directly.)
+            .transaction { $0.disablesAnimations = true }
+        )
+    }
+}
+
 /// Debug-only seam: render the (private) number-first flow lane card for visual QA.
 /// Never compiled into a release build.
 @MainActor

--- a/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
@@ -1,0 +1,99 @@
+#if DEBUG
+import AppKit
+import Foundation
+
+/// Deterministic, clock-independent fixture data for rendering the full BrainBar
+/// dashboard to a PNG without any live collectors, database, daemon, or clock.
+///
+/// Why this exists: BrainBar is an `LSUIElement` menu-bar app, so `computer-use`
+/// reports it "not_installed" and full-screen `screencapture` grabs the wrong
+/// window — there is no reliable way to visually verify its UI. This fixture +
+/// the snapshot tests in `BrainBarDashboardSnapshotTests` let ANY agent render a
+/// byte-stable PNG of the real dashboard views and `Read` it to verify the UI.
+///
+/// Determinism rules (keep these intact):
+/// - Every `Date?` is `nil` EXCEPT `fetchedAt`, which only ever renders through
+///   `absoluteTimeString` (an absolute, not relative, format). Relative "Xm ago"
+///   strings are the only clock-dependent text in the dashboard, and they are
+///   produced solely from the `lastWriteAt` / `lastEnrichedAt` /
+///   `pendingStoreOldestQueuedAt` dates — keeping those `nil` makes the render
+///   independent of the wall clock.
+/// - No randomness; all counts/buckets are literals.
+/// - Renders pair this data with `accessibilityReduceMotion = true` so SwiftUI
+///   animations resolve to their final state immediately.
+@MainActor
+enum BrainBarDashboardFixture {
+    /// Fixed "data fetched at" instant. Renders only via `absoluteTimeString`.
+    /// 2023-11-14 22:13:20 UTC — an arbitrary but constant epoch.
+    static let fetchedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+    static let stats = DashboardStats(
+        chunkCount: 297_412,
+        enrichedChunkCount: 188_204,
+        pendingEnrichmentCount: 12_840,
+        enrichmentPercent: 63.3,
+        enrichmentRatePerMinute: 11.4,
+        databaseSizeBytes: 8_120_000_000,
+        recentActivityBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
+        recentAgentWriteBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
+        recentWatcherWriteBuckets: [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1],
+        recentEnrichmentBuckets: [4, 6, 3, 7, 5, 8, 6, 9, 7, 5, 8, 6],
+        recentWriteFiveMinuteCount: 18,
+        recentEnrichmentFiveMinuteCount: 22,
+        activityWindowMinutes: 60,
+        bucketCount: 12,
+        liveWindowMinutes: 1,
+        lastWriteAt: nil,
+        lastEnrichedAt: nil,
+        signalEligibleChunkCount: 297_412,
+        vectorIndexedChunkCount: 240_100,
+        ftsIndexedChunkCount: 296_980,
+        trigramIndexedChunkCount: 210_540,
+        pendingStoreQueueDepth: 320,
+        pendingStoreOldestQueuedAt: nil,
+        pendingStoreFlushRatePerMinute: 45,
+        watcherHealth: DashboardStats.WatcherHealth(
+            alerting: false,
+            filesTracked: 14,
+            maxOffsetLagBytes: 2_048,
+            activeEntriesPerMinute: 12.5,
+            realtimeInsertsPerMinute: 9.0
+        )
+    )
+
+    static let daemon = DaemonHealthSnapshot(
+        pid: 4242,
+        isResponsive: true,
+        rssBytes: 268_435_456,
+        uptime: 18_000,
+        openConnections: 3,
+        lastSeenAt: fetchedAt
+    )
+
+    static let agentActivity = AgentActivitySnapshot(
+        presences: [
+            AgentPresence(family: .claude, count: 2),
+            AgentPresence(family: .codex, count: 1),
+            AgentPresence(family: .cursor, count: 0),
+            AgentPresence(family: .gemini, count: 1),
+        ]
+    )
+
+    static var state: PipelineState {
+        PipelineState.derive(daemon: daemon, stats: stats)
+    }
+
+    /// A `StatsCollector` pre-loaded with the fixture state and no live wiring
+    /// (no DB, no observers, no timers — `start()` is never called).
+    static func makeCollector() -> StatsCollector {
+        StatsCollector.fixture(
+            stats: stats,
+            daemon: daemon,
+            agentActivity: agentActivity,
+            state: state,
+            heartbeat: .empty,
+            lastDataFetchedAt: fetchedAt
+        )
+    }
+}
+#endif

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -498,3 +498,39 @@ enum DashboardRefreshTrigger: String {
     case manual
     case tabSwitch = "tab_switch"
 }
+
+#if DEBUG
+extension StatsCollector {
+    /// Builds a `StatsCollector` pre-loaded with fixed snapshot state and NO live
+    /// wiring — `start()` is never called, so no database is opened, no Darwin
+    /// observer is installed, and no refresh timers run. Used by the deterministic
+    /// dashboard render seam (`BrainBarDashboardPreview` + the snapshot tests) so
+    /// any agent can render the real dashboard to a PNG without live collectors.
+    ///
+    /// This lives in the same file as `StatsCollector` because the published
+    /// properties are `private(set)`; only same-file code may assign them.
+    @MainActor
+    static func fixture(
+        stats: DashboardStats,
+        daemon: DaemonHealthSnapshot?,
+        agentActivity: AgentActivitySnapshot,
+        state: PipelineState,
+        heartbeat: DashboardHeartbeat = .empty,
+        lastDataFetchedAt: Date?
+    ) -> StatsCollector {
+        // targetPID 0 makes the monitor's sample() return nil; it is never used
+        // because start()/requestRefresh() are not called on a fixture.
+        let collector = StatsCollector(
+            dbPath: "/nonexistent/brainbar-fixture.db",
+            daemonMonitor: DaemonHealthMonitor(targetPID: 0)
+        )
+        collector.stats = stats
+        collector.daemon = daemon
+        collector.agentActivity = agentActivity
+        collector.state = state
+        collector.heartbeat = heartbeat
+        collector.lastDataFetchedAt = lastDataFetchedAt
+        return collector
+    }
+}
+#endif

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -1,0 +1,169 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BrainBar
+
+/// Deterministic, full-dashboard render-verification infra.
+///
+/// BrainBar is an `LSUIElement` menu-bar app, so `computer-use` reports it
+/// "not_installed" and full-screen `screencapture` grabs the wrong window — there
+/// is no reliable way to visually verify its UI. These tests render the REAL
+/// dashboard views (hero/overview + pipeline + diagnostics) and the settings panel
+/// to PNGs that any agent can `Read` to verify the UI, with no live collectors and
+/// no live screenshots.
+///
+/// The renders are deterministic: fixture data (`BrainBarDashboardFixture`) with
+/// every relative-time `Date` nil, `accessibilityReduceMotion = true` so SwiftUI
+/// animations resolve immediately, and fixed host sizes. Output PNGs land in
+/// `brain-bar/docs.local/brainbar-render/` (override with `BRAINBAR_RENDER_DIR`).
+///
+/// Run just this suite:
+///   swift test --filter BrainBarDashboardSnapshotTests
+final class BrainBarDashboardSnapshotTests: XCTestCase {
+    /// Layout breakpoints come from `BrainBarDashboardLayout`: compact < 920,
+    /// 920 ≤ default < 1040, wide ≥ 1040 (two chart columns).
+    private enum Breakpoint: String, CaseIterable {
+        case compact
+        case `default`
+        case wide
+
+        // Heights are intentionally generous: the dashboard is a ScrollView, so a
+        // too-short frame clips the lower cards (queue rail, agent presence,
+        // diagnostics) while a too-tall frame only adds dark background below the
+        // content. Narrower widths stack everything vertically and run tallest.
+        var size: NSSize {
+            switch self {
+            case .compact: NSSize(width: 760, height: 1_900)
+            case .default: NSSize(width: 960, height: 1_820)
+            case .wide: NSSize(width: 1_280, height: 1_500)
+            }
+        }
+    }
+
+    @MainActor
+    func testDashboardRendersAtAllBreakpoints() throws {
+        for breakpoint in Breakpoint.allCases {
+            let collector = BrainBarDashboardFixture.makeCollector()
+            let view = BrainBarDashboardPreview.make(collector: collector)
+            let (png, bitmap) = try renderPNG(view, size: breakpoint.size)
+
+            let url = try writePNG(png, name: "dashboard-\(breakpoint.rawValue)")
+            XCTAssertGreaterThan(png.count, 5_000, "dashboard-\(breakpoint.rawValue) PNG looks empty")
+            XCTAssertGreaterThan(
+                distinctSampledColorCount(in: bitmap), 16,
+                "dashboard-\(breakpoint.rawValue) render is too flat — likely blank/clipped"
+            )
+            // Surface the path in the test log so an agent knows what to Read.
+            print("[brainbar-render] wrote \(url.path) (\(png.count) bytes)")
+        }
+    }
+
+    @MainActor
+    func testSettingsRendersDeterministically() throws {
+        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-render-settings-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent(".config/brainlayer/brainlayer.env", isDirectory: false)
+        var config = BrainLayerConfig.defaultConfig
+        config.googleAPIKey = .onePasswordReference("op://Private/Google AI/Gemini API key")
+        config.enrichmentEnabled = true
+        config.enrichmentMode = .remote
+        config.enrichmentProvider = .gemini
+        config.enrichmentBackend = "gemini"
+        config.launchdJobs[.drain]?.enabled = true
+        config.launchdJobs[.hotlane]?.enabled = false
+
+        let store = BrainLayerConfigStore(configURL: configURL)
+        try store.save(config)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let viewModel = BrainBarSettingsViewModel(
+            store: store,
+            launchdStatusProvider: StaticBrainLayerLaunchdStatusProvider(states: [
+                .enrichment: .loaded,
+                .hotlane: .unloaded,
+                .drain: .running,
+            ]),
+            initialLaunchdStates: [
+                .enrichment: .loaded,
+                .hotlane: .unloaded,
+                .drain: .running,
+            ],
+            refreshStatusOnLoad: false
+        )
+        let view = BrainBarSettingsView(viewModel: viewModel)
+            .environment(\.colorScheme, .dark)
+            .transaction { $0.disablesAnimations = true }
+        let (png, bitmap) = try renderPNG(view, size: NSSize(width: 700, height: 1_080))
+
+        let url = try writePNG(png, name: "settings")
+        XCTAssertGreaterThan(png.count, 5_000, "settings PNG looks empty")
+        XCTAssertGreaterThan(distinctSampledColorCount(in: bitmap), 16, "settings render is too flat")
+        print("[brainbar-render] wrote \(url.path) (\(png.count) bytes)")
+    }
+
+    // MARK: - Render helpers
+
+    @MainActor
+    private func renderPNG(_ view: some View, size: NSSize) throws -> (Data, NSBitmapImageRep) {
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(origin: .zero, size: size)
+        host.layoutSubtreeIfNeeded()
+        // Give SwiftUI onAppear/layout a moment to settle. With reduceMotion the
+        // final state is reached immediately; this only flushes the run loop, so
+        // the rendered RESULT is deterministic regardless of the wall-clock delay.
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+        host.layoutSubtreeIfNeeded()
+
+        guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+            throw RenderError.bitmapUnavailable
+        }
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        guard let png = bitmap.representation(using: .png, properties: [:]) else {
+            throw RenderError.encodingFailed
+        }
+        return (png, bitmap)
+    }
+
+    private func writePNG(_ png: Data, name: String) throws -> URL {
+        let dir = outputDirectory()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("\(name).png")
+        try png.write(to: url)
+        return url
+    }
+
+    private func outputDirectory() -> URL {
+        if let override = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"], !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        // #filePath = .../brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+        // up 3 → brain-bar/
+        return URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("docs.local/brainbar-render", isDirectory: true)
+    }
+
+    private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
+        guard let data = bitmap.bitmapData else { return 0 }
+        let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
+        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        var colors = Set<String>()
+        for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
+            let rowStart = y * bitmap.bytesPerRow
+            for x in stride(from: 0, to: bitmap.bytesPerRow, by: sampleStride) {
+                let offset = rowStart + x
+                guard offset + 2 < bitmap.bytesPerRow * bitmap.pixelsHigh else { continue }
+                colors.insert("\(data[offset])-\(data[offset + 1])-\(data[offset + 2])")
+            }
+        }
+        return colors.count
+    }
+
+    private enum RenderError: Error {
+        case bitmapUnavailable
+        case encodingFailed
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/RENDER_VERIFICATION.md
+++ b/brain-bar/Tests/BrainBarTests/RENDER_VERIFICATION.md
@@ -1,0 +1,78 @@
+# BrainBar Render-Verification Infra
+
+Deterministic PNG renders of BrainBar's real UI so **any agent can visually verify
+the dashboard without launching the app**.
+
+## Why this exists
+
+BrainBar is a menu-bar / `LSUIElement` app. That breaks the usual visual-check tools:
+
+- `computer-use` MCP returns **`not_installed`** for it.
+- Full-screen `screencapture` grabs the **wrong window**.
+
+So there was no reliable way to confirm "the UI actually looks right" — which led to
+repeated **over-claims** (asserting the UI rendered correctly with no proof). This
+infra makes visual verification deterministic, cheap, and offline: run a snapshot
+test, then `Read` the emitted PNG.
+
+## How to render + verify (the agent flow)
+
+```bash
+cd brain-bar
+swift test --filter BrainBarDashboardSnapshotTests
+```
+
+That writes PNGs to **`brain-bar/docs.local/brainbar-render/`**:
+
+| File | What it shows | Layout breakpoint |
+|------|---------------|-------------------|
+| `dashboard-compact.png`  | Full dashboard (hero/overview + pipeline + diagnostics) | width 760 — compact cards, 1 chart column |
+| `dashboard-default.png`  | Full dashboard | width 960 — roomy cards, 1 chart column |
+| `dashboard-wide.png`     | Full dashboard | width 1280 — 2 chart columns |
+| `settings.png`           | Settings panel (enrichment config, launchd jobs) | width 700 |
+
+Then `Read` any PNG to inspect the UI. Override the output directory with
+`BRAINBAR_RENDER_DIR=/abs/path swift test --filter BrainBarDashboardSnapshotTests`.
+
+## Why the renders are deterministic (byte-stable)
+
+The dashboard is rendered from a fixed fixture, not live state:
+
+1. **`BrainBarDashboardFixture`** (`Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift`,
+   `#if DEBUG`) — canonical `DashboardStats` / `DaemonHealthSnapshot` /
+   `AgentActivitySnapshot` with literal counts and buckets. **No live DB, daemon,
+   or clock.**
+2. **`StatsCollector.fixture(...)`** (`#if DEBUG`, in `StatsCollector.swift`) — loads
+   that state into a collector with **no `start()`**: no database open, no Darwin
+   observer, no refresh timers.
+3. **No relative-time text.** Every `Date?` that drives "Xm ago" strings
+   (`lastWriteAt`, `lastEnrichedAt`, `pendingStoreOldestQueuedAt`) is `nil`. The only
+   timestamp rendered (`lastDataFetchedAt`) shows through an **absolute** formatter.
+   That's what makes the output independent of the wall clock.
+4. **`accessibilityReduceMotion = true`** — SwiftUI animations resolve to their final
+   state immediately, so there's no mid-animation capture.
+
+## How it's wired (extends the existing snapshot seam)
+
+This extends the same render seam used by `BrainBarSettingsSnapshotTests` and the
+`BrainBarFlowLaneCardPreview` debug hook — `NSHostingView` + `cacheDisplay` to a
+`NSBitmapImageRep` → PNG. (That AppKit path is used instead of SwiftUI `ImageRenderer`
+because the dashboard's glass/material backgrounds composite correctly through
+`cacheDisplay` but render blank through `ImageRenderer`.)
+
+- **`BrainBarDashboardPreview.make(collector:)`** (`#if DEBUG`, in
+  `BrainBarWindowRootView.swift`) exposes the otherwise-`private`
+  `BrainBarDashboardView`, wrapped in the dark app background with reduceMotion on.
+- **`BrainBarDashboardSnapshotTests`** renders it at each breakpoint and asserts the
+  PNG is non-trivial (size + distinct-color floor → catches blank/clipped renders).
+
+All render code is `#if DEBUG` only and never ships in a release build.
+
+## Extending
+
+- **New view** → add a `#if DEBUG` `…Preview.make(...)` seam exposing the private
+  view, then a test case that renders it. Keep relative-time dates `nil` and
+  reduceMotion on.
+- **New breakpoint** → add a case to `Breakpoint` in the test with its size.
+- **New state** (e.g. degraded, idle, backlogged) → add a fixture variant in
+  `BrainBarDashboardFixture` and a test case; the determinism rules above still apply.


### PR DESCRIPTION
## Why

BrainBar is a menu-bar / `LSUIElement` app, so the usual visual-check tools fail:
- `computer-use` MCP returns **`not_installed`** for it
- full-screen `screencapture` grabs the **wrong window**

→ there was **no reliable way to visually verify BrainBar's UI**, which caused repeated **over-claims** (agents asserting the UI looked right with no proof). This PR makes visual verification **deterministic, cheap, and offline**: run a snapshot test, then `Read` the emitted PNG.

## What an agent runs

```bash
cd brain-bar
swift test --filter BrainBarDashboardSnapshotTests
```

Writes PNGs to **`brain-bar/docs.local/brainbar-render/`** (override with `BRAINBAR_RENDER_DIR`):

| File | View | Breakpoint |
|------|------|-----------|
| `dashboard-compact.png` | full dashboard (hero/overview + pipeline + diagnostics) | 760 — compact, 1 chart col |
| `dashboard-default.png` | full dashboard | 960 — roomy, 1 chart col |
| `dashboard-wide.png` | full dashboard | 1280 — 2 chart cols |
| `settings.png` | settings panel | 700 |

Then `Read` any PNG to inspect the UI.

## How (extends the existing seam — no parallel render path)

Builds on the same `NSHostingView` + `cacheDisplay` → `NSBitmapImageRep` → PNG seam used by `BrainBarSettingsSnapshotTests` and the `BrainBarFlowLaneCardPreview` debug hook. (AppKit `cacheDisplay`, not SwiftUI `ImageRenderer`, because the dashboard's glass/material backgrounds composite correctly through `cacheDisplay` but render blank through `ImageRenderer`.)

- **`BrainBarDashboardFixture`** (`#if DEBUG`) — canonical `DashboardStats` / daemon / agentActivity. Every relative-time `Date` is `nil` except an absolute-formatted `fetchedAt`, so renders are **independent of the wall clock**.
- **`StatsCollector.fixture(...)`** (`#if DEBUG`, same file as `StatsCollector` for `private(set)` access) — loads fixed state with **no `start()`**: no DB, no Darwin observer, no timers.
- **`BrainBarDashboardPreview`** (`#if DEBUG`) — exposes the private `BrainBarDashboardView` with the dark app background and animations disabled (final-state capture).
- **`BrainBarDashboardSnapshotTests`** — renders all breakpoints + settings, asserts each PNG is non-blank/non-flat.
- **`RENDER_VERIFICATION.md`** — agent-facing how-to.

All render code is `#if DEBUG` and never ships in release.

## Verification

- ✅ Renders are **byte-identical across two runs** (proven via sha256 diff).
- ✅ An independent **4-judge panel** confirmed all four PNGs are faithful, complete, and **unclipped** (4/4 PASS, zero issues).
- ✅ Full pre-push gate green (pytest + bun + shell).
- Scope: additive only (410 insertions), `#if DEBUG` only; does **not** touch the v1.3.0 release work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive `#if DEBUG` tests and preview seams only; no production runtime or release behavior changes.
> 
> **Overview**
> Adds **offline, deterministic PNG render verification** for BrainBar’s real dashboard and settings UI so agents can visually QA without launching the menu-bar app.
> 
> New **`#if DEBUG`** pieces: **`BrainBarDashboardFixture`** (fixed stats/daemon/agent data with relative-time dates nil), **`StatsCollector.fixture(...)`** (preloaded collector, no DB/timers), and **`BrainBarDashboardPreview.make`** (exposes private `BrainBarDashboardView` with dark background and animations disabled). **`BrainBarDashboardSnapshotTests`** renders dashboard at compact/default/wide breakpoints plus settings via `NSHostingView` + `cacheDisplay`, writes PNGs under `docs.local/brainbar-render` (or `BRAINBAR_RENDER_DIR`), and asserts non-empty/non-flat output. **`RENDER_VERIFICATION.md`** documents the agent workflow; **`.gitignore`** ignores `brain-bar/.render-logs/`.
> 
> All of this is additive test/debug infrastructure; release builds are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3412892717f99a1e68edf0bb19051892e3b16735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic snapshot render-verification tests for the BrainBar dashboard
> - Adds `BrainBarDashboardSnapshotTests` with two tests: one rendering the dashboard at compact/default/wide breakpoints and one rendering the settings view, each writing PNGs and asserting non-trivial size and color diversity.
> - Introduces `BrainBarDashboardFixture` (debug-only) providing clock-independent fixture data and a preloaded `StatsCollector` for seeding renders.
> - Adds `BrainBarDashboardPreview.make` (debug-only) to wrap the dashboard in its background, force dark scheme, and disable animations for byte-stable snapshots.
> - Adds a `StatsCollector.fixture` debug factory that constructs a non-started collector preloaded with arbitrary snapshot state.
> - PNGs are written to `BRAINBAR_RENDER_DIR` or `brain-bar/docs.local/brainbar-render` by default; render logs are gitignored under `brain-bar/.render-logs/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3412892.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->