### PR TITLE
feat: sandbox DB PID-lease + active-DB guard hardening (follow-up to #541)

### DIFF
--- a/src/brainlayer/sandbox_db.py
+++ b/src/brainlayer/sandbox_db.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -69,16 +70,6 @@ def _resolved(path: Path) -> Path:
     return path.expanduser().resolve(strict=False)
 
 
-def _is_managed_sandbox_db_path(path: Path) -> bool:
-    resolved = _resolved(path)
-    temp_root = _resolved(Path(tempfile.gettempdir()))
-    return (
-        resolved.name == "brainlayer.db"
-        and resolved.parent.name.startswith("bl-sandbox-")
-        and resolved.parent.parent == temp_root
-    )
-
-
 def _protected_db_residue_paths(db_path: Path) -> set[Path]:
     resolved_db = _resolved(db_path)
     return {
@@ -108,7 +99,7 @@ def _assert_not_prod_path(
     for protected_db in protected_paths:
         if protected_db is None:
             continue
-        if resolved_db in _protected_db_residue_paths(protected_db) and not _is_managed_sandbox_db_path(resolved_db):
+        if resolved_db in _protected_db_residue_paths(protected_db):
             raise SandboxProdLeakError(f"sandbox db path resolves to active BrainLayer DB: {resolved_db}")
 
 
@@ -125,6 +116,29 @@ def _load_seed(seed: str) -> list[dict[str, Any]]:
     if not isinstance(payload, list):
         raise ValueError(f"sandbox seed must be a list: {seed}")
     return [dict(item) for item in payload]
+
+
+def _pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _read_lease_owner_pid(path: Path) -> int | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    try:
+        return int(payload["pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def _seed_chunk_payload(*, seed: str, row: dict[str, Any]) -> dict[str, Any]:
@@ -164,11 +178,13 @@ def seed_sandbox_db(db_path: str | Path, seed: str) -> list[str]:
     try:
         chunks = [_seed_chunk_payload(seed=seed, row=row) for row in rows]
         embeddings = [_embed(chunk["content"]) for chunk in chunks]
-        store.upsert_chunks(chunks, embeddings)
+        processed = store.upsert_chunks(chunks, embeddings)
+        if processed != len(chunks):
+            raise RuntimeError(f"seed {seed!r} inserted {processed}/{len(chunks)} chunks")
     finally:
         store.close()
     clear_hybrid_search_cache(path)
-    return [str(row["id"]) for row in rows]
+    return [str(chunk["id"]) for chunk in chunks]
 
 
 class SandboxDB:
@@ -188,12 +204,15 @@ class SandboxDB:
         self.env = {"BRAINLAYER_DB": str(self.db_path)}
         self.seeded_ids: list[str] = []
         self._protected_db_path = _resolved(brain_paths.get_db_path())
+        self._patched_default_paths: list[tuple[object, str, Any]] = []
         self._old_env: str | None = None
         self._started = False
         self._lease_acquired = False
 
     def __enter__(self) -> SandboxDB:
-        return self.start()
+        self.start()
+        self._patch_default_db_paths()
+        return self
 
     def __exit__(
         self,
@@ -220,10 +239,36 @@ class SandboxDB:
         finally:
             self._lease_acquired = False
 
+    def _patch_default_db_paths(self) -> None:
+        self._patched_default_paths = []
+        old_path = self._protected_db_path
+        new_path = Path(self.db_path)
+        for module in list(sys.modules.values()):
+            if module is None or not getattr(module, "__name__", "").startswith("brainlayer"):
+                continue
+            if getattr(module, "DEFAULT_DB_PATH", None) != old_path:
+                continue
+            self._patched_default_paths.append((module, "DEFAULT_DB_PATH", old_path))
+            setattr(module, "DEFAULT_DB_PATH", new_path)
+
+    def _restore_default_db_paths(self) -> None:
+        for module, attr, value in reversed(self._patched_default_paths):
+            setattr(module, attr, value)
+        self._patched_default_paths = []
+
+    def _validate_owned_stop_lease(self) -> bool:
+        if not self._owns_temp_dir:
+            return self._started
+        if self._started:
+            return True
+        owner_pid = _read_lease_owner_pid(self.paths.lease_path)
+        if owner_pid is not None and owner_pid != os.getpid() and _pid_is_running(owner_pid):
+            raise RuntimeError(f"sandbox token is active in another process: {self.token}")
+        return True
+
     def start(self) -> SandboxDB:
         if self._started:
             raise RuntimeError("sandbox already started")
-        _assert_not_prod_path(self.db_path, protected_db_path=self._protected_db_path)
         if self._owns_temp_dir and self.paths.temp_dir.exists():
             if self.paths.lease_path.exists():
                 raise RuntimeError(f"sandbox token already exists and is already active: {self.token}")
@@ -231,6 +276,11 @@ class SandboxDB:
                 raise RuntimeError(f"sandbox token already exists with live DB: {self.token}")
             if any(self.paths.temp_dir.iterdir()):
                 raise RuntimeError(f"sandbox token already exists with residue: {self.token}")
+        _assert_not_prod_path(self.db_path, protected_db_path=self._protected_db_path)
+        if not self._owns_temp_dir and any(
+            path.exists() for path in (self.paths.db_path, self.paths.wal_path, self.paths.shm_path)
+        ):
+            raise RuntimeError(f"sandbox db path already exists with live DB: {self.db_path}")
         self.paths.temp_dir.mkdir(parents=True, exist_ok=True)
         self._acquire_lease()
         try:
@@ -246,10 +296,13 @@ class SandboxDB:
         return self
 
     def stop(self) -> None:
-        ignore_current_active_db = self._started and _resolved(brain_paths.get_db_path()) == _resolved(self.db_path)
+        lease_allows_token_stop = self._validate_owned_stop_lease()
+        ignore_current_active_db = lease_allows_token_stop and _resolved(brain_paths.get_db_path()) == _resolved(
+            self.db_path
+        )
         _assert_not_prod_path(
             self.db_path,
-            protected_db_path=self._protected_db_path,
+            protected_db_path=None if ignore_current_active_db else self._protected_db_path,
             ignore_current_active_db=ignore_current_active_db,
         )
         clear_hybrid_search_cache(self.db_path)
@@ -291,6 +344,7 @@ class SandboxDB:
             else:
                 os.environ["BRAINLAYER_DB"] = self._old_env
             self._started = False
+            self._restore_default_db_paths()
         elif os.environ.get("BRAINLAYER_DB") == str(self.db_path):
             os.environ.pop("BRAINLAYER_DB", None)
 

--- a/tests/test_sandbox_db.py
+++ b/tests/test_sandbox_db.py
@@ -114,6 +114,16 @@ def test_sandbox_rejects_active_noncanonical_db_path(tmp_path: Path, monkeypatch
         SandboxDB(seed="skill-eval-baseline", token="active-live", db_path=active_db).start()
 
 
+def test_sandbox_rejects_active_managed_sandbox_db_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    with SandboxDB(seed="skill-eval-baseline", token="active-managed") as active:
+        with pytest.raises(SandboxProdLeakError):
+            SandboxDB(seed="skill-eval-baseline", token="active-managed-explicit", db_path=active.db_path).start()
+        assert active.db_path.exists()
+
+
 def test_sandbox_rejects_active_db_sidecar_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from brainlayer.sandbox_db import SandboxDB, SandboxProdLeakError
 
@@ -158,18 +168,19 @@ def test_sandbox_stop_clears_hybrid_cache(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.delenv("BRAINLAYER_DB", raising=False)
     sandbox = SandboxDB(seed="skill-eval-baseline", token="cache-clear").start()
-    store = VectorStore(sandbox.db_path, readonly=True)
     try:
-        store.hybrid_search(
-            query_embedding=_embed("deterministic local embeddings"),
-            query_text="deterministic local embeddings",
-            n_results=5,
-        )
+        store = VectorStore(sandbox.db_path, readonly=True)
+        try:
+            store.hybrid_search(
+                query_embedding=_embed("deterministic local embeddings"),
+                query_text="deterministic local embeddings",
+                n_results=5,
+            )
+        finally:
+            store.close()
+        assert any(key[0] == str(sandbox.db_path) for key in _hybrid_cache)
     finally:
-        store.close()
-    assert any(key[0] == str(sandbox.db_path) for key in _hybrid_cache)
-
-    sandbox.stop()
+        sandbox.stop()
 
     assert not any(key[0] == str(sandbox.db_path) for key in _hybrid_cache)
 
@@ -226,6 +237,19 @@ def test_sandbox_start_refuses_existing_live_token(monkeypatch: pytest.MonkeyPat
         sandbox.stop()
 
 
+def test_sandbox_start_refuses_existing_explicit_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    db_path = tmp_path / "brainlayer.db"
+    db_path.write_text("live", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="already exists with live DB"):
+        SandboxDB(seed="skill-eval-baseline", token="explicit-existing", db_path=db_path).start()
+
+    assert db_path.read_text(encoding="utf-8") == "live"
+
+
 def test_sandbox_start_uses_token_lease(monkeypatch: pytest.MonkeyPatch) -> None:
     from brainlayer.sandbox_db import SandboxDB, sandbox_paths_for_token
 
@@ -240,6 +264,27 @@ def test_sandbox_start_uses_token_lease(monkeypatch: pytest.MonkeyPatch) -> None
         sandbox.stop()
 
     assert not paths.lease_path.exists()
+
+
+def test_sandbox_stop_refuses_other_live_lease(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer.sandbox_db import SandboxDB, sandbox_paths_for_token
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    token = "other-live-lease"
+    paths = sandbox_paths_for_token(token)
+    paths.temp_dir.mkdir(parents=True, exist_ok=True)
+    paths.db_path.write_text("live", encoding="utf-8")
+    paths.lease_path.write_text('{"pid": 424242, "token": "other-live-lease"}\n', encoding="utf-8")
+    monkeypatch.setattr("brainlayer.sandbox_db._pid_is_running", lambda pid: pid == 424242)
+
+    with pytest.raises(RuntimeError, match="active in another process"):
+        SandboxDB(seed="skill-eval-baseline", token=token).stop()
+
+    assert paths.db_path.exists()
+    assert paths.lease_path.exists()
+    paths.lease_path.unlink()
+    paths.db_path.unlink()
+    paths.temp_dir.rmdir()
 
 
 def test_sandbox_start_refuses_double_start_and_restores_original_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -258,6 +303,19 @@ def test_sandbox_start_refuses_double_start_and_restores_original_env(monkeypatc
     assert os.environ["BRAINLAYER_DB"] == original_db
 
 
+def test_sandbox_patches_cached_default_db_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer import paths as brain_paths
+    from brainlayer.sandbox_db import SandboxDB
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    original_default = brain_paths.DEFAULT_DB_PATH
+
+    with SandboxDB(seed="skill-eval-baseline", token="default-path") as sandbox:
+        assert brain_paths.DEFAULT_DB_PATH == sandbox.db_path
+
+    assert brain_paths.DEFAULT_DB_PATH == original_default
+
+
 def test_stop_sandbox_clears_matching_env_pointer(monkeypatch: pytest.MonkeyPatch) -> None:
     from brainlayer.sandbox_db import start_sandbox, stop_sandbox
 
@@ -268,6 +326,26 @@ def test_stop_sandbox_clears_matching_env_pointer(monkeypatch: pytest.MonkeyPatc
     stop_sandbox(token="stop-wrapper")
 
     assert "BRAINLAYER_DB" not in os.environ
+
+
+def test_seed_sandbox_db_fails_when_upsert_skips_rows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from brainlayer import sandbox_db
+
+    class PartialStore:
+        def __init__(self, _path: Path) -> None:
+            pass
+
+        def upsert_chunks(self, chunks, embeddings):  # noqa: ANN001
+            return len(chunks) - 1
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    monkeypatch.setattr(sandbox_db, "VectorStore", PartialStore)
+
+    with pytest.raises(RuntimeError, match="inserted 2/3 chunks"):
+        sandbox_db.seed_sandbox_db(tmp_path / "brainlayer.db", "skill-eval-baseline")
 
 
 def test_sandbox_seed_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Follow-up to #541 (merged at c083ad4 via a merge-race before this hardening commit landed). Adds verified hardening that was already reviewed + pushed: PID-based lease ownership (_validate_owned_stop_lease / _read_lease_owner_pid / _pid_is_running) so one process can't tear down another's sandbox, protected-db residue guards, seed-count validation (raises if not all chunks inserted), and DEFAULT_DB_PATH test-isolation patching. +159/-27, tests grew (no test deletions). CI must be green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch production-leak guards and cross-process teardown behavior for eval sandboxes; mistakes could block legitimate teardown or still leak paths, but scope is limited to sandbox/eval isolation code with expanded tests.
> 
> **Overview**
> **Sandbox DB isolation** is tightened for live evals: production/active DB residue checks no longer exempt managed temp sandbox paths, so opening a second sandbox on an already-active sandbox DB path raises `SandboxProdLeakError`.
> 
> **Lifecycle safety** adds PID-based lease ownership on `stop()` (refuse teardown when another live process holds the token lease), stricter start rules for explicit DB paths that already have live DB/WAL/SHM files, and `seed_sandbox_db` fails fast if `upsert_chunks` does not insert every seeded chunk.
> 
> While a sandbox context is active, loaded `brainlayer` modules whose `DEFAULT_DB_PATH` still pointed at the real default are temporarily repointed to the sandbox DB and restored on teardown, alongside existing `BRAINLAYER_DB` env handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da22a2d11c25649e1fe5b6d84149069adfc7902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `SandboxDB` with PID-lease validation and `DEFAULT_DB_PATH` patching
> - `SandboxDB.stop()` now reads the lease file and refuses to tear down a sandbox owned by another live process, using a new `_pid_is_running` helper.
> - `SandboxDB.start()` raises `RuntimeError` if explicit `db_path` already exists with live DB or sidecar files (`.wal`, `.shm`).
> - `SandboxDB.__enter__` patches `DEFAULT_DB_PATH` in all loaded `brainlayer*` modules to point at the sandbox DB; `__exit__` restores the originals via `_restore_default_db_paths`.
> - `_assert_not_prod_path` now raises `SandboxProdLeakError` unconditionally when the path resolves to the active DB or its sidecars, removing the previous exception for managed sandbox paths.
> - `seed_sandbox_db` raises `RuntimeError` if the number of chunks reported by `VectorStore.upsert_chunks` is less than expected.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7da22a2. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox database safety by preventing accidental reuse of active or existing database paths.
  * Ensured sandbox context setup and teardown correctly switch to the sandbox database and restore the original path afterward.
  * Added stricter seeding checks so partial database writes are detected and reported.

* **Tests**
  * Expanded coverage for sandbox lifecycle, path isolation, and seeding error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->