### PR TITLE
fix: bound hotlane vector write transactions

### DIFF
--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -40,6 +40,8 @@ DEFAULT_BACKLOG_BATCH = 4
 MAX_BACKLOG_BATCH = 16
 DEFAULT_HOTLANE_WRITE_BUSY_TIMEOUT_MS = 1000
 MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
+VECTOR_WRITE_YIELD_SECONDS = 0.005
+_sleep = time.sleep
 
 
 class CycleResult(NamedTuple):
@@ -256,7 +258,7 @@ def _write_embedded_vectors(store_or_path: VectorStore | Path | str, vectors: li
 
     count = 0
     try:
-        for chunk_id, content, embedding in vectors:
+        for vector_index, (chunk_id, content, embedding) in enumerate(vectors):
             transaction_started = False
             telemetry_span = start_writer_span(
                 cursor.connection if hasattr(cursor, "connection") else (conn or store.conn),
@@ -295,6 +297,8 @@ def _write_embedded_vectors(store_or_path: VectorStore | Path | str, vectors: li
                 transaction_started = False
                 count += rows_touched
                 telemetry_span.finish("commit", rows_touched=rows_touched)
+                if vector_index < len(vectors) - 1:
+                    _sleep(VECTOR_WRITE_YIELD_SECONDS)
             except Exception as exc:
                 if transaction_started:
                     cursor.execute("ROLLBACK")

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -254,58 +254,59 @@ def _write_embedded_vectors(store_or_path: VectorStore | Path | str, vectors: li
                 binary_index_available=binary_index_available,
             )
 
-    transaction_started = False
     count = 0
-    telemetry_span = start_writer_span(
-        cursor.connection if hasattr(cursor, "connection") else (conn or store.conn),
-        db_path=db_path,
-        producer="hotlane",
-        lane="hotlane",
-        operation="write_vectors",
-        rows_planned=len(vectors),
-    )
     try:
-        cursor.execute("BEGIN IMMEDIATE")
-        transaction_started = True
         for chunk_id, content, embedding in vectors:
-            still_eligible = cursor.execute(
-                """
-                SELECT 1
-                FROM chunks c
-                LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
-                WHERE c.id = ?
-                  AND c.content = ?
-                  AND r.id IS NULL
-                  AND c.content IS NOT NULL
-                  AND c.content != ''
-                  AND c.archived_at IS NULL
-                  AND c.superseded_by IS NULL
-                  AND c.aggregated_into IS NULL
-                  AND COALESCE(c.archived, 0) = 0
-                  AND COALESCE(c.status, 'active') = 'active'
-                """,
-                (chunk_id, content),
-            ).fetchone()
-            if not still_eligible:
-                continue
-            upsert_chunk_vector(cursor, chunk_id, embedding)
-            count += 1
-        cursor.execute("COMMIT")
-        transaction_started = False
-        telemetry_span.finish("commit", rows_touched=count)
-    except Exception as exc:
-        if transaction_started:
-            cursor.execute("ROLLBACK")
-        telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
-        raise
+            transaction_started = False
+            telemetry_span = start_writer_span(
+                cursor.connection if hasattr(cursor, "connection") else (conn or store.conn),
+                db_path=db_path,
+                producer="hotlane",
+                lane="hotlane",
+                operation="write_vectors",
+                rows_planned=1,
+            )
+            try:
+                cursor.execute("BEGIN IMMEDIATE")
+                transaction_started = True
+                still_eligible = cursor.execute(
+                    """
+                    SELECT 1
+                    FROM chunks c
+                    LEFT JOIN chunk_vectors_rowids r ON c.id = r.id
+                    WHERE c.id = ?
+                      AND c.content = ?
+                      AND r.id IS NULL
+                      AND c.content IS NOT NULL
+                      AND c.content != ''
+                      AND c.archived_at IS NULL
+                      AND c.superseded_by IS NULL
+                      AND c.aggregated_into IS NULL
+                      AND COALESCE(c.archived, 0) = 0
+                      AND COALESCE(c.status, 'active') = 'active'
+                    """,
+                    (chunk_id, content),
+                ).fetchone()
+                rows_touched = 0
+                if still_eligible:
+                    upsert_chunk_vector(cursor, chunk_id, embedding)
+                    rows_touched = 1
+                cursor.execute("COMMIT")
+                transaction_started = False
+                count += rows_touched
+                telemetry_span.finish("commit", rows_touched=rows_touched)
+            except Exception as exc:
+                if transaction_started:
+                    cursor.execute("ROLLBACK")
+                telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")
+                raise
     finally:
         if conn is not None:
             conn.close()
+        if count:
+            from brainlayer.search_repo import clear_hybrid_search_cache
 
-    if count:
-        from brainlayer.search_repo import clear_hybrid_search_cache
-
-        clear_hybrid_search_cache(db_path)
+            clear_hybrid_search_cache(db_path)
     return count
 
 

--- a/src/brainlayer/backup_daily.py
+++ b/src/brainlayer/backup_daily.py
@@ -29,6 +29,8 @@ import requests
 
 from .paths import get_db_path
 
+_sleep = time.sleep
+
 DEFAULT_TOKEN_PATH = Path.home() / ".config" / "google-drive-mcp" / "tokens.json"
 DEFAULT_CLIENT_PATH = Path.home() / ".config" / "google-drive-mcp" / "gcp-oauth.keys.json"
 DEFAULT_FOLDER_PARTS = ["Brain Drive", "06_ARCHIVE", "backups", "brainlayer-db"]
@@ -310,7 +312,7 @@ def request_brainbar_vacuum_into(
                 f"retrying in {retry_backoff_seconds}s",
                 flush=True,
             )
-            time.sleep(retry_backoff_seconds)
+            _sleep(retry_backoff_seconds)
     if last_error is not None:
         raise last_error
 
@@ -497,7 +499,7 @@ def upload_file_to_drive_raw(
                         f"sleeping {sleep_seconds}s",
                         flush=True,
                     )
-                    time.sleep(sleep_seconds)
+                    _sleep(sleep_seconds)
 
     raise RuntimeError("Drive upload ended without final response")
 

--- a/src/brainlayer/cloud_backfill.py
+++ b/src/brainlayer/cloud_backfill.py
@@ -49,6 +49,8 @@ from .pipeline.enrichment import (
 from .pipeline.sanitize import Sanitizer
 from .vector_store import VectorStore
 
+_sleep = time.sleep
+
 # ── Config ──────────────────────────────────────────────────────────────
 
 DEFAULT_DB_PATH = get_db_path()
@@ -353,7 +355,7 @@ def save_checkpoint(store: VectorStore, batch_id: str, **kwargs) -> None:
             last_error = exc
             if attempt == CHECKPOINT_WRITE_MAX_RETRIES - 1:
                 break
-            time.sleep(CHECKPOINT_WRITE_BASE_DELAY * (2**attempt))
+            _sleep(CHECKPOINT_WRITE_BASE_DELAY * (2**attempt))
         finally:
             if conn is not None:
                 conn.close()
@@ -793,7 +795,7 @@ def submit_gemini_batch(
             if "429" in err and attempt < max_retries - 1:
                 wait = 30 * (2**attempt)  # 30s, 60s, 120s
                 print(f"  429 RESOURCE_EXHAUSTED — waiting {wait}s before retry...")
-                time.sleep(wait)
+                _sleep(wait)
             else:
                 print(f"  FAILED: {err[:120]}")
                 if store:
@@ -841,7 +843,7 @@ def poll_gemini_batch(batch_name: str, timeout_hours: float = 25) -> Dict[str, A
             return status
 
         print(f"  State: {status.get('raw_state', state)} — waiting {poll_interval:.0f}s...")
-        time.sleep(poll_interval)
+        _sleep(poll_interval)
 
         # Gradually increase poll interval (max 5 min)
         poll_interval = min(poll_interval * 1.2, 300)
@@ -1175,7 +1177,7 @@ def run_full_backfill(
                 batch_names.append(batch_name)
             else:
                 print(f"  [WARN] Submission failed for {jsonl_path}, skipping")
-            time.sleep(2)  # Brief pause between submissions
+            _sleep(2)  # Brief pause between submissions
 
         if not batch_names:
             print("\nNo batch jobs submitted successfully.")

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -35,6 +35,7 @@ from .provenance_integration import enqueue_provenance_resolution_for_entities
 from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
+_sleep = time.sleep
 
 _DEFAULT_DRAIN_BUSY_TIMEOUT_MS = 30000
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
@@ -202,7 +203,7 @@ def _open_connection(db_path: Path) -> apsw.Connection:
                 max_retries + 1,
                 delay,
             )
-            time.sleep(delay)
+            _sleep(delay)
     else:
         raise RuntimeError("unreachable drain open retry state")
     conn.setbusytimeout(_drain_busy_timeout_ms())
@@ -1490,7 +1491,7 @@ def drain_once(
                         _mark_fallback_replays_best_effort(fallback_markers, log_path)
                     yield_seconds = _post_commit_yield_seconds()
                     if yield_seconds > 0:
-                        time.sleep(yield_seconds)
+                        _sleep(yield_seconds)
                     if _is_enrichment_queue_file(path) and _has_high_priority_queue_files(queue_dir):
                         stop_draining = True
                     break
@@ -1505,7 +1506,7 @@ def drain_once(
                     if _is_busy_error(exc) and attempt < 4:
                         delay = 0.05 * (2**attempt)
                         _log(log_path, f"drain busy; retrying in {delay:.2f}s")
-                        time.sleep(delay)
+                        _sleep(delay)
                         continue
                     if events_include_store and _is_missing_chunks_error(exc) and attempt < 4:
                         if conn is not None:

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -36,6 +36,7 @@ from .provenance_integration import enqueue_provenance_resolution_for_entities
 from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
+_sleep = time.sleep
 
 GEMINI_REALTIME_MODEL = os.environ.get("BRAINLAYER_GEMINI_REALTIME_MODEL", "gemini-2.5-flash-lite")
 DEFAULT_MAX_COMMIT_INTERVAL_MS = 250.0
@@ -664,7 +665,7 @@ def _submit_write(store, name: str, callback, *, yield_after: bool = True) -> An
     result = _get_store_write_queue(store).submit(name, callback).result()
     yield_seconds = _current_post_write_yield_seconds() if yield_after else 0.0
     if yield_seconds > 0:
-        time.sleep(yield_seconds)
+        _sleep(yield_seconds)
     return result
 
 
@@ -1461,7 +1462,7 @@ def _retry_with_backoff(
                 max_retries + 1,
                 sleep_for,
             )
-            time.sleep(sleep_for)
+            _sleep(sleep_for)
 
 
 def _generate_content_with_rate_limit(

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -33,6 +33,7 @@ _DEFAULT_STORE_BUSY_BUDGET_MS = 400
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _STORE_BUSY_TIMEOUT_LOCK = threading.Lock()
 _NO_EXEC_TRACE = object()
+_fsync = os.fsync
 
 
 def _positive_int_env(name: str, default: int) -> int:
@@ -447,7 +448,7 @@ def _atomic_rewrite_pending_store(path, lines: list[str]) -> None:
     with open(tmp, "w") as f:
         f.write("\n".join(lines) + "\n")
         f.flush()
-        os.fsync(f.fileno())
+        _fsync(f.fileno())
     tmp.replace(path)
     _fsync_directory(path.parent)
 
@@ -458,7 +459,7 @@ def _fsync_directory(path) -> None:
     except OSError:
         return
     try:
-        os.fsync(fd)
+        _fsync(fd)
     finally:
         os.close(fd)
 
@@ -500,7 +501,7 @@ def _queue_store(item: dict):
         with open(path, "a") as f:
             f.write(json.dumps(item) + "\n")
             f.flush()
-            os.fsync(f.fileno())
+            _fsync(f.fileno())
 
         # Enforce max size — read, trim oldest, atomic rewrite via tempfile
         try:

--- a/src/brainlayer/pipeline/enrichment.py
+++ b/src/brainlayer/pipeline/enrichment.py
@@ -43,6 +43,7 @@ import requests
 logger = logging.getLogger(__name__)
 _prompt_signature_emitted = False
 _prompt_signature_lock = threading.Lock()
+_sleep = time.sleep
 
 from ..chunk_origin import CHUNK_ORIGIN_GROQ, CHUNK_ORIGIN_MLX, CHUNK_ORIGIN_OLLAMA
 from ..tag_normalization import (
@@ -186,7 +187,7 @@ def _try_restart_mlx() -> bool:
         )
         # Wait for server to be ready
         for i in range(MLX_RESTART_WAIT):
-            time.sleep(1)
+            _sleep(1)
             if check_backend_health("mlx"):
                 print(f"MLX server restarted successfully after {i + 1}s", file=sys.stderr)
                 return True
@@ -671,7 +672,7 @@ def call_groq(prompt: str, timeout: int = 60) -> Optional[str]:
             now = time.monotonic()
             elapsed = now - _groq_last_call
             if _groq_last_call > 0 and elapsed < GROQ_RATE_LIMIT_DELAY:
-                time.sleep(GROQ_RATE_LIMIT_DELAY - elapsed)
+                _sleep(GROQ_RATE_LIMIT_DELAY - elapsed)
             _groq_last_call = time.monotonic()
 
         start_ms = int(time.time() * 1000)
@@ -1019,7 +1020,7 @@ def _enrich_one(
                 f"  RETRY: chunk {chunk['id'][:12]} attempt {attempt + 2}/{1 + MAX_RETRIES} in {total_delay:.1f}s",
                 file=sys.stderr,
             )
-            time.sleep(total_delay)
+            _sleep(total_delay)
 
     enrichment = parse_enrichment(response)
     if enrichment:
@@ -1415,7 +1416,7 @@ def run_enrichment(
                             f"Backend alive but struggling. Pausing {HEALTH_CHECK_PAUSE}s...",
                             file=sys.stderr,
                         )
-                        time.sleep(HEALTH_CHECK_PAUSE)
+                        _sleep(HEALTH_CHECK_PAUSE)
 
             # Sync stats to Supabase every 5 batches
             if total_processed % (batch_size * 5) < batch_size:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -24,6 +24,8 @@ from .dedupe import resolve_chunk_id
 from .ingest_guard import recursive_mcp_output_reason
 from .scoping import ConsumerScope
 
+_sleep = time.sleep
+
 # ── hybrid_search result cache ───────────────────────────────────────────────
 # Caches identical (store, query_text, filters) → results for 60s.
 # Warm repeated queries (e.g. hook firing on the same prompt twice) return
@@ -674,7 +676,7 @@ class SearchMixin:
             except apsw.Error as exc:
                 if _is_sqlite_busy_error(exc):
                     if attempt < 2:
-                        time.sleep(0.05 * (2**attempt))
+                        _sleep(0.05 * (2**attempt))
                         continue
                     raise
                 return None
@@ -706,7 +708,7 @@ class SearchMixin:
                 break
             except apsw.Error as exc:
                 if _is_sqlite_busy_error(exc) and attempt < 2:
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
                     continue
                 raise
         clear_hybrid_search_cache(getattr(self, "db_path", None))
@@ -745,7 +747,7 @@ class SearchMixin:
                 return audit_count
             except apsw.Error as exc:
                 if _is_sqlite_busy_error(exc) and attempt < 2:
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
                     continue
                 if cached_count is not None:
                     return int(cached_count)
@@ -776,7 +778,7 @@ class SearchMixin:
             except (apsw.Error, TypeError, IndexError, ValueError) as exc:
                 if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
                     return None
-                time.sleep(0.05 * (2**attempt))
+                _sleep(0.05 * (2**attempt))
         return None
 
     def _checkpoint_filtered_knn_k(
@@ -818,7 +820,7 @@ class SearchMixin:
                     if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
                         checkpoint_count = 0
                         break
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
 
         if checkpoint_count <= 0:
             return n_results
@@ -2271,7 +2273,7 @@ class SearchMixin:
                 except apsw.Error as exc:
                     if not _is_sqlite_busy_error(exc) or attempt == 2:
                         raise
-                    time.sleep(0.05 * (2**attempt))
+                    _sleep(0.05 * (2**attempt))
             # Recency fallback supplements lexical search, so append ranks after
             # existing FTS hits instead of tying the top exact match at rank 0.
             recent_rank_offset = max(fts_ranks.values(), default=-1) + 1

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -50,6 +50,7 @@ from .vector_store import VectorStore
 from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
+_sleep = time.sleep
 
 _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 
@@ -76,7 +77,7 @@ def _sleep_before_busy_retry(delay: float, busy_deadline: Optional[float]) -> No
         if remaining <= 0 or delay >= remaining:
             raise apsw.BusyError("store busy budget exceeded")
         delay = min(delay, remaining)
-    time.sleep(delay)
+    _sleep(delay)
 
 
 def store_memory(

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -71,6 +71,7 @@ _MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 _MAX_INDEX_TXN_BATCH = 10_000
 _WRITE_BUSY_TIMEOUT_STATE = threading.local()
 _NO_EXEC_TRACE = object()
+_sleep = time.sleep
 _KNOWLEDGE_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') NOT IN ('operational', 'test', 'benchmark', 'cold')"
 _OPERATIONAL_FTS_CLASS_SQL = "COALESCE(content_class, 'knowledge') = 'operational'"
 
@@ -398,7 +399,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                         return
                     if attempt == max_create_attempts - 1:
                         raise
-                    time.sleep(0.01 * (attempt + 1))
+                    _sleep(0.01 * (attempt + 1))
 
     def _reclaim_stale_writer_pidfiles(self, pidfile: Path) -> None:
         # Legacy pidfiles do not record the database path. Sweep sibling hashes
@@ -707,7 +708,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     remaining = deadline - time.monotonic()
                     if remaining <= 0 or delay >= remaining:
                         raise last_err
-                time.sleep(delay)
+                _sleep(delay)
             except BaseException as exc:
                 self._finish_init_writer_telemetry("error", error=f"{type(exc).__name__}: {exc}")
                 raise
@@ -2005,7 +2006,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     cursor.execute("ROLLBACK")
                 if attempt == 4:
                     raise
-                time.sleep(0.2 * (2**attempt))
+                _sleep(0.2 * (2**attempt))
             except Exception:
                 if transaction_started:
                     cursor.execute("ROLLBACK")
@@ -2673,7 +2674,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                         if committed_any:
                             invalidate_upsert_caches()
                         raise
-                    time.sleep(0.1 * (2**attempt))
+                    _sleep(0.1 * (2**attempt))
                 except Exception as exc:
                     rollback_active_transaction()
                     telemetry_span.finish("rollback", error=f"{type(exc).__name__}: {exc}")

--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -149,7 +149,7 @@ class TestEnrichSingle:
         failing_client = MagicMock()
         failing_client.models.generate_content.side_effect = Exception("API error")
         monkeypatch.setattr(ctrl, "_get_gemini_client", lambda: failing_client)
-        monkeypatch.setattr(ctrl.time, "sleep", lambda _: None)
+        monkeypatch.setattr(ctrl, "_sleep", lambda _: None)
 
         result = ctrl.enrich_single(store, stored_chunk, max_retries=1)
         assert result is None

--- a/tests/test_backup_daily.py
+++ b/tests/test_backup_daily.py
@@ -256,7 +256,7 @@ def test_brainbar_vacuum_request_retries_closed_socket_with_backoff(tmp_path, mo
         return {"result": {"content": [{"type": "text", "text": '{"status":"ok"}'}]}}
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", flaky_send)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
 
@@ -280,7 +280,7 @@ def test_brainbar_vacuum_request_fails_loud_after_retry_budget(tmp_path, monkeyp
         raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", closed_socket)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     with pytest.raises(RuntimeError, match="BrainBar socket closed without response"):
         backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
@@ -307,7 +307,7 @@ def test_brainbar_vacuum_request_does_not_retry_global_backup_timeout(tmp_path, 
         raise backup_daily.BackupTimeoutError("backup exceeded configured wall-clock timeout")
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", timed_out)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     with pytest.raises(backup_daily.BackupTimeoutError):
         backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
@@ -329,7 +329,7 @@ def test_brainbar_vacuum_request_accepts_valid_target_after_lost_response(tmp_pa
         raise RuntimeError("BrainBar socket closed without response: /tmp/brainbar.sock")
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", closed_after_success)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
 
@@ -355,7 +355,7 @@ def test_brainbar_vacuum_request_removes_invalid_target_before_retry(tmp_path, m
         return {"result": {"content": [{"type": "text", "text": '{"status":"ok"}'}]}}
 
     monkeypatch.setattr(backup_daily, "_send_brainbar_json_request", invalid_then_success)
-    monkeypatch.setattr(backup_daily.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(backup_daily, "_sleep", lambda seconds: sleeps.append(seconds))
 
     backup_daily.request_brainbar_vacuum_into(target, socket_path="/tmp/brainbar.sock")
 

--- a/tests/test_cloud_backfill.py
+++ b/tests/test_cloud_backfill.py
@@ -276,7 +276,7 @@ def test_submit_only_reuses_existing_exports_without_reexporting(tmp_path, monke
 
     monkeypatch.setattr(cloud_backfill, "export_unenriched_chunks", fake_export)
     monkeypatch.setattr(cloud_backfill, "submit_gemini_batch", fake_submit)
-    monkeypatch.setattr(cloud_backfill.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cloud_backfill, "_sleep", lambda *_args, **_kwargs: None)
 
     db_path = tmp_path / "brainlayer.db"
     store = VectorStore(db_path)
@@ -374,7 +374,7 @@ def test_submit_only_exports_new_chunks_when_old_files_are_checkpointed(tmp_path
 
     monkeypatch.setattr(cloud_backfill, "export_unenriched_chunks", fake_export)
     monkeypatch.setattr(cloud_backfill, "submit_gemini_batch", fake_submit)
-    monkeypatch.setattr(cloud_backfill.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cloud_backfill, "_sleep", lambda *_args, **_kwargs: None)
 
     store = VectorStore(tmp_path / "brainlayer.db")
     try:

--- a/tests/test_concurrent_enrichment.py
+++ b/tests/test_concurrent_enrichment.py
@@ -43,7 +43,7 @@ def test_enrich_realtime_processes_chunks(monkeypatch):
     monkeypatch.setattr(controller, "_ensure_content_hash_column", lambda store: True)
     monkeypatch.setattr(controller, "_is_duplicate_content", lambda store, content: False)
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(controller, "_emit_enrichment_start", lambda *args, **kwargs: True)
     monkeypatch.setattr(controller, "_emit_enrichment_complete", lambda *args, **kwargs: True)
     monkeypatch.setattr(controller, "_emit_enrichment_error", lambda *args, **kwargs: True)

--- a/tests/test_enrichment_bounded_commit.py
+++ b/tests/test_enrichment_bounded_commit.py
@@ -142,7 +142,7 @@ def test_submit_write_yields_after_successful_write(monkeypatch):
 
     monkeypatch.setattr(controller, "_get_store_write_queue", lambda store: ImmediateQueue())
     monkeypatch.setattr(controller, "_current_post_write_yield_seconds", lambda: 0.123)
-    monkeypatch.setattr(controller.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(controller, "_sleep", lambda seconds: sleeps.append(seconds))
 
     result = controller._submit_write(MagicMock(), "apply-enrichment:c0", lambda: "ok")
 

--- a/tests/test_enrichment_controller.py
+++ b/tests/test_enrichment_controller.py
@@ -54,7 +54,7 @@ def _patch_realtime_deps(monkeypatch, controller, store, response_text=None):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(
         controller,
         "_get_gemini_client",
@@ -426,7 +426,7 @@ def test_enrich_realtime_calls_build_external_prompt_for_every_chunk(monkeypatch
     monkeypatch.setattr(controller, "_retry_with_backoff", lambda fn, **kwargs: '{"summary":"sum","tags":["python"]}')
     monkeypatch.setattr(controller, "_get_gemini_client", lambda: MagicMock())
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     controller.enrich_realtime(store, limit=2, since_hours=24)
 
@@ -441,7 +441,7 @@ def test_enrich_realtime_sets_thinking_budget_zero_in_gemini_config(monkeypatch)
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     captured = {}
 
@@ -470,7 +470,7 @@ def test_enrich_realtime_passes_flex_service_tier_in_gemini_config(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     captured = {}
 
@@ -548,7 +548,7 @@ def test_enrich_realtime_calls_parse_enrichment_on_response(monkeypatch):
     parse_mock = MagicMock(return_value={"summary": "sum", "tags": ["python"]})
     monkeypatch.setattr(controller, "parse_enrichment", parse_mock)
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     class FakeClient:
         class _Models:
@@ -574,7 +574,7 @@ def test_enrich_realtime_writes_via_update_enrichment_only(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     class FakeClient:
         class _Models:
@@ -600,7 +600,7 @@ def test_enrich_realtime_is_idempotent_on_rerun(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     class FakeClient:
         class _Models:
@@ -624,7 +624,7 @@ def test_retry_with_backoff_retries_12_times_on_429(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    monkeypatch.setattr(controller, "_sleep", sleeps.append)
     monkeypatch.setattr(controller.random, "uniform", lambda a, b: 0.0)
 
     attempts = {"count": 0}
@@ -644,7 +644,7 @@ def test_retry_with_backoff_short_circuits_monthly_spend_cap_429(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    monkeypatch.setattr(controller, "_sleep", sleeps.append)
 
     attempts = {"count": 0}
 
@@ -663,7 +663,7 @@ def test_retry_with_backoff_respects_max_delay_cap(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    monkeypatch.setattr(controller, "_sleep", sleeps.append)
     monkeypatch.setattr(controller.random, "uniform", lambda a, b: b)
 
     attempts = {"count": 0}
@@ -1128,18 +1128,24 @@ def test_batch_rate_limit_uses_batch_setting(monkeypatch):
     assert observed["acquires"] == [1]
 
 
-def test_realtime_no_sleep_when_rate_zero(monkeypatch):
+def test_realtime_rate_zero_disables_limiter(monkeypatch):
     from brainlayer import enrichment_controller as controller
 
     store = MagicMock()
     store.get_enrichment_candidates.return_value = [_candidate("c1"), _candidate("c2")]
     _patch_realtime_deps(monkeypatch, controller, store)
+    real_get_store_rate_limiter = controller._get_store_rate_limiter
+    observed = {}
 
-    sleeps = []
-    monkeypatch.setattr(controller.time, "sleep", sleeps.append)
+    def observed_get_store_rate_limiter(*args, **kwargs):
+        observed["rate"] = kwargs["rate_per_second"]
+        observed["limiter"] = real_get_store_rate_limiter(*args, **kwargs)
+        return observed["limiter"]
+
+    monkeypatch.setattr(controller, "_get_store_rate_limiter", observed_get_store_rate_limiter)
 
     controller.enrich_realtime(store, limit=2, rate_per_second=0)
-    assert len(sleeps) == 0
+    assert observed == {"rate": 0, "limiter": None}
 
 
 # ── Retry logic tests ────────────────────────────────────────────────────────
@@ -1148,7 +1154,7 @@ def test_realtime_no_sleep_when_rate_zero(monkeypatch):
 def test_retry_succeeds_on_first_try(monkeypatch):
     from brainlayer.enrichment_controller import _retry_with_backoff
 
-    monkeypatch.setattr("brainlayer.enrichment_controller.time.sleep", lambda _: None)
+    monkeypatch.setattr("brainlayer.enrichment_controller._sleep", lambda _: None)
     monkeypatch.setattr("brainlayer.enrichment_controller.random.uniform", lambda a, b: 0.0)
 
     result = _retry_with_backoff(lambda: "ok", max_retries=3)
@@ -1158,7 +1164,7 @@ def test_retry_succeeds_on_first_try(monkeypatch):
 def test_retry_succeeds_after_transient_failure(monkeypatch):
     from brainlayer.enrichment_controller import _retry_with_backoff
 
-    monkeypatch.setattr("brainlayer.enrichment_controller.time.sleep", lambda _: None)
+    monkeypatch.setattr("brainlayer.enrichment_controller._sleep", lambda _: None)
     monkeypatch.setattr("brainlayer.enrichment_controller.random.uniform", lambda a, b: 0.0)
 
     attempts = {"n": 0}
@@ -1177,7 +1183,7 @@ def test_retry_succeeds_after_transient_failure(monkeypatch):
 def test_retry_only_catches_specified_errors(monkeypatch):
     from brainlayer.enrichment_controller import _retry_with_backoff
 
-    monkeypatch.setattr("brainlayer.enrichment_controller.time.sleep", lambda _: None)
+    monkeypatch.setattr("brainlayer.enrichment_controller._sleep", lambda _: None)
     monkeypatch.setattr("brainlayer.enrichment_controller.random.uniform", lambda a, b: 0.0)
 
     with pytest.raises(ValueError):
@@ -1200,7 +1206,7 @@ def test_enrich_realtime_stops_new_calls_when_daily_cap_crosses(monkeypatch, tmp
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value={"summary": "sum", "tags": ["python"]}))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
 
     calls = {"count": 0}
 
@@ -1244,7 +1250,7 @@ def test_realtime_counts_failed_on_invalid_enrichment(monkeypatch):
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(return_value=("prompt", SimpleNamespace())))
     monkeypatch.setattr(controller, "parse_enrichment", MagicMock(return_value=None))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(controller, "_get_gemini_client", lambda: _fake_gemini_client("garbage"))
 
     result = controller.enrich_realtime(store, limit=1)
@@ -1260,7 +1266,7 @@ def test_realtime_counts_failed_on_exception(monkeypatch):
     store.get_enrichment_candidates.return_value = [_candidate()]
     monkeypatch.setattr(controller, "build_external_prompt", MagicMock(side_effect=RuntimeError("boom")))
     monkeypatch.setattr(controller, "Sanitizer", SimpleNamespace(from_env=lambda: SimpleNamespace()))
-    monkeypatch.setattr(controller.time, "sleep", lambda _: None)
+    monkeypatch.setattr(controller, "_sleep", lambda _: None)
     monkeypatch.setattr(controller, "_get_gemini_client", lambda: _fake_gemini_client())
 
     result = controller.enrich_realtime(store, limit=1)

--- a/tests/test_enrichment_quality_benchmark.py
+++ b/tests/test_enrichment_quality_benchmark.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 
 from brainlayer.eval.enrichment_quality_benchmark import (
@@ -14,6 +15,7 @@ from brainlayer.eval.enrichment_quality_benchmark import (
 
 
 def test_select_meaningful_chunks_uses_pure_content_not_existing_enrichment(tmp_path: Path):
+    recent_timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     db_path = tmp_path / "brainlayer.db"
     conn = sqlite3.connect(db_path)
     conn.execute(
@@ -53,7 +55,7 @@ def test_select_meaningful_chunks_uses_pure_content_not_existing_enrichment(tmp_
                 "assistant_text",
                 "claude_code",
                 "session.jsonl",
-                "2026-06-15T10:00:00Z",
+                recent_timestamp,
                 75,
                 None,
                 None,
@@ -70,7 +72,7 @@ def test_select_meaningful_chunks_uses_pure_content_not_existing_enrichment(tmp_
                 "user_text",
                 "claude_code",
                 "session.jsonl",
-                "2026-06-15T10:01:00Z",
+                recent_timestamp,
                 9,
                 "Gemini says this is an important correction decision",
                 '["decision","correction","important"]',

--- a/tests/test_enrichment_reliability.py
+++ b/tests/test_enrichment_reliability.py
@@ -303,7 +303,7 @@ class TestRetryWithBackoff:
             patch.object(enrichment, "MAX_RETRIES", 3),
             patch.object(enrichment, "RETRY_BASE_DELAY", 1.0),
             patch.object(enrichment, "RETRY_MAX_DELAY", 100.0),
-            patch("time.sleep", side_effect=mock_sleep),
+            patch.object(enrichment, "_sleep", side_effect=mock_sleep),
         ):
             enrichment._enrich_one(store, chunk, with_context=False)
 

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -282,9 +282,11 @@ def test_write_embedded_vectors_skips_when_content_changed_after_snapshot():
     assert ("upsert", "chunk-1", [0.5]) not in events
 
 
-def test_write_embedded_vectors_commits_each_vector_separately():
+def test_write_embedded_vectors_commits_each_vector_separately(monkeypatch):
     hotlane = _load_hotlane_module()
     statements = []
+    sleeps = []
+    monkeypatch.setattr(hotlane, "_sleep", lambda seconds: sleeps.append(seconds))
 
     class FakeCursor:
         def execute(self, sql, params=()):
@@ -316,6 +318,7 @@ def test_write_embedded_vectors_commits_each_vector_separately():
     assert count == 2
     assert sum(statement == "BEGIN IMMEDIATE" for statement, _params in statements) == 2
     assert sum(statement == "COMMIT" for statement, _params in statements) == 2
+    assert sleeps == [hotlane.VECTOR_WRITE_YIELD_SECONDS]
 
 
 def test_write_embedded_vectors_clears_search_cache_after_partial_commit(monkeypatch):

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -282,6 +282,85 @@ def test_write_embedded_vectors_skips_when_content_changed_after_snapshot():
     assert ("upsert", "chunk-1", [0.5]) not in events
 
 
+def test_write_embedded_vectors_commits_each_vector_separately():
+    hotlane = _load_hotlane_module()
+    statements = []
+
+    class FakeCursor:
+        def execute(self, sql, params=()):
+            statement = " ".join(sql.split())
+            statements.append((statement, params))
+            if statement.startswith("SELECT 1"):
+                return SimpleNamespace(fetchone=lambda: (1,))
+            return []
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+    class FakeStore:
+        db_path = Path("/tmp/brainlayer.db")
+        conn = FakeConn()
+
+        def _upsert_chunk_vector(self, _cursor, _chunk_id, _embedding):
+            pass
+
+    count = hotlane._write_embedded_vectors(
+        FakeStore(),
+        [
+            hotlane.EmbeddedVector("chunk-1", "content one", [0.1]),
+            hotlane.EmbeddedVector("chunk-2", "content two", [0.2]),
+        ],
+    )
+
+    assert count == 2
+    assert sum(statement == "BEGIN IMMEDIATE" for statement, _params in statements) == 2
+    assert sum(statement == "COMMIT" for statement, _params in statements) == 2
+
+
+def test_write_embedded_vectors_clears_search_cache_after_partial_commit(monkeypatch):
+    hotlane = _load_hotlane_module()
+    cleared = []
+    upserted = []
+
+    class FakeCursor:
+        def execute(self, sql, params=()):
+            statement = " ".join(sql.split())
+            if statement.startswith("SELECT 1"):
+                return SimpleNamespace(fetchone=lambda: (1,))
+            return []
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+    class FakeStore:
+        db_path = Path("/tmp/brainlayer.db")
+        conn = FakeConn()
+
+        def _upsert_chunk_vector(self, _cursor, chunk_id, _embedding):
+            upserted.append(chunk_id)
+            if chunk_id == "chunk-2":
+                raise RuntimeError("second vector failed")
+
+    monkeypatch.setattr(
+        "brainlayer.search_repo.clear_hybrid_search_cache",
+        lambda db_path: cleared.append(db_path),
+    )
+
+    with pytest.raises(RuntimeError, match="second vector failed"):
+        hotlane._write_embedded_vectors(
+            FakeStore(),
+            [
+                hotlane.EmbeddedVector("chunk-1", "content one", [0.1]),
+                hotlane.EmbeddedVector("chunk-2", "content two", [0.2]),
+            ],
+        )
+
+    assert upserted == ["chunk-1", "chunk-2"]
+    assert cleared == [Path("/tmp/brainlayer.db")]
+
+
 def test_write_embedded_vectors_path_upserts_without_vectorstore_writer_pidfile(tmp_path, monkeypatch):
     hotlane = _load_hotlane_module()
     from brainlayer.vector_store import VectorStore

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -983,7 +983,7 @@ class TestHybridSearch:
         busy_cursor = BusyOnceCursor()
         sleeps: list[float] = []
         monkeypatch.setattr(store, "_read_cursor", lambda: busy_cursor)
-        monkeypatch.setattr("time.sleep", sleeps.append)
+        monkeypatch.setattr("brainlayer.search_repo._sleep", sleeps.append)
 
         results = store.hybrid_search(
             query_embedding=_embed("latest unrelated"),

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -461,6 +461,7 @@ async def test_store_busy_budget_restores_timeout_between_concurrent_retries(mon
 async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, monkeypatch):
     """The MCP budget must bound store_memory's internal BEGIN IMMEDIATE retry loop."""
     import brainlayer.store as store_module
+    from brainlayer.mcp import store_handler
     from brainlayer.mcp.store_handler import _store
 
     pending_path = tmp_path / "pending-stores.jsonl"
@@ -500,6 +501,7 @@ async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, 
     monkeypatch.setenv("BRAINLAYER_STORE_BUSY_BUDGET_MS", "80")
     monkeypatch.setattr("brainlayer.mcp.store_handler._retry_delay", 0.001)
     monkeypatch.setattr(store_module, "_sleep", lambda delay: real_sleep(min(delay, 0.001)))
+    monkeypatch.setattr(store_handler, "_fsync", lambda _fd: None)
 
     with (
         patch("brainlayer.mcp.store_handler._get_vector_store", return_value=store),

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -499,7 +499,7 @@ async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, 
 
     monkeypatch.setenv("BRAINLAYER_STORE_BUSY_BUDGET_MS", "80")
     monkeypatch.setattr("brainlayer.mcp.store_handler._retry_delay", 0.001)
-    monkeypatch.setattr(store_module.time, "sleep", lambda delay: real_sleep(min(delay, 0.001)))
+    monkeypatch.setattr(store_module, "_sleep", lambda delay: real_sleep(min(delay, 0.001)))
 
     with (
         patch("brainlayer.mcp.store_handler._get_vector_store", return_value=store),

--- a/tests/test_tier0_drills.py
+++ b/tests/test_tier0_drills.py
@@ -48,6 +48,7 @@ def _run_drill(
     last_alert_epoch: int | None = None,
     last_alert_reason: str = "",
     repeat_alert_seconds: int = 1_800,
+    alert_timeout_seconds: int = 3,
     state_contents: str = "{}\n",
 ) -> DrillResult:
     fake_bin = tmp_path / "bin"
@@ -128,7 +129,7 @@ def _run_drill(
         **os.environ,
         "FAKE_LAUNCHCTL_PRINT_EXIT": "0" if label_loaded else "113",
         "FAKE_STATE_MTIME": str(state_mtime or 0),
-        "TIER0_ALERT_TIMEOUT_SECONDS": "1",
+        "TIER0_ALERT_TIMEOUT_SECONDS": str(alert_timeout_seconds),
         "TIER0_ALERT_STATE_PATH": str(alert_state_path),
         "TIER0_CURL": str(fake_bin / "curl"),
         "TIER0_DOMAIN": DOMAIN,
@@ -229,6 +230,7 @@ def test_d3_hanging_notify_endpoint_cannot_suppress_local_alert_or_heal(tmp_path
         label_loaded=True,
         state_mtime=NOW_EPOCH - STALE_SECONDS - 1,
         curl_hangs=True,
+        alert_timeout_seconds=1,
     )
 
     assert result.process.returncode == 1, result.process.stdout + result.process.stderr
@@ -304,6 +306,7 @@ def test_alert_fanout_uses_one_shared_deadline(tmp_path: Path) -> None:
         curl_hangs=True,
         osascript_hangs=True,
         use_fake_wait_sleep=True,
+        alert_timeout_seconds=1,
     )
 
     assert result.process.returncode == 1, result.process.stdout + result.process.stderr

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -678,7 +678,7 @@ def test_init_retry_zero_budget_reraises_original_busy(monkeypatch):
         raise apsw.BusyError("locked")
 
     monkeypatch.setattr(store, "_init_db", busy_init)
-    monkeypatch.setattr("time.sleep", lambda _delay: None)
+    monkeypatch.setattr("brainlayer.vector_store._sleep", lambda _delay: None)
 
     with pytest.raises(apsw.BusyError, match="locked"):
         store._init_db_with_retry()
@@ -729,7 +729,7 @@ def test_drain_open_retries_busy_error_before_connection_exists(tmp_path, monkey
     monkeypatch.setenv("BRAINLAYER_DRAIN_OPEN_RETRY_MAX_DELAY_MS", "100")
     monkeypatch.setattr(drain.apsw, "Connection", flaky_connection)
     monkeypatch.setattr(drain.sqlite_vec, "loadable_path", lambda: "sqlite_vec")
-    monkeypatch.setattr(drain.time, "sleep", lambda delay: sleep_calls.append(delay))
+    monkeypatch.setattr(drain, "_sleep", lambda delay: sleep_calls.append(delay))
 
     conn = drain._open_connection(tmp_path / "drain.db")
 


### PR DESCRIPTION
## Summary
- commit each hotlane vector write in its own transaction
- report per-vector transaction telemetry
- invalidate search caches even when a later vector in the batch fails after earlier commits

## Diagnosis
Production telemetry showed hotlane vector batches holding the SQLite writer for 4-9 vectors and up to 132.57s. The durable high-priority queue correctly gates enrichment and hotlane work, but long writer transactions amplified fleet-wide DB-busy pressure and delayed the deferred drain. This patch bounds future hotlane lock tenure; it does not re-enable the intentionally disabled hotlane enrichment path.

## Verification
- changed-only pre-push gate: 24 focused pytest + 3 MCP registration + 40 eval/routing + 1 Bun + regression shell, all passing
- broader focused suite: 220 passed
- TDD coverage proves per-vector BEGIN/COMMIT and cache clearing after partial commit
- full-suite baseline on origin/main and this branch has the same 3 date/production-DB failures; no branch regression

## Operations
The single authorized daemon restart was performed only after the collaboration notice. Post-restart brain_search and all three deferred-store receipts were verified; queue drain resumed. No additional restart is included or requested.

No merge requested; ready for owner review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQLite write locking behavior on the hotlane embedding path (core writer contention), with partial batch persistence on mid-batch failure; remaining edits are test harness aliases with no production logic change.
> 
> **Overview**
> **Hotlane vector writes** no longer hold one long SQLite transaction across an entire embedded batch. `_write_embedded_vectors` now runs **BEGIN IMMEDIATE → eligibility check → upsert → COMMIT** per vector, emits writer telemetry with `rows_planned=1`, and **yields 5ms** between vectors to shorten writer lock tenure. Hybrid search cache is cleared in `finally` whenever **any** vector committed, including after a later vector in the batch fails.
> 
> Across backup, drain, enrichment, search, vector store, MCP store handler, and related paths, direct `time.sleep` / `os.fsync` calls are routed through module-level **`_sleep` / `_fsync`** so tests can patch delays and fsync without touching the stdlib. Tests were updated accordingly (including hotlane per-commit and partial-commit cache tests, enrichment realtime rate-zero assertion, tier0 drill alert timeout, and a benchmark fixture using a recent timestamp).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f39a7bf43e1b9a2334376ee1f740feae54a603e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound hotlane vector writes to per-vector transactions with inter-write yields
> - Reworks `_write_embedded_vectors` in [hotlane_brainbar_daemon.py](https://github.com/EtanHey/brainlayer/pull/598/files#diff-a6f55cd2d945568d3534e21b0c40cf5a431cb8287640870ba7b2a6149ac2c0d9) to commit each vector in its own `IMMEDIATE` transaction rather than a single bulk transaction, and sleeps `VECTOR_WRITE_YIELD_SECONDS` (5ms) between writes to reduce lock contention.
> - Moves hybrid search cache invalidation to a `finally` block so it fires even after partial writes interrupted by an exception.
> - Adds per-vector telemetry spans with `rows_planned` and `rows_touched` fields.
> - Replaces direct `time.sleep` and `os.fsync` calls with module-local aliases (`_sleep`, `_fsync`) across the codebase so tests can monkeypatch precisely without affecting unrelated callers.
> - Updates all affected tests to patch the module-local aliases instead of `time.sleep`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f39a7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->