### PR TITLE
perf: fix quadratic manifest scan in quarantine rebuild

### DIFF
--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -13,9 +13,10 @@ import os
 import random
 import re
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Iterator
 
 import apsw
 
@@ -68,6 +69,18 @@ def _quote_sqlite_string(value: str) -> str:
 
 def _path(value: str | Path) -> Path:
     return Path(value).expanduser()
+
+
+@contextmanager
+def _operation_writer_lock(db_path: Path) -> Iterator[None]:
+    store = VectorStore.__new__(VectorStore)
+    store.db_path = db_path
+    store._writer_pidfile_acquired = False
+    store._acquire_writer_pidfile()
+    try:
+        yield
+    finally:
+        store._release_writer_pidfile()
 
 
 def _provider(source_file: str) -> str:
@@ -456,7 +469,7 @@ def _record_manifest(
             raise ValueError(f"missing chunk: {missing[0]}")
         cursor.execute(
             f"""
-            INSERT OR REPLACE INTO {QUARANTINE_MANIFEST_TABLE} (
+            INSERT OR IGNORE INTO {QUARANTINE_MANIFEST_TABLE} (
                 run_id, chunk_id, original_content_class, original_provenance_class,
                 original_fts_rowid, original_trigram_rowid, original_operational_rowid, quarantined_at
             )
@@ -607,7 +620,6 @@ def _reserve_manifest_fts_rowids(
     *,
     table_name: str,
     manifest_rowid_column: str,
-    run_id: str,
 ) -> None:
     cursor.execute(
         f"""
@@ -617,10 +629,9 @@ def _reserve_manifest_fts_rowids(
             '', NULL, NULL, NULL, NULL, NULL,
             ?
         FROM {QUARANTINE_MANIFEST_TABLE} m
-        WHERE m.run_id = ?
-          AND m.{manifest_rowid_column} IS NOT NULL
+        WHERE m.{manifest_rowid_column} IS NOT NULL
         """,
-        (f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}", run_id),
+        (f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}",),
     )
 
 
@@ -629,7 +640,6 @@ def _delete_manifest_fts_rowid_reservations(
     *,
     table_name: str,
     manifest_rowid_column: str,
-    run_id: str,
 ) -> None:
     cursor.execute(
         f"""
@@ -637,12 +647,11 @@ def _delete_manifest_fts_rowid_reservations(
         WHERE rowid IN (
             SELECT m.{manifest_rowid_column}
             FROM {QUARANTINE_MANIFEST_TABLE} m
-            WHERE m.run_id = ?
-              AND m.{manifest_rowid_column} IS NOT NULL
+            WHERE m.{manifest_rowid_column} IS NOT NULL
         )
         AND chunk_id = ?
         """,
-        (run_id, f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}"),
+        (f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}",),
     )
 
 
@@ -652,7 +661,6 @@ def _rebuild_knowledge_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
         cursor,
         table_name="chunks_fts",
         manifest_rowid_column="original_fts_rowid",
-        run_id=run_id,
     )
     cursor.execute(
         f"""
@@ -665,12 +673,10 @@ def _rebuild_knowledge_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
           AND NOT EXISTS (
               SELECT 1
               FROM {QUARANTINE_MANIFEST_TABLE} m
-              WHERE m.run_id = ?
-                AND m.original_fts_rowid = r.fts_rowid
+              WHERE m.original_fts_rowid = r.fts_rowid
           )
         ORDER BY r.fts_rowid
-        """,
-        (run_id,),
+        """
     )
     cursor.execute(
         f"""
@@ -684,19 +690,16 @@ def _rebuild_knowledge_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
               OR EXISTS (
                   SELECT 1
                   FROM {QUARANTINE_MANIFEST_TABLE} m
-                  WHERE m.run_id = ?
-                    AND m.original_fts_rowid = r.fts_rowid
+                  WHERE m.original_fts_rowid = r.fts_rowid
               )
           )
         ORDER BY c.id
-        """,
-        (run_id,),
+        """
     )
     _delete_manifest_fts_rowid_reservations(
         cursor,
         table_name="chunks_fts",
         manifest_rowid_column="original_fts_rowid",
-        run_id=run_id,
     )
 
 
@@ -706,7 +709,6 @@ def _rebuild_trigram_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
         cursor,
         table_name="chunks_fts_trigram",
         manifest_rowid_column="original_trigram_rowid",
-        run_id=run_id,
     )
     cursor.execute(
         f"""
@@ -719,12 +721,10 @@ def _rebuild_trigram_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
           AND NOT EXISTS (
               SELECT 1
               FROM {QUARANTINE_MANIFEST_TABLE} m
-              WHERE m.run_id = ?
-                AND m.original_trigram_rowid = r.trigram_rowid
+              WHERE m.original_trigram_rowid = r.trigram_rowid
           )
         ORDER BY r.trigram_rowid
-        """,
-        (run_id,),
+        """
     )
     cursor.execute(
         f"""
@@ -738,19 +738,16 @@ def _rebuild_trigram_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
               OR EXISTS (
                   SELECT 1
                   FROM {QUARANTINE_MANIFEST_TABLE} m
-                  WHERE m.run_id = ?
-                    AND m.original_trigram_rowid = r.trigram_rowid
+                  WHERE m.original_trigram_rowid = r.trigram_rowid
               )
           )
         ORDER BY c.id
-        """,
-        (run_id,),
+        """
     )
     _delete_manifest_fts_rowid_reservations(
         cursor,
         table_name="chunks_fts_trigram",
         manifest_rowid_column="original_trigram_rowid",
-        run_id=run_id,
     )
 
 
@@ -844,69 +841,71 @@ def apply_quarantine_ids(
 
     chunk_ids = list(dict.fromkeys(chunk_ids))
     db_path = _path(db_path)
-    if bootstrap_schema:
-        _recreate_fts_triggers(db_path)
     run_id = run_id or f"retro-self-pollution-{_utc_now()}"
-    conn = apsw.Connection(str(db_path))
-    cursor = conn.cursor()
-    _checkpoint(cursor)
-    _drop_fts_triggers(cursor)
-    _ensure_manifest(cursor)
-    timestamp = _utc_now()
-    include_trigram = _table_exists(cursor, "chunks_fts_trigram")
-    table_names = ["chunks_fts", "chunks_fts_operational"]
-    if include_trigram:
-        table_names.append("chunks_fts_trigram")
-    batches_since_checkpoint = 0
-    try:
-        cursor.execute("BEGIN IMMEDIATE")
-        _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
-        cursor.execute("COMMIT")
-        for ids in _batch(chunk_ids, batch_size):
-            _load_chunk_ids_reconcile_table(cursor, ids)
-            cursor.execute("BEGIN IMMEDIATE")
-            _record_manifest(cursor, run_id=run_id, timestamp=timestamp, include_trigram=include_trigram)
-            _delete_fts_rows_for_reconcile(cursor, table_names=tuple(table_names))
-            cursor.execute(
-                f"""
-                UPDATE chunks
-                SET content_class = 'operational',
-                    provenance_class = ?
-                WHERE id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
-                """,
-                (AGENT_INFERENCE,),
-            )
-            _insert_operational_fts(cursor)
-            cursor.execute("COMMIT")
-            cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
-            batches_since_checkpoint += 1
-            if batches_since_checkpoint >= checkpoint_every:
-                _checkpoint(cursor)
-                batches_since_checkpoint = 0
-        cursor.execute("BEGIN IMMEDIATE")
-        _rebuild_knowledge_fts(cursor, run_id=run_id)
-        if include_trigram:
-            _rebuild_trigram_fts(cursor, run_id=run_id)
-        _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
-        cursor.execute("COMMIT")
-    except Exception:
-        if not conn.getautocommit():
-            cursor.execute("ROLLBACK")
-        raise
-    finally:
-        cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
-        conn.close()
 
-    if finalize:
-        _recreate_fts_triggers(db_path)
+    with _operation_writer_lock(db_path):
+        if bootstrap_schema:
+            _recreate_fts_triggers(db_path)
         conn = apsw.Connection(str(db_path))
+        cursor = conn.cursor()
+        _checkpoint(cursor)
+        _drop_fts_triggers(cursor)
+        _ensure_manifest(cursor)
+        timestamp = _utc_now()
+        include_trigram = _table_exists(cursor, "chunks_fts_trigram")
+        table_names = ["chunks_fts", "chunks_fts_operational"]
+        if include_trigram:
+            table_names.append("chunks_fts_trigram")
+        batches_since_checkpoint = 0
         try:
-            cursor = conn.cursor()
-            _checkpoint(cursor)
-            _optimize_fts(cursor)
-            _checkpoint(cursor)
+            cursor.execute("BEGIN IMMEDIATE")
+            _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
+            cursor.execute("COMMIT")
+            for ids in _batch(chunk_ids, batch_size):
+                _load_chunk_ids_reconcile_table(cursor, ids)
+                cursor.execute("BEGIN IMMEDIATE")
+                _record_manifest(cursor, run_id=run_id, timestamp=timestamp, include_trigram=include_trigram)
+                _delete_fts_rows_for_reconcile(cursor, table_names=tuple(table_names))
+                cursor.execute(
+                    f"""
+                    UPDATE chunks
+                    SET content_class = 'operational',
+                        provenance_class = ?
+                    WHERE id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
+                    """,
+                    (AGENT_INFERENCE,),
+                )
+                _insert_operational_fts(cursor)
+                cursor.execute("COMMIT")
+                cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
+                batches_since_checkpoint += 1
+                if batches_since_checkpoint >= checkpoint_every:
+                    _checkpoint(cursor)
+                    batches_since_checkpoint = 0
+            cursor.execute("BEGIN IMMEDIATE")
+            _rebuild_knowledge_fts(cursor, run_id=run_id)
+            if include_trigram:
+                _rebuild_trigram_fts(cursor, run_id=run_id)
+            _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
+            cursor.execute("COMMIT")
+        except Exception:
+            if not conn.getautocommit():
+                cursor.execute("ROLLBACK")
+            raise
         finally:
+            cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
             conn.close()
+
+        if finalize:
+            _recreate_fts_triggers(db_path)
+            conn = apsw.Connection(str(db_path))
+            try:
+                cursor = conn.cursor()
+                _checkpoint(cursor)
+                _optimize_fts(cursor)
+                _checkpoint(cursor)
+            finally:
+                conn.close()
     return {"quarantined": len(chunk_ids), "run_id": run_id}
 
 
@@ -926,99 +925,101 @@ def unquarantine_ids(
         return {"restored": 0, "run_id": run_id}
 
     db_path = _path(db_path)
-    if bootstrap_schema:
-        _recreate_fts_triggers(db_path)
-    conn = apsw.Connection(str(db_path))
-    cursor = conn.cursor()
-    _checkpoint(cursor)
-    _drop_fts_triggers(cursor)
-    _ensure_manifest(cursor)
     restored = 0
-    include_trigram = _table_exists(cursor, "chunks_fts_trigram")
-    table_names = ["chunks_fts", "chunks_fts_operational"]
-    if include_trigram:
-        table_names.append("chunks_fts_trigram")
-    rowid_cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunk_fts_rowids)")}
-    has_trigram_rowid = "trigram_rowid" in rowid_cols
-    has_operational_rowid = "operational_rowid" in rowid_cols
-    batches_since_checkpoint = 0
-    try:
-        for ids in _batch(chunk_ids, batch_size):
-            cursor.execute("BEGIN IMMEDIATE")
-            _delete_fts_rows(cursor, ids, table_names=tuple(table_names))
-            for chunk_id in ids:
-                manifest = cursor.execute(
-                    f"""
-                    SELECT original_content_class, original_provenance_class,
-                           original_fts_rowid, original_trigram_rowid, original_operational_rowid
-                    FROM {QUARANTINE_MANIFEST_TABLE}
-                    WHERE chunk_id = ? AND run_id = ?
-                    """,
-                    (chunk_id, run_id),
-                ).fetchone()
-                if manifest is None:
-                    raise ValueError(f"missing quarantine manifest row for {chunk_id!r} in run {run_id!r}")
-                original_content_class, original_provenance_class = manifest[0], manifest[1]
-                cursor.execute(
-                    "UPDATE chunks SET content_class = ?, provenance_class = ? WHERE id = ?",
-                    (original_content_class, original_provenance_class, chunk_id),
-                )
-                fts_rowid = None
-                trigram_rowid = None
-                operational_rowid = None
-                if manifest[2] is not None:
-                    fts_rowid = _insert_fts_row(
-                        cursor,
-                        table_name="chunks_fts",
-                        chunk_id=chunk_id,
-                        rowid=manifest[2],
-                    )
-                if include_trigram and manifest[3] is not None:
-                    trigram_rowid = _insert_fts_row(
-                        cursor,
-                        table_name="chunks_fts_trigram",
-                        chunk_id=chunk_id,
-                        rowid=manifest[3],
-                    )
-                if manifest[4] is not None:
-                    operational_rowid = _insert_fts_row(
-                        cursor,
-                        table_name="chunks_fts_operational",
-                        chunk_id=chunk_id,
-                        rowid=manifest[4],
-                    )
-                _upsert_chunk_fts_rowids(
-                    cursor,
-                    chunk_id=chunk_id,
-                    fts_rowid=fts_rowid,
-                    trigram_rowid=trigram_rowid,
-                    operational_rowid=operational_rowid,
-                    has_trigram_rowid=has_trigram_rowid,
-                    has_operational_rowid=has_operational_rowid,
-                )
-                restored += 1
-            cursor.execute("COMMIT")
-            batches_since_checkpoint += 1
-            if batches_since_checkpoint >= checkpoint_every:
-                _checkpoint(cursor)
-                batches_since_checkpoint = 0
-    except Exception:
-        if not conn.getautocommit():
-            cursor.execute("ROLLBACK")
-        raise
-    finally:
-        conn.close()
 
-    if finalize:
-        _recreate_fts_triggers(db_path)
+    with _operation_writer_lock(db_path):
+        if bootstrap_schema:
+            _recreate_fts_triggers(db_path)
         conn = apsw.Connection(str(db_path))
+        cursor = conn.cursor()
+        _checkpoint(cursor)
+        _drop_fts_triggers(cursor)
+        _ensure_manifest(cursor)
+        include_trigram = _table_exists(cursor, "chunks_fts_trigram")
+        table_names = ["chunks_fts", "chunks_fts_operational"]
+        if include_trigram:
+            table_names.append("chunks_fts_trigram")
+        rowid_cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunk_fts_rowids)")}
+        has_trigram_rowid = "trigram_rowid" in rowid_cols
+        has_operational_rowid = "operational_rowid" in rowid_cols
+        batches_since_checkpoint = 0
         try:
-            cursor = conn.cursor()
-            _checkpoint(cursor)
-            _optimize_fts(cursor)
-            _checkpoint(cursor)
+            for ids in _batch(chunk_ids, batch_size):
+                cursor.execute("BEGIN IMMEDIATE")
+                _delete_fts_rows(cursor, ids, table_names=tuple(table_names))
+                for chunk_id in ids:
+                    manifest = cursor.execute(
+                        f"""
+                        SELECT original_content_class, original_provenance_class,
+                               original_fts_rowid, original_trigram_rowid, original_operational_rowid
+                        FROM {QUARANTINE_MANIFEST_TABLE}
+                        WHERE chunk_id = ? AND run_id = ?
+                        """,
+                        (chunk_id, run_id),
+                    ).fetchone()
+                    if manifest is None:
+                        raise ValueError(f"missing quarantine manifest row for {chunk_id!r} in run {run_id!r}")
+                    original_content_class, original_provenance_class = manifest[0], manifest[1]
+                    cursor.execute(
+                        "UPDATE chunks SET content_class = ?, provenance_class = ? WHERE id = ?",
+                        (original_content_class, original_provenance_class, chunk_id),
+                    )
+                    fts_rowid = None
+                    trigram_rowid = None
+                    operational_rowid = None
+                    if manifest[2] is not None:
+                        fts_rowid = _insert_fts_row(
+                            cursor,
+                            table_name="chunks_fts",
+                            chunk_id=chunk_id,
+                            rowid=manifest[2],
+                        )
+                    if include_trigram and manifest[3] is not None:
+                        trigram_rowid = _insert_fts_row(
+                            cursor,
+                            table_name="chunks_fts_trigram",
+                            chunk_id=chunk_id,
+                            rowid=manifest[3],
+                        )
+                    if manifest[4] is not None:
+                        operational_rowid = _insert_fts_row(
+                            cursor,
+                            table_name="chunks_fts_operational",
+                            chunk_id=chunk_id,
+                            rowid=manifest[4],
+                        )
+                    _upsert_chunk_fts_rowids(
+                        cursor,
+                        chunk_id=chunk_id,
+                        fts_rowid=fts_rowid,
+                        trigram_rowid=trigram_rowid,
+                        operational_rowid=operational_rowid,
+                        has_trigram_rowid=has_trigram_rowid,
+                        has_operational_rowid=has_operational_rowid,
+                    )
+                    restored += 1
+                cursor.execute("COMMIT")
+                batches_since_checkpoint += 1
+                if batches_since_checkpoint >= checkpoint_every:
+                    _checkpoint(cursor)
+                    batches_since_checkpoint = 0
+        except Exception:
+            if not conn.getautocommit():
+                cursor.execute("ROLLBACK")
+            raise
         finally:
             conn.close()
+
+        if finalize:
+            _recreate_fts_triggers(db_path)
+            conn = apsw.Connection(str(db_path))
+            try:
+                cursor = conn.cursor()
+                _checkpoint(cursor)
+                _optimize_fts(cursor)
+                _checkpoint(cursor)
+            finally:
+                conn.close()
     return {"restored": restored, "run_id": run_id}
 
 

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -53,9 +53,15 @@ FTS_RESERVED_ROWID_TABLES = {
     "chunks_fts": "_retro_reserved_chunks_fts_rowids",
     "chunks_fts_trigram": "_retro_reserved_chunks_fts_trigram_rowids",
 }
+FTS_DELETE_ROWID_TABLES = {
+    "chunks_fts": "_retro_delete_chunks_fts_rowids",
+    "chunks_fts_operational": "_retro_delete_chunks_fts_operational_rowids",
+    "chunks_fts_trigram": "_retro_delete_chunks_fts_trigram_rowids",
+}
 FTS_RESERVED_CHUNK_ID_PREFIX = "__retro_quarantine_reserved__:"
 QUARANTINE_MANIFEST_TABLE = "retro_self_pollution_quarantine_manifest"
 RECONCILE_CHUNK_ID_TABLE = "_retro_quarantine_reconcile_chunk_ids"
+APPLY_CHUNK_ID_TABLE = "_retro_quarantine_apply_chunk_ids"
 DEFAULT_ESTIMATE = 244_152
 RETRIEVABILITY_TOKEN_RE = re.compile(r"[A-Za-z0-9]{4,}")
 NON_OPERATIONAL_FTS_CLASS_SQL = (
@@ -513,26 +519,17 @@ def _delete_fts_rows_for_reconcile(
     table_names: tuple[str, ...] = ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"),
 ) -> None:
     for table_name in table_names:
-        rowid_column = FTS_ROWID_COLUMNS[table_name]
+        delete_rowids_table = FTS_DELETE_ROWID_TABLES[table_name]
         cursor.execute(
             f"""
             DELETE FROM {table_name}
             WHERE rowid IN (
-                SELECT r.{rowid_column}
-                FROM chunk_fts_rowids r
-                INNER JOIN {RECONCILE_CHUNK_ID_TABLE} q ON q.chunk_id = r.chunk_id
-                WHERE r.{rowid_column} IS NOT NULL
+                SELECT d.rowid
+                FROM {delete_rowids_table} d
+                INNER JOIN {RECONCILE_CHUNK_ID_TABLE} q ON q.chunk_id = d.chunk_id
             )
-            AND chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
             """
         )
-        if table_name == "chunks_fts_operational":
-            cursor.execute(
-                f"""
-                DELETE FROM {table_name}
-                WHERE chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
-                """
-            )
     updates = []
     if "chunks_fts" in table_names:
         updates.append("fts_rowid = NULL")
@@ -583,6 +580,37 @@ def _load_chunk_ids_reconcile_table(cursor: apsw.Cursor, chunk_ids: list[str]) -
         f"INSERT OR IGNORE INTO {RECONCILE_CHUNK_ID_TABLE}(chunk_id) VALUES (?)",
         [(chunk_id,) for chunk_id in chunk_ids],
     )
+
+
+def _load_apply_chunk_ids_table(cursor: apsw.Cursor, chunk_ids: list[str]) -> None:
+    cursor.execute(f"DROP TABLE IF EXISTS {APPLY_CHUNK_ID_TABLE}")
+    cursor.execute(f"CREATE TEMP TABLE {APPLY_CHUNK_ID_TABLE}(chunk_id TEXT PRIMARY KEY)")
+    cursor.executemany(
+        f"INSERT OR IGNORE INTO {APPLY_CHUNK_ID_TABLE}(chunk_id) VALUES (?)",
+        [(chunk_id,) for chunk_id in chunk_ids],
+    )
+
+
+def _load_delete_fts_rowid_tables(cursor: apsw.Cursor, *, table_names: tuple[str, ...]) -> None:
+    for table_name in table_names:
+        delete_rowids_table = FTS_DELETE_ROWID_TABLES[table_name]
+        cursor.execute(f"DROP TABLE IF EXISTS {delete_rowids_table}")
+        cursor.execute(f"CREATE TEMP TABLE {delete_rowids_table}(rowid INTEGER PRIMARY KEY, chunk_id TEXT NOT NULL)")
+        cursor.execute(f"CREATE INDEX {delete_rowids_table}_chunk_id_idx ON {delete_rowids_table}(chunk_id)")
+        cursor.execute(
+            f"""
+            INSERT OR IGNORE INTO {delete_rowids_table}(rowid, chunk_id)
+            SELECT f.rowid, f.chunk_id
+            FROM {table_name} f
+            INNER JOIN {APPLY_CHUNK_ID_TABLE} q ON q.chunk_id = f.chunk_id
+            WHERE f.chunk_id IS NOT NULL
+            """
+        )
+
+
+def _drop_delete_fts_rowid_tables(cursor: apsw.Cursor, *, table_names: tuple[str, ...]) -> None:
+    for table_name in table_names:
+        cursor.execute(f"DROP TABLE IF EXISTS {FTS_DELETE_ROWID_TABLES[table_name]}")
 
 
 def _clear_trigram_fts(cursor: apsw.Cursor) -> None:
@@ -903,6 +931,8 @@ def apply_quarantine_ids(
         try:
             cursor.execute("BEGIN IMMEDIATE")
             _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
+            _load_apply_chunk_ids_table(cursor, chunk_ids)
+            _load_delete_fts_rowid_tables(cursor, table_names=tuple(table_names))
             cursor.execute("COMMIT")
             for ids in _batch(chunk_ids, batch_size):
                 _load_chunk_ids_reconcile_table(cursor, ids)
@@ -937,6 +967,8 @@ def apply_quarantine_ids(
             raise
         finally:
             cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
+            _drop_delete_fts_rowid_tables(cursor, table_names=tuple(table_names))
+            cursor.execute(f"DROP TABLE IF EXISTS {APPLY_CHUNK_ID_TABLE}")
             conn.close()
 
         if finalize:

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -385,7 +385,7 @@ def _select_fts_state_rows(cursor: apsw.Cursor, *, table_name: str, chunk_id: st
         (chunk_id,),
     ).fetchone()
     if rowid_row is None or rowid_row[0] is None:
-        return []
+        return _select_fts_state_rows_by_chunk_id(cursor, table_name=table_name, chunk_id=chunk_id)
     rows = [
         tuple(row)
         for row in cursor.execute(
@@ -404,8 +404,12 @@ def _select_fts_state_rows(cursor: apsw.Cursor, *, table_name: str, chunk_id: st
     if rows:
         return rows
 
-    # Legacy repair tests intentionally corrupt chunk_fts_rowids. Fall back only
-    # when a non-null map entry is stale so restore proofs still snapshot reality.
+    # Legacy repair tests intentionally corrupt chunk_fts_rowids. Fall back when
+    # the map is missing, null, or stale so restore proofs snapshot reality.
+    return _select_fts_state_rows_by_chunk_id(cursor, table_name=table_name, chunk_id=chunk_id)
+
+
+def _select_fts_state_rows_by_chunk_id(cursor: apsw.Cursor, *, table_name: str, chunk_id: str) -> list[tuple[Any, ...]]:
     return [
         tuple(row)
         for row in cursor.execute(
@@ -502,6 +506,13 @@ def _delete_fts_rows_for_reconcile(
             AND chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
             """
         )
+        if table_name == "chunks_fts_operational":
+            cursor.execute(
+                f"""
+                DELETE FROM {table_name}
+                WHERE chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
+                """
+            )
     updates = []
     if "chunks_fts" in table_names:
         updates.append("fts_rowid = NULL")
@@ -746,8 +757,9 @@ def _rebuild_trigram_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
 def _rebuild_chunk_fts_rowids(cursor: apsw.Cursor, *, include_trigram: bool) -> None:
     cursor.execute("DELETE FROM chunk_fts_rowids")
     cursor.execute("""
-        INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+        INSERT OR IGNORE INTO chunk_fts_rowids(chunk_id, fts_rowid)
         SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
+        ORDER BY rowid
     """)
     cursor.execute("""
         INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
@@ -760,6 +772,38 @@ def _rebuild_chunk_fts_rowids(cursor: apsw.Cursor, *, include_trigram: bool) -> 
             SELECT chunk_id, rowid FROM chunks_fts_trigram WHERE chunk_id IS NOT NULL
             ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid
         """)
+
+
+def _upsert_chunk_fts_rowids(
+    cursor: apsw.Cursor,
+    *,
+    chunk_id: str,
+    fts_rowid: int | None,
+    trigram_rowid: int | None,
+    operational_rowid: int | None,
+    has_trigram_rowid: bool,
+    has_operational_rowid: bool,
+) -> None:
+    columns = ["chunk_id", "fts_rowid"]
+    values: list[Any] = [chunk_id, fts_rowid]
+    updates = ["fts_rowid = excluded.fts_rowid"]
+    if has_trigram_rowid:
+        columns.append("trigram_rowid")
+        values.append(trigram_rowid)
+        updates.append("trigram_rowid = excluded.trigram_rowid")
+    if has_operational_rowid:
+        columns.append("operational_rowid")
+        values.append(operational_rowid)
+        updates.append("operational_rowid = excluded.operational_rowid")
+    placeholders = ", ".join("?" for _ in columns)
+    cursor.execute(
+        f"""
+        INSERT INTO chunk_fts_rowids({", ".join(columns)})
+        VALUES ({placeholders})
+        ON CONFLICT(chunk_id) DO UPDATE SET {", ".join(updates)}
+        """,
+        values,
+    )
 
 
 def _insert_fts_row(
@@ -890,11 +934,18 @@ def unquarantine_ids(
     _drop_fts_triggers(cursor)
     _ensure_manifest(cursor)
     restored = 0
+    include_trigram = _table_exists(cursor, "chunks_fts_trigram")
+    table_names = ["chunks_fts", "chunks_fts_operational"]
+    if include_trigram:
+        table_names.append("chunks_fts_trigram")
+    rowid_cols = {row[1] for row in cursor.execute("PRAGMA table_info(chunk_fts_rowids)")}
+    has_trigram_rowid = "trigram_rowid" in rowid_cols
+    has_operational_rowid = "operational_rowid" in rowid_cols
     batches_since_checkpoint = 0
     try:
         for ids in _batch(chunk_ids, batch_size):
             cursor.execute("BEGIN IMMEDIATE")
-            _delete_fts_rows(cursor, ids)
+            _delete_fts_rows(cursor, ids, table_names=tuple(table_names))
             for chunk_id in ids:
                 manifest = cursor.execute(
                     f"""
@@ -922,7 +973,7 @@ def unquarantine_ids(
                         chunk_id=chunk_id,
                         rowid=manifest[2],
                     )
-                if manifest[3] is not None:
+                if include_trigram and manifest[3] is not None:
                     trigram_rowid = _insert_fts_row(
                         cursor,
                         table_name="chunks_fts_trigram",
@@ -936,16 +987,14 @@ def unquarantine_ids(
                         chunk_id=chunk_id,
                         rowid=manifest[4],
                     )
-                cursor.execute(
-                    """
-                    INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid, operational_rowid)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(chunk_id) DO UPDATE SET
-                        fts_rowid = excluded.fts_rowid,
-                        trigram_rowid = excluded.trigram_rowid,
-                        operational_rowid = excluded.operational_rowid
-                    """,
-                    (chunk_id, fts_rowid, trigram_rowid, operational_rowid),
+                _upsert_chunk_fts_rowids(
+                    cursor,
+                    chunk_id=chunk_id,
+                    fts_rowid=fts_rowid,
+                    trigram_rowid=trigram_rowid,
+                    operational_rowid=operational_rowid,
+                    has_trigram_rowid=has_trigram_rowid,
+                    has_operational_rowid=has_operational_rowid,
                 )
                 restored += 1
             cursor.execute("COMMIT")

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -49,6 +49,10 @@ FTS_ROWID_COLUMNS = {
     "chunks_fts_operational": "operational_rowid",
     "chunks_fts_trigram": "trigram_rowid",
 }
+FTS_RESERVED_ROWID_TABLES = {
+    "chunks_fts": "_retro_reserved_chunks_fts_rowids",
+    "chunks_fts_trigram": "_retro_reserved_chunks_fts_trigram_rowids",
+}
 FTS_RESERVED_CHUNK_ID_PREFIX = "__retro_quarantine_reserved__:"
 QUARANTINE_MANIFEST_TABLE = "retro_self_pollution_quarantine_manifest"
 RECONCILE_CHUNK_ID_TABLE = "_retro_quarantine_reconcile_chunk_ids"
@@ -393,12 +397,13 @@ def _qualified_columns(alias: str, columns: tuple[str, ...]) -> str:
 
 def _select_fts_state_rows(cursor: apsw.Cursor, *, table_name: str, chunk_id: str) -> list[tuple[Any, ...]]:
     rowid_column = FTS_ROWID_COLUMNS[table_name]
+    chunk_id_rows = _select_fts_state_rows_by_chunk_id(cursor, table_name=table_name, chunk_id=chunk_id)
     rowid_row = cursor.execute(
         f"SELECT {rowid_column} FROM chunk_fts_rowids WHERE chunk_id = ?",
         (chunk_id,),
     ).fetchone()
     if rowid_row is None or rowid_row[0] is None:
-        return _select_fts_state_rows_by_chunk_id(cursor, table_name=table_name, chunk_id=chunk_id)
+        return chunk_id_rows
     rows = [
         tuple(row)
         for row in cursor.execute(
@@ -415,11 +420,13 @@ def _select_fts_state_rows(cursor: apsw.Cursor, *, table_name: str, chunk_id: st
         )
     ]
     if rows:
-        return rows
+        by_rowid = {row[0]: row for row in rows}
+        by_rowid.update({row[0]: row for row in chunk_id_rows})
+        return [by_rowid[rowid] for rowid in sorted(by_rowid)]
 
     # Legacy repair tests intentionally corrupt chunk_fts_rowids. Fall back when
     # the map is missing, null, or stale so restore proofs snapshot reality.
-    return _select_fts_state_rows_by_chunk_id(cursor, table_name=table_name, chunk_id=chunk_id)
+    return chunk_id_rows
 
 
 def _select_fts_state_rows_by_chunk_id(cursor: apsw.Cursor, *, table_name: str, chunk_id: str) -> list[tuple[Any, ...]]:
@@ -615,21 +622,45 @@ def _insert_operational_fts(cursor: apsw.Cursor) -> None:
     )
 
 
-def _reserve_manifest_fts_rowids(
+def _load_manifest_fts_rowid_reservations(
     cursor: apsw.Cursor,
     *,
     table_name: str,
     manifest_rowid_column: str,
+) -> str:
+    reserved_rowids_table = FTS_RESERVED_ROWID_TABLES[table_name]
+    cursor.execute(f"DROP TABLE IF EXISTS {reserved_rowids_table}")
+    cursor.execute(f"CREATE TEMP TABLE {reserved_rowids_table}(rowid INTEGER PRIMARY KEY)")
+    cursor.execute(
+        f"""
+        INSERT OR IGNORE INTO {reserved_rowids_table}(rowid)
+        SELECT DISTINCT m.{manifest_rowid_column}
+        FROM {QUARANTINE_MANIFEST_TABLE} m
+        LEFT JOIN {table_name} f
+            ON f.rowid = m.{manifest_rowid_column}
+           AND f.chunk_id = m.chunk_id
+        WHERE m.{manifest_rowid_column} IS NOT NULL
+          AND f.rowid IS NULL
+        """
+    )
+    return reserved_rowids_table
+
+
+def _reserve_manifest_fts_rowids(
+    cursor: apsw.Cursor,
+    *,
+    table_name: str,
+    reserved_rowids_table: str,
 ) -> None:
     cursor.execute(
         f"""
         INSERT OR IGNORE INTO {table_name}(rowid, {FTS_COLUMNS})
-        SELECT DISTINCT
-            m.{manifest_rowid_column},
+        SELECT
+            r.rowid,
             '', NULL, NULL, NULL, NULL, NULL,
             ?
-        FROM {QUARANTINE_MANIFEST_TABLE} m
-        WHERE m.{manifest_rowid_column} IS NOT NULL
+        FROM {reserved_rowids_table} r
+        ORDER BY r.rowid
         """,
         (f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}",),
     )
@@ -639,16 +670,12 @@ def _delete_manifest_fts_rowid_reservations(
     cursor: apsw.Cursor,
     *,
     table_name: str,
-    manifest_rowid_column: str,
+    reserved_rowids_table: str,
 ) -> None:
     cursor.execute(
         f"""
         DELETE FROM {table_name}
-        WHERE rowid IN (
-            SELECT m.{manifest_rowid_column}
-            FROM {QUARANTINE_MANIFEST_TABLE} m
-            WHERE m.{manifest_rowid_column} IS NOT NULL
-        )
+        WHERE rowid IN (SELECT rowid FROM {reserved_rowids_table})
         AND chunk_id = ?
         """,
         (f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}",),
@@ -656,99 +683,115 @@ def _delete_manifest_fts_rowid_reservations(
 
 
 def _rebuild_knowledge_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
-    cursor.execute("DELETE FROM chunks_fts")
-    _reserve_manifest_fts_rowids(
+    reserved_rowids_table = _load_manifest_fts_rowid_reservations(
         cursor,
         table_name="chunks_fts",
         manifest_rowid_column="original_fts_rowid",
     )
-    cursor.execute(
-        f"""
-        INSERT INTO chunks_fts(rowid, {FTS_COLUMNS})
-        SELECT r.fts_rowid, {FTS_SELECT_COLUMNS_QUALIFIED}
-        FROM chunks c
-        INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
-        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
-          AND r.fts_rowid IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1
-              FROM {QUARANTINE_MANIFEST_TABLE} m
-              WHERE m.original_fts_rowid = r.fts_rowid
-          )
-        ORDER BY r.fts_rowid
-        """
-    )
-    cursor.execute(
-        f"""
-        INSERT INTO chunks_fts({FTS_COLUMNS})
-        SELECT {FTS_SELECT_COLUMNS_QUALIFIED}
-        FROM chunks c
-        LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
-        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
-          AND (
-              r.fts_rowid IS NULL
-              OR EXISTS (
+    try:
+        cursor.execute("DELETE FROM chunks_fts")
+        _reserve_manifest_fts_rowids(
+            cursor,
+            table_name="chunks_fts",
+            reserved_rowids_table=reserved_rowids_table,
+        )
+        cursor.execute(
+            f"""
+            INSERT INTO chunks_fts(rowid, {FTS_COLUMNS})
+            SELECT r.fts_rowid, {FTS_SELECT_COLUMNS_QUALIFIED}
+            FROM chunks c
+            INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+            WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+              AND r.fts_rowid IS NOT NULL
+              AND NOT EXISTS (
                   SELECT 1
-                  FROM {QUARANTINE_MANIFEST_TABLE} m
-                  WHERE m.original_fts_rowid = r.fts_rowid
+                  FROM {reserved_rowids_table} reserved
+                  WHERE reserved.rowid = r.fts_rowid
               )
-          )
-        ORDER BY c.id
-        """
-    )
-    _delete_manifest_fts_rowid_reservations(
-        cursor,
-        table_name="chunks_fts",
-        manifest_rowid_column="original_fts_rowid",
-    )
+            ORDER BY r.fts_rowid
+            """
+        )
+        cursor.execute(
+            f"""
+            INSERT INTO chunks_fts({FTS_COLUMNS})
+            SELECT {FTS_SELECT_COLUMNS_QUALIFIED}
+            FROM chunks c
+            LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+            WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+              AND (
+                  r.fts_rowid IS NULL
+                  OR EXISTS (
+                      SELECT 1
+                      FROM {reserved_rowids_table} reserved
+                      WHERE reserved.rowid = r.fts_rowid
+                  )
+              )
+            ORDER BY c.id
+            """
+        )
+        _delete_manifest_fts_rowid_reservations(
+            cursor,
+            table_name="chunks_fts",
+            reserved_rowids_table=reserved_rowids_table,
+        )
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {reserved_rowids_table}")
 
 
 def _rebuild_trigram_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
-    cursor.execute("DELETE FROM chunks_fts_trigram")
-    _reserve_manifest_fts_rowids(
+    reserved_rowids_table = _load_manifest_fts_rowid_reservations(
         cursor,
         table_name="chunks_fts_trigram",
         manifest_rowid_column="original_trigram_rowid",
     )
-    cursor.execute(
-        f"""
-        INSERT INTO chunks_fts_trigram(rowid, {FTS_COLUMNS})
-        SELECT r.trigram_rowid, {FTS_SELECT_COLUMNS_QUALIFIED}
-        FROM chunks c
-        INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
-        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
-          AND r.trigram_rowid IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1
-              FROM {QUARANTINE_MANIFEST_TABLE} m
-              WHERE m.original_trigram_rowid = r.trigram_rowid
-          )
-        ORDER BY r.trigram_rowid
-        """
-    )
-    cursor.execute(
-        f"""
-        INSERT INTO chunks_fts_trigram({FTS_COLUMNS})
-        SELECT {FTS_SELECT_COLUMNS_QUALIFIED}
-        FROM chunks c
-        LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
-        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
-          AND (
-              r.trigram_rowid IS NULL
-              OR EXISTS (
+    try:
+        cursor.execute("DELETE FROM chunks_fts_trigram")
+        _reserve_manifest_fts_rowids(
+            cursor,
+            table_name="chunks_fts_trigram",
+            reserved_rowids_table=reserved_rowids_table,
+        )
+        cursor.execute(
+            f"""
+            INSERT INTO chunks_fts_trigram(rowid, {FTS_COLUMNS})
+            SELECT r.trigram_rowid, {FTS_SELECT_COLUMNS_QUALIFIED}
+            FROM chunks c
+            INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+            WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+              AND r.trigram_rowid IS NOT NULL
+              AND NOT EXISTS (
                   SELECT 1
-                  FROM {QUARANTINE_MANIFEST_TABLE} m
-                  WHERE m.original_trigram_rowid = r.trigram_rowid
+                  FROM {reserved_rowids_table} reserved
+                  WHERE reserved.rowid = r.trigram_rowid
               )
-          )
-        ORDER BY c.id
-        """
-    )
-    _delete_manifest_fts_rowid_reservations(
-        cursor,
-        table_name="chunks_fts_trigram",
-        manifest_rowid_column="original_trigram_rowid",
-    )
+            ORDER BY r.trigram_rowid
+            """
+        )
+        cursor.execute(
+            f"""
+            INSERT INTO chunks_fts_trigram({FTS_COLUMNS})
+            SELECT {FTS_SELECT_COLUMNS_QUALIFIED}
+            FROM chunks c
+            LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+            WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+              AND (
+                  r.trigram_rowid IS NULL
+                  OR EXISTS (
+                      SELECT 1
+                      FROM {reserved_rowids_table} reserved
+                      WHERE reserved.rowid = r.trigram_rowid
+                  )
+              )
+            ORDER BY c.id
+            """
+        )
+        _delete_manifest_fts_rowid_reservations(
+            cursor,
+            table_name="chunks_fts_trigram",
+            reserved_rowids_table=reserved_rowids_table,
+        )
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {reserved_rowids_table}")
 
 
 def _rebuild_chunk_fts_rowids(cursor: apsw.Cursor, *, include_trigram: bool) -> None:

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -31,11 +31,30 @@ from brainlayer.vector_store import VectorStore
 
 FTS_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id"
 FTS_SELECT_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, id"
-FTS_STATE_COLUMNS = "rowid, content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id"
+FTS_SELECT_COLUMNS_QUALIFIED = "c.content, c.summary, c.tags, c.resolved_query, c.key_facts, c.resolved_queries, c.id"
+FTS_STATE_COLUMN_NAMES = (
+    "rowid",
+    "content",
+    "summary",
+    "tags",
+    "resolved_query",
+    "key_facts",
+    "resolved_queries",
+    "chunk_id",
+)
+FTS_STATE_COLUMNS = ", ".join(FTS_STATE_COLUMN_NAMES)
+FTS_ROWID_COLUMNS = {
+    "chunks_fts": "fts_rowid",
+    "chunks_fts_operational": "operational_rowid",
+    "chunks_fts_trigram": "trigram_rowid",
+}
 QUARANTINE_MANIFEST_TABLE = "retro_self_pollution_quarantine_manifest"
 RECONCILE_CHUNK_ID_TABLE = "_retro_quarantine_reconcile_chunk_ids"
 DEFAULT_ESTIMATE = 244_152
 RETRIEVABILITY_TOKEN_RE = re.compile(r"[A-Za-z0-9]{4,}")
+NON_OPERATIONAL_FTS_CLASS_SQL = (
+    "COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark', 'cold')"
+)
 
 
 def _utc_now() -> str:
@@ -130,6 +149,16 @@ def _drop_fts_triggers(cursor: apsw.Cursor) -> None:
         "chunks_fts_trigram_update",
     ):
         cursor.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+
+
+def _table_exists(cursor: apsw.Cursor, table_name: str) -> bool:
+    return (
+        cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table','view') AND name = ?",
+            (table_name,),
+        ).fetchone()
+        is not None
+    )
 
 
 def _ensure_manifest(cursor: apsw.Cursor) -> None:
@@ -333,13 +362,7 @@ def capture_restore_state(cursor: apsw.Cursor, chunk_ids: list[str]) -> dict[str
             raise ValueError(f"missing chunk: {chunk_id}")
         fts_rows = {}
         for table_name in ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"):
-            fts_rows[table_name] = [
-                tuple(row)
-                for row in cursor.execute(
-                    f"SELECT {FTS_STATE_COLUMNS} FROM {table_name} WHERE chunk_id = ? ORDER BY rowid",
-                    (chunk_id,),
-                )
-            ]
+            fts_rows[table_name] = _select_fts_state_rows(cursor, table_name=table_name, chunk_id=chunk_id)
         state[chunk_id] = {
             "chunk": tuple(chunk),
             "fts": fts_rows,
@@ -347,30 +370,137 @@ def capture_restore_state(cursor: apsw.Cursor, chunk_ids: list[str]) -> dict[str
     return state
 
 
-def _record_manifest(cursor: apsw.Cursor, chunk_ids: list[str], *, run_id: str, timestamp: str) -> None:
-    for chunk_id in chunk_ids:
-        row = cursor.execute(
-            """
-            SELECT c.content_class,
-                   c.provenance_class,
-                   (SELECT rowid FROM chunks_fts WHERE chunk_id = c.id ORDER BY rowid LIMIT 1),
-                   (SELECT rowid FROM chunks_fts_trigram WHERE chunk_id = c.id ORDER BY rowid LIMIT 1),
-                   (SELECT rowid FROM chunks_fts_operational WHERE chunk_id = c.id ORDER BY rowid LIMIT 1)
-            FROM chunks c
-            WHERE c.id = ?
+def _qualified_columns(alias: str, columns: tuple[str, ...]) -> str:
+    return ", ".join(f"{alias}.{column}" for column in columns)
+
+
+def _select_fts_state_rows(cursor: apsw.Cursor, *, table_name: str, chunk_id: str) -> list[tuple[Any, ...]]:
+    rowid_column = FTS_ROWID_COLUMNS[table_name]
+    rowid_row = cursor.execute(
+        f"SELECT {rowid_column} FROM chunk_fts_rowids WHERE chunk_id = ?",
+        (chunk_id,),
+    ).fetchone()
+    if rowid_row is None or rowid_row[0] is None:
+        return []
+    rows = [
+        tuple(row)
+        for row in cursor.execute(
+            f"""
+            SELECT {_qualified_columns("f", FTS_STATE_COLUMN_NAMES)}
+            FROM chunk_fts_rowids r
+            INNER JOIN {table_name} f
+                ON f.rowid = r.{rowid_column}
+               AND f.chunk_id = r.chunk_id
+            WHERE r.chunk_id = ?
+            ORDER BY f.rowid
             """,
             (chunk_id,),
+        )
+    ]
+    if rows:
+        return rows
+
+    # Legacy repair tests intentionally corrupt chunk_fts_rowids. Fall back only
+    # when a non-null map entry is stale so restore proofs still snapshot reality.
+    return [
+        tuple(row)
+        for row in cursor.execute(
+            f"SELECT {FTS_STATE_COLUMNS} FROM {table_name} WHERE chunk_id = ? ORDER BY rowid",
+            (chunk_id,),
+        )
+    ]
+
+
+def _record_manifest(
+    cursor: apsw.Cursor,
+    chunk_ids: list[str] | None = None,
+    *,
+    run_id: str,
+    timestamp: str,
+) -> None:
+    loaded_temp_table = False
+    if chunk_ids is not None:
+        _load_chunk_ids_reconcile_table(cursor, chunk_ids)
+        loaded_temp_table = True
+    try:
+        missing = cursor.execute(
+            f"""
+            SELECT r.chunk_id
+            FROM {RECONCILE_CHUNK_ID_TABLE} r
+            LEFT JOIN chunks c ON c.id = r.chunk_id
+            WHERE c.id IS NULL
+            """,
         ).fetchone()
-        if row is None:
-            raise ValueError(f"missing chunk: {chunk_id}")
+        if missing is not None:
+            raise ValueError(f"missing chunk: {missing[0]}")
         cursor.execute(
             f"""
             INSERT OR REPLACE INTO {QUARANTINE_MANIFEST_TABLE} (
                 run_id, chunk_id, original_content_class, original_provenance_class,
                 original_fts_rowid, original_trigram_rowid, original_operational_rowid, quarantined_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            )
+            SELECT
+                ?,
+                c.id,
+                c.content_class,
+                c.provenance_class,
+                CASE WHEN f.chunk_id IS NULL THEN NULL ELSE r.fts_rowid END,
+                CASE WHEN t.chunk_id IS NULL THEN NULL ELSE r.trigram_rowid END,
+                CASE WHEN o.chunk_id IS NULL THEN NULL ELSE r.operational_rowid END,
+                ?
+            FROM {RECONCILE_CHUNK_ID_TABLE} q
+            INNER JOIN chunks c ON c.id = q.chunk_id
+            LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+            LEFT JOIN chunks_fts f
+                ON f.rowid = r.fts_rowid
+               AND f.chunk_id = c.id
+            LEFT JOIN chunks_fts_trigram t
+                ON t.rowid = r.trigram_rowid
+               AND t.chunk_id = c.id
+            LEFT JOIN chunks_fts_operational o
+                ON o.rowid = r.operational_rowid
+               AND o.chunk_id = c.id
             """,
-            (run_id, chunk_id, row[0], row[1], row[2], row[3], row[4], timestamp),
+            (run_id, timestamp),
+        )
+    finally:
+        if loaded_temp_table:
+            cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
+
+
+def _delete_fts_rows_for_reconcile(
+    cursor: apsw.Cursor,
+    *,
+    table_names: tuple[str, ...] = ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"),
+) -> None:
+    for table_name in table_names:
+        rowid_column = FTS_ROWID_COLUMNS[table_name]
+        cursor.execute(
+            f"""
+            DELETE FROM {table_name}
+            WHERE rowid IN (
+                SELECT r.{rowid_column}
+                FROM chunk_fts_rowids r
+                INNER JOIN {RECONCILE_CHUNK_ID_TABLE} q ON q.chunk_id = r.chunk_id
+                WHERE r.{rowid_column} IS NOT NULL
+            )
+            AND chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
+            """
+        )
+    updates = []
+    if "chunks_fts" in table_names:
+        updates.append("fts_rowid = NULL")
+    if "chunks_fts_trigram" in table_names:
+        updates.append("trigram_rowid = NULL")
+    if "chunks_fts_operational" in table_names:
+        updates.append("operational_rowid = NULL")
+    if updates:
+        cursor.execute(
+            f"""
+            UPDATE chunk_fts_rowids
+            SET {", ".join(updates)}
+            WHERE chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
+            """
         )
 
 
@@ -401,6 +531,7 @@ def _delete_fts_rows(
 
 
 def _load_chunk_ids_reconcile_table(cursor: apsw.Cursor, chunk_ids: list[str]) -> None:
+    cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
     cursor.execute(f"CREATE TEMP TABLE {RECONCILE_CHUNK_ID_TABLE}(chunk_id TEXT PRIMARY KEY)")
     cursor.executemany(
         f"INSERT OR IGNORE INTO {RECONCILE_CHUNK_ID_TABLE}(chunk_id) VALUES (?)",
@@ -424,28 +555,96 @@ def _clear_trigram_fts(cursor: apsw.Cursor) -> None:
     )
 
 
-def _insert_operational_fts(cursor: apsw.Cursor, chunk_ids: list[str]) -> None:
-    placeholders = _placeholders(chunk_ids)
+def _insert_operational_fts(cursor: apsw.Cursor) -> None:
     cursor.execute(
         f"""
         INSERT INTO chunks_fts_operational({FTS_COLUMNS})
         SELECT {FTS_SELECT_COLUMNS}
         FROM chunks
-        WHERE id IN ({placeholders})
+        WHERE id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
         ORDER BY id
-        """,
-        chunk_ids,
+        """
     )
     cursor.execute(
         f"""
         INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
         SELECT chunk_id, rowid
         FROM chunks_fts_operational
-        WHERE chunk_id IN ({placeholders})
+        WHERE chunk_id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
         ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
-        """,
-        chunk_ids,
+        """
     )
+
+
+def _rebuild_knowledge_fts(cursor: apsw.Cursor) -> None:
+    cursor.execute("DELETE FROM chunks_fts")
+    cursor.execute(
+        f"""
+        INSERT INTO chunks_fts(rowid, {FTS_COLUMNS})
+        SELECT r.fts_rowid, {FTS_SELECT_COLUMNS_QUALIFIED}
+        FROM chunks c
+        INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+          AND r.fts_rowid IS NOT NULL
+        ORDER BY r.fts_rowid
+        """
+    )
+    cursor.execute(
+        f"""
+        INSERT INTO chunks_fts({FTS_COLUMNS})
+        SELECT {FTS_SELECT_COLUMNS_QUALIFIED}
+        FROM chunks c
+        LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+          AND r.fts_rowid IS NULL
+        ORDER BY c.id
+        """
+    )
+
+
+def _rebuild_trigram_fts(cursor: apsw.Cursor) -> None:
+    cursor.execute("DELETE FROM chunks_fts_trigram")
+    cursor.execute(
+        f"""
+        INSERT INTO chunks_fts_trigram(rowid, {FTS_COLUMNS})
+        SELECT r.trigram_rowid, {FTS_SELECT_COLUMNS_QUALIFIED}
+        FROM chunks c
+        INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+          AND r.trigram_rowid IS NOT NULL
+        ORDER BY r.trigram_rowid
+        """
+    )
+    cursor.execute(
+        f"""
+        INSERT INTO chunks_fts_trigram({FTS_COLUMNS})
+        SELECT {FTS_SELECT_COLUMNS_QUALIFIED}
+        FROM chunks c
+        LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+        WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
+          AND r.trigram_rowid IS NULL
+        ORDER BY c.id
+        """
+    )
+
+
+def _rebuild_chunk_fts_rowids(cursor: apsw.Cursor, *, include_trigram: bool) -> None:
+    cursor.execute("DELETE FROM chunk_fts_rowids")
+    cursor.execute("""
+        INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+        SELECT chunk_id, rowid FROM chunks_fts WHERE chunk_id IS NOT NULL
+    """)
+    cursor.execute("""
+        INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+        SELECT chunk_id, rowid FROM chunks_fts_operational WHERE chunk_id IS NOT NULL
+        ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
+    """)
+    if include_trigram:
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, trigram_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts_trigram WHERE chunk_id IS NOT NULL
+            ON CONFLICT(chunk_id) DO UPDATE SET trigram_rowid = excluded.trigram_rowid
+        """)
 
 
 def _insert_fts_row(
@@ -495,31 +694,41 @@ def apply_quarantine_ids(
     _drop_fts_triggers(cursor)
     _ensure_manifest(cursor)
     timestamp = _utc_now()
+    include_trigram = _table_exists(cursor, "chunks_fts_trigram")
+    table_names = ["chunks_fts", "chunks_fts_operational"]
+    if include_trigram:
+        table_names.append("chunks_fts_trigram")
     batches_since_checkpoint = 0
     try:
-        _load_chunk_ids_reconcile_table(cursor, chunk_ids)
+        cursor.execute("BEGIN IMMEDIATE")
+        _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
+        cursor.execute("COMMIT")
         for ids in _batch(chunk_ids, batch_size):
-            placeholders = _placeholders(ids)
+            _load_chunk_ids_reconcile_table(cursor, ids)
             cursor.execute("BEGIN IMMEDIATE")
-            _record_manifest(cursor, ids, run_id=run_id, timestamp=timestamp)
-            _delete_fts_rows(cursor, ids, table_names=("chunks_fts", "chunks_fts_operational"))
+            _record_manifest(cursor, run_id=run_id, timestamp=timestamp)
+            _delete_fts_rows_for_reconcile(cursor, table_names=tuple(table_names))
             cursor.execute(
                 f"""
                 UPDATE chunks
                 SET content_class = 'operational',
                     provenance_class = ?
-                WHERE id IN ({placeholders})
+                WHERE id IN (SELECT chunk_id FROM {RECONCILE_CHUNK_ID_TABLE})
                 """,
-                (AGENT_INFERENCE, *ids),
+                (AGENT_INFERENCE,),
             )
-            _insert_operational_fts(cursor, ids)
+            _insert_operational_fts(cursor)
             cursor.execute("COMMIT")
+            cursor.execute(f"DROP TABLE IF EXISTS {RECONCILE_CHUNK_ID_TABLE}")
             batches_since_checkpoint += 1
             if batches_since_checkpoint >= checkpoint_every:
                 _checkpoint(cursor)
                 batches_since_checkpoint = 0
         cursor.execute("BEGIN IMMEDIATE")
-        _clear_trigram_fts(cursor)
+        _rebuild_knowledge_fts(cursor)
+        if include_trigram:
+            _rebuild_trigram_fts(cursor)
+        _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
         cursor.execute("COMMIT")
     except Exception:
         if not conn.getautocommit():

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -362,6 +362,9 @@ def capture_restore_state(cursor: apsw.Cursor, chunk_ids: list[str]) -> dict[str
             raise ValueError(f"missing chunk: {chunk_id}")
         fts_rows = {}
         for table_name in ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"):
+            if not _table_exists(cursor, table_name):
+                fts_rows[table_name] = []
+                continue
             fts_rows[table_name] = _select_fts_state_rows(cursor, table_name=table_name, chunk_id=chunk_id)
         state[chunk_id] = {
             "chunk": tuple(chunk),
@@ -417,11 +420,24 @@ def _record_manifest(
     *,
     run_id: str,
     timestamp: str,
+    include_trigram: bool = True,
 ) -> None:
     loaded_temp_table = False
     if chunk_ids is not None:
         _load_chunk_ids_reconcile_table(cursor, chunk_ids)
         loaded_temp_table = True
+    trigram_rowid_expr = (
+        "CASE WHEN t.chunk_id IS NULL THEN NULL ELSE r.trigram_rowid END" if include_trigram else "NULL"
+    )
+    trigram_join = (
+        """
+            LEFT JOIN chunks_fts_trigram t
+                ON t.rowid = r.trigram_rowid
+               AND t.chunk_id = c.id
+        """
+        if include_trigram
+        else ""
+    )
     try:
         missing = cursor.execute(
             f"""
@@ -445,7 +461,7 @@ def _record_manifest(
                 c.content_class,
                 c.provenance_class,
                 CASE WHEN f.chunk_id IS NULL THEN NULL ELSE r.fts_rowid END,
-                CASE WHEN t.chunk_id IS NULL THEN NULL ELSE r.trigram_rowid END,
+                {trigram_rowid_expr},
                 CASE WHEN o.chunk_id IS NULL THEN NULL ELSE r.operational_rowid END,
                 ?
             FROM {RECONCILE_CHUNK_ID_TABLE} q
@@ -454,9 +470,7 @@ def _record_manifest(
             LEFT JOIN chunks_fts f
                 ON f.rowid = r.fts_rowid
                AND f.chunk_id = c.id
-            LEFT JOIN chunks_fts_trigram t
-                ON t.rowid = r.trigram_rowid
-               AND t.chunk_id = c.id
+            {trigram_join}
             LEFT JOIN chunks_fts_operational o
                 ON o.rowid = r.operational_rowid
                AND o.chunk_id = c.id
@@ -706,7 +720,7 @@ def apply_quarantine_ids(
         for ids in _batch(chunk_ids, batch_size):
             _load_chunk_ids_reconcile_table(cursor, ids)
             cursor.execute("BEGIN IMMEDIATE")
-            _record_manifest(cursor, run_id=run_id, timestamp=timestamp)
+            _record_manifest(cursor, run_id=run_id, timestamp=timestamp, include_trigram=include_trigram)
             _delete_fts_rows_for_reconcile(cursor, table_names=tuple(table_names))
             cursor.execute(
                 f"""

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -48,6 +48,7 @@ FTS_ROWID_COLUMNS = {
     "chunks_fts_operational": "operational_rowid",
     "chunks_fts_trigram": "trigram_rowid",
 }
+FTS_RESERVED_CHUNK_ID_PREFIX = "__retro_quarantine_reserved__:"
 QUARANTINE_MANIFEST_TABLE = "retro_self_pollution_quarantine_manifest"
 RECONCILE_CHUNK_ID_TABLE = "_retro_quarantine_reconcile_chunk_ids"
 DEFAULT_ESTIMATE = 244_152
@@ -590,8 +591,58 @@ def _insert_operational_fts(cursor: apsw.Cursor) -> None:
     )
 
 
-def _rebuild_knowledge_fts(cursor: apsw.Cursor) -> None:
+def _reserve_manifest_fts_rowids(
+    cursor: apsw.Cursor,
+    *,
+    table_name: str,
+    manifest_rowid_column: str,
+    run_id: str,
+) -> None:
+    cursor.execute(
+        f"""
+        INSERT OR IGNORE INTO {table_name}(rowid, {FTS_COLUMNS})
+        SELECT DISTINCT
+            m.{manifest_rowid_column},
+            '', NULL, NULL, NULL, NULL, NULL,
+            ?
+        FROM {QUARANTINE_MANIFEST_TABLE} m
+        WHERE m.run_id = ?
+          AND m.{manifest_rowid_column} IS NOT NULL
+        """,
+        (f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}", run_id),
+    )
+
+
+def _delete_manifest_fts_rowid_reservations(
+    cursor: apsw.Cursor,
+    *,
+    table_name: str,
+    manifest_rowid_column: str,
+    run_id: str,
+) -> None:
+    cursor.execute(
+        f"""
+        DELETE FROM {table_name}
+        WHERE rowid IN (
+            SELECT m.{manifest_rowid_column}
+            FROM {QUARANTINE_MANIFEST_TABLE} m
+            WHERE m.run_id = ?
+              AND m.{manifest_rowid_column} IS NOT NULL
+        )
+        AND chunk_id = ?
+        """,
+        (run_id, f"{FTS_RESERVED_CHUNK_ID_PREFIX}{table_name}"),
+    )
+
+
+def _rebuild_knowledge_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
     cursor.execute("DELETE FROM chunks_fts")
+    _reserve_manifest_fts_rowids(
+        cursor,
+        table_name="chunks_fts",
+        manifest_rowid_column="original_fts_rowid",
+        run_id=run_id,
+    )
     cursor.execute(
         f"""
         INSERT INTO chunks_fts(rowid, {FTS_COLUMNS})
@@ -600,8 +651,15 @@ def _rebuild_knowledge_fts(cursor: apsw.Cursor) -> None:
         INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
         WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
           AND r.fts_rowid IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM {QUARANTINE_MANIFEST_TABLE} m
+              WHERE m.run_id = ?
+                AND m.original_fts_rowid = r.fts_rowid
+          )
         ORDER BY r.fts_rowid
-        """
+        """,
+        (run_id,),
     )
     cursor.execute(
         f"""
@@ -610,14 +668,35 @@ def _rebuild_knowledge_fts(cursor: apsw.Cursor) -> None:
         FROM chunks c
         LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
         WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
-          AND r.fts_rowid IS NULL
+          AND (
+              r.fts_rowid IS NULL
+              OR EXISTS (
+                  SELECT 1
+                  FROM {QUARANTINE_MANIFEST_TABLE} m
+                  WHERE m.run_id = ?
+                    AND m.original_fts_rowid = r.fts_rowid
+              )
+          )
         ORDER BY c.id
-        """
+        """,
+        (run_id,),
+    )
+    _delete_manifest_fts_rowid_reservations(
+        cursor,
+        table_name="chunks_fts",
+        manifest_rowid_column="original_fts_rowid",
+        run_id=run_id,
     )
 
 
-def _rebuild_trigram_fts(cursor: apsw.Cursor) -> None:
+def _rebuild_trigram_fts(cursor: apsw.Cursor, *, run_id: str) -> None:
     cursor.execute("DELETE FROM chunks_fts_trigram")
+    _reserve_manifest_fts_rowids(
+        cursor,
+        table_name="chunks_fts_trigram",
+        manifest_rowid_column="original_trigram_rowid",
+        run_id=run_id,
+    )
     cursor.execute(
         f"""
         INSERT INTO chunks_fts_trigram(rowid, {FTS_COLUMNS})
@@ -626,8 +705,15 @@ def _rebuild_trigram_fts(cursor: apsw.Cursor) -> None:
         INNER JOIN chunk_fts_rowids r ON r.chunk_id = c.id
         WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
           AND r.trigram_rowid IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM {QUARANTINE_MANIFEST_TABLE} m
+              WHERE m.run_id = ?
+                AND m.original_trigram_rowid = r.trigram_rowid
+          )
         ORDER BY r.trigram_rowid
-        """
+        """,
+        (run_id,),
     )
     cursor.execute(
         f"""
@@ -636,9 +722,24 @@ def _rebuild_trigram_fts(cursor: apsw.Cursor) -> None:
         FROM chunks c
         LEFT JOIN chunk_fts_rowids r ON r.chunk_id = c.id
         WHERE {NON_OPERATIONAL_FTS_CLASS_SQL}
-          AND r.trigram_rowid IS NULL
+          AND (
+              r.trigram_rowid IS NULL
+              OR EXISTS (
+                  SELECT 1
+                  FROM {QUARANTINE_MANIFEST_TABLE} m
+                  WHERE m.run_id = ?
+                    AND m.original_trigram_rowid = r.trigram_rowid
+              )
+          )
         ORDER BY c.id
-        """
+        """,
+        (run_id,),
+    )
+    _delete_manifest_fts_rowid_reservations(
+        cursor,
+        table_name="chunks_fts_trigram",
+        manifest_rowid_column="original_trigram_rowid",
+        run_id=run_id,
     )
 
 
@@ -739,9 +840,9 @@ def apply_quarantine_ids(
                 _checkpoint(cursor)
                 batches_since_checkpoint = 0
         cursor.execute("BEGIN IMMEDIATE")
-        _rebuild_knowledge_fts(cursor)
+        _rebuild_knowledge_fts(cursor, run_id=run_id)
         if include_trigram:
-            _rebuild_trigram_fts(cursor)
+            _rebuild_trigram_fts(cursor, run_id=run_id)
         _rebuild_chunk_fts_rowids(cursor, include_trigram=include_trigram)
         cursor.execute("COMMIT")
     except Exception:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -608,6 +608,76 @@ def test_apply_without_trigram_table_records_manifest_without_trigram_rowid(tmp_
     assert operational_rows == (1,)
 
 
+def test_rebuild_reserves_manifest_rowids_when_repairing_missing_fts_rows(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "reserved-rowids.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    permitted_source = tmp_path / "notes" / "memory.md"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="denied-knowledge",
+            source_file=denied_source,
+            content="denied rowid reservation sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-missing-fts",
+            source_file=permitted_source,
+            content="preserved missing fts repair sentinel",
+        )
+        cursor = store.conn.cursor()
+        original_fts_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts WHERE chunk_id = 'denied-knowledge'"
+        ).fetchone()[0]
+        original_trigram_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts_trigram WHERE chunk_id = 'denied-knowledge'"
+        ).fetchone()[0]
+        cursor.execute("DELETE FROM chunks_fts WHERE chunk_id = 'preserved-missing-fts'")
+        cursor.execute("DELETE FROM chunks_fts_trigram WHERE chunk_id = 'preserved-missing-fts'")
+        cursor.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = 'preserved-missing-fts'")
+    finally:
+        store.close()
+
+    script.apply_quarantine_ids(
+        db_path,
+        ["denied-knowledge"],
+        run_id="reserved-rowids-run",
+        finalize=False,
+    )
+    script.unquarantine_ids(
+        db_path,
+        ["denied-knowledge"],
+        run_id="reserved-rowids-run",
+        finalize=False,
+    )
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        restored_fts_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts WHERE chunk_id = 'denied-knowledge'"
+        ).fetchone()[0]
+        restored_trigram_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts_trigram WHERE chunk_id = 'denied-knowledge'"
+        ).fetchone()[0]
+        repaired_rowids = cursor.execute(
+            """
+            SELECT fts_rowid, trigram_rowid
+            FROM chunk_fts_rowids
+            WHERE chunk_id = 'preserved-missing-fts'
+            """
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert restored_fts_rowid == original_fts_rowid
+    assert restored_trigram_rowid == original_trigram_rowid
+    assert repaired_rowids[0] != original_fts_rowid
+    assert repaired_rowids[1] != original_trigram_rowid
+
+
 def test_quarantine_retrievability_proof_excludes_default_but_preserves_operational_paths(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -4,6 +4,7 @@ import importlib.util
 import shutil
 import subprocess
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -184,7 +185,7 @@ def _captured_plan_details(
 def _assert_uses_indexed_rowid_map(details: list[str]) -> None:
     joined = "\n".join(details)
     assert "chunk_fts_rowids" in joined
-    assert "SEARCH" in joined
+    assert any("SEARCH" in detail and "chunk_fts_rowids" in detail for detail in details), joined
     assert "SCAN chunks_fts VIRTUAL TABLE" not in joined
     assert "SCAN chunks_fts_trigram VIRTUAL TABLE" not in joined
     assert "SCAN chunks_fts_operational VIRTUAL TABLE" not in joined
@@ -509,6 +510,108 @@ def test_apply_rebuild_mode_checkpoints_each_real_batch(tmp_path: Path, monkeypa
     assert checkpoint_calls == 4
 
 
+def test_apply_uses_operation_writer_lock_while_triggers_are_disabled(tmp_path: Path, monkeypatch) -> None:
+    script = _load_script()
+    db_path = tmp_path / "apply-writer-lock.db"
+    denied_source = tmp_path / ".codex" / "sessions" / "worker.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(store, chunk_id="denied-lock", source_file=denied_source)
+    finally:
+        store.close()
+
+    events: list[str] = []
+    lock_active = False
+
+    @contextmanager
+    def fake_operation_writer_lock(path):
+        nonlocal lock_active
+        assert Path(path) == db_path
+        events.append("lock:acquire")
+        lock_active = True
+        try:
+            yield
+        finally:
+            events.append("lock:release")
+            lock_active = False
+
+    original_recreate_fts_triggers = script._recreate_fts_triggers
+    original_drop_fts_triggers = script._drop_fts_triggers
+
+    def checked_recreate_fts_triggers(path: Path) -> None:
+        events.append(f"recreate:{lock_active}")
+        assert lock_active
+        original_recreate_fts_triggers(path)
+
+    def checked_drop_fts_triggers(cursor) -> None:
+        events.append(f"drop:{lock_active}")
+        assert lock_active
+        original_drop_fts_triggers(cursor)
+
+    monkeypatch.setattr(script, "_operation_writer_lock", fake_operation_writer_lock, raising=False)
+    monkeypatch.setattr(script, "_recreate_fts_triggers", checked_recreate_fts_triggers)
+    monkeypatch.setattr(script, "_drop_fts_triggers", checked_drop_fts_triggers)
+
+    script.apply_quarantine_ids(db_path, ["denied-lock"], run_id="apply-lock-run", finalize=False)
+
+    assert events[0] == "lock:acquire"
+    assert "recreate:True" in events
+    assert "drop:True" in events
+    assert events[-1] == "lock:release"
+
+
+def test_unquarantine_uses_operation_writer_lock_while_triggers_are_disabled(tmp_path: Path, monkeypatch) -> None:
+    script = _load_script()
+    db_path = tmp_path / "unquarantine-writer-lock.db"
+    denied_source = tmp_path / ".codex" / "sessions" / "worker.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(store, chunk_id="denied-lock", source_file=denied_source)
+    finally:
+        store.close()
+
+    script.apply_quarantine_ids(db_path, ["denied-lock"], run_id="unquarantine-lock-run", finalize=False)
+
+    events: list[str] = []
+    lock_active = False
+
+    @contextmanager
+    def fake_operation_writer_lock(path):
+        nonlocal lock_active
+        assert Path(path) == db_path
+        events.append("lock:acquire")
+        lock_active = True
+        try:
+            yield
+        finally:
+            events.append("lock:release")
+            lock_active = False
+
+    original_recreate_fts_triggers = script._recreate_fts_triggers
+    original_drop_fts_triggers = script._drop_fts_triggers
+
+    def checked_recreate_fts_triggers(path: Path) -> None:
+        events.append(f"recreate:{lock_active}")
+        assert lock_active
+        original_recreate_fts_triggers(path)
+
+    def checked_drop_fts_triggers(cursor) -> None:
+        events.append(f"drop:{lock_active}")
+        assert lock_active
+        original_drop_fts_triggers(cursor)
+
+    monkeypatch.setattr(script, "_operation_writer_lock", fake_operation_writer_lock, raising=False)
+    monkeypatch.setattr(script, "_recreate_fts_triggers", checked_recreate_fts_triggers)
+    monkeypatch.setattr(script, "_drop_fts_triggers", checked_drop_fts_triggers)
+
+    script.unquarantine_ids(db_path, ["denied-lock"], run_id="unquarantine-lock-run", finalize=False)
+
+    assert events[0] == "lock:acquire"
+    assert "recreate:True" in events
+    assert "drop:True" in events
+    assert events[-1] == "lock:release"
+
+
 def test_apply_without_trigram_table_records_manifest_without_trigram_rowid(tmp_path: Path) -> None:
     script = _load_script()
     db_path = tmp_path / "no-trigram.db"
@@ -632,6 +735,64 @@ def test_apply_without_trigram_table_records_manifest_without_trigram_rowid(tmp_
     assert restored_default_rows == (1,)
 
 
+def test_retry_same_run_preserves_initial_manifest_originals(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "retry-manifest.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="denied-one",
+            source_file=denied_source,
+            content="retry manifest one sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="denied-two",
+            source_file=denied_source,
+            content="retry manifest two sentinel",
+        )
+    finally:
+        store.close()
+
+    script.apply_quarantine_ids(db_path, ["denied-one"], run_id="retry-run", batch_size=1, finalize=False)
+    script.apply_quarantine_ids(
+        db_path,
+        ["denied-one", "denied-two"],
+        run_id="retry-run",
+        batch_size=1,
+        finalize=False,
+    )
+    script.unquarantine_ids(
+        db_path,
+        ["denied-one", "denied-two"],
+        run_id="retry-run",
+        batch_size=1,
+        finalize=False,
+    )
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        rows = {
+            row[0]: (row[1], row[2])
+            for row in conn.cursor().execute(
+                """
+                SELECT id, content_class, provenance_class
+                FROM chunks
+                WHERE id IN ('denied-one', 'denied-two')
+                """
+            )
+        }
+    finally:
+        conn.close()
+
+    assert rows == {
+        "denied-one": ("knowledge", "RAW-ETAN-DIRECT"),
+        "denied-two": ("knowledge", "RAW-ETAN-DIRECT"),
+    }
+
+
 def test_rebuild_reserves_manifest_rowids_when_repairing_missing_fts_rows(tmp_path: Path) -> None:
     script = _load_script()
     db_path = tmp_path / "reserved-rowids.db"
@@ -698,8 +859,88 @@ def test_rebuild_reserves_manifest_rowids_when_repairing_missing_fts_rows(tmp_pa
 
     assert restored_fts_rowid == original_fts_rowid
     assert restored_trigram_rowid == original_trigram_rowid
+    assert repaired_rowids is not None
+    assert repaired_rowids[0] is not None
+    assert repaired_rowids[1] is not None
     assert repaired_rowids[0] != original_fts_rowid
     assert repaired_rowids[1] != original_trigram_rowid
+
+
+def test_rebuild_reserves_prior_run_manifest_rowids(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "prior-run-reserved-rowids.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    permitted_source = tmp_path / "notes" / "memory.md"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="new-denied",
+            source_file=denied_source,
+            content="new denied rowid sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-existing",
+            source_file=permitted_source,
+            content="preserved existing rowid sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="old-denied",
+            source_file=denied_source,
+            content="old denied rowid sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-missing-fts",
+            source_file=permitted_source,
+            content="prior run missing fts repair sentinel",
+        )
+        cursor = store.conn.cursor()
+        old_fts_rowid = cursor.execute("SELECT rowid FROM chunks_fts WHERE chunk_id = 'old-denied'").fetchone()[0]
+        old_trigram_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts_trigram WHERE chunk_id = 'old-denied'"
+        ).fetchone()[0]
+    finally:
+        store.close()
+
+    script.apply_quarantine_ids(db_path, ["old-denied"], run_id="old-run", finalize=False)
+
+    conn = apsw.Connection(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM chunks_fts WHERE chunk_id = 'preserved-missing-fts'")
+        cursor.execute("DELETE FROM chunks_fts_trigram WHERE chunk_id = 'preserved-missing-fts'")
+        cursor.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = 'preserved-missing-fts'")
+    finally:
+        conn.close()
+
+    script.apply_quarantine_ids(db_path, ["new-denied"], run_id="new-run", finalize=False)
+    script.unquarantine_ids(db_path, ["old-denied"], run_id="old-run", finalize=False)
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        restored_fts_rowid = cursor.execute("SELECT rowid FROM chunks_fts WHERE chunk_id = 'old-denied'").fetchone()[0]
+        restored_trigram_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts_trigram WHERE chunk_id = 'old-denied'"
+        ).fetchone()[0]
+        repaired_rowids = cursor.execute(
+            """
+            SELECT fts_rowid, trigram_rowid
+            FROM chunk_fts_rowids
+            WHERE chunk_id = 'preserved-missing-fts'
+            """
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert restored_fts_rowid == old_fts_rowid
+    assert restored_trigram_rowid == old_trigram_rowid
+    assert repaired_rowids is not None
+    assert repaired_rowids[0] not in {None, old_fts_rowid}
+    assert repaired_rowids[1] not in {None, old_trigram_rowid}
 
 
 def test_capture_restore_state_includes_orphan_fts_rows_without_rowid_map(tmp_path: Path) -> None:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -509,6 +509,105 @@ def test_apply_rebuild_mode_checkpoints_each_real_batch(tmp_path: Path, monkeypa
     assert checkpoint_calls == 4
 
 
+def test_apply_without_trigram_table_records_manifest_without_trigram_rowid(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "no-trigram.db"
+    source_file = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    conn = apsw.Connection(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute("""
+            CREATE TABLE chunks (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                metadata TEXT NOT NULL,
+                source_file TEXT NOT NULL,
+                project TEXT,
+                content_type TEXT,
+                value_type TEXT,
+                char_count INTEGER,
+                source TEXT,
+                created_at TEXT,
+                content_class TEXT,
+                provenance_class TEXT,
+                summary TEXT,
+                tags TEXT,
+                resolved_query TEXT,
+                key_facts TEXT,
+                resolved_queries TEXT
+            )
+        """)
+        cursor.execute("""
+            CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
+            )
+        """)
+        cursor.execute("""
+            CREATE VIRTUAL TABLE chunks_fts_operational USING fts5(
+                content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE chunk_fts_rowids (
+                chunk_id TEXT PRIMARY KEY,
+                fts_rowid INTEGER,
+                operational_rowid INTEGER
+            )
+        """)
+        cursor.execute(
+            """INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type, char_count, source,
+                created_at, content_class, provenance_class
+            ) VALUES (?, 'legacy no trigram sentinel', '{}', ?, 'retro-test', 'note', 26,
+                'claude_code', '2026-07-03T00:00:00Z', 'knowledge', 'RAW-ETAN-DIRECT')""",
+            ("legacy-denylisted", str(source_file)),
+        )
+        cursor.execute("""
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id FROM chunks
+        """)
+        cursor.execute("""
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+            SELECT chunk_id, rowid FROM chunks_fts
+        """)
+    finally:
+        conn.close()
+
+    report = script.apply_quarantine_ids(
+        db_path,
+        ["legacy-denylisted"],
+        run_id="no-trigram-run",
+        bootstrap_schema=False,
+        finalize=False,
+    )
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        manifest = cursor.execute(
+            f"""
+            SELECT original_fts_rowid, original_trigram_rowid, original_operational_rowid
+            FROM {script.QUARANTINE_MANIFEST_TABLE}
+            WHERE run_id = 'no-trigram-run' AND chunk_id = 'legacy-denylisted'
+            """
+        ).fetchone()
+        row = cursor.execute(
+            "SELECT content_class, provenance_class FROM chunks WHERE id = 'legacy-denylisted'"
+        ).fetchone()
+        default_rows = cursor.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'legacy-denylisted'").fetchone()
+        operational_rows = cursor.execute(
+            "SELECT COUNT(*) FROM chunks_fts_operational WHERE chunk_id = 'legacy-denylisted'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert report["quarantined"] == 1
+    assert manifest == (1, None, None)
+    assert row == ("operational", "AGENT-INFERENCE")
+    assert default_rows == (0,)
+    assert operational_rows == (1,)
+
+
 def test_quarantine_retrievability_proof_excludes_default_but_preserves_operational_paths(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -1185,6 +1185,70 @@ def test_apply_removes_duplicate_target_operational_fts_rows(tmp_path: Path) -> 
     assert operational_rows == (1,)
 
 
+def test_apply_removes_duplicate_target_default_fts_rows_before_rebuild(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    script = _load_script()
+    db_path = tmp_path / "duplicate-target-default-before-rebuild.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="denied-knowledge",
+            source_file=denied_source,
+            content="denied duplicate default before rebuild sentinel",
+        )
+        for table_name in ("chunks_fts", "chunks_fts_trigram"):
+            for _ in range(2):
+                store.conn.cursor().execute(f"""
+                    INSERT INTO {table_name}(
+                        content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id
+                    )
+                    SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id
+                    FROM chunks
+                    WHERE id = 'denied-knowledge'
+                """)
+    finally:
+        store.close()
+
+    def stop_before_rebuild(cursor, *, run_id):
+        raise RuntimeError("stop before rebuild")
+
+    monkeypatch.setattr(script, "_rebuild_knowledge_fts", stop_before_rebuild)
+
+    with pytest.raises(RuntimeError, match="stop before rebuild"):
+        script.apply_quarantine_ids(
+            db_path,
+            ["denied-knowledge"],
+            run_id="duplicate-default-before-rebuild-run",
+            batch_size=1,
+            finalize=False,
+        )
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        chunk_row = cursor.execute(
+            "SELECT content_class, provenance_class FROM chunks WHERE id = 'denied-knowledge'"
+        ).fetchone()
+        default_rows = cursor.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'denied-knowledge'").fetchone()
+        trigram_rows = cursor.execute(
+            "SELECT COUNT(*) FROM chunks_fts_trigram WHERE chunk_id = 'denied-knowledge'"
+        ).fetchone()
+        operational_rows = cursor.execute(
+            "SELECT COUNT(*) FROM chunks_fts_operational WHERE chunk_id = 'denied-knowledge'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert chunk_row == ("operational", script.AGENT_INFERENCE)
+    assert default_rows == (0,)
+    assert trigram_rows == (0,)
+    assert operational_rows == (1,)
+
+
 def test_quarantine_retrievability_proof_excludes_default_but_preserves_operational_paths(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -607,6 +607,30 @@ def test_apply_without_trigram_table_records_manifest_without_trigram_rowid(tmp_
     assert default_rows == (0,)
     assert operational_rows == (1,)
 
+    revert = script.unquarantine_ids(
+        db_path,
+        ["legacy-denylisted"],
+        run_id="no-trigram-run",
+        bootstrap_schema=False,
+        finalize=False,
+    )
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        restored = cursor.execute(
+            "SELECT content_class, provenance_class FROM chunks WHERE id = 'legacy-denylisted'"
+        ).fetchone()
+        restored_default_rows = cursor.execute(
+            "SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'legacy-denylisted'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert revert["restored"] == 1
+    assert restored == ("knowledge", "RAW-ETAN-DIRECT")
+    assert restored_default_rows == (1,)
+
 
 def test_rebuild_reserves_manifest_rowids_when_repairing_missing_fts_rows(tmp_path: Path) -> None:
     script = _load_script()
@@ -676,6 +700,116 @@ def test_rebuild_reserves_manifest_rowids_when_repairing_missing_fts_rows(tmp_pa
     assert restored_trigram_rowid == original_trigram_rowid
     assert repaired_rowids[0] != original_fts_rowid
     assert repaired_rowids[1] != original_trigram_rowid
+
+
+def test_capture_restore_state_includes_orphan_fts_rows_without_rowid_map(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "orphan-fts-state.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="orphan-default",
+            source_file=denied_source,
+            content="orphan default fts sentinel",
+        )
+        store.conn.cursor().execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = 'orphan-default'")
+        before = script.capture_restore_state(store.conn.cursor(), ["orphan-default"])
+    finally:
+        store.close()
+
+    assert before["orphan-default"]["fts"]["chunks_fts"]
+    assert before["orphan-default"]["fts"]["chunks_fts_trigram"]
+
+
+def test_rebuild_chunk_fts_rowids_tolerates_duplicate_default_fts_rows(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "duplicate-default-rowids.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    permitted_source = tmp_path / "notes" / "memory.md"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="denied-knowledge",
+            source_file=denied_source,
+            content="denied duplicate default sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-duplicate",
+            source_file=permitted_source,
+            content="preserved duplicate default sentinel",
+        )
+        store.conn.cursor().execute("""
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id
+            FROM chunks
+            WHERE id = 'preserved-duplicate'
+        """)
+    finally:
+        store.close()
+
+    report = script.apply_quarantine_ids(
+        db_path,
+        ["denied-knowledge"],
+        run_id="duplicate-default-run",
+        finalize=False,
+    )
+
+    assert report["quarantined"] == 1
+
+
+def test_apply_removes_duplicate_target_operational_fts_rows(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "duplicate-target-operational.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="denied-knowledge",
+            source_file=denied_source,
+            content="denied duplicate operational sentinel",
+        )
+        for _ in range(2):
+            store.conn.cursor().execute("""
+                INSERT INTO chunks_fts_operational(
+                    content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id
+                )
+                SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id
+                FROM chunks
+                WHERE id = 'denied-knowledge'
+            """)
+        store.conn.cursor().execute("""
+            UPDATE chunk_fts_rowids
+            SET operational_rowid = (
+                SELECT MIN(rowid) FROM chunks_fts_operational WHERE chunk_id = 'denied-knowledge'
+            )
+            WHERE chunk_id = 'denied-knowledge'
+        """)
+    finally:
+        store.close()
+
+    script.apply_quarantine_ids(
+        db_path,
+        ["denied-knowledge"],
+        run_id="duplicate-operational-run",
+        finalize=False,
+    )
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        operational_rows = (
+            conn.cursor()
+            .execute("SELECT COUNT(*) FROM chunks_fts_operational WHERE chunk_id = 'denied-knowledge'")
+            .fetchone()
+        )
+    finally:
+        conn.close()
+
+    assert operational_rows == (1,)
 
 
 def test_quarantine_retrievability_proof_excludes_default_but_preserves_operational_paths(

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import apsw
 import pytest
@@ -39,6 +41,161 @@ def _insert_chunk(
             '2026-07-03T00:00:00Z', ?, ?)""",
         (chunk_id, content, str(source_file), len(content), content_class, provenance_class),
     )
+
+
+def _copy_sqlite_db(source: Path, destination: Path) -> None:
+    for suffix in ("", "-wal", "-shm"):
+        source_path = Path(f"{source}{suffix}")
+        if source_path.exists():
+            destination_path = Path(f"{destination}{suffix}")
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, destination_path)
+
+
+def _snapshot_apply_state(
+    script: ModuleType, db_path: str | Path, *, run_id: str, chunk_ids: list[str]
+) -> dict[str, Any]:
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        state: dict[str, Any] = {}
+        for chunk_id in sorted(chunk_ids):
+            chunk_row = cursor.execute(
+                "SELECT id, content_class, provenance_class FROM chunks WHERE id = ?",
+                (chunk_id,),
+            ).fetchone()
+            if chunk_row is None:
+                raise ValueError(f"missing chunk in snapshot: {chunk_id}")
+            membership = {
+                table: cursor.execute(f"SELECT COUNT(*) FROM {table} WHERE chunk_id = ?", (chunk_id,)).fetchone()[0]
+                for table in ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram")
+            }
+            manifest = None
+            manifest_table_exists = cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (script.QUARANTINE_MANIFEST_TABLE,),
+            ).fetchone()
+            if manifest_table_exists:
+                manifest = cursor.execute(
+                    f"""
+                    SELECT original_content_class, original_provenance_class,
+                           original_fts_rowid, original_trigram_rowid, original_operational_rowid
+                    FROM {script.QUARANTINE_MANIFEST_TABLE}
+                    WHERE chunk_id = ? AND run_id = ?
+                    """,
+                    (chunk_id, run_id),
+                ).fetchone()
+            state[chunk_id] = {"chunk": chunk_row, "membership": membership, "manifest": manifest}
+        return state
+    finally:
+        conn.close()
+
+
+def _simulate_incremental_apply(script: ModuleType, db_path: str | Path, chunk_ids: list[str], *, run_id: str) -> None:
+    if not chunk_ids:
+        return
+    chunk_ids = list(dict.fromkeys(chunk_ids))
+    conn = apsw.Connection(str(db_path))
+    try:
+        cursor = conn.cursor()
+        script._recreate_fts_triggers(Path(db_path))
+        script._checkpoint(cursor)
+        script._drop_fts_triggers(cursor)
+        script._ensure_manifest(cursor)
+        script._load_chunk_ids_reconcile_table(cursor, chunk_ids)
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            script._record_manifest(cursor, run_id=run_id, timestamp="sim-legacy")
+        except TypeError:
+            script._record_manifest(cursor, chunk_ids, run_id=run_id, timestamp="sim-legacy")
+        for batch_ids in script._batch(chunk_ids, 5_000):
+            placeholders = script._placeholders(batch_ids)
+            script._delete_fts_rows(cursor, batch_ids, table_names=("chunks_fts", "chunks_fts_operational"))
+            cursor.execute(
+                f"""
+                UPDATE chunks
+                SET content_class = 'operational',
+                    provenance_class = ?
+                WHERE id IN ({placeholders})
+                """,
+                ("AGENT-INFERENCE", *batch_ids),
+            )
+            cursor.execute(
+                f"""
+                INSERT INTO chunks_fts_operational({script.FTS_COLUMNS})
+                SELECT {script.FTS_SELECT_COLUMNS}
+                FROM chunks
+                WHERE id IN ({placeholders})
+                ORDER BY id
+                """,
+                batch_ids,
+            )
+            cursor.execute(
+                f"""
+                INSERT INTO chunk_fts_rowids(chunk_id, operational_rowid)
+                SELECT chunk_id, rowid FROM chunks_fts_operational
+                WHERE chunk_id IN ({placeholders})
+                ON CONFLICT(chunk_id) DO UPDATE SET operational_rowid = excluded.operational_rowid
+                """,
+                batch_ids,
+            )
+        cursor.execute(
+            f"""
+            DELETE FROM chunks_fts_trigram
+            WHERE chunk_id IN (SELECT chunk_id FROM {script.RECONCILE_CHUNK_ID_TABLE})
+            """
+        )
+        cursor.execute("COMMIT")
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {script.RECONCILE_CHUNK_ID_TABLE}")
+        conn.close()
+
+
+def _explain_details(cursor: apsw.Cursor, statement: str, bindings: tuple[Any, ...]) -> list[str]:
+    return [row[3] for row in cursor.execute(f"EXPLAIN QUERY PLAN {statement}", bindings)]
+
+
+def _captured_plan_details(
+    conn: apsw.Connection,
+    action,
+    *,
+    statement_filter,
+) -> list[str]:
+    captured: list[tuple[str, tuple[Any, ...]]] = []
+
+    def trace(_cursor, statement, bindings):
+        if isinstance(statement, str) and statement_filter(statement):
+            captured.append((statement, tuple(bindings or ())))
+        return True
+
+    conn.setexectrace(trace)
+    try:
+        action()
+    finally:
+        conn.setexectrace(None)
+
+    cursor = conn.cursor()
+    details: list[str] = []
+    for statement, bindings in captured:
+        details.extend(_explain_details(cursor, statement, bindings))
+    return details
+
+
+def _assert_uses_indexed_rowid_map(details: list[str]) -> None:
+    joined = "\n".join(details)
+    assert "chunk_fts_rowids" in joined
+    assert "SEARCH" in joined
+    assert "SCAN chunks_fts VIRTUAL TABLE" not in joined
+    assert "SCAN chunks_fts_trigram VIRTUAL TABLE" not in joined
+    assert "SCAN chunks_fts_operational VIRTUAL TABLE" not in joined
+
+
+def _call_record_manifest_for_plan(script: ModuleType, cursor: apsw.Cursor, chunk_ids: list[str]) -> None:
+    script._load_chunk_ids_reconcile_table(cursor, chunk_ids)
+    try:
+        script._record_manifest(cursor, run_id="plan-run", timestamp="2026-07-08T00:00:00Z")
+    except TypeError:
+        script._record_manifest(cursor, chunk_ids, run_id="plan-run", timestamp="2026-07-08T00:00:00Z")
 
 
 def test_dry_run_uses_denylist_and_preserves_direct_sessions(tmp_path: Path) -> None:
@@ -153,6 +310,203 @@ def test_quarantine_unquarantine_round_trip_restores_chunk_and_fts_rows(tmp_path
 
     assert after == before
     assert after_trigram_rows == [("claude-subagent",)]
+
+
+def test_record_manifest_uses_indexed_fts_rowid_lookup_plan(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "manifest-plan.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="claude-subagent",
+            source_file=denied_source,
+            content="manifest plan exact fts sentinel",
+        )
+        cursor = store.conn.cursor()
+        script._ensure_manifest(cursor)
+
+        details = _captured_plan_details(
+            store.conn,
+            lambda: _call_record_manifest_for_plan(script, cursor, ["claude-subagent"]),
+            statement_filter=lambda statement: (
+                "chunks_fts" in statement
+                and (script.QUARANTINE_MANIFEST_TABLE in statement or "content_class" in statement)
+            ),
+        )
+    finally:
+        store.close()
+
+    assert details
+    _assert_uses_indexed_rowid_map(details)
+
+
+def test_capture_restore_state_uses_indexed_fts_rowid_lookup_plan(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "capture-plan.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="claude-subagent",
+            source_file=denied_source,
+            content="capture plan exact fts sentinel",
+        )
+        details = _captured_plan_details(
+            store.conn,
+            lambda: script.capture_restore_state(store.conn.cursor(), ["claude-subagent"]),
+            statement_filter=lambda statement: "chunks_fts" in statement and "chunk_fts_rowids" in statement,
+        )
+    finally:
+        store.close()
+
+    assert details
+    _assert_uses_indexed_rowid_map(details)
+
+
+def test_apply_rebuild_mode_matches_incremental_behavior_on_fixture(tmp_path: Path) -> None:
+    script = _load_script()
+    base_db = tmp_path / "parity-base.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    denied_source_two = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a2.jsonl"
+    permitted_source = tmp_path / "notes" / "memory.md"
+    store = VectorStore(base_db)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="denied-knowledge",
+            source_file=denied_source,
+            content="denied knowledge sentinel",
+            content_class="knowledge",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="denied-operational",
+            source_file=denied_source_two,
+            content="denied operational sentinel",
+            content_class="operational",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-knowledge",
+            source_file=permitted_source,
+            content="preserved knowledge sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-operational",
+            source_file=permitted_source,
+            content="preserved operational sentinel",
+            content_class="operational",
+            provenance_class="RAW-ETAN-DIRECT",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-test",
+            source_file=permitted_source,
+            content="preserved test sentinel",
+            content_class="test",
+            provenance_class="RAW-ETAN-DIRECT",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-cold",
+            source_file=permitted_source,
+            content="preserved cold sentinel",
+            content_class="cold",
+            provenance_class="RAW-ETAN-DIRECT",
+        )
+        denied_ids = script.select_quarantine_ids(base_db)
+    finally:
+        store.close()
+
+    run_id = "parity-run"
+    legacy_db = tmp_path / "parity-legacy.db"
+    rebuild_db = tmp_path / "parity-rebuild.db"
+    _copy_sqlite_db(base_db, legacy_db)
+    _copy_sqlite_db(base_db, rebuild_db)
+    all_ids = sorted(
+        [
+            "denied-knowledge",
+            "denied-operational",
+            "preserved-knowledge",
+            "preserved-operational",
+            "preserved-test",
+            "preserved-cold",
+        ]
+    )
+
+    _simulate_incremental_apply(script, legacy_db, denied_ids, run_id=run_id)
+    rebuild_report = script.apply_quarantine_ids(rebuild_db, denied_ids, run_id=run_id, batch_size=1)
+
+    incremental_state = _snapshot_apply_state(script, legacy_db, run_id=run_id, chunk_ids=all_ids)
+    rebuilt_state = _snapshot_apply_state(script, rebuild_db, run_id=run_id, chunk_ids=all_ids)
+    baseline_state = _snapshot_apply_state(script, base_db, run_id="baseline", chunk_ids=all_ids)
+    assert incremental_state == rebuilt_state
+    assert rebuild_report["run_id"] == run_id
+    for chunk_id in all_ids:
+        expected_chunk = baseline_state[chunk_id]["chunk"]
+        if chunk_id in denied_ids:
+            assert rebuilt_state[chunk_id]["chunk"][1] == "operational"
+            assert rebuilt_state[chunk_id]["membership"]["chunks_fts"] == 0
+            assert rebuilt_state[chunk_id]["membership"]["chunks_fts_trigram"] == 0
+            assert rebuilt_state[chunk_id]["membership"]["chunks_fts_operational"] == 1
+            assert rebuilt_state[chunk_id]["manifest"] is not None
+        else:
+            assert rebuilt_state[chunk_id]["chunk"] == expected_chunk
+            assert rebuilt_state[chunk_id]["membership"] == baseline_state[chunk_id]["membership"]
+            assert rebuilt_state[chunk_id]["manifest"] is None
+
+    script.unquarantine_ids(rebuild_db, denied_ids, run_id=run_id)
+    restored_conn = apsw.Connection(str(rebuild_db), flags=apsw.SQLITE_OPEN_READONLY)
+    baseline_conn = apsw.Connection(str(base_db), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        restored = script.capture_restore_state(restored_conn.cursor(), all_ids)
+        baseline = script.capture_restore_state(baseline_conn.cursor(), all_ids)
+    finally:
+        restored_conn.close()
+        baseline_conn.close()
+    assert restored == baseline
+
+
+def test_apply_rebuild_mode_checkpoints_each_real_batch(tmp_path: Path, monkeypatch) -> None:
+    script = _load_script()
+    db_path = tmp_path / "batching.db"
+    denied_source = tmp_path / ".codex" / "sessions" / "worker.jsonl"
+    store = VectorStore(db_path)
+    try:
+        for index in range(3):
+            _insert_chunk(
+                store,
+                chunk_id=f"denied-{index}",
+                source_file=denied_source,
+                content=f"batch checkpoint sentinel {index}",
+            )
+    finally:
+        store.close()
+
+    checkpoint_calls = 0
+    original_checkpoint = script._checkpoint
+
+    def count_checkpoint(cursor) -> None:
+        nonlocal checkpoint_calls
+        checkpoint_calls += 1
+        original_checkpoint(cursor)
+
+    monkeypatch.setattr(script, "_checkpoint", count_checkpoint)
+
+    script.apply_quarantine_ids(
+        db_path,
+        ["denied-0", "denied-1", "denied-2"],
+        batch_size=1,
+        checkpoint_every=1,
+        run_id="batch-run",
+        finalize=False,
+    )
+
+    assert checkpoint_calls == 4
 
 
 def test_quarantine_retrievability_proof_excludes_default_but_preserves_operational_paths(

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -367,6 +367,69 @@ def test_capture_restore_state_uses_indexed_fts_rowid_lookup_plan(tmp_path: Path
     _assert_uses_indexed_rowid_map(details)
 
 
+def test_rebuild_fts_uses_indexed_reserved_rowid_table_for_manifest_probes(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "rebuild-reserved-plan.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    permitted_source = tmp_path / "notes" / "memory.md"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="denied-knowledge",
+            source_file=denied_source,
+            content="reserved plan denied sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="preserved-knowledge",
+            source_file=permitted_source,
+            content="reserved plan preserved sentinel",
+        )
+        cursor = store.conn.cursor()
+        script._ensure_manifest(cursor)
+        script._record_manifest(cursor, ["denied-knowledge"], run_id="reserved-plan-run", timestamp="plan")
+
+        captured: list[str] = []
+
+        def trace(_cursor, statement, bindings):
+            if (
+                isinstance(statement, str)
+                and " reserved" in statement
+                and "FROM _retro_reserved_chunks_fts" in statement
+            ):
+                captured.append(statement)
+            return True
+
+        store.conn.setexectrace(trace)
+        try:
+            script._rebuild_knowledge_fts(cursor, run_id="reserved-plan-run")
+            script._rebuild_trigram_fts(cursor, run_id="reserved-plan-run")
+        finally:
+            store.conn.setexectrace(None)
+
+        reserved_table = script._load_manifest_fts_rowid_reservations(
+            cursor,
+            table_name="chunks_fts",
+            manifest_rowid_column="original_fts_rowid",
+        )
+        try:
+            details = _explain_details(
+                cursor,
+                f"SELECT 1 FROM {reserved_table} reserved WHERE reserved.rowid = ?",
+                (1,),
+            )
+        finally:
+            cursor.execute(f"DROP TABLE IF EXISTS {reserved_table}")
+    finally:
+        store.close()
+
+    joined = "\n".join(details)
+    assert captured
+    assert all(script.QUARANTINE_MANIFEST_TABLE not in statement for statement in captured)
+    assert "SEARCH reserved USING INTEGER PRIMARY KEY" in joined
+
+
 def test_apply_rebuild_mode_matches_incremental_behavior_on_fixture(tmp_path: Path) -> None:
     script = _load_script()
     base_db = tmp_path / "parity-base.db"
@@ -943,6 +1006,50 @@ def test_rebuild_reserves_prior_run_manifest_rowids(tmp_path: Path) -> None:
     assert repaired_rowids[1] not in {None, old_trigram_rowid}
 
 
+def test_rebuild_does_not_reserve_restored_prior_run_manifest_rowids(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "restored-prior-run-rowids.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="old-denied",
+            source_file=denied_source,
+            content="restored old denied rowid sentinel",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="new-denied",
+            source_file=denied_source,
+            content="new denied after restored old sentinel",
+        )
+        cursor = store.conn.cursor()
+        old_fts_rowid = cursor.execute("SELECT rowid FROM chunks_fts WHERE chunk_id = 'old-denied'").fetchone()[0]
+        old_trigram_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts_trigram WHERE chunk_id = 'old-denied'"
+        ).fetchone()[0]
+    finally:
+        store.close()
+
+    script.apply_quarantine_ids(db_path, ["old-denied"], run_id="old-run", finalize=False)
+    script.unquarantine_ids(db_path, ["old-denied"], run_id="old-run", finalize=False)
+    script.apply_quarantine_ids(db_path, ["new-denied"], run_id="new-run", finalize=False)
+
+    conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        cursor = conn.cursor()
+        current_fts_rowid = cursor.execute("SELECT rowid FROM chunks_fts WHERE chunk_id = 'old-denied'").fetchone()[0]
+        current_trigram_rowid = cursor.execute(
+            "SELECT rowid FROM chunks_fts_trigram WHERE chunk_id = 'old-denied'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert current_fts_rowid == old_fts_rowid
+    assert current_trigram_rowid == old_trigram_rowid
+
+
 def test_capture_restore_state_includes_orphan_fts_rows_without_rowid_map(tmp_path: Path) -> None:
     script = _load_script()
     db_path = tmp_path / "orphan-fts-state.db"
@@ -962,6 +1069,31 @@ def test_capture_restore_state_includes_orphan_fts_rows_without_rowid_map(tmp_pa
 
     assert before["orphan-default"]["fts"]["chunks_fts"]
     assert before["orphan-default"]["fts"]["chunks_fts_trigram"]
+
+
+def test_capture_restore_state_includes_duplicate_fts_rows_with_valid_rowid_map(tmp_path: Path) -> None:
+    script = _load_script()
+    db_path = tmp_path / "duplicate-fts-state.db"
+    denied_source = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(
+            store,
+            chunk_id="duplicate-default",
+            source_file=denied_source,
+            content="duplicate capture fts sentinel",
+        )
+        store.conn.cursor().execute("""
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id
+            FROM chunks
+            WHERE id = 'duplicate-default'
+        """)
+        before = script.capture_restore_state(store.conn.cursor(), ["duplicate-default"])
+    finally:
+        store.close()
+
+    assert len(before["duplicate-default"]["fts"]["chunks_fts"]) == 2
 
 
 def test_rebuild_chunk_fts_rowids_tolerates_duplicate_default_fts_rows(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Port the quarantine rebuild-from-scratch path onto `scripts/retro_quarantine_self_pollution.py` while preserving incremental parity and unquarantine restoration.
- Replace hot `chunk_id` filters on FTS5 tables in `_record_manifest` and `capture_restore_state` with indexed `chunk_fts_rowids` rowid-map lookups.
- Make `batch_size` drive real manifest/reclassify batches with per-batch commits/checkpoints, followed by one rowid-preserving FTS rebuild.

## Dispatch Brief
- Local build brief: `/Users/etanheyman/Gits/brainlayer/docs.local/.build-briefs/2026-07-08-pr3-quadratic-fix.md`
- The brief is in `docs.local` outside this worktree, so the relevant requirement/evidence is included inline here rather than relying on a gitignored PR artifact.

## Query-Plan Evidence
- Added `tests/test_retro_self_pollution_quarantine.py::test_record_manifest_uses_indexed_fts_rowid_lookup_plan`.
- Added `tests/test_retro_self_pollution_quarantine.py::test_capture_restore_state_uses_indexed_fts_rowid_lookup_plan`.
- Both tests execute `EXPLAIN QUERY PLAN` against the SQL emitted by the script and assert the plan uses `chunk_fts_rowids` with `SEARCH`, while rejecting `SCAN chunks_fts VIRTUAL TABLE`, `SCAN chunks_fts_trigram VIRTUAL TABLE`, and `SCAN chunks_fts_operational VIRTUAL TABLE`.

## Test Plan
- [x] RED verified before implementation: the new query-plan tests failed on `SCAN ... VIRTUAL TABLE` before the fix.
- [x] `pytest -q tests/test_retro_self_pollution_quarantine.py`
- [x] `ruff check scripts/retro_quarantine_self_pollution.py tests/test_retro_self_pollution_quarantine.py`
- [x] `ruff format --check scripts/retro_quarantine_self_pollution.py tests/test_retro_self_pollution_quarantine.py`
- [x] `pytest -q tests/test_retro_self_pollution_quarantine.py tests/test_search_trigram_fts.py`
- [x] `pytest -q --ignore=tests/test_vector_store.py --ignore=tests/test_engine.py` (`3446 passed, 49 skipped, 5 xfailed`)
- [x] `BRAINLAYER_PREPUSH_SCOPE=changed-only git push -u origin perf/quarantine-rebuild-quadratic-fix` hook (`13 + 3 + 40 pytest tests`, `bun test`, and `test_fts5_determinism.sh` passed)

## Notes
- Did not run the full 17GB rebuild.
- Did not run `--apply` against production.
- Local pre-commit `coderabbit review --agent` was attempted and stopped after the bounded three-minute window with only heartbeat/status output; PR-level bot reviews are requested next.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes bulk SQLite/FTS5 rewrite logic on the production quarantine path; mistakes could corrupt search indexes or restore metadata on large databases, though tests and revert proofs mitigate this.
> 
> **Overview**
> Reworks **retro self-pollution quarantine apply** so manifest recording and restore snapshots use **`chunk_fts_rowids`** joins instead of **`chunk_id` filters on FTS5 virtual tables**, avoiding quadratic virtual-table scans on large databases.
> 
> **`apply_quarantine_ids`** now syncs the rowid map up front, preloads delete rowids for the full apply set, runs **real per-batch** manifest/reclassify/operational-FTS work with commits and checkpoints, then **rebuilds** knowledge (and trigram) FTS with **manifest rowid reservations** so unquarantine can restore original FTS rowids. **`unquarantine_ids`** and apply both run under **`VectorStore`’s writer pidfile lock** while FTS triggers are dropped.
> 
> **`_record_manifest`** bulk-inserts via a reconcile temp table (`INSERT OR IGNORE` for same-run retries). **`capture_restore_state`** prefers the rowid map with fallbacks for corrupt maps, orphans, and duplicates. Optional trigram tables are detected with **`_table_exists`**.
> 
> Tests add **EXPLAIN QUERY PLAN** guards, incremental-vs-rebuild parity, writer-lock ordering, legacy schemas without trigram, rowid reservation edge cases, and duplicate-FTS cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b04920e31d5b250593ccd38e669d7fbab7009f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix quadratic manifest scan in quarantine rebuild by using indexed rowid map joins
> - Replaces full virtual table scans in `_record_manifest` and FTS operations with indexed lookups via `chunk_fts_rowids`, eliminating O(n²) behavior during quarantine rebuilds.
> - Adds `_delete_fts_rows_for_reconcile` to drive targeted FTS deletions from precomputed rowid staging tables, keeping `chunk_fts_rowids` consistent after each batch.
> - `apply_quarantine_ids` and `unquarantine_ids` now run under `_operation_writer_lock` to serialize writes, tolerate absence of `chunks_fts_trigram`, and use `INSERT OR IGNORE` so re-running with the same `run_id` does not overwrite existing manifest rows.
> - Adds `_rebuild_chunk_fts_rowids` to atomically repopulate the rowid map from all present FTS tables after each batch completes.
> - Risk: `_record_manifest` now raises `ValueError` if any chunk_id in the reconcile table is missing from `chunks`, which is a new failure mode compared to prior behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52b0492.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quarantine and restore reliability for databases with missing or varying FTS data.
  * Fixed restore behavior for tables with duplicate or missing search rows, helping preserve the correct search results.
  * Made apply/unquarantine flows more resilient when optional search indexes are unavailable.
  * Reduced the chance of data mismatches during rebuilds and restores after quarantine operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->