### PR TITLE
feat: add tier-0 health-check watchdog

### DIFF
--- a/docs/plans/2026-07-10-tier0-meta-watchdog-design.md
+++ b/docs/plans/2026-07-10-tier0-meta-watchdog-design.md
@@ -1,0 +1,77 @@
+# Tier-0 Meta-Watchdog Design
+
+## Scope
+
+Add a launchd job that runs under `/bin/sh` and monitors the Python-backed
+`com.brainlayer.health-check` job. The watchdog must remain independent of the
+interpreter class it guards, detect an unloaded health-check label or a stale
+health-check state file, alert through independent local and HTTP channels, and
+then heal the launchd job.
+
+## Architecture
+
+`scripts/tier0-watchdog.sh` is a single POSIX-shell program. It reads production
+defaults from environment-overridable settings, checks the health-check label
+with `launchctl print`, and reads the state-file mtime with macOS `stat`. A state
+file older than 1,200 seconds is stale by default.
+
+The launchd command contract is scoped to the current GUI user. `TIER0_DOMAIN`
+defaults to `gui/$(id -u)`, and the script invokes these exact forms:
+
+- `launchctl print "$TIER0_DOMAIN/$TIER0_LABEL"` for inspection;
+- `launchctl bootstrap "$TIER0_DOMAIN" "$TIER0_HEALTH_PLIST_PATH"` when the
+  label is absent;
+- `launchctl kickstart -k "$TIER0_DOMAIN/$TIER0_LABEL"` after bootstrap or
+  directly when the loaded label has stale or missing state.
+
+On a detected fault, the script records the reason and attempts every alert
+channel before any recovery action:
+
+1. append a timestamped line to the Tier-0 log;
+2. display a macOS notification with `osascript`;
+3. POST the alert to the local notify endpoint with a short timeout.
+
+All three alert processes are dispatched before recovery and bounded by
+`TIER0_ALERT_TIMEOUT_SECONDS` (default three seconds); timed-out processes are
+terminated. The HTTP request also uses curl's three-second max-time. The default
+endpoint is `http://localhost:3847/notify`, with `Content-Type:
+application/json` and a constant JSON object containing `title`, `body`, and
+`source` fields. Keeping the JSON constant avoids shell interpolation and JSON
+escaping hazards. Curl accepts only successful HTTP responses (`-f`) but every
+alert attempt is fail-open, so one broken channel cannot suppress the others or
+prevent recovery. If the label is absent, recovery bootstraps the installed
+health-check plist and then kickstarts the label. If the label is loaded but the
+state is missing or stale, recovery kickstarts it directly. A detected fault
+exits nonzero even when recovery commands succeed, preserving a loud launchd
+signal.
+
+The launchd installer copies the script to
+`~/.local/lib/brainlayer/tier0-watchdog.sh`, renders
+`com.brainlayer.tier0-watchdog.plist`, and loads it through the existing
+installer. The plist invokes only `/bin/sh` plus the installed script path.
+
+## Testability
+
+Tests replace command paths through explicit `TIER0_*` executable variables,
+use temporary state/plist/log files, and provide a deterministic current epoch.
+No drill addresses the live launchd domain or production state file.
+
+The four drills cover:
+
+- unloaded label: alerts, bootstraps, then kickstarts;
+- stale state: alerts and kickstarts without bootstrap;
+- notify endpoint failure: local log and osascript alert still occur, followed
+  by recovery; the curl fixture hangs and proves the bounded alert process
+  cannot delay recovery indefinitely;
+- loaded label plus fresh state: no alerts and no recovery.
+
+A separate regression covers a missing state file and asserts direct kickstart
+without bootstrap. It is not one of the four named exit-gate drills.
+
+## Alternatives Considered
+
+- PATH-prepended command stubs were rejected because absolute production command
+  defaults make command identity clearer and reduce accidental PATH coupling.
+- A sourced shell adapter library was rejected because it creates an additional
+  Tier-0 runtime artifact and failure surface without improving the four-drill
+  contract.

--- a/docs/plans/2026-07-10-tier0-meta-watchdog-design.md
+++ b/docs/plans/2026-07-10-tier0-meta-watchdog-design.md
@@ -31,10 +31,11 @@ channel before any recovery action:
 2. display a macOS notification with `osascript`;
 3. POST the alert to the local notify endpoint with a short timeout.
 
-All three alert processes are dispatched before recovery and bounded by
-`TIER0_ALERT_TIMEOUT_SECONDS` (default three seconds); timed-out processes are
-terminated. The HTTP request also uses curl's three-second max-time. The default
-endpoint is `http://localhost:3847/notify`, with `Content-Type:
+All three alert processes are dispatched before recovery and share one
+`TIER0_ALERT_TIMEOUT_SECONDS` deadline (default three seconds); processes still
+running when it expires are terminated and reaped. The HTTP request also uses
+curl's three-second max-time. The default endpoint is
+`http://localhost:3847/notify`, with `Content-Type:
 application/json` and a constant JSON object containing `title`, `body`, and
 `source` fields. Keeping the JSON constant avoids shell interpolation and JSON
 escaping hazards. Curl accepts only successful HTTP responses (`-f`) but every
@@ -65,8 +66,8 @@ The four drills cover:
   cannot delay recovery indefinitely;
 - loaded label plus fresh state: no alerts and no recovery.
 
-A separate regression covers a missing state file and asserts direct kickstart
-without bootstrap. It is not one of the four named exit-gate drills.
+Separate regressions cover a missing state file, a future-dated state mtime, and
+the shared alert deadline. They are not part of the four named exit-gate drills.
 
 ## Alternatives Considered
 

--- a/docs/plans/2026-07-10-tier0-meta-watchdog.md
+++ b/docs/plans/2026-07-10-tier0-meta-watchdog.md
@@ -1,0 +1,82 @@
+# Tier-0 Meta-Watchdog Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a pure `/bin/sh` launchd watchdog that detects, alerts on, and heals a dead or stale BrainLayer health-check.
+
+**Architecture:** A standalone POSIX-shell script checks the health-check launchd label and state-file mtime, fans bounded alerts out to a local log, macOS notification, and fail-open HTTP endpoint, then bootstraps or kickstarts the health-check. `TIER0_DOMAIN` defaults to `gui/$(id -u)`; inspection uses `launchctl print "$TIER0_DOMAIN/$TIER0_LABEL"`, absent-label recovery uses `launchctl bootstrap "$TIER0_DOMAIN" "$TIER0_HEALTH_PLIST_PATH"`, and all recovery ends with `launchctl kickstart -k "$TIER0_DOMAIN/$TIER0_LABEL"`. The existing launchd installer copies the script to a stable per-user path and renders a plist that calls `/bin/sh` directly. Pytest drives four isolated drills using temporary paths and executable overrides.
+
+**Tech Stack:** POSIX `/bin/sh`, macOS launchd/osascript/curl/stat, plist XML, pytest.
+
+---
+
+### Task 1: Prove the four silent-death drills
+
+**Files:**
+- Create: `tests/test_tier0_drills.py`
+- Create: `scripts/tier0-watchdog.sh`
+
+1. Add a test harness that creates fake `launchctl`, `osascript`, `curl`, and
+   `stat` executables and runs `/bin/sh scripts/tier0-watchdog.sh` with only
+   temporary paths and a deterministic epoch.
+2. Add D1 for an unloaded label and assert alert events precede bootstrap and
+   kickstart events.
+3. Add D2 for a stale state file and assert alert events precede kickstart, with
+   no bootstrap.
+4. Add D3 with a hanging curl stub and a one-second alert-process timeout; assert
+   the Tier-0 log and osascript still alert before kickstart.
+5. Add D4 for a loaded label and fresh state and assert exit zero with no alert,
+   bootstrap, or kickstart.
+6. Add a separate missing-state regression that asserts alerting and direct
+   kickstart without bootstrap; do not count it as a fifth exit-gate drill.
+7. Assert the exact user-domain `print`, `bootstrap`, and `kickstart` argument
+   forms in the applicable drills.
+8. Assert the notify request uses `POST http://localhost:3847/notify`,
+   `Content-Type: application/json`, a constant `title`/`body`/`source` payload,
+   curl fail-on-HTTP-error behavior, and a bounded timeout.
+9. Run `pytest tests/test_tier0_drills.py -v` and confirm RED because the script
+   does not exist.
+10. Implement the minimal POSIX-shell detection, bounded alert fan-out, and
+    healing behavior, with quoted executable/path overrides and no Python
+    dependency.
+11. Re-run the drill suite and confirm GREEN.
+
+### Task 2: Prove the launchd and installer contract
+
+**Files:**
+- Create: `scripts/launchd/com.brainlayer.tier0-watchdog.plist`
+- Modify: `scripts/launchd/install.sh`
+- Modify: `pyproject.toml`
+- Modify: `tests/test_installable_build.py`
+
+1. Add failing plist assertions for the Tier-0 label, 300-second interval,
+   `RunAtLoad`, and exact `ProgramArguments` beginning with `/bin/sh` and never
+   using the environment runner or Python.
+2. Add a failing packaged-installer test that invokes the `tier0-watchdog`
+   target with fake launchctl, then asserts the script is installed executable
+   and the plist contains its stable installed path. Assert installer bootstrap
+   and post-load print use the same `gui/$UID` domain.
+3. Run the focused tests and confirm RED because the plist/target do not exist.
+4. Add the plist, a dedicated installer path that copies the runtime script,
+   and `tier0-watchdog` handling in install/all/remove/usage flows.
+5. Include the runtime script in wheel and sdist packaging.
+6. Re-run the focused installer and drill tests and confirm GREEN.
+
+### Task 3: Verify and publish the worker PR
+
+**Files:**
+- Create: `docs.local/handoffs/BL-C-REPORT.md`
+
+1. Run `pytest tests/test_tier0_drills.py tests/test_installable_build.py -v`.
+2. Run `ruff check src/ tests/` and `ruff format --check src/ tests/`.
+3. Run the full `pytest` suite without any production DB fixture.
+4. Read the complete diff and every deliverable file, then record exact drill,
+   lint, and suite evidence in the report with the install command
+   `brainlayer setup --launchd --target tier0-watchdog`.
+5. Run the bounded local CodeRabbit review, address blocking findings, commit,
+   and push with `BRAINLAYER_PREPUSH_SCOPE=changed-only`.
+6. Open a ready-for-review PR, append the single required channel line, request
+   Codex/Cursor/Bugbot reviews, and inspect CI plus actionable feedback.
+7. Stop at the worker boundary (PR plus addressed review feedback); the lead
+   owns merge and the live install.
+8. Store the implementation decision and milestone in BrainLayer.

--- a/docs/plans/2026-07-10-tier0-meta-watchdog.md
+++ b/docs/plans/2026-07-10-tier0-meta-watchdog.md
@@ -20,15 +20,17 @@
    `stat` executables and runs `/bin/sh scripts/tier0-watchdog.sh` with only
    temporary paths and a deterministic epoch.
 2. Add D1 for an unloaded label and assert alert events precede bootstrap and
-   kickstart events.
+   kickstart events, with a nonzero watchdog exit.
 3. Add D2 for a stale state file and assert alert events precede kickstart, with
-   no bootstrap.
+   no bootstrap and a nonzero watchdog exit.
 4. Add D3 with a hanging curl stub and a one-second alert-process timeout; assert
-   the Tier-0 log and osascript still alert before kickstart.
+   the Tier-0 log and osascript still alert before kickstart and the watchdog
+   exits nonzero.
 5. Add D4 for a loaded label and fresh state and assert exit zero with no alert,
    bootstrap, or kickstart.
 6. Add a separate missing-state regression that asserts alerting and direct
-   kickstart without bootstrap; do not count it as a fifth exit-gate drill.
+   kickstart without bootstrap plus a nonzero exit; do not count it as a fifth
+   exit-gate drill.
 7. Assert the exact user-domain `print`, `bootstrap`, and `kickstart` argument
    forms in the applicable drills.
 8. Assert the notify request uses `POST http://localhost:3847/notify`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,15 +124,19 @@ markers = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/brainlayer"]
-force-include = {"scripts/launchd" = "brainlayer/launchd"}
 exclude = [
     "src/brainlayer/dashboard",
 ]
+
+[tool.hatch.build.targets.wheel.force-include]
+"scripts/launchd" = "brainlayer/launchd"
+"scripts/tier0-watchdog.sh" = "brainlayer/launchd/tier0-watchdog.sh"
 
 [tool.hatch.build.targets.sdist]
 only-include = [
     "src/brainlayer",
     "scripts/launchd",
+    "scripts/tier0-watchdog.sh",
     "README.md",
     "LICENSE",
     "server.json",

--- a/scripts/launchd/com.brainlayer.tier0-watchdog.plist
+++ b/scripts/launchd/com.brainlayer.tier0-watchdog.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.brainlayer.tier0-watchdog</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>__TIER0_WATCHDOG_SCRIPT__</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>__HOME__</string>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/tier0-watchdog.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/tier0-watchdog.err.log</string>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ExitTimeOut</key>
+	<integer>15</integer>
+	<key>SoftResourceLimits</key>
+	<dict>
+		<key>NumberOfFiles</key>
+		<integer>4096</integer>
+	</dict>
+</dict>
+</plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -16,6 +16,7 @@
 #   ./scripts/launchd/install.sh jsonl-backup # Install daily JSONL backup only
 #   ./scripts/launchd/install.sh maintenance  # Install recurring maintenance jobs
 #   ./scripts/launchd/install.sh health-check # Install stability health check only
+#   ./scripts/launchd/install.sh tier0-watchdog # Install /bin/sh meta-watchdog only
 #   ./scripts/launchd/install.sh hotlane      # Install BrainBar hotlane embed/enrich daemon only
 #   ./scripts/launchd/install.sh p0-counter   # Install daily P0 longitudinal counter only
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
@@ -62,6 +63,7 @@ PYTHON_BIN="$(stable_brainlayer_path "${PYTHON_BIN:-$(command -v python3)}")"
 BRAINLAYER_PYTHON="$(stable_brainlayer_path "${BRAINLAYER_PYTHON:-$PYTHON_BIN}")"
 BRAINLAYER_ENV_FILE="${BRAINLAYER_ENV_FILE:-$HOME/.config/brainlayer/brainlayer.env}"
 BRAINLAYER_ENV_RUN="$BRAINLAYER_LIB_DIR/brainlayer-env-run.sh"
+TIER0_WATCHDOG_DST="$BRAINLAYER_LIB_DIR/tier0-watchdog.sh"
 
 if [ -z "$PYTHON_BIN" ]; then
     echo "ERROR: python3 not found in PATH"
@@ -266,6 +268,46 @@ install_jsonl_backup_script() {
     echo "Installed: $dst"
 }
 
+install_tier0_watchdog() {
+    local script_src="$SCRIPT_DIR/tier0-watchdog.sh"
+    local plist_src="$SCRIPT_DIR/com.brainlayer.tier0-watchdog.plist"
+    local plist_dst="$LAUNCH_DIR/com.brainlayer.tier0-watchdog.plist"
+    local escaped_home
+    local escaped_tier0_watchdog_dst
+
+    if [ ! -f "$script_src" ]; then
+        script_src="$SCRIPT_DIR/../tier0-watchdog.sh"
+    fi
+    if [ ! -f "$script_src" ]; then
+        echo "ERROR: tier0-watchdog.sh not found beside or above $SCRIPT_DIR"
+        return 1
+    fi
+    if [ ! -f "$plist_src" ]; then
+        echo "ERROR: $plist_src not found"
+        return 1
+    fi
+
+    escaped_home="$(
+        printf '%s' "$HOME" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
+    )" || return 1
+    escaped_tier0_watchdog_dst="$(
+        printf '%s' "$TIER0_WATCHDOG_DST" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
+    )" || return 1
+
+    install -m 0755 "$script_src" "$TIER0_WATCHDOG_DST" || return 1
+    sed \
+        -e "s|__HOME__|$escaped_home|g" \
+        -e "s|__TIER0_WATCHDOG_SCRIPT__|$escaped_tier0_watchdog_dst|g" \
+        "$plist_src" > "$plist_dst" || return 1
+
+    echo "Installed: $TIER0_WATCHDOG_DST"
+    echo "Installed: $plist_dst"
+    echo "  Logs: $LOG_DIR/ and $BRAINLAYER_LOG_DIR/"
+    load_plist tier0-watchdog
+}
+
 remove_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
@@ -327,6 +369,9 @@ case "${1:-all}" in
     health-check)
         install_plist health-check
         ;;
+    tier0|tier0-watchdog)
+        install_tier0_watchdog
+        ;;
     hotlane|hotlane-brainbar)
         verify_gemini_env_file
         install_plist hotlane-brainbar
@@ -364,6 +409,9 @@ case "${1:-all}" in
         if ! install_many maintenance-nightly maintenance-weekly health-check p0-counter; then
             failures=1
         fi
+        if ! install_tier0_watchdog; then
+            failures=1
+        fi
         # Remove old enrich plist only after the replacement enrichment service loads.
         if [ "$enrichment_ok" -eq 1 ]; then
             remove_plist enrich 2>/dev/null || true
@@ -386,13 +434,15 @@ case "${1:-all}" in
         remove_plist maintenance-nightly 2>/dev/null || true
         remove_plist maintenance-weekly 2>/dev/null || true
         remove_plist health-check 2>/dev/null || true
+        remove_plist tier0-watchdog 2>/dev/null || true
         remove_plist hotlane-brainbar 2>/dev/null || true
         remove_plist p0-counter 2>/dev/null || true
         rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
         rm -f "$BRAINLAYER_LIB_DIR/jsonl-backup.sh"
+        rm -f "$TIER0_WATCHDOG_DST"
         ;;
     *)
-        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|p0-counter|all|remove]"
+        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|tier0-watchdog|p0-counter|all|remove]"
         exit 1
         ;;
 esac

--- a/scripts/tier0-watchdog.sh
+++ b/scripts/tier0-watchdog.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# Tier-0 guard for the Python-backed BrainLayer health-check LaunchAgent.
+
+set -u
+
+TIER0_LAUNCHCTL=${TIER0_LAUNCHCTL:-/bin/launchctl}
+TIER0_STAT=${TIER0_STAT:-/usr/bin/stat}
+TIER0_OSASCRIPT=${TIER0_OSASCRIPT:-/usr/bin/osascript}
+TIER0_CURL=${TIER0_CURL:-/usr/bin/curl}
+TIER0_DATE=${TIER0_DATE:-/bin/date}
+TIER0_ID=${TIER0_ID:-/usr/bin/id}
+TIER0_SLEEP=${TIER0_SLEEP:-/bin/sleep}
+TIER0_DIRNAME=${TIER0_DIRNAME:-/usr/bin/dirname}
+TIER0_MKDIR=${TIER0_MKDIR:-/bin/mkdir}
+
+TIER0_LABEL=${TIER0_LABEL:-com.brainlayer.health-check}
+if [ -z "${TIER0_DOMAIN:-}" ]; then
+    tier0_uid=$($TIER0_ID -u 2>/dev/null) || tier0_uid=
+    if [ -z "$tier0_uid" ]; then
+        printf '%s\n' "tier0-watchdog: unable to determine launchd user domain" >&2
+        exit 2
+    fi
+    TIER0_DOMAIN="gui/$tier0_uid"
+fi
+
+TIER0_STATE_PATH=${TIER0_STATE_PATH:-$HOME/.local/share/brainlayer/health-check-state.json}
+TIER0_HEALTH_PLIST_PATH=${TIER0_HEALTH_PLIST_PATH:-$HOME/Library/LaunchAgents/com.brainlayer.health-check.plist}
+TIER0_LOG_PATH=${TIER0_LOG_PATH:-$HOME/.local/share/brainlayer/logs/tier0-watchdog.log}
+TIER0_NOTIFY_ENDPOINT=${TIER0_NOTIFY_ENDPOINT:-http://localhost:3847/notify}
+TIER0_STALE_SECONDS=${TIER0_STALE_SECONDS:-1200}
+TIER0_ALERT_TIMEOUT_SECONDS=${TIER0_ALERT_TIMEOUT_SECONDS:-3}
+TIER0_NOTIFY_TIMEOUT_SECONDS=${TIER0_NOTIFY_TIMEOUT_SECONDS:-3}
+
+require_positive_integer() {
+    variable_name=$1
+    variable_value=$2
+    case "$variable_value" in
+        ''|*[!0-9]*|0)
+            printf '%s\n' "tier0-watchdog: $variable_name must be a positive integer" >&2
+            exit 2
+            ;;
+    esac
+}
+
+require_epoch() {
+    variable_name=$1
+    variable_value=$2
+    case "$variable_value" in
+        ''|*[!0-9]*)
+            printf '%s\n' "tier0-watchdog: $variable_name must be a non-negative integer" >&2
+            exit 2
+            ;;
+    esac
+}
+
+require_positive_integer TIER0_STALE_SECONDS "$TIER0_STALE_SECONDS"
+require_positive_integer TIER0_ALERT_TIMEOUT_SECONDS "$TIER0_ALERT_TIMEOUT_SECONDS"
+require_positive_integer TIER0_NOTIFY_TIMEOUT_SECONDS "$TIER0_NOTIFY_TIMEOUT_SECONDS"
+
+if [ -n "${TIER0_NOW_EPOCH:-}" ]; then
+    now_epoch=$TIER0_NOW_EPOCH
+else
+    now_epoch=$($TIER0_DATE +%s 2>/dev/null) || now_epoch=
+fi
+require_epoch TIER0_NOW_EPOCH "$now_epoch"
+
+wait_for_alerts() {
+    remaining=$TIER0_ALERT_TIMEOUT_SECONDS
+
+    while [ "$remaining" -gt 0 ]; do
+        any_running=0
+        for child_pid in "$@"; do
+            if kill -0 "$child_pid" 2>/dev/null; then
+                any_running=1
+            fi
+        done
+        if [ "$any_running" -eq 0 ]; then
+            break
+        fi
+        if ! "$TIER0_SLEEP" 1 2>/dev/null; then
+            remaining=0
+            break
+        fi
+        remaining=$((remaining - 1))
+    done
+
+    for child_pid in "$@"; do
+        if kill -0 "$child_pid" 2>/dev/null; then
+            kill "$child_pid" 2>/dev/null || :
+        fi
+    done
+    for child_pid in "$@"; do
+        wait "$child_pid" 2>/dev/null || :
+    done
+}
+
+alert_all_channels() {
+    reason=$1
+    notify_payload='{"title":"BrainLayer Tier-0 alert","body":"Health-check is unavailable or stale; see the Tier-0 log.","source":"alerts"}'
+
+    (
+        log_dir=$($TIER0_DIRNAME "$TIER0_LOG_PATH" 2>/dev/null) || exit 1
+        "$TIER0_MKDIR" -p "$log_dir" 2>/dev/null || exit 1
+        printf 'epoch=%s label=%s reason=%s\n' "$now_epoch" "$TIER0_LABEL" "$reason" >> "$TIER0_LOG_PATH"
+    ) &
+    log_pid=$!
+
+    "$TIER0_OSASCRIPT" \
+        -e 'display notification "Health-check is unavailable or stale; see the Tier-0 log." with title "BrainLayer Tier-0 watchdog"' \
+        >/dev/null 2>&1 &
+    osascript_pid=$!
+
+    "$TIER0_CURL" -fsS \
+        --max-time "$TIER0_NOTIFY_TIMEOUT_SECONDS" \
+        -X POST "$TIER0_NOTIFY_ENDPOINT" \
+        -H 'Content-Type: application/json' \
+        --data "$notify_payload" \
+        >/dev/null 2>&1 &
+    curl_pid=$!
+
+    wait_for_alerts "$log_pid" "$osascript_pid" "$curl_pid"
+}
+
+target="$TIER0_DOMAIN/$TIER0_LABEL"
+failure_reason=
+label_loaded=0
+
+if "$TIER0_LAUNCHCTL" print "$target" >/dev/null 2>&1; then
+    label_loaded=1
+else
+    failure_reason=label_unloaded
+fi
+
+if [ "$label_loaded" -eq 1 ]; then
+    if [ ! -f "$TIER0_STATE_PATH" ]; then
+        failure_reason=state_missing
+    else
+        state_mtime=$($TIER0_STAT -f %m "$TIER0_STATE_PATH" 2>/dev/null) || state_mtime=
+        case "$state_mtime" in
+            ''|*[!0-9]*)
+                failure_reason=state_mtime_unreadable
+                ;;
+            *)
+                if [ "$state_mtime" -gt "$now_epoch" ]; then
+                    future_offset=$((state_mtime - now_epoch))
+                    failure_reason="state_mtime_future offset=${future_offset}s"
+                else
+                    state_age=$((now_epoch - state_mtime))
+                    if [ "$state_age" -ge "$TIER0_STALE_SECONDS" ]; then
+                        failure_reason="state_stale age=${state_age}s threshold=${TIER0_STALE_SECONDS}s"
+                    fi
+                fi
+                ;;
+        esac
+    fi
+fi
+
+if [ -z "$failure_reason" ]; then
+    exit 0
+fi
+
+# Detection and all alert attempts intentionally precede every recovery command.
+alert_all_channels "$failure_reason"
+
+if [ "$label_loaded" -eq 0 ]; then
+    "$TIER0_LAUNCHCTL" bootstrap "$TIER0_DOMAIN" "$TIER0_HEALTH_PLIST_PATH" >/dev/null 2>&1 || :
+fi
+"$TIER0_LAUNCHCTL" kickstart -k "$target" >/dev/null 2>&1 || :
+
+exit 1

--- a/tests/test_engine_package_boundary.py
+++ b/tests/test_engine_package_boundary.py
@@ -23,10 +23,12 @@ def test_pyproject_declares_pure_engine_package_boundary() -> None:
     assert "src/brainlayer/cli" not in wheel_config.get("exclude", [])
     assert "src/brainlayer/cli_new.py" not in wheel_config.get("exclude", [])
     assert wheel_config["force-include"]["scripts/launchd"] == "brainlayer/launchd"
+    assert wheel_config["force-include"]["scripts/tier0-watchdog.sh"] == "brainlayer/launchd/tier0-watchdog.sh"
     assert "src/brainlayer/dashboard" in wheel_config["exclude"]
     assert sdist_config["only-include"] == [
         "src/brainlayer",
         "scripts/launchd",
+        "scripts/tier0-watchdog.sh",
         "README.md",
         "LICENSE",
         "server.json",

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -512,6 +512,70 @@ def test_packaged_launchd_installer_renders_p0_counter_console_shim(tmp_path: Pa
     assert "scripts/p0_longitudinal_count.py" not in content
 
 
+def test_packaged_launchd_installer_installs_tier0_watchdog_without_env_runner(tmp_path: Path) -> None:
+    launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
+    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    source_script = REPO_ROOT / "scripts" / "tier0-watchdog.sh"
+    assert source_script.exists(), "Tier-0 runtime script is missing"
+    shutil.copy2(source_script, launchd_dir / "tier0-watchdog.sh")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+                "exit 0",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+
+    home = tmp_path / "home&watchdog"
+    home.mkdir()
+    result = subprocess.run(
+        [str(launchd_dir / "install.sh"), "tier0-watchdog"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    installed_script = home / ".local" / "lib" / "brainlayer" / "tier0-watchdog.sh"
+    assert installed_script.read_bytes() == source_script.read_bytes()
+    assert os.access(installed_script, os.X_OK)
+
+    rendered = home / "Library" / "LaunchAgents" / "com.brainlayer.tier0-watchdog.plist"
+    plist = plistlib.loads(rendered.read_bytes())
+    assert plist["ProgramArguments"] == ["/bin/sh", str(installed_script)]
+    rendered_content = rendered.read_text(encoding="utf-8")
+    assert "__TIER0_WATCHDOG_SCRIPT__" not in rendered_content
+    assert "brainlayer-env-run" not in rendered_content
+    assert "python" not in rendered_content.lower()
+
+    domain = f"gui/{os.getuid()}"
+    commands = launchctl_log.read_text(encoding="utf-8").splitlines()
+    bootstrap_command = f"bootstrap {domain} {rendered}"
+    print_command = f"print {domain}/com.brainlayer.tier0-watchdog"
+    assert commands.count(bootstrap_command) == 1
+    assert commands.count(print_command) == 1
+    assert commands.index(bootstrap_command) < commands.index(print_command)
+
+
 def test_launchd_installer_renders_launchd_dir_for_maintenance_resume(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -1078,3 +1142,5 @@ def test_wheel_contains_cli_and_launchd_templates(tmp_path: Path) -> None:
     assert "brainlayer/cli_new.py" in listing
     assert "brainlayer/launchd/install.sh" in listing
     assert "brainlayer/launchd/com.brainlayer.enrichment.plist" in listing
+    assert "brainlayer/launchd/com.brainlayer.tier0-watchdog.plist" in listing
+    assert "brainlayer/launchd/tier0-watchdog.sh" in listing

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -16,6 +16,7 @@ LOG_ROOT = "__HOME__/Library/Logs/brainlayer/"
 RENDERED_LOG_ROOT = "/Users/etanheyman/Library/Logs/brainlayer/"
 REQUIRED_PATH_PARTS = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
 DEV_SRC_PATH_RE = re.compile(r"/Users/[^:\s]+/Gits/[^:\s]+/src(?:$|:)")
+ENV_RUN_EXEMPT_LABELS = {"com.brainlayer.tier0-watchdog"}
 
 
 def _load(path: str) -> dict:
@@ -233,7 +234,10 @@ def test_canonical_launchagent_env_has_no_concrete_dev_src_paths():
 
 def test_script_launchagents_use_installed_package_imports():
     for path in sorted((REPO_ROOT / "scripts/launchd").glob("com.brainlayer.*.plist")):
-        _assert_uses_installed_package_not_source_path(path, plistlib.loads(path.read_bytes()))
+        plist = plistlib.loads(path.read_bytes())
+        if plist["Label"] in ENV_RUN_EXEMPT_LABELS:
+            continue
+        _assert_uses_installed_package_not_source_path(path, plist)
 
 
 def test_enrichment_launchagent_sources_standard_env_file_without_embedded_google_key():
@@ -255,6 +259,12 @@ def test_all_script_launchagents_source_unified_config_file():
         args = plist["ProgramArguments"]
         env = plist["EnvironmentVariables"]
         service = plist["Label"].removeprefix("com.brainlayer.")
+
+        if plist["Label"] in ENV_RUN_EXEMPT_LABELS:
+            assert args == ["/bin/sh", "__TIER0_WATCHDOG_SCRIPT__"], str(path)
+            assert "BRAINLAYER_ENV_FILE" not in env, str(path)
+            assert "BRAINLAYER_LAUNCHD_SERVICE" not in env, str(path)
+            continue
 
         assert args[0] == "__BRAINLAYER_ENV_RUN__", str(path)
         assert env["BRAINLAYER_ENV_FILE"] == "__BRAINLAYER_ENV_FILE__", str(path)

--- a/tests/test_tier0_drills.py
+++ b/tests/test_tier0_drills.py
@@ -1,0 +1,262 @@
+"""Synthetic silent-death drills for the Tier-0 health-check watchdog."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "tier0-watchdog.sh"
+PLIST_PATH = REPO_ROOT / "scripts" / "launchd" / "com.brainlayer.tier0-watchdog.plist"
+
+NOW_EPOCH = 10_000
+STALE_SECONDS = 1_200
+DOMAIN = "gui/501"
+LABEL = "com.example.brainlayer-health-check"
+NOTIFY_ENDPOINT = "http://localhost:3847/notify"
+
+
+@dataclass(frozen=True)
+class DrillResult:
+    process: subprocess.CompletedProcess[str]
+    events: list[str]
+    tier0_log: str
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _event_index(events: list[str], prefix: str) -> int:
+    return next(index for index, event in enumerate(events) if event.startswith(prefix))
+
+
+def _run_drill(
+    tmp_path: Path,
+    *,
+    label_loaded: bool,
+    state_mtime: int | None,
+    curl_hangs: bool = False,
+    osascript_hangs: bool = False,
+    use_fake_wait_sleep: bool = False,
+) -> DrillResult:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    events_path = tmp_path / "events.log"
+    state_path = tmp_path / "health-check-state.json"
+    health_plist_path = tmp_path / "com.example.brainlayer-health-check.plist"
+    tier0_log_path = tmp_path / "logs" / "tier0-watchdog.log"
+    health_plist_path.write_text("fixture\n", encoding="utf-8")
+
+    if state_mtime is not None:
+        state_path.write_text("{}\n", encoding="utf-8")
+
+    _write_executable(
+        fake_bin / "launchctl",
+        "\n".join(
+            [
+                "#!/bin/sh",
+                'printf "launchctl:%s\\n" "$*" >> "$TIER0_DRILL_EVENTS"',
+                'if [ "$1" = "print" ]; then exit "$FAKE_LAUNCHCTL_PRINT_EXIT"; fi',
+                "exit 0",
+                "",
+            ]
+        ),
+    )
+    _write_executable(
+        fake_bin / "stat",
+        "\n".join(
+            [
+                "#!/bin/sh",
+                'printf "stat:%s\\n" "$*" >> "$TIER0_DRILL_EVENTS"',
+                'printf "%s\\n" "$FAKE_STATE_MTIME"',
+                "",
+            ]
+        ),
+    )
+    osascript_lines = [
+        "#!/bin/sh",
+        'printf "osascript:%s\\n" "$*" >> "$TIER0_DRILL_EVENTS"',
+    ]
+    if osascript_hangs:
+        osascript_lines.append("exec /bin/sleep 30")
+    else:
+        osascript_lines.append("exit 0")
+    osascript_lines.append("")
+    _write_executable(fake_bin / "osascript", "\n".join(osascript_lines))
+    curl_lines = [
+        "#!/bin/sh",
+        'printf "curl:%s\\n" "$*" >> "$TIER0_DRILL_EVENTS"',
+    ]
+    if curl_hangs:
+        curl_lines.append("exec /bin/sleep 30")
+    else:
+        curl_lines.append("exit 0")
+    curl_lines.append("")
+    _write_executable(fake_bin / "curl", "\n".join(curl_lines))
+    if use_fake_wait_sleep:
+        _write_executable(
+            fake_bin / "wait-sleep",
+            "\n".join(
+                [
+                    "#!/bin/sh",
+                    'printf "wait-sleep:%s\\n" "$*" >> "$TIER0_DRILL_EVENTS"',
+                    "exit 0",
+                    "",
+                ]
+            ),
+        )
+
+    env = {
+        **os.environ,
+        "FAKE_LAUNCHCTL_PRINT_EXIT": "0" if label_loaded else "113",
+        "FAKE_STATE_MTIME": str(state_mtime or 0),
+        "TIER0_ALERT_TIMEOUT_SECONDS": "1",
+        "TIER0_CURL": str(fake_bin / "curl"),
+        "TIER0_DOMAIN": DOMAIN,
+        "TIER0_DRILL_EVENTS": str(events_path),
+        "TIER0_HEALTH_PLIST_PATH": str(health_plist_path),
+        "TIER0_LABEL": LABEL,
+        "TIER0_LAUNCHCTL": str(fake_bin / "launchctl"),
+        "TIER0_LOG_PATH": str(tier0_log_path),
+        "TIER0_NOTIFY_ENDPOINT": NOTIFY_ENDPOINT,
+        "TIER0_NOTIFY_TIMEOUT_SECONDS": "1",
+        "TIER0_NOW_EPOCH": str(NOW_EPOCH),
+        "TIER0_OSASCRIPT": str(fake_bin / "osascript"),
+        "TIER0_SLEEP": str(fake_bin / "wait-sleep") if use_fake_wait_sleep else "/bin/sleep",
+        "TIER0_STALE_SECONDS": str(STALE_SECONDS),
+        "TIER0_STATE_PATH": str(state_path),
+        "TIER0_STAT": str(fake_bin / "stat"),
+    }
+    process = subprocess.run(
+        ["/bin/sh", str(SCRIPT_PATH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=6,
+        check=False,
+    )
+    events = events_path.read_text(encoding="utf-8").splitlines() if events_path.exists() else []
+    tier0_log = tier0_log_path.read_text(encoding="utf-8") if tier0_log_path.exists() else ""
+    return DrillResult(process=process, events=events, tier0_log=tier0_log)
+
+
+def _assert_alert_contract(result: DrillResult) -> None:
+    osascript_index = _event_index(result.events, "osascript:")
+    curl_index = _event_index(result.events, "curl:")
+    kickstart_index = _event_index(result.events, f"launchctl:kickstart -k {DOMAIN}/{LABEL}")
+
+    assert osascript_index < kickstart_index
+    assert curl_index < kickstart_index
+    curl_event = result.events[curl_index]
+    assert "-fsS" in curl_event
+    assert "--max-time 1" in curl_event
+    assert f"-X POST {NOTIFY_ENDPOINT}" in curl_event
+    assert "-H Content-Type: application/json" in curl_event
+    assert '"title":"BrainLayer Tier-0 alert"' in curl_event
+    assert '"source":"alerts"' in curl_event
+
+
+def test_d1_unloaded_label_alerts_before_bootstrap_and_kickstart(tmp_path: Path) -> None:
+    result = _run_drill(tmp_path, label_loaded=False, state_mtime=NOW_EPOCH - 60)
+
+    assert result.process.returncode == 1, result.process.stdout + result.process.stderr
+    _assert_alert_contract(result)
+    bootstrap_index = _event_index(
+        result.events,
+        f"launchctl:bootstrap {DOMAIN} {tmp_path / 'com.example.brainlayer-health-check.plist'}",
+    )
+    kickstart_index = _event_index(result.events, f"launchctl:kickstart -k {DOMAIN}/{LABEL}")
+    assert _event_index(result.events, "osascript:") < bootstrap_index < kickstart_index
+    assert _event_index(result.events, "curl:") < bootstrap_index
+    assert "label_unloaded" in result.tier0_log
+
+
+def test_d2_stale_state_alerts_before_direct_kickstart(tmp_path: Path) -> None:
+    result = _run_drill(
+        tmp_path,
+        label_loaded=True,
+        state_mtime=NOW_EPOCH - STALE_SECONDS - 1,
+    )
+
+    assert result.process.returncode == 1, result.process.stdout + result.process.stderr
+    _assert_alert_contract(result)
+    assert not any(event.startswith("launchctl:bootstrap ") for event in result.events)
+    assert f"state_stale age={STALE_SECONDS + 1}s threshold={STALE_SECONDS}s" in result.tier0_log
+
+
+def test_d3_hanging_notify_endpoint_cannot_suppress_local_alert_or_heal(tmp_path: Path) -> None:
+    result = _run_drill(
+        tmp_path,
+        label_loaded=True,
+        state_mtime=NOW_EPOCH - STALE_SECONDS - 1,
+        curl_hangs=True,
+    )
+
+    assert result.process.returncode == 1, result.process.stdout + result.process.stderr
+    _assert_alert_contract(result)
+    assert "state_stale" in result.tier0_log
+    assert any(event.startswith("osascript:") for event in result.events)
+    assert any(event == f"launchctl:kickstart -k {DOMAIN}/{LABEL}" for event in result.events)
+
+
+def test_d4_loaded_label_and_fresh_state_do_nothing(tmp_path: Path) -> None:
+    result = _run_drill(tmp_path, label_loaded=True, state_mtime=NOW_EPOCH - 60)
+
+    assert result.process.returncode == 0, result.process.stdout + result.process.stderr
+    assert result.events == [
+        f"launchctl:print {DOMAIN}/{LABEL}",
+        f"stat:-f %m {tmp_path / 'health-check-state.json'}",
+    ]
+    assert result.tier0_log == ""
+
+
+def test_missing_state_alerts_and_kickstarts_without_bootstrap(tmp_path: Path) -> None:
+    result = _run_drill(tmp_path, label_loaded=True, state_mtime=None)
+
+    assert result.process.returncode == 1, result.process.stdout + result.process.stderr
+    _assert_alert_contract(result)
+    assert not any(event.startswith("stat:") for event in result.events)
+    assert not any(event.startswith("launchctl:bootstrap ") for event in result.events)
+    assert "state_missing" in result.tier0_log
+
+
+def test_future_state_mtime_alerts_and_kickstarts(tmp_path: Path) -> None:
+    result = _run_drill(tmp_path, label_loaded=True, state_mtime=NOW_EPOCH + 60)
+
+    assert result.process.returncode == 1, result.process.stdout + result.process.stderr
+    _assert_alert_contract(result)
+    assert not any(event.startswith("launchctl:bootstrap ") for event in result.events)
+    assert "state_mtime_future offset=60s" in result.tier0_log
+
+
+def test_alert_fanout_uses_one_shared_deadline(tmp_path: Path) -> None:
+    result = _run_drill(
+        tmp_path,
+        label_loaded=True,
+        state_mtime=NOW_EPOCH - STALE_SECONDS - 1,
+        curl_hangs=True,
+        osascript_hangs=True,
+        use_fake_wait_sleep=True,
+    )
+
+    assert result.process.returncode == 1, result.process.stdout + result.process.stderr
+    assert sum(event.startswith("wait-sleep:") for event in result.events) == 1
+    assert any(event == f"launchctl:kickstart -k {DOMAIN}/{LABEL}" for event in result.events)
+
+
+def test_tier0_launchagent_uses_bin_sh_without_python_wrapper() -> None:
+    plist = plistlib.loads(PLIST_PATH.read_bytes())
+
+    assert plist["Label"] == "com.brainlayer.tier0-watchdog"
+    assert plist["ProgramArguments"] == ["/bin/sh", "__TIER0_WATCHDOG_SCRIPT__"]
+    assert plist["StartInterval"] == 300
+    assert plist["RunAtLoad"] is True
+    args = " ".join(plist["ProgramArguments"])
+    assert "ENV_RUN" not in args
+    assert "PYTHON" not in args.upper()


### PR DESCRIPTION
## Summary
- add a pure `/bin/sh` Tier-0 watchdog for the Python-backed health-check launchd label and state-file freshness
- fan alerts out to a local log, macOS notification, and bounded fail-open notify POST before bootstrap/kickstart recovery
- install and package the watchdog through the existing launchd setup path, with four isolated silent-death drills

## Test plan
- [x] `BRAINLAYER_PREPUSH_SCOPE=changed-only git push -u origin HEAD`
  - 64 changed-file tests passed
  - 3 MCP registration tests passed
  - 40 isolated eval/hook-routing tests passed
  - Bun stale-index test passed
  - FTS5 shell regression passed
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `shellcheck scripts/tier0-watchdog.sh scripts/launchd/install.sh`
- [x] `/bin/sh -n scripts/tier0-watchdog.sh` and `bash -n scripts/launchd/install.sh`
- [x] `plutil -lint scripts/launchd/com.brainlayer.tier0-watchdog.plist`
- [x] Full pytest before main advanced: 3523 passed, 60 skipped, 5 xfailed
- [ ] Full pytest after rebasing onto PR #582: 3546 passed, 60 skipped, 5 xfailed, 1 upstream flaky failure in `test_store_saves_normally_when_uncontended`; it intermittently exceeds the new writer-telemetry initialization path's 400 ms store busy budget on a unique temp DB. This PR changes no store/writer/telemetry files.

## Review notes
- The brief specifies a 20-minute stale threshold and a 5-minute schedule, which implies a stale-state worst-case detection window near 25 minutes and cannot guarantee the separate ≤15-minute MTTD target. This PR preserves the explicit 20-minute default for lead disposition.
- Local CodeRabbit review findings for shared alert deadline, future mtimes, sed/XML path escaping, and package coverage were addressed. The follow-up CLI pass was rate-limited; PR-level reviews are requested separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS launchd install paths and periodically runs bootstrap/kickstart on the health-check agent; impact is limited to operational self-healing, but mis-detection or bad recovery could disturb a live health-check job.
> 
> **Overview**
> Introduces a **Tier-0 meta-watchdog** that guards the existing Python `com.brainlayer.health-check` LaunchAgent without depending on Python itself. A new **`scripts/tier0-watchdog.sh`** runs under `/bin/sh`, checks `launchctl print` and health-check state-file freshness (default 20-minute stale threshold), fans **fail-open alerts** to a log line, macOS notification, and a bounded JSON POST to `localhost:3847/ Portal`, then **bootstraps** the health-check plist when the label is unloaded or **kickstarts** it when state is missing/stale/future-dated. Faults still **exit nonzero** after recovery so launchd keeps a loud signal.
> 
> **Launchd and packaging:** New **`com.brainlayer.tier0-watchdog.plist`** (300s interval, `RunAtLoad`, `/bin/sh` only—no env-runner). **`install.sh`** gains `tier0-watchdog` / `all` / `remove` wiring, copies the script to `~/.local/lib/brainlayer/tier0-watchdog.sh`, and renders plist placeholders with XML-safe escaping. **`pyproject.toml`** force-includes the script in wheel/sdist; hygiene tests exempt this label from Python env-runner rules.
> 
> **Tests and docs:** **`tests/test_tier0_drills.py`** covers four silent-death drills plus missing state, future mtime, and shared alert deadline; installer and wheel assertions were extended. Design/plan markdown documents the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b75b0cffaf9134a1a70149857fef6ab2d2739e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tier-0 health-check watchdog as a launchd LaunchAgent
> - Adds [`scripts/tier0-watchdog.sh`](https://github.com/EtanHey/brainlayer/pull/585/files#diff-573f04739cdefcd79e56d17dcf9068f87e8161ca729a6663836720475de3794c), a POSIX `/bin/sh` script that checks if a target launchd label is loaded and its state file is fresh, then alerts via local log, macOS notification, and HTTP POST before attempting recovery via `bootstrap`/`kickstart`.
> - Adds a [`com.brainlayer.tier0-watchdog.plist`](https://github.com/EtanHey/brainlayer/pull/585/files#diff-a1731cf2a47743f259a018d32f7358eef15875e69a8ec9ae56a6c99dd889ce01) LaunchAgent template that runs the script every 300s; [`install.sh`](https://github.com/EtanHey/brainlayer/pull/585/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756) gains `tier0`/`tier0-watchdog` targets to render and load the plist.
> - Alert fan-out runs in parallel with a shared deadline (`TIER0_ALERT_TIMEOUT_SECONDS`); lingering processes are terminated before recovery proceeds.
> - Packages the watchdog script into the wheel and sdist, and exempts the new label from env-runner enforcement in hygiene tests.
> - Behavioral Change: the watchdog exits 1 on any detected fault even when recovery succeeds, and 0 only when fully healthy.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 74b75b0. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->