### PR TITLE
feat: batch-drain enrichment mode (clears eligible backlog via async Batch API)

### DIFF
--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -1599,7 +1599,11 @@ def enrich(
             f"Realtime mode: only enrich chunks from the last N hours. Default: {DEFAULT_REALTIME_ENRICH_SINCE_HOURS}h"
         ),
     ),
-    phase: str = typer.Option("run", "--phase", help="Batch mode phase: submit, poll, import, run, status"),
+    phase: str = typer.Option(
+        "run",
+        "--phase",
+        help="Batch mode phase: submit, poll, import, run, status, drain-submit, drain-poll, drain-import, drain-run",
+    ),
     model: str = typer.Option(
         "models/gemini-2.5-flash-lite",
         "--model",
@@ -1699,6 +1703,16 @@ def enrich(
             )
             console.print(f"[bold green]Done![/] mode=batch phase=submit sample={limit or 0} model={model}")
             return
+        if phase == "drain-submit":
+            cloud_backfill.run_full_backfill(
+                db_path,
+                model=model,
+                sample=limit or 0,
+                submit_only=True,
+                drain_backlog=True,
+            )
+            console.print(f"[bold green]Done![/] mode=batch phase=drain-submit sample={limit or 0} model={model}")
+            return
         if phase == "run":
             cloud_backfill.run_full_backfill(
                 db_path,
@@ -1708,8 +1722,27 @@ def enrich(
             )
             console.print(f"[bold green]Done![/] mode=batch phase=run sample={limit or 0} model={model}")
             return
+        if phase == "drain-run":
+            cloud_backfill.run_full_backfill(
+                db_path,
+                model=model,
+                sample=limit or 0,
+                submit_only=False,
+                drain_backlog=True,
+            )
+            console.print(f"[bold green]Done![/] mode=batch phase=drain-run sample={limit or 0} model={model}")
+            return
         if phase in {"poll", "import"}:
             summary = cloud_backfill.process_pending_jobs_once(db_path)
+            console.print(
+                "[bold green]Done![/] "
+                f"mode=batch phase={phase} checked={summary['checked']} "
+                f"imported_jobs={summary['imported_jobs']} pending={summary['still_pending']} "
+                f"success={summary['success']} failed={summary['failed']} skipped={summary['skipped']}"
+            )
+            return
+        if phase in {"drain-poll", "drain-import"}:
+            summary = cloud_backfill.process_pending_jobs_once(db_path, import_mode=cloud_backfill.IMPORT_MODE_DRAIN)
             console.print(
                 "[bold green]Done![/] "
                 f"mode=batch phase={phase} checked={summary['checked']} "

--- a/src/brainlayer/cloud_backfill.py
+++ b/src/brainlayer/cloud_backfill.py
@@ -34,6 +34,11 @@ from typing import Any, Dict, List, Optional
 
 import apsw
 
+from .enrichment_controller import (
+    _apply_enrichment,
+    _raise_if_enrich_daily_cap_reached,
+    _record_enrich_cost_usd,
+)
 from .paths import get_db_path
 from .pipeline.enrichment import (
     HIGH_VALUE_TYPES,
@@ -122,7 +127,12 @@ CHECKPOINT_COLUMNS = (
     "input_tokens",
     "output_tokens",
     "cost_usd",
+    "import_mode",
 )
+
+IMPORT_MODE_AUTO = "auto"
+IMPORT_MODE_DRAIN = "drain"
+IMPORT_MODE_PREVIEW = "preview"
 
 
 def build_batch_request_line(chunk_id: str, prompt: str) -> Dict[str, Any]:
@@ -147,6 +157,13 @@ def build_batch_request_line(chunk_id: str, prompt: str) -> Dict[str, Any]:
 def estimate_batch_cost_usd(input_tokens: int, output_tokens: int) -> float:
     """Estimate Gemini 2.5 Flash-Lite Batch API cost using the 50% batch discount."""
     return (input_tokens * BATCH_INPUT_COST_PER_MILLION + output_tokens * BATCH_OUTPUT_COST_PER_MILLION) / 1_000_000
+
+
+def record_batch_usage_against_daily_cap(input_tokens: int, output_tokens: int) -> float:
+    """Record Gemini Batch usage against the shared enrichment daily cap counter."""
+    _raise_if_enrich_daily_cap_reached()
+    cost_usd = estimate_batch_cost_usd(input_tokens, output_tokens)
+    return _record_enrich_cost_usd(cost_usd)
 
 
 # ── DB helpers ──────────────────────────────────────────────────────────
@@ -197,9 +214,13 @@ def _ensure_checkpoint_table_in_conn(conn: apsw.Connection) -> None:
             error TEXT,
             input_tokens INTEGER DEFAULT 0,
             output_tokens INTEGER DEFAULT 0,
-            cost_usd REAL DEFAULT 0
+            cost_usd REAL DEFAULT 0,
+            import_mode TEXT DEFAULT 'auto'
         )
     """)
+    existing_columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({CHECKPOINT_TABLE})")}
+    if "import_mode" not in existing_columns:
+        cursor.execute(f"ALTER TABLE {CHECKPOINT_TABLE} ADD COLUMN import_mode TEXT DEFAULT 'auto'")
 
 
 def _main_checkpoint_rows(store: Optional[VectorStore]) -> List[tuple]:
@@ -217,7 +238,21 @@ def _main_checkpoint_rows(store: Optional[VectorStore]) -> List[tuple]:
     if not table_exists:
         return []
 
-    return list(cursor.execute(f"SELECT {', '.join(CHECKPOINT_COLUMNS)} FROM {CHECKPOINT_TABLE}"))
+    available_columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({CHECKPOINT_TABLE})")}
+    selected_columns = [column for column in CHECKPOINT_COLUMNS if column in available_columns]
+    if not selected_columns:
+        return []
+
+    rows = []
+    for raw_row in cursor.execute(f"SELECT {', '.join(selected_columns)} FROM {CHECKPOINT_TABLE}"):
+        values = dict(zip(selected_columns, raw_row))
+        rows.append(
+            tuple(
+                values.get(column, IMPORT_MODE_AUTO if column == "import_mode" else None)
+                for column in CHECKPOINT_COLUMNS
+            )
+        )
+    return rows
 
 
 def _migrate_checkpoints_from_main_db(store: Optional[VectorStore], conn: apsw.Connection) -> int:
@@ -335,13 +370,23 @@ def get_pending_jobs(store: VectorStore) -> List[Dict[str, Any]]:
         rows = list(
             conn.cursor().execute(
                 f"""
-                SELECT batch_id, backend, model, status, jsonl_path
+                SELECT batch_id, backend, model, status, jsonl_path, import_mode
                 FROM {CHECKPOINT_TABLE}
                 WHERE status = 'submitted'
                 """
             )
         )
-        return [{"batch_id": r[0], "backend": r[1], "model": r[2], "status": r[3], "jsonl_path": r[4]} for r in rows]
+        return [
+            {
+                "batch_id": r[0],
+                "backend": r[1],
+                "model": r[2],
+                "status": r[3],
+                "jsonl_path": r[4],
+                "import_mode": r[5] or IMPORT_MODE_AUTO,
+            }
+            for r in rows
+        ]
     finally:
         conn.close()
 
@@ -469,6 +514,22 @@ def get_reenrichment_stats(
         "remaining": remaining,
         "percent": percent,
     }
+
+
+def get_backlog_drain_stats(store: Any, *, min_char_count: int = 50) -> Dict[str, Any]:
+    """Return the live eligible backlog count used by realtime enrichment."""
+    cursor = store.conn.cursor()
+    remaining = cursor.execute(
+        """
+        SELECT COUNT(*)
+        FROM chunks
+        WHERE enriched_at IS NULL
+          AND enrich_status IS NULL
+          AND char_count >= ?
+        """,
+        (min_char_count,),
+    ).fetchone()[0]
+    return {"remaining": remaining}
 
 
 # ── Export ──────────────────────────────────────────────────────────────
@@ -599,6 +660,63 @@ def export_unenriched_chunks(
     return jsonl_files
 
 
+def export_backlog_drain_chunks(
+    store: VectorStore,
+    max_chunks: int = 0,
+    min_char_count: int = 50,
+    no_sanitize: bool = False,
+) -> List[Path]:
+    """Export realtime-eligible enrichment backlog chunks to Gemini Batch JSONL."""
+    EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if no_sanitize:
+        print("WARNING: PII sanitization DISABLED — use only for local testing!")
+        sanitizer = None
+    else:
+        print("Initializing PII sanitizer...")
+        sanitizer = _init_sanitizer(store)
+
+    limit = max_chunks if max_chunks > 0 else 200_000
+    rows = store.get_enrichment_candidates(
+        limit=limit,
+        min_content_length=min_char_count,
+        order="oldest",
+    )
+    print(f"Fetched {len(rows)} backlog drain chunks for export")
+
+    jsonl_files = []
+    batch_num = 0
+    total_pii_found = 0
+
+    for i in range(0, len(rows), CHUNKS_PER_JOB):
+        batch = rows[i : i + CHUNKS_PER_JOB]
+        batch_num += 1
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = EXPORT_DIR / f"batch_drain_{ts}_{batch_num:03d}.jsonl"
+
+        with open(filename, "w") as f:
+            for chunk in batch:
+                if sanitizer is not None:
+                    prompt, sanitize_result = build_external_prompt(chunk, sanitizer)
+                    if sanitize_result.pii_detected:
+                        total_pii_found += 1
+                else:
+                    prompt = build_prompt(chunk)
+
+                f.write(json.dumps(build_batch_request_line(chunk["id"], prompt)) + "\n")
+
+        jsonl_files.append(filename)
+        print(f"  Wrote {filename.name} ({len(batch)} chunks)")
+
+    if sanitizer is not None:
+        mapping_path = EXPORT_DIR / "pii_mapping.json"
+        sanitizer.save_mapping(mapping_path)
+        print(f"Mapping saved to: {mapping_path}")
+    print(f"\nPII sanitization: {total_pii_found}/{len(rows)} chunks had PII stripped")
+    print(f"Exported {len(rows)} backlog chunks to {len(jsonl_files)} JSONL files")
+    return jsonl_files
+
+
 # ── Gemini Batch API (google.genai SDK) ────────────────────────────────
 
 
@@ -623,8 +741,10 @@ def submit_gemini_batch(
     model: str = DEFAULT_BATCH_MODEL,
     store: Optional[VectorStore] = None,
     max_retries: int = 3,
+    import_mode: str = IMPORT_MODE_AUTO,
 ) -> Optional[str]:
     """Upload JSONL and submit a Gemini batch job. Returns batch job name or None on failure."""
+    _raise_if_enrich_daily_cap_reached()
     client = _get_genai_client()
 
     # Count chunks in file
@@ -663,6 +783,7 @@ def submit_gemini_batch(
                     chunk_count=chunk_count,
                     jsonl_path=str(jsonl_path),
                     submitted_at=datetime.now(timezone.utc).isoformat(),
+                    import_mode=import_mode,
                 )
 
             return batch_job.name
@@ -685,6 +806,7 @@ def submit_gemini_batch(
                         chunk_count=chunk_count,
                         jsonl_path=str(jsonl_path),
                         error=err[:500],
+                        import_mode=import_mode,
                     )
                 return None
 
@@ -824,12 +946,58 @@ def _clear_imported_preview(store: VectorStore, chunk_id: str) -> None:
     )
 
 
+def _extract_batch_response_text(result: Dict[str, Any]) -> Optional[str]:
+    """Extract generated text from a Gemini Batch JSONL result row."""
+    try:
+        response = result.get("response", result.get("output", {}))
+        if isinstance(response, dict):
+            candidates = response.get("candidates", [])
+            if candidates:
+                parts = candidates[0].get("content", {}).get("parts", [])
+                if parts:
+                    return parts[0].get("text", "")
+        elif isinstance(response, str):
+            return response
+    except (KeyError, IndexError, TypeError):
+        return None
+    return None
+
+
+def _get_canonical_import_candidate(store: VectorStore, chunk_id: str) -> Optional[dict[str, Any]]:
+    """Return the realtime-eligible chunk dict for a batch import, if still eligible."""
+    candidates = store.get_enrichment_candidates(limit=1, chunk_ids=[chunk_id])
+    if candidates and candidates[0]["id"] == chunk_id:
+        return candidates[0]
+    return None
+
+
+def _commit_batch_enrichment(
+    store: VectorStore,
+    chunk: dict[str, Any],
+    enrichment: dict[str, Any],
+    *,
+    model: str,
+) -> None:
+    """Commit batch output through the same canonical write path as realtime."""
+    _apply_enrichment(
+        store,
+        chunk,
+        enrichment,
+        chunk_origin=model.replace("models/", ""),
+        enrichment_model=model,
+        enrichment_backend="gemini-batch",
+    )
+
+
 def import_results(
     store: VectorStore,
     results: List[Dict[str, Any]],
     batch_id: str,
+    *,
+    import_mode: str = IMPORT_MODE_AUTO,
+    model: str = DEFAULT_BATCH_MODEL,
 ) -> Dict[str, int]:
-    """Import preview summaries back to DB without mutating the live summary."""
+    """Import batch results, committing eligible backlog rows canonically."""
     success = 0
     failed = 0
     skipped = 0
@@ -842,38 +1010,42 @@ def import_results(
             failed += 1
             continue
 
-        # Skip if preview summary already exists.
-        existing = list(
-            cursor.execute(
-                "SELECT summary_v2 FROM chunks WHERE id = ?",
-                [chunk_id],
-            )
-        )
-        if existing and existing[0][0] is not None:
-            skipped += 1
-            continue
-
-        # Extract the generated text from Gemini response
-        response_text = None
-        try:
-            response = result.get("response", result.get("output", {}))
-            if isinstance(response, dict):
-                candidates = response.get("candidates", [])
-                if candidates:
-                    parts = candidates[0].get("content", {}).get("parts", [])
-                    if parts:
-                        response_text = parts[0].get("text", "")
-            elif isinstance(response, str):
-                response_text = response
-        except (KeyError, IndexError, TypeError):
-            pass
-
+        response_text = _extract_batch_response_text(result)
         if not response_text:
             failed += 1
             continue
 
         enrichment = parse_enrichment(response_text)
         if enrichment:
+            canonical_chunk = None
+            if import_mode in {IMPORT_MODE_AUTO, IMPORT_MODE_DRAIN}:
+                canonical_chunk = _get_canonical_import_candidate(store, chunk_id)
+
+            if canonical_chunk is not None:
+                try:
+                    _commit_batch_enrichment(store, canonical_chunk, enrichment, model=model)
+                except Exception as exc:
+                    print(f"  WARNING: canonical import failed for {chunk_id}: {exc}")
+                    failed += 1
+                    continue
+                success += 1
+                continue
+
+            if import_mode == IMPORT_MODE_DRAIN:
+                skipped += 1
+                continue
+
+            # Skip if preview summary already exists.
+            existing = list(
+                cursor.execute(
+                    "SELECT summary_v2 FROM chunks WHERE id = ?",
+                    [chunk_id],
+                )
+            )
+            if existing and existing[0][0] is not None:
+                skipped += 1
+                continue
+
             try:
                 store.update_reenrichment_preview(
                     chunk_id=chunk_id,
@@ -947,22 +1119,30 @@ def run_full_backfill(
     sample: int = 0,
     no_sanitize: bool = False,
     submit_only: bool = False,
+    drain_backlog: bool = False,
 ) -> None:
     """Run the full backfill: export → submit → poll → import."""
-    store = open_backfill_store(db_path, allow_read_only_fallback=(submit_only or dry_run))
+    store = open_backfill_store(db_path, allow_read_only_fallback=((submit_only or dry_run) and not drain_backlog))
     ensure_checkpoint_table(store)
 
     try:
-        preview_stats = get_reenrichment_stats(store)
-        print(
-            "Current preview progress: "
-            f"{preview_stats['previewed']}/{preview_stats['eligible']} ({preview_stats['percent']}%)"
-        )
-        print(f"Remaining preview candidates: {preview_stats['remaining']}\n")
+        import_mode = IMPORT_MODE_DRAIN if drain_backlog else IMPORT_MODE_AUTO
+        if drain_backlog:
+            drain_stats = get_backlog_drain_stats(store)
+            print(f"Current backlog drain remaining: {drain_stats['remaining']}\n")
+        else:
+            preview_stats = get_reenrichment_stats(store)
+            print(
+                "Current preview progress: "
+                f"{preview_stats['previewed']}/{preview_stats['eligible']} ({preview_stats['percent']}%)"
+            )
+            print(f"Remaining preview candidates: {preview_stats['remaining']}\n")
 
         # Step 1: Export or reuse existing batch files
         max_chunks = sample if sample > 0 else 0
-        if submit_only and sample == 0:
+        if drain_backlog:
+            jsonl_files = export_backlog_drain_chunks(store, max_chunks=max_chunks, no_sanitize=no_sanitize)
+        elif submit_only and sample == 0:
             jsonl_files = get_unsubmitted_export_files(db_path=db_path)
             if jsonl_files:
                 print(f"Reusing {len(jsonl_files)} existing JSONL batch files not yet checkpointed from {EXPORT_DIR}")
@@ -990,7 +1170,7 @@ def run_full_backfill(
         # Step 2: Submit all batch jobs
         batch_names = []
         for jsonl_path in jsonl_files:
-            batch_name = submit_gemini_batch(jsonl_path, model=model, store=store)
+            batch_name = submit_gemini_batch(jsonl_path, model=model, store=store, import_mode=import_mode)
             if batch_name is not None:
                 batch_names.append(batch_name)
             else:
@@ -1017,7 +1197,7 @@ def run_full_backfill(
             if result["state"] == "succeeded":
                 # Download + import
                 batch_results = download_gemini_results(result["job"])
-                counts = import_results(store, batch_results, batch_name)
+                counts = import_results(store, batch_results, batch_name, import_mode=import_mode, model=model)
                 for k in total_imported:
                     total_imported[k] += counts[k]
 
@@ -1025,6 +1205,10 @@ def run_full_backfill(
                 job = result.get("job")
                 usage = _extract_usage_metadata(job) if job else {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0}
                 if usage["input_tokens"] or usage["output_tokens"]:
+                    usage["cost_usd"] = record_batch_usage_against_daily_cap(
+                        usage["input_tokens"],
+                        usage["output_tokens"],
+                    )
                     log_batch_usage(
                         batch_name,
                         model,
@@ -1051,21 +1235,27 @@ def run_full_backfill(
                 print(f"  FAILED: {batch_name} — {result.get('error')}")
 
         # Final stats
-        final_stats = get_reenrichment_stats(store)
         print(f"\n{'=' * 60}")
         print("BACKFILL COMPLETE")
         print(
             f"  Imported: {total_imported['success']} ok, "
             f"{total_imported['failed']} fail, {total_imported['skipped']} skip"
         )
-        print(f"  Preview progress: {final_stats['previewed']}/{final_stats['eligible']} ({final_stats['percent']}%)")
+        if drain_backlog:
+            final_stats = get_backlog_drain_stats(store)
+            print(f"  Backlog drain remaining: {final_stats['remaining']}")
+        else:
+            final_stats = get_reenrichment_stats(store)
+            print(
+                f"  Preview progress: {final_stats['previewed']}/{final_stats['eligible']} ({final_stats['percent']}%)"
+            )
         print(f"{'=' * 60}")
 
     finally:
         store.close()
 
 
-def process_pending_jobs_once(db_path: Path) -> Dict[str, int]:
+def process_pending_jobs_once(db_path: Path, *, import_mode: str | None = None) -> Dict[str, int]:
     """Check each submitted job once, importing any completed results."""
     store = VectorStore(db_path)
     ensure_checkpoint_table(store)
@@ -1080,19 +1270,33 @@ def process_pending_jobs_once(db_path: Path) -> Dict[str, int]:
         "skipped": 0,
     }
     try:
-        pending = get_pending_jobs(store)
+        pending = [
+            job for job in get_pending_jobs(store) if import_mode is None or job.get("import_mode") == import_mode
+        ]
         summary["checked"] = len(pending)
         for job in pending:
+            _raise_if_enrich_daily_cap_reached()
             status = get_gemini_batch_state(job["batch_id"])
             if status["state"] == "succeeded":
                 batch_job = status["job"]
                 batch_results = download_gemini_results(batch_job)
-                counts = import_results(store, batch_results, job["batch_id"])
+                job_import_mode = job.get("import_mode") or IMPORT_MODE_AUTO
+                counts = import_results(
+                    store,
+                    batch_results,
+                    job["batch_id"],
+                    import_mode=job_import_mode,
+                    model=job.get("model") or DEFAULT_BATCH_MODEL,
+                )
                 for key in ("success", "failed", "skipped"):
                     summary[key] += counts[key]
 
                 usage = _extract_usage_metadata(batch_job)
                 if usage["input_tokens"] or usage["output_tokens"]:
+                    usage["cost_usd"] = record_batch_usage_against_daily_cap(
+                        usage["input_tokens"],
+                        usage["output_tokens"],
+                    )
                     log_batch_usage(
                         job["batch_id"],
                         job.get("model") or DEFAULT_BATCH_MODEL,
@@ -1157,12 +1361,23 @@ def resume_backfill(db_path: Path) -> None:
 
             if result["state"] == "succeeded":
                 batch_results = download_gemini_results(result["job"])
-                import_results(store, batch_results, job["batch_id"])
+                job_import_mode = job.get("import_mode") or IMPORT_MODE_AUTO
+                import_results(
+                    store,
+                    batch_results,
+                    job["batch_id"],
+                    import_mode=job_import_mode,
+                    model=job.get("model") or DEFAULT_BATCH_MODEL,
+                )
                 imported_count += 1
 
                 # Log usage to Supabase (best-effort)
                 usage = _extract_usage_metadata(result.get("job"))
                 if usage["input_tokens"] or usage["output_tokens"]:
+                    usage["cost_usd"] = record_batch_usage_against_daily_cap(
+                        usage["input_tokens"],
+                        usage["output_tokens"],
+                    )
                     log_batch_usage(
                         job["batch_id"],
                         job.get("model") or DEFAULT_BATCH_MODEL,

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -190,6 +190,11 @@ def _estimate_gemini_response_cost_usd(response: Any, service_tier: str | None =
 
 def _record_enrich_response_usage(response: Any) -> float:
     cost_usd = _estimate_gemini_response_cost_usd(response)
+    return _record_enrich_cost_usd(cost_usd)
+
+
+def _record_enrich_cost_usd(cost_usd: float) -> float:
+    """Add an already-estimated enrichment cost to the shared daily counter."""
     if cost_usd <= 0:
         return 0.0
 
@@ -1359,6 +1364,8 @@ def _apply_enrichment(
     enrichment: dict[str, Any],
     *,
     chunk_origin: str | None = None,
+    enrichment_model: str | None = None,
+    enrichment_backend: str | None = None,
 ) -> None:
     should_promote_raw_entities = False
     with _savepoint(store.conn, "enrichment_apply_provenance"):
@@ -1386,8 +1393,8 @@ def _apply_enrichment(
             "sentiment_score": enrichment.get("sentiment_score"),
             "sentiment_signals": enrichment.get("sentiment_signals"),
             "chunk_origin": normalized_origin or None,
-            "enrichment_model": GEMINI_REALTIME_MODEL,
-            "enrichment_backend": _current_enrichment_backend(),
+            "enrichment_model": enrichment_model or GEMINI_REALTIME_MODEL,
+            "enrichment_backend": enrichment_backend or _current_enrichment_backend(),
         }
         enrichment_version = (enrichment.get("enrichment_metadata") or {}).get("prompt_version")
         if enrichment_version:

--- a/tests/test_cli_enrich.py
+++ b/tests/test_cli_enrich.py
@@ -219,6 +219,42 @@ def test_cli_enrich_mode_batch_submit_defaults_to_full_batch(monkeypatch):
     assert called["submit_only"] is True
 
 
+def test_cli_enrich_mode_batch_drain_submit_routes_to_cloud_backfill(monkeypatch):
+    monkeypatch.setattr("brainlayer.cli.get_db_path", lambda: "/tmp/test.db")
+    called = {}
+
+    def fake_backfill(
+        db_path,
+        model,
+        dry_run=False,
+        sample=0,
+        no_sanitize=False,
+        submit_only=False,
+        drain_backlog=False,
+    ):
+        called.update(
+            {
+                "db_path": str(db_path),
+                "model": model,
+                "dry_run": dry_run,
+                "sample": sample,
+                "no_sanitize": no_sanitize,
+                "submit_only": submit_only,
+                "drain_backlog": drain_backlog,
+            }
+        )
+
+    monkeypatch.setattr("brainlayer.cloud_backfill.run_full_backfill", fake_backfill)
+
+    result = runner.invoke(app, ["enrich", "--mode", "batch", "--phase", "drain-submit", "--limit", "50"])
+
+    assert result.exit_code == 0
+    assert called["db_path"] == "/tmp/test.db"
+    assert called["sample"] == 50
+    assert called["submit_only"] is True
+    assert called["drain_backlog"] is True
+
+
 def test_cli_enrich_mode_local_is_rejected():
     result = runner.invoke(app, ["enrich", "--mode", "local"])
 

--- a/tests/test_cloud_backfill.py
+++ b/tests/test_cloud_backfill.py
@@ -270,7 +270,7 @@ def test_submit_only_reuses_existing_exports_without_reexporting(tmp_path, monke
     def fake_export(*args, **kwargs):  # pragma: no cover - should not be called
         raise AssertionError("submit-only should reuse existing export files, not regenerate them")
 
-    def fake_submit(jsonl_path, model, store):
+    def fake_submit(jsonl_path, model, store, **kwargs):
         submitted_paths.append(Path(jsonl_path))
         return f"job-{Path(jsonl_path).stem}"
 
@@ -368,7 +368,7 @@ def test_submit_only_exports_new_chunks_when_old_files_are_checkpointed(tmp_path
         new_file.write_text("{}\n")
         return [new_file]
 
-    def fake_submit(jsonl_path, model, store):
+    def fake_submit(jsonl_path, model, store, **kwargs):
         submitted_paths.append(Path(jsonl_path))
         return f"job-{Path(jsonl_path).stem}"
 
@@ -450,8 +450,89 @@ def test_export_unenriched_chunks_includes_legacy_rows_without_summary_v2(tmp_pa
         store.close()
 
 
-def test_import_results_writes_preview_fields_for_unenriched_chunks(tmp_path, monkeypatch):
-    """Fresh chunks should receive preview summaries without mutating live enrichment fields."""
+def test_export_backlog_drain_chunks_uses_realtime_eligible_predicate(tmp_path, monkeypatch):
+    """Batch drain export should target only chunks counted by the realtime backlog."""
+    export_dir = tmp_path / "exports"
+    monkeypatch.setattr(cloud_backfill, "EXPORT_DIR", export_dir)
+
+    store = VectorStore(tmp_path / "backfill.db")
+    try:
+        cursor = store.conn.cursor()
+        _insert_unenriched_chunk(
+            store,
+            "eligible",
+            "This long assistant chunk should be exported by the backlog drain selector.",
+        )
+        _insert_unenriched_chunk(store, "too-short", "short")
+        cursor.execute(
+            """
+            INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type, char_count,
+                source, enrich_status
+            ) VALUES (?, ?, '{}', 'test.jsonl', 'test-project', 'assistant_text', ?, 'claude_code', ?)
+            """,
+            (
+                "terminal-status",
+                "This long chunk already has a terminal enrichment status and must not drain.",
+                74,
+                "failed",
+            ),
+        )
+        cursor.execute(
+            """
+            INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type, char_count,
+                source, summary, enriched_at, summary_v2
+            ) VALUES (?, ?, '{}', 'test.jsonl', 'test-project', 'assistant_text', ?, 'claude_code', ?, ?, NULL)
+            """,
+            (
+                "legacy-preview",
+                "This legacy row belongs to preview re-enrichment, not backlog drain.",
+                67,
+                "Old summary",
+                "2026-04-01T00:00:00+00:00",
+            ),
+        )
+
+        jsonl_files = cloud_backfill.export_backlog_drain_chunks(
+            store,
+            max_chunks=10,
+            no_sanitize=True,
+        )
+
+        exported_keys = [
+            json.loads(line)["key"] for path in jsonl_files for line in path.read_text(encoding="utf-8").splitlines()
+        ]
+
+        assert exported_keys == ["eligible"]
+        assert [chunk["id"] for chunk in store.get_enrichment_candidates(limit=10)] == ["eligible"]
+    finally:
+        store.close()
+
+
+def test_record_batch_usage_counts_against_enrichment_daily_cap(tmp_path, monkeypatch):
+    """Batch usage should spend from the same enrichment daily cost counter."""
+    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(tmp_path))
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "0.10")
+
+    first_cost = cloud_backfill.record_batch_usage_against_daily_cap(1_000_000, 0)
+
+    assert first_cost == pytest.approx(0.05)
+    counter = json.loads((tmp_path / "enrich-daily-cost.json").read_text(encoding="utf-8"))
+    assert counter["spent_usd"] == pytest.approx(0.05)
+
+    second_cost = cloud_backfill.record_batch_usage_against_daily_cap(2_000_000, 0)
+    assert second_cost == pytest.approx(0.10)
+
+    counter = json.loads((tmp_path / "enrich-daily-cost.json").read_text(encoding="utf-8"))
+    assert counter["spent_usd"] == pytest.approx(0.15)
+
+    with pytest.raises(RuntimeError, match="ENRICH_DAILY_CAP_REACHED"):
+        cloud_backfill.record_batch_usage_against_daily_cap(1, 0)
+
+
+def test_import_results_commits_canonical_fields_for_unenriched_chunks(tmp_path, monkeypatch):
+    """Fresh chunks should receive canonical enrichment fields, not preview-only fields."""
     store = VectorStore(tmp_path / "brainlayer.db")
     try:
         _insert_unenriched_chunk(
@@ -497,14 +578,98 @@ def test_import_results_writes_preview_fields_for_unenriched_chunks(tmp_path, mo
         row = (
             store.conn.cursor()
             .execute(
-                "SELECT summary, summary_v2, enrichment_version, enriched_at FROM chunks WHERE id = ?",
+                "SELECT summary, summary_v2, enrichment_version, enriched_at, enrich_status FROM chunks WHERE id = ?",
                 ("chunk-1",),
             )
             .fetchone()
         )
 
         assert counts == {"success": 1, "failed": 0, "skipped": 0}
-        assert row == (None, "Remote enrichment imported successfully.", "2.0", None)
+        assert row[0] == "Remote enrichment imported successfully."
+        assert row[1] is None
+        assert row[2] == "r82-hybrid-taxonomy"
+        assert row[3] is not None
+        assert row[4] == "success"
+    finally:
+        store.close()
+
+
+def test_import_results_commits_enrichment_for_eligible_backlog_chunks(tmp_path, monkeypatch):
+    """Batch-drain imports must clear the same eligible set as realtime enrichment."""
+    store = VectorStore(tmp_path / "brainlayer.db")
+    try:
+        _insert_unenriched_chunk(
+            store,
+            "chunk-drain-1",
+            "Batch drain should commit canonical enrichment for this long eligible chunk.",
+        )
+
+        monkeypatch.setattr(cloud_backfill, "save_checkpoint", lambda *args, **kwargs: None)
+
+        assert [chunk["id"] for chunk in store.get_enrichment_candidates(limit=10)] == ["chunk-drain-1"]
+
+        results = [
+            {
+                "key": "chunk-drain-1",
+                "response": {
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {
+                                        "text": json.dumps(
+                                            {
+                                                "summary": "Canonical batch drain summary.",
+                                                "tags": ["brainlayer", "batch-drain"],
+                                                "importance": 8,
+                                                "intent": "implementing",
+                                                "primary_symbols": ["src/brainlayer/cloud_backfill.py"],
+                                                "resolved_query": "How does batch drain clear eligible chunks?",
+                                                "epistemic_level": "validated",
+                                                "debt_impact": "resolution",
+                                                "external_deps": ["Gemini Batch API"],
+                                                "entities": [
+                                                    {
+                                                        "name": "BrainLayer",
+                                                        "type": "project",
+                                                        "salience": 0.9,
+                                                        "role": "system_under_test",
+                                                    }
+                                                ],
+                                            }
+                                        )
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+            }
+        ]
+
+        counts = cloud_backfill.import_results(store, results, "batch-drain-1")
+
+        row = (
+            store.conn.cursor()
+            .execute(
+                """
+                SELECT summary, tags, importance, intent, enriched_at, enrich_status, summary_v2
+                FROM chunks WHERE id = ?
+                """,
+                ("chunk-drain-1",),
+            )
+            .fetchone()
+        )
+
+        assert counts == {"success": 1, "failed": 0, "skipped": 0}
+        assert row[0] == "Canonical batch drain summary."
+        assert json.loads(row[1]) == ["brainlayer", "batch-drain"]
+        assert row[2] == 8
+        assert row[3] == "implementing"
+        assert row[4] is not None
+        assert row[5] == "success"
+        assert row[6] is None
+        assert store.get_enrichment_candidates(limit=10) == []
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary
- Adds a backlog-drain batch mode for enrichment that selects the same eligible predicate as realtime: `enriched_at IS NULL AND enrich_status IS NULL AND char_count >= 50`.
- Bridges Gemini Batch import results into the canonical enrichment write path so eligible chunks get `enrich_status=success`, `enriched_at`, summary, tags, importance, intent, and entities instead of only `summary_v2` preview fields.
- Records batch-token cost through the existing enrichment daily cap counter using batch-tier pricing.
- Exposes drain phases through `brainlayer enrich --mode batch --phase drain-submit|drain-run|drain-poll|drain-import`; realtime remains the default live daemon path.

## Red / Green Evidence
- RED, before implementation: `pytest tests/test_cloud_backfill.py::test_import_results_commits_enrichment_for_eligible_backlog_chunks` -> `1 failed, 1 warning`; current code left canonical `summary` as `None` after import.
- RED, in-place revert of production fix files only: same command -> `1 failed, 1 warning`; confirms the test fails against current production behavior without PYTHONPATH/worktree source tricks.
- GREEN: `pytest tests/test_cloud_backfill.py::test_import_results_commits_enrichment_for_eligible_backlog_chunks` -> `1 passed, 1 warning`.
- Scoped suite: `.venv/bin/pytest tests/test_cloud_backfill.py tests/test_cli_enrich.py tests/test_enrichment_controller.py::test_apply_enrichment_calls_update_enrichment_with_all_fields` -> `32 passed in 2.32s`.
- Lint/format: `ruff check ... && ruff format --check ...` -> all checks passed, 5 files already formatted.
- Scoped pre-push gate: `BRAINLAYER_PREPUSH=1 BRAINLAYER_PREPUSH_SCOPE=changed-only BRAINLAYER_CHANGED_FILES="tests/test_cloud_backfill.py,tests/test_cli_enrich.py,tests/test_enrichment_controller.py" scripts/run_tests.sh` -> BrainLayer test gate passed (`119 passed`, `3 passed`, `40 passed`, bun `1 pass`, shell regression PASS).
- Push hook full pre-push gate: BrainLayer test gate passed (`3067 passed, 9 skipped, 61 deselected, 1 xfailed`, MCP `3 passed`, eval/hook `40 passed`, bun `1 pass`, shell regression PASS).

## Notes
- Pytest mocks Gemini Batch API behavior; no live API calls are made in tests.
- Step 1 code has not been deployed to production.
- Local `coderabbit review --agent` connected but timed out after 180s, so review is requested on the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how batch results mutate chunk enrichment state and spend against the shared daily cap; wrong import_mode or eligibility logic could skip or mis-apply large backlogs, but behavior is covered by targeted tests and preview mode is preserved for legacy rows.
> 
> **Overview**
> Introduces a **backlog-drain** batch enrichment path aligned with realtime eligibility (`get_enrichment_candidates`), exposed as `brainlayer enrich --mode batch --phase drain-submit|drain-run|drain-poll|drain-import`.
> 
> **Export/import behavior:** Drain mode exports via `export_backlog_drain_chunks` and stores `import_mode=drain` on batch checkpoints. **Batch imports** now prefer committing eligible unenriched chunks through `_apply_enrichment` (canonical `summary`, `enrich_status`, tags, etc.) with `enrichment_backend=gemini-batch`; non-eligible drain rows are skipped, while the existing preview/`summary_v2` path remains for legacy re-enrichment when auto mode does not find a canonical candidate.
> 
> **Cost and ops:** Batch submit, poll/import, and completed-job logging call the shared enrichment daily cap (`record_batch_usage_against_daily_cap` / `_raise_if_enrich_daily_cap_reached`). `_apply_enrichment` accepts optional `enrichment_model` and `enrichment_backend` for batch commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb002064b5ec1833fda1097f56c50b251dad8d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add batch-drain enrichment mode to clear backlog via async Batch API
> - Adds `drain-submit`, `drain-poll`, `drain-import`, and `drain-run` phases to the `enrich --mode batch` CLI command in [cli/__init__.py](https://github.com/EtanHey/brainlayer/pull/538/files#diff-e66ce4ea8b0cf3331154cb15181cb09a7c593566e36380fd9215ff29d24ffd02), routing to new drain-specific paths in [cloud_backfill.py](https://github.com/EtanHey/brainlayer/pull/538/files#diff-fb56f065e2009656ecba034f8387c5d1e24b2a548452961ccf4668f25b4d5d37).
> - Adds `export_backlog_drain_chunks` to export realtime-eligible backlog chunks (unenriched, above char threshold) as JSONL for batch submission, and `get_backlog_drain_stats` to report remaining drain candidates.
> - Extends `import_results` to commit canonical enrichment fields (`summary`, `enriched_at`, `enrich_status`) directly for eligible backlog chunks in drain mode, skipping ineligible chunks instead of falling back to preview.
> - Adds an `import_mode` column (default `'auto'`) to the checkpoint DB with automatic migration via `ALTER TABLE`, and filters pending jobs by `import_mode` in `process_pending_jobs_once`.
> - Batch submissions and imports now check and record usage against the shared enrichment daily cap via `record_batch_usage_against_daily_cap`; cap exhaustion raises immediately.
> - Risk: existing checkpoint DBs are migrated automatically on first use; drain-mode imports write to live enrichment fields rather than preview fields, making changes immediately visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bb00206. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->