### PR TITLE
feat: never-silent-degradation alarm primitive

### DIFF
--- a/src/brainlayer/alarm.py
+++ b/src/brainlayer/alarm.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import json
 import logging
 import sys
+import threading
 from typing import Any, NoReturn
 
 logger = logging.getLogger(__name__)
 
 ALARM_DATASET = "brainlayer-alarms"
+_TELEMETRY_JOIN_TIMEOUT_S = 0.05
 
 
 class BrainLayerAlarm(BaseException):
@@ -71,12 +73,28 @@ def emit_alarm(alarm: BrainLayerAlarm) -> bool:
         print(human_message, file=sys.stderr, flush=True)
     except Exception as exc:
         logger.debug("Alarm stderr emit failed: %s", exc)
-    try:
-        from .telemetry import emit
 
-        return emit(ALARM_DATASET, alarm.to_event())
+    result: dict[str, bool] = {"ok": False}
+    event = alarm.to_event()
+
+    def emit_telemetry() -> None:
+        try:
+            from .telemetry import emit
+
+            result["ok"] = emit(ALARM_DATASET, event)
+        except Exception as exc:
+            logger.debug("Alarm telemetry emit failed: %s", exc)
+
+    try:
+        thread = threading.Thread(target=emit_telemetry, name=f"brainlayer-alarm-{alarm.code}", daemon=True)
+        thread.start()
+        thread.join(_TELEMETRY_JOIN_TIMEOUT_S)
+        if thread.is_alive():
+            logger.debug("Alarm telemetry emit still running in background: %s", alarm.code)
+            return True
+        return result["ok"]
     except Exception as exc:
-        logger.debug("Alarm telemetry emit failed: %s", exc)
+        logger.debug("Alarm telemetry dispatch failed: %s", exc)
         return False
 
 

--- a/src/brainlayer/alarm.py
+++ b/src/brainlayer/alarm.py
@@ -1,0 +1,93 @@
+"""Loud persistent alarms for never-silent degradation paths."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any, NoReturn
+
+logger = logging.getLogger(__name__)
+
+ALARM_DATASET = "brainlayer-alarms"
+
+
+class BrainLayerAlarm(BaseException):
+    """Alarm that bypasses broad ``except Exception`` handlers."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        context: dict[str, Any] | None = None,
+        *,
+        severity: str = "fatal",
+        exit_code: int = 1,
+    ) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+        self.context = dict(context or {})
+        self.severity = severity
+        self.exit_code = exit_code
+
+    @property
+    def details(self) -> dict[str, Any]:
+        return self.context
+
+    def to_event(self) -> dict[str, Any]:
+        return {
+            "_type": "alarm",
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "context": self.context,
+            "exit_code": self.exit_code,
+        }
+
+    def human_message(self) -> str:
+        context = ""
+        if self.context:
+            context = f" context={json.dumps(self.context, sort_keys=True, default=str)}"
+        return f"BRAINLAYER_ALARM {self.code}: {self.message}{context}"
+
+
+def build_alarm(
+    code: str,
+    message: str,
+    context: dict[str, Any] | None = None,
+    *,
+    severity: str = "fatal",
+    exit_code: int = 1,
+) -> BrainLayerAlarm:
+    return BrainLayerAlarm(code, message, context, severity=severity, exit_code=exit_code)
+
+
+def emit_alarm(alarm: BrainLayerAlarm) -> bool:
+    """Persist the alarm to every existing non-blocking notification path."""
+    human_message = alarm.human_message()
+    logger.critical(human_message)
+    try:
+        print(human_message, file=sys.stderr, flush=True)
+    except Exception as exc:
+        logger.debug("Alarm stderr emit failed: %s", exc)
+    try:
+        from .telemetry import emit
+
+        return emit(ALARM_DATASET, alarm.to_event())
+    except Exception as exc:
+        logger.debug("Alarm telemetry emit failed: %s", exc)
+        return False
+
+
+def raise_alarm(
+    code: str,
+    message: str,
+    context: dict[str, Any] | None = None,
+    *,
+    severity: str = "fatal",
+    exit_code: int = 1,
+) -> NoReturn:
+    alarm = build_alarm(code, message, context, severity=severity, exit_code=exit_code)
+    emit_alarm(alarm)
+    raise alarm

--- a/src/brainlayer/alarm.py
+++ b/src/brainlayer/alarm.py
@@ -66,7 +66,11 @@ def build_alarm(
 
 
 def emit_alarm(alarm: BrainLayerAlarm) -> bool:
-    """Persist the alarm to every existing non-blocking notification path."""
+    """Emit local loud alarm output and best-effort non-blocking telemetry.
+
+    stderr/logging are the guaranteed fatal alarm paths. Axiom telemetry stays
+    off the caller thread so a stalled network path cannot delay the alarm raise.
+    """
     human_message = alarm.human_message()
     logger.critical(human_message)
     try:

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
+from .alarm import BrainLayerAlarm, emit_alarm
 from .drain_liveness import (
     DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
     ENRICH_DAILY_COST_COUNTER_FILENAME,
@@ -416,6 +417,8 @@ def run_doctor(
             active_drain_liveness_issue.code == STALLED_CODE and has_drain_backlog and drain_liveness_moving
         )
         if not suppress_stale_drain:
+            if isinstance(active_drain_liveness_issue, BrainLayerAlarm):
+                emit_alarm(active_drain_liveness_issue)
             result.issues.append(
                 DoctorIssue(
                     active_drain_liveness_issue.code,

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -362,6 +362,30 @@ def _refresh_realtime_watcher_ingested_at(conn: apsw.Connection, chunk_id: str, 
     )
 
 
+def _record_watcher_liveness(conn: apsw.Connection, chunk_id: str, ingested_at: int) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS watcher_liveness_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chunk_id TEXT NOT NULL,
+            ingested_at INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_watcher_liveness_ingested_at ON watcher_liveness_events(ingested_at)")
+    conn.execute(
+        """
+        INSERT INTO watcher_liveness_events (chunk_id, ingested_at)
+        VALUES (?, ?)
+        """,
+        (chunk_id, ingested_at),
+    )
+    conn.execute(
+        "DELETE FROM watcher_liveness_events WHERE ingested_at < ?",
+        (ingested_at - 86_400,),
+    )
+
+
 def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
     if "kind" in event:
         return event
@@ -657,6 +681,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         },
     )
     _refresh_realtime_watcher_ingested_at(conn, stored_chunk_id, ingested_at)
+    _record_watcher_liveness(conn, stored_chunk_id, ingested_at)
     return ApplyResult(chunk_id=stored_chunk_id)
 
 

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -632,6 +632,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "char_count": len(content),
             "source": "realtime_watcher",
             "created_at": event.get("created_at") or datetime.now(timezone.utc).isoformat(),
+            "ingested_at": int(time.time()),
             "conversation_id": event.get("conversation_id"),
             "sender": event.get("sender"),
             "tags": json.dumps(tags) if tags else None,

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -362,7 +362,7 @@ def _refresh_realtime_watcher_ingested_at(conn: apsw.Connection, chunk_id: str, 
     )
 
 
-def _record_watcher_liveness(conn: apsw.Connection, chunk_id: str, ingested_at: int) -> None:
+def _ensure_watcher_liveness_schema(conn: apsw.Connection) -> None:
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS watcher_liveness_events (
@@ -373,6 +373,9 @@ def _record_watcher_liveness(conn: apsw.Connection, chunk_id: str, ingested_at: 
         """
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_watcher_liveness_ingested_at ON watcher_liveness_events(ingested_at)")
+
+
+def _record_watcher_liveness(conn: apsw.Connection, chunk_id: str, ingested_at: int) -> None:
     conn.execute(
         """
         INSERT INTO watcher_liveness_events (chunk_id, ingested_at)
@@ -1165,6 +1168,7 @@ def burn_drain_once(
             conn = _open_connection(db_path)
             try:
                 _ensure_enrichment_update_schema(conn)
+                _ensure_watcher_liveness_schema(conn)
                 conn.execute("BEGIN IMMEDIATE")
                 prefetched_state = _prefetch_enrichment_state(conn, all_events)
                 store_chunk_ids: list[str] = []
@@ -1296,6 +1300,7 @@ def drain_once(
                 try:
                     conn = _open_connection(db_path)
                     _ensure_enrichment_update_schema(conn)
+                    _ensure_watcher_liveness_schema(conn)
                     conn.execute("BEGIN IMMEDIATE")
                     ensure_dedupe_schema(conn)
                     for event in events_to_apply:

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -347,6 +347,21 @@ def _insert_or_merge_chunk(conn: apsw.Connection, values: dict[str, Any]) -> str
     return chunk_id
 
 
+def _refresh_realtime_watcher_ingested_at(conn: apsw.Connection, chunk_id: str, ingested_at: int) -> None:
+    cols = _columns(conn, "chunks")
+    if "ingested_at" not in cols or "source" not in cols:
+        return
+    conn.execute(
+        """
+        UPDATE chunks
+        SET ingested_at = ?
+        WHERE id = ?
+          AND source = 'realtime_watcher'
+        """,
+        (ingested_at, chunk_id),
+    )
+
+
 def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
     if "kind" in event:
         return event
@@ -619,6 +634,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         logger.warning("Skipping recursive MCP watcher event: %s", recursive_reason)
         return ApplyResult()
     tags = event.get("tags")
+    ingested_at = int(time.time())
     stored_chunk_id = _insert_or_merge_chunk(
         conn,
         {
@@ -632,7 +648,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "char_count": len(content),
             "source": "realtime_watcher",
             "created_at": event.get("created_at") or datetime.now(timezone.utc).isoformat(),
-            "ingested_at": int(time.time()),
+            "ingested_at": ingested_at,
             "conversation_id": event.get("conversation_id"),
             "sender": event.get("sender"),
             "tags": json.dumps(tags) if tags else None,
@@ -640,6 +656,7 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "chunk_origin": detect_chunk_origin(content, event.get("chunk_origin")),
         },
     )
+    _refresh_realtime_watcher_ingested_at(conn, stored_chunk_id, ingested_at)
     return ApplyResult(chunk_id=stored_chunk_id)
 
 

--- a/src/brainlayer/drain_liveness.py
+++ b/src/brainlayer/drain_liveness.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from .alarm import BrainLayerAlarm, build_alarm
+
 DEFAULT_DRAIN_LIVENESS_STALE_SECONDS = 300.0
 DEFAULT_ENRICH_DAILY_USD_CAP = 5.0
 ENRICH_DAILY_COST_COUNTER_FILENAME = "enrich-daily-cost.json"
@@ -113,7 +115,7 @@ def check_drain_liveness(
     stale_seconds: float = DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
     enrich_cost_counter_path: Path | None = None,
     quota_or_throttle_blocker: str | None = None,
-) -> DrainLivenessIssue | None:
+) -> BrainLayerAlarm | DrainLivenessIssue | None:
     """Return a loud issue when a loaded drain has backlog but no fresh heartbeat."""
     queue_backlog = _positive_int(queue_count)
     enrichment_backlog_count = _positive_int(enrichment_backlog)
@@ -156,9 +158,8 @@ def check_drain_liveness(
         )
 
     stale_description = "missing" if heartbeat_at is None else f"stale for {heartbeat_age:.0f}s"
-    return DrainLivenessIssue(
+    return build_alarm(
         STALLED_CODE,
-        "fatal",
         (
             f"DRAIN_LIVENESS_STALLED: {drain_label} is loaded and backlog={backlog} "
             f"(queue={queue_backlog}, enrichment={enrichment_backlog_count}), "

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -399,6 +399,11 @@ class BatchIndexer:
             logger.error("Batch flush failed (%d items), retaining in buffer: %s", count, e)
             self.total_failed_inputs += self._isolate_failed_flush(batch, e)
 
+    def retained_failed_input_count(self) -> int:
+        """Return currently retained flush-failed inputs without counting retry attempts."""
+        with self._lock:
+            return len(self._buffer) if self._flush_failures > 0 else 0
+
     def _confirmed_watermarks(self, batch: list[dict], result: dict[str, int] | None) -> dict[str, int]:
         if isinstance(result, dict):
             return {str(source_file): int(offset) for source_file, offset in result.items()}
@@ -520,7 +525,6 @@ class JSONLWatcher:
         self._health_window_started_epoch = time.time()
         self._health_entries_seen = 0
         self._health_output_at_start = 0
-        self._health_failed_input_at_start = 0
         self.poll_count = 0
 
     def _advance_confirmed_offsets(self, watermarks: dict[str, int]) -> None:
@@ -646,9 +650,7 @@ class JSONLWatcher:
         elapsed = max(now - self._health_window_started, 1.0)
         normalized_entries_per_min = self._health_entries_seen / elapsed * 60.0
         outputs_per_min = (self.indexer.total_outputs - self._health_output_at_start) / elapsed * 60.0
-        failed_flush_inputs_per_min = (
-            (self.indexer.total_failed_inputs - self._health_failed_input_at_start) / elapsed * 60.0
-        )
+        failed_flush_inputs_per_min = self.indexer.retained_failed_input_count() / elapsed * 60.0
         active_entries_per_min = outputs_per_min + failed_flush_inputs_per_min
         db_inserts = self._db_realtime_inserts_since_window_start()
         db_probe_failed = self.db_path is not None and db_inserts is None
@@ -722,7 +724,6 @@ class JSONLWatcher:
             self._health_window_started_epoch = time.time()
             self._health_entries_seen = 0
             self._health_output_at_start = self.indexer.total_outputs
-            self._health_failed_input_at_start = self.indexer.total_failed_inputs
 
     def _ensure_tailer(self, filepath: str) -> JSONLTailer:
         """Get or create a tailer for a file, respecting stored offsets."""

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -626,11 +626,18 @@ class JSONLWatcher:
         entries_per_min = self._health_entries_seen / elapsed * 60.0
         outputs_per_min = (self.indexer.total_outputs - self._health_output_at_start) / elapsed * 60.0
         db_inserts = self._db_realtime_inserts_since_window_start()
-        inserts_per_min = (db_inserts / elapsed * 60.0) if db_inserts is not None else outputs_per_min
+        db_probe_failed = self.db_path is not None and db_inserts is None
+        if db_inserts is not None:
+            db_inserts_per_min = db_inserts / elapsed * 60.0
+        elif self.db_path is not None:
+            db_inserts_per_min = None
+        else:
+            db_inserts_per_min = outputs_per_min
+        watchdog_inserts_per_min = 0.0 if db_probe_failed else db_inserts_per_min
         max_lag = self._max_offset_lag_bytes(files)
         watchdog = self.coverage_watchdog.evaluate(
             active_entries_per_minute=entries_per_min,
-            realtime_inserts_per_minute=inserts_per_min,
+            realtime_inserts_per_minute=watchdog_inserts_per_min,
             max_offset_lag_bytes=max_lag,
         )
         payload = {
@@ -639,7 +646,8 @@ class JSONLWatcher:
             "providers": sorted({root.provider for root in self.watch_roots}),
             "files_tracked": len(files),
             "active_jsonl_entries_per_minute": entries_per_min,
-            "db_realtime_inserts_per_minute": inserts_per_min,
+            "db_probe_failed": db_probe_failed,
+            "db_realtime_inserts_per_minute": db_inserts_per_min,
             "watcher_chunks_output_per_minute": outputs_per_min,
             "max_offset_lag_bytes": max_lag,
             **watchdog,
@@ -652,7 +660,7 @@ class JSONLWatcher:
         except OSError:
             logger.debug("Failed to write watcher health snapshot", exc_info=True)
 
-        durable_writes_per_min = inserts_per_min if db_inserts is not None else outputs_per_min
+        durable_writes_per_min = watchdog_inserts_per_min
         if (
             watchdog.get("alerting") is True
             and "coverage_drop" in watchdog.get("alert_reasons", [])
@@ -664,7 +672,8 @@ class JSONLWatcher:
                 "watcher observed active JSONL input but produced zero durable realtime writes",
                 {
                     "active_jsonl_entries_per_minute": entries_per_min,
-                    "db_realtime_inserts_per_minute": inserts_per_min,
+                    "db_probe_failed": db_probe_failed,
+                    "db_realtime_inserts_per_minute": db_inserts_per_min,
                     "durable_writes_per_minute": durable_writes_per_min,
                     "files_tracked": len(files),
                     "max_offset_lag_bytes": max_lag,

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -354,6 +354,7 @@ class BatchIndexer:
         self._last_flush = time.monotonic()
         self.total_flushed = 0
         self.total_outputs = 0
+        self.total_failed_inputs = 0
         self._flush_failures = 0
 
     def add(self, items: list[dict]):
@@ -396,7 +397,7 @@ class BatchIndexer:
             self.total_outputs += getattr(result, "inserted", count)
         except Exception as e:
             logger.error("Batch flush failed (%d items), retaining in buffer: %s", count, e)
-            self._isolate_failed_flush(batch, e)
+            self.total_failed_inputs += self._isolate_failed_flush(batch, e)
 
     def _confirmed_watermarks(self, batch: list[dict], result: dict[str, int] | None) -> dict[str, int]:
         if isinstance(result, dict):
@@ -420,14 +421,14 @@ class BatchIndexer:
                 handle.write(json.dumps({"reason": str(reason), "entry": entry}, sort_keys=True) + "\n")
         logger.critical("Quarantined %d watcher flush entries at %s after repeated failures", len(entries), path)
 
-    def _isolate_failed_flush(self, batch: list[dict], reason: Exception) -> None:
+    def _isolate_failed_flush(self, batch: list[dict], reason: Exception) -> int:
         if len(batch) <= 1:
             self._flush_failures += 1
             if self._flush_failures >= self._flush_retain_limit():
                 self._quarantine_entries(batch, reason)
                 self._buffer = []
                 self._flush_failures = 0
-            return
+            return len(batch)
 
         retained: list[dict] = []
         confirmed: dict[str, int] = {}
@@ -449,6 +450,7 @@ class BatchIndexer:
         self.total_flushed += len(batch) - len(retained)
         self._buffer = retained
         self._flush_failures = self._flush_failures + 1 if retained else 0
+        return len(retained)
 
 
 # ── JSONL Watcher ────────────────────────────────────────────────────────────
@@ -518,6 +520,7 @@ class JSONLWatcher:
         self._health_window_started_epoch = time.time()
         self._health_entries_seen = 0
         self._health_output_at_start = 0
+        self._health_failed_input_at_start = 0
         self.poll_count = 0
 
     def _advance_confirmed_offsets(self, watermarks: dict[str, int]) -> None:
@@ -603,15 +606,33 @@ class JSONLWatcher:
         try:
             conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True, timeout=1)
             try:
+                window_started = int(self._health_window_started_epoch)
                 row = conn.execute(
                     """
                     SELECT COUNT(*) FROM chunks
                     WHERE source = 'realtime_watcher'
                       AND COALESCE(ingested_at, strftime('%s', created_at)) >= ?
                     """,
-                    (int(self._health_window_started_epoch),),
+                    (window_started,),
                 ).fetchone()
-                return int(row[0]) if row else 0
+                chunk_count = int(row[0]) if row else 0
+                liveness_count = 0
+                if conn.execute(
+                    """
+                    SELECT 1 FROM sqlite_master
+                    WHERE type = 'table'
+                      AND name = 'watcher_liveness_events'
+                    """
+                ).fetchone():
+                    liveness_row = conn.execute(
+                        """
+                        SELECT COUNT(*) FROM watcher_liveness_events
+                        WHERE ingested_at >= ?
+                        """,
+                        (window_started,),
+                    ).fetchone()
+                    liveness_count = int(liveness_row[0]) if liveness_row else 0
+                return liveness_count if liveness_count > 0 else chunk_count
             finally:
                 conn.close()
         except sqlite3.Error:
@@ -625,7 +646,10 @@ class JSONLWatcher:
         elapsed = max(now - self._health_window_started, 1.0)
         normalized_entries_per_min = self._health_entries_seen / elapsed * 60.0
         outputs_per_min = (self.indexer.total_outputs - self._health_output_at_start) / elapsed * 60.0
-        active_entries_per_min = outputs_per_min
+        failed_flush_inputs_per_min = (
+            (self.indexer.total_failed_inputs - self._health_failed_input_at_start) / elapsed * 60.0
+        )
+        active_entries_per_min = outputs_per_min + failed_flush_inputs_per_min
         db_inserts = self._db_realtime_inserts_since_window_start()
         db_probe_failed = self.db_path is not None and db_inserts is None
         if db_inserts is not None:
@@ -650,6 +674,7 @@ class JSONLWatcher:
             "normalized_jsonl_entries_per_minute": normalized_entries_per_min,
             "db_probe_failed": db_probe_failed,
             "db_realtime_inserts_per_minute": db_inserts_per_min,
+            "failed_flush_inputs_per_minute": failed_flush_inputs_per_min,
             "watcher_chunks_output_per_minute": outputs_per_min,
             "max_offset_lag_bytes": max_lag,
             **watchdog,
@@ -678,6 +703,7 @@ class JSONLWatcher:
                     "db_probe_failed": db_probe_failed,
                     "db_realtime_inserts_per_minute": db_inserts_per_min,
                     "durable_writes_per_minute": durable_writes_per_min,
+                    "failed_flush_inputs_per_minute": failed_flush_inputs_per_min,
                     "files_tracked": len(files),
                     "max_offset_lag_bytes": max_lag,
                     "providers": payload["providers"],
@@ -691,6 +717,7 @@ class JSONLWatcher:
             self._health_window_started_epoch = time.time()
             self._health_entries_seen = 0
             self._health_output_at_start = self.indexer.total_outputs
+            self._health_failed_input_at_start = self.indexer.total_failed_inputs
 
     def _ensure_tailer(self, filepath: str) -> JSONLTailer:
         """Get or create a tailer for a file, respecting stored offsets."""

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -26,6 +26,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from .alarm import raise_alarm
+
 logger = logging.getLogger(__name__)
 
 
@@ -649,6 +651,28 @@ class JSONLWatcher:
             tmp_path.replace(self.health_path)
         except OSError:
             logger.debug("Failed to write watcher health snapshot", exc_info=True)
+
+        durable_writes_per_min = inserts_per_min if db_inserts is not None else outputs_per_min
+        if (
+            watchdog.get("alerting") is True
+            and "coverage_drop" in watchdog.get("alert_reasons", [])
+            and entries_per_min > 0
+            and durable_writes_per_min <= 0
+        ):
+            raise_alarm(
+                "watcher_zero_writes_while_active",
+                "watcher observed active JSONL input but produced zero durable realtime writes",
+                {
+                    "active_jsonl_entries_per_minute": entries_per_min,
+                    "db_realtime_inserts_per_minute": inserts_per_min,
+                    "durable_writes_per_minute": durable_writes_per_min,
+                    "files_tracked": len(files),
+                    "max_offset_lag_bytes": max_lag,
+                    "providers": payload["providers"],
+                    "watcher_chunks_output_per_minute": outputs_per_min,
+                    "watchdog_reasons": watchdog.get("alert_reasons", []),
+                },
+            )
 
         if elapsed >= 60.0:
             self._health_window_started = now

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -665,6 +665,10 @@ class JSONLWatcher:
             realtime_inserts_per_minute=watchdog_inserts_per_min,
             max_offset_lag_bytes=max_lag,
         )
+        coverage_degraded = (
+            active_entries_per_min > 0
+            and watchdog_inserts_per_min / active_entries_per_min < self.coverage_watchdog.coverage_ratio_threshold
+        )
         payload = {
             "updated_at": datetime.now(timezone.utc).isoformat(),
             "poll_count": self.poll_count,
@@ -712,7 +716,7 @@ class JSONLWatcher:
                 },
             )
 
-        if elapsed >= 60.0:
+        if elapsed >= 60.0 and not coverage_degraded:
             self._health_window_started = now
             self._health_window_started_epoch = time.time()
             self._health_entries_seen = 0

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -669,6 +669,8 @@ class JSONLWatcher:
             active_entries_per_min > 0
             and watchdog_inserts_per_min / active_entries_per_min < self.coverage_watchdog.coverage_ratio_threshold
         )
+        durable_writes_per_min = watchdog_inserts_per_min
+        zero_write_degraded = coverage_degraded and durable_writes_per_min <= 0
         payload = {
             "updated_at": datetime.now(timezone.utc).isoformat(),
             "poll_count": self.poll_count,
@@ -691,7 +693,6 @@ class JSONLWatcher:
         except OSError:
             logger.debug("Failed to write watcher health snapshot", exc_info=True)
 
-        durable_writes_per_min = watchdog_inserts_per_min
         if (
             watchdog.get("alerting") is True
             and "coverage_drop" in watchdog.get("alert_reasons", [])
@@ -716,7 +717,7 @@ class JSONLWatcher:
                 },
             )
 
-        if elapsed >= 60.0 and not coverage_degraded:
+        if elapsed >= 60.0 and not zero_write_degraded:
             self._health_window_started = now
             self._health_window_started_epoch = time.time()
             self._health_entries_seen = 0

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -623,8 +623,9 @@ class JSONLWatcher:
 
         now = time.monotonic()
         elapsed = max(now - self._health_window_started, 1.0)
-        entries_per_min = self._health_entries_seen / elapsed * 60.0
+        normalized_entries_per_min = self._health_entries_seen / elapsed * 60.0
         outputs_per_min = (self.indexer.total_outputs - self._health_output_at_start) / elapsed * 60.0
+        active_entries_per_min = outputs_per_min
         db_inserts = self._db_realtime_inserts_since_window_start()
         db_probe_failed = self.db_path is not None and db_inserts is None
         if db_inserts is not None:
@@ -636,7 +637,7 @@ class JSONLWatcher:
         watchdog_inserts_per_min = 0.0 if db_probe_failed else db_inserts_per_min
         max_lag = self._max_offset_lag_bytes(files)
         watchdog = self.coverage_watchdog.evaluate(
-            active_entries_per_minute=entries_per_min,
+            active_entries_per_minute=active_entries_per_min,
             realtime_inserts_per_minute=watchdog_inserts_per_min,
             max_offset_lag_bytes=max_lag,
         )
@@ -645,7 +646,8 @@ class JSONLWatcher:
             "poll_count": self.poll_count,
             "providers": sorted({root.provider for root in self.watch_roots}),
             "files_tracked": len(files),
-            "active_jsonl_entries_per_minute": entries_per_min,
+            "active_jsonl_entries_per_minute": active_entries_per_min,
+            "normalized_jsonl_entries_per_minute": normalized_entries_per_min,
             "db_probe_failed": db_probe_failed,
             "db_realtime_inserts_per_minute": db_inserts_per_min,
             "watcher_chunks_output_per_minute": outputs_per_min,
@@ -664,14 +666,15 @@ class JSONLWatcher:
         if (
             watchdog.get("alerting") is True
             and "coverage_drop" in watchdog.get("alert_reasons", [])
-            and entries_per_min > 0
+            and active_entries_per_min > 0
             and durable_writes_per_min <= 0
         ):
             raise_alarm(
                 "watcher_zero_writes_while_active",
-                "watcher observed active JSONL input but produced zero durable realtime writes",
+                "watcher accepted indexable JSONL input but produced zero durable realtime writes",
                 {
-                    "active_jsonl_entries_per_minute": entries_per_min,
+                    "active_jsonl_entries_per_minute": active_entries_per_min,
+                    "normalized_jsonl_entries_per_minute": normalized_entries_per_min,
                     "db_probe_failed": db_probe_failed,
                     "db_realtime_inserts_per_minute": db_inserts_per_min,
                     "durable_writes_per_minute": durable_writes_per_min,

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -611,7 +611,7 @@ class JSONLWatcher:
                     """
                     SELECT COUNT(*) FROM chunks
                     WHERE source = 'realtime_watcher'
-                      AND COALESCE(ingested_at, strftime('%s', created_at)) >= ?
+                      AND COALESCE(ingested_at, CAST(strftime('%s', created_at) AS INTEGER)) >= ?
                     """,
                     (window_started,),
                 ).fetchone()

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -252,6 +252,25 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
     if arbitrated is None:
         arbitrated = os.environ.get("BRAINLAYER_ARBITRATED") == "1"
     store = None if arbitrated else VectorStore(db_path or get_db_path())
+    liveness_schema_ready = False
+
+    def ensure_direct_liveness_schema() -> None:
+        if liveness_schema_ready or store is None:
+            return
+        from .drain import _ensure_watcher_liveness_schema
+
+        _ensure_watcher_liveness_schema(store.conn)
+
+    def mark_direct_liveness_schema_ready() -> None:
+        nonlocal liveness_schema_ready
+        liveness_schema_ready = True
+
+    def record_direct_liveness(chunk_id: str, ingested_at: int) -> None:
+        if store is None:
+            return
+        from .drain import _record_watcher_liveness
+
+        _record_watcher_liveness(store.conn, chunk_id, ingested_at)
 
     def flush_to_db(entries: list[dict[str, Any]]) -> FlushWatermarks:
         """Process raw JSONL entries through pipeline and insert into DB."""
@@ -392,8 +411,10 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                     while True:
                         transaction_started = False
                         try:
+                            ingested_at = int(time.time())
                             cursor.execute("BEGIN IMMEDIATE")
                             transaction_started = True
+                            ensure_direct_liveness_schema()
                             duplicate, dedupe_fields = find_duplicate(
                                 store.conn,
                                 chunk_id=chunk_id,
@@ -417,7 +438,9 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     mechanism=duplicate.mechanism,
                                     hamming_distance_value=duplicate.hamming_distance,
                                 )
+                                record_direct_liveness(duplicate.canonical_chunk_id, ingested_at)
                                 cursor.execute("COMMIT")
+                                mark_direct_liveness_schema_ready()
                                 transaction_started = False
                                 inserted += 1
                                 break
@@ -432,7 +455,9 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     "last_seen_at": created_at,
                                 },
                             ):
+                                record_direct_liveness(chunk_id, ingested_at)
                                 cursor.execute("COMMIT")
+                                mark_direct_liveness_schema_ready()
                                 transaction_started = False
                                 inserted += 1
                                 break
@@ -445,7 +470,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
                                     ingested_at)
                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                                           CAST(strftime('%s', 'now') AS INTEGER))""",
+                                           ?)""",
                                 (
                                     chunk_id,
                                     clean_content,
@@ -469,10 +494,14 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     dedupe_fields.bands[1],
                                     dedupe_fields.bands[2],
                                     dedupe_fields.bands[3],
+                                    ingested_at,
                                 ),
                             )
                             changed = store.conn.changes() > 0
+                            if changed:
+                                record_direct_liveness(chunk_id, ingested_at)
                             cursor.execute("COMMIT")
+                            mark_direct_liveness_schema_ready()
                             transaction_started = False
                             if changed:
                                 inserted += 1

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+import time
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -12,8 +14,14 @@ NOW = datetime(2026, 6, 25, 12, 0, tzinfo=UTC)
 
 def test_raise_alarm_emits_telemetry_and_escapes_broad_exception_handlers(monkeypatch, capsys):
     emitted: list[tuple[str, dict]] = []
+    telemetry_emitted = threading.Event()
 
-    monkeypatch.setattr("brainlayer.telemetry.emit", lambda dataset, event: emitted.append((dataset, event)) or True)
+    def capture_emit(dataset, event):
+        emitted.append((dataset, event))
+        telemetry_emitted.set()
+        return True
+
+    monkeypatch.setattr("brainlayer.telemetry.emit", capture_emit)
 
     with pytest.raises(BrainLayerAlarm) as raised:
         try:
@@ -25,6 +33,7 @@ def test_raise_alarm_emits_telemetry_and_escapes_broad_exception_handlers(monkey
     assert raised.value.exit_code == 1
     assert raised.value.details == {"active_entries": 4}
     assert "BRAINLAYER_ALARM write_zero: writer produced zero durable writes" in capsys.readouterr().err
+    assert telemetry_emitted.wait(1)
     assert emitted == [
         (
             "brainlayer-alarms",
@@ -38,6 +47,27 @@ def test_raise_alarm_emits_telemetry_and_escapes_broad_exception_handlers(monkey
             },
         )
     ]
+
+
+def test_raise_alarm_does_not_block_on_stuck_telemetry(monkeypatch, capsys):
+    telemetry_started = threading.Event()
+
+    def slow_emit(_dataset, _event):
+        telemetry_started.set()
+        time.sleep(0.35)
+        return True
+
+    monkeypatch.setattr("brainlayer.telemetry.emit", slow_emit)
+
+    started = time.monotonic()
+    with pytest.raises(BrainLayerAlarm) as raised:
+        raise_alarm("telemetry_stuck", "alarm telemetry should not block the caller", {"active_entries": 1})
+    elapsed = time.monotonic() - started
+
+    assert telemetry_started.wait(1)
+    assert elapsed < 0.2
+    assert raised.value.code == "telemetry_stuck"
+    assert "BRAINLAYER_ALARM telemetry_stuck" in capsys.readouterr().err
 
 
 def test_drain_liveness_stalled_uses_alarm_primitive():

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from brainlayer.alarm import BrainLayerAlarm, raise_alarm
+from brainlayer.drain_liveness import check_drain_liveness
+
+NOW = datetime(2026, 6, 25, 12, 0, tzinfo=UTC)
+
+
+def test_raise_alarm_emits_telemetry_and_escapes_broad_exception_handlers(monkeypatch, capsys):
+    emitted: list[tuple[str, dict]] = []
+
+    monkeypatch.setattr("brainlayer.telemetry.emit", lambda dataset, event: emitted.append((dataset, event)) or True)
+
+    with pytest.raises(BrainLayerAlarm) as raised:
+        try:
+            raise_alarm("write_zero", "writer produced zero durable writes", {"active_entries": 4})
+        except Exception:  # noqa: BLE001 - proves the alarm is not silently swallowed by broad exception handlers.
+            pytest.fail("BrainLayerAlarm was swallowed by a broad Exception handler")
+
+    assert raised.value.code == "write_zero"
+    assert raised.value.exit_code == 1
+    assert raised.value.details == {"active_entries": 4}
+    assert "BRAINLAYER_ALARM write_zero: writer produced zero durable writes" in capsys.readouterr().err
+    assert emitted == [
+        (
+            "brainlayer-alarms",
+            {
+                "_type": "alarm",
+                "code": "write_zero",
+                "severity": "fatal",
+                "message": "writer produced zero durable writes",
+                "context": {"active_entries": 4},
+                "exit_code": 1,
+            },
+        )
+    ]
+
+
+def test_drain_liveness_stalled_uses_alarm_primitive():
+    issue = check_drain_liveness(
+        drain_label="com.brainlayer.drain",
+        drain_loaded=True,
+        queue_count=2,
+        enrichment_backlog=0,
+        drain_health={"updated_at": (NOW - timedelta(minutes=10)).isoformat(), "drain_cycles": 3},
+        now=NOW,
+        stale_seconds=300,
+    )
+
+    assert isinstance(issue, BrainLayerAlarm)
+    assert issue.code == "drain_liveness_stalled"
+    assert issue.severity == "fatal"
+    assert issue.details["queue_count"] == 2
+
+
+def test_drain_liveness_quota_blocker_is_not_an_alarm():
+    issue = check_drain_liveness(
+        drain_label="com.brainlayer.drain",
+        drain_loaded=True,
+        queue_count=0,
+        enrichment_backlog=3,
+        drain_health={"updated_at": (NOW - timedelta(minutes=10)).isoformat(), "drain_cycles": 3},
+        now=NOW,
+        stale_seconds=300,
+        quota_or_throttle_blocker="enrichment daily cap reached",
+    )
+
+    assert issue is not None
+    assert not isinstance(issue, BrainLayerAlarm)
+    assert issue.code == "drain_liveness_quota_blocked"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -816,6 +816,56 @@ class TestJSONLWatcher:
         assert raised.value.code == "watcher_zero_writes_while_active"
         assert raised.value.details["db_probe_failed"] is True
 
+    def test_health_snapshot_raises_alarm_when_flush_fails_while_active(self, tmp_path):
+        now = [0.0]
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A substantive assistant response that should be flushed but the writer fails.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.commit()
+        conn.close()
+        health_path = tmp_path / "watcher-health.json"
+        watchdog = CoverageWatchdog(
+            lag_threshold_bytes=1_000_000,
+            alert_after_s=5,
+            now_fn=lambda: now[0],
+        )
+
+        def fail_flush(_items):
+            raise RuntimeError("queue unavailable")
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=fail_flush,
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+            coverage_watchdog=watchdog,
+        )
+
+        watcher.poll_once()
+        now[0] = 6.0
+        with pytest.raises(BrainLayerAlarm) as raised:
+            watcher.poll_once()
+
+        payload = json.loads(health_path.read_text())
+        assert payload["failed_flush_inputs_per_minute"] > 0
+        assert payload["active_jsonl_entries_per_minute"] > 0
+        assert payload["watcher_chunks_output_per_minute"] == 0
+        assert raised.value.code == "watcher_zero_writes_while_active"
+
     def test_health_snapshot_does_not_alarm_when_active_input_is_intentionally_skipped(self, tmp_path):
         now = [0.0]
         sessions = tmp_path / "codex" / "sessions"
@@ -867,6 +917,58 @@ class TestJSONLWatcher:
         assert payload["normalized_jsonl_entries_per_minute"] > 0
         assert payload["active_jsonl_entries_per_minute"] == 0
         assert payload["watcher_chunks_output_per_minute"] == 0
+        assert payload["alerting"] is False
+
+    def test_health_snapshot_counts_drain_watcher_liveness_events(self, tmp_path):
+        now = [0.0]
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A watcher chunk that merges into a non realtime canonical row still writes liveness.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.execute("CREATE TABLE watcher_liveness_events (chunk_id TEXT, ingested_at INTEGER)")
+        conn.commit()
+        conn.close()
+        health_path = tmp_path / "watcher-health.json"
+
+        def flush_with_liveness(items):
+            with sqlite3.connect(db_path) as write_conn:
+                write_conn.execute(
+                    "INSERT INTO watcher_liveness_events (chunk_id, ingested_at) VALUES (?, ?)",
+                    ("manual-canonical", int(time.time())),
+                )
+                write_conn.commit()
+            return FlushWatermarks(
+                {str(transcript): max(item["_line_end_offset"] for item in items)},
+                inserted=len(items),
+                skipped=0,
+            )
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=flush_with_liveness,
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+            coverage_watchdog=CoverageWatchdog(alert_after_s=0, now_fn=lambda: now[0]),
+        )
+
+        watcher.poll_once()
+
+        payload = json.loads(health_path.read_text())
+        assert payload["active_jsonl_entries_per_minute"] > 0
+        assert payload["db_realtime_inserts_per_minute"] > 0
         assert payload["alerting"] is False
 
     def test_health_snapshot_does_not_alarm_when_legitimately_idle(self, tmp_path):

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1002,6 +1002,61 @@ class TestJSONLWatcher:
         assert payload["watcher_chunks_output_per_minute"] == 0
         assert raised.value.code == "watcher_zero_writes_while_active"
 
+    def test_health_snapshot_does_not_treat_quarantined_retry_as_active_input(self, tmp_path, monkeypatch):
+        now = [0.0]
+        monkeypatch.setenv("BRAINLAYER_WATCHER_FLUSH_RETAIN_LIMIT", "2")
+        monkeypatch.setenv("BRAINLAYER_WATCHER_QUARANTINE_DIR", str(tmp_path / "quarantine"))
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A poison watcher line should not remain active after quarantine.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.commit()
+        conn.close()
+        health_path = tmp_path / "watcher-health.json"
+        watchdog = CoverageWatchdog(
+            lag_threshold_bytes=1_000_000,
+            alert_after_s=120,
+            now_fn=lambda: now[0],
+        )
+
+        def fail_flush(_items):
+            raise RuntimeError("poison batch")
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=fail_flush,
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+            coverage_watchdog=watchdog,
+        )
+
+        watcher.poll_once()
+        now[0] = 61.0
+        watcher._health_window_started = time.monotonic() - 61
+        watcher.indexer._last_flush = time.monotonic() - 1
+        assert watcher.poll_once() == 0
+
+        payload = json.loads(health_path.read_text())
+        assert payload["failed_flush_inputs_per_minute"] == 0
+        assert payload["active_jsonl_entries_per_minute"] == 0
+
+        now[0] = 121.0
+        watcher._health_window_started = time.monotonic() - 60
+        assert watcher.poll_once() == 0
+
     def test_health_snapshot_does_not_alarm_when_active_input_is_intentionally_skipped(self, tmp_path):
         now = [0.0]
         sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -769,6 +769,58 @@ class TestJSONLWatcher:
         assert raised.value.details["active_jsonl_entries_per_minute"] > 0
         assert raised.value.details["db_realtime_inserts_per_minute"] == 0
 
+    def test_health_snapshot_holds_zero_write_alarm_across_quiet_burst(self, tmp_path):
+        now = [0.0]
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A finite accepted burst should still alarm if the drain never writes it.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.commit()
+        conn.close()
+        health_path = tmp_path / "watcher-health.json"
+
+        def flush_without_durable_write(items):
+            return {str(transcript): max(item["_line_end_offset"] for item in items)}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=flush_without_durable_write,
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+            coverage_watchdog=CoverageWatchdog(
+                lag_threshold_bytes=1_000_000,
+                alert_after_s=120,
+                now_fn=lambda: now[0],
+            ),
+        )
+
+        watcher.poll_once()
+        now[0] = 61.0
+        watcher._health_window_started = time.monotonic() - 61
+        assert watcher.poll_once() == 0
+        assert json.loads(health_path.read_text())["active_jsonl_entries_per_minute"] > 0
+
+        now[0] = 121.0
+        watcher._health_window_started = time.monotonic() - 121
+        with pytest.raises(BrainLayerAlarm) as raised:
+            watcher.poll_once()
+
+        assert raised.value.code == "watcher_zero_writes_while_active"
+        assert raised.value.details["watcher_chunks_output_per_minute"] > 0
+
     def test_health_snapshot_raises_alarm_when_db_probe_fails_while_active(self, tmp_path):
         now = [0.0]
         sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -821,6 +821,90 @@ class TestJSONLWatcher:
         assert raised.value.code == "watcher_zero_writes_while_active"
         assert raised.value.details["watcher_chunks_output_per_minute"] > 0
 
+    def test_health_snapshot_resets_partial_durable_window_before_later_zero_write_alarm(self, tmp_path, monkeypatch):
+        now = [0.0]
+        monkeypatch.setattr("brainlayer.watcher.time.time", lambda: now[0])
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "The first watcher line gets a durable liveness row.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.execute("CREATE TABLE watcher_liveness_events (chunk_id TEXT, ingested_at INTEGER)")
+        conn.commit()
+        conn.close()
+        health_path = tmp_path / "watcher-health.json"
+        flush_calls = [0]
+
+        def flush_first_call_only(items):
+            flush_calls[0] += 1
+            if flush_calls[0] == 1:
+                with sqlite3.connect(db_path) as write_conn:
+                    write_conn.execute(
+                        "INSERT INTO watcher_liveness_events (chunk_id, ingested_at) VALUES (?, ?)",
+                        ("first-durable", int(now[0])),
+                    )
+                    write_conn.commit()
+            return {str(transcript): max(item["_line_end_offset"] for item in items)}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=flush_first_call_only,
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+            coverage_watchdog=CoverageWatchdog(
+                coverage_ratio_threshold=0.75,
+                lag_threshold_bytes=1_000_000,
+                alert_after_s=60,
+                now_fn=lambda: now[0],
+            ),
+        )
+
+        watcher.poll_once()
+        with transcript.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "The second watcher line is accepted while durable writes are already behind.",
+                    }
+                )
+                + "\n"
+            )
+        now[0] = 61.0
+        watcher._health_window_started = time.monotonic() - 61
+        assert watcher.poll_once() == 1
+        assert watcher._health_window_started_epoch == 61.0
+
+        with transcript.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "The third watcher line should alarm because no durable writes followed reset.",
+                    }
+                )
+                + "\n"
+            )
+        now[0] = 122.0
+        watcher._health_window_started = time.monotonic() - 61
+        with pytest.raises(BrainLayerAlarm) as raised:
+            watcher.poll_once()
+
+        assert raised.value.code == "watcher_zero_writes_while_active"
+        assert raised.value.details["durable_writes_per_minute"] == 0
+
     def test_health_snapshot_raises_alarm_when_db_probe_fails_while_active(self, tmp_path):
         now = [0.0]
         sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -971,6 +971,51 @@ class TestJSONLWatcher:
         assert payload["db_realtime_inserts_per_minute"] > 0
         assert payload["alerting"] is False
 
+    def test_db_realtime_insert_probe_casts_created_at_fallback_to_epoch(self, tmp_path):
+        db_path = tmp_path / "brainlayer.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+            conn.execute(
+                "INSERT INTO chunks (source, ingested_at, created_at) VALUES (?, ?, ?)",
+                ("realtime_watcher", None, "2020-01-01T00:00:00Z"),
+            )
+            conn.commit()
+
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: None,
+            batch_size=1,
+            db_path=db_path,
+        )
+        watcher._health_window_started_epoch = 2_000_000_000
+
+        assert watcher._db_realtime_inserts_since_window_start() == 0
+
+    def test_start_propagates_brainlayer_alarm_from_poll_once(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: None,
+            batch_size=1,
+            poll_interval_s=0,
+        )
+        alarm = BrainLayerAlarm("watcher_zero_writes_while_active", "fatal write-side degradation")
+
+        def raise_from_poll_once():
+            raise alarm
+
+        monkeypatch.setattr(watcher, "poll_once", raise_from_poll_once)
+
+        with pytest.raises(BrainLayerAlarm) as raised:
+            watcher.start()
+
+        assert raised.value is alarm
+
     def test_health_snapshot_does_not_alarm_when_legitimately_idle(self, tmp_path):
         health_path = tmp_path / "watcher-health.json"
         sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -13,6 +13,9 @@ import sqlite3
 import threading
 import time
 
+import pytest
+
+from brainlayer.alarm import BrainLayerAlarm
 from brainlayer.watcher import BatchIndexer, CoverageWatchdog, JSONLTailer, JSONLWatcher, OffsetRegistry, WatchRoot
 
 # ── OffsetRegistry Tests ─────────────────────────────────────────────────────
@@ -713,7 +716,7 @@ class TestJSONLWatcher:
         assert payload["watcher_chunks_output_per_minute"] > 0
         assert payload["db_realtime_inserts_per_minute"] == 0
 
-    def test_health_snapshot_alerts_on_coverage_drop_and_offset_lag(self, tmp_path):
+    def test_health_snapshot_raises_alarm_on_zero_db_writes_while_active(self, tmp_path):
         now = [0.0]
         sessions = tmp_path / "codex" / "sessions"
         sessions.mkdir(parents=True)
@@ -727,30 +730,59 @@ class TestJSONLWatcher:
             )
             + "\n"
         )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.commit()
+        conn.close()
         health_path = tmp_path / "watcher-health.json"
         watchdog = CoverageWatchdog(
-            lag_threshold_bytes=1,
+            lag_threshold_bytes=1_000_000,
             alert_after_s=5,
             now_fn=lambda: now[0],
         )
 
+        def flush_without_durable_write(items):
+            return {str(transcript): max(item["_line_end_offset"] for item in items)}
+
         watcher = JSONLWatcher(
             watch_roots=[WatchRoot("codex", sessions)],
             registry_path=tmp_path / "offsets.json",
-            on_flush=lambda items: None,
-            batch_size=100,
+            on_flush=flush_without_durable_write,
+            batch_size=1,
             health_path=health_path,
+            db_path=db_path,
             coverage_watchdog=watchdog,
         )
 
         watcher.poll_once()
-        transcript.write_text(transcript.read_text() + (" " * 2048))
-        watcher.poll_once()
         now[0] = 6.0
-        watcher.poll_once()
+        with pytest.raises(BrainLayerAlarm) as raised:
+            watcher.poll_once()
 
         payload = json.loads(health_path.read_text())
         assert payload["providers"] == ["codex"]
-        assert payload["max_offset_lag_bytes"] > 1
         assert payload["alerting"] is True
-        assert "offset_lag" in payload["alert_reasons"]
+        assert "coverage_drop" in payload["alert_reasons"]
+        assert raised.value.code == "watcher_zero_writes_while_active"
+        assert raised.value.details["active_jsonl_entries_per_minute"] > 0
+        assert raised.value.details["db_realtime_inserts_per_minute"] == 0
+
+    def test_health_snapshot_does_not_alarm_when_legitimately_idle(self, tmp_path):
+        health_path = tmp_path / "watcher-health.json"
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: None,
+            batch_size=1,
+            health_path=health_path,
+            coverage_watchdog=CoverageWatchdog(alert_after_s=0),
+        )
+
+        watcher.poll_once()
+
+        payload = json.loads(health_path.read_text())
+        assert payload["active_jsonl_entries_per_minute"] == 0
+        assert payload["alerting"] is False

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -768,6 +768,53 @@ class TestJSONLWatcher:
         assert raised.value.details["active_jsonl_entries_per_minute"] > 0
         assert raised.value.details["db_realtime_inserts_per_minute"] == 0
 
+    def test_health_snapshot_raises_alarm_when_db_probe_fails_while_active(self, tmp_path):
+        now = [0.0]
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A substantive assistant response that should be observed by the watcher.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        sqlite3.connect(db_path).close()
+        health_path = tmp_path / "watcher-health.json"
+        watchdog = CoverageWatchdog(
+            lag_threshold_bytes=1_000_000,
+            alert_after_s=5,
+            now_fn=lambda: now[0],
+        )
+
+        def flush_without_probeable_db(items):
+            return {str(transcript): max(item["_line_end_offset"] for item in items)}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=flush_without_probeable_db,
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+            coverage_watchdog=watchdog,
+        )
+
+        watcher.poll_once()
+        now[0] = 6.0
+        with pytest.raises(BrainLayerAlarm) as raised:
+            watcher.poll_once()
+
+        payload = json.loads(health_path.read_text())
+        assert payload["db_realtime_inserts_per_minute"] is None
+        assert payload["db_probe_failed"] is True
+        assert raised.value.code == "watcher_zero_writes_while_active"
+        assert raised.value.details["db_probe_failed"] is True
+
     def test_health_snapshot_does_not_alarm_when_legitimately_idle(self, tmp_path):
         health_path = tmp_path / "watcher-health.json"
         sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -17,6 +17,7 @@ import pytest
 
 from brainlayer.alarm import BrainLayerAlarm
 from brainlayer.watcher import BatchIndexer, CoverageWatchdog, JSONLTailer, JSONLWatcher, OffsetRegistry, WatchRoot
+from brainlayer.watcher_bridge import FlushWatermarks
 
 # ── OffsetRegistry Tests ─────────────────────────────────────────────────────
 
@@ -814,6 +815,59 @@ class TestJSONLWatcher:
         assert payload["db_probe_failed"] is True
         assert raised.value.code == "watcher_zero_writes_while_active"
         assert raised.value.details["db_probe_failed"] is True
+
+    def test_health_snapshot_does_not_alarm_when_active_input_is_intentionally_skipped(self, tmp_path):
+        now = [0.0]
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        transcript = sessions / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "A normalized assistant response that the flush classifier intentionally skips.",
+                }
+            )
+            + "\n"
+        )
+        db_path = tmp_path / "brainlayer.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE chunks (source TEXT, ingested_at INTEGER, created_at TEXT)")
+        conn.commit()
+        conn.close()
+        health_path = tmp_path / "watcher-health.json"
+        watchdog = CoverageWatchdog(
+            lag_threshold_bytes=1_000_000,
+            alert_after_s=5,
+            now_fn=lambda: now[0],
+        )
+
+        def flush_all_skipped(items):
+            return FlushWatermarks(
+                {str(transcript): max(item["_line_end_offset"] for item in items)},
+                inserted=0,
+                skipped=len(items),
+            )
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=flush_all_skipped,
+            batch_size=1,
+            health_path=health_path,
+            db_path=db_path,
+            coverage_watchdog=watchdog,
+        )
+
+        watcher.poll_once()
+        now[0] = 6.0
+        assert watcher.poll_once() == 0
+
+        payload = json.loads(health_path.read_text())
+        assert payload["normalized_jsonl_entries_per_minute"] > 0
+        assert payload["active_jsonl_entries_per_minute"] == 0
+        assert payload["watcher_chunks_output_per_minute"] == 0
+        assert payload["alerting"] is False
 
     def test_health_snapshot_does_not_alarm_when_legitimately_idle(self, tmp_path):
         health_path = tmp_path / "watcher-health.json"

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -384,6 +384,35 @@ class TestFlushCallback:
         assert aliases[0][1] == row[0]
         assert audit_count == 1
 
+    def test_direct_dedup_into_non_realtime_canonical_records_liveness(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        VectorStore(db_path).close()
+
+        flush = create_flush_callback(db_path, arbitrated=False)
+        content = "Direct watcher dedupe liveness should count durable merges into manual canonical chunks"
+        first = _make_jsonl_entry(text=content, entry_type="assistant", timestamp="2026-05-16T09:00:00Z")
+        second = _make_jsonl_entry(text=content, entry_type="assistant", timestamp="2026-05-16T10:00:00Z")
+        first["_source_file"] = "/tmp/projects/test-project/alpha-session.jsonl"
+        second["_source_file"] = "/tmp/projects/test-project/beta-session.jsonl"
+
+        flush([first])
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute("UPDATE chunks SET source = 'manual' WHERE source = 'realtime_watcher'")
+            conn.commit()
+
+        flush([second])
+
+        conn = sqlite3.connect(str(db_path))
+        source, seen_count = conn.execute("SELECT source, seen_count FROM chunks").fetchone()
+        realtime_rows = conn.execute("SELECT COUNT(*) FROM chunks WHERE source = 'realtime_watcher'").fetchone()[0]
+        liveness_count = conn.execute("SELECT COUNT(*) FROM watcher_liveness_events").fetchone()[0]
+        conn.close()
+
+        assert source == "manual"
+        assert seen_count == 2
+        assert realtime_rows == 0
+        assert liveness_count == 2
+
     def test_auto_tags_detected_correction_user_message(self, tmp_path):
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -273,6 +273,27 @@ class TestQueueStore:
         assert chunk_row == ("manual", 123, 2)
         assert liveness_row == (event["chunk_id"], 2000)
 
+    def test_record_watcher_liveness_requires_schema_initialized(self, tmp_path):
+        """Per-event liveness recording must not run schema DDL on the write hot path."""
+        from brainlayer import drain
+
+        conn = apsw.Connection(str(tmp_path / "brainlayer.db"))
+        try:
+            with pytest.raises(apsw.SQLError, match="no such table: watcher_liveness_events"):
+                drain._record_watcher_liveness(conn, "rt-watcher-liveness", 2000)
+
+            drain._ensure_watcher_liveness_schema(conn)
+            drain._record_watcher_liveness(conn, "rt-watcher-liveness", 2000)
+
+            row = conn.execute(
+                "SELECT chunk_id, ingested_at FROM watcher_liveness_events WHERE chunk_id = ?",
+                ("rt-watcher-liveness",),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row == ("rt-watcher-liveness", 2000)
+
     def test_drain_embeds_hook_event_chunk(self, tmp_path, monkeypatch):
         """Hook queue events must return chunk IDs so drain can embed them."""
         from brainlayer.vector_store import VectorStore

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -123,6 +123,44 @@ class TestQueueStore:
         assert drained == 1
         assert row == ("2026-06-06T20:04:14Z", "brainlayer", "realtime")
 
+    def test_drain_sets_ingested_at_for_arbitrated_watcher_chunk(self, tmp_path, monkeypatch):
+        """Queued watcher chunks need drain-time liveness distinct from transcript time."""
+        from brainlayer.vector_store import VectorStore
+
+        db_path = tmp_path / "watcher-ingested-at.db"
+        queue_dir = tmp_path / "queue"
+        VectorStore(db_path).close()
+        monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+        event = {
+            "kind": "watcher_chunk",
+            "chunk_id": "rt-session-watcher-ingested",
+            "content": "queued watcher chunk should preserve old transcript created_at but record fresh ingestion time",
+            "metadata": {"session_id": "session-watcher-ingested"},
+            "project": "brainlayer",
+            "source_file": "/Users/test/Gits/brainlayer/session.jsonl",
+            "content_type": "assistant_text",
+            "value_type": "high",
+            "created_at": "2026-06-06T20:04:14Z",
+            "conversation_id": "session-watcher-ingested",
+        }
+        queue_dir.mkdir()
+        (queue_dir / "watcher-created-at.jsonl").write_text(json.dumps(event) + "\n")
+
+        before = int(time.time())
+        drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log")
+        after = int(time.time())
+
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT created_at, ingested_at, source FROM chunks WHERE id = ?", (event["chunk_id"],)
+            ).fetchone()
+
+        assert drained == 1
+        assert row is not None
+        assert row[0] == "2026-06-06T20:04:14Z"
+        assert before - 5 <= row[1] <= after + 5
+        assert row[2] == "realtime_watcher"
+
     def test_drain_embeds_hook_event_chunk(self, tmp_path, monkeypatch):
         """Hook queue events must return chunk IDs so drain can embed them."""
         from brainlayer.vector_store import VectorStore

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -161,6 +161,60 @@ class TestQueueStore:
         assert before - 5 <= row[1] <= after + 5
         assert row[2] == "realtime_watcher"
 
+    def test_drain_refreshes_ingested_at_for_duplicate_arbitrated_watcher_chunk(self, tmp_path, monkeypatch):
+        """Duplicate watcher chunks still count as fresh durable watcher ingestion."""
+        from brainlayer.vector_store import VectorStore
+
+        db_path = tmp_path / "watcher-duplicate-ingested-at.db"
+        queue_dir = tmp_path / "queue"
+        VectorStore(db_path).close()
+        monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+        content = "duplicate queued watcher chunk should refresh ingestion liveness without changing event time"
+        old_ingested_at = 123
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO chunks (id, content, metadata, source, source_file, created_at, ingested_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "rt-session-watcher-duplicate",
+                    content,
+                    "{}",
+                    "realtime_watcher",
+                    "/Users/test/Gits/brainlayer/session.jsonl",
+                    "2026-06-06T20:04:14Z",
+                    old_ingested_at,
+                ),
+            )
+            conn.commit()
+        event = {
+            "kind": "watcher_chunk",
+            "chunk_id": "rt-session-watcher-duplicate",
+            "content": content,
+            "metadata": {"session_id": "session-watcher-duplicate"},
+            "project": "brainlayer",
+            "source_file": "/Users/test/Gits/brainlayer/session.jsonl",
+            "content_type": "assistant_text",
+            "value_type": "high",
+            "created_at": "2026-06-06T20:04:14Z",
+            "conversation_id": "session-watcher-duplicate",
+        }
+        queue_dir.mkdir()
+        (queue_dir / "watcher-duplicate.jsonl").write_text(json.dumps(event) + "\n")
+
+        monkeypatch.setattr("brainlayer.drain.time.time", lambda: 2000)
+        drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log")
+
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT created_at, ingested_at, seen_count, source FROM chunks WHERE id = ?",
+                (event["chunk_id"],),
+            ).fetchone()
+
+        assert drained == 1
+        assert row == ("2026-06-06T20:04:14Z", 2000, 2, "realtime_watcher")
+
     def test_drain_embeds_hook_event_chunk(self, tmp_path, monkeypatch):
         """Hook queue events must return chunk IDs so drain can embed them."""
         from brainlayer.vector_store import VectorStore

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -215,6 +215,64 @@ class TestQueueStore:
         assert drained == 1
         assert row == ("2026-06-06T20:04:14Z", 2000, 2, "realtime_watcher")
 
+    def test_drain_records_liveness_when_watcher_merges_non_realtime_canonical(self, tmp_path, monkeypatch):
+        """Watcher merges into non-realtime rows still need a durable liveness signal."""
+        from brainlayer.vector_store import VectorStore
+
+        db_path = tmp_path / "watcher-manual-canonical-liveness.db"
+        queue_dir = tmp_path / "queue"
+        VectorStore(db_path).close()
+        monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+        content = "watcher duplicate into a manual canonical row should still count as durable watcher work"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO chunks (id, content, metadata, source, source_file, created_at, ingested_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "rt-session-manual-canonical",
+                    content,
+                    "{}",
+                    "manual",
+                    "brainlayer-store",
+                    "2026-06-06T20:04:14Z",
+                    123,
+                ),
+            )
+            conn.commit()
+        event = {
+            "kind": "watcher_chunk",
+            "chunk_id": "rt-session-manual-canonical",
+            "content": content,
+            "metadata": {"session_id": "session-manual-canonical"},
+            "project": "brainlayer",
+            "source_file": "/Users/test/Gits/brainlayer/session.jsonl",
+            "content_type": "assistant_text",
+            "value_type": "high",
+            "created_at": "2026-06-06T20:04:14Z",
+            "conversation_id": "session-manual-canonical",
+        }
+        queue_dir.mkdir()
+        (queue_dir / "watcher-manual-canonical.jsonl").write_text(json.dumps(event) + "\n")
+
+        monkeypatch.setattr("brainlayer.drain.time.time", lambda: 2000)
+        drained = drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log")
+
+        with sqlite3.connect(db_path) as conn:
+            chunk_row = conn.execute(
+                "SELECT source, ingested_at, seen_count FROM chunks WHERE id = ?",
+                (event["chunk_id"],),
+            ).fetchone()
+            liveness_row = conn.execute(
+                "SELECT chunk_id, ingested_at FROM watcher_liveness_events WHERE chunk_id = ?",
+                (event["chunk_id"],),
+            ).fetchone()
+
+        assert drained == 1
+        assert chunk_row == ("manual", 123, 2)
+        assert liveness_row == (event["chunk_id"], 2000)
+
     def test_drain_embeds_hook_event_chunk(self, tmp_path, monkeypatch):
         """Hook queue events must return chunk IDs so drain can embed them."""
         from brainlayer.vector_store import VectorStore


### PR DESCRIPTION
## Summary
- Adds a reusable loud persistent BrainLayer alarm primitive.
- Routes drain liveness loud failures through the shared alarm path.
- Adds write-side zero-write watchdog coverage for active watcher degradation while avoiding legit idle/quota/skipped/quarantined retry false positives.

## Test plan
- BRAINLAYER_PREPUSH_SCOPE=changed-only git push -u origin feat/never-silent-alarm-primitive
- Pre-push gate: pytest unit suite, MCP registration, isolated eval/hook routing, bun test suite, FTS5 determinism regression

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes realtime ingestion health semantics and can fatally stop the watcher via BaseException alarms; new DB liveness schema and ingested_at behavior affect drain and direct-write paths.
> 
> **Overview**
> Introduces a shared **BrainLayer alarm** path (`BrainLayerAlarm` as `BaseException`, stderr/logging, non-blocking Axiom telemetry) and wires it into **drain liveness** and the **JSONL watcher** so serious degradation is loud instead of only showing up in health JSON.
> 
> **Drain liveness** now returns a fatal alarm for stalled drains (backlog + stale heartbeat, no quota blocker); quota-blocked cases stay warnings. **Doctor** calls `emit_alarm` when it surfaces those alarm-shaped liveness issues.
> 
> **Watcher write-side detection** adds `watcher_liveness_events`, sets/refreshes `ingested_at` on realtime watcher paths (drain, direct bridge, merges into non-`realtime_watcher` rows), and uses liveness counts (with chunk fallback) for durable-write metrics. Health snapshots distinguish normalized vs **active** input (outputs + retained failed flushes), expose `db_probe_failed`, and **`raise_alarm`** on sustained coverage drop with zero durable writes—while tests guard idle, skipped, quarantined-retry, and partial-window cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a71a1b94f1c55ff02d2d58806d5f9b7263486ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add never-silent degradation alarm primitive with watcher liveness tracking
> - Introduces `BrainLayerAlarm`, a `BaseException`-derived exception in [alarm.py](https://github.com/EtanHey/brainlayer/pull/549/files#diff-058895013301c5efc400f7fe50f081872650951587cccf9816bb652f4bd5362e) that bypasses broad `except Exception` handlers and carries structured telemetry, severity, and exit code.
> - Adds `emit_alarm` and `raise_alarm` helpers that log critically, write to STDERR, and dispatch telemetry to the `brainlayer-alarms` dataset in a background thread (≤50ms join timeout).
> - Adds `watcher_liveness_events` table and supporting helpers in [drain.py](https://github.com/EtanHey/brainlayer/pull/549/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) and [watcher_bridge.py](https://github.com/EtanHey/brainlayer/pull/549/files#diff-9c9df603fa7a5ecf5cdb0da9ab4077d520d812083da4b052847100f2874f60c9) to durably record per-chunk watcher liveness with 24-hour rolling retention.
> - `JSONLWatcher._write_health_snapshot` in [watcher.py](https://github.com/EtanHey/brainlayer/pull/549/files#diff-b79db8c32ce15bfa265ba7d0c665c7439dbdf270c58f05156abec78694c7bde5) now raises a `BrainLayerAlarm` when active input is observed alongside zero durable writes during a `coverage_drop` condition; the health window is held (not reset) during zero-write degradation.
> - `check_drain_liveness` in [drain_liveness.py](https://github.com/EtanHey/brainlayer/pull/549/files#diff-9a2ac47db9045b5d9c65cdea8046b83b02cb3a30ec51dc9ebaa0cdfec313e64b) now returns a `BrainLayerAlarm` instead of a `DrainLivenessIssue` for the stalled drain case, and `run_doctor` emits the alarm before recording the issue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a71a1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured alarm system with clearer messages, richer details, and fatal handling for critical failures.
  * Improved watcher and drain tracking with persisted liveness records and more health metrics.

* **Bug Fixes**
  * Health checks now raise alarms when active input is not resulting in durable writes.
  * Better handling for stalled drain progress, flush failures, and database probe issues.
  * Preserved timestamps and source information more consistently during watcher processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->