### PR TITLE
Release BrainLayer 1.4.2 daemon socket hotfix

### DIFF
--- a/.github/workflows/brainbar-release.yml
+++ b/.github/workflows/brainbar-release.yml
@@ -101,16 +101,13 @@ jobs:
           if [ -z "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_BASE64" ] \
             || [ -z "$BRAINBAR_DEVELOPER_ID_CERTIFICATE_PASSWORD" ] \
             || [ -z "$BRAINBAR_DEVELOPER_ID_APPLICATION" ]; then
-            echo "::warning title=BrainBar signing skipped::Developer ID signing secrets are not fully configured; BrainBar.zip will contain an unsigned app."
+            echo "::error title=BrainBar signing unavailable::Developer ID signing secrets are required before BrainBar.zip can be released."
             {
               echo "## BrainBar signing"
               echo ""
-              echo "SIGNING SKIPPED: Developer ID secrets are not fully configured. The uploaded BrainBar.zip contains an unsigned app."
+              echo "SIGNING FAILED: Developer ID secrets are not fully configured. BrainBar.zip was not released."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "signed=false" >> "$GITHUB_OUTPUT"
-            echo "BRAINBAR_SIGNING_STATUS=unsigned - Developer ID signing secrets were missing" >> "$GITHUB_ENV"
-            echo "BRAINBAR_NOTARIZATION_STATUS=skipped - signing was skipped" >> "$GITHUB_ENV"
-            exit 0
+            exit 1
           fi
 
           keychain_password="${BRAINBAR_SIGNING_KEYCHAIN_PASSWORD:-$(uuidgen)}"
@@ -139,6 +136,7 @@ jobs:
         run: |
           set -euo pipefail
           codesign --force --deep --options runtime --timestamp --sign "$BRAINBAR_SIGNING_IDENTITY" dist/BrainBar.app
+          codesign --verify --deep --strict --verbose=4 dist/BrainBar.app
           codesign -dv --verbose=4 dist/BrainBar.app
 
       - name: Notarize BrainBar.app
@@ -153,14 +151,13 @@ jobs:
           if [ -z "$BRAINBAR_NOTARY_APPLE_ID" ] \
             || [ -z "$BRAINBAR_NOTARY_PASSWORD" ] \
             || [ -z "$BRAINBAR_NOTARY_TEAM_ID" ]; then
-            echo "::warning title=BrainBar notarization skipped::Notary secrets are not fully configured; signed BrainBar.app will be packaged without notarization."
+            echo "::error title=BrainBar notarization unavailable::Notary secrets are required before BrainBar.zip can be released."
             {
               echo "## BrainBar notarization"
               echo ""
-              echo "NOTARIZATION SKIPPED: notary secrets are not fully configured. The uploaded BrainBar.zip is signed but not notarized."
+              echo "NOTARIZATION FAILED: notary secrets are not fully configured. BrainBar.zip was not released."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "BRAINBAR_NOTARIZATION_STATUS=skipped - notary secrets were missing" >> "$GITHUB_ENV"
-            exit 0
+            exit 1
           fi
 
           notary_zip="$RUNNER_TEMP/BrainBar-notary.zip"
@@ -171,6 +168,9 @@ jobs:
             --team-id "$BRAINBAR_NOTARY_TEAM_ID" \
             --wait
           xcrun stapler staple dist/BrainBar.app
+          xcrun stapler validate dist/BrainBar.app
+          codesign --verify --deep --strict --verbose=4 dist/BrainBar.app
+          spctl --assess --type execute --verbose=4 dist/BrainBar.app
           echo "BRAINBAR_NOTARIZATION_STATUS=notarized and stapled" >> "$GITHUB_ENV"
 
       - name: Package BrainBar.zip
@@ -187,6 +187,17 @@ jobs:
             exit 1
           fi
           echo "BrainBar.zip size: $(stat -f%z dist/BrainBar.zip) bytes"
+
+      - name: Verify packaged BrainBar.zip
+        run: |
+          set -euo pipefail
+          verify_dir="$RUNNER_TEMP/brainbar-zip-verify"
+          rm -rf "$verify_dir"
+          mkdir -p "$verify_dir"
+          ditto -x -k dist/BrainBar.zip "$verify_dir"
+          codesign --verify --deep --strict --verbose=4 "$verify_dir/BrainBar.app"
+          xcrun stapler validate "$verify_dir/BrainBar.app"
+          spctl --assess --type execute --verbose=4 "$verify_dir/BrainBar.app"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65

--- a/.github/workflows/brainbar-release.yml
+++ b/.github/workflows/brainbar-release.yml
@@ -63,6 +63,7 @@ jobs:
           rm -rf "$PWD/dist"
           mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources" "$launchagents_dir"
           cp brain-bar/bundle/Info.plist "$plist"
+          cp brain-bar/bundle/AppIcon.icns "$app_dir/Contents/Resources/AppIcon.icns"
           cp "$bin_dir/BrainBar" "$app_dir/Contents/MacOS/BrainBar"
           cp "$bin_dir/BrainBarDaemon" "$app_dir/Contents/MacOS/BrainBarDaemon"
           cp brain-bar/bundle/com.brainlayer.brainbar.plist "$launchagents_dir/com.brainlayer.brainbar.plist"

--- a/brain-bar/Sources/BrainBarDaemon/BrainBarDaemonMain.swift
+++ b/brain-bar/Sources/BrainBarDaemon/BrainBarDaemonMain.swift
@@ -15,8 +15,10 @@ enum BrainBarDaemonMain {
         }
         server.start()
         NSLog("[BrainBarDaemon] Started on %@", BrainBarServer.defaultSocketPath())
-        withExtendedLifetime(uiWatchdog) {
-            RunLoop.main.run()
+        withExtendedLifetime(server) {
+            withExtendedLifetime(uiWatchdog) {
+                RunLoop.main.run()
+            }
         }
     }
 

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -618,6 +618,8 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(app.contains("startDaemonWatchdog"))
         XCTAssertTrue(server.contains("startDaemonHeartbeatOnQueue"))
         XCTAssertTrue(daemon.contains("startUIWatchdog"))
+        XCTAssertTrue(daemon.contains("withExtendedLifetime(server)"))
+        XCTAssertTrue(daemon.contains("withExtendedLifetime(uiWatchdog)"))
     }
 
     func testWatchdogPolicyMarksMissingAndStaleHeartbeatUnhealthy() throws {

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -647,6 +647,7 @@ echo "[build-app] Signing..."
 codesign --force --deep --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP_DIR"
 
 echo "[build-app] Verifying signature..."
+codesign --verify --deep --strict --verbose=4 "$APP_DIR"
 if ! codesign -dv --verbose=4 "$APP_DIR" 2>&1 | grep -F "Authority=$SIGN_IDENTITY" >/dev/null; then
     echo "[build-app] ERROR: Installed app is not signed with $SIGN_IDENTITY"
     codesign -dv --verbose=4 "$APP_DIR" 2>&1

--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.4.1</string>
+    <string>1.4.2</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.1</string>
+    <string>1.4.2</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.4.1"
+version = "1.4.2"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents — local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -509,6 +509,7 @@ def test_build_app_runs_hardened_codesign_and_notarization_when_profile_is_avail
     assert "--options runtime" in codesign_calls
     assert "--timestamp " in codesign_calls or codesign_calls.rstrip().endswith("--timestamp")
     assert "--timestamp=none" not in codesign_calls
+    assert "--verify --deep --strict --verbose=4" in codesign_calls
     notarytool_call = notarytool_log.read_text(encoding="utf-8")
     notarytool_parts = notarytool_call.split()
     assert notarytool_parts[0] == "submit"

--- a/tests/test_brainbar_release_workflow.py
+++ b/tests/test_brainbar_release_workflow.py
@@ -124,6 +124,7 @@ def _assert_signing_decode_is_macos_safe(job: dict) -> None:
 
 def _assert_launchagents_are_packaged(job: dict) -> None:
     runs = "\n".join(_step_run(step) for step in job.get("steps", []) if isinstance(step, dict))
+    assert "AppIcon.icns" in runs, "BrainBar.app must package the menu bar app icon resource"
     assert "Contents/Resources/LaunchAgents" in runs, "BrainBar.app must package launch agent templates"
     assert "com.brainlayer.brainbar.plist" in runs, "BrainBar.app must include the UI launch agent plist"
     assert "com.brainlayer.brainbar-daemon.plist" in runs, "BrainBar.app must include the daemon launch agent plist"

--- a/tests/test_brainbar_release_workflow.py
+++ b/tests/test_brainbar_release_workflow.py
@@ -129,6 +129,40 @@ def _assert_launchagents_are_packaged(job: dict) -> None:
     assert "com.brainlayer.brainbar-daemon.plist" in runs, "BrainBar.app must include the daemon launch agent plist"
 
 
+def _assert_gatekeeper_ready_release_contract(job: dict) -> None:
+    runs = "\n".join(_step_run(step) for step in job.get("steps", []) if isinstance(step, dict))
+    assert "::warning title=BrainBar signing skipped" not in runs, (
+        "BrainBar release workflow must not upload unsigned app zips when Developer ID secrets are missing"
+    )
+    assert "::warning title=BrainBar notarization skipped" not in runs, (
+        "BrainBar release workflow must not upload unnotarized app zips when notary secrets are missing"
+    )
+    assert "exit 1" in runs and "BrainBar signing unavailable" in runs, (
+        "BrainBar release workflow must fail closed when Developer ID signing secrets are missing"
+    )
+    assert "exit 1" in runs and "BrainBar notarization unavailable" in runs, (
+        "BrainBar release workflow must fail closed when notary secrets are missing"
+    )
+    assert "codesign --verify --deep --strict --verbose=4 dist/BrainBar.app" in runs, (
+        "BrainBar release workflow must verify the signed app resource seal before notarization"
+    )
+    assert "xcrun stapler validate dist/BrainBar.app" in runs, (
+        "BrainBar release workflow must validate the stapled notarization ticket"
+    )
+    assert "spctl --assess --type execute --verbose=4 dist/BrainBar.app" in runs, (
+        "BrainBar release workflow must require Gatekeeper acceptance before packaging"
+    )
+    assert 'ditto -x -k dist/BrainBar.zip "$verify_dir"' in runs, (
+        "BrainBar release workflow must unpack the final zip before publishing"
+    )
+    assert 'codesign --verify --deep --strict --verbose=4 "$verify_dir/BrainBar.app"' in runs, (
+        "BrainBar release workflow must verify the packaged app signature before publishing"
+    )
+    assert 'spctl --assess --type execute --verbose=4 "$verify_dir/BrainBar.app"' in runs, (
+        "BrainBar release workflow must require Gatekeeper acceptance on the packaged app before publishing"
+    )
+
+
 def _assert_action_refs_are_pinned(job: dict) -> None:
     action_steps = [step for step in job.get("steps", []) if isinstance(step, dict) and "uses" in step]
     assert action_steps, "BrainBar release workflow must declare action steps explicitly"
@@ -158,6 +192,7 @@ def _assert_release_workflow_contract(workflow: dict) -> None:
     _assert_version_stamp(job)
     _assert_signing_decode_is_macos_safe(job)
     _assert_launchagents_are_packaged(job)
+    _assert_gatekeeper_ready_release_contract(job)
     _assert_no_zip_guardrail_before_release(job)
 
 
@@ -181,3 +216,14 @@ def test_release_workflow_without_no_zip_guardrail_fails_contract() -> None:
 
     with pytest.raises(AssertionError, match="missing or empty"):
         _assert_no_zip_guardrail_before_release(job)
+
+
+def test_release_workflow_with_signing_skip_fails_contract() -> None:
+    workflow = deepcopy(_load_workflow())
+    job = _release_job(workflow)
+    for step in job.get("steps", []):
+        if isinstance(step, dict) and step.get("name") == "Import Developer ID certificate":
+            step["run"] += "\necho '::warning title=BrainBar signing skipped::bad'\n"
+
+    with pytest.raises(AssertionError, match="unsigned app zips"):
+        _assert_gatekeeper_ready_release_contract(job)


### PR DESCRIPTION
## Summary
- keep BrainBarDaemon's BrainBarServer alive for the daemon process lifetime so optimized packaged builds bind `/tmp/brainbar.sock`
- add a lifecycle regression guard for the daemon/server lifetime wiring
- bump release metadata to 1.4.2 for the hotfix

## Verification
- `swift test --package-path brain-bar --filter DashboardTests.testBrainBarLifecycleWatchdogWiresUIAndDaemonHeartbeats`
- `swift build --package-path brain-bar -c release --product BrainBarDaemon`
- optimized daemon temp socket proof: `/tmp/brainbar-release-lifetime-test.sock` was owned by `BrainBarD`
- `pytest tests/test_brainbar_build_app_guards.py::test_brainbar_daemon_launchagent_runs_interactive_daemon_binary -q`
- pre-push gate: 3261 passed, 9 skipped, 61 deselected, 1 xfailed

## Runtime context
PR #555 / v1.4.1 got BrainLayer status green, but the installed BrainBarDaemon never owned `/tmp/brainbar.sock`; the live socket smoke failed. This patch fixes the daemon lifetime root cause before publishing 1.4.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The daemon lifetime change fixes a production socket failure but touches core BrainBar runtime; release jobs now hard-fail without full signing/notarization secrets instead of publishing partial artifacts.
> 
> **Overview**
> **BrainBarDaemon socket hotfix (1.4.2)** — In `BrainBarDaemonMain`, the main run loop now runs inside nested `withExtendedLifetime` for both `BrainBarServer` and the UI watchdog so release/optimized builds do not drop the server before `/tmp/brainbar.sock` stays bound. Lifecycle tests assert that wiring.
> 
> **Release metadata** — Version **1.4.2** is stamped in the app bundle, Python package, and MCP `server.json`.
> 
> **Distribution hardening** — The GitHub release workflow copies `AppIcon.icns`, **exits with error** when Developer ID or notary secrets are missing (no more unsigned/unnotarized uploads), and adds `codesign --verify`, `stapler validate`, and `spctl` checks after sign/notarize plus a final unpack-and-verify step on `BrainBar.zip` before publish. Local `build-app.sh` adds strict `codesign --verify` after signing. Workflow and build tests encode the fail-closed Gatekeeper contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16077a9eb6b6fbf4defaafbb5b744002f97ec32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix premature deallocation of `BrainBarServer` in daemon and harden release signing pipeline for BrainLayer 1.4.2
> - Wraps `RunLoop.main.run()` in nested `withExtendedLifetime` blocks in [`BrainBarDaemonMain.swift`](https://github.com/EtanHey/brainlayer/pull/556/files#diff-462f3fd8aad3480789eaa9a6493a8a4c598a94d2631bf33b268001571d92078d) to keep both `server` and `uiWatchdog` alive for the full runloop duration, fixing premature deallocation of `BrainBarServer`.
> - The release workflow now fails closed when Developer ID or notarization secrets are missing, instead of proceeding unsigned/unnotarized.
> - Adds codesign resource-seal verification, `stapler validate`, and Gatekeeper (`spctl`) assessment after signing and again after unpacking the final zip, before publishing the GitHub Release.
> - Copies `AppIcon.icns` into the app bundle during packaging in the release workflow.
> - Bumps version to 1.4.2 across bundle, Python package, and server metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16077a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability by keeping both the daemon server and UI watchdog alive while the main loop runs.
* **Chores**
  * Updated the app/package version to **1.4.2** across release metadata and build files.
* **Tests**
  * Expanded coverage to verify daemon lifecycle wiring remains intact.
  * Strengthened release workflow tests to enforce fail-closed signing/notarization behavior and stricter Gatekeeper/package verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->