### PR TITLE
fix: restore drain and bound status doctor

### DIFF
--- a/scripts/brainlayer-version-check.sh
+++ b/scripts/brainlayer-version-check.sh
@@ -101,22 +101,45 @@ extract_cask_version() {
     ' "$1"
 }
 
+GIT_LOCAL_ENV_VARS=(
+    GIT_ALTERNATE_OBJECT_DIRECTORIES
+    GIT_CONFIG
+    GIT_CONFIG_PARAMETERS
+    GIT_CONFIG_COUNT
+    GIT_OBJECT_DIRECTORY
+    GIT_DIR
+    GIT_WORK_TREE
+    GIT_IMPLICIT_WORK_TREE
+    GIT_GRAFT_FILE
+    GIT_INDEX_FILE
+    GIT_NO_REPLACE_OBJECTS
+    GIT_REPLACE_REF_BASE
+    GIT_PREFIX
+    GIT_SHALLOW_FILE
+    GIT_COMMON_DIR
+)
+
+git_package_root() {
+    local -a env_args=()
+    local name
+
+    for name in "${GIT_LOCAL_ENV_VARS[@]}"; do
+        env_args+=(-u "$name")
+    done
+
+    env "${env_args[@]}" git -C "$PACKAGE_ROOT" "$@"
+}
+
 latest_git_tag() {
     if [[ -n "${BRAINLAYER_VERSION_CHECK_GIT_TAG:-}" ]]; then
         printf '%s\n' "$BRAINLAYER_VERSION_CHECK_GIT_TAG"
         return
     fi
-    local git_env_var
-    while IFS= read -r git_env_var; do
-        if [[ -n "$git_env_var" ]]; then
-            unset "$git_env_var"
-        fi
-    done < <(git rev-parse --local-env-vars 2>/dev/null || true)
-    if ! git -C "$PACKAGE_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    if ! git_package_root rev-parse --git-dir >/dev/null 2>&1; then
         printf '\n'
         return
     fi
-    git -C "$PACKAGE_ROOT" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname 2>/dev/null | head -n 1
+    git_package_root tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname 2>/dev/null | head -n 1
 }
 
 if [[ -z "$TAP_ROOT" ]]; then

--- a/scripts/launchd/com.brainlayer.p0-counter.plist
+++ b/scripts/launchd/com.brainlayer.p0-counter.plist
@@ -3,17 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.brainlayer.drain</string>
+	<string>com.brainlayer.p0-counter</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>__BRAINLAYER_ENV_RUN__</string>
-		<string>/usr/bin/env</string>
-		<string>BRAINLAYER_DRAIN_EMBED=0</string>
 		<string>__BRAINLAYER_BIN__</string>
-		<string>drain</string>
-		<string>--daemon</string>
-		<string>--batch-size</string>
-		<string>50</string>
+		<string>p0-counter</string>
 	</array>
 	<key>EnvironmentVariables</key>
 	<dict>
@@ -26,20 +21,19 @@
 		<key>BRAINLAYER_ENV_FILE</key>
 		<string>__BRAINLAYER_ENV_FILE__</string>
 		<key>BRAINLAYER_LAUNCHD_SERVICE</key>
-		<string>drain</string>
+		<string>p0-counter</string>
 	</dict>
 	<key>StandardOutPath</key>
-	<string>__HOME__/Library/Logs/brainlayer/drain.out.log</string>
+	<string>__HOME__/Library/Logs/brainlayer/p0-counter.out.log</string>
 	<key>StandardErrorPath</key>
-	<string>__HOME__/Library/Logs/brainlayer/drain.err.log</string>
-	<key>KeepAlive</key>
-	<true/>
-	<key>RunAtLoad</key>
-	<true/>
-	<key>ThrottleInterval</key>
-	<integer>10</integer>
-	<key>Nice</key>
-	<integer>10</integer>
+	<string>__HOME__/Library/Logs/brainlayer/p0-counter.err.log</string>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>5</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ExitTimeOut</key>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -17,6 +17,7 @@
 #   ./scripts/launchd/install.sh maintenance  # Install recurring maintenance jobs
 #   ./scripts/launchd/install.sh health-check # Install stability health check only
 #   ./scripts/launchd/install.sh hotlane      # Install BrainBar hotlane embed/enrich daemon only
+#   ./scripts/launchd/install.sh p0-counter   # Install daily P0 longitudinal counter only
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
 set -euo pipefail
 
@@ -330,6 +331,9 @@ case "${1:-all}" in
         verify_gemini_env_file
         install_plist hotlane-brainbar
         ;;
+    p0-counter)
+        install_plist p0-counter
+        ;;
     all)
         install_env_runner
         verify_config_file
@@ -357,7 +361,7 @@ case "${1:-all}" in
         elif ! install_many jsonl-backup; then
             failures=1
         fi
-        if ! install_many maintenance-nightly maintenance-weekly health-check; then
+        if ! install_many maintenance-nightly maintenance-weekly health-check p0-counter; then
             failures=1
         fi
         # Remove old enrich plist only after the replacement enrichment service loads.
@@ -383,11 +387,12 @@ case "${1:-all}" in
         remove_plist maintenance-weekly 2>/dev/null || true
         remove_plist health-check 2>/dev/null || true
         remove_plist hotlane-brainbar 2>/dev/null || true
+        remove_plist p0-counter 2>/dev/null || true
         rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
         rm -f "$BRAINLAYER_LIB_DIR/jsonl-backup.sh"
         ;;
     *)
-        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|all|remove]"
+        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|p0-counter|all|remove]"
         exit 1
         ;;
 esac

--- a/scripts/p0_longitudinal_count.py
+++ b/scripts/p0_longitudinal_count.py
@@ -1,104 +1,14 @@
 #!/usr/bin/env python3
-"""Daily P0 audit-recursion counter for the post-PR287 longitudinal window."""
+"""Compatibility wrapper for the packaged P0 longitudinal counter module."""
 
-from __future__ import annotations
-
-import json
-import os
-import sqlite3
-from datetime import datetime, timezone
+import sys
 from pathlib import Path
 
-from brainlayer.paths import get_db_path
+_REPO_SRC = Path(__file__).resolve().parents[1] / "src"
+if (_REPO_SRC / "brainlayer").is_dir() and str(_REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(_REPO_SRC))
 
-SINCE = "2026-05-16T16:56:00+03:00"
-DEFAULT_LOG_DIR = Path.home() / ".brainlayer-p0-counter"
-
-P0_SQL = """
-WITH normalized AS (
-    SELECT
-        created_at,
-        ltrim(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)) AS content
-    FROM chunks
-)
-SELECT date(datetime(created_at)) AS day, COUNT(*) AS new_audit_chunks
-FROM normalized
-WHERE datetime(created_at) > datetime(?)
-  AND (content GLOB '┌─brain_search:*'
-       OR content GLOB '┌─brain_*:*'
-       OR content GLOB '┌─ brain_search:*'
-       OR content GLOB '┌─ brain_*:*'
-       OR content GLOB '*"jsonrpc"*"2.0"*'
-       OR content GLOB '*MCP BrainLayer Memory: Invalid JSON-RPC*')
-GROUP BY day
-ORDER BY day;
-""".strip()
-
-
-def _db_path() -> Path:
-    return get_db_path().expanduser()
-
-
-def _log_dir() -> Path:
-    return Path(os.environ.get("BRAINLAYER_P0_COUNTER_DIR", DEFAULT_LOG_DIR)).expanduser()
-
-
-def run_count(db_path: Path, since: str = SINCE) -> list[dict[str, object]]:
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
-    try:
-        conn.execute("PRAGMA query_only=true")
-        conn.execute("PRAGMA busy_timeout=5000")
-        return [
-            {"day": day, "new_audit_chunks": int(count)} for day, count in conn.execute(P0_SQL, (since,)).fetchall()
-        ]
-    finally:
-        conn.close()
-
-
-def build_payload(db_path: Path, now: datetime | None = None) -> dict[str, object]:
-    rows = run_count(db_path)
-    total = sum(int(row["new_audit_chunks"]) for row in rows)
-    now = now or datetime.now(timezone.utc)
-    if now.tzinfo is None:
-        now = now.replace(tzinfo=timezone.utc)
-    since = datetime.fromisoformat(SINCE)
-    elapsed_seconds = max(0.0, (now - since).total_seconds())
-    elapsed_days = int(elapsed_seconds // 86400)
-    verdict_ready = elapsed_days >= 7
-    structural_fix = verdict_ready and total == 0
-    return {
-        "generated_at": now.isoformat(),
-        "since": SINCE,
-        "db_path": str(db_path),
-        "sql": P0_SQL,
-        "sql_params": [SINCE],
-        "rows": rows,
-        "total_new_audit_chunks": total,
-        "elapsed_days": elapsed_days,
-        "verdict_ready": verdict_ready,
-        "structural_fix_p_lt_0_001": structural_fix,
-        "brain_store_verdict_content": (
-            f"P0 longitudinal counter verdict: 0 audit-recursion chunks across 7 days "
-            f"since {SINCE}; structural fix p<0.001 per R51."
-            if structural_fix
-            else None
-        ),
-    }
-
-
-def main() -> int:
-    db_path = _db_path()
-    if not db_path.exists():
-        raise SystemExit(f"BrainLayer DB not found: {db_path}")
-
-    log_dir = _log_dir()
-    log_dir.mkdir(parents=True, exist_ok=True)
-    payload = build_payload(db_path)
-    output_path = log_dir / f"{datetime.now().date().isoformat()}.json"
-    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    print(json.dumps({"output_path": str(output_path), **payload}, ensure_ascii=False))
-    return 0
-
+from brainlayer.p0_longitudinal_count import main
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import logging
+import math
 import os
 import re as _re
 import shlex
@@ -12,6 +13,7 @@ import sys
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Annotated, Any, Optional
 
 import typer
@@ -875,6 +877,158 @@ def _run_doctor_cli(config):
     return run_doctor(config)
 
 
+DEFAULT_STATUS_DOCTOR_TIMEOUT_SECONDS = 12.0
+DEFAULT_STATUS_DOCTOR_ROUNDTRIP_TIMEOUT_SECONDS = 3.0
+DEFAULT_STATUS_DOCTOR_QUEUE_SAMPLE_SECONDS = 1.0
+DEFAULT_STATUS_SQLITE_PROGRESS_TIMEOUT_SECONDS = 2.0
+
+
+class StatusDoctorTimeoutError(TimeoutError):
+    pass
+
+
+_STATUS_DOCTOR_CHILD_CODE = r"""
+import json
+import os
+import sys
+from pathlib import Path
+
+from brainlayer.doctor import DoctorConfig, run_doctor
+
+
+def _float_env(name):
+    return float(os.environ[name])
+
+
+def _bool_env(name):
+    return os.environ[name].lower() in {"1", "true", "yes", "on"}
+
+
+try:
+    config = DoctorConfig(
+        db_path=Path(os.environ["BRAINLAYER_STATUS_DOCTOR_DB"]),
+        queue_dir=Path(os.environ["BRAINLAYER_STATUS_DOCTOR_QUEUE_DIR"]),
+        watcher_health_path=Path(os.environ["BRAINLAYER_STATUS_DOCTOR_WATCHER_HEALTH"]),
+        drain_health_path=Path(os.environ["BRAINLAYER_STATUS_DOCTOR_DRAIN_HEALTH"]),
+        roundtrip_timeout_seconds=_float_env("BRAINLAYER_STATUS_DOCTOR_ROUNDTRIP_TIMEOUT_SECONDS"),
+        roundtrip_probe_enabled=_bool_env("BRAINLAYER_STATUS_DOCTOR_ROUNDTRIP_PROBE_ENABLED"),
+        queue_movement_sample_seconds=_float_env("BRAINLAYER_STATUS_DOCTOR_QUEUE_SAMPLE_SECONDS"),
+    )
+    print(json.dumps(run_doctor(config).to_dict(), sort_keys=True))
+except BaseException as exc:
+    print(json.dumps({"__status_doctor_error__": f"{type(exc).__name__}: {exc}"}), file=sys.stdout)
+    raise SystemExit(2)
+"""
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 and math.isfinite(value) else default
+
+
+def _status_doctor_timeout_seconds() -> float:
+    return _positive_float_env("BRAINLAYER_STATUS_DOCTOR_TIMEOUT_SECONDS", DEFAULT_STATUS_DOCTOR_TIMEOUT_SECONDS)
+
+
+def _status_doctor_roundtrip_timeout_seconds() -> float:
+    return _positive_float_env(
+        "BRAINLAYER_STATUS_DOCTOR_ROUNDTRIP_TIMEOUT_SECONDS",
+        DEFAULT_STATUS_DOCTOR_ROUNDTRIP_TIMEOUT_SECONDS,
+    )
+
+
+def _status_doctor_queue_sample_seconds() -> float:
+    return _positive_float_env(
+        "BRAINLAYER_STATUS_DOCTOR_QUEUE_SAMPLE_SECONDS",
+        DEFAULT_STATUS_DOCTOR_QUEUE_SAMPLE_SECONDS,
+    )
+
+
+def _status_sqlite_progress_timeout_seconds() -> float:
+    return _positive_float_env(
+        "BRAINLAYER_STATUS_SQLITE_PROGRESS_TIMEOUT_SECONDS",
+        DEFAULT_STATUS_SQLITE_PROGRESS_TIMEOUT_SECONDS,
+    )
+
+
+def _status_doctor_result_from_payload(payload: dict[str, Any]) -> SimpleNamespace:
+    issues = [
+        SimpleNamespace(
+            code=str(issue.get("code", "unknown")),
+            severity=str(issue.get("severity", "unknown")),
+            message=str(issue.get("message", "")),
+            details=issue.get("details", {}) or {},
+        )
+        for issue in payload.get("issues", [])
+        if isinstance(issue, dict)
+    ]
+    return SimpleNamespace(
+        ok=bool(payload.get("ok", False)),
+        exit_code=int(payload.get("exit_code", 1 if not payload.get("ok") else 0)),
+        issues=issues,
+        roundtrip_latency_seconds=payload.get("roundtrip_latency_seconds"),
+    )
+
+
+def _status_doctor_child_env(config) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "BRAINLAYER_STATUS_DOCTOR_DB": str(config.db_path),
+            "BRAINLAYER_STATUS_DOCTOR_QUEUE_DIR": str(config.queue_dir),
+            "BRAINLAYER_STATUS_DOCTOR_WATCHER_HEALTH": str(config.watcher_health_path),
+            "BRAINLAYER_STATUS_DOCTOR_DRAIN_HEALTH": str(config.drain_health_path),
+            "BRAINLAYER_STATUS_DOCTOR_ROUNDTRIP_TIMEOUT_SECONDS": str(config.roundtrip_timeout_seconds),
+            "BRAINLAYER_STATUS_DOCTOR_ROUNDTRIP_PROBE_ENABLED": "1" if config.roundtrip_probe_enabled else "0",
+            "BRAINLAYER_STATUS_DOCTOR_QUEUE_SAMPLE_SECONDS": str(config.queue_movement_sample_seconds),
+        }
+    )
+    return env
+
+
+def _status_doctor_payload_from_stdout(stdout: str) -> dict[str, Any]:
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("doctor returned a malformed verdict") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("doctor returned a malformed verdict")
+        return payload
+    raise RuntimeError("doctor exited without a verdict")
+
+
+def _run_status_doctor_cli(config, *, timeout_seconds: float | None = None):
+    timeout = timeout_seconds if timeout_seconds is not None else _status_doctor_timeout_seconds()
+    command = [sys.executable, "-c", _STATUS_DOCTOR_CHILD_CODE]
+    try:
+        completed = subprocess.run(
+            command,
+            env=_status_doctor_child_env(config),
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise StatusDoctorTimeoutError(f"doctor timed out after {timeout:g}s") from exc
+    try:
+        payload = _status_doctor_payload_from_stdout(completed.stdout)
+    except RuntimeError as exc:
+        stderr = completed.stderr.strip()
+        detail = f": {stderr}" if stderr else ""
+        raise RuntimeError(f"{exc} (exit code {completed.returncode}){detail}") from exc
+    if "__status_doctor_error__" in payload:
+        raise RuntimeError(str(payload["__status_doctor_error__"]))
+    return _status_doctor_result_from_payload(payload)
+
+
 @app.command("doctor")
 def doctor_command(
     db: Optional[Path] = typer.Option(None, "--db", help="Path to brainlayer.db"),
@@ -941,6 +1095,15 @@ def drain_command(
         typer.echo(json.dumps(result.__dict__, sort_keys=True))
         return
     if daemon:
+        from ..parent_death import install_parent_death_watcher
+
+        install_parent_death_watcher()
+        try:
+            from ..deploy_drift import record_launch_from_environment
+
+            record_launch_from_environment()
+        except Exception:
+            logging.getLogger(__name__).debug("Failed to record drain launch provenance", exc_info=True)
         run_daemon(interval=interval, batch_size=batch_size)
         return
 
@@ -948,24 +1111,48 @@ def drain_command(
     typer.echo(str(drained))
 
 
+@app.command("p0-counter")
+def p0_counter_command() -> None:
+    """Run the daily P0 longitudinal counter once."""
+    from ..p0_longitudinal_count import main as run_p0_counter
+
+    raise typer.Exit(code=run_p0_counter())
+
+
 def _status_count_unembedded(db_path: Path) -> int | None:
     if not db_path.exists():
         return None
     uri = f"file:{db_path}?mode=ro"
     with sqlite3.connect(uri, uri=True, timeout=1.0) as conn:
-        row = conn.execute(
-            """
-            SELECT COUNT(*)
-            FROM chunks c
-            LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
-            WHERE r.id IS NULL
-              AND c.content IS NOT NULL
-              AND c.content != ''
-              AND (c.archived_at IS NULL OR c.archived_at = '')
-              AND c.superseded_by IS NULL
-              AND c.aggregated_into IS NULL
-            """
-        ).fetchone()
+        conn.execute("PRAGMA query_only = ON")
+        conn.execute("PRAGMA busy_timeout = 1000")
+        deadline = time.monotonic() + _status_sqlite_progress_timeout_seconds()
+
+        def progress() -> int:
+            return 1 if time.monotonic() >= deadline else 0
+
+        progress_setter = getattr(conn, "set_progress_handler", None)
+        if progress_setter is not None:
+            progress_setter(progress, 1000)
+        try:
+            row = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM chunks c
+                LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
+                WHERE r.id IS NULL
+                  AND c.content IS NOT NULL
+                  AND c.content != ''
+                  AND (c.archived_at IS NULL OR c.archived_at = '')
+                  AND c.superseded_by IS NULL
+                  AND c.aggregated_into IS NULL
+                """
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        finally:
+            if progress_setter is not None:
+                progress_setter(None, 0)
     return int(row[0]) if row else None
 
 
@@ -1086,7 +1273,11 @@ def _status_issue_to_dict(issue: object) -> dict[str, Any]:
 
 
 def _status_doctor_gate(
-    doctor_result: object | None, doctor_error: str | None
+    doctor_result: object | None,
+    doctor_error: str | None,
+    doctor_error_code: str = "status_doctor_failed",
+    *,
+    roundtrip_probe_enabled: bool = True,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if doctor_error is not None:
         doctor_gate = {
@@ -1095,19 +1286,27 @@ def _status_doctor_gate(
             "error": doctor_error,
             "issues": [
                 {
-                    "code": "status_doctor_failed",
+                    "code": doctor_error_code,
                     "severity": "fatal",
                     "message": doctor_error,
                     "details": {},
                 }
             ],
         }
-        vector_roundtrip = {
-            "checked": True,
-            "status": "failed",
-            "issue": doctor_gate["issues"][0],
-            "latency_seconds": None,
-        }
+        if roundtrip_probe_enabled:
+            vector_roundtrip = {
+                "checked": True,
+                "status": "failed",
+                "issue": doctor_gate["issues"][0],
+                "latency_seconds": None,
+            }
+        else:
+            vector_roundtrip = {
+                "checked": False,
+                "status": "not_checked_status_doctor_error",
+                "blocked_by": doctor_gate["issues"][0],
+                "green_gate": "Run `brainlayer doctor --json` for a full vector roundtrip probe.",
+            }
         return doctor_gate, vector_roundtrip
 
     if doctor_result is None:
@@ -1131,10 +1330,12 @@ def _status_doctor_gate(
         "issues": issues,
     }
     vector_roundtrip = {
-        "checked": True,
-        "status": "failed" if roundtrip_issue else "passed",
+        "checked": latency is not None or roundtrip_issue is not None,
+        "status": "failed" if roundtrip_issue else ("passed" if latency is not None else "skipped_by_status_doctor"),
         "latency_seconds": latency,
     }
+    if latency is None and roundtrip_issue is None:
+        vector_roundtrip["green_gate"] = "Run `brainlayer doctor --json` for the write-probe vector roundtrip."
     if roundtrip_issue:
         vector_roundtrip["issue"] = roundtrip_issue
     return doctor_gate, vector_roundtrip
@@ -1213,7 +1414,7 @@ def status_command(
     check_doctor: bool = typer.Option(
         False,
         "--check-doctor",
-        help="Run the doctor probe gate, including vector roundtrip, before computing operational_green.",
+        help="Run the bounded read-mostly doctor gate before computing operational_green.",
     ),
     fallback_gits_root: Path = typer.Option(
         Path("~/Gits"),
@@ -1273,21 +1474,34 @@ def status_command(
     )
     doctor_result = None
     doctor_error = None
+    doctor_error_code = "status_doctor_failed"
+    doctor_roundtrip_probe_enabled = False
     if check_doctor:
         from ..doctor import DoctorConfig
 
         try:
-            doctor_result = _run_doctor_cli(
+            doctor_result = _run_status_doctor_cli(
                 DoctorConfig(
                     db_path=db_path,
                     queue_dir=queue_path,
                     watcher_health_path=watcher_health,
                     drain_health_path=drain_health,
+                    roundtrip_timeout_seconds=_status_doctor_roundtrip_timeout_seconds(),
+                    roundtrip_probe_enabled=doctor_roundtrip_probe_enabled,
+                    queue_movement_sample_seconds=_status_doctor_queue_sample_seconds(),
                 )
             )
+        except TimeoutError as exc:
+            doctor_error = str(exc)
+            doctor_error_code = "status_doctor_timeout"
         except Exception as exc:
             doctor_error = str(exc)
-    doctor_gate, vector_roundtrip = _status_doctor_gate(doctor_result, doctor_error)
+    doctor_gate, vector_roundtrip = _status_doctor_gate(
+        doctor_result,
+        doctor_error,
+        doctor_error_code,
+        roundtrip_probe_enabled=doctor_roundtrip_probe_enabled,
+    )
     queue_health = _status_queue_health_with_doctor(queue_health, doctor_gate)
     queue_green = queue_health["green"] is True if check_doctor else queue_depth == 0
     fallback_replay = _status_fallback_replay(fallback_gits_root, fallback_scopes)

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -88,6 +88,7 @@ class DoctorConfig:
     enrichment_label: str = DEFAULT_ENRICHMENT_LABEL
     recent_window_hours: int = DEFAULT_RECENT_WINDOW_HOURS
     roundtrip_timeout_seconds: float = DEFAULT_ROUNDTRIP_TIMEOUT_SECONDS
+    roundtrip_probe_enabled: bool = True
     queue_warning_count: int = DEFAULT_QUEUE_WARNING_COUNT
     queue_movement_sample_seconds: float = DEFAULT_QUEUE_MOVEMENT_SAMPLE_SECONDS
     drain_liveness_stale_seconds: float = DEFAULT_DRAIN_LIVENESS_STALE_SECONDS
@@ -458,15 +459,16 @@ def run_doctor(
         except Exception as exc:
             fatal("vector_parity_failed", f"could not check vector parity: {exc}")
 
-        ok, latency, reason = _roundtrip_probe(config.db_path, config.roundtrip_timeout_seconds)
-        result.roundtrip_latency_seconds = round(latency, 4)
-        if not ok:
-            fatal(
-                "roundtrip_vector_probe_failed",
-                "store-to-hybrid vector round-trip did not return the probe",
-                latency_seconds=result.roundtrip_latency_seconds,
-                reason=reason,
-            )
+        if config.roundtrip_probe_enabled:
+            ok, latency, reason = _roundtrip_probe(config.db_path, config.roundtrip_timeout_seconds)
+            result.roundtrip_latency_seconds = round(latency, 4)
+            if not ok:
+                fatal(
+                    "roundtrip_vector_probe_failed",
+                    "store-to-hybrid vector round-trip did not return the probe",
+                    latency_seconds=result.roundtrip_latency_seconds,
+                    reason=reason,
+                )
 
     try:
         result.enrichment_backlog = _enrichment_backlog(config.db_path)

--- a/src/brainlayer/p0_longitudinal_count.py
+++ b/src/brainlayer/p0_longitudinal_count.py
@@ -1,0 +1,120 @@
+"""Daily P0 audit-recursion counter for the post-PR287 longitudinal window."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from brainlayer.paths import get_db_path
+
+SINCE = "2026-05-16T16:56:00+03:00"
+DEFAULT_LOG_DIR = Path.home() / ".brainlayer-p0-counter"
+
+P0_SQL = """
+WITH normalized AS (
+    SELECT
+        created_at,
+        ltrim(content, char(9) || char(10) || char(11) || char(12) || char(13) || char(32)) AS content
+    FROM chunks
+)
+SELECT date(datetime(created_at)) AS day, COUNT(*) AS new_audit_chunks
+FROM normalized
+WHERE datetime(created_at) > datetime(?)
+  AND (content GLOB '┌─brain_search:*'
+       OR content GLOB '┌─brain_*:*'
+       OR content GLOB '┌─entity:*'
+       OR content GLOB '┌─ entity:*'
+       OR content GLOB '┌─ entity search:*'
+       OR content GLOB '┌─ brain_search:*'
+       OR content GLOB '┌─ brain_*:*'
+       OR content GLOB '*"jsonrpc"*"2.0"*'
+       OR content GLOB '*MCP BrainLayer Memory: Invalid JSON-RPC*')
+GROUP BY day
+ORDER BY day;
+""".strip()
+
+
+def _db_path() -> Path:
+    return get_db_path().expanduser()
+
+
+def _log_dir() -> Path:
+    return Path(os.environ.get("BRAINLAYER_P0_COUNTER_DIR", DEFAULT_LOG_DIR)).expanduser()
+
+
+def _sqlite_error_message(exc: sqlite3.Error) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _run_count_with_error(db_path: Path, since: str = SINCE) -> tuple[list[dict[str, object]], str | None]:
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+    except sqlite3.Error as exc:
+        return [], _sqlite_error_message(exc)
+    try:
+        conn.execute("PRAGMA query_only=true")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return [
+            {"day": day, "new_audit_chunks": int(count)} for day, count in conn.execute(P0_SQL, (since,)).fetchall()
+        ], None
+    except sqlite3.Error as exc:
+        return [], _sqlite_error_message(exc)
+    finally:
+        conn.close()
+
+
+def run_count(db_path: Path, since: str = SINCE) -> list[dict[str, object]]:
+    rows, error = _run_count_with_error(db_path, since)
+    if error is not None:
+        raise sqlite3.OperationalError(error)
+    return rows
+
+
+def build_payload(db_path: Path, now: datetime | None = None) -> dict[str, object]:
+    rows, count_error = _run_count_with_error(db_path)
+    total = sum(int(row["new_audit_chunks"]) for row in rows)
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    since = datetime.fromisoformat(SINCE)
+    elapsed_seconds = max(0.0, (now - since).total_seconds())
+    elapsed_days = int(elapsed_seconds // 86400)
+    verdict_ready = count_error is None and elapsed_days >= 7
+    structural_fix = count_error is None and verdict_ready and total == 0
+    return {
+        "generated_at": now.isoformat(),
+        "since": SINCE,
+        "db_path": str(db_path),
+        "count_error": count_error,
+        "sql": P0_SQL,
+        "sql_params": [SINCE],
+        "rows": rows,
+        "total_new_audit_chunks": total,
+        "elapsed_days": elapsed_days,
+        "verdict_ready": verdict_ready,
+        "structural_fix_p_lt_0_001": structural_fix,
+        "brain_store_verdict_content": (
+            f"P0 longitudinal counter verdict: 0 audit-recursion chunks across 7 days "
+            f"since {SINCE}; structural fix p<0.001 per R51."
+            if structural_fix
+            else None
+        ),
+    }
+
+
+def main() -> int:
+    db_path = _db_path()
+    log_dir = _log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    payload = build_payload(db_path)
+    output_path = log_dir / f"{datetime.now().date().isoformat()}.json"
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"output_path": str(output_path), **payload}, ensure_ascii=False))
+    return 1 if payload["count_error"] is not None else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -343,6 +343,31 @@ def test_run_doctor_exits_zero_on_healthy_fixture(tmp_path):
     assert not [issue for issue in result.issues if issue.severity == "fatal"]
 
 
+def test_run_doctor_can_skip_roundtrip_probe_for_bounded_status_gate(tmp_path, monkeypatch):
+    import brainlayer.doctor as doctor
+
+    db_path = tmp_path / "healthy-read-mostly.db"
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    config.roundtrip_probe_enabled = False
+
+    def fail_roundtrip(*_args, **_kwargs):
+        raise AssertionError("bounded status doctor must not run the write roundtrip probe")
+
+    monkeypatch.setattr(doctor, "_roundtrip_probe", fail_roundtrip)
+
+    result = doctor.run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.exit_code == 0
+    assert result.roundtrip_latency_seconds is None
+    assert not [issue for issue in result.issues if issue.code == "roundtrip_vector_probe_failed"]
+
+
 def test_run_doctor_fails_loudly_when_brainbar_version_check_fails(tmp_path):
     from brainlayer.doctor import run_doctor
 

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -56,7 +56,7 @@ def test_brainlayer_cli_exposes_transport_commands(monkeypatch) -> None:
 
     from brainlayer.cli import app
 
-    for args in (["drain", "--help"], ["status", "--help"]):
+    for args in (["drain", "--help"], ["p0-counter", "--help"], ["status", "--help"]):
         result = CliRunner().invoke(app, args)
 
         assert result.exit_code == 0, result.stdout
@@ -346,8 +346,13 @@ def test_config_loader_ignores_unreadable_user_env(monkeypatch, tmp_path: Path) 
 
 
 def test_launchd_repo_only_wrappers_are_not_used_by_packaged_plists() -> None:
-    assert _plist_args("drain")[:3] == ["__BRAINLAYER_ENV_RUN__", "__PYTHON_BIN__", "-m"]
-    assert _plist_args("drain")[3] == "brainlayer.drain"
+    assert _plist_args("drain")[:5] == [
+        "__BRAINLAYER_ENV_RUN__",
+        "/usr/bin/env",
+        "BRAINLAYER_DRAIN_EMBED=0",
+        "__BRAINLAYER_BIN__",
+        "drain",
+    ]
     assert _plist_args("maintenance-nightly")[:3] == ["__BRAINLAYER_ENV_RUN__", "__PYTHON_BIN__", "-m"]
     assert _plist_args("maintenance-nightly")[3] == "brainlayer.maintenance"
     assert _plist_args("maintenance-weekly")[:3] == ["__BRAINLAYER_ENV_RUN__", "__PYTHON_BIN__", "-m"]
@@ -395,6 +400,7 @@ def test_launchd_installer_preflights_all_before_loading_without_google_key(tmp_
         },
         capture_output=True,
         text=True,
+        timeout=30,
         check=False,
     )
 
@@ -447,6 +453,63 @@ def test_launchd_installer_renders_brainlayer_python_override(tmp_path: Path) ->
     rendered = home / "Library" / "LaunchAgents" / "com.brainlayer.backup-daily.plist"
     assert f"<string>{brainlayer_python}</string>" in rendered.read_text(encoding="utf-8")
     assert "__BRAINLAYER_PYTHON__" not in rendered.read_text(encoding="utf-8")
+
+
+def test_packaged_launchd_installer_renders_p0_counter_console_shim(tmp_path: Path) -> None:
+    launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
+    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [str(launchd_dir / "install.sh"), "p0-counter"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": "/usr/bin/python3",
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    rendered = home / "Library" / "LaunchAgents" / "com.brainlayer.p0-counter.plist"
+    plist = plistlib.loads(rendered.read_bytes())
+    assert plist["ProgramArguments"] == [
+        str(home / ".local" / "lib" / "brainlayer" / "brainlayer-env-run.sh"),
+        sys.executable,
+        "p0-counter",
+    ]
+    content = rendered.read_text(encoding="utf-8")
+    assert "__BRAINLAYER_BIN__" not in content
+    assert "__BRAINLAYER_PYTHON__" not in content
+    assert "/usr/bin/python3" not in content
+    assert "brainlayer.p0_longitudinal_count" not in content
+    assert "site-packages/scripts/p0_longitudinal_count.py" not in content
+    assert "scripts/p0_longitudinal_count.py" not in content
 
 
 def test_launchd_installer_renders_launchd_dir_for_maintenance_resume(tmp_path: Path) -> None:

--- a/tests/test_kg_judge.py
+++ b/tests/test_kg_judge.py
@@ -320,6 +320,7 @@ def test_git_shellout_tests_scrub_inherited_git_env():
         "test_doctor.py",
         "test_git_learning.py",
         "test_kg_judge.py",
+        "test_version_consistency.py",
     }
     for text in git_shellout_files.values():
         assert 'if not key.startswith("GIT_")' in text

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -7,6 +7,10 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from brainlayer.cli import app
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LOG_ROOT = "__HOME__/Library/Logs/brainlayer/"
 RENDERED_LOG_ROOT = "/Users/etanheyman/Library/Logs/brainlayer/"
@@ -123,6 +127,87 @@ def test_active_daemon_launchd_hygiene_matrix():
 def test_all_script_launchd_plists_have_common_hygiene():
     for path in sorted((REPO_ROOT / "scripts/launchd").glob("com.brainlayer.*.plist")):
         _assert_common_hygiene(plistlib.loads(path.read_bytes()))
+
+
+def test_drain_launchagent_uses_stable_brainlayer_shim():
+    drain = _load("scripts/launchd/com.brainlayer.drain.plist")
+
+    assert drain["ProgramArguments"][:5] == [
+        "__BRAINLAYER_ENV_RUN__",
+        "/usr/bin/env",
+        "BRAINLAYER_DRAIN_EMBED=0",
+        "__BRAINLAYER_BIN__",
+        "drain",
+    ]
+    assert "--daemon" in drain["ProgramArguments"]
+    assert "BRAINLAYER_DRAIN_EMBED" not in drain["EnvironmentVariables"]
+    assert "__PYTHON_BIN__" not in drain["ProgramArguments"]
+    assert "-m" not in drain["ProgramArguments"]
+    assert "brainlayer.drain" not in drain["ProgramArguments"]
+
+
+def test_drain_launchagent_embed_override_survives_env_file_loading(tmp_path):
+    loader = REPO_ROOT / "scripts/launchd/brainlayer-env-run.sh"
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_DRAIN_EMBED=1\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [
+            str(loader),
+            "/usr/bin/env",
+            "BRAINLAYER_DRAIN_EMBED=0",
+            "/bin/sh",
+            "-c",
+            'test "$BRAINLAYER_DRAIN_EMBED" = "0"',
+        ],
+        env={
+            **os.environ,
+            "BRAINLAYER_ENV_FILE": str(env_file),
+            "BRAINLAYER_LAUNCHD_SERVICE": "drain",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_drain_cli_daemon_records_launch_provenance(monkeypatch):
+    from brainlayer import deploy_drift, drain, parent_death
+
+    calls = []
+    monkeypatch.setattr(parent_death, "install_parent_death_watcher", lambda: calls.append("parent-death"))
+    monkeypatch.setattr(deploy_drift, "record_launch_from_environment", lambda: calls.append("provenance"))
+    monkeypatch.setattr(
+        drain, "run_daemon", lambda interval, batch_size: calls.append(("daemon", interval, batch_size))
+    )
+
+    result = CliRunner().invoke(app, ["drain", "--daemon", "--interval", "0", "--batch-size", "7"])
+
+    assert result.exit_code == 0
+    assert calls == ["parent-death", "provenance", ("daemon", 0.0, 7)]
+
+
+def test_p0_counter_launchagent_uses_brainlayer_console_shim():
+    p0 = _load("scripts/launchd/com.brainlayer.p0-counter.plist")
+
+    assert p0["ProgramArguments"] == [
+        "__BRAINLAYER_ENV_RUN__",
+        "__BRAINLAYER_BIN__",
+        "p0-counter",
+    ]
+    assert p0["StartCalendarInterval"] == {"Hour": 5, "Minute": 0}
+    assert "RunAtLoad" not in p0
+    assert "StartInterval" not in p0
+    assert "/usr/bin/python3" not in p0["ProgramArguments"]
+    assert "__BRAINLAYER_PYTHON__" not in p0["ProgramArguments"]
+    assert "__PYTHON_BIN__" not in p0["ProgramArguments"]
+    assert "-m" not in p0["ProgramArguments"]
+    assert "brainlayer.p0_longitudinal_count" not in p0["ProgramArguments"]
+    assert "__BRAINLAYER_DIR__" not in p0["ProgramArguments"]
 
 
 def test_index_launchagent_runs_nightly_without_keepalive_or_run_at_load():

--- a/tests/test_p0_longitudinal_count.py
+++ b/tests/test_p0_longitudinal_count.py
@@ -1,22 +1,21 @@
 from __future__ import annotations
 
-import importlib.util
+import json
+import os
 import sqlite3
+import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
 
-def _load_counter_module():
-    module_path = Path(__file__).resolve().parents[1] / "scripts" / "p0_longitudinal_count.py"
-    spec = importlib.util.spec_from_file_location("p0_longitudinal_count", module_path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
+from brainlayer import p0_longitudinal_count as counter
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_p0_counter_normalizes_created_at_offsets(tmp_path):
-    counter = _load_counter_module()
     db_path = tmp_path / "counter.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
@@ -31,7 +30,6 @@ def test_p0_counter_normalizes_created_at_offsets(tmp_path):
 
 
 def test_p0_counter_counts_spaced_brain_search_box(tmp_path):
-    counter = _load_counter_module()
     db_path = tmp_path / "counter.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
@@ -46,7 +44,6 @@ def test_p0_counter_counts_spaced_brain_search_box(tmp_path):
 
 
 def test_p0_counter_counts_leading_whitespace_brain_search_box(tmp_path):
-    counter = _load_counter_module()
     db_path = tmp_path / "counter.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
@@ -60,8 +57,54 @@ def test_p0_counter_counts_leading_whitespace_brain_search_box(tmp_path):
     assert rows == [{"day": "2026-05-16", "new_audit_chunks": 1}]
 
 
+def test_p0_counter_counts_entity_mcp_boxes(tmp_path):
+    db_path = tmp_path / "counter.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+        for content in ("┌─entity: Etan", "┌─ entity: Etan", "┌─ entity search: Etan"):
+            conn.execute(
+                "INSERT INTO chunks (created_at, content) VALUES (?, ?)",
+                ("2026-05-16T14:00:00+00:00", content),
+            )
+
+    rows = counter.run_count(db_path)
+
+    assert rows == [{"day": "2026-05-16", "new_audit_chunks": 3}]
+
+
+def test_p0_counter_wrapper_runs_from_source_checkout_without_install(tmp_path):
+    db_path = tmp_path / "counter.db"
+    output_dir = tmp_path / "reports"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
+        conn.execute(
+            "INSERT INTO chunks (created_at, content) VALUES (?, ?)",
+            ("2026-05-16T14:00:00+00:00", '┌─ brain_search: "audit recursion" ─ 1 result'),
+        )
+
+    env = {
+        **os.environ,
+        "BRAINLAYER_DB": str(db_path),
+        "BRAINLAYER_P0_COUNTER_DIR": str(output_dir),
+        "PYTHONPATH": "",
+    }
+    result = subprocess.run(
+        [sys.executable, "-S", str(REPO_ROOT / "scripts" / "p0_longitudinal_count.py")],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["total_new_audit_chunks"] == 1
+    assert Path(payload["output_path"]).is_file()
+
+
 def test_p0_counter_cutoff_uses_since_parameter(tmp_path):
-    counter = _load_counter_module()
     db_path = tmp_path / "counter.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
@@ -75,8 +118,41 @@ def test_p0_counter_cutoff_uses_since_parameter(tmp_path):
     assert rows == []
 
 
+def test_p0_counter_payload_surfaces_sqlite_error_without_positive_verdict(tmp_path):
+    db_path = tmp_path / "counter.db"
+    db_path.write_bytes(b"")
+
+    since_utc = datetime.fromisoformat(counter.SINCE).astimezone(timezone.utc)
+    payload = counter.build_payload(db_path, now=since_utc + timedelta(days=8))
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table: chunks"):
+        counter.run_count(db_path)
+    assert payload["rows"] == []
+    assert payload["total_new_audit_chunks"] == 0
+    assert "no such table: chunks" in payload["count_error"]
+    assert payload["verdict_ready"] is False
+    assert payload["structural_fix_p_lt_0_001"] is False
+    assert payload["brain_store_verdict_content"] is None
+
+
+def test_p0_counter_main_writes_diagnostic_json_for_missing_db(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "missing.db"
+    output_dir = tmp_path / "reports"
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_P0_COUNTER_DIR", str(output_dir))
+
+    exit_code = counter.main()
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["db_path"] == str(db_path)
+    assert payload["count_error"]
+    assert Path(payload["output_path"]).is_file()
+    persisted = json.loads(Path(payload["output_path"]).read_text(encoding="utf-8"))
+    assert persisted["count_error"] == payload["count_error"]
+
+
 def test_p0_counter_verdict_waits_for_full_168_hours(tmp_path):
-    counter = _load_counter_module()
     db_path = tmp_path / "counter.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")
@@ -90,7 +166,6 @@ def test_p0_counter_verdict_waits_for_full_168_hours(tmp_path):
 
 
 def test_p0_counter_verdict_ready_after_full_168_hours(tmp_path):
-    counter = _load_counter_module()
     db_path = tmp_path / "counter.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("CREATE TABLE chunks (created_at TEXT, content TEXT)")

--- a/tests/test_status_truthfulness.py
+++ b/tests/test_status_truthfulness.py
@@ -1,9 +1,11 @@
 import json
 import sqlite3
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 import brainlayer.cli as cli
@@ -71,6 +73,18 @@ class _FakeDoctorResult:
                 for issue in (self.issues or [])
             ],
         }
+
+
+def _fake_doctor_config():
+    return SimpleNamespace(
+        db_path="brainlayer.db",
+        queue_dir="queue",
+        watcher_health_path="watcher-health.json",
+        drain_health_path="drain-health.json",
+        roundtrip_timeout_seconds=2.5,
+        roundtrip_probe_enabled=False,
+        queue_movement_sample_seconds=0.75,
+    )
 
 
 def test_status_json_surfaces_external_coverage_and_backlog_truth(tmp_path):
@@ -153,6 +167,34 @@ def test_status_queue_depth_by_source_falls_back_for_invalid_utf8_jsonl(tmp_path
     assert cli._status_queue_depth_by_source(queue_dir) == {"fallback-replay": 1}
 
 
+def test_status_unembedded_counter_uses_progress_timeout(tmp_path, monkeypatch):
+    db_path = tmp_path / "brainlayer.db"
+    db_path.write_bytes(b"")
+    progress_calls = []
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def set_progress_handler(self, handler, n):
+            progress_calls.append((handler, n))
+
+        def execute(self, sql):
+            if "PRAGMA" in sql:
+                return self
+            assert progress_calls
+            raise sqlite3.OperationalError("interrupted")
+
+    monkeypatch.setattr(cli.sqlite3, "connect", lambda *_args, **_kwargs: FakeConnection())
+
+    assert cli._status_count_unembedded(db_path) is None
+    assert progress_calls[0][1] == 1000
+    assert progress_calls[-1] == (None, 0)
+
+
 def test_status_check_doctor_can_go_green_with_fresh_draining_queue_tail(tmp_path, monkeypatch):
     db_path = tmp_path / "brainlayer.db"
     queue_dir = tmp_path / "queue"
@@ -174,7 +216,12 @@ def test_status_check_doctor_can_go_green_with_fresh_draining_queue_tail(tmp_pat
         )
     )
     drain_health.write_text(json.dumps({"drained_total": 10, "drain_cycles": 2, "updated_at": now.isoformat()}))
-    monkeypatch.setattr(cli, "_run_doctor_cli", lambda _config: _FakeDoctorResult(ok=True))
+
+    def healthy_status_doctor(config):
+        assert config.roundtrip_probe_enabled is False
+        return _FakeDoctorResult(ok=True, roundtrip_latency_seconds=None)
+
+    monkeypatch.setattr(cli, "_run_status_doctor_cli", healthy_status_doctor)
 
     result = CliRunner().invoke(
         app,
@@ -201,8 +248,8 @@ def test_status_check_doctor_can_go_green_with_fresh_draining_queue_tail(tmp_pat
     assert payload["queue_depth"] == 1
     assert payload["queue_health"]["green"] is True
     assert payload["queue_health"]["status"] == "draining"
-    assert payload["vector_roundtrip"]["checked"] is True
-    assert payload["vector_roundtrip"]["status"] == "passed"
+    assert payload["vector_roundtrip"]["checked"] is False
+    assert payload["vector_roundtrip"]["status"] == "skipped_by_status_doctor"
 
 
 def test_status_json_surfaces_docs_local_fallback_replay_debt(tmp_path, monkeypatch):
@@ -238,7 +285,7 @@ def test_status_json_surfaces_docs_local_fallback_replay_debt(tmp_path, monkeypa
         )
     )
     drain_health.write_text(json.dumps({"drained_total": 10, "drain_cycles": 2, "updated_at": now.isoformat()}))
-    monkeypatch.setattr(cli, "_run_doctor_cli", lambda _config: _FakeDoctorResult(ok=True))
+    monkeypatch.setattr(cli, "_run_status_doctor_cli", lambda _config: _FakeDoctorResult(ok=True))
 
     result = CliRunner().invoke(
         app,
@@ -297,7 +344,7 @@ def test_status_check_doctor_keeps_probe_failures_red(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         cli,
-        "_run_doctor_cli",
+        "_run_status_doctor_cli",
         lambda _config: _FakeDoctorResult(ok=False, exit_code=1, issues=[issue], roundtrip_latency_seconds=2.0),
     )
 
@@ -329,6 +376,153 @@ def test_status_check_doctor_keeps_probe_failures_red(tmp_path, monkeypatch):
     assert payload["vector_roundtrip"]["issue"]["details"]["reason"] == "probe_not_vector_retrievable"
 
 
+def test_status_check_doctor_timeout_returns_structured_verdict(tmp_path, monkeypatch):
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    fallback_root = tmp_path / "gits"
+    watcher_health = tmp_path / "watcher-health.json"
+    drain_health = tmp_path / "drain-health.json"
+    _create_vectorized_status_db(db_path)
+    queue_dir.mkdir()
+    now = datetime.now(timezone.utc)
+    watcher_health.write_text(
+        json.dumps(
+            {
+                "providers": ["claude", "codex", "cursor", "cursor-agent-transcripts", "gemini"],
+                "alerting": False,
+                "db_probe_failed": False,
+                "updated_at": now.isoformat(),
+            }
+        )
+    )
+    drain_health.write_text(json.dumps({"drained_total": 10, "drain_cycles": 2, "updated_at": now.isoformat()}))
+    captured_configs = []
+
+    def timed_out_doctor(config):
+        captured_configs.append(config)
+        raise TimeoutError("doctor timed out after 0.01s")
+
+    monkeypatch.setattr(cli, "_run_status_doctor_cli", timed_out_doctor, raising=False)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "status",
+            "--json",
+            "--check-doctor",
+            "--db",
+            str(db_path),
+            "--queue-dir",
+            str(queue_dir),
+            "--drain-health-path",
+            str(drain_health),
+            "--watcher-health-path",
+            str(watcher_health),
+            "--fallback-gits-root",
+            str(fallback_root),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured_configs
+    assert captured_configs[0].roundtrip_probe_enabled is False
+    assert captured_configs[0].queue_movement_sample_seconds > 0
+    payload = json.loads(result.output)
+    assert payload["operational_green"] is False
+    assert payload["doctor_gate"]["checked"] is True
+    assert payload["doctor_gate"]["ok"] is False
+    assert payload["doctor_gate"]["issues"][0]["code"] == "status_doctor_timeout"
+    assert payload["vector_roundtrip"]["checked"] is False
+    assert payload["vector_roundtrip"]["status"] == "not_checked_status_doctor_error"
+    assert payload["vector_roundtrip"]["blocked_by"]["code"] == "status_doctor_timeout"
+
+
+def test_status_doctor_timeout_env_rejects_non_finite_values(monkeypatch):
+    for raw_value in ("inf", "+inf", "nan"):
+        monkeypatch.setenv("BRAINLAYER_STATUS_DOCTOR_TIMEOUT_SECONDS", raw_value)
+        assert cli._status_doctor_timeout_seconds() == cli.DEFAULT_STATUS_DOCTOR_TIMEOUT_SECONDS
+
+
+def test_status_doctor_gate_marks_roundtrip_skipped_without_latency():
+    doctor_gate, vector_roundtrip = cli._status_doctor_gate(
+        _FakeDoctorResult(ok=True, roundtrip_latency_seconds=None),
+        None,
+    )
+
+    assert doctor_gate["ok"] is True
+    assert vector_roundtrip["checked"] is False
+    assert vector_roundtrip["status"] == "skipped_by_status_doctor"
+    assert "brainlayer doctor --json" in vector_roundtrip["green_gate"]
+
+
+def test_status_doctor_runner_execs_child_without_multiprocessing_spawn(tmp_path, monkeypatch):
+    from brainlayer.doctor import DoctorConfig
+
+    config = DoctorConfig(
+        db_path=tmp_path / "brainlayer.db",
+        queue_dir=tmp_path / "queue",
+        watcher_health_path=tmp_path / "watcher-health.json",
+        drain_health_path=tmp_path / "drain-health.json",
+        roundtrip_timeout_seconds=2.5,
+        roundtrip_probe_enabled=False,
+        queue_movement_sample_seconds=0.75,
+    )
+    calls = {}
+
+    def forbidden_context():
+        raise AssertionError("status doctor must not use multiprocessing spawn from the CLI path")
+
+    def fake_run(command, **kwargs):
+        calls["command"] = command
+        calls["kwargs"] = kwargs
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "ok": True,
+                    "exit_code": 0,
+                    "roundtrip_latency_seconds": None,
+                    "issues": [],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(cli, "_multiprocessing_context", forbidden_context, raising=False)
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    result = cli._run_status_doctor_cli(config, timeout_seconds=0.01)
+
+    assert result.ok is True
+    assert calls["command"][:2] == [sys.executable, "-c"]
+    assert "brainlayer.doctor" in calls["command"][2]
+    assert calls["kwargs"]["timeout"] == 0.01
+    env = calls["kwargs"]["env"]
+    assert env["BRAINLAYER_STATUS_DOCTOR_DB"] == str(config.db_path)
+    assert env["BRAINLAYER_STATUS_DOCTOR_QUEUE_DIR"] == str(config.queue_dir)
+    assert env["BRAINLAYER_STATUS_DOCTOR_ROUNDTRIP_PROBE_ENABLED"] == "0"
+
+
+def test_status_doctor_runner_maps_child_timeout(monkeypatch):
+    def fake_run(command, **kwargs):
+        raise cli.subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    with pytest.raises(cli.StatusDoctorTimeoutError, match="doctor timed out after 0.01s"):
+        cli._run_status_doctor_cli(_fake_doctor_config(), timeout_seconds=0.01)
+
+
+def test_status_doctor_runner_reports_malformed_child_verdict(monkeypatch):
+    def fake_run(command, **kwargs):
+        return SimpleNamespace(returncode=2, stdout="not-json\n", stderr="traceback")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="doctor returned a malformed verdict.*exit code 2.*traceback"):
+        cli._run_status_doctor_cli(_fake_doctor_config(), timeout_seconds=0.01)
+
+
 def test_status_check_doctor_accepts_visible_moving_queue_backlog(tmp_path, monkeypatch):
     db_path = tmp_path / "brainlayer.db"
     queue_dir = tmp_path / "queue"
@@ -357,7 +551,7 @@ def test_status_check_doctor_accepts_visible_moving_queue_backlog(tmp_path, monk
         message="queue is moving",
         details={"queue_count": 30, "drain_total": 11},
     )
-    monkeypatch.setattr(cli, "_run_doctor_cli", lambda _config: _FakeDoctorResult(ok=True, issues=[warning]))
+    monkeypatch.setattr(cli, "_run_status_doctor_cli", lambda _config: _FakeDoctorResult(ok=True, issues=[warning]))
 
     result = CliRunner().invoke(
         app,

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -13,6 +13,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "brainlayer-version-check.sh"
 
 
+def _clean_git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
 def _copy_version_fixture(tmp_path: Path) -> tuple[Path, Path, str]:
     fixture_root = tmp_path / "brainlayer"
     tap_root = tmp_path / "homebrew-layers"
@@ -51,15 +55,60 @@ def _run(
     tap_root: Path,
     *,
     git_tag: str | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = {
-        **os.environ,
+        **_clean_git_env(),
         "BRAINLAYER_VERSION_CHECK_REPO_ROOT": str(fixture_root),
         "BRAINLAYER_VERSION_CHECK_TAP_ROOT": str(tap_root),
+        **(extra_env or {}),
     }
     if git_tag is not None:
         env["BRAINLAYER_VERSION_CHECK_GIT_TAG"] = git_tag
     return subprocess.run(["bash", str(SCRIPT)], capture_output=True, text=True, env=env, timeout=30)
+
+
+def _repo_git_env() -> dict[str, str]:
+    git_dir = subprocess.check_output(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--git-dir"],
+        text=True,
+        env=_clean_git_env(),
+    ).strip()
+    git_dir_path = Path(git_dir)
+    if not git_dir_path.is_absolute():
+        git_dir_path = REPO_ROOT / git_dir_path
+    return {
+        "GIT_DIR": str(git_dir_path),
+        "GIT_WORK_TREE": str(REPO_ROOT),
+        "GIT_INDEX_FILE": str(git_dir_path / "index"),
+        "GIT_PREFIX": "hooks/",
+        "GIT_CONFIG_COUNT": "1",
+    }
+
+
+def _init_git_repo(path: Path, tag: str) -> None:
+    env = _clean_git_env()
+    subprocess.run(["git", "-C", str(path), "init"], check=True, capture_output=True, text=True, env=env)
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True, capture_output=True, text=True, env=env)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(path),
+            "-c",
+            "user.name=BrainLayer Tests",
+            "-c",
+            "user.email=tests@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    subprocess.run(["git", "-C", str(path), "tag", tag], check=True, capture_output=True, text=True, env=env)
 
 
 def test_version_check_passes_when_release_metadata_matches(tmp_path: Path) -> None:
@@ -140,3 +189,35 @@ def test_version_check_reports_controlled_error_outside_git_checkout(
     assert result.returncode == 1
     assert "latest git tag could not be determined" in result.stderr
     assert "fatal:" not in result.stderr
+
+
+def test_version_check_ignores_parent_git_env_outside_git_checkout(tmp_path: Path) -> None:
+    fixture_root, tap_root, _package_version = _copy_version_fixture(tmp_path)
+
+    result = _run(fixture_root, tap_root, extra_env=_repo_git_env())
+
+    assert result.returncode == 1
+    assert "latest git tag could not be determined" in result.stderr
+    assert "fatal:" not in result.stderr
+
+
+def test_version_check_ignores_parent_git_env_inside_valid_checkout(tmp_path: Path) -> None:
+    fixture_root, tap_root, package_version = _copy_version_fixture(tmp_path)
+    _init_git_repo(fixture_root, f"v{package_version}")
+
+    result = _run(fixture_root, tap_root, extra_env=_repo_git_env())
+
+    assert result.returncode == 0, result.stderr
+    assert f"PASS: BrainLayer/BrainBar {package_version} release metadata is consistent" in result.stdout
+
+
+def test_version_check_scrubs_all_git_local_env_vars_declared_by_git() -> None:
+    git_local_vars = subprocess.check_output(
+        ["git", "rev-parse", "--local-env-vars"],
+        text=True,
+        env=_clean_git_env(),
+    ).splitlines()
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    missing = [name for name in git_local_vars if name not in script]
+    assert missing == []


### PR DESCRIPTION
## Summary
- Restore the drain launchd path to the installed `brainlayer` console shim and keep the interim FTS-first mode with `BRAINLAYER_DRAIN_EMBED=0`.
- Add/install a p0-counter launchd template that runs through the BrainLayer venv Python and only fires on the scheduled 04:00 calendar interval.
- Make `brainlayer status --check-doctor` return a bounded structured verdict instead of hanging behind SQLite reader/WAL contention.
- Harden the version check script against inherited Git hook environment variables.

## Why
The live drain had been crash-looping and committing zero chunks. The doctor gate also hung during DB init/status reads under the same WAL/reader-lock contention family, which made health checks unable to return a verdict.

## Verification
- Pre-push hook passed on `cmuxlayer/drain-hotfix-2`.
- `pytest tests/test_status_truthfulness.py tests/test_launchd_hygiene.py tests/test_installable_build.py::test_launchd_repo_only_wrappers_are_not_used_by_packaged_plists tests/test_installable_build.py::test_launchd_templates_are_declared_as_package_data tests/test_p0_longitudinal_count.py tests/test_doctor.py -q` -> 81 passed.
- `ruff check src/ tests/` -> passed.
- `ruff format --check src/ tests/` -> passed.
- `plutil -lint` on repo and installed drain/p0 plists -> OK.
- Full local pytest after review fixes -> 3397 passed, 49 skipped, 5 xfailed.
- Version-check targeted regression after hook fix -> passed, including inherited Git env coverage.
- Local bounded status command returned a structured `status_doctor_timeout` verdict instead of hanging.

## Review Notes
- `BRAINLAYER_DRAIN_EMBED=0` is intentional for this PR; vector backfill remains separate.
- Local CodeRabbit review found two major issues before commit; both were fixed. A second local CodeRabbit pass was blocked by OSS rate limiting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the single-writer drain daemon and operational green gates; misconfiguration could leave embedding off or make status appear healthy without a full doctor roundtrip unless operators run `brainlayer doctor` explicitly.
> 
> **Overview**
> Restores production **drain** and **health-check** behavior after crash-loops and hangs under SQLite/WAL contention.
> 
> **Drain launchd** now runs the installed `brainlayer drain --daemon` shim with `BRAINLAYER_DRAIN_EMBED=0` applied before env-file loading (via `/usr/bin/env`), instead of `python -m brainlayer.drain`. The daemon path also installs a parent-death watcher and records launch provenance.
> 
> **`brainlayer status --check-doctor`** runs doctor in a **subprocess with a wall-clock timeout**, disables the write **vector roundtrip** probe by default, and returns structured JSON for timeouts and failures. **`DoctorConfig.roundtrip_probe_enabled`** gates the roundtrip in full `doctor`; status reporting distinguishes skipped vs failed roundtrips. The unembedded-chunk count uses a SQLite **progress handler** so long reads can abort instead of blocking indefinitely.
> 
> **P0 longitudinal counter** moves into `brainlayer.p0_longitudinal_count` with a thin script wrapper, new **`p0-counter`** CLI, daily launchd job (05:00), and install wiring for `all` / `remove`. Payloads surface **`count_error`** and avoid positive verdicts when the DB read fails; detection adds entity MCP box patterns.
> 
> **Version check** scrubs inherited `GIT_*` local env vars via `git_package_root` so hook environments do not break tag resolution in non-repo checkouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3b18414303d06fccb3d9a632b525f2b3cf8ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore drain daemon and status doctor with bounded subprocess execution
> - The `status --check-doctor` path now runs doctor checks in a child subprocess with explicit timeouts instead of spawning multiprocessing from the parent CLI, fixing hangs and restoring the drain/doctor status gates.
> - The drain daemon CLI installs a parent-death watcher and records launch provenance on startup; the launchd plist is updated to launch via the packaged console shim with `BRAINLAYER_DRAIN_EMBED=0`.
> - Adds a new `p0-counter` CLI command and daily launchd job that runs the P0 longitudinal count and produces a diagnostic JSON payload even on database errors.
> - The `_status_count_unembedded` helper now enforces a SQLite progress-handler deadline and returns `None` on errors instead of raising.
> - Vector roundtrip status in the doctor gate now distinguishes between failed, skipped, and not-checked states based on whether the roundtrip probe ran.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae3b184.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily background `p0-counter` launchd service for P0 longitudinal counting.
  * Enhanced the `status --check-doctor` flow with bounded doctor gating and clearer structured results.

* **Bug Fixes**
  * Improved Git version tag detection by sanitizing inherited Git environment variables.
  * Updated `drain` and `p0-counter` launchd jobs to use stable wrapper-based execution with consistent drain embedding behavior.
  * Made status database reads more interruptible and allowed skipping vector roundtrip probing when appropriate.

* **Tests**
  * Expanded coverage for status-doctor timing, launchd hygiene, and `p0-counter` counting/output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->