### PR TITLE
fix: add drain liveness loud-fail probe

### DIFF
--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -19,6 +19,7 @@ from typing import Any, Callable
 from .drain_liveness import (
     DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
     ENRICH_DAILY_COST_COUNTER_FILENAME,
+    STALLED_CODE,
     check_drain_liveness,
 )
 from .health_check import (
@@ -328,7 +329,7 @@ def run_doctor(
     except Exception as exc:
         fatal("enrichment_backlog_failed", f"could not count enrichment backlog: {exc}")
 
-    drain_loaded: bool | None = True if not config.drain_label else None
+    drain_loaded: bool | None = None
     for label, code, message in (
         (config.enrichment_label, "enrichment_unloaded", "enrichment launchd label is not loaded"),
         (config.hotlane_label, "hotlane_unloaded", "hot-lane launchd label is not loaded"),
@@ -366,7 +367,7 @@ def run_doctor(
     # Drain should publish heartbeat cycles even while the durable queue is empty.
     # Stale drain health plus enrichment backlog is the loaded-but-dead case that
     # the generic loaded-but-idle warning cannot distinguish from quota throttling.
-    drain_liveness_issue = check_drain_liveness(
+    pending_drain_liveness_issue = check_drain_liveness(
         drain_label=config.drain_label,
         drain_loaded=drain_loaded,
         queue_count=queue_count,
@@ -376,15 +377,6 @@ def run_doctor(
         stale_seconds=config.drain_liveness_stale_seconds,
         enrich_cost_counter_path=config.db_path.expanduser().parent / ENRICH_DAILY_COST_COUNTER_FILENAME,
     )
-    if drain_liveness_issue is not None:
-        result.issues.append(
-            DoctorIssue(
-                drain_liveness_issue.code,
-                drain_liveness_issue.severity,
-                drain_liveness_issue.message,
-                drain_liveness_issue.details,
-            )
-        )
     drain_total = drain_health.get("drained_total")
     watcher_poll_count = watcher_health.get("poll_count")
     drain_moving = queue_count == 0
@@ -398,6 +390,17 @@ def run_doctor(
         drain_total = next_drain_health.get("drained_total", drain_total)
         watcher_poll_count = next_watcher_health.get("poll_count", watcher_poll_count)
     queue_moving = drain_moving or watcher_moving
+    if pending_drain_liveness_issue is not None:
+        suppress_stale_drain = pending_drain_liveness_issue.code == STALLED_CODE and queue_count > 0 and drain_moving
+        if not suppress_stale_drain:
+            result.issues.append(
+                DoctorIssue(
+                    pending_drain_liveness_issue.code,
+                    pending_drain_liveness_issue.severity,
+                    pending_drain_liveness_issue.message,
+                    pending_drain_liveness_issue.details,
+                )
+            )
     if queue_count > 0 and not queue_moving:
         fatal(
             "queue_not_moving_with_backlog",

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -381,6 +381,7 @@ def run_doctor(
     drain_cycles = drain_health.get("drain_cycles")
     watcher_poll_count = watcher_health.get("poll_count")
     drain_moving = queue_count == 0
+    drain_liveness_moving = queue_count == 0
     watcher_moving = queue_count == 0
     sampled_drain_liveness_issue = pending_drain_liveness_issue
     if queue_count > 0:
@@ -389,10 +390,8 @@ def run_doctor(
         next_watcher_health = _load_json(config.watcher_health_path)
         next_drain_total = next_drain_health.get("drained_total")
         next_drain_cycles = next_drain_health.get("drain_cycles")
-        drain_moving = _counter_increased(drain_total, next_drain_total) or _counter_increased(
-            drain_cycles,
-            next_drain_cycles,
-        )
+        drain_moving = _counter_increased(drain_total, next_drain_total)
+        drain_liveness_moving = drain_moving or _counter_increased(drain_cycles, next_drain_cycles)
         watcher_moving = _counter_increased(watcher_poll_count, next_watcher_health.get("poll_count"))
         drain_total = next_drain_health.get("drained_total", drain_total)
         drain_cycles = next_drain_health.get("drain_cycles", drain_cycles)
@@ -403,24 +402,23 @@ def run_doctor(
             queue_count=queue_count,
             enrichment_backlog=result.enrichment_backlog,
             drain_health=next_drain_health,
-            now=now,
+            now=now_fn(),
             stale_seconds=config.drain_liveness_stale_seconds,
             enrich_cost_counter_path=config.db_path.expanduser().parent / ENRICH_DAILY_COST_COUNTER_FILENAME,
         )
     queue_moving = drain_moving or watcher_moving
-    if pending_drain_liveness_issue is not None:
+    active_drain_liveness_issue = sampled_drain_liveness_issue if queue_count > 0 else pending_drain_liveness_issue
+    if active_drain_liveness_issue is not None:
         suppress_stale_drain = (
-            pending_drain_liveness_issue.code == STALLED_CODE
-            and queue_count > 0
-            and (drain_moving or sampled_drain_liveness_issue is None)
+            active_drain_liveness_issue.code == STALLED_CODE and queue_count > 0 and drain_liveness_moving
         )
         if not suppress_stale_drain:
             result.issues.append(
                 DoctorIssue(
-                    pending_drain_liveness_issue.code,
-                    pending_drain_liveness_issue.severity,
-                    pending_drain_liveness_issue.message,
-                    pending_drain_liveness_issue.details,
+                    active_drain_liveness_issue.code,
+                    active_drain_liveness_issue.severity,
+                    active_drain_liveness_issue.message,
+                    active_drain_liveness_issue.details,
                 )
             )
     if queue_count > 0 and not queue_moving:

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -380,22 +380,25 @@ def run_doctor(
     drain_total = drain_health.get("drained_total")
     drain_cycles = drain_health.get("drain_cycles")
     watcher_poll_count = watcher_health.get("poll_count")
+    has_drain_backlog = queue_count > 0 or bool(result.enrichment_backlog and result.enrichment_backlog > 0)
     drain_moving = queue_count == 0
-    drain_liveness_moving = queue_count == 0
+    drain_liveness_moving = not has_drain_backlog
     watcher_moving = queue_count == 0
     sampled_drain_liveness_issue = pending_drain_liveness_issue
-    if queue_count > 0:
+    if has_drain_backlog:
         time.sleep(max(0.0, config.queue_movement_sample_seconds))
         next_drain_health = _load_json(config.drain_health_path)
-        next_watcher_health = _load_json(config.watcher_health_path)
         next_drain_total = next_drain_health.get("drained_total")
         next_drain_cycles = next_drain_health.get("drain_cycles")
-        drain_moving = _counter_increased(drain_total, next_drain_total)
-        drain_liveness_moving = drain_moving or _counter_increased(drain_cycles, next_drain_cycles)
-        watcher_moving = _counter_increased(watcher_poll_count, next_watcher_health.get("poll_count"))
+        drain_total_moving = _counter_increased(drain_total, next_drain_total)
+        drain_moving = queue_count == 0 or drain_total_moving
+        drain_liveness_moving = drain_total_moving or _counter_increased(drain_cycles, next_drain_cycles)
         drain_total = next_drain_health.get("drained_total", drain_total)
         drain_cycles = next_drain_health.get("drain_cycles", drain_cycles)
-        watcher_poll_count = next_watcher_health.get("poll_count", watcher_poll_count)
+        if queue_count > 0:
+            next_watcher_health = _load_json(config.watcher_health_path)
+            watcher_moving = _counter_increased(watcher_poll_count, next_watcher_health.get("poll_count"))
+            watcher_poll_count = next_watcher_health.get("poll_count", watcher_poll_count)
         sampled_drain_liveness_issue = check_drain_liveness(
             drain_label=config.drain_label,
             drain_loaded=drain_loaded,
@@ -407,10 +410,10 @@ def run_doctor(
             enrich_cost_counter_path=config.db_path.expanduser().parent / ENRICH_DAILY_COST_COUNTER_FILENAME,
         )
     queue_moving = drain_moving or watcher_moving
-    active_drain_liveness_issue = sampled_drain_liveness_issue if queue_count > 0 else pending_drain_liveness_issue
+    active_drain_liveness_issue = sampled_drain_liveness_issue if has_drain_backlog else pending_drain_liveness_issue
     if active_drain_liveness_issue is not None:
         suppress_stale_drain = (
-            active_drain_liveness_issue.code == STALLED_CODE and queue_count > 0 and drain_liveness_moving
+            active_drain_liveness_issue.code == STALLED_CODE and has_drain_backlog and drain_liveness_moving
         )
         if not suppress_stale_drain:
             result.issues.append(

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -16,7 +16,11 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
-from .drain_liveness import DEFAULT_DRAIN_LIVENESS_STALE_SECONDS, check_drain_liveness
+from .drain_liveness import (
+    DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
+    ENRICH_DAILY_COST_COUNTER_FILENAME,
+    check_drain_liveness,
+)
 from .health_check import (
     DEFAULT_DRAIN_LABEL,
     DEFAULT_ENRICHMENT_LABEL,
@@ -365,10 +369,12 @@ def run_doctor(
     drain_liveness_issue = check_drain_liveness(
         drain_label=config.drain_label,
         drain_loaded=drain_loaded,
-        backlog_count=queue_count + (result.enrichment_backlog or 0),
+        queue_count=queue_count,
+        enrichment_backlog=result.enrichment_backlog,
         drain_health=drain_health,
         now=now,
         stale_seconds=config.drain_liveness_stale_seconds,
+        enrich_cost_counter_path=config.db_path.expanduser().parent / ENRICH_DAILY_COST_COUNTER_FILENAME,
     )
     if drain_liveness_issue is not None:
         result.issues.append(

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
+from .drain_liveness import DEFAULT_DRAIN_LIVENESS_STALE_SECONDS, check_drain_liveness
 from .health_check import (
     DEFAULT_DRAIN_LABEL,
     DEFAULT_ENRICHMENT_LABEL,
@@ -67,6 +68,7 @@ class DoctorConfig:
     roundtrip_timeout_seconds: float = DEFAULT_ROUNDTRIP_TIMEOUT_SECONDS
     queue_warning_count: int = DEFAULT_QUEUE_WARNING_COUNT
     queue_movement_sample_seconds: float = DEFAULT_QUEUE_MOVEMENT_SAMPLE_SECONDS
+    drain_liveness_stale_seconds: float = DEFAULT_DRAIN_LIVENESS_STALE_SECONDS
 
 
 @dataclass
@@ -322,6 +324,7 @@ def run_doctor(
     except Exception as exc:
         fatal("enrichment_backlog_failed", f"could not count enrichment backlog: {exc}")
 
+    drain_loaded: bool | None = True if not config.drain_label else None
     for label, code, message in (
         (config.enrichment_label, "enrichment_unloaded", "enrichment launchd label is not loaded"),
         (config.hotlane_label, "hotlane_unloaded", "hot-lane launchd label is not loaded"),
@@ -329,7 +332,15 @@ def run_doctor(
         (config.drain_label, "drain_unloaded", "drain launchd label is not loaded"),
     ):
         if label:
-            _check_launchd(result, label=label, issue_code=code, message=message, command_runner=command_runner)
+            loaded = _check_launchd(
+                result,
+                label=label,
+                issue_code=code,
+                message=message,
+                command_runner=command_runner,
+            )
+            if code == "drain_unloaded":
+                drain_loaded = loaded
 
     hotlane_processes = parse_hotlane_processes(ps_output_fn())
     result.hotlane_running = bool(hotlane_processes)
@@ -348,6 +359,26 @@ def run_doctor(
     result.queue_bytes = queue_bytes
     drain_health = _load_json(config.drain_health_path)
     watcher_health = _load_json(config.watcher_health_path)
+    # Drain should publish heartbeat cycles even while the durable queue is empty.
+    # Stale drain health plus enrichment backlog is the loaded-but-dead case that
+    # the generic loaded-but-idle warning cannot distinguish from quota throttling.
+    drain_liveness_issue = check_drain_liveness(
+        drain_label=config.drain_label,
+        drain_loaded=drain_loaded,
+        backlog_count=queue_count + (result.enrichment_backlog or 0),
+        drain_health=drain_health,
+        now=now,
+        stale_seconds=config.drain_liveness_stale_seconds,
+    )
+    if drain_liveness_issue is not None:
+        result.issues.append(
+            DoctorIssue(
+                drain_liveness_issue.code,
+                drain_liveness_issue.severity,
+                drain_liveness_issue.message,
+                drain_liveness_issue.details,
+            )
+        )
     drain_total = drain_health.get("drained_total")
     watcher_poll_count = watcher_health.get("poll_count")
     drain_moving = queue_count == 0

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -378,20 +378,42 @@ def run_doctor(
         enrich_cost_counter_path=config.db_path.expanduser().parent / ENRICH_DAILY_COST_COUNTER_FILENAME,
     )
     drain_total = drain_health.get("drained_total")
+    drain_cycles = drain_health.get("drain_cycles")
     watcher_poll_count = watcher_health.get("poll_count")
     drain_moving = queue_count == 0
     watcher_moving = queue_count == 0
+    sampled_drain_liveness_issue = pending_drain_liveness_issue
     if queue_count > 0:
         time.sleep(max(0.0, config.queue_movement_sample_seconds))
         next_drain_health = _load_json(config.drain_health_path)
         next_watcher_health = _load_json(config.watcher_health_path)
-        drain_moving = _counter_increased(drain_total, next_drain_health.get("drained_total"))
+        next_drain_total = next_drain_health.get("drained_total")
+        next_drain_cycles = next_drain_health.get("drain_cycles")
+        drain_moving = _counter_increased(drain_total, next_drain_total) or _counter_increased(
+            drain_cycles,
+            next_drain_cycles,
+        )
         watcher_moving = _counter_increased(watcher_poll_count, next_watcher_health.get("poll_count"))
         drain_total = next_drain_health.get("drained_total", drain_total)
+        drain_cycles = next_drain_health.get("drain_cycles", drain_cycles)
         watcher_poll_count = next_watcher_health.get("poll_count", watcher_poll_count)
+        sampled_drain_liveness_issue = check_drain_liveness(
+            drain_label=config.drain_label,
+            drain_loaded=drain_loaded,
+            queue_count=queue_count,
+            enrichment_backlog=result.enrichment_backlog,
+            drain_health=next_drain_health,
+            now=now,
+            stale_seconds=config.drain_liveness_stale_seconds,
+            enrich_cost_counter_path=config.db_path.expanduser().parent / ENRICH_DAILY_COST_COUNTER_FILENAME,
+        )
     queue_moving = drain_moving or watcher_moving
     if pending_drain_liveness_issue is not None:
-        suppress_stale_drain = pending_drain_liveness_issue.code == STALLED_CODE and queue_count > 0 and drain_moving
+        suppress_stale_drain = (
+            pending_drain_liveness_issue.code == STALLED_CODE
+            and queue_count > 0
+            and (drain_moving or sampled_drain_liveness_issue is None)
+        )
         if not suppress_stale_drain:
             result.issues.append(
                 DoctorIssue(

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -98,7 +98,10 @@ def _daily_cap_blocker(now: datetime, *, enrich_cost_counter_path: Path | None =
         cap_usd = _enrich_daily_usd_cap()
         today = now.astimezone().date().isoformat()
         record = _read_enrich_cost_record(_enrich_cost_counter_path(enrich_cost_counter_path), today)
-        spent_usd = float(record.get("spent_usd", 0.0) or 0.0)
+        try:
+            spent_usd = float(record.get("spent_usd", 0.0) or 0.0)
+        except (TypeError, ValueError) as exc:
+            return None, f"invalid spent_usd in quota counter: {exc}"
     except _EnrichCostCounterUnreadable as exc:
         return None, str(exc)
     except Exception:

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -102,6 +103,8 @@ def _daily_cap_blocker(now: datetime, *, enrich_cost_counter_path: Path | None =
             spent_usd = float(record.get("spent_usd", 0.0) or 0.0)
         except (TypeError, ValueError) as exc:
             return None, f"invalid spent_usd in quota counter: {exc}"
+        if not math.isfinite(spent_usd) or spent_usd < 0:
+            return None, f"invalid spent_usd in quota counter: {spent_usd!r}"
     except _EnrichCostCounterUnreadable as exc:
         return None, str(exc)
     except Exception:

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -56,12 +56,12 @@ def _enrich_daily_usd_cap() -> float:
 
 
 def _enrich_cost_counter_path(path: Path | None = None) -> Path:
-    if path is not None:
-        return path.expanduser()
-
     override_dir = os.environ.get("BRAINLAYER_ENRICH_COST_DIR")
     if override_dir:
         return Path(override_dir).expanduser() / ENRICH_DAILY_COST_COUNTER_FILENAME
+
+    if path is not None:
+        return path.expanduser()
 
     from .paths import get_db_path
 

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -15,7 +15,6 @@ DEFAULT_ENRICH_DAILY_USD_CAP = 5.0
 ENRICH_DAILY_COST_COUNTER_FILENAME = "enrich-daily-cost.json"
 STALLED_CODE = "drain_liveness_stalled"
 QUOTA_BLOCKED_CODE = "drain_liveness_quota_blocked"
-UNKNOWN_BLOCKER_CODE = "drain_liveness_blocker_unknown"
 
 
 @dataclass(frozen=True)
@@ -24,10 +23,6 @@ class DrainLivenessIssue:
     severity: str
     message: str
     details: dict[str, Any]
-
-
-class _EnrichCostCounterUnreadable(RuntimeError):
-    """Raised when a present quota counter cannot be trusted."""
 
 
 def _parse_updated_at(value: Any) -> datetime | None:
@@ -76,43 +71,35 @@ def _enrich_cost_counter_path(path: Path | None = None) -> Path:
 
 def _read_enrich_cost_record(path: Path, today: str) -> dict[str, Any]:
     try:
-        raw = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
         return {"date": today, "spent_usd": 0.0}
-    except OSError as exc:
-        raise _EnrichCostCounterUnreadable(f"could not read {path}: {exc}") from exc
-
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise _EnrichCostCounterUnreadable(f"could not parse {path}: {exc}") from exc
 
     if not isinstance(data, dict):
-        raise _EnrichCostCounterUnreadable(f"{path} did not contain a JSON object")
+        return {"date": today, "spent_usd": 0.0}
     if data.get("date") != today:
         return {"date": today, "spent_usd": 0.0}
-    return data
+    try:
+        spent_usd = float(data.get("spent_usd", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        spent_usd = 0.0
+    if not math.isfinite(spent_usd) or spent_usd < 0:
+        spent_usd = 0.0
+    return {"date": today, "spent_usd": spent_usd}
 
 
-def _daily_cap_blocker(now: datetime, *, enrich_cost_counter_path: Path | None = None) -> tuple[str | None, str | None]:
+def _daily_cap_blocker(now: datetime, *, enrich_cost_counter_path: Path | None = None) -> str | None:
     try:
         cap_usd = _enrich_daily_usd_cap()
         today = now.astimezone().date().isoformat()
         record = _read_enrich_cost_record(_enrich_cost_counter_path(enrich_cost_counter_path), today)
-        try:
-            spent_usd = float(record.get("spent_usd", 0.0) or 0.0)
-        except (TypeError, ValueError) as exc:
-            return None, f"invalid spent_usd in quota counter: {exc}"
-        if not math.isfinite(spent_usd) or spent_usd < 0:
-            return None, f"invalid spent_usd in quota counter: {spent_usd!r}"
-    except _EnrichCostCounterUnreadable as exc:
-        return None, str(exc)
+        spent_usd = float(record.get("spent_usd", 0.0))
     except Exception:
-        return None, None
+        return None
 
     if spent_usd >= cap_usd:
-        return f"enrichment daily cap reached: spent=${spent_usd:.6f} cap=${cap_usd:.2f}", None
-    return None, None
+        return f"enrichment daily cap reached: spent=${spent_usd:.6f} cap=${cap_usd:.2f}"
+    return None
 
 
 def check_drain_liveness(
@@ -140,12 +127,11 @@ def check_drain_liveness(
         return None
 
     blocker = None
-    blocker_error = None
     if queue_backlog == 0 and enrichment_backlog_count > 0:
         if quota_or_throttle_blocker:
             blocker = quota_or_throttle_blocker
         else:
-            blocker, blocker_error = _daily_cap_blocker(
+            blocker = _daily_cap_blocker(
                 now,
                 enrich_cost_counter_path=enrich_cost_counter_path,
             )
@@ -166,17 +152,6 @@ def check_drain_liveness(
             QUOTA_BLOCKED_CODE,
             "warning",
             f"DRAIN_LIVENESS_QUOTA_BLOCKED: {blocker}; loaded drain heartbeat is stale but backlog is blocked",
-            details,
-        )
-    if blocker_error:
-        details["blocker_error"] = blocker_error
-        return DrainLivenessIssue(
-            UNKNOWN_BLOCKER_CODE,
-            "warning",
-            (
-                "DRAIN_LIVENESS_BLOCKER_UNKNOWN: loaded drain heartbeat is stale, "
-                f"but quota/throttle blocker state could not be read: {blocker_error}"
-            ),
             details,
         )
 

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -55,7 +55,10 @@ def _enrich_daily_usd_cap() -> float:
     return _bounded_nonnegative_float(os.environ.get("BRAINLAYER_ENRICH_DAILY_USD_CAP"), DEFAULT_ENRICH_DAILY_USD_CAP)
 
 
-def _enrich_cost_counter_path() -> Path:
+def _enrich_cost_counter_path(path: Path | None = None) -> Path:
+    if path is not None:
+        return path.expanduser()
+
     override_dir = os.environ.get("BRAINLAYER_ENRICH_COST_DIR")
     if override_dir:
         return Path(override_dir).expanduser() / ENRICH_DAILY_COST_COUNTER_FILENAME
@@ -78,11 +81,11 @@ def _read_enrich_cost_record(path: Path, today: str) -> dict[str, Any]:
     return data
 
 
-def _daily_cap_blocker(now: datetime) -> str | None:
+def _daily_cap_blocker(now: datetime, *, enrich_cost_counter_path: Path | None = None) -> str | None:
     try:
         cap_usd = _enrich_daily_usd_cap()
         today = now.astimezone().date().isoformat()
-        record = _read_enrich_cost_record(_enrich_cost_counter_path(), today)
+        record = _read_enrich_cost_record(_enrich_cost_counter_path(enrich_cost_counter_path), today)
         spent_usd = float(record.get("spent_usd", 0.0) or 0.0)
     except Exception:
         return None
@@ -96,14 +99,18 @@ def check_drain_liveness(
     *,
     drain_label: str,
     drain_loaded: bool | None,
-    backlog_count: int | None,
+    queue_count: int | None,
+    enrichment_backlog: int | None,
     drain_health: dict[str, Any],
     now: datetime,
     stale_seconds: float = DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
+    enrich_cost_counter_path: Path | None = None,
     quota_or_throttle_blocker: str | None = None,
 ) -> DrainLivenessIssue | None:
     """Return a loud issue when a loaded drain has backlog but no fresh heartbeat."""
-    backlog = _positive_int(backlog_count)
+    queue_backlog = _positive_int(queue_count)
+    enrichment_backlog_count = _positive_int(enrichment_backlog)
+    backlog = queue_backlog + enrichment_backlog_count
     if drain_loaded is not True or backlog <= 0:
         return None
 
@@ -112,13 +119,20 @@ def check_drain_liveness(
     if heartbeat_age is not None and heartbeat_age < max(0.0, stale_seconds):
         return None
 
-    blocker = quota_or_throttle_blocker or _daily_cap_blocker(now)
+    blocker = None
+    if queue_backlog == 0 and enrichment_backlog_count > 0:
+        blocker = quota_or_throttle_blocker or _daily_cap_blocker(
+            now,
+            enrich_cost_counter_path=enrich_cost_counter_path,
+        )
     details = {
         "backlog_count": backlog,
         "drain_cycles": drain_health.get("drain_cycles"),
         "drain_label": drain_label,
         "drained_total": drain_health.get("drained_total"),
+        "enrichment_backlog": enrichment_backlog_count,
         "heartbeat_age_seconds": round(heartbeat_age, 3) if heartbeat_age is not None else None,
+        "queue_count": queue_backlog,
         "stale_seconds": stale_seconds,
         "updated_at": drain_health.get("updated_at"),
     }
@@ -136,7 +150,8 @@ def check_drain_liveness(
         STALLED_CODE,
         "fatal",
         (
-            f"DRAIN_LIVENESS_STALLED: {drain_label} is loaded and backlog={backlog}, "
+            f"DRAIN_LIVENESS_STALLED: {drain_label} is loaded and backlog={backlog} "
+            f"(queue={queue_backlog}, enrichment={enrichment_backlog_count}), "
             f"but drain-health updated_at is {stale_description}; no quota/throttle blocker detected"
         ),
         details,

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -1,0 +1,143 @@
+"""Loud liveness probe for the BrainLayer drain heartbeat."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DRAIN_LIVENESS_STALE_SECONDS = 300.0
+DEFAULT_ENRICH_DAILY_USD_CAP = 5.0
+ENRICH_DAILY_COST_COUNTER_FILENAME = "enrich-daily-cost.json"
+STALLED_CODE = "drain_liveness_stalled"
+QUOTA_BLOCKED_CODE = "drain_liveness_quota_blocked"
+
+
+@dataclass(frozen=True)
+class DrainLivenessIssue:
+    code: str
+    severity: str
+    message: str
+    details: dict[str, Any]
+
+
+def _parse_updated_at(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bounded_nonnegative_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return max(0.0, default)
+    return max(0.0, parsed)
+
+
+def _enrich_daily_usd_cap() -> float:
+    return _bounded_nonnegative_float(os.environ.get("BRAINLAYER_ENRICH_DAILY_USD_CAP"), DEFAULT_ENRICH_DAILY_USD_CAP)
+
+
+def _enrich_cost_counter_path() -> Path:
+    override_dir = os.environ.get("BRAINLAYER_ENRICH_COST_DIR")
+    if override_dir:
+        return Path(override_dir).expanduser() / ENRICH_DAILY_COST_COUNTER_FILENAME
+
+    from .paths import get_db_path
+
+    return get_db_path().parent / ENRICH_DAILY_COST_COUNTER_FILENAME
+
+
+def _read_enrich_cost_record(path: Path, today: str) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"date": today, "spent_usd": 0.0}
+
+    if not isinstance(data, dict):
+        return {"date": today, "spent_usd": 0.0}
+    if data.get("date") != today:
+        return {"date": today, "spent_usd": 0.0}
+    return data
+
+
+def _daily_cap_blocker(now: datetime) -> str | None:
+    try:
+        cap_usd = _enrich_daily_usd_cap()
+        today = now.astimezone().date().isoformat()
+        record = _read_enrich_cost_record(_enrich_cost_counter_path(), today)
+        spent_usd = float(record.get("spent_usd", 0.0) or 0.0)
+    except Exception:
+        return None
+
+    if spent_usd >= cap_usd:
+        return f"enrichment daily cap reached: spent=${spent_usd:.6f} cap=${cap_usd:.2f}"
+    return None
+
+
+def check_drain_liveness(
+    *,
+    drain_label: str,
+    drain_loaded: bool | None,
+    backlog_count: int | None,
+    drain_health: dict[str, Any],
+    now: datetime,
+    stale_seconds: float = DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
+    quota_or_throttle_blocker: str | None = None,
+) -> DrainLivenessIssue | None:
+    """Return a loud issue when a loaded drain has backlog but no fresh heartbeat."""
+    backlog = _positive_int(backlog_count)
+    if drain_loaded is not True or backlog <= 0:
+        return None
+
+    heartbeat_at = _parse_updated_at(drain_health.get("updated_at"))
+    heartbeat_age = None if heartbeat_at is None else max(0.0, now.timestamp() - heartbeat_at.timestamp())
+    if heartbeat_age is not None and heartbeat_age < max(0.0, stale_seconds):
+        return None
+
+    blocker = quota_or_throttle_blocker or _daily_cap_blocker(now)
+    details = {
+        "backlog_count": backlog,
+        "drain_cycles": drain_health.get("drain_cycles"),
+        "drain_label": drain_label,
+        "drained_total": drain_health.get("drained_total"),
+        "heartbeat_age_seconds": round(heartbeat_age, 3) if heartbeat_age is not None else None,
+        "stale_seconds": stale_seconds,
+        "updated_at": drain_health.get("updated_at"),
+    }
+    if blocker:
+        details["blocker"] = blocker
+        return DrainLivenessIssue(
+            QUOTA_BLOCKED_CODE,
+            "warning",
+            f"DRAIN_LIVENESS_QUOTA_BLOCKED: {blocker}; loaded drain heartbeat is stale but backlog is blocked",
+            details,
+        )
+
+    stale_description = "missing" if heartbeat_at is None else f"stale for {heartbeat_age:.0f}s"
+    return DrainLivenessIssue(
+        STALLED_CODE,
+        "fatal",
+        (
+            f"DRAIN_LIVENESS_STALLED: {drain_label} is loaded and backlog={backlog}, "
+            f"but drain-health updated_at is {stale_description}; no quota/throttle blocker detected"
+        ),
+        details,
+    )

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -14,6 +14,7 @@ DEFAULT_ENRICH_DAILY_USD_CAP = 5.0
 ENRICH_DAILY_COST_COUNTER_FILENAME = "enrich-daily-cost.json"
 STALLED_CODE = "drain_liveness_stalled"
 QUOTA_BLOCKED_CODE = "drain_liveness_quota_blocked"
+UNKNOWN_BLOCKER_CODE = "drain_liveness_blocker_unknown"
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,10 @@ class DrainLivenessIssue:
     severity: str
     message: str
     details: dict[str, Any]
+
+
+class _EnrichCostCounterUnreadable(RuntimeError):
+    """Raised when a present quota counter cannot be trusted."""
 
 
 def _parse_updated_at(value: Any) -> datetime | None:
@@ -70,29 +75,38 @@ def _enrich_cost_counter_path(path: Path | None = None) -> Path:
 
 def _read_enrich_cost_record(path: Path, today: str) -> dict[str, Any]:
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
         return {"date": today, "spent_usd": 0.0}
+    except OSError as exc:
+        raise _EnrichCostCounterUnreadable(f"could not read {path}: {exc}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise _EnrichCostCounterUnreadable(f"could not parse {path}: {exc}") from exc
 
     if not isinstance(data, dict):
-        return {"date": today, "spent_usd": 0.0}
+        raise _EnrichCostCounterUnreadable(f"{path} did not contain a JSON object")
     if data.get("date") != today:
         return {"date": today, "spent_usd": 0.0}
     return data
 
 
-def _daily_cap_blocker(now: datetime, *, enrich_cost_counter_path: Path | None = None) -> str | None:
+def _daily_cap_blocker(now: datetime, *, enrich_cost_counter_path: Path | None = None) -> tuple[str | None, str | None]:
     try:
         cap_usd = _enrich_daily_usd_cap()
         today = now.astimezone().date().isoformat()
         record = _read_enrich_cost_record(_enrich_cost_counter_path(enrich_cost_counter_path), today)
         spent_usd = float(record.get("spent_usd", 0.0) or 0.0)
+    except _EnrichCostCounterUnreadable as exc:
+        return None, str(exc)
     except Exception:
-        return None
+        return None, None
 
     if spent_usd >= cap_usd:
-        return f"enrichment daily cap reached: spent=${spent_usd:.6f} cap=${cap_usd:.2f}"
-    return None
+        return f"enrichment daily cap reached: spent=${spent_usd:.6f} cap=${cap_usd:.2f}", None
+    return None, None
 
 
 def check_drain_liveness(
@@ -120,11 +134,15 @@ def check_drain_liveness(
         return None
 
     blocker = None
+    blocker_error = None
     if queue_backlog == 0 and enrichment_backlog_count > 0:
-        blocker = quota_or_throttle_blocker or _daily_cap_blocker(
-            now,
-            enrich_cost_counter_path=enrich_cost_counter_path,
-        )
+        if quota_or_throttle_blocker:
+            blocker = quota_or_throttle_blocker
+        else:
+            blocker, blocker_error = _daily_cap_blocker(
+                now,
+                enrich_cost_counter_path=enrich_cost_counter_path,
+            )
     details = {
         "backlog_count": backlog,
         "drain_cycles": drain_health.get("drain_cycles"),
@@ -142,6 +160,17 @@ def check_drain_liveness(
             QUOTA_BLOCKED_CODE,
             "warning",
             f"DRAIN_LIVENESS_QUOTA_BLOCKED: {blocker}; loaded drain heartbeat is stale but backlog is blocked",
+            details,
+        )
+    if blocker_error:
+        details["blocker_error"] = blocker_error
+        return DrainLivenessIssue(
+            UNKNOWN_BLOCKER_CODE,
+            "warning",
+            (
+                "DRAIN_LIVENESS_BLOCKER_UNKNOWN: loaded drain heartbeat is stale, "
+                f"but quota/throttle blocker state could not be read: {blocker_error}"
+            ),
             details,
         )
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -70,6 +70,41 @@ def _build_db(path: Path, *, missing_recent_vector: bool = False, fts_desync: bo
         store.close()
 
 
+def _add_enrichment_backlog(path: Path) -> None:
+    store = VectorStore(path)
+    try:
+        _insert_chunk(
+            store,
+            "doctor-enrichment-backlog",
+            content="doctor enrichment backlog content long enough to require realtime Gemini enrichment",
+        )
+        _insert_vector(store, "doctor-enrichment-backlog", 3.0)
+        store.conn.cursor().execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        store.close()
+
+
+def _write_drain_health(path: Path, *, updated_at: datetime, drained_total: int = 0) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "drain_cycles": 3,
+                "drained_total": drained_total,
+                "updated_at": updated_at.isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_daily_cap_reached(cost_dir: Path, *, now: datetime, spent_usd: float = 5.0) -> None:
+    cost_dir.mkdir()
+    (cost_dir / "enrich-daily-cost.json").write_text(
+        json.dumps({"date": now.astimezone().date().isoformat(), "spent_usd": spent_usd}),
+        encoding="utf-8",
+    )
+
+
 def _doctor_config(tmp_path: Path, db_path: Path):
     from brainlayer.doctor import DoctorConfig
 
@@ -84,6 +119,7 @@ def _doctor_config(tmp_path: Path, db_path: Path):
         queue_dir=queue_dir,
         watcher_health_path=watcher_health_path,
         drain_health_path=drain_health_path,
+        queue_movement_sample_seconds=0,
     )
 
 
@@ -163,6 +199,83 @@ def test_run_doctor_exits_nonzero_when_queue_backlog_is_not_moving(tmp_path):
 
     assert result.exit_code == 1
     assert any(issue.code == "queue_not_moving_with_backlog" for issue in result.issues)
+
+
+def test_run_doctor_fails_loudly_when_loaded_drain_heartbeat_stale_with_backlog_without_quota(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(tmp_path / "cost"))
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-stalled.db"
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(minutes=10))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_stalled")
+    assert result.exit_code == 1
+    assert issue.severity == "fatal"
+    assert "DRAIN_LIVENESS_STALLED" in issue.message
+    assert issue.details["backlog_count"] == 1
+    assert issue.details["drain_label"] == "com.brainlayer.drain"
+
+
+def test_run_doctor_does_not_fail_drain_liveness_when_heartbeat_is_advancing(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(tmp_path / "cost"))
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-moving.db"
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(seconds=30))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+    assert any(issue.code == "enrichment_idle_with_backlog" for issue in result.issues)
+
+
+def test_run_doctor_keeps_loaded_but_idle_warning_only_when_daily_cap_blocks_enrichment(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    cost_dir = tmp_path / "cost"
+    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(cost_dir))
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    _write_daily_cap_reached(cost_dir, now=NOW)
+    db_path = tmp_path / "drain-liveness-quota.db"
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(minutes=10))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert not [issue for issue in result.issues if issue.severity == "fatal"]
+    assert any(issue.code == "enrichment_idle_with_backlog" for issue in result.issues)
+    assert any(issue.code == "drain_liveness_quota_blocked" for issue in result.issues)
 
 
 def test_doctor_cli_is_registered_with_json_and_db_options():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -110,6 +110,14 @@ def _write_corrupt_daily_cap_counter(cost_dir: Path) -> None:
     (cost_dir / "enrich-daily-cost.json").write_text('{"date": ', encoding="utf-8")
 
 
+def _write_invalid_spent_daily_cap_counter(cost_dir: Path, *, now: datetime) -> None:
+    cost_dir.mkdir(parents=True, exist_ok=True)
+    (cost_dir / "enrich-daily-cost.json").write_text(
+        json.dumps({"date": now.astimezone().date().isoformat(), "spent_usd": "oops"}),
+        encoding="utf-8",
+    )
+
+
 def _doctor_config(tmp_path: Path, db_path: Path):
     from brainlayer.doctor import DoctorConfig
 
@@ -342,6 +350,33 @@ def test_run_doctor_warns_when_drain_liveness_quota_counter_is_corrupt(tmp_path,
     assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
 
 
+def test_run_doctor_warns_when_drain_liveness_quota_counter_has_invalid_spend(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-invalid-counter.db"
+    _write_invalid_spent_daily_cap_counter(db_path.parent, now=NOW)
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(minutes=10))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_blocker_unknown")
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert issue.severity == "warning"
+    assert "invalid spent_usd" in issue.details["blocker_error"]
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+
+
 def test_run_doctor_does_not_let_enrichment_quota_mask_durable_queue_liveness(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
@@ -435,7 +470,10 @@ def test_run_doctor_suppresses_stale_liveness_when_drain_counter_advances(tmp_pa
     assert not [issue for issue in result.issues if issue.code == "queue_not_moving_with_backlog"]
 
 
-def test_run_doctor_suppresses_stale_liveness_when_drain_cycles_advance(tmp_path, monkeypatch):
+def test_run_doctor_suppresses_stale_liveness_but_fails_queue_when_only_drain_cycles_advance(
+    tmp_path,
+    monkeypatch,
+):
     import brainlayer.doctor as doctor
 
     monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
@@ -468,11 +506,57 @@ def test_run_doctor_suppresses_stale_liveness_when_drain_cycles_advance(tmp_path
         now_fn=lambda: NOW,
     )
 
-    assert result.exit_code == 0
-    assert result.ok is True
+    assert result.exit_code == 1
+    assert result.ok is False
     assert drain_reads == 2
     assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
-    assert not [issue for issue in result.issues if issue.code == "queue_not_moving_with_backlog"]
+    assert any(issue.code == "queue_not_moving_with_backlog" for issue in result.issues)
+
+
+def test_run_doctor_uses_sample_time_for_post_sample_drain_liveness(tmp_path, monkeypatch):
+    import brainlayer.doctor as doctor
+
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-sample-time.db"
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    config.drain_liveness_stale_seconds = 300
+    (config.queue_dir / "pending.jsonl").write_text('{"kind":"watcher_chunk"}\n', encoding="utf-8")
+    drain_reads = 0
+    now_reads = 0
+    original_load_json = doctor._load_json
+
+    def fake_load_json(path: Path) -> dict:
+        nonlocal drain_reads
+        if path == config.drain_health_path:
+            drain_reads += 1
+            return {
+                "drain_cycles": 20,
+                "drained_total": 40,
+                "updated_at": (NOW - timedelta(seconds=299)).isoformat(),
+            }
+        return original_load_json(path)
+
+    def fake_now() -> datetime:
+        nonlocal now_reads
+        now_reads += 1
+        return NOW if now_reads == 1 else NOW + timedelta(seconds=2)
+
+    monkeypatch.setattr(doctor, "_load_json", fake_load_json)
+
+    result = doctor.run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=fake_now,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_stalled")
+    assert result.exit_code == 1
+    assert drain_reads == 2
+    assert now_reads == 2
+    assert issue.details["heartbeat_age_seconds"] == 301.0
 
 
 def test_run_doctor_suppresses_stale_liveness_when_sampled_heartbeat_is_fresh(tmp_path, monkeypatch):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -306,6 +306,69 @@ def test_run_doctor_does_not_let_enrichment_quota_mask_durable_queue_liveness(tm
     assert not [issue for issue in result.issues if issue.code == "drain_liveness_quota_blocked"]
 
 
+def test_run_doctor_skips_drain_liveness_when_drain_label_is_disabled(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-disabled-label.db"
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    config.drain_label = ""
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(minutes=10))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert any(issue.code == "enrichment_idle_with_backlog" for issue in result.issues)
+    assert not [issue for issue in result.issues if issue.code.startswith("drain_liveness")]
+
+
+def test_run_doctor_suppresses_stale_liveness_when_drain_counter_advances(tmp_path, monkeypatch):
+    import brainlayer.doctor as doctor
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-counter-advances.db"
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    (config.queue_dir / "pending.jsonl").write_text('{"kind":"watcher_chunk"}\n', encoding="utf-8")
+    stale_updated_at = (NOW - timedelta(minutes=10)).isoformat()
+    drain_reads = 0
+    original_load_json = doctor._load_json
+
+    def fake_load_json(path: Path) -> dict:
+        nonlocal drain_reads
+        if path == config.drain_health_path:
+            drain_reads += 1
+            return {
+                "drain_cycles": 3 + drain_reads,
+                "drained_total": 40 + drain_reads,
+                "updated_at": stale_updated_at,
+            }
+        return original_load_json(path)
+
+    monkeypatch.setattr(doctor, "_load_json", fake_load_json)
+
+    result = doctor.run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert drain_reads == 2
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+    assert not [issue for issue in result.issues if issue.code == "queue_not_moving_with_backlog"]
+
+
 def test_doctor_cli_is_registered_with_json_and_db_options():
     from typer.main import get_command
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -98,7 +98,7 @@ def _write_drain_health(path: Path, *, updated_at: datetime, drained_total: int 
 
 
 def _write_daily_cap_reached(cost_dir: Path, *, now: datetime, spent_usd: float = 5.0) -> None:
-    cost_dir.mkdir()
+    cost_dir.mkdir(parents=True, exist_ok=True)
     (cost_dir / "enrich-daily-cost.json").write_text(
         json.dumps({"date": now.astimezone().date().isoformat(), "spent_usd": spent_usd}),
         encoding="utf-8",
@@ -204,7 +204,6 @@ def test_run_doctor_exits_nonzero_when_queue_backlog_is_not_moving(tmp_path):
 def test_run_doctor_fails_loudly_when_loaded_drain_heartbeat_stale_with_backlog_without_quota(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
-    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(tmp_path / "cost"))
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-stalled.db"
     _build_db(db_path)
@@ -224,13 +223,14 @@ def test_run_doctor_fails_loudly_when_loaded_drain_heartbeat_stale_with_backlog_
     assert issue.severity == "fatal"
     assert "DRAIN_LIVENESS_STALLED" in issue.message
     assert issue.details["backlog_count"] == 1
+    assert issue.details["queue_count"] == 0
+    assert issue.details["enrichment_backlog"] == 1
     assert issue.details["drain_label"] == "com.brainlayer.drain"
 
 
 def test_run_doctor_does_not_fail_drain_liveness_when_heartbeat_is_advancing(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
-    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(tmp_path / "cost"))
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-moving.db"
     _build_db(db_path)
@@ -254,11 +254,12 @@ def test_run_doctor_does_not_fail_drain_liveness_when_heartbeat_is_advancing(tmp
 def test_run_doctor_keeps_loaded_but_idle_warning_only_when_daily_cap_blocks_enrichment(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
-    cost_dir = tmp_path / "cost"
-    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(cost_dir))
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    monkeypatch.setenv("BRAINLAYER_DB", str(canonical_dir / "brainlayer.db"))
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
-    _write_daily_cap_reached(cost_dir, now=NOW)
     db_path = tmp_path / "drain-liveness-quota.db"
+    _write_daily_cap_reached(db_path.parent, now=NOW)
     _build_db(db_path)
     _add_enrichment_backlog(db_path)
     config = _doctor_config(tmp_path, db_path)
@@ -276,6 +277,33 @@ def test_run_doctor_keeps_loaded_but_idle_warning_only_when_daily_cap_blocks_enr
     assert not [issue for issue in result.issues if issue.severity == "fatal"]
     assert any(issue.code == "enrichment_idle_with_backlog" for issue in result.issues)
     assert any(issue.code == "drain_liveness_quota_blocked" for issue in result.issues)
+
+
+def test_run_doctor_does_not_let_enrichment_quota_mask_durable_queue_liveness(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-queue-quota.db"
+    _write_daily_cap_reached(db_path.parent, now=NOW)
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    (config.queue_dir / "pending.jsonl").write_text('{"kind":"watcher_chunk"}\n', encoding="utf-8")
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(minutes=10))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_stalled")
+    assert result.exit_code == 1
+    assert issue.severity == "fatal"
+    assert issue.details["backlog_count"] == 1
+    assert issue.details["queue_count"] == 1
+    assert issue.details["enrichment_backlog"] == 0
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_quota_blocked"]
 
 
 def test_doctor_cli_is_registered_with_json_and_db_options():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -105,6 +105,11 @@ def _write_daily_cap_reached(cost_dir: Path, *, now: datetime, spent_usd: float 
     )
 
 
+def _write_corrupt_daily_cap_counter(cost_dir: Path) -> None:
+    cost_dir.mkdir(parents=True, exist_ok=True)
+    (cost_dir / "enrich-daily-cost.json").write_text('{"date": ', encoding="utf-8")
+
+
 def _doctor_config(tmp_path: Path, db_path: Path):
     from brainlayer.doctor import DoctorConfig
 
@@ -310,6 +315,33 @@ def test_run_doctor_honors_enrich_cost_dir_for_drain_liveness_quota(tmp_path, mo
     assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
 
 
+def test_run_doctor_warns_when_drain_liveness_quota_counter_is_corrupt(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-corrupt-quota.db"
+    _write_corrupt_daily_cap_counter(db_path.parent)
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(minutes=10))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_blocker_unknown")
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert issue.severity == "warning"
+    assert "DRAIN_LIVENESS_BLOCKER_UNKNOWN" in issue.message
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+
+
 def test_run_doctor_does_not_let_enrichment_quota_mask_durable_queue_liveness(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
@@ -399,6 +431,90 @@ def test_run_doctor_suppresses_stale_liveness_when_drain_counter_advances(tmp_pa
     assert result.exit_code == 0
     assert result.ok is True
     assert drain_reads == 2
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+    assert not [issue for issue in result.issues if issue.code == "queue_not_moving_with_backlog"]
+
+
+def test_run_doctor_suppresses_stale_liveness_when_drain_cycles_advance(tmp_path, monkeypatch):
+    import brainlayer.doctor as doctor
+
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-cycles-advance.db"
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    (config.queue_dir / "pending.jsonl").write_text('{"kind":"watcher_chunk"}\n', encoding="utf-8")
+    stale_updated_at = (NOW - timedelta(minutes=10)).isoformat()
+    drain_reads = 0
+    original_load_json = doctor._load_json
+
+    def fake_load_json(path: Path) -> dict:
+        nonlocal drain_reads
+        if path == config.drain_health_path:
+            drain_reads += 1
+            return {
+                "drain_cycles": 20 + drain_reads,
+                "drained_total": 40,
+                "updated_at": stale_updated_at,
+            }
+        return original_load_json(path)
+
+    monkeypatch.setattr(doctor, "_load_json", fake_load_json)
+
+    result = doctor.run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert drain_reads == 2
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+    assert not [issue for issue in result.issues if issue.code == "queue_not_moving_with_backlog"]
+
+
+def test_run_doctor_suppresses_stale_liveness_when_sampled_heartbeat_is_fresh(tmp_path, monkeypatch):
+    import brainlayer.doctor as doctor
+
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-sampled-fresh.db"
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    (config.queue_dir / "pending.jsonl").write_text('{"kind":"watcher_chunk"}\n', encoding="utf-8")
+    drain_reads = 0
+    watcher_reads = 0
+    original_load_json = doctor._load_json
+
+    def fake_load_json(path: Path) -> dict:
+        nonlocal drain_reads, watcher_reads
+        if path == config.drain_health_path:
+            drain_reads += 1
+            return {
+                "drain_cycles": 20,
+                "drained_total": 40,
+                "updated_at": (NOW - timedelta(minutes=10)).isoformat() if drain_reads == 1 else NOW.isoformat(),
+            }
+        if path == config.watcher_health_path:
+            watcher_reads += 1
+            return {"poll_count": 12 + watcher_reads}
+        return original_load_json(path)
+
+    monkeypatch.setattr(doctor, "_load_json", fake_load_json)
+
+    result = doctor.run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert drain_reads == 2
+    assert watcher_reads == 2
     assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
     assert not [issue for issue in result.issues if issue.code == "queue_not_moving_with_backlog"]
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 from brainlayer.vector_store import VectorStore
@@ -110,10 +111,10 @@ def _write_corrupt_daily_cap_counter(cost_dir: Path) -> None:
     (cost_dir / "enrich-daily-cost.json").write_text('{"date": ', encoding="utf-8")
 
 
-def _write_invalid_spent_daily_cap_counter(cost_dir: Path, *, now: datetime) -> None:
+def _write_invalid_spent_daily_cap_counter(cost_dir: Path, *, now: datetime, spent_usd: object = "oops") -> None:
     cost_dir.mkdir(parents=True, exist_ok=True)
     (cost_dir / "enrich-daily-cost.json").write_text(
-        json.dumps({"date": now.astimezone().date().isoformat(), "spent_usd": "oops"}),
+        json.dumps({"date": now.astimezone().date().isoformat(), "spent_usd": spent_usd}),
         encoding="utf-8",
     )
 
@@ -390,13 +391,14 @@ def test_run_doctor_warns_when_drain_liveness_quota_counter_is_corrupt(tmp_path,
     assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
 
 
-def test_run_doctor_warns_when_drain_liveness_quota_counter_has_invalid_spend(tmp_path, monkeypatch):
+@pytest.mark.parametrize("invalid_spend", ["oops", "nan", "inf", "-1"])
+def test_run_doctor_warns_when_drain_liveness_quota_counter_has_invalid_spend(tmp_path, monkeypatch, invalid_spend):
     from brainlayer.doctor import run_doctor
 
     monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-invalid-counter.db"
-    _write_invalid_spent_daily_cap_counter(db_path.parent, now=NOW)
+    _write_invalid_spent_daily_cap_counter(db_path.parent, now=NOW, spent_usd=invalid_spend)
     _build_db(db_path)
     _add_enrichment_backlog(db_path)
     config = _doctor_config(tmp_path, db_path)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -204,6 +204,7 @@ def test_run_doctor_exits_nonzero_when_queue_backlog_is_not_moving(tmp_path):
 def test_run_doctor_fails_loudly_when_loaded_drain_heartbeat_stale_with_backlog_without_quota(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-stalled.db"
     _build_db(db_path)
@@ -231,6 +232,7 @@ def test_run_doctor_fails_loudly_when_loaded_drain_heartbeat_stale_with_backlog_
 def test_run_doctor_does_not_fail_drain_liveness_when_heartbeat_is_advancing(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-moving.db"
     _build_db(db_path)
@@ -254,6 +256,7 @@ def test_run_doctor_does_not_fail_drain_liveness_when_heartbeat_is_advancing(tmp
 def test_run_doctor_keeps_loaded_but_idle_warning_only_when_daily_cap_blocks_enrichment(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
     canonical_dir = tmp_path / "canonical"
     canonical_dir.mkdir()
     monkeypatch.setenv("BRAINLAYER_DB", str(canonical_dir / "brainlayer.db"))
@@ -279,9 +282,38 @@ def test_run_doctor_keeps_loaded_but_idle_warning_only_when_daily_cap_blocks_enr
     assert any(issue.code == "drain_liveness_quota_blocked" for issue in result.issues)
 
 
+def test_run_doctor_honors_enrich_cost_dir_for_drain_liveness_quota(tmp_path, monkeypatch):
+    from brainlayer.doctor import run_doctor
+
+    cost_dir = tmp_path / "configured-cost-dir"
+    monkeypatch.setenv("BRAINLAYER_ENRICH_COST_DIR", str(cost_dir))
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-env-quota.db"
+    _write_daily_cap_reached(cost_dir, now=NOW)
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    _write_drain_health(config.drain_health_path, updated_at=NOW - timedelta(minutes=10))
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert not [issue for issue in result.issues if issue.severity == "fatal"]
+    assert any(issue.code == "enrichment_idle_with_backlog" for issue in result.issues)
+    assert any(issue.code == "drain_liveness_quota_blocked" for issue in result.issues)
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+
+
 def test_run_doctor_does_not_let_enrichment_quota_mask_durable_queue_liveness(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-queue-quota.db"
     _write_daily_cap_reached(db_path.parent, now=NOW)
@@ -309,6 +341,7 @@ def test_run_doctor_does_not_let_enrichment_quota_mask_durable_queue_liveness(tm
 def test_run_doctor_skips_drain_liveness_when_drain_label_is_disabled(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-disabled-label.db"
     _build_db(db_path)
@@ -333,6 +366,7 @@ def test_run_doctor_skips_drain_liveness_when_drain_label_is_disabled(tmp_path, 
 def test_run_doctor_suppresses_stale_liveness_when_drain_counter_advances(tmp_path, monkeypatch):
     import brainlayer.doctor as doctor
 
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
     monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
     db_path = tmp_path / "drain-liveness-counter-advances.db"
     _build_db(db_path)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -364,7 +364,7 @@ def test_run_doctor_honors_enrich_cost_dir_for_drain_liveness_quota(tmp_path, mo
     assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
 
 
-def test_run_doctor_warns_when_drain_liveness_quota_counter_is_corrupt(tmp_path, monkeypatch):
+def test_run_doctor_fails_loudly_when_drain_liveness_quota_counter_is_corrupt(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 
     monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
@@ -383,16 +383,19 @@ def test_run_doctor_warns_when_drain_liveness_quota_counter_is_corrupt(tmp_path,
         now_fn=lambda: NOW,
     )
 
-    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_blocker_unknown")
-    assert result.exit_code == 0
-    assert result.ok is True
-    assert issue.severity == "warning"
-    assert "DRAIN_LIVENESS_BLOCKER_UNKNOWN" in issue.message
-    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_stalled")
+    assert result.exit_code == 1
+    assert result.ok is False
+    assert issue.severity == "fatal"
+    assert "DRAIN_LIVENESS_STALLED" in issue.message
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_quota_blocked"]
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_blocker_unknown"]
 
 
 @pytest.mark.parametrize("invalid_spend", ["oops", "nan", "inf", "-1"])
-def test_run_doctor_warns_when_drain_liveness_quota_counter_has_invalid_spend(tmp_path, monkeypatch, invalid_spend):
+def test_run_doctor_fails_loudly_when_drain_liveness_quota_counter_has_invalid_spend(
+    tmp_path, monkeypatch, invalid_spend
+):
     from brainlayer.doctor import run_doctor
 
     monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
@@ -411,12 +414,13 @@ def test_run_doctor_warns_when_drain_liveness_quota_counter_has_invalid_spend(tm
         now_fn=lambda: NOW,
     )
 
-    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_blocker_unknown")
-    assert result.exit_code == 0
-    assert result.ok is True
-    assert issue.severity == "warning"
-    assert "invalid spent_usd" in issue.details["blocker_error"]
-    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+    issue = next(issue for issue in result.issues if issue.code == "drain_liveness_stalled")
+    assert result.exit_code == 1
+    assert result.ok is False
+    assert issue.severity == "fatal"
+    assert "DRAIN_LIVENESS_STALLED" in issue.message
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_quota_blocked"]
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_blocker_unknown"]
 
 
 def test_run_doctor_does_not_let_enrichment_quota_mask_durable_queue_liveness(tmp_path, monkeypatch):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -266,6 +266,46 @@ def test_run_doctor_does_not_fail_drain_liveness_when_heartbeat_is_advancing(tmp
     assert any(issue.code == "enrichment_idle_with_backlog" for issue in result.issues)
 
 
+def test_run_doctor_suppresses_enrichment_only_stale_liveness_when_drain_cycles_advance(tmp_path, monkeypatch):
+    import brainlayer.doctor as doctor
+
+    monkeypatch.delenv("BRAINLAYER_ENRICH_COST_DIR", raising=False)
+    monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    db_path = tmp_path / "drain-liveness-enrichment-cycles-advance.db"
+    _build_db(db_path)
+    _add_enrichment_backlog(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    stale_updated_at = (NOW - timedelta(minutes=10)).isoformat()
+    drain_reads = 0
+    original_load_json = doctor._load_json
+
+    def fake_load_json(path: Path) -> dict:
+        nonlocal drain_reads
+        if path == config.drain_health_path:
+            drain_reads += 1
+            return {
+                "drain_cycles": 20 + drain_reads,
+                "drained_total": 40,
+                "updated_at": stale_updated_at,
+            }
+        return original_load_json(path)
+
+    monkeypatch.setattr(doctor, "_load_json", fake_load_json)
+
+    result = doctor.run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert drain_reads == 2
+    assert any(issue.code == "enrichment_idle_with_backlog" for issue in result.issues)
+    assert not [issue for issue in result.issues if issue.code == "drain_liveness_stalled"]
+
+
 def test_run_doctor_keeps_loaded_but_idle_warning_only_when_daily_cap_blocks_enrichment(tmp_path, monkeypatch):
     from brainlayer.doctor import run_doctor
 


### PR DESCRIPTION
## Summary
- Add a `drain_liveness` probe that fails loudly when the drain LaunchAgent is loaded, backlog exists, and `drain-health.json.updated_at` is stale beyond the configured interval without a quota blocker.
- Wire the probe into `brainlayer doctor` as a fatal `drain_liveness_stalled` issue, while preserving quota/daily-cap loaded-but-idle as warning-only via `drain_liveness_quota_blocked`.
- Add held two-sided doctor tests for stale/no-quota failure, advancing-heartbeat non-failure, and daily-cap non-failure.

## Test plan
- RED before implementation: `pytest tests/test_doctor.py -k "heartbeat_stale or heartbeat_is_advancing or daily_cap_blocks"` failed with missing `drain_liveness_stalled`/quota warning.
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `pytest tests/test_stability_health_check.py tests/test_doctor.py tests/test_drain_health.py` -> 24 passed
- `pytest tests/test_doctor.py -v --tb=short` -> 9 passed
- Pre-push BrainLayer test gate -> 3076 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun test 1 pass; `test_fts5_determinism.sh` PASS

## Notes
- Local system-python raw `pytest` is blocked by environment drift (`numpy=2.4.6`; `numba` requires NumPy <=2.3). The repo pre-push hook created its isolated `.venv` with Python 3.12.12 and passed the full gate above.
- Pre-commit CodeRabbit local review produced two findings. I did not apply the backlog-only suggestion because the required silent gap is the doctor enrichment backlog warning path; durable queue backlog is already covered by `queue_not_moving_with_backlog`. I also kept daily-cap parity with `enrichment_controller`, which treats `spent_usd >= cap_usd` as cap reached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes doctor exit behavior for operators when drain heartbeats are stale; misclassification could false-alarm or miss a dead drain, but suppression rules and quota handling are heavily tested.
> 
> **Overview**
> Adds **drain liveness** monitoring to `brainlayer doctor` so a loaded drain with backlog but a stale `drain-health.json` heartbeat fails loudly instead of looking like benign enrichment throttling.
> 
> New module `drain_liveness.py` implements `check_drain_liveness`: **fatal** `drain_liveness_stalled` when backlog exists and `updated_at` is missing or older than `drain_liveness_stale_seconds` (default 300s) with no blocker; **warning** `drain_liveness_quota_blocked` when only enrichment backlog is blocked by the daily USD cap (`enrich-daily-cost.json`, `BRAINLAYER_ENRICH_DAILY_USD_CAP` / `BRAINLAYER_ENRICH_COST_DIR`). Durable queue backlog still surfaces as stalled even if enrichment is cap-blocked.
> 
> `run_doctor` records whether the drain launchd label is loaded, runs the probe before/after the queue movement sample when backlog exists, and **suppresses** stalled when `drained_total` or `drain_cycles` advance during the sample. Queue movement logic now treats drain progress via `drain_cycles` and only polls watcher health when the durable queue is non-empty.
> 
> Extensive `test_doctor.py` coverage for stalled vs fresh heartbeat, quota vs queue backlog, counter suppression, and disabled drain label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9046711d0199a7cb4cb8ab24de0e724ac36b127f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drain liveness probe to `run_doctor` with quota-blocker detection
> - Adds a new `check_drain_liveness` function in [`drain_liveness.py`](https://github.com/EtanHey/brainlayer/pull/545/files#diff-9a2ac47db9045b5d9c65cdea8046b83b02cb3a30ec51dc9ebaa0cdfec313e64b) that emits a fatal `drain_liveness_stalled` issue when a loaded drain has backlog but its heartbeat (`updated_at`) is missing or stale beyond a configurable threshold.
> - When backlog is enrichment-only and a daily cost cap has been reached, emits a warning `drain_liveness_quota_blocked` instead of a fatal issue.
> - Integrates the probe into `run_doctor` in [`doctor.py`](https://github.com/EtanHey/brainlayer/pull/545/files#diff-41071e7067b327f299dfaa0e5ce4c4455911658ff543b818c684f321f91b29ff), including a post-sleep sample pass that suppresses `drain_liveness_stalled` if `drained_total` or `drain_cycles` advance during the sampling window.
> - Adds `drain_liveness_stale_seconds` to `DoctorConfig` (defaulting to `DEFAULT_DRAIN_LIVENESS_STALE_SECONDS`) to control the staleness threshold.
> - Risk: `run_doctor` may now emit fatal issues and set a non-zero exit code in cases where it previously reported ok, specifically when a loaded drain has backlog and a stale heartbeat with no detected movement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9046711.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “drain liveness” monitoring to detect stale drain heartbeats and report loud failures when processing appears stalled.
  * Introduced configurable staleness threshold for drain liveness checks.
  * Added clearer warnings when backlog work is blocked by enrichment spending limits or throttling.

* **Bug Fixes**
  * Reduced false alarms by suppressing stale-liveness alerts when drain activity/heartbeats are still advancing.
  * Prevented backlog/spending warnings from masking more serious durable-queue liveness failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->