### PR TITLE
Protect BrainBar version integrity (mirror #323)

### DIFF
--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -58,6 +58,7 @@ BRAINBAR_NOTARY_TEAM_ID="${BRAINBAR_NOTARY_TEAM_ID:-PPN23G925Y}"
 BRAINBAR_NOTARY_KEY="${BRAINBAR_NOTARY_KEY:-}"
 BRAINBAR_NOTARY_KEY_ID="${BRAINBAR_NOTARY_KEY_ID:-}"
 BRAINBAR_NOTARY_ISSUER="${BRAINBAR_NOTARY_ISSUER:-}"
+BRAINBAR_PROTECTED_APPLICATIONS_DIR="${BRAINBAR_PROTECTED_APPLICATIONS_DIR:-/Applications}"
 UI_PLIST_LABEL="com.brainlayer.brainbar"
 DAEMON_PLIST_LABEL="com.brainlayer.brainbar-daemon"
 UI_PLIST_FILENAME="$UI_PLIST_LABEL.plist"
@@ -100,6 +101,117 @@ sanitize_branch_name() {
 
 dev_bundle_apps_dir() {
     printf '%s\n' "$HOME/Applications"
+}
+
+normalize_app_dir_path() {
+    while [ "$APP_DIR" != "/" ] && [[ "$APP_DIR" == */ ]]; do
+        APP_DIR="${APP_DIR%/}"
+    done
+}
+
+canonical_compare_path() {
+    local path="$1"
+    local dir
+    local base
+    while [ "$path" != "/" ] && [[ "$path" == */ ]]; do
+        path="${path%/}"
+    done
+    if [ -d "$path" ]; then
+        (cd "$path" && pwd -P)
+        return
+    fi
+    dir="$(dirname "$path")"
+    base="$(basename "$path")"
+    if [ -d "$dir" ]; then
+        printf '%s/%s\n' "$(cd "$dir" && pwd -P)" "$base"
+        return
+    fi
+    printf '%s\n' "$path"
+}
+
+protected_resident_app_path() {
+    local apps_dir="$BRAINBAR_PROTECTED_APPLICATIONS_DIR"
+    while [ "$apps_dir" != "/" ] && [[ "$apps_dir" == */ ]]; do
+        apps_dir="${apps_dir%/}"
+    done
+    printf '%s\n' "$apps_dir/BrainBar.app"
+}
+
+app_dir_targets_protected_resident() {
+    [ "$(canonical_compare_path "$APP_DIR")" = "$(canonical_compare_path "$(protected_resident_app_path)")" ]
+}
+
+notary_credentials_available() {
+    if [ -n "$BRAINBAR_NOTARY_PROFILE" ]; then
+        return 0
+    fi
+    if [ -n "$BRAINBAR_NOTARY_APPLE_ID" ] && [ -n "$BRAINBAR_NOTARY_PASSWORD" ] && [ -n "$BRAINBAR_NOTARY_TEAM_ID" ]; then
+        return 0
+    fi
+    if [ -n "$BRAINBAR_NOTARY_KEY" ] && [ -n "$BRAINBAR_NOTARY_KEY_ID" ] && [ -n "$BRAINBAR_NOTARY_ISSUER" ]; then
+        return 0
+    fi
+    return 1
+}
+
+protect_notarized_resident_before_rebuild() {
+    local resident_path
+    if ! app_dir_targets_protected_resident || [ ! -d "$APP_DIR" ]; then
+        return 0
+    fi
+    resident_path="$(protected_resident_app_path)"
+
+    if ! spctl --assess --type execute "$resident_path" >/dev/null 2>&1; then
+        if ! notary_credentials_available; then
+            echo "[build-app] WARNING: Notary credentials not configured; resident rebuild will install an unnotarized app." >&2
+        fi
+        return 0
+    fi
+
+    if notary_credentials_available; then
+        return 0
+    fi
+
+    echo "[build-app] ERROR: Refusing to replace notarized $(protected_resident_app_path) with an unnotarized local rebuild." >&2
+    echo "[build-app] Set BRAINBAR_NOTARY_PROFILE=notary-layers or use Homebrew: brew reinstall --cask etanhey/layers/brainbar" >&2
+    return 1
+}
+
+PROTECTED_RESIDENT_STAGED_BUILD=0
+PROTECTED_RESIDENT_FINAL_APP_DIR=""
+PROTECTED_RESIDENT_STAGING_ROOT=""
+
+cleanup_protected_resident_staging() {
+    if [ -n "$PROTECTED_RESIDENT_STAGING_ROOT" ] && [ -d "$PROTECTED_RESIDENT_STAGING_ROOT" ]; then
+        rm -rf "$PROTECTED_RESIDENT_STAGING_ROOT"
+    fi
+}
+
+stage_protected_resident_rebuild() {
+    if [ "$DRY_RUN" -eq 1 ] || ! app_dir_targets_protected_resident || ! notary_credentials_available; then
+        return 0
+    fi
+
+    local tmp_parent
+    tmp_parent="${TMPDIR:-/tmp}"
+    PROTECTED_RESIDENT_STAGED_BUILD=1
+    PROTECTED_RESIDENT_FINAL_APP_DIR="$(protected_resident_app_path)"
+    PROTECTED_RESIDENT_STAGING_ROOT="$(mktemp -d "${tmp_parent%/}/brainbar-resident-rebuild.XXXXXX")"
+    APP_DIR="$PROTECTED_RESIDENT_STAGING_ROOT/BrainBar.app"
+    trap cleanup_protected_resident_staging EXIT
+    echo "[build-app] Protected resident rebuild will stage at $APP_DIR before replacing $PROTECTED_RESIDENT_FINAL_APP_DIR"
+}
+
+promote_protected_resident_rebuild() {
+    if [ "$PROTECTED_RESIDENT_STAGED_BUILD" -ne 1 ]; then
+        return 0
+    fi
+
+    echo "[build-app] Replacing protected resident app after successful signing and notarization..."
+    rm -rf "$PROTECTED_RESIDENT_FINAL_APP_DIR"
+    mkdir -p "$(dirname "$PROTECTED_RESIDENT_FINAL_APP_DIR")"
+    mv "$APP_DIR" "$PROTECTED_RESIDENT_FINAL_APP_DIR"
+    APP_DIR="$PROTECTED_RESIDENT_FINAL_APP_DIR"
 }
 
 safe_branch_is_checked_out_anywhere() {
@@ -289,6 +401,7 @@ if [ "$CURRENT_REPO_ROOT" != "$CANONICAL_REPO_ROOT" ]; then
 else
     APP_DIR="${BRAINBAR_APP_DIR:-$HOME/Applications/BrainBar.app}"
 fi
+normalize_app_dir_path
 
 DIRTY_STATUS="$(git -C "$CURRENT_REPO_ROOT" status --porcelain --untracked-files=all)"
 if [ -n "$DIRTY_STATUS" ] && [ "$FORCE_DIRTY" -ne 1 ]; then
@@ -297,6 +410,9 @@ if [ -n "$DIRTY_STATUS" ] && [ "$FORCE_DIRTY" -ne 1 ]; then
     printf '%s\n' "$DIRTY_STATUS" >&2
     exit 1
 fi
+
+protect_notarized_resident_before_rebuild
+stage_protected_resident_rebuild
 
 if [ "$DEV_BUNDLE_BUILD" -eq 0 ] && [ "$DRY_RUN" -eq 1 ]; then
     cleanup_stale_dev_bundles
@@ -476,19 +592,6 @@ wait_for_socket() {
     return 1
 }
 
-notary_credentials_available() {
-    if [ -n "$BRAINBAR_NOTARY_PROFILE" ]; then
-        return 0
-    fi
-    if [ -n "$BRAINBAR_NOTARY_APPLE_ID" ] && [ -n "$BRAINBAR_NOTARY_PASSWORD" ] && [ -n "$BRAINBAR_NOTARY_TEAM_ID" ]; then
-        return 0
-    fi
-    if [ -n "$BRAINBAR_NOTARY_KEY" ] && [ -n "$BRAINBAR_NOTARY_KEY_ID" ] && [ -n "$BRAINBAR_NOTARY_ISSUER" ]; then
-        return 0
-    fi
-    return 1
-}
-
 notarytool_auth_args() {
     if [ -n "$BRAINBAR_NOTARY_PROFILE" ]; then
         printf '%s\0%s\0' "--keychain-profile" "$BRAINBAR_NOTARY_PROFILE"
@@ -655,6 +758,7 @@ if ! codesign -dv --verbose=4 "$APP_DIR" 2>&1 | grep -F "Authority=$SIGN_IDENTIT
 fi
 verify_spctl_assessment "Developer ID signing"
 notarize_and_staple
+promote_protected_resident_rebuild
 
 # Register URL scheme with Launch Services (ensures brainbar:// works after rebuild)
 "$LSREGISTER" -R "$APP_DIR"

--- a/scripts/brainlayer-dedupe-brainbar.sh
+++ b/scripts/brainlayer-dedupe-brainbar.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Collapse a Mac down to one canonical notarized BrainBar.app.
+#
+# SAFE BY DEFAULT: dry-run inventory only unless --apply is passed. Stray bundles
+# are moved to a timestamped backup directory, never deleted.
+set -euo pipefail
+
+CANONICAL_APP="${BRAINLAYER_DEDUPE_BRAINBAR_CANONICAL_APP:-/Applications/BrainBar.app}"
+BUNDLE_ID="com.brainlayer.brainbar"
+UI_LABEL="com.brainlayer.brainbar"
+DAEMON_LABEL="com.brainlayer.brainbar-daemon"
+HOME_DIR="${HOME:?HOME is required}"
+BACKUP_DIR="$HOME_DIR/.brainlayer/brainbar-dedupe-backup"
+SEARCH_ROOTS="${BRAINLAYER_DEDUPE_BRAINBAR_SEARCH_ROOTS:-/Applications:$HOME_DIR/Applications:$HOME_DIR/Gits:$HOME_DIR/Desktop:$HOME_DIR/Downloads:/tmp:/private/tmp:/var/folders}"
+APPLY=0
+
+usage() {
+    cat <<EOF
+Usage: brainlayer-dedupe-brainbar.sh [--dry-run|--apply]
+
+  --dry-run   Default. Inventory BrainBar.app copies and print the cleanup plan.
+  --apply     Move stray bundles and LaunchAgents to:
+              $BACKUP_DIR/<timestamp>/
+
+Keeps the canonical notarized app at:
+  $CANONICAL_APP
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --apply) APPLY=1 ;;
+        --dry-run) APPLY=0 ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "[brainlayer-dedupe-brainbar] ERROR: unknown argument: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+log() {
+    printf '%s\n' "$*"
+}
+
+sect() {
+    printf '\n==== %s ====\n' "$*"
+}
+
+run() {
+    if [[ "$APPLY" -eq 1 ]]; then
+        log "  + $*"
+        "$@"
+    else
+        log "  (dry-run) would run: $*"
+    fi
+}
+
+app_bundleid() {
+    defaults read "$1/Contents/Info" CFBundleIdentifier 2>/dev/null || echo "?"
+}
+
+is_notarized_app() {
+    local app="$1"
+    [[ -d "$app" ]] || return 1
+    spctl --assess --type execute "$app" >/dev/null 2>&1 || return 1
+    xcrun stapler validate "$app" >/dev/null 2>&1 || return 1
+}
+
+discover_bundles() {
+    local roots=()
+    IFS=':' read -r -a roots <<< "$SEARCH_ROOTS"
+    {
+        mdfind "kMDItemCFBundleIdentifier == '$BUNDLE_ID'" 2>/dev/null || true
+        find "${roots[@]}" -maxdepth 6 -name 'BrainBar.app' -type d -prune 2>/dev/null || true
+    } | sort -u
+}
+
+sect "1. BrainBar.app bundles on this machine"
+declare -a BUNDLES=()
+while IFS= read -r bundle; do
+    [[ -d "$bundle" ]] || continue
+    [[ "$(app_bundleid "$bundle")" == "$BUNDLE_ID" ]] && BUNDLES+=("$bundle")
+done < <(discover_bundles)
+
+if [[ "${#BUNDLES[@]}" -eq 0 ]]; then
+    log "No BrainBar.app bundles found."
+else
+    for bundle in "${BUNDLES[@]}"; do
+        status="STRAY or unverified"
+        is_notarized_app "$bundle" && status="notarized OK"
+        printf '  %-60s bundle=%s -> %s\n' "$bundle" "$(app_bundleid "$bundle")" "$status"
+    done
+fi
+
+sect "2. Canonical decision"
+canonical_bundle_id="$(app_bundleid "$CANONICAL_APP")"
+if ! is_notarized_app "$CANONICAL_APP" || [[ "$canonical_bundle_id" != "$BUNDLE_ID" ]]; then
+    log "  !! Canonical app is missing or not notarized: $CANONICAL_APP"
+    log "  !! Expected bundle id: $BUNDLE_ID; found: $canonical_bundle_id"
+    log "  !! Refusing to clobber it from another local copy."
+    log "  !! Recover through the cask:"
+    log "       brew reinstall --cask etanhey/layers/brainbar"
+    exit 1
+fi
+log "  Canonical notarized app is in place: $CANONICAL_APP"
+
+sect "3. LaunchAgents referencing BrainBar"
+declare -a AGENT_FILES=()
+while IFS= read -r file; do
+    [[ -n "$file" ]] && AGENT_FILES+=("$file")
+done < <(
+    grep -rlE 'BrainBar|brainlayer\.brainbar' \
+        "$HOME_DIR/Library/LaunchAgents" /Library/LaunchAgents /Library/LaunchDaemons 2>/dev/null | sort -u || true
+)
+
+if [[ "${#AGENT_FILES[@]}" -eq 0 ]]; then
+    log "  none"
+else
+    for file in "${AGENT_FILES[@]}"; do
+        target="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "$file" 2>/dev/null || echo '?')"
+        printf '  %s\n      -> %s\n' "$file" "$target"
+    done
+fi
+
+sect "4. Plan / Apply (mode: $([[ "$APPLY" -eq 1 ]] && echo APPLY || echo DRY-RUN))"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+DEST_BACKUP="$BACKUP_DIR/$STAMP"
+
+log "-- quit running BrainBar instances"
+run osascript -e 'tell application "BrainBar" to quit' || true
+run pkill -x BrainBar || true
+run pkill -x BrainBarDaemon || true
+
+log "-- back up stray bundles; never clobber canonical"
+for bundle in "${BUNDLES[@]:-}"; do
+    [[ -n "$bundle" ]] || continue
+    [[ "$bundle" == "$CANONICAL_APP" ]] && { log "  keep canonical: $bundle"; continue; }
+    run mkdir -p "$DEST_BACKUP/bundles"
+    run mv "$bundle" "$DEST_BACKUP/bundles/$(echo "$bundle" | tr '/ ' '__')"
+done
+
+log "-- prune stray LaunchAgents and keep canonical app bundle resources authoritative"
+for file in "${AGENT_FILES[@]:-}"; do
+    [[ -n "$file" ]] || continue
+    base="$(basename "$file")"
+    if [[ ( "$base" == "$UI_LABEL.plist" || "$base" == "$DAEMON_LABEL.plist" ) \
+        && "$file" == "$HOME_DIR/Library/LaunchAgents/$base" ]]; then
+        log "  keep canonical user LaunchAgent: $file"
+        continue
+    fi
+
+    run launchctl bootout "gui/$(id -u)/${base%.plist}" || true
+    run mkdir -p "$DEST_BACKUP/LaunchAgents"
+    run mv "$file" "$DEST_BACKUP/LaunchAgents/"
+done
+
+log "-- restore canonical LaunchAgents from app bundle resources"
+AGENT_SRC="$CANONICAL_APP/Contents/Resources/LaunchAgents"
+for label in "$DAEMON_LABEL" "$UI_LABEL"; do
+    src="$AGENT_SRC/$label.plist"
+    dst="$HOME_DIR/Library/LaunchAgents/$label.plist"
+    if [[ -f "$src" ]]; then
+        run mkdir -p "$HOME_DIR/Library/LaunchAgents"
+        run cp "$src" "$dst"
+        run launchctl bootout "gui/$(id -u)/$label" || true
+        run launchctl bootstrap "gui/$(id -u)" "$dst" || true
+        run launchctl kickstart -k "gui/$(id -u)/$label" || true
+    else
+        log "  missing bundled LaunchAgent: $src"
+    fi
+done
+
+sect "5. Result"
+if [[ "$APPLY" -eq 1 ]]; then
+    log "Backups, if any: $DEST_BACKUP"
+else
+    log "DRY-RUN complete. Re-run with --apply to execute. Nothing was changed."
+fi

--- a/scripts/brainlayer-update-brainbar.sh
+++ b/scripts/brainlayer-update-brainbar.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Update BrainBar through the notarized Homebrew cask artifact.
+set -euo pipefail
+
+DRY_RUN=0
+CASK_TOKEN="${BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN:-etanhey/layers/brainbar}"
+TEST_CASK_INSTALLED="${BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED:-}"
+DRY_RUN_COMMANDS="${BRAINLAYER_UPDATE_DRY_RUN_COMMANDS:-0}"
+
+usage() {
+    cat <<EOF
+Usage: brainlayer-update-brainbar.sh [--dry-run]
+
+Routes BrainBar app updates through Homebrew:
+  installed:     brew reinstall --cask $CASK_TOKEN
+  not installed: brew install --cask $CASK_TOKEN
+
+Default reinstall command:
+  brew reinstall --cask etanhey/layers/brainbar
+
+recovery-no-sudo:
+  If brew fails mid-uninstall on root-owned leftovers, do not rebuild locally.
+  The notarized .app and Homebrew receipt may still survive. Restore the user
+  LaunchAgents from the app bundle and then rerun the cask command:
+
+    app="/Applications/BrainBar.app"
+    agents="\$app/Contents/Resources/LaunchAgents"
+    domain="gui/\$(id -u)"
+    cp "\$agents/com.brainlayer.brainbar.plist" "\$HOME/Library/LaunchAgents/"
+    cp "\$agents/com.brainlayer.brainbar-daemon.plist" "\$HOME/Library/LaunchAgents/"
+    launchctl bootstrap "\$domain" "\$HOME/Library/LaunchAgents/com.brainlayer.brainbar-daemon.plist"
+    launchctl bootstrap "\$domain" "\$HOME/Library/LaunchAgents/com.brainlayer.brainbar.plist"
+    launchctl kickstart -k "\$domain/com.brainlayer.brainbar-daemon"
+    launchctl kickstart -k "\$domain/com.brainlayer.brainbar"
+EOF
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "[brainlayer-update-brainbar] ERROR: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+log() {
+    printf '%s\n' "$*"
+}
+
+brainbar_cask_installed() {
+    local installed_token="${CASK_TOKEN##*/}"
+    case "$TEST_CASK_INSTALLED" in
+        1) return 0 ;;
+        0) return 1 ;;
+    esac
+    command -v brew >/dev/null 2>&1 && brew list --cask "$installed_token" >/dev/null 2>&1
+}
+
+brainbar_update_command() {
+    if brainbar_cask_installed; then
+        printf 'brew\0reinstall\0--cask\0%s\0' "$CASK_TOKEN"
+    else
+        printf 'brew\0install\0--cask\0%s\0' "$CASK_TOKEN"
+    fi
+}
+
+brainbar_update_label() {
+    local parts=()
+    while IFS= read -r -d '' part; do
+        parts+=("$part")
+    done < <(brainbar_update_command)
+    printf '%s' "${parts[*]}"
+}
+
+run_cmd() {
+    log "+ $*"
+    if [[ "$DRY_RUN" -eq 1 || "$DRY_RUN_COMMANDS" = "1" ]]; then
+        return 0
+    fi
+    "$@"
+}
+
+print_plan() {
+    local app_update
+    app_update="$(brainbar_update_label)"
+    log "BrainLayer BrainBar update plan"
+    log "DRY RUN: $([[ "$DRY_RUN" -eq 1 ]] && printf yes || printf no)"
+    log "BRAINBAR APP UPDATE: $app_update"
+    log "Steps:"
+    log "  1. + $app_update"
+    log "  2. Homebrew installs the notarized BrainBar cask artifact"
+    log "Recovery:"
+    log "  recovery-no-sudo: restore LaunchAgents from /Applications/BrainBar.app/Contents/Resources/LaunchAgents if brew stops on root-owned leftovers."
+}
+
+main() {
+    print_plan
+    local command_parts=()
+    while IFS= read -r -d '' part; do
+        command_parts+=("$part")
+    done < <(brainbar_update_command)
+    if [[ "$DRY_RUN" -ne 1 && "$DRY_RUN_COMMANDS" != "1" ]] && ! command -v brew >/dev/null 2>&1; then
+        echo "[brainlayer-update-brainbar] ERROR: brew is required for BrainBar cask updates" >&2
+        exit 127
+    fi
+    run_cmd "${command_parts[@]}"
+    log "BrainBar update command complete."
+}
+
+main

--- a/scripts/brainlayer-version-check.sh
+++ b/scripts/brainlayer-version-check.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Release metadata consistency guard for BrainLayer/BrainBar.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_ROOT="${BRAINLAYER_VERSION_CHECK_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FAILED=0
+
+default_tap_root() {
+    local sibling
+    sibling="$(cd "$PACKAGE_ROOT/.." && pwd)/homebrew-layers"
+    if [[ -d "$sibling" ]]; then
+        printf '%s\n' "$sibling"
+    fi
+}
+
+TAP_ROOT="${BRAINLAYER_VERSION_CHECK_TAP_ROOT:-${BRAINLAYER_HOMEBREW_TAP_ROOT:-$(default_tap_root)}}"
+
+err() {
+    printf '[brainlayer-version-check] ERROR: %s\n' "$*" >&2
+}
+
+require_file() {
+    local label="$1"
+    local path="$2"
+    if [[ ! -f "$path" ]]; then
+        err "$label not found: $path"
+        FAILED=1
+    fi
+}
+
+require_equal() {
+    local label="$1"
+    local actual="$2"
+    local expected="$3"
+    if [[ "$actual" != "$expected" ]]; then
+        err "$label is '$actual', expected '$expected'"
+        FAILED=1
+    fi
+}
+
+read_pyproject_version() {
+    python3 - "$1" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    print(tomllib.load(handle)["project"]["version"])
+PY
+}
+
+read_init_version() {
+    python3 - "$1" <<'PY'
+import ast
+import sys
+
+module = ast.parse(open(sys.argv[1], encoding="utf-8").read())
+for node in module.body:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "__version__":
+                print(ast.literal_eval(node.value))
+                raise SystemExit(0)
+raise SystemExit("__version__ not found")
+PY
+}
+
+read_server_value() {
+    python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+field = sys.argv[2]
+if field == "version":
+    print(manifest.get("version", ""))
+elif field == "packages[0].version":
+    print((manifest.get("packages") or [{}])[0].get("version", ""))
+else:
+    raise SystemExit(f"unknown field: {field}")
+PY
+}
+
+read_plist_string() {
+    python3 - "$1" "$2" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    print(plistlib.load(handle).get(sys.argv[2], ""))
+PY
+}
+
+extract_cask_version() {
+    awk '
+        /^[[:space:]]*version "/ {
+            gsub(/"/, "", $2)
+            print $2
+            exit
+        }
+    ' "$1"
+}
+
+latest_git_tag() {
+    if [[ -n "${BRAINLAYER_VERSION_CHECK_GIT_TAG:-}" ]]; then
+        printf '%s\n' "$BRAINLAYER_VERSION_CHECK_GIT_TAG"
+        return
+    fi
+    if ! git -C "$PACKAGE_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+        printf '\n'
+        return
+    fi
+    git -C "$PACKAGE_ROOT" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname 2>/dev/null | head -n 1
+}
+
+if [[ -z "$TAP_ROOT" ]]; then
+    err "Homebrew tap root is required. Set BRAINLAYER_VERSION_CHECK_TAP_ROOT or BRAINLAYER_HOMEBREW_TAP_ROOT."
+    exit 2
+fi
+
+PYPROJECT="$PACKAGE_ROOT/pyproject.toml"
+INIT_PY="$PACKAGE_ROOT/src/brainlayer/__init__.py"
+SERVER_JSON="$PACKAGE_ROOT/server.json"
+INFO_PLIST="$PACKAGE_ROOT/brain-bar/bundle/Info.plist"
+CASK_PATH="$TAP_ROOT/Casks/brainbar.rb"
+
+require_file "pyproject.toml" "$PYPROJECT"
+require_file "src/brainlayer/__init__.py" "$INIT_PY"
+require_file "server.json" "$SERVER_JSON"
+require_file "brain-bar/bundle/Info.plist" "$INFO_PLIST"
+require_file "Homebrew cask" "$CASK_PATH"
+
+if [[ "$FAILED" -ne 0 ]]; then
+    exit 1
+fi
+
+canonical_version="$(read_pyproject_version "$PYPROJECT")"
+init_version="$(read_init_version "$INIT_PY")"
+server_version="$(read_server_value "$SERVER_JSON" "version")"
+server_package_version="$(read_server_value "$SERVER_JSON" "packages[0].version")"
+plist_short_version="$(read_plist_string "$INFO_PLIST" "CFBundleShortVersionString")"
+cask_version="$(extract_cask_version "$CASK_PATH")"
+git_tag="$(latest_git_tag)"
+expected_git_tag="v$canonical_version"
+
+require_equal "src/brainlayer/__init__.py __version__" "$init_version" "$canonical_version"
+require_equal "server.json version" "$server_version" "$canonical_version"
+require_equal "server.json packages[0].version" "$server_package_version" "$canonical_version"
+require_equal "Info.plist CFBundleShortVersionString" "$plist_short_version" "$canonical_version"
+require_equal "Casks/brainbar.rb version" "$cask_version" "$canonical_version"
+if [[ -z "$git_tag" ]]; then
+    err "latest git tag could not be determined under $PACKAGE_ROOT"
+    FAILED=1
+else
+    require_equal "latest git tag" "$git_tag" "$expected_git_tag"
+fi
+
+if [[ "$FAILED" -ne 0 ]]; then
+    exit 1
+fi
+
+printf '[brainlayer-version-check] PASS: BrainLayer/BrainBar %s release metadata is consistent\n' "$canonical_version"

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -54,6 +54,16 @@ DEFAULT_QUEUE_MOVEMENT_SAMPLE_SECONDS = 10.0
 DOCTOR_PROBE_PROJECT = "brainlayer-doctor"
 
 
+def default_version_check_path() -> Path:
+    current_tree_script = Path(__file__).resolve().parents[2] / "scripts" / "brainlayer-version-check.sh"
+    if current_tree_script.is_file():
+        return current_tree_script
+    repo_script = Path.home() / "Gits" / "brainlayer" / "scripts" / "brainlayer-version-check.sh"
+    if repo_script.is_file():
+        return repo_script
+    return current_tree_script
+
+
 @dataclass(frozen=True)
 class DoctorIssue:
     code: str
@@ -84,6 +94,9 @@ class DoctorConfig:
     deploy_provenance_dir: Path = field(default_factory=default_deploy_provenance_dir)
     deploy_drift_labels: tuple[str, ...] = DEFAULT_DEPLOY_DRIFT_LABELS
     deploy_drift_enabled: bool = True
+    version_check_enabled: bool = True
+    version_check_required: bool = False
+    version_check_path: Path = field(default_factory=default_version_check_path)
 
 
 @dataclass
@@ -317,6 +330,59 @@ def _check_deploy_drift(
         )
 
 
+def _check_brainbar_version_consistency(
+    result: DoctorResult,
+    *,
+    version_check_path: Path,
+    version_check_required: bool,
+    command_runner: CommandRunner,
+) -> None:
+    if not version_check_path.is_file():
+        severity = "fatal" if version_check_required else "warning"
+        result.issues.append(
+            DoctorIssue(
+                "brainbar_version_check_missing",
+                severity,
+                f"BrainBar version check script not found: {version_check_path}",
+                {"path": str(version_check_path)},
+            )
+        )
+        return
+
+    try:
+        check = command_runner(["bash", str(version_check_path)])
+    except Exception as exc:
+        result.issues.append(
+            DoctorIssue(
+                "brainbar_version_check_failed",
+                "fatal",
+                f"BrainBar version consistency check could not run: {exc}",
+                {"path": str(version_check_path), "exception": repr(exc)},
+            )
+        )
+        return
+    returncode = int(getattr(check, "returncode", 0) or 0)
+    if returncode == 0:
+        return
+
+    stderr = str(getattr(check, "stderr", "") or "").strip()
+    stdout = str(getattr(check, "stdout", "") or "").strip()
+    detail = stderr or stdout or f"exit {returncode}"
+    result.issues.append(
+        DoctorIssue(
+            "brainbar_version_check_failed",
+            "fatal",
+            f"BrainBar version consistency check failed: {detail}",
+            {
+                "path": str(version_check_path),
+                "exit_code": returncode,
+                "stdout": stdout,
+                "stderr": stderr,
+            },
+        )
+    )
+
+
 def run_doctor(
     config: DoctorConfig,
     *,
@@ -332,6 +398,14 @@ def run_doctor(
 
     def warning(code: str, message: str, **details: Any) -> None:
         result.issues.append(DoctorIssue(code, "warning", message, details))
+
+    if config.version_check_enabled:
+        _check_brainbar_version_consistency(
+            result,
+            version_check_path=config.version_check_path,
+            version_check_required=config.version_check_required,
+            command_runner=command_runner,
+        )
 
     store: VectorStore | None = None
     try:

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -188,6 +188,9 @@ shift || true
 case "$tool" in
   notarytool)
     printf '%s\n' "$*" >> "${BRAINBAR_FAKE_NOTARYTOOL_LOG:-/dev/null}"
+    if [[ "${BRAINBAR_FAKE_NOTARYTOOL_FAIL:-0}" == "1" ]]; then
+      exit 42
+    fi
     ;;
   stapler)
     printf '%s\n' "$*" >> "${BRAINBAR_FAKE_STAPLER_LOG:-/dev/null}"
@@ -199,6 +202,9 @@ exit 0
     (tool_dir / "spctl").write_text(
         """#!/usr/bin/env bash
 printf '%s\n' "$*" >> "${BRAINBAR_FAKE_SPCTL_LOG:-/dev/null}"
+if [[ -n "${BRAINBAR_FAKE_RESIDENT_APP:-}" && "$*" == *"${BRAINBAR_FAKE_RESIDENT_APP}"* && "${BRAINBAR_FAKE_RESIDENT_SPCTL_FAIL:-0}" == "1" ]]; then
+  exit 1
+fi
 if [[ "${BRAINBAR_FAKE_SPCTL_FAIL:-0}" == "1" ]]; then
   exit 1
 fi
@@ -519,6 +525,150 @@ def test_build_app_runs_hardened_codesign_and_notarization_when_profile_is_avail
     assert "--wait" in notarytool_call
     assert stapler_log.read_text(encoding="utf-8").startswith("staple ")
     assert "-a -vvv" in spctl_log.read_text(encoding="utf-8")
+
+
+def test_build_app_refuses_to_clobber_notarized_resident_with_unnotarized_rebuild(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    resident_app.mkdir(parents=True)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+    spctl_log = tmp_path / "spctl.log"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_APP_DIR": f"{resident_app}/",
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_FAKE_SPCTL_LOG": str(spctl_log),
+        },
+    )
+
+    assert result.returncode == 1
+    assert f"Refusing to replace notarized {resident_app} with an unnotarized local rebuild" in result.stderr
+    assert "BRAINBAR_NOTARY_PROFILE=notary-layers" in result.stderr
+    assert "brew reinstall --cask etanhey/layers/brainbar" in result.stderr
+    spctl_calls = spctl_log.read_text(encoding="utf-8")
+    assert "--assess --type execute" in spctl_calls
+    assert str(resident_app) in spctl_calls
+
+
+def test_build_app_refuses_equivalent_protected_resident_path(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    resident_app.mkdir(parents=True)
+    linked_apps = tmp_path / "LinkedApplications"
+    linked_apps.symlink_to(resident_apps, target_is_directory=True)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+    spctl_log = tmp_path / "spctl.log"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_APP_DIR": str(linked_apps / "BrainBar.app"),
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_FAKE_SPCTL_LOG": str(spctl_log),
+        },
+    )
+
+    assert result.returncode == 1
+    assert "Refusing to replace notarized" in result.stderr
+    assert str(resident_app) in spctl_log.read_text(encoding="utf-8")
+
+
+def test_build_app_keeps_notarized_resident_when_notarization_fails(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    marker = resident_app / "Contents" / "resident-marker"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("keep", encoding="utf-8")
+    _prepare_bundle_inputs(repo)
+    _install_fake_venv_python(repo, import_brainlayer_succeeds=True)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        dry_run=False,
+        extra_args=["--force-dirty"],
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_APP_DIR": str(resident_app),
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_NOTARY_PROFILE": "notary-layers",
+            "BRAINBAR_FAKE_NOTARYTOOL_FAIL": "1",
+        },
+    )
+
+    assert result.returncode != 0
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert "Protected resident rebuild will stage" in result.stdout
+
+
+def test_build_app_allows_notarized_resident_rebuild_when_notary_profile_is_set(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    resident_app.mkdir(parents=True)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_APP_DIR": f"{resident_app}/",
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_NOTARY_PROFILE": "notary-layers",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "[build-app] Dry run OK" in result.stdout
+
+
+def test_build_app_allows_dev_app_dir_when_resident_is_notarized(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    resident_app.mkdir(parents=True)
+    dev_app = tmp_path / "dist" / "BrainBar.app"
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_APP_DIR": str(dev_app),
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert str(dev_app) in result.stdout
 
 
 def test_build_app_submits_before_requiring_post_notary_spctl_acceptance(tmp_path: Path) -> None:

--- a/tests/test_brainbar_update_script.py
+++ b/tests/test_brainbar_update_script.py
@@ -1,0 +1,188 @@
+"""BrainBar cask update and dedupe script contracts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UPDATE_SCRIPT = REPO_ROOT / "scripts" / "brainlayer-update-brainbar.sh"
+DEDUPE_SCRIPT = REPO_ROOT / "scripts" / "brainlayer-dedupe-brainbar.sh"
+
+
+def _run_update(env: dict[str, str] | None = None, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(UPDATE_SCRIPT), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+        timeout=30,
+    )
+
+
+def test_update_brainbar_reinstalls_existing_homebrew_cask_in_dry_run() -> None:
+    result = _run_update({"BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED": "1"}, "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "BRAINBAR APP UPDATE: brew reinstall --cask etanhey/layers/brainbar" in result.stdout
+    assert "+ brew reinstall --cask etanhey/layers/brainbar" in result.stdout
+
+
+def test_update_brainbar_installs_homebrew_cask_when_not_installed_in_dry_run() -> None:
+    result = _run_update({"BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED": "0"}, "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "BRAINBAR APP UPDATE: brew install --cask etanhey/layers/brainbar" in result.stdout
+    assert "+ brew install --cask etanhey/layers/brainbar" in result.stdout
+
+
+def test_update_brainbar_non_dry_run_can_be_command_stubbed_for_tests() -> None:
+    result = _run_update(
+        {
+            "BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED": "1",
+            "BRAINLAYER_UPDATE_DRY_RUN_COMMANDS": "1",
+        }
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "+ brew reinstall --cask etanhey/layers/brainbar" in result.stdout
+
+
+def test_update_brainbar_uses_configured_cask_token_for_detection(tmp_path: Path) -> None:
+    log = tmp_path / "brew.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    brew = bin_dir / "brew"
+    brew.write_text(
+        f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "{log}"
+exit 1
+""",
+        encoding="utf-8",
+    )
+    brew.chmod(0o755)
+
+    result = _run_update(
+        {
+            "BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN": "custom/tap/custombrainbar",
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        },
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "list --cask custombrainbar" in log.read_text(encoding="utf-8")
+    assert "BRAINBAR APP UPDATE: brew install --cask custom/tap/custombrainbar" in result.stdout
+
+
+def test_update_brainbar_documents_recovery_no_sudo_path() -> None:
+    script = UPDATE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "recovery-no-sudo" in script
+    assert "Contents/Resources/LaunchAgents" in script
+    assert "com.brainlayer.brainbar-daemon" in script
+    assert "com.brainlayer.brainbar" in script
+    assert "brew reinstall --cask etanhey/layers/brainbar" in script
+
+
+def test_dedupe_brainbar_dry_run_makes_no_filesystem_changes(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    canonical_app = tmp_path / "Applications" / "BrainBar.app"
+    stray_app = home / "Applications" / "BrainBar.app"
+    wrong_bundle_app = tmp_path / "wrong-bundle" / "BrainBar.app"
+    (canonical_app / "Contents").mkdir(parents=True)
+    (stray_app / "Contents").mkdir(parents=True)
+    (wrong_bundle_app / "Contents").mkdir(parents=True)
+    (canonical_app / "Contents" / "marker").write_text("canonical", encoding="utf-8")
+    (stray_app / "Contents" / "marker").write_text("stray", encoding="utf-8")
+    (wrong_bundle_app / "Contents" / "marker").write_text("wrong", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("spctl", "xcrun"):
+        path = bin_dir / tool
+        path.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        path.chmod(0o755)
+    defaults = bin_dir / "defaults"
+    defaults.write_text(
+        """#!/usr/bin/env bash
+case "$2" in
+  *wrong-bundle*) printf 'com.example.not-brainbar\n' ;;
+  *) printf 'com.brainlayer.brainbar\n' ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    defaults.chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", str(DEDUPE_SCRIPT), "--dry-run"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "BRAINLAYER_DEDUPE_BRAINBAR_CANONICAL_APP": str(canonical_app),
+            "BRAINLAYER_DEDUPE_BRAINBAR_SEARCH_ROOTS": str(tmp_path),
+        },
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "DRY-RUN complete. Re-run with --apply to execute. Nothing was changed." in result.stdout
+    assert (canonical_app / "Contents" / "marker").read_text(encoding="utf-8") == "canonical"
+    assert (stray_app / "Contents" / "marker").read_text(encoding="utf-8") == "stray"
+    assert str(wrong_bundle_app) not in result.stdout
+    assert not (home / ".brainlayer" / "brainbar-dedupe-backup").exists()
+
+
+def test_dedupe_brainbar_rejects_wrong_canonical_bundle_id(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    canonical_app = tmp_path / "Applications" / "BrainBar.app"
+    (canonical_app / "Contents").mkdir(parents=True)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("spctl", "xcrun"):
+        path = bin_dir / tool
+        path.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        path.chmod(0o755)
+    defaults = bin_dir / "defaults"
+    defaults.write_text("#!/usr/bin/env bash\nprintf 'com.example.not-brainbar\\n'\n", encoding="utf-8")
+    defaults.chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", str(DEDUPE_SCRIPT), "--dry-run"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "BRAINLAYER_DEDUPE_BRAINBAR_CANONICAL_APP": str(canonical_app),
+            "BRAINLAYER_DEDUPE_BRAINBAR_SEARCH_ROOTS": str(tmp_path),
+        },
+        timeout=30,
+    )
+
+    assert result.returncode == 1
+    assert "Expected bundle id: com.brainlayer.brainbar; found: com.example.not-brainbar" in result.stdout
+
+
+def test_dedupe_brainbar_script_is_dry_run_safe_and_preserves_canonical_app() -> None:
+    script = DEDUPE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "SAFE BY DEFAULT" in script
+    assert "--apply" in script
+    assert "/Applications/BrainBar.app" in script
+    assert "xcrun stapler validate" in script
+    assert "BACKUP_DIR=" in script
+    assert "keep canonical user LaunchAgent" in script
+    assert 'rm -rf "$CANONICAL_APP"' not in script
+    assert 'run mv "$bundle" "$DEST_BACKUP/bundles/$(echo "$bundle" | tr \'/ \' \'__\')" || true' not in script
+    assert 'run mv "$file" "$DEST_BACKUP/LaunchAgents/" || true' not in script

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -321,6 +321,7 @@ def _doctor_config(tmp_path: Path, db_path: Path):
         drain_health_path=drain_health_path,
         deploy_provenance_dir=tmp_path / "daemon-provenance",
         queue_movement_sample_seconds=0,
+        version_check_enabled=False,
     )
 
 
@@ -340,6 +341,94 @@ def test_run_doctor_exits_zero_on_healthy_fixture(tmp_path):
     assert result.exit_code == 0
     assert result.ok is True
     assert not [issue for issue in result.issues if issue.severity == "fatal"]
+
+
+def test_run_doctor_fails_loudly_when_brainbar_version_check_fails(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "healthy.db"
+    _build_db(db_path)
+    version_check = tmp_path / "brainlayer-version-check.sh"
+    version_check.write_text(
+        "#!/usr/bin/env bash\necho '[brainlayer-version-check] ERROR: cask drift' >&2\nexit 1\n",
+        encoding="utf-8",
+    )
+    version_check.chmod(0o755)
+    config = _doctor_config(tmp_path, db_path)
+    config.version_check_enabled = True
+    config.version_check_path = version_check
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        if args[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        assert args == ["bash", str(version_check)]
+        return SimpleNamespace(returncode=1, stdout="", stderr="[brainlayer-version-check] ERROR: cask drift\n")
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=command_runner,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "brainbar_version_check_failed")
+    assert result.exit_code == 1
+    assert result.ok is False
+    assert issue.severity == "fatal"
+    assert "cask drift" in issue.message
+
+
+def test_run_doctor_warns_when_brainbar_version_check_script_is_missing(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "healthy.db"
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    config.version_check_enabled = True
+    config.version_check_path = tmp_path / "missing-version-check.sh"
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "brainbar_version_check_missing")
+    assert issue.severity == "warning"
+    assert result.exit_code == 0
+    assert result.ok is True
+
+
+def test_run_doctor_reports_brainbar_version_check_runner_exception(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "healthy.db"
+    _build_db(db_path)
+    version_check = tmp_path / "brainlayer-version-check.sh"
+    version_check.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    version_check.chmod(0o755)
+    config = _doctor_config(tmp_path, db_path)
+    config.version_check_enabled = True
+    config.version_check_path = version_check
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        if args[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        assert args == ["bash", str(version_check)]
+        raise RuntimeError("runner unavailable")
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=command_runner,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "brainbar_version_check_failed")
+    assert issue.severity == "fatal"
+    assert result.exit_code == 1
+    assert "runner unavailable" in issue.message
 
 
 def test_roundtrip_probe_ignores_projectless_keyword_competitors(tmp_path):

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,131 @@
+"""BrainBar release metadata consistency guard."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "brainlayer-version-check.sh"
+
+
+def _copy_version_fixture(tmp_path: Path) -> tuple[Path, Path, str]:
+    fixture_root = tmp_path / "brainlayer"
+    tap_root = tmp_path / "homebrew-layers"
+    package_version = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+
+    for rel_path in (
+        "pyproject.toml",
+        "src/brainlayer/__init__.py",
+        "server.json",
+        "brain-bar/bundle/Info.plist",
+    ):
+        source = REPO_ROOT / rel_path
+        target = fixture_root / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+    cask_target = tap_root / "Casks" / "brainbar.rb"
+    cask_target.parent.mkdir(parents=True, exist_ok=True)
+    cask_target.write_text(
+        f"""cask "brainbar" do
+  version "{package_version}"
+  sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+  url "https://example.invalid/BrainBar.zip"
+  name "BrainBar"
+  app "BrainBar.app"
+end
+""",
+        encoding="utf-8",
+    )
+    return fixture_root, tap_root, package_version
+
+
+def _run(
+    fixture_root: Path,
+    tap_root: Path,
+    *,
+    git_tag: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "BRAINLAYER_VERSION_CHECK_REPO_ROOT": str(fixture_root),
+        "BRAINLAYER_VERSION_CHECK_TAP_ROOT": str(tap_root),
+    }
+    if git_tag is not None:
+        env["BRAINLAYER_VERSION_CHECK_GIT_TAG"] = git_tag
+    return subprocess.run(["bash", str(SCRIPT)], capture_output=True, text=True, env=env, timeout=30)
+
+
+def test_version_check_passes_when_release_metadata_matches(tmp_path: Path) -> None:
+    fixture_root, tap_root, package_version = _copy_version_fixture(tmp_path)
+
+    result = _run(fixture_root, tap_root, git_tag=f"v{package_version}")
+
+    assert result.returncode == 0, result.stderr
+    assert f"PASS: BrainLayer/BrainBar {package_version} release metadata is consistent" in result.stdout
+
+
+def test_version_check_fails_loudly_when_cask_version_drifts(tmp_path: Path) -> None:
+    fixture_root, tap_root, package_version = _copy_version_fixture(tmp_path)
+    cask = tap_root / "Casks" / "brainbar.rb"
+    cask.write_text(cask.read_text(encoding="utf-8").replace(package_version, "0.0.0", 1), encoding="utf-8")
+
+    result = _run(fixture_root, tap_root, git_tag=f"v{package_version}")
+
+    assert result.returncode == 1
+    assert f"Casks/brainbar.rb version is '0.0.0', expected '{package_version}'" in result.stderr
+
+
+def test_version_check_fails_loudly_when_checked_in_info_plist_drifts(tmp_path: Path) -> None:
+    fixture_root, tap_root, package_version = _copy_version_fixture(tmp_path)
+    plist = fixture_root / "brain-bar" / "bundle" / "Info.plist"
+    plist.write_text(
+        plist.read_text(encoding="utf-8").replace(
+            f"<key>CFBundleShortVersionString</key>\n    <string>{package_version}</string>",
+            "<key>CFBundleShortVersionString</key>\n    <string>0.0.0</string>",
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run(fixture_root, tap_root, git_tag=f"v{package_version}")
+
+    assert result.returncode == 1
+    assert f"Info.plist CFBundleShortVersionString is '0.0.0', expected '{package_version}'" in result.stderr
+
+
+def test_version_check_fails_loudly_when_server_manifest_drifts(tmp_path: Path) -> None:
+    fixture_root, tap_root, package_version = _copy_version_fixture(tmp_path)
+    server_path = fixture_root / "server.json"
+    server = json.loads(server_path.read_text(encoding="utf-8"))
+    server["packages"][0]["version"] = "0.0.0"
+    server_path.write_text(json.dumps(server), encoding="utf-8")
+
+    result = _run(fixture_root, tap_root, git_tag=f"v{package_version}")
+
+    assert result.returncode == 1
+    assert f"server.json packages[0].version is '0.0.0', expected '{package_version}'" in result.stderr
+
+
+def test_version_check_fails_loudly_when_latest_git_tag_drifts(tmp_path: Path) -> None:
+    fixture_root, tap_root, _package_version = _copy_version_fixture(tmp_path)
+
+    result = _run(fixture_root, tap_root, git_tag="v0.0.0")
+
+    assert result.returncode == 1
+    assert "latest git tag is 'v0.0.0'" in result.stderr
+
+
+def test_version_check_reports_controlled_error_outside_git_checkout(tmp_path: Path) -> None:
+    fixture_root, tap_root, _package_version = _copy_version_fixture(tmp_path)
+
+    result = _run(fixture_root, tap_root)
+
+    assert result.returncode == 1
+    assert "latest git tag could not be determined" in result.stderr
+    assert "fatal:" not in result.stderr


### PR DESCRIPTION
## Summary
- Protect notarized /Applications/BrainBar.app from unnotarized local rebuild clobbering, including equivalent protected paths and staged notarized resident replacement.
- Add BrainBar cask update/dedupe scripts and version-consistency guard across pyproject, __init__, server.json, Info.plist, Homebrew cask, and latest git tag.
- Wire the version guard into brainlayer doctor/status and add TDD coverage for build, update, dedupe, version, and doctor paths.

## Verification
- RED: `pytest tests/test_brainbar_build_app_guards.py tests/test_version_consistency.py tests/test_brainbar_update_script.py tests/test_doctor.py::test_run_doctor_fails_loudly_when_brainbar_version_check_fails -q` -> `12 failed, 33 passed in 16.87s` before implementation.
- `bash -n brain-bar/build-app.sh scripts/brainlayer-version-check.sh scripts/brainlayer-update-brainbar.sh scripts/brainlayer-dedupe-brainbar.sh`
- `pytest tests/test_brainbar_build_app_guards.py tests/test_version_consistency.py tests/test_brainbar_update_script.py tests/test_doctor.py::test_run_doctor_fails_loudly_when_brainbar_version_check_fails tests/test_doctor.py::test_run_doctor_warns_when_brainbar_version_check_script_is_missing tests/test_doctor.py::test_run_doctor_reports_brainbar_version_check_runner_exception -q` -> `53 passed in 19.55s`
- `pytest -q` -> `3394 passed, 49 skipped, 5 xfailed, 329 warnings in 518.27s (0:08:38)`
- `swift test --package-path brain-bar` -> `Executed 743 tests, with 2 tests skipped and 0 failures (0 unexpected) in 51.040 (51.099) seconds`
- `scripts/brainlayer-version-check.sh` -> `PASS: BrainLayer/BrainBar 1.4.2 release metadata is consistent`
- `scripts/brainlayer-update-brainbar.sh --dry-run` -> `brew reinstall --cask etanhey/layers/brainbar`
- pre-push gate -> `BrainLayer test gate passed` (`3291 passed, 9 skipped, 61 deselected, 1 xfailed`; MCP 3 passed; isolated eval/hook 40 passed; Bun 1 pass; FTS5 shell regression PASS)

## Notes
- `brainlayer status --check-doctor` currently exits on an existing deploy drift alarm for `com.brainlayer.enrichment`; not treated as this PR's green signal.
- Local CodeRabbit CLI review found valid issues that were fixed; a final local rerun was blocked by free OSS rate limit (`waitTime: 40 minutes`).
- Do not merge; orc reviews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect macOS install/update paths and doctor gating; mistakes could block legitimate rebuilds or miss version drift, but staging and dry-run defaults limit blast radius.
> 
> **Overview**
> This PR hardens BrainBar **version integrity** on macOS: local rebuilds must not silently downgrade the notarized resident app, and release metadata is checked across the stack.
> 
> **`build-app.sh`** treats the canonical `/Applications/BrainBar.app` (configurable via `BRAINBAR_PROTECTED_APPLICATIONS_DIR`) as a protected resident. It refuses to replace a **notarized** resident when **notary credentials are missing**, compares paths canonically (symlinks included), and when credentials exist **stages** the build in a temp dir and **promotes** it only after sign/notarize succeeds—so a failed notarization does not clobber the live app.
> 
> New **operational scripts**: `brainlayer-version-check.sh` (aligns `pyproject.toml`, `__init__.py`, `server.json`, `Info.plist`, Homebrew cask, and latest git tag), `brainlayer-update-brainbar.sh` (Homebrew cask install/reinstall), and `brainlayer-dedupe-brainbar.sh` (dry-run by default; `--apply` backs up stray bundles/agents and restores LaunchAgents from the canonical app).
> 
> **`brainlayer doctor`** runs the version check by default (`version_check_enabled`, optional `version_check_required`), surfacing fatal issues on mismatch or run failure. Tests cover build guards, scripts, version drift, and doctor integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f3738e9ceb30ae8d4ad059bc1b2764707b7211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Protect BrainBar version integrity with build guards, staging, and release consistency checks
> - Adds a guard in [build-app.sh](https://github.com/EtanHey/brainlayer/pull/559/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb) that refuses to overwrite a notarized resident `BrainBar.app` unless notary credentials are configured; builds with credentials are staged to a temp directory and promoted only after successful notarization.
> - Adds [brainlayer-version-check.sh](https://github.com/EtanHey/brainlayer/pull/559/files#diff-e69f990ce925b29423b565e2f7f01cb7de78d8a7905e07dd74502129a5b8b35e) to verify version consistency across `pyproject.toml`, `__init__.py`, `server.json`, `Info.plist`, the Homebrew cask, and the latest git tag, failing on any mismatch.
> - Integrates the version check into `doctor.run_doctor` via [doctor.py](https://github.com/EtanHey/brainlayer/pull/559/files#diff-41071e7067b327f299dfaa0e5ce4c4455911658ff543b818c684f321f91b29ff); mismatches are reported as fatal issues when `version_check_enabled` is `True` (the new default).
> - Adds [brainlayer-dedupe-brainbar.sh](https://github.com/EtanHey/brainlayer/pull/559/files#diff-55e44d6659fc29d5349d7548b1b842a5f7fa446f00e4c429da39c6bd7dfc25ac) to inventory and consolidate duplicate BrainBar installations, and [brainlayer-update-brainbar.sh](https://github.com/EtanHey/brainlayer/pull/559/files#diff-de4bf10b145451f408303bf14ddfd55b751933051212103907482ccb92a46140) to route updates through the notarized Homebrew cask.
> - Risk: `run_doctor` now runs the version check script by default, which may cause doctor to report fatal issues or fail in environments where the script or expected metadata files are absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 84f3738. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->