### PR TITLE
feat: add verified launchd bootstrap primitive

### DIFF
--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -47,14 +47,16 @@ app.add_typer(sandbox_app, name="sandbox")
 
 
 def _launchd_target(label: str) -> str:
-    return f"gui/{os.getuid()}/{label}"
+    from ..launchd_primitive import launchd_target
+
+    return launchd_target(label)
 
 
-def _run_launchctl(args: list[str]) -> int:
+def _run_launchctl(args: list[str]) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(args, text=True, capture_output=True, check=False)
     if result.returncode != 0 and result.stderr:
         typer.echo(result.stderr.strip(), err=True)
-    return int(result.returncode)
+    return result
 
 
 def _plist_for_launchd_label(
@@ -80,11 +82,28 @@ def _plist_for_launchd_label(
 
 
 def _bootstrap_label(label: str, plist_path: Path) -> None:
-    target = _launchd_target(label)
-    _run_launchctl(["launchctl", "enable", target])
-    _run_launchctl(["launchctl", "bootout", target])
-    _run_launchctl(["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path.expanduser())])
-    _run_launchctl(["launchctl", "print", target])
+    from ..launchd_primitive import install_and_verify_launchagent
+
+    install_and_verify_launchagent(label, plist_path, command_runner=_run_launchctl)
+
+
+def _bootstrap_labels_or_exit(label_plist_pairs: list[tuple[str, Path]], *, action: str) -> None:
+    from ..launchd_primitive import LaunchdVerificationError
+
+    failures: list[LaunchdVerificationError] = []
+    for label, plist_path in label_plist_pairs:
+        if not label:
+            continue
+        try:
+            _bootstrap_label(label, plist_path)
+        except LaunchdVerificationError as exc:
+            failures.append(exc)
+    if not failures:
+        return
+
+    for failure in failures:
+        typer.echo(f"failed to {action} launchd label {failure.label}: {failure}", err=True)
+    raise typer.Exit(1)
 
 
 def _bootout_label(label: str) -> None:
@@ -194,18 +213,23 @@ def resume_command(
         payload = {}
     labels = payload.get("labels") if isinstance(payload, dict) else None
     selected_labels = [str(label) for label in labels] if isinstance(labels, list) else _default_pause_labels()
-    for label in selected_labels:
-        _bootstrap_label(
-            label,
-            _plist_for_launchd_label(
+    _bootstrap_labels_or_exit(
+        [
+            (
                 label,
-                watch=watch_plist_path,
-                drain=drain_plist_path,
-                health_check=health_check_plist_path,
-                hotlane=hotlane_plist_path,
-                enrichment=enrichment_plist_path,
-            ),
-        )
+                _plist_for_launchd_label(
+                    label,
+                    watch=watch_plist_path,
+                    drain=drain_plist_path,
+                    health_check=health_check_plist_path,
+                    hotlane=hotlane_plist_path,
+                    enrichment=enrichment_plist_path,
+                ),
+            )
+            for label in selected_labels
+        ],
+        action="resume",
+    )
     try:
         resolved.unlink()
     except FileNotFoundError:
@@ -242,15 +266,16 @@ def reconcile_launchd_command(
     ),
 ) -> None:
     """Bootstrap BrainLayer launchd labels if absent."""
-    for label, plist_path in (
-        (watch_label, watch_plist_path),
-        (drain_label, drain_plist_path),
-        (hotlane_label, hotlane_plist_path),
-        (enrichment_label, enrichment_plist_path),
-        (health_check_label, health_check_plist_path),
-    ):
-        if label:
-            _bootstrap_label(label, plist_path)
+    _bootstrap_labels_or_exit(
+        [
+            (watch_label, watch_plist_path),
+            (drain_label, drain_plist_path),
+            (hotlane_label, hotlane_plist_path),
+            (enrichment_label, enrichment_plist_path),
+            (health_check_label, health_check_plist_path),
+        ],
+        action="reconcile",
+    )
     typer.echo("reconciled launchd labels")
 
 
@@ -2495,7 +2520,6 @@ def watch(
 
     This is a persistent process — run it as a LaunchAgent or in a terminal.
     """
-    import os
     import signal
 
     from ..parent_death import install_parent_death_watcher

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -30,12 +30,12 @@ from .health_check import (
     CommandRunner,
     _default_command_runner,
     _default_ps_output,
-    _launchd_label_loaded,
     _load_json,
     _queue_stats,
     count_missing_embeddings,
     parse_hotlane_processes,
 )
+from .launchd_primitive import LaunchdLabelNotLoadedError, LaunchdVerificationError, verify_launchd_label_loaded
 from .paths import get_db_path
 from .search_repo import clear_hybrid_search_cache
 from .vector_store import VectorStore
@@ -228,19 +228,21 @@ def _check_launchd(
     message: str,
     command_runner: CommandRunner,
 ) -> bool | None:
-    loaded = _launchd_label_loaded(label, command_runner)
-    if loaded is False:
-        result.issues.append(DoctorIssue(issue_code, "fatal", message, {"label": label}))
-    elif loaded is None:
+    try:
+        return verify_launchd_label_loaded(label, command_runner=command_runner)
+    except LaunchdLabelNotLoadedError as exc:
+        result.issues.append(DoctorIssue(issue_code, "fatal", message, exc.issue_details()))
+        return False
+    except LaunchdVerificationError as exc:
         result.issues.append(
             DoctorIssue(
                 f"{issue_code}_unknown",
                 "warning",
                 f"could not determine whether {label} is loaded",
-                {"label": label},
+                exc.issue_details(),
             )
         )
-    return loaded
+        return None
 
 
 def _counter_increased(before: Any, after: Any) -> bool:

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -15,6 +15,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable
 
+from .launchd_primitive import (
+    LaunchdVerificationError,
+    install_and_verify_launchagent,
+    is_launchd_label_loaded,
+    launchd_target,
+)
 from .paths import get_db_path
 from .watcher import default_watch_roots
 
@@ -156,26 +162,11 @@ def _command_stdout(result: Any) -> str:
 
 
 def _launchd_target(label: str) -> str:
-    return f"gui/{os.getuid()}/{label}"
+    return launchd_target(label)
 
 
 def _launchd_label_loaded(label: str, command_runner: CommandRunner) -> bool | None:
-    if not label:
-        return True
-    result = command_runner(["launchctl", "print", _launchd_target(label)])
-    returncode = _command_returncode(result)
-    stderr = str(getattr(result, "stderr", "") or "")
-    stdout = _command_stdout(result)
-    if returncode == 0:
-        return True
-    if returncode == 127:
-        return None
-    output = f"{stdout}\n{stderr}".lower()
-    if "operation not permitted" in output or "permission" in output or "input/output error" in output:
-        return None
-    if "could not find service" in output or "service is not loaded" in output or returncode in {3, 36, 113}:
-        return False
-    return None
+    return is_launchd_label_loaded(label, command_runner=command_runner)
 
 
 def _kickstart(label: str, command_runner: CommandRunner) -> str:
@@ -190,14 +181,11 @@ def _bootstrap_if_absent(label: str, plist_path: Path, command_runner: CommandRu
         return f"loaded:{label}"
     if loaded is None:
         return f"launchctl-unavailable:{label}"
-    target = _launchd_target(label)
-    command_runner(["launchctl", "enable", target])
-    command_runner(["launchctl", "bootout", target])
-    command_runner(["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path.expanduser())])
-    verified = _launchd_label_loaded(label, command_runner)
-    if verified is True:
+    try:
+        install_and_verify_launchagent(label, plist_path, command_runner=command_runner)
         return f"bootstrap:{label}"
-    return f"bootstrap_failed:{label}"
+    except LaunchdVerificationError:
+        return f"bootstrap_failed:{label}"
 
 
 def _emit_heal_event(event: dict[str, Any]) -> None:

--- a/src/brainlayer/launchd_primitive.py
+++ b/src/brainlayer/launchd_primitive.py
@@ -1,0 +1,238 @@
+"""Reusable launchd install and loaded-state verification primitives."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+CommandRunner = Callable[[list[str]], Any]
+
+
+def _default_command_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(args, text=True, capture_output=True, check=False)
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(args=args, returncode=127, stdout="", stderr=str(exc))
+
+
+def _command_returncode(result: Any) -> int:
+    if isinstance(result, int):
+        return result
+    returncode = getattr(result, "returncode", None)
+    if returncode is None:
+        return 1
+    try:
+        return int(returncode)
+    except (TypeError, ValueError):
+        return 1
+
+
+def _command_stdout(result: Any) -> str:
+    return str(getattr(result, "stdout", "") or "")
+
+
+def _command_stderr(result: Any) -> str:
+    return str(getattr(result, "stderr", "") or "")
+
+
+def launchd_target(label: str, *, uid: int | None = None) -> str:
+    if not label:
+        raise ValueError("launchd label must not be empty")
+    return f"gui/{os.getuid() if uid is None else uid}/{label}"
+
+
+class LaunchdVerificationError(RuntimeError):
+    """Raised when launchd state cannot satisfy a required loaded post-condition."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        label: str,
+        target: str,
+        reason: str,
+        plist_path: Path | None = None,
+        command: list[str] | None = None,
+        returncode: int | None = None,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.label = label
+        self.target = target
+        self.reason = reason
+        self.plist_path = plist_path
+        self.command = command
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def issue_details(self) -> dict[str, Any]:
+        details: dict[str, Any] = {
+            "label": self.label,
+            "target": self.target,
+            "reason": self.reason,
+        }
+        if self.plist_path is not None:
+            details["plist_path"] = str(self.plist_path)
+        if self.command is not None:
+            details["command"] = self.command
+        if self.returncode is not None:
+            details["returncode"] = self.returncode
+        if self.stdout:
+            details["stdout"] = self.stdout
+        if self.stderr:
+            details["stderr"] = self.stderr
+        return details
+
+
+class LaunchdLabelNotLoadedError(LaunchdVerificationError):
+    """Raised when launchd reports that a required label is not loaded."""
+
+
+class LaunchdCommandError(LaunchdVerificationError):
+    """Raised when an install/bootstrap command fails before verification."""
+
+
+def _loaded_state_from_result(result: Any) -> bool | None:
+    returncode = _command_returncode(result)
+    stdout = _command_stdout(result)
+    stderr = _command_stderr(result)
+    if returncode == 0:
+        return True
+    if returncode == 127:
+        return None
+
+    output = f"{stdout}\n{stderr}".lower()
+    if "operation not permitted" in output or "permission" in output or "input/output error" in output:
+        return None
+    if "could not find service" in output or "service is not loaded" in output or returncode in {3, 36, 113}:
+        return False
+    return None
+
+
+def is_launchd_label_loaded(
+    label: str,
+    *,
+    command_runner: CommandRunner = _default_command_runner,
+) -> bool | None:
+    """Return True/False for known launchd loaded state, or None when indeterminate."""
+    if not label:
+        return True
+
+    target = launchd_target(label)
+    print_result = command_runner(["launchctl", "print", target])
+    print_state = _loaded_state_from_result(print_result)
+    if print_state is not None:
+        return print_state
+    return None
+
+
+def verify_launchd_label_loaded(
+    label: str,
+    *,
+    command_runner: CommandRunner = _default_command_runner,
+    plist_path: Path | None = None,
+    context: str = "",
+) -> bool:
+    """Require that launchd positively reports a label as loaded."""
+    if not label:
+        return True
+
+    target = launchd_target(label)
+    loaded = is_launchd_label_loaded(label, command_runner=command_runner)
+    context_suffix = f" {context}" if context else ""
+    if loaded is True:
+        return True
+    if loaded is False:
+        raise LaunchdLabelNotLoadedError(
+            f"launchd label {label} is not loaded{context_suffix}",
+            label=label,
+            target=target,
+            reason="not_loaded",
+            plist_path=plist_path,
+        )
+    raise LaunchdVerificationError(
+        f"could not verify launchd label {label} is loaded{context_suffix}",
+        label=label,
+        target=target,
+        reason="unknown_loaded_state",
+        plist_path=plist_path,
+    )
+
+
+def _run_required_launchctl(
+    args: list[str],
+    *,
+    label: str,
+    plist_path: Path,
+    command_runner: CommandRunner,
+) -> None:
+    result = command_runner(args)
+    returncode = _command_returncode(result)
+    if returncode == 0:
+        return
+    raise LaunchdCommandError(
+        f"launchctl command failed for {label}: {' '.join(args)}",
+        label=label,
+        target=launchd_target(label),
+        reason="launchctl_command_failed",
+        plist_path=plist_path,
+        command=args,
+        returncode=returncode,
+        stdout=_command_stdout(result),
+        stderr=_command_stderr(result),
+    )
+
+
+def install_and_verify_launchagent(
+    label: str,
+    plist_path: Path,
+    *,
+    command_runner: CommandRunner = _default_command_runner,
+    bootout_existing: bool = True,
+) -> bool:
+    """Bootstrap a LaunchAgent and require a positive loaded post-condition."""
+    resolved_plist_path = plist_path.expanduser()
+    target = launchd_target(label)
+    domain = f"gui/{os.getuid()}"
+
+    _run_required_launchctl(
+        ["launchctl", "enable", target],
+        label=label,
+        plist_path=resolved_plist_path,
+        command_runner=command_runner,
+    )
+    if bootout_existing:
+        command_runner(["launchctl", "bootout", target])
+    bootstrap_args = ["launchctl", "bootstrap", domain, str(resolved_plist_path)]
+    bootstrap_result = command_runner(bootstrap_args)
+    bootstrap_returncode = _command_returncode(bootstrap_result)
+    if bootstrap_returncode != 0:
+        try:
+            return verify_launchd_label_loaded(
+                label,
+                command_runner=command_runner,
+                plist_path=resolved_plist_path,
+                context="after bootstrap",
+            )
+        except LaunchdVerificationError as exc:
+            raise LaunchdCommandError(
+                f"launchctl command failed for {label}: {' '.join(bootstrap_args)}",
+                label=label,
+                target=target,
+                reason="launchctl_command_failed",
+                plist_path=resolved_plist_path,
+                command=bootstrap_args,
+                returncode=bootstrap_returncode,
+                stdout=_command_stdout(bootstrap_result),
+                stderr=_command_stderr(bootstrap_result),
+            ) from exc
+    return verify_launchd_label_loaded(
+        label,
+        command_runner=command_runner,
+        plist_path=resolved_plist_path,
+        context="after bootstrap",
+    )

--- a/tests/test_cli_launchd_mode_a.py
+++ b/tests/test_cli_launchd_mode_a.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
@@ -130,3 +131,68 @@ def test_reconcile_launchd_bootstraps_all_mode_a_labels(monkeypatch, tmp_path):
     assert "com.brainlayer.health-check" in command_text
     assert "com.brainlayer.hotlane-brainbar" in command_text
     assert "com.brainlayer.enrichment" in command_text
+
+
+def test_resume_attempts_all_labels_and_keeps_sentinel_when_bootstrap_verification_fails(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        if args[:2] == ["launchctl", "bootstrap"] and str(args[-1]).endswith("com.test.watch.plist"):
+            return SimpleNamespace(returncode=5, stdout="", stderr="bootstrap failed")
+        if args[:2] == ["launchctl", "print"] and args[2].endswith("/com.test.watch"):
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("brainlayer.cli._run_launchctl", command_runner)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.test.watch", "com.test.drain"]}), encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["resume", "--pause-sentinel-path", str(pause_path)])
+
+    assert result.exit_code == 1
+    assert pause_path.exists()
+    command_text = "\n".join(" ".join(command) for command in commands)
+    assert "com.test.watch" in command_text
+    assert "com.test.drain" in command_text
+    assert "failed to resume launchd label com.test.watch" in result.output
+
+
+def test_reconcile_launchd_attempts_remaining_labels_when_one_bootstrap_fails(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        if args[:2] == ["launchctl", "bootstrap"] and str(args[-1]) == str(tmp_path / "watch.plist"):
+            return SimpleNamespace(returncode=5, stdout="", stderr="bootstrap failed")
+        if args[:2] == ["launchctl", "print"] and args[2].endswith("/com.brainlayer.watch"):
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("brainlayer.cli._run_launchctl", command_runner)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "reconcile-launchd",
+            "--watch-plist-path",
+            str(tmp_path / "watch.plist"),
+            "--drain-plist-path",
+            str(tmp_path / "drain.plist"),
+            "--health-check-plist-path",
+            str(tmp_path / "health.plist"),
+            "--hotlane-plist-path",
+            str(tmp_path / "hotlane.plist"),
+            "--enrichment-plist-path",
+            str(tmp_path / "enrichment.plist"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    command_text = "\n".join(" ".join(command) for command in commands)
+    assert "com.brainlayer.watch" in command_text
+    assert "com.brainlayer.drain" in command_text
+    assert "com.brainlayer.health-check" in command_text
+    assert "com.brainlayer.hotlane-brainbar" in command_text
+    assert "com.brainlayer.enrichment" in command_text
+    assert "failed to reconcile launchd label com.brainlayer.watch" in result.output

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,110 @@ NOW = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
 def _loaded_launchctl(args: list[str]) -> SimpleNamespace:
     assert args[:2] == ["launchctl", "print"]
     return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def test_launchd_install_and_verify_returns_true_when_label_is_loaded(tmp_path):
+    from brainlayer.launchd_primitive import install_and_verify_launchagent
+
+    plist_path = tmp_path / "com.example.loaded.plist"
+    plist_path.write_text("<plist />", encoding="utf-8")
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    assert install_and_verify_launchagent(
+        "com.example.loaded",
+        plist_path,
+        command_runner=command_runner,
+    )
+    assert ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path)] in commands
+    assert ["launchctl", "print", f"gui/{os.getuid()}/com.example.loaded"] in commands
+
+
+def test_launchd_install_and_verify_raises_when_bootstrap_does_not_load_label(tmp_path):
+    from brainlayer.launchd_primitive import LaunchdLabelNotLoadedError, install_and_verify_launchagent
+
+    plist_path = tmp_path / "com.example.not-loaded.plist"
+    plist_path.write_text("<plist />", encoding="utf-8")
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        if args[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    try:
+        install_and_verify_launchagent(
+            "com.example.not-loaded",
+            plist_path,
+            command_runner=command_runner,
+        )
+    except LaunchdLabelNotLoadedError as exc:
+        assert exc.label == "com.example.not-loaded"
+        assert exc.plist_path == plist_path
+        assert "not loaded after bootstrap" in str(exc)
+    else:
+        raise AssertionError("install_and_verify_launchagent returned success for an unloaded label")
+
+    assert ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path)] in commands
+    assert ["launchctl", "print", f"gui/{os.getuid()}/com.example.not-loaded"] in commands
+
+
+def test_launchd_install_and_verify_rejects_malformed_command_runner_result(tmp_path):
+    from brainlayer.launchd_primitive import LaunchdCommandError, install_and_verify_launchagent
+
+    plist_path = tmp_path / "com.example.malformed.plist"
+    plist_path.write_text("<plist />", encoding="utf-8")
+
+    try:
+        install_and_verify_launchagent(
+            "com.example.malformed",
+            plist_path,
+            command_runner=lambda _args: object(),
+        )
+    except LaunchdCommandError as exc:
+        assert exc.reason == "launchctl_command_failed"
+        assert exc.returncode == 1
+    else:
+        raise AssertionError("malformed command_runner result was treated as launchctl success")
+
+
+def test_launchd_install_and_verify_accepts_loaded_label_after_bootstrap_already_loaded(tmp_path):
+    from brainlayer.launchd_primitive import install_and_verify_launchagent
+
+    plist_path = tmp_path / "com.example.race.plist"
+    plist_path.write_text("<plist />", encoding="utf-8")
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        if args[:2] == ["launchctl", "bootstrap"]:
+            return SimpleNamespace(returncode=37, stdout="", stderr="service already bootstrapped")
+        if args[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    assert install_and_verify_launchagent(
+        "com.example.race",
+        plist_path,
+        command_runner=command_runner,
+    )
+
+
+def test_launchd_label_loaded_does_not_use_unscoped_list_fallback():
+    from brainlayer.launchd_primitive import is_launchd_label_loaded
+
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        if args[:2] == ["launchctl", "list"]:
+            return SimpleNamespace(returncode=0, stdout="com.example.ambiguous\n", stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="unexpected launchctl failure")
+
+    assert is_launchd_label_loaded("com.example.ambiguous", command_runner=command_runner) is None
+    assert ["launchctl", "list", "com.example.ambiguous"] not in commands
 
 
 def _hotlane_ps() -> str:
@@ -171,6 +276,32 @@ def test_run_doctor_exits_nonzero_for_recent_unvectored_chunk(tmp_path):
     assert result.exit_code == 1
     assert result.ok is False
     assert any(issue.code == "recent_unvectored_chunks" for issue in result.issues)
+
+
+def test_run_doctor_fails_loudly_when_required_launchd_label_is_not_loaded(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "launchd-not-loaded.db"
+    _build_db(db_path)
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        if args == ["launchctl", "print", f"gui/{os.getuid()}/com.brainlayer.watch"]:
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = run_doctor(
+        _doctor_config(tmp_path, db_path),
+        ps_output_fn=_hotlane_ps,
+        command_runner=command_runner,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 1
+    issue = next(issue for issue in result.issues if issue.code == "watch_unloaded")
+    assert issue.severity == "fatal"
+    assert issue.details["label"] == "com.brainlayer.watch"
+    assert issue.details["target"] == f"gui/{os.getuid()}/com.brainlayer.watch"
+    assert issue.details["reason"] == "not_loaded"
 
 
 def test_run_doctor_reports_fts_desync_without_rebuilding(tmp_path):


### PR DESCRIPTION
## Summary
- Add `brainlayer.launchd_primitive` with reusable launchd target, loaded-state probe, raising verifier, and `install_and_verify_launchagent(label, plist_path)` positive post-condition.
- Wire doctor launchd checks through the shared verifier so required-but-unloaded labels fail with label, target, and reason details.
- Reuse the primitive from health-check and CLI bootstrap paths while keeping launchd imports lazy on the CLI fast path.

## Test plan
- RED: `pytest tests/test_doctor.py` failed before implementation with missing `brainlayer.launchd_primitive` and missing doctor target details.
- GREEN: `ruff check src/brainlayer/launchd_primitive.py src/brainlayer/doctor.py src/brainlayer/health_check.py src/brainlayer/cli/__init__.py tests/test_doctor.py`
- GREEN: `pytest tests/test_doctor.py` (10 passed)
- GREEN: `pytest tests/test_doctor.py tests/test_stability_health_check.py tests/test_cli_launchd_mode_a.py` (27 passed)
- GREEN: `.venv/bin/python -m pytest tests/test_cli_direct_sqlite.py::test_cli_stats_p95_under_200ms_with_direct_readonly_store`
- GREEN pre-push gate: pytest unit suite (3077 passed, 9 skipped, 61 deselected, 1 xfailed), MCP tool registration (3 passed), isolated eval/hook routing (40 passed), bun test (1 passed), FTS5 regression shell passed.

## Notes
- Local `python3.13` full `pytest` collection is blocked by an environment mismatch (`numba` rejects installed NumPy 2.4); the repo pre-push hook created/used the Python 3.12 venv and passed the full gate.
- Local CodeRabbit pre-commit found one MAJOR issue in malformed command-runner handling; fixed with a regression test. A second local CodeRabbit run was rate-limited, so PR-level review is requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launchd bootstrap and verification for core BrainLayer LaunchAgents (watch, drain, enrichment); failures are now explicit, which is safer but alters resume/reconcile exit behavior on partial failure.
> 
> **Overview**
> Introduces **`brainlayer.launchd_primitive`** as the shared place for LaunchAgent install and loaded-state checks, replacing duplicated `launchctl` sequences in the CLI, doctor, and health-check.
> 
> **Bootstrap and verify:** `install_and_verify_launchagent` runs enable/bootout/bootstrap and **requires** a positive loaded post-condition via `launchctl print`. Structured errors (`LaunchdVerificationError`, `LaunchdLabelNotLoadedError`, `LaunchdCommandError`) carry label, target, reason, and command output for reporting.
> 
> **Doctor** uses `verify_launchd_label_loaded` so missing required labels become **fatal** issues with rich `issue_details` instead of loose bool handling.
> 
> **CLI** `resume` and `reconcile-launchd` go through `_bootstrap_labels_or_exit`: every label is attempted even when one fails; verification failures exit **1** with stderr messages, and **`resume` keeps the pause sentinel** if bootstrap does not verify.
> 
> **Health-check** heal/bootstrap paths delegate to the same primitive; failed verify surfaces as `bootstrap_failed:` rather than silent success.
> 
> Tests cover primitive edge cases (already bootstrapped, malformed runner, no unscoped `launchctl list` fallback) and CLI multi-label failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d38e26ee866a87a2e5cfe7ccd7cd7e60076a419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add verified launchd bootstrap primitive with structured error handling
> - Introduces [launchd_primitive.py](https://github.com/EtanHey/brainlayer/pull/547/files#diff-b103eca0b1a87ad4f67e0d1b3307289c28ad7cb92de56786efd4aee3e8a6cd39) with `install_and_verify_launchagent`, `is_launchd_label_loaded`, and `verify_launchd_label_loaded` as centralized primitives for bootstrapping and verifying launchd agents.
> - Adds `LaunchdVerificationError`, `LaunchdLabelNotLoadedError`, and `LaunchdCommandError` exception classes that carry structured context (label, target, reason, command outputs) via `issue_details()`.
> - Refactors `cli._bootstrap_label`, `health_check._bootstrap_if_absent`, and `doctor._check_launchd` to delegate to these primitives, replacing duplicated inline enable/bootout/bootstrap/print sequences.
> - Adds `cli._bootstrap_labels_or_exit` to accumulate failures across multiple labels and exit non-zero if any verification fails, so `resume` and `reconcile-launchd` now attempt all labels before reporting.
> - Behavioral Change: `_run_launchctl` now returns `CompletedProcess` instead of an integer return code, affecting any callers that expected an `int`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d38e26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->