### PR TITLE
fix: make health check lock-holder aware

### DIFF
--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -10,7 +10,7 @@ import socket
 import sqlite3
 import subprocess
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -33,6 +33,7 @@ DEFAULT_WATCH_LABEL = "com.brainlayer.watch"
 DEFAULT_DRAIN_LABEL = "com.brainlayer.drain"
 DEFAULT_HEALTH_CHECK_LABEL = "com.brainlayer.health-check"
 DEFAULT_ENRICHMENT_LABEL = "com.brainlayer.enrichment"
+DEFAULT_INDEX_LABEL = "com.brainlayer.index"
 DEFAULT_BACKLOG_BATCH = 4
 DEFAULT_HEAL_MIN_CONSECUTIVE_FAILURES = 2
 DEFAULT_HEAL_CIRCUIT_BREAKER_LIMIT = 3
@@ -69,6 +70,7 @@ class HealthCheckConfig:
     drain_label: str = DEFAULT_DRAIN_LABEL
     health_check_label: str = DEFAULT_HEALTH_CHECK_LABEL
     enrichment_label: str = DEFAULT_ENRICHMENT_LABEL
+    index_label: str = DEFAULT_INDEX_LABEL
     watch_plist_path: Path = field(
         default_factory=lambda: Path("~/Library/LaunchAgents/com.brainlayer.watch.plist").expanduser()
     )
@@ -119,6 +121,14 @@ class HotlaneProcess:
     backlog_batch: int
 
 
+@dataclass(frozen=True)
+class LockHolder:
+    pid: int
+    command: str
+    db_path: str
+    held_ticks: int = 0
+
+
 @dataclass
 class HealthCheckResult:
     checked_at: str
@@ -130,6 +140,7 @@ class HealthCheckResult:
     missing_vectors: int | None = None
     previous_missing_vectors: int | None = None
     stalled_ticks: int = 0
+    lock_holder: LockHolder | None = None
     canary_ok: bool = False
     canary_result_count: int | None = None
 
@@ -255,6 +266,138 @@ def parse_hotlane_processes(ps_output: str) -> list[HotlaneProcess]:
     return processes
 
 
+def _command_for_pid(ps_output: str, pid: int) -> str:
+    for line in ps_output.splitlines():
+        stripped = line.strip()
+        match = re.match(r"(?P<pid>\d+)\s+(?P<command>.+)", stripped)
+        if match and int(match.group("pid")) == pid:
+            return match.group("command")
+    return ""
+
+
+def _read_writer_lock_holder(db_path: Path, ps_output: str) -> LockHolder | None:
+    from .vector_store import VectorStore
+
+    store = object.__new__(VectorStore)
+    store.db_path = db_path.expanduser()
+    try:
+        pidfile = store._writer_pidfile_path()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    fd = VectorStore._open_writer_pidfile_readonly(pidfile)
+    if fd is None:
+        return None
+    try:
+        owner_pid, owner_start_time, owner_db_path = VectorStore._read_writer_pidfile_record_fd(fd)
+    finally:
+        os.close(fd)
+    if owner_db_path is not None and not store._pidfile_db_path_matches(owner_db_path):
+        return None
+    if owner_pid is None or not store._pidfile_owner_matches(owner_pid, owner_start_time):
+        return None
+    try:
+        resolved_db_path = (
+            str(Path(owner_db_path).expanduser().resolve()) if owner_db_path else str(store.db_path.resolve())
+        )
+    except (OSError, RuntimeError, ValueError):
+        resolved_db_path = str(store.db_path.expanduser())
+    return LockHolder(
+        pid=owner_pid,
+        command=_command_for_pid(ps_output, owner_pid),
+        db_path=resolved_db_path,
+    )
+
+
+def _text_has_sqlite_busy_signal(value: Any) -> bool:
+    text = str(value).lower()
+    return (
+        "sqlite_busy" in text
+        or "writerinuseerror" in text
+        or "database is locked" in text
+        or "database table is locked" in text
+        or "database is busy" in text
+    )
+
+
+def _drain_health_has_sqlite_busy_signal(payload: dict[str, Any]) -> bool:
+    for value in payload.values():
+        if isinstance(value, dict):
+            if _drain_health_has_sqlite_busy_signal(value):
+                return True
+        elif isinstance(value, list):
+            if any(_text_has_sqlite_busy_signal(item) for item in value):
+                return True
+        elif _text_has_sqlite_busy_signal(value):
+            return True
+    return False
+
+
+def _same_lock_holder_ticks(state: dict[str, Any], lock_holder: LockHolder | None, *, drain_starved: bool) -> int:
+    if lock_holder is None or not drain_starved:
+        return 0
+    previous_pid = state.get("lock_holder_pid")
+    previous_ticks = state.get("lock_holder_held_ticks")
+    prior_ticks = previous_ticks if isinstance(previous_ticks, int) else 0
+    return prior_ticks + 1 if previous_pid == lock_holder.pid else 1
+
+
+def _known_lock_holder_labels(config: HealthCheckConfig) -> tuple[str, ...]:
+    labels = [
+        config.index_label,
+        config.enrichment_label,
+        config.watch_label,
+        config.drain_label,
+        config.hotlane_label,
+    ]
+    return tuple(dict.fromkeys(label for label in labels if label))
+
+
+def _launchd_print_mentions_pid(stdout: str, pid: int) -> bool:
+    return re.search(rf"\bpid\s*=\s*{pid}\b", stdout) is not None
+
+
+def _command_implies_lock_holder_label(command: str, config: HealthCheckConfig) -> str | None:
+    if not command:
+        return None
+    if "hotlane_brainbar_daemon.py" in command:
+        return config.hotlane_label
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+    commands = {
+        "index": config.index_label,
+        "enrich": config.enrichment_label,
+        "watch": config.watch_label,
+        "drain": config.drain_label,
+    }
+    for index, part in enumerate(parts[:-1]):
+        if Path(part).name == "brainlayer":
+            label = commands.get(parts[index + 1])
+            if label:
+                return label
+    return None
+
+
+def _known_lock_holder_label(
+    holder: LockHolder,
+    config: HealthCheckConfig,
+    command_runner: CommandRunner,
+) -> str | None:
+    for label in _known_lock_holder_labels(config):
+        result = command_runner(["launchctl", "print", _launchd_target(label)])
+        if _command_returncode(result) != 0:
+            continue
+        if _launchd_print_mentions_pid(_command_stdout(result), holder.pid):
+            return label
+    return _command_implies_lock_holder_label(holder.command, config)
+
+
+def _holder_message(holder: LockHolder) -> str:
+    command = holder.command or "<unknown>"
+    return f"holder pid={holder.pid} command={command} db_path={holder.db_path}"
+
+
 def count_missing_embeddings(db_path: Path) -> int:
     uri = f"file:{db_path.expanduser()}?mode=ro"
     conn = sqlite3.connect(uri, uri=True, timeout=5)
@@ -371,15 +514,26 @@ def _heal_key(label: str, issue_code: str) -> str:
     return f"{label}:{issue_code}"
 
 
+def _heal_notification_message(action: str, issue_code: str, details: dict[str, Any]) -> str:
+    lock_holder = details.get("lock_holder")
+    if isinstance(lock_holder, dict):
+        pid = lock_holder.get("pid")
+        command = lock_holder.get("command") or "<unknown>"
+        return f"{action} for {issue_code}: holder pid={pid} command={command}"
+    return f"{action} for {issue_code}"
+
+
 def _apply_heals(
     *,
     result: HealthCheckResult,
     issue_labels: dict[str, tuple[str, Path]],
+    issue_details: dict[str, dict[str, Any]] | None = None,
     previous_failures: dict[str, int],
     previous_tripped: set[str],
     config: HealthCheckConfig,
     command_runner: CommandRunner,
 ) -> tuple[dict[str, int], set[str]]:
+    issue_details = issue_details or {}
     current_issue_codes = {issue.code for issue in result.issues}
     heal_failures: dict[str, int] = {}
     tripped = set(previous_tripped)
@@ -403,6 +557,7 @@ def _apply_heals(
     for issue_code, (label, plist_path) in issue_labels.items():
         key = _heal_key(label, issue_code)
         consecutive_failures = heal_failures.get(key, 0)
+        details = issue_details.get(issue_code, {})
         if consecutive_failures >= breaker_limit:
             if issue_code in bootstrap_issue_codes:
                 action = _bootstrap_if_absent(label, plist_path, command_runner)
@@ -421,9 +576,18 @@ def _apply_heals(
                         "label": label,
                         "issue_code": issue_code,
                         "consecutive_failures": consecutive_failures,
+                        **details,
                     }
                 )
-                _push_notification("BrainLayer heal escalation", f"{label} {issue_code} failed repeatedly")
+                message = (
+                    _heal_notification_message(label, issue_code, details)
+                    if details
+                    else f"{label} {issue_code} failed repeatedly"
+                )
+                _push_notification(
+                    "BrainLayer heal escalation",
+                    message,
+                )
             continue
         if consecutive_failures >= threshold:
             action = (
@@ -448,9 +612,13 @@ def _apply_heals(
                         "issue_code": issue_code,
                         "action": action,
                         "consecutive_failures": consecutive_failures,
+                        **details,
                     }
                 )
-                _push_notification("BrainLayer heal action", f"{action} for {issue_code}")
+                _push_notification(
+                    "BrainLayer heal action",
+                    _heal_notification_message(action, issue_code, details),
+                )
     return heal_failures, tripped
 
 
@@ -533,6 +701,8 @@ def _plist_for_label(config: HealthCheckConfig, label: str) -> Path:
         return config.health_check_plist_path
     if label == config.enrichment_label:
         return config.enrichment_plist_path
+    if label == config.index_label:
+        return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
     if label == config.hotlane_label:
         return Path(f"~/Library/LaunchAgents/{label}.plist").expanduser()
     if label == config.brainbar_daemon_label:
@@ -554,6 +724,7 @@ def run_health_check(
     previous_heal_failures = _previous_heal_failures(state)
     previous_tripped = _previous_tripped_heals(state)
     heal_issue_labels: dict[str, tuple[str, Path]] = {}
+    heal_issue_details: dict[str, dict[str, Any]] = {}
 
     def add_issue(code: str, severity: str, message: str) -> None:
         result.issues.append(HealthIssue(code, severity, message))
@@ -566,7 +737,10 @@ def run_health_check(
             }
         )
 
-    hotlane_processes = parse_hotlane_processes(ps_output_fn())
+    ps_output = ps_output_fn()
+    lock_holder = _read_writer_lock_holder(config.db_path, ps_output)
+    result.lock_holder = lock_holder
+    hotlane_processes = parse_hotlane_processes(ps_output)
     result.hotlane_running = bool(hotlane_processes)
     if not hotlane_processes:
         add_issue("hotlane_dead", "critical", "hotlane BrainBar embedding daemon is not running")
@@ -724,6 +898,7 @@ def run_health_check(
     drain_health = _load_json(config.drain_health_path)
     drain_total = drain_health.get("drained_total")
     previous_drain_total = state.get("drain_drained_total")
+    drain_starved = _drain_health_has_sqlite_busy_signal(drain_health)
     if queue_count > 0 and isinstance(drain_total, int) and drain_total == previous_drain_total:
         add_issue(
             "drain_no_progress",
@@ -731,10 +906,44 @@ def run_health_check(
             f"drain drained_total flat at {drain_total} while queue_count={queue_count}",
         )
         heal_issue_labels["drain_no_progress"] = (config.drain_label, config.drain_plist_path)
+        drain_starved = True
+
+    lock_holder_held_ticks = _same_lock_holder_ticks(state, lock_holder, drain_starved=drain_starved)
+    if lock_holder is not None:
+        result.lock_holder = replace(lock_holder, held_ticks=lock_holder_held_ticks)
+    lock_holder_wedge = (
+        result.lock_holder is not None and drain_starved and lock_holder_held_ticks >= config.max_stalled_ticks
+    )
+    if lock_holder_wedge and result.lock_holder is not None:
+        holder = result.lock_holder
+        add_issue(
+            "lock_holder_wedge",
+            "critical",
+            f"write-lock holder wedge detected after {holder.held_ticks} checks: {_holder_message(holder)}",
+        )
+        holder_details = {"lock_holder": asdict(holder)}
+        heal_issue_details["lock_holder_wedge"] = holder_details
+        for victim_issue_code in ("drain_no_progress", "queue_backed_up"):
+            heal_issue_labels.pop(victim_issue_code, None)
+        if config.heal:
+            _emit_heal_event(
+                {
+                    "_type": "lock_holder_wedge",
+                    **holder_details,
+                }
+            )
+            _push_notification("BrainLayer lock-holder wedge", _holder_message(holder))
+            holder_label = _known_lock_holder_label(holder, config, command_runner)
+            if holder_label:
+                heal_issue_labels["lock_holder_wedge"] = (
+                    holder_label,
+                    _plist_for_label(config, holder_label),
+                )
 
     heal_failures, heal_tripped = _apply_heals(
         result=result,
         issue_labels=heal_issue_labels,
+        issue_details=heal_issue_details,
         previous_failures=previous_heal_failures,
         previous_tripped=previous_tripped,
         config=config,
@@ -751,6 +960,14 @@ def run_health_check(
         state_payload["watcher_poll_count"] = watcher_poll_count
     if isinstance(drain_total, int):
         state_payload["drain_drained_total"] = drain_total
+    if result.lock_holder is not None:
+        state_payload["lock_holder_pid"] = result.lock_holder.pid
+        state_payload["lock_holder_db_path"] = result.lock_holder.db_path
+        state_payload["lock_holder_held_ticks"] = result.lock_holder.held_ticks
+    else:
+        state_payload.pop("lock_holder_pid", None)
+        state_payload.pop("lock_holder_db_path", None)
+        state_payload["lock_holder_held_ticks"] = 0
     if pause_payload:
         state_payload["pause_sentinel"] = pause_payload
     _write_state(config.state_path, state_payload)

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import inspect
 import json
 import os
@@ -13,6 +14,7 @@ import pytest
 
 import brainlayer.health_check as health_check
 from brainlayer.health_check import HealthCheckConfig, run_health_check
+from brainlayer.vector_store import VectorStore
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -81,6 +83,23 @@ def _make_db(path: Path, *, total: int, vector_rows: int) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def _expected_writer_pidfile(pidfile_dir: Path, db_path: Path) -> Path:
+    resolved_path = db_path.resolve()
+    path_hash = hashlib.sha256(str(resolved_path).encode("utf-8")).hexdigest()[:16]
+    return pidfile_dir / f"brainlayer-writer-{path_hash}-{resolved_path.name}.pid"
+
+
+def _write_writer_pidfile(pidfile_dir: Path, db_path: Path, *, pid: int, start_time: str | None = None) -> Path:
+    pidfile_dir.mkdir(parents=True, exist_ok=True)
+    lines = [str(pid)]
+    if start_time is not None:
+        lines.append(f"start_time={start_time}")
+    lines.append(f"db_path={db_path.resolve()}")
+    pidfile = _expected_writer_pidfile(pidfile_dir, db_path)
+    pidfile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return pidfile
 
 
 def _ok_canary(_socket_path: Path, _query: str, _timeout_seconds: float) -> dict:
@@ -200,6 +219,266 @@ def test_missing_embeddings_not_draining_after_two_ticks(tmp_path):
     saved = json.loads(state_path.read_text(encoding="utf-8"))
     assert saved["missing_vectors"] == 2
     assert saved["stalled_ticks"] == 2
+
+
+def test_lock_holder_wedge_flags_live_holder_when_drain_is_starved(tmp_path, monkeypatch):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    drain_health_path = tmp_path / "drain-health.json"
+    queue_dir = tmp_path / "queue"
+    pidfile_dir = tmp_path / "pidfiles"
+    queue_dir.mkdir()
+    _make_db(db_path, total=1, vector_rows=1)
+    drain_health_path.write_text(json.dumps({"drained_total": 10}), encoding="utf-8")
+    (queue_dir / "blocked.jsonl").write_text("{}\n", encoding="utf-8")
+    holder_pid = os.getpid()
+    _write_writer_pidfile(pidfile_dir, db_path, pid=holder_pid, start_time="holder-start")
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(VectorStore, "_pid_start_time", staticmethod(lambda _pid: "holder-start"))
+    state_path.write_text(
+        json.dumps(
+            {
+                "drain_drained_total": 10,
+                "lock_holder_pid": holder_pid,
+                "lock_holder_held_ticks": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            drain_health_path=drain_health_path,
+            queue_dir=queue_dir,
+            max_stalled_ticks=2,
+        ),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
+            f"{holder_pid} /opt/homebrew/bin/brainlayer index\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        now_fn=lambda: datetime(2026, 7, 6, 9, 0, tzinfo=UTC),
+    )
+
+    payload = result.to_dict()
+    assert payload["lock_holder"] == {
+        "pid": holder_pid,
+        "command": "/opt/homebrew/bin/brainlayer index",
+        "db_path": str(db_path.resolve()),
+        "held_ticks": 2,
+    }
+    issue_codes = [issue.code for issue in result.issues]
+    assert "drain_no_progress" in issue_codes
+    assert "lock_holder_wedge" in issue_codes
+    assert any(str(holder_pid) in issue.message and "brainlayer index" in issue.message for issue in result.issues)
+
+
+@pytest.mark.parametrize(
+    ("pid", "recorded_start_time", "current_start_time"),
+    [
+        (999999, "old-process", "old-process"),
+        (os.getpid(), "old-process", "current-process"),
+    ],
+)
+def test_lock_holder_stale_pidfile_is_ignored_without_false_wedge(
+    tmp_path, monkeypatch, pid, recorded_start_time, current_start_time
+):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    drain_health_path = tmp_path / "drain-health.json"
+    queue_dir = tmp_path / "queue"
+    pidfile_dir = tmp_path / "pidfiles"
+    queue_dir.mkdir()
+    _make_db(db_path, total=1, vector_rows=1)
+    drain_health_path.write_text(json.dumps({"drained_total": 10}), encoding="utf-8")
+    (queue_dir / "blocked.jsonl").write_text("{}\n", encoding="utf-8")
+    _write_writer_pidfile(pidfile_dir, db_path, pid=pid, start_time=recorded_start_time)
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(VectorStore, "_pid_start_time", staticmethod(lambda _pid: current_start_time))
+    state_path.write_text(
+        json.dumps(
+            {
+                "drain_drained_total": 10,
+                "lock_holder_pid": pid,
+                "lock_holder_held_ticks": 10,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            drain_health_path=drain_health_path,
+            queue_dir=queue_dir,
+            max_stalled_ticks=2,
+        ),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
+            f"{pid} /opt/homebrew/bin/brainlayer index\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        now_fn=lambda: datetime(2026, 7, 6, 9, 5, tzinfo=UTC),
+    )
+
+    assert result.to_dict()["lock_holder"] is None
+    assert "lock_holder_wedge" not in [issue.code for issue in result.issues]
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    assert saved["lock_holder_held_ticks"] == 0
+
+
+def test_lock_holder_wedge_heal_targets_known_holder_label_and_respects_circuit_breaker(tmp_path, monkeypatch):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    drain_health_path = tmp_path / "drain-health.json"
+    queue_dir = tmp_path / "queue"
+    pidfile_dir = tmp_path / "pidfiles"
+    queue_dir.mkdir()
+    _make_db(db_path, total=1, vector_rows=1)
+    drain_health_path.write_text(json.dumps({"drained_total": 10}), encoding="utf-8")
+    (queue_dir / "blocked.jsonl").write_text("{}\n", encoding="utf-8")
+    holder_pid = os.getpid()
+    _write_writer_pidfile(pidfile_dir, db_path, pid=holder_pid, start_time="holder-start")
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(VectorStore, "_pid_start_time", staticmethod(lambda _pid: "holder-start"))
+    notifications: list[tuple[str, str]] = []
+    events: list[dict] = []
+    monkeypatch.setattr(
+        health_check, "_push_notification", lambda title, message: notifications.append((title, message))
+    )
+    monkeypatch.setattr(health_check, "_emit_heal_event", events.append)
+
+    def ps_output() -> str:
+        return (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
+            f"{holder_pid} /opt/homebrew/bin/brainlayer index\n"
+        )
+
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]):
+        commands.append(args)
+        if args[:2] == ["launchctl", "print"] and "com.brainlayer.index" in args[2]:
+            return SimpleNamespace(returncode=0, stdout=f"pid = {holder_pid}\n", stderr="")
+        if args[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    state_path.write_text(
+        json.dumps(
+            {
+                "drain_drained_total": 10,
+                "lock_holder_pid": holder_pid,
+                "lock_holder_held_ticks": 1,
+                "heal_failures": {"com.brainlayer.index:lock_holder_wedge": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            drain_health_path=drain_health_path,
+            queue_dir=queue_dir,
+            heal=True,
+            max_stalled_ticks=2,
+            heal_min_consecutive_failures=2,
+            heal_circuit_breaker_limit=3,
+        ),
+        ps_output_fn=ps_output,
+        socket_request_fn=_ok_canary,
+        command_runner=command_runner,
+        now_fn=lambda: datetime(2026, 7, 6, 9, 10, tzinfo=UTC),
+    )
+
+    kickstarts = [command for command in commands if command[:3] == ["launchctl", "kickstart", "-k"]]
+    assert len(kickstarts) == 1
+    assert "com.brainlayer.index" in " ".join(kickstarts[0])
+    assert "com.brainlayer.drain" not in " ".join(kickstarts[0])
+    assert "kickstart:com.brainlayer.index" in result.actions
+    assert any(str(holder_pid) in message and "brainlayer index" in message for _title, message in notifications)
+    assert any(
+        event.get("_type") == "heal" and event.get("lock_holder", {}).get("pid") == holder_pid for event in events
+    )
+
+    commands.clear()
+    state_path.write_text(
+        json.dumps(
+            {
+                "drain_drained_total": 10,
+                "lock_holder_pid": holder_pid,
+                "lock_holder_held_ticks": 1,
+                "heal_failures": {"com.brainlayer.index:lock_holder_wedge": 3},
+                "heal_tripped": ["com.brainlayer.index:lock_holder_wedge"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            drain_health_path=drain_health_path,
+            queue_dir=queue_dir,
+            heal=True,
+            max_stalled_ticks=2,
+            heal_min_consecutive_failures=2,
+            heal_circuit_breaker_limit=3,
+        ),
+        ps_output_fn=ps_output,
+        socket_request_fn=_ok_canary,
+        command_runner=command_runner,
+        now_fn=lambda: datetime(2026, 7, 6, 9, 15, tzinfo=UTC),
+    )
+
+    assert not [command for command in commands if command[:3] == ["launchctl", "kickstart", "-k"]]
+
+
+def test_lock_holder_without_starved_drain_reports_holder_but_no_wedge(tmp_path, monkeypatch):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    drain_health_path = tmp_path / "drain-health.json"
+    queue_dir = tmp_path / "queue"
+    pidfile_dir = tmp_path / "pidfiles"
+    queue_dir.mkdir()
+    _make_db(db_path, total=1, vector_rows=1)
+    drain_health_path.write_text(json.dumps({"drained_total": 11}), encoding="utf-8")
+    holder_pid = os.getpid()
+    _write_writer_pidfile(pidfile_dir, db_path, pid=holder_pid, start_time="holder-start")
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(VectorStore, "_pid_start_time", staticmethod(lambda _pid: "holder-start"))
+    state_path.write_text(json.dumps({"drain_drained_total": 10}), encoding="utf-8")
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            drain_health_path=drain_health_path,
+            queue_dir=queue_dir,
+            max_stalled_ticks=2,
+        ),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
+            f"{holder_pid} /opt/homebrew/bin/brainlayer index\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        now_fn=lambda: datetime(2026, 7, 6, 9, 20, tzinfo=UTC),
+    )
+
+    assert result.ok is True
+    payload = result.to_dict()
+    assert payload["lock_holder"]["pid"] == holder_pid
+    assert payload["lock_holder"]["held_ticks"] == 0
+    assert "lock_holder_wedge" not in [issue.code for issue in result.issues]
 
 
 def test_missing_embeddings_climb_resets_stall_counter(tmp_path):


### PR DESCRIPTION
## Summary
- Add a `lock_holder` JSON section for the canonical DB writer pidfile, reusing `VectorStore` pidfile path, parser, pid-alive, start-time, and db-path validation.
- Track same-holder `held_ticks` in `health-check-state.json` while drain is starved, classify `lock_holder_wedge`, and suppress drain/queue victim heals when a live holder is the culprit.
- Route `--heal` to a known holder launchd label such as `com.brainlayer.index` via launchctl pid matching / command fallback, under the existing heal circuit breaker; unknown holder PIDs are reported only, never killed.
- Add isolated tests for live holder wedge detection, stale pidfile rejection, known-label holder heal/circuit-breaker behavior, and healthy-drain no-wedge behavior.

## Verification
- `cd ~/Gits/brainlayer && source .venv/bin/activate && pytest tests/ -k "health" -q`: 74 passed, 3451 deselected, 2 warnings.
- `cd ~/Gits/brainlayer && source .venv/bin/activate && ruff check src/ tests/`: All checks passed.
- `cd ~/Gits/brainlayer && uvx ruff@latest format --check src/ tests/`: 394 files already formatted.
- Additional full suite: `source .venv/bin/activate && pytest tests/ -q`: 3460 passed, 60 skipped, 5 xfailed, 103 warnings.
- Pre-push hook: pytest unit suite 3368 passed, 9 skipped, 61 deselected, 1 xfailed, 103 warnings; MCP tool registration 3 passed; isolated eval/hook routing 40 passed; bun suite 1 passed; `test_fts5_determinism.sh` passed.
- Local CodeRabbit pre-commit review attempted with `coderabbit review --agent`; CLI returned recoverable rate limit with waitTime 47 minutes, so no local review was available before commit.

## Net LOC Delta
+496 net LOC (`2 files changed, 500 insertions(+), 4 deletions(-)`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated healing targets and launchd kickstarts during SQLite lock starvation; mis-identified holders could restart the wrong job, though unknown PIDs are report-only and existing heal thresholds still apply.
> 
> **Overview**
> The stability health check now reads the canonical **VectorStore** writer pidfile and exposes a **`lock_holder`** field (pid, command, db path) in check results and persisted state.
> 
> While drain is **starved** (SQLite busy signals in drain health, or flat `drained_total` with a non-empty queue), it tracks **`held_ticks`** for the same live holder. After enough consecutive checks it raises **`lock_holder_wedge`**, notifies with holder details, and **stops routing `--heal` kickstarts** to drain/queue victim issues when the wedge is attributed to a known holder.
> 
> **Heal** can target the holder’s launchd label (e.g. **`com.brainlayer.index`**) via `launchctl print` PID match or **`brainlayer` subcommand** parsing, still under the existing circuit breaker; stale or mismatched pidfiles are ignored. Heal/escalation notifications include holder context when available.
> 
> Tests cover wedge detection, stale pidfile rejection, index-label heal vs breaker, and healthy drain with a holder but no wedge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6bab78a6c6af1b804d42a2ef41b3721652a4eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make health check detect and heal SQLite writer lock holders wedging drain
> - Adds `LockHolder` detection to `run_health_check` by reading the VectorStore writer pidfile and cross-referencing `ps` output to identify which process holds the SQLite write lock.
> - Tracks consecutive ticks a lock holder starves drain via `_same_lock_holder_ticks`, and raises a `lock_holder_wedge` critical issue once the count reaches `max_stalled_ticks`.
> - Resolves the holding process to a launchd service label via `launchctl print` (with a command-line fallback) so heals target the specific service (e.g. `com.brainlayer.index`) rather than the generic drain.
> - Extends heal events and OS notifications with lock holder pid/command context via `_apply_heals` and `_heal_notification_message`.
> - Persists `lock_holder_pid`, `lock_holder_db_path`, and `lock_holder_held_ticks` in state across runs, resetting ticks when no holder is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6b6bab7. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->