### PR TITLE
feat: add label-gated secret scrubber

### DIFF
--- a/src/brainlayer/pipeline/secret_scrub.py
+++ b/src/brainlayer/pipeline/secret_scrub.py
@@ -1,0 +1,222 @@
+"""Go-forward secret scrubber for persisted BrainLayer chunks.
+
+The scrubber is deliberately two-mode:
+- provider-prefixed secret shapes are redacted fail-closed;
+- unlabeled high-entropy tokens are reported for review but left unchanged.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+
+MAX_SCAN_BYTES = 128 * 1024
+WINDOW_OVERLAP_CHARS = 512
+MIN_ENTROPY_TOKEN_LENGTH = 24
+ENTROPY_THRESHOLD = 4.0
+
+
+@dataclass(frozen=True)
+class SecretRedaction:
+    provider: str
+    original: str
+    placeholder: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class QuarantinedToken:
+    value: str
+    start: int
+    end: int
+    reason: str = "unlabeled_high_entropy"
+
+
+@dataclass(frozen=True)
+class SecretScrubResult:
+    text: str
+    redactions: list[SecretRedaction] = field(default_factory=list)
+    quarantine: list[QuarantinedToken] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _ProviderPattern:
+    provider: str
+    regex: re.Pattern[str]
+
+
+_PROVIDER_PATTERNS = (
+    _ProviderPattern("anthropic", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b")),
+    _ProviderPattern("stripe", re.compile(r"\b(?:[sr]k_(?:live|test)|whsec)_[A-Za-z0-9]{16,}\b")),
+    _ProviderPattern("openai", re.compile(r"\bsk-(?:proj-|svcacct-|admin-|org-)?[A-Za-z0-9_-]{20,}\b")),
+    _ProviderPattern("aws", re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")),
+    _ProviderPattern(
+        "github",
+        re.compile(r"\b(?:gh[opusr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}_[A-Za-z0-9_]{20,})\b"),
+    ),
+    _ProviderPattern("slack", re.compile(r"\bxox[baprs]-(?:[A-Za-z0-9]+-){1,}[A-Za-z0-9]{16,}\b")),
+    _ProviderPattern("google", re.compile(r"\bAIza[A-Za-z0-9_-]{32,}\b")),
+    _ProviderPattern("gitlab", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b")),
+    _ProviderPattern("sendgrid", re.compile(r"\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{32,}\b")),
+)
+
+_SECRET_LABEL_RE = re.compile(
+    r"(?P<prefix>\b[A-Za-z0-9_.-]*(?:key|token|secret|password|api|auth|access)[A-Za-z0-9_.-]*\b\s*[=:]\s*)"
+    r"(?P<quote>[\"']?)"
+    rf"(?P<value>[A-Za-z0-9_./+=:-]{{{MIN_ENTROPY_TOKEN_LENGTH},}})"
+    r"(?P=quote)",
+    re.IGNORECASE,
+)
+_TOKEN_RE = re.compile(r"\b[A-Za-z0-9_./+=:-]{24,}\b")
+_HEX_RE = re.compile(r"\b[0-9a-fA-F]{16,}\b")
+_UUID_RE = re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b")
+
+
+def scrub_secrets(text: str) -> SecretScrubResult:
+    """Redact labeled secrets before persistence while preserving join-key-like tokens."""
+    if not text:
+        return SecretScrubResult(text=text)
+
+    windows = list(_scan_windows(text))
+    spans: list[SecretRedaction] = []
+    for start, end in windows:
+        spans.extend(_provider_redactions(text[start:end], offset=start))
+    for start, end in windows:
+        spans.extend(_assignment_redactions(text[start:end], spans, offset=start))
+    spans = _without_overlaps(sorted(spans, key=lambda item: (item.start, item.end)))
+
+    scrubbed = _apply_redactions(text, spans) if spans else text
+    quarantine: list[QuarantinedToken] = []
+    for start, end in windows:
+        quarantine.extend(_quarantine_unlabeled_entropy(text[start:end], spans, offset=start))
+    quarantine = _without_duplicate_quarantine(sorted(quarantine, key=lambda item: (item.start, item.end)))
+    return SecretScrubResult(text=scrubbed, redactions=spans, quarantine=quarantine)
+
+
+def _scan_windows(text: str) -> list[tuple[int, int]]:
+    if len(text) <= MAX_SCAN_BYTES:
+        return [(0, len(text))]
+    windows: list[tuple[int, int]] = []
+    start = 0
+    while start < len(text):
+        end = min(len(text), start + MAX_SCAN_BYTES)
+        windows.append((start, end))
+        if end == len(text):
+            break
+        start = max(end - WINDOW_OVERLAP_CHARS, start + 1)
+    return windows
+
+
+def _provider_redactions(text: str, *, offset: int = 0) -> list[SecretRedaction]:
+    redactions: list[SecretRedaction] = []
+    for provider_pattern in _PROVIDER_PATTERNS:
+        placeholder = f"[REDACTED:{provider_pattern.provider}]"
+        for match in provider_pattern.regex.finditer(text):
+            redactions.append(
+                SecretRedaction(
+                    provider=provider_pattern.provider,
+                    original=match.group(0),
+                    placeholder=placeholder,
+                    start=offset + match.start(),
+                    end=offset + match.end(),
+                )
+            )
+    return redactions
+
+
+def _assignment_redactions(text: str, existing: list[SecretRedaction], *, offset: int = 0) -> list[SecretRedaction]:
+    redactions: list[SecretRedaction] = []
+    for match in _SECRET_LABEL_RE.finditer(text):
+        value = match.group("value").rstrip(".,;)")
+        value_start = offset + match.start("value")
+        value_end = value_start + len(value)
+        if _span_overlaps(value_start, value_end, existing):
+            continue
+        if _is_join_key_like(value):
+            continue
+        if _looks_like_path_or_url(value):
+            continue
+        if not _is_high_entropy(value):
+            continue
+        redactions.append(
+            SecretRedaction(
+                provider="assignment",
+                original=value,
+                placeholder="[REDACTED:assignment]",
+                start=value_start,
+                end=value_end,
+            )
+        )
+    return redactions
+
+
+def _quarantine_unlabeled_entropy(
+    text: str, redactions: list[SecretRedaction], *, offset: int = 0
+) -> list[QuarantinedToken]:
+    quarantined: list[QuarantinedToken] = []
+    for match in _TOKEN_RE.finditer(text):
+        value = match.group(0).strip(".,;)")
+        start = offset + match.start()
+        end = start + len(value)
+        if _span_overlaps(start, end, redactions):
+            continue
+        if _is_join_key_like(value):
+            continue
+        if _looks_like_path_or_url(value):
+            continue
+        if _is_high_entropy(value):
+            quarantined.append(QuarantinedToken(value=value, start=start, end=end))
+    return quarantined
+
+
+def _without_overlaps(redactions: list[SecretRedaction]) -> list[SecretRedaction]:
+    kept: list[SecretRedaction] = []
+    for redaction in redactions:
+        if not _span_overlaps(redaction.start, redaction.end, kept):
+            kept.append(redaction)
+    return kept
+
+
+def _without_duplicate_quarantine(quarantine: list[QuarantinedToken]) -> list[QuarantinedToken]:
+    kept: list[QuarantinedToken] = []
+    for token in quarantine:
+        if not any(token.start < kept_token.end and token.end > kept_token.start for kept_token in kept):
+            kept.append(token)
+    return kept
+
+
+def _apply_redactions(text: str, redactions: list[SecretRedaction]) -> str:
+    parts: list[str] = []
+    cursor = 0
+    for redaction in redactions:
+        parts.append(text[cursor : redaction.start])
+        parts.append(redaction.placeholder)
+        cursor = redaction.end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _span_overlaps(start: int, end: int, spans: list[SecretRedaction]) -> bool:
+    return any(start < span.end and end > span.start for span in spans)
+
+
+def _is_join_key_like(value: str) -> bool:
+    return bool(_UUID_RE.fullmatch(value) or _HEX_RE.fullmatch(value))
+
+
+def _looks_like_path_or_url(value: str) -> bool:
+    return "/" in value or "\\" in value or "://" in value
+
+
+def _is_high_entropy(value: str) -> bool:
+    if len(value) < MIN_ENTROPY_TOKEN_LENGTH:
+        return False
+    return _shannon_entropy(value) >= ENTROPY_THRESHOLD
+
+
+def _shannon_entropy(value: str) -> float:
+    counts = {character: value.count(character) for character in set(value)}
+    length = len(value)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -30,6 +30,7 @@ from .paths import get_db_path
 from .pipeline.chunk import chunk_content
 from .pipeline.classify import classify_content
 from .pipeline.correction_detection import build_correction_tags
+from .pipeline.secret_scrub import scrub_secrets
 from .queue_io import enqueue_watcher_chunk
 from .vector_store import VectorStore
 
@@ -358,6 +359,8 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
 
             for chunk in chunks:
                 clean_content = _strip_system_reminders(chunk.content)
+                secret_scrub_result = scrub_secrets(clean_content)
+                clean_content = secret_scrub_result.text
                 content_hash = normalized_exact_hash(clean_content)[:16]
                 file_stem = Path(source_file).stem
                 chunk_id = f"rt-{file_stem[:8]}-{content_hash}"
@@ -374,6 +377,12 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
 
                 conversation_id = chunk.metadata.get("session_id") or file_stem
                 metadata = dict(chunk.metadata)
+                if secret_scrub_result.redactions:
+                    metadata["secret_scrub_redactions"] = sorted(
+                        {redaction.provider for redaction in secret_scrub_result.redactions}
+                    )
+                if secret_scrub_result.quarantine:
+                    metadata["secret_scrub_quarantine_count"] = len(secret_scrub_result.quarantine)
                 if claude_conversation_id:
                     metadata["claude_conversation_id"] = claude_conversation_id
                 tags = None

--- a/tests/test_secret_scrub.py
+++ b/tests/test_secret_scrub.py
@@ -1,0 +1,178 @@
+"""Gate tests for the go-forward secret scrubber."""
+
+from __future__ import annotations
+
+import pytest
+
+from brainlayer.pipeline.secret_scrub import MAX_SCAN_BYTES, scrub_secrets
+
+
+def _secret(*parts: str) -> str:
+    return "".join(parts)
+
+
+LABELED_PROVIDER_SECRETS = [
+    # openai
+    _secret("sk-", "proj-", "a" * 48),
+    _secret("sk-", "a" * 48),
+    _secret("sk-", "svcacct-", "a" * 40),
+    _secret("sk-", "admin-", "a" * 40),
+    _secret("sk-", "org-", "a" * 40),
+    # anthropic
+    _secret("sk-", "ant-", "api03-", "a" * 80),
+    _secret("sk-", "ant-", "admin01-", "a" * 64),
+    _secret("sk-", "ant-", "oat01-", "a" * 64),
+    _secret("sk-", "ant-", "sid01-", "a" * 64),
+    _secret("sk-", "ant-", "a" * 56),
+    # aws
+    _secret("AK", "IA", "I" * 16),
+    _secret("AS", "IA", "J" * 16),
+    _secret("AK", "IA", "X" * 16),
+    _secret("AS", "IA", "Y" * 16),
+    _secret("AK", "IA", "1234567890ABCDEF"),
+    # github
+    _secret("gh", "p_", "a" * 36),
+    _secret("gh", "o_", "a" * 36),
+    _secret("gh", "u_", "a" * 36),
+    _secret("gh", "s_", "a" * 36),
+    _secret("gh", "r_", "a" * 36),
+    _secret("github", "_pat_", "11AAAAAAAA0", "a" * 22, "_", "a" * 64),
+    # slack
+    _secret("xox", "b-", "1" * 12, "-", "2" * 12, "-", "a" * 24),
+    _secret("xox", "p-", "1" * 12, "-", "2" * 12, "-", "3" * 12, "-", "a" * 32),
+    _secret("xox", "a-", "1" * 12, "-", "2" * 12, "-", "3" * 12, "-", "a" * 32),
+    _secret("xox", "r-", "1" * 12, "-", "2" * 12, "-", "3" * 12, "-", "a" * 32),
+    _secret("xox", "s-", "1" * 12, "-", "2" * 12, "-", "3" * 12, "-", "a" * 32),
+    # google
+    _secret("AI", "za", "Sy", "A" * 35),
+    _secret("AI", "za", "A" * 36),
+    _secret("AI", "za", "Sy", "B" * 35),
+    _secret("AI", "za", "Sy", "C" * 35),
+    _secret("AI", "za", "Sy", "D" * 35),
+    # gitlab
+    _secret("gl", "pat-", "a" * 20),
+    _secret("gl", "pat-", "b" * 20),
+    _secret("gl", "pat-", "c" * 20),
+    _secret("gl", "pat-", "d" * 20),
+    _secret("gl", "pat-", "e" * 20),
+    # stripe
+    _secret("sk", "_live_", "a" * 24),
+    _secret("sk", "_test_", "a" * 24),
+    _secret("rk", "_live_", "a" * 24),
+    _secret("rk", "_test_", "a" * 24),
+    _secret("wh", "sec_", "a" * 32),
+    # sendgrid
+    _secret("S", "G.", "a" * 22, ".", "a" * 43),
+    _secret("S", "G.", "b" * 22, ".", "b" * 43),
+    _secret("S", "G.", "c" * 22, ".", "c" * 43),
+    _secret("S", "G.", "d" * 22, ".", "d" * 43),
+    _secret("S", "G.", "e" * 22, ".", "e" * 43),
+    _secret("S", "G.", "f" * 22, ".", "f" * 43),
+    _secret("S", "G.", "g" * 22, ".", "g" * 43),
+]
+
+
+BENIGN_BLOCKS = [
+    "/Users/etanheyman/Gits/brainlayer.wt/p1-5-scrubber/src/brainlayer/watcher_bridge.py",
+    "session_id=550e8400-e29b-41d4-a716-446655440000 should stay joinable",
+    "conversation_id: 123e4567-e89b-12d3-a456-426614174000",
+    "chunk_id rt-abcdef12-1234567890abcdef is not a secret",
+    "trace_id=018f9f0a-d8f2-7c41-bb28-7f14a8a8924f",
+    "node_modules/@scope/package-name/dist/index.js",
+    "src/brainlayer/pipeline/secret_scrub.py",
+    "normalized_exact_hash(clean_content)[:16]",
+    "commit 8f14e45fceea167a5a36dedd4bea2543b17fb2d7",
+    "object id 0123456789abcdef0123456789abcdef",
+    "tmp path /var/folders/ab/cdefghijklmn/T/session-0d3f7f7c",
+    "codex session agent-a97fea32fbaeb2961.jsonl",
+    "BRAINLAYER_WATCHER_WRITE_DEADLINE_S=15.0",
+    "https://github.com/EtanHey/brainlayer/pull/123",
+    "symbol _extract_claude_conversation_id",
+    "api_path = /Users/etanheyman/Gits/brainlayer.wt/p1-5-scrubber/session-a97fea32fbaeb2961.jsonl",
+] * 67
+
+
+def test_labeled_provider_secret_recall_gate_is_perfect():
+    text = "\n".join(f"token {idx}: {secret}" for idx, secret in enumerate(LABELED_PROVIDER_SECRETS))
+
+    result = scrub_secrets(text)
+
+    leaked = [secret for secret in LABELED_PROVIDER_SECRETS if secret in result.text]
+    redaction_recall = (len(LABELED_PROVIDER_SECRETS) - len(leaked)) / len(LABELED_PROVIDER_SECRETS)
+    assert redaction_recall == 1.0
+    assert len(result.redactions) == len(LABELED_PROVIDER_SECRETS)
+    assert not leaked
+
+
+def test_benign_corpus_over_redaction_gate_is_at_most_point_one_percent():
+    changed_blocks = 0
+
+    for block in BENIGN_BLOCKS:
+        result = scrub_secrets(block)
+        if result.text != block:
+            changed_blocks += 1
+
+    over_redaction_rate = changed_blocks / len(BENIGN_BLOCKS)
+    assert over_redaction_rate <= 0.001
+
+
+def test_label_gated_entropy_redacts_assignment_value():
+    value = "mF9qP2xL7vR8sK4nT6yB3cD5eG7hJ9kL2mN4pQ6r"
+
+    result = scrub_secrets(f"api_key = {value}")
+
+    assert value not in result.text
+    assert result.text == "api_key = [REDACTED:assignment]"
+    assert result.redactions[0].provider == "assignment"
+
+
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        "session_id = 550e8400-e29b-41d4-a716-446655440000",
+        "access_token = 0123456789abcdef0123456789abcdef",
+    ],
+)
+def test_label_gated_entropy_skips_uuid_and_hex_join_keys(assignment):
+    result = scrub_secrets(assignment)
+
+    assert result.text == assignment
+    assert result.redactions == []
+
+
+def test_label_gated_entropy_skips_file_paths():
+    assignment = "api_path = /Users/etanheyman/Gits/brainlayer.wt/p1-5-scrubber/session-a97fea32fbaeb2961.jsonl"
+
+    result = scrub_secrets(assignment)
+
+    assert result.text == assignment
+    assert result.redactions == []
+
+
+def test_unlabeled_high_entropy_token_is_quarantined_but_not_redacted():
+    token = "mF9qP2xL7vR8sK4nT6yB3cD5eG7hJ9kL2mN4pQ6r"
+
+    result = scrub_secrets(f"Observed opaque id {token} in the path")
+
+    assert token in result.text
+    assert result.redactions == []
+    assert [item.value for item in result.quarantine] == [token]
+
+
+def test_large_input_scans_past_first_window_without_leaking_tail_secrets():
+    secret = _secret("gl", "pat-", "a" * 20)
+    text = ("x" * (MAX_SCAN_BYTES + 512)) + " " + secret
+
+    result = scrub_secrets(text)
+
+    assert secret not in result.text
+    assert result.text.endswith("[REDACTED:gitlab]")
+
+
+def test_large_input_deduplicates_quarantine_from_window_overlap():
+    token = "mF9qP2xL7vR8sK4nT6yB3cD5eG7hJ9kL2mN4pQ6r"
+    text = ("x" * (MAX_SCAN_BYTES - 100)) + f" {token} " + ("x" * 700)
+
+    result = scrub_secrets(text)
+
+    assert [item.value for item in result.quarantine] == [token]

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -16,6 +16,7 @@ import time
 
 import apsw
 
+from brainlayer.dedupe import normalized_exact_hash
 from brainlayer.vector_store import VectorStore
 from brainlayer.watcher import JSONLTailer, JSONLWatcher, default_watch_roots
 from brainlayer.watcher_bridge import (
@@ -169,6 +170,32 @@ class TestProjectExtraction:
 
 
 class TestFlushCallback:
+    def test_flush_scrubs_secrets_before_hash_and_persistence(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "test.db"
+        queue_dir = tmp_path / "queue"
+        VectorStore(db_path).close()
+        monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+
+        secret = "sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        raw_text = f"{_LONG_TEXT}. Provider token: {secret}"
+        scrubbed_text = raw_text.replace(secret, "[REDACTED:anthropic]")
+        source_file = tmp_path / "projects" / "-Users-test-Gits-myproject" / "session.jsonl"
+        flush = create_flush_callback(db_path, arbitrated=True)
+        entry = _make_jsonl_entry(text=raw_text, entry_type="assistant")
+        entry["_source_file"] = str(source_file)
+
+        inserted = flush([entry])
+
+        queued_files = list(queue_dir.glob("watcher-*.jsonl"))
+        queued = json.loads(queued_files[0].read_text(encoding="utf-8"))
+        expected_hash = normalized_exact_hash(scrubbed_text)[:16]
+        raw_hash = normalized_exact_hash(raw_text)[:16]
+        assert inserted == 1
+        assert queued["content"] == scrubbed_text
+        assert secret not in queued["content"]
+        assert queued["chunk_id"] == f"rt-session-{expected_hash}"
+        assert queued["chunk_id"] != f"rt-session-{raw_hash}"
+
     def test_arbitrated_flush_enqueues_watcher_chunks_without_db_write(self, tmp_path, monkeypatch):
         db_path = tmp_path / "test.db"
         queue_dir = tmp_path / "queue"


### PR DESCRIPTION
## Summary
- Add `brainlayer.pipeline.secret_scrub` as a separate two-mode go-forward secret scrubber.
- Wire it into `watcher_bridge` after `_strip_system_reminders()` and before `normalized_exact_hash()`, so scrubbed content is hashed and persisted before any DB write lock.
- Keep unlabeled high-entropy tokens fail-open: they are quarantined in scrubber output and surfaced as metadata count, but the original bytes are preserved.

## Why two-mode
Over-redaction destroys file paths, UUIDs, session ids, and other join keys. This PR only fail-closed redacts:
- provider-prefix families: OpenAI, Anthropic, AWS, GitHub, Slack, Google, GitLab, Stripe, SendGrid
- high-entropy values inside label-gated assignment contexts (`key|token|secret|password|api|auth|access [=:] <value>`), with UUID/hex/path skips

Unlabeled high-entropy tokens stay fail-open/quarantine-only by design.

## Gate metrics
Computed from `tests/test_secret_scrub.py` frozen fixtures:
```text
labeled_secret_count=48
redacted_count=48
redaction_recall=1.000000
benign_block_count=1072
changed_benign_blocks=0
over_redaction_rate=0.000000%
```

## Test plan
- `pytest tests/test_secret_scrub.py tests/test_watcher_bridge.py` -> 49 passed, 1 warning
- `ruff check src/ && ruff format src/` -> All checks passed; 156 files left unchanged
- `pytest` -> 3430 passed, 49 skipped, 5 xfailed, 329 warnings in 511.90s
- Pre-push changed-only gate -> 49 touched tests passed; MCP registration 3 passed; isolated eval/hook routing 40 passed; Bun stale-index test passed; FTS5 regression shell passed

## Review notes
- Initial local CodeRabbit found two MAJOR issues: raw tail after scan cap and assignment regex length mismatch. Both were fixed with bounded sliding windows and regex/entropy length alignment.
- Second local CodeRabbit found one MINOR issue: duplicate quarantine entries from overlap windows. Fixed with quarantine span dedupe.
- Final local CodeRabbit rerun was rate-limited (`waitTime=26 minutes`), so PR-level CodeRabbit review is explicitly requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted chunk content and dedupe identity (hash-based chunk_id); scrubber heuristics could miss novel secret formats or rarely mis-redact labeled assignments despite gate tests.
> 
> **Overview**
> Adds **`brainlayer.pipeline.secret_scrub`** with a two-mode policy: known provider token shapes and label-gated high-entropy assignment values are replaced with `[REDACTED:…]` placeholders; bare high-entropy strings are only **quarantined** (metadata count), not altered. Large text uses overlapping scan windows so secrets past the 128KB cap are still caught.
> 
> **`watcher_bridge`** runs `scrub_secrets` after system-reminder stripping and **before** `normalized_exact_hash`, so queued/DB content and **`chunk_id`** reflect scrubbed text. Chunk metadata gains `secret_scrub_redactions` and `secret_scrub_quarantine_count` when applicable.
> 
> Gate tests cover provider recall, benign over-redaction, assignment/path/UUID skips, and integration that secrets never land in the queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ff04971fc7ee59404b22959473781bf895ce7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add label-gated secret scrubber to pipeline with provider pattern matching
> - Adds [`scrub_secrets`](https://github.com/EtanHey/brainlayer/pull/563/files#diff-504e1098dcc334832df1fd0bc7ac68982a31892c7b3c56ef402bee51473b1eb2) to detect and redact secrets in text using two strategies: provider-pattern matching (Anthropic, Stripe, OpenAI, AWS, GitHub, Slack, Google, GitLab, SendGrid) and label-gated entropy scanning for assignment expressions (`key=`, `token=`, `secret=`, etc.).
> - High-entropy tokens that don't match a label or provider pattern are collected into a quarantine list rather than redacted, allowing callers to inspect them separately.
> - Integrates scrubbing into [`watcher_bridge.py`](https://github.com/EtanHey/brainlayer/pull/563/files#diff-9c9df603fa7a5ecf5cdb0da9ab4077d520d812083da4b052847100f2874f60c9) so chunk content is scrubbed before hashing and persistence; chunk metadata is augmented with `secret_scrub_redactions` (provider labels) and `secret_scrub_quarantine_count`.
> - Uses overlapping window scanning to avoid missing secrets at chunk boundaries for large inputs.
> - Risk: chunk IDs now reflect the scrubbed content hash rather than raw content, which is a breaking change for deduplication of previously ingested chunks.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a3ff049. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic secret scrubbing for stored text, redacting recognized secrets and quarantining suspicious high-entropy tokens for review.
  * Secret-scrub status is now carried in chunk metadata during persistence and processing.

* **Bug Fixes**
  * Improved handling of large inputs so secrets are detected beyond the first scan window.
  * Reduced duplicate quarantine entries caused by overlapping scans.

* **Tests**
  * Added coverage for secret redaction, benign-text false positives, quarantine behavior, and persistence safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->