### PR TITLE
feat: gate retro quarantine retrievability

### DIFF
--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import os
 import random
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,6 +34,7 @@ FTS_SELECT_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolve
 FTS_STATE_COLUMNS = "rowid, content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id"
 QUARANTINE_MANIFEST_TABLE = "retro_self_pollution_quarantine_manifest"
 DEFAULT_ESTIMATE = 244_152
+RETRIEVABILITY_TOKEN_RE = re.compile(r"[A-Za-z0-9]{4,}")
 
 
 def _utc_now() -> str:
@@ -87,6 +89,31 @@ def _placeholders(values: list[Any]) -> str:
     if not values:
         raise ValueError("values must not be empty")
     return ", ".join("?" for _ in values)
+
+
+def _like_exact(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _retrievability_query(content: str) -> str:
+    seen: set[str] = set()
+    tokens: list[str] = []
+    for match in RETRIEVABILITY_TOKEN_RE.finditer(content):
+        token = match.group(0)
+        normalized = token.casefold()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        tokens.append(token)
+    tokens.sort(key=lambda value: (-len(value), value.casefold()))
+    return " ".join(tokens[:3])
+
+
+def _flat_result_ids(search_result: dict[str, Any]) -> list[str]:
+    ids = search_result.get("ids") or [[]]
+    if not ids:
+        return []
+    return list(ids[0] or [])
 
 
 def _drop_fts_triggers(cursor: apsw.Cursor) -> None:
@@ -638,6 +665,142 @@ def run_revert_proof(
     }
 
 
+def run_retrievability_proof(
+    db_path: str | Path,
+    chunk_ids: list[str],
+    *,
+    sample_size: int = 100,
+    random_seed: int = 0,
+    n_results: int = 50,
+) -> dict[str, Any]:
+    db_path = _path(db_path)
+    unique_ids = sorted(dict.fromkeys(chunk_ids))
+    if sample_size < 0:
+        raise ValueError("sample_size must be non-negative")
+    if n_results <= 0:
+        raise ValueError("n_results must be positive")
+    sample_count = min(sample_size, len(unique_ids))
+    rng = random.Random(random_seed)
+    sample_ids = sorted(rng.sample(unique_ids, sample_count)) if sample_count else []
+    chunks: dict[str, Any] = {}
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        store = VectorStore(db_path, readonly=True)
+        try:
+            for chunk_id in sample_ids:
+                row = cursor.execute(
+                    """
+                    SELECT id, content, content_class, project, source_file
+                    FROM chunks
+                    WHERE id = ?
+                    """,
+                    (chunk_id,),
+                ).fetchone()
+                if row is None:
+                    chunks[chunk_id] = {
+                        "chunk_row_exists": False,
+                        "content_class": None,
+                        "default_fts_rows": 0,
+                        "operational_fts_rows": 0,
+                        "default_search_absent": False,
+                        "operational_search_present": False,
+                        "expand_fetchable": False,
+                        "passed": False,
+                        "error": "missing chunk row",
+                    }
+                    continue
+
+                content = row[1] or ""
+                query = _retrievability_query(content)
+                project = row[3]
+                source_file = row[4] or ""
+                search_kwargs: dict[str, Any] = {}
+                if project:
+                    search_kwargs["project_filter"] = project
+                if source_file:
+                    search_kwargs["source_file_filter_like"] = _like_exact(source_file)
+
+                default_result_ids = []
+                operational_result_ids = []
+                if query:
+                    default_result_ids = _flat_result_ids(
+                        store.hybrid_search(
+                            query_embedding=None,
+                            query_text=query,
+                            n_results=n_results,
+                            **search_kwargs,
+                        )
+                    )
+                    operational_result_ids = _flat_result_ids(
+                        store.hybrid_search(
+                            query_embedding=None,
+                            query_text=query,
+                            n_results=n_results,
+                            include_operational=True,
+                            **search_kwargs,
+                        )
+                    )
+
+                context = store.get_context(
+                    chunk_id,
+                    before=0,
+                    after=0,
+                    include_checkpoints=True,
+                    include_audit=True,
+                )
+                target = context.get("target") or {}
+                default_fts_rows = cursor.execute(
+                    "SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = ?",
+                    (chunk_id,),
+                ).fetchone()[0]
+                operational_fts_rows = cursor.execute(
+                    "SELECT COUNT(*) FROM chunks_fts_operational WHERE chunk_id = ?",
+                    (chunk_id,),
+                ).fetchone()[0]
+                default_search_absent = chunk_id not in default_result_ids
+                operational_search_present = chunk_id in operational_result_ids
+                expand_fetchable = target.get("id") == chunk_id
+                chunk_passed = (
+                    row[2] == "operational"
+                    and default_fts_rows == 0
+                    and operational_fts_rows > 0
+                    and bool(query)
+                    and default_search_absent
+                    and operational_search_present
+                    and expand_fetchable
+                )
+                chunks[chunk_id] = {
+                    "chunk_row_exists": True,
+                    "content_class": row[2],
+                    "query": query,
+                    "default_result_ids": default_result_ids,
+                    "operational_result_ids": operational_result_ids,
+                    "default_fts_rows": default_fts_rows,
+                    "operational_fts_rows": operational_fts_rows,
+                    "default_search_absent": default_search_absent,
+                    "operational_search_present": operational_search_present,
+                    "expand_fetchable": expand_fetchable,
+                    "passed": chunk_passed,
+                }
+        finally:
+            store.close()
+    finally:
+        conn.close()
+
+    failed_ids = [chunk_id for chunk_id, proof in chunks.items() if not proof["passed"]]
+    return {
+        "db_path": str(db_path),
+        "sample_size": len(sample_ids),
+        "sample_ids": sample_ids,
+        "total_input_ids": len(unique_ids),
+        "chunks": chunks,
+        "failed_ids": failed_ids,
+        "passed": len(failed_ids) == 0,
+    }
+
+
 def run_apply(
     db_path: str | Path,
     *,
@@ -662,10 +825,17 @@ def run_apply(
         batch_size=batch_size,
         checkpoint_every=checkpoint_every,
     )
+    retrievability_proof = run_retrievability_proof(db_path, ids)
+    if not retrievability_proof["passed"]:
+        raise RuntimeError(
+            "retrievability proof failed for quarantined chunks: "
+            + ", ".join(retrievability_proof["failed_ids"][:10])
+        )
     after = run_dry_run(db_path)
     return {
         "dry_run_before": dry_run,
         "apply": apply_report,
+        "retrievability_proof": retrievability_proof,
         "dry_run_after": after,
         "backup_path": str(backup_path),
     }

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -819,6 +819,19 @@ def run_apply(
     if not dry_run["audit"]["stop_gate_passed"]:
         raise RuntimeError("STOP gate failed: direct/control-session chunks are classified into quarantine set")
     ids = select_quarantine_ids(db_path)
+    snapshot_apply_report = apply_quarantine_ids(
+        backup_path,
+        ids,
+        batch_size=batch_size,
+        checkpoint_every=checkpoint_every,
+        run_id=f"pre-apply-retrievability-{_utc_now()}",
+    )
+    pre_apply_retrievability_proof = run_retrievability_proof(backup_path, ids)
+    if not pre_apply_retrievability_proof["passed"]:
+        raise RuntimeError(
+            "pre-apply retrievability proof failed for quarantined chunks: "
+            + ", ".join(pre_apply_retrievability_proof["failed_ids"][:10])
+        )
     apply_report = apply_quarantine_ids(
         db_path,
         ids,
@@ -828,12 +841,14 @@ def run_apply(
     retrievability_proof = run_retrievability_proof(db_path, ids)
     if not retrievability_proof["passed"]:
         raise RuntimeError(
-            "retrievability proof failed for quarantined chunks: "
+            "post-apply retrievability proof failed for quarantined chunks: "
             + ", ".join(retrievability_proof["failed_ids"][:10])
         )
     after = run_dry_run(db_path)
     return {
         "dry_run_before": dry_run,
+        "snapshot_apply": snapshot_apply_report,
+        "pre_apply_retrievability_proof": pre_apply_retrievability_proof,
         "apply": apply_report,
         "retrievability_proof": retrievability_proof,
         "dry_run_after": after,

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import ModuleType
 
 import apsw
+import pytest
 
 from brainlayer.vector_store import VectorStore
 
@@ -142,6 +143,74 @@ def test_quarantine_unquarantine_round_trip_restores_chunk_and_fts_rows(tmp_path
         restored_store.close()
 
     assert after == before
+
+
+def test_quarantine_retrievability_proof_excludes_default_but_preserves_operational_paths(
+    tmp_path: Path,
+) -> None:
+    script = _load_script()
+    db_path = tmp_path / "retrievability.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="claude-subagent",
+            source_file=denied_source,
+            content="retrievability invariant exactsentinel",
+            provenance_class="RAW-ETAN-DIRECT",
+        )
+    finally:
+        store.close()
+
+    quarantine_report = script.apply_quarantine_ids(db_path, ["claude-subagent"], batch_size=1, run_id="proof-run")
+    assert quarantine_report["quarantined"] == 1
+
+    proof = script.run_retrievability_proof(db_path, ["claude-subagent"])
+
+    assert proof["passed"] is True
+    assert proof["sample_size"] == 1
+    assert proof["sample_ids"] == ["claude-subagent"]
+    chunk_proof = proof["chunks"]["claude-subagent"]
+    assert chunk_proof["default_search_absent"] is True
+    assert chunk_proof["operational_search_present"] is True
+    assert chunk_proof["expand_fetchable"] is True
+    assert chunk_proof["chunk_row_exists"] is True
+    assert chunk_proof["content_class"] == "operational"
+    assert chunk_proof["operational_fts_rows"] == 1
+    assert chunk_proof["default_fts_rows"] == 0
+
+
+def test_run_apply_refuses_when_retrievability_proof_fails(tmp_path: Path, monkeypatch) -> None:
+    script = _load_script()
+    db_path = tmp_path / "apply-proof-gate.db"
+    backup_path = tmp_path / "apply-proof-gate-backup.db"
+    denied_source = tmp_path / ".codex" / "sessions" / "worker.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="codex-session",
+            source_file=denied_source,
+            content="apply gate proof sentinel",
+        )
+    finally:
+        store.close()
+
+    def fail_retrievability_proof(db_path_arg, chunk_ids):
+        assert db_path_arg == db_path
+        assert chunk_ids == ["codex-session"]
+        return {"passed": False, "failed_ids": ["codex-session"]}
+
+    monkeypatch.setattr(script, "run_retrievability_proof", fail_retrievability_proof)
+
+    with pytest.raises(RuntimeError, match="retrievability proof failed"):
+        script.run_apply(
+            db_path,
+            backup_path=backup_path,
+            confirm_workers_stopped=True,
+            confirm_watcher_paused=True,
+        )
 
 
 def test_round_trip_ignores_stale_chunk_fts_rowids(tmp_path: Path) -> None:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -197,8 +197,10 @@ def test_run_apply_refuses_when_retrievability_proof_fails(tmp_path: Path, monke
     finally:
         store.close()
 
+    proof_paths = []
+
     def fail_retrievability_proof(db_path_arg, chunk_ids):
-        assert db_path_arg == db_path
+        proof_paths.append(db_path_arg)
         assert chunk_ids == ["codex-session"]
         return {"passed": False, "failed_ids": ["codex-session"]}
 
@@ -211,6 +213,24 @@ def test_run_apply_refuses_when_retrievability_proof_fails(tmp_path: Path, monke
             confirm_workers_stopped=True,
             confirm_watcher_paused=True,
         )
+
+    assert proof_paths == [backup_path]
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        row = cursor.execute(
+            "SELECT content_class, provenance_class FROM chunks WHERE id = 'codex-session'"
+        ).fetchone()
+        default_fts_rows = cursor.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'codex-session'").fetchone()
+        operational_fts_rows = cursor.execute(
+            "SELECT COUNT(*) FROM chunks_fts_operational WHERE chunk_id = 'codex-session'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row == ("knowledge", "RAW-ETAN-DIRECT")
+    assert default_fts_rows == (1,)
+    assert operational_fts_rows == (0,)
 
 
 def test_round_trip_ignores_stale_chunk_fts_rowids(tmp_path: Path) -> None:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -218,9 +218,7 @@ def test_run_apply_refuses_when_retrievability_proof_fails(tmp_path: Path, monke
     conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
     try:
         cursor = conn.cursor()
-        row = cursor.execute(
-            "SELECT content_class, provenance_class FROM chunks WHERE id = 'codex-session'"
-        ).fetchone()
+        row = cursor.execute("SELECT content_class, provenance_class FROM chunks WHERE id = 'codex-session'").fetchone()
         default_fts_rows = cursor.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'codex-session'").fetchone()
         operational_fts_rows = cursor.execute(
             "SELECT COUNT(*) FROM chunks_fts_operational WHERE chunk_id = 'codex-session'"


### PR DESCRIPTION
## Summary
- Add `run_retrievability_proof(db_path, chunk_ids)` for quarantined ids, proving default search absence, explicit operational search presence, by-id context fetchability, and DB/operational FTS row preservation.
- Gate `run_apply` with a true pre-apply pre-flight: VACUUM-INTO snapshot, quarantine the target ids on that snapshot, prove retrievability there, and raise before any production write if the snapshot proof fails.
- Keep the post-apply retrievability proof as a belt-and-suspenders production verification after the real quarantine write.
- Add tmp-path regression coverage for the quarantine != deletion invariant and for snapshot proof failure refusing apply while leaving prod unmutated.

## Test plan
- `source .venv/bin/activate && pytest tests/test_retro_self_pollution_quarantine.py -x -q`
  - `9 passed in 0.85s`
- `git push origin feat/p16a-retrievability-gate` pre-push gate
  - `BrainLayer test gate passed.`
  - `3360 passed, 9 skipped, 61 deselected, 1 xfailed, 103 warnings in 313.92s (0:05:13)`
  - `3 passed in 0.82s`
  - `40 passed in 1.70s`
  - `1 pass / 0 fail` bun suite

## Fleet §E
- Net LOC delta: +274/-0

## Reviewers
- brainlayerLead owns review/merge for P1.6-a.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lead-gated production apply path for a large retro migration; failures now block writes, but the logic relies on sampled hybrid-search checks rather than altering core ingest/search code.
> 
> **Overview**
> Adds **`run_retrievability_proof`** to the retro self-pollution script so quarantined chunks are verified as *hidden from default hybrid search* but still reachable via **`include_operational`**, **`get_context`**, and operational FTS rows (not deleted).
> 
> **`run_apply`** now runs a **snapshot pre-flight** on the VACUUM backup: quarantine the target IDs there, run the proof, and **abort before touching production** if it fails; production apply is followed by the same proof as a post-check. Apply reports include snapshot apply and both proof payloads.
> 
> Tests cover the quarantine ≠ deletion retrievability invariant and that a failed **pre-apply** proof raises without mutating the live DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26d5f1fdc3437728a1217b2722e93fc0daa6357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate `run_apply` on a retrievability proof that quarantined chunks are absent from default search but present in operational search
> - Adds `run_retrievability_proof` in [retro_quarantine_self_pollution.py](https://github.com/EtanHey/brainlayer/pull/569/files#diff-0e401ad1f91f8128ecafdb7f770efd89d2925d47d36334ea3227936b948e605c) to sample quarantined chunk IDs and verify each is absent from default hybrid search, present in operational hybrid search, and fetchable by ID.
> - Adds helper utilities `_retrievability_query`, `_like_exact`, and `_flat_result_ids` to support query generation and result normalization.
> - `run_apply` now runs the proof against a backup snapshot before touching the live DB, then again after; it raises `RuntimeError` if either proof fails.
> - Risk: `run_apply` will now hard-fail and leave the live DB unmodified if the pre-apply proof on the backup snapshot does not pass.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b26d5f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->