### PR TITLE
fix: restore D2 vector creation paths

### DIFF
--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -170,13 +170,12 @@ def run(
             now = time_fn()
             queue_has_backlog = queue_depth_fn(queue_dir) > 0
             if queue_has_backlog:
-                LOGGER.info("durable queue has backlog; yielding writer slot to drain")
+                LOGGER.info("durable queue has backlog; suppressing enrichment only")
             cycle_backlog_batch = backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
             cycle_enrich_limit = (
                 enrich_limit if not enrich_disabled and enrich_limit > 0 and now - last_enrich >= enrich_interval else 0
             )
             if queue_has_backlog:
-                cycle_backlog_batch = 0
                 cycle_enrich_limit = 0
             if cycle_backlog_batch > 0:
                 last_backlog = now

--- a/scripts/launchd/com.brainlayer.drain.plist
+++ b/scripts/launchd/com.brainlayer.drain.plist
@@ -25,13 +25,9 @@
 		<string>__BRAINLAYER_ENV_FILE__</string>
 		<key>BRAINLAYER_LAUNCHD_SERVICE</key>
 		<string>drain</string>
-		<!-- Write chunks WITHOUT computing embeddings inside the drain's write
-		     transaction. Inline embedding lengthens the write-lock hold time and,
-		     under multi-writer contention (BrainBar/daemon/hybrid/watcher), starves
-		     the drain on SQLITE_BUSY so the realtime queue backs up. Vectors are
-		     backfilled out-of-band by enrichment/hotlane. (M1/throughput fix.) -->
-		<key>BRAINLAYER_DRAIN_EMBED</key>
-		<string>0</string>
+		<!-- Production leaves drain embedding enabled. Embeddings are precomputed
+		     before BEGIN IMMEDIATE, so vector coverage does not depend on hotlane
+		     liveness and the write-lock window stays bounded. -->
 	</dict>
 	<key>StandardOutPath</key>
 	<string>__HOME__/Library/Logs/brainlayer/drain.out.log</string>

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -590,16 +590,16 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     return ApplyResult(chunk_id=stored_chunk_id)
 
 
-def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> None:
+def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     chunk_id = event.get("chunk_id")
     raw_content = event.get("content")
     if not chunk_id or raw_content is None:
         logger.warning("Skipping malformed watcher event without chunk_id/content")
-        return
+        return ApplyResult()
     content = str(raw_content).strip()
     if not content:
         logger.warning("Skipping malformed watcher event with empty content")
-        return
+        return ApplyResult()
     source_file = event.get("source_file") or "realtime-watcher"
     recursive_reason = recursive_mcp_output_reason(
         content,
@@ -609,7 +609,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> None:
     )
     if recursive_reason:
         logger.warning("Skipping recursive MCP watcher event: %s", recursive_reason)
-        return
+        return ApplyResult()
     tags = event.get("tags")
     stored_chunk_id = _insert_or_merge_chunk(
         conn,
@@ -631,6 +631,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> None:
             "chunk_origin": detect_chunk_origin(content, event.get("chunk_origin")),
         },
     )
+    return ApplyResult(chunk_id=stored_chunk_id)
 
 
 def _apply_hook(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
@@ -780,7 +781,7 @@ def _apply_event(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     if kind == "store_memory":
         return _apply_store(conn, event)
     elif kind == "watcher_chunk":
-        _apply_watcher(conn, event)
+        return _apply_watcher(conn, event)
     elif kind == "hook_chunk":
         return _apply_hook(conn, event)
     elif kind == "enrichment_update":
@@ -860,7 +861,7 @@ def _precompute_event_embeddings(
     contents = []
     for event in events:
         payload = _event_payload(event)
-        if payload.get("kind") not in {"store_memory", "hook_chunk"}:
+        if payload.get("kind") not in {"store_memory", "hook_chunk", "watcher_chunk"}:
             continue
         content = str(payload.get("content") or "").strip()
         if content:

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -818,7 +818,15 @@ def _is_busy_error(exc: BaseException) -> bool:
 def _default_embed_fn() -> Callable[[str], list[float]]:
     from .embeddings import get_embedding_model
 
-    return get_embedding_model().embed_query
+    model = get_embedding_model()
+
+    def embed_text(text: str) -> list[float]:
+        embeddings = model.embed_texts([text], batch_size=1)
+        if len(embeddings) != 1:
+            raise RuntimeError(f"single text embedder returned {len(embeddings)} embeddings")
+        return embeddings[0]
+
+    return embed_text
 
 
 def _embedding_enabled() -> bool:

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -81,6 +81,17 @@ def _has_vector(store: VectorStore, chunk_id: str) -> bool:
     )
 
 
+def _has_vector_rowid(store: VectorStore, chunk_id: str) -> bool:
+    cursor = store.conn.cursor()
+    return (
+        cursor.execute(
+            "SELECT COUNT(*) FROM chunk_vectors_rowids WHERE id = ?",
+            (chunk_id,),
+        ).fetchone()[0]
+        == 1
+    )
+
+
 def _pending_active_count(store: VectorStore) -> int:
     cursor = store.conn.cursor()
     return cursor.execute(
@@ -647,6 +658,55 @@ class TestBackgroundEmbedder:
         assert _has_vector(store, "batch-fallback-good-0")
         assert not _has_vector(store, "batch-fallback-bad-1")
         assert _has_vector(store, "batch-fallback-good-2")
+
+
+class TestDrainWatcherEmbedding:
+    def test_drain_precomputes_watcher_chunk_vector_and_hybrid_finds_it(self, store, tmp_path):
+        """D2: watcher_chunk drain must create vectors without depending on hotlane."""
+        from brainlayer.drain import drain_once
+        from brainlayer.queue_io import enqueue_watcher_chunk
+
+        queue_dir = tmp_path / "queue"
+        content = "d2 watcher vector probe alpha unique searchable"
+        chunk_id = "d2-watcher-vector-probe"
+
+        enqueue_watcher_chunk(
+            chunk_id=chunk_id,
+            content=content,
+            metadata={"probe": "d2"},
+            source_file="realtime-watcher",
+            project="test",
+            content_type="assistant_text",
+            value_type="high",
+            created_at="2026-06-21T00:00:00+00:00",
+            conversation_id="d2-watch",
+            sender="assistant",
+            queue_dir=queue_dir,
+        )
+
+        def probe_embed(text: str) -> list[float]:
+            if text == content:
+                return [1.0] + [0.0] * 1023
+            return [0.0, 1.0] + [0.0] * 1022
+
+        assert drain_once(db_path=store.db_path, queue_dir=queue_dir, embed_fn=probe_embed) == 1
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if _has_vector(store, chunk_id) and _has_vector_rowid(store, chunk_id):
+                break
+            time.sleep(0.05)
+
+        assert _has_vector(store, chunk_id)
+        assert _has_vector_rowid(store, chunk_id)
+
+        results = store.hybrid_search(
+            query_embedding=probe_embed(content),
+            query_text="no_keyword_match_for_d2_watcher_vector_probe",
+            n_results=1,
+            project_filter="test",
+        )
+        assert results["ids"][0][0] == chunk_id
 
 
 class TestMCPStoreDeferred:

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -661,6 +661,30 @@ class TestBackgroundEmbedder:
 
 
 class TestDrainWatcherEmbedding:
+    def test_drain_default_precompute_uses_passage_embeddings(self, monkeypatch):
+        """Stored chunk vectors must use passage embeddings, not query-prefixed embeddings."""
+        from brainlayer import drain
+        from brainlayer import embeddings
+        from brainlayer._helpers import serialize_f32
+
+        class FakeModel:
+            def embed_query(self, _text: str) -> list[float]:
+                return [9.0] * 1024
+
+            def embed_texts(self, texts: list[str], batch_size: int = 64) -> list[list[float]]:
+                assert texts == ["d2 passage embedding proof"]
+                assert batch_size == 1
+                return [[2.0] * 1024]
+
+        monkeypatch.setattr(embeddings, "get_embedding_model", lambda: FakeModel())
+
+        precomputed = drain._precompute_event_embeddings(
+            [{"kind": "watcher_chunk", "content": "d2 passage embedding proof"}],
+            embed_fn=None,
+        )
+
+        assert precomputed == {"d2 passage embedding proof": serialize_f32([2.0] * 1024)}
+
     def test_drain_precomputes_watcher_chunk_vector_and_hybrid_finds_it(self, store, tmp_path):
         """D2: watcher_chunk drain must create vectors without depending on hotlane."""
         from brainlayer.drain import drain_once

--- a/tests/test_enrichment_flex_integration.py
+++ b/tests/test_enrichment_flex_integration.py
@@ -15,6 +15,7 @@ def test_sustained_rate_no_contention(tmp_path, monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     monkeypatch.setenv("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", "0")
+    monkeypatch.setitem(controller.RATE_LIMITS, "realtime", 5.0)
     store = VectorStore(tmp_path / "test.db")
     try:
         chunk_ids = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -294,7 +294,7 @@ def test_hotlane_run_opens_and_closes_writer_store_each_cycle(tmp_path):
     assert [event[0] for event in events] == ["open", "close", "open", "close"]
 
 
-def test_hotlane_run_keeps_recent_cycle_while_queue_is_backlogged(tmp_path):
+def test_hotlane_run_keeps_embedding_backlog_while_queue_is_backlogged(tmp_path):
     hotlane = _load_hotlane_module()
     opened = []
     cycle_calls = []
@@ -326,6 +326,6 @@ def test_hotlane_run_keeps_recent_cycle_while_queue_is_backlogged(tmp_path):
 
     assert opened == [tmp_path / "brainlayer.db"]
     assert len(cycle_calls) == 1
-    assert cycle_calls[0]["backlog_batch"] == 0
+    assert cycle_calls[0]["backlog_batch"] == hotlane.DEFAULT_BACKLOG_BATCH
     assert cycle_calls[0]["enrich_limit"] == 0
     assert cycle_calls[0]["recent_limit"] == 5

--- a/tests/test_hybrid_helper_contract.py
+++ b/tests/test_hybrid_helper_contract.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 
 
-def _wait_for_socket(socket_path: Path, process: subprocess.Popen, timeout: float = 5.0) -> None:
+def _wait_for_socket(socket_path: Path, process: subprocess.Popen, timeout: float = 20.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
@@ -21,7 +21,9 @@ def _wait_for_socket(socket_path: Path, process: subprocess.Popen, timeout: floa
         if socket_path.exists():
             return
         time.sleep(0.05)
-    raise AssertionError("helper socket did not appear")
+    stdout = process.stdout.read() if process.poll() is not None and process.stdout else ""
+    stderr = process.stderr.read() if process.poll() is not None and process.stderr else ""
+    raise AssertionError(f"helper socket did not appear within {timeout}s; stdout={stdout!r} stderr={stderr!r}")
 
 
 def test_brainbar_hybrid_helper_ndjson_contract_accepts_documented_brain_search_keys(tmp_path):

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -301,10 +301,26 @@ def test_launchd_installer_rejects_key_only_enrichment_config(tmp_path):
     env_file.write_text("GOOGLE_API_KEY='test-secret'\n", encoding="utf-8")
     env_file.chmod(0o600)
 
+    child_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key
+        not in {
+            "BRAINLAYER_ENRICH_ENABLED",
+            "BRAINLAYER_ENRICH_MODE",
+            "BRAINLAYER_ENRICH_PROVIDER",
+            "BRAINLAYER_ENRICH_BACKEND",
+            "BRAINLAYER_ENRICH_RATE",
+            "BRAINLAYER_ENRICH_CONCURRENCY",
+            "BRAINLAYER_MAX_COMMIT_BATCH",
+            "BRAINLAYER_GEMINI_SERVICE_TIER",
+        }
+    }
+
     result = subprocess.run(
         [str(harness)],
         env={
-            **os.environ,
+            **child_env,
             "HOME": str(tmp_path),
             "BRAINLAYER_BIN": "/usr/bin/true",
             "PYTHON_BIN": "/usr/bin/true",


### PR DESCRIPTION
## Summary
- Return watcher chunk IDs from the drain so queued `watcher_chunk` rows receive precomputed vectors.
- Include `watcher_chunk` in drain-side embedding precompute and stop hotlane from zeroing backlog embedding just because the durable queue has files.
- Remove the production launchd override that forced `BRAINLAYER_DRAIN_EMBED=0`; drain embedding remains precomputed before `BEGIN IMMEDIATE`.
- Harden two order-dependent tests so full-suite verification is deterministic.

## Test plan
- RED verified before implementation:
  - `pytest tests/test_deferred_embedding.py::TestDrainWatcherEmbedding::test_drain_precomputes_watcher_chunk_vector_and_hybrid_finds_it tests/test_hotlane_brainbar_daemon.py::test_hotlane_run_keeps_embedding_backlog_while_queue_is_backlogged` failed for missing watcher vector and `backlog_batch=0`.
- GREEN:
  - `pytest tests/test_deferred_embedding.py::TestDrainWatcherEmbedding::test_drain_precomputes_watcher_chunk_vector_and_hybrid_finds_it tests/test_hotlane_brainbar_daemon.py::test_hotlane_run_keeps_embedding_backlog_while_queue_is_backlogged` → 2 passed.
  - `pytest tests/test_deferred_embedding.py tests/test_hotlane_brainbar_daemon.py tests/test_arbitration.py tests/test_precompact_chunk_origin.py` → 83 passed.
  - `plutil -lint scripts/launchd/com.brainlayer.drain.plist` → OK.
  - Full `pytest` → 3146 passed, 49 skipped, 5 xfailed, 103 warnings in 454.28s.
  - `BRAINLAYER_PREPUSH_SCOPE=changed-only git push` gate → 147 + 3 + 40 Python tests passed, bun test passed, FTS shell regression passed.

## Notes
- Local `coderabbit review --agent` was attempted before commit with a 180s timeout; it stayed in review heartbeat mode and returned no findings before timeout. PR-level bot review is still required before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production drain embedding default and SQLite write/vector path for watcher events; scope is focused and well-tested, but incorrect embedding semantics would affect search quality for realtime ingests.
> 
> **Overview**
> **Restores vector creation for realtime watcher chunks in the drain path** so hybrid search works without relying on hotlane. `_apply_watcher` now returns `ApplyResult` with `chunk_id`, `_apply_event` propagates that for `watcher_chunk`, and `_precompute_event_embeddings` treats `watcher_chunk` like other content events. Default drain embedding uses **`embed_texts` (passage vectors)** instead of query-prefixed `embed_query`.
> 
> **Production launchd** drops the `BRAINLAYER_DRAIN_EMBED=0` override on `com.brainlayer.drain`, with comments that embeddings are precomputed before `BEGIN IMMEDIATE`.
> 
> **Hotlane** when the durable JSONL queue has backlog still runs **pending embedding backlog** (`cycle_backlog_batch` unchanged); only **enrichment** is suppressed (`cycle_enrich_limit = 0`).
> 
> Tests add drain watcher embedding coverage and tighten flaky integration/contract tests (enrichment rate limit, helper socket wait, isolated launchd verify env).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2b97ea01060cf55b34f3b7609e6991631ea33f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore D2 vector creation by enabling watcher_chunk embedding and fixing return paths
> - [`drain._apply_watcher`](https://github.com/EtanHey/brainlayer/pull/536/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) and `_apply_event` now return `ApplyResult` for watcher_chunk events, fixing a missing return that silently dropped results.
> - [`drain._precompute_event_embeddings`](https://github.com/EtanHey/brainlayer/pull/536/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) now includes `watcher_chunk` events, so D2 vectors are precomputed at drain time.
> - [`drain._default_embed_fn`](https://github.com/EtanHey/brainlayer/pull/536/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) switches from query embeddings (`embed_query`) to passage embeddings (`embed_texts` with `batch_size=1`), with an added result-size check.
> - The [hotlane daemon](https://github.com/EtanHey/brainlayer/pull/536/files#diff-a6f55cd2d945568d3534e21b0c40cf5a431cb8287640870ba7b2a6149ac2c0d9) no longer suppresses embedding backlog processing when the durable queue is backlogged — only enrichment is suppressed.
> - The [launchd config](https://github.com/EtanHey/brainlayer/pull/536/files#diff-70207bc8c3e8d94c42e40498a2f1427b0f6d179630f181dd836398cbfd3fa751) removes `BRAINLAYER_DRAIN_EMBED=0`, re-enabling drain embedding in production.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f2b97e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->