### PR TITLE
chore: release BrainLayer and BrainBar 1.4.4

### DIFF
--- a/.github/workflows/brainbar-release.yml
+++ b/.github/workflows/brainbar-release.yml
@@ -18,6 +18,26 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Verify release tag matches package version
+        run: |
+          set -euo pipefail
+          package_version="$({
+            awk '
+              $0 == "[project]" { in_project = 1; next }
+              in_project && /^\[/ { exit }
+              in_project && $1 == "version" && $2 == "=" {
+                gsub(/^"|"$/, "", $3)
+                print $3
+                exit
+              }
+            ' pyproject.toml
+          })"
+          expected_tag="v${package_version}"
+          if [[ -z "$package_version" || "$GITHUB_REF_NAME" != "$expected_tag" ]]; then
+            echo "::error title=Release tag mismatch::Tag '$GITHUB_REF_NAME' must equal '$expected_tag' from pyproject.toml"
+            exit 1
+          fi
+
       - name: Select Xcode (Swift 6)
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,25 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Verify release tag matches package version
+        run: |
+          set -euo pipefail
+          package_version="$({
+            awk '
+              $0 == "[project]" { in_project = 1; next }
+              in_project && /^\[/ { exit }
+              in_project && $1 == "version" && $2 == "=" {
+                gsub(/^"|"$/, "", $3)
+                print $3
+                exit
+              }
+            ' pyproject.toml
+          })"
+          expected_tag="v${package_version}"
+          if [[ -z "$package_version" || "$GITHUB_REF_NAME" != "$expected_tag" ]]; then
+            echo "::error title=Release tag mismatch::Tag '$GITHUB_REF_NAME' must equal '$expected_tag' from pyproject.toml"
+            exit 1
+          fi
       - run: pip install build
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.4.3</string>
+    <string>1.4.4</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.3</string>
+    <string>1.4.4</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.4.3"
+version = "1.4.4"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -26,9 +26,7 @@ def test_release_versions_stay_in_sync() -> None:
 
 def test_tag_publishers_fail_closed_on_metadata_mismatch() -> None:
     for workflow_name in ("publish.yml", "brainbar-release.yml"):
-        workflow = yaml.safe_load(
-            (REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
-        )
+        workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8"))
         steps = next(iter(workflow["jobs"].values()))["steps"]
         gate = next(
             (step for step in steps if step.get("name") == "Verify release tag matches package version"),

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -6,6 +6,8 @@ import json
 import tomllib
 from pathlib import Path
 
+import yaml
+
 from brainlayer import __version__
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -20,3 +22,21 @@ def test_release_versions_stay_in_sync() -> None:
     assert __version__ == package_version
     assert server_manifest["version"] == package_version
     assert server_manifest["packages"][0]["version"] == package_version
+
+
+def test_tag_publishers_fail_closed_on_metadata_mismatch() -> None:
+    for workflow_name in ("publish.yml", "brainbar-release.yml"):
+        workflow = yaml.safe_load(
+            (REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+        )
+        steps = next(iter(workflow["jobs"].values()))["steps"]
+        gate = next(
+            (step for step in steps if step.get("name") == "Verify release tag matches package version"),
+            None,
+        )
+
+        assert gate is not None, f"{workflow_name} must reject a tag that disagrees with pyproject.toml"
+        run = gate.get("run", "")
+        assert "GITHUB_REF_NAME" in run
+        assert "pyproject.toml" in run
+        assert "exit 1" in run


### PR DESCRIPTION
## Summary

- synchronize Python, MCP manifest, and BrainBar bundle metadata at 1.4.4
- carry merged PR #595 APSW-safe rewind archival live
- carry merged PR #596 denylist reversal live

## Verification

- `BRAINLAYER_VERSION_CHECK_GIT_TAG=v1.4.4 BRAINLAYER_VERSION_CHECK_TAP_ROOT=... bash scripts/brainlayer-version-check.sh`
- `pytest -q tests/test_release_version_sync.py tests/test_version_consistency.py tests/test_brainbar_release_workflow.py tests/test_brainbar_build_app_guards.py` (50 passed)
- `python3 -m json.tool server.json`
- `plutil -lint brain-bar/bundle/Info.plist`
- `git diff --check`

## Deployment gate

After merge, tag `v1.4.4`, publish PyPI and a locally notarized/stapled `BrainBar.zip`, update formula+cask in `homebrew-layers`, then upgrade the live watcher and verify sustained chunk flow with no watchdog recovery actions.

The full pre-push suite was intentionally interrupted after focused release gates passed because this is a wedge-critical deployment; remote CI remains authoritative.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bumps and CI guardrails only; no runtime product logic changes.
> 
> **Overview**
> **Release 1.4.4** — bumps synchronized version metadata from **1.4.3** to **1.4.4** in `pyproject.toml`, `brainlayer.__version__`, `server.json` (top-level and PyPI package entry), and BrainBar `Info.plist` bundle strings.
> 
> **Tag–version guard** — adds an early **Verify release tag matches package version** step to **Publish to PyPI** and **BrainBar Release** workflows. It parses `[project].version` from `pyproject.toml`, expects the push tag to be exactly `v{that version}`, and **fails the job** with a GitHub Actions error annotation on mismatch or missing version.
> 
> **Tests** — extends `test_release_version_sync.py` with a check that both tag workflows include that gate and reference `GITHUB_REF_NAME`, `pyproject.toml`, and `exit 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b199a9debf9ec93cf0f215e488d897d3ea09f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release BrainLayer and BrainBar 1.4.4 with tag-version mismatch guard in CI
> - Bumps version to 1.4.4 across `pyproject.toml`, `__version__`, `Info.plist`, and `server.json`.
> - Adds a 'Verify release tag matches package version' step to both [`publish.yml`](https://github.com/EtanHey/brainlayer/pull/601/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7) and [`brainbar-release.yml`](https://github.com/EtanHey/brainlayer/pull/601/files#diff-cc3fd81b9e6337be9b71aa39193a5f97835a9610bdd65c9c95436fd62decdc8b) that compares the git tag (`$GITHUB_REF_NAME`) against `v<version>` from `pyproject.toml` and fails early if they differ.
> - Adds a test in [`tests/test_release_version_sync.py`](https://github.com/EtanHey/brainlayer/pull/601/files#diff-5e66af398368d3d4dc61606a6fe72a134d441da71761dfe725e9405cd8ee8d75) that verifies both workflow files contain the guard step with the expected script content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b199a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and package version from 1.4.3 to 1.4.4 across all release metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->