### PR TITLE
feat: sandboxed-test-BrainLayer DB primitive (gen-19 T10/P0-a, cross-lead blocker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ htmlcov/
 *.db-wal
 *.db-shm
 data/
+!src/brainlayer/data/
+!src/brainlayer/data/sandbox_seeds/
+!src/brainlayer/data/sandbox_seeds/*.json
 
 # Secrets
 .env

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re as _re
+import shlex
 import sqlite3
 import subprocess
 import sys
@@ -41,6 +42,8 @@ agent_profile_app = typer.Typer(help="Manage per-agent search ranking profiles")
 app.add_typer(agent_profile_app, name="agent-profile")
 provenance_app = typer.Typer(help="Resolve provenance conflicts and pending confirmations")
 app.add_typer(provenance_app, name="provenance")
+sandbox_app = typer.Typer(help="Manage isolated sandbox BrainLayer databases")
+app.add_typer(sandbox_app, name="sandbox")
 
 
 def _launchd_target(label: str) -> str:
@@ -86,6 +89,31 @@ def _bootstrap_label(label: str, plist_path: Path) -> None:
 
 def _bootout_label(label: str) -> None:
     _run_launchctl(["launchctl", "bootout", _launchd_target(label)])
+
+
+@sandbox_app.command("start")
+def sandbox_start_command(
+    seed: str = typer.Option(..., "--seed", help="Named seed set to load."),
+    token: str = typer.Option(..., "--token", help="Unique sandbox run token."),
+) -> None:
+    """Start a seeded sandbox DB and print an eval-able export block."""
+    from ..sandbox_db import start_sandbox
+
+    sandbox = start_sandbox(seed=seed, token=token)
+    typer.echo(f"# brainlayer sandbox token={shlex.quote(token)}")
+    typer.echo(f"export BRAINLAYER_DB={shlex.quote(str(sandbox.db_path))}")
+    typer.echo(f"# db_path={shlex.quote(str(sandbox.db_path))}")
+
+
+@sandbox_app.command("stop")
+def sandbox_stop_command(
+    token: str = typer.Option(..., "--token", help="Sandbox run token to tear down."),
+) -> None:
+    """Stop a sandbox DB and assert no DB residue remains."""
+    from ..sandbox_db import stop_sandbox
+
+    stop_sandbox(token=token)
+    typer.echo(f"stopped sandbox token={token}")
 
 
 def _default_pause_labels() -> list[str]:

--- a/src/brainlayer/data/sandbox_seeds/skill-eval-baseline.json
+++ b/src/brainlayer/data/sandbox_seeds/skill-eval-baseline.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "skill-eval-baseline-001",
+    "content": "Sandbox skill eval baseline memory: BrainLayer stores durable project facts and retrieves them through isolated SQLite databases.",
+    "project": "brainlayer-sandbox-eval",
+    "content_type": "assistant_text",
+    "created_at": "2026-06-24T00:00:00Z",
+    "tags": ["sandbox", "skill-eval", "baseline"],
+    "importance": 6
+  },
+  {
+    "id": "skill-eval-baseline-002",
+    "content": "Sandbox skill eval baseline memory: live eval agents must derive task answers from their prompt and tools, not from prior eval writes.",
+    "project": "brainlayer-sandbox-eval",
+    "content_type": "assistant_text",
+    "created_at": "2026-06-24T00:01:00Z",
+    "tags": ["sandbox", "anti-cheat", "baseline"],
+    "importance": 6
+  },
+  {
+    "id": "skill-eval-baseline-003",
+    "content": "Sandbox skill eval baseline memory: deterministic local embeddings keep CI and cmux probes offline-safe.",
+    "project": "brainlayer-sandbox-eval",
+    "content_type": "assistant_text",
+    "created_at": "2026-06-24T00:02:00Z",
+    "tags": ["sandbox", "determinism", "baseline"],
+    "importance": 5
+  }
+]

--- a/src/brainlayer/sandbox_db.py
+++ b/src/brainlayer/sandbox_db.py
@@ -1,0 +1,230 @@
+"""Sandboxed BrainLayer DB primitive for live eval isolation."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+from ._helpers import serialize_f32
+from .isolation_proof import _embed
+from .paths import _CANONICAL_DB_PATH
+from .search_repo import clear_hybrid_search_cache
+from .vector_store import VectorStore
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_SEED_DIR = Path(__file__).resolve().parent / "data" / "sandbox_seeds"
+
+
+class SandboxProdLeakError(RuntimeError):
+    """Raised when a sandbox DB path points at the canonical production area."""
+
+
+@dataclass(frozen=True)
+class SandboxPaths:
+    temp_dir: Path
+    db_path: Path
+    wal_path: Path
+    shm_path: Path
+
+
+def _validate_name(value: str, *, label: str) -> str:
+    if not value or not _TOKEN_RE.fullmatch(value):
+        raise ValueError(f"{label} must contain only letters, numbers, dots, underscores, and dashes")
+    return value
+
+
+def sandbox_paths_for_token(token: str) -> SandboxPaths:
+    """Return deterministic sandbox paths for a token."""
+    safe_token = _validate_name(token, label="token")
+    temp_dir = Path(tempfile.gettempdir()) / f"bl-sandbox-{safe_token}"
+    db_path = temp_dir / "brainlayer.db"
+    return SandboxPaths(
+        temp_dir=temp_dir,
+        db_path=db_path,
+        wal_path=Path(f"{db_path}-wal"),
+        shm_path=Path(f"{db_path}-shm"),
+    )
+
+
+def _paths_for_db_path(db_path: Path) -> SandboxPaths:
+    return SandboxPaths(
+        temp_dir=db_path.parent,
+        db_path=db_path,
+        wal_path=Path(f"{db_path}-wal"),
+        shm_path=Path(f"{db_path}-shm"),
+    )
+
+
+def _resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _assert_not_prod_path(db_path: Path) -> None:
+    resolved_db = _resolved(db_path)
+    canonical_db = _resolved(_CANONICAL_DB_PATH)
+    canonical_dir = _resolved(_CANONICAL_DB_PATH.parent)
+    if resolved_db == canonical_db or resolved_db.is_relative_to(canonical_dir):
+        raise SandboxProdLeakError(f"sandbox db path resolves inside production BrainLayer dir: {resolved_db}")
+
+
+def _seed_path(seed: str) -> Path:
+    safe_seed = _validate_name(seed, label="seed")
+    path = _SEED_DIR / f"{safe_seed}.json"
+    if not path.is_file():
+        raise FileNotFoundError(f"unknown sandbox seed set: {seed}")
+    return path
+
+
+def _load_seed(seed: str) -> list[dict[str, Any]]:
+    payload = json.loads(_seed_path(seed).read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError(f"sandbox seed must be a list: {seed}")
+    return [dict(item) for item in payload]
+
+
+def _insert_seed_chunk(store: VectorStore, *, seed: str, row: dict[str, Any]) -> None:
+    chunk_id = str(row["id"])
+    content = str(row["content"])
+    project = row.get("project")
+    created_at = str(row["created_at"])
+    cursor = store.conn.cursor()
+    cursor.execute(
+        """INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, source, created_at, tags, importance
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            chunk_id,
+            content,
+            json.dumps({"sandbox_seed": seed}, sort_keys=True),
+            f"sandbox-seed:{seed}",
+            project if project is None else str(project),
+            str(row.get("content_type", "assistant_text")),
+            len(content),
+            "sandbox_seed",
+            created_at,
+            json.dumps(row.get("tags", []), sort_keys=True),
+            row.get("importance"),
+        ),
+    )
+    cursor.execute(
+        "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
+        (chunk_id, serialize_f32(_embed(content))),
+    )
+
+
+def seed_sandbox_db(db_path: str | Path, seed: str) -> list[str]:
+    """Create a fresh sandbox DB and load a deterministic named seed set."""
+    path = Path(db_path)
+    _assert_not_prod_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for residue in (path, Path(f"{path}-wal"), Path(f"{path}-shm")):
+        try:
+            residue.unlink()
+        except FileNotFoundError:
+            pass
+
+    rows = _load_seed(seed)
+    store = VectorStore(path)
+    store._binary_index_available = False
+    try:
+        seeded_ids: list[str] = []
+        for row in rows:
+            _insert_seed_chunk(store, seed=seed, row=row)
+            seeded_ids.append(str(row["id"]))
+    finally:
+        store.close()
+    clear_hybrid_search_cache(path)
+    return seeded_ids
+
+
+class SandboxDB:
+    """Context manager for a token-scoped throwaway BrainLayer database."""
+
+    def __init__(self, *, seed: str, token: str, db_path: str | Path | None = None) -> None:
+        self.seed = _validate_name(seed, label="seed")
+        self.token = _validate_name(token, label="token")
+        self._explicit_db_path = Path(db_path).expanduser() if db_path is not None else None
+        self._owns_temp_dir = self._explicit_db_path is None
+        self.paths = (
+            sandbox_paths_for_token(self.token)
+            if self._explicit_db_path is None
+            else _paths_for_db_path(self._explicit_db_path)
+        )
+        self.db_path = self.paths.db_path
+        self.env = {"BRAINLAYER_DB": str(self.db_path)}
+        self.seeded_ids: list[str] = []
+        self._old_env: str | None = None
+        self._started = False
+
+    def __enter__(self) -> SandboxDB:
+        return self.start()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.stop()
+
+    def start(self) -> SandboxDB:
+        _assert_not_prod_path(self.db_path)
+        if self._owns_temp_dir and self.paths.temp_dir.exists():
+            shutil.rmtree(self.paths.temp_dir)
+        self.paths.temp_dir.mkdir(parents=True, exist_ok=True)
+        self.seeded_ids = seed_sandbox_db(self.db_path, self.seed)
+        self._old_env = os.environ.get("BRAINLAYER_DB")
+        os.environ["BRAINLAYER_DB"] = str(self.db_path)
+        self._started = True
+        return self
+
+    def stop(self) -> None:
+        errors: list[str] = []
+        for residue in (self.paths.db_path, self.paths.wal_path, self.paths.shm_path):
+            try:
+                residue.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                errors.append(f"{residue}: {exc}")
+        if self._owns_temp_dir:
+            try:
+                shutil.rmtree(self.paths.temp_dir)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                errors.append(f"{self.paths.temp_dir}: {exc}")
+
+        residue_paths = [self.paths.db_path, self.paths.wal_path, self.paths.shm_path]
+        if self._owns_temp_dir:
+            residue_paths.append(self.paths.temp_dir)
+        remaining = [str(path) for path in residue_paths if path.exists()]
+        if remaining:
+            errors.append(f"residue remains after sandbox teardown: {', '.join(remaining)}")
+
+        if self._started:
+            if self._old_env is None:
+                os.environ.pop("BRAINLAYER_DB", None)
+            else:
+                os.environ["BRAINLAYER_DB"] = self._old_env
+            self._started = False
+
+        if errors:
+            raise RuntimeError("; ".join(errors))
+
+
+def start_sandbox(*, seed: str, token: str) -> SandboxDB:
+    return SandboxDB(seed=seed, token=token).start()
+
+
+def stop_sandbox(*, token: str) -> None:
+    sandbox = SandboxDB(seed="skill-eval-baseline", token=token)
+    sandbox.stop()

--- a/src/brainlayer/sandbox_db.py
+++ b/src/brainlayer/sandbox_db.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any
 
-from ._helpers import serialize_f32
+from . import paths as brain_paths
 from .isolation_proof import _embed
 from .paths import _CANONICAL_DB_PATH
 from .search_repo import clear_hybrid_search_cache
@@ -66,12 +66,25 @@ def _resolved(path: Path) -> Path:
     return path.expanduser().resolve(strict=False)
 
 
+def _is_managed_sandbox_db_path(path: Path) -> bool:
+    resolved = _resolved(path)
+    temp_root = _resolved(Path(tempfile.gettempdir()))
+    return (
+        resolved.name == "brainlayer.db"
+        and resolved.parent.name.startswith("bl-sandbox-")
+        and resolved.parent.parent == temp_root
+    )
+
+
 def _assert_not_prod_path(db_path: Path) -> None:
     resolved_db = _resolved(db_path)
     canonical_db = _resolved(_CANONICAL_DB_PATH)
     canonical_dir = _resolved(_CANONICAL_DB_PATH.parent)
     if resolved_db == canonical_db or resolved_db.is_relative_to(canonical_dir):
         raise SandboxProdLeakError(f"sandbox db path resolves inside production BrainLayer dir: {resolved_db}")
+    active_db = _resolved(brain_paths.get_db_path())
+    if resolved_db == active_db and not _is_managed_sandbox_db_path(resolved_db):
+        raise SandboxProdLeakError(f"sandbox db path resolves to active BrainLayer DB: {resolved_db}")
 
 
 def _seed_path(seed: str) -> Path:
@@ -89,35 +102,25 @@ def _load_seed(seed: str) -> list[dict[str, Any]]:
     return [dict(item) for item in payload]
 
 
-def _insert_seed_chunk(store: VectorStore, *, seed: str, row: dict[str, Any]) -> None:
+def _seed_chunk_payload(*, seed: str, row: dict[str, Any]) -> dict[str, Any]:
     chunk_id = str(row["id"])
     content = str(row["content"])
     project = row.get("project")
     created_at = str(row["created_at"])
-    cursor = store.conn.cursor()
-    cursor.execute(
-        """INSERT INTO chunks (
-            id, content, metadata, source_file, project, content_type,
-            char_count, source, created_at, tags, importance
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (
-            chunk_id,
-            content,
-            json.dumps({"sandbox_seed": seed}, sort_keys=True),
-            f"sandbox-seed:{seed}",
-            project if project is None else str(project),
-            str(row.get("content_type", "assistant_text")),
-            len(content),
-            "sandbox_seed",
-            created_at,
-            json.dumps(row.get("tags", []), sort_keys=True),
-            row.get("importance"),
-        ),
-    )
-    cursor.execute(
-        "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
-        (chunk_id, serialize_f32(_embed(content))),
-    )
+    return {
+        "id": chunk_id,
+        "content": content,
+        "metadata": {"sandbox_seed": seed},
+        "source_file": f"sandbox-seed:{seed}",
+        "project": project if project is None else str(project),
+        "content_type": str(row.get("content_type", "assistant_text")),
+        "char_count": len(content),
+        "source": "sandbox_seed",
+        "created_at": created_at,
+        "tags": row.get("tags", []),
+        "importance": row.get("importance"),
+        "status": "active",
+    }
 
 
 def seed_sandbox_db(db_path: str | Path, seed: str) -> list[str]:
@@ -133,16 +136,14 @@ def seed_sandbox_db(db_path: str | Path, seed: str) -> list[str]:
 
     rows = _load_seed(seed)
     store = VectorStore(path)
-    store._binary_index_available = False
     try:
-        seeded_ids: list[str] = []
-        for row in rows:
-            _insert_seed_chunk(store, seed=seed, row=row)
-            seeded_ids.append(str(row["id"]))
+        chunks = [_seed_chunk_payload(seed=seed, row=row) for row in rows]
+        embeddings = [_embed(chunk["content"]) for chunk in chunks]
+        store.upsert_chunks(chunks, embeddings)
     finally:
         store.close()
     clear_hybrid_search_cache(path)
-    return seeded_ids
+    return [str(row["id"]) for row in rows]
 
 
 class SandboxDB:
@@ -176,9 +177,14 @@ class SandboxDB:
         self.stop()
 
     def start(self) -> SandboxDB:
+        if self._started:
+            raise RuntimeError("sandbox already started")
         _assert_not_prod_path(self.db_path)
         if self._owns_temp_dir and self.paths.temp_dir.exists():
-            shutil.rmtree(self.paths.temp_dir)
+            if any(path.exists() for path in (self.paths.db_path, self.paths.wal_path, self.paths.shm_path)):
+                raise RuntimeError(f"sandbox token already exists with live DB: {self.token}")
+            if any(self.paths.temp_dir.iterdir()):
+                raise RuntimeError(f"sandbox token already exists with residue: {self.token}")
         self.paths.temp_dir.mkdir(parents=True, exist_ok=True)
         self.seeded_ids = seed_sandbox_db(self.db_path, self.seed)
         self._old_env = os.environ.get("BRAINLAYER_DB")

--- a/src/brainlayer/sandbox_db.py
+++ b/src/brainlayer/sandbox_db.py
@@ -32,6 +32,7 @@ class SandboxPaths:
     db_path: Path
     wal_path: Path
     shm_path: Path
+    lease_path: Path
 
 
 def _validate_name(value: str, *, label: str) -> str:
@@ -50,6 +51,7 @@ def sandbox_paths_for_token(token: str) -> SandboxPaths:
         db_path=db_path,
         wal_path=Path(f"{db_path}-wal"),
         shm_path=Path(f"{db_path}-shm"),
+        lease_path=temp_dir / ".brainlayer-sandbox.lease",
     )
 
 
@@ -59,6 +61,7 @@ def _paths_for_db_path(db_path: Path) -> SandboxPaths:
         db_path=db_path,
         wal_path=Path(f"{db_path}-wal"),
         shm_path=Path(f"{db_path}-shm"),
+        lease_path=db_path.parent / f".{db_path.name}.sandbox.lease",
     )
 
 
@@ -76,15 +79,37 @@ def _is_managed_sandbox_db_path(path: Path) -> bool:
     )
 
 
-def _assert_not_prod_path(db_path: Path) -> None:
+def _protected_db_residue_paths(db_path: Path) -> set[Path]:
+    resolved_db = _resolved(db_path)
+    return {
+        resolved_db,
+        _resolved(Path(f"{resolved_db}-wal")),
+        _resolved(Path(f"{resolved_db}-shm")),
+    }
+
+
+def _assert_not_prod_path(
+    db_path: Path,
+    *,
+    protected_db_path: Path | None = None,
+    ignore_current_active_db: bool = False,
+) -> None:
     resolved_db = _resolved(db_path)
     canonical_db = _resolved(_CANONICAL_DB_PATH)
     canonical_dir = _resolved(_CANONICAL_DB_PATH.parent)
     if resolved_db == canonical_db or resolved_db.is_relative_to(canonical_dir):
         raise SandboxProdLeakError(f"sandbox db path resolves inside production BrainLayer dir: {resolved_db}")
     active_db = _resolved(brain_paths.get_db_path())
-    if resolved_db == active_db and not _is_managed_sandbox_db_path(resolved_db):
-        raise SandboxProdLeakError(f"sandbox db path resolves to active BrainLayer DB: {resolved_db}")
+    protected_paths = []
+    if not ignore_current_active_db:
+        protected_paths.append(active_db)
+    if protected_db_path is not None:
+        protected_paths.append(_resolved(protected_db_path))
+    for protected_db in protected_paths:
+        if protected_db is None:
+            continue
+        if resolved_db in _protected_db_residue_paths(protected_db) and not _is_managed_sandbox_db_path(resolved_db):
+            raise SandboxProdLeakError(f"sandbox db path resolves to active BrainLayer DB: {resolved_db}")
 
 
 def _seed_path(seed: str) -> Path:
@@ -162,8 +187,10 @@ class SandboxDB:
         self.db_path = self.paths.db_path
         self.env = {"BRAINLAYER_DB": str(self.db_path)}
         self.seeded_ids: list[str] = []
+        self._protected_db_path = _resolved(brain_paths.get_db_path())
         self._old_env: str | None = None
         self._started = False
+        self._lease_acquired = False
 
     def __enter__(self) -> SandboxDB:
         return self.start()
@@ -176,23 +203,56 @@ class SandboxDB:
     ) -> None:
         self.stop()
 
+    def _acquire_lease(self) -> None:
+        try:
+            fd = os.open(self.paths.lease_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError as exc:
+            raise RuntimeError(f"sandbox token already exists and is already active: {self.token}") from exc
+        with os.fdopen(fd, "w", encoding="utf-8") as lease_file:
+            lease_file.write(json.dumps({"pid": os.getpid(), "token": self.token}, sort_keys=True) + "\n")
+        self._lease_acquired = True
+
+    def _release_lease(self) -> None:
+        try:
+            self.paths.lease_path.unlink()
+        except FileNotFoundError:
+            pass
+        finally:
+            self._lease_acquired = False
+
     def start(self) -> SandboxDB:
         if self._started:
             raise RuntimeError("sandbox already started")
-        _assert_not_prod_path(self.db_path)
+        _assert_not_prod_path(self.db_path, protected_db_path=self._protected_db_path)
         if self._owns_temp_dir and self.paths.temp_dir.exists():
+            if self.paths.lease_path.exists():
+                raise RuntimeError(f"sandbox token already exists and is already active: {self.token}")
             if any(path.exists() for path in (self.paths.db_path, self.paths.wal_path, self.paths.shm_path)):
                 raise RuntimeError(f"sandbox token already exists with live DB: {self.token}")
             if any(self.paths.temp_dir.iterdir()):
                 raise RuntimeError(f"sandbox token already exists with residue: {self.token}")
         self.paths.temp_dir.mkdir(parents=True, exist_ok=True)
-        self.seeded_ids = seed_sandbox_db(self.db_path, self.seed)
-        self._old_env = os.environ.get("BRAINLAYER_DB")
-        os.environ["BRAINLAYER_DB"] = str(self.db_path)
-        self._started = True
+        self._acquire_lease()
+        try:
+            self.seeded_ids = seed_sandbox_db(self.db_path, self.seed)
+            self._old_env = os.environ.get("BRAINLAYER_DB")
+            os.environ["BRAINLAYER_DB"] = str(self.db_path)
+            self._started = True
+        except Exception:
+            self._release_lease()
+            if self._owns_temp_dir:
+                shutil.rmtree(self.paths.temp_dir, ignore_errors=True)
+            raise
         return self
 
     def stop(self) -> None:
+        ignore_current_active_db = self._started and _resolved(brain_paths.get_db_path()) == _resolved(self.db_path)
+        _assert_not_prod_path(
+            self.db_path,
+            protected_db_path=self._protected_db_path,
+            ignore_current_active_db=ignore_current_active_db,
+        )
+        clear_hybrid_search_cache(self.db_path)
         errors: list[str] = []
         for residue in (self.paths.db_path, self.paths.wal_path, self.paths.shm_path):
             try:
@@ -201,6 +261,13 @@ class SandboxDB:
                 pass
             except OSError as exc:
                 errors.append(f"{residue}: {exc}")
+        if not self._owns_temp_dir:
+            try:
+                self.paths.lease_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                errors.append(f"{self.paths.lease_path}: {exc}")
         if self._owns_temp_dir:
             try:
                 shutil.rmtree(self.paths.temp_dir)
@@ -212,6 +279,8 @@ class SandboxDB:
         residue_paths = [self.paths.db_path, self.paths.wal_path, self.paths.shm_path]
         if self._owns_temp_dir:
             residue_paths.append(self.paths.temp_dir)
+        else:
+            residue_paths.append(self.paths.lease_path)
         remaining = [str(path) for path in residue_paths if path.exists()]
         if remaining:
             errors.append(f"residue remains after sandbox teardown: {', '.join(remaining)}")
@@ -222,7 +291,11 @@ class SandboxDB:
             else:
                 os.environ["BRAINLAYER_DB"] = self._old_env
             self._started = False
+        elif os.environ.get("BRAINLAYER_DB") == str(self.db_path):
+            os.environ.pop("BRAINLAYER_DB", None)
 
+        self._lease_acquired = False
+        clear_hybrid_search_cache(self.db_path)
         if errors:
             raise RuntimeError("; ".join(errors))
 

--- a/tests/test_sandbox_db.py
+++ b/tests/test_sandbox_db.py
@@ -63,6 +63,28 @@ def _binary_vector_count(db_path: Path) -> int:
         store.close()
 
 
+def test_sandbox_stop_rejects_active_db_path_without_deleting_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
+
+    active_db = tmp_path / "active-live" / "brainlayer.db"
+    active_db.parent.mkdir()
+    active_db.write_text("live", encoding="utf-8")
+    wal_path = Path(f"{active_db}-wal")
+    shm_path = Path(f"{active_db}-shm")
+    wal_path.write_text("wal", encoding="utf-8")
+    shm_path.write_text("shm", encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_DB", str(active_db))
+
+    with pytest.raises(SandboxProdLeakError):
+        SandboxDB(seed="skill-eval-baseline", token="stop-prod", db_path=active_db).stop()
+
+    assert active_db.read_text(encoding="utf-8") == "live"
+    assert wal_path.read_text(encoding="utf-8") == "wal"
+    assert shm_path.read_text(encoding="utf-8") == "shm"
+
+
 def test_sandbox_rejects_prod_path_and_accepts_temp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from brainlayer.paths import _CANONICAL_DB_PATH
     from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
@@ -92,6 +114,19 @@ def test_sandbox_rejects_active_noncanonical_db_path(tmp_path: Path, monkeypatch
         SandboxDB(seed="skill-eval-baseline", token="active-live", db_path=active_db).start()
 
 
+def test_sandbox_rejects_active_db_sidecar_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
+
+    active_db = tmp_path / "active-live" / "brainlayer.db"
+    monkeypatch.setenv("BRAINLAYER_DB", str(active_db))
+
+    for suffix in ("-wal", "-shm"):
+        with pytest.raises(SandboxProdLeakError):
+            SandboxDB(
+                seed="skill-eval-baseline", token=f"active-live{suffix}", db_path=Path(f"{active_db}{suffix}")
+            ).start()
+
+
 def test_sandbox_seed_is_retrievable_through_real_hybrid_search(monkeypatch: pytest.MonkeyPatch) -> None:
     from brainlayer.isolation_proof import _embed
     from brainlayer.sandbox_db import SandboxDB
@@ -113,6 +148,30 @@ def test_sandbox_seed_is_retrievable_through_real_hybrid_search(monkeypatch: pyt
 
         assert "skill-eval-baseline-003" in results["ids"][0]
         assert _binary_vector_count(sandbox.db_path) == len(sandbox.seeded_ids)
+
+
+def test_sandbox_stop_clears_hybrid_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.isolation_proof import _embed
+    from brainlayer.sandbox_db import SandboxDB
+    from brainlayer.search_repo import _hybrid_cache
+    from brainlayer.vector_store import VectorStore
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    sandbox = SandboxDB(seed="skill-eval-baseline", token="cache-clear").start()
+    store = VectorStore(sandbox.db_path, readonly=True)
+    try:
+        store.hybrid_search(
+            query_embedding=_embed("deterministic local embeddings"),
+            query_text="deterministic local embeddings",
+            n_results=5,
+        )
+    finally:
+        store.close()
+    assert any(key[0] == str(sandbox.db_path) for key in _hybrid_cache)
+
+    sandbox.stop()
+
+    assert not any(key[0] == str(sandbox.db_path) for key in _hybrid_cache)
 
 
 def test_sandbox_tokens_do_not_share_stored_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -167,6 +226,22 @@ def test_sandbox_start_refuses_existing_live_token(monkeypatch: pytest.MonkeyPat
         sandbox.stop()
 
 
+def test_sandbox_start_uses_token_lease(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB, sandbox_paths_for_token
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    sandbox = SandboxDB(seed="skill-eval-baseline", token="lease-token").start()
+    paths = sandbox_paths_for_token("lease-token")
+    try:
+        assert paths.lease_path.exists()
+        with pytest.raises(RuntimeError, match="already active"):
+            SandboxDB(seed="skill-eval-baseline", token="lease-token").start()
+    finally:
+        sandbox.stop()
+
+    assert not paths.lease_path.exists()
+
+
 def test_sandbox_start_refuses_double_start_and_restores_original_env(monkeypatch: pytest.MonkeyPatch) -> None:
     from brainlayer.sandbox_db import SandboxDB
 
@@ -181,6 +256,18 @@ def test_sandbox_start_refuses_double_start_and_restores_original_env(monkeypatc
         sandbox.stop()
 
     assert os.environ["BRAINLAYER_DB"] == original_db
+
+
+def test_stop_sandbox_clears_matching_env_pointer(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import start_sandbox, stop_sandbox
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    sandbox = start_sandbox(seed="skill-eval-baseline", token="stop-wrapper")
+    assert os.environ["BRAINLAYER_DB"] == str(sandbox.db_path)
+
+    stop_sandbox(token="stop-wrapper")
+
+    assert "BRAINLAYER_DB" not in os.environ
 
 
 def test_sandbox_seed_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_sandbox_db.py
+++ b/tests/test_sandbox_db.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _seed_rows(db_path: Path) -> list[tuple[str, str, str | None, str]]:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return conn.execute(
+            """
+            SELECT id, content, project, created_at
+            FROM chunks
+            WHERE source_file = 'sandbox-seed:skill-eval-baseline'
+            ORDER BY id
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _insert_sentinel(db_path: Path, sentinel: str) -> None:
+    from brainlayer.store import store_memory
+    from brainlayer.vector_store import VectorStore
+
+    store = VectorStore(db_path)
+    try:
+        store_memory(
+            store,
+            embed_fn=None,
+            content=sentinel,
+            memory_type="note",
+            project="sandbox-test",
+            chunk_id="sandbox-sentinel",
+            created_at="2026-06-24T00:00:00Z",
+        )
+    finally:
+        store.close()
+
+
+def _search_text(db_path: Path, query: str) -> list[str]:
+    from brainlayer.vector_store import VectorStore
+
+    store = VectorStore(db_path, readonly=True)
+    try:
+        results = store.search(query_text=query, n_results=10)
+        return list(results.get("documents", [[]])[0])
+    finally:
+        store.close()
+
+
+def test_sandbox_rejects_prod_path_and_accepts_temp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.paths import _CANONICAL_DB_PATH
+    from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+
+    with pytest.raises(SandboxProdLeakError):
+        SandboxDB(seed="skill-eval-baseline", token="prod", db_path=_CANONICAL_DB_PATH).start()
+
+    temp_db = tmp_path / "brainlayer.db"
+    sandbox = SandboxDB(seed="skill-eval-baseline", token="temp", db_path=temp_db).start()
+    try:
+        assert sandbox.db_path == temp_db
+        assert os.environ["BRAINLAYER_DB"] == str(temp_db)
+        assert temp_db.exists()
+    finally:
+        sandbox.stop()
+
+
+def test_sandbox_tokens_do_not_share_stored_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    sentinel = "sandbox anti cheat sentinel 1782331071313"
+
+    with SandboxDB(seed="skill-eval-baseline", token="anti-cheat-a") as sandbox_a:
+        _insert_sentinel(sandbox_a.db_path, sentinel)
+        assert _search_text(sandbox_a.db_path, sentinel)
+
+    with SandboxDB(seed="skill-eval-baseline", token="anti-cheat-b") as sandbox_b:
+        assert _search_text(sandbox_b.db_path, sentinel) == []
+
+
+def test_sandbox_cli_stop_removes_db_wal_shm_and_tempdir(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.cli import app
+    from brainlayer.sandbox_db import sandbox_paths_for_token
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    token = "teardown-token"
+    runner = CliRunner()
+
+    start = runner.invoke(app, ["sandbox", "start", "--seed", "skill-eval-baseline", "--token", token])
+    assert start.exit_code == 0, start.stdout
+    assert "export BRAINLAYER_DB=" in start.stdout
+
+    paths = sandbox_paths_for_token(token)
+    assert paths.db_path.exists()
+    paths.wal_path.touch()
+    paths.shm_path.touch()
+
+    stop = runner.invoke(app, ["sandbox", "stop", "--token", token])
+    assert stop.exit_code == 0, stop.stdout
+    assert not paths.db_path.exists()
+    assert not paths.wal_path.exists()
+    assert not paths.shm_path.exists()
+    assert not paths.temp_dir.exists()
+
+
+def test_sandbox_seed_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+
+    with SandboxDB(seed="skill-eval-baseline", token="determinism-a") as sandbox_a:
+        rows_a = _seed_rows(sandbox_a.db_path)
+
+    with SandboxDB(seed="skill-eval-baseline", token="determinism-b") as sandbox_b:
+        rows_b = _seed_rows(sandbox_b.db_path)
+
+    assert rows_a
+    assert rows_a == rows_b

--- a/tests/test_sandbox_db.py
+++ b/tests/test_sandbox_db.py
@@ -53,6 +53,16 @@ def _search_text(db_path: Path, query: str) -> list[str]:
         store.close()
 
 
+def _binary_vector_count(db_path: Path) -> int:
+    from brainlayer.vector_store import VectorStore
+
+    store = VectorStore(db_path, readonly=True)
+    try:
+        return int(store.conn.cursor().execute("SELECT COUNT(*) FROM chunk_vectors_binary").fetchone()[0])
+    finally:
+        store.close()
+
+
 def test_sandbox_rejects_prod_path_and_accepts_temp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from brainlayer.paths import _CANONICAL_DB_PATH
     from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
@@ -70,6 +80,39 @@ def test_sandbox_rejects_prod_path_and_accepts_temp_path(tmp_path: Path, monkeyp
         assert temp_db.exists()
     finally:
         sandbox.stop()
+
+
+def test_sandbox_rejects_active_noncanonical_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
+
+    active_db = tmp_path / "active-live" / "brainlayer.db"
+    monkeypatch.setenv("BRAINLAYER_DB", str(active_db))
+
+    with pytest.raises(SandboxProdLeakError):
+        SandboxDB(seed="skill-eval-baseline", token="active-live", db_path=active_db).start()
+
+
+def test_sandbox_seed_is_retrievable_through_real_hybrid_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.isolation_proof import _embed
+    from brainlayer.sandbox_db import SandboxDB
+    from brainlayer.vector_store import VectorStore
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    phrase = "deterministic local embeddings"
+
+    with SandboxDB(seed="skill-eval-baseline", token="seed-search") as sandbox:
+        store = VectorStore(sandbox.db_path, readonly=True)
+        try:
+            results = store.hybrid_search(
+                query_embedding=_embed(phrase),
+                query_text=phrase,
+                n_results=5,
+            )
+        finally:
+            store.close()
+
+        assert "skill-eval-baseline-003" in results["ids"][0]
+        assert _binary_vector_count(sandbox.db_path) == len(sandbox.seeded_ids)
 
 
 def test_sandbox_tokens_do_not_share_stored_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -109,6 +152,35 @@ def test_sandbox_cli_stop_removes_db_wal_shm_and_tempdir(monkeypatch: pytest.Mon
     assert not paths.wal_path.exists()
     assert not paths.shm_path.exists()
     assert not paths.temp_dir.exists()
+
+
+def test_sandbox_start_refuses_existing_live_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    sandbox = SandboxDB(seed="skill-eval-baseline", token="duplicate-token").start()
+    try:
+        with pytest.raises(RuntimeError, match="already exists"):
+            SandboxDB(seed="skill-eval-baseline", token="duplicate-token").start()
+        assert sandbox.db_path.exists()
+    finally:
+        sandbox.stop()
+
+
+def test_sandbox_start_refuses_double_start_and_restores_original_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB
+
+    original_db = "/tmp/brainlayer-original-env.db"
+    monkeypatch.setenv("BRAINLAYER_DB", original_db)
+
+    sandbox = SandboxDB(seed="skill-eval-baseline", token="double-start").start()
+    try:
+        with pytest.raises(RuntimeError, match="already started"):
+            sandbox.start()
+    finally:
+        sandbox.stop()
+
+    assert os.environ["BRAINLAYER_DB"] == original_db
 
 
 def test_sandbox_seed_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What
A per-eval **sandboxed** `brainlayer.db` so live skill-evals on real cmux agents (1) never leak into prod and (2) can't let the next agent cheat by reading a prior agent's stored answer. Cross-lead P0 blocker — skillCreatorClaude's live-eval track (T3/T9) is RED until this exists.

Contract: `orchestrator/collab/2026-06-24-sandboxed-test-brainlayer.md`.

## How
- `src/brainlayer/sandbox_db.py` — `SandboxDB` ctx manager + `SandboxProdLeakError`. Token-scoped throwaway DB under tempdir, `BRAINLAYER_DB` override (uses existing `paths.py` resolution), deterministic seed via `isolation_proof._embed` (no embedder process), full teardown (db+wal+shm+tempdir) with residue assertion.
- `brainlayer sandbox start --seed <name> --token <t>` prints an `export BRAINLAYER_DB=...` eval-block; `brainlayer sandbox stop --token <t>` tears down.
- `data/sandbox_seeds/skill-eval-baseline.json` — deterministic seed (does NOT contain answers agents must derive).

## Verification (LEAD-verified, two-sided / HELD)
`pytest tests/test_sandbox_db.py` → **4 passed**, `ruff` clean:
- **prod-guard**: pointing at canonical prod path raises `SandboxProdLeakError` (RED specimen = the gate's own threat); temp path accepted.
- **anti-cheat**: sentinel stored in token-A is found in A; in fresh token-B `search()` returns `[]` (zero hits — prior answer unreachable).
- **teardown**: CLI start prints export block; after stop, db/wal/shm/tempdir all absent.
- **determinism**: same `--seed` → identical seeded rows across tokens.

Purely additive (new module + typer sub-app + seed + .gitignore); no existing-logic changes.

## Merge governance
G1 (auto-merge) unresolved → treated as **Etan-reviewed**. LEAD-verified + CI/CodeRabbit pending. Not a UI artifact. Foundational cross-lead blocker — flagging for Etan's merge call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sandbox start/stop mutates process `BRAINLAYER_DB` and deletes temp DB files; guards reduce prod mis-pointing but concurrent sandboxes in one process are not fully serialized beyond token leases.
> 
> **Overview**
> Adds a **token-scoped sandbox BrainLayer database** for live skill evals so each run gets its own seeded SQLite DB under the system temp dir, with **`BRAINLAYER_DB` set for the process** and restored on teardown.
> 
> New **`sandbox_db`** module provides `SandboxDB`, seed loading from JSON under `data/sandbox_seeds/`, deterministic embeddings via `isolation_proof._embed`, **prod/active-DB guards** (`SandboxProdLeakError`), per-token **leases**, and teardown that removes db/wal/shm (and temp dir) with residue checks. CLI adds **`brainlayer sandbox start/stop`**, with start printing shell-ready `export BRAINLAYER_DB=...` lines. Initial seed **`skill-eval-baseline.json`** is tracked via `.gitignore` exceptions.
> 
> Coverage in **`tests/test_sandbox_db.py`** includes anti-cheat isolation between tokens, prod-path rejection, CLI teardown, hybrid search on seeds, and env restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c083ad4731952e302f3bd84509caca5343479bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sandboxed BrainLayer DB primitive with CLI commands and seed data
> - Introduces [`sandbox_db.py`](https://github.com/EtanHey/brainlayer/pull/541/files#diff-1faac7e06d6e4ab7d8d3a54efd890b30780dc4d2315183dcc687eae3903f13ce) with a `SandboxDB` context manager that creates isolated, token-scoped SQLite databases seeded from versioned JSON files, with automatic environment variable scoping and teardown.
> - Adds a `SandboxProdLeakError` guard that prevents sandbox operations from touching production or currently active DB paths (including WAL/SHM sidecars).
> - Exposes `brainlayer sandbox start` and `brainlayer sandbox stop` CLI commands that seed a sandbox DB and print shell-exportable `BRAINLAYER_DB` assignments.
> - Adds a [`skill-eval-baseline.json`](https://github.com/EtanHey/brainlayer/pull/541/files#diff-be032aa96e5578b34ad29745622519c725c06f238ab4a4642d19b3687e4ff31a) seed file with three memory records for baseline test scenarios.
> - Risk: `start_sandbox` deletes any existing DB/WAL/SHM files at the computed token path before seeding, and sets `BRAINLAYER_DB` in the process environment for the lifetime of the sandbox.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c083ad4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `sandbox` command group to the CLI for starting and stopping isolated sandbox environments.
  * Sandbox sessions now run with token-scoped temporary storage, deterministic seeded data, and automatic cleanup.
* **Bug Fixes**
  * Added stronger safety checks to prevent sandbox operations from pointing to production or active database locations.
  * Ensures sandboxed data can’t be accessed across different sandbox tokens.
* **Tests**
  * Added a comprehensive pytest suite covering isolation, lifecycle cleanup, determinism, caching behavior, and CLI lifecycle.
* **Chores**
  * Updated ignore rules to exclude local sandbox data and seed artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->