### PR TITLE
feat: add BrainBar release workflow

### DIFF
--- a/.github/workflows/brainbar-release.yml
+++ b/.github/workflows/brainbar-release.yml
@@ -1,0 +1,197 @@
+name: BrainBar Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: package BrainBar
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode (Swift 6)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Resolve release metadata
+        run: |
+          set -euo pipefail
+          release_version="${GITHUB_REF_NAME#v}"
+          build_time_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "BRAINBAR_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          echo "BRAINBAR_BUILD_TIME_UTC=$build_time_utc" >> "$GITHUB_ENV"
+          echo "BrainBar release version: $release_version"
+          echo "BrainBar build time UTC: $build_time_utc"
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm
+            brain-bar/.build
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('brain-bar/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-swiftpm-
+
+      - name: Build BrainBar
+        run: cd brain-bar && swift build -c release
+
+      - name: Assemble BrainBar.app
+        run: |
+          set -euo pipefail
+
+          app_dir="$PWD/dist/BrainBar.app"
+          bin_dir="$(cd brain-bar && swift build -c release --show-bin-path)"
+          plist="$app_dir/Contents/Info.plist"
+          plist_buddy="/usr/libexec/PlistBuddy"
+
+          rm -rf "$PWD/dist"
+          mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources"
+          cp brain-bar/bundle/Info.plist "$plist"
+          cp "$bin_dir/BrainBar" "$app_dir/Contents/MacOS/BrainBar"
+          cp "$bin_dir/BrainBarDaemon" "$app_dir/Contents/MacOS/BrainBarDaemon"
+
+          set_plist_string() {
+            local key="$1"
+            local value="$2"
+            if "$plist_buddy" -c "Print :$key" "$plist" >/dev/null 2>&1; then
+              "$plist_buddy" -c "Set :$key $value" "$plist"
+            else
+              "$plist_buddy" -c "Add :$key string $value" "$plist"
+            fi
+          }
+
+          set_plist_string CFBundleShortVersionString "$BRAINBAR_RELEASE_VERSION"
+          set_plist_string CFBundleVersion "$BRAINBAR_RELEASE_VERSION"
+          set_plist_string GitCommit "$GITHUB_SHA"
+          set_plist_string GitDescribe "$GITHUB_REF_NAME"
+          set_plist_string BuildTimeUTC "$BRAINBAR_BUILD_TIME_UTC"
+
+          "$plist_buddy" -c "Print :CFBundleShortVersionString" "$plist"
+          "$plist_buddy" -c "Print :GitCommit" "$plist"
+          "$plist_buddy" -c "Print :BuildTimeUTC" "$plist"
+
+      - name: Import Developer ID certificate
+        id: signing
+        env:
+          BRAINBAR_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.BRAINBAR_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          BRAINBAR_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.BRAINBAR_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          BRAINBAR_DEVELOPER_ID_APPLICATION: ${{ secrets.BRAINBAR_DEVELOPER_ID_APPLICATION }}
+          BRAINBAR_SIGNING_KEYCHAIN_PASSWORD: ${{ secrets.BRAINBAR_SIGNING_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_BASE64" ] \
+            || [ -z "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_PASSWORD" ] \
+            || [ -z "$BRAINBAR_DEVELOPER_ID_APPLICATION" ]; then
+            echo "::warning title=BrainBar signing skipped::Developer ID signing secrets are not fully configured; BrainBar.zip will contain an unsigned app."
+            {
+              echo "## BrainBar signing"
+              echo ""
+              echo "SIGNING SKIPPED: Developer ID secrets are not fully configured. The uploaded BrainBar.zip contains an unsigned app."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "BRAINBAR_SIGNING_STATUS=unsigned - Developer ID signing secrets were missing" >> "$GITHUB_ENV"
+            echo "BRAINBAR_NOTARIZATION_STATUS=skipped - signing was skipped" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          keychain_password="${BRAINBAR_SIGNING_KEYCHAIN_PASSWORD:-$(uuidgen)}"
+          cert_path="$RUNNER_TEMP/brainbar-developer-id.p12"
+          keychain_path="$RUNNER_TEMP/brainbar-signing.keychain-db"
+
+          echo "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_BASE64" | base64 --decode > "$cert_path"
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security import "$cert_path" \
+            -P "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "BRAINBAR_SIGNING_IDENTITY=$BRAINBAR_DEVELOPER_ID_APPLICATION" >> "$GITHUB_ENV"
+          echo "BRAINBAR_SIGNING_STATUS=Developer ID signed" >> "$GITHUB_ENV"
+
+      - name: Sign BrainBar.app
+        if: steps.signing.outputs.signed == 'true'
+        run: |
+          set -euo pipefail
+          codesign --force --deep --options runtime --timestamp --sign "$BRAINBAR_SIGNING_IDENTITY" dist/BrainBar.app
+          codesign -dv --verbose=4 dist/BrainBar.app
+
+      - name: Notarize BrainBar.app
+        if: steps.signing.outputs.signed == 'true'
+        env:
+          BRAINBAR_NOTARY_APPLE_ID: ${{ secrets.BRAINBAR_NOTARY_APPLE_ID }}
+          BRAINBAR_NOTARY_PASSWORD: ${{ secrets.BRAINBAR_NOTARY_PASSWORD }}
+          BRAINBAR_NOTARY_TEAM_ID: ${{ secrets.BRAINBAR_NOTARY_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$BRAINBAR_NOTARY_APPLE_ID" ] \
+            || [ -z "$BRAINBAR_NOTARY_PASSWORD" ] \
+            || [ -z "$BRAINBAR_NOTARY_TEAM_ID" ]; then
+            echo "::warning title=BrainBar notarization skipped::Notary secrets are not fully configured; signed BrainBar.app will be packaged without notarization."
+            {
+              echo "## BrainBar notarization"
+              echo ""
+              echo "NOTARIZATION SKIPPED: notary secrets are not fully configured. The uploaded BrainBar.zip is signed but not notarized."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "BRAINBAR_NOTARIZATION_STATUS=skipped - notary secrets were missing" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          notary_zip="$RUNNER_TEMP/BrainBar-notary.zip"
+          ditto -c -k --keepParent dist/BrainBar.app "$notary_zip"
+          xcrun notarytool submit "$notary_zip" \
+            --apple-id "$BRAINBAR_NOTARY_APPLE_ID" \
+            --password "$BRAINBAR_NOTARY_PASSWORD" \
+            --team-id "$BRAINBAR_NOTARY_TEAM_ID" \
+            --wait
+          xcrun stapler staple dist/BrainBar.app
+          echo "BRAINBAR_NOTARIZATION_STATUS=notarized and stapled" >> "$GITHUB_ENV"
+
+      - name: Package BrainBar.zip
+        run: |
+          set -euo pipefail
+          ditto -c -k --keepParent dist/BrainBar.app dist/BrainBar.zip
+          ls -lh dist/BrainBar.zip
+
+      - name: Guard BrainBar.zip exists before release
+        run: |
+          set -euo pipefail
+          if [ ! -s dist/BrainBar.zip ]; then
+            echo "::error title=BrainBar.zip missing::Expected non-empty dist/BrainBar.zip before creating the GitHub Release"
+            exit 1
+          fi
+          echo "BrainBar.zip size: $(stat -f%z dist/BrainBar.zip) bytes"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: BrainBar ${{ github.ref_name }}
+          files: dist/BrainBar.zip
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          append_body: true
+          body: |
+            BrainBar release version: ${{ env.BRAINBAR_RELEASE_VERSION }}
+            Signing status: ${{ env.BRAINBAR_SIGNING_STATUS }}
+            Notarization status: ${{ env.BRAINBAR_NOTARIZATION_STATUS }}

--- a/.github/workflows/brainbar-release.yml
+++ b/.github/workflows/brainbar-release.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           set -euo pipefail
           release_version="${GITHUB_REF_NAME#v}"
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid BrainBar release tag::Expected tag format vX.Y.Z so Info.plist can be stamped with valid macOS bundle versions; got '$GITHUB_REF_NAME'"
+            exit 1
+          fi
           build_time_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "BRAINBAR_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
           echo "BRAINBAR_BUILD_TIME_UTC=$build_time_utc" >> "$GITHUB_ENV"
@@ -54,13 +58,16 @@ jobs:
           app_dir="$PWD/dist/BrainBar.app"
           bin_dir="$(cd brain-bar && swift build -c release --show-bin-path)"
           plist="$app_dir/Contents/Info.plist"
+          launchagents_dir="$app_dir/Contents/Resources/LaunchAgents"
           plist_buddy="/usr/libexec/PlistBuddy"
 
           rm -rf "$PWD/dist"
-          mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources"
+          mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources" "$launchagents_dir"
           cp brain-bar/bundle/Info.plist "$plist"
           cp "$bin_dir/BrainBar" "$app_dir/Contents/MacOS/BrainBar"
           cp "$bin_dir/BrainBarDaemon" "$app_dir/Contents/MacOS/BrainBarDaemon"
+          cp brain-bar/bundle/com.brainlayer.brainbar.plist "$launchagents_dir/com.brainlayer.brainbar.plist"
+          cp brain-bar/bundle/com.brainlayer.brainbar-daemon.plist "$launchagents_dir/com.brainlayer.brainbar-daemon.plist"
 
           set_plist_string() {
             local key="$1"
@@ -111,7 +118,7 @@ jobs:
           cert_path="$RUNNER_TEMP/brainbar-developer-id.p12"
           keychain_path="$RUNNER_TEMP/brainbar-signing.keychain-db"
 
-          echo "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_BASE64" | base64 --decode > "$cert_path"
+          echo "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_BASE64" | base64 -D -o "$cert_path"
           security create-keychain -p "$keychain_password" "$keychain_path"
           security set-keychain-settings -lut 21600 "$keychain_path"
           security unlock-keychain -p "$keychain_password" "$keychain_path"

--- a/.github/workflows/brainbar-release.yml
+++ b/.github/workflows/brainbar-release.yml
@@ -13,12 +13,13 @@ jobs:
     name: package BrainBar
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Select Xcode (Swift 6)
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
         with:
           xcode-version: latest-stable
 
@@ -40,11 +41,9 @@ jobs:
           echo "BrainBar build time UTC: $build_time_utc"
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
-          path: |
-            ~/.swiftpm
-            brain-bar/.build
+          path: ~/.swiftpm
           key: ${{ runner.os }}-swiftpm-${{ hashFiles('brain-bar/Package.resolved') }}
           restore-keys: ${{ runner.os }}-swiftpm-
 
@@ -190,7 +189,7 @@ jobs:
           echo "BrainBar.zip size: $(stat -f%z dist/BrainBar.zip) bytes"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: ${{ github.ref_name }}
           name: BrainBar ${{ github.ref_name }}

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -205,6 +205,11 @@ final class InjectionStore: ObservableObject {
         scheduleRefresh(force: force)
     }
 
+    /// Exposed for tests that need deterministic debounced refresh timing.
+    var _pendingRefreshTask: Task<Void, Never>? {
+        pendingRefreshTask
+    }
+
     private func startPolling() {
         guard pollTask == nil else { return }
         let interval = pollInterval

--- a/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
+++ b/brain-bar/Sources/BrainBar/QuickCapturePanel.swift
@@ -117,6 +117,10 @@ final class QuickCaptureViewModel: ObservableObject {
     var _pendingSearchTask: Task<Void, Never>?
     /// Exposed for test awaiting — set when an async store is in flight.
     var _pendingStoreTask: Task<Void, Never>?
+    /// Exposed for tests that need deterministic feedback auto-clear timing.
+    var _pendingFeedbackResetTask: Task<Void, Never>? {
+        feedbackResetTask
+    }
     /// Feedback state clears back to `.idle` after this delay on success.
     /// Injectable so tests can collapse the wait window.
     private let feedbackAutoClearDelay: Duration

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -199,8 +199,8 @@ final class InjectionStoreTests: XCTestCase {
         store.scheduleRefreshForTesting(force: false)
         store.scheduleRefreshForTesting(force: false)
         store.scheduleRefreshForTesting(force: false)
-
-        try await Task.sleep(for: .milliseconds(120))
+        let pendingRefresh = store._pendingRefreshTask
+        await pendingRefresh?.value
 
         XCTAssertEqual(reader.listCallCount, 2)
         XCTAssertEqual(store.events.map(\.query), ["debounced"])

--- a/brain-bar/Tests/BrainBarTests/QuickCapturePanelTests.swift
+++ b/brain-bar/Tests/BrainBarTests/QuickCapturePanelTests.swift
@@ -576,8 +576,7 @@ final class QuickCapturePanelTests: XCTestCase {
         await model._pendingStoreTask?.value
         XCTAssertEqual(model.feedback, .success("Stored in BrainLayer"))
 
-        // Wait for the auto-clear task to fire (30ms delay + buffer).
-        try? await Task.sleep(for: .milliseconds(80))
+        await model._pendingFeedbackResetTask?.value
         XCTAssertTrue(
             model.feedback.isIdle,
             "Feedback must auto-clear to idle after the success window so the trailing hint returns to its keyboard-shortcut legend."

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -326,6 +326,22 @@ build_time_utc() {
     date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+release_version() {
+    if [ -n "${BRAINBAR_RELEASE_VERSION:-}" ]; then
+        printf '%s\n' "$BRAINBAR_RELEASE_VERSION"
+        return 0
+    fi
+
+    local exact_tag
+    exact_tag="$(git -C "$PACKAGE_DIR" describe --tags --exact-match 2>/dev/null || true)"
+    if [ -n "$exact_tag" ]; then
+        printf '%s\n' "${exact_tag#v}"
+        return 0
+    fi
+
+    "$PLIST_BUDDY" -c "Print :CFBundleShortVersionString" "$BUNDLE_DIR/Info.plist" 2>/dev/null || printf '0.0.0\n'
+}
+
 plist_set_string() {
     local plist_path="$1"
     local key="$2"
@@ -393,7 +409,10 @@ stamp_info_plist() {
     local commit_sha="$2"
     local describe_ref="$3"
     local build_utc="$4"
+    local release_version="$5"
 
+    plist_set_string "$plist_path" "CFBundleShortVersionString" "$release_version"
+    plist_set_string "$plist_path" "CFBundleVersion" "$release_version"
     plist_set_string "$plist_path" "GitCommit" "$commit_sha"
     plist_set_string "$plist_path" "GitDescribe" "$describe_ref"
     plist_set_string "$plist_path" "BuildTimeUTC" "$build_utc"
@@ -594,8 +613,10 @@ cp "$DAEMON_BINARY" "$APP_DIR/Contents/MacOS/BrainBarDaemon"
 COMMIT_SHA="$(git_commit)"
 DESCRIBE_REF="$(git_describe)"
 BUILD_UTC="$(build_time_utc)"
-stamp_info_plist "$APP_DIR/Contents/Info.plist" "$COMMIT_SHA" "$DESCRIBE_REF" "$BUILD_UTC"
+RELEASE_VERSION="$(release_version)"
+stamp_info_plist "$APP_DIR/Contents/Info.plist" "$COMMIT_SHA" "$DESCRIBE_REF" "$BUILD_UTC" "$RELEASE_VERSION"
 echo "[build-app] Stamped Info.plist:"
+echo "  ReleaseVersion=$RELEASE_VERSION"
 echo "  GitCommit=$COMMIT_SHA"
 echo "  GitDescribe=$DESCRIBE_REF"
 echo "  BuildTimeUTC=$BUILD_UTC"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -326,20 +326,36 @@ build_time_utc() {
     date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+validate_release_version() {
+    local version="$1"
+    if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        return 0
+    fi
+    echo "[build-app] ERROR: release version must match X.Y.Z for macOS bundle metadata (got '$version')" >&2
+    return 1
+}
+
 release_version() {
+    local version
     if [ -n "${BRAINBAR_RELEASE_VERSION:-}" ]; then
-        printf '%s\n' "$BRAINBAR_RELEASE_VERSION"
+        version="$BRAINBAR_RELEASE_VERSION"
+        validate_release_version "$version" || return 1
+        printf '%s\n' "$version"
         return 0
     fi
 
     local exact_tag
     exact_tag="$(git -C "$PACKAGE_DIR" describe --tags --exact-match 2>/dev/null || true)"
     if [ -n "$exact_tag" ]; then
-        printf '%s\n' "${exact_tag#v}"
+        version="${exact_tag#v}"
+        validate_release_version "$version" || return 1
+        printf '%s\n' "$version"
         return 0
     fi
 
-    "$PLIST_BUDDY" -c "Print :CFBundleShortVersionString" "$BUNDLE_DIR/Info.plist" 2>/dev/null || printf '0.0.0\n'
+    version="$("$PLIST_BUDDY" -c "Print :CFBundleShortVersionString" "$BUNDLE_DIR/Info.plist" 2>/dev/null || printf '0.0.0\n')"
+    validate_release_version "$version" || return 1
+    printf '%s\n' "$version"
 }
 
 plist_set_string() {
@@ -604,16 +620,21 @@ fi
 echo "[build-app] Creating .app bundle at $APP_DIR..."
 mkdir -p "$APP_DIR/Contents/MacOS"
 mkdir -p "$APP_DIR/Contents/Resources"
+mkdir -p "$APP_DIR/Contents/Resources/LaunchAgents"
 mkdir -p "$BRAINLAYER_LOG_DIR"
 
 cp "$BUNDLE_DIR/Info.plist" "$APP_DIR/Contents/"
 cp "$BINARY" "$APP_DIR/Contents/MacOS/BrainBar"
 cp "$DAEMON_BINARY" "$APP_DIR/Contents/MacOS/BrainBarDaemon"
+cp "$UI_PLIST_SRC" "$APP_DIR/Contents/Resources/LaunchAgents/$UI_PLIST_FILENAME"
+cp "$DAEMON_PLIST_SRC" "$APP_DIR/Contents/Resources/LaunchAgents/$DAEMON_PLIST_FILENAME"
 
 COMMIT_SHA="$(git_commit)"
 DESCRIBE_REF="$(git_describe)"
 BUILD_UTC="$(build_time_utc)"
-RELEASE_VERSION="$(release_version)"
+if ! RELEASE_VERSION="$(release_version)"; then
+    exit 1
+fi
 stamp_info_plist "$APP_DIR/Contents/Info.plist" "$COMMIT_SHA" "$DESCRIBE_REF" "$BUILD_UTC" "$RELEASE_VERSION"
 echo "[build-app] Stamped Info.plist:"
 echo "  ReleaseVersion=$RELEASE_VERSION"

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -346,10 +346,8 @@ release_version() {
 
     local exact_tag
     exact_tag="$(git -C "$PACKAGE_DIR" describe --tags --exact-match 2>/dev/null || true)"
-    if [ -n "$exact_tag" ]; then
-        version="${exact_tag#v}"
-        validate_release_version "$version" || return 1
-        printf '%s\n' "$version"
+    if [[ "$exact_tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
         return 0
     fi
 

--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.4.0</string>
+    <string>0.0.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.0</string>
+    <string>0.0.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>0.0.0</string>
+    <string>1.4.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.0.0</string>
+    <string>1.4.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -369,6 +369,54 @@ def test_canonical_build_allows_launchagent_install_when_brainlayer_package_is_i
     assert "[build-app] brainlayer package is installed" in result.stdout
 
 
+def test_build_app_embeds_launchagent_templates_in_app_resources(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    _prepare_bundle_inputs(repo)
+    _install_fake_venv_python(repo, import_brainlayer_succeeds=True)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        dry_run=False,
+        extra_args=["--force-dirty"],
+        extra_env=_fake_build_env(tmp_path, tool_dir, bin_dir),
+    )
+
+    launchagents_dir = home / "Applications" / "BrainBar.app" / "Contents" / "Resources" / "LaunchAgents"
+    assert result.returncode == 0, result.stderr
+    assert (launchagents_dir / "com.brainlayer.brainbar.plist").is_file()
+    assert (launchagents_dir / "com.brainlayer.brainbar-daemon.plist").is_file()
+
+
+def test_build_app_rejects_invalid_release_version(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-dev-worktree")
+    home = tmp_path / "home"
+    home.mkdir()
+    _prepare_bundle_inputs(repo)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=tmp_path / "canonical",
+        home=home,
+        dry_run=False,
+        extra_args=["--force-worktree-build"],
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_RELEASE_VERSION": "1.2.3-beta1",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "release version must match X.Y.Z" in result.stderr
+
+
 def test_build_app_script_is_notarization_ready_for_developer_id() -> None:
     script = (Path(__file__).resolve().parents[1] / "brain-bar" / "build-app.sh").read_text()
 

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -7,6 +7,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 def _clean_git_env() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
@@ -214,6 +216,10 @@ if [[ "$2" == "Print :GitCommit" && -f "$3" ]]; then
   ' "$3"
   exit 0
 fi
+if [[ "$2" == "Print :CFBundleShortVersionString" ]]; then
+  printf '1.4.0\\n'
+  exit 0
+fi
 if [[ "$2" == Print* ]]; then
   exit 1
 fi
@@ -415,6 +421,29 @@ def test_build_app_rejects_invalid_release_version(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "release version must match X.Y.Z" in result.stderr
+
+
+@pytest.mark.parametrize("tag_name", ["ci-smoke", "1.2.3"])
+def test_build_app_ignores_non_release_exact_tags_and_uses_plist_version(tmp_path: Path, tag_name: str) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-dev-worktree")
+    home = tmp_path / "home"
+    home.mkdir()
+    _prepare_bundle_inputs(repo)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+    _git(repo, "tag", tag_name)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=tmp_path / "canonical",
+        home=home,
+        dry_run=False,
+        extra_args=["--force-worktree-build"],
+        extra_env=_fake_build_env(tmp_path, tool_dir, bin_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ReleaseVersion=1.4.0" in result.stdout
 
 
 def test_build_app_script_is_notarization_ready_for_developer_id() -> None:

--- a/tests/test_brainbar_release_workflow.py
+++ b/tests/test_brainbar_release_workflow.py
@@ -105,6 +105,27 @@ def _assert_version_stamp(job: dict) -> None:
     assert any("CFBundleShortVersionString" in _step_run(step) for step in version_steps), (
         "Info.plist release version must come from the pushed tag"
     )
+    metadata_steps = [
+        step
+        for step in job.get("steps", [])
+        if isinstance(step, dict) and "BRAINBAR_RELEASE_VERSION" in _step_run(step)
+    ]
+    assert any(r"^[0-9]+\.[0-9]+\.[0-9]+$" in _step_run(step) for step in metadata_steps), (
+        "BrainBar release workflow must reject tags that cannot be stamped into macOS bundle versions"
+    )
+
+
+def _assert_signing_decode_is_macos_safe(job: dict) -> None:
+    runs = "\n".join(_step_run(step) for step in job.get("steps", []) if isinstance(step, dict))
+    assert "base64 --decode" not in runs, "macOS base64 does not support --decode in the signing path"
+    assert "base64 -D" in runs, "BrainBar release workflow must decode signing certificates with macOS base64 -D"
+
+
+def _assert_launchagents_are_packaged(job: dict) -> None:
+    runs = "\n".join(_step_run(step) for step in job.get("steps", []) if isinstance(step, dict))
+    assert "Contents/Resources/LaunchAgents" in runs, "BrainBar.app must package launch agent templates"
+    assert "com.brainlayer.brainbar.plist" in runs, "BrainBar.app must include the UI launch agent plist"
+    assert "com.brainlayer.brainbar-daemon.plist" in runs, "BrainBar.app must include the daemon launch agent plist"
 
 
 def _assert_release_workflow_contract(workflow: dict) -> None:
@@ -112,6 +133,8 @@ def _assert_release_workflow_contract(workflow: dict) -> None:
     job = _release_job(workflow)
     _assert_swift_build_contract(job)
     _assert_version_stamp(job)
+    _assert_signing_decode_is_macos_safe(job)
+    _assert_launchagents_are_packaged(job)
     _assert_no_zip_guardrail_before_release(job)
 
 

--- a/tests/test_brainbar_release_workflow.py
+++ b/tests/test_brainbar_release_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from copy import deepcopy
 from pathlib import Path
 
@@ -128,10 +129,32 @@ def _assert_launchagents_are_packaged(job: dict) -> None:
     assert "com.brainlayer.brainbar-daemon.plist" in runs, "BrainBar.app must include the daemon launch agent plist"
 
 
+def _assert_action_refs_are_pinned(job: dict) -> None:
+    action_steps = [step for step in job.get("steps", []) if isinstance(step, dict) and "uses" in step]
+    assert action_steps, "BrainBar release workflow must declare action steps explicitly"
+    for step in action_steps:
+        uses = str(step["uses"])
+        assert re.search(r"@[0-9a-f]{40}$", uses), f"BrainBar release action must be pinned to a SHA: {uses}"
+
+
+def _assert_swift_cache_excludes_local_build(job: dict) -> None:
+    cache_steps = [
+        step
+        for step in job.get("steps", [])
+        if isinstance(step, dict) and str(step.get("uses", "")).startswith("actions/cache@")
+    ]
+    assert cache_steps, "BrainBar release workflow must cache SwiftPM dependencies"
+    cache_paths = "\n".join(str(step.get("with", {}).get("path", "")) for step in cache_steps)
+    assert "~/.swiftpm" in cache_paths, "BrainBar release workflow must cache external SwiftPM dependencies"
+    assert "brain-bar/.build" not in cache_paths, "BrainBar release workflow must not restore local .build artifacts"
+
+
 def _assert_release_workflow_contract(workflow: dict) -> None:
     _assert_tag_triggered(workflow)
     job = _release_job(workflow)
+    _assert_action_refs_are_pinned(job)
     _assert_swift_build_contract(job)
+    _assert_swift_cache_excludes_local_build(job)
     _assert_version_stamp(job)
     _assert_signing_decode_is_macos_safe(job)
     _assert_launchagents_are_packaged(job)

--- a/tests/test_brainbar_release_workflow.py
+++ b/tests/test_brainbar_release_workflow.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+from yaml.parser import ParserError
+from yaml.scanner import ScannerError
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "brainbar-release.yml"
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _events(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True) or {}
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _release_job(workflow: dict) -> dict:
+    for job in workflow.get("jobs", {}).values():
+        if job.get("runs-on") == "macos-15":
+            return job
+    raise AssertionError("BrainBar release workflow must run a job on macos-15")
+
+
+def _step_run(step: dict) -> str:
+    return str(step.get("run", ""))
+
+
+def _step_runs_in_brain_bar(step: dict, command: str) -> bool:
+    run = _step_run(step)
+    working_directory = str(step.get("working-directory", ""))
+    return command in run and (working_directory == "brain-bar" or "cd brain-bar" in run)
+
+
+def _is_release_step(step: dict) -> bool:
+    uses = str(step.get("uses", ""))
+    run = _step_run(step)
+    return "action-gh-release" in uses or "gh release" in run
+
+
+def _is_no_zip_guardrail(step: dict) -> bool:
+    run = _step_run(step)
+    return all(
+        token in run
+        for token in (
+            "BrainBar.zip",
+            "-s",
+            "exit 1",
+            "::error",
+        )
+    )
+
+
+def _assert_tag_triggered(workflow: dict) -> None:
+    push = _events(workflow).get("push", {})
+    assert "tags" in push, "BrainBar release workflow must be triggered by pushed tags"
+    assert _as_list(push["tags"]), "BrainBar release workflow must define at least one pushed tag pattern"
+
+
+def _assert_swift_build_contract(job: dict) -> None:
+    steps = job.get("steps", [])
+    assert any(
+        isinstance(step, dict) and str(step.get("uses", "")).startswith("maxim-lobanov/setup-xcode@") for step in steps
+    ), "BrainBar release workflow must select Xcode with maxim-lobanov/setup-xcode"
+    assert any(
+        isinstance(step, dict) and step.get("with", {}).get("xcode-version") == "latest-stable" for step in steps
+    ), "BrainBar release workflow must use the latest stable Xcode for Swift 6.x"
+    assert any(isinstance(step, dict) and _step_runs_in_brain_bar(step, "swift build -c release") for step in steps), (
+        "BrainBar release workflow must run swift build -c release inside brain-bar"
+    )
+
+
+def _assert_no_zip_guardrail_before_release(job: dict) -> None:
+    steps = job.get("steps", [])
+    guard_indexes = [index for index, step in enumerate(steps) if isinstance(step, dict) and _is_no_zip_guardrail(step)]
+    assert guard_indexes, "BrainBar release workflow must fail loudly when BrainBar.zip is missing or empty"
+
+    release_indexes = [index for index, step in enumerate(steps) if isinstance(step, dict) and _is_release_step(step)]
+    assert release_indexes, "BrainBar release workflow must attach BrainBar.zip to a GitHub Release"
+    assert min(guard_indexes) < min(release_indexes), "BrainBar.zip guardrail must run before the release step"
+
+
+def _assert_version_stamp(job: dict) -> None:
+    version_steps = [
+        step for step in job.get("steps", []) if isinstance(step, dict) and "Info.plist" in _step_run(step)
+    ]
+    assert any("GitCommit" in _step_run(step) for step in version_steps), "Info.plist must be stamped with GitCommit"
+    assert any("BuildTimeUTC" in _step_run(step) for step in version_steps), (
+        "Info.plist must be stamped with BuildTimeUTC"
+    )
+    assert any("CFBundleShortVersionString" in _step_run(step) for step in version_steps), (
+        "Info.plist release version must come from the pushed tag"
+    )
+
+
+def _assert_release_workflow_contract(workflow: dict) -> None:
+    _assert_tag_triggered(workflow)
+    job = _release_job(workflow)
+    _assert_swift_build_contract(job)
+    _assert_version_stamp(job)
+    _assert_no_zip_guardrail_before_release(job)
+
+
+def test_brainbar_release_workflow_is_valid_yaml() -> None:
+    try:
+        _load_workflow()
+    except (ParserError, ScannerError) as exc:
+        raise AssertionError(f"{WORKFLOW_PATH} is not valid YAML") from exc
+
+
+def test_brainbar_release_workflow_contract() -> None:
+    _assert_release_workflow_contract(_load_workflow())
+
+
+def test_release_workflow_without_no_zip_guardrail_fails_contract() -> None:
+    workflow = deepcopy(_load_workflow())
+    job = _release_job(workflow)
+    job["steps"] = [
+        step for step in job.get("steps", []) if not (isinstance(step, dict) and _is_no_zip_guardrail(step))
+    ]
+
+    with pytest.raises(AssertionError, match="missing or empty"):
+        _assert_no_zip_guardrail_before_release(job)


### PR DESCRIPTION
## Summary
- Add a tag-triggered macOS BrainBar release workflow that selects latest-stable Xcode, runs `cd brain-bar && swift build -c release`, assembles `BrainBar.app`, packages `BrainBar.zip`, and uploads it to a GitHub Release.
- Stamp release metadata into `Info.plist`: tag-derived version, `GitCommit`, `GitDescribe`, and `BuildTimeUTC`.
- Add a never-silent release guardrail that fails before release upload if `BrainBar.zip` is missing or empty.
- Add workflow contract tests, including a negative test that proves removing the zip guardrail fails the gate.

## Test plan
- `pytest tests/test_brainbar_release_workflow.py -q` (RED first: failed because `.github/workflows/brainbar-release.yml` was missing)
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `pytest tests/test_brainbar_release_workflow.py tests/test_brainbar_build_app_guards.py -q`
- `python3` PyYAML parse of `.github/workflows/brainbar-release.yml`
- `bash -n brain-bar/build-app.sh`
- `cd brain-bar && swift build -c release` (exit 0; existing Swift 6 sendability warnings in `EntityCache.swift`)
- Pre-push gate: 3,118 passed, 9 skipped, 61 deselected, 1 xfailed; MCP tool registration 3 passed; isolated eval/hook routing 40 passed; Bun stale index test 1 passed; regression shell FTS5 determinism passed

## Notes
- `coderabbit review --agent` was attempted before commit and hit the free OSS rate limit (`waitTime`: about 36 minutes), so PR-level bot review is still requested below.
- This PR does not cut a real release; it only adds the tag-triggered workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release and signing/notarization paths depend on secrets and macOS tooling; misconfiguration can ship unsigned builds or fail releases, but app runtime logic changes are limited to test-only accessors.
> 
> **Overview**
> Adds **BrainBar Release**, a GitHub Actions workflow on `v*` tags that builds on macOS, assembles `BrainBar.app` (binaries + LaunchAgent plists in `Contents/Resources/LaunchAgents`), stamps `Info.plist` from the tag (`vX.Y.Z` required), optionally Developer ID signs and notarizes when secrets exist, packages `BrainBar.zip`, and uploads it to a GitHub Release after a guard that fails if the zip is missing or empty.
> 
> **`build-app.sh`** now resolves and validates release version (`X.Y.Z` from env, exact `v*` tag, or bundle plist), writes `CFBundleShortVersionString` / `CFBundleVersion`, and embeds the same LaunchAgent templates in the app bundle.
> 
> Swift tests drop fixed `Task.sleep` waits in favor of **`_pendingRefreshTask`** and **`_pendingFeedbackResetTask`** test hooks. New Python contract tests cover the release workflow YAML and extended build-script behavior (LaunchAgents in bundle, invalid version rejection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a2545ca436dce28492a2af84d81a65f8a1c5b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub Actions release workflow for BrainBar that builds, signs, notarizes, and publishes BrainBar.zip
> - Adds [brainbar-release.yml](.github/workflows/brainbar-release.yml) triggered on `v*` tags that builds `BrainBar.app` via `swift build -c release`, assembles the bundle with LaunchAgents templates, conditionally signs and notarizes, packages `BrainBar.zip`, and creates a GitHub Release.
> - Extends [build-app.sh](brain-bar/build-app.sh) with version resolution (from env, exact tag, or `Info.plist`) and validation against `X.Y.Z`, and stamps `CFBundleShortVersionString`, `CFBundleVersion`, and build metadata into `Info.plist`.
> - Replaces fixed `Task.sleep` buffers in `InjectionStoreTests` and `QuickCapturePanelTests` with deterministic task awaiting via new internal `_pendingRefreshTask` and `_pendingFeedbackResetTask` accessors.
> - Adds contract tests in [test_brainbar_release_workflow.py](tests/test_brainbar_release_workflow.py) validating SHA-pinned actions, signing approach, and zip guardrail, plus build script tests in [test_brainbar_build_app_guards.py](tests/test_brainbar_build_app_guards.py) covering version rejection and LaunchAgents embedding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20a2545.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated macOS release workflow for tagged releases, including build, packaging, signing, notarization, and GitHub Release creation.
  * Release builds now stamp app metadata with a validated version and build information, and bundle required launch-related resources.

* **Bug Fixes**
  * Improved release packaging checks to stop release uploads if the zip is missing or empty.
  * Added safer handling for environments where signing or notarization credentials are unavailable.

* **Tests**
  * Expanded coverage for release packaging, version validation, and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->