### PR TITLE
feat: per-agent-class provenance classifier + read-only report

### DIFF
--- a/scripts/provenance_classify_report.py
+++ b/scripts/provenance_classify_report.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections import Counter
 from pathlib import Path
 from typing import Any
 
 import apsw
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
 
 from brainlayer.agent_provenance import classify_provenance, effective_visibility
 from brainlayer.paths import DEFAULT_DB_PATH

--- a/scripts/provenance_classify_report.py
+++ b/scripts/provenance_classify_report.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Read-only provenance classifier report for BrainLayer chunks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import apsw
+
+from brainlayer.agent_provenance import classify_provenance, effective_visibility
+from brainlayer.paths import DEFAULT_DB_PATH
+
+
+def build_report(db_path: str | Path) -> dict[str, Any]:
+    """Classify chunks from a read-only DB connection and return JSON-safe counts."""
+    db_path = Path(db_path).expanduser()
+    tags: Counter[str] = Counter()
+    policies: Counter[str] = Counter()
+    visibility: Counter[str] = Counter()
+    total = 0
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        for _chunk_id, source_file, content_class in cursor.execute(
+            "SELECT id, source_file, content_class FROM chunks"
+        ):
+            decision = classify_provenance(str(source_file or ""), content_class)
+            tags[decision.provenance_tag] += 1
+            policies[decision.search_policy] += 1
+            visibility[effective_visibility(decision, content_class)] += 1
+            total += 1
+    finally:
+        conn.close()
+
+    return {
+        "dry_run": True,
+        "db_path": str(db_path),
+        "total_chunks": total,
+        "tags": dict(sorted(tags.items())),
+        "policies": {policy: policies.get(policy, 0) for policy in ("KEEP", "ISOLATE", "OUT")},
+        "effective_visibility": {bucket: visibility.get(bucket, 0) for bucket in ("cold", "default", "operational")},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH, help="BrainLayer SQLite DB path")
+    parser.add_argument("--dry-run", action="store_true", default=True, help="No-op flag; report is always read-only")
+    args = parser.parse_args()
+
+    print(json.dumps(build_report(args.db), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -21,7 +21,7 @@ SearchPolicy = Literal["KEEP", "ISOLATE", "OUT"]
 EffectiveVisibility = Literal["default", "operational", "cold"]
 
 RECON_BRAIN_WORKER_RE = re.compile(r"\bbrain[-_ ]?worker\b", re.IGNORECASE)
-RECON_WEAVE_RE = re.compile(r"(?<!\w)/(?:weave)\b|\bweave(?:\s+worker|\s+agent|\s+recon)?\b", re.IGNORECASE)
+RECON_WEAVE_RE = re.compile(r"(?<!\w)/weave\b|\bweave[-_ ]+(?:worker|agent|recon)\b", re.IGNORECASE)
 RECON_SESSION_MINER_RE = re.compile(r"\bsession[-_ ]?miner\b", re.IGNORECASE)
 RECON_AGENT_SIGNATURES = (
     RECON_BRAIN_WORKER_RE,

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -68,7 +68,11 @@ def _under_provider_sessions(path: Path, provider_dir: str) -> bool:
 
 def _under_cursor_agent_transcripts(path: Path) -> bool:
     parts = path.parts
-    return ".cursor" in parts and "agent-transcripts" in parts
+    try:
+        cursor_index = parts.index(".cursor")
+    except ValueError:
+        return False
+    return "agent-transcripts" in parts[cursor_index + 1 :]
 
 
 def _project_segment(path: Path) -> str | None:
@@ -86,7 +90,7 @@ def _repo_from_project_segment(segment: str | None) -> str | None:
     for marker in ("-Gits-", "--config-"):
         if marker not in normalized:
             continue
-        repo = normalized.rsplit(marker, 1)[-1].strip("-").split("-", 1)[0]
+        repo = normalized.rsplit(marker, 1)[-1].strip("-")
         return repo.casefold() if repo else None
     return normalized.rsplit("-", 1)[-1].casefold() if normalized else None
 

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -1,0 +1,169 @@
+"""Per-agent-class provenance decisions for transcript quarantine planning.
+
+The classifier is pure and side-effect-free. Recon Agent-tool signatures are
+detectable only when caller-provided content is available; source-only report
+runs will classify those rows by path provenance instead.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .content_class import normalize_content_class
+from .ingest_denylist import is_denylisted
+
+SearchPolicy = Literal["KEEP", "ISOLATE", "OUT"]
+EffectiveVisibility = Literal["default", "operational", "cold"]
+
+RECON_BRAIN_WORKER_RE = re.compile(r"\bbrain[-_ ]?worker\b", re.IGNORECASE)
+RECON_WEAVE_RE = re.compile(r"(?<!\w)/(?:weave)\b|\bweave(?:\s+worker|\s+agent|\s+recon)?\b", re.IGNORECASE)
+RECON_SESSION_MINER_RE = re.compile(r"\bsession[-_ ]?miner\b", re.IGNORECASE)
+RECON_AGENT_SIGNATURES = (
+    RECON_BRAIN_WORKER_RE,
+    RECON_WEAVE_RE,
+    RECON_SESSION_MINER_RE,
+)
+
+FLEET_REPOS = frozenset(
+    {
+        "orchestrator",
+        "golems",
+        "skill-creator",
+        "brainlayer",
+        "voicelayer",
+        "cmuxlayer",
+        "dashboard",
+        "cmux",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ProvenanceDecision:
+    provenance_tag: str
+    search_policy: SearchPolicy
+    reason: str
+
+
+def _abspath(source_file: str | Path) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(str(source_file))))
+
+
+def _has_segment(path: Path, pattern: str) -> bool:
+    return any(fnmatch.fnmatchcase(part, pattern) for part in path.parts)
+
+
+def _under_provider_sessions(path: Path, provider_dir: str) -> bool:
+    parts = path.parts
+    for index, part in enumerate(parts[:-1]):
+        if part == provider_dir and index + 1 < len(parts) and parts[index + 1] == "sessions":
+            return True
+    return False
+
+
+def _under_cursor_agent_transcripts(path: Path) -> bool:
+    parts = path.parts
+    return ".cursor" in parts and "agent-transcripts" in parts
+
+
+def _project_segment(path: Path) -> str | None:
+    parts = path.parts
+    for index, part in enumerate(parts[:-1]):
+        if part == "projects" and index > 0 and parts[index - 1] == ".claude":
+            return parts[index + 1]
+    return None
+
+
+def _repo_from_project_segment(segment: str | None) -> str | None:
+    if not segment:
+        return None
+    normalized = segment.strip("-")
+    for marker in ("-Gits-", "--config-"):
+        if marker not in normalized:
+            continue
+        repo = normalized.rsplit(marker, 1)[-1].strip("-").split("-", 1)[0]
+        return repo.casefold() if repo else None
+    return normalized.rsplit("-", 1)[-1].casefold() if normalized else None
+
+
+def _is_subagent(path: Path) -> bool:
+    return "subagents" in path.parts
+
+
+def _is_direct_claude_session(path: Path) -> bool:
+    if is_denylisted(path):
+        return False
+    parts = path.parts
+    if ".claude" not in parts or "projects" not in parts:
+        return False
+    if _is_subagent(path) or _has_segment(path, "wf_*"):
+        return False
+    return path.suffix == ".jsonl"
+
+
+def has_recon_agent_signature(content: str | None) -> bool:
+    """Return True when first-chunk/task text identifies recon Agent-tool work."""
+    if not content:
+        return False
+    return any(regex.search(content) for regex in RECON_AGENT_SIGNATURES)
+
+
+def _has_recon_path_signature(path: Path) -> bool:
+    return any(part in {"brain-worker", "session-miner", "weave"} for part in path.parts)
+
+
+def classify_provenance(
+    source_file: str,
+    content_class: str | None = None,
+    *,
+    content: str | None = None,
+) -> ProvenanceDecision:
+    """Classify a source path into an auditable provenance search policy."""
+    del content_class
+    path = _abspath(source_file)
+
+    if has_recon_agent_signature(content) or _has_recon_path_signature(path):
+        return ProvenanceDecision("recon-agent", "OUT", "recon Agent-tool signature wins precedence")
+
+    if _has_segment(path, "wf_*"):
+        return ProvenanceDecision("workflow-agent", "ISOLATE", "workflow wf_* path segment")
+
+    if _under_provider_sessions(path, ".codex"):
+        return ProvenanceDecision("codex-session", "KEEP", "Codex session root stays searchable")
+
+    if _under_cursor_agent_transcripts(path):
+        return ProvenanceDecision("cursor-gather", "ISOLATE", "Cursor agent-transcripts root")
+
+    if _under_provider_sessions(path, ".gemini"):
+        return ProvenanceDecision("gemini-session", "OUT", "Gemini session root")
+
+    if _is_subagent(path):
+        repo = _repo_from_project_segment(_project_segment(path))
+        if repo in FLEET_REPOS:
+            return ProvenanceDecision("fleet-subagent", "KEEP", f"fleet subagent project token {repo}")
+        return ProvenanceDecision("product-subagent", "KEEP", "non-fleet product subagent")
+
+    if _is_direct_claude_session(path):
+        return ProvenanceDecision("direct-session", "KEEP", "direct/control Claude session")
+
+    return ProvenanceDecision("unknown", "KEEP", "no agent provenance rule matched")
+
+
+def effective_visibility(decision: ProvenanceDecision, content_class: str | None) -> EffectiveVisibility:
+    """Map provenance + content class onto P1.4 default/operational/cold visibility."""
+    if decision.search_policy == "OUT":
+        return "cold"
+    if decision.search_policy == "ISOLATE":
+        return "operational"
+
+    normalized = normalize_content_class(content_class)
+    if normalized in {"knowledge", "decision"}:
+        return "default"
+    if normalized == "operational":
+        return "operational"
+    return "cold"

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -118,7 +118,19 @@ def has_recon_agent_signature(content: str | None) -> bool:
 
 
 def _has_recon_path_signature(path: Path) -> bool:
-    return any(part in {"brain-worker", "session-miner", "weave"} for part in path.parts)
+    markers = {"brain-worker", "session-miner", "weave"}
+    parts = path.parts
+    marker_indexes = [index for index, part in enumerate(parts) if part in markers]
+    if not marker_indexes:
+        return False
+
+    root_indexes: list[int] = []
+    if "subagents" in parts:
+        root_indexes.append(parts.index("subagents"))
+    if _under_cursor_agent_transcripts(path):
+        root_indexes.append(parts.index("agent-transcripts"))
+
+    return any(marker_index > root_index for marker_index in marker_indexes for root_index in root_indexes)
 
 
 def classify_provenance(

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -1,0 +1,181 @@
+import json
+from pathlib import Path
+
+import apsw
+
+from brainlayer.agent_provenance import (
+    classify_provenance,
+    effective_visibility,
+    has_recon_agent_signature,
+)
+from scripts.provenance_classify_report import build_report
+
+
+def test_classifies_provider_roots_and_workflow_paths(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+
+    cases = [
+        (
+            home / ".codex" / "sessions" / "2026" / "07" / "worker.jsonl",
+            "codex-session",
+            "KEEP",
+        ),
+        (
+            home / ".cursor" / "projects" / "brainlayer" / "agent-transcripts" / "session.jsonl",
+            "cursor-gather",
+            "ISOLATE",
+        ),
+        (
+            home / ".gemini" / "sessions" / "session.jsonl",
+            "gemini-session",
+            "OUT",
+        ),
+        (
+            home
+            / ".claude"
+            / "projects"
+            / "-Users-etanheyman-Gits-brainlayer"
+            / "session"
+            / "subagents"
+            / "workflows"
+            / "wf_c83ce37d"
+            / "agent.jsonl",
+            "workflow-agent",
+            "ISOLATE",
+        ),
+    ]
+
+    for source_file, expected_tag, expected_policy in cases:
+        decision = classify_provenance(str(source_file))
+        assert decision.provenance_tag == expected_tag
+        assert decision.search_policy == expected_policy
+        assert decision.reason
+
+
+def test_classifies_fleet_and_product_subagents_by_transferable_project_token(tmp_path: Path) -> None:
+    home = tmp_path / "alt-home"
+
+    fleet = classify_provenance(
+        str(
+            home
+            / ".claude"
+            / "projects"
+            / "-private-tmp-Gits-brainlayer"
+            / "session"
+            / "subagents"
+            / "agent-a25d6b3aa6880db8e.jsonl"
+        )
+    )
+    product = classify_provenance(
+        str(
+            home
+            / ".claude"
+            / "projects"
+            / "-Users-someone-Gits-domica"
+            / "session"
+            / "subagents"
+            / "agent-product.jsonl"
+        )
+    )
+    mehayom = classify_provenance(
+        str(
+            home
+            / ".claude"
+            / "projects"
+            / "-Users-someone-Gits-Mehayom"
+            / "session"
+            / "subagents"
+            / "agent-product.jsonl"
+        )
+    )
+
+    assert (fleet.provenance_tag, fleet.search_policy) == ("fleet-subagent", "KEEP")
+    assert (product.provenance_tag, product.search_policy) == ("product-subagent", "KEEP")
+    assert (mehayom.provenance_tag, mehayom.search_policy) == ("product-subagent", "KEEP")
+
+
+def test_direct_claude_sessions_stay_keep_and_never_isolate_or_out(tmp_path: Path) -> None:
+    direct_session = (
+        tmp_path / "home" / ".claude" / "projects" / "-Users-etanheyman-Gits-brainlayer" / "4220c177-8816-446d.jsonl"
+    )
+
+    decision = classify_provenance(str(direct_session))
+
+    assert decision.provenance_tag == "direct-session"
+    assert decision.search_policy == "KEEP"
+
+
+def test_recon_agent_signature_is_out_and_has_precedence_over_fleet_subagent(tmp_path: Path) -> None:
+    fleet_subagent = (
+        tmp_path
+        / "home"
+        / ".claude"
+        / "projects"
+        / "-Users-etanheyman-Gits-brainlayer"
+        / "session"
+        / "subagents"
+        / "agent-a25d6b3aa6880db8e.jsonl"
+    )
+
+    decision = classify_provenance(
+        str(fleet_subagent),
+        content_class="knowledge",
+        content="Task for brain-worker: mine workflow JSONL transcripts and write the recon synthesis.",
+    )
+
+    assert has_recon_agent_signature("session-miner should inspect these transcripts")
+    assert decision.provenance_tag == "recon-agent"
+    assert decision.search_policy == "OUT"
+
+
+def test_effective_visibility_preserves_keep_knowledge_and_decision_but_isolates_operational(
+    tmp_path: Path,
+) -> None:
+    keep = classify_provenance(str(tmp_path / ".codex" / "sessions" / "session.jsonl"))
+    isolate = classify_provenance(
+        str(tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "session.jsonl")
+    )
+    out = classify_provenance(str(tmp_path / ".gemini" / "sessions" / "session.jsonl"))
+
+    assert effective_visibility(keep, "knowledge") == "default"
+    assert effective_visibility(keep, "decision") == "default"
+    assert effective_visibility(keep, "operational") == "operational"
+    assert effective_visibility(isolate, "knowledge") == "operational"
+    assert effective_visibility(out, "knowledge") == "cold"
+
+
+def test_report_summarizes_tags_policies_and_effective_visibility_without_real_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "brainlayer-test.db"
+    conn = apsw.Connection(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source_file TEXT, content_class TEXT)")
+    rows = [
+        ("codex-knowledge", str(tmp_path / ".codex" / "sessions" / "session.jsonl"), "knowledge"),
+        (
+            "cursor-operational",
+            str(tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "session.jsonl"),
+            "knowledge",
+        ),
+        ("gemini-cold", str(tmp_path / ".gemini" / "sessions" / "session.jsonl"), "knowledge"),
+        (
+            "direct-decision",
+            str(tmp_path / ".claude" / "projects" / "-Users-x-Gits-brainlayer" / "session.jsonl"),
+            "decision",
+        ),
+    ]
+    cursor.executemany("INSERT INTO chunks (id, source_file, content_class) VALUES (?, ?, ?)", rows)
+    conn.close()
+
+    report = build_report(db_path)
+
+    assert json.loads(json.dumps(report)) == report
+    assert report["dry_run"] is True
+    assert report["total_chunks"] == 4
+    assert report["tags"] == {
+        "codex-session": 1,
+        "cursor-gather": 1,
+        "direct-session": 1,
+        "gemini-session": 1,
+    }
+    assert report["policies"] == {"KEEP": 2, "ISOLATE": 1, "OUT": 1}
+    assert report["effective_visibility"] == {"cold": 1, "default": 2, "operational": 1}

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -164,6 +164,23 @@ def test_recon_agent_signature_is_out_and_has_precedence_over_fleet_subagent(tmp
     assert decision.search_policy == "OUT"
 
 
+def test_recon_agent_signature_does_not_match_plain_weave_verb(tmp_path: Path) -> None:
+    direct_session = (
+        tmp_path / "home" / ".claude" / "projects" / "-Users-etanheyman-Gits-brainlayer" / "4220c177-8816-446d.jsonl"
+    )
+
+    decision = classify_provenance(
+        str(direct_session),
+        content="Weave together the launch notes into one summary.",
+    )
+
+    assert has_recon_agent_signature("/weave run the recon")
+    assert has_recon_agent_signature("Send this to the weave agent.")
+    assert not has_recon_agent_signature("Weave together the launch notes into one summary.")
+    assert decision.provenance_tag == "direct-session"
+    assert decision.search_policy == "KEEP"
+
+
 def test_effective_visibility_preserves_keep_knowledge_and_decision_but_isolates_operational(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -183,6 +183,28 @@ def test_recon_agent_signature_does_not_match_plain_weave_verb(tmp_path: Path) -
     assert decision.search_policy == "KEEP"
 
 
+def test_recon_path_signature_is_scoped_to_agent_transcript_roots(tmp_path: Path) -> None:
+    normal_project = tmp_path / "home" / "Gits" / "weave" / "notes" / "memory.md"
+    direct_weave_repo_session = (
+        tmp_path / "home" / ".claude" / "projects" / "-Users-etanheyman-Gits-weave" / "session.jsonl"
+    )
+    recon_subagent = (
+        tmp_path
+        / "home"
+        / ".claude"
+        / "projects"
+        / "-Users-etanheyman-Gits-brainlayer"
+        / "session"
+        / "subagents"
+        / "session-miner"
+        / "agent.jsonl"
+    )
+
+    assert classify_provenance(str(normal_project)).search_policy == "KEEP"
+    assert classify_provenance(str(direct_weave_repo_session)).provenance_tag == "direct-session"
+    assert classify_provenance(str(recon_subagent)).provenance_tag == "recon-agent"
+
+
 def test_effective_visibility_preserves_keep_knowledge_and_decision_but_isolates_operational(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import apsw
@@ -232,3 +234,26 @@ def test_report_summarizes_tags_policies_and_effective_visibility_without_real_d
     }
     assert report["policies"] == {"KEEP": 2, "ISOLATE": 1, "OUT": 1}
     assert report["effective_visibility"] == {"cold": 1, "default": 2, "operational": 1}
+
+
+def test_report_script_bootstraps_src_when_run_directly(tmp_path: Path) -> None:
+    fake_apsw = tmp_path / "apsw.py"
+    fake_apsw.write_text("", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "scripts/provenance_classify_report.py",
+            "--help",
+        ],
+        check=False,
+        cwd=Path(__file__).resolve().parents[1],
+        env={"PYTHONPATH": str(tmp_path)},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Read-only provenance classifier report" in result.stdout

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -66,12 +66,34 @@ def test_classifies_fleet_and_product_subagents_by_transferable_project_token(tm
             / "agent-a25d6b3aa6880db8e.jsonl"
         )
     )
+    hyphenated_fleet = classify_provenance(
+        str(
+            home
+            / ".claude"
+            / "projects"
+            / "-Users-someone-Gits-skill-creator"
+            / "session"
+            / "subagents"
+            / "agent-fleet.jsonl"
+        )
+    )
     product = classify_provenance(
         str(
             home
             / ".claude"
             / "projects"
             / "-Users-someone-Gits-domica"
+            / "session"
+            / "subagents"
+            / "agent-product.jsonl"
+        )
+    )
+    product_with_fleet_prefix = classify_provenance(
+        str(
+            home
+            / ".claude"
+            / "projects"
+            / "-Users-someone-Gits-golems-packages-coach"
             / "session"
             / "subagents"
             / "agent-product.jsonl"
@@ -90,8 +112,22 @@ def test_classifies_fleet_and_product_subagents_by_transferable_project_token(tm
     )
 
     assert (fleet.provenance_tag, fleet.search_policy) == ("fleet-subagent", "KEEP")
+    assert (hyphenated_fleet.provenance_tag, hyphenated_fleet.search_policy) == ("fleet-subagent", "KEEP")
     assert (product.provenance_tag, product.search_policy) == ("product-subagent", "KEEP")
+    assert (product_with_fleet_prefix.provenance_tag, product_with_fleet_prefix.search_policy) == (
+        "product-subagent",
+        "KEEP",
+    )
     assert (mehayom.provenance_tag, mehayom.search_policy) == ("product-subagent", "KEEP")
+
+
+def test_cursor_agent_transcripts_requires_cursor_ancestor(tmp_path: Path) -> None:
+    reversed_segments = tmp_path / "agent-transcripts" / "archive" / ".cursor" / "rules.jsonl"
+
+    decision = classify_provenance(str(reversed_segments))
+
+    assert decision.provenance_tag == "unknown"
+    assert decision.search_policy == "KEEP"
 
 
 def test_direct_claude_sessions_stay_keep_and_never_isolate_or_out(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a pure `brainlayer.agent_provenance` classifier that returns auditable provenance tags, KEEP/ISOLATE/OUT policy, and P1.4 effective visibility routing.
- Add `scripts/provenance_classify_report.py`, a read-only APSW report over `chunks(id, source_file, content_class)` that emits per-tag, per-policy, and effective visibility JSON counts.
- Add synthetic-path/unit tests for every PR1 class row, direct-session safety, recon precedence, content-class tiering, and report counts without touching the real DB.

## LARGE-PLAN P1.4/P1.6 Context
Source cited by the build brief: `docs.local/plans/2026-06-30-brainlayer-10x-recon/LARGE-PLAN.md` P1.4/P1.6. Because `docs.local` is local-only, the load-bearing requirements are copied here for reviewers:

- P1.4: BrainLayer uses 3-tier routing: knowledge/decision remain default-visible in `chunks_fts`, operational goes to `chunks_fts_operational`, and cold rows are not FTS-indexed.
- P1.6: retroactive quarantine must gate search visibility on SOURCE path OR `content_class`, never on agent provenance alone, because blanket agent hiding would bury high-value Codex/cmux implementation memory.

## Revised Class Table
| provenance_tag | match rule | search_policy |
|---|---|---|
| `recon-agent` | brain-worker, `/weave`, or session-miner signature/path | `OUT` |
| `workflow-agent` | path has a `wf_*` segment | `ISOLATE` |
| `codex-session` | under `.codex/sessions/` | `KEEP` |
| `cursor-gather` | under `.cursor/**/agent-transcripts/` | `ISOLATE` |
| `gemini-session` | under `.gemini/sessions/` | `OUT` |
| `fleet-subagent` | `.claude` subagent with fleet repo project token | `KEEP` |
| `product-subagent` | `.claude` subagent with non-fleet repo project token | `KEEP` |
| `direct-session` | direct/control Claude JSONL session, not denylisted | `KEEP` |

Precedence: recon-agent > workflow-agent > provider roots > subagent fleet/product > direct-session.

## Test Plan
- [x] RED observed first: `pytest tests/test_agent_provenance.py -q` failed with `ModuleNotFoundError: No module named 'brainlayer.agent_provenance'` before implementation.
- [x] `pytest tests/test_agent_provenance.py tests/test_ingest_denylist.py tests/test_content_class.py -q` -> 50 passed.
- [x] `ruff check src/brainlayer/agent_provenance.py scripts/provenance_classify_report.py tests/test_agent_provenance.py && ruff format --check src/brainlayer/agent_provenance.py scripts/provenance_classify_report.py tests/test_agent_provenance.py` -> passed.
- [x] `pytest -q --ignore=tests/test_vector_store.py --ignore=tests/test_engine.py` -> 3433 passed, 49 skipped, 5 xfailed.
- [x] Pre-push gate -> 3376 passed, 9 skipped, 61 deselected, 1 xfailed; MCP tool registration 3 passed; isolated eval/hook 40 passed; bun 1 passed; regression shell passed.

## Notes
- This PR does not wire watcher/ingest behavior and does not mutate any production DB state.
- PR 2 should wire this classifier into quarantine rebuild/watcher flows.
- Local `coderabbit review --agent` was attempted with a 180s timeout before commit; it emitted heartbeat-only review progress and timed out without findings, so PR-level bot review is required here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only classification and reporting only; search/ingest behavior is unchanged until a follow-up wires this in.
> 
> **Overview**
> Introduces a **pure provenance classifier** for transcript quarantine planning: each chunk source path (and optional task text) gets a tag, **KEEP / ISOLATE / OUT** policy, and a reason. Rules cover provider session roots (Codex, Cursor agent-transcripts, Gemini), workflow `wf_*` paths, fleet vs product Claude subagents, direct Claude JSONL sessions, and **recon-agent** detection via content or scoped path markers—with explicit precedence so recon wins over fleet KEEP.
> 
> Adds **`effective_visibility`** to combine policy with `content_class` into **default / operational / cold** buckets (P1.4-style routing).
> 
> Adds **`scripts/provenance_classify_report.py`**, which scans `chunks` read-only and prints JSON counts by tag, policy, and visibility. **No ingest, watcher, or DB mutation** in this PR.
> 
> Tests cover routing tables, recon false positives, visibility mapping, and the report script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103d0ef310ea0338e27081f0989462dea61b0f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-agent-class provenance classifier and read-only report CLI
> - Introduces [`classify_provenance`](https://github.com/EtanHey/brainlayer/pull/576/files#diff-57296bee549fc366c410ccd22072917ab0333369dd41c4fc2917d3b281e6a268) with deterministic precedence rules to tag source paths (e.g. `direct-session`, `recon-agent`, `cursor-gather`, `fleet-subagent`) and assign a `KEEP`/`ISOLATE`/`OUT` search policy based on path structure and optional content signatures.
> - Adds `effective_visibility` to map classification outcomes and content class to `default`/`operational`/`cold` visibility buckets.
> - Adds [`scripts/provenance_classify_report.py`](https://github.com/EtanHey/brainlayer/pull/576/files#diff-24e43e3a2e69f335b3a57011fb5966e4af8f7d2f6860bfa4b1944de32efe46a1), a read-only CLI that opens the BrainLayer SQLite DB via apsw, aggregates tag/policy/visibility counts across the `chunks` table, and prints a JSON report to stdout.
> - Covers classification and reporting with a full test suite in [`tests/test_agent_provenance.py`](https://github.com/EtanHey/brainlayer/pull/576/files#diff-01aec664a8657844da8ed30949bda5ac389fc2589fdb5011be770449af9c696b), including provider root detection, fleet vs. product subagent distinction, recon signature precedence, and visibility mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 103d0ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance classification for records, helping organize items into visibility and search-handling categories.
  * Added a read-only JSON reporting command that summarizes provenance counts and visibility buckets from a database.

* **Tests**
  * Added coverage for classification rules, visibility mapping, reporting output, and command-line help behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->