### PR TITLE
Bound index runtime with transaction-safe watchdog

### DIFF
--- a/docs/plans/2026-07-10-index-run-watchdog.md
+++ b/docs/plans/2026-07-10-index-run-watchdog.md
@@ -1,0 +1,53 @@
+# Index Run Watchdog Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Bound `brainlayer index` wall-clock runtime and exit loudly after releasing the current write transaction.
+
+**Architecture:** The CLI computes one monotonic deadline from `BRAINLAYER_INDEX_MAX_RUNTIME_S` (default 1800 seconds) and checks it at file/entry boundaries while passing it through embedding batches to `VectorStore.upsert_chunks`. The upsert loop checks outside each transaction and installs an APSW progress handler during statements; deadline interruption rolls back the active sub-batch before a typed exception carries earlier committed progress back to the CLI. The CLI emits the existing alarm telemetry/stderr signal and exits non-zero.
+
+**Tech Stack:** Python, Typer, APSW, pytest, Rich, existing BrainLayer alarm telemetry.
+
+---
+
+### Task 1: Prove transaction-boundary deadline behavior
+
+**Files:**
+- Modify: `tests/test_vector_store_upsert_transactions.py`
+- Modify: `src/brainlayer/vector_store.py`
+
+1. Add a test with `BRAINLAYER_INDEX_TXN_BATCH=2` and a controlled monotonic clock.
+2. Call `upsert_chunks(..., deadline_monotonic=...)` with four unique chunks.
+3. Assert a typed deadline exception after the first committed sub-batch, including `processed_count == 2`.
+4. Assert exactly two rows remain committed in the temporary database.
+5. Run the test and confirm it fails because deadline support does not exist.
+6. Add the optional deadline argument, processed-count tracking, and outside-transaction checks.
+7. Re-run the focused transaction tests.
+
+### Task 2: Prove CLI deadline signaling and fast-run behavior
+
+**Files:**
+- Create: `tests/test_cli_index_watchdog.py`
+- Modify: `src/brainlayer/index_new.py`
+- Modify: `src/brainlayer/cli/__init__.py`
+
+1. Add a Typer CLI test using only `tmp_path` sources and a fake indexing adapter.
+2. Set `BRAINLAYER_INDEX_MAX_RUNTIME_S`, capture the propagated deadline, simulate the typed deadline exception, and assert non-zero exit plus alarm code/context.
+3. Add a second test where indexing finishes under the deadline and assert exit zero with no alarm.
+4. Run both tests and confirm they fail because the CLI does not create or propagate a deadline.
+5. Add the 1800-second default, positive env parsing, deadline propagation, file-boundary checks, and alarm-to-`typer.Exit` handling.
+6. Re-run the CLI and transaction watchdog tests.
+
+### Task 3: Verify and publish worker PR
+
+**Files:**
+- Create: `docs.local/handoffs/2026-07-10-brainlayerLead-w2-REPORT.md`
+
+1. Run focused watchdog tests.
+2. Run `ruff check src/` and `ruff format src/`, then re-run focused tests.
+3. Run the safe pytest suite excluding `tests/test_vector_store.py` and `tests/test_engine.py`.
+4. Review the complete diff and status.
+5. Commit on `feat/index-txn-watchdog`, push, and open a ready-for-review PR.
+6. Request `codex`, `cursor`, and `bugbot` reviews; inspect CI and actionable feedback without merging (lead owns merge).
+7. Write the report with exact evidence and final `DONE_W2_INDEX_WATCHDOG` marker.
+8. Append the required one-line buddy-channel status and store the milestone in BrainLayer.

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -40,12 +40,23 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
+_DEFAULT_INDEX_MAX_RUNTIME_S = 1800.0
 agent_profile_app = typer.Typer(help="Manage per-agent search ranking profiles")
 app.add_typer(agent_profile_app, name="agent-profile")
 provenance_app = typer.Typer(help="Resolve provenance conflicts and pending confirmations")
 app.add_typer(provenance_app, name="provenance")
 sandbox_app = typer.Typer(help="Manage isolated sandbox BrainLayer databases")
 app.add_typer(sandbox_app, name="sandbox")
+
+
+def _index_max_runtime_s() -> float:
+    try:
+        value = float(os.environ.get("BRAINLAYER_INDEX_MAX_RUNTIME_S", _DEFAULT_INDEX_MAX_RUNTIME_S))
+    except (TypeError, ValueError):
+        return _DEFAULT_INDEX_MAX_RUNTIME_S
+    if not math.isfinite(value) or value <= 0:
+        return _DEFAULT_INDEX_MAX_RUNTIME_S
+    return value
 
 
 def _launchd_target(label: str) -> str:
@@ -3486,6 +3497,7 @@ def index_fast(
         from ..pipeline.chunk import chunk_content
         from ..pipeline.classify import classify_content
         from ..pipeline.extract import parse_jsonl
+        from ..vector_store import IndexDeadlineExceeded
 
         if not source.exists():
             rprint(f"[bold red]Error:[/] Source directory not found: {source}")
@@ -3510,7 +3522,12 @@ def index_fast(
         rprint(f"[bold blue]זיכרון[/] - Fast Indexing: [bold]{len(jsonl_files)}[/] files")
 
         total_chunks = 0
+        files_completed = 0
+        current_file: Path | None = None
         start_time = time.time()
+        start_monotonic = time.monotonic()
+        max_runtime_s = _index_max_runtime_s()
+        deadline_monotonic = start_monotonic + max_runtime_s
 
         with Progress(
             SpinnerColumn(),
@@ -3525,12 +3542,17 @@ def index_fast(
             task = progress.add_task("Processing files...", total=len(jsonl_files))
 
             for i, jsonl_file in enumerate(jsonl_files):
+                current_file = jsonl_file
+                if time.monotonic() >= deadline_monotonic:
+                    raise IndexDeadlineExceeded(processed_count=0)
                 raw_proj = jsonl_file.parent.name if jsonl_file.parent != source else None
                 proj_name = _normalize_project_name(raw_proj) if raw_proj else None
 
                 # Parse, classify, and chunk each entry
                 all_chunks = []
                 for entry in parse_jsonl(jsonl_file):
+                    if time.monotonic() >= deadline_monotonic:
+                        raise IndexDeadlineExceeded(processed_count=0)
                     classified = classify_content(entry)
                     if classified is not None:  # Skip noise entries
                         chunks = chunk_content(classified)
@@ -3546,8 +3568,12 @@ def index_fast(
                         source_file=str(jsonl_file),
                         project=proj_name,
                         on_progress=progress_callback,
+                        deadline_monotonic=deadline_monotonic,
                     )
                     total_chunks += indexed
+                files_completed = i + 1
+                if time.monotonic() >= deadline_monotonic:
+                    raise IndexDeadlineExceeded(processed_count=0)
 
                 # Update progress
                 elapsed = time.time() - start_time
@@ -3585,6 +3611,23 @@ def index_fast(
         except Exception as e:
             rprint(f"[dim]Supabase stats sync skipped: {e}[/]")
 
+    except IndexDeadlineExceeded as exc:
+        from ..alarm import build_alarm, emit_alarm
+
+        committed_chunks = total_chunks + exc.processed_count
+        alarm = build_alarm(
+            "INDEX_RUNTIME_EXCEEDED",
+            "brainlayer index exceeded its maximum runtime and stopped at a transaction boundary",
+            {
+                "max_runtime_s": max_runtime_s,
+                "elapsed_s": round(max(0.0, time.monotonic() - start_monotonic), 3),
+                "committed_chunks": committed_chunks,
+                "files_completed": files_completed,
+                "source_file": str(current_file) if current_file else None,
+            },
+        )
+        emit_alarm(alarm)
+        raise typer.Exit(alarm.exit_code) from exc
     except typer.Exit:
         raise
     except Exception as e:

--- a/src/brainlayer/embeddings.py
+++ b/src/brainlayer/embeddings.py
@@ -89,12 +89,12 @@ class EmbeddingModel:
                 for chunk, embedding in zip(batch_chunks, embeddings):
                     results.append(EmbeddedChunk(chunk=chunk, embedding=embedding.tolist()))
 
-                if on_progress:
-                    on_progress(len(results), total)
-
             except Exception as e:
                 logger.error(f"Failed to embed batch: {e}")
                 continue
+
+            if on_progress:
+                on_progress(len(results), total)
 
         return results
 

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -1,6 +1,7 @@
 """New indexing pipeline using sqlite-vec and sentence-transformers."""
 
 import logging
+import time
 from pathlib import Path
 from typing import Callable, List, Optional
 
@@ -8,7 +9,7 @@ from .claude_paths import extract_claude_conversation_id as _extract_claude_conv
 from .embeddings import embed_chunks
 from .pipeline.chunk import Chunk
 from .system_prompt_guard import looks_like_system_prompt
-from .vector_store import VectorStore
+from .vector_store import IndexDeadlineExceeded, VectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ def index_chunks_to_sqlite(
     project: Optional[str] = None,
     db_path: Path = DEFAULT_DB_PATH,
     on_progress: Optional[Callable[[int, int], None]] = None,
+    deadline_monotonic: float | None = None,
 ) -> int:
     """Index chunks to sqlite-vec database."""
     if not chunks:
@@ -40,7 +42,16 @@ def index_chunks_to_sqlite(
         return 0
 
     # Generate embeddings
-    embedded_chunks = embed_chunks(filtered_chunks, on_progress=on_progress)
+    def embedding_progress(completed: int, total: int) -> None:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            raise IndexDeadlineExceeded(processed_count=0)
+        if on_progress is not None:
+            on_progress(completed, total)
+
+    embedded_chunks = embed_chunks(
+        filtered_chunks,
+        on_progress=embedding_progress if deadline_monotonic is not None else on_progress,
+    )
 
     if not embedded_chunks:
         return 0
@@ -106,7 +117,7 @@ def index_chunks_to_sqlite(
 
     # Store in database
     with VectorStore(db_path) as store:
-        return store.upsert_chunks(chunk_data, embeddings)
+        return store.upsert_chunks(chunk_data, embeddings, deadline_monotonic=deadline_monotonic)
 
 
 def get_stats(db_path: Path = DEFAULT_DB_PATH) -> dict:

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -65,12 +65,21 @@ from .tag_normalization import ensure_tag_tombstone_schema
 _DEFAULT_BUSY_TIMEOUT_MS = 30_000
 _DEFAULT_READ_BUSY_TIMEOUT_MS = 5_000
 _DEFAULT_INDEX_TXN_BATCH = 250
+_INDEX_DEADLINE_PROGRESS_STEPS = 1000
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _MAX_INDEX_TXN_BATCH = 10_000
 _WRITE_BUSY_TIMEOUT_STATE = threading.local()
 _NO_EXEC_TRACE = object()
 _KNOWLEDGE_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark', 'cold')"
 _OPERATIONAL_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') = 'operational'"
+
+
+class IndexDeadlineExceeded(RuntimeError):
+    """Raised outside a write transaction when an index deadline expires."""
+
+    def __init__(self, processed_count: int) -> None:
+        super().__init__("index deadline exceeded")
+        self.processed_count = processed_count
 
 
 def _positive_int_env(name: str, default: int, *, max_value: int = _MAX_APSW_BUSY_TIMEOUT_MS) -> int:
@@ -2356,7 +2365,13 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
     # ── Chunk CRUD ──────────────────────────────────────────────────────
 
-    def upsert_chunks(self, chunks: List[Dict[str, Any]], embeddings: List[List[float]]) -> int:
+    def upsert_chunks(
+        self,
+        chunks: List[Dict[str, Any]],
+        embeddings: List[List[float]],
+        *,
+        deadline_monotonic: float | None = None,
+    ) -> int:
         """Upsert chunks with embeddings, returning the number of input chunks processed.
 
         Large calls commit in bounded sub-batches. If a later sub-batch fails after
@@ -2390,12 +2405,50 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             self._invalidate_filtered_count_caches()
 
         committed_any = False
+        processed_count = 0
         batch_size = _index_txn_batch_size()
+
+        def raise_if_deadline_exceeded() -> None:
+            if deadline_monotonic is None or time.monotonic() < deadline_monotonic:
+                return
+            if committed_any:
+                invalidate_upsert_caches()
+            raise IndexDeadlineExceeded(processed_count)
+
         for start in range(0, len(valid_pairs), batch_size):
+            raise_if_deadline_exceeded()
             sub_batch = valid_pairs[start : start + batch_size]
             for attempt in range(5):
                 cursor = self.conn.cursor()
                 transaction_started = False
+                deadline_state = {"expired": False}
+                progress_handler_id = object()
+                progress_handler_installed = False
+
+                def clear_deadline_progress_handler() -> None:
+                    nonlocal progress_handler_installed
+                    if not progress_handler_installed:
+                        return
+                    self.conn.set_progress_handler(None, id=progress_handler_id)
+                    progress_handler_installed = False
+
+                def rollback_active_transaction() -> None:
+                    clear_deadline_progress_handler()
+                    if transaction_started and self.conn.in_transaction:
+                        cursor.execute("ROLLBACK")
+
+                if deadline_monotonic is not None:
+
+                    def stop_expired_statement() -> bool:
+                        deadline_state["expired"] = time.monotonic() >= deadline_monotonic
+                        return deadline_state["expired"]
+
+                    self.conn.set_progress_handler(
+                        stop_expired_statement,
+                        _INDEX_DEADLINE_PROGRESS_STEPS,
+                        id=progress_handler_id,
+                    )
+                    progress_handler_installed = True
                 try:
                     cursor.execute("BEGIN IMMEDIATE")
                     transaction_started = True
@@ -2543,21 +2596,30 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     cursor.execute("COMMIT")
                     transaction_started = False
                     committed_any = True
+                    processed_count += len(sub_batch)
                     break
+                except apsw.InterruptError:
+                    rollback_active_transaction()
+                    if committed_any:
+                        invalidate_upsert_caches()
+                    if deadline_state["expired"]:
+                        raise IndexDeadlineExceeded(processed_count)
+                    raise
                 except apsw.BusyError:
-                    if transaction_started:
-                        cursor.execute("ROLLBACK")
+                    rollback_active_transaction()
                     if attempt == 4:
                         if committed_any:
                             invalidate_upsert_caches()
                         raise
                     time.sleep(0.1 * (2**attempt))
                 except Exception:
-                    if transaction_started:
-                        cursor.execute("ROLLBACK")
+                    rollback_active_transaction()
                     if committed_any:
                         invalidate_upsert_caches()
                     raise
+                finally:
+                    clear_deadline_progress_handler()
+            raise_if_deadline_exceeded()
 
         invalidate_upsert_caches()
 

--- a/tests/test_cli_index_watchdog.py
+++ b/tests/test_cli_index_watchdog.py
@@ -1,0 +1,199 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+import brainlayer.cli as cli
+from brainlayer.alarm import BrainLayerAlarm
+from brainlayer.cli import app
+from brainlayer.vector_store import IndexDeadlineExceeded
+
+
+def _prepare_index_source(tmp_path, monkeypatch):
+    source = tmp_path / "projects"
+    project = source / "watchdog-test"
+    project.mkdir(parents=True)
+    (project / "session.jsonl").write_text("{}\n")
+
+    monkeypatch.setattr("brainlayer.pipeline.extract.parse_jsonl", lambda _path: [{}])
+    monkeypatch.setattr("brainlayer.pipeline.classify.classify_content", lambda entry: entry)
+    monkeypatch.setattr("brainlayer.pipeline.chunk.chunk_content", lambda _entry: [object()])
+    monkeypatch.setattr(cli.time, "monotonic", lambda: 100.0)
+    return source
+
+
+def test_index_deadline_exits_nonzero_with_loud_alarm(tmp_path, monkeypatch):
+    source = _prepare_index_source(tmp_path, monkeypatch)
+    monkeypatch.setenv("BRAINLAYER_INDEX_MAX_RUNTIME_S", "7")
+    captured: dict[str, object] = {}
+    alarms: list[BrainLayerAlarm] = []
+
+    def fake_index(
+        _chunks,
+        *,
+        source_file,
+        project,
+        on_progress,
+        deadline_monotonic=None,
+    ):
+        captured["deadline"] = deadline_monotonic
+        raise IndexDeadlineExceeded(processed_count=2)
+
+    def fake_emit_alarm(alarm):
+        alarms.append(alarm)
+        print(alarm.human_message(), file=sys.stderr)
+        return True
+
+    monkeypatch.setattr("brainlayer.index_new.index_chunks_to_sqlite", fake_index)
+    monkeypatch.setattr("brainlayer.alarm.emit_alarm", fake_emit_alarm)
+
+    result = CliRunner().invoke(app, ["index", str(source)])
+
+    assert result.exit_code == 1
+    assert captured["deadline"] == 107.0
+    assert "BRAINLAYER_ALARM INDEX_RUNTIME_EXCEEDED" in result.stderr
+    assert len(alarms) == 1
+    assert alarms[0].context["max_runtime_s"] == 7.0
+    assert alarms[0].context["committed_chunks"] == 2
+
+
+def test_fast_index_under_deadline_completes_without_alarm(tmp_path, monkeypatch):
+    source = _prepare_index_source(tmp_path, monkeypatch)
+    monkeypatch.setenv("BRAINLAYER_INDEX_MAX_RUNTIME_S", "7")
+    captured: dict[str, object] = {}
+    alarms: list[BrainLayerAlarm] = []
+
+    def fake_index(
+        _chunks,
+        *,
+        source_file,
+        project,
+        on_progress,
+        deadline_monotonic=None,
+    ):
+        captured["deadline"] = deadline_monotonic
+        return 3
+
+    monkeypatch.setattr("brainlayer.index_new.index_chunks_to_sqlite", fake_index)
+    monkeypatch.setattr("brainlayer.alarm.emit_alarm", lambda alarm: alarms.append(alarm) or True)
+
+    result = CliRunner().invoke(app, ["index", str(source)])
+
+    assert result.exit_code == 0
+    assert captured["deadline"] == 107.0
+    assert alarms == []
+    assert "Indexed 3 chunks" in result.stdout
+
+
+def test_index_deadline_trips_after_file_that_produces_no_writes(tmp_path, monkeypatch):
+    source = _prepare_index_source(tmp_path, monkeypatch)
+    monkeypatch.setenv("BRAINLAYER_INDEX_MAX_RUNTIME_S", "7")
+    monotonic_values = iter([100.0, 100.0, 108.0])
+    monkeypatch.setattr(cli.time, "monotonic", lambda: next(monotonic_values, 108.0))
+    alarms: list[BrainLayerAlarm] = []
+
+    monkeypatch.setattr("brainlayer.index_new.index_chunks_to_sqlite", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr("brainlayer.alarm.emit_alarm", lambda alarm: alarms.append(alarm) or True)
+
+    result = CliRunner().invoke(app, ["index", str(source)])
+
+    assert result.exit_code == 1
+    assert len(alarms) == 1
+    assert alarms[0].code == "INDEX_RUNTIME_EXCEEDED"
+    assert alarms[0].context["committed_chunks"] == 0
+
+
+def test_index_deadline_stops_before_parsing_next_entry(tmp_path, monkeypatch):
+    source = _prepare_index_source(tmp_path, monkeypatch)
+    monkeypatch.setenv("BRAINLAYER_INDEX_MAX_RUNTIME_S", "7")
+    monotonic_values = iter([100.0, 100.0, 108.0])
+    monkeypatch.setattr(cli.time, "monotonic", lambda: next(monotonic_values, 108.0))
+    index_called = False
+
+    def fake_index(*_args, **_kwargs):
+        nonlocal index_called
+        index_called = True
+        return 0
+
+    monkeypatch.setattr("brainlayer.index_new.index_chunks_to_sqlite", fake_index)
+    monkeypatch.setattr("brainlayer.alarm.emit_alarm", lambda _alarm: True)
+
+    result = CliRunner().invoke(app, ["index", str(source)])
+
+    assert result.exit_code == 1
+    assert index_called is False
+
+
+def test_index_adapter_stops_after_embedding_batch_deadline(tmp_path, monkeypatch):
+    import brainlayer.index_new as index_new
+
+    source_file = tmp_path / "session.jsonl"
+    source_file.write_text('{"timestamp":"2026-07-10T00:00:00Z"}\n')
+    chunk = SimpleNamespace(
+        metadata={},
+        content="Embedding deadline test content",
+        content_type=SimpleNamespace(value="note"),
+        value=SimpleNamespace(value="medium"),
+        char_count=31,
+    )
+
+    def fake_embed(chunks, on_progress=None):
+        assert on_progress is not None
+        on_progress(len(chunks), len(chunks))
+        return [SimpleNamespace(chunk=chunk, embedding=[0.1])]
+
+    monkeypatch.setattr(index_new, "embed_chunks", fake_embed)
+    monkeypatch.setattr(cli.time, "monotonic", lambda: 43.0)
+
+    with pytest.raises(IndexDeadlineExceeded):
+        index_new.index_chunks_to_sqlite(
+            [chunk],
+            source_file=str(source_file),
+            db_path=tmp_path / "brainlayer.db",
+            deadline_monotonic=42.0,
+        )
+
+
+def test_index_adapter_forwards_deadline_to_vector_store(tmp_path, monkeypatch):
+    import brainlayer.index_new as index_new
+
+    source_file = tmp_path / "session.jsonl"
+    source_file.write_text('{"timestamp":"2026-07-10T00:00:00Z"}\n')
+    chunk = SimpleNamespace(
+        metadata={},
+        content="Deadline forwarding test content",
+        content_type=SimpleNamespace(value="note"),
+        value=SimpleNamespace(value="medium"),
+        char_count=32,
+    )
+    captured: dict[str, object] = {}
+
+    class FakeVectorStore:
+        def __init__(self, db_path):
+            captured["db_path"] = db_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def upsert_chunks(self, chunks, embeddings, *, deadline_monotonic=None):
+            captured["deadline"] = deadline_monotonic
+            return len(chunks)
+
+    monkeypatch.setattr(
+        index_new, "embed_chunks", lambda chunks, on_progress=None: [SimpleNamespace(chunk=chunk, embedding=[0.1])]
+    )
+    monkeypatch.setattr(index_new, "VectorStore", FakeVectorStore)
+
+    result = index_new.index_chunks_to_sqlite(
+        [chunk],
+        source_file=str(source_file),
+        db_path=tmp_path / "brainlayer.db",
+        deadline_monotonic=42.0,
+    )
+
+    assert result == 1
+    assert captured["deadline"] == 42.0

--- a/tests/test_embedding_truncation.py
+++ b/tests/test_embedding_truncation.py
@@ -15,6 +15,7 @@ import time
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 from brainlayer.embeddings import (
     MAX_QUERY_CHARS,
@@ -39,6 +40,21 @@ def _make_chunk(content: str, chunk_id: str = "test-chunk") -> Chunk:
 def _fake_encode(texts, **kwargs):
     """Return deterministic 1024-dim vectors for each text."""
     return np.array([[float(i) / 1000.0] * 1024 for i in range(len(texts))])
+
+
+def test_embedding_progress_callback_exceptions_propagate():
+    chunk = _make_chunk("Progress callback cancellation")
+    model = EmbeddingModel.__new__(EmbeddingModel)
+    model.model_name = "test"
+    mock_st = MagicMock()
+    mock_st.encode.side_effect = _fake_encode
+    model._model = mock_st
+
+    def stop_after_batch(_completed, _total):
+        raise RuntimeError("stop after embedding batch")
+
+    with pytest.raises(RuntimeError, match="stop after embedding batch"):
+        model.embed_chunks([chunk], on_progress=stop_after_batch)
 
 
 # ── Tests ────────────────────────────────────────────────────────

--- a/tests/test_vector_store_upsert_transactions.py
+++ b/tests/test_vector_store_upsert_transactions.py
@@ -65,6 +65,83 @@ def test_upsert_chunks_commits_large_batches_in_bounded_transactions(isolated_st
     assert isolated_store.conn.cursor().execute("SELECT COUNT(*) FROM chunks").fetchone() == (5,)
 
 
+def test_upsert_chunks_deadline_stops_after_committed_sub_batch(isolated_store, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", "2")
+    monkeypatch.setattr(vector_store, "_INDEX_DEADLINE_PROGRESS_STEPS", 1_000_000_000)
+    monotonic_values = iter([100.0, 101.0])
+    monkeypatch.setattr(vector_store.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(RuntimeError, match="index deadline exceeded") as exc_info:
+        isolated_store.upsert_chunks(
+            [_chunk(f"chunk-{index}") for index in range(4)],
+            [_embedding(index) for index in range(4)],
+            deadline_monotonic=100.5,
+        )
+
+    assert exc_info.value.processed_count == 2
+    assert isolated_store.conn.cursor().execute("SELECT id FROM chunks ORDER BY id").fetchall() == [
+        ("chunk-0",),
+        ("chunk-1",),
+    ]
+
+
+def test_upsert_chunks_deadline_interrupts_and_rolls_back_active_sub_batch(isolated_store, monkeypatch):
+    monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", "2")
+    monkeypatch.setattr(vector_store, "_INDEX_DEADLINE_PROGRESS_STEPS", 1, raising=False)
+    inside_insert = False
+    statements: list[str] = []
+
+    def trace(_cursor, statement, bindings):
+        nonlocal inside_insert
+        normalized = " ".join(str(statement).upper().split())
+        statements.append(normalized)
+        if _is_insert_chunk_statement(normalized) and bindings and bindings[0] == "chunk-2":
+            inside_insert = True
+        return True
+
+    isolated_store.conn.setexectrace(trace)
+    monkeypatch.setattr(vector_store.time, "monotonic", lambda: 101.0 if inside_insert else 100.0)
+
+    with pytest.raises(RuntimeError, match="index deadline exceeded") as exc_info:
+        isolated_store.upsert_chunks(
+            [_chunk(f"chunk-{index}") for index in range(4)],
+            [_embedding(index) for index in range(4)],
+            deadline_monotonic=100.5,
+        )
+
+    assert exc_info.value.processed_count == 2
+    assert isolated_store.conn.in_transaction is False
+    assert isolated_store.conn.cursor().execute("SELECT id FROM chunks ORDER BY id").fetchall() == [
+        ("chunk-0",),
+        ("chunk-1",),
+    ]
+
+
+def test_upsert_chunks_clears_deadline_handler_before_error_rollback(isolated_store, monkeypatch):
+    monkeypatch.setattr(vector_store, "_INDEX_DEADLINE_PROGRESS_STEPS", 1)
+    deadline_expired = False
+
+    def trace(_cursor, statement, bindings):
+        nonlocal deadline_expired
+        if _is_insert_chunk_statement(str(statement)) and bindings and bindings[0] == "chunk-0":
+            deadline_expired = True
+            raise RuntimeError("simulated non-interrupt write failure")
+        return True
+
+    isolated_store.conn.setexectrace(trace)
+    monkeypatch.setattr(vector_store.time, "monotonic", lambda: 101.0 if deadline_expired else 100.0)
+
+    with pytest.raises(RuntimeError, match="simulated non-interrupt write failure"):
+        isolated_store.upsert_chunks(
+            [_chunk("chunk-0")],
+            [_embedding(0)],
+            deadline_monotonic=100.5,
+        )
+
+    assert isolated_store.conn.in_transaction is False
+    assert isolated_store.conn.cursor().execute("SELECT COUNT(*) FROM chunks").fetchone() == (0,)
+
+
 def test_index_txn_batch_env_uses_dedicated_cap(monkeypatch):
     monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", str(vector_store._MAX_INDEX_TXN_BATCH + 1))
 


### PR DESCRIPTION
## Summary
- add BRAINLAYER_INDEX_MAX_RUNTIME_S with a 30-minute default to the brainlayer index command
- stop cooperatively at parsing and embedding boundaries, and interrupt stalled SQLite statements via APSW before rolling back the active sub-batch
- emit INDEX_RUNTIME_EXCEEDED through the existing loud alarm/telemetry path with committed progress, then exit non-zero

## Verification
- ruff check src/
- ruff format src/ (158 files unchanged)
- 44 affected-path tests passed
- pre-push gate passed with ulimit -n 4096: 3,428 selected unit tests, isolated routing tests, Bun test, and FTS5 regression shell test
- broad local shards: A-M 2,264 passed; N-Z 1,153 passed with one load-sensitive store-handler timing failure that passed alone; numeric shards 57 passed

## Review notes
- no health_check.py changes; no overlap with the drain lock-holder worker
- prior committed sub-batches remain committed; an interrupted active sub-batch is rolled back before the watchdog exception escapes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core index write path and SQLite transaction handling; partial commits on timeout are intentional but operators must understand resume behavior.
> 
> **Overview**
> Adds a **wall-clock cap** for `brainlayer index` via `BRAINLAYER_INDEX_MAX_RUNTIME_S` (default **1800s**). The CLI builds one monotonic deadline and checks it at file/entry boundaries, passes it through embedding and into `VectorStore.upsert_chunks`.
> 
> **`IndexDeadlineExceeded`** stops indexing cooperatively: prior sub-batch commits stay in SQLite; an in-flight transaction is rolled back (including APSW progress-handler interrupts during long statements). The CLI then emits **`INDEX_RUNTIME_EXCEEDED`** through the existing alarm path with committed progress and exits non-zero.
> 
> Also moves embedding **`on_progress`** to run **after** each batch completes so deadline/cancel callbacks can fire without being skipped on failed batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e563f05f64707a7032074198f726e3f0aa05b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound index runtime with a transaction-safe watchdog that emits an alarm on timeout
> - Adds a wall-clock deadline to the `index-fast` CLI command, defaulting to 1800s and configurable via `BRAINLAYER_INDEX_MAX_RUNTIME_S`. On timeout, an `INDEX_RUNTIME_EXCEEDED` alarm is emitted and the process exits non-zero.
> - Deadline is propagated from the CLI through [`index_chunks_to_sqlite`](https://github.com/EtanHey/brainlayer/pull/581/files#diff-3eb235a245c1358fe9f27dc834fcc7c992b79adc05b2488782ab2204f236218e) into [`VectorStore.upsert_chunks`](https://github.com/EtanHey/brainlayer/pull/581/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261), where an APSW progress handler checks it during statement execution.
> - Interruptions roll back the in-flight sub-batch while retaining earlier committed sub-batches; `IndexDeadlineExceeded(processed_count)` is raised to report durable progress to callers.
> - Fixes a bug in [`EmbeddingModel.embed_chunks`](https://github.com/EtanHey/brainlayer/pull/581/files#diff-a66c3335f636eacc8b2192acffc9d01b3443a146803c6dfc1ab4e441bcddfdc9) where exceptions raised by the `on_progress` callback were silently swallowed.
> - Risk: `upsert_chunks` callers that do not handle `IndexDeadlineExceeded` will now see an unhandled exception on timeout; existing callers without a deadline are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9e563f0. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->