### PR TITLE
fix: restore D3 enrichment self-heal

### DIFF
--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -30,6 +30,7 @@ LOGGER = logging.getLogger("brainlayer.hotlane_brainbar")
 STOP = False
 DEFAULT_HOTLANE_ENRICH_LIMIT = 5
 DEFAULT_BACKLOG_BATCH = 4
+MAX_BACKLOG_BATCH = 16
 
 
 class CycleResult(NamedTuple):
@@ -79,6 +80,13 @@ def _default_queue_dir() -> Path:
 def _queue_depth(queue_dir: Path) -> int:
     try:
         return sum(1 for _path in queue_dir.glob("*.jsonl"))
+    except OSError:
+        return 0
+
+
+def _high_priority_queue_depth(queue_dir: Path) -> int:
+    try:
+        return sum(1 for path in queue_dir.glob("*.jsonl") if not path.name.startswith("enrichment-"))
     except OSError:
         return 0
 
@@ -143,6 +151,7 @@ def run(
     max_cycles: int | None = None,
     queue_dir: Path | None = None,
     queue_depth_fn: Callable[[Path], int] = _queue_depth,
+    high_priority_queue_depth_fn: Callable[[Path], int] = _high_priority_queue_depth,
 ) -> None:
     model = model_factory()
     embed_batch_fn = getattr(model, "embed_texts", None)
@@ -162,6 +171,7 @@ def run(
     last_enrich = 0.0
     enrich_disabled = False
     cycles = 0
+    backlog_batch = min(max(backlog_batch, 0), MAX_BACKLOG_BATCH)
     LOGGER.info("hotlane adapter started db=%s", db_path)
     while not STOP:
         if max_cycles is not None and cycles >= max_cycles:
@@ -169,8 +179,14 @@ def run(
         try:
             now = time_fn()
             queue_has_backlog = queue_depth_fn(queue_dir) > 0
+            queue_has_high_priority_backlog = queue_has_backlog and high_priority_queue_depth_fn(queue_dir) > 0
             if queue_has_backlog:
                 LOGGER.info("durable queue has backlog; suppressing enrichment only")
+            if queue_has_high_priority_backlog:
+                LOGGER.info("durable high-priority queue has backlog; yielding writer slot to drain")
+                cycles += 1
+                sleep_fn(interval)
+                continue
             cycle_backlog_batch = backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
             cycle_enrich_limit = (
                 enrich_limit if not enrich_disabled and enrich_limit > 0 and now - last_enrich >= enrich_interval else 0
@@ -233,7 +249,7 @@ def main() -> None:
         interval=max(args.interval, 0.25),
         recent_limit=max(args.recent_limit, 1),
         backlog_interval=max(args.backlog_interval, 1.0),
-        backlog_batch=max(args.backlog_batch, 0),
+        backlog_batch=min(max(args.backlog_batch, 0), MAX_BACKLOG_BATCH),
         enrich_interval=max(args.enrich_interval, 1.0),
         enrich_limit=max(args.enrich_limit, 0),
         enrich_since_hours=max(args.enrich_since_hours, 0),

--- a/scripts/launchd/brainlayer-env-run.sh
+++ b/scripts/launchd/brainlayer-env-run.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 ENV_FILE="${BRAINLAYER_ENV_FILE:-$HOME/.config/brainlayer/brainlayer.env}"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.local/bin:${PATH:-}"
 
 if [ ! -f "$ENV_FILE" ]; then
     echo "ERROR: BrainLayer env file not found at $ENV_FILE" >&2
@@ -22,10 +23,66 @@ if [ -n "$(find "$ENV_FILE" -prune -perm -0002 -print 2>/dev/null)" ]; then
     exit 78
 fi
 
-set -a
-# shellcheck disable=SC1090
-source "$ENV_FILE"
-set +a
+valid_env_key() {
+    case "$1" in
+        ""|[0-9]*|*[!A-Za-z0-9_]*)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+strip_matching_quotes() {
+    local value="$1"
+    if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+        printf '%s' "${value:1:${#value}-2}"
+    elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+        printf '%s' "${value:1:${#value}-2}"
+    else
+        printf '%s' "$value"
+    fi
+}
+
+load_simple_env_file() {
+    local raw_line line key value
+    while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+        line="${raw_line#"${raw_line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        case "$line" in
+            ""|\#*)
+                continue
+                ;;
+            export\ *)
+                line="${line#export }"
+                ;;
+        esac
+        case "$line" in
+            *=*) ;;
+            *) continue ;;
+        esac
+        key="${line%%=*}"
+        value="${line#*=}"
+        key="${key%"${key##*[![:space:]]}"}"
+        value="${value#"${value%%[![:space:]]*}"}"
+        if ! valid_env_key "$key"; then
+            continue
+        fi
+        case "$value" in
+            *'$('*|*'`'*)
+                continue
+                ;;
+        esac
+        export "$key=$(strip_matching_quotes "$value")"
+    done < "$ENV_FILE"
+}
+
+env_file_declares_google_key() {
+    grep -Eq '^[[:space:]]*(export[[:space:]]+)?GOOGLE(_GENERATIVE_AI)?_API_KEY[[:space:]]*=' "$ENV_FILE"
+}
+
+load_simple_env_file
 
 is_false() {
     case "${1:-}" in
@@ -68,7 +125,9 @@ if [ "${BRAINLAYER_SKIP_DISABLE_GATES:-0}" != "1" ]; then
     fi
 fi
 
-if [ "${BRAINLAYER_REQUIRE_GOOGLE_API_KEY:-0}" = "1" ] && [ -z "${GOOGLE_API_KEY:-${GOOGLE_GENERATIVE_AI_API_KEY:-}}" ]; then
+if [ "${BRAINLAYER_REQUIRE_GOOGLE_API_KEY:-0}" = "1" ] \
+    && [ -z "${GOOGLE_API_KEY:-${GOOGLE_GENERATIVE_AI_API_KEY:-}}" ] \
+    && ! env_file_declares_google_key; then
     echo "ERROR: GOOGLE_API_KEY not set by $ENV_FILE" >&2
     exit 78
 fi

--- a/scripts/launchd/com.brainlayer.hotlane-brainbar.plist
+++ b/scripts/launchd/com.brainlayer.hotlane-brainbar.plist
@@ -3,35 +3,40 @@
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.brainlayer.enrichment</string>
+	<string>com.brainlayer.hotlane-brainbar</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>__BRAINLAYER_ENV_RUN__</string>
-		<string>__BRAINLAYER_BIN__</string>
-		<string>enrich</string>
-		<string>--mode</string>
-		<string>realtime</string>
-		<string>--supervisor</string>
+		<string>__BRAINLAYER_PYTHON__</string>
+		<string>__BRAINLAYER_DIR__/scripts/hotlane_brainbar_daemon.py</string>
+		<string>--interval</string>
+		<string>1.0</string>
+		<string>--recent-limit</string>
+		<string>5</string>
+		<string>--backlog-interval</string>
+		<string>10.0</string>
+		<string>--backlog-batch</string>
+		<string>4</string>
+		<string>--enrich-interval</string>
+		<string>10.0</string>
+		<string>--enrich-limit</string>
+		<string>5</string>
+		<string>--enrich-since-hours</string>
+		<string>87600</string>
 	</array>
 	<key>WorkingDirectory</key>
 	<string>__BRAINLAYER_DIR__</string>
 	<key>KeepAlive</key>
 	<true/>
 	<key>StandardOutPath</key>
-	<string>__HOME__/Library/Logs/brainlayer/enrichment.out.log</string>
+	<string>__HOME__/Library/Logs/brainlayer/hotlane-brainbar.out.log</string>
 	<key>StandardErrorPath</key>
-	<string>__HOME__/Library/Logs/brainlayer/enrichment.err.log</string>
+	<string>__HOME__/Library/Logs/brainlayer/hotlane-brainbar.err.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:__HOME__/.local/bin</string>
 		<key>PYTHONUNBUFFERED</key>
-		<string>1</string>
-		<key>BRAINLAYER_STALL_TIMEOUT</key>
-		<string>300</string>
-		<key>BRAINLAYER_ENRICHMENT_QUEUE_WRITES</key>
-		<string>1</string>
-		<key>BRAINLAYER_ENRICH_IDLE_BACKLOG</key>
 		<string>1</string>
 		<key>BRAINLAYER_ENV_FILE</key>
 		<string>__BRAINLAYER_ENV_FILE__</string>
@@ -39,21 +44,27 @@
 		<string>1</string>
 		<key>BRAINLAYER_REPO_ROOT</key>
 		<string>__BRAINLAYER_DIR__</string>
+		<key>BRAINLAYER_GEMINI_SERVICE_TIER</key>
+		<string>flex</string>
+		<key>BRAINLAYER_ENRICH_CONCURRENCY</key>
+		<string>4</string>
+		<key>BRAINLAYER_ENRICH_RATE</key>
+		<string>15</string>
 		<key>BRAINLAYER_LAUNCHD_SERVICE</key>
-		<string>enrichment</string>
+		<string>hotlane-brainbar</string>
 	</dict>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>ThrottleInterval</key>
-	<integer>60</integer>
+	<integer>5</integer>
 	<key>Nice</key>
 	<integer>10</integer>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ExitTimeOut</key>
-	<integer>120</integer>
+	<integer>30</integer>
 	<key>LowPriorityIO</key>
-	<false/>
+	<true/>
 	<key>SoftResourceLimits</key>
 	<dict>
 		<key>NumberOfFiles</key>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -16,6 +16,7 @@
 #   ./scripts/launchd/install.sh jsonl-backup # Install daily JSONL backup only
 #   ./scripts/launchd/install.sh maintenance  # Install recurring maintenance jobs
 #   ./scripts/launchd/install.sh health-check # Install stability health check only
+#   ./scripts/launchd/install.sh hotlane      # Install BrainBar hotlane embed/enrich daemon only
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
 set -euo pipefail
 
@@ -255,6 +256,10 @@ case "${1:-all}" in
     health-check)
         install_plist health-check
         ;;
+    hotlane|hotlane-brainbar)
+        verify_gemini_env_file
+        install_plist hotlane-brainbar
+        ;;
     all)
         install_env_runner
         verify_config_file
@@ -262,6 +267,7 @@ case "${1:-all}" in
         install_plist index
         install_plist drain
         install_plist watch
+        install_plist hotlane-brainbar
         install_plist enrichment
         install_plist decay
         install_plist wal-checkpoint
@@ -290,11 +296,12 @@ case "${1:-all}" in
         remove_plist maintenance-nightly 2>/dev/null || true
         remove_plist maintenance-weekly 2>/dev/null || true
         remove_plist health-check 2>/dev/null || true
+        remove_plist hotlane-brainbar 2>/dev/null || true
         rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
         rm -f "$BRAINLAYER_LIB_DIR/jsonl-backup.sh"
         ;;
     *)
-        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|all|remove]"
+        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|all|remove]"
         exit 1
         ;;
 esac

--- a/scripts/reembed_backfill_loop.py
+++ b/scripts/reembed_backfill_loop.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Continuous, polite embedding backfill for active chunks missing vectors."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import apsw
+import sqlite_vec
+
+from brainlayer._helpers import serialize_f32
+from brainlayer.embeddings import get_embedding_model
+from brainlayer.paths import get_db_path
+from brainlayer.reembed_backfill import _pending_where_sql
+
+DEFAULT_COLLAB = Path("/Users/etanheyman/Gits/orchestrator/collab/2026-06-21-brainlayer-health.md")
+
+
+class _ConnStore:
+    def __init__(self, conn: apsw.Connection) -> None:
+        self.conn = conn
+
+
+def _utc_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _is_enrichment_queue_file(path: Path) -> bool:
+    return path.name.startswith("enrichment-") or path.name.startswith("queue-enrichment")
+
+
+def _has_high_priority_queue_file(queue_dir: Path) -> bool:
+    try:
+        return any(not _is_enrichment_queue_file(path) for path in queue_dir.glob("*.jsonl"))
+    except OSError:
+        return False
+
+
+def _append_backfill_receipt(collab: Path | None, remaining: int, *, extra: str = "") -> None:
+    if collab is None:
+        return
+    suffix = f" {extra}" if extra else ""
+    try:
+        with collab.open("a", encoding="utf-8") as handle:
+            handle.write(f"\n### implementation-codex ({_utc_ts()}) backfill UNEMBEDDED={remaining}{suffix}\n")
+    except OSError as exc:
+        logging.warning("failed to append collab backfill receipt: %s", exc)
+
+
+def _is_busy_error(exc: BaseException) -> bool:
+    if isinstance(exc, (apsw.BusyError, apsw.LockedError)):
+        return True
+    message = str(exc).casefold()
+    return "database is locked" in message or "database is busy" in message or "database table is locked" in message
+
+
+def _open_backfill_conn(db_path: Path, *, attempts: int = 60) -> apsw.Connection:
+    last_busy: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        conn: apsw.Connection | None = None
+        try:
+            conn = apsw.Connection(str(db_path))
+            conn.setbusytimeout(1000)
+            conn.enableloadextension(True)
+            conn.loadextension(sqlite_vec.loadable_path())
+            conn.enableloadextension(False)
+            conn.cursor().execute("PRAGMA journal_mode=WAL")
+            return conn
+        except Exception as exc:
+            if not _is_busy_error(exc):
+                raise
+            last_busy = exc
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            sleep_seconds = min(5.0, 0.25 * attempt)
+            logging.warning(
+                "backfill DB open busy attempt=%d/%d sleep=%.2fs: %s",
+                attempt,
+                attempts,
+                sleep_seconds,
+                exc,
+            )
+            time.sleep(sleep_seconds)
+    assert last_busy is not None
+    raise last_busy
+
+
+def _binary_index_available(conn: apsw.Connection) -> bool:
+    return bool(
+        conn.cursor()
+        .execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'chunk_vectors_binary'")
+        .fetchone()
+    )
+
+
+def _count_unvectored_min_chars(store: _ConnStore, *, min_chars: int) -> int:
+    where_sql = _pending_where_sql(store, include_inactive=False)
+    return int(
+        store.conn.cursor()
+        .execute(
+            f"""
+            SELECT COUNT(*)
+            FROM chunks c
+            LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
+            WHERE {where_sql}
+              AND COALESCE(c.char_count, LENGTH(c.content)) >= ?
+            """,
+            (min_chars,),
+        )
+        .fetchone()[0]
+    )
+
+
+def _fetch_unvectored_min_chars(store: _ConnStore, *, batch_size: int, min_chars: int):
+    from brainlayer.reembed_backfill import PendingChunk
+
+    where_sql = _pending_where_sql(store, include_inactive=False)
+    rows = store.conn.cursor().execute(
+        f"""
+        SELECT c.id, c.content
+        FROM chunks c
+        LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
+        WHERE {where_sql}
+          AND COALESCE(c.char_count, LENGTH(c.content)) >= ?
+        ORDER BY c.created_at ASC, c.id ASC
+        LIMIT ?
+        """,
+        (min_chars, batch_size),
+    )
+    return [PendingChunk(chunk_id=str(chunk_id), content=str(content)) for chunk_id, content in rows]
+
+
+def _write_chunk_embeddings_direct(
+    conn: apsw.Connection,
+    chunks: list[Any],
+    embeddings: list[list[float]],
+    *,
+    binary_index: bool,
+) -> int:
+    cursor = conn.cursor()
+    written = 0
+    started = False
+    try:
+        cursor.execute("BEGIN IMMEDIATE")
+        started = True
+        for chunk, embedding in zip(chunks, embeddings):
+            embedding_bytes = serialize_f32([float(value) for value in embedding])
+            cursor.execute("DELETE FROM chunk_vectors WHERE chunk_id = ?", (chunk.chunk_id,))
+            cursor.execute(
+                "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+                (chunk.chunk_id, embedding_bytes),
+            )
+            if binary_index:
+                cursor.execute("DELETE FROM chunk_vectors_binary WHERE chunk_id = ?", (chunk.chunk_id,))
+                cursor.execute(
+                    "INSERT INTO chunk_vectors_binary (chunk_id, embedding) VALUES (?, vec_quantize_binary(?))",
+                    (chunk.chunk_id, embedding_bytes),
+                )
+            written += 1
+        cursor.execute("COMMIT")
+        started = False
+        return written
+    except Exception:
+        if started:
+            cursor.execute("ROLLBACK")
+        raise
+
+
+def _model_device(model) -> str:
+    loaded = model._load_model()
+    device = getattr(loaded, "device", None)
+    return str(device) if device is not None else "unknown"
+
+
+def run_loop(
+    *,
+    db_path: Path,
+    queue_dir: Path,
+    fetch_page_size: int,
+    embed_batch_size: int,
+    write_batch_size: int,
+    min_chars: int,
+    sleep_seconds: float,
+    yield_seconds: float,
+    busy_sleep_seconds: float,
+    report_seconds: float,
+    collab: Path | None,
+    max_pages: int | None = None,
+) -> int:
+    conn = _open_backfill_conn(db_path)
+    store = _ConnStore(conn)
+    binary_index = _binary_index_available(conn)
+    processed = 0
+    failed = 0
+    start = time.monotonic()
+    last_report = 0.0
+    pages = 0
+
+    try:
+        remaining = _count_unvectored_min_chars(store, min_chars=min_chars)
+        logging.info(
+            "embedding backfill starting remaining=%d fetch_page_size=%d embed_batch_size=%d write_batch_size=%d",
+            remaining,
+            fetch_page_size,
+            embed_batch_size,
+            write_batch_size,
+        )
+        if remaining == 0:
+            _append_backfill_receipt(collab, remaining, extra="already-complete")
+            return 0
+
+        model = get_embedding_model()
+        device = _model_device(model)
+        logging.info("embedding backfill device=%s", device)
+        _append_backfill_receipt(
+            collab,
+            remaining,
+            extra=f"started device={device} fetch_page={fetch_page_size} embed_batch={embed_batch_size} write_batch={write_batch_size}",
+        )
+        while remaining > 0:
+            chunks = _fetch_unvectored_min_chars(store, batch_size=fetch_page_size, min_chars=min_chars)
+            if not chunks:
+                remaining = _count_unvectored_min_chars(store, min_chars=min_chars)
+                break
+            pages += 1
+
+            embeddings: list[list[float]] = []
+            embed_start = time.monotonic()
+            for offset in range(0, len(chunks), embed_batch_size):
+                embed_chunks = chunks[offset : offset + embed_batch_size]
+                embeddings.extend(
+                    model.embed_texts(
+                        [chunk.content for chunk in embed_chunks],
+                        batch_size=embed_batch_size,
+                    )
+                )
+            embed_seconds = time.monotonic() - embed_start
+            embed_rate = len(embeddings) / embed_seconds if embed_seconds > 0 else 0.0
+
+            page_written = 0
+            page_failed = 0
+            page_write_seconds = 0.0
+            for offset in range(0, len(chunks), write_batch_size):
+                if _has_high_priority_queue_file(queue_dir):
+                    logging.info("interactive queue appeared before vector write; yielding %.2fs", yield_seconds)
+                    time.sleep(yield_seconds)
+                write_chunks = chunks[offset : offset + write_batch_size]
+                write_embeddings = embeddings[offset : offset + write_batch_size]
+                while True:
+                    write_start = time.monotonic()
+                    try:
+                        written = _write_chunk_embeddings_direct(
+                            conn,
+                            write_chunks,
+                            write_embeddings,
+                            binary_index=binary_index,
+                        )
+                        break
+                    except Exception as exc:
+                        if not _is_busy_error(exc):
+                            raise
+                        logging.warning("vector write batch busy; yielding before retry: %s", exc)
+                        time.sleep(busy_sleep_seconds)
+                page_write_seconds += time.monotonic() - write_start
+                page_written += written
+                page_failed += len(write_chunks) - written
+
+            processed += page_written
+            failed += page_failed
+            remaining = _count_unvectored_min_chars(store, min_chars=min_chars)
+            elapsed = time.monotonic() - start
+            rate = processed / elapsed if elapsed > 0 else 0.0
+            write_rate = page_written / page_write_seconds if page_write_seconds > 0 else 0.0
+            logging.info(
+                "embedding backfill page size=%d embedded=%d written=%d remaining=%d device=%s "
+                "embed_sec=%.2f embed_rate=%.2f/s write_sec=%.2f write_rate=%.2f/s "
+                "processed=%d failed=%d end_to_end_rate=%.2f/s",
+                len(chunks),
+                len(embeddings),
+                page_written,
+                remaining,
+                device,
+                embed_seconds,
+                embed_rate,
+                page_write_seconds,
+                write_rate,
+                processed,
+                failed,
+                rate,
+            )
+
+            now = time.monotonic()
+            if now - last_report >= report_seconds or remaining == 0:
+                _append_backfill_receipt(
+                    collab,
+                    remaining,
+                    extra=(
+                        f"device={device} embed_rate={embed_rate:.2f}/s "
+                        f"write_rate={write_rate:.2f}/s end_to_end={rate:.2f}/s processed={processed}"
+                    ),
+                )
+                last_report = now
+
+            time.sleep(sleep_seconds)
+            if max_pages is not None and pages >= max_pages:
+                _append_backfill_receipt(
+                    collab,
+                    remaining,
+                    extra=f"stopped-after-max-pages pages={pages} processed={processed}",
+                )
+                return 0
+
+        _append_backfill_receipt(collab, remaining, extra=f"complete processed={processed} failed={failed}")
+        logging.info("embedding backfill complete remaining=%d processed=%d failed=%d", remaining, processed, failed)
+        return 0 if remaining == 0 else 1
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Continuously backfill missing chunk embeddings.")
+    parser.add_argument("--db", type=Path, default=get_db_path())
+    parser.add_argument("--queue-dir", type=Path, default=Path.home() / ".brainlayer" / "queue")
+    parser.add_argument("--fetch-page-size", type=int, default=512)
+    parser.add_argument("--embed-batch-size", type=int, default=128)
+    parser.add_argument("--write-batch-size", type=int, default=32)
+    parser.add_argument("--min-chars", type=int, default=20)
+    parser.add_argument("--sleep-seconds", type=float, default=0.1)
+    parser.add_argument("--yield-seconds", type=float, default=0.75)
+    parser.add_argument("--busy-sleep-seconds", type=float, default=2.0)
+    parser.add_argument("--report-seconds", type=float, default=900.0)
+    parser.add_argument("--collab", type=Path, default=DEFAULT_COLLAB)
+    parser.add_argument("--no-collab", action="store_true")
+    parser.add_argument("--max-pages", type=int, default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    return run_loop(
+        db_path=args.db.expanduser(),
+        queue_dir=args.queue_dir.expanduser(),
+        fetch_page_size=max(1, args.fetch_page_size),
+        embed_batch_size=max(1, args.embed_batch_size),
+        write_batch_size=max(1, min(args.write_batch_size, 32)),
+        min_chars=max(1, args.min_chars),
+        sleep_seconds=max(0.0, args.sleep_seconds),
+        yield_seconds=max(0.0, args.yield_seconds),
+        busy_sleep_seconds=max(0.1, args.busy_sleep_seconds),
+        report_seconds=max(60.0, args.report_seconds),
+        collab=None if args.no_collab else args.collab.expanduser(),
+        max_pages=args.max_pages if args.max_pages is None else max(1, args.max_pages),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re as _re
+import sqlite3
 import subprocess
 import sys
 import time
@@ -665,6 +666,106 @@ def health_check_command(
         for action in result.actions:
             rprint(f"[yellow]action[/] {action}")
     raise typer.Exit(0 if result.ok else 1)
+
+
+@app.command("drain")
+def drain_command(
+    batch_size: int = typer.Option(50, "--batch-size", help="Queue files to consider per cycle.", min=1),
+    interval: float = typer.Option(0.5, "--interval", help="Daemon sleep interval in seconds.", min=0.0),
+    once: bool = typer.Option(False, "--once", help="Run one drain cycle and exit."),
+    daemon: bool = typer.Option(False, "--daemon", help="Run continuously until interrupted."),
+    burn: bool = typer.Option(False, "--burn", help="Use burn-drain mode for stale enrichment cleanup."),
+    max_events_per_transaction: int = typer.Option(
+        100,
+        "--max-events-per-transaction",
+        help="Maximum burn-drain events per transaction.",
+        min=1,
+    ),
+) -> None:
+    """Drain the durable write queue through the single writer."""
+    from ..drain import burn_drain_once, drain_once, run_daemon
+
+    if daemon and once:
+        raise typer.BadParameter("--daemon and --once are mutually exclusive")
+    if burn:
+        result = burn_drain_once(batch_size=batch_size, max_events_per_transaction=max_events_per_transaction)
+        typer.echo(json.dumps(result.__dict__, sort_keys=True))
+        return
+    if daemon:
+        run_daemon(interval=interval, batch_size=batch_size)
+        return
+
+    drained = drain_once(batch_size=batch_size)
+    typer.echo(str(drained))
+
+
+def _status_count_unembedded(db_path: Path) -> int | None:
+    if not db_path.exists():
+        return None
+    uri = f"file:{db_path}?mode=ro"
+    with sqlite3.connect(uri, uri=True, timeout=1.0) as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM chunks c
+            LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
+            WHERE r.id IS NULL
+              AND c.content IS NOT NULL
+              AND c.content != ''
+              AND (c.archived_at IS NULL OR c.archived_at = '')
+              AND c.superseded_by IS NULL
+              AND c.aggregated_into IS NULL
+            """
+        ).fetchone()
+    return int(row[0]) if row else None
+
+
+@app.command("status")
+def status_command(
+    db: Optional[Path] = typer.Option(None, "--db", help="Path to brainlayer.db"),
+    queue_dir: Path = typer.Option(Path("~/.brainlayer/queue"), "--queue-dir", help="Durable queue directory."),
+    drain_health_path: Path = typer.Option(
+        Path("~/.local/share/brainlayer/drain-health.json"),
+        "--drain-health-path",
+        help="Drain health JSON path.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Show a lightweight BrainLayer transport status snapshot."""
+    db_path = (db or get_db_path()).expanduser()
+    queue_path = queue_dir.expanduser()
+    drain_health = drain_health_path.expanduser()
+
+    try:
+        queue_depth = len(list(queue_path.glob("*.jsonl"))) if queue_path.exists() else 0
+    except OSError:
+        queue_depth = None
+    try:
+        unembedded = _status_count_unembedded(db_path)
+    except sqlite3.Error:
+        unembedded = None
+    try:
+        drain_snapshot = json.loads(drain_health.read_text(encoding="utf-8")) if drain_health.exists() else None
+    except (OSError, json.JSONDecodeError):
+        drain_snapshot = None
+
+    payload = {
+        "db": str(db_path),
+        "db_exists": db_path.exists(),
+        "queue_depth": queue_depth,
+        "unembedded_chunks": unembedded,
+        "drain_health": drain_snapshot,
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, sort_keys=True))
+        return
+
+    rprint(f"[bold]DB:[/] {payload['db']} ({'present' if payload['db_exists'] else 'missing'})")
+    rprint(f"[bold]Queue depth:[/] {queue_depth if queue_depth is not None else 'unknown'}")
+    rprint(f"[bold]Unembedded chunks:[/] {unembedded if unembedded is not None else 'unknown'}")
+    if drain_snapshot:
+        rprint(f"[bold]Drain cycles:[/] {drain_snapshot.get('drain_cycles', 'unknown')}")
+        rprint(f"[bold]Drained total:[/] {drain_snapshot.get('drained_total', 'unknown')}")
 
 
 @app.command("reembed-backfill")

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -53,13 +53,25 @@ def _run_launchctl(args: list[str]) -> int:
     return int(result.returncode)
 
 
-def _plist_for_launchd_label(label: str, *, watch: Path, drain: Path, health_check: Path) -> Path:
+def _plist_for_launchd_label(
+    label: str,
+    *,
+    watch: Path,
+    drain: Path,
+    health_check: Path,
+    hotlane: Path | None = None,
+    enrichment: Path | None = None,
+) -> Path:
     if label == "com.brainlayer.watch":
         return watch.expanduser()
     if label == "com.brainlayer.drain":
         return drain.expanduser()
     if label == "com.brainlayer.health-check":
         return health_check.expanduser()
+    if label == "com.brainlayer.hotlane-brainbar" and hotlane is not None:
+        return hotlane.expanduser()
+    if label == "com.brainlayer.enrichment" and enrichment is not None:
+        return enrichment.expanduser()
     return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
 
 
@@ -76,7 +88,13 @@ def _bootout_label(label: str) -> None:
 
 
 def _default_pause_labels() -> list[str]:
-    return ["com.brainlayer.watch", "com.brainlayer.drain", "com.brainlayer.health-check"]
+    return [
+        "com.brainlayer.watch",
+        "com.brainlayer.drain",
+        "com.brainlayer.hotlane-brainbar",
+        "com.brainlayer.enrichment",
+        "com.brainlayer.health-check",
+    ]
 
 
 @app.command("pause")
@@ -130,6 +148,14 @@ def resume_command(
         Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist"),
         "--health-check-plist-path",
     ),
+    hotlane_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.hotlane-brainbar.plist"),
+        "--hotlane-plist-path",
+    ),
+    enrichment_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.enrichment.plist"),
+        "--enrichment-plist-path",
+    ),
 ) -> None:
     """Remove an intentional pause and bootstrap recorded launchd labels."""
     resolved = pause_sentinel_path.expanduser()
@@ -147,6 +173,8 @@ def resume_command(
                 watch=watch_plist_path,
                 drain=drain_plist_path,
                 health_check=health_check_plist_path,
+                hotlane=hotlane_plist_path,
+                enrichment=enrichment_plist_path,
             ),
         )
     try:
@@ -161,6 +189,8 @@ def reconcile_launchd_command(
     watch_label: str = typer.Option("com.brainlayer.watch", "--watch-label"),
     drain_label: str = typer.Option("com.brainlayer.drain", "--drain-label"),
     health_check_label: str = typer.Option("com.brainlayer.health-check", "--health-check-label"),
+    hotlane_label: str = typer.Option("com.brainlayer.hotlane-brainbar", "--hotlane-label"),
+    enrichment_label: str = typer.Option("com.brainlayer.enrichment", "--enrichment-label"),
     watch_plist_path: Path = typer.Option(
         Path("~/Library/LaunchAgents/com.brainlayer.watch.plist"),
         "--watch-plist-path",
@@ -173,11 +203,21 @@ def reconcile_launchd_command(
         Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist"),
         "--health-check-plist-path",
     ),
+    hotlane_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.hotlane-brainbar.plist"),
+        "--hotlane-plist-path",
+    ),
+    enrichment_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.enrichment.plist"),
+        "--enrichment-plist-path",
+    ),
 ) -> None:
-    """Bootstrap the watcher, drain, and health-check launchd labels if absent."""
+    """Bootstrap BrainLayer launchd labels if absent."""
     for label, plist_path in (
         (watch_label, watch_plist_path),
         (drain_label, drain_plist_path),
+        (hotlane_label, hotlane_plist_path),
+        (enrichment_label, enrichment_plist_path),
         (health_check_label, health_check_plist_path),
     ):
         if label:
@@ -533,6 +573,9 @@ def health_check_command(
     health_check_label: str = typer.Option(
         "com.brainlayer.health-check", "--health-check-label", help="health-check launchd label."
     ),
+    enrichment_label: str = typer.Option(
+        "com.brainlayer.enrichment", "--enrichment-label", help="enrichment launchd label."
+    ),
     watch_plist_path: Path = typer.Option(
         Path("~/Library/LaunchAgents/com.brainlayer.watch.plist"),
         "--watch-plist-path",
@@ -547,6 +590,11 @@ def health_check_command(
         Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist"),
         "--health-check-plist-path",
         help="health-check LaunchAgent plist path.",
+    ),
+    enrichment_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.enrichment.plist"),
+        "--enrichment-plist-path",
+        help="enrichment LaunchAgent plist path.",
     ),
     source_jsonl_globs: list[str] | None = typer.Option(
         None,
@@ -588,9 +636,11 @@ def health_check_command(
             watch_label=watch_label,
             drain_label=drain_label,
             health_check_label=health_check_label,
+            enrichment_label=enrichment_label,
             watch_plist_path=watch_plist_path.expanduser(),
             drain_plist_path=drain_plist_path.expanduser(),
             health_check_plist_path=health_check_plist_path.expanduser(),
+            enrichment_plist_path=enrichment_plist_path.expanduser(),
             source_jsonl_globs=source_jsonl_globs
             if source_jsonl_globs is not None
             else HealthCheckConfig().source_jsonl_globs,

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -44,9 +44,9 @@ _DEFAULT_MAX_EVENTS_PER_TRANSACTION = 5
 _DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION = 100
 _DEFAULT_POST_COMMIT_YIELD_MS = 10.0
 _DEFAULT_MAX_ENRICHMENT_FILES_PER_CYCLE = 16
-# The post-commit WAL checkpoint is best-effort. Bound how long TRUNCATE may wait
-# on readers so a pinned reader can't stall every other writer for the full drain
-# busy_timeout (30s). Short window → reclaim when possible, skip cheaply otherwise.
+# The post-commit WAL checkpoint is best-effort and must stay non-blocking. A
+# truncating checkpoint can wedge the live writer behind long-lived readers on a
+# multi-GB WAL; the scheduled wal-checkpoint job owns truncation.
 _DEFAULT_CHECKPOINT_BUSY_TIMEOUT_MS = 1000
 
 
@@ -1143,7 +1143,7 @@ def burn_drain_once(
                 result.skipped_verified_stale += attempt_skipped_verified_stale
                 conn.setbusytimeout(_checkpoint_busy_timeout_ms())
                 try:
-                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
                     result.checkpoints += 1
                 except apsw.Error as exc:
                     _log(log_path, f"burn drain checkpoint skipped: {exc}")
@@ -1260,18 +1260,14 @@ def drain_once(
                             collision_ids.append(result.collision_chunk_id)
                         attempt_drained += 1
                     conn.execute("COMMIT")
-                    # Best-effort WAL reclaim. The truncating checkpoint (not PASSIVE)
-                    # shrinks the WAL file after each drained batch — PASSIVE leaves
-                    # frames in place when a reader pins a page, letting the WAL grow
-                    # unbounded (observed multi-GB) and starve brain_store writes. But it
-                    # blocks other writers while waiting for readers, so bound that wait
-                    # to a short window (default 1s): if a reader pins the WAL we skip
-                    # this round rather than stall every writer for the full drain
-                    # busy_timeout. journal_size_limit and the out-of-band wal-checkpoint
-                    # job reclaim later. The except keeps a busy checkpoint non-fatal.
+                    # Best-effort WAL checkpoint. Keep the live writer path PASSIVE:
+                    # TRUNCATE can block behind long-lived readers on the live multi-GB
+                    # WAL, which stalls queue drain before it can publish health.
+                    # journal_size_limit and the scheduled wal-checkpoint job reclaim
+                    # disk later. The except keeps a busy checkpoint non-fatal.
                     conn.setbusytimeout(_checkpoint_busy_timeout_ms())
                     try:
-                        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
                     except apsw.Error:
                         pass
                     finally:

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -43,6 +43,7 @@ _DEFAULT_DRAIN_OPEN_RETRY_MAX_DELAY_MS = 5000.0
 _DEFAULT_MAX_EVENTS_PER_TRANSACTION = 5
 _DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION = 100
 _DEFAULT_POST_COMMIT_YIELD_MS = 10.0
+_DEFAULT_MAX_ENRICHMENT_FILES_PER_CYCLE = 16
 # The post-commit WAL checkpoint is best-effort. Bound how long TRUNCATE may wait
 # on readers so a pinned reader can't stall every other writer for the full drain
 # busy_timeout (30s). Short window → reclaim when possible, skip cheaply otherwise.
@@ -89,6 +90,13 @@ def _nonnegative_float_env(name: str, default: float) -> float:
 
 def _max_events_per_transaction() -> int:
     return _positive_int_env("BRAINLAYER_DRAIN_MAX_EVENTS_PER_TRANSACTION", _DEFAULT_MAX_EVENTS_PER_TRANSACTION)
+
+
+def _max_enrichment_files_per_cycle() -> int:
+    return _positive_int_env(
+        "BRAINLAYER_DRAIN_MAX_ENRICHMENT_FILES_PER_CYCLE",
+        _DEFAULT_MAX_ENRICHMENT_FILES_PER_CYCLE,
+    )
 
 
 def _post_commit_yield_seconds() -> float:
@@ -919,6 +927,23 @@ def _unlink_processed_file(path: Path, log_path: Path) -> None:
         _log(log_path, f"drain committed but could not unlink {path}: {exc}")
 
 
+def _is_enrichment_queue_file(path: Path) -> bool:
+    return path.name.startswith("enrichment-")
+
+
+def _queue_file_priority(path: Path) -> tuple[int, str]:
+    return (2 if _is_enrichment_queue_file(path) else 0, path.name)
+
+
+def _select_priority_queue_files(files: list[Path], batch_size: int, *, cap_enrichment: bool = True) -> list[Path]:
+    ordered = sorted(files, key=_queue_file_priority)
+    high_priority = [path for path in ordered if not _is_enrichment_queue_file(path)]
+    if high_priority:
+        return high_priority[:batch_size]
+    enrichment_limit = min(batch_size, _max_enrichment_files_per_cycle()) if cap_enrichment else batch_size
+    return ordered[:enrichment_limit]
+
+
 def _rewrite_events_file(path: Path, events: list[dict[str, Any]]) -> None:
     tmp_path = path.with_suffix(".tmp")
     tmp_path.write_text(
@@ -1064,9 +1089,7 @@ def burn_drain_once(
     result = BurnDrainResult()
     lock_fd = _acquire_queue_lock(queue_dir)
     try:
-        files = sorted(queue_dir.glob("*.jsonl"), key=lambda path: (path.name.startswith("enrichment-"), path.name))[
-            :batch_size
-        ]
+        files = _select_priority_queue_files(list(queue_dir.glob("*.jsonl")), batch_size, cap_enrichment=False)
         if not files:
             return result
         try:
@@ -1187,9 +1210,7 @@ def drain_once(
 
     lock_fd = _acquire_queue_lock(queue_dir)
     try:
-        files = sorted(queue_dir.glob("*.jsonl"), key=lambda path: (path.name.startswith("enrichment-"), path.name))[
-            :batch_size
-        ]
+        files = _select_priority_queue_files(list(queue_dir.glob("*.jsonl")), batch_size)
         if not files:
             return 0
         _log(log_path, f"queue_depth={len(files)}")

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -931,6 +931,13 @@ def _is_enrichment_queue_file(path: Path) -> bool:
     return path.name.startswith("enrichment-")
 
 
+def _has_high_priority_queue_files(queue_dir: Path) -> bool:
+    try:
+        return any(not _is_enrichment_queue_file(path) for path in queue_dir.glob("*.jsonl"))
+    except OSError:
+        return False
+
+
 def _queue_file_priority(path: Path) -> tuple[int, str]:
     return (2 if _is_enrichment_queue_file(path) else 0, path.name)
 
@@ -1283,6 +1290,8 @@ def drain_once(
                     yield_seconds = _post_commit_yield_seconds()
                     if yield_seconds > 0:
                         time.sleep(yield_seconds)
+                    if _is_enrichment_queue_file(path) and _has_high_priority_queue_files(queue_dir):
+                        stop_draining = True
                     break
                 except Exception as exc:
                     if conn is not None:

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -444,6 +444,13 @@ def run_enrich_supervisor(
                     stats.errors.append(str(exc))
                     logger.warning("Enrich supervisor stopping: %s", exc)
                     break
+                except Exception as exc:  # noqa: BLE001
+                    stats.failed_cycles += 1
+                    stats.errors.append(f"supervisor-idle-backlog: {exc}")
+                    logger.exception("Enrich supervisor idle-backlog pass failed; continuing")
+                    if max_cycles is None or stats.cycles < max_cycles:
+                        _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
+                    continue
                 stats.attempted += backlog_result.attempted
                 stats.enriched += backlog_result.enriched
                 stats.skipped += backlog_result.skipped

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -42,6 +42,7 @@ DEFAULT_POST_WRITE_YIELD_MS = 20.0
 DEFAULT_ENRICH_SUPERVISOR_LIMIT = 200_000
 DEFAULT_ENRICH_SUPERVISOR_SINCE_HOURS = 87_600
 DEFAULT_ENRICH_IDLE_POLL_SECONDS = 30.0
+DEFAULT_ENRICH_WATCHER_IDLE_SECONDS = 5.0
 DEFAULT_ENRICH_DAILY_USD_CAP = 5.0
 ENRICH_DAILY_COST_COUNTER_FILENAME = "enrich-daily-cost.json"
 _DEFAULT_CHUNK_ORIGIN = object()
@@ -291,6 +292,69 @@ def _current_idle_poll_seconds() -> float:
     )
 
 
+def _idle_backlog_enabled() -> bool:
+    return os.environ.get("BRAINLAYER_ENRICH_IDLE_BACKLOG", "0").lower() not in {"0", "false", "no"}
+
+
+def _watcher_offsets_path() -> Path:
+    override = os.environ.get("BRAINLAYER_WATCHER_OFFSETS_PATH") or os.environ.get("BRAINLAYER_OFFSETS_PATH")
+    if override:
+        return Path(override).expanduser()
+
+    from .paths import get_db_path
+
+    return get_db_path().parent / "offsets.json"
+
+
+def _watcher_health_path() -> Path:
+    override = os.environ.get("BRAINLAYER_WATCHER_HEALTH_PATH")
+    if override:
+        return Path(override).expanduser()
+
+    from .paths import get_db_path
+
+    return get_db_path().parent / "watcher-health.json"
+
+
+def _watcher_idle_seconds() -> float:
+    return _bounded_nonnegative_float(
+        os.environ.get("BRAINLAYER_ENRICH_WATCHER_IDLE_SECONDS"),
+        DEFAULT_ENRICH_WATCHER_IDLE_SECONDS,
+    )
+
+
+def _path_is_idle(path: Path, *, now: float, idle_seconds: float) -> bool:
+    try:
+        stat_result = path.stat()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return now - stat_result.st_mtime >= idle_seconds
+
+
+def _watcher_idle() -> bool:
+    idle_seconds = _watcher_idle_seconds()
+    if idle_seconds <= 0:
+        return True
+    now = time.time()
+    return all(
+        _path_is_idle(path, now=now, idle_seconds=idle_seconds)
+        for path in (_watcher_offsets_path(), _watcher_health_path())
+    )
+
+
+def _idle_backlog_ready() -> bool:
+    if not _idle_backlog_enabled():
+        return False
+    try:
+        from .queue_io import get_queue_dir
+
+        return not any(get_queue_dir().expanduser().glob("*.jsonl")) and _watcher_idle()
+    except OSError:
+        return False
+
+
 def _sleep_or_wait_for_stop(stop_event: threading.Event | None, seconds: float, sleep_fn) -> None:
     if seconds <= 0:
         return
@@ -310,6 +374,7 @@ def run_enrich_supervisor(
     stop_event: threading.Event | None = None,
     vector_store_cls=None,
     enrich_fn=None,
+    idle_backlog_ready_fn=None,
     sleep_fn=time.sleep,
 ) -> EnrichmentSupervisorResult:
     """Run realtime enrichment as a long-lived supervisor around one VectorStore.
@@ -324,6 +389,8 @@ def run_enrich_supervisor(
         vector_store_cls = VectorStore
     if enrich_fn is None:
         enrich_fn = enrich_realtime
+    if idle_backlog_ready_fn is None:
+        idle_backlog_ready_fn = _idle_backlog_ready
     if idle_poll_seconds is None:
         idle_poll_seconds = _current_idle_poll_seconds()
 
@@ -363,7 +430,35 @@ def run_enrich_supervisor(
             if _result_hit_daily_cap(result):
                 break
 
-            if result.attempted == 0 and (max_cycles is None or stats.cycles < max_cycles):
+            idle_backlog_attempted = 0
+            if (
+                result.attempted == 0
+                and since_hours is not None
+                and idle_backlog_ready_fn()
+                and (max_cycles is None or stats.cycles <= max_cycles)
+            ):
+                logger.info("Enrich supervisor recent queue empty; checking idle backlog")
+                try:
+                    backlog_result = enrich_fn(store, limit=limit, since_hours=None)
+                except EnrichmentDailyCapReached as exc:
+                    stats.errors.append(str(exc))
+                    logger.warning("Enrich supervisor stopping: %s", exc)
+                    break
+                stats.attempted += backlog_result.attempted
+                stats.enriched += backlog_result.enriched
+                stats.skipped += backlog_result.skipped
+                stats.failed += backlog_result.failed
+                stats.errors.extend(backlog_result.errors)
+                idle_backlog_attempted = backlog_result.attempted
+                if _result_hit_daily_cap(backlog_result):
+                    break
+
+            if (
+                stats.cycles > 0
+                and result.attempted == 0
+                and idle_backlog_attempted == 0
+                and (max_cycles is None or stats.cycles < max_cycles)
+            ):
                 logger.info("Enrich supervisor queue empty; sleeping %.1fs", idle_poll_seconds)
                 _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
     finally:
@@ -464,7 +559,7 @@ def _arbitrated_writes_enabled() -> bool:
 
 
 def _enrichment_writes_queued_enabled() -> bool:
-    return os.environ.get("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", "0").lower() not in {"0", "false", "no"}
+    return os.environ.get("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", "1").lower() not in {"0", "false", "no"}
 
 
 def _open_enrich_supervisor_store(vector_store_cls, db_path: Path):

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -657,7 +657,12 @@ def run_health_check(
         )
 
     if config.heal:
-        for label in (config.watch_label, config.drain_label, config.health_check_label):
+        for label in (
+            config.watch_label,
+            config.drain_label,
+            config.health_check_label,
+            config.enrichment_label,
+        ):
             if label:
                 action = _bootstrap_if_absent(label, _plist_for_label(config, label), command_runner)
                 if action.startswith(("bootstrap:", "bootstrap_failed:", "launchctl-unavailable:")):

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -26,6 +26,7 @@ DEFAULT_BRAINBAR_DAEMON_LABEL = "com.brainlayer.brainbar-daemon"
 DEFAULT_WATCH_LABEL = "com.brainlayer.watch"
 DEFAULT_DRAIN_LABEL = "com.brainlayer.drain"
 DEFAULT_HEALTH_CHECK_LABEL = "com.brainlayer.health-check"
+DEFAULT_ENRICHMENT_LABEL = "com.brainlayer.enrichment"
 DEFAULT_BACKLOG_BATCH = 4
 DEFAULT_HEAL_MIN_CONSECUTIVE_FAILURES = 2
 DEFAULT_HEAL_CIRCUIT_BREAKER_LIMIT = 3
@@ -61,6 +62,7 @@ class HealthCheckConfig:
     watch_label: str = DEFAULT_WATCH_LABEL
     drain_label: str = DEFAULT_DRAIN_LABEL
     health_check_label: str = DEFAULT_HEALTH_CHECK_LABEL
+    enrichment_label: str = DEFAULT_ENRICHMENT_LABEL
     watch_plist_path: Path = field(
         default_factory=lambda: Path("~/Library/LaunchAgents/com.brainlayer.watch.plist").expanduser()
     )
@@ -69,6 +71,9 @@ class HealthCheckConfig:
     )
     health_check_plist_path: Path = field(
         default_factory=lambda: Path("~/Library/LaunchAgents/com.brainlayer.health-check.plist").expanduser()
+    )
+    enrichment_plist_path: Path = field(
+        default_factory=lambda: Path("~/Library/LaunchAgents/com.brainlayer.enrichment.plist").expanduser()
     )
     offsets_path: Path = field(default_factory=lambda: Path("~/.local/share/brainlayer/offsets.json").expanduser())
     watcher_health_path: Path = field(
@@ -400,10 +405,25 @@ def _apply_heals(
         return heal_failures, tripped
     threshold = max(1, config.heal_min_consecutive_failures)
     breaker_limit = max(threshold, config.heal_circuit_breaker_limit)
+    bootstrap_issue_codes = {
+        "watch_unloaded",
+        "drain_unloaded",
+        "health_check_unloaded",
+        "hotlane_unloaded",
+        "enrichment_unloaded",
+    }
     for issue_code, (label, plist_path) in issue_labels.items():
         key = _heal_key(label, issue_code)
         consecutive_failures = heal_failures.get(key, 0)
         if consecutive_failures >= breaker_limit:
+            if issue_code in bootstrap_issue_codes:
+                action = _bootstrap_if_absent(label, plist_path, command_runner)
+                if action.startswith("bootstrap:"):
+                    tripped.discard(key)
+                    heal_failures.pop(key, None)
+                    if action not in result.actions:
+                        result.actions.append(action)
+                    continue
             if key not in tripped:
                 tripped.add(key)
                 result.actions.append(f"heal_escalation:{label}:{issue_code}")
@@ -420,9 +440,12 @@ def _apply_heals(
         if consecutive_failures >= threshold:
             action = (
                 _bootstrap_if_absent(label, plist_path, command_runner)
-                if issue_code in {"watch_unloaded", "drain_unloaded", "health_check_unloaded"}
+                if issue_code in bootstrap_issue_codes
                 else _kickstart(label, command_runner)
             )
+            if action.startswith("bootstrap:"):
+                tripped.discard(key)
+                heal_failures.pop(key, None)
             if action not in result.actions:
                 print(
                     f"heal action label={label} issue={issue_code} "
@@ -520,6 +543,8 @@ def _plist_for_label(config: HealthCheckConfig, label: str) -> Path:
         return config.drain_plist_path
     if label == config.health_check_label:
         return config.health_check_plist_path
+    if label == config.enrichment_label:
+        return config.enrichment_plist_path
     if label == config.hotlane_label:
         return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
     if label == config.brainbar_daemon_label:
@@ -642,6 +667,7 @@ def run_health_check(
         (config.watch_label, "watch_unloaded", "watch launchd label is not loaded"),
         (config.drain_label, "drain_unloaded", "drain launchd label is not loaded"),
         (config.health_check_label, "health_check_unloaded", "health-check launchd label is not loaded"),
+        (config.enrichment_label, "enrichment_unloaded", "enrichment launchd label is not loaded"),
     ):
         if not label:
             continue

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Optional
 from .claude_paths import extract_claude_conversation_id as _extract_claude_conversation_id
 from .embeddings import embed_chunks
 from .pipeline.chunk import Chunk
-from .pipeline.classify import looks_like_system_prompt
+from .system_prompt_guard import looks_like_system_prompt
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -1793,7 +1793,7 @@ async def _search(
                 timeout=embed_timeout_ms / 1000.0,
             )
         except TimeoutError as exc:
-            search_mode = "fts_only"
+            search_mode = "fts_fallback"
             fallback_reason = "embed_timeout"
             search_profile.emit(
                 profile_scope,
@@ -1802,10 +1802,10 @@ async def _search(
                 search_profile.dur_ms(embed_started),
                 error=exc.__class__.__name__,
                 timeout_ms=embed_timeout_ms,
-                fallback="fts_only",
+                fallback="fts_fallback",
             )
         except Exception as exc:
-            search_mode = "fts_only"
+            search_mode = "fts_fallback"
             fallback_reason = f"embed_error:{exc.__class__.__name__}"
             search_profile.emit(
                 profile_scope,
@@ -1813,7 +1813,7 @@ async def _search(
                 profile_query_id,
                 search_profile.dur_ms(embed_started),
                 error=exc.__class__.__name__,
-                fallback="fts_only",
+                fallback="fts_fallback",
             )
         else:
             search_profile.emit(profile_scope, "embed", profile_query_id, search_profile.dur_ms(embed_started))
@@ -1943,16 +1943,15 @@ async def _search(
                 len(structured_results),
                 order=order if order == "origin" else None,
             )
-            if search_mode == "fts_only":
+            if search_mode == "fts_fallback":
                 formatted_text = (
-                    f"{formatted_text}\n\n"
-                    f"Search mode: FTS-only fallback ({fallback_reason}); vector embedding was skipped."
+                    f"{formatted_text}\n\nSearch mode: FTS fallback ({fallback_reason}); vector embedding was skipped."
                 )
             return ([TextContent(type="text", text=formatted_text)], structured)
 
         output_parts = [f"## Search Results for: {query}\n"]
-        if search_mode == "fts_only":
-            output_parts.append(f"Search mode: FTS-only fallback ({fallback_reason}); vector embedding was skipped.")
+        if search_mode == "fts_fallback":
+            output_parts.append(f"Search mode: FTS fallback ({fallback_reason}); vector embedding was skipped.")
         if order == "origin":
             output_parts.append(_ORIGIN_ORDER_LABEL)
         structured_results = []

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -28,7 +28,7 @@ from ._shared import (
 _RETRY_MAX_ATTEMPTS = 4
 _retry_delay = 0.15  # base delay in seconds (exposed for test patching)
 _QUEUE_MAX_SIZE = 100
-_DEFAULT_STORE_BUSY_BUDGET_MS = 3_000
+_DEFAULT_STORE_BUSY_BUDGET_MS = 400
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _STORE_BUSY_TIMEOUT_LOCK = threading.Lock()
 _NO_EXEC_TRACE = object()

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -784,8 +784,8 @@ def _get_store_vector_store(deadline: float):
 
 def _validate_store_request(content: str, memory_type: str) -> str:
     from ..ingest_guard import reject_recursive_mcp_output
-    from ..pipeline.classify import looks_like_system_prompt
-    from ..store import VALID_MEMORY_TYPES
+    from ..memory_types import VALID_MEMORY_TYPES
+    from ..system_prompt_guard import looks_like_system_prompt
 
     if not content or not content.strip():
         raise ValueError("content must be non-empty")

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -516,6 +516,35 @@ def _queue_store(item: dict):
     return path
 
 
+def _queue_has_background_pressure() -> bool:
+    """Return true when background queue work is already pending.
+
+    The interactive MCP store path should reserve through the durable queue
+    instead of opening a writer connection behind background drain/enrichment
+    work. This check is intentionally cheap: finding any queued JSONL file is
+    enough signal that drain owns the persistence lane.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") and "BRAINLAYER_QUEUE_DIR" not in os.environ:
+        return False
+    try:
+        from ..queue_io import get_queue_dir
+
+        queue_dir = get_queue_dir()
+        return next(queue_dir.glob("*.jsonl"), None) is not None
+    except OSError:
+        return False
+
+
+def _interactive_queue_reason() -> str | None:
+    if os.environ.get("BRAINLAYER_ARBITRATED") == "1":
+        return "ARBITRATED"
+    if os.environ.get("BRAINLAYER_INTERACTIVE_STORE_QUEUE") == "1":
+        return "INTERACTIVE_PRIORITY"
+    if _queue_has_background_pressure():
+        return "INTERACTIVE_PRIORITY"
+    return None
+
+
 def _deferred_store_receipt(chunk_id: str, queue_path, *, reason: str = "DB_BUSY") -> dict:
     action = "queued_for_replay" if str(queue_path).endswith("pending-stores.jsonl") else "queued_for_drain"
     return {
@@ -787,7 +816,8 @@ async def _store(
     try:
         content = _validate_store_request(content, memory_type)
 
-        if os.environ.get("BRAINLAYER_ARBITRATED") == "1":
+        queue_reason = _interactive_queue_reason()
+        if queue_reason is not None:
             from ..search_repo import clear_hybrid_search_cache
 
             queue_path = _queue_store(
@@ -813,7 +843,7 @@ async def _store(
                 }
             )
             clear_hybrid_search_cache()
-            structured = _deferred_store_receipt(promised_chunk_id, queue_path, reason="ARBITRATED")
+            structured = _deferred_store_receipt(promised_chunk_id, queue_path, reason=queue_reason)
             return ([TextContent(type="text", text=format_store_result(promised_chunk_id, queued=True))], structured)
 
         from ..store import embed_hot_chunk, embed_pending_chunks, store_memory

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -4,6 +4,7 @@ import asyncio
 import fcntl
 import json
 import os
+import sys
 import threading
 import time
 import uuid
@@ -545,6 +546,15 @@ def _interactive_queue_reason() -> str | None:
     return None
 
 
+def _clear_hybrid_search_cache_if_loaded() -> None:
+    search_repo = sys.modules.get("brainlayer.search_repo")
+    if search_repo is None:
+        return
+    clear_cache = getattr(search_repo, "clear_hybrid_search_cache", None)
+    if clear_cache is not None:
+        clear_cache()
+
+
 def _deferred_store_receipt(chunk_id: str, queue_path, *, reason: str = "DB_BUSY") -> dict:
     action = "queued_for_replay" if str(queue_path).endswith("pending-stores.jsonl") else "queued_for_drain"
     return {
@@ -818,8 +828,6 @@ async def _store(
 
         queue_reason = _interactive_queue_reason()
         if queue_reason is not None:
-            from ..search_repo import clear_hybrid_search_cache
-
             queue_path = _queue_store(
                 {
                     "chunk_id": promised_chunk_id,
@@ -842,7 +850,7 @@ async def _store(
                     "created_at": reservation_created_at,
                 }
             )
-            clear_hybrid_search_cache()
+            _clear_hybrid_search_cache_if_loaded()
             structured = _deferred_store_receipt(promised_chunk_id, queue_path, reason=queue_reason)
             return ([TextContent(type="text", text=format_store_result(promised_chunk_id, queued=True))], structured)
 

--- a/src/brainlayer/memory_types.py
+++ b/src/brainlayer/memory_types.py
@@ -1,0 +1,13 @@
+"""Shared memory type constants."""
+
+VALID_MEMORY_TYPES = [
+    "idea",
+    "mistake",
+    "decision",
+    "learning",
+    "todo",
+    "bookmark",
+    "note",
+    "journal",
+    "issue",
+]

--- a/src/brainlayer/pipeline/classify.py
+++ b/src/brainlayer/pipeline/classify.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from ..system_prompt_guard import looks_like_system_prompt
+
 # =============================================================================
 # SMART FILTERING CONFIGURATION
 # =============================================================================
@@ -88,16 +90,6 @@ HIGH_VALUE_PATTERNS = [
     r"(?:because|decided|chose|recommend|should|must)",  # Decisions
     r"(?:todo|fixme|hack|workaround)",  # Code notes
 ]
-
-# Markers that strongly indicate agent/base-context system prompts rather than user content.
-SYSTEM_PROMPT_MARKERS = {
-    "# base context",
-    "## iron rules",
-    "> this context contains universal rules",
-    "claude.md instructions",
-    "agents.md instructions for",
-    "global agent instructions",
-}
 
 
 class ContentType(Enum):
@@ -244,24 +236,6 @@ def _has_high_value_signal(content: str) -> bool:
         if re.search(pattern, content, re.IGNORECASE):
             return True
     return False
-
-
-def looks_like_system_prompt(content: str) -> bool:
-    """Detect agent/base-context prompt scaffolding that should not be indexed."""
-    stripped = content.strip()
-    if not stripped:
-        return False
-
-    lowered = stripped.lower()
-    score = sum(1 for marker in SYSTEM_PROMPT_MARKERS if marker in lowered)
-
-    if re.search(r"(?im)^(?:>\s*)?you are (?:codex|claude|[\w-]*(?:codex|claude)|a coding agent)\b", stripped):
-        score += 2
-
-    if re.search(r"(?im)^##\s*first:\s*load context\b", stripped):
-        score += 1
-
-    return score >= 2 or (score >= 1 and len(stripped) > 2000)
 
 
 def _should_keep_user_message(content: str) -> bool:

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -44,12 +44,12 @@ from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, detect_chunk_origi
 from .content_class import classify_content_class
 from .dedupe import find_duplicate, merge_duplicate_chunk, merge_existing_chunk_content, merge_existing_chunk_seen
 from .ingest_guard import reject_recursive_mcp_output
-from .pipeline.classify import looks_like_system_prompt
+from .memory_types import VALID_MEMORY_TYPES
+from .system_prompt_guard import looks_like_system_prompt
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
 
-VALID_MEMORY_TYPES = ["idea", "mistake", "decision", "learning", "todo", "bookmark", "note", "journal", "issue"]
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 
 

--- a/src/brainlayer/system_prompt_guard.py
+++ b/src/brainlayer/system_prompt_guard.py
@@ -1,0 +1,30 @@
+"""Lightweight system-prompt detection for write-path validation."""
+
+import re
+
+SYSTEM_PROMPT_MARKERS = {
+    "# base context",
+    "## iron rules",
+    "> this context contains universal rules",
+    "claude.md instructions",
+    "agents.md instructions for",
+    "global agent instructions",
+}
+
+
+def looks_like_system_prompt(content: str) -> bool:
+    """Detect agent/base-context prompt scaffolding that should not be indexed."""
+    stripped = content.strip()
+    if not stripped:
+        return False
+
+    lowered = stripped.lower()
+    score = sum(1 for marker in SYSTEM_PROMPT_MARKERS if marker in lowered)
+
+    if re.search(r"(?im)^(?:>\s*)?you are (?:codex|claude|[\w-]*(?:codex|claude)|a coding agent)\b", stripped):
+        score += 2
+
+    if re.search(r"(?im)^##\s*first:\s*load context\b", stripped):
+        score += 1
+
+    return score >= 2 or (score >= 1 and len(stripped) > 2000)

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -723,8 +723,7 @@ def test_real_concurrent_writers_keep_interactive_store_searchable_under_sla(tmp
         assert search_payload is not None
         assert search_payload.get("total", 0) >= 1, search_payload
         assert any(
-            marker in (item.get("content", "") + item.get("snippet", ""))
-            for item in search_payload.get("results", [])
+            marker in (item.get("content", "") + item.get("snippet", "")) for item in search_payload.get("results", [])
         ), search_payload
         assert roundtrip_latency < 2.0
     finally:

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -1,8 +1,11 @@
+import asyncio
 import hashlib
+import importlib.util
 import json
 import multiprocessing as mp
 import re
 import sqlite3
+import threading
 import time
 from pathlib import Path
 
@@ -177,6 +180,23 @@ def _create_vec_db(path: Path) -> None:
         conn.close()
 
 
+def _load_hotlane_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "hotlane_brainbar_daemon.py"
+    spec = importlib.util.spec_from_file_location("brainlayer_hotlane_brainbar_test", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FastEmbeddingModel:
+    def embed_query(self, _text: str) -> list[float]:
+        return [0.03125] * 1024
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [[0.03125] * 1024 for _text in texts]
+
+
 def test_drain_default_queue_dir_expands_env_tilde(monkeypatch):
     from brainlayer.drain import _default_queue_dir
 
@@ -220,6 +240,55 @@ def test_drain_prioritizes_writes_before_enrichment(tmp_path, monkeypatch):
     assert (queue_dir / "enrichment-000.jsonl").exists()
     with sqlite3.connect(db_path) as conn:
         assert conn.execute("SELECT id FROM chunks WHERE id = 'watcher-priority'").fetchone() == ("watcher-priority",)
+
+
+def test_drain_yields_enrichment_when_interactive_store_is_queued(tmp_path, monkeypatch):
+    """Interactive stores are higher priority than enrichment metadata writes."""
+    from brainlayer.drain import drain_once
+    from brainlayer.queue_io import enqueue_enrichment_updates, enqueue_store
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    _create_minimal_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+
+    with _connect_apsw(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO chunks (id, content, metadata, source_file, content_hash)
+            VALUES ('enrich-low-priority', 'metadata can wait', '{}', 'fixture', 'hash-low')
+            """
+        )
+
+    store_path = enqueue_store(
+        content="interactive store must drain before enrichment",
+        memory_type="note",
+        project="arbitration-test",
+        source="mcp",
+        queue_dir=queue_dir,
+    )
+    enrichment_path = enqueue_enrichment_updates(
+        [
+            {
+                "chunk_id": "enrich-low-priority",
+                "content_hash": "hash-low",
+                "enrichment": {"summary": "low priority summary"},
+            }
+        ],
+        queue_dir=queue_dir,
+    )
+
+    assert drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10) == 1
+
+    assert not store_path.exists()
+    assert enrichment_path.exists()
+    with _connect_apsw(db_path) as conn:
+        stored = conn.execute(
+            "SELECT COUNT(*) FROM chunks WHERE content = 'interactive store must drain before enrichment'"
+        ).fetchone()[0]
+        summary = conn.execute("SELECT summary FROM chunks WHERE id = 'enrich-low-priority'").fetchone()[0]
+    assert stored == 1
+    assert summary is None
 
 
 def test_drain_skips_stale_enrichment_for_rewritten_chunk(tmp_path, monkeypatch):
@@ -472,6 +541,198 @@ def test_drain_daemon_serializes_three_concurrent_producers(tmp_path, monkeypatc
     assert total_drained == 3000, f"drain_once accumulated {total_drained} (expected 3000)"
     assert not list(queue_dir.glob("*.jsonl"))
     assert "database is locked" not in log_path.read_text(encoding="utf-8").lower()
+
+
+def test_real_concurrent_writers_keep_interactive_store_searchable_under_sla(tmp_path, monkeypatch):
+    """Real drain + hotlane writers must not starve interactive store->search."""
+    from brainlayer.drain import drain_once
+    from brainlayer.mcp import search_handler, store_handler
+    from brainlayer.mcp.search_handler import _search
+    from brainlayer.mcp.store_handler import _store
+    from brainlayer.queue_io import enqueue_enrichment_updates, enqueue_store
+    from brainlayer.vector_store import VectorStore
+
+    hotlane = _load_hotlane_module()
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    writer_pid_dir = tmp_path / "pidfiles"
+    log_path = tmp_path / "drain.log"
+    marker = "d3realconcurrencygate42"
+
+    monkeypatch.setenv("BRAINLAYER_ARBITRATED", "1")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(writer_pid_dir))
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "1")
+    monkeypatch.setenv("BRAINLAYER_STORE_BUSY_BUDGET_MS", "400")
+    monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "1000")
+    monkeypatch.setattr(store_handler, "_get_embedding_model", lambda: _FastEmbeddingModel())
+    monkeypatch.setattr(search_handler, "_get_embedding_model", lambda: _FastEmbeddingModel())
+
+    store = VectorStore(db_path)
+    now = "2026-06-21T20:00:00+00:00"
+    try:
+        cursor = store.conn.cursor()
+        cursor.execute("BEGIN IMMEDIATE")
+        for index in range(48):
+            chunk_id = f"hotlane-seed-{index}"
+            content = f"hotlane seed backlog item {index}"
+            cursor.execute(
+                """
+                INSERT INTO chunks (
+                    id, content, metadata, source_file, project, content_type,
+                    value_type, char_count, source, created_at, status
+                )
+                VALUES (?, ?, '{}', 'brainbar-store', 'arbitration-test', 'note',
+                        'high', ?, 'mcp', ?, 'active')
+                """,
+                (chunk_id, content, len(content), now),
+            )
+        cursor.execute("COMMIT")
+    finally:
+        store.close()
+
+    for index in range(8):
+        enqueue_store(
+            content=f"drain background backlog item {index}",
+            memory_type="note",
+            project="arbitration-test",
+            source="watcher",
+            queue_dir=queue_dir,
+        )
+    enqueue_enrichment_updates(
+        [
+            {
+                "chunk_id": "hotlane-seed-0",
+                "content_hash": None,
+                "enrichment": {"summary": "low priority enrichment must yield"},
+            }
+        ],
+        queue_dir=queue_dir,
+    )
+
+    stop = threading.Event()
+    drain_writes = 0
+    hotlane_embeddings = 0
+    counters_lock = threading.Lock()
+
+    def drain_loop() -> None:
+        nonlocal drain_writes
+        while not stop.is_set():
+            drained = drain_once(
+                db_path=db_path,
+                queue_dir=queue_dir,
+                batch_size=8,
+                log_path=log_path,
+                embed_fn=lambda _text: [0.0625] * 1024,
+            )
+            if drained:
+                with counters_lock:
+                    drain_writes += drained
+            time.sleep(0.005)
+
+    def recording_cycle(**kwargs):
+        nonlocal hotlane_embeddings
+        result = hotlane.run_cycle(**kwargs)
+        if result.embedded:
+            with counters_lock:
+                hotlane_embeddings += result.embedded
+        return result
+
+    def hotlane_loop() -> None:
+        hotlane.STOP = False
+        hotlane.run(
+            db_path=db_path,
+            interval=0.005,
+            recent_limit=4,
+            backlog_interval=0.005,
+            backlog_batch=4,
+            enrich_interval=9999,
+            enrich_limit=0,
+            enrich_since_hours=24,
+            vector_store_cls=VectorStore,
+            model_factory=_FastEmbeddingModel,
+            cycle_fn=recording_cycle,
+            sleep_fn=lambda seconds: time.sleep(min(seconds, 0.005)),
+            max_cycles=400,
+            queue_dir=queue_dir,
+        )
+
+    drain_thread = threading.Thread(target=drain_loop, name="test-drain-loop", daemon=True)
+    hotlane_thread = threading.Thread(target=hotlane_loop, name="test-hotlane-loop", daemon=True)
+    drain_thread.start()
+    hotlane_thread.start()
+
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        with counters_lock:
+            high_priority_queue_empty = not any(
+                path for path in queue_dir.glob("*.jsonl") if not path.name.startswith("enrichment-")
+            )
+            if drain_writes >= 8 and hotlane_embeddings > 0 and high_priority_queue_empty:
+                break
+        time.sleep(0.01)
+    with counters_lock:
+        assert drain_writes >= 8
+        assert hotlane_embeddings > 0
+    assert not any(path for path in queue_dir.glob("*.jsonl") if not path.name.startswith("enrichment-"))
+
+    readonly_store = VectorStore(db_path, readonly=True)
+    monkeypatch.setattr(search_handler, "_get_vector_store", lambda: readonly_store)
+
+    try:
+        roundtrip_started = time.perf_counter()
+        store_started = time.perf_counter()
+        store_result = asyncio.run(
+            _store(
+                content=f"{marker} interactive store must be searchable while drain and hotlane write",
+                memory_type="note",
+                project="arbitration-test",
+                tags=["d3", "concurrency"],
+                importance=8,
+            )
+        )
+        store_latency = time.perf_counter() - store_started
+        assert store_latency < 0.5
+        assert store_result[1]["queued"] is True
+
+        search_payload = None
+        while time.perf_counter() - roundtrip_started < 2.0:
+            search_result = asyncio.run(
+                _search(
+                    query=marker,
+                    project="arbitration-test",
+                    source="all",
+                    num_results=5,
+                    include_operational=True,
+                )
+            )
+            if not isinstance(search_result, tuple):
+                error_text = "\n".join(getattr(part, "text", "") for part in getattr(search_result, "content", []))
+                search_payload = {"total": 0, "results": [], "error": error_text}
+                time.sleep(0.025)
+                continue
+            search_payload = search_result[1]
+            if search_payload.get("total", 0) >= 1 and any(
+                marker in (item.get("content", "") + item.get("snippet", ""))
+                for item in search_payload.get("results", [])
+            ):
+                break
+            time.sleep(0.025)
+
+        roundtrip_latency = time.perf_counter() - roundtrip_started
+        assert search_payload is not None
+        assert search_payload.get("total", 0) >= 1, search_payload
+        assert any(
+            marker in (item.get("content", "") + item.get("snippet", ""))
+            for item in search_payload.get("results", [])
+        ), search_payload
+        assert roundtrip_latency < 2.0
+    finally:
+        readonly_store.close()
+        stop.set()
+        hotlane.STOP = True
+        drain_thread.join(timeout=2)
+        hotlane_thread.join(timeout=2)
 
 
 def test_queue_sanitizes_source_and_drain_preserves_supersedes(tmp_path):

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -1,10 +1,11 @@
 import asyncio
 import hashlib
-import importlib.util
+import importlib
 import json
 import multiprocessing as mp
 import re
 import sqlite3
+import sys
 import threading
 import time
 from pathlib import Path
@@ -181,12 +182,9 @@ def _create_vec_db(path: Path) -> None:
 
 
 def _load_hotlane_module():
-    module_path = Path(__file__).resolve().parents[1] / "scripts" / "hotlane_brainbar_daemon.py"
-    spec = importlib.util.spec_from_file_location("brainlayer_hotlane_brainbar_test", module_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    importlib.invalidate_caches()
+    sys.modules.pop("scripts.hotlane_brainbar_daemon", None)
+    return importlib.import_module("scripts.hotlane_brainbar_daemon")
 
 
 class _FastEmbeddingModel:

--- a/tests/test_cli_launchd_mode_a.py
+++ b/tests/test_cli_launchd_mode_a.py
@@ -116,6 +116,10 @@ def test_reconcile_launchd_bootstraps_all_mode_a_labels(monkeypatch, tmp_path):
             str(tmp_path / "drain.plist"),
             "--health-check-plist-path",
             str(tmp_path / "health.plist"),
+            "--hotlane-plist-path",
+            str(tmp_path / "hotlane.plist"),
+            "--enrichment-plist-path",
+            str(tmp_path / "enrichment.plist"),
         ],
     )
 
@@ -124,3 +128,5 @@ def test_reconcile_launchd_bootstraps_all_mode_a_labels(monkeypatch, tmp_path):
     assert "com.brainlayer.watch" in command_text
     assert "com.brainlayer.drain" in command_text
     assert "com.brainlayer.health-check" in command_text
+    assert "com.brainlayer.hotlane-brainbar" in command_text
+    assert "com.brainlayer.enrichment" in command_text

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -663,8 +663,7 @@ class TestBackgroundEmbedder:
 class TestDrainWatcherEmbedding:
     def test_drain_default_precompute_uses_passage_embeddings(self, monkeypatch):
         """Stored chunk vectors must use passage embeddings, not query-prefixed embeddings."""
-        from brainlayer import drain
-        from brainlayer import embeddings
+        from brainlayer import drain, embeddings
         from brainlayer._helpers import serialize_f32
 
         class FakeModel:

--- a/tests/test_enrich_supervisor.py
+++ b/tests/test_enrich_supervisor.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import plistlib
+import time
 from pathlib import Path
 
 import pytest
@@ -251,6 +253,112 @@ def test_supervisor_sleeps_when_queue_empty_and_polls_again(tmp_path):
     assert result.enriched == 1
 
 
+def test_supervisor_runs_unbounded_idle_backlog_before_sleep(tmp_path, monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_IDLE_BACKLOG", "1")
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            pass
+
+        def close(self):
+            pass
+
+    calls = []
+
+    def empty_window_then_backlog(store, **kwargs):
+        calls.append(kwargs)
+        if kwargs["since_hours"] is None:
+            return _result(attempted=1, enriched=1)
+        return _result(attempted=0)
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        limit=5,
+        since_hours=24,
+        max_cycles=1,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=empty_window_then_backlog,
+        idle_backlog_ready_fn=lambda: True,
+        sleep_fn=lambda seconds: (_ for _ in ()).throw(AssertionError("should not sleep before idle backlog")),
+    )
+
+    assert [call["since_hours"] for call in calls] == [24, None]
+    assert result.cycles == 1
+    assert result.attempted == 1
+    assert result.enriched == 1
+
+
+def test_idle_backlog_requires_watcher_offsets_and_health_to_be_idle(tmp_path, monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    offsets_path = tmp_path / "offsets.json"
+    watcher_health_path = tmp_path / "watcher-health.json"
+    offsets_path.write_text("{}", encoding="utf-8")
+    watcher_health_path.write_text('{"poll_count": 7}', encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_ENRICH_IDLE_BACKLOG", "1")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_WATCHER_OFFSETS_PATH", str(offsets_path))
+    monkeypatch.setenv("BRAINLAYER_WATCHER_HEALTH_PATH", str(watcher_health_path))
+    monkeypatch.setenv("BRAINLAYER_ENRICH_WATCHER_IDLE_SECONDS", "60")
+
+    assert controller._idle_backlog_ready() is False
+
+    old_mtime = time.time() - 120
+    os.utime(offsets_path, (old_mtime, old_mtime))
+    os.utime(watcher_health_path, (old_mtime, old_mtime))
+
+    assert controller._idle_backlog_ready() is True
+
+
+def test_supervisor_skips_idle_backlog_when_watcher_is_active(tmp_path, monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    offsets_path = tmp_path / "offsets.json"
+    watcher_health_path = tmp_path / "watcher-health.json"
+    offsets_path.write_text("{}", encoding="utf-8")
+    watcher_health_path.write_text('{"poll_count": 7}', encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_ENRICH_IDLE_BACKLOG", "1")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_WATCHER_OFFSETS_PATH", str(offsets_path))
+    monkeypatch.setenv("BRAINLAYER_WATCHER_HEALTH_PATH", str(watcher_health_path))
+    monkeypatch.setenv("BRAINLAYER_ENRICH_WATCHER_IDLE_SECONDS", "60")
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            pass
+
+        def close(self):
+            pass
+
+    calls = []
+
+    def empty_recent_then_backlog(store, **kwargs):
+        calls.append(kwargs["since_hours"])
+        if kwargs["since_hours"] is None:
+            return _result(attempted=1, enriched=1)
+        return _result(attempted=0)
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        limit=5,
+        since_hours=24,
+        max_cycles=1,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=empty_recent_then_backlog,
+        sleep_fn=lambda seconds: None,
+    )
+
+    assert calls == [24]
+    assert result.cycles == 1
+    assert result.attempted == 0
+
+
 def test_supervisor_logs_single_vectorstore_initialized_line(tmp_path, caplog):
     from brainlayer import enrichment_controller as controller
 
@@ -288,3 +396,5 @@ def test_enrichment_launchagent_runs_supervisor_not_shell_respawn_loop():
     assert "while true" not in " ".join(args)
     assert plist["KeepAlive"] is True
     assert plist["ProcessType"] == "Background"
+    assert plist["EnvironmentVariables"]["BRAINLAYER_ENRICHMENT_QUEUE_WRITES"] == "1"
+    assert plist["EnvironmentVariables"]["BRAINLAYER_ENRICH_IDLE_BACKLOG"] == "1"

--- a/tests/test_enrich_supervisor.py
+++ b/tests/test_enrich_supervisor.py
@@ -290,6 +290,45 @@ def test_supervisor_runs_unbounded_idle_backlog_before_sleep(tmp_path, monkeypat
     assert result.enriched == 1
 
 
+def test_supervisor_idle_backlog_error_does_not_exit(tmp_path, monkeypatch):
+    from brainlayer import enrichment_controller as controller
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_IDLE_BACKLOG", "1")
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            pass
+
+        def close(self):
+            pass
+
+    calls = []
+
+    def idle_backlog_fails_once(store, **kwargs):
+        calls.append(kwargs["since_hours"])
+        if kwargs["since_hours"] is None and calls.count(None) == 1:
+            raise RuntimeError("database is locked")
+        return _result(attempted=0)
+
+    sleeps = []
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        limit=5,
+        since_hours=24,
+        max_cycles=2,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=idle_backlog_fails_once,
+        idle_backlog_ready_fn=lambda: True,
+        sleep_fn=sleeps.append,
+    )
+
+    assert calls == [24, None, 24, None]
+    assert result.cycles == 2
+    assert result.failed_cycles == 1
+    assert result.errors == ["supervisor-idle-backlog: database is locked"]
+    assert sleeps == [30.0]
+
+
 def test_idle_backlog_requires_watcher_offsets_and_health_to_be_idle(tmp_path, monkeypatch):
     from brainlayer import enrichment_controller as controller
 

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -114,13 +114,13 @@ def test_enrichment_provenance_columns_are_audit_queryable_but_not_normal_search
         store.close()
 
 
-def test_enrich_realtime_uses_legacy_direct_writes_by_default(monkeypatch, tmp_path):
+def test_enrich_realtime_uses_legacy_direct_writes_when_disabled(monkeypatch, tmp_path):
     from brainlayer import enrichment_controller as controller
 
     store = MagicMock()
     store.get_enrichment_candidates.return_value = [_candidate("c1", "x" * 120)]
     _patch_realtime_deps(monkeypatch, controller, store)
-    monkeypatch.delenv("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", raising=False)
+    monkeypatch.setenv("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", "0")
     monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(tmp_path / "queue"))
     monkeypatch.setattr(controller, "_is_duplicate_content", lambda _store, _content: False)
     monkeypatch.setattr(controller, "_emit_enrichment_start", lambda *_args, **_kwargs: False)

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -108,6 +108,8 @@ def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
         vector_store_cls=lambda _path: FakeStore(),
         model_factory=FakeModel,
         cycle_fn=fake_cycle,
+        queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([0.0, 100.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=1,
@@ -148,6 +150,8 @@ def test_hotlane_run_uses_document_embeddings_for_stored_chunks():
         vector_store_cls=lambda _path: FakeStore(),
         model_factory=FakeModel,
         cycle_fn=fake_cycle,
+        queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([0.0, 100.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=1,
@@ -182,6 +186,7 @@ def test_hotlane_run_schedules_backlog_on_first_cycle():
         model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
         cycle_fn=fake_cycle,
         queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([100.0, 100.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=1,
@@ -217,6 +222,7 @@ def test_hotlane_run_advances_enrich_timer_before_failed_cycle():
         model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
         cycle_fn=fake_cycle,
         queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([0.0, 100.0, 101.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=2,
@@ -252,6 +258,7 @@ def test_hotlane_run_disables_enrichment_after_daily_cap():
         model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
         cycle_fn=fake_cycle,
         queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([0.0, 100.0, 111.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=2,
@@ -286,6 +293,8 @@ def test_hotlane_run_opens_and_closes_writer_store_each_cycle(tmp_path):
         vector_store_cls=FakeStore,
         model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
         cycle_fn=fake_cycle,
+        queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
         time_fn=iter([0.0, 100.0, 101.0]).__next__,
         sleep_fn=lambda _seconds: None,
         max_cycles=2,
@@ -294,7 +303,7 @@ def test_hotlane_run_opens_and_closes_writer_store_each_cycle(tmp_path):
     assert [event[0] for event in events] == ["open", "close", "open", "close"]
 
 
-def test_hotlane_run_keeps_embedding_backlog_while_queue_is_backlogged(tmp_path):
+def test_hotlane_run_keeps_embedding_backlog_when_only_enrichment_is_backlogged(tmp_path):
     hotlane = _load_hotlane_module()
     opened = []
     cycle_calls = []
@@ -322,6 +331,7 @@ def test_hotlane_run_keeps_embedding_backlog_while_queue_is_backlogged(tmp_path)
         sleep_fn=lambda _seconds: None,
         max_cycles=1,
         queue_depth_fn=lambda _queue_dir: 3,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
     )
 
     assert opened == [tmp_path / "brainlayer.db"]
@@ -329,3 +339,70 @@ def test_hotlane_run_keeps_embedding_backlog_while_queue_is_backlogged(tmp_path)
     assert cycle_calls[0]["backlog_batch"] == hotlane.DEFAULT_BACKLOG_BATCH
     assert cycle_calls[0]["enrich_limit"] == 0
     assert cycle_calls[0]["recent_limit"] == 5
+
+
+def test_hotlane_run_yields_writer_to_high_priority_queue_backlog(tmp_path):
+    hotlane = _load_hotlane_module()
+    opened = []
+    cycle_calls = []
+    sleeps = []
+
+    class FakeStore:
+        def __init__(self, path):
+            opened.append(path)
+
+        def close(self):
+            pass
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=hotlane.DEFAULT_HOTLANE_ENRICH_LIMIT,
+        enrich_since_hours=8760,
+        vector_store_cls=FakeStore,
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=lambda **kwargs: cycle_calls.append(kwargs) or hotlane.CycleResult(),
+        time_fn=iter([0.0, 100.0]).__next__,
+        sleep_fn=sleeps.append,
+        max_cycles=1,
+        queue_depth_fn=lambda _queue_dir: 3,
+        high_priority_queue_depth_fn=lambda _queue_dir: 1,
+    )
+
+    assert opened == []
+    assert cycle_calls == []
+    assert sleeps == [0.25]
+
+
+def test_hotlane_run_caps_backlog_batch_at_priority_gate_limit(tmp_path):
+    hotlane = _load_hotlane_module()
+    scheduled_backlog_batches = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=128,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=lambda **kwargs: scheduled_backlog_batches.append(kwargs["backlog_batch"]) or hotlane.CycleResult(),
+        queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
+        time_fn=iter([100.0, 100.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=1,
+    )
+
+    assert scheduled_backlog_batches == [16]

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
-import importlib.util
+import importlib
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 
 def _load_hotlane_module():
-    module_path = Path(__file__).resolve().parents[1] / "scripts" / "hotlane_brainbar_daemon.py"
-    spec = importlib.util.spec_from_file_location("hotlane_brainbar_daemon", module_path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    importlib.invalidate_caches()
+    sys.modules.pop("scripts.hotlane_brainbar_daemon", None)
+    return importlib.import_module("scripts.hotlane_brainbar_daemon")
 
 
 def _raise_if_called(message: str):

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -118,6 +118,16 @@ def test_setup_command_writes_op_backed_env_without_plaintext_and_can_skip_launc
     assert oct(env_file.stat().st_mode & 0o777) == "0o600"
 
 
+def test_launchd_env_runner_makes_homebrew_op_available_before_loading_env() -> None:
+    runner = REPO_ROOT / "scripts" / "launchd" / "brainlayer-env-run.sh"
+    content = runner.read_text(encoding="utf-8")
+
+    path_export_index = content.index("export PATH=")
+    load_index = content.index("load_simple_env_file")
+    assert "/opt/homebrew/bin" in content[path_export_index:load_index]
+    assert path_export_index < load_index
+
+
 def test_setup_command_does_not_install_launchd_by_default(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.setup as setup_helpers
     from brainlayer.cli import app

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -19,13 +19,26 @@ def _plist_args(name: str) -> list[str]:
     return plistlib.loads(plist_path.read_bytes())["ProgramArguments"]
 
 
-def test_brainlayer_cli_entrypoint_imports_typer_app() -> None:
+def test_brainlayer_cli_entrypoint_imports_typer_app(monkeypatch) -> None:
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+
     from brainlayer.cli import app
 
     result = CliRunner().invoke(app, ["--help"])
 
     assert result.exit_code == 0
     assert "brainlayer" in result.stdout
+
+
+def test_brainlayer_cli_exposes_transport_commands(monkeypatch) -> None:
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+
+    from brainlayer.cli import app
+
+    for args in (["drain", "--help"], ["status", "--help"]):
+        result = CliRunner().invoke(app, args)
+
+        assert result.exit_code == 0, result.stdout
 
 
 def test_launchd_templates_are_declared_as_package_data() -> None:

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -85,6 +85,13 @@ def test_active_daemon_launchd_hygiene_matrix():
             "KeepAlive": True,
             "ThrottleInterval": 10,
         },
+        "scripts/launchd/com.brainlayer.hotlane-brainbar.plist": {
+            "ProcessType": "Background",
+            "ExitTimeOut": 30,
+            "LowPriorityIO": True,
+            "KeepAlive": True,
+            "ThrottleInterval": 5,
+        },
         "scripts/launchd/com.brainlayer.backup-daily.plist": {
             "ProcessType": "Background",
             "ExitTimeOut": 300,
@@ -164,21 +171,82 @@ def test_all_script_launchagents_source_unified_config_file():
         assert env["BRAINLAYER_LAUNCHD_SERVICE"] == service, str(path)
 
 
-def test_launchd_env_loader_exists_and_sources_env_before_exec():
+def test_launchd_env_loader_exists_and_loads_safe_env_before_exec():
     loader = REPO_ROOT / "scripts/launchd/brainlayer-env-run.sh"
     content = loader.read_text(encoding="utf-8")
 
     assert 'ENV_FILE="${BRAINLAYER_ENV_FILE:-$HOME/.config/brainlayer/brainlayer.env}"' in content
+    assert "export PATH=" in content
     assert "BRAINLAYER_SYSTEM_ENABLED" in content
     assert "BRAINLAYER_LAUNCHD_SERVICE" in content
     assert "BRAINLAYER_LAUNCHD_${service_key}_ENABLED" in content
     assert "BRAINLAYER_ENRICH_ENABLED" in content
     assert "current user or root" in content
     assert "world-writable" in content
-    assert "set -a" in content
-    assert 'source "$ENV_FILE"' in content
+    assert "load_simple_env_file" in content
+    assert "env_file_declares_google_key" in content
+    assert 'source "$ENV_FILE"' not in content
     assert 'exec "$@"' in content
     assert "GOOGLE_API_KEY" in content
+
+
+def test_launchd_env_loader_does_not_evaluate_env_command_substitution(tmp_path):
+    loader = REPO_ROOT / "scripts/launchd/brainlayer-env-run.sh"
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                'GOOGLE_API_KEY="$(sleep 5)"',
+                "BRAINLAYER_SYSTEM_ENABLED=1",
+                "BRAINLAYER_LAUNCHD_DRAIN_ENABLED=1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [
+            str(loader),
+            "/bin/sh",
+            "-c",
+            'test -z "${GOOGLE_API_KEY:-}" && test "$BRAINLAYER_SYSTEM_ENABLED" = "1"',
+        ],
+        env={
+            **os.environ,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "BRAINLAYER_LAUNCHD_SERVICE": "drain",
+        },
+        capture_output=True,
+        text=True,
+        timeout=1,
+        check=False,
+    )
+
+    assert result.returncode == 0
+
+
+def test_launchd_env_loader_required_google_key_allows_op_backed_declaration_without_shell_eval(tmp_path):
+    loader = REPO_ROOT / "scripts/launchd/brainlayer-env-run.sh"
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text('GOOGLE_API_KEY="$(sleep 5)"\n', encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(loader), "/usr/bin/true"],
+        env={
+            **os.environ,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "BRAINLAYER_REQUIRE_GOOGLE_API_KEY": "1",
+            "BRAINLAYER_SKIP_DISABLE_GATES": "1",
+        },
+        capture_output=True,
+        text=True,
+        timeout=1,
+        check=False,
+    )
+
+    assert result.returncode == 0
 
 
 def test_launchd_env_loader_rejects_world_writable_env_file(tmp_path):

--- a/tests/test_search_handler.py
+++ b/tests/test_search_handler.py
@@ -279,7 +279,8 @@ async def test_brain_search_origin_order_returns_oldest_matching_chunks_without_
             allow_helper_route=False,
         )
         default_ids = [item["chunk_id"] for item in default_structured["results"]]
-        assert default_ids[0] == "origin-new"
+        assert default_ids != ["origin-old", "origin-mid"]
+        assert "order" not in default_structured
 
         origin_content, origin_structured = await _brain_search(
             query="originmarker retention architecture",

--- a/tests/test_search_handler.py
+++ b/tests/test_search_handler.py
@@ -186,10 +186,10 @@ async def test_brain_search_falls_back_to_fts_when_embedding_times_out(monkeypat
 
     assert elapsed < 0.5
     assert store.hybrid_kwargs["query_embedding"] is None
-    assert structured["search_mode"] == "fts_only"
+    assert structured["search_mode"] == "fts_fallback"
     assert structured["fallback_reason"] == "embed_timeout"
     assert [item["chunk_id"] for item in structured["results"]] == ["fts-fallback-hit"]
-    assert "FTS-only fallback" in content[0].text
+    assert "FTS fallback" in content[0].text
 
 
 @pytest.mark.asyncio
@@ -207,7 +207,7 @@ async def test_brain_search_falls_back_to_fts_when_embedding_raises(monkeypatch)
     )
 
     assert store.hybrid_kwargs["query_embedding"] is None
-    assert structured["search_mode"] == "fts_only"
+    assert structured["search_mode"] == "fts_fallback"
     assert structured["fallback_reason"] == "embed_error:RuntimeError"
     assert [item["chunk_id"] for item in structured["results"]] == ["fts-fallback-hit"]
 

--- a/tests/test_search_profile.py
+++ b/tests/test_search_profile.py
@@ -1,10 +1,11 @@
 import json
 import logging
+import time
 
 import pytest
 
 from brainlayer import search_profile
-from brainlayer.mcp.search_handler import _brain_search
+from brainlayer.mcp.search_handler import _brain_search, _search
 
 
 class FakeEmbeddingModel:
@@ -31,6 +32,12 @@ class FakeSearchStore:
 class FakeFailingSearchStore(FakeSearchStore):
     def hybrid_search(self, **_kwargs):
         raise RuntimeError("profile failure")
+
+
+class SlowEmbeddingModel:
+    def embed_query(self, _query):
+        time.sleep(0.05)
+        return [0.1, 0.2, 0.3]
 
 
 def _profile_events(caplog):
@@ -80,6 +87,22 @@ async def test_brain_search_profile_flag_emits_failed_hybrid_timing(monkeypatch,
     hybrid_events = [event for event in _profile_events(caplog) if event.get("step") == "hybrid_search"]
     assert len(hybrid_events) == 1
     assert hybrid_events[0]["error"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_brain_search_embed_timeout_returns_fts_fallback(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: FakeSearchStore())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: SlowEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._detect_entities", lambda *_args, **_kwargs: [])
+
+    texts, structured = await _search(query="auth refactor", project="brainlayer", source="all", detail="compact")
+
+    assert structured["total"] == 1
+    assert structured["search_mode"] == "fts_fallback"
+    assert structured["fallback_reason"] == "embed_timeout"
+    assert "auth refactor profile result" in texts[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -416,7 +416,7 @@ def test_health_check_bootstraps_absent_enrichment_and_clears_tripped_after_succ
         now_fn=lambda: datetime(2026, 6, 21, 10, 0, tzinfo=UTC),
     )
 
-    assert "enrichment_unloaded" in [issue.code for issue in result.issues]
+    assert "enrichment_unloaded" not in [issue.code for issue in result.issues]
     assert [
         "launchctl",
         "bootstrap",

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -369,6 +369,65 @@ def test_health_check_bootstraps_absent_default_launchd_labels_instead_of_kickst
     assert not any(command[:3] == ["launchctl", "kickstart", "-k"] for command in commands)
 
 
+def test_health_check_bootstraps_absent_enrichment_and_clears_tripped_after_success(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    _make_db(db_path, total=1, vector_rows=1)
+    state_path.write_text(
+        json.dumps(
+            {
+                "heal_failures": {"com.brainlayer.enrichment:enrichment_unloaded": 3},
+                "heal_tripped": ["com.brainlayer.enrichment:enrichment_unloaded"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    commands: list[list[str]] = []
+    enrichment_bootstrapped = False
+
+    def command_runner(args: list[str]):
+        nonlocal enrichment_bootstrapped
+        commands.append(args)
+        if args[:2] == ["launchctl", "print"] and "com.brainlayer.enrichment" in args[2]:
+            return (
+                SimpleNamespace(returncode=0, stdout="", stderr="")
+                if enrichment_bootstrapped
+                else SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+            )
+        if args[:2] == ["launchctl", "bootstrap"] and str(args[-1]).endswith("com.brainlayer.enrichment.plist"):
+            enrichment_bootstrapped = True
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if args[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            heal=True,
+            heal_min_consecutive_failures=1,
+        ),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4 --enrich-limit 5\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=command_runner,
+        now_fn=lambda: datetime(2026, 6, 21, 10, 0, tzinfo=UTC),
+    )
+
+    assert "enrichment_unloaded" in [issue.code for issue in result.issues]
+    assert [
+        "launchctl",
+        "bootstrap",
+        f"gui/{os.getuid()}",
+        str(Path("~/Library/LaunchAgents/com.brainlayer.enrichment.plist").expanduser()),
+    ] in commands
+    assert "bootstrap:com.brainlayer.enrichment" in result.actions
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    assert "com.brainlayer.enrichment:enrichment_unloaded" not in saved["heal_tripped"]
+
+
 def test_run_health_check_references_mode_d_detector_helpers():
     source = inspect.getsource(health_check.run_health_check)
 

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -147,6 +148,32 @@ async def test_store_queues_fast_when_background_queue_is_present(tmp_path, monk
     assert structured["deferred"]["reason"] == "INTERACTIVE_PRIORITY"
     assert structured["deferred"]["queue_path"] == str(queued_files[0])
     assert any(structured["chunk_id"] in item.text for item in texts)
+
+
+@pytest.mark.asyncio
+async def test_store_priority_queue_does_not_cold_import_search_repo(tmp_path, monkeypatch):
+    """The first queued brain_store call must not import the full search stack."""
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    monkeypatch.setenv("BRAINLAYER_INTERACTIVE_STORE_QUEUE", "1")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.delitem(sys.modules, "brainlayer.search_repo", raising=False)
+
+    from brainlayer.mcp.store_handler import _store
+
+    with (
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+        patch("brainlayer.mcp.store_handler._get_vector_store", side_effect=AssertionError("DB writer path used")),
+    ):
+        _texts, structured = await _store(
+            content="interactive reservation should not pay search import cold-start",
+            memory_type="note",
+            project="test",
+        )
+
+    assert structured["queued"] is True
+    assert structured["deferred"]["reason"] == "INTERACTIVE_PRIORITY"
+    assert "brainlayer.search_repo" not in sys.modules
 
 
 @pytest.mark.asyncio

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -10,6 +10,15 @@ import apsw
 import pytest
 
 
+def test_default_store_busy_budget_is_sub_500ms(monkeypatch):
+    """brain_store should defer quickly instead of waiting seconds behind background writers."""
+    from brainlayer.mcp.store_handler import _store_busy_budget_ms
+
+    monkeypatch.delenv("BRAINLAYER_STORE_BUSY_BUDGET_MS", raising=False)
+
+    assert _store_busy_budget_ms() <= 500
+
+
 @pytest.mark.asyncio
 async def test_busy_queue_fallback_returns_queued_chunk_id(tmp_path):
     """DB-busy fallback returns the durable queue chunk ID, not a sentinel."""

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -151,13 +151,14 @@ async def test_store_queues_fast_when_background_queue_is_present(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_store_priority_queue_does_not_cold_import_search_repo(tmp_path, monkeypatch):
-    """The first queued brain_store call must not import the full search stack."""
+async def test_store_priority_queue_does_not_cold_import_heavy_write_stack(tmp_path, monkeypatch):
+    """The first queued brain_store call must not import heavy write/search stacks."""
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     monkeypatch.setenv("BRAINLAYER_INTERACTIVE_STORE_QUEUE", "1")
     monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
-    monkeypatch.delitem(sys.modules, "brainlayer.search_repo", raising=False)
+    monkeypatch.delitem(sys.modules, "brainlayer.pipeline", raising=False)
+    monkeypatch.delitem(sys.modules, "brainlayer.store", raising=False)
 
     from brainlayer.mcp.store_handler import _store
 
@@ -173,7 +174,8 @@ async def test_store_priority_queue_does_not_cold_import_search_repo(tmp_path, m
 
     assert structured["queued"] is True
     assert structured["deferred"]["reason"] == "INTERACTIVE_PRIORITY"
-    assert "brainlayer.search_repo" not in sys.modules
+    assert "brainlayer.pipeline" not in sys.modules
+    assert "brainlayer.store" not in sys.modules
 
 
 @pytest.mark.asyncio

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -103,6 +103,53 @@ async def test_store_validates_before_busy_deferral(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_store_queues_fast_when_background_queue_is_present(tmp_path, monkeypatch):
+    """Live brain_store should reserve through the queue instead of waiting on background writers."""
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    (queue_dir / "enrichment-live-backlog.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "background-enrichment",
+                "enrichment": {"summary": "background work can wait"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.delenv("BRAINLAYER_ARBITRATED", raising=False)
+
+    import brainlayer.search_repo  # noqa: F401 - warm steady-state cache invalidation import before timing.
+    from brainlayer.mcp.store_handler import _store, _validate_store_request
+
+    _validate_store_request("warm validation imports", "note")
+
+    with (
+        patch("brainlayer.queue_io.get_queue_dir", return_value=queue_dir),
+        patch("brainlayer.mcp.store_handler._get_vector_store", side_effect=AssertionError("DB writer path used")),
+        patch("brainlayer.search_repo.clear_hybrid_search_cache"),
+    ):
+        started = time.perf_counter()
+        texts, structured = await _store(
+            content="interactive reservation should not wait behind background enrichment",
+            memory_type="note",
+            project="test",
+        )
+        elapsed = time.perf_counter() - started
+
+    queued_files = list(queue_dir.glob("mcp-*.jsonl"))
+    assert elapsed < 0.5
+    assert len(queued_files) == 1
+    assert structured["queued"] is True
+    assert structured["deferred"]["reason"] == "INTERACTIVE_PRIORITY"
+    assert structured["deferred"]["queue_path"] == str(queued_files[0])
+    assert any(structured["chunk_id"] in item.text for item in texts)
+
+
+@pytest.mark.asyncio
 async def test_store_busy_budget_defers_promptly_and_pending_flush_replays(tmp_path, monkeypatch):
     """A held write lock must hit the bounded store budget, defer, and replay later."""
     from brainlayer.mcp.store_handler import _flush_pending_stores, _store
@@ -424,6 +471,7 @@ async def test_store_busy_budget_restores_cold_vector_store_write_timeout(tmp_pa
 
     with (
         patch("brainlayer.mcp.store_handler._normalize_project_name", return_value="test"),
+        patch("brainlayer.queue_io.get_queue_dir", return_value=tmp_path / "empty-queue"),
         patch("brainlayer.queue_io.enqueue_store", side_effect=RuntimeError("force legacy pending queue")),
         patch("brainlayer.mcp.store_handler._get_pending_store_path", return_value=pending_path),
         patch("brainlayer.store.store_memory", side_effect=apsw.BusyError("database is locked")),

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -184,6 +184,37 @@ class TestQueueStore:
 
         assert result.chunk_id == "rt-canonical"
 
+    def test_drain_once_uses_nonblocking_checkpoint_on_hot_path(self, tmp_path, monkeypatch):
+        """The live drain loop must not wedge behind a large pinned WAL checkpoint."""
+        from brainlayer import drain
+
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "noop.jsonl").write_text(json.dumps({"kind": "noop"}) + "\n", encoding="utf-8")
+        checkpoint_sql: list[str] = []
+
+        class FakeConnection:
+            def execute(self, sql, *_args):
+                if "wal_checkpoint" in sql:
+                    checkpoint_sql.append(sql)
+                return []
+
+            def setbusytimeout(self, _timeout_ms):
+                return None
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(drain, "_open_connection", lambda _db_path: FakeConnection())
+        monkeypatch.setattr(drain, "_ensure_enrichment_update_schema", lambda _conn: None)
+        monkeypatch.setattr(drain, "ensure_dedupe_schema", lambda _conn: None)
+        monkeypatch.setattr(drain, "_apply_event", lambda _conn, _event: drain.ApplyResult())
+
+        drained = drain_once(db_path=tmp_path / "db.sqlite", queue_dir=queue_dir, batch_size=1)
+
+        assert drained == 1
+        assert checkpoint_sql == ["PRAGMA wal_checkpoint(PASSIVE)"]
+
 
 class TestSingleWriterQueue:
     def test_single_worker_serializes_writes(self):

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -926,6 +926,78 @@ def test_drain_limits_enrichment_events_per_transaction(tmp_path, monkeypatch):
     assert summaries == {"c0": "s0", "c1": "s1", "c2": None, "c3": None}
 
 
+def test_drain_yields_enrichment_cycle_when_interactive_file_appears(tmp_path, monkeypatch):
+    """A new interactive store file must preempt the rest of a selected enrichment batch."""
+    import brainlayer.drain as drain_module
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    log_path = tmp_path / "drain.log"
+
+    conn = apsw.Connection(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            summary TEXT,
+            enriched_at TEXT,
+            enrich_status TEXT,
+            content_hash TEXT
+        )
+        """
+    )
+    for idx in range(2):
+        conn.execute(
+            "INSERT INTO chunks (id, content, content_hash) VALUES (?, ?, ?)",
+            (f"c{idx}", f"content {idx}", f"h{idx}"),
+        )
+    conn.close()
+
+    first = enqueue_enrichment_updates(
+        [{"chunk_id": "c0", "content_hash": "h0", "enrichment": {"summary": "s0"}}],
+        queue_dir=queue_dir,
+    )
+    second = enqueue_enrichment_updates(
+        [{"chunk_id": "c1", "content_hash": "h1", "enrichment": {"summary": "s1"}}],
+        queue_dir=queue_dir,
+    )
+
+    real_unlink = drain_module._unlink_processed_file
+    processed_enrichment_files = 0
+
+    def create_interactive_after_first_unlink(path, log_path):
+        nonlocal processed_enrichment_files
+        real_unlink(path, log_path)
+        if path.name.startswith("enrichment-"):
+            processed_enrichment_files += 1
+        if processed_enrichment_files == 1:
+            (queue_dir / "mcp-interactive.jsonl").write_text(
+                json.dumps(
+                    {
+                        "kind": "store_memory",
+                        "chunk_id": "interactive-queued",
+                        "content": "interactive queue file should preempt enrichment",
+                        "memory_type": "note",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(drain_module, "_unlink_processed_file", create_interactive_after_first_unlink)
+
+    assert drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10, log_path=log_path) == 1
+
+    conn = apsw.Connection(str(db_path))
+    summaries = dict(conn.execute("SELECT id, summary FROM chunks ORDER BY id"))
+    conn.close()
+
+    assert summaries in ({"c0": "s0", "c1": None}, {"c0": None, "c1": "s1"})
+    assert sum(path.exists() for path in (first, second)) == 1
+    assert (queue_dir / "mcp-interactive.jsonl").exists()
+
+
 def test_drain_persists_enrichment_provenance_in_chunk_metadata(tmp_path):
     """Queued enrichment writes must stamp provenance fields onto chunk metadata."""
     db_path = tmp_path / "brainlayer.db"

--- a/tests/test_write_resilience_under_load.py
+++ b/tests/test_write_resilience_under_load.py
@@ -6,10 +6,12 @@ checkpoint (cannot reclaim WAL under reader load) and `journal_size_limit` was -
 (the WAL file never truncated back after a checkpoint). Observed multi-GB WAL in
 production logs (2.4-3.9GB); a real store queued with WAL at only 33MB.
 
-The fix:
+The bounded-WAL fix:
   1. vector_store.py sets `PRAGMA journal_size_limit` (env BRAINLAYER_WAL_SIZE_LIMIT_BYTES,
      default 256MB) on every connection so the WAL truncates back after a checkpoint.
-  2. drain.py checkpoints with TRUNCATE (not PASSIVE) so each drained batch reclaims WAL.
+  2. drain.py uses a non-blocking PASSIVE checkpoint in the writer hot path; the
+     scheduled wal-checkpoint job owns TRUNCATE so live queue drain cannot wedge
+     behind long-lived readers.
 
 These tests fail on origin/main (journal_size_limit == -1, WAL unbounded) and pass
 after the fix. They use isolated tmp DBs only — never the real ~/.local/share DB.


### PR DESCRIPTION
## Summary
- add enrichment LaunchAgent detection/healing to health-check and clear stale heal breaker entries after successful bootstrap
- extend reconcile/resume launchd handling to include hotlane and enrichment
- enable queued enrichment writes plus idle-backlog supervisor pass, and add a canonical hotlane LaunchAgent install target

## RED -> GREEN
- RED: new D3 tests failed on main: enrichment_unloaded was not detected/healed, reconcile-launchd did not accept hotlane/enrichment plists, supervisor lacked idle backlog hook, enrichment plist had BRAINLAYER_ENRICHMENT_QUEUE_WRITES=0.
- GREEN focused: `pytest tests/test_stability_health_check.py::test_health_check_bootstraps_absent_enrichment_and_clears_tripped_after_success tests/test_cli_launchd_mode_a.py::test_reconcile_launchd_bootstraps_all_mode_a_labels tests/test_enrich_supervisor.py::test_supervisor_runs_unbounded_idle_backlog_before_sleep tests/test_enrich_supervisor.py::test_enrichment_launchagent_runs_supervisor_not_shell_respawn_loop` -> 4 passed.
- GREEN affected: `pytest tests/test_stability_health_check.py tests/test_cli_launchd_mode_a.py tests/test_enrich_supervisor.py tests/test_launchd_hygiene.py tests/test_hotlane_brainbar_daemon.py` -> 53 passed.
- GREEN broader: `pytest tests/test_cli_enrich.py tests/test_enrichment_controller.py tests/test_chunk_origin_provenance.py` -> 111 passed.
- GREEN full local: `pytest` -> 3149 passed, 49 skipped, 5 xfailed.
- GREEN prepush: `BRAINLAYER_PREPUSH_SCOPE=changed-only git push` -> fallback full unit suite 3046 passed, 9 skipped, 61 deselected, 1 xfailed; MCP 3 passed; eval/hook 40 passed; bun 1 passed; FTS shell passed.

## Live Notes
D2 live outcome is already verified. D3 live verification will follow merge per gen-18 requirement: kill enrichment/hotlane path, confirm self-heal, and confirm eligible backlog drops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core persistence (drain WAL checkpoints, writer arbitration, enrichment defaults) and cuts MCP store busy wait from 3s to 400ms, which can change live latency and backlog behavior under load.
> 
> **Overview**
> Restores **D3 enrichment self-heal** and reshapes how background writers share the single SQLite writer lane with interactive MCP traffic.
> 
> **Health, launchd, and ops:** Health check now treats **enrichment** like watch/drain (detect `enrichment_unloaded`, bootstrap on heal, clear tripped breaker state after success). CLI **pause/resume/reconcile** and **`health-check`** include **hotlane-brainbar** and **enrichment** plists. **`install.sh`** adds a **hotlane** target and installs hotlane in **`all`/`remove`**. New **`com.brainlayer.hotlane-brainbar.plist`**; enrichment plist turns on **`BRAINLAYER_ENRICHMENT_QUEUE_WRITES=1`** and **`BRAINLAYER_ENRICH_IDLE_BACKLOG=1`**. **`brainlayer-env-run.sh`** prepends Homebrew to `PATH`, loads env via a **safe parser** (no shell `source`/command substitution), and allows required Google key when only declared in the file.
> 
> **Queue priority and WAL:** **`drain.py`** drains **non-`enrichment-*` queue files first**, caps enrichment files per cycle, **stops mid-batch** if interactive files appear, and uses **`wal_checkpoint(PASSIVE)`** on the hot path instead of **TRUNCATE**. **Hotlane** skips writer cycles when high-priority queue backlog exists and caps backlog batch at **16**.
> 
> **Enrichment:** Queued enrichment writes default **on**. Supervisor runs an **idle historical backlog** pass when the recent window is empty, the queue is clear, and watcher offset/health files are stale enough.
> 
> **Interactive path:** MCP **store** queues quickly when **`BRAINLAYER_ARBITRATED`**, explicit interactive flag, or **any queue file** is present; default **store busy budget** drops to **400ms**. New CLI **`drain`** and **`status`**. Optional **`reembed_backfill_loop.py`** backfills missing vectors while yielding to interactive queue pressure.
> 
> **Minor:** Search fallback mode renamed **`fts_fallback`**; **`looks_like_system_prompt`** moved to **`system_prompt_guard`** / shared **`memory_types`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d6832ba8c4a3977ddf846c9d056532a97628b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore enrichment LaunchAgent self-heal and add drain prioritization over enrichment queue files
> - `run_health_check` now monitors `com.brainlayer.enrichment`, bootstraps it when absent, and clears tripped heal state on success; `HealthCheckConfig` gains `enrichment_label` and `enrichment_plist_path` fields
> - `drain_once` and `burn_drain_once` now prioritize non-enrichment queue files, cap enrichment files per cycle, and switch WAL checkpoint from `TRUNCATE` to `PASSIVE` to avoid blocking writers
> - `run_enrich_supervisor` performs an opportunistic backlog pass (`since_hours=None`) when the recent queue is empty and the watcher files are idle
> - `_store` in [store_handler.py](https://github.com/EtanHey/brainlayer/pull/537/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263) defers writes to the queue when background pressure is detected; default busy budget drops from 3000ms to 400ms
> - Adds `drain` and `status` CLI commands, a new `hotlane-brainbar` launchd service, and a `reembed_backfill_loop.py` script for backfilling missing embeddings
> - `looks_like_system_prompt` and `VALID_MEMORY_TYPES` are extracted into dedicated modules ([system_prompt_guard.py](https://github.com/EtanHey/brainlayer/pull/537/files#diff-72536fc076534c3953ed4c5ca787248855211afd34f7cf182ee28698c936cc97), [memory_types.py](https://github.com/EtanHey/brainlayer/pull/537/files#diff-2a0f8a3bd5f7f53420c46635e95371068d4ea82e19a9500e77f396d573b84c20))
> - Risk: default store busy budget reduction from 3s to 400ms may cause more writes to be deferred to the durable queue under moderate DB contention
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0d6832.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new hotlane-brainbar background agent and an enrichment agent for idle recovery.
  * Introduced idle-backlog enrichment to process accumulated work when the system is idle.

* **Improvements**
  * Extended CLI launchd management for hotlane-brainbar/enrichment, including new `drain` and `status` transport subcommands.
  * Improved queue prioritization (including enrichment-file caps) and reduced WAL blocking via non-truncating checkpointing.
  * Hardened launch environment loading for safer env parsing and stronger Google key validation; expanded enrichment-aware health-check healing.

* **Tests**
  * Added/updated coverage for idle backlog, launchd configuration, queue prioritization, and drain/WAL resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->