### PR TITLE
feat: detect stale BrainLayer daemon deploys

### DIFF
--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -1,0 +1,5 @@
+- deploy-drift-worker | feat/deploy-drift-detector | STARTED | 2026-06-25T23:42:23+0300
+- deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:04:51+0300
+- deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:18:20+0300
+- deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:30:35+0300
+- deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:43:29+0300

--- a/collab/2026-06-25-brainlayer-worker-status.md
+++ b/collab/2026-06-25-brainlayer-worker-status.md
@@ -3,3 +3,4 @@
 - deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:18:20+0300
 - deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:30:35+0300
 - deploy-drift-worker | feat/deploy-drift-detector | GREEN | 2026-06-26T00:43:29+0300
+- deploy-drift-worker | feat/deploy-drift-detector | PR#553 | 2026-06-26T00:50:37+0300

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -110,6 +110,12 @@ def _bootout_label(label: str) -> None:
     _run_launchctl(["launchctl", "bootout", _launchd_target(label)])
 
 
+def _launchctl_returncode(result) -> int:
+    if isinstance(result, int):
+        return result
+    return int(getattr(result, "returncode", 1) or 0)
+
+
 @sandbox_app.command("start")
 def sandbox_start_command(
     seed: str = typer.Option(..., "--seed", help="Named seed set to load."),
@@ -277,6 +283,148 @@ def reconcile_launchd_command(
         action="reconcile",
     )
     typer.echo("reconciled launchd labels")
+
+
+def _default_deploy_labels() -> list[str]:
+    return [
+        "com.mcplayer.brainlayer-proxy",
+        "com.brainlayer.enrichment",
+        "com.brainlayer.drain",
+        "com.brainlayer.watch",
+    ]
+
+
+def _deploy_plist_for_label(
+    label: str,
+    *,
+    proxy: Path,
+    enrichment: Path,
+    drain: Path,
+    watch: Path,
+) -> Path:
+    if label == "com.mcplayer.brainlayer-proxy":
+        return proxy.expanduser()
+    if label == "com.brainlayer.enrichment":
+        return enrichment.expanduser()
+    if label == "com.brainlayer.drain":
+        return drain.expanduser()
+    if label == "com.brainlayer.watch":
+        return watch.expanduser()
+    return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
+
+
+def _kickstart_label_or_raise(label: str) -> None:
+    from ..launchd_primitive import LaunchdCommandError, verify_launchd_label_loaded
+
+    command = ["launchctl", "kickstart", "-k", _launchd_target(label)]
+    result = _run_launchctl(command)
+    returncode = _launchctl_returncode(result)
+    if returncode != 0:
+        raise LaunchdCommandError(
+            f"launchctl command failed for {label}: {' '.join(command)}",
+            label=label,
+            target=_launchd_target(label),
+            reason="launchctl_command_failed",
+            plist_path=Path(f"~/Library/LaunchAgents/{label}.plist").expanduser(),
+            command=command,
+            returncode=returncode,
+            stdout=str(getattr(result, "stdout", "") or ""),
+            stderr=str(getattr(result, "stderr", "") or ""),
+        )
+    verify_launchd_label_loaded(label, command_runner=_run_launchctl, context="after deploy kickstart")
+
+
+def _restart_deploy_label(label: str, plist_path: Path) -> str:
+    from ..launchd_primitive import LaunchdVerificationError, is_launchd_label_loaded
+
+    loaded = is_launchd_label_loaded(label, command_runner=_run_launchctl)
+    if loaded is True:
+        _kickstart_label_or_raise(label)
+        return f"kickstart:{label}"
+    if loaded is False:
+        _bootstrap_label(label, plist_path)
+        return f"bootstrap:{label}"
+    raise LaunchdVerificationError(
+        f"could not determine whether {label} is loaded before deploy",
+        label=label,
+        target=_launchd_target(label),
+        reason="unknown_loaded_state",
+        plist_path=plist_path,
+    )
+
+
+def _record_deploy_provenance_for_label(*, label: str, plist_path: Path, provenance_dir: Path) -> None:
+    from ..deploy_drift import record_deploy_provenance_for_label
+
+    record_deploy_provenance_for_label(label=label, plist_path=plist_path, provenance_dir=provenance_dir)
+
+
+def _brainbar_changed_for_deploy(provenance_dir: Path) -> bool:
+    from ..deploy_drift import brainbar_changed_for_deploy
+
+    return brainbar_changed_for_deploy(provenance_dir)
+
+
+@app.command("deploy")
+def deploy_command(
+    labels: list[str] | None = typer.Option(None, "--label", help="launchd label to restart; repeatable."),
+    provenance_dir: Optional[Path] = typer.Option(
+        None,
+        "--provenance-dir",
+        help="Directory for daemon launch provenance JSON files.",
+    ),
+    proxy_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.mcplayer.brainlayer-proxy.plist"),
+        "--proxy-plist-path",
+    ),
+    enrichment_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.enrichment.plist"),
+        "--enrichment-plist-path",
+    ),
+    drain_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.drain.plist"),
+        "--drain-plist-path",
+    ),
+    watch_plist_path: Path = typer.Option(
+        Path("~/Library/LaunchAgents/com.brainlayer.watch.plist"),
+        "--watch-plist-path",
+    ),
+) -> None:
+    """Restart long-running BrainLayer daemons so merged code becomes live."""
+    from ..deploy_drift import DeployProvenanceError, default_deploy_provenance_dir
+    from ..launchd_primitive import LaunchdVerificationError
+
+    selected_labels = labels or _default_deploy_labels()
+    resolved_provenance_dir = (provenance_dir or default_deploy_provenance_dir()).expanduser()
+    brainbar_changed = _brainbar_changed_for_deploy(resolved_provenance_dir)
+    failures: list[LaunchdVerificationError | DeployProvenanceError] = []
+    actions: list[str] = []
+    for label in selected_labels:
+        plist_path = _deploy_plist_for_label(
+            label,
+            proxy=proxy_plist_path,
+            enrichment=enrichment_plist_path,
+            drain=drain_plist_path,
+            watch=watch_plist_path,
+        )
+        try:
+            actions.append(_restart_deploy_label(label, plist_path))
+            _record_deploy_provenance_for_label(
+                label=label,
+                plist_path=plist_path,
+                provenance_dir=resolved_provenance_dir,
+            )
+        except (LaunchdVerificationError, DeployProvenanceError) as exc:
+            failures.append(exc)
+
+    if brainbar_changed:
+        rprint("[bold yellow]BrainBar source changed; rebuild BrainBar manually.[/]")
+
+    for failure in failures:
+        typer.echo(f"failed to deploy launchd label {failure.label}: {failure}", err=True)
+    if failures:
+        raise typer.Exit(1)
+    typer.echo(f"deployed labels={','.join(selected_labels)} actions={','.join(actions)}")
 
 
 @app.command()
@@ -1753,6 +1901,13 @@ def enrich(
                 import signal
                 import threading
 
+                try:
+                    from ..deploy_drift import record_launch_from_environment
+
+                    record_launch_from_environment()
+                except Exception:
+                    logging.getLogger(__name__).debug("Failed to record enrichment launch provenance", exc_info=True)
+
                 stop_event = threading.Event()
 
                 def handle_signal(signum, frame):
@@ -2529,6 +2684,12 @@ def watch(
 
     install_parent_death_watcher()
     os.environ.setdefault("BRAINLAYER_ARBITRATED", "1")
+    try:
+        from ..deploy_drift import record_launch_from_environment
+
+        record_launch_from_environment()
+    except Exception:
+        logging.getLogger(__name__).debug("Failed to record watcher launch provenance", exc_info=True)
 
     db_path = get_db_path()
     offsets_path = db_path.parent / "offsets.json"

--- a/src/brainlayer/deploy_drift.py
+++ b/src/brainlayer/deploy_drift.py
@@ -1,0 +1,258 @@
+"""Deploy provenance helpers for long-running BrainLayer daemons."""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Callable
+
+from .paths import get_db_path
+
+DEFAULT_DEPLOY_DRIFT_LABELS = (
+    "com.mcplayer.brainlayer-proxy",
+    "com.brainlayer.enrichment",
+    "com.brainlayer.drain",
+    "com.brainlayer.watch",
+)
+
+BRAINLAYER_LABEL_BY_SERVICE = {
+    "enrichment": "com.brainlayer.enrichment",
+    "drain": "com.brainlayer.drain",
+    "watch": "com.brainlayer.watch",
+}
+
+
+class DeployProvenanceError(RuntimeError):
+    """Raised when daemon provenance cannot be tied to the launchd plist source."""
+
+    def __init__(self, label: str, plist_path: Path, message: str) -> None:
+        super().__init__(message)
+        self.label = label
+        self.plist_path = plist_path
+
+
+@dataclass(frozen=True)
+class DeployDriftFinding:
+    label: str
+    repo_root: str
+    launch_commit: str
+    deployed_commit: str
+    provenance_path: str
+    drift_status: str
+
+    def to_context(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def default_deploy_provenance_dir() -> Path:
+    return get_db_path().expanduser().parent / "daemon-provenance"
+
+
+def provenance_path_for_label(provenance_dir: Path, label: str) -> Path:
+    return provenance_dir.expanduser() / f"{label}.json"
+
+
+def _clean_git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
+def _git_stdout(repo_root: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root.expanduser()), *args],
+            text=True,
+            capture_output=True,
+            env=_clean_git_env(),
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def git_head(repo_root: Path) -> str | None:
+    return _git_stdout(repo_root, "rev-parse", "HEAD")
+
+
+def git_root_for_path(path: Path) -> Path | None:
+    candidate = path.expanduser()
+    if candidate.is_file():
+        candidate = candidate.parent
+    root = _git_stdout(candidate, "rev-parse", "--show-toplevel")
+    return Path(root) if root else None
+
+
+def commit_is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root.expanduser()), "merge-base", "--is-ancestor", ancestor, descendant],
+            text=True,
+            capture_output=True,
+            env=_clean_git_env(),
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def detect_deploy_drift(label: str, provenance_dir: Path) -> DeployDriftFinding | None:
+    provenance_path = provenance_path_for_label(provenance_dir, label)
+    try:
+        payload = json.loads(provenance_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    repo_root_value = payload.get("repo_root")
+    launch_commit = payload.get("launch_commit")
+    if not isinstance(repo_root_value, str) or not isinstance(launch_commit, str):
+        return None
+    repo_root = Path(repo_root_value).expanduser()
+    deployed_commit = git_head(repo_root)
+    if not deployed_commit or deployed_commit == launch_commit:
+        return None
+    drift_status = "older" if commit_is_ancestor(repo_root, launch_commit, deployed_commit) else "diverged"
+    return DeployDriftFinding(
+        label=label,
+        repo_root=str(repo_root),
+        launch_commit=launch_commit,
+        deployed_commit=deployed_commit,
+        provenance_path=str(provenance_path),
+        drift_status=drift_status,
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, object]) -> None:
+    resolved = path.expanduser()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    tmp = resolved.with_name(f".{resolved.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, resolved)
+
+
+def write_daemon_launch_provenance(
+    *,
+    label: str,
+    repo_root: Path | None = None,
+    provenance_dir: Path | None = None,
+    now_fn: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> Path:
+    resolved_repo = repo_root or _repo_root_from_env_or_cwd()
+    launch_commit = git_head(resolved_repo) if resolved_repo is not None else None
+    path = provenance_path_for_label(provenance_dir or default_deploy_provenance_dir(), label)
+    payload: dict[str, object] = {
+        "label": label,
+        "launched_at": now_fn().isoformat(),
+        "pid": os.getpid(),
+    }
+    if resolved_repo is not None:
+        payload["repo_root"] = str(resolved_repo)
+    if launch_commit is not None:
+        payload["launch_commit"] = launch_commit
+    _atomic_write_json(path, payload)
+    return path
+
+
+def record_launch_from_environment() -> Path | None:
+    service = os.environ.get("BRAINLAYER_LAUNCHD_SERVICE", "")
+    label = BRAINLAYER_LABEL_BY_SERVICE.get(service)
+    if not label:
+        return None
+    return write_daemon_launch_provenance(label=label)
+
+
+def repo_root_from_launchd_plist(plist_path: Path) -> Path | None:
+    try:
+        with plist_path.expanduser().open("rb") as handle:
+            payload = plistlib.load(handle)
+    except (FileNotFoundError, OSError, plistlib.InvalidFileException):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    env = payload.get("EnvironmentVariables")
+    if isinstance(env, dict):
+        repo_root = env.get("BRAINLAYER_REPO_ROOT")
+        if isinstance(repo_root, str) and repo_root:
+            return Path(repo_root).expanduser()
+
+    working_directory = payload.get("WorkingDirectory")
+    if isinstance(working_directory, str) and working_directory:
+        root = git_root_for_path(Path(working_directory))
+        if root is not None:
+            return root
+
+    program_args = payload.get("ProgramArguments")
+    if isinstance(program_args, list):
+        for item in program_args:
+            if not isinstance(item, str) or not item.startswith("/"):
+                continue
+            root = git_root_for_path(Path(item))
+            if root is not None:
+                return root
+    return None
+
+
+def record_deploy_provenance_for_label(*, label: str, plist_path: Path, provenance_dir: Path) -> Path:
+    repo_root = repo_root_from_launchd_plist(plist_path)
+    if repo_root is None:
+        raise DeployProvenanceError(
+            label,
+            plist_path,
+            f"could not resolve repo root from launchd plist for {label}: {plist_path.expanduser()}",
+        )
+    return write_daemon_launch_provenance(
+        label=label,
+        repo_root=repo_root,
+        provenance_dir=provenance_dir,
+    )
+
+
+def brainbar_changed_for_deploy(provenance_dir: Path, *, repo_root: Path | None = None) -> bool:
+    resolved_repo = repo_root or git_root_for_path(Path(__file__).resolve())
+    if resolved_repo is None:
+        return False
+    head = git_head(resolved_repo)
+    if head is None:
+        return False
+
+    previous_commits: list[str] = []
+    for path in provenance_dir.expanduser().glob("*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("repo_root") != str(resolved_repo):
+            continue
+        launch_commit = payload.get("launch_commit")
+        if isinstance(launch_commit, str) and launch_commit:
+            previous_commits.append(launch_commit)
+
+    if previous_commits:
+        changed_files: set[str] = set()
+        for commit in previous_commits:
+            diff = _git_stdout(resolved_repo, "diff", "--name-only", f"{commit}..{head}") or ""
+            changed_files.update(line.strip() for line in diff.splitlines() if line.strip())
+    else:
+        diff_tree = _git_stdout(resolved_repo, "diff-tree", "--no-commit-id", "--name-only", "-r", head) or ""
+        changed_files = {line.strip() for line in diff_tree.splitlines() if line.strip()}
+
+    return any(path == "brain-bar" or path.startswith("brain-bar/") for path in changed_files)
+
+
+def _repo_root_from_env_or_cwd() -> Path | None:
+    env_root = os.environ.get("BRAINLAYER_REPO_ROOT")
+    if env_root:
+        return Path(env_root).expanduser()
+    return git_root_for_path(Path.cwd())

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -16,7 +16,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
-from .alarm import BrainLayerAlarm, emit_alarm
+from .alarm import BrainLayerAlarm, emit_alarm, raise_alarm
+from .deploy_drift import DEFAULT_DEPLOY_DRIFT_LABELS, default_deploy_provenance_dir, detect_deploy_drift
 from .drain_liveness import (
     DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
     ENRICH_DAILY_COST_COUNTER_FILENAME,
@@ -36,7 +37,12 @@ from .health_check import (
     count_missing_embeddings,
     parse_hotlane_processes,
 )
-from .launchd_primitive import LaunchdLabelNotLoadedError, LaunchdVerificationError, verify_launchd_label_loaded
+from .launchd_primitive import (
+    LaunchdLabelNotLoadedError,
+    LaunchdVerificationError,
+    is_launchd_label_loaded,
+    verify_launchd_label_loaded,
+)
 from .paths import get_db_path
 from .search_repo import clear_hybrid_search_cache
 from .vector_store import VectorStore
@@ -75,6 +81,9 @@ class DoctorConfig:
     queue_warning_count: int = DEFAULT_QUEUE_WARNING_COUNT
     queue_movement_sample_seconds: float = DEFAULT_QUEUE_MOVEMENT_SAMPLE_SECONDS
     drain_liveness_stale_seconds: float = DEFAULT_DRAIN_LIVENESS_STALE_SECONDS
+    deploy_provenance_dir: Path = field(default_factory=default_deploy_provenance_dir)
+    deploy_drift_labels: tuple[str, ...] = DEFAULT_DEPLOY_DRIFT_LABELS
+    deploy_drift_enabled: bool = True
 
 
 @dataclass
@@ -250,6 +259,26 @@ def _counter_increased(before: Any, after: Any) -> bool:
     return isinstance(before, int) and isinstance(after, int) and after > before
 
 
+def _check_deploy_drift(
+    *,
+    labels: tuple[str, ...],
+    provenance_dir: Path,
+    command_runner: CommandRunner,
+) -> None:
+    for label in labels:
+        loaded = is_launchd_label_loaded(label, command_runner=command_runner)
+        if loaded is not True:
+            continue
+        finding = detect_deploy_drift(label, provenance_dir)
+        if finding is None:
+            continue
+        raise_alarm(
+            "deploy_drift",
+            f"daemon {label} running stale code, redeploy needed",
+            finding.to_context(),
+        )
+
+
 def run_doctor(
     config: DoctorConfig,
     *,
@@ -349,6 +378,13 @@ def run_doctor(
             )
             if code == "drain_unloaded":
                 drain_loaded = loaded
+
+    if config.deploy_drift_enabled:
+        _check_deploy_drift(
+            labels=config.deploy_drift_labels,
+            provenance_dir=config.deploy_provenance_dir,
+            command_runner=command_runner,
+        )
 
     hotlane_processes = parse_hotlane_processes(ps_output_fn())
     result.hotlane_running = bool(hotlane_processes)

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -1445,6 +1445,12 @@ def main() -> int:
     if args.once:
         print(drain_once(batch_size=args.batch_size))
         return 0
+    try:
+        from brainlayer.deploy_drift import record_launch_from_environment
+
+        record_launch_from_environment()
+    except Exception:
+        logger.debug("Failed to record drain launch provenance", exc_info=True)
     run_daemon(args.interval, args.batch_size)
     return 0
 

--- a/tests/test_cli_launchd_mode_a.py
+++ b/tests/test_cli_launchd_mode_a.py
@@ -133,6 +133,62 @@ def test_reconcile_launchd_bootstraps_all_mode_a_labels(monkeypatch, tmp_path):
     assert "com.brainlayer.enrichment" in command_text
 
 
+def test_deploy_kickstarts_runtime_daemons_and_does_not_restart_brainbar(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+    recorded: list[str] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("brainlayer.cli._run_launchctl", command_runner)
+    monkeypatch.setattr(
+        "brainlayer.cli._record_deploy_provenance_for_label",
+        lambda *, label, plist_path, provenance_dir: recorded.append(label),
+        raising=False,
+    )
+    monkeypatch.setattr("brainlayer.cli._brainbar_changed_for_deploy", lambda *_args, **_kwargs: False, raising=False)
+
+    result = CliRunner().invoke(app, ["deploy", "--provenance-dir", str(tmp_path / "provenance")])
+
+    assert result.exit_code == 0, result.output
+    command_text = "\n".join(" ".join(command) for command in commands)
+    for label in (
+        "com.mcplayer.brainlayer-proxy",
+        "com.brainlayer.enrichment",
+        "com.brainlayer.drain",
+        "com.brainlayer.watch",
+    ):
+        assert ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{label}"] in commands
+        assert label in recorded
+    assert "com.brainlayer.brainbar" not in command_text
+    assert "com.brainlayer.brainbar-daemon" not in command_text
+
+
+def test_deploy_flags_brainbar_changes_without_restart(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("brainlayer.cli._run_launchctl", command_runner)
+    monkeypatch.setattr(
+        "brainlayer.cli._record_deploy_provenance_for_label",
+        lambda *, label, plist_path, provenance_dir: None,
+        raising=False,
+    )
+    monkeypatch.setattr("brainlayer.cli._brainbar_changed_for_deploy", lambda *_args, **_kwargs: True, raising=False)
+
+    result = CliRunner().invoke(app, ["deploy", "--provenance-dir", str(tmp_path / "provenance")])
+
+    assert result.exit_code == 0, result.output
+    assert "BrainBar source changed; rebuild BrainBar manually" in result.output
+    command_text = "\n".join(" ".join(command) for command in commands)
+    assert "com.brainlayer.brainbar" not in command_text
+    assert "com.brainlayer.brainbar-daemon" not in command_text
+
+
 def test_resume_attempts_all_labels_and_keeps_sentinel_when_bootstrap_verification_fails(monkeypatch, tmp_path):
     commands: list[list[str]] = []
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+import plistlib
+import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +19,85 @@ NOW = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
 def _loaded_launchctl(args: list[str]) -> SimpleNamespace:
     assert args[:2] == ["launchctl", "print"]
     return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _clean_git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        capture_output=True,
+        env=_clean_git_env(),
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_repo_with_two_commits(path: Path) -> tuple[str, str]:
+    path.mkdir()
+    _run_git(path, "init")
+    _run_git(path, "config", "user.email", "brainlayer-tests@example.com")
+    _run_git(path, "config", "user.name", "BrainLayer Tests")
+    source = path / "src" / "brainlayer"
+    source.mkdir(parents=True)
+    marker = source / "deploy_marker.py"
+    marker.write_text("VERSION = 'old'\n", encoding="utf-8")
+    _run_git(path, "add", ".")
+    _run_git(path, "commit", "-m", "old launch commit")
+    old_commit = _run_git(path, "rev-parse", "HEAD")
+    marker.write_text("VERSION = 'new'\n", encoding="utf-8")
+    _run_git(path, "add", ".")
+    _run_git(path, "commit", "-m", "new deployed commit")
+    head_commit = _run_git(path, "rev-parse", "HEAD")
+    return old_commit, head_commit
+
+
+def _git_repo_with_diverged_commits(path: Path) -> tuple[str, str]:
+    path.mkdir()
+    _run_git(path, "init", "-b", "main")
+    _run_git(path, "config", "user.email", "brainlayer-tests@example.com")
+    _run_git(path, "config", "user.name", "BrainLayer Tests")
+    marker = path / "marker.txt"
+    marker.write_text("base\n", encoding="utf-8")
+    _run_git(path, "add", ".")
+    _run_git(path, "commit", "-m", "base commit")
+    _run_git(path, "checkout", "-b", "daemon-launch")
+    marker.write_text("daemon launch\n", encoding="utf-8")
+    _run_git(path, "add", ".")
+    _run_git(path, "commit", "-m", "daemon launch commit")
+    launch_commit = _run_git(path, "rev-parse", "HEAD")
+    _run_git(path, "checkout", "main")
+    marker.write_text("deployed head\n", encoding="utf-8")
+    _run_git(path, "add", ".")
+    _run_git(path, "commit", "-m", "deployed head commit")
+    deployed_commit = _run_git(path, "rev-parse", "HEAD")
+    return launch_commit, deployed_commit
+
+
+def _write_daemon_provenance(
+    provenance_dir: Path,
+    *,
+    label: str,
+    repo_root: Path,
+    launch_commit: str,
+) -> None:
+    provenance_dir.mkdir(parents=True, exist_ok=True)
+    (provenance_dir / f"{label}.json").write_text(
+        json.dumps(
+            {
+                "label": label,
+                "repo_root": str(repo_root),
+                "launch_commit": launch_commit,
+                "launched_at": "2026-06-22T10:00:00+00:00",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def test_launchd_install_and_verify_returns_true_when_label_is_loaded(tmp_path):
@@ -258,6 +339,197 @@ def test_run_doctor_exits_zero_on_healthy_fixture(tmp_path):
     assert result.exit_code == 0
     assert result.ok is True
     assert not [issue for issue in result.issues if issue.severity == "fatal"]
+
+
+def test_run_doctor_stays_silent_when_loaded_daemon_launch_commit_matches_head(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "deploy-drift-current.db"
+    repo_root = tmp_path / "repo-current"
+    _build_db(db_path)
+    _old_commit, head_commit = _git_repo_with_two_commits(repo_root)
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.drain",
+        repo_root=repo_root,
+        launch_commit=head_commit,
+    )
+    config = _doctor_config(tmp_path, db_path)
+    config.deploy_provenance_dir = provenance_dir
+    config.deploy_drift_labels = ("com.brainlayer.drain",)
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.ok is True
+    assert not [issue for issue in result.issues if issue.code == "deploy_drift"]
+
+
+def test_run_doctor_raises_alarm_when_loaded_daemon_launch_commit_is_older_than_head(tmp_path):
+    from brainlayer.alarm import BrainLayerAlarm
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "deploy-drift-stale.db"
+    repo_root = tmp_path / "repo-stale"
+    _build_db(db_path)
+    old_commit, head_commit = _git_repo_with_two_commits(repo_root)
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.drain",
+        repo_root=repo_root,
+        launch_commit=old_commit,
+    )
+    config = _doctor_config(tmp_path, db_path)
+    config.deploy_provenance_dir = provenance_dir
+    config.deploy_drift_labels = ("com.brainlayer.drain",)
+
+    with pytest.raises(BrainLayerAlarm) as alarm:
+        run_doctor(
+            config,
+            ps_output_fn=_hotlane_ps,
+            command_runner=_loaded_launchctl,
+            now_fn=lambda: NOW,
+        )
+
+    assert alarm.value.code == "deploy_drift"
+    assert alarm.value.message == "daemon com.brainlayer.drain running stale code, redeploy needed"
+    assert alarm.value.context["label"] == "com.brainlayer.drain"
+    assert alarm.value.context["launch_commit"] == old_commit
+    assert alarm.value.context["deployed_commit"] == head_commit
+
+
+def test_deploy_drift_git_shellouts_ignore_inherited_git_env(tmp_path, monkeypatch):
+    from brainlayer.alarm import BrainLayerAlarm
+    from brainlayer.doctor import run_doctor
+
+    parent_repo = tmp_path / "parent-repo"
+    _old_parent, _head_parent = _git_repo_with_two_commits(parent_repo)
+    repo_root = tmp_path / "repo-stale-with-poisoned-env"
+    db_path = tmp_path / "deploy-drift-poisoned-env.db"
+    _build_db(db_path)
+    old_commit, head_commit = _git_repo_with_two_commits(repo_root)
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.drain",
+        repo_root=repo_root,
+        launch_commit=old_commit,
+    )
+    config = _doctor_config(tmp_path, db_path)
+    config.deploy_provenance_dir = provenance_dir
+    config.deploy_drift_labels = ("com.brainlayer.drain",)
+    monkeypatch.setenv("GIT_DIR", str(parent_repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(parent_repo))
+
+    with pytest.raises(BrainLayerAlarm) as alarm:
+        run_doctor(
+            config,
+            ps_output_fn=_hotlane_ps,
+            command_runner=_loaded_launchctl,
+            now_fn=lambda: NOW,
+        )
+
+    assert alarm.value.context["launch_commit"] == old_commit
+    assert alarm.value.context["deployed_commit"] == head_commit
+
+
+def test_run_doctor_raises_alarm_when_loaded_daemon_launch_commit_diverged_from_head(tmp_path):
+    from brainlayer.alarm import BrainLayerAlarm
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "deploy-drift-diverged.db"
+    repo_root = tmp_path / "repo-diverged"
+    _build_db(db_path)
+    launch_commit, deployed_commit = _git_repo_with_diverged_commits(repo_root)
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.drain",
+        repo_root=repo_root,
+        launch_commit=launch_commit,
+    )
+    config = _doctor_config(tmp_path, db_path)
+    config.deploy_provenance_dir = provenance_dir
+    config.deploy_drift_labels = ("com.brainlayer.drain",)
+
+    with pytest.raises(BrainLayerAlarm) as alarm:
+        run_doctor(
+            config,
+            ps_output_fn=_hotlane_ps,
+            command_runner=_loaded_launchctl,
+            now_fn=lambda: NOW,
+        )
+
+    assert alarm.value.code == "deploy_drift"
+    assert alarm.value.context["drift_status"] == "diverged"
+    assert alarm.value.context["launch_commit"] == launch_commit
+    assert alarm.value.context["deployed_commit"] == deployed_commit
+
+
+def test_brainbar_changed_for_deploy_detects_brainbar_changes_since_launch(tmp_path):
+    from brainlayer.deploy_drift import brainbar_changed_for_deploy
+
+    repo_root = tmp_path / "repo-brainbar"
+    old_commit, _head_commit = _git_repo_with_two_commits(repo_root)
+    brainbar_file = repo_root / "brain-bar" / "Sources" / "BrainBar" / "Marker.swift"
+    brainbar_file.parent.mkdir(parents=True)
+    brainbar_file.write_text("let marker = 1\n", encoding="utf-8")
+    _run_git(repo_root, "add", ".")
+    _run_git(repo_root, "commit", "-m", "brainbar source changed")
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.watch",
+        repo_root=repo_root,
+        launch_commit=old_commit,
+    )
+
+    assert brainbar_changed_for_deploy(provenance_dir, repo_root=repo_root) is True
+
+
+def test_brainbar_changed_for_deploy_ignores_non_brainbar_changes_since_launch(tmp_path):
+    from brainlayer.deploy_drift import brainbar_changed_for_deploy
+
+    repo_root = tmp_path / "repo-non-brainbar"
+    old_commit, _head_commit = _git_repo_with_two_commits(repo_root)
+    marker = repo_root / "src" / "brainlayer" / "deploy_marker.py"
+    marker.write_text("VERSION = 'after-deploy'\n", encoding="utf-8")
+    _run_git(repo_root, "add", ".")
+    _run_git(repo_root, "commit", "-m", "python source changed")
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.watch",
+        repo_root=repo_root,
+        launch_commit=old_commit,
+    )
+
+    assert brainbar_changed_for_deploy(provenance_dir, repo_root=repo_root) is False
+
+
+def test_record_deploy_provenance_requires_repo_root_from_launchd_plist(tmp_path):
+    from brainlayer.deploy_drift import DeployProvenanceError, record_deploy_provenance_for_label
+
+    plist_path = tmp_path / "com.example.no-repo.plist"
+    with plist_path.open("wb") as handle:
+        plistlib.dump({"Label": "com.example.no-repo", "ProgramArguments": ["/bin/echo", "hello"]}, handle)
+    provenance_dir = tmp_path / "daemon-provenance"
+
+    with pytest.raises(DeployProvenanceError) as exc:
+        record_deploy_provenance_for_label(
+            label="com.example.no-repo",
+            plist_path=plist_path,
+            provenance_dir=provenance_dir,
+        )
+
+    assert exc.value.label == "com.example.no-repo"
+    assert not (provenance_dir / "com.example.no-repo.json").exists()
 
 
 def test_run_doctor_exits_nonzero_for_recent_unvectored_chunk(tmp_path):

--- a/tests/test_kg_judge.py
+++ b/tests/test_kg_judge.py
@@ -317,6 +317,7 @@ def test_git_shellout_tests_scrub_inherited_git_env():
 
     assert set(git_shellout_files) == {
         "test_brainbar_build_app_guards.py",
+        "test_doctor.py",
         "test_git_learning.py",
         "test_kg_judge.py",
     }


### PR DESCRIPTION
## Summary
- Detect stale long-running BrainLayer daemons in `doctor` by comparing recorded launch provenance with current deployed git HEAD.
- Raise the deploy-drift alarm loudly for older or diverged daemon launch commits.
- Add `brainlayer deploy` to safely restart/kickstart runtime daemons and record fresh provenance, while only flagging BrainBar changes for human rebuild.

## Tests
- `ruff check src tests`
- `pytest` (`3266 passed, 49 skipped, 5 xfailed` locally)
- pre-push pytest hook on Python 3.12 completed before push

## Review Notes
- RED tests were added first for stale-vs-in-sync doctor behavior.
- Local CodeRabbit pre-commit reported two major findings: unsafe cwd fallback for provenance recording and silent diverged commits. Both are fixed with tests.
- A second local CodeRabbit attempt was rate-limited before PR creation.
- `ruff check .` still reports pre-existing unrelated lint debt under `scripts/`; touched source/tests pass ruff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches launchd restart paths and doctor alarms that can fail deploy if plists lack repo root; git shellouts are mitigated with env scrubbing and provenance recording failures are non-fatal on daemon startup.
> 
> **Overview**
> Adds **deploy drift detection** so long-running launchd daemons can be compared against the current git checkout, plus a **`brainlayer deploy`** path to restart them and refresh provenance.
> 
> A new **`deploy_drift`** module writes per-label JSON provenance (repo root, launch commit, PID) and classifies drift as **older** (ancestor relationship) or **diverged**. **`doctor`** now checks loaded proxy/enrichment/drain/watch labels and **`raise_alarm`s** `deploy_drift` when HEAD no longer matches recorded launch commits. Git subprocesses use a scrubbed env (no inherited `GIT_*`).
> 
> The **`deploy`** command kickstarts loaded labels or bootstraps missing ones, records provenance from launchd plists (requires resolvable repo root), and prints a **BrainBar rebuild** warning when `brain-bar/` changed since prior deploy commits—without auto-restarting BrainBar labels.
> 
> **Enrichment supervisor**, **watch**, and **drain daemon** startup now call **`record_launch_from_environment()`** (via `BRAINLAYER_LAUNCHD_SERVICE`) in a try/except so failures do not block service start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c1e465426bf45d785c14c3a2889e7de479e6f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect stale BrainLayer daemon deploys by comparing launch commit to repo HEAD
> - Adds [`deploy_drift.py`](https://github.com/EtanHey/brainlayer/pull/553/files#diff-104020c1accd6a40c76e68a42d5ea2293fb67b81be388b3b841265d2c42699d8) with logic to write per-daemon provenance JSON files (recording the git commit at launch time) and detect drift when the running commit is older than or diverged from the current repo HEAD.
> - Adds a `deploy` CLI command in [`cli/__init__.py`](https://github.com/EtanHey/brainlayer/pull/553/files#diff-e66ce4ea8b0cf3331154cb15181cb09a7c593566e36380fd9215ff29d24ffd02) that kickstarts or bootstraps the four runtime daemons (proxy, enrichment, drain, watch), records provenance per label, and warns if BrainBar sources changed without restarting BrainBar.
> - Integrates drift detection into [`doctor.py`](https://github.com/EtanHey/brainlayer/pull/553/files#diff-41071e7067b327f299dfaa0e5ce4c4455911658ff543b818c684f321f91b29ff) via a new `_check_deploy_drift` helper that raises a `deploy_drift` alarm for any loaded daemon running stale code.
> - The drain, enrichment supervisor, and watch daemons each record launch provenance at startup via `record_launch_from_environment`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 64195be. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deploy command to restart long-running services and record launch history.
  * The doctor now checks for deployment drift and raises an alert when a service is running from an older or different code state.
  * Launch-time provenance is now recorded automatically for key background processes.

* **Bug Fixes**
  * Improved reliability by keeping provenance-recording failures from interrupting service startup.
  * Added safeguards to better handle missing repository information and environment contamination during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->