### PR TITLE
feat: isolate operational FTS rows

### DIFF
--- a/scripts/migrate_fts_operational_isolation.py
+++ b/scripts/migrate_fts_operational_isolation.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Move existing mixed FTS rows into P1.4 routed FTS tables.
+
+Dry run is the default. Apply mode rebuilds FTS tables from `chunks` instead of
+editing individual FTS rows, which keeps BM25 statistics deterministic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import apsw
+
+from brainlayer.paths import DEFAULT_DB_PATH
+from brainlayer.vector_store import VectorStore
+
+KNOWLEDGE_CLASS_SQL = "COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')"
+OPERATIONAL_CLASS_SQL = "COALESCE(content_class, 'knowledge') = 'operational'"
+COLD_CLASS_SQL = "COALESCE(content_class, 'knowledge') IN ('test', 'benchmark')"
+FTS_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id"
+FTS_SELECT_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, id"
+
+
+def _table_exists(cursor: apsw.Cursor, table_name: str) -> bool:
+    return (
+        cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?",
+            (table_name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _ids(cursor: apsw.Cursor, sql: str, params: tuple[Any, ...] = ()) -> list[str]:
+    return [row[0] for row in cursor.execute(sql, params)]
+
+
+def _count(cursor: apsw.Cursor, sql: str) -> int:
+    return int(cursor.execute(sql).fetchone()[0])
+
+
+def _report(cursor: apsw.Cursor) -> dict[str, Any]:
+    has_operational_fts = _table_exists(cursor, "chunks_fts_operational")
+    has_trigram_fts = _table_exists(cursor, "chunks_fts_trigram")
+
+    report: dict[str, Any] = {
+        "chunk_counts": {
+            "knowledge": _count(cursor, f"SELECT COUNT(*) FROM chunks WHERE {KNOWLEDGE_CLASS_SQL}"),
+            "operational": _count(cursor, f"SELECT COUNT(*) FROM chunks WHERE {OPERATIONAL_CLASS_SQL}"),
+            "cold": _count(cursor, f"SELECT COUNT(*) FROM chunks WHERE {COLD_CLASS_SQL}"),
+        },
+        "knowledge_fts_ids": _ids(cursor, "SELECT chunk_id FROM chunks_fts ORDER BY chunk_id"),
+        "operational_fts_ids": [],
+        "cold_fts_ids": _ids(
+            cursor,
+            f"""
+            SELECT f.chunk_id
+            FROM chunks_fts f
+            JOIN chunks c ON c.id = f.chunk_id
+            WHERE {COLD_CLASS_SQL}
+            ORDER BY f.chunk_id
+            """,
+        ),
+        "knowledge_fts_operational_rows": _count(
+            cursor,
+            f"""
+            SELECT COUNT(*)
+            FROM chunks_fts f
+            JOIN chunks c ON c.id = f.chunk_id
+            WHERE {OPERATIONAL_CLASS_SQL}
+            """,
+        ),
+        "has_chunks_fts_operational": has_operational_fts,
+        "has_chunks_fts_trigram": has_trigram_fts,
+    }
+    if has_operational_fts:
+        report["operational_fts_ids"] = _ids(
+            cursor,
+            "SELECT chunk_id FROM chunks_fts_operational ORDER BY chunk_id",
+        )
+    return report
+
+
+def _drop_fts_triggers(cursor: apsw.Cursor) -> None:
+    for trigger_name in (
+        "chunks_fts_insert",
+        "chunks_fts_operational_insert",
+        "chunks_fts_trigram_insert",
+        "chunks_fts_delete",
+        "chunks_fts_operational_delete",
+        "chunks_fts_trigram_delete",
+        "chunks_fts_update",
+        "chunks_fts_operational_update",
+        "chunks_fts_trigram_update",
+    ):
+        cursor.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+
+
+def _insert_batches(cursor: apsw.Cursor, table_name: str, chunk_ids: list[str], batch_size: int) -> None:
+    for start in range(0, len(chunk_ids), batch_size):
+        batch = chunk_ids[start : start + batch_size]
+        placeholders = ", ".join("?" for _ in batch)
+        cursor.execute(
+            f"""
+            INSERT INTO {table_name}({FTS_COLUMNS})
+            SELECT {FTS_SELECT_COLUMNS}
+            FROM chunks
+            WHERE id IN ({placeholders})
+            ORDER BY id
+            """,
+            batch,
+        )
+
+
+def _sync_rowids(cursor: apsw.Cursor, *, include_trigram: bool) -> None:
+    cursor.execute("DELETE FROM chunk_fts_rowids")
+    cursor.execute("""
+        INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+        SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
+    """)
+    cursor.execute("""
+        INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+        SELECT chunk_id, rowid FROM chunks_fts_operational WHERE chunk_id IS NOT NULL
+        ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
+    """)
+    if include_trigram:
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts_trigram WHERE chunk_id IS NOT NULL
+            ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid
+        """)
+
+
+def migrate_fts_isolation(db_path: str | Path, *, dry_run: bool = True, batch_size: int = 5_000) -> dict[str, Any]:
+    """Report or apply P1.4 FTS isolation for an existing BrainLayer DB."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+
+    db_path = Path(db_path).expanduser()
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+
+    if dry_run:
+        conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+        try:
+            before = _report(conn.cursor())
+        finally:
+            conn.close()
+        return {"dry_run": True, "db_path": str(db_path), "before": before, "after": None}
+
+    # Ensure the new tables/rowid columns exist before bulk rebuilding them.
+    schema_store = VectorStore(db_path)
+    schema_store.close()
+
+    conn = apsw.Connection(str(db_path))
+    cursor = conn.cursor()
+    before = _report(cursor)
+    transaction_started = False
+    try:
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+        cursor.execute("BEGIN IMMEDIATE")
+        transaction_started = True
+        _drop_fts_triggers(cursor)
+
+        knowledge_ids = _ids(cursor, f"SELECT id FROM chunks WHERE {KNOWLEDGE_CLASS_SQL} ORDER BY id")
+        operational_ids = _ids(cursor, f"SELECT id FROM chunks WHERE {OPERATIONAL_CLASS_SQL} ORDER BY id")
+        include_trigram = _table_exists(cursor, "chunks_fts_trigram")
+
+        cursor.execute("DELETE FROM chunks_fts")
+        cursor.execute("DELETE FROM chunks_fts_operational")
+        if include_trigram:
+            cursor.execute("DELETE FROM chunks_fts_trigram")
+        cursor.execute("DELETE FROM chunk_fts_rowids")
+
+        _insert_batches(cursor, "chunks_fts", knowledge_ids, batch_size)
+        _insert_batches(cursor, "chunks_fts_operational", operational_ids, batch_size)
+        if include_trigram:
+            _insert_batches(cursor, "chunks_fts_trigram", knowledge_ids, batch_size)
+        _sync_rowids(cursor, include_trigram=include_trigram)
+
+        cursor.execute("COMMIT")
+        transaction_started = False
+        cursor.execute("PRAGMA wal_checkpoint(FULL)")
+    except Exception:
+        if transaction_started:
+            cursor.execute("ROLLBACK")
+        raise
+    finally:
+        conn.close()
+
+    # Recreate insert/delete/update triggers through the canonical initializer.
+    trigger_store = VectorStore(db_path)
+    try:
+        after = _report(trigger_store.conn.cursor())
+    finally:
+        trigger_store.close()
+    return {"dry_run": False, "db_path": str(db_path), "before": before, "after": after}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH, help="BrainLayer SQLite DB path")
+    parser.add_argument("--apply", action="store_true", help="Apply changes. Default is dry run.")
+    parser.add_argument("--batch-size", type=int, default=5_000, help="Chunk-id batch size for FTS rebuilds")
+    args = parser.parse_args()
+
+    report = migrate_fts_isolation(args.db, dry_run=not args.apply, batch_size=args.batch_size)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -21,7 +21,7 @@ from mcp.types import TextContent
 from .. import search_profile, telemetry
 from .._helpers import _escape_fts5_query, _is_sqlite_busy_error
 from ..chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_checkpoint_content
-from ..content_class import content_class_is_default_hidden, normalize_content_class, query_signals_operational_intent
+from ..content_class import content_class_is_default_hidden, normalize_content_class
 from ..lexical_defense import _normalize_surface, load_lexical_defense_dictionary
 from ..search_repo import _is_audit_recursion_metadata, _metadata_matches_project_scope
 
@@ -560,12 +560,7 @@ def _exact_chunk_lookup_result(
     chunk_class = normalize_content_class(chunk.get("content_class"))
     if content_class_filter and chunk_class != normalize_content_class(content_class_filter):
         return _empty_exact_chunk_lookup_result(query)
-    if (
-        not content_class_filter
-        and not include_operational
-        and not query_signals_operational_intent(query)
-        and content_class_is_default_hidden(chunk_class)
-    ):
+    if not include_operational and content_class_is_default_hidden(chunk_class):
         return _empty_exact_chunk_lookup_result(query)
     if importance_min is not None:
         chunk_importance = chunk.get("importance")
@@ -1034,12 +1029,7 @@ async def _brain_search_dispatch(
             if content_class_filter and chunk_class != normalize_content_class(content_class_filter):
                 empty = {"query": query, "total": 0, "results": []}
                 return ([TextContent(type="text", text="No results found.")], empty)
-            if (
-                not content_class_filter
-                and not include_operational
-                and not query_signals_operational_intent(query)
-                and content_class_is_default_hidden(chunk_class)
-            ):
+            if not include_operational and content_class_is_default_hidden(chunk_class):
                 empty = {"query": query, "total": 0, "results": []}
                 return ([TextContent(type="text", text="No results found.")], empty)
         return await _context(

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -19,7 +19,7 @@ from . import search_profile
 from ._helpers import _escape_fts5_query, _is_sqlite_busy_error, serialize_f32
 from .agent_profiles import boost_weight, source_weight, validate_agent_profile
 from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_checkpoint_content
-from .content_class import DEFAULT_CONTENT_CLASS, normalize_content_class, query_signals_operational_intent
+from .content_class import DEFAULT_CONTENT_CLASS, normalize_content_class
 from .dedupe import resolve_chunk_id
 from .ingest_guard import recursive_mcp_output_reason
 from .scoping import ConsumerScope
@@ -353,7 +353,8 @@ def _content_class_where(
             DEFAULT_CONTENT_CLASS,
             normalize_content_class(content_class_filter),
         ]
-    if include_operational or query_signals_operational_intent(query_text):
+    del query_text
+    if include_operational:
         return None, []
     return f"COALESCE({column_expr}, ?) NOT IN ('operational', 'test', 'benchmark')", [DEFAULT_CONTENT_CLASS]
 
@@ -2072,6 +2073,8 @@ class SearchMixin:
                         progress_setter(None, 0)
 
             fts_results = _fetch_fts_rows("chunks_fts", timeout_ms=fts_timeout_ms)
+            if include_operational:
+                fts_results.extend(_fetch_fts_rows("chunks_fts_operational", timeout_ms=fts_timeout_ms))
             if getattr(self, "_trigram_fts_available", False) and not brainbar_helper_fast_profile:
                 trigram_fts_results = _fetch_fts_rows("chunks_fts_trigram")
         search_profile.emit(

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -67,6 +67,8 @@ _DEFAULT_READ_BUSY_TIMEOUT_MS = 5_000
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _WRITE_BUSY_TIMEOUT_STATE = threading.local()
 _NO_EXEC_TRACE = object()
+_KNOWLEDGE_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')"
+_OPERATIONAL_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') = 'operational'"
 
 
 def _positive_int_env(name: str, default: int) -> int:
@@ -1009,12 +1011,21 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         if _needs_fts_rebuild:
             cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_insert")
+            cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_operational_insert")
             cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_delete")
+            cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_operational_delete")
             cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_update")
+            cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_operational_update")
             cursor.execute("DROP TABLE IF EXISTS chunks_fts")
+            cursor.execute("DROP TABLE IF EXISTS chunks_fts_operational")
 
         cursor.execute(f"""
             CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+                {_FTS5_COLUMNS}
+            )
+        """)
+        cursor.execute(f"""
+            CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts_operational USING fts5(
                 {_FTS5_COLUMNS}
             )
         """)
@@ -1029,9 +1040,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             CREATE TABLE IF NOT EXISTS chunk_fts_rowids (
                 chunk_id TEXT PRIMARY KEY,
                 fts_rowid INTEGER,
-                trigram_rowid INTEGER
+                trigram_rowid INTEGER,
+                operational_rowid INTEGER
             )
         """)
+        rowid_cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunk_fts_rowids)")}
+        if "operational_rowid" not in rowid_cols:
+            cursor.execute("ALTER TABLE chunk_fts_rowids ADD COLUMN operational_rowid INTEGER")
         cursor.execute("""
             INSERT OR IGNORE INTO chunk_fts_rowids(chunk_id, fts_rowid)
             SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
@@ -1041,13 +1056,18 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             SELECT chunk_id, rowid FROM chunks_fts_trigram WHERE chunk_id IS NOT NULL
             ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid
         """)
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts_operational WHERE chunk_id IS NOT NULL
+            ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
+        """)
 
         # FTS5 sync triggers — keep summary/tags/resolved_query in sync
         cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_insert")
         cursor.execute("""
             CREATE TRIGGER IF NOT EXISTS chunks_fts_insert AFTER INSERT ON chunks BEGIN
                 INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
-                VALUES (
+                SELECT
                     new.content,
                     new.summary,
                     new.tags,
@@ -1055,17 +1075,39 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     new.key_facts,
                     new.resolved_queries,
                     new.id
-                );
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark');
                 INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
-                VALUES (new.id, last_insert_rowid())
+                SELECT new.id, last_insert_rowid()
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
                 ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid;
+            END
+        """)
+        cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_operational_insert")
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS chunks_fts_operational_insert AFTER INSERT ON chunks BEGIN
+                INSERT INTO chunks_fts_operational(
+                    content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id
+                )
+                SELECT
+                    new.content,
+                    new.summary,
+                    new.tags,
+                    new.resolved_query,
+                    new.key_facts,
+                    new.resolved_queries,
+                    new.id
+                WHERE COALESCE(new.content_class, 'knowledge') = 'operational';
+                INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+                SELECT new.id, last_insert_rowid()
+                WHERE COALESCE(new.content_class, 'knowledge') = 'operational'
+                ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid;
             END
         """)
         cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_insert")
         cursor.execute("""
             CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_insert AFTER INSERT ON chunks BEGIN
                 INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
-                VALUES (
+                SELECT
                     new.content,
                     new.summary,
                     new.tags,
@@ -1073,9 +1115,10 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     new.key_facts,
                     new.resolved_queries,
                     new.id
-                );
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark');
                 INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
-                VALUES (new.id, last_insert_rowid())
+                SELECT new.id, last_insert_rowid()
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
                 ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid;
             END
         """)
@@ -1086,6 +1129,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
                 DELETE FROM chunks_fts_trigram
                 WHERE rowid = (SELECT trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+                DELETE FROM chunks_fts_operational
+                WHERE rowid = (SELECT operational_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
                 DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
             END
         """)
@@ -1096,38 +1141,25 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
                 DELETE FROM chunks_fts_trigram
                 WHERE rowid = (SELECT trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
+                DELETE FROM chunks_fts_operational
+                WHERE rowid = (SELECT operational_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
                 DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
             END
         """)
+        cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_operational_delete")
         cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_update")
         cursor.execute("""
             CREATE TRIGGER IF NOT EXISTS chunks_fts_update
-            AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries ON chunks BEGIN
+            AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries, content_class ON chunks BEGIN
                 DELETE FROM chunks_fts
                 WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
-                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
-                VALUES (
-                    new.content,
-                    new.summary,
-                    new.tags,
-                    new.resolved_query,
-                    new.key_facts,
-                    new.resolved_queries,
-                    new.id
-                );
-                INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
-                VALUES (new.id, last_insert_rowid())
-                ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid;
-            END
-        """)
-        cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_update")
-        cursor.execute("""
-            CREATE TRIGGER IF NOT EXISTS chunks_fts_trigram_update
-            AFTER UPDATE OF content, summary, tags, resolved_query, key_facts, resolved_queries ON chunks BEGIN
+                DELETE FROM chunks_fts_operational
+                WHERE rowid = (SELECT operational_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
                 DELETE FROM chunks_fts_trigram
                 WHERE rowid = (SELECT trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
-                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
-                VALUES (
+                DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
+                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                SELECT
                     new.content,
                     new.summary,
                     new.tags,
@@ -1135,12 +1167,47 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     new.key_facts,
                     new.resolved_queries,
                     new.id
-                );
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark');
+                INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+                SELECT new.id, last_insert_rowid()
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
+                ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid;
+
+                INSERT INTO chunks_fts_operational(
+                    content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id
+                )
+                SELECT
+                    new.content,
+                    new.summary,
+                    new.tags,
+                    new.resolved_query,
+                    new.key_facts,
+                    new.resolved_queries,
+                    new.id
+                WHERE COALESCE(new.content_class, 'knowledge') = 'operational';
+                INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+                SELECT new.id, last_insert_rowid()
+                WHERE COALESCE(new.content_class, 'knowledge') = 'operational'
+                ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid;
+
+                INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                SELECT
+                    new.content,
+                    new.summary,
+                    new.tags,
+                    new.resolved_query,
+                    new.key_facts,
+                    new.resolved_queries,
+                    new.id
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark');
                 INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
-                VALUES (new.id, last_insert_rowid())
+                SELECT new.id, last_insert_rowid()
+                WHERE COALESCE(new.content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
                 ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid;
             END
         """)
+        cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_operational_update")
+        cursor.execute("DROP TRIGGER IF EXISTS chunks_fts_trigram_update")
 
         self._schema_user_version = cursor.execute("PRAGMA user_version").fetchone()[0]
         if os.environ.get("BRAINLAYER_REPAIR") == "1":
@@ -1721,14 +1788,39 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
               AND expired_at IS NULL
         """)
 
-        # FTS5 backfill check — populate from chunks if FTS is empty (fresh rebuild or first run)
+        # FTS5 backfill check — populate routed indexes if empty (fresh rebuild or first run).
         fts_count = list(cursor.execute("SELECT COUNT(*) FROM chunks_fts"))[0][0]
-        chunk_count = list(cursor.execute("SELECT COUNT(*) FROM chunks"))[0][0]
-        if chunk_count > 0 and fts_count == 0:
+        operational_fts_count = list(cursor.execute("SELECT COUNT(*) FROM chunks_fts_operational"))[0][0]
+        visible_chunk_count = list(cursor.execute(f"SELECT COUNT(*) FROM chunks WHERE {_KNOWLEDGE_FTS_CLASS_SQL}"))[0][
+            0
+        ]
+        operational_chunk_count = list(
+            cursor.execute(f"SELECT COUNT(*) FROM chunks WHERE {_OPERATIONAL_FTS_CLASS_SQL}")
+        )[0][0]
+        if visible_chunk_count > 0 and fts_count == 0:
             cursor.execute("""
                 INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
                 SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                WHERE COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
             """)
+        if operational_chunk_count > 0 and operational_fts_count == 0:
+            cursor.execute("""
+                INSERT INTO chunks_fts_operational(
+                    content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id
+                )
+                SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                WHERE COALESCE(content_class, 'knowledge') = 'operational'
+            """)
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
+            ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid
+        """)
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts_operational WHERE chunk_id IS NOT NULL
+            ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
+        """)
 
         existing_cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunks)")}
         self._has_invalid_at = "invalid_at" in existing_cols
@@ -1799,15 +1891,50 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 cursor.execute("PRAGMA wal_checkpoint(FULL)")
                 cursor.execute("BEGIN IMMEDIATE")
                 transaction_started = True
+                cursor.execute("DELETE FROM chunks_fts")
+                cursor.execute("""
+                    INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                    SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                    WHERE COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
+                """)
+                repaired["chunks_fts"] = cursor.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0]
+                cursor.execute("DELETE FROM chunks_fts_operational")
+                cursor.execute("""
+                    INSERT INTO chunks_fts_operational(
+                        content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id
+                    )
+                    SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                    WHERE COALESCE(content_class, 'knowledge') = 'operational'
+                """)
+                repaired["chunks_fts_operational"] = cursor.execute(
+                    "SELECT COUNT(*) FROM chunks_fts_operational"
+                ).fetchone()[0]
                 if rebuild_trigram:
                     cursor.execute("DELETE FROM chunks_fts_trigram")
                     cursor.execute("""
                         INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
                         SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                        WHERE COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
                     """)
                     repaired["chunks_fts_trigram"] = cursor.execute(
                         "SELECT COUNT(*) FROM chunks_fts_trigram"
                     ).fetchone()[0]
+                cursor.execute("DELETE FROM chunk_fts_rowids")
+                cursor.execute("""
+                    INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+                    SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
+                """)
+                cursor.execute("""
+                    INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+                    SELECT chunk_id, rowid FROM chunks_fts_operational WHERE chunk_id IS NOT NULL
+                    ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
+                """)
+                if rebuild_trigram:
+                    cursor.execute("""
+                        INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
+                        SELECT chunk_id, rowid FROM chunks_fts_trigram WHERE chunk_id IS NOT NULL
+                        ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid
+                    """)
                 cursor.execute("COMMIT")
                 transaction_started = False
                 cursor.execute("PRAGMA wal_checkpoint(FULL)")
@@ -1853,24 +1980,65 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             return
 
     def _get_fts5_counts(self) -> tuple[int, int]:
-        """Read chunks and FTS counts using a single query on the readonly path."""
+        """Read FTS-eligible chunk and knowledge FTS counts using a single query."""
         row = (
             self._read_cursor()
-            .execute("SELECT (SELECT COUNT(*) FROM chunks), (SELECT COUNT(*) FROM chunks_fts)")
+            .execute(
+                f"""
+                SELECT
+                    (SELECT COUNT(*) FROM chunks WHERE {_KNOWLEDGE_FTS_CLASS_SQL}),
+                    (SELECT COUNT(*) FROM chunks_fts)
+                """
+            )
             .fetchone()
         )
         return int(row[0]), int(row[1])
 
+    def _get_fts5_health_counts(self) -> tuple[int, int, int, int]:
+        """Read expected/actual counts for both routed FTS indexes."""
+        row = (
+            self._read_cursor()
+            .execute(
+                f"""
+                SELECT
+                    (SELECT COUNT(*) FROM chunks WHERE {_KNOWLEDGE_FTS_CLASS_SQL}),
+                    (SELECT COUNT(*) FROM chunks_fts),
+                    (SELECT COUNT(*) FROM chunks WHERE {_OPERATIONAL_FTS_CLASS_SQL}),
+                    (SELECT COUNT(*) FROM chunks_fts_operational)
+                """
+            )
+            .fetchone()
+        )
+        return int(row[0]), int(row[1]), int(row[2]), int(row[3])
+
     @staticmethod
-    def _build_fts5_health_result(chunk_count: int, fts_count: int, severity: str) -> Dict[str, Any]:
+    def _build_fts5_health_result(
+        chunk_count: int,
+        fts_count: int,
+        severity: str,
+        *,
+        operational_chunk_count: int = 0,
+        operational_fts_count: int = 0,
+    ) -> Dict[str, Any]:
         """Shape a health payload from count data."""
-        desync_pct = 0.0
+        knowledge_desync_pct = 0.0
         if chunk_count > 0:
-            desync_pct = round(abs(chunk_count - fts_count) * 100.0 / chunk_count, 2)
+            knowledge_desync_pct = round(abs(chunk_count - fts_count) * 100.0 / chunk_count, 2)
+        operational_desync_pct = 0.0
+        if operational_chunk_count > 0:
+            operational_desync_pct = round(
+                abs(operational_chunk_count - operational_fts_count) * 100.0 / operational_chunk_count,
+                2,
+            )
+        desync_pct = max(knowledge_desync_pct, operational_desync_pct)
         return {
             "synced": desync_pct <= 1.0,
             "chunk_count": chunk_count,
             "fts_count": fts_count,
+            "operational_chunk_count": operational_chunk_count,
+            "operational_fts_count": operational_fts_count,
+            "knowledge_desync_pct": knowledge_desync_pct,
+            "operational_desync_pct": operational_desync_pct,
             "desync_pct": desync_pct,
             "severity": severity,
         }
@@ -1882,35 +2050,73 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         if cache_ttl_seconds > 0 and cache.get("expires_at", 0) > now:
             return dict(cache["result"])
 
-        chunk_count, fts_count = self._get_fts5_counts()
-        desync_pct = 0.0 if chunk_count == 0 else abs(chunk_count - fts_count) * 100.0 / chunk_count
+        chunk_count, fts_count, operational_chunk_count, operational_fts_count = self._get_fts5_health_counts()
+        knowledge_desync_pct = 0.0 if chunk_count == 0 else abs(chunk_count - fts_count) * 100.0 / chunk_count
+        operational_desync_pct = (
+            0.0
+            if operational_chunk_count == 0
+            else abs(operational_chunk_count - operational_fts_count) * 100.0 / operational_chunk_count
+        )
+        desync_pct = max(knowledge_desync_pct, operational_desync_pct)
 
         if desync_pct > 20.0 and auto_rebuild:
             self._log_health_event(
                 "fts5_desync_critical",
                 "emergency",
-                {"chunk_count": chunk_count, "fts_count": fts_count, "desync_pct": round(desync_pct, 2)},
+                {
+                    "chunk_count": chunk_count,
+                    "fts_count": fts_count,
+                    "operational_chunk_count": operational_chunk_count,
+                    "operational_fts_count": operational_fts_count,
+                    "desync_pct": round(desync_pct, 2),
+                },
             )
             rebuild_result = self.rebuild_fts5()
             result = {
                 "synced": rebuild_result["success"],
                 "chunk_count": rebuild_result["chunk_count"],
                 "fts_count": rebuild_result["fts_count"],
+                "operational_chunk_count": rebuild_result["operational_chunk_count"],
+                "operational_fts_count": rebuild_result["operational_fts_count"],
                 "desync_pct": rebuild_result["desync_pct"],
                 "severity": "emergency",
                 "rebuild_triggered": True,
             }
         elif desync_pct > 20.0:
-            result = self._build_fts5_health_result(chunk_count, fts_count, "emergency")
+            result = self._build_fts5_health_result(
+                chunk_count,
+                fts_count,
+                "emergency",
+                operational_chunk_count=operational_chunk_count,
+                operational_fts_count=operational_fts_count,
+            )
             result["rebuild_triggered"] = False
         elif desync_pct > 5.0:
-            result = self._build_fts5_health_result(chunk_count, fts_count, "critical")
+            result = self._build_fts5_health_result(
+                chunk_count,
+                fts_count,
+                "critical",
+                operational_chunk_count=operational_chunk_count,
+                operational_fts_count=operational_fts_count,
+            )
             self._log_health_event("fts5_desync_critical", "critical", result)
         elif desync_pct > 1.0:
-            result = self._build_fts5_health_result(chunk_count, fts_count, "warning")
+            result = self._build_fts5_health_result(
+                chunk_count,
+                fts_count,
+                "warning",
+                operational_chunk_count=operational_chunk_count,
+                operational_fts_count=operational_fts_count,
+            )
             self._log_health_event("fts5_desync_warning", "warning", result)
         else:
-            result = self._build_fts5_health_result(chunk_count, fts_count, "info")
+            result = self._build_fts5_health_result(
+                chunk_count,
+                fts_count,
+                "info",
+                operational_chunk_count=operational_chunk_count,
+                operational_fts_count=operational_fts_count,
+            )
 
         if cache_ttl_seconds > 0:
             self._fts5_health_cache = {"result": dict(result), "expires_at": now + cache_ttl_seconds}
@@ -1959,12 +2165,12 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         cursor = self.conn.cursor()
         cursor.execute("INSERT INTO chunks_fts(chunks_fts) VALUES('integrity-check')")
 
-        total_chunks = cursor.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        total_chunks = cursor.execute(f"SELECT COUNT(*) FROM chunks WHERE {_KNOWLEDGE_FTS_CLASS_SQL}").fetchone()[0]
         spot_check_count = min(100, total_chunks)
         sample_ids = [
             row[0]
             for row in cursor.execute(
-                "SELECT id FROM chunks ORDER BY random() LIMIT ?",
+                f"SELECT id FROM chunks WHERE {_KNOWLEDGE_FTS_CLASS_SQL} ORDER BY random() LIMIT ?",
                 (spot_check_count,),
             )
         ]
@@ -2003,14 +2209,29 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self._log_health_event("fts5_rebuild", "emergency", {"db_path": str(self.db_path)})
         cursor = self.conn.cursor()
         cursor.execute("INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild')")
+        cursor.execute("INSERT INTO chunks_fts_operational(chunks_fts_operational) VALUES('rebuild')")
         if getattr(self, "_trigram_fts_available", False):
             cursor.execute("INSERT INTO chunks_fts_trigram(chunks_fts_trigram) VALUES('rebuild')")
         chunk_count, fts_count = self._get_fts5_counts()
         if chunk_count != fts_count:
             cursor.execute("DELETE FROM chunks_fts")
             cursor.execute("""
-                INSERT INTO chunks_fts(content, summary, tags, resolved_query, chunk_id)
-                SELECT content, summary, tags, resolved_query, id FROM chunks
+                INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+                SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                WHERE COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
+            """)
+        operational_chunk_count = cursor.execute(
+            f"SELECT COUNT(*) FROM chunks WHERE {_OPERATIONAL_FTS_CLASS_SQL}"
+        ).fetchone()[0]
+        operational_count = cursor.execute("SELECT COUNT(*) FROM chunks_fts_operational").fetchone()[0]
+        if operational_chunk_count != operational_count:
+            cursor.execute("DELETE FROM chunks_fts_operational")
+            cursor.execute("""
+                INSERT INTO chunks_fts_operational(
+                    content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id
+                )
+                SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                WHERE COALESCE(content_class, 'knowledge') = 'operational'
             """)
         if getattr(self, "_trigram_fts_available", False):
             trigram_count = cursor.execute("SELECT COUNT(*) FROM chunks_fts_trigram").fetchone()[0]
@@ -2019,27 +2240,55 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 cursor.execute("""
                     INSERT INTO chunks_fts_trigram(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
                     SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+                    WHERE COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')
                 """)
+        cursor.execute("DELETE FROM chunk_fts_rowids")
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
+        """)
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts_operational WHERE chunk_id IS NOT NULL
+            ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
+        """)
+        if getattr(self, "_trigram_fts_available", False):
+            cursor.execute("""
+                INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
+                SELECT chunk_id, rowid FROM chunks_fts_trigram WHERE chunk_id IS NOT NULL
+                ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid
+            """)
         try:
             cursor.execute("PRAGMA wal_checkpoint(PASSIVE)")
         except apsw.Error:
             pass
 
         self._fts5_health_cache = {}
-        chunk_count, fts_count = self._get_fts5_counts()
+        chunk_count, fts_count, operational_chunk_count, operational_fts_count = self._get_fts5_health_counts()
         trigram_count = None
         fts_desync_pct = 0.0 if chunk_count == 0 else round(abs(chunk_count - fts_count) * 100.0 / chunk_count, 2)
+        operational_desync_pct = (
+            0.0
+            if operational_chunk_count == 0
+            else round(abs(operational_chunk_count - operational_fts_count) * 100.0 / operational_chunk_count, 2)
+        )
         trigram_desync_pct = 0.0
         if getattr(self, "_trigram_fts_available", False):
             trigram_count = cursor.execute("SELECT COUNT(*) FROM chunks_fts_trigram").fetchone()[0]
             trigram_desync_pct = (
                 0.0 if chunk_count == 0 else round(abs(chunk_count - trigram_count) * 100.0 / chunk_count, 2)
             )
-        desync_pct = max(fts_desync_pct, trigram_desync_pct)
+        desync_pct = max(fts_desync_pct, operational_desync_pct, trigram_desync_pct)
         return {
-            "success": chunk_count == fts_count and (trigram_count is None or chunk_count == trigram_count),
+            "success": (
+                chunk_count == fts_count
+                and operational_chunk_count == operational_fts_count
+                and (trigram_count is None or chunk_count == trigram_count)
+            ),
             "chunk_count": chunk_count,
             "fts_count": fts_count,
+            "operational_chunk_count": operational_chunk_count,
+            "operational_fts_count": operational_fts_count,
             "trigram_count": trigram_count,
             "desync_pct": desync_pct,
         }

--- a/tests/test_content_class.py
+++ b/tests/test_content_class.py
@@ -43,6 +43,15 @@ def _insert_chunk(
         )
 
 
+def _fts_ids(store: VectorStore, table_name: str) -> list[str]:
+    return [
+        row[0]
+        for row in store.conn.cursor().execute(
+            f"SELECT chunk_id FROM {table_name} ORDER BY chunk_id"  # noqa: S608 - test-controlled table names
+        )
+    ]
+
+
 def test_content_class_schema_defaults_to_knowledge(tmp_path: Path) -> None:
     store = VectorStore(tmp_path / "content-class-schema.db")
     try:
@@ -64,6 +73,129 @@ def test_content_class_schema_defaults_to_knowledge(tmp_path: Path) -> None:
         store.close()
 
     assert row == ("knowledge",)
+
+
+def test_fts_routes_operational_out_of_knowledge_index_and_skips_cold_classes(tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "content-class-fts-routing.db")
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="knowledge-doc",
+            content="durable knowledge routing sentinel",
+            content_class="knowledge",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="operational-doc",
+            content="[BL-LEAD tick] status-only coordination routing sentinel",
+            content_class="operational",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="test-doc",
+            content="ad-hoc eval test query routing sentinel",
+            content_class="test",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="benchmark-doc",
+            content="BrainLayer Search Benchmark diagnostic routing sentinel",
+            content_class="benchmark",
+        )
+
+        knowledge_fts_ids = _fts_ids(store, "chunks_fts")
+        operational_fts_ids = _fts_ids(store, "chunks_fts_operational")
+    finally:
+        store.close()
+
+    assert knowledge_fts_ids == ["knowledge-doc"]
+    assert operational_fts_ids == ["operational-doc"]
+
+
+def test_knowledge_fts_rows_match_knowledge_only_build_when_operational_and_cold_rows_exist(tmp_path: Path) -> None:
+    mixed_store = VectorStore(tmp_path / "mixed-fts-routing.db")
+    isolated_store = VectorStore(tmp_path / "knowledge-only-fts-routing.db")
+    try:
+        _insert_chunk(
+            mixed_store,
+            chunk_id="knowledge-doc",
+            content="durable avgdl sentinel exactmatch",
+            content_class="knowledge",
+        )
+        _insert_chunk(
+            mixed_store,
+            chunk_id="operational-doc",
+            content="[BL-LEAD tick] status-only exactmatch",
+            content_class="operational",
+        )
+        _insert_chunk(
+            mixed_store,
+            chunk_id="benchmark-doc",
+            content="BrainLayer Search Benchmark diagnostic exactmatch",
+            content_class="benchmark",
+        )
+        _insert_chunk(
+            isolated_store,
+            chunk_id="knowledge-doc",
+            content="durable avgdl sentinel exactmatch",
+            content_class="knowledge",
+        )
+
+        mixed_rows = list(
+            mixed_store.conn.cursor().execute(
+                "SELECT chunk_id, content, summary, tags, resolved_query, key_facts, resolved_queries "
+                "FROM chunks_fts ORDER BY chunk_id"
+            )
+        )
+        isolated_rows = list(
+            isolated_store.conn.cursor().execute(
+                "SELECT chunk_id, content, summary, tags, resolved_query, key_facts, resolved_queries "
+                "FROM chunks_fts ORDER BY chunk_id"
+            )
+        )
+        mixed_avg_len = sum(len(row[1] or "") for row in mixed_rows) / len(mixed_rows)
+        isolated_avg_len = sum(len(row[1] or "") for row in isolated_rows) / len(isolated_rows)
+    finally:
+        mixed_store.close()
+        isolated_store.close()
+
+    assert mixed_rows == isolated_rows
+    assert mixed_avg_len - isolated_avg_len == 0
+
+
+def test_operational_fts_rows_require_explicit_include_operational(tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "operational-fts-search.db")
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="operational-doc",
+            content="[BL-LEAD tick] status-only coordination explicitoperational",
+            content_class="operational",
+        )
+        store._trigram_fts_available = False
+
+        default_results = store.hybrid_search(
+            query_embedding=None,
+            query_text="explicitoperational",
+            n_results=5,
+        )
+        intent_only_results = store.hybrid_search(
+            query_embedding=None,
+            query_text="operational status explicitoperational",
+            n_results=5,
+        )
+        included_results = store.hybrid_search(
+            query_embedding=None,
+            query_text="explicitoperational",
+            n_results=5,
+            include_operational=True,
+        )
+    finally:
+        store.close()
+
+    assert default_results["ids"][0] == []
+    assert intent_only_results["ids"][0] == []
+    assert included_results["ids"][0] == ["operational-doc"]
 
 
 @pytest.mark.parametrize(
@@ -306,6 +438,7 @@ def test_hybrid_search_excludes_operational_and_test_by_default(tmp_path: Path) 
             query_embedding=query_embedding,
             query_text="exactmatch",
             n_results=5,
+            include_operational=True,
             content_class_filter="operational",
         )
     finally:
@@ -318,7 +451,7 @@ def test_hybrid_search_excludes_operational_and_test_by_default(tmp_path: Path) 
     assert class_filter_results["ids"][0] == ["operational-semantic"]
 
 
-def test_hybrid_search_auto_includes_operational_for_status_intent(tmp_path: Path) -> None:
+def test_hybrid_search_requires_explicit_operational_include_for_status_intent(tmp_path: Path) -> None:
     store = VectorStore(tmp_path / "content-class-status-intent.db")
     query_embedding = _embed(0.3)
     try:
@@ -332,15 +465,22 @@ def test_hybrid_search_auto_includes_operational_for_status_intent(tmp_path: Pat
         store.build_binary_index()
         store._trigram_fts_available = False
 
-        results = store.hybrid_search(
+        default_results = store.hybrid_search(
             query_embedding=query_embedding,
             query_text="operational status heartbeat exactstatus",
             n_results=3,
         )
+        included_results = store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="operational status heartbeat exactstatus",
+            n_results=3,
+            include_operational=True,
+        )
     finally:
         store.close()
 
-    assert results["ids"][0] == ["operational-status"]
+    assert default_results["ids"][0] == []
+    assert included_results["ids"][0] == ["operational-status"]
 
 
 class RecordingSearchStore:
@@ -446,3 +586,54 @@ def test_dry_run_backfill_reports_counts_and_samples_without_updating(tmp_path: 
         "person-visible": "knowledge",
         "personal-visible": "knowledge",
     }
+
+
+def test_migrate_fts_isolation_dry_run_and_apply_moves_existing_mixed_rows(tmp_path: Path) -> None:
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "migrate_fts_operational_isolation.py"
+    spec = importlib.util.spec_from_file_location("migrate_fts_operational_isolation", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    db_path = tmp_path / "mixed-existing-fts.db"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="knowledge-doc",
+            content="durable migration knowledge exactmigrate",
+            content_class="knowledge",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="operational-doc",
+            content="[BL-LEAD tick] migration operational exactmigrate",
+            content_class="operational",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="benchmark-doc",
+            content="BrainLayer Search Benchmark diagnostic exactmigrate",
+            content_class="benchmark",
+        )
+        cursor = store.conn.cursor()
+        cursor.execute("DELETE FROM chunks_fts")
+        cursor.execute("DELETE FROM chunks_fts_operational")
+        cursor.execute("DELETE FROM chunks_fts_trigram")
+        cursor.execute("DELETE FROM chunk_fts_rowids")
+        cursor.execute("""
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+        """)
+    finally:
+        store.close()
+
+    dry_run = module.migrate_fts_isolation(db_path, dry_run=True, batch_size=2)
+    assert dry_run["dry_run"] is True
+    assert dry_run["before"]["knowledge_fts_operational_rows"] == 1
+    assert dry_run["after"] is None
+
+    apply_report = module.migrate_fts_isolation(db_path, dry_run=False, batch_size=2)
+    assert apply_report["after"]["knowledge_fts_ids"] == ["knowledge-doc"]
+    assert apply_report["after"]["operational_fts_ids"] == ["operational-doc"]
+    assert apply_report["after"]["cold_fts_ids"] == []

--- a/tests/test_fts5_health.py
+++ b/tests/test_fts5_health.py
@@ -17,15 +17,22 @@ def store(tmp_path):
     s.close()
 
 
-def _insert_chunk(store: VectorStore, chunk_id: str, content: str | None = None) -> None:
+def _insert_chunk(
+    store: VectorStore,
+    chunk_id: str,
+    content: str | None = None,
+    *,
+    content_class: str = "knowledge",
+) -> None:
     """Insert a chunk and let triggers populate FTS rows."""
     text = content or f"content for {chunk_id}"
     cursor = store.conn.cursor()
     cursor.execute(
         """
         INSERT INTO chunks (
-            id, content, metadata, source_file, project, content_type, char_count, source, tags, summary
-        ) VALUES (?, ?, ?, 'test.jsonl', 'brainlayer', 'assistant_text', ?, 'test', ?, ?)
+            id, content, metadata, source_file, project, content_type, char_count, source, tags, summary,
+            content_class
+        ) VALUES (?, ?, ?, 'test.jsonl', 'brainlayer', 'assistant_text', ?, 'test', ?, ?, ?)
         """,
         (
             chunk_id,
@@ -34,6 +41,7 @@ def _insert_chunk(store: VectorStore, chunk_id: str, content: str | None = None)
             len(text),
             json.dumps(["fts5", "health"]),
             text[:50],
+            content_class,
         ),
     )
 
@@ -79,6 +87,24 @@ class TestFTS5HealthMonitoring:
         assert result["fts_count"] == 98
         assert result["desync_pct"] == pytest.approx(2.0)
         assert result["severity"] == "warning"
+
+    def test_check_fts5_health_detects_operational_index_desync(self, store):
+        """Operational FTS desync should fail health even when knowledge FTS is synced."""
+        _insert_chunk(store, "knowledge-chunk", "knowledge synced content")
+        _insert_chunk(
+            store,
+            "operational-chunk",
+            "operational synced content",
+            content_class="operational",
+        )
+        store.conn.cursor().execute("DELETE FROM chunks_fts_operational WHERE chunk_id = 'operational-chunk'")
+
+        result = store.check_fts5_health(cache_ttl_seconds=0, auto_rebuild=False)
+
+        assert result["synced"] is False
+        assert result["operational_chunk_count"] == 1
+        assert result["operational_fts_count"] == 0
+        assert result["severity"] == "emergency"
 
     def test_check_fts5_health_desync_critical(self, store):
         """A 10% desync should surface as critical."""
@@ -158,6 +184,29 @@ class TestFTS5HealthMonitoring:
         assert result["fts_count"] == 6
         assert result["trigram_count"] == 6
         assert result["desync_pct"] == 0.0
+
+    def test_repair_fts_rebuilds_knowledge_operational_and_trigram_indexes(self, store):
+        """Explicit repair should restore every routed FTS table."""
+        _insert_chunk(store, "knowledge-chunk", "knowledge repair content")
+        _insert_chunk(
+            store,
+            "operational-chunk",
+            "operational repair content",
+            content_class="operational",
+        )
+        cursor = store.conn.cursor()
+        cursor.execute("DELETE FROM chunks_fts")
+        cursor.execute("DELETE FROM chunks_fts_operational")
+        cursor.execute("DELETE FROM chunks_fts_trigram")
+        cursor.execute("DELETE FROM chunk_fts_rowids")
+
+        result = store.repair_fts()
+
+        assert result["chunks_fts"] == 1
+        assert result["chunks_fts_operational"] == 1
+        assert result["chunks_fts_trigram"] == 1
+        assert cursor.execute("SELECT chunk_id FROM chunks_fts").fetchone() == ("knowledge-chunk",)
+        assert cursor.execute("SELECT chunk_id FROM chunks_fts_operational").fetchone() == ("operational-chunk",)
 
     def test_health_events_logged(self, store):
         """Non-OK checks should append rows to health_events."""

--- a/tests/test_search_trigram_fts.py
+++ b/tests/test_search_trigram_fts.py
@@ -51,14 +51,15 @@ def test_fts_update_triggers_delete_by_mapped_rowid(tmp_path):
             for row in store.conn.cursor().execute(
                 """
                 SELECT name, sql FROM sqlite_master
-                WHERE type = 'trigger' AND name IN ('chunks_fts_update', 'chunks_fts_trigram_update')
+                WHERE type = 'trigger' AND name = 'chunks_fts_update'
                 """
             )
         }
-        assert "DELETE FROM chunks_fts WHERE chunk_id = old.id" not in trigger_sql["chunks_fts_update"]
-        assert "DELETE FROM chunks_fts_trigram WHERE chunk_id = old.id" not in trigger_sql["chunks_fts_trigram_update"]
-        assert "chunk_fts_rowids" in trigger_sql["chunks_fts_update"]
-        assert "chunk_fts_rowids" in trigger_sql["chunks_fts_trigram_update"]
+        update_trigger = trigger_sql["chunks_fts_update"]
+        assert "DELETE FROM chunks_fts WHERE chunk_id = old.id" not in update_trigger
+        assert "DELETE FROM chunks_fts_trigram WHERE chunk_id = old.id" not in update_trigger
+        assert "chunk_fts_rowids" in update_trigger
+        assert "trigram_rowid" in update_trigger
 
         store.update_enrichment("chunk-rowid", summary="fresh rowid summary", tags=["rowid"])
 


### PR DESCRIPTION
## Summary

Implements P1.4 FTS isolation and explicit operational routing:

- Adds `chunks_fts_operational`, mirrored from `chunks_fts`, with routed insert/update/delete trigger behavior.
- Keeps default-visible knowledge/decision/legacy rows in `chunks_fts`; routes `content_class='operational'` to `chunks_fts_operational`; keeps cold classes (`test`, `benchmark`) out of FTS.
- Adds keyword-only `include_operational: bool = False` to hybrid search plumbing and removes query-text auto opt-in for operational/test/benchmark content.
- Adds a dry-run/apply maintenance script for routed FTS rebuilds: `scripts/migrate_fts_operational_isolation.py`.
- Extends FTS health/rebuild/repair checks to cover operational FTS desync.

## Verification

TDD red gates observed before implementation:

```text
missing chunks_fts_operational
mixed operational rows present in chunks_fts
missing migration script
```

Focused content-class gate:

```text
pytest tests/test_content_class.py -q
40 passed
```

Focused regression gate after CodeRabbit fixes:

```text
pytest tests/test_content_class.py tests/test_fts5_health.py tests/test_hybrid_search.py tests/test_vector_store.py tests/test_search_handler.py tests/test_search_trigram_fts.py -q
122 passed, 3 warnings
```

Full local pytest before push:

```text
pytest
3446 passed, 49 skipped, 5 xfailed, 329 warnings in 520.94s (0:08:40)
```

Lint/format:

```text
ruff check src/ && ruff format src/ && ruff check scripts/migrate_fts_operational_isolation.py tests/test_content_class.py tests/test_search_trigram_fts.py tests/test_fts5_health.py
All checks passed!
157 files left unchanged
All checks passed!
```

Pre-push gate:

```text
BRAINLAYER_PREPUSH_SCOPE=changed-only git push -u origin feat/p1.4-fts-operational-isolation
changed-only scope found an unmapped source change; falling back to full pytest unit suite
= 3345 passed, 9 skipped, 61 deselected, 1 xfailed, 108 warnings in 385.61s (0:06:25) =
PASS: pytest unit suite
3 passed in 0.80s
PASS: pytest MCP tool registration
40 passed in 2.91s
PASS: pytest isolated eval and hook routing
1 pass / 0 fail
PASS: bun test suite
PASS: regression shell test_fts5_determinism.sh
BrainLayer test gate passed.
```

Structural tmp-db invariant probe:

```text
op_ids_in_chunks_fts=0
operational_ids_in_chunks_fts_operational=1
knowledge_rows_equal_isolated=True
knowledge_avgdl_delta=0.0
default_ids=[]
include_operational_ids=['operational-doc']
```

Agada bench status:

```text
python3 /Users/etanheyman/Gits/golems/skills/golem-powers/agada-bench/scripts/run-bench.py prepare ...
domains=4 queries=67 gold_pairs=198 l2_l3=53 low_power=['architecture']
```

The full Agada scorecard is not yet complete. The `/agada-bench` workflow requires live `brain_search` result collection and provenance classification for all 67 queries. A safe temp DB backup attempt via `brain_backup_vacuum_into` timed out after 300s, so I am not pasting fabricated per-domain after numbers. Baseline found locally from `2026-05-16-brainlayer-quality-bench-results.md`:

```text
techgym: recall@5 true 68.3%, inflated 86.1%, placebo 30.9%, FM6 19.2%, YELLOW
freelance: recall@5 true 100%, placebo 4.2%, FM6 36.4%, GREEN
recruiting: recall@5 true 100%, placebo 1.8%, FM6 48.2%, GREEN
architecture: recall@5 true 0%, LOW-POWER / excluded from pass-fail
```

## Review Notes

Local CodeRabbit CLI first pass timed out but emitted two valid major findings:

1. Operational FTS desync was not included in health/rebuild counts.
2. `repair_fts()` rebuilt only trigram, not routed knowledge/operational FTS.

Both were fixed with tests. A second local CodeRabbit run was rate-limited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core search indexing and default result visibility; clients relying on status-keyword auto-inclusion of operational chunks will see fewer hits unless they pass include_operational=True. Apply-mode migration rewrites FTS tables under a transaction but is still a one-time production DB operation.
> 
> **Overview**
> Implements **P1.4 FTS isolation**: operational chunks are indexed in **`chunks_fts_operational`** while **`chunks_fts`** (and trigram) hold knowledge-visible rows only; **`test`/`benchmark`** stay out of FTS. Schema init adds **`operational_rowid`** on **`chunk_fts_rowids`**, class-aware insert/update/delete triggers, and backfill/repair/rebuild paths that repopulate both indexes from **`chunks`**.
> 
> **Search behavior** changes: hybrid FTS queries **`chunks_fts_operational`** only when **`include_operational=True`**. **`query_signals_operational_intent`** is no longer used for SQL filters or MCP chunk lookup—operational/test/benchmark results need **`include_operational`** or an explicit **`content_class`** filter.
> 
> Adds **`scripts/migrate_fts_operational_isolation.py`** (dry-run by default, transactional apply with batched rebuilds) for existing databases that still mix operational rows in **`chunks_fts`**. FTS health checks now track operational chunk vs FTS counts and desync alongside knowledge FTS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b5c98c835ea372300a14dc38371f644459ebd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate operational content into a separate FTS table from knowledge content
> - Adds `chunks_fts_operational` as a dedicated FTS5 table for operational/test/benchmark chunks, while `chunks_fts` now holds knowledge-only rows. Insert/delete/update triggers and rowid mappings in `chunk_fts_rowids` are updated to maintain both tables.
> - Updates `SearchMixin.hybrid_search` in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/567/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) to query `chunks_fts_operational` only when `include_operational=True`, and removes the previous behavior that auto-included operational results based on query text intent.
> - Removes `query_signals_operational_intent` from [search_handler.py](https://github.com/EtanHey/brainlayer/pull/567/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0) gating — operational content now requires explicit `include_operational=True` or a matching `content_class_filter`.
> - Adds [migrate_fts_isolation.py](https://github.com/EtanHey/brainlayer/pull/567/files#diff-540ae4b4234f54ebd25521c26df4a4ec9265deffef60cac19bcb306791af6e3a) to migrate existing mixed FTS rows into the correct routed tables, with dry-run and apply modes.
> - Behavioral Change: queries that previously returned operational results due to inferred intent (e.g. status-related queries) will now return no operational results unless `include_operational=True` is passed explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 50b5c98. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->