### PR TITLE
Salvage FTS embed-gate hardening (#524) + pause-sentinel test isolation (#527)

### DIFF
--- a/hooks/brainlayer-prompt-search.py
+++ b/hooks/brainlayer-prompt-search.py
@@ -12,6 +12,7 @@ Target: <500ms total.
 """
 
 import json
+import math
 import os
 import queue
 import re
@@ -37,6 +38,7 @@ MAX_ADAPTIVE_INJECTION = 3
 MAX_HYBRID_CANDIDATES = 8
 DEGRADED_PREFIX = "⚠️ DEGRADED: BrainLayer"
 DEFAULT_EMBED_TIMEOUT_MS = 1000.0
+HYBRID_IN_FLIGHT = threading.Lock()
 
 
 def degraded_notice(reason):
@@ -53,12 +55,15 @@ def embed_timeout_ms():
         value = float(raw)
     except (TypeError, ValueError):
         return DEFAULT_EMBED_TIMEOUT_MS
-    if not value or value < 0:
+    if not math.isfinite(value) or value <= 0:
         return DEFAULT_EMBED_TIMEOUT_MS
     return min(value, 30_000.0)
 
 
 def run_with_timeout(func, timeout_ms, *args, **kwargs):
+    if not HYBRID_IN_FLIGHT.acquire(blocking=False):
+        raise TimeoutError("hybrid search already in progress")
+
     results = queue.Queue(maxsize=1)
 
     def target():
@@ -66,9 +71,15 @@ def run_with_timeout(func, timeout_ms, *args, **kwargs):
             results.put((True, func(*args, **kwargs)))
         except BaseException as exc:
             results.put((False, exc))
+        finally:
+            HYBRID_IN_FLIGHT.release()
 
     thread = threading.Thread(target=target, name="brainlayer-hook-hybrid", daemon=True)
-    thread.start()
+    try:
+        thread.start()
+    except Exception:
+        HYBRID_IN_FLIGHT.release()
+        raise
     thread.join(timeout_ms / 1000.0)
     if thread.is_alive():
         raise TimeoutError(f"hybrid search exceeded {timeout_ms:.0f}ms")

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -3,10 +3,12 @@
 import asyncio
 import glob
 import json
+import math
 import os
 import platform
 import re
 import socket
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -35,6 +37,7 @@ _ORIGIN_ORDER_LABEL = "- Order: origin (earliest among expanded hybrid candidate
 _HELPER_SOCKET_GLOB = "/tmp/brainbar-hybrid-*.sock"
 _HELPER_SOCKET_TIMEOUT_SECONDS = 2.0
 _DEFAULT_EMBED_TIMEOUT_MS = 1000.0
+_EMBED_IN_FLIGHT = threading.Lock()
 
 from ._format import format_kg_search, format_recalled_context, format_search_results, format_stats
 from ._shared import (
@@ -67,7 +70,7 @@ def _embed_timeout_ms() -> float:
         value = float(raw)
     except (TypeError, ValueError):
         return _DEFAULT_EMBED_TIMEOUT_MS
-    if not value or value < 0:
+    if not math.isfinite(value) or value <= 0:
         return _DEFAULT_EMBED_TIMEOUT_MS
     return min(value, 30_000.0)
 
@@ -1783,40 +1786,87 @@ async def _search(
         query_embedding = None
         search_mode = "hybrid"
         fallback_reason = None
-        try:
-            embed_timeout_ms = _embed_timeout_ms()
-            query_embedding = await asyncio.wait_for(
-                loop.run_in_executor(
-                    None,
-                    lambda: _get_embedding_model().embed_query(query),
-                ),
-                timeout=embed_timeout_ms / 1000.0,
-            )
-        except TimeoutError as exc:
+        embed_timeout_ms = _embed_timeout_ms()
+        if not _EMBED_IN_FLIGHT.acquire(blocking=False):
             search_mode = "fts_fallback"
-            fallback_reason = "embed_timeout"
+            fallback_reason = "embed_busy"
             search_profile.emit(
                 profile_scope,
                 "embed",
                 profile_query_id,
                 search_profile.dur_ms(embed_started),
-                error=exc.__class__.__name__,
-                timeout_ms=embed_timeout_ms,
-                fallback="fts_fallback",
-            )
-        except Exception as exc:
-            search_mode = "fts_fallback"
-            fallback_reason = f"embed_error:{exc.__class__.__name__}"
-            search_profile.emit(
-                profile_scope,
-                "embed",
-                profile_query_id,
-                search_profile.dur_ms(embed_started),
-                error=exc.__class__.__name__,
+                error="EmbedBusy",
                 fallback="fts_fallback",
             )
         else:
-            search_profile.emit(profile_scope, "embed", profile_query_id, search_profile.dur_ms(embed_started))
+            embed_state = {"started": False, "released": False}
+            embed_state_lock = threading.Lock()
+
+            def release_embed_lock_once() -> None:
+                should_release = False
+                with embed_state_lock:
+                    if not embed_state["released"]:
+                        embed_state["released"] = True
+                        should_release = True
+                if should_release:
+                    _EMBED_IN_FLIGHT.release()
+
+            def release_if_embed_never_started() -> None:
+                should_release = False
+                with embed_state_lock:
+                    if not embed_state["started"] and not embed_state["released"]:
+                        embed_state["released"] = True
+                        should_release = True
+                if should_release:
+                    _EMBED_IN_FLIGHT.release()
+
+            def embed_query_guarded() -> list[float] | None:
+                with embed_state_lock:
+                    if embed_state["released"]:
+                        return None
+                    embed_state["started"] = True
+                try:
+                    return _get_embedding_model().embed_query(query)
+                finally:
+                    release_embed_lock_once()
+
+            try:
+                try:
+                    embed_future = loop.run_in_executor(None, embed_query_guarded)
+                except Exception:
+                    release_embed_lock_once()
+                    raise
+                query_embedding = await asyncio.wait_for(embed_future, timeout=embed_timeout_ms / 1000.0)
+            except asyncio.CancelledError:
+                release_if_embed_never_started()
+                raise
+            except asyncio.TimeoutError as exc:
+                release_if_embed_never_started()
+                search_mode = "fts_fallback"
+                fallback_reason = "embed_timeout"
+                search_profile.emit(
+                    profile_scope,
+                    "embed",
+                    profile_query_id,
+                    search_profile.dur_ms(embed_started),
+                    error=exc.__class__.__name__,
+                    timeout_ms=embed_timeout_ms,
+                    fallback="fts_fallback",
+                )
+            except Exception as exc:
+                release_if_embed_never_started()
+                search_mode = "fts_fallback"
+                fallback_reason = f"embed_error:{exc.__class__.__name__}"
+                search_profile.emit(
+                    profile_scope,
+                    "embed",
+                    profile_query_id,
+                    search_profile.dur_ms(embed_started),
+                    error=exc.__class__.__name__,
+                    fallback="fts_fallback",
+                )
+            else:
+                search_profile.emit(profile_scope, "embed", profile_query_id, search_profile.dur_ms(embed_started))
 
         if source == "all":
             source_filter = None
@@ -1895,8 +1945,12 @@ async def _search(
             )
 
         if not results["documents"][0]:
-            empty = {"query": query, "total": 0, "results": []}
-            return ([TextContent(type="text", text="No results found.")], empty)
+            empty = {"query": query, "total": 0, "results": [], "search_mode": search_mode}
+            text = "No results found."
+            if fallback_reason:
+                empty["fallback_reason"] = fallback_reason
+                text = f"No results found. Search mode: FTS fallback ({fallback_reason}); vector embedding was skipped."
+            return ([TextContent(type="text", text=text)], empty)
 
         results = store.enrich_results_with_session_context(results)
         if order == "origin":

--- a/tests/test_adaptive_injection.py
+++ b/tests/test_adaptive_injection.py
@@ -136,6 +136,12 @@ class TestPollutionFiltering:
 
 
 class TestSearchFallback:
+    def _wait_for_hybrid_release(self, prompt_search, timeout_s: float = 1.0):
+        deadline = time.monotonic() + timeout_s
+        while prompt_search.HYBRID_IN_FLIGHT.locked() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert not prompt_search.HYBRID_IN_FLIGHT.locked()
+
     def test_fallback_to_fts_only(self, prompt_search, monkeypatch):
         fts_rows = [_row("fts-best", 0.0)]
 
@@ -167,18 +173,65 @@ class TestSearchFallback:
         monkeypatch.setattr(prompt_search, "run_hybrid_search", slow_hybrid)
         monkeypatch.setattr(prompt_search, "run_fts_search", lambda *args, **kwargs: fts_rows)
 
-        started = time.monotonic()
-        rows, used_hybrid = prompt_search.search_prompt_chunks(
-            prompt="keyword fallback query",
-            db_path="/tmp/test.db",
-            keywords=["keyword", "fallback"],
-            limit=8,
-        )
-        elapsed = time.monotonic() - started
+        try:
+            started = time.monotonic()
+            rows, used_hybrid = prompt_search.search_prompt_chunks(
+                prompt="keyword fallback query",
+                db_path="/tmp/test.db",
+                keywords=["keyword", "fallback"],
+                limit=8,
+            )
+            elapsed = time.monotonic() - started
 
-        assert elapsed < 0.5
-        assert used_hybrid is False
-        assert [row["id"] for row in rows] == ["fts-timeout"]
+            assert elapsed < 0.5
+            assert used_hybrid is False
+            assert [row["id"] for row in rows] == ["fts-timeout"]
+        finally:
+            self._wait_for_hybrid_release(prompt_search)
+
+    def test_timed_out_hybrid_search_does_not_spawn_parallel_workers(self, prompt_search, monkeypatch):
+        fts_rows = [_row("fts-busy", 0.0)]
+        calls = 0
+
+        def slow_hybrid(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            time.sleep(0.2)
+            return [_row("late-hybrid", 0.02)]
+
+        monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "1")
+        monkeypatch.setattr(prompt_search, "run_hybrid_search", slow_hybrid)
+        monkeypatch.setattr(prompt_search, "run_fts_search", lambda *args, **kwargs: fts_rows)
+
+        try:
+            rows1, used_hybrid1 = prompt_search.search_prompt_chunks(
+                prompt="keyword fallback query",
+                db_path="/tmp/test.db",
+                keywords=["keyword", "fallback"],
+                limit=8,
+            )
+            rows2, used_hybrid2 = prompt_search.search_prompt_chunks(
+                prompt="keyword fallback query",
+                db_path="/tmp/test.db",
+                keywords=["keyword", "fallback"],
+                limit=8,
+            )
+
+            assert used_hybrid1 is False
+            assert used_hybrid2 is False
+            assert [row["id"] for row in rows1] == ["fts-busy"]
+            assert [row["id"] for row in rows2] == ["fts-busy"]
+        finally:
+            self._wait_for_hybrid_release(prompt_search)
+
+        assert calls == 1
+
+    def test_embed_timeout_rejects_non_finite_values(self, prompt_search, monkeypatch):
+        monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "nan")
+        assert prompt_search.embed_timeout_ms() == 1000.0
+
+        monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "inf")
+        assert prompt_search.embed_timeout_ms() == 1000.0
 
     def test_fast_hybrid_search_stays_on_hybrid_path(self, prompt_search, monkeypatch):
         hybrid_rows = [_row("hybrid-best", 0.02)]

--- a/tests/test_search_handler.py
+++ b/tests/test_search_handler.py
@@ -1,10 +1,19 @@
+import asyncio
 import time
 
 import pytest
 
+import brainlayer.mcp.search_handler as search_handler_module
 from brainlayer.mcp import call_tool
 from brainlayer.mcp.search_handler import _brain_search, _search
 from brainlayer.vector_store import VectorStore
+
+
+async def _wait_for_embed_release(timeout_s: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while search_handler_module._EMBED_IN_FLIGHT.locked() and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert not search_handler_module._EMBED_IN_FLIGHT.locked()
 
 
 class FakeEmbeddingModel:
@@ -15,6 +24,16 @@ class FakeEmbeddingModel:
 class SlowEmbeddingModel:
     def embed_query(self, _query: str) -> list[float]:
         time.sleep(0.05)
+        return [0.9, 0.9, 0.9]
+
+
+class CountingSlowEmbeddingModel:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def embed_query(self, _query: str) -> list[float]:
+        self.calls += 1
+        time.sleep(0.2)
         return [0.9, 0.9, 0.9]
 
 
@@ -66,6 +85,17 @@ class FtsFallbackSearchStore(RecordingSearchStore):
             "documents": [["semantic and keyword hybrid result"]],
             "metadatas": [[{"source_file": "hybrid.md", "project": "brainlayer"}]],
             "distances": [[0.25]],
+        }
+
+
+class EmptyFtsFallbackSearchStore(RecordingSearchStore):
+    def hybrid_search(self, **kwargs):
+        self.hybrid_kwargs = kwargs
+        return {
+            "ids": [[]],
+            "documents": [[]],
+            "metadatas": [[]],
+            "distances": [[]],
         }
 
 
@@ -176,20 +206,23 @@ async def test_brain_search_falls_back_to_fts_when_embedding_times_out(monkeypat
     monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: SlowEmbeddingModel())
     monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
 
-    started = time.monotonic()
-    content, structured = await _search(
-        query="keyword fallback",
-        source="all",
-        num_results=1,
-    )
-    elapsed = time.monotonic() - started
+    try:
+        started = time.monotonic()
+        content, structured = await _search(
+            query="keyword fallback",
+            source="all",
+            num_results=1,
+        )
+        elapsed = time.monotonic() - started
 
-    assert elapsed < 0.5
-    assert store.hybrid_kwargs["query_embedding"] is None
-    assert structured["search_mode"] == "fts_fallback"
-    assert structured["fallback_reason"] == "embed_timeout"
-    assert [item["chunk_id"] for item in structured["results"]] == ["fts-fallback-hit"]
-    assert "FTS fallback" in content[0].text
+        assert elapsed < 0.5
+        assert store.hybrid_kwargs["query_embedding"] is None
+        assert structured["search_mode"] == "fts_fallback"
+        assert structured["fallback_reason"] == "embed_timeout"
+        assert [item["chunk_id"] for item in structured["results"]] == ["fts-fallback-hit"]
+        assert "FTS fallback" in content[0].text
+    finally:
+        await _wait_for_embed_release()
 
 
 @pytest.mark.asyncio
@@ -231,6 +264,155 @@ async def test_brain_search_uses_hybrid_when_embedding_is_fast(monkeypatch):
     assert structured["search_mode"] == "hybrid"
     assert "fallback_reason" not in structured
     assert [item["chunk_id"] for item in structured["results"]] == ["hybrid-hit"]
+
+
+@pytest.mark.asyncio
+async def test_brain_search_skips_parallel_embedding_after_timeout(monkeypatch):
+    store = FtsFallbackSearchStore()
+    model = CountingSlowEmbeddingModel()
+
+    monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: model)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+
+    try:
+        _content1, structured1 = await _search(
+            query="keyword fallback",
+            source="all",
+            num_results=1,
+        )
+        _content2, structured2 = await _search(
+            query="keyword fallback",
+            source="all",
+            num_results=1,
+        )
+
+        assert structured1["search_mode"] == "fts_fallback"
+        assert structured1["fallback_reason"] == "embed_timeout"
+        assert structured2["search_mode"] == "fts_fallback"
+        assert structured2["fallback_reason"] == "embed_busy"
+    finally:
+        await _wait_for_embed_release()
+
+    assert model.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_brain_search_releases_embed_lock_when_executor_timeout_cancels_queued_future(monkeypatch):
+    store = FtsFallbackSearchStore()
+    loop = asyncio.get_running_loop()
+    original_run_in_executor = loop.run_in_executor
+
+    def queued_forever(_executor, _func, *_args):
+        return loop.create_future()
+
+    monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "1")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: FakeEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+    monkeypatch.setattr(loop, "run_in_executor", queued_forever)
+
+    try:
+        _content1, structured1 = await _search(
+            query="keyword fallback",
+            source="all",
+            num_results=1,
+        )
+
+        monkeypatch.setattr(loop, "run_in_executor", original_run_in_executor)
+        _content2, structured2 = await _search(
+            query="keyword fallback",
+            source="all",
+            num_results=1,
+        )
+
+        assert structured1["search_mode"] == "fts_fallback"
+        assert structured1["fallback_reason"] == "embed_timeout"
+        assert structured2["search_mode"] == "hybrid"
+        assert search_handler_module._EMBED_IN_FLIGHT.locked() is False
+    finally:
+        monkeypatch.setattr(loop, "run_in_executor", original_run_in_executor)
+        if search_handler_module._EMBED_IN_FLIGHT.locked():
+            search_handler_module._EMBED_IN_FLIGHT.release()
+
+
+@pytest.mark.asyncio
+async def test_brain_search_releases_embed_lock_when_cancelled_before_executor_starts(monkeypatch):
+    store = FtsFallbackSearchStore()
+    loop = asyncio.get_running_loop()
+    original_run_in_executor = loop.run_in_executor
+
+    def queued_forever(_executor, _func, *_args):
+        return loop.create_future()
+
+    monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "1000")
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: FakeEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+    monkeypatch.setattr(loop, "run_in_executor", queued_forever)
+
+    task = asyncio.create_task(
+        _search(
+            query="keyword fallback",
+            source="all",
+            num_results=1,
+        )
+    )
+    try:
+        deadline = time.monotonic() + 1.0
+        while not search_handler_module._EMBED_IN_FLIGHT.locked() and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert search_handler_module._EMBED_IN_FLIGHT.locked()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        monkeypatch.setattr(loop, "run_in_executor", original_run_in_executor)
+        _content, structured = await _search(
+            query="keyword fallback",
+            source="all",
+            num_results=1,
+        )
+
+        assert structured["search_mode"] == "hybrid"
+        assert search_handler_module._EMBED_IN_FLIGHT.locked() is False
+    finally:
+        if not task.done():
+            task.cancel()
+        if search_handler_module._EMBED_IN_FLIGHT.locked():
+            search_handler_module._EMBED_IN_FLIGHT.release()
+
+
+def test_embed_timeout_rejects_non_finite_env_values(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "nan")
+    assert search_handler_module._embed_timeout_ms() == 1000.0
+
+    monkeypatch.setenv("BRAINLAYER_EMBED_TIMEOUT_MS", "inf")
+    assert search_handler_module._embed_timeout_ms() == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_brain_search_empty_fts_fallback_includes_fallback_metadata(monkeypatch):
+    store = EmptyFtsFallbackSearchStore()
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: store)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_embedding_model", lambda: RaisingEmbeddingModel())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._normalize_project_name", lambda project: project)
+
+    content, structured = await _search(
+        query="keyword fallback",
+        source="all",
+        num_results=1,
+    )
+
+    assert store.hybrid_kwargs["query_embedding"] is None
+    assert structured["search_mode"] == "fts_fallback"
+    assert structured["fallback_reason"] == "embed_error:RuntimeError"
+    assert structured["total"] == 0
+    assert structured["results"] == []
+    assert "Search mode: FTS fallback (embed_error:RuntimeError)" in content[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -18,25 +18,39 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(autouse=True)
-def _isolate_default_queue_dir(tmp_path_factory, monkeypatch):
-    """Isolate the default HealthCheckConfig queue_dir from the live queue.
+def _isolate_default_live_paths(tmp_path_factory, monkeypatch):
+    """Isolate HealthCheckConfig defaults that point at live developer state.
 
-    Tests that build HealthCheckConfig without an explicit queue_dir otherwise
-    read the developer's real ~/.brainlayer/queue; a populated live queue then
-    makes them spuriously report `queue_backed_up`. We redirect _queue_stats
-    so the live default path is treated as the empty isolated dir, while tests
-    that pass an explicit queue_dir are honored unchanged.
+    Tests that build HealthCheckConfig without overriding every path otherwise
+    read the developer's real ~/.brainlayer/queue and
+    ~/.local/share/brainlayer/pause.sentinel. A populated live queue can make
+    them spuriously report `queue_backed_up`, and a live pause sentinel suppresses
+    `watcher_stalled`. We redirect the default readers to isolated paths, while
+    tests that pass explicit paths are honored unchanged.
     """
     empty_queue = tmp_path_factory.mktemp("hc-queue")
-    live_default = Path("~/.brainlayer/queue").expanduser()
+    live_queue_default = Path("~/.brainlayer/queue").expanduser()
     real_queue_stats = health_check._queue_stats
 
     def _isolated_queue_stats(queue_dir, now):
-        if queue_dir.expanduser() == live_default:
+        if queue_dir.expanduser() == live_queue_default:
             queue_dir = empty_queue
         return real_queue_stats(queue_dir, now)
 
     monkeypatch.setattr(health_check, "_queue_stats", _isolated_queue_stats)
+
+    absent_sentinel = tmp_path_factory.mktemp("hc-sentinel") / "pause.sentinel"
+    live_sentinel_default = Path("~/.local/share/brainlayer/pause.sentinel").expanduser()
+    real_pause_state = health_check._pause_sentinel_state
+
+    def _isolated_pause_state(config, now):
+        if config.pause_sentinel_path.expanduser() == live_sentinel_default:
+            from dataclasses import replace
+
+            config = replace(config, pause_sentinel_path=absent_sentinel)
+        return real_pause_state(config, now)
+
+    monkeypatch.setattr(health_check, "_pause_sentinel_state", _isolated_pause_state)
     yield
 
 


### PR DESCRIPTION
## Summary
Salvages the still-useful parts of stale PRs #524 and #527 onto current `main` without merging or rebasing either branch wholesale.

## Salvaged
- From #524: MCP `brain_search` embed gate hardening with `_EMBED_IN_FLIGHT`, non-blocking `embed_busy` fallback, guarded executor release helpers, queued-timeout release, and cancellation release.
- From #524: `BRAINLAYER_EMBED_TIMEOUT_MS` validation now rejects non-finite and non-positive values in both `src/brainlayer/mcp/search_handler.py` and `hooks/brainlayer-prompt-search.py`.
- From #524: prompt hook `HYBRID_IN_FLIGHT` suppresses overlapping hybrid workers and releases the gate in the worker thread `finally`.
- From #524: empty FTS fallback results include `search_mode` and optional `fallback_reason` in structured output and user-facing text.
- From #524: regression coverage for `embed_busy`, queued timeout lock release, cancellation lock release, non-finite timeouts, empty fallback metadata, and hook worker suppression.
- From #527: test-only pause-sentinel isolation in `tests/test_stability_health_check.py`, redirecting the live default pause sentinel to an absent temp file before calling the real `_pause_sentinel_state`.

## Discarded
- Discarded #524 branch merge/rebase wholesale because it is stale and conflicts broadly with current main.
- Discarded #524 `fts_only` naming; current naming remains `fts_fallback`.
- Discarded #524 accidental origin-order test regression; main's strict origin-order assertions remain intact.
- Discarded #527 version bumps in `pyproject.toml`, `src/brainlayer/__init__.py`, and `server.json`; no version files changed.
- Discarded #527 release intent for `1.2.2`; current main is already on the 1.4.x line.

## Verification
- RED subset before implementation: 7 failed on missing `_EMBED_IN_FLIGHT` / `HYBRID_IN_FLIGHT`, non-finite timeout validation, parallel worker suppression, and empty fallback metadata.
- `pytest tests/test_search_handler.py tests/test_adaptive_injection.py tests/test_search_profile.py tests/test_hybrid_search.py tests/test_stability_health_check.py -q`: 90 passed, 1 warning.
- `ruff check src/ && ruff format --check src/`: All checks passed; 154 files already formatted.
- Full local `pytest -q`: 3372 passed, 49 skipped, 5 xfailed, 329 warnings.
- Pre-push gate: 3269 passed, 9 skipped, 61 deselected, 1 xfailed, 103 warnings; MCP registration 3 passed; isolated eval/hook routing 40 passed; Bun suite 1 pass; FTS5 determinism regression passed.
- CodeRabbit pre-commit review: 3 minor test-stability findings; all fixed before this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and timeout behavior on the hot search/embed path; regressions could cause stuck locks or unexpected FTS-only search, but behavior is heavily regression-tested.
> 
> **Overview**
> **Search and hook paths** now use non-blocking locks so only one query embedding (MCP `_EMBED_IN_FLIGHT`) or hybrid worker (hook `HYBRID_IN_FLIGHT`) runs at a time. Overlapping MCP searches skip embedding with **`embed_busy`** and FTS fallback instead of stacking parallel embed workers; the hook treats an in-flight hybrid as a timeout and falls back to FTS. Lock release is guarded on executor timeout, cancellation, and thread start failure so the gate cannot stick.
> 
> **`BRAINLAYER_EMBED_TIMEOUT_MS`** is validated with `math.isfinite` and must be positive in both MCP and prompt hook; `nan`/`inf` fall back to the default.
> 
> **Empty MCP search results** when embedding was skipped now include **`search_mode`**, optional **`fallback_reason`**, and user-facing text explaining FTS fallback.
> 
> **Tests** cover parallel worker suppression, lock release edge cases, non-finite timeouts, empty fallback metadata, and health-check isolation for the default **pause sentinel** (alongside existing queue isolation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d46bc3ea63ebe0010f1c4421157ef1ce203cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden FTS embed-gate with process-wide lock serialization and fix non-finite timeout parsing
> - Adds a module-level `threading.Lock` (`_EMBED_IN_FLIGHT` / `HYBRID_IN_FLIGHT`) in [search_handler.py](https://github.com/EtanHey/brainlayer/pull/557/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) and [brainlayer-prompt-search.py](https://github.com/EtanHey/brainlayer/pull/557/files#diff-337bf7c8c2cbf907be6bc00e08029e422d8a2b9d2947392655ff795e0df36e15) to ensure only one embedding operation runs at a time; concurrent callers fall back to FTS with `fallback_reason='embed_busy'`.
> - Fixes `_embed_timeout_ms` / `embed_timeout_ms` to reject non-finite (NaN/Inf) and non-positive env values, falling back to the module default instead of using them.
> - `_search` now returns `search_mode` and `fallback_reason` fields in all responses, and shows a descriptive message when an FTS fallback occurs.
> - Expands test coverage in [test_search_handler.py](https://github.com/EtanHey/brainlayer/pull/557/files#diff-707cb62c14691b48148e5e0a3edbba7882d201fca323785bf4718d77fa8efd15) and [test_adaptive_injection.py](https://github.com/EtanHey/brainlayer/pull/557/files#diff-9c59ccce273a9a3fe0c25bcd6ae5452f092fac99872295169851a16a1880b84d) for lock release on timeout, cancellation, and executor failure paths.
> - Isolates pause-sentinel state in [test_stability_health_check.py](https://github.com/EtanHey/brainlayer/pull/557/files#diff-1e1847cfcf0367700d03d50d1ada976cb14799056dbfc8d380b3b3f5ba7c6ae3) by redirecting default queue and sentinel paths to temporary locations in the `_isolate_default_queue_dir` fixture.
> - Risk: concurrent search callers that previously ran parallel embeddings will now receive FTS results instead of hybrid results when the lock is held.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 10d46bc. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search timeout handling so invalid or non-finite timeout values fall back to safe defaults.
  * Prevented overlapping hybrid searches and embedding runs, reducing duplicate work and improving stability.
  * Search results now show clearer fallback details when vector search is skipped or returns no matches.

* **Tests**
  * Expanded coverage for timeout, cancellation, fallback, and concurrency scenarios.
  * Added checks for non-finite timeout values and empty fallback responses.

* **Documentation**
  * Updated health-check isolation to better avoid reading live local state during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->