### PR TITLE
fix: cover mixed-format agent CLI backups

### DIFF
--- a/scripts/brainlayer-version-check.sh
+++ b/scripts/brainlayer-version-check.sh
@@ -106,6 +106,12 @@ latest_git_tag() {
         printf '%s\n' "$BRAINLAYER_VERSION_CHECK_GIT_TAG"
         return
     fi
+    local git_env_var
+    while IFS= read -r git_env_var; do
+        if [[ -n "$git_env_var" ]]; then
+            unset "$git_env_var"
+        fi
+    done < <(git rev-parse --local-env-vars 2>/dev/null || true)
     if ! git -C "$PACKAGE_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
         printf '\n'
         return

--- a/src/brainlayer/jsonl_backup.py
+++ b/src/brainlayer/jsonl_backup.py
@@ -190,6 +190,40 @@ def _state_matches(entry: Any, candidate: JsonlCandidate) -> bool:
     return entry.get("mtime") == candidate.mtime and entry.get("size") == candidate.size
 
 
+def _backup_unit_key(candidate: JsonlCandidate) -> tuple[int, str]:
+    path = candidate.path.as_posix()
+    for sidecar_suffix in ("-wal", "-shm"):
+        if path.endswith(f".db{sidecar_suffix}"):
+            return (candidate.root_index, path[: -len(sidecar_suffix)])
+    return (candidate.root_index, path)
+
+
+def _select_backup_candidates(
+    candidates: list[JsonlCandidate],
+    *,
+    state: dict[str, Any],
+    now: float,
+    active_skip_seconds: int,
+) -> tuple[list[JsonlCandidate], list[JsonlCandidate], int]:
+    grouped: dict[tuple[int, str], list[JsonlCandidate]] = {}
+    for candidate in candidates:
+        grouped.setdefault(_backup_unit_key(candidate), []).append(candidate)
+
+    changed: list[JsonlCandidate] = []
+    active: list[JsonlCandidate] = []
+    covered = 0
+    state_files = state.get("files", {})
+    for backup_unit in grouped.values():
+        if any(now - candidate.mtime < active_skip_seconds for candidate in backup_unit):
+            active.extend(backup_unit)
+            continue
+        if all(_state_matches(state_files.get(candidate.path.as_posix()), candidate) for candidate in backup_unit):
+            covered += len(backup_unit)
+            continue
+        changed.extend(backup_unit)
+    return changed, active, covered
+
+
 def _archive_name(candidate: JsonlCandidate) -> str:
     try:
         relative = candidate.path.relative_to(candidate.root)
@@ -200,6 +234,14 @@ def _archive_name(candidate: JsonlCandidate) -> str:
 
 def _forever_enabled() -> bool:
     return os.environ.get("BRAINLAYER_JSONL_FOREVER", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _upload_forever_files(
@@ -214,17 +256,17 @@ def _upload_forever_files(
     staging_dir.mkdir(parents=True, exist_ok=True)
     uploaded: list[dict[str, Any]] = []
     for candidate in candidates:
-        digest = hashlib.sha256()
-        with candidate.path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-        forever_name = f"{digest.hexdigest()}{candidate.path.suffix or '.bin'}"
         with tempfile.TemporaryDirectory(prefix=".forever-", dir=staging_dir) as tmp_dir:
-            temp_path = Path(tmp_dir) / forever_name
+            suffix = candidate.path.suffix or ".bin"
+            temp_path = Path(tmp_dir) / f"payload{suffix}"
             shutil.copyfile(candidate.path, temp_path)
+            sha256 = _sha256_file(temp_path)
+            forever_name = f"{sha256}{suffix}"
+            forever_path = Path(tmp_dir) / forever_name
+            os.replace(temp_path, forever_path)
             folder_parts = [*forever_folder_parts, f"source-{candidate.root_index}"]
             folder_id = backup_daily.ensure_drive_folder_chain(service, folder_parts)
-            drive_file = backup_daily.upload_file_to_drive_raw(temp_path, folder_id, credentials)
+            drive_file = backup_daily.upload_file_to_drive_raw(forever_path, folder_id, credentials)
             file_id = drive_file.get("id")
             if not file_id:
                 raise RuntimeError(f"Drive forever upload response missing file id: {drive_file!r}")
@@ -232,13 +274,13 @@ def _upload_forever_files(
                 service,
                 file_id=file_id,
                 expected_name=forever_name,
-                expected_size=temp_path.stat().st_size,
+                expected_size=forever_path.stat().st_size,
             )
             uploaded.append(
                 {
                     "source": candidate.path.as_posix(),
                     "drive_file": drive_file,
-                    "sha256": digest.hexdigest(),
+                    "sha256": sha256,
                     "folder_parts": folder_parts,
                 }
             )
@@ -343,19 +385,12 @@ def run_backup(
     state_path = Path(state_path).expanduser()
     state = _load_state(state_path)
     candidates = _discover_jsonl_candidates(roots)
-
-    changed: list[JsonlCandidate] = []
-    active: list[JsonlCandidate] = []
-    covered = 0
-    for candidate in candidates:
-        if now - candidate.mtime < active_skip_seconds:
-            active.append(candidate)
-            continue
-        entry = state.get("files", {}).get(candidate.path.as_posix())
-        if _state_matches(entry, candidate):
-            covered += 1
-            continue
-        changed.append(candidate)
+    changed, active, covered = _select_backup_candidates(
+        candidates,
+        state=state,
+        now=now,
+        active_skip_seconds=active_skip_seconds,
+    )
 
     if not changed:
         result: dict[str, Any] = {
@@ -406,25 +441,27 @@ def run_backup(
 
     result.update(verify_jsonl_bundle(archive_path, expected_file_count=len(changed)))
     if result["verified"] and upload:
-        if _forever_enabled():
-            forever_files = _upload_forever_files(
-                changed,
-                service=service,
-                credentials=credentials,
-                staging_dir=staging_dir,
-                forever_folder_parts=forever_folder_parts,
-            )
-            result["forever_files"] = forever_files
-            result["forever_uploaded_file_count"] = len(forever_files)
         _atomic_write_json(state_path, _update_state_for_uploaded(state, changed))
-        deleted = backup_daily.prune_drive_backups(
-            service,
-            folder_parts=folder_parts,
-            retention_policy=JSONL_RETENTION,
-        )
-        result["retention_deleted"] = deleted
-        archive_path.unlink(missing_ok=True)
-        result["local_archive_removed"] = True
+        try:
+            deleted = backup_daily.prune_drive_backups(
+                service,
+                folder_parts=folder_parts,
+                retention_policy=JSONL_RETENTION,
+            )
+            result["retention_deleted"] = deleted
+            if _forever_enabled():
+                forever_files = _upload_forever_files(
+                    changed,
+                    service=service,
+                    credentials=credentials,
+                    staging_dir=staging_dir,
+                    forever_folder_parts=forever_folder_parts,
+                )
+                result["forever_files"] = forever_files
+                result["forever_uploaded_file_count"] = len(forever_files)
+        finally:
+            archive_path.unlink(missing_ok=True)
+            result["local_archive_removed"] = True
 
     _append_json_log(log_path, result)
     _enqueue_run_summary(result, queue_dir=queue_dir)

--- a/src/brainlayer/jsonl_backup.py
+++ b/src/brainlayer/jsonl_backup.py
@@ -3,13 +3,21 @@
 Install note: commit `launchd/com.brainlayer.jsonl-backup.plist`, then install it
 after merge with the repo's launchd flow or a manual `launchctl bootstrap`; this
 module intentionally does not install the agent itself.
+
+Source format policy: Claude/Codex/Cursor/Gemini JSONL files are backed up as
+plain transcript files. Antigravity has no stable text export contract, so this
+job backs up its raw restore units: conversation SQLite DB/WAL/SHM files,
+opaque `.pb` implicit records, and per-session `.system_generated` /
+`.tempmediaStorage` artifacts.
 """
 
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import json
 import os
+import shutil
 import signal
 import subprocess
 import tarfile
@@ -23,12 +31,8 @@ from typing import Any
 from . import backup_daily
 from .queue_io import enqueue_store
 
-DEFAULT_SOURCE_ROOTS = [
-    Path.home() / ".claude" / "projects",
-    Path.home() / ".claude-archive",
-    Path.home() / ".codex" / "sessions",
-]
 DEFAULT_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "claude-jsonl"]
+DEFAULT_FOREVER_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "claude-jsonl-forever"]
 DEFAULT_STATE_PATH = Path.home() / ".local" / "share" / "brainlayer" / "jsonl-backup-state.json"
 DEFAULT_STAGING_DIR = Path.home() / ".local" / "share" / "brainlayer" / "jsonl-backups"
 DEFAULT_LOG_PATH = Path.home() / ".local" / "share" / "brainlayer" / "logs" / "jsonl-backup.log"
@@ -42,12 +46,66 @@ JSONL_RETENTION = backup_daily.DriveRetentionPolicy(
 
 
 @dataclass(frozen=True)
+class BackupSourceRoot:
+    path: Path
+    include_globs: tuple[str, ...] = ("**/*.jsonl",)
+
+
+def default_source_roots() -> list[BackupSourceRoot]:
+    home = Path.home()
+    return [
+        BackupSourceRoot(home / ".claude" / "projects"),
+        BackupSourceRoot(home / ".claude-archive"),
+        BackupSourceRoot(home / ".codex" / "sessions"),
+        BackupSourceRoot(home / ".cursor" / "sessions", ("**/*.jsonl", "**/*.json")),
+        BackupSourceRoot(
+            home / ".cursor" / "projects",
+            ("**/agent-transcripts/**/*.jsonl", "**/agent-transcripts/**/*.json"),
+        ),
+        BackupSourceRoot(home / ".cursor" / "acp-sessions", ("**/*.json",)),
+        BackupSourceRoot(home / ".cursor" / "plans", ("**/*.md",)),
+        BackupSourceRoot(home / ".gemini" / "sessions"),
+        # Antigravity has no stable text export contract; back up its raw restore units.
+        BackupSourceRoot(
+            home / ".gemini" / "antigravity-cli" / "conversations",
+            ("**/*.db", "**/*.db-wal", "**/*.db-shm"),
+        ),
+        BackupSourceRoot(home / ".gemini" / "antigravity-cli" / "implicit", ("**/*.pb",)),
+        BackupSourceRoot(
+            home / ".gemini" / "antigravity-cli" / "brain",
+            (
+                "**/.system_generated/**/*.jsonl",
+                "**/.system_generated/**/*.json",
+                "**/.system_generated/**/*.log",
+                "**/.system_generated/**/*.md",
+                "**/.system_generated/**/*.png",
+                "**/.system_generated/**/*.jpg",
+                "**/.system_generated/**/*.mp4",
+                "**/.tempmediaStorage/**/*.png",
+                "**/.tempmediaStorage/**/*.jpg",
+                "**/.tempmediaStorage/**/*.mp4",
+            ),
+        ),
+        BackupSourceRoot(home / ".gemini" / "antigravity-cli" / "cache", ("last_conversations.json", "projects.json")),
+    ]
+
+
+DEFAULT_SOURCE_ROOTS = default_source_roots()
+
+
+@dataclass(frozen=True)
 class JsonlCandidate:
     path: Path
     root: Path
     root_index: int
     mtime: float
     size: int
+
+
+def _source_root_config(root: Path | BackupSourceRoot) -> BackupSourceRoot:
+    if isinstance(root, BackupSourceRoot):
+        return root
+    return BackupSourceRoot(Path(root))
 
 
 def _today() -> str:
@@ -96,30 +154,32 @@ def _append_json_log(path: Path, payload: dict[str, Any]) -> None:
         handle.write(json.dumps(payload, sort_keys=True) + "\n")
 
 
-def _discover_jsonl_candidates(source_roots: list[Path]) -> list[JsonlCandidate]:
+def _discover_jsonl_candidates(source_roots: list[Path | BackupSourceRoot]) -> list[JsonlCandidate]:
     candidates: list[JsonlCandidate] = []
     seen: set[Path] = set()
     for index, root in enumerate(source_roots):
-        expanded_root = Path(root).expanduser()
+        config = _source_root_config(root)
+        expanded_root = config.path.expanduser()
         if not expanded_root.exists():
             continue
-        for path in sorted(expanded_root.rglob("*.jsonl")):
-            if not path.is_file():
-                continue
-            resolved = path.resolve()
-            if resolved in seen:
-                continue
-            seen.add(resolved)
-            stat = path.stat()
-            candidates.append(
-                JsonlCandidate(
-                    path=path,
-                    root=expanded_root,
-                    root_index=index,
-                    mtime=stat.st_mtime,
-                    size=stat.st_size,
+        for include_glob in config.include_globs:
+            for path in sorted(expanded_root.glob(include_glob)):
+                if not path.is_file():
+                    continue
+                resolved = path.resolve()
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                stat = path.stat()
+                candidates.append(
+                    JsonlCandidate(
+                        path=path,
+                        root=expanded_root,
+                        root_index=index,
+                        mtime=stat.st_mtime,
+                        size=stat.st_size,
+                    )
                 )
-            )
     candidates.sort(key=lambda item: item.path.as_posix())
     return candidates
 
@@ -136,6 +196,53 @@ def _archive_name(candidate: JsonlCandidate) -> str:
     except ValueError:
         relative = Path(candidate.path.name)
     return f"source-{candidate.root_index}/{relative.as_posix()}"
+
+
+def _forever_enabled() -> bool:
+    return os.environ.get("BRAINLAYER_JSONL_FOREVER", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _upload_forever_files(
+    candidates: list[JsonlCandidate],
+    *,
+    service: Any,
+    credentials: Any,
+    staging_dir: Path,
+    forever_folder_parts: list[str],
+) -> list[dict[str, Any]]:
+    staging_dir = Path(staging_dir).expanduser()
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    uploaded: list[dict[str, Any]] = []
+    for candidate in candidates:
+        digest = hashlib.sha256()
+        with candidate.path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        forever_name = f"{digest.hexdigest()}{candidate.path.suffix or '.bin'}"
+        with tempfile.TemporaryDirectory(prefix=".forever-", dir=staging_dir) as tmp_dir:
+            temp_path = Path(tmp_dir) / forever_name
+            shutil.copyfile(candidate.path, temp_path)
+            folder_parts = [*forever_folder_parts, f"source-{candidate.root_index}"]
+            folder_id = backup_daily.ensure_drive_folder_chain(service, folder_parts)
+            drive_file = backup_daily.upload_file_to_drive_raw(temp_path, folder_id, credentials)
+            file_id = drive_file.get("id")
+            if not file_id:
+                raise RuntimeError(f"Drive forever upload response missing file id: {drive_file!r}")
+            backup_daily.verify_drive_upload(
+                service,
+                file_id=file_id,
+                expected_name=forever_name,
+                expected_size=temp_path.stat().st_size,
+            )
+            uploaded.append(
+                {
+                    "source": candidate.path.as_posix(),
+                    "drive_file": drive_file,
+                    "sha256": digest.hexdigest(),
+                    "folder_parts": folder_parts,
+                }
+            )
+    return uploaded
 
 
 def create_jsonl_bundle(candidates: list[JsonlCandidate], staging_dir: Path, *, date_stamp: str) -> Path:
@@ -218,7 +325,7 @@ def _enqueue_run_summary(result: dict[str, Any], *, queue_dir: Path | None) -> N
 
 def run_backup(
     *,
-    source_roots: list[Path] | None = None,
+    source_roots: list[Path | BackupSourceRoot] | None = None,
     state_path: Path = DEFAULT_STATE_PATH,
     staging_dir: Path = DEFAULT_STAGING_DIR,
     log_path: Path = DEFAULT_LOG_PATH,
@@ -228,6 +335,7 @@ def run_backup(
     now: float | None = None,
     upload: bool = True,
     active_skip_seconds: int = DEFAULT_ACTIVE_SKIP_SECONDS,
+    forever_folder_parts: list[str] = DEFAULT_FOREVER_FOLDER_PARTS,
 ) -> dict[str, Any]:
     date_stamp = date_stamp or _today()
     now = time.time() if now is None else now
@@ -276,6 +384,8 @@ def run_backup(
         "already_covered_files": covered,
         "source_file_count": len(candidates),
         "retention_deleted": [],
+        "forever_uploaded_file_count": 0,
+        "forever_files": [],
     }
 
     if upload:
@@ -296,6 +406,16 @@ def run_backup(
 
     result.update(verify_jsonl_bundle(archive_path, expected_file_count=len(changed)))
     if result["verified"] and upload:
+        if _forever_enabled():
+            forever_files = _upload_forever_files(
+                changed,
+                service=service,
+                credentials=credentials,
+                staging_dir=staging_dir,
+                forever_folder_parts=forever_folder_parts,
+            )
+            result["forever_files"] = forever_files
+            result["forever_uploaded_file_count"] = len(forever_files)
         _atomic_write_json(state_path, _update_state_for_uploaded(state, changed))
         deleted = backup_daily.prune_drive_backups(
             service,
@@ -303,6 +423,8 @@ def run_backup(
             retention_policy=JSONL_RETENTION,
         )
         result["retention_deleted"] = deleted
+        archive_path.unlink(missing_ok=True)
+        result["local_archive_removed"] = True
 
     _append_json_log(log_path, result)
     _enqueue_run_summary(result, queue_dir=queue_dir)

--- a/src/brainlayer/jsonl_backup.py
+++ b/src/brainlayer/jsonl_backup.py
@@ -255,6 +255,7 @@ def _upload_forever_files(
     staging_dir = Path(staging_dir).expanduser()
     staging_dir.mkdir(parents=True, exist_ok=True)
     uploaded: list[dict[str, Any]] = []
+    folder_ids_by_root_index: dict[int, str] = {}
     for candidate in candidates:
         with tempfile.TemporaryDirectory(prefix=".forever-", dir=staging_dir) as tmp_dir:
             suffix = candidate.path.suffix or ".bin"
@@ -265,7 +266,10 @@ def _upload_forever_files(
             forever_path = Path(tmp_dir) / forever_name
             os.replace(temp_path, forever_path)
             folder_parts = [*forever_folder_parts, f"source-{candidate.root_index}"]
-            folder_id = backup_daily.ensure_drive_folder_chain(service, folder_parts)
+            folder_id = folder_ids_by_root_index.get(candidate.root_index)
+            if folder_id is None:
+                folder_id = backup_daily.ensure_drive_folder_chain(service, folder_parts)
+                folder_ids_by_root_index[candidate.root_index] = folder_id
             drive_file = backup_daily.upload_file_to_drive_raw(forever_path, folder_id, credentials)
             file_id = drive_file.get("id")
             if not file_id:
@@ -278,7 +282,8 @@ def _upload_forever_files(
             )
             uploaded.append(
                 {
-                    "source": candidate.path.as_posix(),
+                    "source_root_index": candidate.root_index,
+                    "source_suffix": suffix,
                     "drive_file": drive_file,
                     "sha256": sha256,
                     "folder_parts": folder_parts,

--- a/tests/test_jsonl_backup.py
+++ b/tests/test_jsonl_backup.py
@@ -327,6 +327,7 @@ def test_jsonl_forever_upload_uses_separate_folder_and_rolling_prune_only(tmp_pa
     assert uploaded[0][0].name == "claude-jsonl-2026-06-30.tar.gz"
     assert uploaded[1][0].name.endswith(".db")
     assert uploaded[1][2] == source_file.read_bytes()
+    assert jsonl_backup.DEFAULT_FOLDER_PARTS in folder_calls
     assert jsonl_backup.DEFAULT_FOREVER_FOLDER_PARTS + ["source-0"] in folder_calls
     assert pruned_folder_parts == [jsonl_backup.DEFAULT_FOLDER_PARTS]
     assert jsonl_backup.DEFAULT_FOREVER_FOLDER_PARTS not in pruned_folder_parts
@@ -378,6 +379,53 @@ def test_jsonl_forever_hashes_the_staged_copy_before_upload(tmp_path, monkeypatc
     assert uploaded[1][0].name == f"{staged_digest}.db"
     assert uploaded[1][1] == b"staged bytes"
     assert result["forever_files"][0]["sha256"] == staged_digest
+    assert "source" not in result["forever_files"][0]
+    assert result["forever_files"][0]["source_root_index"] == 0
+    assert result["forever_files"][0]["source_suffix"] == ".db"
+
+
+def test_jsonl_forever_upload_caches_source_folder_lookup_per_root(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    source_root = tmp_path / "sessions"
+    for name in ("one.jsonl", "two.jsonl"):
+        _write_jsonl(source_root / name, mtime=now - 3600)
+    folder_calls: list[list[str]] = []
+    uploaded: list[Path] = []
+
+    monkeypatch.setenv("BRAINLAYER_JSONL_FOREVER", "1")
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+
+    def fake_ensure(service, folder_parts):  # noqa: ARG001
+        folder_calls.append(list(folder_parts))
+        return "folder-" + "-".join(folder_parts[-2:])
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        path = Path(file_path)
+        uploaded.append(path)
+        return {"id": f"drive-{len(uploaded)}", "name": path.name, "size": str(path.stat().st_size)}
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "ensure_drive_folder_chain", fake_ensure)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "upload_file_to_drive_raw", fake_upload)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "prune_drive_backups", lambda *args, **kwargs: [])
+
+    result = jsonl_backup.run_backup(
+        source_roots=[source_root],
+        state_path=tmp_path / "state.json",
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-30",
+        now=now,
+        upload=True,
+    )
+
+    assert result["forever_uploaded_file_count"] == 2
+    assert len(uploaded) == 3
+    assert folder_calls.count(jsonl_backup.DEFAULT_FOREVER_FOLDER_PARTS + ["source-0"]) == 1
 
 
 def test_jsonl_backup_persists_daily_state_when_forever_upload_fails(tmp_path, monkeypatch):

--- a/tests/test_jsonl_backup.py
+++ b/tests/test_jsonl_backup.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tarfile
 import time
 from pathlib import Path
 
@@ -73,6 +74,188 @@ def test_run_jsonl_backup_uploads_incremental_bundle_verifies_and_enqueues_summa
     queued = list((tmp_path / "queue").glob("jsonl_backup-*.jsonl"))
     assert len(queued) == 1
     assert "JSONL backup uploaded 3 files" in queued[0].read_text()
+
+
+def test_default_source_roots_append_all_agent_cli_transcript_roots(monkeypatch):
+    from brainlayer import jsonl_backup
+
+    home = Path("/Users/tester")
+    monkeypatch.setattr(jsonl_backup.Path, "home", lambda: home)
+
+    roots = jsonl_backup.default_source_roots()
+
+    assert [(root.path, root.include_globs) for root in roots] == [
+        (home / ".claude" / "projects", ("**/*.jsonl",)),
+        (home / ".claude-archive", ("**/*.jsonl",)),
+        (home / ".codex" / "sessions", ("**/*.jsonl",)),
+        (home / ".cursor" / "sessions", ("**/*.jsonl", "**/*.json")),
+        (home / ".cursor" / "projects", ("**/agent-transcripts/**/*.jsonl", "**/agent-transcripts/**/*.json")),
+        (home / ".cursor" / "acp-sessions", ("**/*.json",)),
+        (home / ".cursor" / "plans", ("**/*.md",)),
+        (home / ".gemini" / "sessions", ("**/*.jsonl",)),
+        (home / ".gemini" / "antigravity-cli" / "conversations", ("**/*.db", "**/*.db-wal", "**/*.db-shm")),
+        (home / ".gemini" / "antigravity-cli" / "implicit", ("**/*.pb",)),
+        (
+            home / ".gemini" / "antigravity-cli" / "brain",
+            (
+                "**/.system_generated/**/*.jsonl",
+                "**/.system_generated/**/*.json",
+                "**/.system_generated/**/*.log",
+                "**/.system_generated/**/*.md",
+                "**/.system_generated/**/*.png",
+                "**/.system_generated/**/*.jpg",
+                "**/.system_generated/**/*.mp4",
+                "**/.tempmediaStorage/**/*.png",
+                "**/.tempmediaStorage/**/*.jpg",
+                "**/.tempmediaStorage/**/*.mp4",
+            ),
+        ),
+        (home / ".gemini" / "antigravity-cli" / "cache", ("last_conversations.json", "projects.json")),
+    ]
+
+
+def test_appended_agent_cli_roots_cover_mixed_formats_and_keep_existing_archive_indices(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    home = tmp_path / "home"
+    monkeypatch.setattr(jsonl_backup.Path, "home", lambda: home)
+    now = time.time()
+    _write_jsonl(home / ".claude" / "projects" / "project-a" / "session.jsonl", mtime=now - 3600)
+    _write_jsonl(home / ".claude-archive" / "project-b" / "archive.jsonl", mtime=now - 3600)
+    _write_jsonl(home / ".codex" / "sessions" / "2026" / "06" / "session.jsonl", mtime=now - 3600)
+    _write_jsonl(home / ".cursor" / "sessions" / "cursor-session.jsonl", mtime=now - 3600)
+    _write_jsonl(home / ".cursor" / "sessions" / "cursor-session.json", mtime=now - 3600)
+    _write_jsonl(
+        home / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent" / "cursor.jsonl",
+        mtime=now - 3600,
+    )
+    _write_jsonl(
+        home / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent" / "cursor.json",
+        mtime=now - 3600,
+    )
+    _write_jsonl(home / ".cursor" / "projects" / "repo" / "mcps" / "tool.json", mtime=now - 3600)
+    _write_jsonl(home / ".cursor" / "acp-sessions" / "session" / "meta.json", mtime=now - 3600)
+    _write_jsonl(home / ".cursor" / "plans" / "plan.md", line="# plan\n", mtime=now - 3600)
+    _write_jsonl(home / ".gemini" / "sessions" / "gemini.jsonl", mtime=now - 3600)
+    _write_jsonl(
+        home / ".gemini" / "antigravity-cli" / "brain" / "session" / ".system_generated" / "logs" / "transcript.jsonl",
+        mtime=now - 3600,
+    )
+    _write_jsonl(
+        home / ".gemini" / "antigravity-cli" / "brain" / "session" / ".system_generated" / "messages" / "message.json",
+        mtime=now - 3600,
+    )
+    _write_jsonl(
+        home / ".gemini" / "antigravity-cli" / "brain" / "session" / ".system_generated" / "tasks" / "task.log",
+        line="task log\n",
+        mtime=now - 3600,
+    )
+    media = home / ".gemini" / "antigravity-cli" / "brain" / "session" / ".tempmediaStorage" / "screenshot.png"
+    media.parent.mkdir(parents=True, exist_ok=True)
+    media.write_bytes(b"png")
+    os.utime(media, (now - 3600, now - 3600))
+    _write_jsonl(home / ".gemini" / "antigravity-cli" / "mcp" / "tool.json", mtime=now - 3600)
+    raw_files = [
+        home / ".gemini" / "antigravity-cli" / "conversations" / "conv.db",
+        home / ".gemini" / "antigravity-cli" / "conversations" / "conv.db-wal",
+        home / ".gemini" / "antigravity-cli" / "conversations" / "conv.db-shm",
+        home / ".gemini" / "antigravity-cli" / "implicit" / "implicit.pb",
+    ]
+    for path in raw_files:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"raw")
+        os.utime(path, (now - 3600, now - 3600))
+    _write_jsonl(home / ".gemini" / "antigravity-cli" / "cache" / "last_conversations.json", mtime=now - 3600)
+    _write_jsonl(home / ".gemini" / "antigravity-cli" / "cache" / "projects.json", mtime=now - 3600)
+
+    candidates = jsonl_backup._discover_jsonl_candidates(jsonl_backup.default_source_roots())
+    archive = jsonl_backup.create_jsonl_bundle(candidates, tmp_path / "staging", date_stamp="2026-06-30")
+
+    with tarfile.open(archive, "r:gz") as tar:
+        names = tar.getnames()
+
+    assert "source-0/project-a/session.jsonl" in names
+    assert "source-1/project-b/archive.jsonl" in names
+    assert "source-2/2026/06/session.jsonl" in names
+    assert "source-3/cursor-session.jsonl" in names
+    assert "source-3/cursor-session.json" in names
+    assert "source-4/repo/agent-transcripts/agent/cursor.jsonl" in names
+    assert "source-4/repo/agent-transcripts/agent/cursor.json" in names
+    assert "source-4/repo/mcps/tool.json" not in names
+    assert "source-5/session/meta.json" in names
+    assert "source-6/plan.md" in names
+    assert "source-7/gemini.jsonl" in names
+    assert "source-8/conv.db" in names
+    assert "source-8/conv.db-wal" in names
+    assert "source-8/conv.db-shm" in names
+    assert "source-9/implicit.pb" in names
+    assert "source-10/session/.system_generated/logs/transcript.jsonl" in names
+    assert "source-10/session/.system_generated/messages/message.json" in names
+    assert "source-10/session/.system_generated/tasks/task.log" in names
+    assert "source-10/session/.tempmediaStorage/screenshot.png" in names
+    assert "source-11/last_conversations.json" in names
+    assert "source-11/projects.json" in names
+    assert not any(name.endswith("mcp/tool.json") for name in names)
+
+
+def test_jsonl_forever_upload_uses_separate_folder_and_rolling_prune_only(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    source_root = tmp_path / "sessions"
+    source_file = source_root / "changed.db"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_bytes(b"sqlite bytes")
+    os.utime(source_file, (now - 3600, now - 3600))
+    folder_calls: list[list[str]] = []
+    uploaded: list[tuple[Path, str, bytes]] = []
+    pruned_folder_parts: list[list[str]] = []
+
+    monkeypatch.setenv("BRAINLAYER_JSONL_FOREVER", "1")
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+
+    def fake_ensure(service, folder_parts):  # noqa: ARG001
+        folder_calls.append(list(folder_parts))
+        return "folder-" + "-".join(folder_parts[-2:])
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        uploaded.append((Path(file_path), folder_id, Path(file_path).read_bytes()))
+        return {
+            "id": f"drive-{len(uploaded)}",
+            "name": Path(file_path).name,
+            "size": str(Path(file_path).stat().st_size),
+        }
+
+    def fake_prune(service, *, folder_parts, retention_policy):  # noqa: ARG001
+        pruned_folder_parts.append(list(folder_parts))
+        return []
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "ensure_drive_folder_chain", fake_ensure)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "upload_file_to_drive_raw", fake_upload)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "prune_drive_backups", fake_prune)
+
+    result = jsonl_backup.run_backup(
+        source_roots=[jsonl_backup.BackupSourceRoot(source_root, ("**/*.db",))],
+        state_path=tmp_path / "state.json",
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-30",
+        now=now,
+        upload=True,
+    )
+
+    assert result["verified"] is True
+    assert result["forever_uploaded_file_count"] == 1
+    assert uploaded[0][0].name == "claude-jsonl-2026-06-30.tar.gz"
+    assert uploaded[1][0].name.endswith(".db")
+    assert uploaded[1][2] == source_file.read_bytes()
+    assert jsonl_backup.DEFAULT_FOREVER_FOLDER_PARTS + ["source-0"] in folder_calls
+    assert pruned_folder_parts == [jsonl_backup.DEFAULT_FOLDER_PARTS]
+    assert jsonl_backup.DEFAULT_FOREVER_FOLDER_PARTS not in pruned_folder_parts
+    assert not uploaded[0][0].exists()
 
 
 def test_run_jsonl_backup_second_run_noops_when_state_covers_files(tmp_path, monkeypatch):

--- a/tests/test_jsonl_backup.py
+++ b/tests/test_jsonl_backup.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import tarfile
@@ -198,6 +199,80 @@ def test_appended_agent_cli_roots_cover_mixed_formats_and_keep_existing_archive_
     assert not any(name.endswith("mcp/tool.json") for name in names)
 
 
+def test_antigravity_sqlite_restore_unit_is_skipped_together_when_sidecar_is_active(tmp_path):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    conversations_root = tmp_path / "antigravity-cli" / "conversations"
+    for name, mtime in {
+        "conv.db": now - 3600,
+        "conv.db-wal": now - 60,
+        "conv.db-shm": now - 3600,
+    }.items():
+        path = conversations_root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(name.encode())
+        os.utime(path, (mtime, mtime))
+
+    result = jsonl_backup.run_backup(
+        source_roots=[jsonl_backup.BackupSourceRoot(conversations_root, ("**/*.db", "**/*.db-wal", "**/*.db-shm"))],
+        state_path=tmp_path / "state.json",
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-30",
+        now=now,
+        upload=False,
+    )
+
+    assert result["status"] == "no-op"
+    assert result["skipped_active_count"] == 3
+    assert not (tmp_path / "staging" / "claude-jsonl-2026-06-30.tar.gz").exists()
+
+
+def test_antigravity_sqlite_restore_unit_is_bundled_together_when_sidecar_changes(tmp_path):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    conversations_root = tmp_path / "antigravity-cli" / "conversations"
+    db = conversations_root / "conv.db"
+    wal = conversations_root / "conv.db-wal"
+    shm = conversations_root / "conv.db-shm"
+    for path, content in [(db, b"db"), (wal, b"wal"), (shm, b"shm")]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        os.utime(path, (now - 3600, now - 3600))
+    state_path = tmp_path / "state.json"
+    jsonl_backup._atomic_write_json(
+        state_path,
+        {
+            "files": {
+                db.as_posix(): {"mtime": db.stat().st_mtime, "size": db.stat().st_size},
+                shm.as_posix(): {"mtime": shm.stat().st_mtime, "size": shm.stat().st_size},
+            }
+        },
+    )
+
+    result = jsonl_backup.run_backup(
+        source_roots=[jsonl_backup.BackupSourceRoot(conversations_root, ("**/*.db", "**/*.db-wal", "**/*.db-shm"))],
+        state_path=state_path,
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-30",
+        now=now,
+        upload=False,
+    )
+
+    archive = Path(result["archive"])
+    with tarfile.open(archive, "r:gz") as tar:
+        names = tar.getnames()
+
+    assert result["status"] == "created"
+    assert result["bundled_file_count"] == 3
+    assert names == ["source-0/conv.db", "source-0/conv.db-shm", "source-0/conv.db-wal"]
+
+
 def test_jsonl_forever_upload_uses_separate_folder_and_rolling_prune_only(tmp_path, monkeypatch):
     from brainlayer import jsonl_backup
 
@@ -256,6 +331,104 @@ def test_jsonl_forever_upload_uses_separate_folder_and_rolling_prune_only(tmp_pa
     assert pruned_folder_parts == [jsonl_backup.DEFAULT_FOLDER_PARTS]
     assert jsonl_backup.DEFAULT_FOREVER_FOLDER_PARTS not in pruned_folder_parts
     assert not uploaded[0][0].exists()
+
+
+def test_jsonl_forever_hashes_the_staged_copy_before_upload(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    source_root = tmp_path / "sessions"
+    source_file = source_root / "changed.db"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_bytes(b"source bytes")
+    os.utime(source_file, (now - 3600, now - 3600))
+    uploaded: list[tuple[Path, bytes]] = []
+
+    monkeypatch.setenv("BRAINLAYER_JSONL_FOREVER", "1")
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "ensure_drive_folder_chain", lambda *args, **kwargs: "folder-id")
+    monkeypatch.setattr(jsonl_backup.backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "prune_drive_backups", lambda *args, **kwargs: [])
+
+    def fake_copyfile(source, destination):  # noqa: ARG001
+        Path(destination).write_bytes(b"staged bytes")
+        return destination
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        path = Path(file_path)
+        uploaded.append((path, path.read_bytes()))
+        return {"id": f"drive-{len(uploaded)}", "name": path.name, "size": str(path.stat().st_size)}
+
+    monkeypatch.setattr(jsonl_backup.shutil, "copyfile", fake_copyfile)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "upload_file_to_drive_raw", fake_upload)
+
+    result = jsonl_backup.run_backup(
+        source_roots=[jsonl_backup.BackupSourceRoot(source_root, ("**/*.db",))],
+        state_path=tmp_path / "state.json",
+        staging_dir=tmp_path / "staging",
+        log_path=tmp_path / "jsonl-backup.log",
+        queue_dir=tmp_path / "queue",
+        date_stamp="2026-06-30",
+        now=now,
+        upload=True,
+    )
+
+    staged_digest = hashlib.sha256(b"staged bytes").hexdigest()
+    assert uploaded[1][0].name == f"{staged_digest}.db"
+    assert uploaded[1][1] == b"staged bytes"
+    assert result["forever_files"][0]["sha256"] == staged_digest
+
+
+def test_jsonl_backup_persists_daily_state_when_forever_upload_fails(tmp_path, monkeypatch):
+    from brainlayer import jsonl_backup
+
+    now = time.time()
+    source_root = tmp_path / "sessions"
+    source_file = source_root / "changed.db"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_bytes(b"sqlite bytes")
+    os.utime(source_file, (now - 3600, now - 3600))
+    state_path = tmp_path / "state.json"
+    uploads: list[Path] = []
+    pruned_folder_parts: list[list[str]] = []
+
+    monkeypatch.setenv("BRAINLAYER_JSONL_FOREVER", "1")
+    monkeypatch.setattr(jsonl_backup.backup_daily, "get_drive_credentials", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "build_drive_service", lambda *args, **kwargs: object())
+    monkeypatch.setattr(jsonl_backup.backup_daily, "ensure_drive_folder_chain", lambda *args, **kwargs: "folder-id")
+    monkeypatch.setattr(jsonl_backup.backup_daily, "verify_drive_upload", lambda *args, **kwargs: None)
+
+    def fake_upload(file_path, folder_id, credentials):  # noqa: ARG001
+        path = Path(file_path)
+        uploads.append(path)
+        if len(uploads) == 2:
+            raise RuntimeError("forever failed")
+        return {"id": "daily-drive-id", "name": path.name, "size": str(path.stat().st_size)}
+
+    def fake_prune(service, *, folder_parts, retention_policy):  # noqa: ARG001
+        pruned_folder_parts.append(list(folder_parts))
+        return []
+
+    monkeypatch.setattr(jsonl_backup.backup_daily, "upload_file_to_drive_raw", fake_upload)
+    monkeypatch.setattr(jsonl_backup.backup_daily, "prune_drive_backups", fake_prune)
+
+    with pytest.raises(RuntimeError, match="forever failed"):
+        jsonl_backup.run_backup(
+            source_roots=[jsonl_backup.BackupSourceRoot(source_root, ("**/*.db",))],
+            state_path=state_path,
+            staging_dir=tmp_path / "staging",
+            log_path=tmp_path / "jsonl-backup.log",
+            queue_dir=tmp_path / "queue",
+            date_stamp="2026-06-30",
+            now=now,
+            upload=True,
+        )
+
+    state = json.loads(state_path.read_text())
+    assert source_file.as_posix() in state["files"]
+    assert pruned_folder_parts == [jsonl_backup.DEFAULT_FOLDER_PARTS]
+    assert not (tmp_path / "staging" / "claude-jsonl-2026-06-30.tar.gz").exists()
 
 
 def test_run_jsonl_backup_second_run_noops_when_state_covers_files(tmp_path, monkeypatch):

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -121,8 +121,19 @@ def test_version_check_fails_loudly_when_latest_git_tag_drifts(tmp_path: Path) -
     assert "latest git tag is 'v0.0.0'" in result.stderr
 
 
-def test_version_check_reports_controlled_error_outside_git_checkout(tmp_path: Path) -> None:
+def test_version_check_reports_controlled_error_outside_git_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     fixture_root, tap_root, _package_version = _copy_version_fixture(tmp_path)
+    repo_git_path = REPO_ROOT / ".git"
+    if repo_git_path.is_file():
+        git_dir = repo_git_path.read_text(encoding="utf-8").strip().removeprefix("gitdir: ")
+    else:
+        git_dir = str(repo_git_path)
+    if not Path(git_dir).is_absolute():
+        git_dir = str(repo_git_path.parent / git_dir)
+    monkeypatch.setenv("GIT_DIR", git_dir)
+    monkeypatch.setenv("GIT_WORK_TREE", str(REPO_ROOT))
 
     result = _run(fixture_root, tap_root)
 


### PR DESCRIPTION
## Summary

- Extend JSONL backup discovery from jsonl-only roots to per-root include globs so Cursor, Gemini CLI, and Antigravity are backed up in the formats they actually write.
- Capture Antigravity SQLite conversation restore units atomically: if any `.db`/`.db-wal`/`.db-shm` member is active the whole unit is skipped, and if any member changed the whole existing unit is bundled together.
- Add the `BRAINLAYER_JSONL_FOREVER=1` content-hash tier under `claude-jsonl-forever/source-N`, preserving each raw file suffix and staying outside rolling prune.
- Hash forever-tier staged copies immediately before upload so content-hash filenames match the bytes actually sent to Drive, cache forever folder lookup per source root, and keep result metadata free of local absolute paths.
- Persist verified daily-upload state and run rolling prune before optional forever uploads, so a forever-tier failure does not duplicate the already-verified daily archive on the next run.
- Remove verified local staging archives after Drive upload to avoid staging leaks.
- Fix the pre-push version-check hook so inherited hook-local `GIT_*` env vars do not make a non-git fixture look like the repository checkout.
- Operationally pinned the 2026-06-06 Claude baseline in Drive forever storage before pruning risk.

## CLI backup coverage verified locally

Total default discovery: 9,398 files.

| CLI | Path | Formats | Count |
| --- | --- | --- | ---: |
| Cursor | `~/.cursor/sessions` | `.jsonl` | 5 |
| Cursor | `~/.cursor/projects/**/agent-transcripts` | `.jsonl` | 1,080 |
| Cursor | `~/.cursor/acp-sessions` | `.json` | 1 |
| Cursor | `~/.cursor/plans` | `.md` | 22 |
| Gemini CLI | `~/.gemini/sessions` | `.jsonl` | 6 |
| Antigravity | `~/.gemini/antigravity-cli/conversations` | `.db`, `.db-wal`, `.db-shm` | 229 + 10 + 10 |
| Antigravity | `~/.gemini/antigravity-cli/implicit` | `.pb` | 17 |
| Antigravity | `~/.gemini/antigravity-cli/brain` | `.jsonl`, `.json`, `.log`, `.md`, media | 444 + 45 + 38 + 4 + 24 |
| Antigravity | `~/.gemini/antigravity-cli/cache` | `.json` | 2 |

## Antigravity raw-backup rationale

Watcher ingestion only tails JSONL transcript sources for Cursor/Gemini/Claude today. Antigravity does not expose a stable plain transcript export in the watcher path, while its durable conversation state is stored as SQLite databases plus WAL/SHM sidecars, protobuf records, generated brain files, cache metadata, and media. Exporting those files during this hotfix would be speculative and could lose restore fidelity, so the backup captures the raw restore units with suffixes preserved and keeps SQLite sidecars grouped for restore consistency.

## Baseline pin

Pinned source Drive object `1_2X2XoEX6sAYCEQXx0oFpayFcL-itPHq` (`claude-jsonl-2026-06-06.tar.gz`, 1,698,081,242 bytes) into `My Drive/Brain Drive/06_ARCHIVE/backups/claude-jsonl-forever/` as object `1GIQ0lC8bHmqnKkn7wC2yKfpYEFgNrRcf`. Source and copy sizes match; rolling prune remains scoped to `claude-jsonl`, not the forever folder.

## Verification

- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `.venv/bin/pytest tests/test_backup_daily.py tests/test_jsonl_backup.py tests/test_version_consistency.py::test_version_check_reports_controlled_error_outside_git_checkout tests/test_kg_judge.py::test_git_shellout_tests_scrub_inherited_git_env -q` -> 38 passed
- Pre-push hook on final commit `a291f6c3` -> full BrainLayer gate passed: 3,299 pytest passed, 9 skipped, 61 deselected, 1 xfailed, plus MCP registration, isolated eval/hook routing, bun suite, and `test_fts5_determinism.sh`
