### PR TITLE
feat: add weighted RRF and opt-in rerank

### DIFF
--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -35,6 +35,7 @@ from .scoping import ConsumerScope
 # - Copy-on-read: callers enrich and mutate result metadata after search.
 _HYBRID_CACHE_TTL = 60.0  # seconds
 _HYBRID_CACHE_MAX = 128  # max entries (LRU eviction)
+RRF_VECTOR_ALPHA = 0.25
 _MMR_CANDIDATE_LIMIT = 50
 _DEFAULT_MMR_LAMBDA = 0.7
 try:
@@ -304,6 +305,8 @@ def _hybrid_cache_key(
     include_audit: bool = False,
     include_operational: bool = False,
     content_class_filter: Optional[str] = None,
+    recency_rerank: bool = False,
+    importance_rerank: bool = False,
 ) -> tuple:
     return (
         store_key,
@@ -329,6 +332,8 @@ def _hybrid_cache_key(
         include_audit,
         include_operational,
         normalize_content_class(content_class_filter) if content_class_filter else None,
+        recency_rerank,
+        importance_rerank,
     )
 
 
@@ -1743,6 +1748,9 @@ class SearchMixin:
         profile_scope: str = "search.repo",
         brainbar_helper_fast_profile: bool = False,
         consumer_scope: ConsumerScope | None = None,
+        *,
+        recency_rerank: bool = False,
+        importance_rerank: bool = False,
     ) -> Dict[str, List]:
         """Hybrid search combining semantic (vector) + keyword (FTS5) via Reciprocal Rank Fusion.
 
@@ -1787,6 +1795,8 @@ class SearchMixin:
             include_audit,
             include_operational,
             content_class_filter,
+            recency_rerank,
+            importance_rerank,
         ) + (
             fts_query_override,
             kg_boost,
@@ -2114,7 +2124,7 @@ class SearchMixin:
         _ingest_keyword_rows(trigram_fts_results, trigram_ranks)
 
         recency_intent = _has_recency_intent(query_text)
-        if recency_intent and not date_from:
+        if recency_rerank and recency_intent and not date_from:
             recent_extra = []
             recent_params: list = []
             project_clause, project_params = _project_scope_where("project", project_filter, consumer_scope)
@@ -2269,13 +2279,14 @@ class SearchMixin:
             sem_entry = semantic_by_id.get(cid)
             fts_rank = fts_ranks.get(cid)
             trigram_rank = trigram_ranks.get(cid)
+            lexical_leg_weight = 1.0 - RRF_VECTOR_ALPHA
 
             if sem_entry is not None:
-                score += 1.0 / (k + sem_entry["rank"])
+                score += RRF_VECTOR_ALPHA / (k + sem_entry["rank"])
             if fts_rank is not None:
-                score += 1.0 / (k + fts_rank)
+                score += lexical_leg_weight / (k + fts_rank)
             if trigram_rank is not None:
-                score += 1.0 / (k + trigram_rank)
+                score += lexical_leg_weight / (k + trigram_rank)
 
             # Get data — prefer semantic (has distance)
             if sem_entry is not None:
@@ -2358,7 +2369,7 @@ class SearchMixin:
             if stored_profile:
                 agent_profile = stored_profile["profile"]
 
-        # Post-RRF boost: importance and recency adjustments
+        # Post-RRF boost: optional importance and recency adjustments
         now = datetime.now(timezone.utc)
         for i, (score, cid, doc, meta, dist) in enumerate(scored):
             boost = 1.0
@@ -2368,13 +2379,13 @@ class SearchMixin:
 
             # Importance boost: scale 0-10 → 1.0-1.5x multiplier
             imp = meta.get("importance")
-            if imp is not None and isinstance(imp, (int, float)):
+            if importance_rerank and imp is not None and isinstance(imp, (int, float)):
                 importance_boost = 1.0 + min(max(float(imp), 0), 10) / 20.0
                 boost *= _profiled_multiplier(importance_boost, agent_profile, "importance")
 
             # Recency boost: exponential decay with 30-day half-life
             created = meta.get("created_at")
-            if created and isinstance(created, str):
+            if recency_rerank and created and isinstance(created, str):
                 try:
                     dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
                     if dt.tzinfo is None:

--- a/tests/test_agent_profiles.py
+++ b/tests/test_agent_profiles.py
@@ -155,7 +155,7 @@ def test_hybrid_search_agent_profile_applies_orc_weights(tmp_path: Path) -> None
         store._trigram_fts_available = False
         store.set_agent_profile(
             "orcClaude",
-            {"boost_weights": {"fts": 3.0, "vector": 0.5}},
+            {"boost_weights": {"fts": 0.25, "vector": 4.0}},
             notes="test profile",
         )
         _hybrid_cache.clear()
@@ -177,8 +177,8 @@ def test_hybrid_search_agent_profile_applies_orc_weights(tmp_path: Path) -> None
         store.close()
         _hybrid_cache.clear()
 
-    assert default_results["ids"][0][0] == "vector-only"
-    assert profiled_results["ids"][0][0] == "fts-only"
+    assert default_results["ids"][0][0] == "fts-only"
+    assert profiled_results["ids"][0][0] == "vector-only"
 
 
 def test_hybrid_search_agent_profile_scales_recency_intent_neutral_point(monkeypatch, tmp_path: Path) -> None:
@@ -223,6 +223,7 @@ def test_hybrid_search_agent_profile_scales_recency_intent_neutral_point(monkeyp
             query_text="latest needle phrase",
             n_results=2,
             agent_id="recencyTest",
+            recency_rerank=True,
         )
     finally:
         store.close()

--- a/tests/test_consumer_scoping.py
+++ b/tests/test_consumer_scoping.py
@@ -458,6 +458,7 @@ def test_coach_consumer_scope_uses_personal_lane_and_recency_checkpoints(store):
         query_text="latest coach personal checkpoint",
         n_results=5,
         consumer_scope=ConsumerScope.for_coach(),
+        recency_rerank=True,
     )
 
     assert _ids(results)[:2] == ["new-personal-checkpoint", "old-personal-checkpoint"]

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,13 +1,21 @@
 """Tests for binary-quantized RRF hybrid search."""
 
 import json
+import math
 import uuid
+from datetime import datetime, timezone
 
 import apsw
 import pytest
 
+import brainlayer.search_repo as search_repo
 from brainlayer._helpers import serialize_f32
-from brainlayer.search_repo import _contains_precompact_or_quarantined_meta, _has_recency_intent, _hybrid_cache
+from brainlayer.search_repo import (
+    RRF_VECTOR_ALPHA,
+    _contains_precompact_or_quarantined_meta,
+    _has_recency_intent,
+    _hybrid_cache,
+)
 from brainlayer.vector_store import VectorStore
 
 
@@ -196,6 +204,114 @@ class TestHybridSearch:
         ids = results["ids"][0]
         assert ids[0] == "both", ids
         assert set(ids) == {"both", "fts-only", "vec-only"}
+
+    def test_hybrid_search_weighted_rrf_uses_vector_alpha(self, store, monkeypatch):
+        query_embedding = _embed("weighted rrf alpha control")
+        _insert_chunk(
+            store,
+            chunk_id="vector-only",
+            content="semantic neighbor without lexical tokens",
+            embedding=query_embedding,
+        )
+        _insert_chunk(
+            store,
+            chunk_id="lexical-only",
+            content="weighted rrf alpha control exact keyword hit",
+            embedding=_embed("distant lexical"),
+        )
+        store.build_binary_index()
+        monkeypatch.setattr(store, "_trigram_fts_available", False)
+
+        results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="weighted rrf alpha control",
+            n_results=2,
+        )
+
+        assert 0.0 < RRF_VECTOR_ALPHA < 0.5
+        assert results["ids"][0] == ["lexical-only", "vector-only"]
+
+    def test_hybrid_search_default_does_not_apply_recency_or_importance_boost(self, store, monkeypatch):
+        monkeypatch.setattr(search_repo, "RRF_VECTOR_ALPHA", 0.5)
+        query_embedding = _embed("neutral rerank evidence")
+        _insert_chunk(
+            store,
+            chunk_id="old-important",
+            content="neutral rerank evidence padded old important exact hit with extra words",
+            embedding=query_embedding,
+            importance=10.0,
+            created_at="2020-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="fresh-low",
+            content="neutral rerank evidence",
+            embedding=[value + 0.00001 for value in query_embedding],
+            importance=0.0,
+            created_at="2999-01-01T00:00:00Z",
+        )
+        store.build_binary_index()
+        monkeypatch.setattr(store, "_trigram_fts_available", False)
+        captured_scores: dict[str, float] = {}
+
+        def capture_scores(scored, *, n_results):
+            captured_scores.update({chunk_id: score for score, chunk_id, *_rest in scored})
+            return scored
+
+        monkeypatch.setattr(store, "_mmr_rerank_scored_results", capture_scores)
+
+        store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="neutral rerank evidence",
+            n_results=2,
+        )
+
+        assert captured_scores["old-important"] == pytest.approx(captured_scores["fresh-low"])
+
+    def test_hybrid_search_opt_in_recency_and_importance_rerank_change_scores(self, store, monkeypatch):
+        monkeypatch.setattr(search_repo, "RRF_VECTOR_ALPHA", 0.5)
+        query_embedding = _embed("opt in rerank evidence")
+        _insert_chunk(
+            store,
+            chunk_id="old-important",
+            content="opt in rerank evidence padded old important exact hit with extra words",
+            embedding=query_embedding,
+            importance=10.0,
+            created_at="2020-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="fresh-low",
+            content="opt in rerank evidence",
+            embedding=[value + 0.00001 for value in query_embedding],
+            importance=0.0,
+            created_at="2999-01-01T00:00:00Z",
+        )
+        store.build_binary_index()
+        monkeypatch.setattr(store, "_trigram_fts_available", False)
+        captured_scores: dict[str, float] = {}
+
+        def capture_scores(scored, *, n_results):
+            captured_scores.update({chunk_id: score for score, chunk_id, *_rest in scored})
+            return scored
+
+        monkeypatch.setattr(store, "_mmr_rerank_scored_results", capture_scores)
+
+        store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="opt in rerank evidence",
+            n_results=2,
+            recency_rerank=True,
+            importance_rerank=True,
+        )
+
+        base_rrf = 0.5 / 60.0 + 0.5 / 61.0
+        old_age_days = (
+            datetime.now(timezone.utc) - datetime.fromisoformat("2020-01-01T00:00:00+00:00")
+        ).total_seconds() / 86400
+        old_recency_boost = 0.7 + 0.3 * math.exp(-0.023 * old_age_days)
+        assert captured_scores["old-important"] == pytest.approx(base_rrf * 1.5 * old_recency_boost)
+        assert captured_scores["fresh-low"] == pytest.approx(base_rrf)
 
     def test_hybrid_search_fts_only_fallback(self, store):
         _insert_chunk(
@@ -510,6 +626,7 @@ class TestHybridSearch:
             query_text="latest work",
             n_results=5,
             entity_id="person-a",
+            recency_rerank=True,
         )
 
         assert "recent-a" in results["ids"][0]
@@ -539,6 +656,7 @@ class TestHybridSearch:
             query_text="latest work",
             n_results=5,
             sentiment_filter="positive",
+            recency_rerank=True,
         )
 
         assert "recent-positive" in results["ids"][0]
@@ -572,6 +690,7 @@ class TestHybridSearch:
             query_text="latest work",
             n_results=5,
             content_type_filter="ai_code",
+            recency_rerank=True,
         )
 
         assert "recent-ai-code" in results["ids"][0]
@@ -602,6 +721,7 @@ class TestHybridSearch:
             query_embedding=_embed("latest unrelated"),
             query_text="latest unrelated",
             n_results=5,
+            recency_rerank=True,
         )
 
         assert "stale-boundary" not in results["ids"][0]
@@ -636,6 +756,7 @@ class TestHybridSearch:
             query_text="latest unrelated",
             n_results=5,
             date_to=date_to,
+            recency_rerank=True,
         )
 
         assert "recent-before-date-to" in results["ids"][0]
@@ -675,6 +796,7 @@ class TestHybridSearch:
             query_embedding=_embed("latest unrelated"),
             query_text="latest unrelated",
             n_results=5,
+            recency_rerank=True,
         )
 
         assert busy_cursor.busy_count == 1
@@ -714,6 +836,7 @@ class TestHybridSearch:
             query_embedding=_embed("latest arbitration mutex"),
             query_text="latest arbitration mutex",
             n_results=5,
+            recency_rerank=True,
         )
 
         assert captured_scores["exact-fts-hit"] > captured_scores["recent-only"]

--- a/tests/test_search_quality.py
+++ b/tests/test_search_quality.py
@@ -317,6 +317,7 @@ class TestPostRRFReranking:
             query_embedding=emb,
             query_text="database optimization",
             n_results=2,
+            importance_rerank=True,
         )
         ids = results["ids"][0]
         assert len(ids) == 2
@@ -347,6 +348,7 @@ class TestPostRRFReranking:
             query_embedding=emb,
             query_text="authentication flow",
             n_results=2,
+            recency_rerank=True,
         )
         ids = results["ids"][0]
         assert len(ids) == 2


### PR DESCRIPTION
## Summary

Implements P1.3 fusion-only search ranking changes in `src/brainlayer/search_repo.py`:

- Adds fixed weighted-RRF with `RRF_VECTOR_ALPHA = 0.25`; semantic/vector leg gets alpha, lexical FTS and trigram legs each get `1 - alpha`.
- Makes recency and importance post-RRF reranking opt-in via keyword-only `recency_rerank=False` and `importance_rerank=False` defaults.
- Gates the recency-intent recent-row fallback behind `recency_rerank`, so default search no longer silently injects recency as a truth/ranking signal.
- Keeps noise/quarantine demotion and MMR behavior unchanged.

## Agada Gate

Standing gold power tiers per lead ruler-check:

- HIGH-power gate domains: `techgym` (33 relevant), `freelance` (13 relevant)
- BORDERLINE: `recruiting` (6 relevant)
- LOW-POWER informational only: `architecture` (1 relevant), excluded from pass/fail aggregate

Method: generated the canonical 67-query agada file from all four frozen corpora, ran live-DB `hybrid_search` before/after on the same canonical DB, scored with `/agada-bench` `run-bench.py score`. Main baseline was `origin/main` before this branch; after is this branch at alpha 0.25. Results below are `true_hit` scorer values.

Default aggregate excluding Architecture:

| Variant | recall@5 | precision@5 | recall@10 | recall@20 | recall@50 |
|---|---:|---:|---:|---:|---:|
| main hybrid | 0.1809 | 0.0618 | 0.2400 | 0.2709 | 0.3085 |
| weighted-RRF alpha=0.25 | 0.1809 | 0.0618 | 0.2409 | 0.2709 | 0.3212 |
| plain FTS | 0.1682 | 0.0545 | 0.2027 | 0.2527 | 0.3009 |

Per-domain recall@5 / precision@5:

| Domain | Power | main recall@5 | after recall@5 | main p@5 | after p@5 |
|---|---|---:|---:|---:|---:|
| techgym | HIGH | 0.0906 | 0.1531 | 0.0875 | 0.1000 |
| freelance | HIGH | 0.1750 | 0.1250 | 0.0500 | 0.0400 |
| recruiting | BORDERLINE | 0.2632 | 0.2632 | 0.0526 | 0.0526 |
| architecture | LOW-POWER informational | 0.0000 | 0.0000 | 0.0000 | 0.0000 |

Per-domain recall curve:

| Domain | main r@10 | after r@10 | main r@20 | after r@20 | main r@50 | after r@50 |
|---|---:|---:|---:|---:|---:|---:|
| techgym | 0.2313 | 0.2344 | 0.2750 | 0.2750 | 0.3729 | 0.4167 |
| freelance | 0.2250 | 0.2250 | 0.2250 | 0.2250 | 0.2500 | 0.2500 |
| recruiting | 0.2632 | 0.2632 | 0.3158 | 0.3158 | 0.3158 | 0.3158 |
| architecture | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 |

Alpha sweep notes: measured 0.05, 0.10, 0.15, 0.20, 0.25, 0.35, 0.50, 0.75. Alpha 0.25 is the landed value because it holds default aggregate excluding Architecture, improves high-power aggregate recall@5/precision@5, improves TechGym, holds Freelance at recall@10/20/50, and beats plain FTS. Freelance top-5 is explicitly called out above for lead review rather than hidden in the aggregate.

## Test Plan

- `ruff check src/ && ruff format src/` → passed; 157 files left unchanged after rebase
- `pytest tests/test_hybrid_search.py tests/test_agent_profiles.py tests/test_consumer_scoping.py tests/test_search_quality.py -q` → 89 passed
- `pytest` → 3440 passed, 49 skipped, 5 xfailed, 329 warnings
- Local CodeRabbit pre-commit review → findings: 0
- `BRAINLAYER_PREPUSH_SCOPE=changed-only git push` → hook fell back to full pytest unit suite and passed:
  - pytest unit suite: 3339 passed, 9 skipped, 61 deselected, 1 xfailed
  - MCP tool registration: 3 passed
  - isolated eval/hook routing: 40 passed
  - bun suite: 1 passed
  - regression shell `test_fts5_determinism.sh`: PASS

## Review

REVIEW REQUIRED. Lead: brainlayerP1Lead. Do not self-merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core hybrid_search ranking for all default callers (engine, MCP, CLI) without API breakage, but alters which chunks surface unless opt-in rerank flags are wired through later.
> 
> **Overview**
> **Hybrid search default ranking** now uses **weighted reciprocal rank fusion**: vector leg weight `RRF_VECTOR_ALPHA` (0.25), lexical FTS/trigram legs share the remainder—so keyword matches rank higher than before when vector and text disagree.
> 
> **Recency and importance are no longer applied by default.** New keyword-only flags `recency_rerank` and `importance_rerank` (both default `False`) gate post-RRF boosts and the recency-intent “recent rows” SQL fallback; callers that want “latest” behavior must opt in. Cache keys include these flags so mixed calls do not share results.
> 
> Agent-profile tests were flipped to match the new lexical-first default; coach/scoping and quality tests pass `recency_rerank=True` where recency behavior is asserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1678efd05da3c70d65cbc5b6bbf034ea4fcd080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add weighted RRF with `RRF_VECTOR_ALPHA` and opt-in recency/importance rerank to `hybrid_search`
> - Introduces `RRF_VECTOR_ALPHA=0.25` in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/565/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) to weight vector scores lower than FTS scores in the RRF fusion formula.
> - Adds `recency_rerank` and `importance_rerank` boolean flags to `SearchMixin.hybrid_search`, both defaulting to `False`; reranking must now be explicitly opted into.
> - Cache keys in `_hybrid_cache_key` are extended to include the new flags, so different flag combinations produce separate cache entries.
> - Behavioral Change: existing callers that relied on recency or importance reranking being applied by default must now pass the corresponding flags explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a1678ef. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable search reranking options for recency and importance, giving results more flexible ranking behavior.
  * Improved hybrid search scoring to balance semantic and lexical matches more precisely.

* **Bug Fixes**
  * Search caches now account for reranking settings, preventing mismatched cached results.
  * Recency and importance boosts now apply only when enabled, making ranking behavior more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Revert path (Etan morning-veto, one command)
Single `git revert` of this squash-merge commit — **no data migration, no schema change, no reindex**. This PR only changes in-process fusion math + adds default-OFF keyword-only flags; reverting restores the prior unweighted-RRF + always-on recency/importance ranking instantly. Command: `git revert <merge-sha> && git push` (or GitHub 'Revert' button on the merged PR).

## On-record (orc P1.3 decision 2026-07-03)
freelance recall@5 0.175→0.125 is the recency-confound removal working (item holds top-10 at its relevance-earned rank), NOT a silent loss. Carried as a REQUIRED measured domain into the P2/RQ1 bakeoff — if it is a real user-felt loss (freelance = Etan's client/coach memories), it surfaces there explicitly, never buried.