### PR TITLE
chore: release BrainLayer 1.4.5

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.4.4</string>
+    <string>1.4.5</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.4</string>
+    <string>1.4.5</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.4.4"
+version = "1.4.5"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.4.4"
+__version__ = "1.4.5"


### PR DESCRIPTION
## Summary
- bump BrainLayer Python, MCP manifest, and BrainBar bundle metadata from 1.4.4 to 1.4.5
- cut from current master merge `80239838`, which contains PR #603 exact head `e9a8c36`
- keep the release diff metadata-only: six synchronized version-string substitutions across four files

## Why
Ship the merged DB-lock cure from #603:
- MECH-1: rewind archival failure retries without wedging ingest
- MECH-2 source is present on master for watchdog reinstall after this PR merges

## Verification
- `uv run pytest -q tests/test_release_version_sync.py` — 2 passed
- `uv build` — built `brainlayer-1.4.5.tar.gz` and `brainlayer-1.4.5-py3-none-any.whl`
- full local gate — 3,595 passed, 9 skipped, 61 deselected, 1 xfailed
- MCP registration — 3 passed
- isolated eval/hook routing — 40 passed
- Bun — 1 passed
- FTS determinism — passed
- Ruff check/format — passed; 417 files formatted
- local CodeRabbit — 0 findings across all four changed files

## Post-merge pipeline
1. tag `v1.4.5`
2. verify PyPI publication and notarized/stapled `BrainBar.zip`
3. update Homebrew formula and cask SHA
4. reinstall throughput-watchdog from master
5. brew upgrade and bounce watcher/drain
6. collect process, launchctl, build-stamp, and live-ingestion receipts

layerSpec owns merge and final disk-truth acceptance.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string-only changes with no runtime or security behavior modified in the diff.
> 
> **Overview**
> **Release 1.4.5** — metadata-only version bump from **1.4.4** to **1.4.5** with no application logic changes in this diff.
> 
> The same version string is updated in **`pyproject.toml`**, **`src/brainlayer/__init__.py`** (`__version__`), **`server.json`** (top-level and PyPI package entry), and **`brain-bar/bundle/Info.plist`** (`CFBundleVersion` / `CFBundleShortVersionString`) so PyPI, MCP registry, and BrainBar stay aligned for the release cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e117b8b677c0a85a32c8bf449a456d8f8806b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release BrainLayer version 1.4.5
> Bumps the version string from 1.4.4 to 1.4.5 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/604/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/604/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/604/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [__init__.py](https://github.com/EtanHey/brainlayer/pull/604/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45e117b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->