### PR TITLE
Release BrainLayer 1.4.3 — wedge-class stopgap gates

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.4.2</string>
+    <string>1.4.3</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.2</string>
+    <string>1.4.3</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.4.2"
+version = "1.4.3"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
-  "description": "Persistent memory for AI agents — local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.4.2",
+  "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
+  "version": "1.4.3",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"


### PR DESCRIPTION
## Summary
Version bump 1.4.2 → 1.4.3 (pyproject, __init__, server.json, BrainBar Info.plist — version-sync tests green). Ships the 07-10 wedge-class stopgap gates to the PyPI→homebrew→launchd deploy chain:
- #574 batch rewind-archival (watcher-spin fix)
- #580 frozen-drain heal (heal kills the write-lock holder even when the drain heartbeat freezes silently)
- #581 index watchdog (BRAINLAYER_INDEX_MAX_RUNTIME_S, default 1800s — bounded index runs, loud INDEX_RUNTIME_EXCEEDED alarm)

Release ruling: orc-driver GO (2026-07-10). After merge: tag v1.4.3 → publish.yml (PyPI) + brainbar-release.yml (app asset) → etanhey/layers formula+cask bump → brew upgrade → service restarts with live-probe receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only and metadata string changes with no runtime logic in the diff.
> 
> **Overview**
> **Release 1.4.3** — bumps the package and app version from **1.4.2** to **1.4.3** everywhere it must stay aligned for PyPI, MCP registry metadata, and BrainBar.
> 
> Updates `pyproject.toml`, `src/brainlayer/__init__.py`, `server.json` (root and PyPI package `version` fields), and BrainBar `Info.plist` (`CFBundleVersion` / `CFBundleShortVersionString`). In `server.json`, the description string also switches to a Unicode em dash (`—`) in place of the prior ASCII hyphen form; tool count text is unchanged at 12 MCP tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 716366df37f1318a0905d5e419f6cd484cb7fc98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release BrainLayer 1.4.3 with wedge-class stopgap gates
> Bumps the version string from 1.4.2 to 1.4.3 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/583/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/583/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/583/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [src/brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/583/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954). Also updates the description text in `server.json` to use an em dash.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 716366d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->