### PR TITLE
docs: reframe BrainLayer purpose as fleet organizational memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
-<!-- IDENTITY: brainlayer, owner=EtanHey, purpose=local private knowledge pipeline for Claude Code sessions (index, search, enrich, visualize) -->
-# BrainLayer (זיכרון) - Local Knowledge Pipeline
+<!-- IDENTITY: brainlayer, owner=EtanHey, purpose=the fleet's organizational memory — Etan's prompts+intent AND the agents' work-history (what worked where, what eroded why), indexed/searchable/enriched -->
+# BrainLayer (זיכרון) - Fleet Organizational Memory
 
-> Memory for Claude Code conversations: index, search, enrich, and visualize sessions.
+> The fleet's memory: Etan's prompts + intent AND the agents' work-history — what was tried, what worked where, what eroded and why — searchable across every session.
 
 ## Purpose (WHY)
-- Build a local, private knowledge base from Claude Code sessions.
-- Provide fast search, context retrieval, and exports for downstream tools.
+- BrainLayer is the FLEET's organizational memory — not one person's private notebook.
+- It captures BOTH sides of the work: Etan's prompts + intent, AND the agents' work-history — what was tried, what worked where, what eroded and why.
+- So any agent inherits the fleet's accumulated experience: search prior decisions, skip re-solving already-fixed bugs, and see WHY a past choice was made before repeating a mistake.
+- Fast search, context retrieval, and exports for downstream tools.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 [![Tests](https://img.shields.io/badge/tests-1%2C848%20Python%20%2B%2054%20Swift-brightgreen.svg)](#testing)
 [![Website](https://img.shields.io/badge/site-brainlayer.etanheyman.com-d4956a.svg)](https://brainlayer.etanheyman.com)
 
-Every architecture decision, every debugging session, every preference you've expressed — **gone between sessions.** You repeat yourself constantly. Your agent rediscovers bugs it already fixed.
+Every architecture decision, every debugging session, every preference you've expressed — **gone between sessions.** You repeat yourself constantly. Your agents rediscover bugs they already fixed, and re-make choices the team already reasoned through.
 
-BrainLayer gives any MCP-compatible AI agent persistent memory across conversations. One SQLite file. No cloud. No Docker. Just `pip install`.
+BrainLayer gives any MCP-compatible AI agent persistent memory across conversations — and gives a whole **fleet** of agents a shared organizational memory: what one agent learns (a fix, a decision, what eroded and why) becomes experience the others inherit before they repeat the mistake. One SQLite file. No cloud. No Docker. Just `pip install`.
 
 ```text
 "What approach did I use for auth last month?"     →  brain_search


### PR DESCRIPTION
**Etan-ordered doc-drift audit.** Purpose framing had drifted to "Etan's private knowledge base from Claude Code sessions" — stale vs the imp-10 reframe: **BrainLayer = the FLEET's organizational memory** (Etan's prompts+intent AND the agents' work-history: what worked where, what eroded and why).

**Changed (repo files only):**
- `CLAUDE.md` — IDENTITY + tagline + Purpose(WHY) reframed to fleet organizational memory.
- `README.md` — kept the product pitch, added the fleet/shared-organizational-memory dimension (additive, public-facing).

**Global CLAUDE.md files not touched** — proposed diffs go to Etan/orc per docs-maintenance law.

Wording is Etan's call — flagged for his blessing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only wording updates with no behavioral or deployment impact; only product-positioning drift correction.
> 
> **Overview**
> **Documentation-only** reframe: BrainLayer is described as the **fleet's organizational memory**, not a single-user private knowledge base from Claude Code sessions.
> 
> **`CLAUDE.md`** updates the IDENTITY comment, title (**Fleet Organizational Memory**), intro blurb, and **Purpose (WHY)** bullets to stress dual capture (Etan's prompts/intent plus agents' work-history), cross-agent inheritance of fixes and decisions, and avoiding repeated mistakes.
> 
> **`README.md`** keeps the existing pitch but extends the problem statement (agents/team repeating work) and the value prop with **shared fleet memory**—learnings from one agent available to others—without changing setup, tools, or architecture sections.
> 
> No runtime, API, or config behavior changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b91628a2e392d175ec4c307cd467a06c2d4007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reframe BrainLayer documentation to position the product as fleet organizational memory
> Updates [CLAUDE.md](https://github.com/EtanHey/brainlayer/pull/578/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) and [README.md](https://github.com/EtanHey/brainlayer/pull/578/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to shift the product narrative from a personal/local knowledge base to a fleet-wide shared memory system. The revised framing emphasizes dual capture of prompts/intent and agents' work-history, and stresses that knowledge learned by one agent becomes inherited experience for others, including lessons about fixes, decisions, and erosion causes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80b9162.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->