### PR TITLE
fix: make importance/recency score boosts opt-in (boost-confound)

### DIFF
--- a/docs/plans/2026-07-10-relevance-score-controls-weighted-rrf.md
+++ b/docs/plans/2026-07-10-relevance-score-controls-weighted-rrf.md
@@ -1,0 +1,69 @@
+# Relevance Score Controls and Weighted RRF Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Finish the two settled relevance wins by exposing score boosts as opt-in environment controls and making warm hybrid search use configurable two-leg weighted RRF.
+
+**Architecture:** Keep the existing explicit rerank kwargs and add small call-time environment helpers so current callers remain compatible while process-wide opt-ins work without module reloads. Keep fusion in `search_repo.py`, but isolate alpha parsing and deterministic two-leg RRF math so vector and FTS ranks are the only fusion inputs; the MCP layer continues to expose honest FTS fallback metadata when embeddings are unavailable.
+
+**Tech Stack:** Python 3.11+, pytest, APSW/FTS5, Ruff, GitHub CLI.
+
+---
+
+### Task 1: Add opt-in environment controls for importance and recency boosts
+
+**Files:**
+- Modify: `src/brainlayer/search_repo.py`
+- Test: `tests/test_hybrid_search.py`
+
+**Step 1: Write the failing tests**
+
+Add focused tests proving that unset environment controls leave equal base scores, `BRAINLAYER_SCORE_IMPORTANCE_BOOST=1` enables only the importance multiplier, `BRAINLAYER_SCORE_RECENCY_DECAY=1` enables only recency decay, and explicit kwargs still enable their existing behavior.
+
+**Step 2: Run tests to verify RED**
+
+Run: `pytest -q tests/test_hybrid_search.py -k 'score_boost or default_does_not_apply_recency'`
+
+Expected: the environment-controlled tests fail because `hybrid_search` does not yet read either setting.
+
+**Step 3: Write the minimal implementation**
+
+Add a strict boolean environment helper, combine each environment control with its existing explicit kwarg at the start of `hybrid_search`, and use the effective values for the cache key and boost gates.
+
+**Step 4: Run tests to verify GREEN**
+
+Run the focused tests, then `pytest -q tests/test_hybrid_search.py tests/test_search_quality.py tests/test_agent_profiles.py tests/test_consumer_scoping.py`.
+
+**Step 5: Verify and publish PR 1**
+
+Run the brief-required Ruff commands and permitted pytest suite, commit only PR-1 files, push with `BRAINLAYER_PREPUSH_SCOPE=changed-only`, open the specified ready-for-review PR, and request Codex/Cursor/Bugbot review.
+
+### Task 2: Make warm hybrid fusion a configurable two-leg weighted RRF
+
+**Files:**
+- Modify: `src/brainlayer/search_repo.py`
+- Modify: `src/brainlayer/mcp/search_handler.py` only if the existing fallback response lacks the required explicit degraded marker
+- Test: `tests/test_hybrid_search.py`
+- Test: `tests/test_search_handler.py`
+
+**Step 1: Write the failing tests**
+
+Add deterministic rank-fixture tests for alpha `0.25`, a valid `BRAINLAYER_RRF_ALPHA` override, invalid/non-finite fallback to `0.25`, no trigram contribution, and MCP FTS-only fallback with explicit degraded honesty.
+
+**Step 2: Run tests to verify RED**
+
+Run: `pytest -q tests/test_hybrid_search.py tests/test_search_handler.py -k 'weighted_rrf or trigram or fts_fallback'`
+
+Expected: math/override/trigram tests fail because fusion is inline, alpha is constant, and trigram is still a scored leg; the degraded marker test fails if the current MCP payload exposes only `search_mode` and `fallback_reason`.
+
+**Step 3: Write the minimal implementation**
+
+Add a bounded finite alpha parser and a pure two-leg weighted-RRF helper. Fuse only semantic and FTS candidate ranks, retain trigram diagnostics only if needed outside fusion, and add `degraded: true` to fallback payloads without changing hybrid success payloads.
+
+**Step 4: Run tests to verify GREEN**
+
+Run the focused tests, then all permitted search/MCP tests and the full suite excluding `tests/test_vector_store.py` and `tests/test_engine.py`.
+
+**Step 5: Verify and publish PR 2**
+
+Branch from PR 1, run Ruff and permitted pytest verification, commit only PR-2 files, push with the scoped pre-push gate, open the specified stacked PR, request reviewers, and record both URLs/evidence in `docs.local/handoffs/BL-A-REPORT.md`.

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -121,6 +121,10 @@ AUDIT_RECURSION_TAG_PATTERNS = (
 _hybrid_cache: "OrderedDict[tuple, tuple[dict, float]]" = OrderedDict()
 
 
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().casefold() in {"1", "true", "yes", "on"}
+
+
 def _has_recency_intent(query_text: str) -> bool:
     """Return true when recency words appear as terms, not substrings."""
     return bool(_RECENCY_SINGLE_TERM_RE.search(query_text) or _RECENCY_THIS_WEEK_RE.search(query_text))
@@ -1764,6 +1768,8 @@ class SearchMixin:
         Cache is module-level LRU (128 entries) with defensive copy-on-read.
         """
 
+        recency_rerank = recency_rerank or _env_flag_enabled("BRAINLAYER_SCORE_RECENCY_DECAY")
+        importance_rerank = importance_rerank or _env_flag_enabled("BRAINLAYER_SCORE_IMPORTANCE_BOOST")
         project_filter = _effective_project_filter(project_filter, consumer_scope)
         source_filter = _effective_source_filter(source_filter, consumer_scope)
         include_checkpoints = _effective_include_checkpoints(include_checkpoints, consumer_scope)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -232,6 +232,8 @@ class TestHybridSearch:
         assert results["ids"][0] == ["lexical-only", "vector-only"]
 
     def test_hybrid_search_default_does_not_apply_recency_or_importance_boost(self, store, monkeypatch):
+        monkeypatch.delenv("BRAINLAYER_SCORE_IMPORTANCE_BOOST", raising=False)
+        monkeypatch.delenv("BRAINLAYER_SCORE_RECENCY_DECAY", raising=False)
         monkeypatch.setattr(search_repo, "RRF_VECTOR_ALPHA", 0.5)
         query_embedding = _embed("neutral rerank evidence")
         _insert_chunk(
@@ -268,7 +270,95 @@ class TestHybridSearch:
 
         assert captured_scores["old-important"] == pytest.approx(captured_scores["fresh-low"])
 
+    def test_hybrid_search_importance_score_boost_env_opt_in(self, store, monkeypatch):
+        monkeypatch.setenv("BRAINLAYER_SCORE_IMPORTANCE_BOOST", "1")
+        monkeypatch.delenv("BRAINLAYER_SCORE_RECENCY_DECAY", raising=False)
+        monkeypatch.setattr(search_repo, "RRF_VECTOR_ALPHA", 0.5)
+        query_embedding = _embed("importance env rerank evidence")
+        _insert_chunk(
+            store,
+            chunk_id="high-importance",
+            content="importance env rerank evidence padded exact hit with extra words",
+            embedding=query_embedding,
+            importance=10.0,
+            created_at="2020-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="low-importance",
+            content="importance env rerank evidence",
+            embedding=[value + 0.00001 for value in query_embedding],
+            importance=0.0,
+            created_at="2020-01-01T00:00:00Z",
+        )
+        store.build_binary_index()
+        monkeypatch.setattr(store, "_trigram_fts_available", False)
+        captured_scores: dict[str, float] = {}
+
+        def capture_scores(scored, *, n_results):
+            captured_scores.update({chunk_id: score for score, chunk_id, *_rest in scored})
+            return scored
+
+        monkeypatch.setattr(store, "_mmr_rerank_scored_results", capture_scores)
+
+        store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="importance env rerank evidence",
+            n_results=2,
+        )
+
+        base_rrf = 0.5 / 60.0 + 0.5 / 61.0
+        assert captured_scores["high-importance"] == pytest.approx(base_rrf * 1.5)
+        assert captured_scores["low-importance"] == pytest.approx(base_rrf)
+
+    def test_hybrid_search_recency_score_boost_env_opt_in(self, store, monkeypatch):
+        monkeypatch.delenv("BRAINLAYER_SCORE_IMPORTANCE_BOOST", raising=False)
+        monkeypatch.setenv("BRAINLAYER_SCORE_RECENCY_DECAY", "1")
+        monkeypatch.setattr(search_repo, "RRF_VECTOR_ALPHA", 0.5)
+        query_embedding = _embed("recency env rerank evidence")
+        _insert_chunk(
+            store,
+            chunk_id="old-result",
+            content="recency env rerank evidence padded exact hit with extra words",
+            embedding=query_embedding,
+            importance=5.0,
+            created_at="2020-01-01T00:00:00Z",
+        )
+        _insert_chunk(
+            store,
+            chunk_id="fresh-result",
+            content="recency env rerank evidence",
+            embedding=[value + 0.00001 for value in query_embedding],
+            importance=5.0,
+            created_at="2999-01-01T00:00:00Z",
+        )
+        store.build_binary_index()
+        monkeypatch.setattr(store, "_trigram_fts_available", False)
+        captured_scores: dict[str, float] = {}
+
+        def capture_scores(scored, *, n_results):
+            captured_scores.update({chunk_id: score for score, chunk_id, *_rest in scored})
+            return scored
+
+        monkeypatch.setattr(store, "_mmr_rerank_scored_results", capture_scores)
+
+        store.hybrid_search(
+            query_embedding=query_embedding,
+            query_text="recency env rerank evidence",
+            n_results=2,
+        )
+
+        base_rrf = 0.5 / 60.0 + 0.5 / 61.0
+        old_age_days = (
+            datetime.now(timezone.utc) - datetime.fromisoformat("2020-01-01T00:00:00+00:00")
+        ).total_seconds() / 86400
+        old_recency_boost = 0.7 + 0.3 * math.exp(-0.023 * old_age_days)
+        assert captured_scores["old-result"] == pytest.approx(base_rrf * old_recency_boost)
+        assert captured_scores["fresh-result"] == pytest.approx(base_rrf)
+
     def test_hybrid_search_opt_in_recency_and_importance_rerank_change_scores(self, store, monkeypatch):
+        monkeypatch.delenv("BRAINLAYER_SCORE_IMPORTANCE_BOOST", raising=False)
+        monkeypatch.delenv("BRAINLAYER_SCORE_RECENCY_DECAY", raising=False)
         monkeypatch.setattr(search_repo, "RRF_VECTOR_ALPHA", 0.5)
         query_embedding = _embed("opt in rerank evidence")
         _insert_chunk(


### PR DESCRIPTION
## Summary
- add process-wide opt-ins for the existing importance multiplier and recency rerank/decay controls
- keep explicit `importance_rerank` and `recency_rerank` kwargs working for existing callers
- use effective opt-in values in the hybrid-search cache key
- document the two-PR implementation plan

## Context
PR #565 already made the explicit rerank kwargs default-off. This follow-up finishes the handoff contract by exposing strict call-time environment controls:
- `BRAINLAYER_SCORE_IMPORTANCE_BOOST`
- `BRAINLAYER_SCORE_RECENCY_DECAY`

Accepted enabled values are `1`, `true`, `yes`, and `on` (case-insensitive). Unset or other values remain off.

## Test plan
- [x] TDD red: both env-control tests failed before implementation
- [x] focused scoring/consumer suite: 91 passed
- [x] Ruff check + format: clean
- [x] pre-push Python 3.12 unit gate: 3450 passed, 9 skipped, 61 deselected, 1 xfailed
- [x] MCP registration: 3 passed
- [x] isolated eval/hook routing: 40 passed
- [x] Bun regression: 1 passed
- [x] FTS5 determinism shell regression: passed

## Review note
The local CodeRabbit CLI was attempted before commit but returned the public OSS rate limit (15-minute reset), so PR-level bot review is requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes relevance ranking when env flags are enabled and affects cache partitioning by rerank mode; defaults unchanged so production risk is low unless operators opt in.
> 
> **Overview**
> Adds **process-wide opt-ins** for hybrid search post-RRF boosts that previously required explicit kwargs. At the start of `hybrid_search`, **`recency_rerank`** and **`importance_rerank`** are combined with **`BRAINLAYER_SCORE_RECENCY_DECAY`** and **`BRAINLAYER_SCORE_IMPORTANCE_BOOST`** via a new **`_env_flag_enabled`** helper (truthy values: `1`, `true`, `yes`, `on`, case-insensitive). Explicit kwargs still work; unset env keeps default-off behavior from the prior kwargs-only contract.
> 
> Effective rerank flags continue to drive boost gates and the **hybrid result cache key**, so env-on vs env-off queries do not share cached rankings. Tests assert isolated importance and recency effects under each env flag and clear those variables in existing default/opt-in kwargs tests. A **docs plan** describes this PR as task 1 of a two-PR relevance stack (weighted RRF follows separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53e5129318e44ab4dbf6d0c04f06d8a110371ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make importance and recency score boosts opt-in via environment variables in `hybrid_search`
> - Recency decay and importance boost in `SearchMixin.hybrid_search` previously applied based only on kwargs; they now also require the corresponding env vars (`BRAINLAYER_SCORE_RECENCY_DECAY`, `BRAINLAYER_SCORE_IMPORTANCE_BOOST`) to be set to a truthy value.
> - Adds a `_env_flag_enabled` helper in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/584/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) that parses boolean-like env vars (`"1"`, `"true"`, `"yes"`, `"on"`, case-insensitive).
> - Behavioral Change: boosts that previously fired when kwargs were set will no longer fire unless the env var is also enabled, making these features opt-in by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f53e512. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->