### PR TITLE
test: lock brain-worker subagent denylist coverage (Etan flag)

### DIFF
--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -20,3 +20,33 @@ def test_default_denylist_is_segment_scoped(monkeypatch, tmp_path):
 
     assert not is_denylisted(tmp_path / ".claude" / "projects" / "proj" / "direct-session.jsonl")
     assert is_denylisted(Path(tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "worker.jsonl"))
+
+
+def test_brain_worker_subagent_transcript_is_denylisted(monkeypatch, tmp_path):
+    """Regression (Etan flag 2026-07-03): the brain-worker off-grid recon subagent
+    (~/.claude/agents/brain-worker.md) writes its session JSONL like every Agent-tool
+    subagent — under a `subagents/` dir — so it MUST be in the agent-output exclusion set.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    projects = tmp_path / ".claude" / "projects"
+
+    # brain-worker (and any Agent-tool subagent) transcript path
+    assert is_denylisted(
+        projects / "-Users-etanheyman-Gits-brainlayer" / "session-uuid" / "subagents" / "agent-a25d6b3aa6880db8e.jsonl"
+    )
+    # workflow subagents nested a level deeper still excluded
+    assert is_denylisted(
+        projects / "-Users-x" / "session-uuid" / "subagents" / "workflows" / "wf_c83ce37d" / "agent-x.jsonl"
+    )
+
+
+def test_direct_control_transcripts_still_ingest(monkeypatch, tmp_path):
+    """Regression (Etan flag 2026-07-03): DIRECT/CONTROL transcripts — a lead's or a
+    top-level worker's own reasoning session — are NOT agent-output roots and MUST keep
+    ingesting. The denylist targets agent-OUTPUT paths only, never direct sessions.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    projects = tmp_path / ".claude" / "projects"
+
+    assert not is_denylisted(projects / "-Users-etanheyman-Gits-brainlayer" / "4220c177-8816-446d.jsonl")
+    assert not is_denylisted(projects / "-Users-x" / "session-uuid" / "session-uuid.jsonl")


### PR DESCRIPTION
## Why
Etan flagged (2026-07-03, via orc) a **possible gap**: is the new `brain-worker` off-grid recon subagent transcript path covered by the #562 BL-10 denylist?

## Verification (done, no gap found)
`brain-worker` is `~/.claude/agents/brain-worker.md` — an Agent-tool subagent. Like every Agent-tool subagent, it writes its session JSONL under a `subagents/` dir (`~/.claude/projects/<proj>/<session>/subagents/agent-<id>.jsonl`). Ran the merged `is_denylisted()` against real on-disk paths:

| Path | Result |
|---|---|
| brain-worker subagent transcript | **DENYLISTED** ✓ |
| nested workflow under `subagents/workflows/wf_*` | **DENYLISTED** ✓ |
| codex worker session | **DENYLISTED** ✓ |
| DIRECT lead/user session | **INGEST** ✓ |

So the existing `~/.claude/projects/*/**/subagents/**` glob already covers brain-worker — **no new glob needed**.

## What this PR does
Test-only. Adds two **named regression tests** so the coverage is locked on-record against future drift:
- `test_brain_worker_subagent_transcript_is_denylisted` — brain-worker + nested-workflow subagent paths are excluded.
- `test_direct_control_transcripts_still_ingest` — DIRECT/CONTROL (lead/worker reasoning) sessions **keep ingesting** (Etan item 1b: denylist is agent-OUTPUT roots only).

No source change; behavior already correct on main since #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds tests; ingest denylist behavior is unchanged.
> 
> **Overview**
> **Test-only PR** — no production changes. Adds two named regression tests in `tests/test_ingest_denylist.py` after an Etan flag that asked whether `brain-worker` subagent transcript paths are covered by the BL-10 denylist.
> 
> `test_brain_worker_subagent_transcript_is_denylisted` asserts that paths under `.../subagents/` (including brain-worker and nested `subagents/workflows/wf_*`) are **denylisted**. `test_direct_control_transcripts_still_ingest` asserts that top-level lead/worker session JSONL files **are not** denylisted and should keep ingesting. Together they document that agent-output roots are excluded while DIRECT/CONTROL sessions are not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d005f20121228c764bbbb6373d579b453d7d9f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add regression tests for `is_denylisted` coverage of brain-worker subagent transcripts
> Adds two regression tests in [test_ingest_denylist.py](https://github.com/EtanHey/brainlayer/pull/564/files#diff-4dae57a4e433e47812dc62d976d45a9d6c71c1f7c3b6b0c72467e85cae57dc11) to lock denylist behavior for Claude agent transcript paths.
>
> - `test_brain_worker_subagent_transcript_is_denylisted`: asserts `is_denylisted` returns `True` for paths under `.claude/projects/<project>/session-uuid/subagents/`, including nested `subagents/workflows/<wf_id>/` paths.
> - `test_direct_control_transcripts_still_ingest`: asserts `is_denylisted` returns `False` for transcript files directly under `.claude/projects/<project>/` with no `subagents/` segment.
>
> Both tests use a tmp `HOME` path to isolate filesystem state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d005f20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->