### PR TITLE
perf: defer retro quarantine trigram FTS churn

### DIFF
--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -33,6 +33,7 @@ FTS_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queri
 FTS_SELECT_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, id"
 FTS_STATE_COLUMNS = "rowid, content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id"
 QUARANTINE_MANIFEST_TABLE = "retro_self_pollution_quarantine_manifest"
+RECONCILE_CHUNK_ID_TABLE = "_retro_quarantine_reconcile_chunk_ids"
 DEFAULT_ESTIMATE = 244_152
 RETRIEVABILITY_TOKEN_RE = re.compile(r"[A-Za-z0-9]{4,}")
 
@@ -193,7 +194,7 @@ def _recreate_fts_triggers(db_path: Path) -> None:
 
 
 def _checkpoint(cursor: apsw.Cursor) -> None:
-    cursor.execute("PRAGMA wal_checkpoint(FULL)")
+    cursor.execute("PRAGMA wal_checkpoint(PASSIVE)")
 
 
 def _optimize_fts(cursor: apsw.Cursor) -> None:
@@ -373,17 +374,53 @@ def _record_manifest(cursor: apsw.Cursor, chunk_ids: list[str], *, run_id: str, 
         )
 
 
-def _delete_fts_rows(cursor: apsw.Cursor, chunk_ids: list[str]) -> None:
+def _delete_fts_rows(
+    cursor: apsw.Cursor,
+    chunk_ids: list[str],
+    table_names: tuple[str, ...] = ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"),
+) -> None:
     placeholders = _placeholders(chunk_ids)
-    for table_name in ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"):
+    for table_name in table_names:
         cursor.execute(f"DELETE FROM {table_name} WHERE chunk_id IN ({placeholders})", chunk_ids)
+    updates = []
+    if "chunks_fts" in table_names:
+        updates.append("fts_rowid = NULL")
+    if "chunks_fts_trigram" in table_names:
+        updates.append("trigram_rowid = NULL")
+    if "chunks_fts_operational" in table_names:
+        updates.append("operational_rowid = NULL")
+    if updates:
+        cursor.execute(
+            f"""
+            UPDATE chunk_fts_rowids
+            SET {", ".join(updates)}
+            WHERE chunk_id IN ({placeholders})
+            """,
+            chunk_ids,
+        )
+
+
+def _load_chunk_ids_reconcile_table(cursor: apsw.Cursor, chunk_ids: list[str]) -> None:
+    cursor.execute(f"CREATE TEMP TABLE {RECONCILE_CHUNK_ID_TABLE}(chunk_id TEXT PRIMARY KEY)")
+    cursor.executemany(
+        f"INSERT OR IGNORE INTO {RECONCILE_CHUNK_ID_TABLE}(chunk_id) VALUES (?)",
+        [(chunk_id,) for chunk_id in chunk_ids],
+    )
+
+
+def _clear_trigram_fts(cursor: apsw.Cursor) -> None:
+    cursor.execute(
+        f"""
+        DELETE FROM chunks_fts_trigram
+        WHERE chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
+        """
+    )
     cursor.execute(
         f"""
         UPDATE chunk_fts_rowids
-        SET fts_rowid = NULL, trigram_rowid = NULL, operational_rowid = NULL
-        WHERE chunk_id IN ({placeholders})
-        """,
-        chunk_ids,
+        SET trigram_rowid = NULL
+        WHERE chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
+        """
     )
 
 
@@ -447,6 +484,7 @@ def apply_quarantine_ids(
     if not chunk_ids:
         return {"quarantined": 0, "run_id": run_id or ""}
 
+    chunk_ids = list(dict.fromkeys(chunk_ids))
     db_path = _path(db_path)
     if bootstrap_schema:
         _recreate_fts_triggers(db_path)
@@ -459,11 +497,12 @@ def apply_quarantine_ids(
     timestamp = _utc_now()
     batches_since_checkpoint = 0
     try:
+        _load_chunk_ids_reconcile_table(cursor, chunk_ids)
         for ids in _batch(chunk_ids, batch_size):
             placeholders = _placeholders(ids)
             cursor.execute("BEGIN IMMEDIATE")
             _record_manifest(cursor, ids, run_id=run_id, timestamp=timestamp)
-            _delete_fts_rows(cursor, ids)
+            _delete_fts_rows(cursor, ids, table_names=("chunks_fts", "chunks_fts_operational"))
             cursor.execute(
                 f"""
                 UPDATE chunks
@@ -479,11 +518,15 @@ def apply_quarantine_ids(
             if batches_since_checkpoint >= checkpoint_every:
                 _checkpoint(cursor)
                 batches_since_checkpoint = 0
+        cursor.execute("BEGIN IMMEDIATE")
+        _clear_trigram_fts(cursor)
+        cursor.execute("COMMIT")
     except Exception:
         if not conn.getautocommit():
             cursor.execute("ROLLBACK")
         raise
     finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
         conn.close()
 
     if finalize:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -123,6 +123,9 @@ def test_quarantine_unquarantine_round_trip_restores_chunk_and_fts_rows(tmp_path
             "SELECT content_class, provenance_class FROM chunks WHERE id = 'claude-subagent'"
         ).fetchone()
         knowledge_rows = cursor.execute("SELECT chunk_id FROM chunks_fts WHERE chunk_id = 'claude-subagent'").fetchall()
+        trigram_rows = cursor.execute(
+            "SELECT chunk_id FROM chunks_fts_trigram WHERE chunk_id = 'claude-subagent'"
+        ).fetchall()
         operational_rows = cursor.execute(
             "SELECT chunk_id FROM chunks_fts_operational WHERE chunk_id = 'claude-subagent'"
         ).fetchall()
@@ -131,6 +134,7 @@ def test_quarantine_unquarantine_round_trip_restores_chunk_and_fts_rows(tmp_path
 
     assert row == ("operational", "AGENT-INFERENCE")
     assert knowledge_rows == []
+    assert trigram_rows == []
     assert operational_rows == [("claude-subagent",)]
 
     revert_report = script.unquarantine_ids(db_path, ["claude-subagent"], run_id="test-run")
@@ -139,10 +143,16 @@ def test_quarantine_unquarantine_round_trip_restores_chunk_and_fts_rows(tmp_path
     restored_store = VectorStore(db_path)
     try:
         after = script.capture_restore_state(restored_store.conn.cursor(), ["claude-subagent"])
+        after_trigram_rows = (
+            restored_store.conn.cursor()
+            .execute("SELECT chunk_id FROM chunks_fts_trigram WHERE chunk_id = 'claude-subagent'")
+            .fetchall()
+        )
     finally:
         restored_store.close()
 
     assert after == before
+    assert after_trigram_rows == [("claude-subagent",)]
 
 
 def test_quarantine_retrievability_proof_excludes_default_but_preserves_operational_paths(


### PR DESCRIPTION
## Summary
- Deferred chunks_fts_trigram deletions to one end-of-run set-based reconciliation.
- Switched wal checkpoints in quarantine script to PASSIVE.
- Kept end-state semantics by removing chunk IDs from chunks_fts_trigram and clearing trigram rowids after batch updates.
- Updated round-trip test to assert trigram rows are absent during quarantine and restored after unquarantine.
- Added dedupe/ordering guard for input chunk IDs.

## Verification
- ruff check src/ tests/
- uvx ruff@latest format --check src/ tests/
- Push gate test matrix executed via git hook
- Measured benchmark: 50k chunks in 300.74s => 9,975.49 rows/min, projected 261k in ~26.16 min.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bulk FTS and rowid bookkeeping on the vector DB during quarantine; end-state behavior is asserted in tests but a failed mid-run could leave trigram rows until reconciliation completes.
> 
> **Overview**
> **Retro self-pollution quarantine** is tuned for large runs by moving **`chunks_fts_trigram`** work out of every batch and doing it once at the end.
> 
> During each batch, FTS deletes now target only **`chunks_fts`** and **`chunks_fts_operational`**; **`_delete_fts_rows`** takes a **`table_names`** filter and only clears the matching **`chunk_fts_rowids`** columns. All quarantined IDs are loaded into a temp reconcile table, then **`_clear_trigram_fts`** removes trigram rows and nulls **`trigram_rowid`** in a single transaction after batches finish. Input **`chunk_ids`** are deduped before processing, and WAL checkpoints use **`PASSIVE`** instead of **`FULL`**.
> 
> The round-trip test now checks that trigram FTS is empty while quarantined and present again after unquarantine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47977030b14a50bf7c0c57c82cb297e8bc33834e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer trigram FTS deletions to a single bulk step during retro quarantine
> - In [`apply_quarantine_ids`](https://github.com/EtanHey/brainlayer/pull/573/files#diff-0e401ad1f91f8128ecafdb7f770efd89d2925d47d36334ea3227936b948e605c), trigram FTS deletions are now deferred until after all per-batch processing, then executed in one bulk operation via a new `_clear_trigram_fts` helper, reducing write churn on `chunks_fts_trigram`.
> - A temporary reconcile table (`_retro_quarantine_reconcile_chunk_ids`) is loaded upfront with deduplicated chunk IDs to drive the final trigram cleanup.
> - `_delete_fts_rows` now accepts a `table_names` parameter so per-batch deletions target only `chunks_fts` and `chunks_fts_operational`, nulling only their corresponding rowid columns.
> - WAL checkpoint mode is changed from `FULL` to `PASSIVE` to reduce blocking during the operation.
> - Behavioral Change: the returned quarantined count now reflects deduplicated input IDs rather than raw input length.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4797703. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->