### PR TITLE
feat: add bounded readonly WAL pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,11 @@ brainlayer enrich
 - All scripts and CLI use `paths.py` for DB path resolution
 - Concurrency: retry on `SQLITE_BUSY`; each worker uses its own connection
 
+## P1 Pipeline Contracts
+- BL-10 source denylist is implemented in `src/brainlayer/ingest_denylist.py`. Default excluded agent-output roots are `~/.claude/projects/*/**/subagents/**`, `~/.claude/projects/**/wf_*/**`, `~/.codex/sessions/**`, `~/.cursor/**/agent-transcripts/**`, and `~/.gemini/sessions/**`; direct/control Claude sessions still ingest through normal roots.
+- Go-forward secret scrubbing runs in `src/brainlayer/pipeline/secret_scrub.py` from `src/brainlayer/watcher_bridge.py` before chunk persistence. Provider-prefixed and labeled high-entropy secrets are redacted; unlabeled high-entropy tokens are recorded in quarantine metadata.
+- MCP search uses a fixed-size readonly WAL `VectorStore` pool in `src/brainlayer/mcp/_shared.py`. `BRAINLAYER_READ_POOL_SIZE` defaults to 8, or 4 on detected Apple M1; M1 machines can keep the lower override explicitly. Checkout beyond the fixed pool blocks up to `BRAINLAYER_READ_BUSY_TIMEOUT_MS`, and startup rejects `pool_size * BRAINLAYER_READ_CACHE_KB` above about 768MB.
+
 <!-- ARCHITECTURE: classification preserves ai_code/stack_trace/user_message verbatim; skips noise; AST-aware chunking via tree-sitter; never split stack traces -->
 ## Classification & Chunking Rules
 - Preserve verbatim: `ai_code`, `stack_trace`, `user_message`

--- a/src/brainlayer/mcp/_shared.py
+++ b/src/brainlayer/mcp/_shared.py
@@ -2,8 +2,12 @@
 
 import logging
 import os
+import platform
+import queue
 import re
+import subprocess
 import threading
+from contextlib import contextmanager
 
 import apsw
 from mcp.types import CallToolResult, TextContent
@@ -13,10 +17,14 @@ logger = logging.getLogger(__name__)
 # Lazy-loaded globals with thread-safe initialization
 _vector_store = None
 _search_vector_store = None
+_search_vector_store_pool = None
+_search_vector_store_pool_handles = []
 _embedding_model = None
 _store_lock = threading.Lock()
 _search_store_lock = threading.Lock()
 _model_lock = threading.Lock()
+
+_READ_POOL_RAM_CLAMP_KB = 768 * 1024
 
 _SEARCH_REQUIRED_TABLES = {"chunks", "chunk_vectors"}
 _SEARCH_REQUIRED_CHUNK_COLUMNS = {
@@ -74,6 +82,78 @@ def _bootstrap_search_store(db_path) -> None:
     bootstrap_store.close()
 
 
+def _detected_default_read_pool_size() -> int:
+    """Return the platform default for the readonly WAL pool."""
+    if platform.system() == "Darwin":
+        try:
+            brand = subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=0.5,
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            brand = ""
+        if "Apple M1" in brand:
+            return 4
+    return 8
+
+
+def _read_pool_size() -> int:
+    raw = os.environ.get("BRAINLAYER_READ_POOL_SIZE")
+    if raw is None:
+        return _detected_default_read_pool_size()
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _detected_default_read_pool_size()
+    return value if value > 0 else _detected_default_read_pool_size()
+
+
+def _assert_read_pool_ram_clamp(pool_size: int) -> None:
+    from ..vector_store import _read_cache_size_kb
+
+    read_cache_kb = abs(_read_cache_size_kb())
+    total_kb = pool_size * read_cache_kb
+    if total_kb > _READ_POOL_RAM_CLAMP_KB:
+        raise ValueError(
+            "read pool RAM clamp exceeded: "
+            f"pool_size={pool_size} * read_cache_kb={read_cache_kb} = {total_kb}KB "
+            f"> {_READ_POOL_RAM_CLAMP_KB}KB. Lower BRAINLAYER_READ_POOL_SIZE or BRAINLAYER_READ_CACHE_KB."
+        )
+
+
+def _initialize_search_vector_store_pool() -> None:
+    """Pre-open the fixed readonly VectorStore pool."""
+    global _search_vector_store, _search_vector_store_pool, _search_vector_store_pool_handles
+
+    from ..paths import get_db_path
+    from ..vector_store import VectorStore
+
+    db_path = get_db_path()
+    pool_size = _read_pool_size()
+    _assert_read_pool_ram_clamp(pool_size)
+    _bootstrap_search_store(db_path)
+
+    handles = []
+    try:
+        for _ in range(pool_size):
+            handles.append(VectorStore(db_path, readonly=True))
+    except Exception:
+        for store in handles:
+            store.close()
+        raise
+
+    pool: queue.Queue = queue.Queue(maxsize=pool_size)
+    for store in handles:
+        pool.put(store)
+
+    _search_vector_store_pool_handles = handles
+    _search_vector_store = handles[0]
+    _search_vector_store_pool = pool
+
+
 def _get_vector_store(timeout: float | None = None):
     """Get or initialize the global VectorStore (thread-safe)."""
     global _vector_store
@@ -93,18 +173,45 @@ def _get_vector_store(timeout: float | None = None):
 
 
 def _get_search_vector_store():
-    """Get or initialize the read-only VectorStore for search-only handlers."""
-    global _search_vector_store
-    if _search_vector_store is None:
+    """Get or initialize one read-only VectorStore for compatibility callers."""
+    if _search_vector_store_pool is None:
         with _search_store_lock:
-            if _search_vector_store is None:
-                from ..paths import get_db_path
-                from ..vector_store import VectorStore
-
-                db_path = get_db_path()
-                _bootstrap_search_store(db_path)
-                _search_vector_store = VectorStore(db_path, readonly=True)
+            if _search_vector_store_pool is None:
+                _initialize_search_vector_store_pool()
     return _search_vector_store
+
+
+@contextmanager
+def _search_store_checkout():
+    """Checkout a bounded readonly VectorStore handle and return it to the pool."""
+    if _search_vector_store_pool is None:
+        with _search_store_lock:
+            if _search_vector_store_pool is None:
+                _initialize_search_vector_store_pool()
+
+    from ..vector_store import _read_busy_timeout_ms
+
+    try:
+        store = _search_vector_store_pool.get(timeout=_read_busy_timeout_ms() / 1000.0)
+    except queue.Empty as exc:
+        raise apsw.BusyError("timed out waiting for read pool checkout") from exc
+
+    try:
+        yield store
+    finally:
+        _search_vector_store_pool.put(store)
+
+
+def _close_search_vector_store() -> None:
+    """Close and reset the readonly search pool."""
+    global _search_vector_store, _search_vector_store_pool, _search_vector_store_pool_handles
+    with _search_store_lock:
+        handles = list(_search_vector_store_pool_handles)
+        _search_vector_store = None
+        _search_vector_store_pool = None
+        _search_vector_store_pool_handles = []
+    for store in handles:
+        store.close()
 
 
 def _get_embedding_model():

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -10,6 +10,7 @@ import re
 import socket
 import threading
 import time
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -52,6 +53,7 @@ from ._shared import (
     _query_signals_current_context,
     _query_signals_recall,
     _query_signals_think,
+    _search_store_checkout,
     logger,
 )
 from ._shared import (
@@ -62,6 +64,19 @@ from ._shared import (
 def _get_vector_store():
     """Compatibility hook for tests; search handlers use the readonly store by default."""
     return _get_search_vector_store()
+
+
+_DEFAULT_GET_VECTOR_STORE = _get_vector_store
+
+
+@contextmanager
+def _vector_store_checkout():
+    """Checkout a readonly search store while preserving test monkeypatch hooks."""
+    if _get_vector_store is _DEFAULT_GET_VECTOR_STORE:
+        with _search_store_checkout() as store:
+            yield store
+    else:
+        yield _get_vector_store()
 
 
 def _embed_timeout_ms() -> float:
@@ -988,8 +1003,8 @@ async def _brain_search_dispatch(
         )
 
     if chunk_id is not None:
-        store = _get_vector_store()
-        chunk = store.get_chunk(chunk_id)
+        with _vector_store_checkout() as store:
+            chunk = store.get_chunk(chunk_id)
         if isinstance(chunk, dict) and not _metadata_matches_project_scope(
             {"project": chunk.get("project")},
             project,
@@ -1153,32 +1168,32 @@ async def _brain_search_dispatch(
             consumer_scope=consumer_scope,
         )
 
-    store = _get_vector_store()
     effective_source = None if source == "all" else source
-    exact_chunk_hit = _exact_chunk_lookup_result(
-        query,
-        store,
-        detail,
-        project=project,
-        content_type=content_type,
-        tag=tag,
-        importance_min=importance_min,
-        date_from=date_from,
-        date_to=date_to,
-        source=effective_source,
-        intent=intent,
-        sentiment=sentiment,
-        source_filter=source_filter,
-        correction_category=correction_category,
-        include_checkpoints=include_checkpoints,
-        include_audit=include_audit,
-        include_operational=include_operational,
-        content_class_filter=content_class_filter,
-        consumer_scope=consumer_scope,
-    )
-    if exact_chunk_hit is not None:
-        return exact_chunk_hit
-    fts_query_override = _expanded_fts_query(query, store)
+    with _vector_store_checkout() as store:
+        exact_chunk_hit = _exact_chunk_lookup_result(
+            query,
+            store,
+            detail,
+            project=project,
+            content_type=content_type,
+            tag=tag,
+            importance_min=importance_min,
+            date_from=date_from,
+            date_to=date_to,
+            source=effective_source,
+            intent=intent,
+            sentiment=sentiment,
+            source_filter=source_filter,
+            correction_category=correction_category,
+            include_checkpoints=include_checkpoints,
+            include_audit=include_audit,
+            include_operational=include_operational,
+            content_class_filter=content_class_filter,
+            consumer_scope=consumer_scope,
+        )
+        if exact_chunk_hit is not None:
+            return exact_chunk_hit
+        fts_query_override = _expanded_fts_query(query, store)
     source_file_filter_like = _source_file_like_pattern(origin_file_path)
 
     # Entity-aware routing: detect known entity names in query.
@@ -1201,14 +1216,19 @@ async def _brain_search_dispatch(
             source_file_filter_like,
         ]
     )
-    detected_entities = _detect_entities(query, store) if not has_active_filters else []
+    if has_active_filters:
+        detected_entities = []
+    else:
+        with _vector_store_checkout() as store:
+            detected_entities = _detect_entities(query, store)
     if detected_entities:
         entity_name = detected_entities[0]["name"]
 
         # Path 1: Pure SQL KG facts (no embedding model needed, always runs)
-        fact_items = _kg_facts_sql(
-            store, entity_name, include_checkpoints=include_checkpoints, include_audit=include_audit
-        )
+        with _vector_store_checkout() as store:
+            fact_items = _kg_facts_sql(
+                store, entity_name, include_checkpoints=include_checkpoints, include_audit=include_audit
+            )
 
         # Path 2: Try full hybrid search (embedding + vector + KG)
         structured_results = []
@@ -1240,20 +1260,21 @@ async def _brain_search_dispatch(
             query_embedding = await loop.run_in_executor(None, model.embed_query, query)
             kg_n_results = _origin_candidate_count(num_results) if order == "origin" else num_results
 
-            kg_results = store.kg_hybrid_search(
-                query_embedding=query_embedding,
-                query_text=query,
-                n_results=kg_n_results,
-                entity_name=entity_name,
-                project_filter=normalized_project,
-                include_checkpoints=include_checkpoints,
-                include_audit=include_audit,
-                include_operational=include_operational,
-                content_class_filter=content_class_filter,
-                agent_id=agent_id,
-                brainbar_helper_fast_profile=brainbar_helper_fast_profile,
-                consumer_scope=consumer_scope,
-            )
+            with _vector_store_checkout() as store:
+                kg_results = store.kg_hybrid_search(
+                    query_embedding=query_embedding,
+                    query_text=query,
+                    n_results=kg_n_results,
+                    entity_name=entity_name,
+                    project_filter=normalized_project,
+                    include_checkpoints=include_checkpoints,
+                    include_audit=include_audit,
+                    include_operational=include_operational,
+                    content_class_filter=content_class_filter,
+                    agent_id=agent_id,
+                    brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+                    consumer_scope=consumer_scope,
+                )
             chunk_results = kg_results.get("chunks", {})
             if order == "origin" and chunk_results.get("ids") and chunk_results["ids"][0]:
                 chunk_results = _sort_hybrid_results_by_origin(chunk_results, num_results)
@@ -1440,23 +1461,23 @@ async def _brain_resume(session_id: str | None = None, lookback_days: int = 7):
             params.extend([session_id, session_like, session_like])
         params.append(20)
 
-        store = _get_vector_store()
-        if not getattr(store, "_has_chunk_origin", True):
-            structured = {"session_id": session_id, "lookback_days": days, "total": 0, "results": []}
-            return ([TextContent(type="text", text="No PreCompact checkpoints found.")], structured)
+        with _vector_store_checkout() as store:
+            if not getattr(store, "_has_chunk_origin", True):
+                structured = {"session_id": session_id, "lookback_days": days, "total": 0, "results": []}
+                return ([TextContent(type="text", text="No PreCompact checkpoints found.")], structured)
 
-        rows = await _execute_resume_query_with_retry(
-            store,
-            f"""
-                SELECT id, content, source_file, project, content_type, created_at,
-                       source, conversation_id, summary, importance
-                FROM chunks
-                WHERE {" AND ".join(where_clauses)}
-                ORDER BY COALESCE(created_at, '') DESC
-                LIMIT ?
-                """,
-            params,
-        )
+            rows = await _execute_resume_query_with_retry(
+                store,
+                f"""
+                    SELECT id, content, source_file, project, content_type, created_at,
+                           source, conversation_id, summary, importance
+                    FROM chunks
+                    WHERE {" AND ".join(where_clauses)}
+                    ORDER BY COALESCE(created_at, '') DESC
+                    LIMIT ?
+                    """,
+                params,
+            )
 
         structured_results = [
             {
@@ -1771,14 +1792,13 @@ async def _search(
             num_results = 100
         hybrid_n_results = _origin_candidate_count(num_results) if order == "origin" else num_results
 
-        store = _get_vector_store()
-
-        if store.count() == 0:
-            empty = {"query": query, "total": 0, "results": []}
-            return (
-                [TextContent(type="text", text="Knowledge base is empty. Run 'brainlayer index' to populate it.")],
-                empty,
-            )
+        with _vector_store_checkout() as store:
+            if store.count() == 0:
+                empty = {"query": query, "total": 0, "results": []}
+                return (
+                    [TextContent(type="text", text="Knowledge base is empty. Run 'brainlayer index' to populate it.")],
+                    empty,
+                )
 
         normalized_project = _normalize_project_name(project)
         loop = asyncio.get_running_loop()
@@ -1888,35 +1908,36 @@ async def _search(
         try:
             for attempt in range(_RETRY_MAX_ATTEMPTS):
                 try:
-                    results = store.hybrid_search(
-                        query_embedding=query_embedding,
-                        query_text=query,
-                        fts_query_override=fts_query_override,
-                        n_results=hybrid_n_results,
-                        project_filter=normalized_project,
-                        content_type_filter=content_type,
-                        source_filter=source_filter,
-                        tag_filter=tag,
-                        intent_filter=intent,
-                        importance_min=importance_min,
-                        date_from=date_from,
-                        date_to=date_to,
-                        sentiment_filter=sentiment,
-                        entity_id=entity_id,
-                        agent_id=agent_id,
-                        source_filter_like=source_filter_like,
-                        source_file_filter_like=source_file_filter_like,
-                        correction_category=correction_category,
-                        include_checkpoints=include_checkpoints,
-                        include_audit=include_audit,
-                        include_operational=include_operational,
-                        content_class_filter=content_class_filter,
-                        kg_boost=_kg_boost_enabled(),
-                        profile_query_id=profile_query_id,
-                        profile_scope=profile_scope,
-                        brainbar_helper_fast_profile=brainbar_helper_fast_profile,
-                        consumer_scope=consumer_scope,
-                    )
+                    with _vector_store_checkout() as store:
+                        results = store.hybrid_search(
+                            query_embedding=query_embedding,
+                            query_text=query,
+                            fts_query_override=fts_query_override,
+                            n_results=hybrid_n_results,
+                            project_filter=normalized_project,
+                            content_type_filter=content_type,
+                            source_filter=source_filter,
+                            tag_filter=tag,
+                            intent_filter=intent,
+                            importance_min=importance_min,
+                            date_from=date_from,
+                            date_to=date_to,
+                            sentiment_filter=sentiment,
+                            entity_id=entity_id,
+                            agent_id=agent_id,
+                            source_filter_like=source_filter_like,
+                            source_file_filter_like=source_file_filter_like,
+                            correction_category=correction_category,
+                            include_checkpoints=include_checkpoints,
+                            include_audit=include_audit,
+                            include_operational=include_operational,
+                            content_class_filter=content_class_filter,
+                            kg_boost=_kg_boost_enabled(),
+                            profile_query_id=profile_query_id,
+                            profile_scope=profile_scope,
+                            brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+                            consumer_scope=consumer_scope,
+                        )
                     break
                 except Exception as e:
                     is_lock = isinstance(e, apsw.BusyError) or "locked" in str(e).lower() or "busy" in str(e).lower()
@@ -1952,7 +1973,8 @@ async def _search(
                 text = f"No results found. Search mode: FTS fallback ({fallback_reason}); vector embedding was skipped."
             return ([TextContent(type="text", text=text)], empty)
 
-        results = store.enrich_results_with_session_context(results)
+        with _vector_store_checkout() as store:
+            results = store.enrich_results_with_session_context(results)
         if order == "origin":
             results = _sort_hybrid_results_by_origin(results, num_results)
 
@@ -2119,8 +2141,8 @@ async def _stats():
 async def _list_projects() -> list[TextContent]:
     """List all projects."""
     try:
-        store = _get_vector_store()
-        stats = store.get_stats()
+        with _vector_store_checkout() as store:
+            stats = store.get_stats()
         if not stats["projects"]:
             return [TextContent(type="text", text="No projects indexed yet.")]
         output = "## Indexed Projects\n\n"
@@ -2142,15 +2164,15 @@ async def _context(
 ) -> list[TextContent]:
     """Get surrounding conversation context for a chunk."""
     try:
-        store = _get_vector_store()
-        result = store.get_context(
-            chunk_id,
-            before=before,
-            after=after,
-            include_checkpoints=include_checkpoints,
-            include_audit=include_audit,
-            consumer_scope=consumer_scope,
-        )
+        with _vector_store_checkout() as store:
+            result = store.get_context(
+                chunk_id,
+                before=before,
+                after=after,
+                include_checkpoints=include_checkpoints,
+                include_audit=include_audit,
+                consumer_scope=consumer_scope,
+            )
         if result.get("error"):
             return _error_result(f"Unknown chunk_id '{chunk_id[:20]}...'. Use chunk_id from brainlayer_search results.")
         if not result.get("context"):
@@ -2181,9 +2203,9 @@ async def _file_timeline(
 ) -> list[TextContent]:
     """Get interaction timeline for a file."""
     try:
-        store = _get_vector_store()
         prefilter_project = _prefilter_project_for_consumer_scope(project, consumer_scope)
-        interactions = store.get_file_timeline(file_path, project=prefilter_project, limit=limit)
+        with _vector_store_checkout() as store:
+            interactions = store.get_file_timeline(file_path, project=prefilter_project, limit=limit)
         interactions = _filter_rows_for_consumer_scope(interactions, project, consumer_scope)
         if not interactions:
             return [TextContent(type="text", text=f"No interactions found for '{file_path}'.")]
@@ -2203,8 +2225,8 @@ async def _file_timeline(
 async def _operations(session_id: str) -> list[TextContent]:
     """Get operations for a session."""
     try:
-        store = _get_vector_store()
-        ops = store.get_session_operations(session_id)
+        with _vector_store_checkout() as store:
+            ops = store.get_session_operations(session_id)
         if not ops:
             return [TextContent(type="text", text=f"No operations for session '{session_id[:8]}...'.")]
         output_parts = [f"## Operations: {session_id[:8]}...\n", f"Found {len(ops)} operations:\n"]
@@ -2226,9 +2248,9 @@ async def _regression(
 ) -> list[TextContent]:
     """Analyze a file for regressions."""
     try:
-        store = _get_vector_store()
         prefilter_project = _prefilter_project_for_consumer_scope(project, consumer_scope)
-        result = store.get_file_regression(file_path, project=prefilter_project)
+        with _vector_store_checkout() as store:
+            result = store.get_file_regression(file_path, project=prefilter_project)
         result = _filter_regression_for_consumer_scope(result, project, consumer_scope)
         if not result["timeline"]:
             return [TextContent(type="text", text=f"No interactions found for '{file_path}'.")]
@@ -2256,9 +2278,12 @@ async def _plan_links(
 ) -> list[TextContent]:
     """Query plan-linked sessions."""
     try:
-        store = _get_vector_store()
+        with _vector_store_checkout() as store:
+            if session_id:
+                ctx = store.get_session_context(session_id)
+            else:
+                ctx = None
         if session_id:
-            ctx = store.get_session_context(session_id)
             if not ctx:
                 return [TextContent(type="text", text=f"No context for session '{session_id[:8]}'.")]
             parts = [
@@ -2271,7 +2296,9 @@ async def _plan_links(
             ]
             return [TextContent(type="text", text="\n".join(parts))]
 
-        sessions = store.get_sessions_by_plan(plan_name=plan_name, project=project)
+        with _vector_store_checkout() as store:
+            sessions = store.get_sessions_by_plan(plan_name=plan_name, project=project)
+            stats = store.get_plan_linking_stats()
         if not sessions:
             msg = f"No sessions linked to plan '{plan_name}'." if plan_name else "No plan-linked sessions found."
             return [TextContent(type="text", text=msg)]
@@ -2286,7 +2313,6 @@ async def _plan_links(
             plan = s.get("plan_name") or ""
             started = (s.get("started_at") or "")[:19]
             parts.append(f"- {sid} | {plan}/{phase} | {branch} {pr} | {started}")
-        stats = store.get_plan_linking_stats()
         parts.append(f"\nTotal: {stats['linked_sessions']}/{stats['total_sessions']} linked")
         return [TextContent(type="text", text="\n".join(parts))]
     except Exception as e:
@@ -2305,7 +2331,6 @@ async def _think(
     try:
         from ..engine import think
 
-        store = _get_vector_store()
         model = _get_embedding_model()
         loop = asyncio.get_running_loop()
 
@@ -2314,19 +2339,20 @@ async def _think(
 
         normalized_project = _normalize_project_name(project)
         prefilter_project = _prefilter_project_for_consumer_scope(normalized_project, consumer_scope)
-        result = await loop.run_in_executor(
-            None,
-            lambda: think(
-                context=context,
-                store=store,
-                embed_fn=_embed,
-                project=prefilter_project,
-                max_results=max_results,
-                include_audit=include_audit,
-                agent_id=agent_id,
-                consumer_scope=consumer_scope,
-            ),
-        )
+        with _vector_store_checkout() as store:
+            result = await loop.run_in_executor(
+                None,
+                lambda: think(
+                    context=context,
+                    store=store,
+                    embed_fn=_embed,
+                    project=prefilter_project,
+                    max_results=max_results,
+                    include_audit=include_audit,
+                    agent_id=agent_id,
+                    consumer_scope=consumer_scope,
+                ),
+            )
         result = _filter_think_result_for_consumer_scope(result, normalized_project, consumer_scope)
         structured = {
             "query": result.query,
@@ -2354,7 +2380,6 @@ async def _recall(
     try:
         from ..engine import recall
 
-        store = _get_vector_store()
         model = _get_embedding_model()
         normalized_project = _normalize_project_name(project)
         prefilter_project = _prefilter_project_for_consumer_scope(normalized_project, consumer_scope)
@@ -2363,20 +2388,21 @@ async def _recall(
         def _embed(text: str) -> list[float]:
             return model.embed_query(text)
 
-        result = await loop.run_in_executor(
-            None,
-            lambda: recall(
-                store=store,
-                embed_fn=_embed,
-                file_path=file_path,
-                topic=topic,
-                project=prefilter_project,
-                max_results=max_results,
-                include_audit=include_audit,
-                agent_id=agent_id,
-                consumer_scope=consumer_scope,
-            ),
-        )
+        with _vector_store_checkout() as store:
+            result = await loop.run_in_executor(
+                None,
+                lambda: recall(
+                    store=store,
+                    embed_fn=_embed,
+                    file_path=file_path,
+                    topic=topic,
+                    project=prefilter_project,
+                    max_results=max_results,
+                    include_audit=include_audit,
+                    agent_id=agent_id,
+                    consumer_scope=consumer_scope,
+                ),
+            )
         result = _filter_recall_result_for_consumer_scope(result, normalized_project, consumer_scope)
         structured = {
             "target": result.target,
@@ -2415,10 +2441,10 @@ async def _sessions(
     try:
         from ..engine import format_sessions, sessions
 
-        store = _get_vector_store()
         normalized_project = _normalize_project_name(project)
         prefilter_project = _prefilter_project_for_consumer_scope(normalized_project, consumer_scope)
-        result = sessions(store=store, project=prefilter_project, days=days, limit=limit)
+        with _vector_store_checkout() as store:
+            result = sessions(store=store, project=prefilter_project, days=days, limit=limit)
         result = _filter_sessions_for_consumer_scope(result, normalized_project, consumer_scope)
         return [TextContent(type="text", text=format_sessions(result, days=days))]
     except Exception as e:
@@ -2428,8 +2454,8 @@ async def _sessions(
 async def _session_summary(session_id: str):
     """Get enriched session summary."""
     try:
-        store = _get_vector_store()
-        enrichment = store.get_session_enrichment(session_id)
+        with _vector_store_checkout() as store:
+            enrichment = store.get_session_enrichment(session_id)
         if not enrichment:
             return [
                 TextContent(
@@ -2492,8 +2518,8 @@ async def _current_context(hours: int = 24, project: str | None = None, consumer
     try:
         from ..engine import current_context
 
-        store = _get_vector_store()
-        result = current_context(store=store, hours=hours)
+        with _vector_store_checkout() as store:
+            result = current_context(store=store, hours=hours)
         result = _filter_current_context_for_consumer_scope(result, project, consumer_scope)
         structured = {
             "active_projects": result.active_projects,

--- a/tests/test_vector_store_readonly.py
+++ b/tests/test_vector_store_readonly.py
@@ -1,21 +1,26 @@
+import concurrent.futures
+import threading
+import time
+
 import apsw
 import pytest
 
 from brainlayer._helpers import serialize_f32
 from brainlayer.mcp import _shared
+from brainlayer.mcp import search_handler
 from brainlayer.search_repo import _hybrid_cache
 from brainlayer.vector_store import VectorStore
 
 
 @pytest.fixture(autouse=True)
 def clear_hybrid_cache():
-    _shared._search_vector_store = None
+    _shared._close_search_vector_store()
     _shared._vector_store = None
     _hybrid_cache.clear()
     yield
-    for store in (_shared._search_vector_store, _shared._vector_store):
-        if store is not None:
-            store.close()
+    _shared._close_search_vector_store()
+    if _shared._vector_store is not None:
+        _shared._vector_store.close()
     _shared._search_vector_store = None
     _shared._vector_store = None
     _hybrid_cache.clear()
@@ -24,6 +29,20 @@ def clear_hybrid_cache():
 def _embed(text: str) -> list[float]:
     seed = (sum(ord(c) for c in text[:40]) % 97) / 1000.0
     return [seed + (i / 10000.0) for i in range(1024)]
+
+
+class FakeEmbeddingModel:
+    def embed_query(self, _query: str) -> list[float]:
+        return _embed("pooled handler search")
+
+
+def _minimal_search_results(chunk_id: str) -> dict:
+    return {
+        "ids": [[chunk_id]],
+        "documents": [["pooled handler search result"]],
+        "metadatas": [[{"source_file": "pooled.md", "project": "brainlayer"}]],
+        "distances": [[0.25]],
+    }
 
 
 def _create_vector_db(db_path):
@@ -165,6 +184,7 @@ def test_explicit_readonly_does_not_create_parent_directory(tmp_path, monkeypatc
 def test_search_vector_store_bootstraps_missing_db_then_reopens_readonly(tmp_path, monkeypatch):
     db_path = tmp_path / "fresh" / "brainlayer.db"
     monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
 
     store = _shared._get_search_vector_store()
     try:
@@ -176,8 +196,7 @@ def test_search_vector_store_bootstraps_missing_db_then_reopens_readonly(tmp_pat
                 "INSERT INTO chunks (id, content, metadata, source_file) VALUES ('x', 'x', '{}', 'x')"
             )
     finally:
-        store.close()
-        _shared._search_vector_store = None
+        _shared._close_search_vector_store()
 
 
 def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_path, monkeypatch):
@@ -206,6 +225,7 @@ def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_p
     )
     conn.close()
     monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
 
     store = _shared._get_search_vector_store()
     try:
@@ -217,8 +237,7 @@ def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_p
                 "INSERT INTO chunks (id, content, metadata, source_file) VALUES ('x', 'x', '{}', 'x')"
             )
     finally:
-        store.close()
-        _shared._search_vector_store = None
+        _shared._close_search_vector_store()
 
 
 def test_search_store_bootstrap_required_for_partial_kg_schema(tmp_path):
@@ -234,3 +253,160 @@ def test_search_store_bootstrap_required_for_partial_kg_schema(tmp_path):
         conn.close()
 
     assert _shared._search_store_needs_bootstrap(db_path) is True
+
+
+def test_search_store_pool_preopens_fixed_readonly_handles(tmp_path, monkeypatch):
+    db_path = tmp_path / "pooled.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "3")
+
+    first = _shared._get_search_vector_store()
+
+    assert first._readonly is True
+    assert _shared._search_vector_store is first
+    assert len(_shared._search_vector_store_pool_handles) == 3
+    assert {id(store) for store in _shared._search_vector_store_pool_handles} == {
+        id(store) for store in _shared._search_vector_store_pool.queue
+    }
+    assert all(store._readonly for store in _shared._search_vector_store_pool_handles)
+
+
+def test_search_store_checkout_deserializes_slow_reads(tmp_path, monkeypatch):
+    db_path = tmp_path / "parallel.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "3")
+
+    start_gate = threading.Barrier(4)
+    release_gate = threading.Event()
+    seen_store_ids: set[int] = set()
+    lock = threading.Lock()
+
+    def slow_read() -> None:
+        with _shared._search_store_checkout() as store:
+            with lock:
+                seen_store_ids.add(id(store))
+            start_gate.wait(timeout=1.0)
+            assert release_gate.wait(timeout=1.0)
+
+    started = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [executor.submit(slow_read) for _ in range(3)]
+        start_gate.wait(timeout=1.0)
+        elapsed_before_release = time.perf_counter() - started
+        release_gate.set()
+        for future in futures:
+            future.result(timeout=1.0)
+
+    assert len(seen_store_ids) == 3
+    assert elapsed_before_release < 0.5
+
+
+def test_search_handler_uses_distinct_pool_handles_for_concurrent_slow_reads(tmp_path, monkeypatch):
+    db_path = tmp_path / "handler-pool.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "3")
+    monkeypatch.setattr(search_handler, "_get_embedding_model", lambda: FakeEmbeddingModel())
+
+    _shared._get_search_vector_store()
+    start_gate = threading.Barrier(4)
+    release_gate = threading.Event()
+    seen_store_ids: set[int] = set()
+    lock = threading.Lock()
+
+    for handle in _shared._search_vector_store_pool_handles:
+        handle.count = lambda: 1
+        handle.enrich_results_with_session_context = lambda results: results
+
+        def slow_search(*, _handle=handle, **_kwargs):
+            with lock:
+                seen_store_ids.add(id(_handle))
+            start_gate.wait(timeout=1.0)
+            assert release_gate.wait(timeout=1.0)
+            return _minimal_search_results(f"chunk-{id(_handle)}")
+
+        handle.hybrid_search = slow_search
+
+    def run_search() -> None:
+        import asyncio
+
+        asyncio.run(search_handler._search(query="pooled handler search"))
+
+    started = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [executor.submit(run_search) for _ in range(3)]
+        start_gate.wait(timeout=1.0)
+        elapsed_before_release = time.perf_counter() - started
+        release_gate.set()
+        for future in futures:
+            future.result(timeout=1.0)
+
+    assert len(seen_store_ids) == 3
+    assert elapsed_before_release < 0.5
+
+
+def test_search_store_checkout_beyond_pool_blocks_then_raises(tmp_path, monkeypatch):
+    db_path = tmp_path / "bounded.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
+    monkeypatch.setenv("BRAINLAYER_READ_BUSY_TIMEOUT_MS", "120")
+
+    with _shared._search_store_checkout(), _shared._search_store_checkout():
+        started = time.perf_counter()
+        with pytest.raises(apsw.BusyError, match="read pool"):
+            with _shared._search_store_checkout():
+                pass
+        elapsed = time.perf_counter() - started
+
+    assert elapsed >= 0.10
+    assert len(_shared._search_vector_store_pool_handles) == 2
+
+
+def test_search_store_ram_clamp_rejects_oversized_pool(tmp_path, monkeypatch):
+    db_path = tmp_path / "clamped.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "13")
+    monkeypatch.setenv("BRAINLAYER_READ_CACHE_KB", "64000")
+
+    with pytest.raises(ValueError, match="read pool RAM clamp"):
+        _shared._get_search_vector_store()
+
+
+def test_writer_completes_while_read_pool_handles_are_checked_out(tmp_path, monkeypatch):
+    db_path = tmp_path / "writer-progress.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
+
+    with _shared._search_store_checkout() as reader_a, _shared._search_store_checkout() as reader_b:
+        for reader in (reader_a, reader_b):
+            reader.conn.cursor().execute("BEGIN")
+            reader.conn.cursor().execute("SELECT COUNT(*) FROM chunks").fetchone()
+        writer = VectorStore(db_path)
+        try:
+            started = time.perf_counter()
+            _insert_chunk(
+                writer,
+                chunk_id="writer-progress",
+                content="writer completes while readers are checked out",
+                embedding=_embed("writer completes while readers are checked out"),
+            )
+            writer.conn.cursor().execute("PRAGMA wal_checkpoint(PASSIVE)")
+            elapsed = time.perf_counter() - started
+        finally:
+            writer.close()
+            for reader in (reader_a, reader_b):
+                reader.conn.cursor().execute("ROLLBACK")
+
+    inspector = VectorStore(db_path, readonly=True)
+    try:
+        count = inspector.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE id = 'writer-progress'").fetchone()[0]
+    finally:
+        inspector.close()
+
+    assert count == 1
+    assert elapsed < 1.0

--- a/tests/test_vector_store_readonly.py
+++ b/tests/test_vector_store_readonly.py
@@ -1,21 +1,25 @@
+import concurrent.futures
+import threading
+import time
+
 import apsw
 import pytest
 
 from brainlayer._helpers import serialize_f32
-from brainlayer.mcp import _shared
+from brainlayer.mcp import _shared, search_handler
 from brainlayer.search_repo import _hybrid_cache
 from brainlayer.vector_store import VectorStore
 
 
 @pytest.fixture(autouse=True)
 def clear_hybrid_cache():
-    _shared._search_vector_store = None
+    _shared._close_search_vector_store()
     _shared._vector_store = None
     _hybrid_cache.clear()
     yield
-    for store in (_shared._search_vector_store, _shared._vector_store):
-        if store is not None:
-            store.close()
+    _shared._close_search_vector_store()
+    if _shared._vector_store is not None:
+        _shared._vector_store.close()
     _shared._search_vector_store = None
     _shared._vector_store = None
     _hybrid_cache.clear()
@@ -24,6 +28,20 @@ def clear_hybrid_cache():
 def _embed(text: str) -> list[float]:
     seed = (sum(ord(c) for c in text[:40]) % 97) / 1000.0
     return [seed + (i / 10000.0) for i in range(1024)]
+
+
+class FakeEmbeddingModel:
+    def embed_query(self, _query: str) -> list[float]:
+        return _embed("pooled handler search")
+
+
+def _minimal_search_results(chunk_id: str) -> dict:
+    return {
+        "ids": [[chunk_id]],
+        "documents": [["pooled handler search result"]],
+        "metadatas": [[{"source_file": "pooled.md", "project": "brainlayer"}]],
+        "distances": [[0.25]],
+    }
 
 
 def _create_vector_db(db_path):
@@ -165,6 +183,7 @@ def test_explicit_readonly_does_not_create_parent_directory(tmp_path, monkeypatc
 def test_search_vector_store_bootstraps_missing_db_then_reopens_readonly(tmp_path, monkeypatch):
     db_path = tmp_path / "fresh" / "brainlayer.db"
     monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
 
     store = _shared._get_search_vector_store()
     try:
@@ -176,8 +195,7 @@ def test_search_vector_store_bootstraps_missing_db_then_reopens_readonly(tmp_pat
                 "INSERT INTO chunks (id, content, metadata, source_file) VALUES ('x', 'x', '{}', 'x')"
             )
     finally:
-        store.close()
-        _shared._search_vector_store = None
+        _shared._close_search_vector_store()
 
 
 def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_path, monkeypatch):
@@ -206,6 +224,7 @@ def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_p
     )
     conn.close()
     monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
 
     store = _shared._get_search_vector_store()
     try:
@@ -217,8 +236,7 @@ def test_search_vector_store_bootstraps_stale_schema_then_reopens_readonly(tmp_p
                 "INSERT INTO chunks (id, content, metadata, source_file) VALUES ('x', 'x', '{}', 'x')"
             )
     finally:
-        store.close()
-        _shared._search_vector_store = None
+        _shared._close_search_vector_store()
 
 
 def test_search_store_bootstrap_required_for_partial_kg_schema(tmp_path):
@@ -234,3 +252,162 @@ def test_search_store_bootstrap_required_for_partial_kg_schema(tmp_path):
         conn.close()
 
     assert _shared._search_store_needs_bootstrap(db_path) is True
+
+
+def test_search_store_pool_preopens_fixed_readonly_handles(tmp_path, monkeypatch):
+    db_path = tmp_path / "pooled.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "3")
+
+    first = _shared._get_search_vector_store()
+
+    assert first._readonly is True
+    assert _shared._search_vector_store is first
+    assert len(_shared._search_vector_store_pool_handles) == 3
+    assert {id(store) for store in _shared._search_vector_store_pool_handles} == {
+        id(store) for store in _shared._search_vector_store_pool.queue
+    }
+    assert all(store._readonly for store in _shared._search_vector_store_pool_handles)
+
+
+def test_search_store_checkout_deserializes_slow_reads(tmp_path, monkeypatch):
+    db_path = tmp_path / "parallel.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "3")
+
+    start_gate = threading.Barrier(4)
+    release_gate = threading.Event()
+    seen_store_ids: set[int] = set()
+    lock = threading.Lock()
+
+    def slow_read() -> None:
+        with _shared._search_store_checkout() as store:
+            with lock:
+                seen_store_ids.add(id(store))
+            start_gate.wait(timeout=1.0)
+            assert release_gate.wait(timeout=1.0)
+
+    started = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [executor.submit(slow_read) for _ in range(3)]
+        start_gate.wait(timeout=1.0)
+        elapsed_before_release = time.perf_counter() - started
+        release_gate.set()
+        for future in futures:
+            future.result(timeout=1.0)
+
+    assert len(seen_store_ids) == 3
+    assert elapsed_before_release < 0.5
+
+
+def test_search_handler_uses_distinct_pool_handles_for_concurrent_slow_reads(tmp_path, monkeypatch):
+    db_path = tmp_path / "handler-pool.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "3")
+    monkeypatch.setattr(search_handler, "_get_embedding_model", lambda: FakeEmbeddingModel())
+
+    _shared._get_search_vector_store()
+    start_gate = threading.Barrier(4)
+    release_gate = threading.Event()
+    seen_store_ids: set[int] = set()
+    lock = threading.Lock()
+
+    for handle in _shared._search_vector_store_pool_handles:
+        handle.count = lambda: 1
+        handle.enrich_results_with_session_context = lambda results: results
+
+        def slow_search(*, _handle=handle, **_kwargs):
+            with lock:
+                seen_store_ids.add(id(_handle))
+            start_gate.wait(timeout=1.0)
+            assert release_gate.wait(timeout=1.0)
+            return _minimal_search_results(f"chunk-{id(_handle)}")
+
+        handle.hybrid_search = slow_search
+
+    def run_search() -> None:
+        import asyncio
+
+        asyncio.run(search_handler._search(query="pooled handler search"))
+
+    started = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [executor.submit(run_search) for _ in range(3)]
+        start_gate.wait(timeout=1.0)
+        elapsed_before_release = time.perf_counter() - started
+        release_gate.set()
+        for future in futures:
+            future.result(timeout=1.0)
+
+    assert len(seen_store_ids) == 3
+    assert elapsed_before_release < 0.5
+
+
+def test_search_store_checkout_beyond_pool_blocks_then_raises(tmp_path, monkeypatch):
+    db_path = tmp_path / "bounded.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
+    monkeypatch.setenv("BRAINLAYER_READ_BUSY_TIMEOUT_MS", "120")
+
+    with _shared._search_store_checkout(), _shared._search_store_checkout():
+        started = time.perf_counter()
+        with pytest.raises(apsw.BusyError, match="read pool"):
+            with _shared._search_store_checkout():
+                pass
+        elapsed = time.perf_counter() - started
+
+    assert elapsed >= 0.10
+    assert len(_shared._search_vector_store_pool_handles) == 2
+
+
+def test_search_store_ram_clamp_rejects_oversized_pool(tmp_path, monkeypatch):
+    db_path = tmp_path / "clamped.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "13")
+    monkeypatch.setenv("BRAINLAYER_READ_CACHE_KB", "64000")
+
+    with pytest.raises(ValueError, match="read pool RAM clamp"):
+        _shared._get_search_vector_store()
+
+
+def test_writer_completes_while_read_pool_handles_are_checked_out(tmp_path, monkeypatch):
+    db_path = tmp_path / "writer-progress.db"
+    _create_vector_db(db_path)
+    monkeypatch.setenv("BRAINLAYER_DB", str(db_path))
+    monkeypatch.setenv("BRAINLAYER_READ_POOL_SIZE", "2")
+
+    with _shared._search_store_checkout() as reader_a, _shared._search_store_checkout() as reader_b:
+        for reader in (reader_a, reader_b):
+            reader.conn.cursor().execute("BEGIN")
+            reader.conn.cursor().execute("SELECT COUNT(*) FROM chunks").fetchone()
+        writer = VectorStore(db_path)
+        try:
+            started = time.perf_counter()
+            _insert_chunk(
+                writer,
+                chunk_id="writer-progress",
+                content="writer completes while readers are checked out",
+                embedding=_embed("writer completes while readers are checked out"),
+            )
+            writer.conn.cursor().execute("PRAGMA wal_checkpoint(PASSIVE)")
+            elapsed = time.perf_counter() - started
+        finally:
+            writer.close()
+            for reader in (reader_a, reader_b):
+                reader.conn.cursor().execute("ROLLBACK")
+
+    inspector = VectorStore(db_path, readonly=True)
+    try:
+        count = (
+            inspector.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE id = 'writer-progress'").fetchone()[0]
+        )
+    finally:
+        inspector.close()
+
+    assert count == 1
+    assert elapsed < 1.0


### PR DESCRIPTION
## Summary
- Replace the single shared MCP readonly `VectorStore` with a fixed-size pre-opened WAL read pool and checkout context manager.
- Route MCP search/read handlers through bounded readonly checkout while keeping `_get_search_vector_store()` compatibility.
- Add RAM clamp/startup guard, pool-size env handling, blocking checkout timeout behavior, and factual P1 notes in `CLAUDE.md`.

## Gate evidence
- Reader de-serialization / distinct handles:
  `tests/test_vector_store_readonly.py::test_search_handler_uses_distinct_pool_handles_for_concurrent_slow_reads PASSED [ 50%]`
- Writer not starved while readers hold read transactions:
  `tests/test_vector_store_readonly.py::test_writer_completes_while_read_pool_handles_are_checked_out PASSED [100%]`
- Gate command:
  `pytest tests/test_vector_store_readonly.py::test_search_handler_uses_distinct_pool_handles_for_concurrent_slow_reads tests/test_vector_store_readonly.py::test_writer_completes_while_read_pool_handles_are_checked_out -vv`
  `2 passed in 0.87s`

## Test plan
- `pytest tests/test_vector_store_readonly.py tests/test_search_handler.py -q` -> `40 passed in 2.28s`
- `ruff check src/ && ruff format src/` -> `All checks passed!` / `157 files left unchanged`
- `pytest` -> `3441 passed, 49 skipped, 5 xfailed, 329 warnings in 413.72s (0:06:53)`
- `BRAINLAYER_PREPUSH_SCOPE=changed-only git push -u origin feat/p1.1-wal-read-pool` -> changed-only fell back to full hook; `BrainLayer test gate passed.` including `3340 passed, 9 skipped, 61 deselected, 1 xfailed, 108 warnings in 384.77s (0:06:24)`, MCP registration `3 passed`, isolated eval/hook routing `40 passed`, bun `1 pass`, and `PASS: regression shell test_fts5_determinism.sh`.

## Review notes
- Local `coderabbit review --agent` first found a valid init-publication ordering issue in `_shared.py`; fixed before commit.
- Second local `coderabbit review --agent` timed out at 180s with no new findings emitted before timeout.

Review-required: lead owns review/merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MCP search concurrency and SQLite read connection lifecycle; mitigated by bounded pool, startup RAM guard, and targeted concurrency tests, but mis-tuned pool size could still cause search timeouts under load.
> 
> **Overview**
> Replaces the **single shared MCP readonly `VectorStore`** with a **fixed-size, pre-opened WAL read pool** in `mcp/_shared.py`, so concurrent search/read traffic can use separate connections instead of serializing on one handle.
> 
> **Pool behavior:** size from `BRAINLAYER_READ_POOL_SIZE` (default **8**, **4** on detected Apple M1), checkout via `_search_store_checkout()` with timeout from `BRAINLAYER_READ_BUSY_TIMEOUT_MS`, and startup **RAM clamp** that rejects `pool_size × BRAINLAYER_READ_CACHE_KB` above ~768MB. `_get_search_vector_store()` remains for compatibility; `_close_search_vector_store()` resets the pool for tests.
> 
> **Handler wiring:** `search_handler.py` routes read paths through `_vector_store_checkout()` (pool when unpatched, monkeypatched store in tests). Hybrid search, KG routing, recall/think/sessions, and related MCP reads now borrow/return pool handles per operation.
> 
> **Docs & tests:** `CLAUDE.md` adds P1 pipeline notes (denylist, secret scrub, read pool). `test_vector_store_readonly.py` adds coverage for distinct concurrent checkouts, pool exhaustion → `BusyError`, RAM clamp, and writers completing while readers hold checkouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550fd11fc8b748aaa502e8cf3bda3feee01675d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bounded readonly WAL VectorStore pool for concurrent MCP search reads
> - Replaces the single shared readonly `VectorStore` handle with a fixed-size pool of pre-opened handles in [`_shared.py`](https://github.com/EtanHey/brainlayer/pull/566/files#diff-8d50696b7d699becb60051866c0f5ad08fb051abf31b0ba06846824756994879), sized by platform (4 on Apple M1, 8 otherwise) or `BRAINLAYER_READ_POOL_SIZE`.
> - Adds a `_search_store_checkout` context manager that blocks up to `BRAINLAYER_READ_BUSY_TIMEOUT_MS` when the pool is exhausted and raises `apsw.BusyError` on timeout.
> - All search handlers in [`search_handler.py`](https://github.com/EtanHey/brainlayer/pull/566/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) now acquire a handle via `_vector_store_checkout` instead of calling `_get_vector_store` directly.
> - Enforces a ~768MB RAM clamp: initialization raises `ValueError` if `pool_size × read_cache_size` exceeds the limit.
> - Risk: concurrent callers that exhaust the pool will now block and can receive `BusyError`, which is a new failure mode absent from the single-handle design.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d66d4ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search and recall behavior with better support for search- and entity-based queries.
  * Added more reliable concurrent read access for faster search handling under load.

* **Bug Fixes**
  * Search operations now wait and fail cleanly when read capacity is exhausted instead of hanging unpredictably.
  * Strengthened startup safeguards to prevent overly large read-pool settings from using too much memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->