### PR TITLE
feat: add writer transaction observability

### DIFF
--- a/docs/plans/2026-07-10-writerd-phase0-observability.md
+++ b/docs/plans/2026-07-10-writerd-phase0-observability.md
@@ -1,0 +1,218 @@
+# Writerd Phase 0 Observability Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add fail-open local telemetry that identifies every current writer transaction, its active SQL fingerprint, queue delay, WAL/FTS context, and outcome without changing write semantics.
+
+**Architecture:** A new `writer_telemetry` module owns JSONL rotation, SQL fingerprinting, APSW `trace_v2` statement aggregation, and a pid/DB-specific active-transaction marker. Existing writer paths create spans immediately before their current `BEGIN IMMEDIATE`, `SAVEPOINT`, or implicit init/autocommit operation and finish them only after the existing commit/rollback path. The CLI reads telemetry files only; no Phase 1 coordination or write-path behavior is introduced.
+
+**Tech Stack:** Python 3.11+, APSW `trace_v2`, Typer, pytest, Ruff.
+
+---
+
+### Task 1: Core telemetry sink, fingerprint, span, and heartbeat
+
+**Files:**
+- Create: `src/brainlayer/writer_telemetry.py`
+- Create: `tests/test_writer_telemetry.py`
+- Modify: `tests/conftest.py`
+
+**Step 1: Write failing sink/fingerprint tests**
+
+Cover stable whitespace-normalized fingerprints, literal/binding safety, JSONL append, capped rotation, and fail-open behavior when directory creation or append fails.
+
+**Step 2: Run the tests and verify RED**
+
+Run: `pytest -q tests/test_writer_telemetry.py`
+
+Expected: collection/import failure because `brainlayer.writer_telemetry` does not exist.
+
+**Step 3: Implement the minimal sink and configuration**
+
+Add environment-backed defaults for enabled state, `~/.local/share/brainlayer/logs/writer-telemetry.jsonl`, rotation bytes/backups, heartbeat path, and FTS sample TTL. All public instrumentation entrypoints catch telemetry errors and return no-op state; telemetry exceptions never propagate into a writer.
+
+Because telemetry is enabled by default in production, add an autouse test fixture that redirects the log and heartbeat directory to `tmp_path`; no test may write to the user's live telemetry paths.
+
+**Step 4: Write failing span/heartbeat tests**
+
+Using only `tmp_path` SQLite databases, assert:
+
+- the active marker exists before `BEGIN IMMEDIATE` executes;
+- `trace_v2` records the current normalized SQL fingerprint and aggregates profile duration/status;
+- commit and rollback clear the marker and emit an outcome;
+- WAL bytes/frames, total row changes, executor PID, monotonic/wall starts, producer/lane/operation, and sampled FTS segment counts are present;
+- disabled instrumentation installs no trace and writes no files.
+
+**Step 5: Run the tests and verify RED**
+
+Run: `pytest -q tests/test_writer_telemetry.py`
+
+Expected: behavioral assertion failures for missing span/heartbeat APIs.
+
+**Step 6: Implement the minimal span**
+
+Use APSW `trace_v2(SQLITE_TRACE_STMT | SQLITE_TRACE_PROFILE, ..., id=...)` so existing exec traces remain untouched. Keep per-fingerprint aggregates in memory and emit one bounded transaction-end record. Write the active JSON atomically before yielding to the caller; update it for an open transaction through one process-level polling thread; clear it only after the caller records commit/rollback/completed/error.
+
+**Step 7: Run tests and verify GREEN**
+
+Run: `pytest -q tests/test_writer_telemetry.py`
+
+Expected: all tests pass.
+
+### Task 2: Read-only writer-telemetry CLI
+
+**Files:**
+- Modify: `src/brainlayer/cli/__init__.py`
+- Create: `tests/test_cli_writer_telemetry.py`
+
+**Step 1: Write failing CLI tests**
+
+Use `typer.testing.CliRunner` and tmp JSONL fixtures to require:
+
+- `brainlayer writer-telemetry tail --lines N --path ...` prints the newest N raw events;
+- `brainlayer writer-telemetry summary --lines N --path ...` reports counts by producer/lane/outcome plus max/p95 duration;
+- missing files return an empty, successful read-only result.
+
+**Step 2: Verify RED**
+
+Run: `pytest -q tests/test_cli_writer_telemetry.py`
+
+Expected: command-not-found failures.
+
+**Step 3: Implement and verify GREEN**
+
+Add one Typer command with a `tail|summary` action and delegate parsing/summarization to pure functions in `writer_telemetry.py`.
+
+Run: `pytest -q tests/test_cli_writer_telemetry.py tests/test_writer_telemetry.py`
+
+Expected: all tests pass.
+
+### Task 3: VectorStore init/upsert and MCP direct-store spans
+
+**Files:**
+- Modify: `src/brainlayer/vector_store.py`
+- Modify: `src/brainlayer/store.py`
+- Modify: `tests/test_vector_store_upsert_transactions.py`
+- Create: `tests/test_writer_telemetry_store_paths.py`
+
+**Step 1: Write failing path tests**
+
+Assert init emits a `vector_store/init` operation span whose current statement changes during schema/FTS work; each PR #570 sub-batch emits its own `index/upsert_chunks` transaction with planned/applied row counts; direct `store_memory` and re-embed transactions emit `mcp/store_memory` spans; retries produce rollback then commit without changing existing DB results.
+
+**Step 2: Verify RED**
+
+Run: `pytest -q tests/test_writer_telemetry_store_paths.py tests/test_vector_store_upsert_transactions.py`
+
+Expected: no writer telemetry events from these paths.
+
+**Step 3: Instrument without owning transactions**
+
+Start spans immediately before the existing transaction or implicit init work, leave all BEGIN/COMMIT/ROLLBACK/retry statements in their current order, and finish spans only after those existing statements. Mark init as `span_kind=writer_operation` and `transaction_mode=implicit_per_statement` so telemetry never falsely claims its entire duration held the SQLite writer lock.
+
+**Step 4: Verify GREEN**
+
+Run: `pytest -q tests/test_writer_telemetry_store_paths.py tests/test_vector_store_upsert_transactions.py`
+
+Expected: all tests pass with the existing transaction-count assertions unchanged.
+
+### Task 4: Drain queue wait and hotlane spans
+
+**Files:**
+- Modify: `src/brainlayer/drain.py`
+- Modify: `scripts/hotlane_brainbar_daemon.py`
+- Modify: `tests/test_drain_health.py`
+- Modify: `tests/test_hotlane_brainbar_daemon.py`
+- Create: `tests/test_writer_telemetry_drain.py`
+
+**Step 1: Write failing drain/hotlane tests**
+
+Require one span per burn/live drain attempt and hotlane vector transaction. Drain events must include producer `drain`, a lane/source derived from queued event metadata, and queue wait measured from the spool file mtime at apply time. Busy retries must close the failed attempt before opening the next.
+
+**Step 2: Verify RED**
+
+Run: `pytest -q tests/test_writer_telemetry_drain.py tests/test_hotlane_brainbar_daemon.py`
+
+Expected: missing transaction events/queue fields.
+
+**Step 3: Instrument existing seams and verify GREEN**
+
+Wrap, but do not move, the existing BEGIN/COMMIT/ROLLBACK blocks. Compute queue metadata before BEGIN and pass it to the span; do not query SQLite solely for queue timing.
+
+Run: `pytest -q tests/test_writer_telemetry_drain.py tests/test_drain_health.py tests/test_hotlane_brainbar_daemon.py`
+
+Expected: all tests pass.
+
+### Task 5: Watcher rewind and direct enrichment-apply spans
+
+**Files:**
+- Modify: `src/brainlayer/cli/__init__.py`
+- Modify: `src/brainlayer/enrichment_controller.py`
+- Modify: `tests/test_cli_direct_sqlite.py`
+- Modify: `tests/test_enrichment_controller.py`
+- Create: `tests/test_writer_telemetry_misc_paths.py`
+
+**Step 1: Write failing tests**
+
+Require rewind flush to emit `watcher/rewind_archive` with session/row counts and direct `_apply_enrichment` to emit `enrichment/apply` around the existing SAVEPOINT transaction. Error tests must preserve the original exception and record a rollback/error outcome.
+
+**Step 2: Verify RED**
+
+Run: `pytest -q tests/test_writer_telemetry_misc_paths.py tests/test_cli_direct_sqlite.py tests/test_enrichment_controller.py`
+
+Expected: telemetry assertions fail while existing behavior tests remain green.
+
+**Step 3: Instrument and verify GREEN**
+
+Start/finish observation around existing code only. Do not enable direct enrichment, change queue defaults, alter commit boundaries, or add retries.
+
+Run: `pytest -q tests/test_writer_telemetry_misc_paths.py tests/test_cli_direct_sqlite.py tests/test_enrichment_controller.py`
+
+Expected: all tests pass.
+
+### Task 6: Deliberately slow FTS gate, full verification, and PR loop
+
+**Files:**
+- Create: `tests/test_writer_telemetry_gate.py`
+- Modify: `docs/plans/2026-07-10-writerd-phase0-observability.md` only if implementation receipts require clarification
+
+**Step 1: Write the failing gate test**
+
+Create a tmp SQLite database with a synthetic FTS5 corpus. Run an intentionally slowed FTS write statement on a worker thread/connection. While it is open, assert the independent marker contains the transaction start and that statement's fingerprint; after completion, assert JSONL contains its start, duration, profile counters, and committed outcome.
+
+**Step 2: Verify RED, implement only missing telemetry behavior, then verify GREEN**
+
+Run: `pytest -q tests/test_writer_telemetry_gate.py`
+
+Expected RED: the gate exposes any missing live marker/fingerprint/duration field. Expected GREEN: the gate passes without touching production or `tests/test_vector_store.py` / `tests/test_engine.py`.
+
+**Step 3: Run required verification**
+
+Run:
+
+```bash
+pytest -q \
+  tests/test_writer_telemetry.py \
+  tests/test_cli_writer_telemetry.py \
+  tests/test_writer_telemetry_store_paths.py \
+  tests/test_writer_telemetry_drain.py \
+  tests/test_writer_telemetry_misc_paths.py \
+  tests/test_writer_telemetry_gate.py \
+  tests/test_vector_store_upsert_transactions.py \
+  tests/test_drain_health.py \
+  tests/test_hotlane_brainbar_daemon.py \
+  tests/test_enrichment_controller.py \
+  tests/test_cli_direct_sqlite.py
+ruff check src/ tests/
+ruff format src/ tests/
+git diff --check
+```
+
+Do not run `tests/test_vector_store.py` or `tests/test_engine.py`.
+
+**Step 4: Complete the authorized PR loop**
+
+Run bounded local CodeRabbit, commit intentional files, push with `BRAINLAYER_PREPUSH_SCOPE=changed-only`, open a ready PR, post the PR immediately to the buddy channel, invoke CodeRabbit/Codex/Cursor/Bugbot plus the required Claude review, address findings through clean re-review, merge only after the reviewer matrix and CI are clean, and verify the remote merge contains the latest pushed tree.
+
+**Step 5: Write the handoff report**
+
+Create `docs.local/handoffs/2026-07-10-brainlayerLead-w3-phase0-REPORT.md` containing branch, PR URL, changed files, slow-FTS gate receipt, verification counts, review/merge receipt, and exact final line `DONE_W3_PHASE0_OBSERVABILITY`.

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -31,6 +31,7 @@ from brainlayer.enrichment_controller import (
 from brainlayer.paths import get_db_path
 from brainlayer.store import embed_hot_chunk, embed_pending_chunks
 from brainlayer.vector_store import VectorStore
+from brainlayer.writer_telemetry import start_writer_span
 
 LOGGER = logging.getLogger("brainlayer.hotlane_brainbar")
 STOP = False
@@ -255,6 +256,14 @@ def _write_embedded_vectors(store_or_path: VectorStore | Path | str, vectors: li
 
     transaction_started = False
     count = 0
+    telemetry_span = start_writer_span(
+        cursor.connection if hasattr(cursor, "connection") else (conn or store.conn),
+        db_path=db_path,
+        producer="hotlane",
+        lane="hotlane",
+        operation="write_vectors",
+        rows_planned=len(vectors),
+    )
     try:
         cursor.execute("BEGIN IMMEDIATE")
         transaction_started = True
@@ -283,9 +292,11 @@ def _write_embedded_vectors(store_or_path: VectorStore | Path | str, vectors: li
             count += 1
         cursor.execute("COMMIT")
         transaction_started = False
-    except Exception:
+        telemetry_span.finish("commit", rows_touched=count)
+    except Exception as exc:
         if transaction_started:
             cursor.execute("ROLLBACK")
+        telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
         raise
     finally:
         if conn is not None:

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -33,6 +33,7 @@ from rich.table import Table
 
 from ..config import DEFAULT_REALTIME_ENRICH_SINCE_HOURS
 from ..paths import get_db_path
+from ..writer_telemetry import start_writer_span
 
 app = typer.Typer(
     name="brainlayer",
@@ -57,6 +58,25 @@ def _index_max_runtime_s() -> float:
     if not math.isfinite(value) or value <= 0:
         return _DEFAULT_INDEX_MAX_RUNTIME_S
     return value
+
+
+@app.command("writer-telemetry")
+def writer_telemetry_command(
+    action: Annotated[str, typer.Argument(help="Read mode: tail or summary.")] = "summary",
+    lines: int = typer.Option(100, "--lines", min=1, help="Maximum newest JSONL lines to read."),
+    path: Path | None = typer.Option(None, "--path", help="Telemetry JSONL path; defaults to the configured sink."),
+) -> None:
+    """Read local writer telemetry without opening the BrainLayer database."""
+    from ..writer_telemetry import summarize_events, tail_event_lines
+
+    if action == "tail":
+        for line in tail_event_lines(path, lines=lines):
+            typer.echo(line)
+        return
+    if action == "summary":
+        typer.echo(json.dumps(summarize_events(path, lines=lines), sort_keys=True))
+        return
+    raise typer.BadParameter("action must be 'tail' or 'summary'", param_hint="action")
 
 
 def _launchd_target(label: str) -> str:
@@ -3256,18 +3276,34 @@ class _RewindArchiveBatcher:
         placeholders = ",".join("?" for _ in self._pending_session_ids)
         now = datetime.now(UTC).isoformat()
         params = [now, *sorted(self._pending_session_ids)]
-        cursor.execute(
-            f"""
-            UPDATE chunks
-               SET archived_at = ?, value_type = 'ARCHIVED'
-             WHERE source = 'realtime_watcher'
-               AND archived_at IS NULL
-               AND conversation_id IN ({placeholders})
-            """,
-            params,
+        telemetry_span = start_writer_span(
+            vector_store.conn,
+            db_path=self.db_path,
+            producer="watcher",
+            lane="realtime",
+            operation="rewind_archive",
+            metadata={
+                "flush_reason": reason,
+                "sessions_planned": len(self._pending_session_ids),
+            },
         )
-        affected = vector_store.conn.changes()
-        vector_store.conn.commit()
+        try:
+            cursor.execute(
+                f"""
+                UPDATE chunks
+                   SET archived_at = ?, value_type = 'ARCHIVED'
+                 WHERE source = 'realtime_watcher'
+                   AND archived_at IS NULL
+                   AND conversation_id IN ({placeholders})
+                """,
+                params,
+            )
+            affected = vector_store.conn.changes()
+            vector_store.conn.commit()
+        except Exception as exc:
+            telemetry_span.finish("error", error=f"{type(exc).__name__}: {exc}")
+            raise
+        telemetry_span.finish("commit", rows_touched=affected)
         self.archived_total += affected
         if affected > 0:
             rprint(

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -32,6 +32,7 @@ from .dedupe import (
 from .ingest_guard import recursive_mcp_output_reason
 from .paths import get_db_path
 from .provenance_integration import enqueue_provenance_resolution_for_entities
+from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
 
@@ -1065,6 +1066,30 @@ def _is_enrichment_queue_file(path: Path) -> bool:
     return path.name.startswith("enrichment-")
 
 
+def _queue_telemetry(paths: list[Path], events: list[dict[str, Any]]) -> dict[str, Any]:
+    sources = sorted({str(event.get("source") or "").strip() for event in events} - {""})
+    kinds = {str(event.get("kind") or "").strip() for event in events}
+    if "store_memory" in kinds:
+        lane = "interactive"
+    elif kinds & {"watcher_chunk", "hook_chunk"}:
+        lane = "realtime"
+    elif kinds == {"enrichment_update"}:
+        lane = "enrichment"
+    else:
+        lane = "background"
+    mtimes: list[float] = []
+    for path in paths:
+        try:
+            mtimes.append(path.stat().st_mtime)
+        except OSError:
+            continue
+    return {
+        "lane": lane,
+        "queue_source": ",".join(sources) if sources else "unknown",
+        "queue_wait_ms": max(0.0, (time.time() - min(mtimes)) * 1000.0) if mtimes else None,
+    }
+
+
 def _has_high_priority_queue_files(queue_dir: Path) -> bool:
     try:
         return any(not _is_enrichment_queue_file(path) for path in queue_dir.glob("*.jsonl"))
@@ -1244,6 +1269,7 @@ def burn_drain_once(
             return result
 
         all_events = [event for _, events in batch for event in events]
+        queue_telemetry = _queue_telemetry([path for path, _events in batch], all_events)
         batch_includes_store = _events_include_store(all_events)
         if batch_includes_store and not _ensure_drain_db_schema_preserving_queue(
             db_path,
@@ -1254,6 +1280,16 @@ def burn_drain_once(
             return result
         for schema_attempt in range(2):
             conn = _open_connection(db_path)
+            telemetry_span = start_writer_span(
+                conn,
+                db_path=db_path,
+                producer="drain",
+                lane=queue_telemetry["lane"],
+                operation="burn_apply",
+                rows_planned=len(all_events),
+                queue_wait_ms=queue_telemetry["queue_wait_ms"],
+                queue_source=queue_telemetry["queue_source"],
+            )
             try:
                 _ensure_enrichment_update_schema(conn)
                 _ensure_watcher_liveness_schema(conn)
@@ -1286,6 +1322,7 @@ def burn_drain_once(
                 if _embedding_enabled():
                     _embed_store_chunks(conn, store_chunk_ids, embed_fn)
                 conn.execute("COMMIT")
+                telemetry_span.finish("commit", rows_touched=attempt_applied_events)
                 result.applied_events += attempt_applied_events
                 result.skipped_verified_stale += attempt_skipped_verified_stale
                 conn.setbusytimeout(_checkpoint_busy_timeout_ms())
@@ -1302,6 +1339,7 @@ def burn_drain_once(
                     conn.execute("ROLLBACK")
                 except Exception:
                     pass
+                telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
                 if batch_includes_store and _is_missing_chunks_error(exc) and schema_attempt == 0:
                     conn.close()
                     conn = None
@@ -1379,6 +1417,7 @@ def drain_once(
                 continue
             events_to_apply = events[: _max_events_per_transaction()]
             remaining_events = events[len(events_to_apply) :]
+            queue_telemetry = _queue_telemetry([path], events_to_apply)
             events_include_store = _events_include_store(events_to_apply)
             if events_include_store and not _ensure_drain_db_schema_preserving_queue(
                 db_path,
@@ -1391,12 +1430,23 @@ def drain_once(
             precomputed_embeddings = _precompute_event_embeddings(events_to_apply, embed_fn)
             for attempt in range(5):
                 conn: apsw.Connection | None = None
+                telemetry_span = None
                 attempt_drained = 0
                 collision_ids: list[str] = []
                 store_chunk_ids: list[str] = []
                 fallback_markers: list[FallbackReplayMarker] = []
                 try:
                     conn = _open_connection(db_path)
+                    telemetry_span = start_writer_span(
+                        conn,
+                        db_path=db_path,
+                        producer="drain",
+                        lane=queue_telemetry["lane"],
+                        operation="apply_file",
+                        rows_planned=len(events_to_apply),
+                        queue_wait_ms=queue_telemetry["queue_wait_ms"],
+                        queue_source=queue_telemetry["queue_source"],
+                    )
                     _ensure_enrichment_update_schema(conn)
                     _ensure_watcher_liveness_schema(conn)
                     conn.execute("BEGIN IMMEDIATE")
@@ -1414,6 +1464,7 @@ def drain_once(
                             collision_ids.append(result.collision_chunk_id)
                         attempt_drained += 1
                     conn.execute("COMMIT")
+                    telemetry_span.finish("commit", rows_touched=attempt_drained)
                     # Best-effort WAL checkpoint. Keep the live writer path PASSIVE:
                     # TRUNCATE can block behind long-lived readers on the live multi-GB
                     # WAL, which stalls queue drain before it can publish health.
@@ -1449,6 +1500,8 @@ def drain_once(
                             conn.execute("ROLLBACK")
                         except Exception:
                             pass
+                    if telemetry_span is not None:
+                        telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
                     if _is_busy_error(exc) and attempt < 4:
                         delay = 0.05 * (2**attempt)
                         _log(log_path, f"drain busy; retrying in {delay:.2f}s")

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -33,6 +33,7 @@ from .pipeline.write_queue import WriteQueue
 from .provenance import derive_provenance_class
 from .provenance_autosupersede import auto_supersede
 from .provenance_integration import enqueue_provenance_resolution_for_entities
+from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
 
@@ -1478,7 +1479,7 @@ def _generate_content_with_rate_limit(
     return response
 
 
-def _apply_enrichment(
+def _apply_enrichment_impl(
     store,
     chunk: dict[str, Any],
     enrichment: dict[str, Any],
@@ -1557,6 +1558,43 @@ def _apply_enrichment(
             promote_chunk_raw_entities(store, chunk["id"])
         except Exception:
             logger.debug("raw entity KG promotion skipped for %s", chunk["id"], exc_info=True)
+
+
+def _apply_enrichment(
+    store,
+    chunk: dict[str, Any],
+    enrichment: dict[str, Any],
+    *,
+    chunk_origin: str | None = None,
+    enrichment_model: str | None = None,
+    enrichment_backend: str | None = None,
+) -> None:
+    try:
+        owns_transaction = bool(store.conn.getautocommit())
+    except Exception:
+        owns_transaction = True
+    telemetry_span = start_writer_span(
+        store.conn,
+        db_path=getattr(store, "db_path", None),
+        producer="enrichment",
+        lane="enrichment",
+        operation="apply",
+        rows_planned=1,
+        transaction_mode="savepoint",
+    )
+    try:
+        _apply_enrichment_impl(
+            store,
+            chunk,
+            enrichment,
+            chunk_origin=chunk_origin,
+            enrichment_model=enrichment_model,
+            enrichment_backend=enrichment_backend,
+        )
+    except Exception as exc:
+        telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
+        raise
+    telemetry_span.finish("commit" if owns_transaction else "completed")
 
 
 def _enrich_single_chunk(

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -47,6 +47,7 @@ from .ingest_guard import reject_recursive_mcp_output
 from .memory_types import VALID_MEMORY_TYPES
 from .system_prompt_guard import looks_like_system_prompt
 from .vector_store import VectorStore
+from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
 
@@ -219,6 +220,14 @@ def store_memory(
     for attempt in range(5):
         cursor = store.conn.cursor()
         transaction_started = False
+        telemetry_span = start_writer_span(
+            store.conn,
+            db_path=store.db_path,
+            producer="mcp",
+            lane="interactive",
+            operation="store_memory",
+            rows_planned=1,
+        )
         try:
             _set_busy_timeout_for_deadline(store.conn, busy_deadline)
             cursor.execute("BEGIN IMMEDIATE")
@@ -364,16 +373,19 @@ def store_memory(
                 )
             cursor.execute("COMMIT")
             transaction_started = False
+            telemetry_span.finish("commit")
             break
-        except apsw.BusyError:
+        except apsw.BusyError as exc:
             if transaction_started:
                 cursor.execute("ROLLBACK")
+            telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
             if not retry_on_busy or attempt == 4:
                 raise
             _sleep_before_busy_retry(0.1 * (2**attempt), busy_deadline)
-        except Exception:
+        except Exception as exc:
             if transaction_started:
                 cursor.execute("ROLLBACK")
+            telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
             raise
 
     if pending_reembed is not None and embed_fn is not None:
@@ -382,6 +394,14 @@ def store_memory(
         for attempt in range(5):
             cursor = store.conn.cursor()
             transaction_started = False
+            telemetry_span = start_writer_span(
+                store.conn,
+                db_path=store.db_path,
+                producer="mcp",
+                lane="interactive",
+                operation="store_memory_reembed",
+                rows_planned=1,
+            )
             try:
                 _set_busy_timeout_for_deadline(store.conn, busy_deadline)
                 cursor.execute("BEGIN IMMEDIATE")
@@ -389,16 +409,19 @@ def store_memory(
                 store._upsert_chunk_vector(cursor, reembed_chunk_id, merged_embedding)
                 cursor.execute("COMMIT")
                 transaction_started = False
+                telemetry_span.finish("commit")
                 break
-            except apsw.BusyError:
+            except apsw.BusyError as exc:
                 if transaction_started:
                     cursor.execute("ROLLBACK")
+                telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
                 if not retry_on_busy or attempt == 4:
                     raise
                 _sleep_before_busy_retry(0.1 * (2**attempt), busy_deadline)
-            except Exception:
+            except Exception as exc:
                 if transaction_started:
                     cursor.execute("ROLLBACK")
+                telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
                 raise
 
     from .search_repo import clear_hybrid_search_cache

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -61,6 +61,7 @@ from .kg_repo import KGMixin
 from .search_repo import SearchMixin
 from .session_repo import SessionMixin
 from .tag_normalization import ensure_tag_tombstone_schema
+from .writer_telemetry import start_writer_span
 
 _DEFAULT_BUSY_TIMEOUT_MS = 30_000
 _DEFAULT_READ_BUSY_TIMEOUT_MS = 5_000
@@ -661,9 +662,11 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 raise last_err or apsw.BusyError("write busy deadline exceeded")
             try:
                 self._init_db()
+                self._finish_init_writer_telemetry("completed")
                 self._restore_default_write_busy_timeout()
                 return
             except apsw.Error as e:
+                self._finish_init_writer_telemetry("error", error=f"{type(e).__name__}: {e}")
                 if not _is_retryable_init_error(e):
                     raise
                 last_err = e
@@ -681,7 +684,16 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     if remaining <= 0 or delay >= remaining:
                         raise last_err
                 time.sleep(delay)
+            except BaseException as exc:
+                self._finish_init_writer_telemetry("error", error=f"{type(exc).__name__}: {exc}")
+                raise
         raise last_err  # type: ignore[misc]
+
+    def _finish_init_writer_telemetry(self, outcome: str, *, error: str | None = None) -> None:
+        span = getattr(self, "_init_writer_telemetry_span", None)
+        self._init_writer_telemetry_span = None
+        if span is not None:
+            span.finish(outcome, error=error)
 
     def _restore_default_write_busy_timeout(self) -> None:
         conn = getattr(self, "conn", None)
@@ -710,6 +722,16 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self.conn.enableloadextension(True)
         self.conn.loadextension(sqlite_vec.loadable_path())
         self.conn.enableloadextension(False)
+
+        self._init_writer_telemetry_span = start_writer_span(
+            self.conn,
+            db_path=self.db_path,
+            producer="vector_store",
+            lane="maintenance",
+            operation="init",
+            span_kind="writer_operation",
+            transaction_mode="implicit_per_statement",
+        )
 
         cursor = self.conn.cursor()
 
@@ -2449,6 +2471,14 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                         id=progress_handler_id,
                     )
                     progress_handler_installed = True
+                telemetry_span = start_writer_span(
+                    self.conn,
+                    db_path=self.db_path,
+                    producer="index",
+                    lane="batch",
+                    operation="upsert_chunks",
+                    rows_planned=len(sub_batch),
+                )
                 try:
                     cursor.execute("BEGIN IMMEDIATE")
                     transaction_started = True
@@ -2595,25 +2625,34 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                         self._upsert_chunk_vector(cursor, chunk_id, embedding)
                     cursor.execute("COMMIT")
                     transaction_started = False
+                    telemetry_span.finish("commit")
                     committed_any = True
                     processed_count += len(sub_batch)
                     break
-                except apsw.InterruptError:
+                except apsw.InterruptError as exc:
                     rollback_active_transaction()
                     if committed_any:
                         invalidate_upsert_caches()
                     if deadline_state["expired"]:
-                        raise IndexDeadlineExceeded(processed_count)
+                        deadline_error = IndexDeadlineExceeded(processed_count)
+                        telemetry_span.finish(
+                            "rollback",
+                            error=f"{type(deadline_error).__name__}: {deadline_error}",
+                        )
+                        raise deadline_error from exc
+                    telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
                     raise
-                except apsw.BusyError:
+                except apsw.BusyError as exc:
                     rollback_active_transaction()
+                    telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
                     if attempt == 4:
                         if committed_any:
                             invalidate_upsert_caches()
                         raise
                     time.sleep(0.1 * (2**attempt))
-                except Exception:
+                except Exception as exc:
                     rollback_active_transaction()
+                    telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
                     if committed_any:
                         invalidate_upsert_caches()
                     raise

--- a/src/brainlayer/writer_telemetry.py
+++ b/src/brainlayer/writer_telemetry.py
@@ -1,0 +1,623 @@
+"""Fail-open local telemetry for BrainLayer writer transactions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import apsw
+
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_DEFAULT_MAX_BYTES = 10 * 1024 * 1024
+_DEFAULT_BACKUPS = 3
+_DEFAULT_HEARTBEAT_INTERVAL_MS = 250
+_DEFAULT_FTS_SAMPLE_TTL_SECONDS = 60.0
+_TRACE_MASK = apsw.SQLITE_TRACE_STMT | apsw.SQLITE_TRACE_PROFILE
+_SINK_LOCK = threading.Lock()
+_ACTIVE_LOCK = threading.Lock()
+_ACTIVE_SPANS: dict[Path, dict[str, _WriterSpan]] = {}
+_HEARTBEAT_THREAD: threading.Thread | None = None
+_FTS_CACHE_LOCK = threading.Lock()
+_FTS_CACHE: dict[Path, tuple[float, dict[str, int]]] = {}
+_QUOTED_LITERAL_RE = re.compile(r"(?:[xX])?'(?:''|[^'])*'")
+_NUMBER_LITERAL_RE = re.compile(r"(?<![\w.])[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?(?![\w.])")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+
+
+@dataclass(frozen=True)
+class SqlFingerprint:
+    digest: str
+    normalized: str
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _int_env(name: str, default: int, *, minimum: int = 0) -> int:
+    try:
+        return max(minimum, int(os.environ.get(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float, *, minimum: float = 0.0) -> float:
+    try:
+        return max(minimum, float(os.environ.get(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def telemetry_enabled() -> bool:
+    return os.environ.get("BRAINLAYER_WRITER_TELEMETRY", "1").strip().lower() not in _FALSE_VALUES
+
+
+def telemetry_path() -> Path:
+    configured = os.environ.get("BRAINLAYER_WRITER_TELEMETRY_PATH")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".local" / "share" / "brainlayer" / "logs" / "writer-telemetry.jsonl"
+
+
+def heartbeat_dir() -> Path:
+    configured = os.environ.get("BRAINLAYER_WRITER_HEARTBEAT_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path("/tmp")
+
+
+def fingerprint_sql(sql: str) -> SqlFingerprint:
+    """Return a stable SQL shape without literal values."""
+    stripped = _LINE_COMMENT_RE.sub(" ", _BLOCK_COMMENT_RE.sub(" ", str(sql)))
+    without_strings = _QUOTED_LITERAL_RE.sub("?", stripped)
+    without_numbers = _NUMBER_LITERAL_RE.sub("?", without_strings)
+    normalized = " ".join(without_numbers.split())
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+    return SqlFingerprint(digest=digest, normalized=normalized)
+
+
+def _rotate(path: Path, backups: int) -> None:
+    if backups <= 0:
+        path.unlink(missing_ok=True)
+        return
+    path.with_name(f"{path.name}.{backups}").unlink(missing_ok=True)
+    for index in range(backups - 1, 0, -1):
+        source = path.with_name(f"{path.name}.{index}")
+        if source.exists():
+            source.replace(path.with_name(f"{path.name}.{index + 1}"))
+    if path.exists():
+        path.replace(path.with_name(f"{path.name}.1"))
+
+
+def append_event(event: dict[str, Any]) -> bool:
+    """Append one JSON event, returning False rather than affecting a writer."""
+    if not telemetry_enabled():
+        return False
+    try:
+        path = telemetry_path()
+        payload = {"schema_version": 1, **event}
+        encoded = (json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+        max_bytes = _int_env("BRAINLAYER_WRITER_TELEMETRY_MAX_BYTES", _DEFAULT_MAX_BYTES, minimum=1)
+        backups = _int_env("BRAINLAYER_WRITER_TELEMETRY_BACKUPS", _DEFAULT_BACKUPS)
+        with _SINK_LOCK:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if path.exists() and path.stat().st_size + len(encoded) > max_bytes:
+                _rotate(path, backups)
+            with path.open("ab") as handle:
+                handle.write(encoded)
+        return True
+    except Exception:
+        return False
+
+
+def tail_event_lines(path: Path | None = None, *, lines: int = 100) -> list[str]:
+    """Read the newest telemetry lines without creating or modifying the sink."""
+    resolved = Path(path) if path is not None else telemetry_path()
+    limit = max(0, int(lines))
+    if limit == 0:
+        return []
+    try:
+        with resolved.open("r", encoding="utf-8") as handle:
+            buffered: list[str] = []
+            for raw_line in handle:
+                line = raw_line.rstrip("\n")
+                if line:
+                    buffered.append(line)
+                    if len(buffered) > limit:
+                        buffered.pop(0)
+            return buffered
+    except (OSError, UnicodeError):
+        return []
+
+
+def summarize_event_lines(raw_lines: list[str]) -> dict[str, Any]:
+    """Summarize completed transaction events from JSONL lines."""
+    counts_by_producer: dict[str, int] = {}
+    counts_by_lane: dict[str, int] = {}
+    counts_by_outcome: dict[str, int] = {}
+    durations: list[float] = []
+    finished = 0
+    for raw_line in raw_lines:
+        try:
+            event = json.loads(raw_line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(event, dict) or event.get("event") != "txn_finished":
+            continue
+        finished += 1
+        for field, target in (
+            ("producer", counts_by_producer),
+            ("lane", counts_by_lane),
+            ("outcome", counts_by_outcome),
+        ):
+            value = str(event.get(field) or "unknown")
+            target[value] = target.get(value, 0) + 1
+        try:
+            durations.append(max(0.0, float(event.get("duration_ms") or 0.0)))
+        except (TypeError, ValueError):
+            durations.append(0.0)
+    durations.sort()
+    p95_index = max(0, math.ceil(len(durations) * 0.95) - 1) if durations else 0
+    return {
+        "counts_by_lane": dict(sorted(counts_by_lane.items())),
+        "counts_by_outcome": dict(sorted(counts_by_outcome.items())),
+        "counts_by_producer": dict(sorted(counts_by_producer.items())),
+        "duration_ms": {
+            "max": durations[-1] if durations else 0.0,
+            "p95": durations[p95_index] if durations else 0.0,
+        },
+        "finished_transactions": finished,
+        "lines_read": len(raw_lines),
+    }
+
+
+def summarize_events(path: Path | None = None, *, lines: int = 1000) -> dict[str, Any]:
+    return summarize_event_lines(tail_event_lines(path, lines=lines))
+
+
+def _db_page_size(db_path: Path) -> int:
+    try:
+        with db_path.open("rb") as handle:
+            header = handle.read(100)
+        if len(header) < 18 or header[:16] != b"SQLite format 3\x00":
+            return 4096
+        value = int.from_bytes(header[16:18], "big")
+        return 65536 if value == 1 else max(value, 512)
+    except Exception:
+        return 4096
+
+
+def _wal_metrics(db_path: Path) -> tuple[int, int]:
+    try:
+        size = Path(f"{db_path}-wal").stat().st_size
+        if size < 32:
+            return size, 0
+        return size, max(0, (size - 32) // (_db_page_size(db_path) + 24))
+    except OSError:
+        return 0, 0
+
+
+def _fts_segment_counts(conn: apsw.Connection, db_path: Path) -> dict[str, int]:
+    now = time.monotonic()
+    ttl = _float_env(
+        "BRAINLAYER_WRITER_TELEMETRY_FTS_SAMPLE_TTL_SECONDS",
+        _DEFAULT_FTS_SAMPLE_TTL_SECONDS,
+    )
+    resolved = db_path.resolve()
+    with _FTS_CACHE_LOCK:
+        cached = _FTS_CACHE.get(resolved)
+        if cached is not None and now - cached[0] < ttl:
+            return dict(cached[1])
+    counts: dict[str, int] = {}
+    fts_tables = ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram")
+    shadow_names = {f"{table}_idx" for table in fts_tables}
+    try:
+        placeholders = ",".join("?" for _ in shadow_names)
+        existing = {
+            str(row[0])
+            for row in conn.execute(
+                f"SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ({placeholders})",
+                sorted(shadow_names),
+            )
+        }
+    except Exception:
+        existing = set()
+    for table in fts_tables:
+        if f"{table}_idx" not in existing:
+            continue
+        try:
+            row = conn.execute(f'SELECT COUNT(DISTINCT segid) FROM "{table}_idx"').fetchone()
+            counts[table] = int(row[0] or 0) if row else 0
+        except Exception:
+            continue
+    with _FTS_CACHE_LOCK:
+        _FTS_CACHE[resolved] = (now, dict(counts))
+    return counts
+
+
+def _heartbeat_path(db_path: Path) -> Path:
+    digest = hashlib.sha256(str(db_path.resolve()).encode("utf-8")).hexdigest()[:16]
+    return heartbeat_dir() / f"writer-txn-{digest}-{os.getpid()}.json"
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> bool:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}.tmp")
+        temporary.write_text(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.replace(path)
+        return True
+    except Exception:
+        return False
+
+
+def _flush_heartbeat(path: Path) -> None:
+    try:
+        with _ACTIVE_LOCK:
+            spans = list(_ACTIVE_SPANS.get(path, {}).values())
+        if not spans:
+            path.unlink(missing_ok=True)
+            return
+        _atomic_write_json(
+            path,
+            {
+                "updated_at": _utc_now(),
+                "executor_pid": os.getpid(),
+                "active_transactions": [span.heartbeat_payload() for span in spans],
+            },
+        )
+    except Exception:
+        return
+
+
+def _heartbeat_loop() -> None:
+    while True:
+        interval = _int_env(
+            "BRAINLAYER_WRITER_TELEMETRY_HEARTBEAT_INTERVAL_MS",
+            _DEFAULT_HEARTBEAT_INTERVAL_MS,
+            minimum=10,
+        )
+        time.sleep(interval / 1000.0)
+        try:
+            with _ACTIVE_LOCK:
+                paths = list(_ACTIVE_SPANS)
+            for path in paths:
+                _flush_heartbeat(path)
+        except Exception:
+            continue
+
+
+def _ensure_heartbeat_thread() -> None:
+    global _HEARTBEAT_THREAD
+    try:
+        with _ACTIVE_LOCK:
+            if _HEARTBEAT_THREAD is not None and _HEARTBEAT_THREAD.is_alive():
+                return
+            _HEARTBEAT_THREAD = threading.Thread(
+                target=_heartbeat_loop,
+                name="brainlayer-writer-heartbeat",
+                daemon=True,
+            )
+            _HEARTBEAT_THREAD.start()
+    except Exception:
+        return
+
+
+class _NoopWriterSpan:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> bool:
+        return False
+
+    def commit(self, *, rows_touched: int | None = None) -> None:
+        return
+
+    def rollback(self, *, error: str | None = None) -> None:
+        return
+
+    def complete(self, *, rows_touched: int | None = None) -> None:
+        return
+
+    def finish(
+        self,
+        outcome: str,
+        *,
+        rows_touched: int | None = None,
+        error: str | None = None,
+    ) -> None:
+        return
+
+
+class _WriterSpan:
+    def __init__(
+        self,
+        conn: apsw.Connection,
+        *,
+        db_path: Path,
+        producer: str,
+        lane: str,
+        operation: str,
+        rows_planned: int | None,
+        queue_wait_ms: float | None,
+        queue_source: str | None,
+        span_kind: str,
+        transaction_mode: str,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        self.conn = conn
+        self.db_path = Path(db_path)
+        self.producer = producer
+        self.lane = lane
+        self.operation = operation
+        self.rows_planned = rows_planned
+        self.queue_wait_ms = queue_wait_ms
+        self.queue_source = queue_source
+        self.span_kind = span_kind
+        self.transaction_mode = transaction_mode
+        self.metadata = dict(metadata or {})
+        self.txn_id = uuid.uuid4().hex
+        self.started_at = _utc_now()
+        self.started_monotonic = time.monotonic()
+        self._total_changes_before = self._total_changes()
+        self.wal_bytes_before, self.wal_frames_before = _wal_metrics(self.db_path)
+        self.fts_segments_before: dict[str, int] = {}
+        self._statements: dict[str, dict[str, Any]] = {}
+        self._statement_starts: dict[int, dict[str, Any]] = {}
+        self._current_statement: dict[str, Any] | None = None
+        self._lock = threading.Lock()
+        self._trace_id = ("brainlayer-writer-telemetry", self.txn_id)
+        self._heartbeat_path = _heartbeat_path(self.db_path)
+        self._outcome: str | None = None
+        self._error: str | None = None
+        self._rows_touched: int | None = None
+        self._entered = False
+        self._finished = False
+        self._trace_installed = False
+
+    def _total_changes(self) -> int:
+        try:
+            return int(self.conn.totalchanges())
+        except Exception:
+            return 0
+
+    def __enter__(self):
+        try:
+            self.fts_segments_before = _fts_segment_counts(self.conn, self.db_path)
+        except Exception:
+            self.fts_segments_before = {}
+        try:
+            self.conn.trace_v2(_TRACE_MASK, self._trace, id=self._trace_id)
+            self._trace_installed = True
+        except Exception:
+            self._trace_installed = False
+        self._entered = True
+        append_event(self._base_event("txn_started"))
+        try:
+            with _ACTIVE_LOCK:
+                _ACTIVE_SPANS.setdefault(self._heartbeat_path, {})[self.txn_id] = self
+            _flush_heartbeat(self._heartbeat_path)
+            _ensure_heartbeat_thread()
+        except Exception:
+            pass
+        return self
+
+    def __exit__(self, exc_type, exc, _traceback) -> bool:
+        if exc is not None:
+            self._outcome = "rollback" if self._outcome == "rollback" else "error"
+            self._error = self._error or f"{type(exc).__name__}: {exc}"
+        self._finish()
+        return False
+
+    def _trace(self, event: dict[str, Any]) -> None:
+        try:
+            code = event.get("code")
+            sql = str(event.get("sql") or "")
+            fingerprint = fingerprint_sql(sql)
+            if code == apsw.SQLITE_TRACE_STMT:
+                if bool(event.get("trigger")):
+                    return
+                statement_start = {
+                    "fingerprint": fingerprint.digest,
+                    "normalized_sql": fingerprint.normalized[:500],
+                    "started_at": _utc_now(),
+                    "started_monotonic": time.monotonic(),
+                    "trigger": False,
+                }
+                with self._lock:
+                    self._current_statement = statement_start
+                    statement_id = event.get("id")
+                    if isinstance(statement_id, int):
+                        self._statement_starts[statement_id] = statement_start
+                return
+            if code != apsw.SQLITE_TRACE_PROFILE:
+                return
+            duration_ms = max(0.0, float(event.get("nanoseconds") or 0) / 1_000_000.0)
+            status = event.get("stmt_status") if isinstance(event.get("stmt_status"), dict) else {}
+            with self._lock:
+                statement_id = event.get("id")
+                statement_start = self._statement_starts.get(statement_id, {}) if isinstance(statement_id, int) else {}
+                aggregate = self._statements.setdefault(
+                    fingerprint.digest,
+                    {
+                        "fingerprint": fingerprint.digest,
+                        "normalized_sql": fingerprint.normalized[:500],
+                        "count": 0,
+                        "total_duration_ms": 0.0,
+                        "max_duration_ms": 0.0,
+                        "vm_steps": 0,
+                        "fullscan_steps": 0,
+                        "sorts": 0,
+                        "started_at": statement_start.get("started_at"),
+                    },
+                )
+                if aggregate.get("started_at") is None and statement_start.get("started_at") is not None:
+                    aggregate["started_at"] = statement_start["started_at"]
+                aggregate["count"] += 1
+                aggregate["total_duration_ms"] += duration_ms
+                aggregate["max_duration_ms"] = max(aggregate["max_duration_ms"], duration_ms)
+                aggregate["vm_steps"] += int(status.get("SQLITE_STMTSTATUS_VM_STEP", 0) or 0)
+                aggregate["fullscan_steps"] += int(status.get("SQLITE_STMTSTATUS_FULLSCAN_STEP", 0) or 0)
+                aggregate["sorts"] += int(status.get("SQLITE_STMTSTATUS_SORT", 0) or 0)
+                if statement_start.get("fingerprint") == fingerprint.digest and isinstance(statement_id, int):
+                    self._statement_starts.pop(statement_id, None)
+        except Exception:
+            return
+
+    def _base_event(self, event_name: str) -> dict[str, Any]:
+        event: dict[str, Any] = {
+            "event": event_name,
+            "txn_id": self.txn_id,
+            "producer": self.producer,
+            "lane": self.lane,
+            "operation": self.operation,
+            "span_kind": self.span_kind,
+            "transaction_mode": self.transaction_mode,
+            "executor_pid": os.getpid(),
+            "db_path": str(self.db_path),
+            "txn_started_at": self.started_at,
+            "txn_started_monotonic": self.started_monotonic,
+            "rows_planned": self.rows_planned,
+            "queue_wait_ms": self.queue_wait_ms,
+            "queue_source": self.queue_source,
+            **self.metadata,
+        }
+        return event
+
+    def heartbeat_payload(self) -> dict[str, Any]:
+        now = time.monotonic()
+        with self._lock:
+            current = dict(self._current_statement or {})
+        started = current.get("started_monotonic")
+        return {
+            **self._base_event("txn_active"),
+            "open_ms": max(0.0, (now - self.started_monotonic) * 1000.0),
+            "current_statement_fingerprint": current.get("fingerprint"),
+            "current_statement": current.get("normalized_sql"),
+            "current_statement_started_at": current.get("started_at"),
+            "current_statement_open_ms": max(0.0, (now - started) * 1000.0) if isinstance(started, float) else None,
+            "current_statement_trigger": current.get("trigger"),
+        }
+
+    def commit(self, *, rows_touched: int | None = None) -> None:
+        self._outcome = "commit"
+        self._rows_touched = rows_touched
+
+    def rollback(self, *, error: str | None = None) -> None:
+        self._outcome = "rollback"
+        self._error = error
+
+    def complete(self, *, rows_touched: int | None = None) -> None:
+        self._outcome = "completed"
+        self._rows_touched = rows_touched
+
+    def finish(
+        self,
+        outcome: str,
+        *,
+        rows_touched: int | None = None,
+        error: str | None = None,
+    ) -> None:
+        self._outcome = outcome
+        self._rows_touched = rows_touched
+        self._error = error
+        self._finish()
+
+    def _finish(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        if self._trace_installed:
+            try:
+                self.conn.trace_v2(_TRACE_MASK, None, id=self._trace_id)
+            except Exception:
+                pass
+        try:
+            fts_segments = _fts_segment_counts(self.conn, self.db_path)
+        except Exception:
+            fts_segments = dict(self.fts_segments_before)
+        wal_bytes_after, wal_frames_after = _wal_metrics(self.db_path)
+        changed_rows = max(0, self._total_changes() - self._total_changes_before)
+        with self._lock:
+            statements = sorted(self._statements.values(), key=lambda item: item["max_duration_ms"], reverse=True)[:64]
+        finished = {
+            **self._base_event("txn_finished"),
+            "finished_at": _utc_now(),
+            "duration_ms": max(0.0, (time.monotonic() - self.started_monotonic) * 1000.0),
+            "outcome": self._outcome or "completed",
+            "error": self._error,
+            "rows_touched": self._rows_touched if self._rows_touched is not None else changed_rows,
+            "wal_bytes_before": self.wal_bytes_before,
+            "wal_bytes_after": wal_bytes_after,
+            "wal_frames_before": self.wal_frames_before,
+            "wal_frames_after": wal_frames_after,
+            "fts_segments_before": self.fts_segments_before,
+            "fts_segments": fts_segments,
+            "statements": statements,
+        }
+        append_event(finished)
+        try:
+            with _ACTIVE_LOCK:
+                active = _ACTIVE_SPANS.get(self._heartbeat_path)
+                if active is not None:
+                    active.pop(self.txn_id, None)
+                    if not active:
+                        _ACTIVE_SPANS.pop(self._heartbeat_path, None)
+            _flush_heartbeat(self._heartbeat_path)
+        except Exception:
+            pass
+
+
+def writer_span(
+    conn: apsw.Connection,
+    *,
+    db_path: Path,
+    producer: str,
+    lane: str,
+    operation: str,
+    rows_planned: int | None = None,
+    queue_wait_ms: float | None = None,
+    queue_source: str | None = None,
+    span_kind: str = "transaction",
+    transaction_mode: str = "explicit",
+    metadata: dict[str, Any] | None = None,
+):
+    """Create a fail-open observer; the caller retains transaction ownership."""
+    if not telemetry_enabled():
+        return _NoopWriterSpan()
+    try:
+        return _WriterSpan(
+            conn,
+            db_path=Path(db_path),
+            producer=producer,
+            lane=lane,
+            operation=operation,
+            rows_planned=rows_planned,
+            queue_wait_ms=queue_wait_ms,
+            queue_source=queue_source,
+            span_kind=span_kind,
+            transaction_mode=transaction_mode,
+            metadata=metadata,
+        )
+    except Exception:
+        return _NoopWriterSpan()
+
+
+def start_writer_span(*args, **kwargs):
+    """Start a span for call sites that cannot use a lexical context manager."""
+    span = writer_span(*args, **kwargs)
+    try:
+        return span.__enter__()
+    except Exception:
+        return _NoopWriterSpan()

--- a/src/brainlayer/writer_telemetry.py
+++ b/src/brainlayer/writer_telemetry.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import apsw
 
+_MONOTONIC = time.monotonic
 _FALSE_VALUES = {"0", "false", "no", "off"}
 _DEFAULT_MAX_BYTES = 10 * 1024 * 1024
 _DEFAULT_BACKUPS = 3
@@ -26,6 +27,7 @@ _TRACE_MASK = apsw.SQLITE_TRACE_STMT | apsw.SQLITE_TRACE_PROFILE
 _SINK_LOCK = threading.Lock()
 _ACTIVE_LOCK = threading.Lock()
 _ACTIVE_SPANS: dict[Path, dict[str, _WriterSpan]] = {}
+_HEARTBEAT_PATH_LOCKS: dict[Path, threading.Lock] = {}
 _HEARTBEAT_THREAD: threading.Thread | None = None
 _FTS_CACHE_LOCK = threading.Lock()
 _FTS_CACHE: dict[Path, tuple[float, dict[str, int]]] = {}
@@ -209,7 +211,7 @@ def _wal_metrics(db_path: Path) -> tuple[int, int]:
 
 
 def _fts_segment_counts(conn: apsw.Connection, db_path: Path) -> dict[str, int]:
-    now = time.monotonic()
+    now = _MONOTONIC()
     ttl = _float_env(
         "BRAINLAYER_WRITER_TELEMETRY_FTS_SAMPLE_TTL_SECONDS",
         _DEFAULT_FTS_SAMPLE_TTL_SECONDS,
@@ -262,21 +264,27 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> bool:
         return False
 
 
+def _heartbeat_path_lock(path: Path) -> threading.Lock:
+    with _ACTIVE_LOCK:
+        return _HEARTBEAT_PATH_LOCKS.setdefault(path, threading.Lock())
+
+
 def _flush_heartbeat(path: Path) -> None:
     try:
-        with _ACTIVE_LOCK:
-            spans = list(_ACTIVE_SPANS.get(path, {}).values())
-        if not spans:
-            path.unlink(missing_ok=True)
-            return
-        _atomic_write_json(
-            path,
-            {
-                "updated_at": _utc_now(),
-                "executor_pid": os.getpid(),
-                "active_transactions": [span.heartbeat_payload() for span in spans],
-            },
-        )
+        with _heartbeat_path_lock(path):
+            with _ACTIVE_LOCK:
+                spans = list(_ACTIVE_SPANS.get(path, {}).values())
+            if not spans:
+                path.unlink(missing_ok=True)
+                return
+            _atomic_write_json(
+                path,
+                {
+                    "updated_at": _utc_now(),
+                    "executor_pid": os.getpid(),
+                    "active_transactions": [span.heartbeat_payload() for span in spans],
+                },
+            )
     except Exception:
         return
 
@@ -369,7 +377,7 @@ class _WriterSpan:
         self.metadata = dict(metadata or {})
         self.txn_id = uuid.uuid4().hex
         self.started_at = _utc_now()
-        self.started_monotonic = time.monotonic()
+        self.started_monotonic = _MONOTONIC()
         self._total_changes_before = self._total_changes()
         self.wal_bytes_before, self.wal_frames_before = _wal_metrics(self.db_path)
         self.fts_segments_before: dict[str, int] = {}
@@ -432,7 +440,7 @@ class _WriterSpan:
                     "fingerprint": fingerprint.digest,
                     "normalized_sql": fingerprint.normalized[:500],
                     "started_at": _utc_now(),
-                    "started_monotonic": time.monotonic(),
+                    "started_monotonic": _MONOTONIC(),
                     "trigger": False,
                 }
                 with self._lock:
@@ -496,7 +504,7 @@ class _WriterSpan:
         return event
 
     def heartbeat_payload(self) -> dict[str, Any]:
-        now = time.monotonic()
+        now = _MONOTONIC()
         with self._lock:
             current = dict(self._current_statement or {})
         started = current.get("started_monotonic")
@@ -554,7 +562,7 @@ class _WriterSpan:
         finished = {
             **self._base_event("txn_finished"),
             "finished_at": _utc_now(),
-            "duration_ms": max(0.0, (time.monotonic() - self.started_monotonic) * 1000.0),
+            "duration_ms": max(0.0, (_MONOTONIC() - self.started_monotonic) * 1000.0),
             "outcome": self._outcome or "completed",
             "error": self._error,
             "rows_touched": self._rows_touched if self._rows_touched is not None else changed_rows,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,13 @@ def isolate_backup_daily_log(monkeypatch, tmp_path):
     monkeypatch.setenv("BRAINLAYER_BACKUP_LOG_PROVENANCE", "pytest")
 
 
+@pytest.fixture(autouse=True)
+def isolate_writer_telemetry(monkeypatch, tmp_path):
+    """Keep writer tests from touching the live telemetry log or heartbeat directory."""
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_PATH", str(tmp_path / "writer-telemetry.jsonl"))
+    monkeypatch.setenv("BRAINLAYER_WRITER_HEARTBEAT_DIR", str(tmp_path / "writer-heartbeats"))
+
+
 @pytest.fixture
 def test_user() -> str:
     """Username for path-based tests.

--- a/tests/test_cli_writer_telemetry.py
+++ b/tests/test_cli_writer_telemetry.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from brainlayer.cli import app
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.write_text("".join(json.dumps(event) + "\n" for event in events), encoding="utf-8")
+
+
+def test_writer_telemetry_tail_prints_newest_events_without_mutating_file(tmp_path):
+    path = tmp_path / "writer-telemetry.jsonl"
+    _write_events(path, [{"event": "txn_finished", "txn_id": str(index)} for index in range(3)])
+    before = path.stat().st_mtime_ns
+
+    result = CliRunner().invoke(app, ["writer-telemetry", "tail", "--lines", "2", "--path", str(path)])
+
+    assert result.exit_code == 0, result.output
+    assert [json.loads(line)["txn_id"] for line in result.output.splitlines()] == ["1", "2"]
+    assert path.stat().st_mtime_ns == before
+
+
+def test_writer_telemetry_summary_aggregates_finished_transactions(tmp_path):
+    path = tmp_path / "writer-telemetry.jsonl"
+    _write_events(
+        path,
+        [
+            {"event": "txn_started", "producer": "drain", "lane": "interactive"},
+            {
+                "event": "txn_finished",
+                "producer": "drain",
+                "lane": "interactive",
+                "outcome": "commit",
+                "duration_ms": 10.0,
+            },
+            {
+                "event": "txn_finished",
+                "producer": "index",
+                "lane": "batch",
+                "outcome": "rollback",
+                "duration_ms": 30.0,
+            },
+        ],
+    )
+
+    result = CliRunner().invoke(app, ["writer-telemetry", "summary", "--lines", "100", "--path", str(path)])
+
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.output)
+    assert summary == {
+        "counts_by_lane": {"batch": 1, "interactive": 1},
+        "counts_by_outcome": {"commit": 1, "rollback": 1},
+        "counts_by_producer": {"drain": 1, "index": 1},
+        "duration_ms": {"max": 30.0, "p95": 30.0},
+        "finished_transactions": 2,
+        "lines_read": 3,
+    }
+
+
+def test_writer_telemetry_missing_file_is_an_empty_read_only_result(tmp_path):
+    path = tmp_path / "missing.jsonl"
+    runner = CliRunner()
+
+    tail = runner.invoke(app, ["writer-telemetry", "tail", "--path", str(path)])
+    summary = runner.invoke(app, ["writer-telemetry", "summary", "--path", str(path)])
+
+    assert tail.exit_code == 0, tail.output
+    assert tail.output == ""
+    assert summary.exit_code == 0, summary.output
+    assert json.loads(summary.output)["finished_transactions"] == 0
+    assert not path.exists()
+
+
+def test_writer_telemetry_rejects_unknown_action(tmp_path):
+    result = CliRunner().invoke(
+        app,
+        ["writer-telemetry", "delete", "--path", str(tmp_path / "writer-telemetry.jsonl")],
+    )
+
+    assert result.exit_code != 0

--- a/tests/test_writer_telemetry.py
+++ b/tests/test_writer_telemetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 import apsw
@@ -108,6 +109,54 @@ def test_writer_span_emits_start_end_metrics_and_clears_heartbeat(tmp_path, monk
     assert "chunks_fts" in finished["fts_segments"]
     assert any(statement["normalized_sql"].startswith("INSERT INTO chunks") for statement in finished["statements"])
     assert all(statement["max_duration_ms"] >= 0 for statement in finished["statements"])
+
+
+def test_finishing_span_wins_race_with_stale_heartbeat_flush(tmp_path, monkeypatch):
+    import brainlayer.writer_telemetry as writer_telemetry
+
+    _log_path, heartbeat_dir = _configure_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_HEARTBEAT_INTERVAL_MS", "1000")
+    db_path = tmp_path / "brainlayer.db"
+    conn = apsw.Connection(str(db_path))
+    conn.execute("CREATE TABLE chunks(id TEXT PRIMARY KEY)")
+    span = writer_telemetry.start_writer_span(
+        conn,
+        db_path=db_path,
+        producer="index",
+        lane="batch",
+        operation="upsert_chunks",
+    )
+    heartbeat_path = next(heartbeat_dir.glob("writer-txn-*.json"))
+    stale_flush_entered = threading.Event()
+    release_stale_flush = threading.Event()
+    finish_returned = threading.Event()
+    original_atomic_write = writer_telemetry._atomic_write_json
+
+    def delayed_atomic_write(path, payload):
+        stale_flush_entered.set()
+        assert release_stale_flush.wait(3.0)
+        return original_atomic_write(path, payload)
+
+    monkeypatch.setattr(writer_telemetry, "_atomic_write_json", delayed_atomic_write)
+    stale_flush = threading.Thread(target=writer_telemetry._flush_heartbeat, args=(heartbeat_path,))
+    stale_flush.start()
+    assert stale_flush_entered.wait(1.0)
+
+    def finish_span() -> None:
+        span.finish("commit")
+        finish_returned.set()
+
+    finisher = threading.Thread(target=finish_span)
+    finisher.start()
+    finish_returned.wait(0.1)
+    release_stale_flush.set()
+    stale_flush.join(timeout=3.0)
+    finisher.join(timeout=3.0)
+
+    assert not stale_flush.is_alive()
+    assert not finisher.is_alive()
+    assert not heartbeat_path.exists()
+    conn.close()
 
 
 def test_writer_span_records_rollback_without_masking_writer_result(tmp_path, monkeypatch):

--- a/tests/test_writer_telemetry.py
+++ b/tests/test_writer_telemetry.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import apsw
+
+
+def _configure_paths(monkeypatch, tmp_path: Path, *, enabled: bool = True) -> tuple[Path, Path]:
+    log_path = tmp_path / "logs" / "writer-telemetry.jsonl"
+    heartbeat_dir = tmp_path / "heartbeats"
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY", "1" if enabled else "0")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_PATH", str(log_path))
+    monkeypatch.setenv("BRAINLAYER_WRITER_HEARTBEAT_DIR", str(heartbeat_dir))
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_MAX_BYTES", "1048576")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_BACKUPS", "2")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_HEARTBEAT_INTERVAL_MS", "10")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_FTS_SAMPLE_TTL_SECONDS", "0")
+    return log_path, heartbeat_dir
+
+
+def _events(log_path: Path) -> list[dict]:
+    return [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_sql_fingerprint_is_stable_and_does_not_expose_literals():
+    from brainlayer.writer_telemetry import fingerprint_sql
+
+    first = fingerprint_sql(" INSERT  INTO chunks(content) VALUES ('private-one') ")
+    second = fingerprint_sql("INSERT INTO chunks(content)\nVALUES ('private-two')")
+
+    assert first.digest == second.digest
+    assert first.normalized == "INSERT INTO chunks(content) VALUES (?)"
+    assert "private" not in first.normalized
+
+
+def test_append_event_rotates_at_configured_size(tmp_path, monkeypatch):
+    from brainlayer.writer_telemetry import append_event
+
+    log_path, _heartbeat_dir = _configure_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_MAX_BYTES", "180")
+
+    assert append_event({"event": "one", "payload": "x" * 120}) is True
+    assert append_event({"event": "two", "payload": "y" * 120}) is True
+
+    assert log_path.exists()
+    assert log_path.with_name("writer-telemetry.jsonl.1").exists()
+    assert json.loads(log_path.read_text(encoding="utf-8"))["event"] == "two"
+
+
+def test_append_event_is_fail_open_when_sink_is_unwritable(tmp_path, monkeypatch):
+    from brainlayer.writer_telemetry import append_event
+
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("block", encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY", "1")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_PATH", str(blocker / "writer-telemetry.jsonl"))
+
+    assert append_event({"event": "must-not-break-writer"}) is False
+
+
+def test_writer_span_emits_start_end_metrics_and_clears_heartbeat(tmp_path, monkeypatch):
+    from brainlayer.writer_telemetry import writer_span
+
+    log_path, heartbeat_dir = _configure_paths(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    conn = apsw.Connection(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE chunks(id TEXT PRIMARY KEY, content TEXT)")
+    conn.execute("CREATE VIRTUAL TABLE chunks_fts USING fts5(content)")
+
+    with writer_span(
+        conn,
+        db_path=db_path,
+        producer="index",
+        lane="batch",
+        operation="upsert_chunks",
+        rows_planned=1,
+    ) as span:
+        heartbeat_files = list(heartbeat_dir.glob("writer-txn-*.json"))
+        assert len(heartbeat_files) == 1
+        active = json.loads(heartbeat_files[0].read_text(encoding="utf-8"))
+        assert active["active_transactions"][0]["producer"] == "index"
+        assert active["active_transactions"][0]["txn_started_monotonic"] > 0
+
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("INSERT INTO chunks VALUES (?, ?)", ("one", "hello"))
+        conn.execute("INSERT INTO chunks_fts(content) VALUES (?)", ("hello",))
+        conn.execute("COMMIT")
+        span.commit(rows_touched=1)
+
+    assert list(heartbeat_dir.glob("writer-txn-*.json")) == []
+    events = _events(log_path)
+    assert [event["event"] for event in events] == ["txn_started", "txn_finished"]
+    finished = events[-1]
+    assert finished["producer"] == "index"
+    assert finished["lane"] == "batch"
+    assert finished["operation"] == "upsert_chunks"
+    assert finished["outcome"] == "commit"
+    assert finished["duration_ms"] >= 0
+    assert finished["rows_planned"] == 1
+    assert finished["rows_touched"] >= 1
+    assert finished["executor_pid"] > 0
+    assert finished["wal_bytes_before"] >= 0
+    assert finished["wal_bytes_after"] >= 0
+    assert finished["wal_frames_before"] >= 0
+    assert finished["wal_frames_after"] >= 0
+    assert "chunks_fts" in finished["fts_segments"]
+    assert any(statement["normalized_sql"].startswith("INSERT INTO chunks") for statement in finished["statements"])
+    assert all(statement["max_duration_ms"] >= 0 for statement in finished["statements"])
+
+
+def test_writer_span_records_rollback_without_masking_writer_result(tmp_path, monkeypatch):
+    from brainlayer.writer_telemetry import writer_span
+
+    log_path, heartbeat_dir = _configure_paths(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    conn = apsw.Connection(str(db_path))
+    conn.execute("CREATE TABLE chunks(id TEXT PRIMARY KEY)")
+
+    with writer_span(
+        conn,
+        db_path=db_path,
+        producer="mcp",
+        lane="interactive",
+        operation="store_memory",
+    ) as span:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("INSERT INTO chunks VALUES ('rolled-back')")
+        conn.execute("ROLLBACK")
+        span.rollback(error="synthetic")
+
+    assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone() == (0,)
+    assert list(heartbeat_dir.glob("writer-txn-*.json")) == []
+    finished = _events(log_path)[-1]
+    assert finished["outcome"] == "rollback"
+    assert finished["error"] == "synthetic"
+
+
+def test_writer_span_is_noop_when_disabled(tmp_path, monkeypatch):
+    from brainlayer.writer_telemetry import writer_span
+
+    log_path, heartbeat_dir = _configure_paths(monkeypatch, tmp_path, enabled=False)
+    db_path = tmp_path / "brainlayer.db"
+    conn = apsw.Connection(str(db_path))
+    conn.execute("CREATE TABLE chunks(id TEXT PRIMARY KEY)")
+
+    with writer_span(
+        conn,
+        db_path=db_path,
+        producer="index",
+        lane="batch",
+        operation="upsert_chunks",
+    ) as span:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("INSERT INTO chunks VALUES ('one')")
+        conn.execute("COMMIT")
+        span.commit(rows_touched=1)
+
+    assert not log_path.exists()
+    assert not heartbeat_dir.exists()
+
+
+def test_writer_span_preserves_existing_exec_trace(tmp_path, monkeypatch):
+    from brainlayer.writer_telemetry import writer_span
+
+    _configure_paths(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    conn = apsw.Connection(str(db_path))
+    conn.execute("CREATE TABLE chunks(id TEXT PRIMARY KEY)")
+    traced: list[str] = []
+
+    def trace(_cursor, statement, _bindings):
+        traced.append(str(statement))
+        return True
+
+    conn.setexectrace(trace)
+    with writer_span(
+        conn,
+        db_path=db_path,
+        producer="index",
+        lane="batch",
+        operation="upsert_chunks",
+    ) as span:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("INSERT INTO chunks VALUES ('one')")
+        conn.execute("COMMIT")
+        span.commit(rows_touched=1)
+
+    assert any("INSERT INTO chunks" in statement for statement in traced)
+    assert conn.getexectrace() is trace
+
+
+def test_fts_sampling_skips_missing_shadow_tables_without_sqlite_errors(tmp_path, monkeypatch, caplog):
+    import brainlayer.vector_store  # noqa: F401 - installs the production APSW log callback
+    from brainlayer.writer_telemetry import writer_span
+
+    _configure_paths(monkeypatch, tmp_path)
+    db_path = tmp_path / "empty.db"
+    conn = apsw.Connection(str(db_path))
+
+    with writer_span(
+        conn,
+        db_path=db_path,
+        producer="vector_store",
+        lane="maintenance",
+        operation="init",
+    ) as span:
+        conn.execute("CREATE TABLE chunks(id TEXT PRIMARY KEY)")
+        span.complete()
+
+    assert "no such table" not in caplog.text.lower()

--- a/tests/test_writer_telemetry_drain.py
+++ b/tests/test_writer_telemetry_drain.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from brainlayer.drain import burn_drain_once, drain_once
+from brainlayer.queue_io import enqueue_store
+from brainlayer.vector_store import VectorStore
+
+
+def _configure(monkeypatch, tmp_path: Path) -> Path:
+    log_path = tmp_path / "writer-telemetry.jsonl"
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY", "1")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_PATH", str(log_path))
+    monkeypatch.setenv("BRAINLAYER_WRITER_HEARTBEAT_DIR", str(tmp_path / "heartbeats"))
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "pidfiles"))
+    monkeypatch.setenv("BRAINLAYER_DRAIN_POST_COMMIT_YIELD_MS", "0")
+    return log_path
+
+
+def _finished(log_path: Path, operation: str) -> list[dict]:
+    if not log_path.exists():
+        return []
+    return [
+        event
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if (event := json.loads(line)).get("event") == "txn_finished" and event.get("operation") == operation
+    ]
+
+
+def _seed_store(db_path: Path) -> None:
+    store = VectorStore(db_path)
+    store.close()
+
+
+def test_live_drain_records_queue_wait_lane_and_source_from_spool_mtime(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    _seed_store(db_path)
+    log_path.unlink(missing_ok=True)
+    queued = enqueue_store(content="Unique queued telemetry memory", source="mcp", queue_dir=queue_dir)
+    old = time.time() - 2.0
+    os.utime(queued, (old, old))
+
+    assert drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=1, log_path=tmp_path / "drain.log") == 1
+
+    events = _finished(log_path, "apply_file")
+    assert len(events) == 1
+    event = events[0]
+    assert event["producer"] == "drain"
+    assert event["lane"] == "interactive"
+    assert event["queue_source"] == "mcp"
+    assert event["queue_wait_ms"] >= 1_500
+    assert event["rows_planned"] == 1
+    assert event["outcome"] == "commit"
+
+
+def test_burn_drain_records_one_span_for_selected_batch(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    _seed_store(db_path)
+    log_path.unlink(missing_ok=True)
+    enqueue_store(content="First unique burn telemetry memory", source="mcp", queue_dir=queue_dir)
+    enqueue_store(content="Second unique burn telemetry memory", source="mcp", queue_dir=queue_dir)
+
+    result = burn_drain_once(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        batch_size=10,
+        max_events_per_transaction=10,
+        log_path=tmp_path / "drain.log",
+    )
+
+    assert result.applied_events == 2
+    events = _finished(log_path, "burn_apply")
+    assert len(events) == 1
+    assert events[0]["rows_planned"] == 2
+    assert events[0]["queue_source"] == "mcp"
+    assert events[0]["outcome"] == "commit"
+
+
+def test_hotlane_vector_write_emits_bounded_transaction_span(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    _seed_store(db_path)
+    store = VectorStore(db_path)
+    store.conn.execute(
+        "INSERT INTO chunks (id, content, metadata, source_file, source) VALUES (?, ?, '{}', 'test', 'mcp')",
+        ("hotlane-chunk", "stable hotlane content"),
+    )
+    store.close()
+    log_path.unlink(missing_ok=True)
+    importlib.invalidate_caches()
+    sys.modules.pop("scripts.hotlane_brainbar_daemon", None)
+    hotlane = importlib.import_module("scripts.hotlane_brainbar_daemon")
+
+    assert (
+        hotlane._write_embedded_vectors(
+            db_path,
+            [hotlane.EmbeddedVector("hotlane-chunk", "stable hotlane content", [0.25] * 1024)],
+        )
+        == 1
+    )
+
+    events = _finished(log_path, "write_vectors")
+    assert len(events) == 1
+    assert events[0]["producer"] == "hotlane"
+    assert events[0]["lane"] == "hotlane"
+    assert events[0]["rows_planned"] == 1
+    assert events[0]["outcome"] == "commit"

--- a/tests/test_writer_telemetry_gate.py
+++ b/tests/test_writer_telemetry_gate.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import apsw
+
+from brainlayer.writer_telemetry import fingerprint_sql, writer_span
+
+
+def _wait_for_current_statement(heartbeat_dir: Path, fingerprint: str, timeout: float = 3.0) -> dict:
+    deadline = time.monotonic() + timeout
+    last_payload: dict = {}
+    while time.monotonic() < deadline:
+        files = list(heartbeat_dir.glob("writer-txn-*.json"))
+        if files:
+            try:
+                last_payload = json.loads(files[0].read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                time.sleep(0.01)
+                continue
+            active = last_payload.get("active_transactions") or []
+            if active and active[0].get("current_statement_fingerprint") == fingerprint:
+                return active[0]
+        time.sleep(0.01)
+    raise AssertionError(f"slow statement fingerprint never became visible; last={last_payload}")
+
+
+def test_slow_fts_write_exposes_open_heartbeat_and_completed_statement_span(tmp_path, monkeypatch):
+    log_path = tmp_path / "writer-telemetry.jsonl"
+    heartbeat_dir = tmp_path / "heartbeats"
+    db_path = tmp_path / "fts-gate.db"
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY", "1")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_PATH", str(log_path))
+    monkeypatch.setenv("BRAINLAYER_WRITER_HEARTBEAT_DIR", str(heartbeat_dir))
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_HEARTBEAT_INTERVAL_MS", "10")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_FTS_SAMPLE_TTL_SECONDS", "0")
+    setup = apsw.Connection(str(db_path))
+    setup.execute("PRAGMA journal_mode=WAL")
+    setup.execute("CREATE TABLE source_docs(content TEXT NOT NULL)")
+    setup.executemany("INSERT INTO source_docs VALUES (?)", [(f"document {index}",) for index in range(100)])
+    setup.execute("CREATE VIRTUAL TABLE chunks_fts USING fts5(content)")
+    setup.close()
+
+    entered_slow_function = threading.Event()
+    release_slow_function = threading.Event()
+    worker_errors: list[BaseException] = []
+    sql = "INSERT INTO chunks_fts(content) SELECT slow_fts(content) FROM source_docs"
+    expected_fingerprint = fingerprint_sql(sql).digest
+
+    def run_slow_fts_write() -> None:
+        conn = apsw.Connection(str(db_path))
+
+        def slow_fts(value: str) -> str:
+            entered_slow_function.set()
+            if not release_slow_function.wait(5.0):
+                raise TimeoutError("gate did not release slow FTS function")
+            return value
+
+        conn.create_scalar_function("slow_fts", slow_fts, 1)
+        try:
+            with writer_span(
+                conn,
+                db_path=db_path,
+                producer="gate",
+                lane="maintenance",
+                operation="slow_fts_write",
+                rows_planned=100,
+            ) as span:
+                conn.execute("BEGIN IMMEDIATE")
+                conn.execute(sql)
+                conn.execute("COMMIT")
+                span.commit(rows_touched=100)
+        except BaseException as exc:
+            worker_errors.append(exc)
+        finally:
+            conn.close()
+
+    worker = threading.Thread(target=run_slow_fts_write, name="slow-fts-gate")
+    worker.start()
+    assert entered_slow_function.wait(3.0), "slow FTS statement did not start"
+
+    active = _wait_for_current_statement(heartbeat_dir, expected_fingerprint)
+    assert active["txn_started_at"]
+    assert active["txn_started_monotonic"] > 0
+    assert active["current_statement"].startswith("INSERT INTO chunks_fts")
+    assert active["current_statement_started_at"]
+    assert active["current_statement_open_ms"] >= 0
+
+    release_slow_function.set()
+    worker.join(timeout=5.0)
+    assert not worker.is_alive()
+    assert worker_errors == []
+    assert list(heartbeat_dir.glob("writer-txn-*.json")) == []
+
+    events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    started = [event for event in events if event["event"] == "txn_started"]
+    finished = [event for event in events if event["event"] == "txn_finished"]
+    assert len(started) == 1
+    assert len(finished) == 1
+    assert finished[0]["outcome"] == "commit"
+    assert finished[0]["duration_ms"] > 0
+    statement = next(item for item in finished[0]["statements"] if item["fingerprint"] == expected_fingerprint)
+    assert statement["started_at"]
+    assert statement["max_duration_ms"] > 0
+    assert statement["vm_steps"] > 0

--- a/tests/test_writer_telemetry_misc_paths.py
+++ b/tests/test_writer_telemetry_misc_paths.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from brainlayer.cli import _RewindArchiveBatcher
+from brainlayer.enrichment_controller import _apply_enrichment
+from brainlayer.vector_store import VectorStore
+
+
+def _configure(monkeypatch, tmp_path: Path) -> Path:
+    log_path = tmp_path / "writer-telemetry.jsonl"
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY", "1")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_PATH", str(log_path))
+    monkeypatch.setenv("BRAINLAYER_WRITER_HEARTBEAT_DIR", str(tmp_path / "heartbeats"))
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "pidfiles"))
+    return log_path
+
+
+def _finished(log_path: Path, operation: str) -> list[dict]:
+    if not log_path.exists():
+        return []
+    return [
+        event
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if (event := json.loads(line)).get("event") == "txn_finished" and event.get("operation") == operation
+    ]
+
+
+def _insert_chunk(store: VectorStore, chunk_id: str, *, conversation_id: str = "session-one") -> None:
+    store.conn.execute(
+        """
+        INSERT INTO chunks (id, content, metadata, source_file, source, conversation_id, content_type)
+        VALUES (?, ?, '{}', 'watcher.jsonl', 'realtime_watcher', ?, 'assistant_text')
+        """,
+        (chunk_id, f"Content for {chunk_id}", conversation_id),
+    )
+
+
+class _SqliteConnectionAdapter:
+    def __init__(self, db_path: Path):
+        self._conn = sqlite3.connect(db_path)
+        self._change_anchor = 0
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def changes(self) -> int:
+        changed = self._conn.total_changes - self._change_anchor
+        self._change_anchor = self._conn.total_changes
+        return changed
+
+
+class _SqliteStoreAdapter:
+    def __init__(self, db_path: Path):
+        self.conn = _SqliteConnectionAdapter(db_path)
+
+    def close(self) -> None:
+        self.conn.close()
+
+
+def test_rewind_archive_flush_emits_watcher_span(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    _insert_chunk(store, "rewind-one", conversation_id="session-one")
+    _insert_chunk(store, "rewind-two", conversation_id="session-two")
+    store.close()
+    log_path.unlink(missing_ok=True)
+    batcher = _RewindArchiveBatcher(
+        db_path,
+        batch_size=10,
+        flush_interval_ms=1_000,
+        vector_store_factory=_SqliteStoreAdapter,
+    )
+    batcher.add("session-one")
+    batcher.add("session-two")
+
+    try:
+        assert batcher.flush("test") == 2
+    finally:
+        batcher.close()
+
+    events = _finished(log_path, "rewind_archive")
+    assert len(events) == 1
+    assert events[0]["producer"] == "watcher"
+    assert events[0]["lane"] == "realtime"
+    assert events[0]["rows_planned"] is None
+    assert events[0]["sessions_planned"] == 2
+    assert events[0]["rows_touched"] == 2
+    assert events[0]["outcome"] == "commit"
+
+
+def test_direct_enrichment_apply_emits_savepoint_span(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    _insert_chunk(store, "enrich-one")
+    log_path.unlink(missing_ok=True)
+
+    try:
+        _apply_enrichment(
+            store,
+            {"id": "enrich-one", "content": "Content for enrich-one"},
+            {"summary": "Observed enrichment", "tags": ["telemetry"], "entities": []},
+        )
+    finally:
+        store.close()
+
+    events = _finished(log_path, "apply")
+    assert len(events) == 1
+    assert events[0]["producer"] == "enrichment"
+    assert events[0]["lane"] == "enrichment"
+    assert events[0]["transaction_mode"] == "savepoint"
+    assert events[0]["rows_planned"] == 1
+    assert events[0]["outcome"] == "commit"
+
+
+def test_direct_enrichment_apply_preserves_exception_and_records_rollback(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    db_path = tmp_path / "brainlayer.db"
+    store = VectorStore(db_path)
+    _insert_chunk(store, "enrich-error")
+    log_path.unlink(missing_ok=True)
+
+    def fail_update(**_kwargs):
+        raise RuntimeError("synthetic enrichment failure")
+
+    monkeypatch.setattr(store, "update_enrichment", fail_update)
+    try:
+        with pytest.raises(RuntimeError, match="synthetic enrichment failure"):
+            _apply_enrichment(
+                store,
+                {"id": "enrich-error", "content": "Content for enrich-error"},
+                {"summary": "will fail"},
+            )
+    finally:
+        store.close()
+
+    events = _finished(log_path, "apply")
+    assert len(events) == 1
+    assert events[0]["outcome"] == "rollback"
+    assert "synthetic enrichment failure" in events[0]["error"]

--- a/tests/test_writer_telemetry_store_paths.py
+++ b/tests/test_writer_telemetry_store_paths.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brainlayer.store import store_memory
+from brainlayer.vector_store import VectorStore
+
+
+def _configure(monkeypatch, tmp_path: Path) -> Path:
+    log_path = tmp_path / "writer-telemetry.jsonl"
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY", "1")
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_PATH", str(log_path))
+    monkeypatch.setenv("BRAINLAYER_WRITER_HEARTBEAT_DIR", str(tmp_path / "heartbeats"))
+    monkeypatch.setenv("BRAINLAYER_WRITER_PIDFILE_DIR", str(tmp_path / "pidfiles"))
+    monkeypatch.setenv("BRAINLAYER_WRITER_TELEMETRY_FTS_SAMPLE_TTL_SECONDS", "0")
+    return log_path
+
+
+def _finished(log_path: Path, operation: str) -> list[dict]:
+    if not log_path.exists():
+        return []
+    return [
+        event
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if (event := json.loads(line)).get("event") == "txn_finished" and event.get("operation") == operation
+    ]
+
+
+def _chunk(chunk_id: str) -> dict:
+    content = f"Unique telemetry store path content {chunk_id}"
+    return {
+        "id": chunk_id,
+        "content": content,
+        "metadata": {"test": "writer-telemetry"},
+        "source_file": "telemetry.jsonl",
+        "project": "writer-telemetry",
+        "content_type": "note",
+        "char_count": len(content),
+        "source": "test",
+        "created_at": "2026-07-10T00:00:00Z",
+    }
+
+
+def _embedding(seed: int) -> list[float]:
+    return [float(seed)] * 1024
+
+
+def test_vector_store_init_emits_implicit_operation_span(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+
+    store = VectorStore(tmp_path / "brainlayer.db")
+    store.close()
+
+    events = _finished(log_path, "init")
+    assert len(events) == 1
+    event = events[0]
+    assert event["producer"] == "vector_store"
+    assert event["lane"] == "maintenance"
+    assert event["span_kind"] == "writer_operation"
+    assert event["transaction_mode"] == "implicit_per_statement"
+    assert event["outcome"] == "completed"
+    assert any("chunks_fts" in statement["normalized_sql"] for statement in event["statements"])
+
+
+def test_upsert_chunks_emits_one_span_per_pr570_sub_batch(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", "2")
+    store = VectorStore(tmp_path / "brainlayer.db")
+    log_path.unlink()
+
+    assert (
+        store.upsert_chunks(
+            [_chunk(f"chunk-{index}") for index in range(3)],
+            [_embedding(index) for index in range(3)],
+        )
+        == 3
+    )
+    store.close()
+
+    events = _finished(log_path, "upsert_chunks")
+    assert len(events) == 2
+    assert [event["rows_planned"] for event in events] == [2, 1]
+    assert all(event["producer"] == "index" for event in events)
+    assert all(event["lane"] == "batch" for event in events)
+    assert all(event["outcome"] == "commit" for event in events)
+    assert all(event["duration_ms"] >= 0 for event in events)
+
+
+def test_direct_store_memory_emits_interactive_transaction_span(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    store = VectorStore(tmp_path / "brainlayer.db")
+    log_path.unlink()
+
+    result = store_memory(
+        store=store,
+        embed_fn=None,
+        content="A unique direct MCP telemetry store memory",
+        memory_type="note",
+        project="writer-telemetry",
+        retry_on_busy=False,
+    )
+    store.close()
+
+    assert result["id"]
+    events = _finished(log_path, "store_memory")
+    assert len(events) == 1
+    assert events[0]["producer"] == "mcp"
+    assert events[0]["lane"] == "interactive"
+    assert events[0]["rows_planned"] == 1
+    assert events[0]["outcome"] == "commit"

--- a/tests/test_writer_telemetry_store_paths.py
+++ b/tests/test_writer_telemetry_store_paths.py
@@ -7,8 +7,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from brainlayer.store import store_memory
 import brainlayer.vector_store as vector_store
+from brainlayer.store import store_memory
 from brainlayer.vector_store import VectorStore
 
 

--- a/tests/test_writer_telemetry_store_paths.py
+++ b/tests/test_writer_telemetry_store_paths.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import json
+import time as stdlib_time
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from brainlayer.store import store_memory
+import brainlayer.vector_store as vector_store
 from brainlayer.vector_store import VectorStore
 
 
@@ -85,6 +90,49 @@ def test_upsert_chunks_emits_one_span_per_pr570_sub_batch(tmp_path, monkeypatch)
     assert all(event["lane"] == "batch" for event in events)
     assert all(event["outcome"] == "commit" for event in events)
     assert all(event["duration_ms"] >= 0 for event in events)
+
+
+def test_upsert_deadline_interrupt_records_rollback_telemetry(tmp_path, monkeypatch):
+    log_path = _configure(monkeypatch, tmp_path)
+    monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", "1")
+    monkeypatch.setattr(vector_store, "_INDEX_DEADLINE_PROGRESS_STEPS", 1, raising=False)
+    store = VectorStore(tmp_path / "brainlayer.db")
+    log_path.unlink()
+    inside_insert = False
+
+    def trace(_cursor, statement, bindings):
+        nonlocal inside_insert
+        normalized = " ".join(str(statement).upper().split())
+        if "INSERT INTO CHUNKS" in normalized and bindings and bindings[0] == "deadline-chunk":
+            inside_insert = True
+        return True
+
+    store.conn.setexectrace(trace)
+    monkeypatch.setattr(
+        vector_store,
+        "time",
+        SimpleNamespace(
+            monotonic=lambda: 101.0 if inside_insert else 100.0,
+            sleep=stdlib_time.sleep,
+            time=stdlib_time.time,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="index deadline exceeded"):
+        store.upsert_chunks(
+            [_chunk("deadline-chunk")],
+            [_embedding(1)],
+            deadline_monotonic=100.5,
+        )
+
+    assert store.conn.in_transaction is False
+    assert store.conn.cursor().execute("SELECT COUNT(*) FROM chunks").fetchone() == (0,)
+    store.close()
+
+    events = _finished(log_path, "upsert_chunks")
+    assert len(events) == 1
+    assert events[0]["outcome"] == "rollback"
+    assert events[0]["error"] == "IndexDeadlineExceeded: index deadline exceeded"
 
 
 def test_direct_store_memory_emits_interactive_transaction_span(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add fail-open, size-rotated writer transaction telemetry at `~/.local/share/brainlayer/logs/writer-telemetry.jsonl`
- write a pid/DB-specific active transaction marker before the existing `BEGIN IMMEDIATE`/savepoint operation, then clear it after the existing commit/rollback path
- capture top-level SQL fingerprints, statement starts/durations/VM counters, producer/lane, rows, queue wait, WAL frames, sampled FTS segments, outcome, and PID through APSW `trace_v2`
- instrument VectorStore init and PR #570 sub-batches, drain/burn drain, hotlane, direct MCP store, watcher rewind, and direct enrichment apply without moving transaction boundaries
- add read-only `brainlayer writer-telemetry tail|summary` commands

## Phase 0 gate

A tmp-only FTS5 test blocks an `INSERT INTO chunks_fts ... SELECT slow_fts(...)` statement while a second thread reads the active marker. The test verifies the top-level statement start/fingerprint while open, then verifies duration and VM counters after commit.

## Test plan

- `pytest` focused Phase 0/writer paths: 156 passed
- expanded Python 3.13 suite, excluding the two handoff-prohibited real-DB files: 3,485 passed, 49 skipped, 5 xfailed
- `ruff check src/ tests/`: passed
- `ruff format --check src/ tests/`: passed
- required `BRAINLAYER_PREPUSH_SCOPE=changed-only git push`: passed its full fallback gate under Python 3.12; unit result 3,430 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; configured isolated-eval/Bun/shell gates also returned exit 0

## Review note

The observability tests exposed a pre-existing PR #574 mismatch: the production rewind factory returns an APSW connection, while `_RewindArchiveBatcher.flush()` calls the sqlite3-only `.commit()` method. This PR records that path's error outcome but deliberately does not change behavior in the Phase 0 telemetry-only lane.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spans run on every major SQLite writer path and install trace_v2 on connections, but design is observability-only with fail-open sinks and no moved transaction boundaries; default-on telemetry adds I/O and tracing overhead in production.
> 
> **Overview**
> Introduces **Phase 0 writer observability**: a new `writer_telemetry` module that logs rotated JSONL events, maintains pid/DB **active-transaction heartbeat** files, and aggregates SQL via APSW **`trace_v2`** (fingerprints, durations, VM counters). Spans wrap existing **`BEGIN IMMEDIATE` / savepoint / init** boundaries only—callers still own commit/rollback; telemetry errors are **fail-open**.
> 
> **Instrumentation** is added on drain (live + burn, with **queue wait** from spool mtimes), hotlane vector writes, MCP `store_memory` (and re-embed), VectorStore **init** (`implicit_per_statement`) and **upsert_chunks** sub-batches, watcher **rewind_archive**, and enrichment **apply** (savepoint mode).
> 
> Adds **`brainlayer writer-telemetry tail|summary`** for read-only inspection, an autouse pytest fixture to redirect telemetry paths, and a slow-FTS **gate test** that asserts live fingerprints in the heartbeat while a statement runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc65d5d0ed8d9943d4e0d2b4dc4a7cb12a711251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add writer transaction observability with JSONL telemetry and live heartbeat files
> - Introduces [writer_telemetry.py](https://github.com/EtanHey/brainlayer/pull/582/files#diff-276857421d9ff433867d961428f5f02497699f193203da137f8d2ec7f47e2f63) with a `writer_span`/`_WriterSpan` API that installs an APSW `trace_v2` handler to aggregate per-statement counts and durations, emits `txn_started`/`txn_finished` JSONL events (with WAL metrics, FTS segment counts, and outcome), and maintains a live heartbeat JSON file while a transaction is open.
> - Instruments transactions in `drain.py`, `store.py`, `vector_store.py`, `enrichment_controller.py`, `hotlane_brainbar_daemon.py`, and the CLI rewind-archive flush — each wrapping its DB transaction with a span and recording commit/rollback outcomes and row counts.
> - Adds a `brainlayer writer-telemetry tail|summary` CLI command to read and aggregate telemetry logs without opening the database.
> - All telemetry is fail-open: errors inside span/sink code are swallowed and never propagate to the writer call sites; DB semantics and return values are unchanged.
> - Tests redirect telemetry output to `tmp_path` via an autouse fixture in [conftest.py](https://github.com/EtanHey/brainlayer/pull/582/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128), with dedicated test files for drain, store, CLI, gate, and misc paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc65d5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in fail-open writer transaction telemetry with JSONL logging, SQL fingerprinting, per-operation commit/rollback outcomes, performance metrics, and live heartbeat snapshots.
  * Added `writer-telemetry` CLI commands to tail recent telemetry lines and generate JSON summaries.
  * Instrumented writer-adjacent operations including storage, indexing/upserts, enrichment apply, draining/burn draining, watcher rewind archive, and hotlane vector writes.
* **Bug Fixes**
  * Telemetry remains non-blocking: instrumentation errors won’t interrupt database behavior.
* **Documentation**
  * Added an implementation plan for “Writerd Phase 0 Observability.”
* **Tests**
  * Expanded coverage for telemetry gating, heartbeats, summaries, rotation, drain/burn/hotlane emissions, and deadline/rollback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->