### PR TITLE
fix: auto-recover zero-throughput watcher wedges

### DIFF
--- a/scripts/launchd/com.brainlayer.throughput-watchdog.plist
+++ b/scripts/launchd/com.brainlayer.throughput-watchdog.plist
@@ -6,6 +6,7 @@
 	<string>com.brainlayer.throughput-watchdog</string>
 	<key>ProgramArguments</key>
 	<array>
+		<string>__BRAINLAYER_ENV_RUN__</string>
 		<string>__PYTHON_BIN__</string>
 		<string>__THROUGHPUT_WATCHDOG_SCRIPT__</string>
 		<string>--json</string>
@@ -14,6 +15,10 @@
 	<dict>
 		<key>HOME</key>
 		<string>__HOME__</string>
+		<key>BRAINLAYER_ENV_FILE</key>
+		<string>__BRAINLAYER_ENV_FILE__</string>
+		<key>BRAINLAYER_LAUNCHD_SERVICE</key>
+		<string>watch</string>
 		<key>PATH</key>
 		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 	</dict>

--- a/scripts/launchd/com.brainlayer.throughput-watchdog.plist
+++ b/scripts/launchd/com.brainlayer.throughput-watchdog.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.brainlayer.throughput-watchdog</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__PYTHON_BIN__</string>
+		<string>__THROUGHPUT_WATCHDOG_SCRIPT__</string>
+		<string>--json</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>__HOME__</string>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StartInterval</key>
+	<integer>60</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>ExitTimeOut</key>
+	<integer>30</integer>
+	<key>SoftResourceLimits</key>
+	<dict>
+		<key>NumberOfFiles</key>
+		<integer>4096</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/throughput-watchdog.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/Library/Logs/brainlayer/throughput-watchdog.err.log</string>
+</dict>
+</plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -314,6 +314,8 @@ install_throughput_watchdog() {
     local script_src="$SCRIPT_DIR/throughput-watchdog.py"
     local plist_src="$SCRIPT_DIR/com.brainlayer.throughput-watchdog.plist"
     local plist_dst="$LAUNCH_DIR/com.brainlayer.throughput-watchdog.plist"
+    local escaped_env_file
+    local escaped_env_run
     local escaped_home
     local escaped_python_bin
     local escaped_watchdog_dst
@@ -327,8 +329,19 @@ install_throughput_watchdog() {
         return 1
     fi
 
+    install_env_runner || return 1
+    verify_config_file || return 1
+
     escaped_home="$(
         printf '%s' "$HOME" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
+    )" || return 1
+    escaped_env_file="$(
+        printf '%s' "$BRAINLAYER_ENV_FILE" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
+    )" || return 1
+    escaped_env_run="$(
+        printf '%s' "$BRAINLAYER_ENV_RUN" \
             | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
     )" || return 1
     escaped_watchdog_dst="$(
@@ -343,6 +356,8 @@ install_throughput_watchdog() {
     install -m 0755 "$script_src" "$THROUGHPUT_WATCHDOG_DST" || return 1
     sed \
         -e "s|__HOME__|$escaped_home|g" \
+        -e "s|__BRAINLAYER_ENV_FILE__|$escaped_env_file|g" \
+        -e "s|__BRAINLAYER_ENV_RUN__|$escaped_env_run|g" \
         -e "s|__PYTHON_BIN__|$escaped_python_bin|g" \
         -e "s|__THROUGHPUT_WATCHDOG_SCRIPT__|$escaped_watchdog_dst|g" \
         "$plist_src" > "$plist_dst" || return 1

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -17,6 +17,7 @@
 #   ./scripts/launchd/install.sh maintenance  # Install recurring maintenance jobs
 #   ./scripts/launchd/install.sh health-check # Install stability health check only
 #   ./scripts/launchd/install.sh tier0-watchdog # Install /bin/sh meta-watchdog only
+#   ./scripts/launchd/install.sh throughput-watchdog # Install watcher throughput watchdog only
 #   ./scripts/launchd/install.sh hotlane      # Install BrainBar hotlane embed/enrich daemon only
 #   ./scripts/launchd/install.sh p0-counter   # Install daily P0 longitudinal counter only
 #   ./scripts/launchd/install.sh remove       # Unload and remove all
@@ -64,6 +65,7 @@ BRAINLAYER_PYTHON="$(stable_brainlayer_path "${BRAINLAYER_PYTHON:-$PYTHON_BIN}")
 BRAINLAYER_ENV_FILE="${BRAINLAYER_ENV_FILE:-$HOME/.config/brainlayer/brainlayer.env}"
 BRAINLAYER_ENV_RUN="$BRAINLAYER_LIB_DIR/brainlayer-env-run.sh"
 TIER0_WATCHDOG_DST="$BRAINLAYER_LIB_DIR/tier0-watchdog.sh"
+THROUGHPUT_WATCHDOG_DST="$BRAINLAYER_LIB_DIR/throughput-watchdog.py"
 
 if [ -z "$PYTHON_BIN" ]; then
     echo "ERROR: python3 not found in PATH"
@@ -308,6 +310,49 @@ install_tier0_watchdog() {
     load_plist tier0-watchdog
 }
 
+install_throughput_watchdog() {
+    local script_src="$SCRIPT_DIR/throughput-watchdog.py"
+    local plist_src="$SCRIPT_DIR/com.brainlayer.throughput-watchdog.plist"
+    local plist_dst="$LAUNCH_DIR/com.brainlayer.throughput-watchdog.plist"
+    local escaped_home
+    local escaped_python_bin
+    local escaped_watchdog_dst
+
+    if [ ! -f "$script_src" ]; then
+        echo "ERROR: throughput-watchdog.py not found in $SCRIPT_DIR"
+        return 1
+    fi
+    if [ ! -f "$plist_src" ]; then
+        echo "ERROR: $plist_src not found"
+        return 1
+    fi
+
+    escaped_home="$(
+        printf '%s' "$HOME" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
+    )" || return 1
+    escaped_watchdog_dst="$(
+        printf '%s' "$THROUGHPUT_WATCHDOG_DST" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
+    )" || return 1
+    escaped_python_bin="$(
+        printf '%s' "$PYTHON_BIN" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/[\\&|]/\\&/g'
+    )" || return 1
+
+    install -m 0755 "$script_src" "$THROUGHPUT_WATCHDOG_DST" || return 1
+    sed \
+        -e "s|__HOME__|$escaped_home|g" \
+        -e "s|__PYTHON_BIN__|$escaped_python_bin|g" \
+        -e "s|__THROUGHPUT_WATCHDOG_SCRIPT__|$escaped_watchdog_dst|g" \
+        "$plist_src" > "$plist_dst" || return 1
+
+    echo "Installed: $THROUGHPUT_WATCHDOG_DST"
+    echo "Installed: $plist_dst"
+    echo "  Logs: $LOG_DIR/ and $BRAINLAYER_LOG_DIR/"
+    load_plist throughput-watchdog
+}
+
 remove_plist() {
     local name="$1"
     local dst="$LAUNCH_DIR/com.brainlayer.${name}.plist"
@@ -372,6 +417,9 @@ case "${1:-all}" in
     tier0|tier0-watchdog)
         install_tier0_watchdog
         ;;
+    throughput-watchdog)
+        install_throughput_watchdog
+        ;;
     hotlane|hotlane-brainbar)
         verify_gemini_env_file
         install_plist hotlane-brainbar
@@ -412,6 +460,9 @@ case "${1:-all}" in
         if ! install_tier0_watchdog; then
             failures=1
         fi
+        if ! install_throughput_watchdog; then
+            failures=1
+        fi
         # Remove old enrich plist only after the replacement enrichment service loads.
         if [ "$enrichment_ok" -eq 1 ]; then
             remove_plist enrich 2>/dev/null || true
@@ -435,14 +486,16 @@ case "${1:-all}" in
         remove_plist maintenance-weekly 2>/dev/null || true
         remove_plist health-check 2>/dev/null || true
         remove_plist tier0-watchdog 2>/dev/null || true
+        remove_plist throughput-watchdog 2>/dev/null || true
         remove_plist hotlane-brainbar 2>/dev/null || true
         remove_plist p0-counter 2>/dev/null || true
         rm -f "$BRAINLAYER_LIB_DIR/backup-daily.sh"
         rm -f "$BRAINLAYER_LIB_DIR/jsonl-backup.sh"
         rm -f "$TIER0_WATCHDOG_DST"
+        rm -f "$THROUGHPUT_WATCHDOG_DST"
         ;;
     *)
-        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|tier0-watchdog|p0-counter|all|remove]"
+        echo "Usage: $0 [index|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|tier0-watchdog|throughput-watchdog|p0-counter|all|remove]"
         exit 1
         ;;
 esac

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -182,6 +182,19 @@ def _registry_offset(entry: object, *, current_inode: int) -> int | None:
     return offset
 
 
+def _matches_watcher_input(source_file: Path, source_roots: list[Path]) -> bool:
+    """Mirror the watcher's narrower Cursor projects discovery pattern."""
+    for source_root in source_roots:
+        try:
+            relative = source_file.relative_to(source_root)
+        except ValueError:
+            continue
+        if source_root.name == "projects" and source_root.parent.name == ".cursor":
+            return "agent-transcripts" in relative.parts
+        return True
+    return False
+
+
 def _stop_process(process: subprocess.Popen) -> None:
     if process.poll() is not None:
         return
@@ -291,6 +304,8 @@ def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
     for source_file in recent_paths:
         if time.monotonic() - started > config.max_scan_seconds:
             raise RuntimeError(f"source evidence exceeded {config.max_scan_seconds:.1f}s")
+        if not _matches_watcher_input(source_file, roots):
+            continue
         try:
             source_stat = source_file.stat()
         except OSError as exc:
@@ -302,6 +317,9 @@ def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
         offset = _registry_offset(registry.get(str(source_file)), current_inode=source_stat.st_ino)
         if offset is None:
             untracked_recent_files += 1
+            if source_stat.st_size > 0:
+                pending_files += 1
+                pending_bytes += source_stat.st_size
             continue
         if source_stat.st_size > offset:
             pending_files += 1

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Recover a live-but-wedged watcher using disk and DB throughput evidence."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import math
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+DEFAULT_WATCH_LABEL = "com.brainlayer.watch"
+DEFAULT_NOTIFY_ENDPOINT = "http://localhost:3847/notify"
+
+
+@dataclass(frozen=True)
+class Config:
+    db_path: Path
+    registry_path: Path
+    state_path: Path
+    source_roots: tuple[Path, ...]
+    watch_label: str = DEFAULT_WATCH_LABEL
+    watch_plist_path: Path = Path("~/Library/LaunchAgents/com.brainlayer.watch.plist").expanduser()
+    stall_threshold: int = 3
+    cooldown_seconds: int = 600
+    recent_window_seconds: int = 600
+    max_source_files: int = 100_000
+    max_scan_seconds: float = 20.0
+    dry_run: bool = False
+    log_path: Path = Path("~/.local/share/brainlayer/logs/throughput-watchdog.log").expanduser()
+    notify_endpoint: str = DEFAULT_NOTIFY_ENDPOINT
+
+
+@dataclass(frozen=True)
+class SourceEvidence:
+    pending_files: int
+    pending_bytes: int
+    recent_files: int
+    newest_mtime: float | None
+    untracked_recent_files: int = 0
+    scan_errors: int = 0
+
+
+@dataclass
+class WatchdogResult:
+    checked_at_epoch: int
+    watcher_highwater_rowid: int
+    watcher_highwater_delta: int | None
+    pending_files: int
+    pending_bytes: int
+    recent_files: int
+    untracked_recent_files: int
+    newest_source_mtime: float | None
+    scan_errors: int
+    stalled_ticks: int
+    action: str
+    error: str = ""
+    alert_error: str = ""
+
+
+CommandRunner = Callable[[list[str]], object]
+HighwaterReader = Callable[[Path], int]
+SourceProbe = Callable[[Config, int], SourceEvidence]
+AlertFn = Callable[[Config, WatchdogResult], None]
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _default_source_roots(home: Path) -> tuple[Path, ...]:
+    return (
+        home / ".claude" / "projects",
+        home / ".codex" / "sessions",
+        home / ".cursor" / "sessions",
+        home / ".cursor" / "projects",
+        home / ".gemini" / "sessions",
+    )
+
+
+def _read_json_object(path: Path) -> dict:
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"cannot read trustworthy JSON from {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"expected a JSON object in {path}")
+    return payload
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp.{os.getpid()}")
+    try:
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        directory_fd = os.open(destination.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def read_watcher_highwater(db_path: Path) -> int:
+    database = db_path.expanduser().resolve()
+    if not database.is_file():
+        raise RuntimeError(f"BrainLayer DB does not exist: {database}")
+    uri = f"{database.as_uri()}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True, timeout=2.0) as connection:
+            connection.execute("PRAGMA query_only = ON")
+            row = connection.execute(
+                "SELECT COALESCE(MAX(rowid), 0) FROM chunks WHERE source = 'realtime_watcher'"
+            ).fetchone()
+    except sqlite3.Error as exc:
+        raise RuntimeError(f"watcher high-water query failed: {exc}") from exc
+    if row is None:
+        raise RuntimeError("watcher high-water query returned no row")
+    return int(row[0])
+
+
+def _registry_offset(entry: object, *, current_inode: int) -> int | None:
+    if not isinstance(entry, dict):
+        return None
+    offset = entry.get("offset")
+    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+        return None
+    registry_inode = entry.get("inode")
+    if isinstance(registry_inode, int) and registry_inode > 0 and registry_inode != current_inode:
+        return 0
+    return offset
+
+
+def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
+    registry = _read_json_object(config.registry_path)
+    cutoff = now_epoch - config.recent_window_seconds
+    started = time.monotonic()
+    pending_files = 0
+    pending_bytes = 0
+    recent_files = 0
+    untracked_recent_files = 0
+    newest_mtime: float | None = None
+    scan_errors = 0
+    roots = [source_root.expanduser() for source_root in config.source_roots if source_root.expanduser().exists()]
+    if not roots:
+        return SourceEvidence(0, 0, 0, None)
+    find_binary = shutil.which("find")
+    if find_binary is None:
+        raise RuntimeError("find is required for the bounded recent-source scan")
+    recent_minutes = max(1, math.ceil(config.recent_window_seconds / 60))
+    try:
+        completed = subprocess.run(
+            [
+                find_binary,
+                *(str(root) for root in roots),
+                "-type",
+                "f",
+                "-name",
+                "*.jsonl",
+                "-mmin",
+                f"-{recent_minutes}",
+                "-print0",
+            ],
+            capture_output=True,
+            timeout=config.max_scan_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"recent-source scan exceeded {config.max_scan_seconds:.1f}s") from exc
+    if completed.returncode != 0:
+        scan_errors += 1
+    recent_paths = [Path(os.fsdecode(raw)) for raw in completed.stdout.split(b"\0") if raw]
+    if len(recent_paths) > config.max_source_files:
+        raise RuntimeError(f"recent-source scan exceeded {config.max_source_files} JSONL files")
+
+    for source_file in recent_paths:
+        if time.monotonic() - started > config.max_scan_seconds:
+            raise RuntimeError(f"source evidence exceeded {config.max_scan_seconds:.1f}s")
+        try:
+            source_stat = source_file.stat()
+        except OSError:
+            scan_errors += 1
+            continue
+        if source_stat.st_mtime < cutoff:
+            continue
+        recent_files += 1
+        newest_mtime = source_stat.st_mtime if newest_mtime is None else max(newest_mtime, source_stat.st_mtime)
+        offset = _registry_offset(registry.get(str(source_file)), current_inode=source_stat.st_ino)
+        if offset is None:
+            untracked_recent_files += 1
+            continue
+        if source_stat.st_size > offset:
+            pending_files += 1
+            pending_bytes += source_stat.st_size - offset
+
+    return SourceEvidence(
+        pending_files=pending_files,
+        pending_bytes=pending_bytes,
+        recent_files=recent_files,
+        newest_mtime=newest_mtime,
+        untracked_recent_files=untracked_recent_files,
+        scan_errors=scan_errors,
+    )
+
+
+def _default_command_runner(args: list[str]):
+    return subprocess.run(args, capture_output=True, text=True, timeout=15, check=False)
+
+
+def _command_result(command_runner: CommandRunner, args: list[str]) -> tuple[int, str]:
+    try:
+        completed = command_runner(args)
+    except Exception as exc:
+        return 1, str(exc)
+    returncode = int(getattr(completed, "returncode", 0))
+    stderr = str(getattr(completed, "stderr", "") or "").strip()
+    stdout = str(getattr(completed, "stdout", "") or "").strip()
+    return returncode, stderr or stdout
+
+
+def _restart_watch(config: Config, command_runner: CommandRunner) -> str:
+    domain = f"gui/{os.getuid()}"
+    target = f"{domain}/{config.watch_label}"
+    loaded_returncode, _loaded_output = _command_result(command_runner, ["launchctl", "print", target])
+    if loaded_returncode != 0:
+        plist_path = config.watch_plist_path.expanduser()
+        if not plist_path.is_file():
+            raise RuntimeError(f"watch label is absent and plist is missing: {plist_path}")
+        bootstrap_returncode, bootstrap_output = _command_result(
+            command_runner,
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+        )
+        if bootstrap_returncode != 0:
+            raise RuntimeError(f"launchctl bootstrap failed: {bootstrap_output or bootstrap_returncode}")
+    kickstart_returncode, kickstart_output = _command_result(
+        command_runner,
+        ["launchctl", "kickstart", "-k", target],
+    )
+    if kickstart_returncode != 0:
+        raise RuntimeError(f"launchctl kickstart failed: {kickstart_output or kickstart_returncode}")
+    verify_returncode, verify_output = _command_result(command_runner, ["launchctl", "print", target])
+    if verify_returncode != 0:
+        raise RuntimeError(f"launchctl print after kickstart failed: {verify_output or verify_returncode}")
+    return f"kickstart:{config.watch_label}"
+
+
+def _best_effort_alert(config: Config, result: WatchdogResult) -> None:
+    config.log_path.expanduser().parent.mkdir(parents=True, exist_ok=True)
+    with config.log_path.expanduser().open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(asdict(result), sort_keys=True) + "\n")
+    body = (
+        "Watcher has registry-tracked JSONL bytes pending but realtime_watcher chunks are flat; "
+        "automatic recovery is starting."
+    )
+    try:
+        subprocess.run(
+            [
+                "/usr/bin/osascript",
+                "-e",
+                f'display notification "{body}" with title "BrainLayer throughput watchdog"',
+            ],
+            capture_output=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+    request = urllib.request.Request(
+        config.notify_endpoint,
+        data=json.dumps({"title": "BrainLayer throughput watchdog", "body": body, "source": "alerts"}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=3):
+            pass
+    except Exception:
+        pass
+
+
+def run_once(
+    config: Config,
+    *,
+    now_epoch: int | None = None,
+    highwater_reader: HighwaterReader = read_watcher_highwater,
+    source_probe: SourceProbe = collect_source_evidence,
+    command_runner: CommandRunner = _default_command_runner,
+    alert_fn: AlertFn = _best_effort_alert,
+) -> WatchdogResult:
+    checked_at = int(time.time()) if now_epoch is None else int(now_epoch)
+    state = _read_json_object(config.state_path)
+    current_highwater = highwater_reader(config.db_path)
+    evidence = source_probe(config, checked_at)
+    previous_highwater = state.get("watcher_highwater_rowid")
+    previous_stalled = state.get("stalled_ticks", 0)
+    if not isinstance(previous_stalled, int) or previous_stalled < 0:
+        previous_stalled = 0
+    delta = current_highwater - previous_highwater if isinstance(previous_highwater, int) else None
+
+    if delta is None or delta < 0:
+        action = "baseline"
+        stalled_ticks = 0
+    elif delta > 0:
+        action = "progress"
+        stalled_ticks = 0
+    elif evidence.pending_files == 0:
+        action = "idle"
+        stalled_ticks = 0
+    else:
+        action = "stalled"
+        stalled_ticks = previous_stalled + 1
+
+    result = WatchdogResult(
+        checked_at_epoch=checked_at,
+        watcher_highwater_rowid=current_highwater,
+        watcher_highwater_delta=delta,
+        pending_files=evidence.pending_files,
+        pending_bytes=evidence.pending_bytes,
+        recent_files=evidence.recent_files,
+        untracked_recent_files=evidence.untracked_recent_files,
+        newest_source_mtime=evidence.newest_mtime,
+        scan_errors=evidence.scan_errors,
+        stalled_ticks=stalled_ticks,
+        action=action,
+    )
+
+    last_restart_epoch = state.get("last_restart_epoch")
+    cooldown_active = (
+        isinstance(last_restart_epoch, int)
+        and checked_at >= last_restart_epoch
+        and checked_at - last_restart_epoch < config.cooldown_seconds
+    )
+    if stalled_ticks >= config.stall_threshold:
+        if cooldown_active:
+            result.action = "cooldown"
+        elif config.dry_run:
+            result.action = "would_kickstart"
+        else:
+            try:
+                alert_fn(config, result)
+            except Exception as exc:
+                result.alert_error = str(exc)
+            try:
+                result.action = _restart_watch(config, command_runner)
+            except RuntimeError as exc:
+                result.action = "recovery_failed"
+                result.error = str(exc)
+            else:
+                result.stalled_ticks = 0
+
+    next_state = dict(state)
+    next_state.update(
+        {
+            "checked_at_epoch": checked_at,
+            "watcher_highwater_rowid": current_highwater,
+            "pending_files": evidence.pending_files,
+            "pending_bytes": evidence.pending_bytes,
+            "recent_files": evidence.recent_files,
+            "untracked_recent_files": evidence.untracked_recent_files,
+            "newest_source_mtime": evidence.newest_mtime,
+            "scan_errors": evidence.scan_errors,
+            "stalled_ticks": result.stalled_ticks,
+            "last_action": result.action,
+        }
+    )
+    if result.action.startswith("kickstart:"):
+        next_state["last_restart_epoch"] = checked_at
+        next_state["restart_count"] = int(state.get("restart_count", 0)) + 1
+        next_state.pop("last_recovery_error", None)
+    elif result.action == "recovery_failed":
+        next_state["last_recovery_error"] = result.error
+    if result.alert_error:
+        next_state["last_alert_error"] = result.alert_error
+    else:
+        next_state.pop("last_alert_error", None)
+    _atomic_write_json(config.state_path, next_state)
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    home = Path.home()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db", type=Path, default=Path(os.environ.get("BRAINLAYER_DB", home / ".local/share/brainlayer/brainlayer.db"))
+    )
+    parser.add_argument("--registry", type=Path, default=home / ".local/share/brainlayer/offsets.json")
+    parser.add_argument("--state", type=Path, default=home / ".local/share/brainlayer/throughput-watchdog-state.json")
+    parser.add_argument("--source-root", action="append", type=Path, dest="source_roots")
+    parser.add_argument("--watch-label", default=DEFAULT_WATCH_LABEL)
+    parser.add_argument("--watch-plist", type=Path, default=home / "Library/LaunchAgents/com.brainlayer.watch.plist")
+    parser.add_argument("--stall-threshold", type=_positive_int, default=3)
+    parser.add_argument("--cooldown-seconds", type=_positive_int, default=600)
+    parser.add_argument("--recent-window-seconds", type=_positive_int, default=600)
+    parser.add_argument("--max-source-files", type=_positive_int, default=100_000)
+    parser.add_argument("--max-scan-seconds", type=float, default=20.0)
+    parser.add_argument("--log", type=Path, default=home / ".local/share/brainlayer/logs/throughput-watchdog.log")
+    parser.add_argument("--notify-endpoint", default=DEFAULT_NOTIFY_ENDPOINT)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--now-epoch", type=int)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.max_scan_seconds <= 0:
+        raise SystemExit("--max-scan-seconds must be positive")
+    config = Config(
+        db_path=args.db,
+        registry_path=args.registry,
+        state_path=args.state,
+        source_roots=tuple(args.source_roots or _default_source_roots(Path.home())),
+        watch_label=args.watch_label,
+        watch_plist_path=args.watch_plist,
+        stall_threshold=args.stall_threshold,
+        cooldown_seconds=args.cooldown_seconds,
+        recent_window_seconds=args.recent_window_seconds,
+        max_source_files=args.max_source_files,
+        max_scan_seconds=args.max_scan_seconds,
+        dry_run=args.dry_run,
+        log_path=args.log,
+        notify_endpoint=args.notify_endpoint,
+    )
+    lock_path = config.state_path.expanduser().with_suffix(config.state_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            payload = {"action": "already_running", "checked_at_epoch": int(time.time())}
+            print(json.dumps(payload, sort_keys=True) if args.json else "throughput watchdog already running")
+            return 0
+        try:
+            result = run_once(config, now_epoch=args.now_epoch)
+        except Exception as exc:
+            payload = {"action": "probe_failed", "error": str(exc), "checked_at_epoch": int(time.time())}
+            print(json.dumps(payload, sort_keys=True) if args.json else f"throughput watchdog failed: {exc}")
+            return 1
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    print(json.dumps(asdict(result), sort_keys=True) if args.json else f"{result.action}: {result}")
+    return 1 if result.action == "recovery_failed" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -321,7 +321,10 @@ def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
                 pending_files += 1
                 pending_bytes += source_stat.st_size
             continue
-        if source_stat.st_size > offset:
+        if source_stat.st_size < offset:
+            pending_files += 1
+            pending_bytes += source_stat.st_size
+        elif source_stat.st_size > offset:
             pending_files += 1
             pending_bytes += source_stat.st_size - offset
 
@@ -556,7 +559,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--db", type=Path, default=Path(os.environ.get("BRAINLAYER_DB", home / ".local/share/brainlayer/brainlayer.db"))
     )
-    parser.add_argument("--registry", type=Path, default=home / ".local/share/brainlayer/offsets.json")
+    parser.add_argument("--registry", type=Path)
     parser.add_argument("--state", type=Path, default=home / ".local/share/brainlayer/throughput-watchdog-state.json")
     parser.add_argument("--source-root", action="append", type=Path, dest="source_roots")
     parser.add_argument("--watch-label", default=DEFAULT_WATCH_LABEL)
@@ -574,13 +577,12 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = _build_parser().parse_args(argv)
-    if args.max_scan_seconds <= 0:
-        raise SystemExit("--max-scan-seconds must be positive")
-    config = Config(
-        db_path=args.db,
-        registry_path=args.registry,
+def _config_from_args(args: argparse.Namespace) -> Config:
+    db_path = args.db.expanduser()
+    registry_path = args.registry.expanduser() if args.registry is not None else db_path.parent / "offsets.json"
+    return Config(
+        db_path=db_path,
+        registry_path=registry_path,
         state_path=args.state,
         source_roots=tuple(args.source_roots or _default_source_roots(Path.home())),
         watch_label=args.watch_label,
@@ -594,6 +596,13 @@ def main(argv: list[str] | None = None) -> int:
         log_path=args.log,
         notify_endpoint=args.notify_endpoint,
     )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.max_scan_seconds <= 0:
+        raise SystemExit("--max-scan-seconds must be positive")
+    config = _config_from_args(args)
     lock_path = config.state_path.expanduser().with_suffix(config.state_path.suffix + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a+b") as lock_file:

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -192,7 +192,8 @@ def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"recent-source scan exceeded {config.max_scan_seconds:.1f}s") from exc
     if completed.returncode != 0:
-        scan_errors += 1
+        detail = os.fsdecode(completed.stderr).strip()
+        raise RuntimeError(f"recent-source scan failed: {detail or completed.returncode}")
     recent_paths = [Path(os.fsdecode(raw)) for raw in completed.stdout.split(b"\0") if raw]
     if len(recent_paths) > config.max_source_files:
         raise RuntimeError(f"recent-source scan exceeded {config.max_source_files} JSONL files")
@@ -364,6 +365,7 @@ def run_once(
                 alert_fn(config, result)
             except Exception as exc:
                 result.alert_error = str(exc)
+                print(f"throughput-watchdog alert failed: {exc}", file=sys.stderr)
             try:
                 result.action = _restart_watch(config, command_runner)
             except RuntimeError as exc:

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -21,6 +21,8 @@ from typing import Callable
 
 DEFAULT_WATCH_LABEL = "com.brainlayer.watch"
 DEFAULT_NOTIFY_ENDPOINT = "http://localhost:3847/notify"
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15
+KICKSTART_TIMEOUT_SECONDS = 45
 
 
 @dataclass(frozen=True)
@@ -316,7 +318,10 @@ def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
 
 
 def _default_command_runner(args: list[str]):
-    return subprocess.run(args, capture_output=True, text=True, timeout=15, check=False)
+    timeout_seconds = (
+        KICKSTART_TIMEOUT_SECONDS if args[:3] == ["launchctl", "kickstart", "-k"] else DEFAULT_COMMAND_TIMEOUT_SECONDS
+    )
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout_seconds, check=False)
 
 
 def _command_result(command_runner: CommandRunner, args: list[str]) -> tuple[int, str]:

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -8,6 +8,7 @@ import fcntl
 import json
 import math
 import os
+import selectors
 import shutil
 import sqlite3
 import subprocess
@@ -50,11 +51,19 @@ class SourceEvidence:
     scan_errors: int = 0
 
 
+@dataclass(frozen=True)
+class WatcherProgress:
+    chunk_rowid: int
+    liveness_rowid: int
+
+
 @dataclass
 class WatchdogResult:
     checked_at_epoch: int
     watcher_highwater_rowid: int
     watcher_highwater_delta: int | None
+    watcher_liveness_highwater_rowid: int
+    watcher_liveness_highwater_delta: int | None
     pending_files: int
     pending_bytes: int
     recent_files: int
@@ -68,7 +77,7 @@ class WatchdogResult:
 
 
 CommandRunner = Callable[[list[str]], object]
-HighwaterReader = Callable[[Path], int]
+ProgressReader = Callable[[Path], WatcherProgress]
 SourceProbe = Callable[[Config, int], SourceEvidence]
 AlertFn = Callable[[Config, WatchdogResult], None]
 
@@ -125,7 +134,7 @@ def _atomic_write_json(path: Path, payload: dict) -> None:
             pass
 
 
-def read_watcher_highwater(db_path: Path) -> int:
+def read_watcher_progress(db_path: Path) -> WatcherProgress:
     database = db_path.expanduser().resolve()
     if not database.is_file():
         raise RuntimeError(f"BrainLayer DB does not exist: {database}")
@@ -133,14 +142,30 @@ def read_watcher_highwater(db_path: Path) -> int:
     try:
         with sqlite3.connect(uri, uri=True, timeout=2.0) as connection:
             connection.execute("PRAGMA query_only = ON")
-            row = connection.execute(
+            chunk_row = connection.execute(
                 "SELECT COALESCE(MAX(rowid), 0) FROM chunks WHERE source = 'realtime_watcher'"
             ).fetchone()
+            has_liveness_table = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'watcher_liveness_events'"
+            ).fetchone()
+            liveness_row = (
+                connection.execute("SELECT COALESCE(MAX(rowid), 0) FROM watcher_liveness_events").fetchone()
+                if has_liveness_table
+                else (0,)
+            )
     except sqlite3.Error as exc:
-        raise RuntimeError(f"watcher high-water query failed: {exc}") from exc
-    if row is None:
-        raise RuntimeError("watcher high-water query returned no row")
-    return int(row[0])
+        raise RuntimeError(f"watcher progress query failed: {exc}") from exc
+    if chunk_row is None or liveness_row is None:
+        raise RuntimeError("watcher progress query returned no row")
+    return WatcherProgress(
+        chunk_rowid=int(chunk_row[0]),
+        liveness_rowid=int(liveness_row[0]),
+    )
+
+
+def read_watcher_highwater(db_path: Path) -> int:
+    """Compatibility helper for callers that only need committed watcher chunks."""
+    return read_watcher_progress(db_path).chunk_rowid
 
 
 def _registry_offset(entry: object, *, current_inode: int) -> int | None:
@@ -153,6 +178,79 @@ def _registry_offset(entry: object, *, current_inode: int) -> int | None:
     if isinstance(registry_inode, int) and registry_inode > 0 and registry_inode != current_inode:
         return 0
     return offset
+
+
+def _stop_process(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=1)
+
+
+def _bounded_nul_paths(command: list[str], *, max_paths: int, timeout_seconds: float) -> list[Path]:
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if process.stdout is None or process.stderr is None:
+        _stop_process(process)
+        raise RuntimeError("recent-source scan did not expose output pipes")
+
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    deadline = time.monotonic() + timeout_seconds
+    stdout_buffer = bytearray()
+    stderr_buffer = bytearray()
+    paths: list[Path] = []
+    completed = False
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(f"recent-source scan exceeded {timeout_seconds:.1f}s")
+            events = selector.select(timeout=min(remaining, 0.25))
+            if not events:
+                continue
+            for key, _mask in events:
+                chunk = os.read(key.fd, 65_536)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                if key.data == "stderr":
+                    if len(stderr_buffer) < 65_536:
+                        stderr_buffer.extend(chunk[: 65_536 - len(stderr_buffer)])
+                    continue
+                stdout_buffer.extend(chunk)
+                while True:
+                    separator = stdout_buffer.find(0)
+                    if separator < 0:
+                        break
+                    raw_path = bytes(stdout_buffer[:separator])
+                    del stdout_buffer[: separator + 1]
+                    if not raw_path:
+                        continue
+                    paths.append(Path(os.fsdecode(raw_path)))
+                    if len(paths) > max_paths:
+                        raise RuntimeError(f"recent-source scan exceeded {max_paths} JSONL files")
+
+        remaining = max(0.0, deadline - time.monotonic())
+        try:
+            returncode = process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"recent-source scan exceeded {timeout_seconds:.1f}s") from exc
+        completed = True
+        if returncode != 0:
+            detail = os.fsdecode(bytes(stderr_buffer)).strip()
+            raise RuntimeError(f"recent-source scan failed: {detail or returncode}")
+        if stdout_buffer:
+            raise RuntimeError("recent-source scan returned a non-NUL-terminated path")
+        return paths
+    finally:
+        selector.close()
+        if not completed:
+            _stop_process(process)
 
 
 def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
@@ -172,40 +270,29 @@ def collect_source_evidence(config: Config, now_epoch: int) -> SourceEvidence:
     if find_binary is None:
         raise RuntimeError("find is required for the bounded recent-source scan")
     recent_minutes = max(1, math.ceil(config.recent_window_seconds / 60))
-    try:
-        completed = subprocess.run(
-            [
-                find_binary,
-                *(str(root) for root in roots),
-                "-type",
-                "f",
-                "-name",
-                "*.jsonl",
-                "-mmin",
-                f"-{recent_minutes}",
-                "-print0",
-            ],
-            capture_output=True,
-            timeout=config.max_scan_seconds,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"recent-source scan exceeded {config.max_scan_seconds:.1f}s") from exc
-    if completed.returncode != 0:
-        detail = os.fsdecode(completed.stderr).strip()
-        raise RuntimeError(f"recent-source scan failed: {detail or completed.returncode}")
-    recent_paths = [Path(os.fsdecode(raw)) for raw in completed.stdout.split(b"\0") if raw]
-    if len(recent_paths) > config.max_source_files:
-        raise RuntimeError(f"recent-source scan exceeded {config.max_source_files} JSONL files")
+    recent_paths = _bounded_nul_paths(
+        [
+            find_binary,
+            *(str(root) for root in roots),
+            "-type",
+            "f",
+            "-name",
+            "*.jsonl",
+            "-mmin",
+            f"-{recent_minutes}",
+            "-print0",
+        ],
+        max_paths=config.max_source_files,
+        timeout_seconds=config.max_scan_seconds,
+    )
 
     for source_file in recent_paths:
         if time.monotonic() - started > config.max_scan_seconds:
             raise RuntimeError(f"source evidence exceeded {config.max_scan_seconds:.1f}s")
         try:
             source_stat = source_file.stat()
-        except OSError:
-            scan_errors += 1
-            continue
+        except OSError as exc:
+            raise RuntimeError(f"cannot inspect recent source file {source_file}: {exc}") from exc
         if source_stat.st_mtime < cutoff:
             continue
         recent_files += 1
@@ -263,10 +350,17 @@ def _restart_watch(config: Config, command_runner: CommandRunner) -> str:
     )
     if kickstart_returncode != 0:
         raise RuntimeError(f"launchctl kickstart failed: {kickstart_output or kickstart_returncode}")
-    verify_returncode, verify_output = _command_result(command_runner, ["launchctl", "print", target])
-    if verify_returncode != 0:
-        raise RuntimeError(f"launchctl print after kickstart failed: {verify_output or verify_returncode}")
-    return f"kickstart:{config.watch_label}"
+    last_verify = ""
+    for attempt in range(10):
+        verify_returncode, verify_output = _command_result(command_runner, ["launchctl", "print", target])
+        last_verify = verify_output or str(verify_returncode)
+        if verify_returncode == 0 and any(line.strip() == "state = running" for line in verify_output.splitlines()):
+            return f"kickstart:{config.watch_label}"
+        if attempt < 9:
+            time.sleep(0.2)
+    raise RuntimeError(
+        f"watch label did not reach running state after kickstart: {last_verify or 'no launchctl output'}"
+    )
 
 
 def _best_effort_alert(config: Config, result: WatchdogResult) -> None:
@@ -307,25 +401,33 @@ def run_once(
     config: Config,
     *,
     now_epoch: int | None = None,
-    highwater_reader: HighwaterReader = read_watcher_highwater,
+    progress_reader: ProgressReader = read_watcher_progress,
     source_probe: SourceProbe = collect_source_evidence,
     command_runner: CommandRunner = _default_command_runner,
     alert_fn: AlertFn = _best_effort_alert,
 ) -> WatchdogResult:
     checked_at = int(time.time()) if now_epoch is None else int(now_epoch)
     state = _read_json_object(config.state_path)
-    current_highwater = highwater_reader(config.db_path)
+    current_progress = progress_reader(config.db_path)
+    current_highwater = current_progress.chunk_rowid
+    current_liveness_highwater = current_progress.liveness_rowid
     evidence = source_probe(config, checked_at)
     previous_highwater = state.get("watcher_highwater_rowid")
+    previous_liveness_highwater = state.get("watcher_liveness_highwater_rowid")
     previous_stalled = state.get("stalled_ticks", 0)
     if not isinstance(previous_stalled, int) or previous_stalled < 0:
         previous_stalled = 0
     delta = current_highwater - previous_highwater if isinstance(previous_highwater, int) else None
+    liveness_delta = (
+        current_liveness_highwater - previous_liveness_highwater
+        if isinstance(previous_liveness_highwater, int)
+        else None
+    )
 
-    if delta is None or delta < 0:
+    if delta is None or liveness_delta is None or delta < 0 or liveness_delta < 0:
         action = "baseline"
         stalled_ticks = 0
-    elif delta > 0:
+    elif delta > 0 or liveness_delta > 0:
         action = "progress"
         stalled_ticks = 0
     elif evidence.pending_files == 0:
@@ -339,6 +441,8 @@ def run_once(
         checked_at_epoch=checked_at,
         watcher_highwater_rowid=current_highwater,
         watcher_highwater_delta=delta,
+        watcher_liveness_highwater_rowid=current_liveness_highwater,
+        watcher_liveness_highwater_delta=liveness_delta,
         pending_files=evidence.pending_files,
         pending_bytes=evidence.pending_bytes,
         recent_files=evidence.recent_files,
@@ -366,6 +470,26 @@ def run_once(
             except Exception as exc:
                 result.alert_error = str(exc)
                 print(f"throughput-watchdog alert failed: {exc}", file=sys.stderr)
+            attempt_state = dict(state)
+            attempt_state.update(
+                {
+                    "checked_at_epoch": checked_at,
+                    "watcher_highwater_rowid": current_highwater,
+                    "watcher_liveness_highwater_rowid": current_liveness_highwater,
+                    "pending_files": evidence.pending_files,
+                    "pending_bytes": evidence.pending_bytes,
+                    "recent_files": evidence.recent_files,
+                    "untracked_recent_files": evidence.untracked_recent_files,
+                    "newest_source_mtime": evidence.newest_mtime,
+                    "scan_errors": evidence.scan_errors,
+                    "stalled_ticks": stalled_ticks,
+                    "last_action": "recovery_attempt",
+                    "last_restart_epoch": checked_at,
+                    "restart_attempt_count": int(state.get("restart_attempt_count", 0)) + 1,
+                }
+            )
+            _atomic_write_json(config.state_path, attempt_state)
+            state = attempt_state
             try:
                 result.action = _restart_watch(config, command_runner)
             except RuntimeError as exc:
@@ -379,6 +503,7 @@ def run_once(
         {
             "checked_at_epoch": checked_at,
             "watcher_highwater_rowid": current_highwater,
+            "watcher_liveness_highwater_rowid": current_liveness_highwater,
             "pending_files": evidence.pending_files,
             "pending_bytes": evidence.pending_bytes,
             "recent_files": evidence.recent_files,
@@ -390,7 +515,6 @@ def run_once(
         }
     )
     if result.action.startswith("kickstart:"):
-        next_state["last_restart_epoch"] = checked_at
         next_state["restart_count"] = int(state.get("restart_count", 0)) + 1
         next_state.pop("last_recovery_error", None)
     elif result.action == "recovery_failed":

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -581,6 +581,65 @@ def test_packaged_launchd_installer_installs_tier0_watchdog_without_env_runner(t
     assert commands.index(bootstrap_command) < commands.index(print_command)
 
 
+def test_packaged_launchd_installer_installs_throughput_watchdog(tmp_path: Path) -> None:
+    launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
+    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    source_script = REPO_ROOT / "scripts" / "launchd" / "throughput-watchdog.py"
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$*" >> "$FAKE_LAUNCHCTL_LOG"',
+                "exit 0",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_launchctl.chmod(0o755)
+
+    home = tmp_path / "home&throughput"
+    home.mkdir()
+    result = subprocess.run(
+        [str(launchd_dir / "install.sh"), "throughput-watchdog"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": sys.executable,
+            "PYTHON_BIN": sys.executable,
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    installed_script = home / ".local" / "lib" / "brainlayer" / "throughput-watchdog.py"
+    assert installed_script.read_bytes() == source_script.read_bytes()
+    assert os.access(installed_script, os.X_OK)
+
+    rendered = home / "Library" / "LaunchAgents" / "com.brainlayer.throughput-watchdog.plist"
+    plist = plistlib.loads(rendered.read_bytes())
+    assert plist["ProgramArguments"] == [sys.executable, str(installed_script), "--json"]
+    assert plist["EnvironmentVariables"]["HOME"] == str(home)
+    assert plist["StartInterval"] == 60
+    assert "__THROUGHPUT_WATCHDOG_SCRIPT__" not in rendered.read_text(encoding="utf-8")
+    assert "__PYTHON_BIN__" not in rendered.read_text(encoding="utf-8")
+
+    domain = f"gui/{os.getuid()}"
+    commands = launchctl_log.read_text(encoding="utf-8").splitlines()
+    assert f"bootstrap {domain} {rendered}" in commands
+    assert f"print {domain}/com.brainlayer.throughput-watchdog" in commands
+
+
 def test_launchd_installer_renders_launchd_dir_for_maintenance_resume(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -1149,3 +1208,5 @@ def test_wheel_contains_cli_and_launchd_templates(tmp_path: Path) -> None:
     assert "brainlayer/launchd/com.brainlayer.enrichment.plist" in listing
     assert "brainlayer/launchd/com.brainlayer.tier0-watchdog.plist" in listing
     assert "brainlayer/launchd/tier0-watchdog.sh" in listing
+    assert "brainlayer/launchd/com.brainlayer.throughput-watchdog.plist" in listing
+    assert "brainlayer/launchd/throughput-watchdog.py" in listing

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -605,6 +605,9 @@ def test_packaged_launchd_installer_installs_throughput_watchdog(tmp_path: Path)
 
     home = tmp_path / "home&throughput"
     home.mkdir()
+    env_file = home / ".config" / "brainlayer" / "brainlayer.env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text("BRAINLAYER_SYSTEM_ENABLED=1\n", encoding="utf-8")
     result = subprocess.run(
         [str(launchd_dir / "install.sh"), "throughput-watchdog"],
         env={
@@ -623,13 +626,17 @@ def test_packaged_launchd_installer_installs_throughput_watchdog(tmp_path: Path)
 
     assert result.returncode == 0, result.stdout + result.stderr
     installed_script = home / ".local" / "lib" / "brainlayer" / "throughput-watchdog.py"
+    installed_env_runner = home / ".local" / "lib" / "brainlayer" / "brainlayer-env-run.sh"
     assert installed_script.read_bytes() == source_script.read_bytes()
     assert os.access(installed_script, os.X_OK)
+    assert os.access(installed_env_runner, os.X_OK)
 
     rendered = home / "Library" / "LaunchAgents" / "com.brainlayer.throughput-watchdog.plist"
     plist = plistlib.loads(rendered.read_bytes())
-    assert plist["ProgramArguments"] == [sys.executable, str(installed_script), "--json"]
+    assert plist["ProgramArguments"] == [str(installed_env_runner), sys.executable, str(installed_script), "--json"]
     assert plist["EnvironmentVariables"]["HOME"] == str(home)
+    assert plist["EnvironmentVariables"]["BRAINLAYER_ENV_FILE"] == str(env_file)
+    assert plist["EnvironmentVariables"]["BRAINLAYER_LAUNCHD_SERVICE"] == "watch"
     assert plist["StartInterval"] == 60
     assert "__THROUGHPUT_WATCHDOG_SCRIPT__" not in rendered.read_text(encoding="utf-8")
     assert "__PYTHON_BIN__" not in rendered.read_text(encoding="utf-8")

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -17,8 +17,10 @@ RENDERED_LOG_ROOT = "/Users/etanheyman/Library/Logs/brainlayer/"
 REQUIRED_PATH_PARTS = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
 DEV_SRC_PATH_RE = re.compile(r"/Users/[^:\s]+/Gits/[^:\s]+/src(?:$|:)")
 ENV_RUN_EXEMPT_LABELS = {
-    "com.brainlayer.throughput-watchdog",
     "com.brainlayer.tier0-watchdog",
+}
+PACKAGE_IMPORT_EXEMPT_LABELS = ENV_RUN_EXEMPT_LABELS | {
+    "com.brainlayer.throughput-watchdog",
 }
 
 
@@ -243,7 +245,7 @@ def test_canonical_launchagent_env_has_no_concrete_dev_src_paths():
 def test_script_launchagents_use_installed_package_imports():
     for path in sorted((REPO_ROOT / "scripts/launchd").glob("com.brainlayer.*.plist")):
         plist = plistlib.loads(path.read_bytes())
-        if plist["Label"] in ENV_RUN_EXEMPT_LABELS:
+        if plist["Label"] in PACKAGE_IMPORT_EXEMPT_LABELS:
             continue
         _assert_uses_installed_package_not_source_path(path, plist)
 
@@ -270,11 +272,6 @@ def test_all_script_launchagents_source_unified_config_file():
 
         if plist["Label"] in ENV_RUN_EXEMPT_LABELS:
             expected_args = {
-                "com.brainlayer.throughput-watchdog": [
-                    "__PYTHON_BIN__",
-                    "__THROUGHPUT_WATCHDOG_SCRIPT__",
-                    "--json",
-                ],
                 "com.brainlayer.tier0-watchdog": ["/bin/sh", "__TIER0_WATCHDOG_SCRIPT__"],
             }
             assert args == expected_args[plist["Label"]], str(path)
@@ -284,7 +281,8 @@ def test_all_script_launchagents_source_unified_config_file():
 
         assert args[0] == "__BRAINLAYER_ENV_RUN__", str(path)
         assert env["BRAINLAYER_ENV_FILE"] == "__BRAINLAYER_ENV_FILE__", str(path)
-        assert env["BRAINLAYER_LAUNCHD_SERVICE"] == service, str(path)
+        expected_service = "watch" if plist["Label"] == "com.brainlayer.throughput-watchdog" else service
+        assert env["BRAINLAYER_LAUNCHD_SERVICE"] == expected_service, str(path)
 
 
 def test_launchd_env_loader_exists_and_loads_safe_env_before_exec():

--- a/tests/test_launchd_hygiene.py
+++ b/tests/test_launchd_hygiene.py
@@ -16,7 +16,10 @@ LOG_ROOT = "__HOME__/Library/Logs/brainlayer/"
 RENDERED_LOG_ROOT = "/Users/etanheyman/Library/Logs/brainlayer/"
 REQUIRED_PATH_PARTS = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
 DEV_SRC_PATH_RE = re.compile(r"/Users/[^:\s]+/Gits/[^:\s]+/src(?:$|:)")
-ENV_RUN_EXEMPT_LABELS = {"com.brainlayer.tier0-watchdog"}
+ENV_RUN_EXEMPT_LABELS = {
+    "com.brainlayer.throughput-watchdog",
+    "com.brainlayer.tier0-watchdog",
+}
 
 
 def _load(path: str) -> dict:
@@ -100,6 +103,11 @@ def test_active_daemon_launchd_hygiene_matrix():
         "scripts/launchd/com.brainlayer.backup-daily.plist": {
             "ProcessType": "Background",
             "ExitTimeOut": 300,
+            "LowPriorityIO": True,
+        },
+        "scripts/launchd/com.brainlayer.throughput-watchdog.plist": {
+            "ProcessType": "Background",
+            "ExitTimeOut": 30,
             "LowPriorityIO": True,
         },
     }
@@ -261,7 +269,15 @@ def test_all_script_launchagents_source_unified_config_file():
         service = plist["Label"].removeprefix("com.brainlayer.")
 
         if plist["Label"] in ENV_RUN_EXEMPT_LABELS:
-            assert args == ["/bin/sh", "__TIER0_WATCHDOG_SCRIPT__"], str(path)
+            expected_args = {
+                "com.brainlayer.throughput-watchdog": [
+                    "__PYTHON_BIN__",
+                    "__THROUGHPUT_WATCHDOG_SCRIPT__",
+                    "--json",
+                ],
+                "com.brainlayer.tier0-watchdog": ["/bin/sh", "__TIER0_WATCHDOG_SCRIPT__"],
+            }
+            assert args == expected_args[plist["Label"]], str(path)
             assert "BRAINLAYER_ENV_FILE" not in env, str(path)
             assert "BRAINLAYER_LAUNCHD_SERVICE" not in env, str(path)
             continue
@@ -511,6 +527,15 @@ def test_launchd_installer_wires_health_check_target():
     assert "health-check)" in install_source
     assert "install_plist health-check" in install_source
     assert "remove_plist health-check" in install_source
+
+
+def test_launchd_installer_wires_throughput_watchdog_target():
+    install_source = (REPO_ROOT / "scripts/launchd/install.sh").read_text(encoding="utf-8")
+
+    assert "./scripts/launchd/install.sh throughput-watchdog" in install_source
+    assert "throughput-watchdog)" in install_source
+    assert "install_throughput_watchdog" in install_source
+    assert "remove_plist throughput-watchdog" in install_source
 
 
 def test_launchd_installer_uses_bootstrap_not_legacy_load_unload():

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import plistlib
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "launchd" / "throughput-watchdog.py"
+PLIST_PATH = REPO_ROOT / "scripts" / "launchd" / "com.brainlayer.throughput-watchdog.plist"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("brainlayer_throughput_watchdog", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _config(module, tmp_path: Path, *, stall_threshold: int = 3, cooldown_seconds: int = 600):
+    return module.Config(
+        db_path=tmp_path / "brainlayer.db",
+        registry_path=tmp_path / "offsets.json",
+        state_path=tmp_path / "throughput-watchdog-state.json",
+        source_roots=(tmp_path / "sessions",),
+        watch_label="com.example.brainlayer.watch",
+        watch_plist_path=tmp_path / "com.example.brainlayer.watch.plist",
+        stall_threshold=stall_threshold,
+        cooldown_seconds=cooldown_seconds,
+    )
+
+
+def test_first_observation_establishes_a_baseline_without_restart(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path)
+    commands: list[list[str]] = []
+
+    result = module.run_once(
+        config,
+        now_epoch=1_000,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: module.SourceEvidence(2, 120, 3, 999.0),
+        command_runner=lambda args: commands.append(args),
+    )
+
+    assert result.action == "baseline"
+    assert result.stalled_ticks == 0
+    assert commands == []
+
+
+def test_process_alive_zero_throughput_with_pending_bytes_kickstarts_after_threshold(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=3)
+    command_events: list[str] = []
+
+    def command_runner(args: list[str]):
+        command_events.append("command:" + " ".join(args))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def alert_fn(_config, _result):
+        command_events.append("alert")
+
+    evidence = module.SourceEvidence(2, 120, 3, 999.0)
+    baseline = module.run_once(
+        config,
+        now_epoch=1_000,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=command_runner,
+        alert_fn=alert_fn,
+    )
+    first = module.run_once(
+        config,
+        now_epoch=1_060,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=command_runner,
+        alert_fn=alert_fn,
+    )
+    second = module.run_once(
+        config,
+        now_epoch=1_120,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=command_runner,
+        alert_fn=alert_fn,
+    )
+    third = module.run_once(
+        config,
+        now_epoch=1_180,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=command_runner,
+        alert_fn=alert_fn,
+    )
+
+    assert baseline.action == "baseline"
+    assert [first.stalled_ticks, second.stalled_ticks] == [1, 2]
+    assert third.action == "kickstart:com.example.brainlayer.watch"
+    assert third.stalled_ticks == 0
+    assert command_events[0] == "alert"
+    assert command_events[1:] == [
+        f"command:launchctl print gui/{os.getuid()}/com.example.brainlayer.watch",
+        f"command:launchctl kickstart -k gui/{os.getuid()}/com.example.brainlayer.watch",
+        f"command:launchctl print gui/{os.getuid()}/com.example.brainlayer.watch",
+    ]
+
+
+def test_chunk_progress_or_no_pending_input_resets_stall_counter(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=2)
+    pending = module.SourceEvidence(1, 20, 1, 999.0)
+    idle = module.SourceEvidence(0, 0, 1, 999.0)
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: pending,
+    )
+    stalled = module.run_once(
+        config,
+        now_epoch=1_060,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: pending,
+    )
+    progressed = module.run_once(
+        config,
+        now_epoch=1_120,
+        highwater_reader=lambda _path: 41,
+        source_probe=lambda _config, _now: pending,
+    )
+    idle_result = module.run_once(
+        config,
+        now_epoch=1_180,
+        highwater_reader=lambda _path: 41,
+        source_probe=lambda _config, _now: idle,
+    )
+
+    assert stalled.stalled_ticks == 1
+    assert progressed.action == "progress"
+    assert progressed.watcher_highwater_delta == 1
+    assert progressed.stalled_ticks == 0
+    assert idle_result.action == "idle"
+    assert idle_result.stalled_ticks == 0
+
+
+def test_restart_failure_is_visible_and_not_recorded_as_recovered(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+    )
+
+    def command_runner(args: list[str]):
+        if args[:3] == ["launchctl", "kickstart", "-k"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="kickstart refused")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=command_runner,
+        alert_fn=lambda _config, _result: None,
+    )
+
+    assert result.action == "recovery_failed"
+    assert "kickstart refused" in result.error
+    state = json.loads(config.state_path.read_text(encoding="utf-8"))
+    assert "last_restart_epoch" not in state
+    assert state["last_recovery_error"] == result.error
+
+
+def test_alert_failure_does_not_block_watcher_recovery(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+    )
+    commands: list[list[str]] = []
+
+    def broken_alert(_config, _result):
+        raise OSError("notification path unavailable")
+
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        highwater_reader=lambda _path: 40,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=lambda args: commands.append(args),
+        alert_fn=broken_alert,
+    )
+
+    assert result.action == "kickstart:com.example.brainlayer.watch"
+    assert result.alert_error == "notification path unavailable"
+    assert any(command[:3] == ["launchctl", "kickstart", "-k"] for command in commands)
+
+
+def test_source_probe_only_treats_recent_registry_tracked_lag_as_pending(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path)
+    source_root = config.source_roots[0]
+    source_root.mkdir(parents=True)
+    pending = source_root / "pending.jsonl"
+    caught_up = source_root / "caught-up.jsonl"
+    untracked = source_root / "untracked.jsonl"
+    stale = source_root / "stale.jsonl"
+    for source_file in (pending, caught_up, untracked, stale):
+        source_file.write_text("1234567890\n", encoding="utf-8")
+    os.utime(stale, (100, 100))
+    config.registry_path.write_text(
+        json.dumps(
+            {
+                str(pending): {"offset": 3},
+                str(caught_up): {"offset": caught_up.stat().st_size},
+                str(stale): {"offset": 0},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = module.collect_source_evidence(config, now_epoch=1_000)
+
+    assert result.recent_files == 3
+    assert result.pending_files == 1
+    assert result.pending_bytes == pending.stat().st_size - 3
+    assert result.untracked_recent_files == 1
+
+
+def test_highwater_is_scoped_to_realtime_watcher_without_a_count_scan(tmp_path: Path) -> None:
+    module = _load_module()
+    db_path = tmp_path / "brainlayer.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source TEXT)")
+        connection.executemany(
+            "INSERT INTO chunks(id, source) VALUES (?, ?)",
+            [("w1", "realtime_watcher"), ("m1", "mcp"), ("w2", "realtime_watcher")],
+        )
+
+    assert module.read_watcher_highwater(db_path) == 3
+
+
+def test_launchagent_runs_every_minute_and_invokes_installed_script() -> None:
+    plist = plistlib.loads(PLIST_PATH.read_bytes())
+
+    assert plist["Label"] == "com.brainlayer.throughput-watchdog"
+    assert plist["StartInterval"] == 60
+    assert plist["RunAtLoad"] is True
+    assert plist["ProgramArguments"] == ["__PYTHON_BIN__", "__THROUGHPUT_WATCHDOG_SCRIPT__", "--json"]
+    assert plist["EnvironmentVariables"]["HOME"] == "__HOME__"
+    assert plist["SoftResourceLimits"]["NumberOfFiles"] >= 4096

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -7,6 +7,7 @@ import plistlib
 import sqlite3
 import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -256,7 +257,7 @@ def test_alert_failure_does_not_block_watcher_recovery(tmp_path: Path) -> None:
     assert any(command[:3] == ["launchctl", "kickstart", "-k"] for command in commands)
 
 
-def test_source_probe_only_treats_recent_registry_tracked_lag_as_pending(tmp_path: Path) -> None:
+def test_source_probe_treats_recent_unregistered_input_as_pending(tmp_path: Path) -> None:
     module = _load_module()
     config = _config(module, tmp_path)
     source_root = config.source_roots[0]
@@ -282,8 +283,28 @@ def test_source_probe_only_treats_recent_registry_tracked_lag_as_pending(tmp_pat
     result = module.collect_source_evidence(config, now_epoch=1_000)
 
     assert result.recent_files == 3
+    assert result.pending_files == 2
+    assert result.pending_bytes == pending.stat().st_size - 3 + untracked.stat().st_size
+    assert result.untracked_recent_files == 1
+
+
+def test_source_probe_ignores_unwatched_cursor_project_jsonl(tmp_path: Path) -> None:
+    module = _load_module()
+    cursor_projects = tmp_path / ".cursor" / "projects"
+    watched = cursor_projects / "repo" / "agent-transcripts" / "agent" / "session.jsonl"
+    unwatched = cursor_projects / "repo" / "tool-state.jsonl"
+    watched.parent.mkdir(parents=True)
+    unwatched.parent.mkdir(parents=True, exist_ok=True)
+    watched.write_text("watched\n", encoding="utf-8")
+    unwatched.write_text("not watcher input\n", encoding="utf-8")
+    config = replace(_config(module, tmp_path), source_roots=(cursor_projects,))
+    config.registry_path.write_text("{}", encoding="utf-8")
+
+    result = module.collect_source_evidence(config, now_epoch=1_000)
+
+    assert result.recent_files == 1
     assert result.pending_files == 1
-    assert result.pending_bytes == pending.stat().st_size - 3
+    assert result.pending_bytes == watched.stat().st_size
     assert result.untracked_recent_files == 1
 
 
@@ -547,6 +568,13 @@ def test_launchagent_runs_every_minute_and_invokes_installed_script() -> None:
     assert plist["Label"] == "com.brainlayer.throughput-watchdog"
     assert plist["StartInterval"] == 60
     assert plist["RunAtLoad"] is True
-    assert plist["ProgramArguments"] == ["__PYTHON_BIN__", "__THROUGHPUT_WATCHDOG_SCRIPT__", "--json"]
+    assert plist["ProgramArguments"] == [
+        "__BRAINLAYER_ENV_RUN__",
+        "__PYTHON_BIN__",
+        "__THROUGHPUT_WATCHDOG_SCRIPT__",
+        "--json",
+    ]
     assert plist["EnvironmentVariables"]["HOME"] == "__HOME__"
+    assert plist["EnvironmentVariables"]["BRAINLAYER_ENV_FILE"] == "__BRAINLAYER_ENV_FILE__"
+    assert plist["EnvironmentVariables"]["BRAINLAYER_LAUNCHD_SERVICE"] == "watch"
     assert plist["SoftResourceLimits"]["NumberOfFiles"] >= 4096

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -308,6 +308,34 @@ def test_source_probe_ignores_unwatched_cursor_project_jsonl(tmp_path: Path) -> 
     assert result.untracked_recent_files == 1
 
 
+def test_source_probe_treats_truncated_tracked_file_as_pending_rewind(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path)
+    config.source_roots[0].mkdir(parents=True)
+    rewound = config.source_roots[0] / "rewound.jsonl"
+    rewound.write_text("new\n", encoding="utf-8")
+    config.registry_path.write_text(
+        json.dumps({str(rewound): {"offset": rewound.stat().st_size + 100}}),
+        encoding="utf-8",
+    )
+
+    result = module.collect_source_evidence(config, now_epoch=1_000)
+
+    assert result.pending_files == 1
+    assert result.pending_bytes == rewound.stat().st_size
+
+
+def test_config_defaults_registry_next_to_selected_database(tmp_path: Path) -> None:
+    module = _load_module()
+    custom_db = tmp_path / "sandbox" / "brainlayer.db"
+
+    args = module._build_parser().parse_args(["--db", str(custom_db)])
+    config = module._config_from_args(args)
+
+    assert config.db_path == custom_db
+    assert config.registry_path == custom_db.parent / "offsets.json"
+
+
 def test_source_probe_fails_visibly_when_find_cannot_complete(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     config = _config(module, tmp_path)

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -5,6 +5,7 @@ import json
 import os
 import plistlib
 import sqlite3
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -118,6 +119,22 @@ def test_process_alive_zero_throughput_with_pending_bytes_kickstarts_after_thres
         f"command:launchctl kickstart -k gui/{os.getuid()}/com.example.brainlayer.watch",
         f"command:launchctl print gui/{os.getuid()}/com.example.brainlayer.watch",
     ]
+
+
+def test_default_runner_allows_bounded_time_for_uninterruptible_watcher_kickstart(monkeypatch) -> None:
+    module = _load_module()
+    observed_timeouts: list[int] = []
+
+    def fake_run(args, **kwargs):
+        observed_timeouts.append(kwargs["timeout"])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    module._default_command_runner(["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/com.brainlayer.watch"])
+    module._default_command_runner(["launchctl", "print", f"gui/{os.getuid()}/com.brainlayer.watch"])
+
+    assert observed_timeouts == [45, 15]
 
 
 def test_chunk_progress_or_no_pending_input_resets_stall_counter(tmp_path: Path) -> None:

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -36,6 +36,13 @@ def _config(module, tmp_path: Path, *, stall_threshold: int = 3, cooldown_second
     )
 
 
+def _progress(module, chunk_rowid: int, liveness_rowid: int = 0):
+    return module.WatcherProgress(
+        chunk_rowid=chunk_rowid,
+        liveness_rowid=liveness_rowid,
+    )
+
+
 def test_first_observation_establishes_a_baseline_without_restart(tmp_path: Path) -> None:
     module = _load_module()
     config = _config(module, tmp_path)
@@ -44,7 +51,7 @@ def test_first_observation_establishes_a_baseline_without_restart(tmp_path: Path
     result = module.run_once(
         config,
         now_epoch=1_000,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: module.SourceEvidence(2, 120, 3, 999.0),
         command_runner=lambda args: commands.append(args),
     )
@@ -61,7 +68,8 @@ def test_process_alive_zero_throughput_with_pending_bytes_kickstarts_after_thres
 
     def command_runner(args: list[str]):
         command_events.append("command:" + " ".join(args))
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
+        stdout = "state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
 
     def alert_fn(_config, _result):
         command_events.append("alert")
@@ -70,7 +78,7 @@ def test_process_alive_zero_throughput_with_pending_bytes_kickstarts_after_thres
     baseline = module.run_once(
         config,
         now_epoch=1_000,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
         command_runner=command_runner,
         alert_fn=alert_fn,
@@ -78,7 +86,7 @@ def test_process_alive_zero_throughput_with_pending_bytes_kickstarts_after_thres
     first = module.run_once(
         config,
         now_epoch=1_060,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
         command_runner=command_runner,
         alert_fn=alert_fn,
@@ -86,7 +94,7 @@ def test_process_alive_zero_throughput_with_pending_bytes_kickstarts_after_thres
     second = module.run_once(
         config,
         now_epoch=1_120,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
         command_runner=command_runner,
         alert_fn=alert_fn,
@@ -94,7 +102,7 @@ def test_process_alive_zero_throughput_with_pending_bytes_kickstarts_after_thres
     third = module.run_once(
         config,
         now_epoch=1_180,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
         command_runner=command_runner,
         alert_fn=alert_fn,
@@ -121,25 +129,25 @@ def test_chunk_progress_or_no_pending_input_resets_stall_counter(tmp_path: Path)
     module.run_once(
         config,
         now_epoch=1_000,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: pending,
     )
     stalled = module.run_once(
         config,
         now_epoch=1_060,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: pending,
     )
     progressed = module.run_once(
         config,
         now_epoch=1_120,
-        highwater_reader=lambda _path: 41,
+        progress_reader=lambda _path: _progress(module, 41),
         source_probe=lambda _config, _now: pending,
     )
     idle_result = module.run_once(
         config,
         now_epoch=1_180,
-        highwater_reader=lambda _path: 41,
+        progress_reader=lambda _path: _progress(module, 41),
         source_probe=lambda _config, _now: idle,
     )
 
@@ -158,7 +166,7 @@ def test_restart_failure_is_visible_and_not_recorded_as_recovered(tmp_path: Path
     module.run_once(
         config,
         now_epoch=1_000,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
     )
 
@@ -170,7 +178,7 @@ def test_restart_failure_is_visible_and_not_recorded_as_recovered(tmp_path: Path
     result = module.run_once(
         config,
         now_epoch=1_060,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
         command_runner=command_runner,
         alert_fn=lambda _config, _result: None,
@@ -179,8 +187,20 @@ def test_restart_failure_is_visible_and_not_recorded_as_recovered(tmp_path: Path
     assert result.action == "recovery_failed"
     assert "kickstart refused" in result.error
     state = json.loads(config.state_path.read_text(encoding="utf-8"))
-    assert "last_restart_epoch" not in state
+    assert state["last_restart_epoch"] == 1_060
     assert state["last_recovery_error"] == result.error
+
+    commands: list[list[str]] = []
+    cooldown = module.run_once(
+        config,
+        now_epoch=1_120,
+        progress_reader=lambda _path: _progress(module, 40),
+        source_probe=lambda _config, _now: evidence,
+        command_runner=lambda args: commands.append(args),
+        alert_fn=lambda _config, _result: None,
+    )
+    assert cooldown.action == "cooldown"
+    assert not any(command[:3] == ["launchctl", "kickstart", "-k"] for command in commands)
 
 
 def test_alert_failure_does_not_block_watcher_recovery(tmp_path: Path) -> None:
@@ -190,7 +210,7 @@ def test_alert_failure_does_not_block_watcher_recovery(tmp_path: Path) -> None:
     module.run_once(
         config,
         now_epoch=1_000,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
     )
     commands: list[list[str]] = []
@@ -201,9 +221,16 @@ def test_alert_failure_does_not_block_watcher_recovery(tmp_path: Path) -> None:
     result = module.run_once(
         config,
         now_epoch=1_060,
-        highwater_reader=lambda _path: 40,
+        progress_reader=lambda _path: _progress(module, 40),
         source_probe=lambda _config, _now: evidence,
-        command_runner=lambda args: commands.append(args),
+        command_runner=lambda args: (
+            commands.append(args)
+            or SimpleNamespace(
+                returncode=0,
+                stdout="state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else "",
+                stderr="",
+            )
+        ),
         alert_fn=broken_alert,
     )
 
@@ -248,11 +275,11 @@ def test_source_probe_fails_visibly_when_find_cannot_complete(tmp_path: Path, mo
     config = _config(module, tmp_path)
     config.source_roots[0].mkdir(parents=True)
     config.registry_path.write_text("{}", encoding="utf-8")
-    monkeypatch.setattr(
-        module.subprocess,
-        "run",
-        lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout=b"", stderr=b"permission denied"),
-    )
+
+    def fail_scan(*_args, **_kwargs):
+        raise RuntimeError("recent-source scan failed: permission denied")
+
+    monkeypatch.setattr(module, "_bounded_nul_paths", fail_scan)
 
     try:
         module.collect_source_evidence(config, now_epoch=1_000)
@@ -262,17 +289,239 @@ def test_source_probe_fails_visibly_when_find_cannot_complete(tmp_path: Path, mo
         raise AssertionError("an incomplete source scan must not report idle")
 
 
-def test_highwater_is_scoped_to_realtime_watcher_without_a_count_scan(tmp_path: Path) -> None:
+def test_bounded_find_streams_and_terminates_before_buffering_unbounded_paths(tmp_path: Path) -> None:
+    module = _load_module()
+    producer = tmp_path / "produce_paths.py"
+    producer.write_text(
+        "import sys, time\nsys.stdout.buffer.write(b'a\\0b\\0c\\0')\nsys.stdout.buffer.flush()\ntime.sleep(30)\n",
+        encoding="utf-8",
+    )
+
+    try:
+        module._bounded_nul_paths(
+            [sys.executable, str(producer)],
+            max_paths=2,
+            timeout_seconds=5,
+        )
+    except RuntimeError as exc:
+        assert "exceeded 2" in str(exc)
+    else:
+        raise AssertionError("the producer must be terminated as soon as the path bound is exceeded")
+
+
+def test_bounded_find_preserves_nonzero_exit_and_timeout_failures(tmp_path: Path) -> None:
+    module = _load_module()
+    failed = tmp_path / "failed_scan.py"
+    failed.write_text(
+        "import sys\nsys.stderr.write('permission denied')\nraise SystemExit(7)\n",
+        encoding="utf-8",
+    )
+    stalled = tmp_path / "stalled_scan.py"
+    stalled.write_text("import time\ntime.sleep(30)\n", encoding="utf-8")
+
+    try:
+        module._bounded_nul_paths(
+            [sys.executable, str(failed)],
+            max_paths=2,
+            timeout_seconds=5,
+        )
+    except RuntimeError as exc:
+        assert "permission denied" in str(exc)
+    else:
+        raise AssertionError("a nonzero find exit must fail the probe")
+
+    try:
+        module._bounded_nul_paths(
+            [sys.executable, str(stalled)],
+            max_paths=2,
+            timeout_seconds=0.1,
+        )
+    except RuntimeError as exc:
+        assert "exceeded 0.1s" in str(exc)
+    else:
+        raise AssertionError("a stalled find process must be terminated at the scan timeout")
+
+
+def test_source_probe_fails_closed_when_a_recent_file_cannot_be_statted(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path)
+    source_root = config.source_roots[0]
+    source_root.mkdir(parents=True)
+    unreadable = source_root / "unreadable.jsonl"
+    unreadable.write_text("{}\n", encoding="utf-8")
+    config.registry_path.write_text("{}", encoding="utf-8")
+    original_stat = Path.stat
+
+    def fail_selected_stat(path: Path, *args, **kwargs):
+        if path == unreadable:
+            raise PermissionError("stat denied")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fail_selected_stat)
+
+    try:
+        module.collect_source_evidence(config, now_epoch=int(original_stat(unreadable).st_mtime) + 1)
+    except RuntimeError as exc:
+        assert "stat denied" in str(exc)
+    else:
+        raise AssertionError("partial source evidence must never authorize recovery")
+
+
+def test_progress_tracks_realtime_chunks_and_durable_watcher_liveness(tmp_path: Path) -> None:
     module = _load_module()
     db_path = tmp_path / "brainlayer.db"
     with sqlite3.connect(db_path) as connection:
         connection.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source TEXT)")
+        connection.execute(
+            "CREATE TABLE watcher_liveness_events (id INTEGER PRIMARY KEY AUTOINCREMENT, chunk_id TEXT, ingested_at INTEGER)"
+        )
         connection.executemany(
             "INSERT INTO chunks(id, source) VALUES (?, ?)",
             [("w1", "realtime_watcher"), ("m1", "mcp"), ("w2", "realtime_watcher")],
         )
+        connection.executemany(
+            "INSERT INTO watcher_liveness_events(chunk_id, ingested_at) VALUES (?, ?)",
+            [("w1", 100), ("manual-canonical", 101)],
+        )
 
-    assert module.read_watcher_highwater(db_path) == 3
+    assert module.read_watcher_progress(db_path) == _progress(module, 3, 2)
+
+
+def test_liveness_progress_prevents_false_restart_for_dedupe_only_ingest(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    commands: list[list[str]] = []
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        source_probe=lambda _config, _now: evidence,
+    )
+
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40, 11),
+        source_probe=lambda _config, _now: evidence,
+        command_runner=lambda args: commands.append(args),
+    )
+
+    assert result.action == "progress"
+    assert result.watcher_highwater_delta == 0
+    assert result.watcher_liveness_highwater_delta == 1
+    assert commands == []
+
+
+def test_recovery_requires_kickstarted_job_to_reach_running_state(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40),
+        source_probe=lambda _config, _now: evidence,
+    )
+
+    def command_runner(args: list[str]):
+        stdout = "state = exited\nlast exit code = 1\n" if args[:2] == ["launchctl", "print"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40),
+        source_probe=lambda _config, _now: evidence,
+        command_runner=command_runner,
+        alert_fn=lambda _config, _result: None,
+    )
+
+    assert result.action == "recovery_failed"
+    assert "did not reach running state" in result.error
+
+
+def test_recovery_attempt_is_persisted_before_external_kickstart(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40),
+        source_probe=lambda _config, _now: evidence,
+    )
+    events: list[str] = []
+    original_write = module._atomic_write_json
+
+    def recording_write(path: Path, payload: dict) -> None:
+        events.append(f"write:{payload.get('last_action')}")
+        original_write(path, payload)
+
+    def command_runner(args: list[str]):
+        events.append("command:" + " ".join(args))
+        stdout = "state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module, "_atomic_write_json", recording_write)
+    module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40),
+        source_probe=lambda _config, _now: evidence,
+        command_runner=command_runner,
+        alert_fn=lambda _config, _result: None,
+    )
+
+    attempt_index = events.index("write:recovery_attempt")
+    kickstart_index = next(
+        index for index, event in enumerate(events) if event.startswith("command:launchctl kickstart")
+    )
+    assert attempt_index < kickstart_index
+
+
+def test_recovery_attempt_survives_a_post_kickstart_state_write_failure(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40),
+        source_probe=lambda _config, _now: evidence,
+    )
+    original_write = module._atomic_write_json
+    writes = 0
+
+    def fail_final_write(path: Path, payload: dict) -> None:
+        nonlocal writes
+        writes += 1
+        if writes == 2:
+            raise OSError("disk unavailable after kickstart")
+        original_write(path, payload)
+
+    def command_runner(args: list[str]):
+        stdout = "state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module, "_atomic_write_json", fail_final_write)
+    try:
+        module.run_once(
+            config,
+            now_epoch=1_060,
+            progress_reader=lambda _path: _progress(module, 40),
+            source_probe=lambda _config, _now: evidence,
+            command_runner=command_runner,
+            alert_fn=lambda _config, _result: None,
+        )
+    except OSError as exc:
+        assert "disk unavailable" in str(exc)
+    else:
+        raise AssertionError("the final state-write failure must remain visible")
+
+    durable_state = json.loads(config.state_path.read_text(encoding="utf-8"))
+    assert durable_state["last_action"] == "recovery_attempt"
+    assert durable_state["last_restart_epoch"] == 1_060
 
 
 def test_launchagent_runs_every_minute_and_invokes_installed_script() -> None:

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -243,6 +243,25 @@ def test_source_probe_only_treats_recent_registry_tracked_lag_as_pending(tmp_pat
     assert result.untracked_recent_files == 1
 
 
+def test_source_probe_fails_visibly_when_find_cannot_complete(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path)
+    config.source_roots[0].mkdir(parents=True)
+    config.registry_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout=b"", stderr=b"permission denied"),
+    )
+
+    try:
+        module.collect_source_evidence(config, now_epoch=1_000)
+    except RuntimeError as exc:
+        assert "permission denied" in str(exc)
+    else:
+        raise AssertionError("an incomplete source scan must not report idle")
+
+
 def test_highwater_is_scoped_to_realtime_watcher_without_a_count_scan(tmp_path: Path) -> None:
     module = _load_module()
     db_path = tmp_path / "brainlayer.db"


### PR DESCRIPTION
## Summary

- add a dedicated 60-second `com.brainlayer.throughput-watchdog` LaunchAgent
- compare the indexed `realtime_watcher` high-water rowid with recent registry-tracked JSONL bytes that remain ahead of confirmed offsets
- require three consecutive zero-throughput ticks with positive pending evidence before recovery
- alert before a checked `launchctl kickstart -k`, verify the label afterward, and apply a ten-minute recovery cooldown
- install the standalone bounded probe through the packaged launchd installer

## Why

The third production incident left `com.brainlayer.watch` alive but wedged in an uninterruptible SQLite wait. Process liveness and launchd KeepAlive therefore remained green while ingestion stopped. Recovery must use throughput plus pending-input evidence.

## Verification

- focused launchd/install/watchdog/tier-0 suite: 75 passed
- Ruff check and format: passed
- `bash -n`, ShellCheck, plist lint, and `git diff --check`: passed
- live dry-run against the 687k-row production DB and 13.7k-entry offset registry: 0.44-1.64 seconds
- live pre-deploy evidence: watcher high-water rowid 985223 remained flat while 5 tracked files held about 4.5 MB beyond confirmed offsets

## Deployment gate

This is deploy-bearing. After merge, install and load the LaunchAgent, then perform the authorized forced-wedge drill: stop the live watcher without exiting it, create positive pending-input evidence, prove the watchdog replaces the PID automatically, and prove watcher chunks resume. LayerSpec owns merge timing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production ingestion recovery now depends on automatic `launchctl kickstart -k` and filesystem/DB heuristics; mis-stalls could restart a healthy watcher, though thresholds, cooldown, and liveness checks mitigate false positives.
> 
> **Overview**
> Adds a **throughput watchdog** for when `com.brainlayer.watch` stays alive but stops ingesting—complementing process-level checks like tier0-watchdog.
> 
> A new **`throughput-watchdog.py`** runs on a **60s** LaunchAgent schedule. Each tick compares SQLite **`realtime_watcher`** chunk high-water and **`watcher_liveness_events`** progress against recent JSONL under the usual session roots (with bounded `find` and offset-registry logic aligned to watcher Cursor paths). If pending bytes remain but throughput is flat for **three** consecutive checks, it alerts, persists recovery state, **`launchctl kickstart -k`** the watch job (with post-kickstart running verification), and enforces a **10-minute** cooldown. A file lock avoids overlapping runs; probe failures fail closed rather than treating a bad scan as idle.
> 
> **`install.sh`** gains `throughput-watchdog` install/remove, includes it in **`all`**, and ships **`com.brainlayer.throughput-watchdog.plist`** via the packaged wheel. Tests cover stall/recovery edge cases, installer rendering, and launchd hygiene.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d41786958ce53a5b9d4077b91e55f067be34fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add throughput watchdog to auto-recover zero-throughput realtime watcher stalls
> - Adds [throughput-watchdog.py](https://github.com/EtanHey/brainlayer/pull/600/files#diff-ce23882a33c4aca82486682d2aded2534de2839e67bbb05ef8b09c0c0e7063e6), a new Python CLI that detects wedged realtime watcher processes by comparing SQLite DB highwater marks and on-disk JSONL source evidence across successive runs.
> - When the watcher appears stalled beyond a configurable threshold, the watchdog issues `launchctl kickstart` (with bootstrap if needed) and polls until the job reaches `running` state, with cooldown and dry-run support.
> - Adds [com.brainlayer.throughput-watchdog.plist](https://github.com/EtanHey/brainlayer/pull/600/files#diff-f7f0161ea3523ee4f664f0308cf63e4841ba7462b54a10fd9770fafdfbdd062d) as a LaunchAgent that runs the watchdog every 60 seconds under the BrainLayer env loader, logging to per-user BrainLayer logs.
> - Extends [install.sh](https://github.com/EtanHey/brainlayer/pull/600/files#diff-c2e9ec925e37d2fc11ea258b25bb7f65308a6755174d1b556a6c077d798bf756) with an `install_throughput_watchdog` function and wires it into the `all` and `remove` targets.
> - Risk: the watchdog uses a file lock to prevent concurrent runs, but a stale lock file could skip a recovery cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44d4178.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated throughput watchdog that monitors realtime processing and detects stalled activity.
  * Automatically attempts recovery when processing remains stalled, with configurable notifications and logging.
  * Added installation and removal support for the new background service.
  * The watchdog runs automatically at regular intervals and supports status output in JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->