### PR TITLE
fix(enrichment): yield supervisor writer between cycles

### DIFF
--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -413,7 +413,12 @@ def _open_enrich_supervisor_pass_store(
 
 def _should_propagate_supervisor_open_error(exc: BaseException) -> bool:
     text = str(exc).lower()
-    return "another writer is using" in text or "writer pidfile" in text or "writer is using" in text
+    return (
+        "another writer is using" in text
+        or "writer pidfile" in text
+        or "writer is using" in text
+        or "pidfile ref mismatch" in text
+    )
 
 
 def run_enrich_supervisor(

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -369,6 +369,53 @@ def _sleep_or_wait_for_stop(stop_event: threading.Event | None, seconds: float, 
     sleep_fn(seconds)
 
 
+def _checkpoint_enrich_supervisor_wal(db_path: Path) -> None:
+    """Best-effort non-blocking WAL checkpoint after a supervisor pass."""
+    if not db_path.exists():
+        return
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=0.0)
+        try:
+            conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        logger.debug("Enrich supervisor WAL checkpoint skipped for %s", db_path, exc_info=True)
+
+
+def _run_enrich_supervisor_pass(
+    store,
+    db_path: Path,
+    enrich_fn,
+    *,
+    limit: int,
+    since_hours: int | None,
+) -> EnrichmentResult:
+    try:
+        return enrich_fn(store, limit=limit, since_hours=since_hours)
+    finally:
+        try:
+            store.close()
+        finally:
+            _checkpoint_enrich_supervisor_wal(db_path)
+
+
+def _open_enrich_supervisor_pass_store(
+    vector_store_cls,
+    db_path: Path,
+) -> Any:
+    store = _open_enrich_supervisor_store(vector_store_cls, db_path)
+    logger.debug("VectorStore initialized for enrich supervisor pass: %s", db_path)
+    return store
+
+
+def _should_propagate_supervisor_open_error(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return "another writer is using" in text or "writer pidfile" in text or "writer is using" in text
+
+
 def run_enrich_supervisor(
     db_path: Path | str,
     *,
@@ -382,11 +429,10 @@ def run_enrich_supervisor(
     idle_backlog_ready_fn=None,
     sleep_fn=time.sleep,
 ) -> EnrichmentSupervisorResult:
-    """Run realtime enrichment as a long-lived supervisor around one VectorStore.
+    """Run realtime enrichment as a long-lived supervisor with bounded store passes.
 
-    PR-alpha's writer pidfile mutex is acquired by the writable VectorStore
-    constructor. Keeping that store alive here keeps the pidfile for the whole
-    supervisor lifetime instead of reacquiring it on every launchd respawn.
+    Each pass opens and closes its own store so enrichment cannot pin a writer,
+    reader transaction, or WAL checkpoint across supervisor cycles.
     """
     from .vector_store import VectorStore
 
@@ -401,80 +447,106 @@ def run_enrich_supervisor(
 
     db_path = Path(db_path)
     stats = EnrichmentSupervisorResult()
-    store = _open_enrich_supervisor_store(vector_store_cls, db_path)
-    logger.info("VectorStore initialized for enrich supervisor: %s", db_path)
-    try:
-        while stop_event is None or not stop_event.is_set():
-            if max_cycles is not None and stats.cycles >= max_cycles:
-                break
+    while stop_event is None or not stop_event.is_set():
+        if max_cycles is not None and stats.cycles >= max_cycles:
+            break
 
+        try:
+            store = _open_enrich_supervisor_pass_store(vector_store_cls, db_path)
+        except Exception as exc:  # noqa: BLE001
+            if _should_propagate_supervisor_open_error(exc):
+                raise
+            stats.cycles += 1
+            stats.failed_cycles += 1
+            error = f"supervisor-open: {exc}"
+            stats.errors.append(error)
+            logger.exception("Enrich supervisor store open failed; continuing")
+            if max_cycles is None or stats.cycles < max_cycles:
+                _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
+            continue
+
+        try:
+            result = _run_enrich_supervisor_pass(store, db_path, enrich_fn, limit=limit, since_hours=since_hours)
+        except EnrichmentDailyCapReached as exc:
+            stats.cycles += 1
+            stats.errors.append(str(exc))
+            logger.warning("Enrich supervisor stopping: %s", exc)
+            break
+        except Exception as exc:  # noqa: BLE001
+            stats.cycles += 1
+            stats.failed_cycles += 1
+            error = f"supervisor: {exc}"
+            stats.errors.append(error)
+            logger.exception("Enrich supervisor cycle failed; continuing")
+            if max_cycles is None or stats.cycles < max_cycles:
+                _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
+            continue
+
+        stats.cycles += 1
+        stats.attempted += result.attempted
+        stats.enriched += result.enriched
+        stats.skipped += result.skipped
+        stats.failed += result.failed
+        stats.errors.extend(result.errors)
+
+        if _result_hit_daily_cap(result):
+            break
+
+        idle_backlog_attempted = 0
+        if (
+            result.attempted == 0
+            and since_hours is not None
+            and idle_backlog_ready_fn()
+            and (max_cycles is None or stats.cycles <= max_cycles)
+        ):
+            logger.info("Enrich supervisor recent queue empty; checking idle backlog")
             try:
-                result = enrich_fn(store, limit=limit, since_hours=since_hours)
+                store = _open_enrich_supervisor_pass_store(vector_store_cls, db_path)
+            except Exception as exc:  # noqa: BLE001
+                if _should_propagate_supervisor_open_error(exc):
+                    raise
+                stats.failed_cycles += 1
+                stats.errors.append(f"supervisor-idle-backlog-open: {exc}")
+                logger.exception("Enrich supervisor idle-backlog store open failed; continuing")
+                if max_cycles is None or stats.cycles < max_cycles:
+                    _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
+                continue
+            try:
+                backlog_result = _run_enrich_supervisor_pass(
+                    store,
+                    db_path,
+                    enrich_fn,
+                    limit=limit,
+                    since_hours=None,
+                )
             except EnrichmentDailyCapReached as exc:
-                stats.cycles += 1
                 stats.errors.append(str(exc))
                 logger.warning("Enrich supervisor stopping: %s", exc)
                 break
             except Exception as exc:  # noqa: BLE001
-                stats.cycles += 1
                 stats.failed_cycles += 1
-                error = f"supervisor: {exc}"
-                stats.errors.append(error)
-                logger.exception("Enrich supervisor cycle failed; continuing")
+                stats.errors.append(f"supervisor-idle-backlog: {exc}")
+                logger.exception("Enrich supervisor idle-backlog pass failed; continuing")
                 if max_cycles is None or stats.cycles < max_cycles:
                     _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
                 continue
-
-            stats.cycles += 1
-            stats.attempted += result.attempted
-            stats.enriched += result.enriched
-            stats.skipped += result.skipped
-            stats.failed += result.failed
-            stats.errors.extend(result.errors)
-
-            if _result_hit_daily_cap(result):
+            stats.attempted += backlog_result.attempted
+            stats.enriched += backlog_result.enriched
+            stats.skipped += backlog_result.skipped
+            stats.failed += backlog_result.failed
+            stats.errors.extend(backlog_result.errors)
+            idle_backlog_attempted = backlog_result.attempted
+            if _result_hit_daily_cap(backlog_result):
                 break
 
-            idle_backlog_attempted = 0
-            if (
-                result.attempted == 0
-                and since_hours is not None
-                and idle_backlog_ready_fn()
-                and (max_cycles is None or stats.cycles <= max_cycles)
-            ):
-                logger.info("Enrich supervisor recent queue empty; checking idle backlog")
-                try:
-                    backlog_result = enrich_fn(store, limit=limit, since_hours=None)
-                except EnrichmentDailyCapReached as exc:
-                    stats.errors.append(str(exc))
-                    logger.warning("Enrich supervisor stopping: %s", exc)
-                    break
-                except Exception as exc:  # noqa: BLE001
-                    stats.failed_cycles += 1
-                    stats.errors.append(f"supervisor-idle-backlog: {exc}")
-                    logger.exception("Enrich supervisor idle-backlog pass failed; continuing")
-                    if max_cycles is None or stats.cycles < max_cycles:
-                        _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
-                    continue
-                stats.attempted += backlog_result.attempted
-                stats.enriched += backlog_result.enriched
-                stats.skipped += backlog_result.skipped
-                stats.failed += backlog_result.failed
-                stats.errors.extend(backlog_result.errors)
-                idle_backlog_attempted = backlog_result.attempted
-                if _result_hit_daily_cap(backlog_result):
-                    break
-
-            if (
-                stats.cycles > 0
-                and result.attempted == 0
-                and idle_backlog_attempted == 0
-                and (max_cycles is None or stats.cycles < max_cycles)
-            ):
-                logger.info("Enrich supervisor queue empty; sleeping %.1fs", idle_poll_seconds)
-                _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
-    finally:
-        store.close()
+        if (
+            stats.cycles > 0
+            and result.attempted == 0
+            and idle_backlog_attempted == 0
+            and (max_cycles is None or stats.cycles < max_cycles)
+        ):
+            logger.info("Enrich supervisor queue empty; sleeping %.1fs", idle_poll_seconds)
+            _sleep_or_wait_for_stop(stop_event, idle_poll_seconds, sleep_fn)
     return stats
 
 

--- a/tests/test_enrich_supervisor.py
+++ b/tests/test_enrich_supervisor.py
@@ -255,6 +255,25 @@ def test_supervisor_propagates_writer_in_use_from_vector_store(tmp_path):
         )
 
 
+def test_supervisor_propagates_pidfile_ref_mismatch_from_vector_store(tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    class WriterInUseError(RuntimeError):
+        pass
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            raise WriterInUseError("pidfile ref mismatch for brainlayer.db; refusing to clear active refs")
+
+    with pytest.raises(WriterInUseError, match="pidfile ref mismatch"):
+        controller.run_enrich_supervisor(
+            tmp_path / "brainlayer.db",
+            vector_store_cls=FakeVectorStore,
+            enrich_fn=lambda store, **kwargs: _result(attempted=0),
+            sleep_fn=lambda seconds: None,
+        )
+
+
 def test_supervisor_sleeps_when_queue_empty_and_polls_again(tmp_path):
     from brainlayer import enrichment_controller as controller
 

--- a/tests/test_enrich_supervisor.py
+++ b/tests/test_enrich_supervisor.py
@@ -20,19 +20,22 @@ def _result(*, attempted: int, enriched: int = 0, skipped: int = 0, failed: int 
     )
 
 
-def test_supervisor_reuses_one_vector_store_across_cycles(tmp_path):
+def test_supervisor_releases_vector_store_between_cycles(tmp_path):
     from brainlayer import enrichment_controller as controller
 
     init_paths = []
     enrich_calls = []
+    closed = []
 
     class FakeVectorStore:
         def __init__(self, db_path: Path):
+            self.index = len(init_paths)
             init_paths.append(db_path)
             self.closed = False
 
         def close(self):
             self.closed = True
+            closed.append(self.index)
 
     def fake_enrich(store, **kwargs):
         enrich_calls.append((store, kwargs))
@@ -48,10 +51,11 @@ def test_supervisor_reuses_one_vector_store_across_cycles(tmp_path):
         sleep_fn=lambda seconds: None,
     )
 
-    assert init_paths == [tmp_path / "brainlayer.db"]
-    assert len({id(call[0]) for call in enrich_calls}) == 1
+    assert init_paths == [tmp_path / "brainlayer.db"] * 3
+    assert len({id(call[0]) for call in enrich_calls}) == 3
     assert len(enrich_calls) == 3
     assert all(call[1]["limit"] == 7 and call[1]["since_hours"] == 12 for call in enrich_calls)
+    assert closed == [0, 1, 2]
     assert result.cycles == 3
     assert result.enriched == 3
 
@@ -166,6 +170,38 @@ def test_supervisor_backs_off_between_persistent_cycle_errors(tmp_path):
     assert result.failed == 0
     assert result.failed_cycles == 3
     assert sleeps == [30.0, 30.0]
+
+
+def test_supervisor_backs_off_after_transient_store_open_error(tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    init_attempts = 0
+    sleeps = []
+
+    class FakeVectorStore:
+        def __init__(self, db_path: Path):
+            nonlocal init_attempts
+            init_attempts += 1
+            if init_attempts == 2:
+                raise RuntimeError("sqlite transient open busy")
+
+        def close(self):
+            pass
+
+    result = controller.run_enrich_supervisor(
+        tmp_path / "brainlayer.db",
+        max_cycles=3,
+        vector_store_cls=FakeVectorStore,
+        enrich_fn=lambda store, **kwargs: _result(attempted=1, enriched=1),
+        sleep_fn=sleeps.append,
+    )
+
+    assert init_attempts == 3
+    assert result.cycles == 3
+    assert result.enriched == 2
+    assert result.failed_cycles == 1
+    assert result.errors == ["supervisor-open: sqlite transient open busy"]
+    assert sleeps == [30.0]
 
 
 def test_supervisor_graceful_shutdown_closes_store_after_inflight_cycle(tmp_path):
@@ -398,7 +434,7 @@ def test_supervisor_skips_idle_backlog_when_watcher_is_active(tmp_path, monkeypa
     assert result.attempted == 0
 
 
-def test_supervisor_logs_single_vectorstore_initialized_line(tmp_path, caplog):
+def test_supervisor_does_not_log_per_cycle_store_initialization_at_info(tmp_path, caplog):
     from brainlayer import enrichment_controller as controller
 
     class FakeVectorStore:
@@ -417,10 +453,8 @@ def test_supervisor_logs_single_vectorstore_initialized_line(tmp_path, caplog):
             sleep_fn=lambda seconds: None,
         )
 
-    init_lines = [
-        record for record in caplog.records if "VectorStore initialized for enrich supervisor" in record.message
-    ]
-    assert len(init_lines) == 1
+    init_lines = [record for record in caplog.records if "initialized for enrich supervisor pass" in record.message]
+    assert init_lines == []
 
 
 def test_enrichment_launchagent_runs_supervisor_not_shell_respawn_loop():

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -196,6 +196,121 @@ def test_enrich_supervisor_opens_readonly_store_when_writes_are_queued(monkeypat
     assert opened == [(tmp_path / "supervisor.db", True)]
 
 
+def test_enrich_supervisor_releases_store_between_cycles_when_writes_are_queued(monkeypatch, tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    monkeypatch.setenv("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", "1")
+    opened = []
+    closed = []
+
+    class FakeStore:
+        def __init__(self, db_path, readonly=False):
+            self.index = len(opened)
+            opened.append((db_path, readonly))
+
+        def close(self):
+            closed.append(self.index)
+
+    controller.run_enrich_supervisor(
+        tmp_path / "supervisor.db",
+        max_cycles=2,
+        idle_poll_seconds=0,
+        sleep_fn=lambda _seconds: None,
+        vector_store_cls=FakeStore,
+        enrich_fn=lambda _store, **_kwargs: controller.EnrichmentResult(
+            mode="realtime",
+            attempted=0,
+            enriched=0,
+            skipped=0,
+            failed=0,
+            errors=[],
+        ),
+    )
+
+    assert opened == [(tmp_path / "supervisor.db", True), (tmp_path / "supervisor.db", True)]
+    assert closed == [0, 1]
+
+
+def test_enrich_supervisor_yields_writer_so_drain_can_advance_between_cycles(monkeypatch, tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    monkeypatch.setenv("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", "1")
+
+    db_path = tmp_path / "supervisor-drain.db"
+
+    class WriterHoldingStore:
+        active_writers = 0
+
+        def __init__(self, db_path, readonly=False):
+            WriterHoldingStore.active_writers += 1
+
+        def close(self):
+            WriterHoldingStore.active_writers -= 1
+
+    drain_heartbeats = []
+
+    def drain_during_supervisor_sleep(_seconds):
+        drain_heartbeats.append(0 if WriterHoldingStore.active_writers else 1)
+
+    controller.run_enrich_supervisor(
+        db_path,
+        max_cycles=2,
+        idle_poll_seconds=0.001,
+        sleep_fn=drain_during_supervisor_sleep,
+        vector_store_cls=WriterHoldingStore,
+        enrich_fn=lambda _store, **_kwargs: controller.EnrichmentResult(
+            mode="realtime",
+            attempted=0,
+            enriched=0,
+            skipped=0,
+            failed=0,
+            errors=[],
+        ),
+    )
+
+    assert drain_heartbeats == [1]
+
+
+def test_enrich_supervisor_checkpoints_wal_after_each_cycle(monkeypatch, tmp_path):
+    from brainlayer import enrichment_controller as controller
+
+    monkeypatch.setenv("BRAINLAYER_ENRICHMENT_QUEUE_WRITES", "1")
+    db_path = tmp_path / "supervisor.db"
+    checkpoints = []
+
+    class FakeStore:
+        def __init__(self, db_path, readonly=False):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        controller,
+        "_checkpoint_enrich_supervisor_wal",
+        lambda checkpoint_db_path: checkpoints.append(checkpoint_db_path),
+        raising=False,
+    )
+
+    controller.run_enrich_supervisor(
+        db_path,
+        max_cycles=2,
+        idle_poll_seconds=0,
+        sleep_fn=lambda _seconds: None,
+        vector_store_cls=FakeStore,
+        enrich_fn=lambda _store, **_kwargs: controller.EnrichmentResult(
+            mode="realtime",
+            attempted=0,
+            enriched=0,
+            skipped=0,
+            failed=0,
+            errors=[],
+        ),
+    )
+
+    assert checkpoints == [db_path, db_path]
+
+
 def test_enrich_realtime_runs_with_readonly_store_while_writer_is_open(monkeypatch, tmp_path):
     from brainlayer import enrichment_controller as controller
     from brainlayer.vector_store import VectorStore


### PR DESCRIPTION
## Summary
- Bound `run_enrich_supervisor` store lifetime to one supervisor pass so enrichment cannot pin a writer/read transaction across cycles.
- Add best-effort non-blocking passive WAL checkpointing after each supervisor pass.
- Preserve supervisor survival behavior for transient open/enrich failures while still propagating writer-in-use ownership conflicts so enrichment yields the single-writer lane.
- Add regression coverage for bounded pass lifecycle, drain heartbeat/yield behavior, WAL checkpoint cadence, transient open backoff, and updated supervisor invariants.

## Incident Linkage
- Live incident: enrichment held a long-open SQLite writer/WAL, starving drain and causing interactive `brain_store` hangs.
- Fix direction: interactive/drain keep priority; enrichment opens short-lived stores and releases between cycles.

## Verification
- RED first: new supervisor lifecycle/drain-yield/checkpoint tests failed on the old long-lived-store behavior.
- `pytest tests/test_enrich_supervisor.py tests/test_enrichment_controller.py -q` with isolated cost counter: 106 passed, 1 warning.
- `pytest tests/test_enrichment_controller.py tests/test_enrich_supervisor.py tests/test_write_queue.py tests/test_arbitration.py tests/test_store_handler.py::test_writer_in_use_error_queues_instead_of_erroring tests/test_store_handler.py::test_arbitrated_queue_fallback_returns_queued_chunk_id -q`: 185 passed, 3 warnings.
- `BRAINLAYER_ENRICH_DAILY_USD_CAP=999 BRAINLAYER_ENRICH_COST_DIR=/tmp/brainlayer-full-verify-$$ pytest -q`: 3247 passed, 49 skipped, 5 xfailed, 329 warnings.
- `ruff check src/ tests/`: passed.
- `ruff format --check src/ tests/`: 379 files already formatted.
- Pre-push gate on push: 3146 passed, 9 skipped, 61 deselected, 1 xfailed; MCP tool registration 3 passed; isolated eval/hook routing 40 passed; bun suite 1 passed; regression shell `test_fts5_determinism.sh` passed.

## Review Notes
- Spawned cmux reviewer pane reviewed the uncommitted diff. Initial finding: transient store-open failures should back off under the new per-cycle open path.
- Fixed with `test_supervisor_backs_off_after_transient_store_open_error` and writer-in-use propagation guard.
- Reviewer re-check: Critical None, Important None, Minor None, Verdict Ready.
- Local CodeRabbit CLI pre-commit review was attempted but rate-limited before findings: free OSS reset wait reported as 7m49s.

## Notes
- `ruff check .` still fails on existing unrelated `scripts/` lint outside CI scope; CI lint is `ruff check src/ tests/` and `ruff format --check src/ tests/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-lived enrichment supervisor SQLite lifecycle on a path tied to writer starvation and interactive hangs; behavior is well-tested but alters mutex/WAL timing for drain and other writers.
> 
> **Overview**
> **`run_enrich_supervisor`** no longer keeps a single **`VectorStore`** open for the whole process. Each supervisor cycle (and optional idle-backlog pass) opens a store, runs enrichment, **closes** it, and runs a best-effort **`PRAGMA wal_checkpoint(PASSIVE)`** so enrichment does not hold a writer, long-lived read transaction, or WAL state between polls.
> 
> Transient **store open** or **enrich** failures are logged, counted as failed cycles, and followed by the usual idle poll sleep so the supervisor keeps running. **Writer-in-use** / **pidfile** errors (including ref mismatch) still **propagate** instead of being swallowed. Per-cycle store init is logged at **DEBUG** only, not INFO.
> 
> Tests now expect a **new store instance per cycle**, plus coverage for open-error backoff, WAL checkpoint cadence, drain yield between cycles, and pidfile mismatch propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a581c44f0ba2d64d6723f3dae6cdfc66a8ff13ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Yield vector store writer between enrichment supervisor cycles with WAL checkpoint
> - The enrichment supervisor previously held a single store open across all cycles, pinning a writer/reader and blocking WAL checkpoints. Each cycle now opens its own store and closes it in a `finally` block after the pass.
> - A passive, non-blocking WAL checkpoint (`PRAGMA wal_checkpoint(PASSIVE)`) is attempted after each cycle via `_checkpoint_enrich_supervisor_wal`; errors are swallowed and logged at debug.
> - Store open errors are classified by `_should_propagate_supervisor_open_error`: errors matching writer/pidfile substrings propagate, while transient errors log and count a failed cycle before backing off.
> - Behavioral Change: each supervisor cycle now incurs one additional store open/close per pass instead of reusing a single long-lived store instance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a581c44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->