### PR TITLE
fix: close weighted RRF review gaps

### DIFF
--- a/src/brainlayer/engine.py
+++ b/src/brainlayer/engine.py
@@ -181,6 +181,7 @@ def think(
     include_audit: bool = False,
     agent_id: str | None = None,
     consumer_scope: Any | None = None,
+    warm_rrf: bool = False,
 ) -> ThinkResult:
     """Given current task context, retrieve relevant past knowledge.
 
@@ -212,6 +213,7 @@ def think(
         include_audit=include_audit,
         agent_id=agent_id,
         consumer_scope=consumer_scope,
+        warm_rrf=warm_rrf,
     )
 
     if not results["documents"][0]:
@@ -248,6 +250,7 @@ def recall(
     include_audit: bool = False,
     agent_id: str | None = None,
     consumer_scope: Any | None = None,
+    warm_rrf: bool = False,
 ) -> RecallResult:
     """Proactive smart retrieval based on file or topic.
 
@@ -290,6 +293,7 @@ def recall(
                 include_audit=include_audit,
                 agent_id=agent_id,
                 consumer_scope=consumer_scope,
+                warm_rrf=warm_rrf,
             )
             for doc, meta in zip(search_results["documents"][0], search_results["metadatas"][0]):
                 result.related_chunks.append(
@@ -314,6 +318,7 @@ def recall(
             include_audit=include_audit,
             agent_id=agent_id,
             consumer_scope=consumer_scope,
+            warm_rrf=warm_rrf,
         )
         for doc, meta in zip(search_results["documents"][0], search_results["metadatas"][0]):
             result.related_chunks.append(

--- a/src/brainlayer/mcp/search_handler.py
+++ b/src/brainlayer/mcp/search_handler.py
@@ -2456,6 +2456,7 @@ async def _think(
                     include_audit=include_audit,
                     agent_id=agent_id,
                     consumer_scope=consumer_scope,
+                    warm_rrf=True,
                 ),
             )
         result = _filter_think_result_for_consumer_scope(result, normalized_project, consumer_scope)
@@ -2506,6 +2507,7 @@ async def _recall(
                     include_audit=include_audit,
                     agent_id=agent_id,
                     consumer_scope=consumer_scope,
+                    warm_rrf=True,
                 ),
             )
         result = _filter_recall_result_for_consumer_scope(result, normalized_project, consumer_scope)

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -2323,6 +2323,14 @@ class SearchMixin:
         if not warm_rrf:
             all_chunk_ids |= set(trigram_ranks.keys())
 
+        # A degraded single-leg search must retain that leg's rank signal even
+        # when the configured fusion weight assigns it zero weight.
+        fusion_alpha = rrf_vector_alpha
+        if warm_rrf and not semantic_by_id:
+            fusion_alpha = 0.0
+        elif warm_rrf and not fts_ranks:
+            fusion_alpha = 1.0
+
         scored = []
         match_features_by_id: dict[str, dict[str, bool]] = {}
         for cid in all_chunk_ids:
@@ -2334,7 +2342,7 @@ class SearchMixin:
                 semantic_rank=sem_entry["rank"] if sem_entry is not None else None,
                 fts_rank=fts_rank,
                 k=k,
-                alpha=rrf_vector_alpha,
+                alpha=fusion_alpha,
             )
             if not warm_rrf and trigram_rank is not None:
                 score += (1.0 - RRF_VECTOR_ALPHA) / (k + trigram_rank)

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -338,6 +338,7 @@ def _hybrid_cache_key(
     include_operational: bool = False,
     content_class_filter: Optional[str] = None,
     recency_rerank: bool = False,
+    recency_decay: bool = False,
     importance_rerank: bool = False,
     warm_rrf: bool = False,
     rrf_vector_alpha: float = RRF_VECTOR_ALPHA,
@@ -367,6 +368,7 @@ def _hybrid_cache_key(
         include_operational,
         normalize_content_class(content_class_filter) if content_class_filter else None,
         recency_rerank,
+        recency_decay,
         importance_rerank,
         warm_rrf,
         rrf_vector_alpha,
@@ -1801,7 +1803,7 @@ class SearchMixin:
         Cache is module-level LRU (128 entries) with defensive copy-on-read.
         """
 
-        recency_rerank = recency_rerank or _env_flag_enabled("BRAINLAYER_SCORE_RECENCY_DECAY")
+        recency_decay = recency_rerank or _env_flag_enabled("BRAINLAYER_SCORE_RECENCY_DECAY")
         importance_rerank = importance_rerank or _env_flag_enabled("BRAINLAYER_SCORE_IMPORTANCE_BOOST")
         rrf_vector_alpha = _rrf_vector_alpha() if warm_rrf else RRF_VECTOR_ALPHA
         project_filter = _effective_project_filter(project_filter, consumer_scope)
@@ -1837,6 +1839,7 @@ class SearchMixin:
             include_operational,
             content_class_filter,
             recency_rerank,
+            recency_decay,
             importance_rerank,
             warm_rrf,
             rrf_vector_alpha,
@@ -2434,7 +2437,7 @@ class SearchMixin:
 
             # Recency boost: exponential decay with 30-day half-life
             created = meta.get("created_at")
-            if recency_rerank and created and isinstance(created, str):
+            if recency_decay and created and isinstance(created, str):
                 try:
                     dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
                     if dt.tzinfo is None:

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -409,6 +409,24 @@ class TestHybridSearch:
         assert captured_scores["old-result"] == pytest.approx(base_rrf * old_recency_boost)
         assert captured_scores["fresh-result"] == pytest.approx(base_rrf)
 
+    def test_recency_decay_env_does_not_enable_recent_candidate_fallback(self, store, monkeypatch):
+        monkeypatch.setenv("BRAINLAYER_SCORE_RECENCY_DECAY", "1")
+        _insert_chunk(
+            store,
+            chunk_id="recent-unrelated",
+            content="fresh notes without query overlap",
+            embedding=_embed("unrelated recent content"),
+            created_at="2999-01-01T00:00:00Z",
+        )
+
+        results = store.hybrid_search(
+            query_embedding=None,
+            query_text="latest deployment status",
+            n_results=5,
+        )
+
+        assert results["ids"][0] == []
+
     def test_hybrid_search_opt_in_recency_and_importance_rerank_change_scores(self, store, monkeypatch):
         monkeypatch.delenv("BRAINLAYER_SCORE_IMPORTANCE_BOOST", raising=False)
         monkeypatch.delenv("BRAINLAYER_SCORE_RECENCY_DECAY", raising=False)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -284,6 +284,38 @@ class TestHybridSearch:
 
         assert results["ids"][0] == []
 
+    def test_warm_fts_fallback_preserves_fts_rank_when_alpha_is_one(self, store, monkeypatch):
+        monkeypatch.setenv("BRAINLAYER_RRF_ALPHA", "1.0")
+        _insert_chunk(
+            store,
+            chunk_id="exact-fts",
+            content="alpha fallback",
+            embedding=_embed("distant exact"),
+        )
+        _insert_chunk(
+            store,
+            chunk_id="verbose-fts",
+            content="alpha fallback with several unrelated padding words",
+            embedding=_embed("distant verbose"),
+        )
+        captured: list[tuple] = []
+
+        def capture_ranked(scored, *, n_results):
+            captured.extend(scored)
+            return scored
+
+        monkeypatch.setattr(store, "_mmr_rerank_scored_results", capture_ranked)
+
+        store.hybrid_search(
+            query_embedding=None,
+            query_text="alpha fallback",
+            n_results=2,
+            warm_rrf=True,
+        )
+
+        assert [item[1] for item in captured] == ["exact-fts", "verbose-fts"]
+        assert captured[0][0] > captured[1][0] > 0.0
+
     def test_hybrid_search_default_does_not_apply_recency_or_importance_boost(self, store, monkeypatch):
         monkeypatch.delenv("BRAINLAYER_SCORE_IMPORTANCE_BOOST", raising=False)
         monkeypatch.delenv("BRAINLAYER_SCORE_RECENCY_DECAY", raising=False)

--- a/tests/test_search_handler.py
+++ b/tests/test_search_handler.py
@@ -446,6 +446,7 @@ async def test_brain_search_mcp_threads_agent_id_to_hybrid_search(monkeypatch):
 
     assert store.hybrid_kwargs is not None
     assert store.hybrid_kwargs["agent_id"] == "codex-test-agent"
+    assert store.hybrid_kwargs["warm_rrf"] is True
 
 
 @pytest.mark.asyncio
@@ -840,6 +841,7 @@ async def test_brain_search_think_route_threads_agent_id_to_hybrid_search(monkey
 
     assert store.hybrid_kwargs is not None
     assert store.hybrid_kwargs["agent_id"] == "codex-test-agent"
+    assert store.hybrid_kwargs["warm_rrf"] is True
 
 
 @pytest.mark.asyncio
@@ -861,3 +863,4 @@ async def test_brain_search_recall_route_threads_agent_id_to_hybrid_search(monke
 
     assert store.hybrid_kwargs is not None
     assert store.hybrid_kwargs["agent_id"] == "codex-test-agent"
+    assert store.hybrid_kwargs["warm_rrf"] is True


### PR DESCRIPTION
## Summary
- keep score-only recency-decay opt-in separate from recent-candidate fallback
- preserve the available retrieval leg when warm weighted RRF has only FTS or only vector results
- route smart `brain_search` think/recall paths through warm two-leg RRF

## Context
PRs #584 and #587 were merged by the lead before their review follow-up commits reached the merged heads. This recovery PR carries the omitted #584 fix and resolves both unresolved #587 inline findings.

## Test plan
- pre-push: 3481 passed, 9 skipped, 61 deselected, 1 xfailed; MCP 3 passed; isolated 40 passed; Bun 1 passed; FTS shell passed
- full permitted suite: 3519 passed, 9 skipped, 61 deselected, 1 xfailed
- focused search/KG/trigram/consumer suite: 142 passed
- local CodeRabbit review: 0 findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hybrid search ranking and MCP think/recall retrieval paths; behavior shifts are intentional but could affect result ordering in edge cases (single-leg search, recency env).
> 
> **Overview**
> Fixes follow-up gaps in **weighted RRF** and **recency scoring** after earlier merges.
> 
> **Recency behavior** is split so `BRAINLAYER_SCORE_RECENCY_DECAY` (and explicit `recency_rerank`) only drive **post-fusion score decay** via a new internal `recency_decay` flag. That env opt-in no longer implies pulling in unrelated recent chunks when lexical/vector legs miss.
> 
> **Warm two-leg RRF** now adjusts fusion `alpha` when only one leg has candidates (FTS-only or vector-only), so a degraded search still ranks by the surviving leg instead of wiping its contribution when config weight would zero it out.
> 
> **MCP smart routes** pass `warm_rrf=True` from `think`/`recall` in `engine.py` through `search_handler`, aligning interactive memory retrieval with warm vector+FTS fusion (no legacy trigram leg on those paths).
> 
> Tests cover FTS-only warm fallback ordering, env recency decay without spurious recent hits, and handler wiring for `warm_rrf`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6207d2f2ab8164dce90ff7f1cbdc5e95950e306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix weighted RRF review gaps by propagating `warm_rrf` through search paths
> - Adds a `warm_rrf` boolean parameter to `engine.think` and `engine.recall` in [engine.py](https://github.com/EtanHey/brainlayer/pull/588/files#diff-ae9618aa043a902acc12fb2abf6e3da736acfb43f3e71a7f3ace9ab8cd35f8e6), forwarded into `hybrid_search` calls.
> - Sets `warm_rrf=True` in the MCP search handler for both `_think` and `_recall` coroutines in [search_handler.py](https://github.com/EtanHey/brainlayer/pull/588/files#diff-1f952ebc3cd8256a9bc05612e63df4c5cdcc59336a777da97375fa88fdb8bac0).
> - Fixes a variable naming bug in [search_repo.py](https://github.com/EtanHey/brainlayer/pull/588/files#diff-04cdc398ab5fa5accca0e4da7bec7bf6df2310018b643baafb2f7271db00d472) where `BRAINLAYER_SCORE_RECENCY_DECAY` was incorrectly toggling `recency_rerank` instead of a distinct `recency_decay` variable; also extends `_hybrid_cache_key` to include `recency_decay` for proper cache segregation.
> - Behavioral Change: the env flag `BRAINLAYER_SCORE_RECENCY_DECAY` no longer influences `recency_rerank` directly, which may change which recency behaviors are active at runtime for deployments using that flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6207d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hybrid search ranking when only semantic or full-text results are available.
  * Added warm ranking support to think and recall search flows.
* **Bug Fixes**
  * Prevented recency-decay settings from incorrectly returning unrelated recent results.
  * Preserved full-text result ordering during fallback ranking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->