### PR TITLE
chore: release 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.2.0"
+version = "1.3.0"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents — local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"


### PR DESCRIPTION
## Release 1.3.0

Bumps BrainLayer from 1.2.0 to 1.3.0.

### Changes
- `pyproject.toml` — `version = "1.3.0"`
- `src/brainlayer/__init__.py` — `__version__ = "1.3.0"`
- `server.json` — manifest `version` + pypi package `version` bumped to 1.3.0 (required by `test_release_version_sync.py`)

### Verification
- `tests/test_release_version_sync.py::test_release_versions_stay_in_sync` — PASS
- Pre-push full suite: 3038 passed. Two timing/environment-flaky tests (`test_sustained_rate_no_contention`, `test_launchd_installer_rejects_key_only_enrichment_config`) failed only under concurrent full-suite load and PASS in isolation and on clean `main` — not caused by this version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string-only changes with no runtime or behavioral impact; guarded by an existing sync test.
> 
> **Overview**
> **Release 1.3.0** — bumps the package version from **1.2.0** to **1.3.0** everywhere it must stay aligned.
> 
> `pyproject.toml` project version, `src/brainlayer/__init__.py` `__version__`, and `server.json` (top-level manifest version plus the PyPI package entry) are all updated together so `test_release_versions_stay_in_sync` continues to pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb32ff7f774a9475519532b0252297d0c562707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 1.3.0
> Bumps the version string from 1.2.0 to 1.3.0 in [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/534/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/534/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [src/brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/534/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdb32ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->