### PR TITLE
fix: heal frozen drain lock holders

### DIFF
--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -15,6 +15,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable
 
+from .drain_liveness import (
+    DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
+    ENRICH_DAILY_COST_COUNTER_FILENAME,
+    STALLED_CODE,
+    check_drain_liveness,
+)
 from .launchd_primitive import (
     LaunchdVerificationError,
     install_and_verify_launchagent,
@@ -91,6 +97,10 @@ class HealthCheckConfig:
         default_factory=lambda: Path("~/.local/share/brainlayer/drain-health.json").expanduser()
     )
     queue_dir: Path = field(default_factory=lambda: Path("~/.brainlayer/queue").expanduser())
+    pending_stores_path: Path = field(
+        default_factory=lambda: Path("~/.local/share/brainlayer/pending-stores.jsonl").expanduser()
+    )
+    drain_liveness_stale_seconds: float = DEFAULT_DRAIN_LIVENESS_STALE_SECONDS
     source_jsonl_globs: list[str] = field(
         default_factory=lambda: [str(root.resolved_path / "**" / "*.jsonl") for root in default_watch_roots()]
     )
@@ -423,6 +433,32 @@ def count_missing_embeddings(db_path: Path) -> int:
         conn.close()
 
 
+def _enrichment_backlog(db_path: Path) -> int:
+    uri = f"file:{db_path.expanduser()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=5)
+    try:
+        conn.execute("PRAGMA query_only = ON")
+        row = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM chunks
+            WHERE enriched_at IS NULL
+              AND enrich_status IS NULL
+              AND COALESCE(char_count, length(content), 0) >= 50
+              AND content IS NOT NULL
+              AND content != ''
+              AND archived_at IS NULL
+              AND superseded_by IS NULL
+              AND aggregated_into IS NULL
+              AND COALESCE(archived, 0) = 0
+              AND COALESCE(status, 'active') = 'active'
+            """
+        ).fetchone()
+        return int(row[0] if row else 0)
+    finally:
+        conn.close()
+
+
 def _load_state(path: Path) -> dict[str, Any]:
     try:
         return json.loads(path.expanduser().read_text(encoding="utf-8"))
@@ -692,6 +728,14 @@ def _queue_stats(queue_dir: Path, now: datetime) -> tuple[int, int, float | None
     return count, total_bytes, oldest
 
 
+def _pending_stores_count(path: Path) -> int:
+    try:
+        with path.expanduser().open(encoding="utf-8") as pending_stores:
+            return sum(1 for line in pending_stores if line.strip())
+    except FileNotFoundError:
+        return 0
+
+
 def _plist_for_label(config: HealthCheckConfig, label: str) -> Path:
     if label == config.watch_label:
         return config.watch_plist_path
@@ -830,6 +874,7 @@ def run_health_check(
                 if action.startswith(("bootstrap:", "bootstrap_failed:", "launchctl-unavailable:")):
                     result.actions.append(action)
 
+    drain_loaded: bool | None = None
     for label, issue_code, message in (
         (config.watch_label, "watch_unloaded", "watch launchd label is not loaded"),
         (config.drain_label, "drain_unloaded", "drain launchd label is not loaded"),
@@ -839,6 +884,8 @@ def run_health_check(
         if not label:
             continue
         loaded = _launchd_label_loaded(label, command_runner)
+        if issue_code == "drain_unloaded":
+            drain_loaded = loaded
         if loaded is False:
             add_issue(issue_code, "critical", message)
             heal_issue_labels[issue_code] = (label, _plist_for_label(config, label))
@@ -857,6 +904,15 @@ def run_health_check(
                 result.actions.append("resume_failed:stale-pause-sentinel")
 
     queue_count, queue_bytes, queue_oldest_age = _queue_stats(config.queue_dir, now)
+    try:
+        pending_stores_count = _pending_stores_count(config.pending_stores_path)
+    except OSError as exc:
+        pending_stores_count = 0
+        add_issue(
+            "pending_stores_count_failed",
+            "critical",
+            f"could not count pending stores: {exc}",
+        )
     if queue_count >= config.queue_auto_heal_count:
         severity = "critical" if queue_count >= config.queue_page_count else "warning"
         add_issue(
@@ -899,6 +955,30 @@ def run_health_check(
     drain_total = drain_health.get("drained_total")
     previous_drain_total = state.get("drain_drained_total")
     drain_starved = _drain_health_has_sqlite_busy_signal(drain_health)
+    try:
+        enrichment_backlog = _enrichment_backlog(config.db_path)
+    except Exception as exc:
+        enrichment_backlog = 0
+        add_issue(
+            "enrichment_backlog_count_failed",
+            "critical",
+            f"could not count enrichment backlog: {exc}",
+        )
+    drain_liveness_issue = check_drain_liveness(
+        drain_label=config.drain_label,
+        drain_loaded=drain_loaded,
+        queue_count=queue_count + pending_stores_count,
+        enrichment_backlog=enrichment_backlog,
+        drain_health=drain_health,
+        now=now,
+        stale_seconds=config.drain_liveness_stale_seconds,
+        enrich_cost_counter_path=config.db_path.expanduser().parent / ENRICH_DAILY_COST_COUNTER_FILENAME,
+    )
+    if drain_liveness_issue is not None:
+        severity = "critical" if drain_liveness_issue.code == STALLED_CODE else drain_liveness_issue.severity
+        add_issue(drain_liveness_issue.code, severity, drain_liveness_issue.message)
+        if drain_liveness_issue.code == STALLED_CODE:
+            drain_starved = True
     if queue_count > 0 and isinstance(drain_total, int) and drain_total == previous_drain_total:
         add_issue(
             "drain_no_progress",

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -347,7 +347,9 @@ def _run_frozen_drain_liveness_scenario(
     )
 
     if command_runner is None:
-        command_runner = lambda _args: SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        def command_runner(_args):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     result = run_health_check(
         HealthCheckConfig(

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -41,6 +41,17 @@ def _isolate_default_live_paths(tmp_path_factory, monkeypatch):
 
     monkeypatch.setattr(health_check, "_queue_stats", _isolated_queue_stats)
 
+    absent_pending_stores = tmp_path_factory.mktemp("hc-pending-stores") / "pending-stores.jsonl"
+    live_pending_stores_default = Path("~/.local/share/brainlayer/pending-stores.jsonl").expanduser()
+    real_pending_stores_count = health_check._pending_stores_count
+
+    def _isolated_pending_stores_count(path):
+        if path.expanduser() == live_pending_stores_default:
+            path = absent_pending_stores
+        return real_pending_stores_count(path)
+
+    monkeypatch.setattr(health_check, "_pending_stores_count", _isolated_pending_stores_count)
+
     absent_sentinel = tmp_path_factory.mktemp("hc-sentinel") / "pause.sentinel"
     live_sentinel_default = Path("~/.local/share/brainlayer/pause.sentinel").expanduser()
     real_pause_state = health_check._pause_sentinel_state
@@ -68,7 +79,10 @@ def _make_db(path: Path, *, total: int, vector_rows: int) -> None:
                 superseded_by TEXT,
                 aggregated_into TEXT,
                 archived INTEGER DEFAULT 0,
-                status TEXT DEFAULT 'active'
+                status TEXT DEFAULT 'active',
+                enriched_at TEXT,
+                enrich_status TEXT,
+                char_count INTEGER
             );
             CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
             """
@@ -274,6 +288,186 @@ def test_lock_holder_wedge_flags_live_holder_when_drain_is_starved(tmp_path, mon
     assert "drain_no_progress" in issue_codes
     assert "lock_holder_wedge" in issue_codes
     assert any(str(holder_pid) in issue.message and "brainlayer index" in issue.message for issue in result.issues)
+
+
+def _run_frozen_drain_liveness_scenario(
+    tmp_path,
+    monkeypatch,
+    *,
+    heartbeat_age: timedelta,
+    pending_store_count: int,
+    quota_blocked_enrichment: bool = False,
+    heal: bool = False,
+    command_runner=None,
+):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    drain_health_path = tmp_path / "drain-health.json"
+    queue_dir = tmp_path / "queue"
+    pending_stores_path = tmp_path / "pending-stores.jsonl"
+    pidfile_dir = tmp_path / "pidfiles"
+    queue_dir.mkdir()
+    _make_db(db_path, total=1, vector_rows=1)
+    if quota_blocked_enrichment:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE chunks SET content = ?, char_count = ?",
+                ("x" * 60, 60),
+            )
+        (db_path.parent / "enrich-daily-cost.json").write_text(
+            json.dumps({"date": "2026-07-10", "spent_usd": 5.0}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BRAINLAYER_ENRICH_DAILY_USD_CAP", "5.0")
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+    drain_health_path.write_text(
+        json.dumps(
+            {
+                "drained_total": 10,
+                "drain_cycles": 4,
+                "updated_at": (now - heartbeat_age).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    pending_stores_path.write_text('{"content":"pending"}\n' * pending_store_count, encoding="utf-8")
+    holder_pid = os.getpid()
+    _write_writer_pidfile(pidfile_dir, db_path, pid=holder_pid, start_time="holder-start")
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(pidfile_dir))
+    monkeypatch.setattr(VectorStore, "_pid_start_time", staticmethod(lambda _pid: "holder-start"))
+    state_path.write_text(
+        json.dumps(
+            {
+                "drain_drained_total": 10,
+                "lock_holder_pid": holder_pid,
+                "lock_holder_held_ticks": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    if command_runner is None:
+        command_runner = lambda _args: SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            drain_health_path=drain_health_path,
+            queue_dir=queue_dir,
+            pending_stores_path=pending_stores_path,
+            heal=heal,
+            heal_min_consecutive_failures=1,
+            max_stalled_ticks=2,
+        ),
+        ps_output_fn=lambda: (
+            "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n"
+            f"{holder_pid} /opt/homebrew/bin/brainlayer index\n"
+        ),
+        socket_request_fn=_ok_canary,
+        command_runner=command_runner,
+        now_fn=lambda: now,
+    )
+    return result, holder_pid
+
+
+def test_frozen_drain_with_pending_stores_heals_live_index_lock_holder(tmp_path, monkeypatch):
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]):
+        commands.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result, _holder_pid = _run_frozen_drain_liveness_scenario(
+        tmp_path,
+        monkeypatch,
+        heartbeat_age=timedelta(minutes=10),
+        pending_store_count=2,
+        heal=True,
+        command_runner=command_runner,
+    )
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert "drain_liveness_stalled" in issue_codes
+    assert "lock_holder_wedge" in issue_codes
+    assert "kickstart:com.brainlayer.index" in result.actions
+    kickstarts = [command for command in commands if command[:3] == ["launchctl", "kickstart", "-k"]]
+    assert len(kickstarts) == 1
+    assert "com.brainlayer.index" in " ".join(kickstarts[0])
+    assert "com.brainlayer.drain" not in " ".join(kickstarts[0])
+
+
+def test_frozen_drain_without_backlog_does_not_wedge_lock_holder(tmp_path, monkeypatch):
+    result, _holder_pid = _run_frozen_drain_liveness_scenario(
+        tmp_path,
+        monkeypatch,
+        heartbeat_age=timedelta(minutes=10),
+        pending_store_count=0,
+    )
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert "drain_liveness_stalled" not in issue_codes
+    assert "lock_holder_wedge" not in issue_codes
+
+
+def test_frozen_drain_quota_blocker_does_not_wedge_lock_holder(tmp_path, monkeypatch):
+    result, _holder_pid = _run_frozen_drain_liveness_scenario(
+        tmp_path,
+        monkeypatch,
+        heartbeat_age=timedelta(minutes=10),
+        pending_store_count=0,
+        quota_blocked_enrichment=True,
+    )
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert "drain_liveness_quota_blocked" in issue_codes
+    assert "drain_liveness_stalled" not in issue_codes
+    assert "lock_holder_wedge" not in issue_codes
+
+
+def test_fresh_drain_heartbeat_does_not_wedge_lock_holder(tmp_path, monkeypatch):
+    result, _holder_pid = _run_frozen_drain_liveness_scenario(
+        tmp_path,
+        monkeypatch,
+        heartbeat_age=timedelta(seconds=30),
+        pending_store_count=2,
+    )
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert "drain_liveness_stalled" not in issue_codes
+    assert "lock_holder_wedge" not in issue_codes
+
+
+def test_pending_store_backlog_read_failure_is_reported(tmp_path, monkeypatch):
+    def fail_pending_store_read(_path):
+        raise PermissionError("pending stores unreadable")
+
+    monkeypatch.setattr(health_check, "_pending_stores_count", fail_pending_store_read)
+
+    result, _holder_pid = _run_frozen_drain_liveness_scenario(
+        tmp_path,
+        monkeypatch,
+        heartbeat_age=timedelta(seconds=30),
+        pending_store_count=1,
+    )
+
+    assert "pending_stores_count_failed" in [issue.code for issue in result.issues]
+
+
+def test_enrichment_backlog_query_failure_is_reported(tmp_path, monkeypatch):
+    def fail_enrichment_backlog(_path):
+        raise sqlite3.OperationalError("enrichment backlog unavailable")
+
+    monkeypatch.setattr(health_check, "_enrichment_backlog", fail_enrichment_backlog)
+
+    result, _holder_pid = _run_frozen_drain_liveness_scenario(
+        tmp_path,
+        monkeypatch,
+        heartbeat_age=timedelta(seconds=30),
+        pending_store_count=0,
+    )
+
+    assert "enrichment_backlog_count_failed" in [issue.code for issue in result.issues]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- wire the existing drain-liveness detector into health-check healing
- include pending-stores.jsonl and enrichment backlog in liveness decisions
- feed only true stalled-drain alarms into the existing lock-holder wedge kill path
- report backlog read/query failures instead of silently treating them as empty

## Test plan
- ruff check src/
- ruff format src/
- pytest -q tests/test_stability_health_check.py tests/test_alarm.py tests/test_doctor.py (74 passed)
- full pre-push gate with ulimit -n 4096 (3414 passed, 9 skipped, 61 deselected, 1 xfailed; MCP 3 passed; isolated 40 passed; Bun 1 passed; shell regression passed)
- CodeRabbit local review round 2: 0 findings

## Resource note
The default shell file-descriptor limit of 256 caused pytest to abort around 69 percent with Errno 24 while rendering/cleaning up. Raising only the per-process FD limit allowed the unchanged full gate to complete; no tests were skipped beyond the hook defaults and the two prohibited real-DB files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Stalled drain detection now feeds automated lock-holder wedge healing (launchctl kickstart of the index job), a new remediation path that can disrupt a long-running writer if misclassified.
> 
> **Overview**
> **Drain liveness is now part of the periodic health check**, calling the existing `check_drain_liveness` helper with combined durable queue plus **pending-stores.jsonl** backlog, SQLite **enrichment backlog**, stale **drain-health** heartbeat, and the enrich daily cost counter.
> 
> New **`HealthCheckConfig`** fields default **`pending_stores_path`** and **`drain_liveness_stale_seconds`**. Helpers **`_pending_stores_count`** and **`_enrichment_backlog`** supply counts; read/query failures emit **`pending_stores_count_failed`** or **`enrichment_backlog_count_failed`** instead of treating backlog as zero.
> 
> When liveness reports **`drain_liveness_stalled`**, severity is forced to critical and **`drain_starved`** is set so the existing **`lock_holder_wedge`** path can run; with heal enabled, tests expect **`kickstart:com.brainlayer.index`** (not drain) when a frozen drain coincides with pending stores and a wedged index lock holder. Quota-blocked enrichment and no-backlog cases avoid false stalled/wedge alarms.
> 
> Tests isolate default pending-stores paths and add scenarios for frozen drain, quota block, fresh heartbeat, and backlog read failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d65580598d08b0d1fdc8b55938c53d7a055a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Heal frozen drain lock holders by detecting stalled drain liveness
> - Adds `check_drain_liveness` integration to `run_health_check` in [health_check.py](https://github.com/EtanHey/brainlayer/pull/580/files#diff-02ee89f403d662ff87be28bc3f25fb618f788bc46a8ea0cc752df6b38268671a): a stale drain heartbeat combined with a non-zero backlog (pending stores + queue) raises a `drain_liveness_stalled` issue and treats the drain as starved, triggering `lock_holder_wedge` and a kickstart of the index label.
> - Adds `_enrichment_backlog` (reads from SQLite) and `_pending_stores_count` (counts lines in a JSONL file) as backlog sources; failures surface as distinct health issues (`enrichment_backlog_count_failed`, `pending_stores_count_failed`).
> - Stale heartbeats with no backlog or quota-blocked enrichment do not raise a stalled issue or wedge lock holders.
> - Adds `pending_stores_path` and `drain_liveness_stale_seconds` fields to `HealthCheckConfig` with sensible defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70d6558.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->