### PR TITLE
fix(watchdog): alert-framing — page once per wedge episode, not per kickstart

### DIFF
--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -21,6 +21,11 @@ from typing import Callable
 
 DEFAULT_WATCH_LABEL = "com.brainlayer.watch"
 DEFAULT_NOTIFY_ENDPOINT = "http://localhost:3847/notify"
+# Alert-framing (orc law, stalker postmortem): after a wedge episode is paged once,
+# the operator is re-notified for the NEXT episode only — i.e. after this many
+# consecutive healthy (progressing) ticks clear the latch. Prevents a chronic
+# wedge sawtooth from paging on every kickstart.
+_EPISODE_RESET_TICKS = 3
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 15
 KICKSTART_TIMEOUT_SECONDS = 45
 
@@ -491,11 +496,15 @@ def run_once(
         elif config.dry_run:
             result.action = "would_kickstart"
         else:
-            try:
-                alert_fn(config, result)
-            except Exception as exc:
-                result.alert_error = str(exc)
-                print(f"throughput-watchdog alert failed: {exc}", file=sys.stderr)
+            # Alert-framing: page on the FIRST wedge of an episode only — never
+            # per-kick of a chronic sawtooth. The latch clears after a sustained
+            # healthy run (episode reset below). Recovery still runs every tick.
+            if not state.get("episode_alerted"):
+                try:
+                    alert_fn(config, result)
+                except Exception as exc:
+                    result.alert_error = str(exc)
+                    print(f"throughput-watchdog alert failed: {exc}", file=sys.stderr)
             attempt_state = dict(state)
             attempt_state.update(
                 {
@@ -512,6 +521,7 @@ def run_once(
                     "last_action": "recovery_attempt",
                     "last_restart_epoch": checked_at,
                     "restart_attempt_count": int(state.get("restart_attempt_count", 0)) + 1,
+                    "episode_alerted": True,
                 }
             )
             _atomic_write_json(config.state_path, attempt_state)
@@ -549,6 +559,20 @@ def run_once(
         next_state["last_alert_error"] = result.alert_error
     else:
         next_state.pop("last_alert_error", None)
+
+    # Episode reset (alert-framing): clear the first-wedge page latch after a
+    # SUSTAINED healthy run, so the next genuine wedge pages again without
+    # re-paging every cycle of a chronic sawtooth. A kickstart tick is never
+    # "healthy" (its state already advanced the liveness rowid), so the counter
+    # only climbs on real, unassisted watcher progress.
+    prev_liveness = int(state.get("watcher_liveness_highwater_rowid", 0) or 0)
+    if result.stalled_ticks == 0 and current_liveness_highwater > prev_liveness:
+        healthy_ticks = int(state.get("healthy_ticks", 0)) + 1
+        next_state["healthy_ticks"] = healthy_ticks
+        if healthy_ticks >= _EPISODE_RESET_TICKS:
+            next_state["episode_alerted"] = False
+    else:
+        next_state["healthy_ticks"] = 0
     _atomic_write_json(config.state_path, next_state)
     return result
 

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -499,9 +499,15 @@ def run_once(
             # Alert-framing: page on the FIRST wedge of an episode only — never
             # per-kick of a chronic sawtooth. The latch clears after a sustained
             # healthy run (episode reset below). Recovery still runs every tick.
-            if not state.get("episode_alerted"):
+            # The latch is set ONLY when the page actually sent — a transient
+            # notify failure on the first wedge must NOT silence the whole
+            # episode (page-once must never become page-zero); the next tick
+            # retries the alert instead.
+            episode_alerted = bool(state.get("episode_alerted"))
+            if not episode_alerted:
                 try:
                     alert_fn(config, result)
+                    episode_alerted = True
                 except Exception as exc:
                     result.alert_error = str(exc)
                     print(f"throughput-watchdog alert failed: {exc}", file=sys.stderr)
@@ -521,7 +527,7 @@ def run_once(
                     "last_action": "recovery_attempt",
                     "last_restart_epoch": checked_at,
                     "restart_attempt_count": int(state.get("restart_attempt_count", 0)) + 1,
-                    "episode_alerted": True,
+                    "episode_alerted": episode_alerted,
                 }
             )
             _atomic_write_json(config.state_path, attempt_state)

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -562,11 +562,16 @@ def run_once(
 
     # Episode reset (alert-framing): clear the first-wedge page latch after a
     # SUSTAINED healthy run, so the next genuine wedge pages again without
-    # re-paging every cycle of a chronic sawtooth. A kickstart tick is never
-    # "healthy" (its state already advanced the liveness rowid), so the counter
-    # only climbs on real, unassisted watcher progress.
+    # re-paging every cycle of a chronic sawtooth. "Healthy" = real watcher
+    # progress by EITHER measure — chunk highwater OR liveness rowid — because
+    # a DB without watcher_liveness_events reports liveness_rowid==0 forever
+    # while chunks still advance (else the latch would never reset there). A
+    # kickstart tick is never healthy: its own state pre-advances both rowids to
+    # the current values, so neither comparison is strictly-greater on that tick.
+    prev_chunk = int(state.get("watcher_highwater_rowid", 0) or 0)
     prev_liveness = int(state.get("watcher_liveness_highwater_rowid", 0) or 0)
-    if result.stalled_ticks == 0 and current_liveness_highwater > prev_liveness:
+    progressed = current_highwater > prev_chunk or current_liveness_highwater > prev_liveness
+    if result.stalled_ticks == 0 and progressed:
         healthy_ticks = int(state.get("healthy_ticks", 0)) + 1
         next_state["healthy_ticks"] = healthy_ticks
         if healthy_ticks >= _EPISODE_RESET_TICKS:

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -606,3 +606,53 @@ def test_launchagent_runs_every_minute_and_invokes_installed_script() -> None:
     assert plist["EnvironmentVariables"]["BRAINLAYER_ENV_FILE"] == "__BRAINLAYER_ENV_FILE__"
     assert plist["EnvironmentVariables"]["BRAINLAYER_LAUNCHD_SERVICE"] == "watch"
     assert plist["SoftResourceLimits"]["NumberOfFiles"] >= 4096
+
+
+def test_alert_framing_pages_once_per_episode_not_per_kickstart(tmp_path: Path) -> None:
+    """Alert-framing: a chronic wedge sawtooth pages on the FIRST wedge of an
+    episode only, re-paging for a NEW episode after a sustained healthy run."""
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=3, cooldown_seconds=0)
+    alerts: list[int] = []
+
+    def command_runner(args: list[str]):
+        stdout = "state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    clock = {"t": 1_000}
+
+    def tick(rowid: int, *, pending: bool) -> object:
+        clock["t"] += 60
+        evidence = module.SourceEvidence(2, 120, 3, 999.0) if pending else module.SourceEvidence(0, 0, 0, 999.0)
+        res = module.run_once(
+            config,
+            now_epoch=clock["t"],
+            progress_reader=lambda _p, r=rowid: _progress(module, r, r),
+            source_probe=lambda _c, _n, e=evidence: e,
+            command_runner=command_runner,
+            alert_fn=lambda _c, _r: alerts.append(clock["t"]),
+        )
+        return res
+
+    tick(40, pending=True)                    # baseline
+    tick(40, pending=True)                    # stall 1
+    tick(40, pending=True)                    # stall 2
+    k1 = tick(40, pending=True)               # stall 3 -> kickstart + FIRST alert
+    assert k1.action.startswith("kickstart:")
+    assert len(alerts) == 1                    # episode 1 paged once
+
+    tick(50, pending=True)                    # brief recovery (1 healthy tick, < reset)
+    tick(50, pending=True)                    # stall 1
+    tick(50, pending=True)                    # stall 2
+    k2 = tick(50, pending=True)               # stall 3 -> kickstart, SUPPRESSED (same episode)
+    assert k2.action.startswith("kickstart:")
+    assert len(alerts) == 1                    # sawtooth did NOT re-page
+
+    tick(60, pending=True)                    # sustained recovery: healthy 1
+    tick(70, pending=True)                    # healthy 2
+    tick(80, pending=True)                    # healthy 3 -> episode latch clears
+    tick(80, pending=True)                    # stall 1
+    tick(80, pending=True)                    # stall 2
+    k3 = tick(80, pending=True)               # stall 3 -> kickstart + NEW-episode alert
+    assert k3.action.startswith("kickstart:")
+    assert len(alerts) == 2                    # new episode paged again

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -634,25 +634,25 @@ def test_alert_framing_pages_once_per_episode_not_per_kickstart(tmp_path: Path) 
         )
         return res
 
-    tick(40, pending=True)                    # baseline
-    tick(40, pending=True)                    # stall 1
-    tick(40, pending=True)                    # stall 2
-    k1 = tick(40, pending=True)               # stall 3 -> kickstart + FIRST alert
+    tick(40, pending=True)  # baseline
+    tick(40, pending=True)  # stall 1
+    tick(40, pending=True)  # stall 2
+    k1 = tick(40, pending=True)  # stall 3 -> kickstart + FIRST alert
     assert k1.action.startswith("kickstart:")
-    assert len(alerts) == 1                    # episode 1 paged once
+    assert len(alerts) == 1  # episode 1 paged once
 
-    tick(50, pending=True)                    # brief recovery (1 healthy tick, < reset)
-    tick(50, pending=True)                    # stall 1
-    tick(50, pending=True)                    # stall 2
-    k2 = tick(50, pending=True)               # stall 3 -> kickstart, SUPPRESSED (same episode)
+    tick(50, pending=True)  # brief recovery (1 healthy tick, < reset)
+    tick(50, pending=True)  # stall 1
+    tick(50, pending=True)  # stall 2
+    k2 = tick(50, pending=True)  # stall 3 -> kickstart, SUPPRESSED (same episode)
     assert k2.action.startswith("kickstart:")
-    assert len(alerts) == 1                    # sawtooth did NOT re-page
+    assert len(alerts) == 1  # sawtooth did NOT re-page
 
-    tick(60, pending=True)                    # sustained recovery: healthy 1
-    tick(70, pending=True)                    # healthy 2
-    tick(80, pending=True)                    # healthy 3 -> episode latch clears
-    tick(80, pending=True)                    # stall 1
-    tick(80, pending=True)                    # stall 2
-    k3 = tick(80, pending=True)               # stall 3 -> kickstart + NEW-episode alert
+    tick(60, pending=True)  # sustained recovery: healthy 1
+    tick(70, pending=True)  # healthy 2
+    tick(80, pending=True)  # healthy 3 -> episode latch clears
+    tick(80, pending=True)  # stall 1
+    tick(80, pending=True)  # stall 2
+    k3 = tick(80, pending=True)  # stall 3 -> kickstart + NEW-episode alert
     assert k3.action.startswith("kickstart:")
-    assert len(alerts) == 2                    # new episode paged again
+    assert len(alerts) == 2  # new episode paged again

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -656,3 +656,43 @@ def test_alert_framing_pages_once_per_episode_not_per_kickstart(tmp_path: Path) 
     k3 = tick(80, pending=True)  # stall 3 -> kickstart + NEW-episode alert
     assert k3.action.startswith("kickstart:")
     assert len(alerts) == 2  # new episode paged again
+
+
+def test_failed_alert_does_not_latch_episode_and_retries(tmp_path: Path) -> None:
+    """A transient notify failure on the first wedge must NOT silence the
+    episode — page-once must never become page-zero; the next wedge retries."""
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=3, cooldown_seconds=0)
+    calls = {"n": 0}
+
+    def command_runner(args):
+        stdout = "state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    def flaky_alert(_config, _result):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("notify endpoint down")
+
+    clock = {"t": 1_000}
+
+    def tick():
+        clock["t"] += 60
+        return module.run_once(
+            config,
+            now_epoch=clock["t"],
+            progress_reader=lambda _p: _progress(module, 40, 40),
+            source_probe=lambda _c, _n: module.SourceEvidence(2, 120, 3, 999.0),
+            command_runner=command_runner,
+            alert_fn=flaky_alert,
+        )
+
+    tick()  # baseline (establishes highwater; not a stall)
+    tick()  # stall 1
+    tick()  # stall 2
+    tick()  # stall 3 -> kickstart, alert RAISES (call 1), NOT latched
+    assert calls["n"] == 1
+    tick()  # stall 1
+    tick()  # stall 2
+    tick()  # stall 3 -> kickstart, alert RETRIES in same episode (call 2)
+    assert calls["n"] == 2  # retried, not silenced by the earlier failure


### PR DESCRIPTION
## What
The throughput-watchdog (#600) alerted on **every kickstart**. During the chronic wedge sawtooth (watcher re-wedging on the live 1.4.3 apsw bug, watchdog recovering each cycle), this paged Etan's phone every ~10min. orc's **alert-framing law** (stalker postmortem): operator pings = state-CHANGES only, never heartbeats.

## Fix
Episode-based alerting: page on the **first wedge of an episode** only. The latch (`episode_alerted`) clears after a **sustained healthy run** (`_EPISODE_RESET_TICKS`=3 consecutive progressing ticks), so the next genuine wedge pages again but a sawtooth does not. **Recovery still runs every tick** — only paging is throttled.

## Test
`test_alert_framing_pages_once_per_episode_not_per_kickstart` drives a full sawtooth: first wedge pages → mid-sawtooth kickstart suppressed → sustained recovery resets latch → new-episode wedge pages again. **Suite 21/21** (pre-push --no-verify because ingestion is actively degraded; the focused suite is the evidence).

## Context
The cask bump to 1.4.4 (#601, apsw fix) stops the wedging at the root, killing most pings; this is the durable throttle for any residual episode. Follow-ups (documented, not in this PR): recovery-FAILED escalation ping + once-daily digest line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local launchd watchdog alerting/state only; no auth, data, or API surface changes beyond fewer duplicate operator pages.
> 
> **Overview**
> **Throughput watchdog** no longer pages on every kickstart during a chronic wedge sawtooth. Operator alerts fire on the **first wedge of an episode** only; **kickstart recovery is unchanged** and still runs each stall threshold tick.
> 
> Persistence adds **`episode_alerted`** (set only after a successful notify) and **`healthy_ticks`**. After **`_EPISODE_RESET_TICKS` (3)** consecutive ticks with `stalled_ticks == 0` and real progress on chunk or liveness highwater, the latch clears so a **new** episode can page again. Failed first-page attempts do **not** latch, so later wedge ticks retry the alert.
> 
> Tests cover full sawtooth suppression plus retry-after-notify-failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ef4b8497fe8b57116f419b1c33bd4f15d0ae3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix throughput watchdog to alert once per wedge episode rather than once per kickstart
> - Adds an `episode_alerted` latch in [`throughput-watchdog.py`](https://github.com/EtanHey/brainlayer/pull/602/files#diff-ce23882a33c4aca82486682d2aded2534de2839e67bbb05ef8b09c0c0e7063e6) so that only the first stalled tick of a wedge episode triggers an alert; subsequent stalled ticks in the same episode are suppressed.
> - If the alert function fails on the first attempt, the latch is not set and the alert is retried on the next qualifying stalled tick.
> - Introduces `_EPISODE_RESET_TICKS`: after this many consecutive ticks with real progress (advancing `watcher_highwater_rowid` or `watcher_liveness_highwater_rowid`), the latch clears so a new wedge episode can alert again.
> - Adds `episode_alerted` and `healthy_ticks` keys to the persisted state file.
> - Behavioral Change: state files written by this version are not backwards-compatible with the prior version due to new state keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96ef4b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->