### PR TITLE
feat: add deterministic scoped search fan-out

### DIFF
--- a/docs/plans/2026-07-10-deterministic-fanout-design.md
+++ b/docs/plans/2026-07-10-deterministic-fanout-design.md
@@ -1,0 +1,44 @@
+# Deterministic Scoped Fan-Out Design
+
+## Status
+
+Approved by the BL-B dispatch brief, which directs implementation of the V2 synthesis verdict `SHIP` and permits either an opt-in `brain_search` parameter or an internal weak-result fallback. This document records the selected integration and its invariants.
+
+## Goal
+
+Add a zero-LLM, bounded search fan-out that improves recall without creating a daemon, weakening consumer visibility, or hiding degraded search legs.
+
+## Approaches considered
+
+1. **Opt-in `brain_search(fan_out=true)` (selected).** Preserves the existing default path and makes the additional read work explicit. It is straightforward to test at the MCP schema and handler boundaries.
+2. **Automatic fan-out after a weak first result.** Reduces caller decisions, but “weak” requires a policy threshold and would unpredictably change latency for existing calls.
+3. **A separate tool or daemon.** Makes isolation obvious but duplicates the search contract and violates the no-new-daemon constraint.
+
+## Architecture
+
+The existing dispatcher resolves consumer visibility first. Generic searches with `fan_out=true` then execute at most four sequential search legs using the existing `_search` function:
+
+- `raw`: the query under the already-resolved consumer scope;
+- `project`: an explicit project-filtered leg when a project scope exists;
+- `recent`: a relevance search constrained to the last 30 days (or the caller's stricter lower date bound);
+- `tag:<tag>`: one tag-filtered leg when the normalized query surface matches a known taxonomy tag and the caller did not already supply a tag.
+
+Sequential execution is intentional. `_search` protects embedding work with a single in-flight lock; parallel legs would deterministically degrade all but one leg to keyword-only fallback.
+
+Each leg asks for at most 10 results, so four legs can inspect no more than 40 candidates. Results are deduplicated by `chunk_id` and ranked with reciprocal-rank fusion (`k=60`). Equal fused scores use first-seen order, then `chunk_id`, making output stable for identical leg outputs.
+
+## Contract and honesty
+
+Each returned result includes `fan_out_provenance`, listing every leg that found its `chunk_id`, and `fan_out_score`. The top-level structured response records the executed scopes, candidate count, and ranking rule.
+
+If any leg returns an MCP error, reports `degraded=true`, or falls back from hybrid search, the merged response sets `degraded=true`, lists the affected scopes and reasons, and appends a warning to the text response. Successful legs are still returned; a degraded leg is never converted into a silent empty result.
+
+## Testing
+
+Tests use deterministic fake search callables only—never the canonical DB or a real-DB fixture. They prove:
+
+- schema and routing are opt-in;
+- four-leg and 40-candidate hard bounds;
+- stable merge/dedupe ordering and per-result provenance;
+- tag and recency scope planning;
+- degraded propagation while preserving successful results.

--- a/docs/plans/2026-07-10-deterministic-fanout.md
+++ b/docs/plans/2026-07-10-deterministic-fanout.md
@@ -1,0 +1,104 @@
+# Deterministic Scoped Fan-Out Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an opt-in, deterministic `brain_search` fan-out with bounded candidates, stable dedupe, scope provenance, and fail-loud degradation metadata.
+
+**Architecture:** The MCP dispatcher retains all existing routing and consumer-scope checks, then hands generic opt-in searches to a small fan-out helper. The helper plans no more than four sequential `_search` calls, caps each at 10 candidates, merges by `chunk_id` with stable RRF, and formats the combined structured/text response.
+
+**Tech Stack:** Python 3.11+, asyncio, MCP `TextContent`/`CallToolResult`, pytest, Ruff.
+
+---
+
+### Task 1: Specify the pure fan-out contract
+
+**Files:**
+- Create: `tests/test_search_fanout.py`
+- Create: `src/brainlayer/search_fanout.py`
+
+**Step 1: Write failing tests**
+
+Add deterministic unit tests for scope planning, tag-surface matching, the four-call/40-candidate bounds, RRF ordering, dedupe provenance, and degraded propagation. Use fake structured responses only; do not create a DB.
+
+**Step 2: Run tests to verify RED**
+
+Run: `python3 -m pytest tests/test_search_fanout.py -q`
+
+Expected: collection failure because `brainlayer.search_fanout` does not exist.
+
+**Step 3: Implement the minimum pure helper**
+
+Create constants for four scopes, 10 candidates per scope, and RRF `k=60`; a deterministic taxonomy-tag matcher; a scope planner; and an async executor that accepts a search callable and base keyword arguments.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `python3 -m pytest tests/test_search_fanout.py -q`
+
+Expected: all new helper tests pass.
+
+### Task 2: Integrate the opt-in MCP parameter
+
+**Files:**
+- Modify: `src/brainlayer/mcp/__init__.py`
+- Modify: `src/brainlayer/mcp/search_handler.py`
+- Modify: `src/brainlayer/mcp/_format.py`
+- Test: `tests/test_search_fanout.py`
+
+**Step 1: Write failing integration tests**
+
+Assert `brain_search` exposes a boolean `fan_out` schema property, `call_tool` forwards it through `_brain_recall`, and `_brain_search` bypasses the warm helper and invokes fan-out only when opted in.
+
+**Step 2: Run tests to verify RED**
+
+Run: `python3 -m pytest tests/test_search_fanout.py -q`
+
+Expected: failures for absent schema/forwarding/dispatch behavior.
+
+**Step 3: Implement minimal routing**
+
+Thread `fan_out=False` through `call_tool`, `_brain_recall`, `_brain_search`, and `_brain_search_dispatch`. Skip the warm-helper route for fan-out calls. At the generic search seam, invoke the helper with the resolved consumer scope and existing filters. Add scope labels to formatted results and a visible degraded warning.
+
+**Step 4: Run focused tests to verify GREEN**
+
+Run: `python3 -m pytest tests/test_search_fanout.py tests/test_search_handler.py tests/test_search_filter_params.py -q`
+
+Expected: all focused tests pass.
+
+### Task 3: Verify, publish, and report
+
+**Files:**
+- Create: `docs.local/handoffs/BL-B-REPORT.md`
+- Append: `/Users/etanheyman/Gits/orchestrator/docs.local/collab/driver-buddy-2026-07-07.md`
+
+**Step 1: Run required verification**
+
+Run:
+
+```bash
+python3 -m pytest
+ruff check src/ tests/
+ruff format src/ tests/
+git diff --check
+```
+
+Re-run tests if formatting changes Python files.
+
+**Step 2: Run the local review gate**
+
+Run `coderabbit review --agent` with a bounded timeout. Address critical findings or record an unavailable/rate-limited reviewer.
+
+**Step 3: Commit and push**
+
+Commit only the planned source, test, and tracked docs. Push with:
+
+```bash
+BRAINLAYER_PREPUSH_SCOPE=changed-only git push -u origin feat/deterministic-fanout
+```
+
+**Step 4: Open the ready-for-review PR and invoke reviewers**
+
+Create a structured PR, then request `@codex review` and `@cursor @bugbot review` as required by the repository brief. Read all returned feedback and address actionable findings; the lead owns merge.
+
+**Step 5: Write and verify the worker report**
+
+Record branch, PR URL, integration rationale, exact test evidence, and final line `DONE_BLB_FANOUT` in `docs.local/handoffs/BL-B-REPORT.md`. Append one timestamped PR-open line to the collab file and store the milestone in BrainLayer.

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -566,6 +566,11 @@ async def list_tools() -> list[Tool]:
                             "enum": ["knowledge", "decision", "operational", "test", "benchmark"],
                             "description": "Restrict search to one content_class. Defaults to visible knowledge/decision classes.",
                         },
+                        "fan_out": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Run bounded deterministic scoped fan-out (max 4 searches / 40 candidates). Generic relevance queries only; incompatible with order='origin', file_path, chunk_id, and entity_id.",
+                        },
                         "detail": {
                             "type": "string",
                             "enum": ["compact", "full"],
@@ -1353,6 +1358,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
                 include_audit=arguments.get("include_audit", False),
                 include_operational=arguments.get("include_operational", False),
                 content_class_filter=arguments.get("content_class"),
+                fan_out=arguments.get("fan_out", False),
             )
         )
 

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -111,9 +111,14 @@ def format_search_results(
         chunk_id = r.get("chunk_id")
         if include_chunk_id and chunk_id:
             lines.append(f"- ID: {chunk_id}")
+        if r.get("fan_out_provenance"):
+            lines.append(f"- Fan-out scopes: {', '.join(r['fan_out_provenance'])}")
         lines.append(f"- Source: {source}")
         lines.append(f"- Date: {date}")
-        lines.append(f"- Preview: {preview}")
+        if detail == "full":
+            lines.extend(["- Content:", "", str(r.get("content") or r.get("snippet") or summary)])
+        else:
+            lines.append(f"- Preview: {preview}")
 
     return "\n".join(lines)
 

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -23,6 +23,7 @@ from .._helpers import _escape_fts5_query, _is_sqlite_busy_error
 from ..chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_checkpoint_content
 from ..content_class import content_class_is_default_hidden, normalize_content_class
 from ..lexical_defense import _normalize_surface, load_lexical_defense_dictionary
+from ..search_fanout import run_fan_out
 from ..search_repo import _is_audit_recursion_metadata, _metadata_matches_project_scope
 
 # Retry settings for DB lock resilience on reads
@@ -818,6 +819,7 @@ async def _brain_search(
     profile_scope: str = "search.mcp",
     allow_helper_route: bool = True,
     brainbar_helper_fast_profile: bool = False,
+    fan_out: bool = False,
 ):
     """Unified search dispatcher -- routes to the right internal handler."""
     if search_profile.enabled() and profile_query_id is None:
@@ -826,6 +828,7 @@ async def _brain_search(
     try:
         if (
             allow_helper_route
+            and not fan_out
             and order == "relevance"
             and _helper_route_enabled()
             and _should_try_helper_route(
@@ -908,6 +911,7 @@ async def _brain_search(
             profile_query_id=profile_query_id,
             profile_scope=profile_scope,
             brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+            fan_out=fan_out,
         )
     finally:
         search_profile.emit(profile_scope, "brain_search", profile_query_id, search_profile.dur_ms(profile_started))
@@ -944,6 +948,7 @@ async def _brain_search_dispatch(
     profile_query_id: str | None = None,
     profile_scope: str = "search.mcp",
     brainbar_helper_fast_profile: bool = False,
+    fan_out: bool = False,
 ):
     if detail not in _VALID_SEARCH_DETAILS:
         return _error_result(f"Invalid detail='{detail}'. Must be one of: {sorted(_VALID_SEARCH_DETAILS)}")
@@ -953,8 +958,11 @@ async def _brain_search_dispatch(
         return _error_result(
             f"num_results={num_results} must be between {_MIN_PUBLIC_NUM_RESULTS} and {_MAX_PUBLIC_NUM_RESULTS}"
         )
+    if fan_out and order != "relevance":
+        return _error_result("fan_out requires order='relevance'")
+    if fan_out and any(value is not None for value in (file_path, chunk_id, entity_id)):
+        return _error_result("fan_out supports generic query search only; omit file_path, chunk_id, and entity_id")
 
-    consumer_scope = None
     if project is None:
         try:
             from ..scoping import resolve_project_scope
@@ -962,10 +970,12 @@ async def _brain_search_dispatch(
             project = resolve_project_scope()
         except Exception:
             logger.debug("Project auto-scope failed, proceeding without scope")
+    requested_project = project
     from ..scoping import resolve_consumer_scope
 
     consumer_scope = resolve_consumer_scope(project=project, consumer=consumer, include_checkpoints=include_checkpoints)
     project = consumer_scope.project_filter
+    fan_out_project = project or _normalize_project_name(requested_project) or requested_project
     include_checkpoints = consumer_scope.include_checkpoints
 
     if entity_id is not None:
@@ -1041,7 +1051,7 @@ async def _brain_search_dispatch(
             consumer_scope=consumer_scope,
         )
 
-    allow_file_route = order == "relevance"
+    allow_file_route = order == "relevance" and not fan_out
     origin_file_path = file_path if order == "origin" else None
 
     if allow_file_route and file_path is not None and _query_has_regression_signal(query):
@@ -1082,7 +1092,7 @@ async def _brain_search_dispatch(
             merged_text.extend(recall_result)
         return merged_text
 
-    extracted_file = _extract_file_path(query)
+    extracted_file = None if fan_out else _extract_file_path(query)
     if extracted_file:
         if allow_file_route:
             return await _brain_search(
@@ -1115,7 +1125,7 @@ async def _brain_search_dispatch(
             )
         origin_file_path = origin_file_path or extracted_file
 
-    allow_smart_route = order == "relevance"
+    allow_smart_route = order == "relevance" and not fan_out
 
     if allow_smart_route and _query_signals_current_context(query):
         ctx = await _current_context(hours=24, project=project, consumer_scope=consumer_scope)
@@ -1185,6 +1195,35 @@ async def _brain_search_dispatch(
             return exact_chunk_hit
         fts_query_override = _expanded_fts_query(query, store)
     source_file_filter_like = _source_file_like_pattern(origin_file_path)
+
+    if fan_out:
+        return await _fan_out_search(
+            query=query,
+            project=fan_out_project,
+            content_type=content_type,
+            source=source,
+            tag=tag,
+            intent=intent,
+            importance_min=importance_min,
+            date_from=date_from,
+            date_to=date_to,
+            sentiment=sentiment,
+            agent_id=agent_id,
+            num_results=num_results,
+            detail=detail,
+            fts_query_override=fts_query_override,
+            source_filter_like=source_filter,
+            source_file_filter_like=source_file_filter_like,
+            correction_category=correction_category,
+            include_checkpoints=include_checkpoints,
+            include_audit=include_audit,
+            include_operational=include_operational,
+            content_class_filter=content_class_filter,
+            profile_query_id=profile_query_id,
+            profile_scope=profile_scope,
+            brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+            consumer_scope=consumer_scope,
+        )
 
     # Entity-aware routing: detect known entity names in query.
     # Path 1: Pure SQL KG lookup (no embeddings, always works).
@@ -1403,6 +1442,74 @@ async def _brain_search_dispatch(
     return result
 
 
+async def _fan_out_search(
+    *,
+    query: str,
+    project: str | None,
+    content_type: str | None,
+    source: str | None,
+    tag: str | None,
+    intent: str | None,
+    importance_min: float | None,
+    date_from: str | None,
+    date_to: str | None,
+    sentiment: str | None,
+    agent_id: str | None,
+    num_results: int,
+    detail: str,
+    fts_query_override: str | None,
+    source_filter_like: str | None,
+    source_file_filter_like: str | None,
+    correction_category: str | None,
+    include_checkpoints: bool,
+    include_audit: bool,
+    include_operational: bool,
+    content_class_filter: str | None,
+    profile_query_id: str | None,
+    profile_scope: str,
+    brainbar_helper_fast_profile: bool,
+    consumer_scope: Any | None,
+):
+    structured = await run_fan_out(
+        search=_search,
+        query=query,
+        num_results=num_results,
+        project=project,
+        date_from=date_from,
+        tag=tag,
+        base_kwargs={
+            "project": project,
+            "content_type": content_type,
+            "source": source,
+            "tag": tag,
+            "intent": intent,
+            "importance_min": importance_min,
+            "date_from": date_from,
+            "date_to": date_to,
+            "sentiment": sentiment,
+            "agent_id": agent_id,
+            "detail": detail,
+            "fts_query_override": fts_query_override,
+            "source_filter_like": source_filter_like,
+            "source_file_filter_like": source_file_filter_like,
+            "correction_category": correction_category,
+            "include_checkpoints": include_checkpoints,
+            "include_audit": include_audit,
+            "include_operational": include_operational,
+            "content_class_filter": content_class_filter,
+            "profile_query_id": profile_query_id,
+            "profile_scope": profile_scope,
+            "brainbar_helper_fast_profile": brainbar_helper_fast_profile,
+            "consumer_scope": consumer_scope,
+        },
+    )
+    text = format_search_results(query, structured["results"], structured["total"], detail=detail)
+    if structured["degraded"]:
+        reasons = "; ".join(f"{item['scope']}: {item['reason']}" for item in structured["degraded_scopes"])
+        text += f"\n\n⚠ Fan-out degraded — {reasons}"
+    return ([TextContent(type="text", text=text)], structured)
+
+
 def _escape_like_pattern(value: str) -> str:
     """Escape user text for a literal SQLite LIKE pattern."""
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -1609,6 +1716,7 @@ async def _brain_recall(
     include_audit: bool = False,
     include_operational: bool = False,
     content_class_filter: str | None = None,
+    fan_out: bool = False,
 ):
     """Unified recall dispatcher -- routes to session/context/search/entity handlers.
 
@@ -1647,6 +1755,7 @@ async def _brain_recall(
             project = resolve_project_scope()
         except Exception:
             logger.debug("Project auto-scope failed, proceeding without scope")
+    requested_project = project
     from ..scoping import resolve_consumer_scope
 
     consumer_scope = resolve_consumer_scope(
@@ -1664,7 +1773,7 @@ async def _brain_recall(
             return _error_result("query is required for mode=search")
         return await _brain_search(
             query=query,
-            project=project,
+            project=requested_project if fan_out else project,
             consumer=consumer,
             file_path=file_path,
             chunk_id=chunk_id,
@@ -1690,6 +1799,7 @@ async def _brain_recall(
             include_audit=include_audit,
             include_operational=include_operational,
             content_class_filter=content_class_filter,
+            fan_out=fan_out,
         )
 
     if resolved_mode == "entity":

--- a/src/brainlayer/search_fanout.py
+++ b/src/brainlayer/search_fanout.py
@@ -1,0 +1,167 @@
+"""Deterministic, bounded fan-out primitives for memory search."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Iterable
+
+from mcp.types import CallToolResult
+
+from .scoping import ConsumerScope
+from .tag_normalization import valid_taxonomy_tags
+
+_MAX_SCOPES = 4
+_CANDIDATES_PER_SCOPE = 10
+_RRF_K = 60
+
+
+@dataclass(frozen=True)
+class FanOutScope:
+    name: str
+    overrides: dict[str, Any]
+
+
+def _matching_tag(query: str, known_tags: Iterable[str]) -> str | None:
+    normalized_query = re.sub(r"[^a-z0-9]+", " ", query.casefold()).strip()
+    matches: list[tuple[int, str]] = []
+    for tag in known_tags:
+        leaf = re.sub(r"[^a-z0-9]+", " ", tag.rsplit("/", 1)[-1].casefold()).strip()
+        if leaf and re.search(rf"(?:^| ){re.escape(leaf)}(?: |$)", normalized_query):
+            matches.append((len(leaf), tag))
+    return min(matches, key=lambda item: (-item[0], item[1]))[1] if matches else None
+
+
+def plan_fan_out_scopes(
+    *,
+    query: str,
+    project: str | None,
+    date_from: str | None,
+    tag: str | None,
+    now: datetime | None = None,
+    known_tags: Iterable[str] | None = None,
+) -> list[FanOutScope]:
+    """Build a stable scope list without exceeding the hard four-search bound."""
+    now = now or datetime.now(timezone.utc)
+    recent_from = (now - timedelta(days=30)).date().isoformat()
+    scopes = [FanOutScope("raw", {"project": None})]
+    if project:
+        scopes.append(FanOutScope("project", {"project": project}))
+    scopes.append(FanOutScope("recent", {"project": project, "date_from": max(date_from or "", recent_from)}))
+    if tag is None and (matched_tag := _matching_tag(query, known_tags or valid_taxonomy_tags())):
+        scopes.append(FanOutScope(f"tag:{matched_tag}", {"project": project, "tag": matched_tag}))
+    return scopes[:_MAX_SCOPES]
+
+
+def _error_text(result: CallToolResult) -> str:
+    for item in result.content:
+        text = getattr(item, "text", None)
+        if text:
+            return str(text)
+    return "search error"
+
+
+def _narrow_consumer_scope(scope: ConsumerScope, project: str) -> ConsumerScope:
+    allowed = scope.project_filters or ((scope.project_filter,) if scope.project_filter else ())
+    if allowed and project not in allowed:
+        return replace(scope, project_filter=None, project_filters=(), allow_null_project=False, deny_all=True)
+    return replace(scope, project_filter=project, project_filters=(project,), allow_null_project=False)
+
+
+async def run_fan_out(
+    *,
+    search: Callable[..., Awaitable[Any]],
+    query: str,
+    num_results: int,
+    base_kwargs: dict[str, Any],
+    project: str | None,
+    date_from: str | None,
+    tag: str | None,
+    now: datetime | None = None,
+    known_tags: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Run bounded scopes sequentially and merge results by stable RRF."""
+    scopes = plan_fan_out_scopes(
+        query=query,
+        project=project,
+        date_from=date_from,
+        tag=tag,
+        now=now,
+        known_tags=known_tags,
+    )
+    merged: dict[str, dict[str, Any]] = {}
+    candidate_count = 0
+    first_seen = 0
+    degraded_scopes: list[dict[str, str]] = []
+
+    for scope in scopes:
+        search_kwargs = {
+            **base_kwargs,
+            **scope.overrides,
+            "query": query,
+            "num_results": _CANDIDATES_PER_SCOPE,
+            "order": "relevance",
+        }
+        if scope.overrides.get("project") and isinstance(search_kwargs.get("consumer_scope"), ConsumerScope):
+            search_kwargs["consumer_scope"] = _narrow_consumer_scope(
+                search_kwargs["consumer_scope"], scope.overrides["project"]
+            )
+        response = await search(**search_kwargs)
+        if isinstance(response, CallToolResult):
+            degraded_scopes.append({"scope": scope.name, "reason": _error_text(response)})
+            continue
+        _content, structured = response
+        reason = structured.get("degrade_reason") or structured.get("fallback_reason")
+        if structured.get("degraded") or structured.get("search_mode") not in (None, "hybrid"):
+            degraded_scopes.append({"scope": scope.name, "reason": reason or "degraded search"})
+
+        candidates = list(structured.get("results") or [])[:_CANDIDATES_PER_SCOPE]
+        if scope.name == "recent":
+            candidates.sort(key=lambda item: str(item.get("date") or item.get("created_at") or ""), reverse=True)
+        scope_chunk_ids: set[str] = set()
+        for rank, item in enumerate(candidates, start=1):
+            candidate_count += 1
+            chunk_id = item.get("chunk_id")
+            if not chunk_id:
+                if not any(entry["scope"] == scope.name for entry in degraded_scopes):
+                    degraded_scopes.append({"scope": scope.name, "reason": "candidate missing chunk_id"})
+                continue
+            if chunk_id in scope_chunk_ids:
+                continue
+            scope_chunk_ids.add(chunk_id)
+            if chunk_id not in merged:
+                first_seen += 1
+                merged[chunk_id] = {
+                    "item": dict(item),
+                    "score": 0.0,
+                    "first_seen": first_seen,
+                    "provenance": [],
+                }
+            entry = merged[chunk_id]
+            entry["score"] += 1 / (_RRF_K + rank)
+            entry["provenance"].append(scope.name)
+
+    ranked = sorted(
+        merged.values(), key=lambda entry: (-entry["score"], entry["first_seen"], entry["item"]["chunk_id"])
+    )
+    results = []
+    for entry in ranked[:num_results]:
+        item = entry["item"]
+        item["fan_out_score"] = round(entry["score"], 8)
+        item["fan_out_provenance"] = entry["provenance"]
+        results.append(item)
+
+    return {
+        "query": query,
+        "total": len(results),
+        "results": results,
+        "fan_out": True,
+        "fan_out_scopes": [scope.name for scope in scopes],
+        "fan_out_manifest": [{"scope": scope.name, **scope.overrides} for scope in scopes],
+        "candidate_count": candidate_count,
+        "candidate_limit": _MAX_SCOPES * _CANDIDATES_PER_SCOPE,
+        "ranking": "rrf(k=60), tie-break=first-seen,chunk_id",
+        "degraded": bool(degraded_scopes),
+        "degraded_scopes": degraded_scopes,
+    }

--- a/tests/test_search_fanout.py
+++ b/tests/test_search_fanout.py
@@ -1,0 +1,419 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from brainlayer.mcp import call_tool, list_tools
+from brainlayer.mcp._format import format_search_results
+from brainlayer.mcp.search_handler import _brain_search
+from brainlayer.scoping import ConsumerScope
+from brainlayer.search_fanout import plan_fan_out_scopes, run_fan_out
+from brainlayer.search_repo import _effective_project_filters, _metadata_matches_project_scope
+
+NOW = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+KNOWN_TAGS = {"pm/decision", "tech/architecture", "tech/testing"}
+
+
+def _structured(*chunk_ids: str, search_mode: str = "hybrid", **extra):
+    return (
+        [TextContent(type="text", text="fake search")],
+        {
+            "query": "architecture decision",
+            "total": len(chunk_ids),
+            "results": [
+                {
+                    "chunk_id": chunk_id,
+                    "score": 0.9 - (index / 10),
+                    "content": f"content for {chunk_id}",
+                }
+                for index, chunk_id in enumerate(chunk_ids)
+            ],
+            "search_mode": search_mode,
+            **extra,
+        },
+    )
+
+
+def test_plan_fan_out_scopes_is_bounded_and_deterministic():
+    scopes = plan_fan_out_scopes(
+        query="architecture decision",
+        project="brainlayer",
+        date_from=None,
+        tag=None,
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert [scope.name for scope in scopes] == [
+        "raw",
+        "project",
+        "recent",
+        "tag:tech/architecture",
+    ]
+    assert len(scopes) == 4
+    assert scopes[0].overrides == {"project": None}
+    assert scopes[1].overrides == {"project": "brainlayer"}
+    assert scopes[2].overrides == {"project": "brainlayer", "date_from": "2026-06-10"}
+    assert scopes[3].overrides == {"project": "brainlayer", "tag": "tech/architecture"}
+
+
+def test_plan_fan_out_scopes_respects_stricter_date_and_explicit_tag():
+    scopes = plan_fan_out_scopes(
+        query="architecture decision",
+        project=None,
+        date_from="2026-07-01",
+        tag="pm/decision",
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert [scope.name for scope in scopes] == ["raw", "recent"]
+    assert scopes[1].overrides == {"project": None, "date_from": "2026-07-01"}
+
+
+def test_full_detail_fan_out_format_preserves_complete_content():
+    content = "x" * 220 + "END-OF-FULL-CONTENT"
+
+    output = format_search_results(
+        "full fan-out",
+        [{"chunk_id": "full-1", "content": content, "fan_out_provenance": ["raw"]}],
+        1,
+        detail="full",
+    )
+
+    assert "END-OF-FULL-CONTENT" in output
+
+
+@pytest.mark.asyncio
+async def test_run_fan_out_merges_dedupes_and_records_scope_provenance():
+    responses = {
+        None: _structured("a", "b"),
+        "brainlayer": _structured("b", "c"),
+        "2026-06-10": _structured("c", "d"),
+        "tech/architecture": _structured("d", "a"),
+    }
+
+    async def fake_search(**kwargs):
+        key = kwargs.get("tag") or kwargs.get("date_from") or kwargs.get("project")
+        return responses[key]
+
+    result = await run_fan_out(
+        search=fake_search,
+        query="architecture decision",
+        num_results=3,
+        base_kwargs={},
+        project="brainlayer",
+        date_from=None,
+        tag=None,
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert [item["chunk_id"] for item in result["results"]] == ["a", "b", "c"]
+    assert result["results"][0]["fan_out_provenance"] == ["raw", "tag:tech/architecture"]
+    assert result["results"][1]["fan_out_provenance"] == ["raw", "project"]
+    assert result["candidate_count"] == 8
+    assert result["total"] == 3
+    assert result["ranking"] == "rrf(k=60), tie-break=first-seen,chunk_id"
+    assert result["degraded"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_fan_out_does_not_double_count_duplicate_ids_within_one_scope():
+    async def fake_search(**kwargs):
+        return _structured("duplicate", "duplicate") if not kwargs.get("date_from") else _structured()
+
+    result = await run_fan_out(
+        search=fake_search,
+        query="unmatched surface",
+        num_results=2,
+        base_kwargs={"tag": "already-scoped"},
+        project=None,
+        date_from=None,
+        tag="already-scoped",
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert [item["chunk_id"] for item in result["results"]] == ["duplicate"]
+    assert result["results"][0]["fan_out_provenance"] == ["raw"]
+    assert result["results"][0]["fan_out_score"] == round(1 / 61, 8)
+
+
+@pytest.mark.asyncio
+async def test_run_fan_out_project_legs_narrow_orchestrator_consumer_scope():
+    effective_projects = {}
+
+    async def fake_search(**kwargs):
+        scope_key = kwargs.get("tag") or kwargs.get("date_from") or kwargs.get("project") or "raw"
+        effective_projects[scope_key] = _effective_project_filters(kwargs.get("project"), kwargs["consumer_scope"])
+        return _structured()
+
+    await run_fan_out(
+        search=fake_search,
+        query="architecture decision",
+        num_results=3,
+        base_kwargs={"consumer_scope": ConsumerScope.for_orchestrator()},
+        project="golems",
+        date_from=None,
+        tag=None,
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert effective_projects == {
+        "raw": (),
+        "golems": ("golems",),
+        "2026-06-10": ("golems",),
+        "tech/architecture": ("golems",),
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_fan_out_project_provenance_excludes_cross_project_candidates():
+    candidates = [
+        {"chunk_id": "golems-hit", "project": "golems", "content": "golems"},
+        {"chunk_id": "brainlayer-hit", "project": "brainlayer", "content": "brainlayer"},
+    ]
+
+    async def fake_search(**kwargs):
+        visible = [
+            item
+            for item in candidates
+            if _metadata_matches_project_scope(item, kwargs.get("project"), kwargs["consumer_scope"])
+        ]
+        return ([TextContent(type="text", text="fake")], {"results": visible, "search_mode": "hybrid"})
+
+    result = await run_fan_out(
+        search=fake_search,
+        query="architecture decision",
+        num_results=2,
+        base_kwargs={"consumer_scope": ConsumerScope.for_orchestrator()},
+        project="golems",
+        date_from=None,
+        tag=None,
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    by_id = {item["chunk_id"]: item for item in result["results"]}
+    assert by_id["golems-hit"]["fan_out_provenance"] == [
+        "raw",
+        "project",
+        "recent",
+        "tag:tech/architecture",
+    ]
+    assert by_id["brainlayer-hit"]["fan_out_provenance"] == ["raw"]
+
+
+@pytest.mark.asyncio
+async def test_run_fan_out_enforces_four_search_and_forty_candidate_bounds():
+    calls = []
+
+    async def fake_search(**kwargs):
+        calls.append(kwargs)
+        scope_key = kwargs.get("tag") or kwargs.get("date_from") or kwargs.get("project") or "raw"
+        return _structured(*(f"{scope_key}-{index}" for index in range(20)))
+
+    result = await run_fan_out(
+        search=fake_search,
+        query="architecture decision",
+        num_results=100,
+        base_kwargs={},
+        project="brainlayer",
+        date_from=None,
+        tag=None,
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert len(calls) == 4
+    assert all(call["num_results"] == 10 for call in calls)
+    assert result["candidate_count"] == 40
+    assert len(result["results"]) == 40
+    assert result["candidate_limit"] == 40
+
+
+@pytest.mark.asyncio
+async def test_run_fan_out_recent_scope_ranks_newest_candidate_first():
+    async def fake_search(**kwargs):
+        if kwargs.get("date_from"):
+            content, structured = _structured("older", "newer")
+            structured["results"][0]["date"] = "2026-06-15"
+            structured["results"][1]["date"] = "2026-07-09"
+            return content, structured
+        return _structured()
+
+    result = await run_fan_out(
+        search=fake_search,
+        query="unmatched surface",
+        num_results=2,
+        base_kwargs={"tag": "already-scoped"},
+        project=None,
+        date_from=None,
+        tag="already-scoped",
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert [item["chunk_id"] for item in result["results"]] == ["newer", "older"]
+
+
+@pytest.mark.asyncio
+async def test_run_fan_out_propagates_degraded_scopes_without_dropping_good_results():
+    async def fake_search(**kwargs):
+        if kwargs.get("project") == "brainlayer" and not kwargs.get("date_from") and not kwargs.get("tag"):
+            return _structured("project-hit", search_mode="fts_fallback", fallback_reason="embed_busy")
+        if kwargs.get("date_from"):
+            return CallToolResult(
+                content=[TextContent(type="text", text="Search error: database busy")],
+                isError=True,
+            )
+        return _structured("good-hit")
+
+    result = await run_fan_out(
+        search=fake_search,
+        query="architecture decision",
+        num_results=5,
+        base_kwargs={},
+        project="brainlayer",
+        date_from=None,
+        tag=None,
+        now=NOW,
+        known_tags=KNOWN_TAGS,
+    )
+
+    assert result["degraded"] is True
+    assert result["degraded_scopes"] == [
+        {"scope": "project", "reason": "embed_busy"},
+        {"scope": "recent", "reason": "Search error: database busy"},
+    ]
+    assert {item["chunk_id"] for item in result["results"]} == {"good-hit", "project-hit"}
+
+
+@pytest.mark.asyncio
+async def test_brain_search_schema_exposes_opt_in_fan_out():
+    search_tool = next(tool for tool in await list_tools() if tool.name == "brain_search")
+
+    fan_out = search_tool.inputSchema["properties"]["fan_out"]
+    assert fan_out == {
+        "type": "boolean",
+        "default": False,
+        "description": "Run bounded deterministic scoped fan-out (max 4 searches / 40 candidates). Generic relevance queries only; incompatible with order='origin', file_path, chunk_id, and entity_id.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_call_tool_forwards_fan_out_to_recall():
+    with patch(
+        "brainlayer.mcp._brain_recall", new_callable=AsyncMock, return_value=CallToolResult(content=[])
+    ) as recall:
+        await call_tool("brain_search", {"query": "architecture decision", "fan_out": True})
+
+    assert recall.await_args.kwargs["fan_out"] is True
+
+
+@pytest.mark.asyncio
+async def test_brain_search_fan_out_bypasses_helper_and_uses_generic_fan_out(monkeypatch):
+    sentinel = ([TextContent(type="text", text="fan-out")], {"fan_out": True})
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: True)
+    monkeypatch.setattr(
+        "brainlayer.mcp.search_handler._warm_helper_socket_candidates",
+        lambda: pytest.fail("fan-out must not use the helper socket"),
+    )
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._exact_chunk_lookup_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    fan_out_search = AsyncMock(return_value=sentinel)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._fan_out_search", fan_out_search)
+
+    result = await _brain_search(
+        query="architecture decision",
+        project="brainlayer",
+        consumer="worker",
+        source="all",
+        fan_out=True,
+    )
+
+    assert result == sentinel
+    assert fan_out_search.await_count == 1
+    assert fan_out_search.await_args.kwargs["project"] == "brainlayer"
+
+
+@pytest.mark.asyncio
+async def test_brain_search_fan_out_keeps_explicit_project_leg_for_orchestrator(monkeypatch):
+    sentinel = ([TextContent(type="text", text="fan-out")], {"fan_out": True})
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._exact_chunk_lookup_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    fan_out_search = AsyncMock(return_value=sentinel)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._fan_out_search", fan_out_search)
+
+    result = await _brain_search(
+        query="architecture decision",
+        project="brainlayer",
+        consumer="orchestrator",
+        source="all",
+        fan_out=True,
+    )
+
+    assert result == sentinel
+    assert fan_out_search.await_args.kwargs["project"] == "brainlayer"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_fan_out_preserves_orchestrator_requested_project(monkeypatch):
+    sentinel = ([TextContent(type="text", text="fan-out")], {"fan_out": True})
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._exact_chunk_lookup_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.scoping.resolve_project_scope", lambda: "brainlayer")
+    fan_out_search = AsyncMock(return_value=sentinel)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._fan_out_search", fan_out_search)
+
+    result = await call_tool(
+        "brain_search",
+        {
+            "query": "architecture decision",
+            "project": "golems",
+            "consumer": "orchestrator",
+            "source": "all",
+            "fan_out": True,
+        },
+    )
+
+    assert result == sentinel
+    assert fan_out_search.await_args.kwargs["project"] == "golems"
+
+
+@pytest.mark.asyncio
+async def test_brain_search_fan_out_bypasses_smart_think_routing(monkeypatch):
+    sentinel = ([TextContent(type="text", text="fan-out")], {"fan_out": True})
+
+    monkeypatch.setattr("brainlayer.mcp.search_handler._helper_route_enabled", lambda: False)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._get_vector_store", lambda: object())
+    monkeypatch.setattr("brainlayer.mcp.search_handler._exact_chunk_lookup_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._expanded_fts_query", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "brainlayer.mcp.search_handler._think",
+        AsyncMock(side_effect=AssertionError("fan-out must bypass smart think routing")),
+    )
+    fan_out_search = AsyncMock(return_value=sentinel)
+    monkeypatch.setattr("brainlayer.mcp.search_handler._fan_out_search", fan_out_search)
+
+    result = await _brain_search(
+        query="how did I implement architecture",
+        project="brainlayer",
+        consumer="worker",
+        source="all",
+        fan_out=True,
+    )
+
+    assert result == sentinel
+    assert fan_out_search.await_count == 1


### PR DESCRIPTION
## Summary
- add opt-in `brain_search(fan_out=true)` with deterministic raw/project/recent/tag legs
- cap execution at four sequential searches and 40 candidates, then dedupe by `chunk_id` with stable RRF
- expose per-result provenance and fail-loud degraded-leg metadata while preserving consumer scoping

## Verification
- `ulimit -n 4096; python3 -m pytest`: 3530 passed, 60 skipped, 5 xfailed
- pre-push Python 3.12 gate: 3440 passed, 9 skipped, 61 deselected, 1 xfailed; MCP registration 3 passed; isolated eval/routing 40 passed; Bun and FTS determinism passed
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `git diff --check`
- real stdio MCP smoke: four scopes / 40 candidates / no cross-project scoped provenance; degraded embedding fallback surfaced

## Review notes
- independent code review is clean after an orchestrator project-scope regression fix
- local CodeRabbit CLI review was unavailable because the free OSS rate limit requested a 22-minute wait
- the requested fresh-Claude cmux runtime gate could not run because cmux control calls returned a transport broken pipe; direct stdio MCP smoke is included as secondary evidence

Lead owns review and merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MCP search dispatch, consumer/project scoping, and multi-call latency; mitigated by opt-in default, hard bounds, sequential execution, and extensive tests.
> 
> **Overview**
> Adds **opt-in** `brain_search(fan_out=true)` so callers can run a bounded, zero-LLM multi-leg search for better recall while the default single-search path stays unchanged.
> 
> A new `search_fanout` module plans up to four sequential legs (`raw`, optional `project`, `recent`, optional `tag:<taxonomy>`), caps each leg at 10 candidates (40 total), dedupes by `chunk_id`, and merges with stable RRF (`k=60`). MCP wiring forwards `fan_out` through `call_tool` → recall/search, rejects incompatible modes (`order='origin'`, `file_path`, `chunk_id`, `entity_id`), skips helper/smart/file/think shortcuts when enabled, and preserves explicit orchestrator project legs via `_fan_out_search`. Responses expose `fan_out_provenance` / `fan_out_score`, structured fan-out metadata, and **fail-loud** `degraded` scope reasons without dropping good hits; text formatting shows fan-out scopes and full content for `detail='full'`.
> 
> Design and implementation plan docs are added; coverage is in `tests/test_search_fanout.py` with fake search callables only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 042199fda572a36c4e97191859b39d39529e85f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic scoped search fan-out to the `brain_search` MCP tool
> - Adds a new `fan_out` boolean parameter to the `brain_search` MCP tool that triggers a multi-scope search strategy instead of a single query.
> - Introduces [`search_fanout.py`](https://github.com/EtanHey/brainlayer/pull/586/files#diff-ed554087a9d9e70a1332366c086c4a25acc4e0063002771e69e564cd5825a2af) with a planner (`plan_fan_out_scopes`) that deterministically produces up to four search legs: raw, project-scoped, recent (last 30 days), and tag-matched. Results are merged using stable Reciprocal Rank Fusion (k=60).
> - Each fan-out leg narrows the `ConsumerScope` per project to enforce cross-project access boundaries, and per-result provenance is included in formatted output.
> - Degraded or failed legs are collected and surfaced as a visible warning appended to the search response text.
> - Risk: `fan_out=True` enforces `order='relevance'` and rejects `file_path`, `chunk_id`, or `entity_id` filters; requests using those params will be rejected at dispatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 042199f. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->