### PR TITLE
Fix batch rewind archival in watcher

### DIFF
--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -3199,6 +3199,90 @@ def export_obsidian(
         store.close()
 
 
+class _RewindArchiveBatcher:
+    """Buffer and flush watcher rewind archival updates in batches."""
+
+    def __init__(
+        self,
+        db_path: Path,
+        batch_size: int,
+        flush_interval_ms: int,
+        vector_store_factory=None,
+    ) -> None:
+        self.db_path = db_path
+        self.batch_size = max(1, int(batch_size))
+        self.flush_interval_ms = max(1, int(flush_interval_ms))
+        self._vector_store_factory = vector_store_factory
+        self._vector_store = None
+        self._pending_session_ids: set[str] = set()
+        self._last_flush_at = time.perf_counter()
+        self.archived_total = 0
+
+    def _get_vector_store(self):
+        if self._vector_store is None:
+            from ..vector_store import VectorStore
+
+            factory = self._vector_store_factory or VectorStore
+            self._vector_store = factory(self.db_path)
+        return self._vector_store
+
+    def add(self, session_id: str) -> None:
+        if not session_id:
+            return
+        self._pending_session_ids.add(session_id)
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending_session_ids)
+
+    def flush(self, reason: str) -> int:
+        if not self._pending_session_ids:
+            self._last_flush_at = time.perf_counter()
+            return 0
+
+        vector_store = self._get_vector_store()
+        cursor = vector_store.conn.cursor()
+        placeholders = ",".join("?" for _ in self._pending_session_ids)
+        now = datetime.now(UTC).isoformat()
+        params = [now, *sorted(self._pending_session_ids)]
+        cursor.execute(
+            f"""
+            UPDATE chunks
+               SET archived_at = ?, value_type = 'ARCHIVED'
+             WHERE source = 'realtime_watcher'
+               AND archived_at IS NULL
+               AND conversation_id IN ({placeholders})
+            """,
+            params,
+        )
+        affected = vector_store.conn.changes()
+        vector_store.conn.commit()
+        self.archived_total += affected
+        if affected > 0:
+            rprint(
+                f"  Archived {affected} chunks from {len(self._pending_session_ids)} sessions after rewind ({reason})"
+            )
+        self._pending_session_ids.clear()
+        self._last_flush_at = time.perf_counter()
+        return affected
+
+    def maybe_flush(self, reason: str) -> int:
+        now = time.perf_counter()
+        if not self._pending_session_ids:
+            return 0
+        if len(self._pending_session_ids) >= self.batch_size:
+            return self.flush(f"batch={self.batch_size}")
+        elapsed_ms = int((now - self._last_flush_at) * 1000)
+        if elapsed_ms >= self.flush_interval_ms:
+            return self.flush(reason)
+        return 0
+
+    def close(self) -> None:
+        if self._vector_store is not None:
+            self._vector_store.close()
+            self._vector_store = None
+
+
 @app.command()
 def watch(
     source: Optional[list[Path]] = typer.Option(
@@ -3251,30 +3335,35 @@ def watch(
     rprint()
 
     on_flush = create_flush_callback(db_path, arbitrated=True)
+    rewind_archive_batch_size = 50
+    rewind_archive_interval_ms = flush_interval * 3
+    if env_batch := os.environ.get("BRAINLAYER_REWIND_ARCHIVE_BATCH"):
+        try:
+            rewind_archive_batch_size = max(1, int(env_batch))
+        except ValueError:
+            rprint(
+                f"[yellow]Invalid BRAINLAYER_REWIND_ARCHIVE_BATCH={env_batch}, using default {rewind_archive_batch_size}[/]"
+            )
+    if env_interval := os.environ.get("BRAINLAYER_REWIND_ARCHIVE_INTERVAL_MS"):
+        try:
+            rewind_archive_interval_ms = max(1, int(env_interval))
+        except ValueError:
+            rprint(
+                f"[yellow]Invalid BRAINLAYER_REWIND_ARCHIVE_INTERVAL_MS={env_interval}, using default {rewind_archive_interval_ms}ms[/]"
+            )
+
+    rewind_archiver = _RewindArchiveBatcher(
+        db_path=db_path,
+        batch_size=rewind_archive_batch_size,
+        flush_interval_ms=rewind_archive_interval_ms,
+    )
 
     def on_rewind(filepath: str, session_id: str, old_offset: int, new_offset: int):
         """Handle checkpoint restore — soft-archive chunks from reverted timeline."""
-        from ..vector_store import VectorStore as _VS
-
         rprint(f"[bold yellow]Rewind detected:[/] {session_id} ({old_offset}→{new_offset})")
+        rewind_archiver.add(session_id)
         try:
-            s = _VS(db_path)
-            cursor = s.conn.cursor()
-            # Mark realtime_watcher chunks from this session as archived
-            from datetime import datetime, timezone
-
-            now = datetime.now(timezone.utc).isoformat()
-            cursor.execute(
-                """UPDATE chunks SET archived_at = ?, value_type = 'ARCHIVED'
-                   WHERE source = 'realtime_watcher'
-                     AND conversation_id = ?
-                     AND archived_at IS NULL""",
-                (now, session_id),
-            )
-            affected = s.conn.changes()
-            if affected > 0:
-                rprint(f"  Archived {affected} chunks from reverted timeline")
-            s.close()
+            rewind_archiver.maybe_flush(f"interval={rewind_archive_interval_ms}ms")
         except Exception as e:
             rprint(f"  [red]Failed to archive reverted chunks: {e}[/]")
 
@@ -3297,7 +3386,11 @@ def watch(
     signal.signal(signal.SIGTERM, handle_signal)
     signal.signal(signal.SIGINT, handle_signal)
 
-    watcher.start()
+    try:
+        watcher.start()
+    finally:
+        rewind_archiver.flush("shutdown")
+        rewind_archiver.close()
     rprint(f"[bold green]Done.[/] Total flushed: {watcher.indexer.total_flushed}")
 
 

--- a/tests/test_rewind_batch_archival.py
+++ b/tests/test_rewind_batch_archival.py
@@ -1,0 +1,217 @@
+import sqlite3
+import time
+
+from brainlayer.cli import _RewindArchiveBatcher
+from brainlayer.vector_store import VectorStore
+
+
+class _CountingCursor:
+    def __init__(self, cursor: sqlite3.Cursor, counters: dict[str, int]):
+        self._cursor = cursor
+        self._counters = counters
+
+    def execute(self, sql: str, parameters=()):
+        if sql.lstrip().upper().startswith("UPDATE"):
+            self._counters["updates"] += 1
+        if parameters:
+            return self._cursor.execute(sql, parameters)
+        return self._cursor.execute(sql)
+
+    def __getattr__(self, item):
+        return getattr(self._cursor, item)
+
+
+class _CountingConnection:
+    def __init__(self, path, counters: dict[str, int]):
+        self._conn = sqlite3.connect(path)
+        self._counters = counters
+        self._change_anchor = 0
+
+    def cursor(self):
+        return _CountingCursor(self._conn.cursor(), self._counters)
+
+    def commit(self) -> None:
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def changes(self) -> int:
+        total_changes = self._conn.total_changes
+        delta = total_changes - self._change_anchor
+        self._change_anchor = total_changes
+        return delta
+
+    def __getattr__(self, item):
+        return getattr(self._conn, item)
+
+
+class _CountingVectorStore:
+    def __init__(self, db_path, counters: dict[str, int]):
+        counters["opens"] += 1
+        self.conn = _CountingConnection(db_path, counters)
+
+    def close(self) -> None:
+        self.conn.close()
+
+
+def _prepare_rewind_archive_db(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    rows = [
+        ("s1-a", "s1", "realtime_watcher"),
+        ("s1-b", "s1", "realtime_watcher"),
+        ("s2-a", "s2", "realtime_watcher"),
+        ("s2-b", "s2", "realtime_watcher"),
+        ("s3-a", "s3", "realtime_watcher"),
+        ("other", "s1", "manual"),
+    ]
+    for chunk_id, session_id, source in rows:
+        store.conn.execute(
+            """
+            INSERT INTO chunks (
+              id, content, metadata, source_file, source, conversation_id, value_type, content_type
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (chunk_id, "test", "{}", "/tmp/session.jsonl", source, session_id, "KNOWLEDGE", "assistant_text"),
+        )
+    store.conn.execute(
+        "INSERT INTO chunks (id, content, metadata, source_file, source, conversation_id, value_type, content_type, archived_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "pre",
+            "already",
+            "{}",
+            "/tmp/session.jsonl",
+            "realtime_watcher",
+            "s3",
+            "KNOWLEDGE",
+            "assistant_text",
+            "2026-01-01T00:00:00Z",
+        ),
+    )
+    store.close()
+    return db_path
+
+
+def test_rewind_archiver_batches_multiple_sessions(tmp_path):
+    db_path = _prepare_rewind_archive_db(tmp_path)
+    counters = {"opens": 0, "updates": 0}
+
+    archiver = _RewindArchiveBatcher(
+        db_path=db_path,
+        batch_size=10_000,
+        flush_interval_ms=60_000,
+        vector_store_factory=lambda p: _CountingVectorStore(p, counters),
+    )
+
+    archiver.add("s1")
+    archiver.maybe_flush("interval")
+    archiver.add("s2")
+    archiver.maybe_flush("interval")
+    archiver.add("s3")
+    archiver.maybe_flush("interval")
+
+    assert archiver.pending_count == 3
+    assert archiver.flush("shutdown") == 5
+
+    assert counters["opens"] == 1
+    assert counters["updates"] == 1
+
+    conn = sqlite3.connect(db_path)
+    archived = conn.execute("SELECT conversation_id, source FROM chunks WHERE archived_at IS NOT NULL").fetchall()
+    assert ("s1", "realtime_watcher") in archived
+    assert ("s2", "realtime_watcher") in archived
+    assert ("s3", "realtime_watcher") in archived  # pre-archived baseline
+    assert ("s1", "manual") not in archived
+    conn.close()
+    archiver.close()
+
+
+def test_rewind_archiver_flushes_on_threshold(tmp_path):
+    db_path = _prepare_rewind_archive_db(tmp_path)
+    counters = {"opens": 0, "updates": 0}
+    archiver = _RewindArchiveBatcher(
+        db_path=db_path,
+        batch_size=2,
+        flush_interval_ms=60_000,
+        vector_store_factory=lambda p: _CountingVectorStore(p, counters),
+    )
+
+    archiver.add("s1")
+    assert archiver.maybe_flush("interval") == 0
+    archiver.add("s2")
+    assert archiver.maybe_flush("interval") == 4
+
+    assert archiver.pending_count == 0
+    assert counters["opens"] == 1
+    assert counters["updates"] == 1
+
+    conn = sqlite3.connect(db_path)
+    archived = conn.execute(
+        "SELECT COUNT(*) FROM chunks WHERE source='realtime_watcher' AND archived_at IS NOT NULL AND conversation_id IN ('s1', 's2')"
+    ).fetchone()[0]
+    assert archived == 4
+    conn.close()
+    archiver.close()
+
+
+def test_rewind_archiver_rewind_interval_shutdown_flush(tmp_path):
+    db_path = _prepare_rewind_archive_db(tmp_path)
+    counters = {"opens": 0, "updates": 0}
+    archiver = _RewindArchiveBatcher(
+        db_path=db_path,
+        batch_size=10_000,
+        flush_interval_ms=5,
+        vector_store_factory=lambda p: _CountingVectorStore(p, counters),
+    )
+
+    archiver.add("s1")
+    assert archiver.pending_count == 1
+    assert archiver.maybe_flush("interval") == 0
+    time.sleep(0.02)
+    assert archiver.maybe_flush("interval") == 2
+    assert counters["updates"] == 1
+    assert archiver.pending_count == 0
+
+    archiver.add("s2")
+    archiver.flush("shutdown")
+    assert archiver.pending_count == 0
+    assert counters["updates"] == 2
+
+    conn = sqlite3.connect(db_path)
+    archived = conn.execute(
+        "SELECT COUNT(*) FROM chunks WHERE source='realtime_watcher' AND archived_at IS NOT NULL AND conversation_id IN ('s1', 's2')"
+    ).fetchone()[0]
+    assert archived == 4
+    conn.close()
+    archiver.close()
+
+
+def test_rewind_archiver_idempotent_no_duplicate_archival(tmp_path):
+    db_path = _prepare_rewind_archive_db(tmp_path)
+    counters = {"opens": 0, "updates": 0}
+    archiver = _RewindArchiveBatcher(
+        db_path=db_path,
+        batch_size=1,
+        flush_interval_ms=60_000,
+        vector_store_factory=lambda p: _CountingVectorStore(p, counters),
+    )
+
+    archiver.add("s1")
+    first_flush = archiver.flush("test")
+    archiver.add("s1")
+    second_flush = archiver.flush("test")
+
+    assert first_flush == 2
+    assert second_flush == 0
+    assert archiver.archived_total == 2
+    assert archiver.pending_count == 0
+
+    conn = sqlite3.connect(db_path)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM chunks WHERE conversation_id = 's1' AND source='realtime_watcher' AND archived_at IS NOT NULL"
+    ).fetchone()[0]
+    assert count == 2
+    conn.close()
+    assert counters["opens"] == 1


### PR DESCRIPTION
## Summary
- Buffer rewind session ids in watcher, flush as batched UPDATE with IN (...).
- Reuse one VectorStore for rewind archival until shutdown.
- Add interval and threshold-based batching with fallback shutdown flush.
- Keep direct write path and idempotent guard .
- Add tmp_path-only tests for batching, threshold, interval, shutdown, and idempotency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime watcher DB write timing for rewind archival; deferred updates could leave reverted chunks visible briefly until flush, though shutdown flush and idempotent SQL limit data corruption risk.
> 
> **Overview**
> The **`watch`** command no longer archives reverted timeline chunks on every rewind event. It buffers session IDs in **`_RewindArchiveBatcher`** and runs one batched `UPDATE` (with `conversation_id IN (...)`) when the batch hits a size threshold, a time interval elapses, or the watcher shuts down.
> 
> **Behavior change:** archival is deferred instead of opening **`VectorStore`** and writing immediately per rewind. A single store connection is reused until shutdown; **`try/finally`** ensures a final flush and close.
> 
> Batch size (default 50) and interval (default 3× flush-ms) are overridable via **`BRAINLAYER_REWIND_ARCHIVE_BATCH`** and **`BRAINLAYER_REWIND_ARCHIVE_INTERVAL_MS`**. Existing filters (`realtime_watcher`, null `archived_at`) keep repeat flushes idempotent.
> 
> Adds **`tests/test_rewind_batch_archival.py`** for multi-session batching, threshold/interval flush, shutdown flush, and idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 470d4b9079a1daf8b49d417f955492fd2e54b295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix batch rewind archival in the watcher by coalescing session updates into a single DB write
> - Introduces `_RewindArchiveBatcher` in [`brainlayer/cli/__init__.py`](https://github.com/EtanHey/brainlayer/pull/574/files#diff-e66ce4ea8b0cf3331154cb15181cb09a7c593566e36380fd9215ff29d24ffd02) to buffer session IDs and flush them in a single `UPDATE` against the chunks table, rather than one DB write per rewind event.
> - Flush is triggered when the pending batch reaches a size threshold (default 50) or a configurable time interval elapses; a final flush runs on watcher shutdown via `try/finally`.
> - Batch size and interval are configurable via `BRAINLAYER_REWIND_ARCHIVE_BATCH` and `BRAINLAYER_REWIND_ARCHIVE_INTERVAL_MS` environment variables, with fallback defaults and warnings on invalid values.
> - Adds tests in [`tests/test_rewind_batch_archival.py`](https://github.com/EtanHey/brainlayer/pull/574/files#diff-b7c79d35dbda680843f0b93ea11543fa8bc08f57faa10652ac67a1d03a2e8e2b) covering threshold flush, interval flush, idempotency, and shutdown flush.
> - Behavioral Change: the `on_rewind` handler no longer writes to the DB immediately; archival is deferred until a flush condition is met.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7cf7fcc. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->