### PR TITLE
fix: narrow transcript ingest denylist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ brainlayer enrich
 - Concurrency: retry on `SQLITE_BUSY`; each worker uses its own connection
 
 ## P1 Pipeline Contracts
-- BL-10 source denylist is implemented in `src/brainlayer/ingest_denylist.py`. Default excluded agent-output roots are `~/.claude/projects/*/**/subagents/**`, `~/.claude/projects/**/wf_*/**`, `~/.codex/sessions/**`, `~/.cursor/**/agent-transcripts/**`, and `~/.gemini/sessions/**`; direct/control Claude sessions still ingest through normal roots.
+- BL-10 source denylist is implemented in `src/brainlayer/ingest_denylist.py`. By default, provider sessions and ordinary Claude subagents ingest; only exact `brain-worker` subagents and workflow paths under `wf_*` are excluded. Exclusion never deletes the source JSONL. `BRAINLAYER_INGEST_DENYLIST` remains an explicit deployment override.
 - Go-forward secret scrubbing runs in `src/brainlayer/pipeline/secret_scrub.py` from `src/brainlayer/watcher_bridge.py` before chunk persistence. Provider-prefixed and labeled high-entropy secrets are redacted; unlabeled high-entropy tokens are recorded in quarantine metadata.
 - MCP search uses a fixed-size readonly WAL `VectorStore` pool in `src/brainlayer/mcp/_shared.py`. `BRAINLAYER_READ_POOL_SIZE` defaults to 8, or 4 on detected Apple M1; M1 machines can keep the lower override explicitly. Checkout beyond the fixed pool blocks up to `BRAINLAYER_READ_BUSY_TIMEOUT_MS`, and startup rejects `pool_size * BRAINLAYER_READ_CACHE_KB` above about 768MB.
 

--- a/scripts/retro_quarantine_self_pollution.py
+++ b/scripts/retro_quarantine_self_pollution.py
@@ -121,7 +121,7 @@ def _is_direct_claude_session(source_file: str) -> bool:
 def _is_denylisted_source(source_file: str | None) -> bool:
     if not source_file or not str(source_file).strip():
         return False
-    return is_denylisted(source_file)
+    return is_denylisted(source_file, unknown_subagent_is_denylisted=False)
 
 
 def _batch(items: list[str], batch_size: int) -> Iterable[list[str]]:

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -156,7 +156,7 @@ def classify_provenance(
         return ProvenanceDecision("cursor-gather", "ISOLATE", "Cursor agent-transcripts root")
 
     if _under_provider_sessions(path, ".gemini"):
-        return ProvenanceDecision("gemini-session", "OUT", "Gemini session root")
+        return ProvenanceDecision("gemini-session", "KEEP", "Gemini session root stays searchable")
 
     if _is_subagent(path):
         repo = _repo_from_project_segment(_project_segment(path))

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -29,6 +29,8 @@ import requests
 
 from .paths import get_db_path
 
+_sleep = time.sleep
+
 DEFAULT_TOKEN_PATH = Path.home() / ".config" / "google-drive-mcp" / "tokens.json"
 DEFAULT_CLIENT_PATH = Path.home() / ".config" / "google-drive-mcp" / "gcp-oauth.keys.json"
 DEFAULT_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"]
@@ -310,7 +312,7 @@ def request_brainbar_vacuum_into(
                 f"retrying in {retry_backoff_seconds}s",
                 flush=True,
             )
-            time.sleep(retry_backoff_seconds)
+            _sleep(retry_backoff_seconds)
     if last_error is not None:
         raise last_error
 
@@ -497,7 +499,7 @@ def upload_file_to_drive_raw(
                         f"sleeping {sleep_seconds}s",
                         flush=True,
                     )
-                    time.sleep(sleep_seconds)
+                    _sleep(sleep_seconds)
 
     raise RuntimeError("Drive upload ended without final response")
 

--- a/src/brainlayer/cloud_backfill.py
+++ b/src/brainlayer/cloud_backfill.py
@@ -49,6 +49,8 @@ from .pipeline.enrichment import (
 from .pipeline.sanitize import Sanitizer
 from .vector_store import VectorStore
 
+_sleep = time.sleep
+
 # ── Config ──────────────────────────────────────────────────────────────
 
 DEFAULT_DB_PATH = get_db_path()
@@ -353,7 +355,7 @@ def save_checkpoint(store: VectorStore, batch_id: str, **kwargs) -> None:
             last_error = exc
             if attempt == CHECKPOINT_WRITE_MAX_RETRIES - 1:
                 break
-            time.sleep(CHECKPOINT_WRITE_BASE_DELAY * (2**attempt))
+            _sleep(CHECKPOINT_WRITE_BASE_DELAY * (2**attempt))
         finally:
             if conn is not None:
                 conn.close()
@@ -793,7 +795,7 @@ def submit_gemini_batch(
             if "429" in err and attempt < max_retries - 1:
                 wait = 30 * (2**attempt)  # 30s, 60s, 120s
                 print(f"  429 RESOURCE_EXHAUSTED — waiting {wait}s before retry...")
-                time.sleep(wait)
+                _sleep(wait)
             else:
                 print(f"  FAILED: {err[:120]}")
                 if store:
@@ -841,7 +843,7 @@ def poll_gemini_batch(batch_name: str, timeout_hours: float = 25) -> Dict[str, A
             return status
 
         print(f"  State: {status.get('raw_state', state)} — waiting {poll_interval:.0f}s...")
-        time.sleep(poll_interval)
+        _sleep(poll_interval)
 
         # Gradually increase poll interval (max 5 min)
         poll_interval = min(poll_interval * 1.2, 300)
@@ -1175,7 +1177,7 @@ def run_full_backfill(
                 batch_names.append(batch_name)
             else:
                 print(f"  [WARN] Submission failed for {jsonl_path}, skipping")
-            time.sleep(2)  # Brief pause between submissions
+            _sleep(2)  # Brief pause between submissions
 
         if not batch_names:
             print("\nNo batch jobs submitted successfully.")

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -35,6 +35,7 @@ from .provenance_integration import enqueue_provenance_resolution_for_entities
 from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
+_sleep = time.sleep
 
 _DEFAULT_DRAIN_BUSY_TIMEOUT_MS = 30000
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
@@ -202,7 +203,7 @@ def _open_connection(db_path: Path) -> apsw.Connection:
                 max_retries + 1,
                 delay,
             )
-            time.sleep(delay)
+            _sleep(delay)
     else:
         raise RuntimeError("unreachable drain open retry state")
     conn.setbusytimeout(_drain_busy_timeout_ms())
@@ -1490,7 +1491,7 @@ def drain_once(
                         _mark_fallback_replays_best_effort(fallback_markers, log_path)
                     yield_seconds = _post_commit_yield_seconds()
                     if yield_seconds > 0:
-                        time.sleep(yield_seconds)
+                        _sleep(yield_seconds)
                     if _is_enrichment_queue_file(path) and _has_high_priority_queue_files(queue_dir):
                         stop_draining = True
                     break
@@ -1505,7 +1506,7 @@ def drain_once(
                     if _is_busy_error(exc) and attempt < 4:
                         delay = 0.05 * (2**attempt)
                         _log(log_path, f"drain busy; retrying in {delay:.2f}s")
-                        time.sleep(delay)
+                        _sleep(delay)
                         continue
                     if events_include_store and _is_missing_chunks_error(exc) and attempt < 4:
                         if conn is not None:

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -36,6 +36,7 @@ from .provenance_integration import enqueue_provenance_resolution_for_entities
 from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
+_sleep = time.sleep
 
 GEMINI_REALTIME_MODEL = os.environ.get("BRAINLAYER_GEMINI_REALTIME_MODEL", "gemini-2.5-flash-lite")
 DEFAULT_MAX_COMMIT_INTERVAL_MS = 250.0
@@ -664,7 +665,7 @@ def _submit_write(store, name: str, callback, *, yield_after: bool = True) -> An
     result = _get_store_write_queue(store).submit(name, callback).result()
     yield_seconds = _current_post_write_yield_seconds() if yield_after else 0.0
     if yield_seconds > 0:
-        time.sleep(yield_seconds)
+        _sleep(yield_seconds)
     return result
 
 
@@ -1461,7 +1462,7 @@ def _retry_with_backoff(
                 max_retries + 1,
                 sleep_for,
             )
-            time.sleep(sleep_for)
+            _sleep(sleep_for)
 
 
 def _generate_content_with_rate_limit(

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 import fnmatch
+import json
 import os
 from pathlib import Path
 
 BRAINLAYER_INGEST_DENYLIST_ENV = "BRAINLAYER_INGEST_DENYLIST"
 
-DEFAULT_INGEST_DENYLIST = (
-    "~/.claude/projects/*/**/subagents/**",
-    "~/.claude/projects/**/wf_*/**",
-    "~/.codex/sessions/**",
-    "~/.cursor/**/agent-transcripts/**",
-    "~/.gemini/sessions/**",
-)
+DEFAULT_INGEST_DENYLIST = ("~/.claude/projects/**/wf_*/**",)
+
+_SUBAGENT_ATTRIBUTION_SCAN_LINES = 256
+_SUBAGENT_ATTRIBUTION_CACHE: dict[str, tuple[int, int, str | None]] = {}
 
 
 def _configured_patterns() -> tuple[str, ...]:
@@ -53,6 +51,44 @@ def _match_parts(path_parts: tuple[str, ...], pattern_parts: tuple[str, ...]) ->
     return fnmatch.fnmatchcase(path_parts[0], pattern_parts[0]) and _match_parts(path_parts[1:], pattern_parts[1:])
 
 
+def _is_claude_subagent(path: Path) -> bool:
+    parts = path.parts
+    return ".claude" in parts and "projects" in parts and "subagents" in parts
+
+
+def _claude_subagent_attribution(path: Path) -> str | None:
+    """Read the first stable worker attribution without rescanning unchanged JSONLs."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+
+    cache_key = str(path)
+    cached = _SUBAGENT_ATTRIBUTION_CACHE.get(cache_key)
+    if cached is not None and cached[:2] == (stat.st_size, stat.st_mtime_ns):
+        return cached[2]
+
+    attribution = None
+    try:
+        with path.open(encoding="utf-8", errors="replace") as handle:
+            for line_number, raw_line in enumerate(handle):
+                if line_number >= _SUBAGENT_ATTRIBUTION_SCAN_LINES:
+                    break
+                try:
+                    entry = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+                raw_attribution = entry.get("attributionAgent")
+                if isinstance(raw_attribution, str) and raw_attribution.strip():
+                    attribution = raw_attribution.strip()
+                    break
+    except OSError:
+        return None
+
+    _SUBAGENT_ATTRIBUTION_CACHE[cache_key] = (stat.st_size, stat.st_mtime_ns, attribution)
+    return attribution
+
+
 def is_denylisted(path: str | Path) -> bool:
     """Return True when a source path is under an ingest-denylisted transcript root."""
     candidate = Path(os.path.abspath(os.path.expanduser(str(path))))
@@ -61,4 +97,7 @@ def is_denylisted(path: str | Path) -> bool:
         for expanded_pattern in _expand_globs(pattern, homes):
             if _match_parts(candidate.parts, expanded_pattern.parts):
                 return True
+    if _is_claude_subagent(candidate):
+        attribution = _claude_subagent_attribution(candidate)
+        return attribution is None or attribution == "brain-worker"
     return False

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import json
 import os
 from dataclasses import dataclass
@@ -20,6 +21,7 @@ class _AttributionCacheEntry:
     size: int
     mtime_ns: int
     scanned_offset: int
+    prefix_sha256: str
     attribution: str | None
 
 
@@ -79,30 +81,49 @@ def _claude_subagent_attribution(path: Path) -> str | None:
     same_file = cached is not None and (cached.device, cached.inode) == (stat.st_dev, stat.st_ino)
     if same_file and (cached.size, cached.mtime_ns) == (stat.st_size, stat.st_mtime_ns):
         return cached.attribution
-    if same_file and cached.attribution is not None and stat.st_size > cached.size:
-        _SUBAGENT_ATTRIBUTION_CACHE[cache_key] = _AttributionCacheEntry(
-            stat.st_dev,
-            stat.st_ino,
-            stat.st_size,
-            stat.st_mtime_ns,
-            cached.scanned_offset,
-            cached.attribution,
-        )
-        return cached.attribution
 
-    attribution = None
-    scan_offset = (
-        cached.scanned_offset if same_file and cached.attribution is None and stat.st_size > cached.size else 0
-    )
-    scanned_offset = scan_offset
+    attribution: str | None = None
+    scanned_offset = 0
     final_stat = stat
     try:
         with path.open("rb") as handle:
+            prefix_hasher = hashlib.sha256()
+            prefix_matches = False
+            if same_file and cached.scanned_offset <= stat.st_size:
+                remaining = cached.scanned_offset
+                while remaining:
+                    chunk = handle.read(min(remaining, 64 * 1024))
+                    if not chunk:
+                        break
+                    prefix_hasher.update(chunk)
+                    remaining -= len(chunk)
+                prefix_matches = remaining == 0 and prefix_hasher.hexdigest() == cached.prefix_sha256
+
+            if prefix_matches:
+                scanned_offset = cached.scanned_offset
+                if cached.attribution is not None:
+                    final_stat = os.fstat(handle.fileno())
+                    _SUBAGENT_ATTRIBUTION_CACHE[cache_key] = _AttributionCacheEntry(
+                        final_stat.st_dev,
+                        final_stat.st_ino,
+                        final_stat.st_size,
+                        final_stat.st_mtime_ns,
+                        scanned_offset,
+                        cached.prefix_sha256,
+                        cached.attribution,
+                    )
+                    return cached.attribution
+            else:
+                prefix_hasher = hashlib.sha256()
+                handle.seek(0)
+
+            scan_offset = scanned_offset
             handle.seek(scan_offset)
             for raw_line in handle:
                 line_end = handle.tell()
                 if raw_line.endswith(b"\n"):
                     scanned_offset = line_end
+                    prefix_hasher.update(raw_line)
                 try:
                     entry = json.loads(raw_line.decode("utf-8", errors="replace"))
                 except json.JSONDecodeError:
@@ -112,6 +133,8 @@ def _claude_subagent_attribution(path: Path) -> str | None:
                 raw_attribution = entry.get("attributionAgent")
                 if isinstance(raw_attribution, str) and raw_attribution.strip():
                     attribution = raw_attribution.strip()
+                    if not raw_line.endswith(b"\n"):
+                        prefix_hasher.update(raw_line)
                     scanned_offset = line_end
                     break
             final_stat = os.fstat(handle.fileno())
@@ -124,6 +147,7 @@ def _claude_subagent_attribution(path: Path) -> str | None:
         final_stat.st_size,
         final_stat.st_mtime_ns,
         scanned_offset,
+        prefix_hasher.hexdigest(),
         attribution,
     )
     return attribution

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -5,13 +5,25 @@ from __future__ import annotations
 import fnmatch
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 BRAINLAYER_INGEST_DENYLIST_ENV = "BRAINLAYER_INGEST_DENYLIST"
 
 DEFAULT_INGEST_DENYLIST = ("~/.claude/projects/**/wf_*/**",)
 
-_SUBAGENT_ATTRIBUTION_CACHE: dict[str, tuple[int, int, str | None]] = {}
+
+@dataclass(frozen=True)
+class _AttributionCacheEntry:
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    scanned_offset: int
+    attribution: str | None
+
+
+_SUBAGENT_ATTRIBUTION_CACHE: dict[str, _AttributionCacheEntry] = {}
 
 
 def _configured_patterns() -> tuple[str, ...]:
@@ -56,7 +68,7 @@ def _is_claude_subagent(path: Path) -> bool:
 
 
 def _claude_subagent_attribution(path: Path) -> str | None:
-    """Read the first stable worker attribution without rescanning unchanged JSONLs."""
+    """Incrementally read the first stable worker attribution from an appending JSONL."""
     try:
         stat = path.stat()
     except OSError:
@@ -64,15 +76,35 @@ def _claude_subagent_attribution(path: Path) -> str | None:
 
     cache_key = str(path)
     cached = _SUBAGENT_ATTRIBUTION_CACHE.get(cache_key)
-    if cached is not None and cached[:2] == (stat.st_size, stat.st_mtime_ns):
-        return cached[2]
+    same_file = cached is not None and (cached.device, cached.inode) == (stat.st_dev, stat.st_ino)
+    if same_file and (cached.size, cached.mtime_ns) == (stat.st_size, stat.st_mtime_ns):
+        return cached.attribution
+    if same_file and cached.attribution is not None and stat.st_size > cached.size:
+        _SUBAGENT_ATTRIBUTION_CACHE[cache_key] = _AttributionCacheEntry(
+            stat.st_dev,
+            stat.st_ino,
+            stat.st_size,
+            stat.st_mtime_ns,
+            cached.scanned_offset,
+            cached.attribution,
+        )
+        return cached.attribution
 
     attribution = None
+    scan_offset = (
+        cached.scanned_offset if same_file and cached.attribution is None and stat.st_size > cached.size else 0
+    )
+    scanned_offset = scan_offset
+    final_stat = stat
     try:
-        with path.open(encoding="utf-8", errors="replace") as handle:
+        with path.open("rb") as handle:
+            handle.seek(scan_offset)
             for raw_line in handle:
+                line_end = handle.tell()
+                if raw_line.endswith(b"\n"):
+                    scanned_offset = line_end
                 try:
-                    entry = json.loads(raw_line)
+                    entry = json.loads(raw_line.decode("utf-8", errors="replace"))
                 except json.JSONDecodeError:
                     continue
                 if not isinstance(entry, dict):
@@ -80,11 +112,20 @@ def _claude_subagent_attribution(path: Path) -> str | None:
                 raw_attribution = entry.get("attributionAgent")
                 if isinstance(raw_attribution, str) and raw_attribution.strip():
                     attribution = raw_attribution.strip()
+                    scanned_offset = line_end
                     break
+            final_stat = os.fstat(handle.fileno())
     except OSError:
         return None
 
-    _SUBAGENT_ATTRIBUTION_CACHE[cache_key] = (stat.st_size, stat.st_mtime_ns, attribution)
+    _SUBAGENT_ATTRIBUTION_CACHE[cache_key] = _AttributionCacheEntry(
+        final_stat.st_dev,
+        final_stat.st_ino,
+        final_stat.st_size,
+        final_stat.st_mtime_ns,
+        scanned_offset,
+        attribution,
+    )
     return attribution
 
 

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -11,7 +11,6 @@ BRAINLAYER_INGEST_DENYLIST_ENV = "BRAINLAYER_INGEST_DENYLIST"
 
 DEFAULT_INGEST_DENYLIST = ("~/.claude/projects/**/wf_*/**",)
 
-_SUBAGENT_ATTRIBUTION_SCAN_LINES = 256
 _SUBAGENT_ATTRIBUTION_CACHE: dict[str, tuple[int, int, str | None]] = {}
 
 
@@ -71,12 +70,12 @@ def _claude_subagent_attribution(path: Path) -> str | None:
     attribution = None
     try:
         with path.open(encoding="utf-8", errors="replace") as handle:
-            for line_number, raw_line in enumerate(handle):
-                if line_number >= _SUBAGENT_ATTRIBUTION_SCAN_LINES:
-                    break
+            for raw_line in handle:
                 try:
                     entry = json.loads(raw_line)
                 except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
                     continue
                 raw_attribution = entry.get("attributionAgent")
                 if isinstance(raw_attribution, str) and raw_attribution.strip():
@@ -97,7 +96,7 @@ def is_denylisted(path: str | Path) -> bool:
         for expanded_pattern in _expand_globs(pattern, homes):
             if _match_parts(candidate.parts, expanded_pattern.parts):
                 return True
-    if _is_claude_subagent(candidate):
+    if BRAINLAYER_INGEST_DENYLIST_ENV not in os.environ and _is_claude_subagent(candidate):
         attribution = _claude_subagent_attribution(candidate)
         return attribution is None or attribution == "brain-worker"
     return False

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -88,7 +88,7 @@ def _claude_subagent_attribution(path: Path) -> str | None:
     return attribution
 
 
-def is_denylisted(path: str | Path) -> bool:
+def is_denylisted(path: str | Path, *, unknown_subagent_is_denylisted: bool = True) -> bool:
     """Return True when a source path is under an ingest-denylisted transcript root."""
     candidate = Path(os.path.abspath(os.path.expanduser(str(path))))
     homes = _inferred_homes(candidate)
@@ -98,5 +98,5 @@ def is_denylisted(path: str | Path) -> bool:
                 return True
     if BRAINLAYER_INGEST_DENYLIST_ENV not in os.environ and _is_claude_subagent(candidate):
         attribution = _claude_subagent_attribution(candidate)
-        return attribution is None or attribution == "brain-worker"
+        return (attribution is None and unknown_subagent_is_denylisted) or attribution == "brain-worker"
     return False

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -33,6 +33,7 @@ _DEFAULT_STORE_BUSY_BUDGET_MS = 400
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _STORE_BUSY_TIMEOUT_LOCK = threading.Lock()
 _NO_EXEC_TRACE = object()
+_fsync = os.fsync
 
 
 def _positive_int_env(name: str, default: int) -> int:
@@ -447,7 +448,7 @@ def _atomic_rewrite_pending_store(path, lines: list[str]) -> None:
     with open(tmp, "w") as f:
         f.write("\n".join(lines) + "\n")
         f.flush()
-        os.fsync(f.fileno())
+        _fsync(f.fileno())
     tmp.replace(path)
     _fsync_directory(path.parent)
 
@@ -458,7 +459,7 @@ def _fsync_directory(path) -> None:
     except OSError:
         return
     try:
-        os.fsync(fd)
+        _fsync(fd)
     finally:
         os.close(fd)
 
@@ -500,7 +501,7 @@ def _queue_store(item: dict):
         with open(path, "a") as f:
             f.write(json.dumps(item) + "\n")
             f.flush()
-            os.fsync(f.fileno())
+            _fsync(f.fileno())
 
         # Enforce max size — read, trim oldest, atomic rewrite via tempfile
         try:

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -43,6 +43,7 @@ import requests
 logger = logging.getLogger(__name__)
 _prompt_signature_emitted = False
 _prompt_signature_lock = threading.Lock()
+_sleep = time.sleep
 
 from ..chunk_origin import CHUNK_ORIGIN_GROQ, CHUNK_ORIGIN_MLX, CHUNK_ORIGIN_OLLAMA
 from ..tag_normalization import (
@@ -186,7 +187,7 @@ def _try_restart_mlx() -> bool:
         )
         # Wait for server to be ready
         for i in range(MLX_RESTART_WAIT):
-            time.sleep(1)
+            _sleep(1)
             if check_backend_health("mlx"):
                 print(f"MLX server restarted successfully after {i + 1}s", file=sys.stderr)
                 return True
@@ -671,7 +672,7 @@ def call_groq(prompt: str, timeout: int = 60) -> Optional[str]:
             now = time.monotonic()
             elapsed = now - _groq_last_call
             if _groq_last_call > 0 and elapsed < GROQ_RATE_LIMIT_DELAY:
-                time.sleep(GROQ_RATE_LIMIT_DELAY - elapsed)
+                _sleep(GROQ_RATE_LIMIT_DELAY - elapsed)
             _groq_last_call = time.monotonic()
 
         start_ms = int(time.time() * 1000)
@@ -1019,7 +1020,7 @@ def _enrich_one(
                 f"  RETRY: chunk {chunk['id'][:12]} attempt {attempt + 2}/{1 + MAX_RETRIES} in {total_delay:.1f}s",
                 file=sys.stderr,
             )
-            time.sleep(total_delay)
+            _sleep(total_delay)
 
     enrichment = parse_enrichment(response)
     if enrichment:
@@ -1415,7 +1416,7 @@ def run_enrichment(
                             f"Backend alive but struggling. Pausing {HEALTH_CHECK_PAUSE}s...",
                             file=sys.stderr,
                         )
-                        time.sleep(HEALTH_CHECK_PAUSE)
+                        _sleep(HEALTH_CHECK_PAUSE)
 
             # Sync stats to Supabase every 5 batches
             if total_processed % (batch_size * 5) < batch_size:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -24,6 +24,8 @@ from .dedupe import resolve_chunk_id
 from .ingest_guard import recursive_mcp_output_reason
 from .scoping import ConsumerScope
 
+_sleep = time.sleep
+
 # ── hybrid_search result cache ───────────────────────────────────────────────
 # Caches identical (store, query_text, filters) → results for 60s.
 # Warm repeated queries (e.g. hook firing on the same prompt twice) return
@@ -674,7 +676,7 @@ class SearchMixin:
             except apsw.Error as exc:
                 if _is_sqlite_busy_error(exc):
                     if attempt < 2:
-                        time.sleep(0.05 * (2**attempt))
+                        _sleep(0.05 * (2**attempt))
                         continue
                     raise
                 return None
@@ -706,7 +708,7 @@ class SearchMixin:
                 break
             except apsw.Error as exc:
                 if _is_sqlite_busy_error(exc) and attempt < 2:
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
                     continue
                 raise
         clear_hybrid_search_cache(getattr(self, "db_path", None))
@@ -745,7 +747,7 @@ class SearchMixin:
                 return audit_count
             except apsw.Error as exc:
                 if _is_sqlite_busy_error(exc) and attempt < 2:
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
                     continue
                 if cached_count is not None:
                     return int(cached_count)
@@ -776,7 +778,7 @@ class SearchMixin:
             except (apsw.Error, TypeError, IndexError, ValueError) as exc:
                 if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
                     return None
-                time.sleep(0.05 * (2**attempt))
+                _sleep(0.05 * (2**attempt))
         return None
 
     def _checkpoint_filtered_knn_k(
@@ -818,7 +820,7 @@ class SearchMixin:
                     if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
                         checkpoint_count = 0
                         break
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
 
         if checkpoint_count <= 0:
             return n_results
@@ -2271,7 +2273,7 @@ class SearchMixin:
                 except apsw.Error as exc:
                     if not _is_sqlite_busy_error(exc) or attempt == 2:
                         raise
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
             # Recency fallback supplements lexical search, so append ranks after
             # existing FTS hits instead of tying the top exact match at rank 0.
             recent_rank_offset = max(fts_ranks.values(), default=-1) + 1

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -50,6 +50,7 @@ from .vector_store import VectorStore
 from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
+_sleep = time.sleep
 
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 
@@ -76,7 +77,7 @@ def _sleep_before_busy_retry(delay: float, busy_deadline: Optional[float]) -> No
         if remaining <= 0 or delay >= remaining:
             raise apsw.BusyError("store busy budget exceeded")
         delay = min(delay, remaining)
-    time.sleep(delay)
+    _sleep(delay)
 
 
 def store_memory(

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -71,6 +71,7 @@ _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _MAX_INDEX_TXN_BATCH = 10_000
 _WRITE_BUSY_TIMEOUT_STATE = threading.local()
 _NO_EXEC_TRACE = object()
+_sleep = time.sleep
 _KNOWLEDGE_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark', 'cold')"
 _OPERATIONAL_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') = 'operational'"
 
@@ -398,7 +399,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                         return
                     if attempt == max_create_attempts - 1:
                         raise
-                    time.sleep(0.01 * (attempt + 1))
+                    _sleep(0.01 * (attempt + 1))
 
     def _reclaim_stale_writer_pidfiles(self, pidfile: Path) -> None:
         # Legacy pidfiles do not record the database path. Sweep sibling hashes
@@ -707,7 +708,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     remaining = deadline - time.monotonic()
                     if remaining <= 0 or delay >= remaining:
                         raise last_err
-                time.sleep(delay)
+                _sleep(delay)
             except BaseException as exc:
                 self._finish_init_writer_telemetry("error", error=f"{type(exc).__name__}: {exc}")
                 raise
@@ -2005,7 +2006,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     cursor.execute("ROLLBACK")
                 if attempt == 4:
                     raise
-                time.sleep(0.2 * (2**attempt))
+                _sleep(0.2 * (2**attempt))
             except Exception:
                 if transaction_started:
                     cursor.execute("ROLLBACK")
@@ -2673,7 +2674,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                         if committed_any:
                             invalidate_upsert_caches()
                         raise
-                    time.sleep(0.1 * (2**attempt))
+                    _sleep(0.1 * (2**attempt))
                 except Exception as exc:
                     rollback_active_transaction()
                     telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -30,7 +30,7 @@ def test_classifies_provider_roots_and_workflow_paths(tmp_path: Path) -> None:
         (
             home / ".gemini" / "sessions" / "session.jsonl",
             "gemini-session",
-            "OUT",
+            "KEEP",
         ),
         (
             home
@@ -212,13 +212,13 @@ def test_effective_visibility_preserves_keep_knowledge_and_decision_but_isolates
     isolate = classify_provenance(
         str(tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "session.jsonl")
     )
-    out = classify_provenance(str(tmp_path / ".gemini" / "sessions" / "session.jsonl"))
+    gemini = classify_provenance(str(tmp_path / ".gemini" / "sessions" / "session.jsonl"))
 
     assert effective_visibility(keep, "knowledge") == "default"
     assert effective_visibility(keep, "decision") == "default"
     assert effective_visibility(keep, "operational") == "operational"
     assert effective_visibility(isolate, "knowledge") == "operational"
-    assert effective_visibility(out, "knowledge") == "cold"
+    assert effective_visibility(gemini, "knowledge") == "default"
 
 
 def test_report_summarizes_tags_policies_and_effective_visibility_without_real_db(tmp_path: Path) -> None:
@@ -254,8 +254,8 @@ def test_report_summarizes_tags_policies_and_effective_visibility_without_real_d
         "direct-session": 1,
         "gemini-session": 1,
     }
-    assert report["policies"] == {"KEEP": 2, "ISOLATE": 1, "OUT": 1}
-    assert report["effective_visibility"] == {"cold": 1, "default": 2, "operational": 1}
+    assert report["policies"] == {"KEEP": 3, "ISOLATE": 1, "OUT": 0}
+    assert report["effective_visibility"] == {"cold": 0, "default": 3, "operational": 1}
 
 
 def test_report_script_bootstraps_src_when_run_directly(tmp_path: Path) -> None:

--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -149,7 +149,7 @@ class TestEnrichSingle:
         failing_client = MagicMock()
         failing_client.models.generate_content.side_effect = Exception("API error")
         monkeypatch.setattr(ctrl, "_get_gemini_client", lambda: failing_client)
-        monkeypatch.setattr(ctrl.time, "sleep", lambda _: None)
+        monkeypatch.setattr(ctrl, "_sleep", lambda _: None)
 
         result = ctrl.enrich_single(store, stored_chunk, max_retries=1)
         assert result is None

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -256,7 +256,7 @@ def test_brainbar_vacuum_request_retries_closed_socket_with_backoff(tmp_path, mo
         return {"result": {"content": [{"type": "text", "text": '{"status":"ok"}'}]}}
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", flaky_send)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
 
@@ -280,7 +280,7 @@ def test_brainbar_vacuum_request_fails_loud_after_retry_budget(tmp_path, monkeyp
         raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", closed_socket)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     with pytest.raises(RuntimeError, match="BrainBar socket closed without response"):
         backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
@@ -307,7 +307,7 @@ def test_brainbar_vacuum_request_does_not_retry_global_backup_timeout(tmp_path, 
         raise backup_daily.BackupTimeoutError("backup exceeded configured wall-clock timeout")
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", timed_out)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     with pytest.raises(backup_daily.BackupTimeoutError):
         backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
@@ -329,7 +329,7 @@ def test_brainbar_vacuum_request_accepts_valid_target_after_lost_response(tmp_pa
         raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", closed_after_success)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
 
@@ -355,7 +355,7 @@ def test_brainbar_vacuum_request_removes_invalid_target_before_retry(tmp_path, m
         return {"result": {"content": [{"type": "text", "text": '{"status":"ok"}'}]}}
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", invalid_then_success)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
 

--- a/tests/test_cloud_backfill.py
+++ b/tests/test_cloud_backfill.py
@@ -276,7 +276,7 @@ def test_submit_only_reuses_existing_exports_without_reexporting(tmp_path, monke
 
     monkeypatch.setattr(cloud_backfill, "export_unenriched_chunks", fake_export)
     monkeypatch.setattr(cloud_backfill, "submit_gemini_batch", fake_submit)
-    monkeypatch.setattr(cloud_backfill.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cloud_backfill, "_sleep", lambda *_args, **_kwargs: None)
 
     db_path = tmp_path / "brainlayer.db"
     store = VectorStore(db_path)
@@ -374,7 +374,7 @@ def test_submit_only_exports_new_chunks_when_old_files_are_checkpointed(tmp_path
 
     monkeypatch.setattr(cloud_backfill, "export_unenriched_chunks", fake_export)
     monkeypatch.setattr(cloud_backfill, "submit_gemini_batch", fake_submit)
-    monkeypatch.setattr(cloud_backfill.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cloud_backfill, "_sleep", lambda *_args, **_kwargs: None)
 
     store = VectorStore(tmp_path / "brainlayer.db")
     try:

--- a/tests/test_concurrent_enrichment.py
+++ b/tests/test_concurrent_enrichment.py
@@ -43,7 +43,7 @@ def test_enrich_realtime_processes_chunks(monkeypatch):
     monkeypatch.setattr(controller, "_ensure_content_hash_column", lambda store: True)
     monkeypatch.setattr(controller, "_is_duplicate_content", lambda store, content: False)
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(controller, "_emit_enrichment_start", lambda *args, **kwargs: True)
     monkeypatch.setattr(controller, "_emit_enrichment_complete", lambda *args, **kwargs: True)
     monkeypatch.setattr(controller, "_emit_enrichment_error", lambda *args, **kwargs: True)

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -142,7 +142,7 @@ def test_submit_write_yields_after_successful_write(monkeypatch):
 
     monkeypatch.setattr(controller, "_get_store_write_queue", lambda store: ImmediateQueue())
     monkeypatch.setattr(controller, "_current_post_write_yield_seconds", lambda: 0.123)
-    monkeypatch.setattr(controller.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(controller, "_sleep", lambda seconds: sleeps.append(seconds))
 
     result = controller._submit_write(MagicMock(), "apply-enrichment:c0", lambda: "ok")
 

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -54,7 +54,7 @@ def _patch_realtime_deps(monkeypatch, controller, store, response_text=None):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(
         controller,
         "_get_gemini_client",
@@ -426,7 +426,7 @@ def test_enrich_realtime_calls_build_external_prompt_for_every_chunk(monkeypatch
     monkeypatch.setattr(controller, "_retry_with_backoff", lambda fn, **kwargs: '{"summary":"sum","tags":["python"]}')
     monkeypatch.setattr(controller, "_get_gemini_client", lambda: MagicMock())
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     controller.enrich_realtime(store, limit=2, since_hours=24)
 
@@ -441,7 +441,7 @@ def test_enrich_realtime_sets_thinking_budget_zero_in_gemini_config(monkeypatch)
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     captured = {}
 
@@ -470,7 +470,7 @@ def test_enrich_realtime_passes_flex_service_tier_in_gemini_config(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     captured = {}
 
@@ -548,7 +548,7 @@ def test_enrich_realtime_calls_parse_enrichment_on_response(monkeypatch):
     parse_mock = MagicMock(return_value={"summary": "sum", "tags": ["python"]})
     monkeypatch.setattr(controller, "parse_enrichment", parse_mock)
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     class FakeClient:
         class _Models:
@@ -574,7 +574,7 @@ def test_enrich_realtime_writes_via_update_enrichment_only(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     class FakeClient:
         class _Models:
@@ -600,7 +600,7 @@ def test_enrich_realtime_is_idempotent_on_rerun(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     class FakeClient:
         class _Models:
@@ -624,7 +624,7 @@ def test_retry_with_backoff_retries_12_times_on_429(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    monkeypatch.setattr(controller, "_sleep", sleeps.append)
     monkeypatch.setattr(controller.random, "uniform", lambda a, b: 0.0)
 
     attempts = {"count": 0}
@@ -644,7 +644,7 @@ def test_retry_with_backoff_short_circuits_monthly_spend_cap_429(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    monkeypatch.setattr(controller, "_sleep", sleeps.append)
 
     attempts = {"count": 0}
 
@@ -663,7 +663,7 @@ def test_retry_with_backoff_respects_max_delay_cap(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    monkeypatch.setattr(controller, "_sleep", sleeps.append)
     monkeypatch.setattr(controller.random, "uniform", lambda a, b: b)
 
     attempts = {"count": 0}
@@ -1128,18 +1128,24 @@ def test_batch_rate_limit_uses_batch_setting(monkeypatch):
     assert observed["acquires"] == [1]
 
 
-def test_realtime_no_sleep_when_rate_zero(monkeypatch):
+def test_realtime_rate_zero_disables_limiter(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     store = MagicMock()
     store.get_enrichment_candidates.return_value = [_candidate("c1"), _candidate("c2")]
     _patch_realtime_deps(monkeypatch, controller, store)
+    real_get_store_rate_limiter = controller._get_store_rate_limiter
+    observed = {}
 
-    sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    def observed_get_store_rate_limiter(*args, **kwargs):
+        observed["rate"] = kwargs["rate_per_second"]
+        observed["limiter"] = real_get_store_rate_limiter(*args, **kwargs)
+        return observed["limiter"]
+
+    monkeypatch.setattr(controller, "_get_store_rate_limiter", observed_get_store_rate_limiter)
 
     controller.enrich_realtime(store, limit=2, rate_per_second=0)
-    assert len(sleeps) == 0
+    assert observed == {"rate": 0, "limiter": None}
 
 
 # ── Retry logic tests ────────────────────────────────────────────────────────
@@ -1148,7 +1154,7 @@ def test_realtime_no_sleep_when_rate_zero(monkeypatch):
 def test_retry_succeeds_on_first_try(monkeypatch):
     from brainlayer.enrichment_controller import _retry_with_backoff
 
-    monkeypatch.setattr("brainlayer.enrichment_controller.time.sleep", lambda _: None)
+    monkeypatch.setattr("brainlayer.enrichment_controller._sleep", lambda _: None)
     monkeypatch.setattr("brainlayer.enrichment_controller.random.uniform", lambda a, b: 0.0)
 
     result = _retry_with_backoff(lambda: "ok", max_retries=3)
@@ -1158,7 +1164,7 @@ def test_retry_succeeds_on_first_try(monkeypatch):
 def test_retry_succeeds_after_transient_failure(monkeypatch):
     from brainlayer.enrichment_controller import _retry_with_backoff
 
-    monkeypatch.setattr("brainlayer.enrichment_controller.time.sleep", lambda _: None)
+    monkeypatch.setattr("brainlayer.enrichment_controller._sleep", lambda _: None)
     monkeypatch.setattr("brainlayer.enrichment_controller.random.uniform", lambda a, b: 0.0)
 
     attempts = {"n": 0}
@@ -1177,7 +1183,7 @@ def test_retry_succeeds_after_transient_failure(monkeypatch):
 def test_retry_only_catches_specified_errors(monkeypatch):
     from brainlayer.enrichment_controller import _retry_with_backoff
 
-    monkeypatch.setattr("brainlayer.enrichment_controller.time.sleep", lambda _: None)
+    monkeypatch.setattr("brainlayer.enrichment_controller._sleep", lambda _: None)
     monkeypatch.setattr("brainlayer.enrichment_controller.random.uniform", lambda a, b: 0.0)
 
     with pytest.raises(ValueError):
@@ -1200,7 +1206,7 @@ def test_enrich_realtime_stops_new_calls_when_daily_cap_crosses(monkeypatch, tmp
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     calls = {"count": 0}
 
@@ -1244,7 +1250,7 @@ def test_realtime_counts_failed_on_invalid_enrichment(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value=None))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(controller, "_get_gemini_client", lambda: _fake_gemini_client("garbage"))
 
     result = controller.enrich_realtime(store, limit=1)
@@ -1260,7 +1266,7 @@ def test_realtime_counts_failed_on_exception(monkeypatch):
     store.get_enrichment_candidates.return_value = [_candidate()]
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(side_effect=RuntimeError("boom")))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(controller, "_get_gemini_client", lambda: _fake_gemini_client())
 
     result = controller.enrich_realtime(store, limit=1)

--- a/tests/test_enrichment_quality_benchmark.py
+++ b/tests/test_enrichment_quality_benchmark.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 
 from brainlayer.eval.enrichment_quality_benchmark import (
@@ -14,6 +15,7 @@ from brainlayer.eval.enrichment_quality_benchmark import (
 
 
 def test_select_meaningful_chunks_uses_pure_content_not_existing_enrichment(tmp_path: Path):
+    recent_timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     db_path = tmp_path / "brainlayer.db"
     conn = sqlite3.connect(db_path)
     conn.execute(
@@ -53,7 +55,7 @@ def test_select_meaningful_chunks_uses_pure_content_not_existing_enrichment(tmp_
                 "assistant_text",
                 "claude_code",
                 "session.jsonl",
-                "2026-06-15T10:00:00Z",
+                recent_timestamp,
                 75,
                 None,
                 None,
@@ -70,7 +72,7 @@ def test_select_meaningful_chunks_uses_pure_content_not_existing_enrichment(tmp_
                 "user_text",
                 "claude_code",
                 "session.jsonl",
-                "2026-06-15T10:01:00Z",
+                recent_timestamp,
                 9,
                 "Gemini says this is an important correction decision",
                 '["decision","correction","important"]',

--- a/tests/test_enrichment_reliability.py
+++ b/tests/test_enrichment_reliability.py
@@ -303,7 +303,7 @@ class TestRetryWithBackoff:
             patch.object(enrichment, "MAX_RETRIES", 3),
             patch.object(enrichment, "RETRY_BASE_DELAY", 1.0),
             patch.object(enrichment, "RETRY_MAX_DELAY", 100.0),
-            patch("time.sleep", side_effect=mock_sleep),
+            patch.object(enrichment, "_sleep", side_effect=mock_sleep),
         ):
             enrichment._enrich_one(store, chunk, with_context=False)
 

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -983,7 +983,7 @@ class TestHybridSearch:
         busy_cursor = BusyOnceCursor()
         sleeps: list[float] = []
         monkeypatch.setattr(store, "_read_cursor", lambda: busy_cursor)
-        monkeypatch.setattr("time.sleep", sleeps.append)
+        monkeypatch.setattr("brainlayer.search_repo._sleep", sleeps.append)
 
         results = store.hybrid_search(
             query_embedding=_embed("latest unrelated"),

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -1,52 +1,121 @@
+import json
 from pathlib import Path
 
-from brainlayer.ingest_denylist import is_denylisted
+from brainlayer.ingest_denylist import BRAINLAYER_INGEST_DENYLIST_ENV, is_denylisted
 
 
-def test_default_denylist_matches_alternate_home_without_process_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("HOME", str(tmp_path / "real-home"))
+def _write_subagent(path: Path, attribution: str | None) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entries = [
+        {
+            "type": "user",
+            "agentId": path.stem.removeprefix("agent-"),
+            "message": {"role": "user", "content": "Investigate the assigned task."},
+        }
+    ]
+    if attribution is not None:
+        entries.append(
+            {
+                "type": "assistant",
+                "attributionAgent": attribution,
+                "message": {"role": "assistant", "content": "Attributed worker response."},
+            }
+        )
+    path.write_text("".join(json.dumps(entry) + "\n" for entry in entries), encoding="utf-8")
+    return path
+
+
+def test_default_policy_allows_normal_provider_sessions(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path / "process-home"))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
     backup_home = tmp_path / "backup-home"
 
-    assert is_denylisted(backup_home / ".codex" / "sessions" / "worker.jsonl")
-    assert is_denylisted(backup_home / ".gemini" / "sessions" / "worker.jsonl")
-    assert is_denylisted(
+    assert not is_denylisted(backup_home / ".codex" / "sessions" / "worker.jsonl")
+    assert not is_denylisted(backup_home / ".gemini" / "sessions" / "worker.jsonl")
+    assert not is_denylisted(
         backup_home / ".cursor" / "projects" / "repo" / "agent-transcripts" / "session" / "worker.jsonl"
     )
-    assert is_denylisted(backup_home / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a111.jsonl")
+    assert not is_denylisted(backup_home / ".claude" / "projects" / "proj" / "direct-session.jsonl")
 
 
-def test_default_denylist_is_segment_scoped(monkeypatch, tmp_path):
+def test_default_policy_allows_ordinary_claude_subagents(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    projects = tmp_path / ".claude" / "projects" / "-Users-test-Gits-brainlayer" / "session-uuid"
 
-    assert not is_denylisted(tmp_path / ".claude" / "projects" / "proj" / "direct-session.jsonl")
-    assert is_denylisted(Path(tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "worker.jsonl"))
+    explore = _write_subagent(projects / "subagents" / "agent-explore.jsonl", "Explore")
+    general = _write_subagent(projects / "subagents" / "agent-general.jsonl", "general-purpose")
+
+    assert not is_denylisted(explore)
+    assert not is_denylisted(general)
 
 
-def test_brain_worker_subagent_transcript_is_denylisted(monkeypatch, tmp_path):
-    """Regression (Etan flag 2026-07-03): the brain-worker off-grid recon subagent
-    (~/.claude/agents/brain-worker.md) writes its session JSONL like every Agent-tool
-    subagent — under a `subagents/` dir — so it MUST be in the agent-output exclusion set.
-    """
+def test_default_policy_excludes_exact_brain_worker_but_keeps_raw_jsonl(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
-    projects = tmp_path / ".claude" / "projects"
-
-    # brain-worker (and any Agent-tool subagent) transcript path
-    assert is_denylisted(
-        projects / "-Users-etanheyman-Gits-brainlayer" / "session-uuid" / "subagents" / "agent-a25d6b3aa6880db8e.jsonl"
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    worker = _write_subagent(
+        tmp_path
+        / ".claude"
+        / "projects"
+        / "-Users-test-Gits-brainlayer"
+        / "session-uuid"
+        / "subagents"
+        / "agent-brain.jsonl",
+        "brain-worker",
     )
-    # workflow subagents nested a level deeper still excluded
-    assert is_denylisted(
-        projects / "-Users-x" / "session-uuid" / "subagents" / "workflows" / "wf_c83ce37d" / "agent-x.jsonl"
+
+    assert is_denylisted(worker)
+    assert worker.exists()
+
+
+def test_default_policy_excludes_workflow_workers_by_path_and_keeps_raw_jsonl(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    workflow = _write_subagent(
+        tmp_path
+        / ".claude"
+        / "projects"
+        / "-Users-test-Gits-brainlayer"
+        / "session-uuid"
+        / "subagents"
+        / "workflows"
+        / "wf_c83ce37d"
+        / "agent-workflow.jsonl",
+        "workflow-subagent",
     )
 
+    assert is_denylisted(workflow)
+    assert workflow.exists()
 
-def test_direct_control_transcripts_still_ingest(monkeypatch, tmp_path):
-    """Regression (Etan flag 2026-07-03): DIRECT/CONTROL transcripts — a lead's or a
-    top-level worker's own reasoning session — are NOT agent-output roots and MUST keep
-    ingesting. The denylist targets agent-OUTPUT paths only, never direct sessions.
-    """
+
+def test_unattributed_subagent_is_deferred_until_identity_is_known(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
-    projects = tmp_path / ".claude" / "projects"
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    worker = _write_subagent(
+        tmp_path / ".claude" / "projects" / "proj" / "session-uuid" / "subagents" / "agent-new.jsonl",
+        None,
+    )
 
-    assert not is_denylisted(projects / "-Users-etanheyman-Gits-brainlayer" / "4220c177-8816-446d.jsonl")
-    assert not is_denylisted(projects / "-Users-x" / "session-uuid" / "session-uuid.jsonl")
+    assert is_denylisted(worker)
+
+    with worker.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "attributionAgent": "general-purpose",
+                    "message": {"role": "assistant", "content": "Identity is now available."},
+                }
+            )
+            + "\n"
+        )
+
+    assert not is_denylisted(worker)
+
+
+def test_explicit_environment_override_can_deny_an_otherwise_allowed_provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(BRAINLAYER_INGEST_DENYLIST_ENV, "~/.codex/sessions/**")
+
+    assert is_denylisted(tmp_path / ".codex" / "sessions" / "worker.jsonl")
+    assert not is_denylisted(tmp_path / ".gemini" / "sessions" / "worker.jsonl")

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -119,10 +119,7 @@ def test_subagent_attribution_skips_non_object_json_values(monkeypatch, tmp_path
     worker = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent.jsonl"
     worker.parent.mkdir(parents=True)
     worker.write_text(
-        "null\n"
-        "[]\n"
-        + json.dumps({"attributionAgent": "general-purpose"})
-        + "\n",
+        "null\n[]\n" + json.dumps({"attributionAgent": "general-purpose"}) + "\n",
         encoding="utf-8",
     )
 

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -113,6 +113,15 @@ def test_unattributed_subagent_is_deferred_until_identity_is_known(monkeypatch, 
     assert not is_denylisted(worker)
 
 
+def test_historical_policy_preserves_unverifiable_subagents(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    missing_worker = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-missing.jsonl"
+
+    assert is_denylisted(missing_worker)
+    assert not is_denylisted(missing_worker, unknown_subagent_is_denylisted=False)
+
+
 def test_subagent_attribution_skips_non_object_json_values(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -178,6 +178,35 @@ def test_unattributed_appends_are_scanned_incrementally(monkeypatch, tmp_path):
     assert calls == 202
 
 
+def test_cached_attribution_is_invalidated_when_same_inode_is_rewritten_larger(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    denylist._SUBAGENT_ATTRIBUTION_CACHE.clear()
+    worker = _write_subagent(
+        tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent.jsonl",
+        "general-purpose",
+    )
+    assert not is_denylisted(worker)
+    initial_stat = worker.stat()
+
+    worker.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "attributionAgent": "brain-worker",
+                "message": {"role": "assistant", "content": "rewritten" + "x" * 1_000},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rewritten_stat = worker.stat()
+
+    assert rewritten_stat.st_ino == initial_stat.st_ino
+    assert rewritten_stat.st_size > initial_stat.st_size
+    assert is_denylisted(worker)
+
+
 def test_explicit_empty_override_disables_default_subagent_policy(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv(BRAINLAYER_INGEST_DENYLIST_ENV, "")

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -113,6 +113,47 @@ def test_unattributed_subagent_is_deferred_until_identity_is_known(monkeypatch, 
     assert not is_denylisted(worker)
 
 
+def test_subagent_attribution_skips_non_object_json_values(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    worker = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent.jsonl"
+    worker.parent.mkdir(parents=True)
+    worker.write_text(
+        "null\n"
+        "[]\n"
+        + json.dumps({"attributionAgent": "general-purpose"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert not is_denylisted(worker)
+
+
+def test_subagent_attribution_is_found_after_legacy_scan_limit(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    worker = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent.jsonl"
+    worker.parent.mkdir(parents=True)
+    unattributed = json.dumps({"type": "progress"})
+    worker.write_text(
+        "\n".join([unattributed] * 300 + [json.dumps({"attributionAgent": "general-purpose"})]) + "\n",
+        encoding="utf-8",
+    )
+
+    assert not is_denylisted(worker)
+
+
+def test_explicit_empty_override_disables_default_subagent_policy(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(BRAINLAYER_INGEST_DENYLIST_ENV, "")
+    worker = _write_subagent(
+        tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent.jsonl",
+        "brain-worker",
+    )
+
+    assert not is_denylisted(worker)
+
+
 def test_explicit_environment_override_can_deny_an_otherwise_allowed_provider(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv(BRAINLAYER_INGEST_DENYLIST_ENV, "~/.codex/sessions/**")

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import brainlayer.ingest_denylist as denylist
 from brainlayer.ingest_denylist import BRAINLAYER_INGEST_DENYLIST_ENV, is_denylisted
 
 
@@ -147,6 +148,34 @@ def test_subagent_attribution_is_found_after_legacy_scan_limit(monkeypatch, tmp_
     )
 
     assert not is_denylisted(worker)
+
+
+def test_unattributed_appends_are_scanned_incrementally(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    denylist._SUBAGENT_ATTRIBUTION_CACHE.clear()
+    worker = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent.jsonl"
+    worker.parent.mkdir(parents=True)
+    progress = json.dumps({"type": "progress"})
+    worker.write_text("\n".join([progress] * 200) + "\n", encoding="utf-8")
+    real_loads = json.loads
+    calls = 0
+
+    def counting_loads(value):
+        nonlocal calls
+        calls += 1
+        return real_loads(value)
+
+    monkeypatch.setattr(denylist.json, "loads", counting_loads)
+
+    assert is_denylisted(worker)
+    with worker.open("a", encoding="utf-8") as handle:
+        handle.write(progress + "\n")
+    assert is_denylisted(worker)
+    with worker.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"attributionAgent": "general-purpose"}) + "\n")
+    assert not is_denylisted(worker)
+    assert calls == 202
 
 
 def test_explicit_empty_override_disables_default_subagent_policy(monkeypatch, tmp_path):

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -505,10 +505,11 @@ class TestJSONLWatcher:
         assert len(files) == 4
         assert {watcher.provider_for_file(path) for path in files} == {"claude", "codex", "cursor", "gemini"}
 
-    def test_default_roots_denylist_cursor_agent_transcripts(self, tmp_path):
+    def test_default_roots_include_cursor_agent_transcripts(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
         cursor_session = tmp_path / ".cursor" / "sessions" / "session.jsonl"
         cursor_agent_transcript = (
-            tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent-session.jsonl"
+            tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent-session" / "agent-session.jsonl"
         )
         unrelated_project_jsonl = tmp_path / ".cursor" / "projects" / "repo" / "state.jsonl"
         for path in (cursor_session, cursor_agent_transcript, unrelated_project_jsonl):
@@ -524,12 +525,13 @@ class TestJSONLWatcher:
         files = set(watcher._discover_jsonl_files())
 
         assert str(cursor_session) in files
-        assert str(cursor_agent_transcript) not in files
+        assert str(cursor_agent_transcript) in files
         assert str(unrelated_project_jsonl) not in files
         assert watcher.provider_for_file(str(cursor_session)) == "cursor"
-        assert watcher.provider_for_file(str(cursor_agent_transcript)) == "unknown"
+        assert watcher.provider_for_file(str(cursor_agent_transcript)) == "cursor-agent-transcripts"
 
-    def test_default_roots_denylist_codex_and_gemini_sessions(self, tmp_path):
+    def test_default_roots_include_codex_and_gemini_sessions(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
         codex_session = tmp_path / ".codex" / "sessions" / "2026" / "07" / "worker.jsonl"
         gemini_session = tmp_path / ".gemini" / "sessions" / "worker.jsonl"
         for path in (codex_session, gemini_session):
@@ -544,10 +546,10 @@ class TestJSONLWatcher:
 
         files = set(watcher._discover_jsonl_files())
 
-        assert str(codex_session) not in files
-        assert str(gemini_session) not in files
-        assert watcher.provider_for_file(str(codex_session)) == "unknown"
-        assert watcher.provider_for_file(str(gemini_session)) == "unknown"
+        assert str(codex_session) in files
+        assert str(gemini_session) in files
+        assert watcher.provider_for_file(str(codex_session)) == "codex"
+        assert watcher.provider_for_file(str(gemini_session)) == "gemini"
 
     def test_multi_root_discovers_newest_jsonl_files_first(self, tmp_path):
         codex_sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -199,7 +199,8 @@ def _call_record_manifest_for_plan(script: ModuleType, cursor: apsw.Cursor, chun
         script._record_manifest(cursor, chunk_ids, run_id="plan-run", timestamp="2026-07-08T00:00:00Z")
 
 
-def test_dry_run_uses_denylist_and_preserves_direct_sessions(tmp_path: Path) -> None:
+def test_dry_run_uses_denylist_and_preserves_direct_sessions(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
     script = _load_script()
     db_path = tmp_path / "dry-run.db"
     store = VectorStore(db_path)
@@ -225,9 +226,10 @@ def test_dry_run_uses_denylist_and_preserves_direct_sessions(tmp_path: Path) -> 
 
     report = script.run_dry_run(db_path, sample_size=10, random_seed=7)
 
-    assert report["counts"] == {"quarantine_set": 2, "preserved": 2, "total": 4}
-    assert report["provider_breakdown"]["quarantine_set"] == {"claude": 1, "codex": 1}
-    assert report["audit"]["quarantine_sample_size"] == 2
+    assert report["counts"] == {"quarantine_set": 1, "preserved": 3, "total": 4}
+    assert report["provider_breakdown"]["quarantine_set"] == {"claude": 1}
+    assert report["provider_breakdown"]["preserved"] == {"codex": 1, "claude": 1, "other": 1}
+    assert report["audit"]["quarantine_sample_size"] == 1
     assert report["audit"]["direct_session_source_files_checked"] == 1
     assert report["audit"]["direct_session_false_positive_count"] == 0
     assert report["audit"]["stop_gate_passed"] is True
@@ -1289,7 +1291,17 @@ def test_run_apply_refuses_when_retrievability_proof_fails(tmp_path: Path, monke
     script = _load_script()
     db_path = tmp_path / "apply-proof-gate.db"
     backup_path = tmp_path / "apply-proof-gate-backup.db"
-    denied_source = tmp_path / ".codex" / "sessions" / "worker.jsonl"
+    denied_source = (
+        tmp_path
+        / ".claude"
+        / "projects"
+        / "proj"
+        / "session"
+        / "subagents"
+        / "workflows"
+        / "wf_test"
+        / "agent-worker.jsonl"
+    )
     store = VectorStore(db_path)
     try:
         _insert_chunk(

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -208,7 +208,17 @@ def test_dry_run_uses_denylist_and_preserves_direct_sessions(tmp_path: Path, mon
         _insert_chunk(
             store,
             chunk_id="claude-subagent",
-            source_file=tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl",
+            source_file=(
+                tmp_path
+                / ".claude"
+                / "projects"
+                / "proj"
+                / "session"
+                / "subagents"
+                / "workflows"
+                / "wf_test"
+                / "agent-a1.jsonl"
+            ),
         )
         _insert_chunk(
             store,
@@ -1443,7 +1453,17 @@ def test_revert_proof_runs_only_on_snapshot_path(tmp_path: Path) -> None:
         _insert_chunk(
             store,
             chunk_id="claude-subagent",
-            source_file=tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl",
+            source_file=(
+                tmp_path
+                / ".claude"
+                / "projects"
+                / "proj"
+                / "session"
+                / "subagents"
+                / "workflows"
+                / "wf_test"
+                / "agent-a1.jsonl"
+            ),
             content="snapshot revert proof sentinel",
         )
     finally:
@@ -1467,7 +1487,17 @@ def test_revert_proof_runs_only_on_snapshot_path(tmp_path: Path) -> None:
 def test_direct_script_execution_bootstraps_operational_fts_for_legacy_snapshot(tmp_path: Path) -> None:
     db_path = tmp_path / "legacy-source.db"
     snapshot_path = tmp_path / "legacy-snapshot.db"
-    source_file = tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "agent-a1.jsonl"
+    source_file = (
+        tmp_path
+        / ".claude"
+        / "projects"
+        / "proj"
+        / "session"
+        / "subagents"
+        / "workflows"
+        / "wf_test"
+        / "agent-a1.jsonl"
+    )
     conn = apsw.Connection(str(db_path))
     try:
         cursor = conn.cursor()

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -461,6 +461,7 @@ async def test_store_busy_budget_restores_timeout_between_concurrent_retries(mon
 async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, monkeypatch):
     """The MCP budget must bound store_memory's internal BEGIN IMMEDIATE retry loop."""
     import brainlayer.store as store_module
+    from brainlayer.mcp import store_handler
     from brainlayer.mcp.store_handler import _store
 
     pending_path = tmp_path / "pending-stores.jsonl"
@@ -500,6 +501,7 @@ async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, 
     monkeypatch.setenv("BRAINLAYER_STORE_BUSY_BUDGET_MS", "80")
     monkeypatch.setattr("brainlayer.mcp.store_handler._retry_delay", 0.001)
     monkeypatch.setattr(store_module, "_sleep", lambda delay: real_sleep(min(delay, 0.001)))
+    monkeypatch.setattr(store_handler, "_fsync", lambda _fd: None)
 
     with (
         patch("brainlayer.mcp.store_handler._get_vector_store", return_value=store),

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -499,7 +499,7 @@ async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, 
 
     monkeypatch.setenv("BRAINLAYER_STORE_BUSY_BUDGET_MS", "80")
     monkeypatch.setattr("brainlayer.mcp.store_handler._retry_delay", 0.001)
-    monkeypatch.setattr(store_module.time, "sleep", lambda delay: real_sleep(min(delay, 0.001)))
+    monkeypatch.setattr(store_module, "_sleep", lambda delay: real_sleep(min(delay, 0.001)))
 
     with (
         patch("brainlayer.mcp.store_handler._get_vector_store", return_value=store),

--- a/tests/test_watch_backfill_cli.py
+++ b/tests/test_watch_backfill_cli.py
@@ -5,8 +5,11 @@ from typer.testing import CliRunner
 from brainlayer.cli import app
 
 
-def test_watch_backfill_dry_run_excludes_cursor_agent_transcripts(tmp_path):
-    transcript = tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent-session.jsonl"
+def test_watch_backfill_dry_run_includes_cursor_agent_transcripts(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
+    transcript = (
+        tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent-session" / "agent-session.jsonl"
+    )
     unrelated = tmp_path / ".cursor" / "projects" / "repo" / "state.jsonl"
     transcript.parent.mkdir(parents=True)
     transcript.write_text(
@@ -27,13 +30,14 @@ def test_watch_backfill_dry_run_excludes_cursor_agent_transcripts(tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "candidate_files=0" in result.output
-    assert "cursor-agent-transcripts=1" not in result.output
+    assert "candidate_files=1" in result.output
+    assert "cursor-agent-transcripts=1" in result.output
     assert "processed_entries=0" in result.output
     assert not (tmp_path / "offsets.json").exists()
 
 
-def test_watch_backfill_dry_run_excludes_codex_and_gemini_sessions(tmp_path):
+def test_watch_backfill_dry_run_includes_codex_and_gemini_sessions(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
     codex_transcript = tmp_path / ".codex" / "sessions" / "2026" / "07" / "worker.jsonl"
     gemini_transcript = tmp_path / ".gemini" / "sessions" / "worker.jsonl"
     for path in (codex_transcript, gemini_transcript):
@@ -53,15 +57,18 @@ def test_watch_backfill_dry_run_excludes_codex_and_gemini_sessions(tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "candidate_files=0" in result.output
-    assert "codex=1" not in result.output
-    assert "gemini=1" not in result.output
+    assert "candidate_files=2" in result.output
+    assert "codex=1" in result.output
+    assert "gemini=1" in result.output
     assert "processed_entries=0" in result.output
     assert not (tmp_path / "offsets.json").exists()
 
 
-def test_watch_backfill_skips_cursor_agent_transcripts_without_queueing(tmp_path):
-    transcript = tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent-session.jsonl"
+def test_watch_backfill_indexes_cursor_agent_transcripts_once(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
+    transcript = (
+        tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "agent-session" / "agent-session.jsonl"
+    )
     registry = tmp_path / "offsets.json"
     queue_dir = tmp_path / "queue"
     transcript.parent.mkdir(parents=True)
@@ -94,10 +101,10 @@ def test_watch_backfill_skips_cursor_agent_transcripts_without_queueing(tmp_path
     )
 
     assert first.exit_code == 0, first.output
-    assert "processed_entries=0" in first.output
+    assert "processed_entries=1" in first.output
     queue_files = list(queue_dir.glob("watcher-*.jsonl"))
-    assert queue_files == []
-    assert not registry.exists()
+    assert len(queue_files) == 1
+    assert registry.exists()
 
     second = CliRunner().invoke(
         app,
@@ -115,4 +122,4 @@ def test_watch_backfill_skips_cursor_agent_transcripts_without_queueing(tmp_path
 
     assert second.exit_code == 0, second.output
     assert "processed_entries=0" in second.output
-    assert list(queue_dir.glob("watcher-*.jsonl")) == []
+    assert list(queue_dir.glob("watcher-*.jsonl")) == queue_files

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -475,14 +475,38 @@ class TestFlushCallback:
 
 
 class TestFullPipeline:
-    def test_watcher_denylist_blocks_agent_transcript_roots_before_db_insert(self, tmp_path, monkeypatch):
+    def test_watcher_denylist_blocks_only_brain_and_workflow_workers(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()
 
         denylisted = {
-            "claude": tmp_path / ".claude" / "projects" / "proj" / "session-123" / "subagents" / "agent-a111.jsonl",
+            "brain-worker": tmp_path
+            / ".claude"
+            / "projects"
+            / "proj"
+            / "session-123"
+            / "subagents"
+            / "agent-brain.jsonl",
+            "workflow-worker": tmp_path
+            / ".claude"
+            / "projects"
+            / "proj"
+            / "session-123"
+            / "subagents"
+            / "workflows"
+            / "wf_123"
+            / "agent-workflow.jsonl",
+        }
+        allowed = {
+            "claude-subagent": tmp_path
+            / ".claude"
+            / "projects"
+            / "proj"
+            / "session-123"
+            / "subagents"
+            / "agent-general.jsonl",
             "codex": tmp_path / ".codex" / "sessions" / "2026" / "07" / "02" / "worker.jsonl",
             "cursor": tmp_path
             / ".cursor"
@@ -492,9 +516,11 @@ class TestFullPipeline:
             / "agent-session"
             / "agent-session.jsonl",
             "gemini": tmp_path / ".gemini" / "sessions" / "worker.jsonl",
+            "claude-direct": tmp_path / ".claude" / "projects" / "proj" / "direct-session.jsonl",
         }
         for provider, path in denylisted.items():
             path.parent.mkdir(parents=True, exist_ok=True)
+            attribution = "brain-worker" if provider == "brain-worker" else "workflow-subagent"
             path.write_text(
                 json.dumps(
                     _make_jsonl_entry(
@@ -504,25 +530,30 @@ class TestFullPipeline:
                             "substantial technical detail for classification and chunking."
                         ),
                         entry_type="assistant",
+                        attributionAgent=attribution,
                     )
                 )
                 + "\n"
             )
 
-        control = tmp_path / ".claude" / "projects" / "proj" / "direct-session.jsonl"
-        control.write_text(
-            json.dumps(
-                _make_jsonl_entry(
-                    text=(
-                        "BL10CONTROLINDEXES genuine direct Claude session sentinel. "
-                        "This assistant response explains durable watcher ingestion and contains enough "
-                        "substantial technical detail for classification and chunking."
-                    ),
-                    entry_type="assistant",
+        for provider, path in allowed.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            extra = {"attributionAgent": "general-purpose"} if provider == "claude-subagent" else {}
+            sentinel_provider = provider.replace("-", "").upper()
+            path.write_text(
+                json.dumps(
+                    _make_jsonl_entry(
+                        text=(
+                            f"BL10SHOULDINDEX{sentinel_provider} source allowlist sentinel. "
+                            "This assistant response explains durable watcher ingestion and contains enough "
+                            "substantial technical detail for classification and chunking."
+                        ),
+                        entry_type="assistant",
+                        **extra,
+                    )
                 )
+                + "\n"
             )
-            + "\n"
-        )
 
         flush = create_flush_callback(db_path, arbitrated=False)
         watcher = JSONLWatcher(
@@ -536,15 +567,11 @@ class TestFullPipeline:
 
         conn = sqlite3.connect(str(db_path))
         try:
-            denylist_globs = [
-                str(tmp_path / ".claude" / "projects") + "/*/*/subagents/*",
-                str(tmp_path / ".codex" / "sessions") + "/*",
-                str(tmp_path / ".cursor") + "/*/agent-transcripts/*",
-                str(tmp_path / ".gemini" / "sessions") + "/*",
-            ]
-            for glob in denylist_globs:
-                assert conn.execute("SELECT count(*) FROM chunks WHERE source_file GLOB ?", (glob,)).fetchone()[0] == 0
-            for provider in denylisted:
+            for provider, path in denylisted.items():
+                assert path.exists()
+                assert (
+                    conn.execute("SELECT count(*) FROM chunks WHERE source_file = ?", (str(path),)).fetchone()[0] == 0
+                )
                 assert (
                     conn.execute(
                         "SELECT count(*) FROM chunks_fts WHERE chunks_fts MATCH ?",
@@ -552,10 +579,22 @@ class TestFullPipeline:
                     ).fetchone()[0]
                     == 0
                 )
+            for provider, path in allowed.items():
+                sentinel_provider = provider.replace("-", "").upper()
+                assert (
+                    conn.execute("SELECT count(*) FROM chunks WHERE source_file = ?", (str(path),)).fetchone()[0] >= 1
+                )
+                assert (
+                    conn.execute(
+                        "SELECT count(*) FROM chunks WHERE source_file = ? AND content LIKE ?",
+                        (str(path), f"%BL10SHOULDINDEX{sentinel_provider}%"),
+                    ).fetchone()[0]
+                    >= 1
+                ), provider
             assert (
                 conn.execute(
                     "SELECT count(*) FROM chunks_fts WHERE chunks_fts MATCH ?",
-                    ('"BL10CONTROLINDEXES"',),
+                    ('"BL10SHOULDINDEXCODEX"',),
                 ).fetchone()[0]
                 >= 1
             )
@@ -635,6 +674,7 @@ class TestFullPipeline:
         entry = _make_jsonl_entry(
             text="Nested subagent transcript should be discovered on startup and stored under brainlayer-grill",
             entry_type="assistant",
+            attributionAgent="general-purpose",
         )
         jsonl_file.write_text(json.dumps(entry) + "\n")
 

--- a/tests/test_watcher_provenance_ingest.py
+++ b/tests/test_watcher_provenance_ingest.py
@@ -71,10 +71,10 @@ def test_cursor_agent_transcript_ingest_is_tagged_and_routed_operational(tmp_pat
     assert metadata["provenance_effective_visibility"] == "operational"
 
 
-def test_gemini_session_ingest_is_tagged_cold_and_not_fts_indexed(tmp_path):
+def test_gemini_session_ingest_is_searchable_by_default(tmp_path):
     db_path = tmp_path / "brainlayer.db"
     source_file = tmp_path / "home" / ".gemini" / "sessions" / "gemini-session.jsonl"
-    text = "Gemini scratch synthesis should be retained as cold provenance without FTS indexing."
+    text = "Gemini session synthesis should remain available to normal BrainLayer search."
     flush = create_flush_callback(db_path=db_path, arbitrated=False)
 
     result = flush([_entry(source_file, text)])
@@ -82,10 +82,10 @@ def test_gemini_session_ingest_is_tagged_cold_and_not_fts_indexed(tmp_path):
     assert result.inserted == 1
     content_class, provenance_class, metadata, normal_fts_count, operational_fts_count = _single_inserted_row(db_path)
     assert (content_class, provenance_class, normal_fts_count, operational_fts_count) == (
-        "cold",
+        "knowledge",
         "gemini-session",
-        0,
+        1,
         0,
     )
     assert metadata["provenance_tag"] == "gemini-session"
-    assert metadata["provenance_effective_visibility"] == "cold"
+    assert metadata["provenance_effective_visibility"] == "default"

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -678,7 +678,7 @@ def test_init_retry_zero_budget_reraises_original_busy(monkeypatch):
         raise apsw.BusyError("locked")
 
     monkeypatch.setattr(store, "_init_db", busy_init)
-    monkeypatch.setattr("time.sleep", lambda _delay: None)
+    monkeypatch.setattr("brainlayer.vector_store._sleep", lambda _delay: None)
 
     with pytest.raises(apsw.BusyError, match="locked"):
         store._init_db_with_retry()
@@ -729,7 +729,7 @@ def test_drain_open_retries_busy_error_before_connection_exists(tmp_path, monkey
     monkeypatch.setenv("BRAINLAYER_DRAIN_OPEN_RETRY_MAX_DELAY_MS", "100")
     monkeypatch.setattr(drain.apsw, "Connection", flaky_connection)
     monkeypatch.setattr(drain.sqlite_vec, "loadable_path", lambda: "sqlite_vec")
-    monkeypatch.setattr(drain.time, "sleep", lambda delay: sleep_calls.append(delay))
+    monkeypatch.setattr(drain, "_sleep", lambda delay: sleep_calls.append(delay))
 
     conn = drain._open_connection(tmp_path / "drain.db")
 


### PR DESCRIPTION
## Summary
- index Codex, Cursor, Gemini, direct Claude, and ordinary Claude subagent transcripts by default
- exclude exact `brain-worker` attribution and `wf_*` workflow paths without deleting source JSONLs
- preserve explicit `BRAINLAYER_INGEST_DENYLIST` deployment overrides and defer unattributed subagents until identity appears

## Verification
- `PYTHONPATH=src pytest -q tests/test_ingest_denylist.py tests/test_jsonl_watcher.py tests/test_watch_backfill_cli.py tests/test_watcher_bridge.py tests/test_agent_provenance.py tests/test_watcher_provenance_ingest.py tests/test_retro_self_pollution_quarantine.py` — 144 passed
- scoped pre-push gate — 105 pytest + 3 MCP registration + 40 isolated eval/hook + bun + shell regression passed
- full `PYTHONPATH=src pytest -q` with raised fd limit — 3617 passed, 60 skipped, 5 xfailed; 3 baseline failures independently reproduced on origin-main worktree
- `ruff check` and `ruff format --check` — passed

## Deployment note
- the current local `BRAINLAYER_INGEST_DENYLIST` override still contains the legacy blanket patterns; it must be narrowed during the post-merge service rollout, not before review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which transcript roots enter the fleet memory index and how subagent files are classified at ingest time; legacy `BRAINLAYER_INGEST_DENYLIST` overrides can still block the new defaults until rollout is narrowed.
> 
> **Overview**
> **Narrows BL-10 ingest** so Codex, Cursor, Gemini, direct Claude sessions, and ordinary Claude subagents are indexed by default; only **`wf_*` workflow paths** and subagents whose JSONL **`attributionAgent` is exactly `brain-worker`** are skipped. Source JSONLs are never deleted.
> 
> The default path globs in `ingest_denylist.py` shrink to `wf_*` only when `BRAINLAYER_INGEST_DENYLIST` is unset. Subagent decisions use **incremental JSONL scanning** (inode/size/mtime cache) for `attributionAgent`; **unattributed** subagents stay denied until identity appears. Retro quarantine uses `unknown_subagent_is_denylisted=False` so historical rows without verifiable attribution are not auto-quarantined.
> 
> **Gemini** provenance moves from `OUT`/`cold` to **`KEEP`/default** search visibility in `agent_provenance.py`, aligned with sessions being ingested again.
> 
> Watcher, backfill CLI, and pipeline tests are updated for the new allow/deny behavior. **`_sleep` / `_fsync` module aliases** replace patching `time.sleep` / `os.fsync` in tests across backup, drain, enrichment, search, and MCP store code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1647e3e7c46c4f95280e2b35f41d73efc8242b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Narrow transcript ingest denylist to brain-worker and workflow subagents only
> - Changes `DEFAULT_INGEST_DENYLIST` in [`ingest_denylist.py`](https://github.com/EtanHey/brainlayer/pull/596/files#diff-cd497ed29389a77123701126fbd694b207cb9d83c46cdcc9204ad270f2ae88ea) to only exclude `~/.claude/projects/**/wf_*/**`; Codex, Gemini, Cursor, and ordinary Claude subagent sessions are now ingested by default.
> - Adds attribution-driven denylisting for Claude subagent transcripts: `is_denylisted` reads `attributionAgent` from the JSONL file incrementally and denies only `brain-worker` or unresolved-but-required attribution; results are cached by inode/size/mtime.
> - Classifies Gemini provider sessions as `KEEP` (was `OUT`) in `classify_provenance`, making Gemini content searchable as default knowledge.
> - Adds `unknown_subagent_is_denylisted=False` when calling `is_denylisted` from the retro-quarantine script so historical unverifiable subagents are not over-blocked.
> - Replaces direct `time.sleep` calls across multiple modules with a patchable `_sleep` alias, and similarly wraps `os.fsync` in `store_handler.py`, to make retry/backoff paths unit-testable without monkeypatching the stdlib.
> - Behavioral Change: Gemini sessions and Cursor agent transcripts are now ingested and indexed by default; previously they were excluded or treated as cold/out-of-policy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1647e3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refined ingestion denylist behavior to exclude only exact `brain-worker` subagents and `wf_*` workflow paths, with incremental attribution detection for subagent JSONL.
  - Kept `BRAINLAYER_INGEST_DENYLIST` as an explicit deployment override; adjusted default denylist scope.

- **Bug Fixes**
  - Gemini sessions are searchable by default again.
  - Cursor, Codex, and Gemini transcripts are now included in discovery/backfill when the denylist override is not set.

- **Tests**
  - Expanded denylist, attribution, and ingestion/search coverage; updated backfill and retry timing assertions to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->