### PR TITLE
fix: return full content from expansion paths

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3891,21 +3891,33 @@ final class BrainDatabase: @unchecked Sendable {
 
     // MARK: - brain_expand: get chunk + surrounding session context
 
-    func expandChunk(id: String, before: Int = 3, after: Int = 3) throws -> [String: Any] {
+    func expandChunk(
+        id: String,
+        before: Int = 3,
+        after: Int = 3,
+        includeFullTargetContent: Bool = false
+    ) throws -> [String: Any] {
         guard let db else { throw DBError.notOpen }
         let boundedBefore = min(max(before, 0), Self.maximumConversationContextPerSide)
         let boundedAfter = min(max(after, 0), Self.maximumConversationContextPerSide)
+        let contentLimit = Int32(Self.maximumConversationContentCharacters)
         let chunkColumns = try tableColumns(name: "chunks", on: db)
         let senderSelect = chunkColumns.contains("sender") ? "sender" : "NULL AS sender"
+        let targetContentSelect = includeFullTargetContent ? "content" : "substr(content, 1, ?)"
 
         // Get the target chunk with its session_id and rowid
-        let targetSQL = "SELECT rowid, id, content, conversation_id, project, content_type, \(senderSelect), importance, created_at, summary, tags FROM chunks WHERE id = ?"
+        let targetSQL = "SELECT rowid, id, \(targetContentSelect), conversation_id, project, content_type, \(senderSelect), importance, created_at, summary, tags FROM chunks WHERE id = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, targetSQL, -1, &stmt, nil) == SQLITE_OK else {
             throw DBError.prepare(sqlite3_errcode(db))
         }
         defer { sqlite3_finalize(stmt) }
-        bindText(id, to: stmt, index: 1)
+        var targetBindIndex: Int32 = 1
+        if !includeFullTargetContent {
+            sqlite3_bind_int(stmt, targetBindIndex, contentLimit)
+            targetBindIndex += 1
+        }
+        bindText(id, to: stmt, index: targetBindIndex)
         guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
 
         let targetRowID = sqlite3_column_int64(stmt, 0)
@@ -3924,7 +3936,6 @@ final class BrainDatabase: @unchecked Sendable {
         ]
 
         // Get surrounding chunks from same session using two separate queries
-        let contentLimit = Int32(Self.maximumConversationContentCharacters)
         var beforeContext: [[String: Any]] = []
         var afterContext: [[String: Any]] = []
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3895,19 +3895,17 @@ final class BrainDatabase: @unchecked Sendable {
         guard let db else { throw DBError.notOpen }
         let boundedBefore = min(max(before, 0), Self.maximumConversationContextPerSide)
         let boundedAfter = min(max(after, 0), Self.maximumConversationContextPerSide)
-        let contentLimit = Int32(Self.maximumConversationContentCharacters)
         let chunkColumns = try tableColumns(name: "chunks", on: db)
         let senderSelect = chunkColumns.contains("sender") ? "sender" : "NULL AS sender"
 
         // Get the target chunk with its session_id and rowid
-        let targetSQL = "SELECT rowid, id, substr(content, 1, ?), conversation_id, project, content_type, \(senderSelect), importance, created_at, summary, tags FROM chunks WHERE id = ?"
+        let targetSQL = "SELECT rowid, id, content, conversation_id, project, content_type, \(senderSelect), importance, created_at, summary, tags FROM chunks WHERE id = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, targetSQL, -1, &stmt, nil) == SQLITE_OK else {
             throw DBError.prepare(sqlite3_errcode(db))
         }
         defer { sqlite3_finalize(stmt) }
-        sqlite3_bind_int(stmt, 1, contentLimit)
-        bindText(id, to: stmt, index: 2)
+        bindText(id, to: stmt, index: 1)
         guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
 
         let targetRowID = sqlite3_column_int64(stmt, 0)
@@ -3926,6 +3924,7 @@ final class BrainDatabase: @unchecked Sendable {
         ]
 
         // Get surrounding chunks from same session using two separate queries
+        let contentLimit = Int32(Self.maximumConversationContentCharacters)
         var beforeContext: [[String: Any]] = []
         var afterContext: [[String: Any]] = []
 
@@ -3991,7 +3990,9 @@ final class BrainDatabase: @unchecked Sendable {
 
         let target = ConversationChunk(
             chunkID: targetPayload["chunk_id"] as? String ?? "",
-            content: targetPayload["content"] as? String ?? "",
+            content: String(
+                (targetPayload["content"] as? String ?? "").prefix(Self.maximumConversationContentCharacters)
+            ),
             contentType: targetPayload["content_type"] as? String ?? "",
             sender: targetPayload["sender"] as? String ?? "",
             importance: targetPayload["importance"] as? Double ?? 0,

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -756,10 +756,10 @@ final class MCPRouter: @unchecked Sendable {
         let context = expanded["context"] as? [[String: Any]] ?? []
         var lines: [String] = []
         lines.append("\u{250c}\u{2500} brain_expand: \(chunkId)")
-        let targetContent = (target["summary"] as? String) ?? (target["content"] as? String) ?? ""
+        let targetContent = (target["content"] as? String) ?? ""
         if !targetContent.isEmpty {
             lines.append("\u{251c}\u{2500} Target")
-            lines.append("\u{2502} \(String(targetContent.prefix(200)))")
+            lines.append("\u{2502} \(targetContent)")
         }
         if !context.isEmpty {
             lines.append("\u{251c}\u{2500} Context (\(context.count) chunks)")

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -1173,13 +1173,13 @@ final class MCPRouter: @unchecked Sendable {
 
     nonisolated(unsafe) static let recallAnnotations: [String: Any] = {
         var annotations = MCPRouter.readOnlyAnnotations
-        annotations["anthropic/maxResultSizeChars"] = 200_000
+        annotations["anthropic/maxResultSizeChars"] = 250_000
         return annotations
     }()
 
     nonisolated(unsafe) static let expandAnnotations: [String: Any] = {
         var annotations = MCPRouter.readOnlyAnnotations
-        annotations["anthropic/maxResultSizeChars"] = 200_000
+        annotations["anthropic/maxResultSizeChars"] = 250_000
         return annotations
     }()
 

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -1173,7 +1173,13 @@ final class MCPRouter: @unchecked Sendable {
 
     nonisolated(unsafe) static let recallAnnotations: [String: Any] = {
         var annotations = MCPRouter.readOnlyAnnotations
-        annotations["anthropic/maxResultSizeChars"] = 100_000
+        annotations["anthropic/maxResultSizeChars"] = 200_000
+        return annotations
+    }()
+
+    nonisolated(unsafe) static let expandAnnotations: [String: Any] = {
+        var annotations = MCPRouter.readOnlyAnnotations
+        annotations["anthropic/maxResultSizeChars"] = 200_000
         return annotations
     }()
 
@@ -1294,7 +1300,7 @@ final class MCPRouter: @unchecked Sendable {
         [
             "name": "brain_expand",
             "description": "Drill into a specific search result. Returns full content + surrounding chunks.",
-            "annotations": MCPRouter.readOnlyAnnotations,
+            "annotations": MCPRouter.expandAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
                 "properties": [

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -751,7 +751,12 @@ final class MCPRouter: @unchecked Sendable {
         let db = try readDB()
         let before = args["before"] as? Int ?? 3
         let after = args["after"] as? Int ?? 3
-        let expanded = try db.expandChunk(id: chunkId, before: before, after: after)
+        let expanded = try db.expandChunk(
+            id: chunkId,
+            before: before,
+            after: after,
+            includeFullTargetContent: true
+        )
         let target = expanded["target"] as? [String: Any] ?? [:]
         let context = expanded["context"] as? [[String: Any]] ?? []
         var lines: [String] = []

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -1686,6 +1686,33 @@ final class DatabaseTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(context.count, 2, "Should return at least 2 surrounding chunks")
     }
 
+    func testExpandChunkCapsTargetByDefaultAndAllowsFullTargetOptIn() throws {
+        let fullBody = "BEGIN-" + String(repeating: "complete target body ", count: 300) + "END-OF-FULL-CONTENT"
+        try db.insertChunk(
+            id: "exp-full-target",
+            content: fullBody,
+            sessionId: "expand-full-session",
+            project: "test",
+            contentType: "assistant_text",
+            importance: 5
+        )
+
+        let capped = try db.expandChunk(id: "exp-full-target", before: 0, after: 0)
+        let cappedTarget = capped["target"] as? [String: Any] ?? [:]
+        let cappedContent = cappedTarget["content"] as? String ?? ""
+        XCTAssertFalse(cappedContent.contains("END-OF-FULL-CONTENT"))
+        XCTAssertLessThan(cappedContent.count, fullBody.count)
+
+        let full = try db.expandChunk(
+            id: "exp-full-target",
+            before: 0,
+            after: 0,
+            includeFullTargetContent: true
+        )
+        let fullTarget = full["target"] as? [String: Any] ?? [:]
+        XCTAssertEqual(fullTarget["content"] as? String, fullBody)
+    }
+
     // MARK: - brain_entity (lookup entity + relations)
 
     func testEntityLookup() throws {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -652,6 +652,40 @@ No results found.
         XCTAssertTrue(tagsText.contains("readonly-route"), tagsText)
     }
 
+    func testBrainExpandReturnsFullTargetContentWhenSummaryExists() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-expand-full-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        let fullBody = "BEGIN-" + String(repeating: "complete target body ", count: 300) + "END-OF-FULL-CONTENT"
+        XCTAssertGreaterThan(fullBody.count, 200)
+        XCTAssertGreaterThan(fullBody.count, 4_000)
+
+        try db.insertChunk(
+            id: "expand-full-target",
+            content: fullBody,
+            sessionId: "expand-full-session",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 7
+        )
+        try sqliteExec(
+            path: tempDB,
+            sql: "UPDATE chunks SET summary = 'Short generated summary' WHERE id = 'expand-full-target'"
+        )
+
+        let router = MCPRouter()
+        router.setDatabase(db)
+        let expandText = try toolText(router.handle(toolCall(id: 307, name: "brain_expand", arguments: [
+            "chunk_id": "expand-full-target"
+        ])))
+
+        XCTAssertTrue(expandText.contains(fullBody), expandText)
+        XCTAssertTrue(expandText.contains("END-OF-FULL-CONTENT"), expandText)
+        XCTAssertFalse(expandText.contains("\u{2502} Short generated summary"), expandText)
+    }
+
     /// Regression: brain_search(unread_only) marks messages delivered (a write).
     /// It must run on the writable connection, not the read-only read handle —
     /// otherwise markDelivered fails with `SQLite step failed: 8` (SQLITE_READONLY).

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -278,7 +278,7 @@ final class MCPRouterTests: XCTestCase {
 
             XCTAssertGreaterThanOrEqual(
                 annotations["anthropic/maxResultSizeChars"] as? Int ?? 0,
-                200_000,
+                250_000,
                 "\(toolName) should declare enough result budget for full stored chunks"
             )
         }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -268,11 +268,20 @@ final class MCPRouterTests: XCTestCase {
         }
     }
 
-    func testBrainRecallDeclaresLargeResultBudget() throws {
-        let tool = try XCTUnwrap(MCPRouter.toolDefinitions.first { ($0["name"] as? String) == "brain_recall" })
-        let annotations = try XCTUnwrap(tool["annotations"] as? [String: Any])
+    func testFullContentToolsDeclareLargeResultBudget() throws {
+        for toolName in ["brain_recall", "brain_expand"] {
+            let tool = try XCTUnwrap(
+                MCPRouter.toolDefinitions.first { ($0["name"] as? String) == toolName },
+                "\(toolName) should be registered"
+            )
+            let annotations = try XCTUnwrap(tool["annotations"] as? [String: Any])
 
-        XCTAssertGreaterThanOrEqual(annotations["anthropic/maxResultSizeChars"] as? Int ?? 0, 100_000)
+            XCTAssertGreaterThanOrEqual(
+                annotations["anthropic/maxResultSizeChars"] as? Int ?? 0,
+                200_000,
+                "\(toolName) should declare enough result budget for full stored chunks"
+            )
+        }
     }
 
     func testEachToolSchemaBoundsStringInputs() throws {

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -116,7 +116,7 @@ server = Server(
 )
 
 # Tool annotations
-_MAX_FULL_CONTENT_RESULT_CHARS = 200_000
+_MAX_FULL_CONTENT_RESULT_CHARS = 250_000
 
 _READ_ONLY = ToolAnnotations(
     readOnlyHint=True,

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -116,11 +116,14 @@ server = Server(
 )
 
 # Tool annotations
+_MAX_FULL_CONTENT_RESULT_CHARS = 200_000
+
 _READ_ONLY = ToolAnnotations(
     readOnlyHint=True,
     destructiveHint=False,
     idempotentHint=True,
     openWorldHint=False,
+    **{"anthropic/maxResultSizeChars": _MAX_FULL_CONTENT_RESULT_CHARS},
 )
 
 _RECALL_READ_ONLY = ToolAnnotations(
@@ -128,7 +131,7 @@ _RECALL_READ_ONLY = ToolAnnotations(
     destructiveHint=False,
     idempotentHint=True,
     openWorldHint=False,
-    **{"anthropic/maxResultSizeChars": 100_000},
+    **{"anthropic/maxResultSizeChars": _MAX_FULL_CONTENT_RESULT_CHARS},
 )
 
 _WRITE = ToolAnnotations(

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -140,13 +140,7 @@ def format_recalled_context(query: str, chunks: list[dict]) -> str:
         if meta_lines:
             lines.extend(meta_lines)
             lines.append("")
-        if len(content) <= 1500:
-            lines.append(content)
-        else:
-            lines.append(content[:1500] + "...")
-            if chunk.get("chunk_id"):
-                lines.append("")
-                lines.append(f"Reference: {chunk['chunk_id']}")
+        lines.append(content)
     return "\n".join(lines)
 
 

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -144,6 +144,9 @@ def format_recalled_context(query: str, chunks: list[dict]) -> str:
             lines.append(content)
         else:
             lines.append(_truncate(content, 200))
+            if len(content) > 200 and chunk.get("chunk_id"):
+                lines.append("")
+                lines.append(f"Reference: {chunk['chunk_id']}")
     return "\n".join(lines)
 
 

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -140,7 +140,10 @@ def format_recalled_context(query: str, chunks: list[dict]) -> str:
         if meta_lines:
             lines.extend(meta_lines)
             lines.append("")
-        lines.append(content)
+        if chunk.get("is_target"):
+            lines.append(content)
+        else:
+            lines.append(_truncate(content, 200))
     return "\n".join(lines)
 
 

--- a/tests/test_mcp_labeled_field_output.py
+++ b/tests/test_mcp_labeled_field_output.py
@@ -244,6 +244,7 @@ def test_brain_recall_context_compacts_non_target_neighbors():
 
     assert len(body) > 1500
     assert "END-OF-NEIGHBOR-CONTENT" not in output
+    assert "Reference: chunk-neighbor" in output
     assert "END-OF-FULL-CONTENT" in output
 
 

--- a/tests/test_mcp_labeled_field_output.py
+++ b/tests/test_mcp_labeled_field_output.py
@@ -201,6 +201,26 @@ def test_brain_recall_context_preserves_position_target_and_type():
     assert "- Target: yes" in output
 
 
+def test_brain_recall_context_preserves_full_target_content():
+    body = "BEGIN " + ("full body detail " * 120) + "END-OF-FULL-CONTENT"
+
+    output = format_recalled_context(
+        "chunk-long-body",
+        [
+            {
+                "chunk_id": "chunk-long-body",
+                "source_file": "session.jsonl",
+                "is_target": True,
+                "content": body,
+            }
+        ],
+    )
+
+    assert len(body) > 1500
+    assert body in output
+    assert "END-OF-FULL-CONTENT" in output
+
+
 def test_brain_recall_context_uses_project_when_source_file_missing():
     output = format_recalled_context(
         "session context",

--- a/tests/test_mcp_labeled_field_output.py
+++ b/tests/test_mcp_labeled_field_output.py
@@ -221,6 +221,32 @@ def test_brain_recall_context_preserves_full_target_content():
     assert "END-OF-FULL-CONTENT" in output
 
 
+def test_brain_recall_context_compacts_non_target_neighbors():
+    body = "NEIGHBOR " + ("surrounding detail " * 120) + "END-OF-NEIGHBOR-CONTENT"
+
+    output = format_recalled_context(
+        "chunk-long-body",
+        [
+            {
+                "chunk_id": "chunk-neighbor",
+                "source_file": "session.jsonl",
+                "is_target": False,
+                "content": body,
+            },
+            {
+                "chunk_id": "chunk-long-body",
+                "source_file": "session.jsonl",
+                "is_target": True,
+                "content": "TARGET " + ("full target detail " * 120) + "END-OF-FULL-CONTENT",
+            },
+        ],
+    )
+
+    assert len(body) > 1500
+    assert "END-OF-NEIGHBOR-CONTENT" not in output
+    assert "END-OF-FULL-CONTENT" in output
+
+
 def test_brain_recall_context_uses_project_when_source_file_missing():
     output = format_recalled_context(
         "session context",

--- a/tests/test_mcp_labeled_field_output.py
+++ b/tests/test_mcp_labeled_field_output.py
@@ -270,4 +270,4 @@ def test_brain_recall_tool_declares_anthropic_max_result_size():
     recall = next(tool for tool in tools if tool.name == "brain_recall")
     annotation_dump = recall.annotations.model_dump(by_alias=True)
 
-    assert annotation_dump["anthropic/maxResultSizeChars"] >= 200_000
+    assert annotation_dump["anthropic/maxResultSizeChars"] > 200_000

--- a/tests/test_mcp_labeled_field_output.py
+++ b/tests/test_mcp_labeled_field_output.py
@@ -270,4 +270,4 @@ def test_brain_recall_tool_declares_anthropic_max_result_size():
     recall = next(tool for tool in tools if tool.name == "brain_recall")
     annotation_dump = recall.annotations.model_dump(by_alias=True)
 
-    assert annotation_dump["anthropic/maxResultSizeChars"] >= 100_000
+    assert annotation_dump["anthropic/maxResultSizeChars"] >= 200_000


### PR DESCRIPTION
## Summary
- Removed the Python recalled-context `detail:"full"` formatter cap so stored chunk content is emitted in full instead of ending at 1500 chars.
- Updated BrainBar `brain_expand` to serve the target chunk's full stored `content`, not its short summary and not a 200-char prefix.
- Changed BrainBar target expansion SQL to fetch full target content while keeping surrounding context and UI conversation rendering capped for responsiveness.

## Tests
- RED then GREEN: `pytest tests/test_mcp_labeled_field_output.py::test_brain_recall_context_preserves_full_target_content -q`
- RED then GREEN: `cd brain-bar && swift test --filter MCPRouterTests/testBrainExpandReturnsFullTargetContentWhenSummaryExists`
- Regression guard: `cd brain-bar && swift test --filter ChunkConversationTests/testExpandedConversationCapsHugeThreadWorkForResponsiveOpen`
- Scoped lint: `ruff check src/brainlayer/mcp/_format.py tests/test_mcp_labeled_field_output.py`
- Full Python: `pytest` -> 3244 passed, 49 skipped, 5 xfailed
- Swift build: `cd brain-bar && swift build -c release`
- Swift tests: `cd brain-bar && swift test` -> 696 tests, 2 skipped, 0 failures
- Pre-push gate: 3143 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; eval/hook routing 40 passed; Bun suite 1 passed; FTS5 determinism shell passed

## Notes
- `ruff check .` still fails on unrelated pre-existing script lint in `scripts/`; scoped Ruff over touched Python files passes.
- Local `coderabbit review --agent` was attempted before PR creation and was rate-limited by the OSS free quota.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only MCP output changes only; UI conversation expansion remains capped, with larger tool responses possible for long chunks.
> 
> **Overview**
> **`brain_expand` and recalled context now emit the full stored body for the target chunk**, instead of truncating at ~200 chars, falling back to summary, or capping at 1500 characters in Python formatting.
> 
> On **BrainBar**, `expandChunk` adds an opt-in `includeFullTargetContent` flag so MCP expansion reads full `content` from SQL while default callers stay truncated; **`expandedConversation` still caps target text** at `maximumConversationContentCharacters` for responsive UI. The MCP handler prints the full target `content` and registers **`anthropic/maxResultSizeChars` at 250,000** for both `brain_recall` and `brain_expand` (up from 100k on recall only).
> 
> On **Python**, `format_recalled_context` keeps **full text for `is_target` chunks** and **compacts neighbors to 200 characters** with a reference id when longer; shared read-only tool annotations use the same **250k** result budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b17a3f60a922ac2865a69db3e7bc3fa0962b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return full content from `brain_expand` and cap target content in `expandedConversation`
> - `brain_expand` now returns the full target chunk content, ignoring summaries and without truncation; previously content was capped at `maximumConversationContentCharacters`.
> - `BrainDatabase.expandChunk` gains an `includeFullTargetContent` parameter (default `false`) to control whether the SQL query returns full content or applies the character limit.
> - `format_recalled_context` in [_format.py](https://github.com/EtanHey/brainlayer/pull/550/files#diff-620f1b58e5c06f4a3deffae64c1f9ae5a2889d8ae71386fe2251340fb17c6644) now includes target chunk content in full; non-target neighbor chunks are compacted to 200 characters with a `Reference:` line appended if truncated.
> - `anthropic/maxResultSizeChars` is raised to 250,000 for `brain_expand` and `brain_recall` in both the Swift and Python MCP tool annotations.
> - Behavioral Change: `brain_expand` responses may now be significantly larger than before due to removal of the content truncation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32b17a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded content views now show the full selected target item instead of a shortened excerpt.
  * Recalled context output keeps the target content intact while still shortening surrounding items.

* **Bug Fixes**
  * Fixed expand and recall results when a summary is present so the full original content is shown correctly.
  * Improved output formatting so non-target items are more compact without affecting the target content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->