### PR TITLE
fix: preserve upsert cache invalidation after partial commits

### DIFF
--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -66,18 +66,19 @@ _DEFAULT_BUSY_TIMEOUT_MS = 30_000
 _DEFAULT_READ_BUSY_TIMEOUT_MS = 5_000
 _DEFAULT_INDEX_TXN_BATCH = 250
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
+_MAX_INDEX_TXN_BATCH = 10_000
 _WRITE_BUSY_TIMEOUT_STATE = threading.local()
 _NO_EXEC_TRACE = object()
 _KNOWLEDGE_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark')"
 _OPERATIONAL_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') = 'operational'"
 
 
-def _positive_int_env(name: str, default: int) -> int:
+def _positive_int_env(name: str, default: int, *, max_value: int = _MAX_APSW_BUSY_TIMEOUT_MS) -> int:
     try:
         value = int(os.environ.get(name, str(default)))
     except (TypeError, ValueError):
         return default
-    if value <= 0 or value > _MAX_APSW_BUSY_TIMEOUT_MS:
+    if value <= 0 or value > max_value:
         return default
     return value
 
@@ -87,7 +88,7 @@ def _read_busy_timeout_ms() -> int:
 
 
 def _index_txn_batch_size() -> int:
-    return _positive_int_env("BRAINLAYER_INDEX_TXN_BATCH", _DEFAULT_INDEX_TXN_BATCH)
+    return _positive_int_env("BRAINLAYER_INDEX_TXN_BATCH", _DEFAULT_INDEX_TXN_BATCH, max_value=_MAX_INDEX_TXN_BATCH)
 
 
 def _write_busy_deadline() -> float | None:
@@ -2356,7 +2357,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
     # ── Chunk CRUD ──────────────────────────────────────────────────────
 
     def upsert_chunks(self, chunks: List[Dict[str, Any]], embeddings: List[List[float]]) -> int:
-        """Upsert chunks with embeddings, returning the number of input chunks processed."""
+        """Upsert chunks with embeddings, returning the number of input chunks processed.
+
+        Large calls commit in bounded sub-batches. If a later sub-batch fails after
+        earlier sub-batches commit, the committed chunks are intentionally not
+        replayed on retry; callers should retry the failed call with the same
+        inputs to converge via the existing dedupe/replay-tolerant paths.
+        """
         if len(chunks) != len(embeddings):
             raise ValueError("Chunks and embeddings must have same length")
 
@@ -2376,6 +2383,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         if not valid_pairs and rejected_error is not None:
             raise rejected_error
 
+        def invalidate_upsert_caches() -> None:
+            from .search_repo import clear_hybrid_search_cache
+
+            clear_hybrid_search_cache(getattr(self, "db_path", None))
+            self._invalidate_filtered_count_caches()
+
+        committed_any = False
         batch_size = _index_txn_batch_size()
         for start in range(0, len(valid_pairs), batch_size):
             sub_batch = valid_pairs[start : start + batch_size]
@@ -2528,22 +2542,24 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                         self._upsert_chunk_vector(cursor, chunk_id, embedding)
                     cursor.execute("COMMIT")
                     transaction_started = False
+                    committed_any = True
                     break
                 except apsw.BusyError:
                     if transaction_started:
                         cursor.execute("ROLLBACK")
                     if attempt == 4:
+                        if committed_any:
+                            invalidate_upsert_caches()
                         raise
                     time.sleep(0.1 * (2**attempt))
                 except Exception:
                     if transaction_started:
                         cursor.execute("ROLLBACK")
+                    if committed_any:
+                        invalidate_upsert_caches()
                     raise
 
-        from .search_repo import clear_hybrid_search_cache
-
-        clear_hybrid_search_cache(getattr(self, "db_path", None))
-        self._invalidate_filtered_count_caches()
+        invalidate_upsert_caches()
 
         return len(valid_pairs)
 

--- a/tests/test_vector_store_upsert_transactions.py
+++ b/tests/test_vector_store_upsert_transactions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import apsw
 import pytest
 
+import brainlayer.vector_store as vector_store
 from brainlayer.vector_store import VectorStore
 
 
@@ -64,6 +65,12 @@ def test_upsert_chunks_commits_large_batches_in_bounded_transactions(isolated_st
     assert isolated_store.conn.cursor().execute("SELECT COUNT(*) FROM chunks").fetchone() == (5,)
 
 
+def test_index_txn_batch_env_uses_dedicated_cap(monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", str(vector_store._MAX_INDEX_TXN_BATCH + 1))
+
+    assert vector_store._index_txn_batch_size() == vector_store._DEFAULT_INDEX_TXN_BATCH
+
+
 def test_upsert_chunks_preserves_dedupe_and_repeat_upsert_shape(isolated_store, monkeypatch):
     monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", "2")
     duplicate_content = "Repeat bounded transaction dedupe content should collapse"
@@ -118,3 +125,36 @@ def test_busy_sub_batch_retries_without_replaying_committed_sub_batches(isolated
         "chunk-3": 1,
     }
     assert isolated_store.conn.cursor().execute("SELECT COUNT(*) FROM chunks").fetchone() == (4,)
+
+
+def test_failed_later_sub_batch_invalidates_after_prior_commit(isolated_store, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", "2")
+    cleared_paths: list[object] = []
+    invalidated_filtered_counts = 0
+
+    def fake_clear_hybrid_search_cache(db_path=None):
+        cleared_paths.append(db_path)
+
+    def fake_invalidate_filtered_count_caches():
+        nonlocal invalidated_filtered_counts
+        invalidated_filtered_counts += 1
+
+    def trace(_cursor, statement, bindings):
+        if _is_insert_chunk_statement(str(statement)) and bindings and bindings[0] == "chunk-2":
+            raise RuntimeError("simulated permanent second sub-batch failure")
+        return True
+
+    monkeypatch.setattr("brainlayer.search_repo.clear_hybrid_search_cache", fake_clear_hybrid_search_cache)
+    monkeypatch.setattr(isolated_store, "_invalidate_filtered_count_caches", fake_invalidate_filtered_count_caches)
+    isolated_store.conn.setexectrace(trace)
+
+    with pytest.raises(RuntimeError, match="permanent second sub-batch failure"):
+        isolated_store.upsert_chunks(
+            [_chunk(f"chunk-{index}") for index in range(4)],
+            [_embedding(index) for index in range(4)],
+        )
+
+    cursor = isolated_store.conn.cursor()
+    assert cursor.execute("SELECT id FROM chunks ORDER BY id").fetchall() == [("chunk-0",), ("chunk-1",)]
+    assert cleared_paths == [isolated_store.db_path]
+    assert invalidated_filtered_counts == 1


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #570 after CodeRabbit review surfaced two valid live-write-path hardening points.
- Adds a dedicated `_MAX_INDEX_TXN_BATCH` cap so `BRAINLAYER_INDEX_TXN_BATCH` is bounded by a batch-count limit, not the APSW busy-timeout ceiling.
- Preserves cache invalidation when `upsert_chunks()` has already committed an earlier sub-batch and a later sub-batch fails.
- Documents the partial-persistence retry contract for bounded sub-batch commits.

## Tests
- `source .venv/bin/activate && pytest tests/test_vector_store_upsert_transactions.py -q`
  - `5 passed in 0.42s`
- `source .venv/bin/activate && pytest tests/ -k "upsert or vector_store" -q`
  - `73 passed, 11 skipped, 3438 deselected, 2 warnings in 8.83s`
- `source .venv/bin/activate && ruff check src/ tests/`
  - `All checks passed!`
- `source .venv/bin/activate && ruff format --check src/ tests/`
  - `394 files already formatted`
- `source .venv/bin/activate && uvx ruff@latest format --check src/ tests/`
  - `394 files already formatted`
- Pre-push hook:
  - `= 3365 passed, 9 skipped, 61 deselected, 1 xfailed, 103 warnings in 300.52s (0:05:00) =`
  - `3 passed in 0.76s`
  - `40 passed in 1.69s`
  - `1 pass / 0 fail`
  - `PASS: regression shell test_fts5_determinism.sh`
  - `BrainLayer test gate passed.`

## Review Notes
- PR #570 was merged and its branch deleted while the review-response push was in progress, so these CodeRabbit follow-ups are split into this small PR.
- All new tests use tmp-path isolated `VectorStore` fixtures only; no production DB access.

## Fleet §E
- LOC delta: +64 / -8, net +56

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live chunk index write path and cache coherence on failure; behavior change is intentional hardening with isolated tests, but incorrect invalidation could still affect search freshness under rare partial-failure scenarios.
> 
> **Overview**
> Hardens **`VectorStore.upsert_chunks`** after bounded sub-batch commits: hybrid search and filtered-count caches are cleared when a later sub-batch fails **after** earlier ones committed, so readers do not keep stale cache state on partial writes. A **`committed_any`** flag drives that invalidation on both final **`BusyError`** exhaustion and other exceptions; success still invalidates once at the end.
> 
> **`BRAINLAYER_INDEX_TXN_BATCH`** is capped at **`_MAX_INDEX_TXN_BATCH` (10,000)** via a configurable **`max_value`** on **`_positive_int_env`**, instead of sharing the APSW busy-timeout ceiling. The upsert docstring documents the partial-persistence retry contract (retry the same inputs; dedupe paths converge).
> 
> Tests cover the env cap and cache invalidation when the second sub-batch fails after the first commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f08069259683dfa4a3866c40f6bbcf89018eb92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cache invalidation in `VectorStore.upsert_chunks` after partial sub-batch commits
> - Introduces a local `invalidate_upsert_caches()` helper and a `committed_any` flag in `upsert_chunks` to track whether any sub-batch has committed successfully.
> - On failure (both `apsw.BusyError` and general exceptions), caches are now invalidated before re-raising if at least one sub-batch committed, preventing stale cache state after partial writes.
> - Caps the `BRAINLAYER_INDEX_TXN_BATCH` env var at a new `_MAX_INDEX_TXN_BATCH = 10_000` constant by refactoring `_positive_int_env` to accept a `max_value` parameter; values above 10,000 fall back to the default of 250.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f08069.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch handling during bulk updates so environment settings stay within safe limits.
  * Fixed cache refresh behavior after partial write failures, ensuring previously committed data is handled correctly and search results stay consistent.
* **Documentation**
  * Clarified update behavior in the user-facing method description for bulk chunk writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->