### PR TITLE
fix: make brain_store snappy under writer contention

### DIFF
--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -5,6 +5,7 @@ See search_repo.py, kg_repo.py, session_repo.py for the extracted methods.
 """
 
 import atexit
+import errno
 import fcntl
 import glob
 import hashlib
@@ -398,7 +399,15 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         if fd is None:
             return False
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                if not isinstance(exc, BlockingIOError) and exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                    raise
+                other_pid, _other_start_time = self._read_writer_pidfile_owner_fd(fd)
+                if other_pid is not None:
+                    raise WriterInUseError(f"another writer is using {self.db_path} (pid {other_pid})") from exc
+                raise WriterInUseError(f"writer pidfile is locked for {self.db_path}") from exc
             other_pid, other_start_time = self._read_writer_pidfile_owner_fd(fd)
             if other_pid == pid and self._pidfile_owner_matches(other_pid, other_start_time):
                 with self._PIDFILE_REFS_LOCK:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -404,9 +404,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             except OSError as exc:
                 if not isinstance(exc, BlockingIOError) and exc.errno not in {errno.EACCES, errno.EAGAIN}:
                     raise
-                other_pid, _other_start_time = self._read_writer_pidfile_owner_fd(fd)
-                if other_pid is not None:
+                other_pid, other_start_time, other_db_path = self._read_writer_pidfile_record_fd(fd)
+                if other_db_path is not None and not self._pidfile_db_path_matches(other_db_path):
+                    return False
+                if other_pid is not None and self._pidfile_owner_matches(other_pid, other_start_time):
                     raise WriterInUseError(f"another writer is using {self.db_path} (pid {other_pid})") from exc
+                if other_pid is not None:
+                    return False
                 raise WriterInUseError(f"writer pidfile is locked for {self.db_path}") from exc
             other_pid, other_start_time = self._read_writer_pidfile_owner_fd(fd)
             if other_pid == pid and self._pidfile_owner_matches(other_pid, other_start_time):

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import os
+import subprocess
 import sys
 import threading
 import time
@@ -9,6 +11,54 @@ from unittest.mock import MagicMock, patch
 
 import apsw
 import pytest
+
+
+def _locked_writer_pidfile_process(pidfile, db_path, *, lock_seconds: float = 0.45, live_seconds: float = 1.0):
+    script = """
+import fcntl
+import os
+import time
+from pathlib import Path
+
+pidfile = Path(os.environ["PIDFILE"])
+db_path = Path(os.environ["DB_PATH"]).resolve()
+pidfile.parent.mkdir(parents=True, exist_ok=True)
+fd = os.open(pidfile, os.O_CREAT | os.O_RDWR, 0o644)
+fcntl.flock(fd, fcntl.LOCK_EX)
+os.ftruncate(fd, 0)
+os.write(fd, f"{os.getpid()}\\ndb_path={db_path}\\n".encode("utf-8"))
+print("LOCKED", flush=True)
+time.sleep(float(os.environ["LOCK_SECONDS"]))
+fcntl.flock(fd, fcntl.LOCK_UN)
+print("UNLOCKED", flush=True)
+time.sleep(float(os.environ["LIVE_SECONDS"]))
+os.close(fd)
+"""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        env={
+            **os.environ,
+            "PIDFILE": str(pidfile),
+            "DB_PATH": str(db_path),
+            "LOCK_SECONDS": str(lock_seconds),
+            "LIVE_SECONDS": str(live_seconds),
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None
+    try:
+        assert proc.stdout.readline().strip() == "LOCKED"
+        return proc
+    except Exception:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate(timeout=2)
+        raise
 
 
 def test_default_store_busy_budget_is_sub_500ms(monkeypatch):
@@ -147,6 +197,102 @@ async def test_store_queues_fast_when_background_queue_is_present(tmp_path, monk
     assert structured["queued"] is True
     assert structured["deferred"]["reason"] == "INTERACTIVE_PRIORITY"
     assert structured["deferred"]["queue_path"] == str(queued_files[0])
+    assert any(structured["chunk_id"] in item.text for item in texts)
+
+
+@pytest.mark.asyncio
+async def test_store_queues_within_bound_when_writer_pidfile_is_locked(tmp_path, monkeypatch):
+    """A drain-held writer pidfile lock must not block interactive brain_store."""
+    from brainlayer.mcp import _shared
+    from brainlayer.mcp.store_handler import _store
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    pidfile_dir = tmp_path / "pidfiles"
+    probe = object.__new__(VectorStore)
+    probe.db_path = db_path
+
+    monkeypatch.setenv("BRAINLAYER_STORE_BUSY_BUDGET_MS", "80")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(_shared, "_vector_store", None)
+    monkeypatch.setattr("brainlayer.paths.get_db_path", lambda: db_path)
+
+    proc = _locked_writer_pidfile_process(probe._writer_pidfile_path(), db_path)
+    try:
+        started = time.perf_counter()
+        texts, structured = await _store(
+            content="interactive store must not wait for drain-held writer pidfile",
+            memory_type="note",
+            project="brainlayer",
+        )
+        elapsed = time.perf_counter() - started
+    finally:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate(timeout=2)
+
+    queued_files = list(queue_dir.glob("mcp-*.jsonl"))
+    assert elapsed < 0.25
+    assert structured["status"] == "DEFERRED"
+    assert structured["deferred"]["action"] == "queued_for_drain"
+    assert len(queued_files) == 1
+    assert any("DEFERRED" in item.text for item in texts)
+
+
+@pytest.mark.asyncio
+async def test_store_saves_normally_when_uncontended(tmp_path, monkeypatch):
+    """The snappy contention path must not turn ordinary brain_store calls into queue writes."""
+    from brainlayer.mcp import _shared
+    from brainlayer.mcp.store_handler import _store
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    started_threads = []
+
+    class NoopThread:
+        def __init__(self, *, target, daemon):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            started_threads.append(self)
+
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "pidfiles"))
+    monkeypatch.setattr(_shared, "_vector_store", None)
+    monkeypatch.setattr("brainlayer.paths.get_db_path", lambda: db_path)
+    monkeypatch.setattr("brainlayer.mcp.store_handler.threading.Thread", NoopThread)
+
+    try:
+        texts, structured = await _store(
+            content="uncontended brain_store should persist immediately",
+            memory_type="note",
+            project="brainlayer",
+        )
+
+        row = (
+            _shared._vector_store.conn.cursor()
+            .execute("SELECT id, content, project FROM chunks WHERE id = ?", (structured["chunk_id"],))
+            .fetchone()
+        )
+    finally:
+        if _shared._vector_store is not None:
+            _shared._vector_store.close()
+            _shared._vector_store = None
+
+    assert row == (
+        structured["chunk_id"],
+        "uncontended brain_store should persist immediately",
+        "brainlayer",
+    )
+    assert "queued" not in structured
+    assert not list(queue_dir.glob("*.jsonl"))
+    assert len(started_threads) == 1
     assert any(structured["chunk_id"] in item.text for item in texts)
 
 

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -557,6 +557,22 @@ def test_stale_pidfile_unlink_missing_race_is_ignored(tmp_path, monkeypatch):
     assert store._handle_existing_writer_pidfile(pidfile, os.getpid()) is False
 
 
+def test_locked_stale_pidfile_is_retryable_not_active_writer(tmp_path, monkeypatch):
+    pidfile = tmp_path / "writer.pid"
+    pidfile.write_text("999999\nstart_time=stale-start\n", encoding="utf-8")
+    store = object.__new__(VectorStore)
+    store.db_path = tmp_path / "writer.db"
+    monkeypatch.setattr(store, "_pid_is_alive", lambda _pid: False)
+
+    def locked_flock(_fd: int, operation: int) -> None:
+        if operation == (fcntl.LOCK_EX | fcntl.LOCK_NB):
+            raise BlockingIOError
+
+    monkeypatch.setattr(fcntl, "flock", locked_flock)
+
+    assert store._handle_existing_writer_pidfile(pidfile, os.getpid()) is False
+
+
 def test_pidfile_removed_on_close(tmp_path, monkeypatch):
     pidfile_dir = tmp_path / "pidfiles"
     db_path = tmp_path / "writer.db"


### PR DESCRIPTION
## Summary
- Make writer pidfile arbitration non-blocking so a drain-held writer lock raises `WriterInUseError` immediately instead of blocking `brain_store` before its busy budget can apply.
- Preserve the existing MCP fallback path: under live writer contention, `brain_store` durably queues and returns `DEFERRED` quickly; when uncontended, it still saves immediately.
- Add a two-sided timing gate covering both contended deferred behavior and the uncontended happy path.
- Addressed Codex/Macroscope review finding: a locked stale pidfile is now retryable and is not treated as active contention unless the recorded owner passes the liveness/start-time check.

## RED
- New contention test failed on the previous code by blocking past the bound:
  - `assert 0.4543372499756515 < 0.25`

## GREEN / Verification
- `pytest tests/test_store_handler.py::test_store_queues_within_bound_when_writer_pidfile_is_locked tests/test_store_handler.py::test_store_saves_normally_when_uncontended -q`
  - `2 passed in 1.46s`
- `pytest tests/test_writer_pidfile_mutex.py -q`
  - `34 passed in 2.05s`
- `pytest tests/test_mcp_timeout.py tests/test_brainstore.py tests/test_store_handler.py -q`
  - `55 passed in 4.95s`
- `ruff check src/brainlayer/vector_store.py tests/test_store_handler.py tests/test_writer_pidfile_mutex.py`
  - `All checks passed!`
- `git diff --check`
  - clean
- Full suite in isolated Python 3.12 env:
  - `/tmp/brainlayer-snappy-venv/bin/pytest -q`
  - `3179 passed, 49 skipped, 5 xfailed, 105 warnings in 357.11s (0:05:57)`
- Repo pre-push hook:
  - unit subset: `3076 passed, 9 skipped, 61 deselected, 1 xfailed, 103 warnings in 264.28s`
  - MCP tool registration: `3 passed`
  - isolated eval/hook routing: `40 passed`
  - Bun suite: `1 pass`
  - regression shell `test_fts5_determinism.sh`: pass
- GitHub checks on `e5b647d`:
  - `lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`: pass
  - `Cursor Bugbot`, `Macroscope - Correctness Check`, `CodeRabbit`: pass

## Notes
- Local global `pytest -q` in the original repo environment is blocked by environment drift: `Numba needs NumPy 2.3 or less. Got NumPy 2.4.` I used an isolated Python 3.12 env installed from `.[dev]` for full-suite evidence.
- Existing real stdio MCP smoke was attempted. A 15s run timed out during cold startup; a 60s run reached shutdown with `anyio.BrokenResourceError`. I am not using that smoke as green evidence.
- CodeRabbit cloud hit a rate-limit comment, but its PR status check is passing. Local `coderabbit review --agent` initially found a test-helper process leak; that was fixed before the final push.
