### PR TITLE
fix: harden launchd plist paths and maintenance resume

### DIFF
--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -12,3 +12,5 @@
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:32:30 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 00:52:22 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:56:19 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 01:13:20 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 01:14:30 IDT

--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -8,3 +8,5 @@
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-25 23:57:35 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:16:46 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | PR#552 | 2026-06-26 00:25:28 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 00:31:46 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:32:30 IDT

--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -10,3 +10,5 @@
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | PR#552 | 2026-06-26 00:25:28 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 00:31:46 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:32:30 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 00:52:22 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:56:19 IDT

--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -15,3 +15,4 @@
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 01:13:20 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 01:14:30 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 01:25:57 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 01:27:22 IDT

--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -7,3 +7,4 @@
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-25 23:44:01 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-25 23:57:35 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:16:46 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | PR#552 | 2026-06-26 00:25:28 IDT

--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -14,3 +14,4 @@
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:56:19 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 01:13:20 IDT
 - m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 01:14:30 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-26 01:25:57 IDT

--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -4,3 +4,6 @@
 - deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:30:35+0300
 - deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:43:29+0300
 - deploy-drift-worker | feat/deploy-drift-detector | PR#553 | 2026-06-26T00:50:37+0300
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | STARTED | 2026-06-25 23:44:01 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-25 23:57:35 IDT
+- m1-fixes-worker | fix/launchd-plist-symlink-and-maintenance-resume | GREEN | 2026-06-26 00:16:46 IDT

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -86,7 +86,7 @@ install_env_runner() {
         return 1
     fi
 
-    install -m 0755 "$src" "$BRAINLAYER_ENV_RUN"
+    install -m 0755 "$src" "$BRAINLAYER_ENV_RUN" || return 1
     echo "Installed: $BRAINLAYER_ENV_RUN"
 }
 
@@ -137,14 +137,28 @@ load_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
     local label="com.brainlayer.${name}"
+    local enable_error=""
+    local retry_enable_after_bootstrap=0
     launchctl bootout "gui/$UID/$label" 2>/dev/null || true
-    if ! launchctl enable "gui/$UID/$label"; then
-        echo "ERROR: launchctl enable failed for $label" >&2
-        return 1
+    if ! enable_error="$(launchctl enable "gui/$UID/$label" 2>&1)"; then
+        if printf "%s" "$enable_error" | grep -qi "could not find service"; then
+            echo "WARN: launchctl enable could not find $label before bootstrap; retrying after bootstrap" >&2
+            retry_enable_after_bootstrap=1
+        else
+            printf "%s\n" "$enable_error" >&2
+            echo "ERROR: launchctl enable failed for $label" >&2
+            return 1
+        fi
     fi
     if ! launchctl bootstrap "gui/$UID" "$dst"; then
         echo "ERROR: launchctl bootstrap failed for $label" >&2
         return 1
+    fi
+    if [ "$retry_enable_after_bootstrap" -ne 0 ]; then
+        if ! launchctl enable "gui/$UID/$label"; then
+            echo "ERROR: launchctl enable failed for $label after bootstrap" >&2
+            return 1
+        fi
     fi
     if ! launchctl print "gui/$UID/$label" >/dev/null; then
         echo "ERROR: launchctl print failed for $label after bootstrap" >&2
@@ -188,7 +202,7 @@ install_plist() {
         -e "s|__REPO_ROOT__|$BRAINLAYER_DIR|g" \
         -e "s|__BRAINLAYER_ENV_FILE__|$BRAINLAYER_ENV_FILE|g" \
         -e "s|__BRAINLAYER_ENV_RUN__|$BRAINLAYER_ENV_RUN|g" \
-        "$src" > "$dst"
+        "$src" > "$dst" || return 1
 
     echo "Installed: $dst"
     echo "  Logs: $LOG_DIR/ and $BRAINLAYER_LOG_DIR/"
@@ -225,11 +239,11 @@ install_backup_script() {
         return 1
     fi
 
-    escaped_brainlayer_dir="$(printf '%s' "$BRAINLAYER_DIR" | sed 's/[\\&|]/\\&/g')"
+    escaped_brainlayer_dir="$(printf '%s' "$BRAINLAYER_DIR" | sed 's/[\\&|]/\\&/g')" || return 1
     sed \
         -e "s|__BRAINLAYER_DIR_VALUE__|$escaped_brainlayer_dir|g" \
-        "$src" > "$dst"
-    chmod 755 "$dst"
+        "$src" > "$dst" || return 1
+    chmod 755 "$dst" || return 1
     echo "Installed: $dst"
 }
 
@@ -243,11 +257,11 @@ install_jsonl_backup_script() {
         return 1
     fi
 
-    escaped_brainlayer_dir="$(printf '%s' "$BRAINLAYER_DIR" | sed 's/[\\&|]/\\&/g')"
+    escaped_brainlayer_dir="$(printf '%s' "$BRAINLAYER_DIR" | sed 's/[\\&|]/\\&/g')" || return 1
     sed \
         -e "s|__BRAINLAYER_DIR_VALUE__|$escaped_brainlayer_dir|g" \
-        "$src" > "$dst"
-    chmod 755 "$dst"
+        "$src" > "$dst" || return 1
+    chmod 755 "$dst" || return 1
     echo "Installed: $dst"
 }
 
@@ -321,7 +335,10 @@ case "${1:-all}" in
         verify_config_file
         verify_gemini_env_file
         failures=0
-        if ! install_many index drain watch hotlane-brainbar enrichment decay wal-checkpoint repair-fts; then
+        main_services_ok=0
+        if install_many index drain watch hotlane-brainbar enrichment decay wal-checkpoint repair-fts; then
+            main_services_ok=1
+        else
             failures=1
         fi
         if ! install_backup_script; then
@@ -337,8 +354,10 @@ case "${1:-all}" in
         if ! install_many maintenance-nightly maintenance-weekly health-check; then
             failures=1
         fi
-        # Remove old enrich plist if present
-        remove_plist enrich 2>/dev/null || true
+        # Remove old enrich plist only after the replacement enrichment batch loads.
+        if [ "$main_services_ok" -eq 1 ]; then
+            remove_plist enrich 2>/dev/null || true
+        fi
         if [ "$failures" -ne 0 ]; then
             exit 1
         fi

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -21,15 +21,44 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+stable_brainlayer_path() {
+    local value="${1:-}"
+    local prefix
+    local after_cellar
+    local after_version
+
+    if [ -z "$value" ]; then
+        printf "%s" "$value"
+        return 0
+    fi
+
+    case "$value" in
+        */Cellar/brainlayer/*)
+            prefix="${value%%/Cellar/brainlayer/*}"
+            after_cellar="${value#*/Cellar/brainlayer/}"
+            after_version="${after_cellar#*/}"
+            if [ "$after_version" = "$after_cellar" ]; then
+                printf "%s/opt/brainlayer" "$prefix"
+            else
+                printf "%s/opt/brainlayer/%s" "$prefix" "$after_version"
+            fi
+            ;;
+        *)
+            printf "%s" "$value"
+            ;;
+    esac
+}
+
 LAUNCH_DIR="$HOME/Library/LaunchAgents"
 LOG_DIR="$HOME/Library/Logs"
 BRAINLAYER_LOG_DIR="$HOME/.local/share/brainlayer/logs"
 BRAINLAYER_LIB_DIR="$HOME/.local/lib/brainlayer"
-BRAINLAYER_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-BRAINLAYER_LAUNCHD_DIR="${BRAINLAYER_LAUNCHD_DIR:-$SCRIPT_DIR}"
-BRAINLAYER_BIN="${BRAINLAYER_BIN:-$(which brainlayer 2>/dev/null || echo "$HOME/.local/bin/brainlayer")}"
-PYTHON_BIN="${PYTHON_BIN:-$(command -v python3)}"
-BRAINLAYER_PYTHON="${BRAINLAYER_PYTHON:-$PYTHON_BIN}"
+BRAINLAYER_DIR="$(stable_brainlayer_path "$(cd "$SCRIPT_DIR/../.." && pwd)")"
+BRAINLAYER_LAUNCHD_DIR="$(stable_brainlayer_path "${BRAINLAYER_LAUNCHD_DIR:-$SCRIPT_DIR}")"
+BRAINLAYER_BIN="$(stable_brainlayer_path "${BRAINLAYER_BIN:-$(which brainlayer 2>/dev/null || echo "$HOME/.local/bin/brainlayer")}")"
+PYTHON_BIN="$(stable_brainlayer_path "${PYTHON_BIN:-$(command -v python3)}")"
+BRAINLAYER_PYTHON="$(stable_brainlayer_path "${BRAINLAYER_PYTHON:-$PYTHON_BIN}")"
 BRAINLAYER_ENV_FILE="${BRAINLAYER_ENV_FILE:-$HOME/.config/brainlayer/brainlayer.env}"
 BRAINLAYER_ENV_RUN="$BRAINLAYER_LIB_DIR/brainlayer-env-run.sh"
 
@@ -108,10 +137,19 @@ load_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
     local label="com.brainlayer.${name}"
-    launchctl enable "gui/$UID/$label"
     launchctl bootout "gui/$UID/$label" 2>/dev/null || true
-    launchctl bootstrap "gui/$UID" "$dst"
-    launchctl print "gui/$UID/$label" >/dev/null
+    if ! launchctl enable "gui/$UID/$label"; then
+        echo "ERROR: launchctl enable failed for $label" >&2
+        return 1
+    fi
+    if ! launchctl bootstrap "gui/$UID" "$dst"; then
+        echo "ERROR: launchctl bootstrap failed for $label" >&2
+        return 1
+    fi
+    if ! launchctl print "gui/$UID/$label" >/dev/null; then
+        echo "ERROR: launchctl print failed for $label after bootstrap" >&2
+        return 1
+    fi
     echo "  Loaded: com.brainlayer.${name}"
 }
 
@@ -132,11 +170,11 @@ install_plist() {
         return 1
     fi
 
-    install_env_runner
-    verify_config_file
+    install_env_runner || return 1
+    verify_config_file || return 1
 
     if [ "$name" = "enrichment" ] || [ "$name" = "enrich" ]; then
-        verify_gemini_env_file
+        verify_gemini_env_file || return 1
     fi
 
     # Replace placeholders
@@ -155,7 +193,26 @@ install_plist() {
     echo "Installed: $dst"
     echo "  Logs: $LOG_DIR/ and $BRAINLAYER_LOG_DIR/"
 
-    load_plist "$name"
+    if ! load_plist "$name"; then
+        return 1
+    fi
+}
+
+install_many() {
+    local failures=0
+    local name
+
+    for name in "$@"; do
+        if ! install_plist "$name"; then
+            echo "ERROR: failed to install/load com.brainlayer.${name}" >&2
+            failures=$((failures + 1))
+        fi
+    done
+
+    if [ "$failures" -ne 0 ]; then
+        echo "ERROR: failed to install/load $failures launchd service(s)" >&2
+        return 1
+    fi
 }
 
 install_backup_script() {
@@ -250,8 +307,7 @@ case "${1:-all}" in
         install_plist maintenance-weekly
         ;;
     maintenance)
-        install_plist maintenance-nightly
-        install_plist maintenance-weekly
+        install_many maintenance-nightly maintenance-weekly
         ;;
     health-check)
         install_plist health-check
@@ -264,23 +320,28 @@ case "${1:-all}" in
         install_env_runner
         verify_config_file
         verify_gemini_env_file
-        install_plist index
-        install_plist drain
-        install_plist watch
-        install_plist hotlane-brainbar
-        install_plist enrichment
-        install_plist decay
-        install_plist wal-checkpoint
-        install_plist repair-fts
-        install_backup_script
-        install_plist backup-daily
-        install_jsonl_backup_script
-        install_plist jsonl-backup
-        install_plist maintenance-nightly
-        install_plist maintenance-weekly
-        install_plist health-check
+        failures=0
+        if ! install_many index drain watch hotlane-brainbar enrichment decay wal-checkpoint repair-fts; then
+            failures=1
+        fi
+        if ! install_backup_script; then
+            failures=1
+        elif ! install_many backup-daily; then
+            failures=1
+        fi
+        if ! install_jsonl_backup_script; then
+            failures=1
+        elif ! install_many jsonl-backup; then
+            failures=1
+        fi
+        if ! install_many maintenance-nightly maintenance-weekly health-check; then
+            failures=1
+        fi
         # Remove old enrich plist if present
         remove_plist enrich 2>/dev/null || true
+        if [ "$failures" -ne 0 ]; then
+            exit 1
+        fi
         ;;
     remove)
         remove_plist index

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -335,10 +335,16 @@ case "${1:-all}" in
         verify_config_file
         verify_gemini_env_file
         failures=0
-        main_services_ok=0
-        if install_many index drain watch hotlane-brainbar enrichment decay wal-checkpoint repair-fts; then
-            main_services_ok=1
+        enrichment_ok=0
+        if ! install_many index drain watch hotlane-brainbar; then
+            failures=1
+        fi
+        if install_plist enrichment; then
+            enrichment_ok=1
         else
+            failures=1
+        fi
+        if ! install_many decay wal-checkpoint repair-fts; then
             failures=1
         fi
         if ! install_backup_script; then
@@ -354,8 +360,8 @@ case "${1:-all}" in
         if ! install_many maintenance-nightly maintenance-weekly health-check; then
             failures=1
         fi
-        # Remove old enrich plist only after the replacement enrichment batch loads.
-        if [ "$main_services_ok" -eq 1 ]; then
+        # Remove old enrich plist only after the replacement enrichment service loads.
+        if [ "$enrichment_ok" -eq 1 ]; then
             remove_plist enrich 2>/dev/null || true
         fi
         if [ "$failures" -ne 0 ]; then

--- a/src/brainlayer/maintenance.py
+++ b/src/brainlayer/maintenance.py
@@ -548,7 +548,11 @@ def run_maintenance(mode: str, *, config: MaintenanceConfig | None = None, dry_r
     finally:
         resume_failures = _resume_services(config.repo_root, services)
         if resume_failures and body_error is not None:
-            body_error.add_note(_format_resume_failures(resume_failures))
+            resume_failure_reason = _format_resume_failures(resume_failures)
+            body_error.add_note(resume_failure_reason)
+            if isinstance(body_error, MaintenanceAbort):
+                body_error.reason = f"{body_error.reason}; {resume_failure_reason}"
+                body_error.args = (body_error.reason,)
 
     if resume_failures:
         raise MaintenanceAbort(_format_resume_failures(resume_failures))

--- a/src/brainlayer/maintenance.py
+++ b/src/brainlayer/maintenance.py
@@ -403,9 +403,21 @@ def _quiesce_services(services: Sequence[str]) -> None:
         _bootout_service(service)
 
 
-def _resume_services(repo_root: Path, services: Sequence[str]) -> None:
+def _resume_services(repo_root: Path, services: Sequence[str]) -> list[tuple[str, Exception]]:
+    failures: list[tuple[str, Exception]] = []
     for service in services:
-        _resume_service(repo_root, service)
+        try:
+            _resume_service(repo_root, service)
+        except Exception as exc:
+            failures.append((service, exc))
+    return failures
+
+
+def _format_resume_failures(failures: Sequence[tuple[str, Exception]]) -> str:
+    details = "; ".join(f"{service}: {failure}" for service, failure in failures)
+    count = len(failures)
+    noun = "service" if count == 1 else "services"
+    return f"failed to resume {count} launchd {noun}: {details}"
 
 
 def _checkpoint_full(db_path: Path) -> tuple[int, int, int]:
@@ -508,6 +520,8 @@ def run_maintenance(mode: str, *, config: MaintenanceConfig | None = None, dry_r
     services = DEFAULT_SERVICES
     if mode == "burn":
         services = (*REFEED_SERVICES, "drain")
+    resume_failures: list[tuple[str, Exception]] = []
+    body_error: BaseException | None = None
     _quiesce_services(services)
     try:
         result.checkpoint = _checkpoint_full(config.db_path)
@@ -528,8 +542,16 @@ def run_maintenance(mode: str, *, config: MaintenanceConfig | None = None, dry_r
                 dry_run=False,
                 now=config.now_fn(),
             )
+    except BaseException as exc:
+        body_error = exc
+        raise
     finally:
-        _resume_services(config.repo_root, services)
+        resume_failures = _resume_services(config.repo_root, services)
+        if resume_failures and body_error is not None:
+            body_error.add_note(_format_resume_failures(resume_failures))
+
+    if resume_failures:
+        raise MaintenanceAbort(_format_resume_failures(resume_failures))
 
     result.db_after_bytes = _file_size(config.db_path)
     result.queue_after_files = len(_queue_files(config.queue_dir))

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -918,6 +918,54 @@ def test_launchd_all_preserves_legacy_enrich_when_replacement_batch_fails(tmp_pa
     assert not any(command.startswith("unload ") and "com.brainlayer.enrich.plist" in command for command in commands)
 
 
+def test_launchd_all_removes_legacy_enrich_when_replacement_loads_despite_sibling_failure(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+                'if [ "$1" = "bootstrap" ] && [[ "$3" == *"com.brainlayer.repair-fts.plist" ]]; then',
+                '  printf "%s\\n" "repair bootstrap failed" >&2',
+                "  exit 5",
+                "fi",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    _write_full_launchd_env(env_file)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "all"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    commands = launchctl_log.read_text(encoding="utf-8").splitlines()
+    assert result.returncode != 0
+    assert "repair bootstrap failed" in result.stderr
+    assert any(command.startswith("unload ") and "com.brainlayer.enrich.plist" in command for command in commands)
+
+
 def test_wheel_contains_cli_and_launchd_templates(tmp_path: Path) -> None:
     wheel_dir = tmp_path / "dist"
     pip_available = (

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -19,6 +19,27 @@ def _plist_args(name: str) -> list[str]:
     return plistlib.loads(plist_path.read_bytes())["ProgramArguments"]
 
 
+def _write_full_launchd_env(env_file: Path) -> None:
+    env_file.write_text(
+        "\n".join(
+            [
+                "GOOGLE_API_KEY=test-key",
+                "BRAINLAYER_ENRICH_ENABLED=1",
+                "BRAINLAYER_ENRICH_MODE=realtime",
+                "BRAINLAYER_ENRICH_PROVIDER=google",
+                "BRAINLAYER_ENRICH_BACKEND=gemini",
+                "BRAINLAYER_ENRICH_RATE=1",
+                "BRAINLAYER_ENRICH_CONCURRENCY=1",
+                "BRAINLAYER_MAX_COMMIT_BATCH=1",
+                "BRAINLAYER_GEMINI_SERVICE_TIER=flex",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    env_file.chmod(0o600)
+
+
 def test_brainlayer_cli_entrypoint_imports_typer_app(monkeypatch) -> None:
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
 
@@ -451,7 +472,7 @@ def test_launchd_installer_renders_launchd_dir_for_maintenance_resume(tmp_path: 
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
 
     result = subprocess.run(
-        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "maintenance-nightly"],
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "maintenance"],
         env={
             **os.environ,
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
@@ -632,6 +653,269 @@ def test_launchd_installer_does_not_load_services_when_env_runner_install_fails(
     assert "brainlayer-env-run.sh" in result.stdout
     assert not launchctl_log.exists()
     assert not list((home / "Library" / "LaunchAgents").glob("com.brainlayer.*.plist"))
+
+
+def test_launchd_installer_does_not_load_service_when_env_runner_copy_fails(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_install = fake_bin / "install"
+    fake_install.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "install failed" >&2',
+                "exit 13",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_install.chmod(0o755)
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "maintenance-nightly"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "install failed" in result.stderr
+    assert not launchctl_log.exists()
+
+
+def test_launchd_installer_does_not_load_service_when_plist_render_fails(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_sed = fake_bin / "sed"
+    fake_sed.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "sed failed" >&2',
+                "exit 7",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_sed.chmod(0o755)
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "maintenance-nightly"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "sed failed" in result.stderr
+    assert not launchctl_log.exists()
+
+
+def test_launchd_enable_missing_service_is_retried_after_bootstrap(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    bootstrap_state = tmp_path / "bootstrapped"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+                'if [ "$1" = "enable" ] && [ ! -f "$FAKE_BOOTSTRAPPED" ]; then',
+                '  printf "%s\\n" "Could not find service" >&2',
+                "  exit 113",
+                "fi",
+                'if [ "$1" = "bootstrap" ]; then',
+                '  touch "$FAKE_BOOTSTRAPPED"',
+                "fi",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "maintenance-nightly"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+            "FAKE_BOOTSTRAPPED": str(bootstrap_state),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    commands = launchctl_log.read_text(encoding="utf-8").splitlines()
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert [command.split()[0] for command in commands] == ["bootout", "enable", "bootstrap", "enable", "print"]
+
+
+def test_launchd_all_does_not_load_backup_jobs_when_wrapper_render_fails(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_sed = fake_bin / "sed"
+    fake_sed.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'last="${@: -1}"',
+                'case "$last" in',
+                '  */backup-daily.sh|*/jsonl-backup.sh) printf "%s\\n" "wrapper render failed" >&2; exit 7 ;;',
+                "esac",
+                'exec /usr/bin/sed "$@"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_sed.chmod(0o755)
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    _write_full_launchd_env(env_file)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "all"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    commands = launchctl_log.read_text(encoding="utf-8").splitlines()
+    assert result.returncode != 0
+    assert "wrapper render failed" in result.stderr
+    assert not any(command.startswith("bootstrap ") and "backup-daily.plist" in command for command in commands)
+    assert not any(command.startswith("bootstrap ") and "jsonl-backup.plist" in command for command in commands)
+
+
+def test_launchd_all_preserves_legacy_enrich_when_replacement_batch_fails(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+                'if [ "$1" = "bootstrap" ] && [[ "$3" == *"com.brainlayer.enrichment.plist" ]]; then',
+                '  printf "%s\\n" "replacement bootstrap failed" >&2',
+                "  exit 5",
+                "fi",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    _write_full_launchd_env(env_file)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "all"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    commands = launchctl_log.read_text(encoding="utf-8").splitlines()
+    assert result.returncode != 0
+    assert "replacement bootstrap failed" in result.stderr
+    assert not any(command.startswith("unload ") and "com.brainlayer.enrich.plist" in command for command in commands)
 
 
 def test_wheel_contains_cli_and_launchd_templates(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -578,8 +578,14 @@ def test_launchd_installer_attempts_remaining_services_after_bootstrap_error(tmp
 
     commands = launchctl_log.read_text(encoding="utf-8").splitlines()
     assert result.returncode != 0
-    assert any(command.startswith("bootstrap ") and command.endswith("com.brainlayer.maintenance-nightly.plist") for command in commands)
-    assert any(command.startswith("bootstrap ") and command.endswith("com.brainlayer.maintenance-weekly.plist") for command in commands)
+    assert any(
+        command.startswith("bootstrap ") and command.endswith("com.brainlayer.maintenance-nightly.plist")
+        for command in commands
+    )
+    assert any(
+        command.startswith("bootstrap ") and command.endswith("com.brainlayer.maintenance-weekly.plist")
+        for command in commands
+    )
 
 
 def test_launchd_installer_does_not_load_services_when_env_runner_install_fails(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -474,6 +474,160 @@ def test_launchd_installer_renders_launchd_dir_for_maintenance_resume(tmp_path: 
     assert "__BRAINLAYER_LAUNCHD_DIR__" not in content
 
 
+def test_launchd_installer_renders_homebrew_opt_symlink_instead_of_cellar_version(tmp_path: Path) -> None:
+    fake_homebrew = tmp_path / "opt" / "homebrew"
+    cellar_root = fake_homebrew / "Cellar" / "brainlayer" / "9.9.9"
+    opt_root = fake_homebrew / "opt" / "brainlayer"
+    launchd_dir = cellar_root / "libexec" / "lib" / "python3.12" / "site-packages" / "brainlayer" / "launchd"
+    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    opt_root.parent.mkdir(parents=True)
+    opt_root.symlink_to(cellar_root)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    brainlayer_bin = cellar_root / "libexec" / "bin" / "brainlayer"
+    brainlayer_bin.parent.mkdir(parents=True)
+    brainlayer_bin.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    brainlayer_bin.chmod(0o755)
+    python_bin = cellar_root / "libexec" / "bin" / "python3"
+    python_bin.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    python_bin.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(launchd_dir / "install.sh"), "maintenance-nightly"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": str(brainlayer_bin),
+            "PYTHON_BIN": str(python_bin),
+            "BRAINLAYER_PYTHON": str(python_bin),
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    rendered = home / "Library" / "LaunchAgents" / "com.brainlayer.maintenance-nightly.plist"
+    content = rendered.read_text(encoding="utf-8")
+    assert f"{fake_homebrew}/Cellar/brainlayer/9.9.9" not in content
+    assert f"<string>{opt_root}/libexec/bin/python3</string>" in content
+    assert f"<string>{opt_root}/libexec/lib/python3.12/site-packages</string>" in content
+    assert f"<string>{opt_root}/libexec/lib/python3.12/site-packages/brainlayer/launchd</string>" in content
+
+
+def test_launchd_installer_attempts_remaining_services_after_bootstrap_error(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+                'if [ "$1" = "bootstrap" ] && [[ "$3" == *"maintenance-nightly.plist" ]]; then',
+                '  printf "%s\\n" "bootstrap failed" >&2',
+                "  exit 5",
+                "fi",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "maintenance"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    commands = launchctl_log.read_text(encoding="utf-8").splitlines()
+    assert result.returncode != 0
+    assert any(command.startswith("bootstrap ") and command.endswith("com.brainlayer.maintenance-nightly.plist") for command in commands)
+    assert any(command.startswith("bootstrap ") and command.endswith("com.brainlayer.maintenance-weekly.plist") for command in commands)
+
+
+def test_launchd_installer_does_not_load_services_when_env_runner_install_fails(tmp_path: Path) -> None:
+    launchd_dir = tmp_path / "launchd"
+    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    (launchd_dir / "brainlayer-env-run.sh").unlink()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(launchd_dir / "install.sh"), "maintenance"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "brainlayer-env-run.sh" in result.stdout
+    assert not launchctl_log.exists()
+    assert not list((home / "Library" / "LaunchAgents").glob("com.brainlayer.*.plist"))
+
+
 def test_wheel_contains_cli_and_launchd_templates(tmp_path: Path) -> None:
     wheel_dir = tmp_path / "dist"
     pip_available = (

--- a/tests/test_maintenance_routine.py
+++ b/tests/test_maintenance_routine.py
@@ -442,6 +442,7 @@ def test_maintenance_body_error_reports_resume_failures_as_exception_note(tmp_pa
         maintenance.run_maintenance("light", config=config)
 
     assert resumed == list(maintenance.DEFAULT_SERVICES)
+    assert "failed to resume 1 launchd service: enrichment: bootstrap I/O error" in exc_info.value.reason
     assert any(
         "failed to resume 1 launchd service: enrichment: bootstrap I/O error" in note
         for note in getattr(exc_info.value, "__notes__", [])

--- a/tests/test_maintenance_routine.py
+++ b/tests/test_maintenance_routine.py
@@ -389,6 +389,65 @@ def test_resume_service_uses_configured_launchd_dir_for_packaged_installs(tmp_pa
     assert commands == [[str(launchd_dir / "install.sh"), "enrichment"]]
 
 
+def test_maintenance_resume_attempts_all_services_after_mid_resume_failure(tmp_path, monkeypatch):
+    from brainlayer import maintenance
+
+    config = _config(tmp_path, now=dt.datetime(2026, 5, 30, 4, 5, tzinfo=dt.timezone.utc))
+    config.queue_dir.mkdir(parents=True)
+    config.db_path.write_bytes(b"db")
+    quiesced: list[str] = []
+    resumed: list[str] = []
+    monkeypatch.setattr(maintenance, "collect_lsof_entries", lambda _paths: [])
+    monkeypatch.setattr(maintenance, "_bootout_service", lambda service: quiesced.append(service))
+    monkeypatch.setattr(maintenance, "_checkpoint_full", lambda _db_path: (0, 0, 0))
+    monkeypatch.setattr(maintenance, "_verify_search_latency", lambda _db_path: 1.0)
+
+    def fail_mid_resume(_repo_root: Path, service: str) -> None:
+        resumed.append(service)
+        if service == "enrichment":
+            raise RuntimeError("bootstrap I/O error")
+
+    monkeypatch.setattr(maintenance, "_resume_service", fail_mid_resume)
+
+    with pytest.raises(maintenance.MaintenanceAbort, match="failed to resume 1 launchd service"):
+        maintenance.run_maintenance("light", config=config)
+
+    assert quiesced == list(maintenance.DEFAULT_SERVICES)
+    assert resumed == list(maintenance.DEFAULT_SERVICES)
+
+
+def test_maintenance_body_error_reports_resume_failures_as_exception_note(tmp_path, monkeypatch):
+    from brainlayer import maintenance
+
+    config = _config(tmp_path, now=dt.datetime(2026, 5, 30, 4, 5, tzinfo=dt.timezone.utc))
+    config.queue_dir.mkdir(parents=True)
+    config.db_path.write_bytes(b"db")
+    resumed: list[str] = []
+    monkeypatch.setattr(maintenance, "collect_lsof_entries", lambda _paths: [])
+    monkeypatch.setattr(maintenance, "_bootout_service", lambda _service: None)
+    monkeypatch.setattr(
+        maintenance,
+        "_checkpoint_full",
+        lambda _db_path: (_ for _ in ()).throw(maintenance.MaintenanceAbort("checkpoint failed")),
+    )
+
+    def fail_mid_resume(_repo_root: Path, service: str) -> None:
+        resumed.append(service)
+        if service == "enrichment":
+            raise RuntimeError("bootstrap I/O error")
+
+    monkeypatch.setattr(maintenance, "_resume_service", fail_mid_resume)
+
+    with pytest.raises(maintenance.MaintenanceAbort, match="checkpoint failed") as exc_info:
+        maintenance.run_maintenance("light", config=config)
+
+    assert resumed == list(maintenance.DEFAULT_SERVICES)
+    assert any(
+        "failed to resume 1 launchd service: enrichment: bootstrap I/O error" in note
+        for note in getattr(exc_info.value, "__notes__", [])
+    )
+
+
 def test_enrichment_template_flex_validation_parses_active_env_lines(tmp_path):
     from brainlayer.maintenance import _verify_enrichment_template_flex_backend
 


### PR DESCRIPTION
## Summary
- Render Homebrew-installed launchd paths through the stable `opt/brainlayer` symlink instead of versioned `Cellar/brainlayer/<version>` paths.
- Make launchd service loading idempotent as `bootout -> enable -> bootstrap -> print`, with multi-service installer targets attempting remaining services after one service fails.
- Make maintenance resume every paused service before reporting resume failures, including exception notes when maintenance work fails first.
- Add regression coverage for Homebrew Cellar path leakage, bootstrap-error continuation, preflight failure short-circuiting, and maintenance resume aggregation.

## Test plan
- RED first: new BL-2/BL-9 tests failed on current behavior before production edits.
- `pytest tests/test_installable_build.py::test_launchd_installer_renders_homebrew_opt_symlink_instead_of_cellar_version tests/test_installable_build.py::test_launchd_installer_attempts_remaining_services_after_bootstrap_error tests/test_maintenance_routine.py::test_maintenance_resume_attempts_all_services_after_mid_resume_failure` -> failed before fix, passed after fix.
- Reviewer REDs: `pytest tests/test_installable_build.py::test_launchd_installer_does_not_load_services_when_env_runner_install_fails tests/test_maintenance_routine.py::test_maintenance_body_error_reports_resume_failures_as_exception_note` -> failed before review fixes, passed after review fixes.
- `pytest tests/test_installable_build.py tests/test_maintenance_routine.py tests/test_launchd_hygiene.py` -> 58 passed, 1 warning.
- `ruff check src/brainlayer/maintenance.py tests/test_installable_build.py tests/test_maintenance_routine.py` -> passed.
- `bash -n scripts/launchd/install.sh` -> passed.
- `git diff --check` -> passed.
- Full local `pytest` on Python 3.13 -> 3262 passed, 49 skipped, 5 xfailed, 329 warnings in 448.41s.
- Pre-push gate on Python 3.12 -> pytest unit suite 3161 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/hook routing 40 passed; bun test 1 passed; FTS5 regression shell passed.

## Review notes
- Local `coderabbit review --agent` was run under a 180s hard timeout and timed out while still in `reviewing`; not treated as clean.
- Spawned reviewer pane `brainlayerCodex-pending-1782421332-4r6u` returned FAIL with two findings. Both were fixed with RED tests first:
  - installer preflight failures could be ignored under `if ! install_plist` because Bash disables `errexit` in conditional function calls.
  - maintenance body errors did not report resume failures. Now resume failures are attached as exception notes when a body error is already propagating.
- Full `ruff check .` was also run and still fails on unrelated pre-existing lint in `scripts/*.py` outside this diff; scoped ruff on touched Python/test files passes.

## Tracking
- Lifecycle status appended to `collab/2026-06-25-brainlayer-worker-status.md` for STARTED and GREEN.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect local launchd agent installation and maintenance shutdown/resume of core background services; misbehavior could leave agents down or mis-pointed after Homebrew upgrades, though behavior is heavily regression-tested.
> 
> **Overview**
> **Launchd installer** now rewrites Homebrew `Cellar/brainlayer/<version>` paths to stable `opt/brainlayer` targets in rendered plists, and **`load_plist`** handles missing-service `enable` by retrying after bootstrap with explicit failures on other steps. Preflight and render steps propagate errors correctly (including under `if ! install_plist`), **`install_many`** keeps going when one service fails, and the **`all`** target only drops legacy **`enrich`** after **`enrichment`** loads successfully.
> 
> **Maintenance** resumes every quiesced launchd service even when one resume fails, then raises **`MaintenanceAbort`** with aggregated resume details; if maintenance work already failed, those resume failures are appended to the exception reason and notes.
> 
> Regression tests cover opt-vs-Cellar rendering, bootstrap/enable edge cases, preflight short-circuiting, and resume aggregation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641dbe62a4475daa2a7004d1ca07c8dfb8737870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden launchd plist installer paths and maintenance resume error handling
> - Adds `stable_brainlayer_path` to [install.sh](https://github.com/EtanHey/brainlayer/pull/552/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756) to normalize Homebrew Cellar paths to stable `opt` symlinks, preventing versioned Cellar paths from being embedded in rendered plists.
> - Hardens `install_plist`, `load_plist`, `install_backup_script`, and related handlers with `|| return 1` guards to abort on failure and prevent partial installs or spurious `launchctl` calls.
> - Adds `install_many` batch installer that continues past individual service failures and reports aggregate results; the `maintenance` command now uses it for nightly and weekly services.
> - Changes `_resume_services` in [maintenance.py](https://github.com/EtanHey/brainlayer/pull/552/files#diff-5623eb0b0ddbc791b2b25c828a74927787f1cf710501ff90555ebf92981b041d) to attempt all services before reporting failures, and `run_maintenance` now raises `MaintenanceAbort` if any resume fails.
> - Behavioral Change: `load_plist` now retries `launchctl enable` after bootstrap if the service is not found before bootstrap, rather than failing immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 641dbe6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->