### PR TITLE
feat(brainbar): ship truth-first operator surfaces

### DIFF
--- a/brain-bar/Package.swift
+++ b/brain-bar/Package.swift
@@ -50,7 +50,10 @@ let package = Package(
                 "BrainBarLifecycle",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
-            path: "Tests/BrainBarTests"
+            path: "Tests/BrainBarTests",
+            exclude: [
+                "RENDER_VERIFICATION.md",
+            ]
         ),
         .testTarget(
             name: "BrainBarDaemonTests",

--- a/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarAppSupport.swift
@@ -22,11 +22,13 @@ enum BrainBarAppSupport {
         dbPath: String,
         targetPID: pid_t,
         brainBusEvents: BrainBusEventSource? = BrainBusClient(),
+        watcherProcessProbe: any WatcherProcessProbing = LaunchctlWatcherProcessProbe(),
         databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) -> StatsCollector {
         StatsCollector(
             dbPath: dbPath,
             daemonMonitor: DaemonHealthMonitor(targetPID: targetPID),
+            watcherProcessProbe: watcherProcessProbe,
             brainBusEvents: brainBusEvents,
             databaseOpenConfiguration: databaseOpenConfiguration
         )

--- a/brain-bar/Sources/BrainBar/BrainBarCommandBar.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarCommandBar.swift
@@ -46,6 +46,7 @@ private struct BrainBarCommandBarReady: View {
         )
         .animation(.easeInOut(duration: 0.14), value: viewModel.mode)
         .animation(.easeInOut(duration: 0.18), value: viewModel.feedback)
+        .accessibilityIdentifier("brainbar.command")
     }
 
     private var borderColor: Color {
@@ -82,6 +83,7 @@ private struct BrainBarCommandBarPlaceholder: View {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .strokeBorder(Color.brainBarWhite.opacity(0.06), lineWidth: 1)
         )
+        .accessibilityIdentifier("brainbar.command.loading")
     }
 }
 
@@ -92,10 +94,18 @@ private struct ModePillPair: View {
 
     var body: some View {
         HStack(spacing: 2) {
-            ModePill(title: "Capture", isActive: viewModel.mode == .capture) {
+            ModePill(
+                title: "Capture",
+                accessibilityIdentifier: "brainbar.command.mode.capture",
+                isActive: viewModel.mode == .capture
+            ) {
                 viewModel.setMode(.capture)
             }
-            ModePill(title: "Search", isActive: viewModel.mode == .search) {
+            ModePill(
+                title: "Search",
+                accessibilityIdentifier: "brainbar.command.mode.search",
+                isActive: viewModel.mode == .search
+            ) {
                 viewModel.setMode(.search)
             }
         }
@@ -111,6 +121,7 @@ private struct ModePillPair: View {
 
 private struct ModePill: View {
     let title: String
+    let accessibilityIdentifier: String
     let isActive: Bool
     let action: () -> Void
 
@@ -127,7 +138,8 @@ private struct ModePill: View {
                 .contentShape(Capsule())
         }
         .buttonStyle(.plain)
-        .focusable(false)
+        .accessibilityIdentifier(accessibilityIdentifier)
+        .focusable()
     }
 }
 
@@ -226,6 +238,7 @@ private struct CommandBarInput: NSViewRepresentable {
         field.onCommandReturn = { [viewModel] in
             viewModel.handleInputReturn(modifiers: [.command])
         }
+        field.setAccessibilityIdentifier("brainbar.command.input")
         return field
     }
 
@@ -285,8 +298,8 @@ private struct CommandBarTrailingHint: View {
 
     private var keyboardHint: String {
         switch viewModel.mode {
-        case .capture: return "⏎ Store · ⌘⏎ Store · ⇥ Search"
-        case .search: return "⏎ Copy · ⌘⏎ Capture · ⇥ Capture"
+        case .capture: return "⏎ Store · ⇥ Search"
+        case .search: return "⏎ Copy · ⌘⏎ Capture"
         }
     }
 }
@@ -363,6 +376,7 @@ private struct BrainBarCommandBarResultsOverlayReady: View {
                 .strokeBorder(Color.brainBarWhite.opacity(0.08), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.28), radius: 18, y: 8)
+        .accessibilityIdentifier("brainbar.command.results")
     }
 
     @ViewBuilder
@@ -477,6 +491,8 @@ private struct BrainBarCommandBarResultRow: View {
             Text(row.metadata)
         }
         .animation(.easeInOut(duration: 0.14), value: isCopied)
+        .accessibilityIdentifier("brainbar.command.result.\(row.id)")
+        .focusable()
     }
 
     private var rowBackground: Color {

--- a/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
@@ -69,7 +69,8 @@ final class BrainBarSettingsViewModel: ObservableObject {
         }
         updateConfig { nextConfig in
             nextConfig.enrichmentProvider = provider
-            if provider == .gemini, nextConfig.enrichmentBackend.isEmpty {
+            if provider == .gemini,
+               nextConfig.enrichmentBackend.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 nextConfig.enrichmentBackend = "gemini"
             }
         }
@@ -137,7 +138,7 @@ final class BrainBarSettingsViewModel: ObservableObject {
         let previousConfig = config
         var nextConfig = config
         apply(&nextConfig)
-        let validation = BrainLayerConfigValidator.validate(nextConfig)
+        let validation = BrainLayerConfigValidator.validate(nextConfig, previousConfig: previousConfig)
         guard validation == .passed else {
             if case let .failed(message) = validation {
                 recordValidationFailure(message)
@@ -146,8 +147,10 @@ final class BrainBarSettingsViewModel: ObservableObject {
         }
 
         let restartRequirements = Self.restartRequirements(from: previousConfig, to: nextConfig)
+        var fileUpdated = false
         do {
             try store.save(nextConfig)
+            fileUpdated = true
             let persistedConfig = try store.loadDocument().config
             guard persistedConfig.persistedValuesEqual(to: nextConfig) else {
                 recordPostWriteValidationFailure(
@@ -181,10 +184,14 @@ final class BrainBarSettingsViewModel: ObservableObject {
             lastSaveReceipt = BrainLayerSettingsSaveReceipt(
                 configURL: store.configURL,
                 savedAt: now(),
-                fileUpdated: false,
-                validation: .passed,
-                servicesRequiringRestart: [],
-                activeRuntimeState: .unknown("Configuration file was not updated.")
+                fileUpdated: fileUpdated,
+                validation: fileUpdated ? .failed("Saved configuration could not be reloaded.") : .passed,
+                servicesRequiringRestart: fileUpdated ? restartRequirements : [],
+                activeRuntimeState: .unknown(
+                    fileUpdated
+                        ? "Configuration file changed, but reload failed."
+                        : "Configuration file was not updated."
+                )
             )
             return false
         }

--- a/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarSettingsView.swift
@@ -9,18 +9,28 @@ final class BrainBarSettingsViewModel: ObservableObject {
     @Published var backendDraft: String
     @Published var errorMessage: String?
     @Published var isRefreshingLaunchdStatus = false
+    @Published private(set) var activeRuntimeObservation: BrainLayerActiveRuntimeObservation
+    @Published private(set) var lastSaveReceipt: BrainLayerSettingsSaveReceipt?
 
     private let store: BrainLayerConfigStore
     private let launchdStatusProvider: any BrainLayerLaunchdStatusSampling
+    private let runtimeStatusProvider: any BrainLayerActiveRuntimeSampling
+    private let now: @Sendable () -> Date
+    private var previousConfigForLastSaveReceipt: BrainLayerConfig?
 
     init(
         store: BrainLayerConfigStore = BrainLayerConfigStore(),
         launchdStatusProvider: any BrainLayerLaunchdStatusSampling = BrainLayerLaunchdStatusProvider(),
+        runtimeStatusProvider: any BrainLayerActiveRuntimeSampling = UnknownBrainLayerActiveRuntimeProvider(),
         initialLaunchdStates: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] = [:],
-        refreshStatusOnLoad: Bool = true
+        refreshStatusOnLoad: Bool = true,
+        now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.store = store
         self.launchdStatusProvider = launchdStatusProvider
+        self.runtimeStatusProvider = runtimeStatusProvider
+        self.now = now
+        activeRuntimeObservation = runtimeStatusProvider.sample()
         do {
             let document = try store.loadDocument()
             config = document.config
@@ -51,6 +61,12 @@ final class BrainBarSettingsViewModel: ObservableObject {
     }
 
     func setEnrichmentProvider(_ provider: BrainLayerEnrichmentProvider) {
+        guard provider.isWiredToday else {
+            recordValidationFailure(
+                "\(provider.title) cannot be activated because its runtime integration is unavailable."
+            )
+            return
+        }
         updateConfig { nextConfig in
             nextConfig.enrichmentProvider = provider
             if provider == .gemini, nextConfig.enrichmentBackend.isEmpty {
@@ -61,7 +77,7 @@ final class BrainBarSettingsViewModel: ObservableObject {
 
     func commitBackendDraft() {
         let backend = backendDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !backend.isEmpty, backend != config.enrichmentBackend else {
+        guard backend != config.enrichmentBackend else {
             backendDraft = config.enrichmentBackend
             return
         }
@@ -104,6 +120,8 @@ final class BrainBarSettingsViewModel: ObservableObject {
                 provider.sample()
             }.value
             applyLaunchdStates(states)
+            activeRuntimeObservation = runtimeStatusProvider.sample()
+            refreshLastSaveReceiptActiveState()
             isRefreshingLaunchdStatus = false
         }
     }
@@ -116,17 +134,176 @@ final class BrainBarSettingsViewModel: ObservableObject {
 
     @discardableResult
     private func updateConfig(_ apply: (inout BrainLayerConfig) -> Void) -> Bool {
+        let previousConfig = config
         var nextConfig = config
         apply(&nextConfig)
+        let validation = BrainLayerConfigValidator.validate(nextConfig)
+        guard validation == .passed else {
+            if case let .failed(message) = validation {
+                recordValidationFailure(message)
+            }
+            return false
+        }
+
+        let restartRequirements = Self.restartRequirements(from: previousConfig, to: nextConfig)
         do {
             try store.save(nextConfig)
+            let persistedConfig = try store.loadDocument().config
+            guard persistedConfig.persistedValuesEqual(to: nextConfig) else {
+                recordPostWriteValidationFailure(
+                    "Saved configuration did not validate on reload.",
+                    previousConfig: previousConfig,
+                    persistedConfig: persistedConfig
+                )
+                return false
+            }
+            activeRuntimeObservation = runtimeStatusProvider.sample()
             config = nextConfig
             backendDraft = nextConfig.enrichmentBackend
             errorMessage = nil
+            previousConfigForLastSaveReceipt = previousConfig
+            lastSaveReceipt = BrainLayerSettingsSaveReceipt(
+                configURL: store.configURL,
+                savedAt: now(),
+                fileUpdated: true,
+                validation: .passed,
+                servicesRequiringRestart: restartRequirements,
+                activeRuntimeState: activeRuntimeState(
+                    from: previousConfig,
+                    configured: nextConfig,
+                    requirements: restartRequirements
+                )
+            )
             return true
         } catch {
             errorMessage = error.localizedDescription
+            previousConfigForLastSaveReceipt = nil
+            lastSaveReceipt = BrainLayerSettingsSaveReceipt(
+                configURL: store.configURL,
+                savedAt: now(),
+                fileUpdated: false,
+                validation: .passed,
+                servicesRequiringRestart: [],
+                activeRuntimeState: .unknown("Configuration file was not updated.")
+            )
             return false
+        }
+    }
+
+    private func recordValidationFailure(_ message: String) {
+        errorMessage = nil
+        previousConfigForLastSaveReceipt = nil
+        lastSaveReceipt = BrainLayerSettingsSaveReceipt(
+            configURL: store.configURL,
+            savedAt: now(),
+            fileUpdated: false,
+            validation: .failed(message),
+            servicesRequiringRestart: [],
+            activeRuntimeState: .unknown("Configuration was not written.")
+        )
+    }
+
+    private func recordPostWriteValidationFailure(
+        _ message: String,
+        previousConfig: BrainLayerConfig,
+        persistedConfig: BrainLayerConfig
+    ) {
+        config = persistedConfig
+        backendDraft = persistedConfig.enrichmentBackend
+        onePasswordReference = persistedConfig.googleAPIKey.opReference
+        errorMessage = nil
+        activeRuntimeObservation = runtimeStatusProvider.sample()
+        previousConfigForLastSaveReceipt = nil
+        lastSaveReceipt = BrainLayerSettingsSaveReceipt(
+            configURL: store.configURL,
+            savedAt: now(),
+            fileUpdated: true,
+            validation: .failed(message),
+            servicesRequiringRestart: Self.restartRequirements(from: previousConfig, to: persistedConfig),
+            activeRuntimeState: .unknown("Configuration file changed, but reload validation failed.")
+        )
+    }
+
+    private func refreshLastSaveReceiptActiveState() {
+        guard let receipt = lastSaveReceipt,
+              receipt.fileUpdated,
+              receipt.validation == .passed,
+              let previousConfig = previousConfigForLastSaveReceipt else {
+            return
+        }
+        lastSaveReceipt = BrainLayerSettingsSaveReceipt(
+            configURL: receipt.configURL,
+            savedAt: receipt.savedAt,
+            fileUpdated: receipt.fileUpdated,
+            validation: receipt.validation,
+            servicesRequiringRestart: receipt.servicesRequiringRestart,
+            activeRuntimeState: activeRuntimeState(
+                from: previousConfig,
+                configured: config,
+                requirements: receipt.servicesRequiringRestart
+            )
+        )
+    }
+
+    private static func restartRequirements(
+        from previous: BrainLayerConfig,
+        to configured: BrainLayerConfig
+    ) -> [BrainLayerSettingsService] {
+        var requirements: [BrainLayerSettingsService] = []
+        if previous.googleAPIKey != configured.googleAPIKey ||
+            previous.enrichmentEnabled != configured.enrichmentEnabled ||
+            previous.enrichmentMode != configured.enrichmentMode ||
+            previous.enrichmentProvider != configured.enrichmentProvider ||
+            previous.enrichmentBackend != configured.enrichmentBackend ||
+            previous.tuningValues != configured.tuningValues {
+            requirements.append(.enrichment)
+        }
+        if previous.systemEnabled != configured.systemEnabled {
+            requirements.append(.systemJobs)
+        }
+        for job in BrainLayerLaunchdJob.allCases
+        where previous.launchdJobs[job]?.enabled != configured.launchdJobs[job]?.enabled {
+            requirements.append(.launchdJob(job))
+        }
+        return requirements
+    }
+
+    private func activeRuntimeState(
+        from previous: BrainLayerConfig,
+        configured: BrainLayerConfig,
+        requirements: [BrainLayerSettingsService]
+    ) -> BrainLayerActiveRuntimeReceiptState {
+        if previous.googleAPIKey != configured.googleAPIKey || previous.tuningValues != configured.tuningValues {
+            return .unknown("Secret and tuning reload state is not observable.")
+        }
+
+        for requirement in requirements {
+            guard case let .launchdJob(job) = requirement else { continue }
+            let setting = configured.launchdJobs[job] ?? BrainLayerLaunchdJobSetting(
+                enabled: true,
+                loadState: .unknown
+            )
+            switch setting.loadState {
+            case .unknown:
+                return .unknown("\(job.title) active state is unknown.")
+            case let .probeError(reason):
+                return .unknown("\(job.title) probe failed: \(reason)")
+            case .running where setting.enabled, .loaded where setting.enabled:
+                continue
+            case .unloaded where !setting.enabled:
+                continue
+            default:
+                return .notObserved
+            }
+        }
+
+        let hasRuntimeConfigRequirement = requirements.contains(.enrichment) || requirements.contains(.systemJobs)
+        guard hasRuntimeConfigRequirement else { return .observed }
+        switch activeRuntimeObservation {
+        case let .observed(values):
+            return values.matches(configured) ? .observed : .notObserved
+        case let .unknown(reason):
+            return .unknown(reason)
         }
     }
 
@@ -164,6 +341,11 @@ struct BrainBarSettingsView: View {
                 }
                 BrainBarSettingsPanel(title: "Enrichment") {
                     enrichmentControls
+                }
+                if let receipt = viewModel.lastSaveReceipt {
+                    BrainBarSettingsPanel(title: "Last save receipt") {
+                        saveReceipt(receipt)
+                    }
                 }
                 BrainBarSettingsPanel(title: "Gemini API Key") {
                     secretControls
@@ -245,9 +427,23 @@ struct BrainBarSettingsView: View {
                 )
             ) {
                 ForEach(BrainLayerEnrichmentProvider.allCases) { provider in
-                    Text(provider.title)
+                    Text(provider.isWiredToday ? provider.title : "\(provider.title) — Unavailable")
                         .tag(provider)
+                        .disabled(!provider.isWiredToday)
                 }
+            }
+
+            if let reason = viewModel.config.enrichmentProvider.unavailableReason {
+                Label(
+                    "Configured provider unavailable: \(reason)",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color(nsColor: BrainBarStateTheme.error.theme.color))
+            } else {
+                Text("OpenAI and Anthropic are unavailable because this build has no runtime integration for them.")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.brainBarTextMuted)
             }
 
             HStack {
@@ -271,6 +467,42 @@ struct BrainBarSettingsView: View {
                         viewModel.backendDraft.trimmingCharacters(in: .whitespacesAndNewlines) == viewModel.config.enrichmentBackend
                 )
             }
+
+            Divider()
+                .overlay(Color.brainBarBorderSoft)
+
+            settingsTruthRow(
+                label: "Configured",
+                value: BrainLayerActiveRuntimeValues(config: viewModel.config).summary
+            )
+            settingsTruthRow(label: "Active", value: viewModel.activeRuntimeObservation.summary)
+        }
+    }
+
+    private func saveReceipt(_ receipt: BrainLayerSettingsSaveReceipt) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            settingsTruthRow(label: "File", value: receipt.fileUpdated ? "Updated" : "Not updated")
+            settingsTruthRow(label: "Validation", value: receipt.validation.title)
+            settingsTruthRow(
+                label: "Restart",
+                value: receipt.servicesRequiringRestart.isEmpty
+                    ? "Not required"
+                    : receipt.servicesRequiringRestart.map(\.title).joined(separator: ", ")
+            )
+            settingsTruthRow(label: "Active runtime", value: receipt.activeRuntimeState.title)
+        }
+    }
+
+    private func settingsTruthRow(label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.brainBarTextMuted)
+                .frame(width: 110, alignment: .leading)
+            Text(value)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color.brainBarTextSecondary)
+                .textSelection(.enabled)
         }
     }
 
@@ -346,6 +578,7 @@ private struct BrainBarSettingsPanel<Content: View>: View {
                 content
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
         .background(Color.brainBarGlassPrimary)
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
@@ -378,6 +611,9 @@ private struct BrainBarJobToggle: View {
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(Color.brainBarTextMuted)
             }
+            Text("Configured: \(setting.enabled ? "Enabled" : "Disabled")")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(Color.brainBarTextMuted)
         }
         .padding(12)
         .background(Color.brainBarGlassSecondary)
@@ -394,6 +630,7 @@ private struct BrainBarJobToggle: View {
         case .loaded: BrainBarStateTheme.loading.theme.swiftUIColor
         case .unloaded: BrainBarStateTheme.idle.theme.swiftUIColor
         case .unknown: BrainBarStateTheme.degraded.theme.swiftUIColor
+        case .probeError: BrainBarStateTheme.degraded.theme.swiftUIColor
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -2133,6 +2133,8 @@ enum BrainBarPipelinePanelPreview {
                 replayDebtExpanded: replayDebtExpanded,
                 selectedTimeframe: selectedTimeframe
             )
+            .environment(\.colorScheme, .dark)
+            .transaction { $0.disablesAnimations = true }
         )
     }
 }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -209,8 +209,6 @@ private struct BrainBarWindowHeader: View {
                 brand
                 Spacer(minLength: 12)
                 BrainBarAppControlMenu()
-                hotkeyLabel
-                    .frame(maxWidth: 200, alignment: .trailing)
             }
             HStack(alignment: .center, spacing: 10) {
                 sectionPicker(maxWidth: .infinity)
@@ -231,14 +229,7 @@ private struct BrainBarWindowHeader: View {
             .font(.system(size: 18, weight: .semibold))
             .labelStyle(.titleAndIcon)
             .lineLimit(1)
-    }
-
-    private var hotkeyLabel: some View {
-        Text(hotkeyStatus)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-            .truncationMode(.tail)
+            .accessibilityIdentifier("brainbar.shell.brand")
     }
 
     @ViewBuilder
@@ -251,12 +242,16 @@ private struct BrainBarWindowHeader: View {
     private func sectionPicker(maxWidth: CGFloat) -> some View {
         Picker("Section", selection: $selectedTab) {
             ForEach(BrainBarTab.allCases) { tab in
-                Text(tab.title).tag(tab)
+                Text(tab.title)
+                    .tag(tab)
+                    .accessibilityIdentifier("brainbar.shell.tab.\(tab.title.lowercased())")
             }
         }
         .pickerStyle(.segmented)
         .frame(maxWidth: maxWidth)
         .labelsHidden()
+        .accessibilityIdentifier("brainbar.shell.tabs")
+        .focusable()
     }
 }
 
@@ -288,6 +283,9 @@ private struct BrainBarHeaderRefreshControls: View {
 }
 
 private struct BrainBarAppControlMenu: View {
+    @State private var showRestartConfirmation = false
+    @State private var showQuitConfirmation = false
+
     var body: some View {
         Menu {
             Button("Settings...") {
@@ -295,10 +293,10 @@ private struct BrainBarAppControlMenu: View {
             }
             Divider()
             Button("Restart BrainBar") {
-                BrainBarProcessControl.restart()
+                showRestartConfirmation = true
             }
             Button("Quit BrainBar") {
-                BrainBarProcessControl.quit()
+                showQuitConfirmation = true
             }
         } label: {
             Image(systemName: "power")
@@ -307,6 +305,29 @@ private struct BrainBarAppControlMenu: View {
         .menuStyle(.borderlessButton)
         .controlSize(.small)
         .help("Restart or quit BrainBar")
+        .accessibilityIdentifier("brainbar.shell.power")
+        .confirmationDialog(
+            "Restart BrainBar?",
+            isPresented: $showRestartConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Restart BrainBar", role: .destructive) {
+                BrainBarProcessControl.restart()
+            }
+        } message: {
+            Text("The menu bar app will close and relaunch.")
+        }
+        .confirmationDialog(
+            "Quit BrainBar?",
+            isPresented: $showQuitConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Quit BrainBar", role: .destructive) {
+                BrainBarProcessControl.quit()
+            }
+        } message: {
+            Text("Quick capture and dashboard access will be unavailable until BrainBar is opened again.")
+        }
     }
 }
 
@@ -328,8 +349,8 @@ private struct BrainBarDashboardView: View {
     @State private var vectorSignalDetailExpanded = false
     @State private var vectorSignalRowFrame: CGRect = .zero
     @State private var vectorSignalRootFrame: CGRect = .zero
-    /// ONE shared timeframe for ALL pipeline graphs (all commits / agent /
-    /// watcher / enrichment). Selecting 3h/24h re-fetches REAL DB history for
+    /// ONE shared timeframe for all pipeline graphs (chunk rows / agent-origin /
+    /// watcher-ingested / successful enrichment). Selecting 3h/24h re-fetches real DB history for
     /// that window via the collector and feeds every chart at once — no
     /// per-card expand.
     @State private var selectedTimeframe: PipelineTimeframe = .live
@@ -380,17 +401,23 @@ private struct BrainBarDashboardView: View {
             ZStack(alignment: .topLeading) {
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(alignment: .leading, spacing: layout.sectionSpacing) {
-                        overviewCard(layout: layout)
-                        freshnessLine
-                        pipelinePanel(layout: layout)
-                        flowPanel(layout: layout)
-                        diagnostics(layout: layout)
+                        freshnessBanner
+                        Group {
+                            overviewCard(layout: layout)
+                            pipelinePanel(layout: layout)
+                            flowPanel(layout: layout)
+                            diagnostics(layout: layout)
+                        }
+                        .opacity(lastGoodContentOpacity)
                     }
                     .padding(layout.outerPadding)
                     .frame(maxWidth: layout.maxContentWidth, alignment: .topLeading)
                     .frame(maxWidth: .infinity, alignment: .top)
+                    .focusSection()
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .accessibilityIdentifier("brainbar.dashboard.scroll")
+                .focusable()
             }
             .coordinateSpace(name: BrainBarVectorSignalCoordinateSpace.root)
             .onPreferenceChange(BrainBarVectorSignalRootFrameKey.self) { frame in
@@ -476,15 +503,10 @@ private struct BrainBarDashboardView: View {
 
     @ViewBuilder
     private func overviewCard(layout: BrainBarDashboardLayout) -> some View {
-        // RESPONSIVE HERO: when wide, the stats column is tall while the narrative
-        // is short — so the live-agents row rides at the BOTTOM of the narrative
-        // column (a Spacer pushes it down) to fill that gap instead of leaving a
-        // big empty band. When narrow, everything stacks vertically.
         ViewThatFits(in: .horizontal) {
             HStack(alignment: .top, spacing: layout.gridSpacing) {
-                VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 10) {
                     overviewNarrative(layout: layout)
-                    Spacer(minLength: layout.gridSpacing)
                     heroLiveAgentsRow(layout: layout)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -514,30 +536,25 @@ private struct BrainBarDashboardView: View {
     private func heroLiveAgentsRow(layout: BrainBarDashboardLayout) -> some View {
         let activity = collector.agentActivity
         let anyLive = activity.totalActiveAgents > 0
-        VStack(alignment: .leading, spacing: 8) {
-            Divider()
-                .overlay(Color.brainBarBorderSoft)
-            HStack(alignment: .center, spacing: 12) {
-                HStack(spacing: 7) {
-                    Circle()
-                        .fill(anyLive
-                            ? BrainBarStateTheme.active.theme.swiftUIColor
-                            : Color.brainBarTextSecondary.opacity(0.45))
-                        .frame(width: 8, height: 8)
-                    Text("Live agents")
-                        .font(.system(size: 13, weight: .semibold))
-                    Text(activity.summaryText)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 8)
-                WrappingPillLayout(spacing: 8, lineSpacing: 8) {
-                    ForEach(activity.presences.filter(\.isActive), id: \.family) { presence in
-                        BrainBarAgentPresencePill(presence: presence)
-                    }
+        HStack(alignment: .center, spacing: 10) {
+            Circle()
+                .fill(anyLive
+                    ? BrainBarStateTheme.active.theme.swiftUIColor
+                    : Color.brainBarTextSecondary.opacity(0.45))
+                .frame(width: 8, height: 8)
+            Text("Live agents")
+                .font(.system(size: 12, weight: .semibold))
+            Text(activity.summaryText)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            WrappingPillLayout(spacing: 6, lineSpacing: 6) {
+                ForEach(activity.presences.filter(\.isActive), id: \.family) { presence in
+                    BrainBarAgentPresencePill(presence: presence)
                 }
             }
         }
+        .padding(.top, 4)
     }
 
     private func overviewNarrative(layout: BrainBarDashboardLayout) -> some View {
@@ -564,40 +581,24 @@ private struct BrainBarDashboardView: View {
         }
     }
 
-    private var freshnessLine: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "clock")
-                .font(.system(size: 11, weight: .semibold))
-            Text(collector.snapshotFreshnessState.label)
-                .font(.system(size: 11, weight: .bold))
-            Text("Data fetched at: \(dataFetchedText)")
-                .font(.system(size: 11, weight: .semibold))
-                .monospacedDigit()
-            if let heartbeatText {
-                Text("Heartbeat: \(heartbeatText)")
-                    .font(.system(size: 11, weight: .medium))
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-                if collector.isHeartbeatAheadOfStats {
-                    Text("updating...")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                }
-            }
-            if let lastFetchError = collector.lastFetchError {
-                Text("Fetch error: \(lastFetchError)")
-                    .font(.system(size: 11, weight: .semibold))
-                    .lineLimit(1)
-            }
-            Spacer(minLength: 0)
-        }
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 4)
+    private var freshnessBanner: some View {
+        BrainBarSnapshotFreshnessBanner(
+            state: collector.snapshotFreshnessState,
+            lastGoodFetchedAt: collector.lastDataFetchedAt,
+            heartbeatText: heartbeatText,
+            isHeartbeatAheadOfStats: collector.isHeartbeatAheadOfStats
+        )
     }
 
-    private var dataFetchedText: String {
-        guard let lastDataFetchedAt = collector.lastDataFetchedAt else { return "not yet" }
-        return DashboardMetricFormatter.absoluteTimeString(lastDataFetchedAt)
+    private var lastGoodContentOpacity: Double {
+        switch collector.snapshotFreshnessState {
+        case .stale, .error:
+            return 0.72
+        case .loading:
+            return 0.55
+        case .live:
+            return 1
+        }
     }
 
     private var heartbeatText: String? {
@@ -610,22 +611,31 @@ private struct BrainBarDashboardView: View {
         Group {
             BrainBarHeroBadge(text: flowSummary.windowLabel)
             BrainBarHeroBadge(text: flowSummary.queue.status.label)
-            BrainBarHeroBadge(text: "Writes \(flowSummary.ingress.lastEventText)")
-            BrainBarHeroBadge(text: "Enrichments \(flowSummary.enrichment.lastEventText)")
+            BrainBarHeroBadge(text: "Watcher \(flowSummary.watcherFlowState.label)")
+            if collector.stats.replayDebtBreakdown.deduplicatedTotal > 0 {
+                BrainBarHeroBadge(text: replayDebtBadgeText)
+            }
         }
+    }
+
+    private var replayDebtBadgeText: String {
+        let debt = collector.stats.replayDebtBreakdown
+        let partialSuffix = debt.isPartial ? " · PARTIAL" : ""
+        return "Replay debt \(debt.deduplicatedTotal)\(partialSuffix)"
     }
 
     private func overviewMetaRow(layout: BrainBarDashboardLayout) -> some View {
         let columns = Array(
-            repeating: GridItem(.flexible(minimum: 150), spacing: layout.gridSpacing, alignment: .leading),
-            count: 2
+            repeating: GridItem(.flexible(minimum: 92), spacing: layout.gridSpacing, alignment: .leading),
+            count: 3
         )
 
         return LazyVGrid(columns: columns, spacing: layout.gridSpacing) {
-            BrainBarOverviewStat(label: "Chunks", value: "\(collector.stats.chunkCount)", isHero: true)
-            BrainBarOverviewStat(label: "Enriched", value: "\(collector.stats.enrichedChunkCount)", isHero: false)
-            BrainBarOverviewStat(label: "Backlog", value: "\(collector.stats.pendingEnrichmentCount)", isHero: false)
-            BrainBarOverviewStat(label: "Coverage", value: "\(Int(collector.stats.enrichmentPercent.rounded()))%", isHero: false)
+            BrainBarOverviewStat(label: "Chunk rows", value: "\(collector.stats.chunkCount)", isHero: true)
+            BrainBarOverviewStat(label: "Enriched successfully", value: "\(collector.stats.enrichedChunkCount)", isHero: false)
+            BrainBarOverviewStat(label: "Pending", value: "\(collector.stats.pendingEnrichmentCount)", isHero: false)
+            BrainBarOverviewStat(label: "Failed", value: "\(collector.stats.failedEnrichmentCount)", isHero: false)
+            BrainBarOverviewStat(label: "Skipped", value: "\(collector.stats.skippedEnrichmentCount)", isHero: false)
         }
     }
 
@@ -641,7 +651,7 @@ private struct BrainBarDashboardView: View {
                 HStack(alignment: .center, spacing: 12) {
                     BrainBarSectionLabel(
                         "Ingest",
-                        caption: "What is landing — all committed chunks, agent MCP stores, and the JSONL watcher — plus retrieval signal coverage."
+                        caption: "Three independently scaled ingest series. Source-time charts count chunk rows; the watcher chart counts unique chunk IDs by ingest time."
                     )
                     Spacer(minLength: 8)
                     sharedTimeframeSelector
@@ -650,7 +660,7 @@ private struct BrainBarDashboardView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     BrainBarSectionLabel(
                         "Ingest",
-                        caption: "What is landing — all committed chunks, agent MCP stores, and the JSONL watcher — plus retrieval signal coverage."
+                        caption: "Three independently scaled ingest series. Source-time charts count chunk rows; the watcher chart counts unique chunk IDs by ingest time."
                     )
                     sharedTimeframeSelector
                 }
@@ -796,8 +806,10 @@ private struct BrainBarDashboardView: View {
     private func queueRail(layout: BrainBarDashboardLayout) -> some View {
         BrainBarQueueRail(
             summary: flowSummary.queue,
+            replayDebtBreakdown: collector.stats.replayDebtBreakdown,
+            censusText: collector.lastDataFetchedAt.map(DashboardMetricFormatter.absoluteTimeString) ?? "not yet",
             coverageText: "\(Int(collector.stats.enrichmentPercent.rounded()))% enriched",
-            watcherText: collector.stats.watcherHealth?.summaryText ?? "unknown",
+            watcherText: collector.stats.watcherHealth?.updatedAt.map(DashboardMetricFormatter.absoluteTimeString) ?? "unavailable",
             compact: layout.compactCards
         )
     }
@@ -896,6 +908,8 @@ private struct BrainBarDashboardView: View {
                         .truncationMode(.tail)
                 }
             }
+            .accessibilityIdentifier("brainbar.dashboard.runtime-disclosure")
+            .focusable()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
@@ -919,6 +933,143 @@ private struct BrainBarDashboardView: View {
             lastEventAt: daemon.lastSeenAt,
             activityWindowMinutes: collector.stats.activityWindowMinutes
         )
+    }
+}
+
+private struct BrainBarSnapshotFreshnessBanner: View {
+    let state: SnapshotFreshnessState
+    let lastGoodFetchedAt: Date?
+    let heartbeatText: String?
+    let isHeartbeatAheadOfStats: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 10) {
+                    stateLabel
+                    Text(dataAgeText)
+                    Text(lastGoodText)
+                    Spacer(minLength: 8)
+                    heartbeatLabel
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 10) {
+                        stateLabel
+                        Text(dataAgeText)
+                        Spacer(minLength: 0)
+                    }
+                    Text(lastGoodText)
+                    heartbeatLabel
+                }
+            }
+
+            if let errorMessage {
+                Text("Current error: \(errorMessage)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(stateColor)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .font(.system(size: 11, weight: .semibold))
+        .monospacedDigit()
+        .foregroundStyle(Color.brainBarTextSecondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                .fill(stateColor.opacity(isAttentionState ? 0.14 : 0.07))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
+                .stroke(stateColor.opacity(isAttentionState ? 0.48 : 0.22), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilitySummary)
+        .accessibilityIdentifier("brainbar.dashboard.freshness")
+        .focusable()
+        .help(accessibilitySummary)
+    }
+
+    private var stateLabel: some View {
+        Label(state.label, systemImage: stateSymbol)
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(stateColor)
+    }
+
+    @ViewBuilder
+    private var heartbeatLabel: some View {
+        if let heartbeatText {
+            Text("Collector heartbeat: \(heartbeatText)\(isHeartbeatAheadOfStats ? " · refreshing" : "")")
+                .foregroundStyle(Color.brainBarTextSecondary.opacity(0.78))
+                .lineLimit(1)
+        }
+    }
+
+    private var dataAgeText: String {
+        guard let ageSeconds = state.ageSeconds else { return "Data age: not yet available" }
+        return "Data age: \(ageLabel(ageSeconds))"
+    }
+
+    private var lastGoodText: String {
+        guard let lastGoodFetchedAt else { return "Last good: none yet" }
+        return "Last good: \(DashboardMetricFormatter.absoluteTimeString(lastGoodFetchedAt))"
+    }
+
+    private var errorMessage: String? {
+        guard case .error(let message, _) = state else { return nil }
+        return message
+    }
+
+    private var isAttentionState: Bool {
+        switch state {
+        case .stale, .error:
+            return true
+        case .loading, .live:
+            return false
+        }
+    }
+
+    private var stateColor: Color {
+        switch state {
+        case .loading:
+            return BrainBarStateTheme.loading.theme.swiftUIColor
+        case .live:
+            return BrainBarStateTheme.active.theme.swiftUIColor
+        case .stale:
+            return BrainBarStateTheme.degraded.theme.swiftUIColor
+        case .error:
+            return BrainBarStateTheme.error.theme.swiftUIColor
+        }
+    }
+
+    private var stateSymbol: String {
+        switch state {
+        case .loading: return "arrow.clockwise"
+        case .live: return "checkmark.circle.fill"
+        case .stale: return "clock.badge.exclamationmark"
+        case .error: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var accessibilitySummary: String {
+        var parts = [state.label, dataAgeText, lastGoodText]
+        if let errorMessage {
+            parts.append("Current error: \(errorMessage)")
+        }
+        if let heartbeatText {
+            parts.append("Collector heartbeat: \(heartbeatText)")
+        }
+        return parts.joined(separator: ". ")
+    }
+
+    private func ageLabel(_ seconds: Int) -> String {
+        if seconds < 60 { return "\(seconds)s" }
+        let minutes = seconds / 60
+        let remainder = seconds % 60
+        return remainder == 0 ? "\(minutes)m" : "\(minutes)m \(remainder)s"
     }
 }
 
@@ -1138,6 +1289,8 @@ private struct BrainBarSignalCoveragePanel: View {
         }
         .buttonStyle(.plain)
         .help("Show retrieval signal coverage")
+        .accessibilityIdentifier("brainbar.dashboard.signal-coverage-disclosure")
+        .focusable()
     }
 
     private var disclosureButton: some View {
@@ -1169,6 +1322,8 @@ private struct BrainBarSignalCoveragePanel: View {
         }
         .buttonStyle(.plain)
         .help("Hide retrieval signal coverage")
+        .accessibilityIdentifier("brainbar.dashboard.signal-coverage-disclosure")
+        .focusable()
     }
 
     @ViewBuilder
@@ -1515,7 +1670,9 @@ private struct BrainBarFlowLaneCard: View {
                 activityWindowMinutes: lane.activityWindowMinutes,
                 fetchedAt: fetchedAt,
                 pulseRevision: pulseRevision,
-                referenceValue: sparklineReferenceValue
+                referenceValue: sparklineReferenceValue,
+                metricDisclosure: nil,
+                accessibilitySummary: nil
             )
             .frame(height: chartHeight)
 
@@ -1659,12 +1816,18 @@ struct BrainBarSharedTimeframeSelector: View {
                 }
                 .buttonStyle(.plain)
                 .help("Show \(frame.label) window")
+                .accessibilityIdentifier("brainbar.dashboard.timeframe.\(frame.rawValue)")
+                .focusable()
             }
         }
+        .accessibilityIdentifier("brainbar.dashboard.timeframe")
+        .accessibilityLabel("Dashboard chart window")
+        .focusable()
     }
 }
 
-/// A single-series pipeline card (All commits / Agent MCP stores / JSONL watcher / Enrichment).
+/// A single-series truth card for chunk rows, agent-origin chunks,
+/// watcher-ingested chunks, or successful enrichments.
 ///
 /// Unlike `BrainBarFlowLaneCard` (kept for legacy `ingress`/diagnostics callers),
 /// this card plots exactly ONE series so `SparklineChartPresentation.maxValue`
@@ -1687,12 +1850,15 @@ private struct BrainBarPipelineSeriesCard: View {
     let timeframe: PipelineTimeframe
 
     private var presentation: SparklineChartPresentation {
-        SparklineChartPresentation(
+        let disclosure = chartDisclosure
+        return SparklineChartPresentation(
             label: lane.sparklineLabel,
             values: lane.values,
             activityWindowMinutes: lane.activityWindowMinutes,
             latestBucketName: lane.latestBucketName,
-            fetchedAt: fetchedAt
+            fetchedAt: fetchedAt,
+            metricDisclosure: disclosure.tooltipDisclosure,
+            accessibilitySummary: disclosure.accessibilitySummary
         )
     }
 
@@ -1722,6 +1888,10 @@ private struct BrainBarPipelineSeriesCard: View {
 
     private var accent: Color { Color.brainBar(nsColor: lane.accentColor) }
 
+    private var chartDisclosure: BrainBarDashboardChartDisclosure {
+        BrainBarDashboardChartDisclosure(series: series, lane: lane, timeframe: timeframe)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 8 : 10) {
             header
@@ -1740,9 +1910,11 @@ private struct BrainBarPipelineSeriesCard: View {
                     secondaryAccentColor: nil,
                     tertiaryAccentColor: nil,
                     activityWindowMinutes: lane.activityWindowMinutes,
-                    fetchedAt: fetchedAt,
-                    pulseRevision: pulseRevision,
-                    referenceValue: sparklineReferenceValue
+                fetchedAt: fetchedAt,
+                pulseRevision: pulseRevision,
+                referenceValue: sparklineReferenceValue,
+                metricDisclosure: chartDisclosure.tooltipDisclosure,
+                accessibilitySummary: chartDisclosure.accessibilitySummary
                 )
                 .frame(height: chartHeight)
 
@@ -1788,8 +1960,10 @@ private struct BrainBarPipelineSeriesCard: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(compact ? 16 : 18)
+        .padding(compact ? 12 : 14)
         .background(BrainBarDashboardCardStyle(emphasized: true))
+        .accessibilityIdentifier(chartDisclosure.accessibilityIdentifier)
+        .focusable()
     }
 
     private var header: some View {
@@ -1805,9 +1979,23 @@ private struct BrainBarPipelineSeriesCard: View {
                     .foregroundStyle(Color.brainBarTextPrimary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.78)
+                Text(chartDisclosure.subtitle)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.brainBarTextSecondary.opacity(0.76))
+                    .fixedSize(horizontal: false, vertical: true)
+                if let detail = chartDisclosure.visibleDetail {
+                    Text(detail)
+                        .font(.system(size: 9.5, weight: .medium))
+                        .foregroundStyle(Color.brainBarTextSecondary.opacity(0.64))
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             Spacer(minLength: 12)
-            BrainBarFlowStatusPill(text: lane.status.label, accentColor: accent)
+            BrainBarFlowStatusPill(
+                text: chartDisclosure.statusLabel,
+                accentColor: lane.status.stateTheme.theme.swiftUIColor
+            )
         }
     }
 
@@ -1815,6 +2003,56 @@ private struct BrainBarPipelineSeriesCard: View {
         guard series == .enrichment else { return nil }
         let peak = lane.values.max() ?? 0
         return peak > 0 ? peak : nil
+    }
+}
+
+struct BrainBarDashboardChartDisclosure: Equatable {
+    let subtitle: String
+    let visibleDetail: String?
+    let accessibilityIdentifier: String
+    let statusLabel: String
+    let accessibilitySummary: String
+    let tooltipDisclosure: String
+
+    init(series: PipelineSeries, lane: DashboardFlowLane, timeframe: PipelineTimeframe) {
+        let totalCount = lane.values.reduce(0, +)
+        let windowLabel = DashboardMetricFormatter.windowLabel(minutes: timeframe.windowMinutes)
+        let clockLabel: String
+        let unitLabel: String
+
+        switch series {
+        case .allCommits:
+            subtitle = "Source time · chunk rows"
+            visibleDetail = nil
+            accessibilityIdentifier = "brainbar.dashboard.chart.chunk-rows"
+            statusLabel = lane.status.label
+            clockLabel = "source time"
+            unitLabel = "chunk rows"
+        case .agentStores:
+            subtitle = "Source time · chunk rows · documented agent origins"
+            visibleDetail = "Sources: MCP, manual, digest, precompact-hook, brain_store, pending, fallback, fallback-replay."
+            accessibilityIdentifier = "brainbar.dashboard.chart.agent-origin-chunks"
+            statusLabel = lane.status.label
+            clockLabel = "source time"
+            unitLabel = "agent-origin chunk rows"
+        case .jsonlWatcher:
+            subtitle = "Ingest time · unique chunk IDs first seen in window · not additive with source-time charts"
+            visibleDetail = "Live state uses a 60s process-and-flow truth window; this chart uses the selected context window."
+            accessibilityIdentifier = "brainbar.dashboard.chart.watcher-ingested-chunks"
+            statusLabel = lane.statusText
+            clockLabel = "ingest time"
+            unitLabel = "unique chunk IDs first seen in this window"
+        case .enrichment:
+            subtitle = "Completion time · successful chunk rows"
+            visibleDetail = "Success status only; failed, skipped, and pending rows are disclosed above."
+            accessibilityIdentifier = "brainbar.dashboard.chart.enriched-successfully"
+            statusLabel = lane.status.label
+            clockLabel = "successful enrichment completion time"
+            unitLabel = "success-status chunk rows"
+        }
+
+        accessibilitySummary = "\(lane.name). Window: \(windowLabel). Count: \(totalCount). Unit: \(unitLabel). Clock: \(clockLabel)."
+        tooltipDisclosure = "Window: \(windowLabel) · Count: hovered value below · Unit: \(unitLabel) · Clock: \(clockLabel)"
     }
 }
 
@@ -1833,7 +2071,7 @@ enum BrainBarDashboardPreview {
         AnyView(
             ZStack {
                 BrainBarAppBackground()
-                BrainBarDashboardView(collector: collector, hotkeyStatus: hotkeyStatus)
+                BrainBarDashboardContent(collector: collector, hotkeyStatus: hotkeyStatus)
             }
             .environment(\.colorScheme, .dark)
             // Suppress SwiftUI animations so every value lands at its final state
@@ -1941,7 +2179,7 @@ private struct BrainBarPipelinePanelPreviewView: View {
                 HStack(alignment: .center, spacing: 12) {
                     BrainBarSectionLabel(
                         "Ingest",
-                        caption: "What is landing — all committed chunks, agent MCP stores, and the JSONL watcher — plus retrieval signal coverage."
+                        caption: "Three independently scaled ingest series. Source-time charts count chunk rows; the watcher chart counts unique chunk IDs by ingest time."
                     )
                     Spacer(minLength: 8)
                     BrainBarSharedTimeframeSelector(selection: $selectedTimeframe)
@@ -1984,6 +2222,8 @@ private struct BrainBarPipelinePanelPreviewView: View {
 
                 BrainBarQueueRail(
                     summary: flowSummary.queue,
+                    replayDebtBreakdown: stats.replayDebtBreakdown,
+                    censusText: DashboardMetricFormatter.absoluteTimeString(fetchedAt),
                     coverageText: "\(Int(stats.enrichmentPercent.rounded()))% enriched",
                     watcherText: watcherText,
                     compact: layout.compactCards
@@ -2016,9 +2256,12 @@ private struct BrainBarPipelinePanelPreviewView: View {
 
 private struct BrainBarQueueRail: View {
     let summary: DashboardQueueSummary
+    let replayDebtBreakdown: BrainDatabase.ReplayDebtBreakdown
+    let censusText: String
     let coverageText: String
     let watcherText: String
     let compact: Bool
+    @State private var replayDebtExpanded = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 6 : 8) {
@@ -2035,15 +2278,95 @@ private struct BrainBarQueueRail: View {
                 }
             }
 
-            Text(summary.detail)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
+            if replayDebtBreakdown.deduplicatedTotal > 0 || replayDebtBreakdown.isPartial {
+                replayDebtDisclosure
+            } else {
+                Text(summary.detail)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(compact ? 10 : 12)
         .background(BrainBarDashboardCardStyle())
+    }
+
+    private var replayDebtDisclosure: some View {
+        DisclosureGroup(isExpanded: $replayDebtExpanded) {
+            VStack(alignment: .leading, spacing: 7) {
+                replayDebtRow("Pending stores", component: replayDebtBreakdown.pendingStores)
+                replayDebtRow("Queue entries", component: replayDebtBreakdown.durableQueue)
+                replayDebtRow("Fallback entries", component: replayDebtBreakdown.repositoryFallback)
+                replayDebtValueRow("Deduplicated total", value: "\(replayDebtBreakdown.deduplicatedTotal)")
+                replayDebtValueRow("Unreadable inputs", value: unreadableInputsText)
+                replayDebtValueRow("Census time", value: censusText)
+                Text("Path identities are de-duplicated before the aggregate is calculated.")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Color.brainBarTextSecondary.opacity(0.72))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.top, 7)
+        } label: {
+            HStack(spacing: 8) {
+                Text("Replay debt")
+                    .font(.system(size: 11, weight: .bold))
+                Text("\(replayDebtBreakdown.deduplicatedTotal)")
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                if replayDebtBreakdown.isPartial {
+                    Text("PARTIAL")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(BrainBarStateTheme.degraded.theme.swiftUIColor)
+                }
+                Spacer(minLength: 0)
+                Text("Pending stores · queue entries · fallback entries")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .accessibilityIdentifier("brainbar.dashboard.replay-debt-disclosure")
+        .focusable()
+    }
+
+    private func replayDebtRow(
+        _ label: String,
+        component: BrainDatabase.ReplayDebtBreakdown.Component
+    ) -> some View {
+        let readability: String
+        switch component.readability {
+        case .readable:
+            readability = "readable"
+        case .unreadable(let reason):
+            readability = "unreadable · \(reason)"
+        }
+        return replayDebtValueRow(label, value: "\(component.snapshot.depth) · \(readability)")
+    }
+
+    private func replayDebtValueRow(_ label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color.brainBarTextSecondary)
+            Spacer(minLength: 8)
+            Text(value)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(Color.brainBarTextPrimary)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private var unreadableInputsText: String {
+        guard replayDebtBreakdown.isPartial else { return "None" }
+        return replayDebtBreakdown.unreadableSources.map { source in
+            switch source {
+            case .pendingStores: return "pending stores"
+            case .durableQueue: return "queue entries"
+            case .repositoryFallback: return "fallback entries"
+            }
+        }.joined(separator: ", ")
     }
 
     private var queueHeader: some View {
@@ -2062,15 +2385,13 @@ private struct BrainBarQueueRail: View {
     private var queueMetrics: some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: 14) {
-                BrainBarLaneMetric(label: "Backlog", value: "\(summary.backlogCount)")
                 BrainBarLaneMetric(label: "Coverage", value: coverageText)
-                BrainBarLaneMetric(label: "Watcher", value: watcherText)
+                BrainBarLaneMetric(label: "Last watcher heartbeat", value: watcherText)
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                BrainBarLaneMetric(label: "Backlog", value: "\(summary.backlogCount)")
                 BrainBarLaneMetric(label: "Coverage", value: coverageText)
-                BrainBarLaneMetric(label: "Watcher", value: watcherText)
+                BrainBarLaneMetric(label: "Last watcher heartbeat", value: watcherText)
             }
         }
     }
@@ -2204,16 +2525,16 @@ struct BrainBarDashboardLayout {
         diagnosticItemColumns = containerSize.width >= 760 ? 2 : 1
 
         compactCards = compactWidth || compactHeight
-        outerPadding = compactCards ? 24 : 36
-        sectionSpacing = compactCards ? 20 : 28
-        gridSpacing = compactCards ? 16 : 22
-        cardPadding = compactCards ? 22 : 32
+        outerPadding = compactCards ? 16 : 24
+        sectionSpacing = compactCards ? 14 : 20
+        gridSpacing = compactCards ? 12 : 16
+        cardPadding = compactCards ? 16 : 22
         overviewTitleFontSize = compactCards ? BrainBarDesignTokens.TypeScale.title : BrainBarDesignTokens.TypeScale.display
         overviewSubtitleFontSize = BrainBarDesignTokens.TypeScale.body
-        overviewStatsWidth = compactCards ? 310 : 420
-        metricCardMinHeight = compactCards ? 96 : 128
-        metricValueFontSize = compactCards ? 48 : BrainBarDesignTokens.TypeScale.hero
-        sparklineHeight = compactCards ? 140 : 170
+        overviewStatsWidth = compactCards ? 330 : 430
+        metricCardMinHeight = compactCards ? 72 : 88
+        metricValueFontSize = compactCards ? 32 : 40
+        sparklineHeight = compactCards ? 112 : 140
         panelCornerRadius = BrainBarDesignTokens.Radius.xl
         maxContentWidth = 1_280
     }
@@ -2391,22 +2712,24 @@ private struct BrainBarOverviewStat: View {
     let isHero: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: isHero ? 8 : 4) {
+        VStack(alignment: .leading, spacing: 4) {
             Text(label)
                 .font(.system(size: BrainBarDesignTokens.TypeScale.label, weight: .semibold))
                 .tracking(0.66)
                 .foregroundStyle(Color.brainBarTextSecondary.opacity(0.50))
                 .textCase(.uppercase)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
             Text(value)
-                .font(.system(size: isHero ? BrainBarDesignTokens.TypeScale.hero : BrainBarDesignTokens.TypeScale.title, weight: .semibold, design: .rounded))
+                .font(.system(size: isHero ? 28 : 20, weight: .semibold, design: .rounded))
                 .lineLimit(1)
                 .minimumScaleFactor(0.42)
                 .monospacedDigit()
                 .foregroundStyle(isHero ? Color.brainBarTextPrimary : Color.brainBarTextSecondary)
         }
-        .frame(maxWidth: .infinity, minHeight: isHero ? 128 : 62, alignment: .leading)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 11)
+        .frame(maxWidth: .infinity, minHeight: 62, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
         .background(
             RoundedRectangle(cornerRadius: BrainBarDesignTokens.Radius.md, style: .continuous)
                 .fill(Color.brainBarGlassSecondary)
@@ -2549,6 +2872,8 @@ private struct BrainBarHeroSparkline: View {
     let fetchedAt: Date
     let pulseRevision: Int
     let referenceValue: Int?
+    let metricDisclosure: String?
+    let accessibilitySummary: String?
 
     var body: some View {
         GeometryReader { proxy in
@@ -2568,7 +2893,9 @@ private struct BrainBarHeroSparkline: View {
                     tertiarySeriesLabel: tertiarySeriesLabel,
                     activityWindowMinutes: activityWindowMinutes,
                     latestBucketName: latestBucketName,
-                    fetchedAt: fetchedAt
+                    fetchedAt: fetchedAt,
+                    metricDisclosure: metricDisclosure,
+                    accessibilitySummary: accessibilitySummary
                 ),
                 accentColor: accentColor,
                 secondaryAccentColor: secondaryAccentColor,

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -162,7 +162,7 @@ private struct BrainBarDashboardContent: View {
     let hotkeyStatus: String
 
     var body: some View {
-        if collector.lastDataFetchedAt == nil {
+        if collector.snapshotFreshnessState.isLoading {
             BrainBarLoadingView(title: "BrainBar", subtitle: "Connecting to daemon and loading dashboard data...")
         } else {
             BrainBarDashboardView(
@@ -568,6 +568,8 @@ private struct BrainBarDashboardView: View {
         HStack(spacing: 8) {
             Image(systemName: "clock")
                 .font(.system(size: 11, weight: .semibold))
+            Text(collector.snapshotFreshnessState.label)
+                .font(.system(size: 11, weight: .bold))
             Text("Data fetched at: \(dataFetchedText)")
                 .font(.system(size: 11, weight: .semibold))
                 .monospacedDigit()
@@ -581,6 +583,11 @@ private struct BrainBarDashboardView: View {
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(.secondary)
                 }
+            }
+            if let lastFetchError = collector.lastFetchError {
+                Text("Fetch error: \(lastFetchError)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
             }
             Spacer(minLength: 0)
         }

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -356,7 +356,7 @@ private struct BrainBarDashboardView: View {
     @State private var selectedTimeframe: PipelineTimeframe = .live
     @State private var vectorDetailHeight: CGFloat = 0
 
-    /// The stats the graphs render. For the live (30m) lens this is the resting
+    /// The stats the graphs render. For the live (1h) lens this is the resting
     /// `collector.stats`; for a wider lens, if the collector has published REAL
     /// windowed buckets for that window, they are swapped in so the charts show
     /// genuine history (not a relabel).
@@ -368,6 +368,13 @@ private struct BrainBarDashboardView: View {
             return collector.stats
         }
         return collector.stats.withWindowedPipelineBuckets(buckets)
+    }
+
+    private var displayedTimeframe: PipelineTimeframe {
+        PipelineTimeframe.truthfulDisplay(
+            selected: selectedTimeframe,
+            loadedWindowMinutes: collector.windowedBucketsWindowMinutes
+        )
     }
 
     private var flowSummary: DashboardFlowSummary {
@@ -492,7 +499,7 @@ private struct BrainBarDashboardView: View {
         }
         // Shared timeframe selector → REAL windowed re-fetch. Selecting 3h/24h
         // triggers an off-main DB fetch over that window; the published buckets
-        // flow into every graph at once. `.live` clears the fetch (resting 30m).
+        // flow into every graph at once. `.live` clears the fetch (resting 1h).
         .onChange(of: selectedTimeframe) { _, newTimeframe in
             collector.selectTimeframe(
                 windowMinutes: newTimeframe.windowMinutes,
@@ -682,13 +689,14 @@ private struct BrainBarDashboardView: View {
         }
     }
 
-    /// The ONE shared Live(30m)/3h/24h control. It is the SOLE timeframe control
+    /// The ONE shared Live(1h)/3h/24h control. It is the SOLE timeframe control
     /// on the dashboard — every pipeline graph reads `selectedTimeframe`, so the
     /// cards no longer expand to reveal a per-card picker.
     private var sharedTimeframeSelector: some View {
         BrainBarSharedTimeframeSelector(
             selection: $selectedTimeframe,
-            isLoading: collector.isWindowedBucketsLoading
+            isLoading: collector.isWindowedBucketsLoading,
+            loadError: collector.windowedBucketsError
         )
     }
 
@@ -727,7 +735,7 @@ private struct BrainBarDashboardView: View {
             compact: layout.compactCards,
             chartHeight: restingHeight,
             fetchedAt: fetchedAt,
-            timeframe: selectedTimeframe
+            timeframe: displayedTimeframe
         )
     }
 
@@ -743,7 +751,7 @@ private struct BrainBarDashboardView: View {
             compact: layout.compactCards,
             chartHeight: restingHeight,
             fetchedAt: fetchedAt,
-            timeframe: selectedTimeframe
+            timeframe: displayedTimeframe
         )
     }
 
@@ -759,7 +767,7 @@ private struct BrainBarDashboardView: View {
             compact: layout.compactCards,
             chartHeight: restingHeight,
             fetchedAt: fetchedAt,
-            timeframe: selectedTimeframe
+            timeframe: displayedTimeframe
         )
     }
 
@@ -792,7 +800,7 @@ private struct BrainBarDashboardView: View {
                 compact: layout.compactCards,
                 chartHeight: restingHeight,
                 fetchedAt: fetchedAt,
-                timeframe: selectedTimeframe
+                timeframe: displayedTimeframe
             )
 
             queueRail(layout: layout)
@@ -1717,8 +1725,8 @@ private struct BrainBarFlowLaneCard: View {
     }
 }
 
-/// The ONE shared window for every pipeline graph: Live(30m) / 3h / 24h.
-/// `.live` is the resting 30m window the graphs always have; `.threeHour` and
+/// The ONE shared window for every pipeline graph: Live(1h) / 3h / 24h.
+/// `.live` is the resting 1h window the graphs always have; `.threeHour` and
 /// `.day` trigger a REAL windowed re-fetch from `BrainDatabase` (180 / 1440
 /// minutes) so the charts show genuine historical data, not a relabel. Selecting
 /// a window switches ALL graphs at once — there is no per-card timeframe control.
@@ -1738,7 +1746,7 @@ enum PipelineTimeframe: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Sublabel for the live chip so "Live" still surfaces the 30m window.
+    /// Sublabel for the live chip so "Live" still surfaces the 1h window.
     var subLabel: String? {
         switch self {
         case .live: return "1h"
@@ -1755,6 +1763,17 @@ enum PipelineTimeframe: String, CaseIterable, Identifiable {
         case .day: return 1_440
         }
     }
+
+    static func truthfulDisplay(
+        selected: PipelineTimeframe,
+        loadedWindowMinutes: Int?
+    ) -> PipelineTimeframe {
+        guard selected != .live,
+              loadedWindowMinutes == selected.windowMinutes else {
+            return .live
+        }
+        return selected
+    }
 }
 
 enum BrainBarPipelinePulseGate {
@@ -1769,55 +1788,65 @@ enum BrainBarPipelinePulseGate {
 }
 
 /// The single shared Live/3h/24h selector that drives every pipeline graph.
-/// Replaces the removed per-card 30m/3h/24h picker. A small spinner appears
+/// Replaces the removed per-card 1h/3h/24h picker. A small spinner appears
 /// while a wider window is being fetched from the DB.
 struct BrainBarSharedTimeframeSelector: View {
     @Binding var selection: PipelineTimeframe
     var isLoading: Bool = false
+    var loadError: String?
 
     var body: some View {
-        HStack(spacing: 6) {
-            if isLoading {
-                ProgressView()
-                    .controlSize(.small)
-                    .scaleEffect(0.7)
-                    .frame(width: 14, height: 14)
-            }
-            ForEach(PipelineTimeframe.allCases) { frame in
-                Button {
-                    selection = frame
-                } label: {
-                    HStack(spacing: 4) {
-                        Text(frame.label)
-                            .font(.system(size: 11, weight: .semibold))
-                        if let sub = frame.subLabel {
-                            Text(sub)
-                                .font(.system(size: 9, weight: .medium))
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .monospacedDigit()
-                    .padding(.horizontal, 11)
-                    .padding(.vertical, 5)
-                    .foregroundStyle(
-                        selection == frame
-                            ? Color.brainBarAccent
-                            : Color.brainBarTextSecondary.opacity(0.85)
-                    )
-                    .background(
-                        Capsule().fill(selection == frame ? Color.brainBarAccent.opacity(0.16) : .clear)
-                    )
-                    .overlay(
-                        Capsule().stroke(
-                            selection == frame ? Color.brainBarAccent.opacity(0.32) : Color.brainBarBorderSoft,
-                            lineWidth: 1
-                        )
-                    )
+        VStack(alignment: .trailing, spacing: 4) {
+            HStack(spacing: 6) {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.7)
+                        .frame(width: 14, height: 14)
                 }
-                .buttonStyle(.plain)
-                .help("Show \(frame.label) window")
-                .accessibilityIdentifier("brainbar.dashboard.timeframe.\(frame.rawValue)")
-                .focusable()
+                ForEach(PipelineTimeframe.allCases) { frame in
+                    Button {
+                        selection = frame
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text(frame.label)
+                                .font(.system(size: 11, weight: .semibold))
+                            if let sub = frame.subLabel {
+                                Text(sub)
+                                    .font(.system(size: 9, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .monospacedDigit()
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 5)
+                        .foregroundStyle(
+                            selection == frame
+                                ? Color.brainBarAccent
+                                : Color.brainBarTextSecondary.opacity(0.85)
+                        )
+                        .background(
+                            Capsule().fill(selection == frame ? Color.brainBarAccent.opacity(0.16) : .clear)
+                        )
+                        .overlay(
+                            Capsule().stroke(
+                                selection == frame ? Color.brainBarAccent.opacity(0.32) : Color.brainBarBorderSoft,
+                                lineWidth: 1
+                            )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .help("Show \(frame.label) window")
+                    .accessibilityIdentifier("brainbar.dashboard.timeframe.\(frame.rawValue)")
+                    .focusable()
+                }
+            }
+            if let loadError {
+                Text(loadError)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(BrainBarStateTheme.degraded.theme.swiftUIColor)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("brainbar.dashboard.timeframe.error")
             }
         }
         .accessibilityIdentifier("brainbar.dashboard.timeframe")
@@ -1873,7 +1902,7 @@ private struct BrainBarPipelineSeriesCard: View {
         return "scale · peak \(presentation.axisMax)"
     }
 
-    /// The window currently selected by the shared control, e.g. "Last 30m" /
+    /// The window currently selected by the shared control, e.g. "Last 1h" /
     /// "Last 3h" / "Last 24h" — kept in the caption so the chart always names the
     /// window it is plotting.
     private var timeframeWindowText: String {

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -117,7 +117,7 @@ struct BrainBarWindowRootView: View {
         if let store = runtime.injectionStore {
             BrainBarInjectionTab(store: store, isActive: selectedTab == .injections && windowObserver.isWindowVisible)
         } else {
-            BrainBarLoadingView(title: "Injections", subtitle: BrainBarPlaceholderCopy.injectionFeedNotWired)
+            InjectionFeedView(disconnectedAt: Date())
         }
     }
 

--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -2120,6 +2120,7 @@ enum BrainBarPipelinePanelPreview {
         fetchedAt: Date = Date(),
         watcherText: String = "12 files",
         signalCoverageExpanded: Bool = true,
+        replayDebtExpanded: Bool = false,
         selectedTimeframe: PipelineTimeframe = .live
     ) -> AnyView {
         AnyView(
@@ -2129,6 +2130,7 @@ enum BrainBarPipelinePanelPreview {
                 fetchedAt: fetchedAt,
                 watcherText: watcherText,
                 signalCoverageExpanded: signalCoverageExpanded,
+                replayDebtExpanded: replayDebtExpanded,
                 selectedTimeframe: selectedTimeframe
             )
         )
@@ -2145,6 +2147,7 @@ private struct BrainBarPipelinePanelPreviewView: View {
     let containerSize: CGSize
     let fetchedAt: Date
     let watcherText: String
+    let replayDebtExpanded: Bool
     @State private var signalCoverageExpanded: Bool
     @State private var vectorSignalDetailExpanded = false
     @State private var selectedTimeframe: PipelineTimeframe
@@ -2155,12 +2158,14 @@ private struct BrainBarPipelinePanelPreviewView: View {
         fetchedAt: Date,
         watcherText: String,
         signalCoverageExpanded: Bool,
+        replayDebtExpanded: Bool,
         selectedTimeframe: PipelineTimeframe
     ) {
         self.stats = stats
         self.containerSize = containerSize
         self.fetchedAt = fetchedAt
         self.watcherText = watcherText
+        self.replayDebtExpanded = replayDebtExpanded
         _signalCoverageExpanded = State(initialValue: signalCoverageExpanded)
         _selectedTimeframe = State(initialValue: selectedTimeframe)
     }
@@ -2226,7 +2231,8 @@ private struct BrainBarPipelinePanelPreviewView: View {
                     censusText: DashboardMetricFormatter.absoluteTimeString(fetchedAt),
                     coverageText: "\(Int(stats.enrichmentPercent.rounded()))% enriched",
                     watcherText: watcherText,
-                    compact: layout.compactCards
+                    compact: layout.compactCards,
+                    replayDebtExpanded: replayDebtExpanded
                 )
             }
             .padding(layout.cardPadding)
@@ -2261,7 +2267,25 @@ private struct BrainBarQueueRail: View {
     let coverageText: String
     let watcherText: String
     let compact: Bool
-    @State private var replayDebtExpanded = false
+    @State private var replayDebtExpanded: Bool
+
+    init(
+        summary: DashboardQueueSummary,
+        replayDebtBreakdown: BrainDatabase.ReplayDebtBreakdown,
+        censusText: String,
+        coverageText: String,
+        watcherText: String,
+        compact: Bool,
+        replayDebtExpanded: Bool = false
+    ) {
+        self.summary = summary
+        self.replayDebtBreakdown = replayDebtBreakdown
+        self.censusText = censusText
+        self.coverageText = coverageText
+        self.watcherText = watcherText
+        self.compact = compact
+        _replayDebtExpanded = State(initialValue: replayDebtExpanded)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 6 : 8) {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -35,7 +35,6 @@ final class BrainDatabase: @unchecked Sendable {
     private static let fallbackReplayGitsRootEnv = "BRAINBAR_FALLBACK_REPLAY_GITS_ROOT"
     private static let brainLayerQueueDirEnv = "BRAINLAYER_QUEUE_DIR"
     private static let agentWriteSourceWhereClause = "COALESCE(LOWER(TRIM(source)), '') IN ('mcp', 'manual', 'digest', 'precompact-hook', 'brain_store', 'pending', 'fallback', 'fallback-replay')"
-    private static let watcherWriteSourceWhereClause = "COALESCE(LOWER(TRIM(source)), '') IN ('realtime_watcher', 'realtime')"
     private static let lexicalDefenseReplacements: [String: [String]] = [
         "hershkovitz": ["Hershkovits"],
         "hershkovits": ["Hershkovitz"]
@@ -119,6 +118,8 @@ final class BrainDatabase: @unchecked Sendable {
 
         let chunkCount: Int
         let enrichedChunkCount: Int
+        let failedEnrichmentCount: Int
+        let skippedEnrichmentCount: Int
         let pendingEnrichmentCount: Int
         let enrichmentPercent: Double
         let enrichmentRatePerMinute: Double
@@ -143,10 +144,16 @@ final class BrainDatabase: @unchecked Sendable {
         let pendingStoreOldestQueuedAt: Date?
         let pendingStoreFlushRatePerMinute: Double
         let watcherHealth: WatcherHealth?
+        let replayDebtBreakdown: ReplayDebtBreakdown
+        let watcherProcessProbeResult: WatcherProcessProbeResult?
+        let watcherRecentDistinctChunkCount: Int
+        let watcherFlowReadability: MetricEvidenceReadability
 
         init(
             chunkCount: Int,
             enrichedChunkCount: Int,
+            failedEnrichmentCount: Int = 0,
+            skippedEnrichmentCount: Int = 0,
             pendingEnrichmentCount: Int,
             enrichmentPercent: Double,
             enrichmentRatePerMinute: Double,
@@ -170,10 +177,16 @@ final class BrainDatabase: @unchecked Sendable {
             pendingStoreFlushQueueDepth: Int? = nil,
             pendingStoreOldestQueuedAt: Date? = nil,
             pendingStoreFlushRatePerMinute: Double = 0,
-            watcherHealth: WatcherHealth? = nil
+            watcherHealth: WatcherHealth? = nil,
+            replayDebtBreakdown: ReplayDebtBreakdown? = nil,
+            watcherProcessProbeResult: WatcherProcessProbeResult? = nil,
+            watcherRecentDistinctChunkCount: Int? = nil,
+            watcherFlowReadability: MetricEvidenceReadability? = nil
         ) {
             self.chunkCount = chunkCount
             self.enrichedChunkCount = enrichedChunkCount
+            self.failedEnrichmentCount = failedEnrichmentCount
+            self.skippedEnrichmentCount = skippedEnrichmentCount
             self.pendingEnrichmentCount = pendingEnrichmentCount
             self.enrichmentPercent = enrichmentPercent
             self.enrichmentRatePerMinute = enrichmentRatePerMinute
@@ -198,6 +211,16 @@ final class BrainDatabase: @unchecked Sendable {
             self.pendingStoreOldestQueuedAt = pendingStoreOldestQueuedAt
             self.pendingStoreFlushRatePerMinute = pendingStoreFlushRatePerMinute
             self.watcherHealth = watcherHealth
+            self.replayDebtBreakdown = replayDebtBreakdown ?? ReplayDebtBreakdown.legacy(
+                totalDepth: pendingStoreQueueDepth,
+                pendingStoreDepth: pendingStoreFlushQueueDepth ?? pendingStoreQueueDepth,
+                oldestQueuedAt: pendingStoreOldestQueuedAt
+            )
+            self.watcherProcessProbeResult = watcherProcessProbeResult
+            self.watcherRecentDistinctChunkCount = watcherRecentDistinctChunkCount
+                ?? self.recentWatcherWriteBuckets.reduce(0, +)
+            self.watcherFlowReadability = watcherFlowReadability
+                ?? (recentWatcherWriteBuckets == nil ? .unreadable("watcher flow evidence not supplied") : .readable)
         }
 
         var recentWriteCount: Int {
@@ -299,6 +322,8 @@ final class BrainDatabase: @unchecked Sendable {
             DashboardStats(
                 chunkCount: chunkCount,
                 enrichedChunkCount: enrichedChunkCount,
+                failedEnrichmentCount: failedEnrichmentCount,
+                skippedEnrichmentCount: skippedEnrichmentCount,
                 pendingEnrichmentCount: pendingEnrichmentCount,
                 enrichmentPercent: enrichmentPercent,
                 enrichmentRatePerMinute: enrichmentRatePerMinute,
@@ -322,7 +347,11 @@ final class BrainDatabase: @unchecked Sendable {
                 pendingStoreFlushQueueDepth: pendingStoreFlushQueueDepth,
                 pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
                 pendingStoreFlushRatePerMinute: pendingStoreFlushRatePerMinute,
-                watcherHealth: watcherHealth
+                watcherHealth: watcherHealth,
+                replayDebtBreakdown: replayDebtBreakdown,
+                watcherProcessProbeResult: watcherProcessProbeResult,
+                watcherRecentDistinctChunkCount: watcherRecentDistinctChunkCount,
+                watcherFlowReadability: watcherFlowReadability
             )
         }
 
@@ -330,6 +359,8 @@ final class BrainDatabase: @unchecked Sendable {
             DashboardStats(
                 chunkCount: chunkCount,
                 enrichedChunkCount: enrichedChunkCount,
+                failedEnrichmentCount: failedEnrichmentCount,
+                skippedEnrichmentCount: skippedEnrichmentCount,
                 pendingEnrichmentCount: pendingEnrichmentCount,
                 enrichmentPercent: enrichmentPercent,
                 enrichmentRatePerMinute: enrichmentRatePerMinute,
@@ -353,7 +384,48 @@ final class BrainDatabase: @unchecked Sendable {
                 pendingStoreFlushQueueDepth: pendingStoreFlushQueueDepth,
                 pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
                 pendingStoreFlushRatePerMinute: rate,
-                watcherHealth: watcherHealth
+                watcherHealth: watcherHealth,
+                replayDebtBreakdown: replayDebtBreakdown,
+                watcherProcessProbeResult: watcherProcessProbeResult,
+                watcherRecentDistinctChunkCount: watcherRecentDistinctChunkCount,
+                watcherFlowReadability: watcherFlowReadability
+            )
+        }
+
+        func withWatcherProcessProbeResult(_ result: WatcherProcessProbeResult) -> DashboardStats {
+            DashboardStats(
+                chunkCount: chunkCount,
+                enrichedChunkCount: enrichedChunkCount,
+                failedEnrichmentCount: failedEnrichmentCount,
+                skippedEnrichmentCount: skippedEnrichmentCount,
+                pendingEnrichmentCount: pendingEnrichmentCount,
+                enrichmentPercent: enrichmentPercent,
+                enrichmentRatePerMinute: enrichmentRatePerMinute,
+                databaseSizeBytes: databaseSizeBytes,
+                recentActivityBuckets: recentActivityBuckets,
+                recentAgentWriteBuckets: recentAgentWriteBuckets,
+                recentWatcherWriteBuckets: recentWatcherWriteBuckets,
+                recentEnrichmentBuckets: recentEnrichmentBuckets,
+                recentWriteFiveMinuteCount: recentWriteFiveMinuteCount,
+                recentEnrichmentFiveMinuteCount: recentEnrichmentFiveMinuteCount,
+                activityWindowMinutes: activityWindowMinutes,
+                bucketCount: bucketCount,
+                liveWindowMinutes: liveWindowMinutes,
+                lastWriteAt: lastWriteAt,
+                lastEnrichedAt: lastEnrichedAt,
+                signalEligibleChunkCount: signalEligibleChunkCount,
+                vectorIndexedChunkCount: vectorIndexedChunkCount,
+                ftsIndexedChunkCount: ftsIndexedChunkCount,
+                trigramIndexedChunkCount: trigramIndexedChunkCount,
+                pendingStoreQueueDepth: pendingStoreQueueDepth,
+                pendingStoreFlushQueueDepth: pendingStoreFlushQueueDepth,
+                pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
+                pendingStoreFlushRatePerMinute: pendingStoreFlushRatePerMinute,
+                watcherHealth: watcherHealth,
+                replayDebtBreakdown: replayDebtBreakdown,
+                watcherProcessProbeResult: result,
+                watcherRecentDistinctChunkCount: watcherRecentDistinctChunkCount,
+                watcherFlowReadability: watcherFlowReadability
             )
         }
     }
@@ -390,6 +462,82 @@ final class BrainDatabase: @unchecked Sendable {
         }
     }
 
+    struct ReplayDebtBreakdown: Sendable, Equatable {
+        enum Source: String, Sendable, Equatable, CaseIterable {
+            case pendingStores
+            case durableQueue
+            case repositoryFallback
+
+            var label: String {
+                switch self {
+                case .pendingStores: return "pending stores"
+                case .durableQueue: return "durable queue"
+                case .repositoryFallback: return "repository fallback"
+                }
+            }
+        }
+
+        struct Component: Sendable, Equatable {
+            let source: Source
+            let snapshot: PendingStoreQueueSnapshot
+            let readability: MetricEvidenceReadability
+        }
+
+        let pendingStores: Component
+        let durableQueue: Component
+        let repositoryFallback: Component
+
+        var components: [Component] {
+            [pendingStores, durableQueue, repositoryFallback]
+        }
+
+        var deduplicatedSnapshot: PendingStoreQueueSnapshot {
+            pendingStores.snapshot
+                .merged(with: durableQueue.snapshot)
+                .merged(with: repositoryFallback.snapshot)
+        }
+
+        var deduplicatedTotal: Int { deduplicatedSnapshot.depth }
+        var oldestQueuedAt: Date? { deduplicatedSnapshot.oldestQueuedAt }
+        var isPartial: Bool { components.contains { !$0.readability.isReadable } }
+        var unreadableSources: [Source] {
+            components.compactMap { $0.readability.isReadable ? nil : $0.source }
+        }
+
+        var detailText: String {
+            var parts = components.map { "\($0.source.label): \($0.snapshot.depth)" }
+            parts.append("deduplicated total: \(deduplicatedTotal)")
+            if isPartial {
+                parts.append("partial; unreadable: \(unreadableSources.map(\.label).joined(separator: ", "))")
+            }
+            return parts.joined(separator: "; ")
+        }
+
+        static func legacy(totalDepth: Int, pendingStoreDepth: Int, oldestQueuedAt: Date?) -> ReplayDebtBreakdown {
+            let pending = PendingStoreQueueSnapshot(
+                depth: pendingStoreDepth,
+                oldestQueuedAt: oldestQueuedAt
+            )
+            let fallback = PendingStoreQueueSnapshot(
+                depth: max(totalDepth - pendingStoreDepth, 0),
+                oldestQueuedAt: oldestQueuedAt
+            )
+            return ReplayDebtBreakdown(
+                pendingStores: Component(source: .pendingStores, snapshot: pending, readability: .readable),
+                durableQueue: Component(
+                    source: .durableQueue,
+                    snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                    readability: .readable
+                ),
+                repositoryFallback: Component(
+                    source: .repositoryFallback,
+                    snapshot: fallback,
+                    readability: .readable
+                )
+            )
+        }
+    }
+
     /// The pipeline series (all commits / agent stores / JSONL watcher / enrichment)
     /// bucketed over an ARBITRARY window — the data primitive behind the shared
     /// Live(30m)/3h/24h selector. Unlike `DashboardStats` (which is pinned to the
@@ -403,11 +551,23 @@ final class BrainDatabase: @unchecked Sendable {
         let agentWriteBuckets: [Int]
         let watcherWriteBuckets: [Int]
         let enrichmentBuckets: [Int]
+        let watcherFlowReadability: MetricEvidenceReadability
+
+        let allWriteContract = DashboardMetricContract.chunkRows
+        let agentWriteContract = DashboardMetricContract.agentOriginChunks
+        let watcherWriteContract = DashboardMetricContract.watcherIngestedChunks
 
         var allWriteTotal: Int { allWriteBuckets.reduce(0, +) }
         var agentTotal: Int { agentWriteBuckets.reduce(0, +) }
         var watcherTotal: Int { watcherWriteBuckets.reduce(0, +) }
         var enrichmentTotal: Int { enrichmentBuckets.reduce(0, +) }
+    }
+
+    private struct WatcherIngestSnapshot {
+        let buckets: [Int]
+        let readability: MetricEvidenceReadability
+
+        var total: Int { buckets.reduce(0, +) }
     }
 
     struct SubscriberRecord: Sendable {
@@ -1778,10 +1938,9 @@ final class BrainDatabase: @unchecked Sendable {
     }
 
     func dashboardStats(activityWindowMinutes: Int = 30, bucketCount: Int = 12) throws -> DashboardStats {
-        let pendingStoreFlushQueue = pendingStoreQueueSnapshot()
-        let pendingStoreQueue = pendingStoreFlushQueue
-            .merged(with: Self.fallbackReplayQueueSnapshot())
-            .merged(with: Self.durableStoreQueueSnapshot())
+        let replayDebtBreakdown = replayDebtBreakdown()
+        let pendingStoreFlushQueue = replayDebtBreakdown.pendingStores.snapshot
+        let pendingStoreQueue = replayDebtBreakdown.deduplicatedSnapshot
         let watcherHealth = watcherHealthSnapshot()
         return try withReadTransaction {
             let liveWindowMinutes = 1
@@ -1824,9 +1983,14 @@ final class BrainDatabase: @unchecked Sendable {
                 bucketCount: bucketCount,
                 now: now
             )
-            let recentWatcherWriteBuckets = try recentWatcherWriteBuckets(
+            let recentWatcherIngest = recentWatcherWriteBuckets(
                 activityWindowMinutes: activityWindowMinutes,
                 bucketCount: bucketCount,
+                now: now
+            )
+            let recentWatcherTruth = recentWatcherWriteBuckets(
+                activityWindowMinutes: liveWindowMinutes,
+                bucketCount: 1,
                 now: now
             )
             let recentEnrichmentBuckets = try recentEnrichmentBuckets(
@@ -1840,13 +2004,15 @@ final class BrainDatabase: @unchecked Sendable {
             return DashboardStats(
                 chunkCount: chunkCount,
                 enrichedChunkCount: enrichedChunkCount,
+                failedEnrichmentCount: counts.failedEnrichmentCount,
+                skippedEnrichmentCount: counts.skippedEnrichmentCount,
                 pendingEnrichmentCount: pendingEnrichmentCount,
                 enrichmentPercent: enrichmentPercent,
                 enrichmentRatePerMinute: enrichmentRatePerMinute,
                 databaseSizeBytes: databaseSizeBytes(),
                 recentActivityBuckets: recentActivityBuckets,
                 recentAgentWriteBuckets: recentAgentWriteBuckets,
-                recentWatcherWriteBuckets: recentWatcherWriteBuckets,
+                recentWatcherWriteBuckets: recentWatcherIngest.buckets,
                 recentEnrichmentBuckets: recentEnrichmentBuckets,
                 recentWriteFiveMinuteCount: recentWriteFiveMinuteCount,
                 recentEnrichmentFiveMinuteCount: recentEnrichmentFiveMinuteCount,
@@ -1862,7 +2028,10 @@ final class BrainDatabase: @unchecked Sendable {
                 pendingStoreQueueDepth: pendingStoreQueue.depth,
                 pendingStoreFlushQueueDepth: pendingStoreFlushQueue.depth,
                 pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt,
-                watcherHealth: watcherHealth
+                watcherHealth: watcherHealth,
+                replayDebtBreakdown: replayDebtBreakdown,
+                watcherRecentDistinctChunkCount: recentWatcherTruth.total,
+                watcherFlowReadability: recentWatcherTruth.readability
             )
         }
     }
@@ -1886,7 +2055,8 @@ final class BrainDatabase: @unchecked Sendable {
                     allWriteBuckets: Array(repeating: 0, count: max(bucketCount, 0)),
                     agentWriteBuckets: Array(repeating: 0, count: max(bucketCount, 0)),
                     watcherWriteBuckets: Array(repeating: 0, count: max(bucketCount, 0)),
-                    enrichmentBuckets: Array(repeating: 0, count: max(bucketCount, 0))
+                    enrichmentBuckets: Array(repeating: 0, count: max(bucketCount, 0)),
+                    watcherFlowReadability: .readable
                 )
             }
 
@@ -1901,7 +2071,7 @@ final class BrainDatabase: @unchecked Sendable {
                 bucketCount: bucketCount,
                 now: now
             )
-            let watcherWriteBuckets = try recentWatcherWriteBuckets(
+            let watcherIngest = recentWatcherWriteBuckets(
                 activityWindowMinutes: activityWindowMinutes,
                 bucketCount: bucketCount,
                 now: now
@@ -1917,8 +2087,9 @@ final class BrainDatabase: @unchecked Sendable {
                 bucketCount: bucketCount,
                 allWriteBuckets: allWriteBuckets,
                 agentWriteBuckets: agentWriteBuckets,
-                watcherWriteBuckets: watcherWriteBuckets,
-                enrichmentBuckets: enrichmentBuckets
+                watcherWriteBuckets: watcherIngest.buckets,
+                enrichmentBuckets: enrichmentBuckets,
+                watcherFlowReadability: watcherIngest.readability
             )
         }
     }
@@ -2004,10 +2175,18 @@ final class BrainDatabase: @unchecked Sendable {
         return Int(sqlite3_column_int(stmt, 0))
     }
 
-    private func dashboardCounts() throws -> (chunkCount: Int, enrichedChunkCount: Int, pendingEnrichmentCount: Int) {
+    private func dashboardCounts() throws -> (
+        chunkCount: Int,
+        enrichedChunkCount: Int,
+        failedEnrichmentCount: Int,
+        skippedEnrichmentCount: Int,
+        pendingEnrichmentCount: Int
+    ) {
         return (
             chunkCount: try scalarInt("SELECT COUNT(*) FROM chunks"),
-            enrichedChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL"),
+            enrichedChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE LOWER(TRIM(enrich_status)) = 'success'"),
+            failedEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE LOWER(TRIM(enrich_status)) = 'failed'"),
+            skippedEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE LOWER(TRIM(enrich_status)) = 'skipped'"),
             pendingEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NULL AND enriched_at IS NULL")
         )
     }
@@ -2094,7 +2273,7 @@ final class BrainDatabase: @unchecked Sendable {
         )
         let lastEnrichedAt = try latestIndexedTimestampEpoch(
             column: "enriched_at",
-            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            whereClause: "enriched_at IS NOT NULL AND LOWER(TRIM(enrich_status)) = 'success'",
             since: recentWindowStart
         )
         return (lastWriteAt: lastWriteAt, lastEnrichedAt: lastEnrichedAt)
@@ -2133,27 +2312,40 @@ final class BrainDatabase: @unchecked Sendable {
         activityWindowMinutes: Int,
         bucketCount: Int,
         now: Date
-    ) throws -> [Int] {
-        guard activityWindowMinutes > 0 else { return Array(repeating: 0, count: bucketCount) }
-
-        if try tableExists("watcher_liveness_events"),
-           let db,
-           try tableColumns(name: "watcher_liveness_events", on: db).contains("ingested_at") {
-            return try indexedUnixEpochBuckets(
-                tableName: "watcher_liveness_events",
-                epochColumn: "ingested_at",
-                activityWindowMinutes: activityWindowMinutes,
-                bucketCount: bucketCount,
-                now: now
-            )
+    ) -> WatcherIngestSnapshot {
+        let empty = Array(repeating: 0, count: max(bucketCount, 0))
+        guard activityWindowMinutes > 0, bucketCount > 0 else {
+            return WatcherIngestSnapshot(buckets: empty, readability: .readable)
         }
 
-        return try recentWriteBuckets(
-            whereClause: Self.watcherWriteSourceWhereClause,
-            activityWindowMinutes: activityWindowMinutes,
-            bucketCount: bucketCount,
-            now: now
-        )
+        do {
+            guard try tableExists("watcher_liveness_events"), let db else {
+                return WatcherIngestSnapshot(
+                    buckets: empty,
+                    readability: .unreadable("watcher_liveness_events table unavailable")
+                )
+            }
+            let columns = try tableColumns(name: "watcher_liveness_events", on: db)
+            guard columns.contains("chunk_id"), columns.contains("ingested_at") else {
+                return WatcherIngestSnapshot(
+                    buckets: empty,
+                    readability: .unreadable("watcher_liveness_events columns unavailable")
+                )
+            }
+            return WatcherIngestSnapshot(
+                buckets: try distinctWatcherIngestBuckets(
+                    activityWindowMinutes: activityWindowMinutes,
+                    bucketCount: bucketCount,
+                    now: now
+                ),
+                readability: .readable
+            )
+        } catch {
+            return WatcherIngestSnapshot(
+                buckets: empty,
+                readability: .unreadable(String(describing: error))
+            )
+        }
     }
 
     private func recentEnrichmentBuckets(activityWindowMinutes: Int, bucketCount: Int, now: Date) throws -> [Int] {
@@ -2161,7 +2353,7 @@ final class BrainDatabase: @unchecked Sendable {
 
         return try indexedTimestampBuckets(
             column: "enriched_at",
-            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            whereClause: "enriched_at IS NOT NULL AND LOWER(TRIM(enrich_status)) = 'success'",
             activityWindowMinutes: activityWindowMinutes,
             bucketCount: bucketCount,
             now: now
@@ -2181,7 +2373,7 @@ final class BrainDatabase: @unchecked Sendable {
         guard windowSeconds > 0 else { return 0 }
         return try indexedTimestampEpochs(
             column: "enriched_at",
-            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            whereClause: "enriched_at IS NOT NULL AND LOWER(TRIM(enrich_status)) = 'success'",
             since: now.addingTimeInterval(-windowSeconds)
         ).count
     }
@@ -2190,7 +2382,7 @@ final class BrainDatabase: @unchecked Sendable {
         guard windowMinutes > 0 else { return 0 }
         let count = Double(try indexedTimestampEpochs(
             column: "enriched_at",
-            whereClause: "enriched_at IS NOT NULL AND enrich_status = 'success'",
+            whereClause: "enriched_at IS NOT NULL AND LOWER(TRIM(enrich_status)) = 'success'",
             since: now.addingTimeInterval(Double(-windowMinutes * 60))
         ).count)
         return count / Double(windowMinutes)
@@ -2227,20 +2419,12 @@ final class BrainDatabase: @unchecked Sendable {
         return buckets
     }
 
-    private func indexedUnixEpochBuckets(
-        tableName: String,
-        epochColumn: String,
+    private func distinctWatcherIngestBuckets(
         activityWindowMinutes: Int,
         bucketCount: Int,
         now: Date
     ) throws -> [Int] {
         guard bucketCount > 0, activityWindowMinutes > 0 else { return Array(repeating: 0, count: max(bucketCount, 0)) }
-        let allowedEpochTables = [
-            "watcher_liveness_events": Set(["ingested_at"]),
-        ]
-        guard allowedEpochTables[tableName]?.contains(epochColumn) == true else {
-            throw DBError.exec(SQLITE_ERROR, "invalid epoch bucket source")
-        }
         guard let db else { throw DBError.notOpen }
 
         let windowDuration = Double(activityWindowMinutes * 60)
@@ -2251,11 +2435,12 @@ final class BrainDatabase: @unchecked Sendable {
         var buckets = Array(repeating: 0, count: bucketCount)
 
         let sql = """
-            SELECT \(epochColumn)
-            FROM \(tableName)
-            WHERE \(epochColumn) >= ?
-              AND \(epochColumn) <= ?
-            ORDER BY \(epochColumn) ASC
+            SELECT MIN(ingested_at) AS first_ingested_at
+            FROM watcher_liveness_events
+            WHERE ingested_at >= ?
+              AND ingested_at <= ?
+            GROUP BY chunk_id
+            ORDER BY first_ingested_at ASC
         """
 
         var stmt: OpaquePointer?
@@ -3583,22 +3768,42 @@ final class BrainDatabase: @unchecked Sendable {
         return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Gits", isDirectory: true)
     }
 
-    private static func durableStoreQueueSnapshot() -> PendingStoreQueueSnapshot {
+    private static func durableStoreQueueComponent() -> ReplayDebtBreakdown.Component {
         let queueDir = durableStoreQueuePath()
         let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: queueDir.path) else {
+            return ReplayDebtBreakdown.Component(
+                source: .durableQueue,
+                snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                readability: .readable
+            )
+        }
+        guard urlIsDirectory(queueDir) else {
+            return ReplayDebtBreakdown.Component(
+                source: .durableQueue,
+                snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                readability: .unreadable("durable queue path is not a directory")
+            )
+        }
         guard let files = try? fileManager.contentsOfDirectory(
             at: queueDir,
             includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) else {
-            return PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil)
+            return ReplayDebtBreakdown.Component(
+                source: .durableQueue,
+                snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                readability: .unreadable("durable queue directory could not be read")
+            )
         }
 
         var depth = 0
         var oldestQueuedAt: Date?
         var identityKeys = Set<String>()
+        var isReadable = true
         for file in files where file.pathExtension == "jsonl" && urlIsRegularFile(file) {
             guard let data = try? Data(contentsOf: file) else {
+                isReadable = false
                 depth += 1
                 identityKeys.insert(normalizedPathIdentityKey(file))
                 if let values = try? file.resourceValues(forKeys: [.contentModificationDateKey]),
@@ -3626,23 +3831,50 @@ final class BrainDatabase: @unchecked Sendable {
                 oldestQueuedAt = oldestQueuedAt.map { min($0, modified) } ?? modified
             }
         }
-        return PendingStoreQueueSnapshot(depth: depth, oldestQueuedAt: oldestQueuedAt, identityKeys: identityKeys)
+        return ReplayDebtBreakdown.Component(
+            source: .durableQueue,
+            snapshot: PendingStoreQueueSnapshot(
+                depth: depth,
+                oldestQueuedAt: oldestQueuedAt,
+                identityKeys: identityKeys
+            ),
+            readability: isReadable ? .readable : .unreadable("one or more durable queue files could not be read")
+        )
     }
 
-    private static func fallbackReplayQueueSnapshot() -> PendingStoreQueueSnapshot {
+    private static func fallbackReplayQueueComponent() -> ReplayDebtBreakdown.Component {
         let root = fallbackReplayGitsRoot()
         let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: root.path) else {
+            return ReplayDebtBreakdown.Component(
+                source: .repositoryFallback,
+                snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                readability: .readable
+            )
+        }
+        guard urlIsDirectory(root) else {
+            return ReplayDebtBreakdown.Component(
+                source: .repositoryFallback,
+                snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                readability: .unreadable("repository fallback root is not a directory")
+            )
+        }
         guard let repos = try? fileManager.contentsOfDirectory(
             at: root,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
         ) else {
-            return PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil)
+            return ReplayDebtBreakdown.Component(
+                source: .repositoryFallback,
+                snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                readability: .unreadable("repository fallback root could not be read")
+            )
         }
 
         var depth = 0
         var oldestQueuedAt: Date?
         var identityKeys = Set<String>()
+        var isReadable = true
         func record(_ date: Date?, _ identityKey: String?) {
             depth += 1
             if let identityKey {
@@ -3654,25 +3886,33 @@ final class BrainDatabase: @unchecked Sendable {
 
         for repo in repos where Self.urlIsDirectory(repo) {
             let docsLocal = repo.appendingPathComponent("docs.local", isDirectory: true)
-            scanFallbackReplayDirectory(
+            isReadable = scanFallbackReplayDirectory(
                 docsLocal.appendingPathComponent("decisions", isDirectory: true),
                 recursive: false,
                 originRepoPath: repo,
                 countParsedWithoutIntent: false,
                 countUnparseableAsDebt: true,
                 record: record
-            )
-            scanFallbackReplayDirectory(
+            ) && isReadable
+            isReadable = scanFallbackReplayDirectory(
                 docsLocal.appendingPathComponent("brain-store-fallback", isDirectory: true),
                 recursive: true,
                 originRepoPath: repo,
                 countParsedWithoutIntent: true,
                 countUnparseableAsDebt: true,
                 record: record
-            )
+            ) && isReadable
         }
 
-        return PendingStoreQueueSnapshot(depth: depth, oldestQueuedAt: oldestQueuedAt, identityKeys: identityKeys)
+        return ReplayDebtBreakdown.Component(
+            source: .repositoryFallback,
+            snapshot: PendingStoreQueueSnapshot(
+                depth: depth,
+                oldestQueuedAt: oldestQueuedAt,
+                identityKeys: identityKeys
+            ),
+            readability: isReadable ? .readable : .unreadable("one or more repository fallback directories could not be read")
+        )
     }
 
     private static func scanFallbackReplayDirectory(
@@ -3682,15 +3922,17 @@ final class BrainDatabase: @unchecked Sendable {
         countParsedWithoutIntent: Bool,
         countUnparseableAsDebt: Bool,
         record: (Date?, String?) -> Void
-    ) {
+    ) -> Bool {
         let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: directory.path) else { return true }
+        guard urlIsDirectory(directory) else { return false }
         if recursive {
             guard let enumerator = fileManager.enumerator(
                 at: directory,
                 includingPropertiesForKeys: [.isRegularFileKey],
                 options: [.skipsHiddenFiles]
             ) else {
-                return
+                return false
             }
             for case let file as URL in enumerator where file.pathExtension == "md" {
                 if let pending = pendingFallbackReplayRecord(
@@ -3702,7 +3944,7 @@ final class BrainDatabase: @unchecked Sendable {
                     record(pending.queuedAt, pending.identityKey)
                 }
             }
-            return
+            return true
         }
 
         guard let files = try? fileManager.contentsOfDirectory(
@@ -3710,7 +3952,7 @@ final class BrainDatabase: @unchecked Sendable {
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) else {
-            return
+            return false
         }
         for file in files where file.pathExtension == "md" {
             if let pending = pendingFallbackReplayRecord(
@@ -3722,6 +3964,7 @@ final class BrainDatabase: @unchecked Sendable {
                 record(pending.queuedAt, pending.identityKey)
             }
         }
+        return true
     }
 
     private static func pendingFallbackReplayRecord(
@@ -4024,6 +4267,28 @@ final class BrainDatabase: @unchecked Sendable {
 
     func pendingStoreQueueSnapshot() -> PendingStoreQueueSnapshot {
         pendingStoreQueueSnapshotIfReadable() ?? PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil)
+    }
+
+    private func replayDebtBreakdown() -> ReplayDebtBreakdown {
+        let pendingStores: ReplayDebtBreakdown.Component
+        if let snapshot = pendingStoreQueueSnapshotIfReadable() {
+            pendingStores = ReplayDebtBreakdown.Component(
+                source: .pendingStores,
+                snapshot: snapshot,
+                readability: .readable
+            )
+        } else {
+            pendingStores = ReplayDebtBreakdown.Component(
+                source: .pendingStores,
+                snapshot: PendingStoreQueueSnapshot(depth: 0, oldestQueuedAt: nil),
+                readability: .unreadable("pending stores queue could not be read")
+            )
+        }
+        return ReplayDebtBreakdown(
+            pendingStores: pendingStores,
+            durableQueue: Self.durableStoreQueueComponent(),
+            repositoryFallback: Self.fallbackReplayQueueComponent()
+        )
     }
 
     func pendingStoreQueueSnapshotIfReadable() -> PendingStoreQueueSnapshot? {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3970,7 +3970,11 @@ final class BrainDatabase: @unchecked Sendable {
             guard let enumerator = fileManager.enumerator(
                 at: directory,
                 includingPropertiesForKeys: [.isRegularFileKey],
-                options: [.skipsHiddenFiles]
+                options: [.skipsHiddenFiles],
+                errorHandler: { _, _ in
+                    isReadable = false
+                    return true
+                }
             ) else {
                 return false
             }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3926,6 +3926,26 @@ final class BrainDatabase: @unchecked Sendable {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: directory.path) else { return true }
         guard urlIsDirectory(directory) else { return false }
+        var isReadable = true
+        func inspect(_ file: URL) {
+            switch pendingFallbackReplayRecord(
+                at: file,
+                originRepoPath: originRepoPath,
+                countParsedWithoutIntent: countParsedWithoutIntent,
+                countUnparseableAsDebt: countUnparseableAsDebt
+            ) {
+            case .ignored:
+                break
+            case .pending(let queuedAt, let identityKey):
+                record(queuedAt, identityKey)
+            case .unreadable(let queuedAt, let identityKey):
+                isReadable = false
+                if countUnparseableAsDebt {
+                    record(queuedAt, identityKey)
+                }
+            }
+        }
+
         if recursive {
             guard let enumerator = fileManager.enumerator(
                 at: directory,
@@ -3935,16 +3955,9 @@ final class BrainDatabase: @unchecked Sendable {
                 return false
             }
             for case let file as URL in enumerator where file.pathExtension == "md" {
-                if let pending = pendingFallbackReplayRecord(
-                    at: file,
-                    originRepoPath: originRepoPath,
-                    countParsedWithoutIntent: countParsedWithoutIntent,
-                    countUnparseableAsDebt: countUnparseableAsDebt
-                ) {
-                    record(pending.queuedAt, pending.identityKey)
-                }
+                inspect(file)
             }
-            return true
+            return isReadable
         }
 
         guard let files = try? fileManager.contentsOfDirectory(
@@ -3955,16 +3968,15 @@ final class BrainDatabase: @unchecked Sendable {
             return false
         }
         for file in files where file.pathExtension == "md" {
-            if let pending = pendingFallbackReplayRecord(
-                at: file,
-                originRepoPath: originRepoPath,
-                countParsedWithoutIntent: countParsedWithoutIntent,
-                countUnparseableAsDebt: countUnparseableAsDebt
-            ) {
-                record(pending.queuedAt, pending.identityKey)
-            }
+            inspect(file)
         }
-        return true
+        return isReadable
+    }
+
+    private enum FallbackReplayRecordResult {
+        case ignored
+        case pending(queuedAt: Date?, identityKey: String?)
+        case unreadable(queuedAt: Date?, identityKey: String?)
     }
 
     private static func pendingFallbackReplayRecord(
@@ -3972,15 +3984,21 @@ final class BrainDatabase: @unchecked Sendable {
         originRepoPath: URL,
         countParsedWithoutIntent: Bool,
         countUnparseableAsDebt: Bool
-    ) -> (queuedAt: Date?, identityKey: String?)? {
+    ) -> FallbackReplayRecordResult {
         guard let data = try? Data(contentsOf: file),
               let text = String(data: data, encoding: .utf8) else {
-            return nil
+            return .unreadable(
+                queuedAt: inferLegacyFallbackTimestamp(from: file),
+                identityKey: normalizedPathIdentityKey(file)
+            )
         }
         guard let parsed = fallbackReplayComponents(from: text) else {
-            guard countUnparseableAsDebt else { return nil }
-            guard countParsedWithoutIntent || textLooksLikeFrontmatterAttempt(text) else { return nil }
-            return (inferLegacyFallbackTimestamp(from: file), normalizedPathIdentityKey(file))
+            guard countUnparseableAsDebt else { return .ignored }
+            guard countParsedWithoutIntent || textLooksLikeFrontmatterAttempt(text) else { return .ignored }
+            return .pending(
+                queuedAt: inferLegacyFallbackTimestamp(from: file),
+                identityKey: normalizedPathIdentityKey(file)
+            )
         }
         let frontmatter = parsed.frontmatter
         let hasIntentFlag = isTruthyFrontmatterValue(frontmatter["intended_brain_store"])
@@ -3992,11 +4010,11 @@ final class BrainDatabase: @unchecked Sendable {
                 frontmatter: frontmatter,
                 body: parsed.body
               ) else {
-            return nil
+            return .ignored
         }
-        return (
-            parsePendingStoreQueuedAt(frontmatter["timestamp"] ?? ""),
-            fallbackReplayIdentityKey(
+        return .pending(
+            queuedAt: parsePendingStoreQueuedAt(frontmatter["timestamp"] ?? ""),
+            identityKey: fallbackReplayIdentityKey(
                 frontmatter: frontmatter,
                 file: file,
                 originRepoPath: originRepoPath,

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -351,7 +351,7 @@ final class BrainDatabase: @unchecked Sendable {
                 replayDebtBreakdown: replayDebtBreakdown,
                 watcherProcessProbeResult: watcherProcessProbeResult,
                 watcherRecentDistinctChunkCount: watcherRecentDistinctChunkCount,
-                watcherFlowReadability: watcherFlowReadability
+                watcherFlowReadability: buckets.watcherFlowReadability
             )
         }
 

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -2186,7 +2186,9 @@ final class BrainDatabase: @unchecked Sendable {
             chunkCount: try scalarInt("SELECT COUNT(*) FROM chunks"),
             enrichedChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE LOWER(TRIM(enrich_status)) = 'success'"),
             failedEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE LOWER(TRIM(enrich_status)) = 'failed'"),
-            skippedEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE LOWER(TRIM(enrich_status)) = 'skipped'"),
+            skippedEnrichmentCount: try scalarInt(
+                "SELECT COUNT(*) FROM chunks WHERE enrich_status IS NOT NULL AND LOWER(TRIM(enrich_status)) NOT IN ('success', 'failed')"
+            ),
             pendingEnrichmentCount: try scalarInt("SELECT COUNT(*) FROM chunks WHERE enrich_status IS NULL AND enriched_at IS NULL")
         )
     }
@@ -3801,13 +3803,32 @@ final class BrainDatabase: @unchecked Sendable {
         var oldestQueuedAt: Date?
         var identityKeys = Set<String>()
         var isReadable = true
-        for file in files where file.pathExtension == "jsonl" && urlIsRegularFile(file) {
+        for file in files where file.pathExtension == "jsonl" {
+            let resourceValues: URLResourceValues
+            do {
+                resourceValues = try file.resourceValues(
+                    forKeys: [.contentModificationDateKey, .isRegularFileKey]
+                )
+            } catch {
+                isReadable = false
+                depth += 1
+                identityKeys.insert(normalizedPathIdentityKey(file))
+                continue
+            }
+            guard resourceValues.isRegularFile == true else {
+                isReadable = false
+                depth += 1
+                identityKeys.insert(normalizedPathIdentityKey(file))
+                if let modified = resourceValues.contentModificationDate {
+                    oldestQueuedAt = oldestQueuedAt.map { min($0, modified) } ?? modified
+                }
+                continue
+            }
             guard let data = try? Data(contentsOf: file) else {
                 isReadable = false
                 depth += 1
                 identityKeys.insert(normalizedPathIdentityKey(file))
-                if let values = try? file.resourceValues(forKeys: [.contentModificationDateKey]),
-                   let modified = values.contentModificationDate {
+                if let modified = resourceValues.contentModificationDate {
                     oldestQueuedAt = oldestQueuedAt.map { min($0, modified) } ?? modified
                 }
                 continue
@@ -3826,8 +3847,7 @@ final class BrainDatabase: @unchecked Sendable {
             }
             guard storeLineCount > 0 else { continue }
             depth += storeLineCount
-            if let values = try? file.resourceValues(forKeys: [.contentModificationDateKey]),
-               let modified = values.contentModificationDate {
+            if let modified = resourceValues.contentModificationDate {
                 oldestQueuedAt = oldestQueuedAt.map { min($0, modified) } ?? modified
             }
         }

--- a/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
+++ b/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
@@ -233,8 +233,16 @@ enum BrainLayerConfigValidationResult: Equatable, Sendable {
 }
 
 enum BrainLayerConfigValidator {
-    static func validate(_ config: BrainLayerConfig) -> BrainLayerConfigValidationResult {
-        if config.enrichmentProvider.unavailableReason != nil {
+    static func validate(
+        _ config: BrainLayerConfig,
+        previousConfig: BrainLayerConfig? = nil
+    ) -> BrainLayerConfigValidationResult {
+        let activatesUnavailableProvider = previousConfig == nil ||
+            previousConfig?.enrichmentProvider != config.enrichmentProvider ||
+            (previousConfig?.enrichmentEnabled == false && config.enrichmentEnabled)
+        if config.enrichmentEnabled,
+           config.enrichmentProvider.unavailableReason != nil,
+           activatesUnavailableProvider {
             return .failed(
                 "\(config.enrichmentProvider.title) cannot be activated because its runtime integration is unavailable."
             )
@@ -501,7 +509,14 @@ struct BrainLayerEnvDocument {
     }
 
     private static func parseGoogleKey(_ raw: String) -> BrainLayerGoogleAPIKey {
-        let value = strippedValue(raw)
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        let value: String
+        if trimmed.count >= 2, trimmed.first == "'", trimmed.last == "'" {
+            value = String(trimmed.dropFirst().dropLast())
+                .replacingOccurrences(of: "'\"'\"'", with: "'")
+        } else {
+            value = strippedValue(raw)
+        }
         guard !value.isEmpty else { return .missing }
         if value.contains("op read") {
             return .onePasswordReference(extractOpReference(from: value) ?? "op://Private/Google AI/Gemini API key")
@@ -559,6 +574,8 @@ struct BrainLayerEnvDocument {
 struct BrainLayerConfigStore {
     let configURL: URL
     var fileManager: FileManager = .default
+    private let loadDocumentOverride: (() throws -> BrainLayerEnvDocument)?
+    private let saveOverride: ((BrainLayerConfig) throws -> Void)?
 
     static func defaultConfigURL(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
         homeDirectory
@@ -567,11 +584,22 @@ struct BrainLayerConfigStore {
             .appendingPathComponent("brainlayer.env", isDirectory: false)
     }
 
-    init(configURL: URL = BrainLayerConfigStore.defaultConfigURL()) {
+    init(
+        configURL: URL = BrainLayerConfigStore.defaultConfigURL(),
+        fileManager: FileManager = .default,
+        loadDocumentOverride: (() throws -> BrainLayerEnvDocument)? = nil,
+        saveOverride: ((BrainLayerConfig) throws -> Void)? = nil
+    ) {
         self.configURL = configURL
+        self.fileManager = fileManager
+        self.loadDocumentOverride = loadDocumentOverride
+        self.saveOverride = saveOverride
     }
 
     func loadDocument() throws -> BrainLayerEnvDocument {
+        if let loadDocumentOverride {
+            return try loadDocumentOverride()
+        }
         guard fileManager.fileExists(atPath: configURL.path) else {
             return BrainLayerEnvDocument(config: .defaultConfig)
         }
@@ -580,6 +608,10 @@ struct BrainLayerConfigStore {
     }
 
     func save(_ config: BrainLayerConfig) throws {
+        if let saveOverride {
+            try saveOverride(config)
+            return
+        }
         var document = try loadDocument()
         document.update { $0 = config }
         try fileManager.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)

--- a/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
+++ b/brain-bar/Sources/BrainBar/BrainLayerConfig.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BrainLayerEnrichmentMode: String, CaseIterable, Identifiable {
+enum BrainLayerEnrichmentMode: String, CaseIterable, Identifiable, Sendable {
     case remote
     case local
 
@@ -14,7 +14,7 @@ enum BrainLayerEnrichmentMode: String, CaseIterable, Identifiable {
     }
 }
 
-enum BrainLayerEnrichmentProvider: String, CaseIterable, Identifiable {
+enum BrainLayerEnrichmentProvider: String, CaseIterable, Identifiable, Sendable {
     case gemini
     case openai
     case anthropic
@@ -32,9 +32,17 @@ enum BrainLayerEnrichmentProvider: String, CaseIterable, Identifiable {
     var isWiredToday: Bool {
         self == .gemini
     }
+
+    static var selectableCases: [BrainLayerEnrichmentProvider] {
+        allCases.filter(\.isWiredToday)
+    }
+
+    var unavailableReason: String? {
+        isWiredToday ? nil : "Runtime integration is not available in this build."
+    }
 }
 
-enum BrainLayerGoogleAPIKey: Equatable {
+enum BrainLayerGoogleAPIKey: Equatable, Sendable, CustomStringConvertible, CustomDebugStringConvertible {
     enum Kind: Equatable {
         case missing
         case plainPresent
@@ -68,6 +76,10 @@ enum BrainLayerGoogleAPIKey: Equatable {
         return "op://Private/Google AI/Gemini API key"
     }
 
+    var description: String { displayText }
+
+    var debugDescription: String { displayText }
+
     fileprivate var renderedValue: String {
         switch self {
         case .missing:
@@ -84,11 +96,12 @@ enum BrainLayerGoogleAPIKey: Equatable {
     }
 }
 
-enum BrainLayerLaunchdLoadState: Equatable {
+enum BrainLayerLaunchdLoadState: Equatable, Sendable {
     case running
     case loaded
     case unloaded
     case unknown
+    case probeError(String)
 
     var title: String {
         switch self {
@@ -96,11 +109,12 @@ enum BrainLayerLaunchdLoadState: Equatable {
         case .loaded: "Loaded"
         case .unloaded: "Unloaded"
         case .unknown: "Unknown"
+        case let .probeError(reason): "Unknown — probe error: \(reason)"
         }
     }
 }
 
-enum BrainLayerLaunchdJob: String, CaseIterable, Identifiable {
+enum BrainLayerLaunchdJob: String, CaseIterable, Identifiable, Sendable {
     case enrichment
     case hotlane
     case decay
@@ -163,12 +177,12 @@ enum BrainLayerLaunchdJob: String, CaseIterable, Identifiable {
     }
 }
 
-struct BrainLayerLaunchdJobSetting: Equatable {
+struct BrainLayerLaunchdJobSetting: Equatable, Sendable {
     var enabled: Bool
     var loadState: BrainLayerLaunchdLoadState
 }
 
-struct BrainLayerConfig: Equatable {
+struct BrainLayerConfig: Equatable, Sendable {
     var googleAPIKey: BrainLayerGoogleAPIKey
     var systemEnabled: Bool
     var enrichmentEnabled: Bool
@@ -192,6 +206,142 @@ struct BrainLayerConfig: Equatable {
             }
         )
     )
+
+    func persistedValuesEqual(to other: BrainLayerConfig) -> Bool {
+        googleAPIKey == other.googleAPIKey &&
+            systemEnabled == other.systemEnabled &&
+            enrichmentEnabled == other.enrichmentEnabled &&
+            enrichmentMode == other.enrichmentMode &&
+            enrichmentProvider == other.enrichmentProvider &&
+            enrichmentBackend == other.enrichmentBackend &&
+            tuningValues == other.tuningValues &&
+            Dictionary(uniqueKeysWithValues: launchdJobs.map { ($0.key, $0.value.enabled) }) ==
+            Dictionary(uniqueKeysWithValues: other.launchdJobs.map { ($0.key, $0.value.enabled) })
+    }
+}
+
+enum BrainLayerConfigValidationResult: Equatable, Sendable {
+    case passed
+    case failed(String)
+
+    var title: String {
+        switch self {
+        case .passed: "Passed"
+        case let .failed(message): "Failed — \(message)"
+        }
+    }
+}
+
+enum BrainLayerConfigValidator {
+    static func validate(_ config: BrainLayerConfig) -> BrainLayerConfigValidationResult {
+        if config.enrichmentProvider.unavailableReason != nil {
+            return .failed(
+                "\(config.enrichmentProvider.title) cannot be activated because its runtime integration is unavailable."
+            )
+        }
+        if config.enrichmentBackend.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return .failed("Enrichment backend is required.")
+        }
+        return .passed
+    }
+}
+
+struct BrainLayerActiveRuntimeValues: Equatable, Sendable {
+    let systemEnabled: Bool
+    let enrichmentEnabled: Bool
+    let enrichmentMode: BrainLayerEnrichmentMode
+    let enrichmentProvider: BrainLayerEnrichmentProvider
+    let enrichmentBackend: String
+
+    init(config: BrainLayerConfig) {
+        systemEnabled = config.systemEnabled
+        enrichmentEnabled = config.enrichmentEnabled
+        enrichmentMode = config.enrichmentMode
+        enrichmentProvider = config.enrichmentProvider
+        enrichmentBackend = config.enrichmentBackend
+    }
+
+    func matches(_ config: BrainLayerConfig) -> Bool {
+        self == BrainLayerActiveRuntimeValues(config: config)
+    }
+
+    var summary: String {
+        "\(enrichmentEnabled ? "Enrichment on" : "Enrichment off") · " +
+            "\(enrichmentMode.title) · \(enrichmentProvider.title) · \(enrichmentBackend)"
+    }
+}
+
+enum BrainLayerActiveRuntimeObservation: Equatable, Sendable {
+    case observed(BrainLayerActiveRuntimeValues)
+    case unknown(String)
+
+    var summary: String {
+        switch self {
+        case let .observed(values): values.summary
+        case let .unknown(reason): "Unknown — \(reason)"
+        }
+    }
+}
+
+protocol BrainLayerActiveRuntimeSampling: Sendable {
+    func sample() -> BrainLayerActiveRuntimeObservation
+}
+
+struct UnknownBrainLayerActiveRuntimeProvider: BrainLayerActiveRuntimeSampling {
+    func sample() -> BrainLayerActiveRuntimeObservation {
+        .unknown("Active runtime configuration is not observable.")
+    }
+}
+
+struct StaticBrainLayerActiveRuntimeProvider: BrainLayerActiveRuntimeSampling {
+    let observation: BrainLayerActiveRuntimeObservation
+
+    func sample() -> BrainLayerActiveRuntimeObservation { observation }
+}
+
+enum BrainLayerSettingsService: Equatable, Hashable, Sendable {
+    case enrichment
+    case systemJobs
+    case launchdJob(BrainLayerLaunchdJob)
+
+    var title: String {
+        switch self {
+        case .enrichment: "Enrichment service"
+        case .systemJobs: "BrainLayer jobs"
+        case let .launchdJob(job): job.launchdLabel
+        }
+    }
+}
+
+enum BrainLayerActiveRuntimeReceiptState: Equatable, Sendable {
+    case observed
+    case notObserved
+    case unknown(String)
+
+    var title: String {
+        switch self {
+        case .observed: "Observed active"
+        case .notObserved: "Not active yet"
+        case let .unknown(reason): "Unknown — \(reason)"
+        }
+    }
+}
+
+struct BrainLayerSettingsSaveReceipt: Equatable, Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    let configURL: URL
+    let savedAt: Date
+    let fileUpdated: Bool
+    let validation: BrainLayerConfigValidationResult
+    let servicesRequiringRestart: [BrainLayerSettingsService]
+    let activeRuntimeState: BrainLayerActiveRuntimeReceiptState
+
+    var description: String {
+        let services = servicesRequiringRestart.map(\.title).joined(separator: ", ")
+        return "fileUpdated=\(fileUpdated) validation=\(validation.title) " +
+            "restart=\(services.isEmpty ? "none" : services) active=\(activeRuntimeState.title)"
+    }
+
+    var debugDescription: String { description }
 }
 
 struct BrainLayerEnvDocument {
@@ -438,11 +588,29 @@ struct BrainLayerConfigStore {
     }
 }
 
+struct BrainLayerLaunchdCommandResult: Sendable, Equatable {
+    let terminationStatus: Int32
+    let output: String
+}
+
 protocol BrainLayerLaunchdStatusSampling: Sendable {
     func sample() -> [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]
 }
 
 struct BrainLayerLaunchdStatusProvider: BrainLayerLaunchdStatusSampling {
+    typealias CommandRunner = @Sendable ([String]) -> BrainLayerLaunchdCommandResult
+
+    private let commandRunner: CommandRunner
+    private let uidProvider: @Sendable () -> uid_t
+
+    init(
+        commandRunner: @escaping CommandRunner = BrainLayerLaunchdStatusProvider.run,
+        uidProvider: @escaping @Sendable () -> uid_t = getuid
+    ) {
+        self.commandRunner = commandRunner
+        self.uidProvider = uidProvider
+    }
+
     func sample() -> [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] {
         Dictionary(
             uniqueKeysWithValues: BrainLayerLaunchdJob.allCases.map { job in
@@ -452,21 +620,39 @@ struct BrainLayerLaunchdStatusProvider: BrainLayerLaunchdStatusSampling {
     }
 
     private func state(for label: String) -> BrainLayerLaunchdLoadState {
+        let target = "gui/\(uidProvider())/\(label)"
+        let result = commandRunner(["/bin/launchctl", "print", target])
+        if result.terminationStatus == 0 {
+            return result.output.contains("pid =") ? .running : .loaded
+        }
+
+        if result.terminationStatus == 113 ||
+            result.output.localizedCaseInsensitiveContains("could not find service") {
+            return .unloaded
+        }
+        return .probeError("launchctl exited \(result.terminationStatus)")
+    }
+
+    private static func run(_ command: [String]) -> BrainLayerLaunchdCommandResult {
+        guard let executable = command.first else {
+            return BrainLayerLaunchdCommandResult(terminationStatus: 1, output: "")
+        }
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-        process.arguments = ["print", "gui/\(getuid())/\(label)"]
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = Array(command.dropFirst())
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = pipe
         do {
             try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return .unloaded }
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-            return output.contains("pid =") ? .running : .loaded
+            process.waitUntilExit()
+            return BrainLayerLaunchdCommandResult(
+                terminationStatus: process.terminationStatus,
+                output: String(data: data, encoding: .utf8) ?? ""
+            )
         } catch {
-            return .unknown
+            return BrainLayerLaunchdCommandResult(terminationStatus: 1, output: "")
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
@@ -134,6 +134,9 @@ enum BrainBarDashboardFixture {
         watcherRecentDistinctChunkCount: Int = 14
     ) -> DashboardStats {
         let windowScale = max(activityWindowMinutes / 60, 1)
+        let watcherBuckets = watcherRecentDistinctChunkCount == 0
+            ? Array(repeating: 0, count: 12)
+            : [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1].map { $0 * windowScale }
         return DashboardStats(
             chunkCount: 297_412,
             enrichedChunkCount: 188_204,
@@ -145,7 +148,7 @@ enum BrainBarDashboardFixture {
             databaseSizeBytes: 8_120_000_000,
             recentActivityBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4].map { $0 * windowScale },
             recentAgentWriteBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4].map { $0 * windowScale },
-            recentWatcherWriteBuckets: [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1].map { $0 * windowScale },
+            recentWatcherWriteBuckets: watcherBuckets,
             recentEnrichmentBuckets: [4, 6, 3, 7, 5, 8, 6, 9, 7, 5, 8, 6].map { $0 * windowScale },
             recentWriteFiveMinuteCount: 18,
             recentEnrichmentFiveMinuteCount: 22,

--- a/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
@@ -106,7 +106,7 @@ enum BrainBarDashboardFixture {
     )
     static let watcherUnknownStats = makeStats(
         replayDebtBreakdown: readableReplayDebt,
-        watcherProcessProbeResult: .failure("fixture launchctl probe failed"),
+        watcherProcessProbeResult: .failure("fixture watcher process probe failed"),
         watcherRecentDistinctChunkCount: 0
     )
     static let watcherRunningNoRecentFlowStats = makeStats(

--- a/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
@@ -29,6 +29,10 @@ enum BrainBarDashboardFixture {
         case stale
         case error
         case partialReplayDebt
+        case watcherOffline
+        case watcherUnknown
+        case watcherRunningNoRecentFlow
+        case watcherStalledWithPendingWork
     }
 
     /// Fixed "data fetched at" instant. Renders only via `absoluteTimeString`.
@@ -75,11 +79,51 @@ enum BrainBarDashboardFixture {
         repositoryFallback: readableReplayDebt.repositoryFallback
     )
 
+    private static let emptyReplayDebt = BrainDatabase.ReplayDebtBreakdown(
+        pendingStores: .init(
+            source: .pendingStores,
+            snapshot: .init(depth: 0, oldestQueuedAt: nil, identityKeys: []),
+            readability: .readable
+        ),
+        durableQueue: .init(
+            source: .durableQueue,
+            snapshot: .init(depth: 0, oldestQueuedAt: nil, identityKeys: []),
+            readability: .readable
+        ),
+        repositoryFallback: .init(
+            source: .repositoryFallback,
+            snapshot: .init(depth: 0, oldestQueuedAt: nil, identityKeys: []),
+            readability: .readable
+        )
+    )
+
     static let stats = makeStats(replayDebtBreakdown: readableReplayDebt)
     static let partialReplayDebtStats = makeStats(replayDebtBreakdown: partialReplayDebt)
+    static let watcherOfflineStats = makeStats(
+        replayDebtBreakdown: readableReplayDebt,
+        watcherProcessProbeResult: .absent,
+        watcherRecentDistinctChunkCount: 0
+    )
+    static let watcherUnknownStats = makeStats(
+        replayDebtBreakdown: readableReplayDebt,
+        watcherProcessProbeResult: .failure("fixture launchctl probe failed"),
+        watcherRecentDistinctChunkCount: 0
+    )
+    static let watcherRunningNoRecentFlowStats = makeStats(
+        replayDebtBreakdown: emptyReplayDebt,
+        watcherProcessProbeResult: .running(pid: 4242),
+        watcherRecentDistinctChunkCount: 0
+    )
+    static let watcherStalledWithPendingWorkStats = makeStats(
+        replayDebtBreakdown: readableReplayDebt,
+        watcherProcessProbeResult: .running(pid: 4242),
+        watcherRecentDistinctChunkCount: 0
+    )
 
     private static func makeStats(
-        replayDebtBreakdown: BrainDatabase.ReplayDebtBreakdown
+        replayDebtBreakdown: BrainDatabase.ReplayDebtBreakdown,
+        watcherProcessProbeResult: WatcherProcessProbeResult = .running(pid: 4242),
+        watcherRecentDistinctChunkCount: Int = 14
     ) -> DashboardStats {
         DashboardStats(
             chunkCount: 297_412,
@@ -118,8 +162,8 @@ enum BrainBarDashboardFixture {
                 updatedAt: fetchedAt
             ),
             replayDebtBreakdown: replayDebtBreakdown,
-            watcherProcessProbeResult: .running(pid: 4242),
-            watcherRecentDistinctChunkCount: 14,
+            watcherProcessProbeResult: watcherProcessProbeResult,
+            watcherRecentDistinctChunkCount: watcherRecentDistinctChunkCount,
             watcherFlowReadability: .readable
         )
     }
@@ -149,7 +193,21 @@ enum BrainBarDashboardFixture {
     /// A `StatsCollector` pre-loaded with the fixture state and no live wiring
     /// (no DB, no observers, no timers — `start()` is never called).
     static func makeCollector(_ operatorState: OperatorState = .live) -> StatsCollector {
-        let fixtureStats = operatorState == .partialReplayDebt ? partialReplayDebtStats : stats
+        let fixtureStats: DashboardStats
+        switch operatorState {
+        case .partialReplayDebt:
+            fixtureStats = partialReplayDebtStats
+        case .watcherOffline:
+            fixtureStats = watcherOfflineStats
+        case .watcherUnknown:
+            fixtureStats = watcherUnknownStats
+        case .watcherRunningNoRecentFlow:
+            fixtureStats = watcherRunningNoRecentFlowStats
+        case .watcherStalledWithPendingWork:
+            fixtureStats = watcherStalledWithPendingWorkStats
+        case .loading, .live, .stale, .error:
+            fixtureStats = stats
+        }
         let freshness: SnapshotFreshnessState
         let lastDataFetchedAt: Date?
         let lastFetchError: String?
@@ -158,7 +216,11 @@ enum BrainBarDashboardFixture {
             freshness = .loading
             lastDataFetchedAt = nil
             lastFetchError = nil
-        case .live:
+        case .live,
+             .watcherOffline,
+             .watcherUnknown,
+             .watcherRunningNoRecentFlow,
+             .watcherStalledWithPendingWork:
             freshness = .live(ageSeconds: 0)
             lastDataFetchedAt = fetchedAt
             lastFetchError = nil

--- a/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
@@ -23,6 +23,13 @@ import Foundation
 ///   animations resolve to their final state immediately.
 @MainActor
 enum BrainBarDashboardFixture {
+    enum OperatorState: CaseIterable {
+        case loading
+        case live
+        case stale
+        case error
+    }
+
     /// Fixed "data fetched at" instant. Renders only via `absoluteTimeString`.
     /// 2023-11-14 22:13:20 UTC — an arbitrary but constant epoch.
     static let fetchedAt = Date(timeIntervalSince1970: 1_700_000_000)
@@ -86,14 +93,38 @@ enum BrainBarDashboardFixture {
 
     /// A `StatsCollector` pre-loaded with the fixture state and no live wiring
     /// (no DB, no observers, no timers — `start()` is never called).
-    static func makeCollector() -> StatsCollector {
-        StatsCollector.fixture(
+    static func makeCollector(_ operatorState: OperatorState = .live) -> StatsCollector {
+        let freshness: SnapshotFreshnessState
+        let lastDataFetchedAt: Date?
+        let lastFetchError: String?
+        switch operatorState {
+        case .loading:
+            freshness = .loading
+            lastDataFetchedAt = nil
+            lastFetchError = nil
+        case .live:
+            freshness = .live(ageSeconds: 0)
+            lastDataFetchedAt = fetchedAt
+            lastFetchError = nil
+        case .stale:
+            freshness = .stale(ageSeconds: 61)
+            lastDataFetchedAt = fetchedAt
+            lastFetchError = nil
+        case .error:
+            freshness = .error(message: "Fixture fetch failed", lastSuccessAgeSeconds: 15)
+            lastDataFetchedAt = fetchedAt
+            lastFetchError = "Fixture fetch failed"
+        }
+
+        return StatsCollector.fixture(
             stats: stats,
             daemon: daemon,
             agentActivity: agentActivity,
             state: state,
             heartbeat: .empty,
-            lastDataFetchedAt: fetchedAt
+            lastDataFetchedAt: lastDataFetchedAt,
+            lastFetchError: lastFetchError,
+            snapshotFreshnessState: freshness
         )
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
@@ -23,51 +23,106 @@ import Foundation
 ///   animations resolve to their final state immediately.
 @MainActor
 enum BrainBarDashboardFixture {
-    enum OperatorState: CaseIterable {
+    enum OperatorState: CaseIterable, Equatable {
         case loading
         case live
         case stale
         case error
+        case partialReplayDebt
     }
 
     /// Fixed "data fetched at" instant. Renders only via `absoluteTimeString`.
     /// 2023-11-14 22:13:20 UTC — an arbitrary but constant epoch.
     static let fetchedAt = Date(timeIntervalSince1970: 1_700_000_000)
 
-    static let stats = DashboardStats(
-        chunkCount: 297_412,
-        enrichedChunkCount: 188_204,
-        pendingEnrichmentCount: 12_840,
-        enrichmentPercent: 63.3,
-        enrichmentRatePerMinute: 11.4,
-        databaseSizeBytes: 8_120_000_000,
-        recentActivityBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
-        recentAgentWriteBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
-        recentWatcherWriteBuckets: [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1],
-        recentEnrichmentBuckets: [4, 6, 3, 7, 5, 8, 6, 9, 7, 5, 8, 6],
-        recentWriteFiveMinuteCount: 18,
-        recentEnrichmentFiveMinuteCount: 22,
-        activityWindowMinutes: 60,
-        bucketCount: 12,
-        liveWindowMinutes: 1,
-        lastWriteAt: nil,
-        lastEnrichedAt: nil,
-        signalEligibleChunkCount: 297_412,
-        vectorIndexedChunkCount: 240_100,
-        ftsIndexedChunkCount: 296_980,
-        trigramIndexedChunkCount: 210_540,
-        pendingStoreQueueDepth: 320,
-        pendingStoreOldestQueuedAt: nil,
-        pendingStoreFlushRatePerMinute: 45,
-        watcherHealth: DashboardStats.WatcherHealth(
-            alerting: false,
-            filesTracked: 14,
-            maxOffsetLagBytes: 2_048,
-            activeEntriesPerMinute: 12.5,
-            realtimeInsertsPerMinute: 9.0,
-            updatedAt: fetchedAt
+    private static let readableReplayDebt = BrainDatabase.ReplayDebtBreakdown(
+        pendingStores: .init(
+            source: .pendingStores,
+            snapshot: .init(
+                depth: 320,
+                oldestQueuedAt: nil,
+                identityKeys: ["shared-pending-queue"]
+            ),
+            readability: .readable
+        ),
+        durableQueue: .init(
+            source: .durableQueue,
+            snapshot: .init(
+                depth: 18,
+                oldestQueuedAt: nil,
+                identityKeys: ["shared-pending-queue", "shared-queue-fallback"]
+            ),
+            readability: .readable
+        ),
+        repositoryFallback: .init(
+            source: .repositoryFallback,
+            snapshot: .init(
+                depth: 7,
+                oldestQueuedAt: nil,
+                identityKeys: ["shared-queue-fallback"]
+            ),
+            readability: .readable
         )
     )
+
+    private static let partialReplayDebt = BrainDatabase.ReplayDebtBreakdown(
+        pendingStores: readableReplayDebt.pendingStores,
+        durableQueue: .init(
+            source: .durableQueue,
+            snapshot: readableReplayDebt.durableQueue.snapshot,
+            readability: .unreadable("fixture queue directory could not be read completely")
+        ),
+        repositoryFallback: readableReplayDebt.repositoryFallback
+    )
+
+    static let stats = makeStats(replayDebtBreakdown: readableReplayDebt)
+    static let partialReplayDebtStats = makeStats(replayDebtBreakdown: partialReplayDebt)
+
+    private static func makeStats(
+        replayDebtBreakdown: BrainDatabase.ReplayDebtBreakdown
+    ) -> DashboardStats {
+        DashboardStats(
+            chunkCount: 297_412,
+            enrichedChunkCount: 188_204,
+            failedEnrichmentCount: 1_204,
+            skippedEnrichmentCount: 2_104,
+            pendingEnrichmentCount: 12_840,
+            enrichmentPercent: 63.3,
+            enrichmentRatePerMinute: 11.4,
+            databaseSizeBytes: 8_120_000_000,
+            recentActivityBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
+            recentAgentWriteBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
+            recentWatcherWriteBuckets: [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1],
+            recentEnrichmentBuckets: [4, 6, 3, 7, 5, 8, 6, 9, 7, 5, 8, 6],
+            recentWriteFiveMinuteCount: 18,
+            recentEnrichmentFiveMinuteCount: 22,
+            activityWindowMinutes: 60,
+            bucketCount: 12,
+            liveWindowMinutes: 1,
+            lastWriteAt: nil,
+            lastEnrichedAt: nil,
+            signalEligibleChunkCount: 297_412,
+            vectorIndexedChunkCount: 240_100,
+            ftsIndexedChunkCount: 296_980,
+            trigramIndexedChunkCount: 210_540,
+            pendingStoreQueueDepth: replayDebtBreakdown.deduplicatedTotal,
+            pendingStoreFlushQueueDepth: replayDebtBreakdown.pendingStores.snapshot.depth,
+            pendingStoreOldestQueuedAt: nil,
+            pendingStoreFlushRatePerMinute: 45,
+            watcherHealth: DashboardStats.WatcherHealth(
+                alerting: false,
+                filesTracked: 14,
+                maxOffsetLagBytes: 2_048,
+                activeEntriesPerMinute: 12.5,
+                realtimeInsertsPerMinute: 9.0,
+                updatedAt: fetchedAt
+            ),
+            replayDebtBreakdown: replayDebtBreakdown,
+            watcherProcessProbeResult: .running(pid: 4242),
+            watcherRecentDistinctChunkCount: 14,
+            watcherFlowReadability: .readable
+        )
+    }
 
     static let daemon = DaemonHealthSnapshot(
         pid: 4242,
@@ -94,6 +149,7 @@ enum BrainBarDashboardFixture {
     /// A `StatsCollector` pre-loaded with the fixture state and no live wiring
     /// (no DB, no observers, no timers — `start()` is never called).
     static func makeCollector(_ operatorState: OperatorState = .live) -> StatsCollector {
+        let fixtureStats = operatorState == .partialReplayDebt ? partialReplayDebtStats : stats
         let freshness: SnapshotFreshnessState
         let lastDataFetchedAt: Date?
         let lastFetchError: String?
@@ -114,13 +170,17 @@ enum BrainBarDashboardFixture {
             freshness = .error(message: "Fixture fetch failed", lastSuccessAgeSeconds: 15)
             lastDataFetchedAt = fetchedAt
             lastFetchError = "Fixture fetch failed"
+        case .partialReplayDebt:
+            freshness = .live(ageSeconds: 0)
+            lastDataFetchedAt = fetchedAt
+            lastFetchError = nil
         }
 
         return StatsCollector.fixture(
-            stats: stats,
+            stats: fixtureStats,
             daemon: daemon,
             agentActivity: agentActivity,
-            state: state,
+            state: PipelineState.derive(daemon: daemon, stats: fixtureStats),
             heartbeat: .empty,
             lastDataFetchedAt: lastDataFetchedAt,
             lastFetchError: lastFetchError,

--- a/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift
@@ -120,12 +120,21 @@ enum BrainBarDashboardFixture {
         watcherRecentDistinctChunkCount: 0
     )
 
+    static func makeStats(activityWindowMinutes: Int) -> DashboardStats {
+        makeStats(
+            replayDebtBreakdown: readableReplayDebt,
+            activityWindowMinutes: activityWindowMinutes
+        )
+    }
+
     private static func makeStats(
         replayDebtBreakdown: BrainDatabase.ReplayDebtBreakdown,
+        activityWindowMinutes: Int = 60,
         watcherProcessProbeResult: WatcherProcessProbeResult = .running(pid: 4242),
         watcherRecentDistinctChunkCount: Int = 14
     ) -> DashboardStats {
-        DashboardStats(
+        let windowScale = max(activityWindowMinutes / 60, 1)
+        return DashboardStats(
             chunkCount: 297_412,
             enrichedChunkCount: 188_204,
             failedEnrichmentCount: 1_204,
@@ -134,13 +143,13 @@ enum BrainBarDashboardFixture {
             enrichmentPercent: 63.3,
             enrichmentRatePerMinute: 11.4,
             databaseSizeBytes: 8_120_000_000,
-            recentActivityBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
-            recentAgentWriteBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4],
-            recentWatcherWriteBuckets: [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1],
-            recentEnrichmentBuckets: [4, 6, 3, 7, 5, 8, 6, 9, 7, 5, 8, 6],
+            recentActivityBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4].map { $0 * windowScale },
+            recentAgentWriteBuckets: [3, 5, 2, 8, 6, 4, 9, 7, 5, 6, 8, 4].map { $0 * windowScale },
+            recentWatcherWriteBuckets: [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1].map { $0 * windowScale },
+            recentEnrichmentBuckets: [4, 6, 3, 7, 5, 8, 6, 9, 7, 5, 8, 6].map { $0 * windowScale },
             recentWriteFiveMinuteCount: 18,
             recentEnrichmentFiveMinuteCount: 22,
-            activityWindowMinutes: 60,
+            activityWindowMinutes: activityWindowMinutes,
             bucketCount: 12,
             liveWindowMinutes: 1,
             lastWriteAt: nil,

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -399,8 +399,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
         let storeOldestAgeSeconds = stats.pendingStoreOldestQueuedAt.map { max(0, Int(now.timeIntervalSince($0).rounded())) }
         let storeHealth = storeQueueHealth(depth: stats.pendingStoreQueueDepth, oldestAgeSeconds: storeOldestAgeSeconds)
         let watcherProcess = stats.watcherProcessProbeResult
-            ?? daemon.map { WatcherProcessProbeResult.running(pid: $0.pid) }
-            ?? .absent
+            ?? .failure("watcher process evidence unavailable")
         let watcherFlowState = WatcherFlowState.derive(
             process: watcherProcess,
             recentDistinctChunkCount: stats.watcherRecentDistinctChunkCount,

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -889,7 +889,6 @@ extension DashboardFlowSummary {
                     activityWindowMinutes: ingress.activityWindowMinutes
                 ),
                 lastEventText: jsonlWatcherLastEventText(
-                    status: watcherStatus,
                     totalEvents: watcherTotal,
                     latestBucketCount: watcherValues.last ?? 0,
                     windowLabel: ingress.windowLabel
@@ -970,7 +969,6 @@ extension DashboardFlowSummary {
     }
 
     private func jsonlWatcherLastEventText(
-        status: DashboardFlowLaneStatus,
         totalEvents: Int,
         latestBucketCount: Int,
         windowLabel: String
@@ -978,7 +976,7 @@ extension DashboardFlowSummary {
         if totalEvents == 0 {
             return "No watcher-ingested chunks in \(windowLabel)"
         }
-        if latestBucketCount > 0 || status == .live {
+        if latestBucketCount > 0 {
             return "\(latestBucketCount) watcher-ingested chunks in latest ingest-time bucket"
         }
         return "\(totalEvents) watcher-ingested chunks in \(windowLabel)"

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -3,6 +3,139 @@ import Foundation
 
 typealias DashboardStats = BrainDatabase.DashboardStats
 
+enum MetricClock: String, Sendable, Equatable {
+    case sourceTime
+    case ingestTime
+}
+
+enum MetricCardinality: String, Sendable, Equatable {
+    case chunkRows
+    case distinctChunkIDs
+    case events
+}
+
+struct MetricContract: Sendable, Equatable {
+    let clock: MetricClock
+    let cardinality: MetricCardinality
+}
+
+enum DashboardMetricContract {
+    static let chunkRows = MetricContract(clock: .sourceTime, cardinality: .chunkRows)
+    static let agentOriginChunks = MetricContract(clock: .sourceTime, cardinality: .chunkRows)
+    static let watcherIngestedChunks = MetricContract(clock: .ingestTime, cardinality: .distinctChunkIDs)
+}
+
+enum MetricEvidenceReadability: Sendable, Equatable {
+    case readable
+    case unreadable(String)
+
+    var isReadable: Bool {
+        if case .readable = self { return true }
+        return false
+    }
+}
+
+enum WatcherProcessProbeResult: Sendable, Equatable {
+    case running(pid: pid_t)
+    case absent
+    case failure(String)
+}
+
+enum WatcherFlowState: Sendable, Equatable {
+    case flowing
+    case stalled
+    case runningNoRecentFlow
+    case offline
+    case runningFlowUnverified
+    case unknown
+
+    static func derive(
+        process: WatcherProcessProbeResult,
+        recentDistinctChunkCount: Int,
+        recentFlowReadable: Bool,
+        pendingWorkCount: Int
+    ) -> WatcherFlowState {
+        switch process {
+        case .failure:
+            return .unknown
+        case .absent:
+            return .offline
+        case .running:
+            guard recentFlowReadable else { return .runningFlowUnverified }
+            if recentDistinctChunkCount > 0 { return .flowing }
+            if pendingWorkCount > 0 { return .stalled }
+            return .runningNoRecentFlow
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .flowing: return "FLOWING"
+        case .stalled: return "STALLED"
+        case .runningNoRecentFlow: return "RUNNING · NO RECENT FLOW"
+        case .offline: return "OFFLINE"
+        case .runningFlowUnverified: return "RUNNING · FLOW UNVERIFIED"
+        case .unknown: return "UNKNOWN"
+        }
+    }
+}
+
+enum SnapshotFreshnessState: Sendable, Equatable {
+    case loading
+    case live(ageSeconds: Int)
+    case stale(ageSeconds: Int)
+    case error(message: String, lastSuccessAgeSeconds: Int?)
+
+    static func derive(
+        lastSuccessAt: Date?,
+        isRefreshing: Bool,
+        lastFetchError: String?,
+        now: Date,
+        snapshotFreshnessThreshold: TimeInterval
+    ) -> SnapshotFreshnessState {
+        let ageSeconds = lastSuccessAt.map { max(0, Int(now.timeIntervalSince($0))) }
+        if let lastFetchError {
+            return .error(message: lastFetchError, lastSuccessAgeSeconds: ageSeconds)
+        }
+        if lastSuccessAt == nil && isRefreshing {
+            return .loading
+        }
+        guard let lastSuccessAt else {
+            return .loading
+        }
+        let age = max(0, now.timeIntervalSince(lastSuccessAt))
+        if age > snapshotFreshnessThreshold {
+            return .stale(ageSeconds: Int(age))
+        }
+        return .live(ageSeconds: Int(age))
+    }
+
+    var isLoading: Bool {
+        if case .loading = self { return true }
+        return false
+    }
+
+    var label: String {
+        switch self {
+        case .loading: return "LOADING"
+        case .live: return "LIVE"
+        case .stale: return "STALE"
+        case .error: return "ERROR"
+        }
+    }
+
+    var ageSeconds: Int? {
+        switch self {
+        case .loading:
+            return nil
+        case .live(let ageSeconds), .stale(let ageSeconds):
+            return ageSeconds
+        case .error(_, let lastSuccessAgeSeconds):
+            return lastSuccessAgeSeconds
+        }
+    }
+}
+
 struct DaemonHealthSnapshot: Sendable, Equatable {
     let pid: pid_t
     let isResponsive: Bool
@@ -228,6 +361,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
     let ingress: DashboardFlowLane
     let queue: DashboardQueueSummary
     let enrichment: DashboardFlowLane
+    let watcherFlowState: WatcherFlowState
     let watcherHealth: DashboardStats.WatcherHealth?
     let watcherHealthIsFresh: Bool
 
@@ -247,6 +381,15 @@ struct DashboardFlowSummary: Sendable, Equatable {
         let backlogCount = stats.pendingEnrichmentCount
         let storeOldestAgeSeconds = stats.pendingStoreOldestQueuedAt.map { max(0, Int(now.timeIntervalSince($0).rounded())) }
         let storeHealth = storeQueueHealth(depth: stats.pendingStoreQueueDepth, oldestAgeSeconds: storeOldestAgeSeconds)
+        let watcherProcess = stats.watcherProcessProbeResult
+            ?? daemon.map { WatcherProcessProbeResult.running(pid: $0.pid) }
+            ?? .absent
+        let watcherFlowState = WatcherFlowState.derive(
+            process: watcherProcess,
+            recentDistinctChunkCount: stats.watcherRecentDistinctChunkCount,
+            recentFlowReadable: stats.watcherFlowReadability.isReadable,
+            pendingWorkCount: stats.replayDebtBreakdown.deduplicatedTotal
+        )
 
         let ingressStatus: DashboardFlowLaneStatus
         if writesLive {
@@ -452,6 +595,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
                 tertiarySeriesLabel: nil,
                 tertiaryAccentColor: nil
             ),
+            watcherFlowState: watcherFlowState,
             watcherHealth: stats.watcherHealth,
             watcherHealthIsFresh: stats.watcherHealth?.isFresh(now: now) ?? false
         )
@@ -608,17 +752,17 @@ struct DashboardFlowSummary: Sendable, Equatable {
         windowLabel: String
     ) -> String {
         if storeHealth != .empty {
-            let depth = storeDepthText(
-                totalDepth: storeDepth,
-                flushDepth: storeFlushDepth,
-                replayDebtDepth: storeReplayDebtDepth
-            )
+            let breakdown = stats.replayDebtBreakdown.detailText
             let oldest = storeOldestAgeText(storeOldestAgeSeconds)
             guard storeFlushDepth > 0 else {
-                return "\(depth), \(oldest)."
+                return "\(breakdown); \(oldest)."
             }
             let rate = DashboardMetricFormatter.speedString(ratePerMinute: storeFlushRatePerMinute)
-            return "\(depth), \(oldest), flush draining \(rate) over 60s."
+            return "\(breakdown); \(oldest); pending-store flush draining \(rate) over 60s."
+        }
+
+        if stats.replayDebtBreakdown.isPartial {
+            return "\(stats.replayDebtBreakdown.detailText)."
         }
 
         switch status {
@@ -717,20 +861,11 @@ extension DashboardFlowSummary {
         case .jsonlWatcher:
             let watcherValues = ingress.secondaryValues
             let watcherTotal = watcherValues.reduce(0, +)
-            let watcherStatus = jsonlWatcherStatus(
-                values: watcherValues,
-                health: watcherHealth,
-                healthIsFresh: watcherHealthIsFresh
-            )
-            let watcherStatusText = jsonlWatcherStatusText(
-                status: watcherStatus,
-                totalEvents: watcherTotal,
-                windowLabel: ingress.windowLabel
-            )
+            let watcherStatus = jsonlWatcherStatus(flowState: watcherFlowState)
             return DashboardFlowLane(
                 name: "JSONL watcher",
                 status: watcherStatus,
-                statusText: watcherStatusText,
+                statusText: watcherFlowState.label,
                 windowLabel: ingress.windowLabel,
                 activityWindowMinutes: ingress.activityWindowMinutes,
                 rateText: DashboardMetricFormatter.rateString(
@@ -843,63 +978,16 @@ extension DashboardFlowSummary {
         return "\(totalEvents) agent MCP stores in \(windowLabel)\(queuedSuffix)"
     }
 
-    private func jsonlWatcherStatus(
-        values: [Int],
-        health: DashboardStats.WatcherHealth?,
-        healthIsFresh: Bool
-    ) -> DashboardFlowLaneStatus {
-        let totalEvents = values.reduce(0, +)
-        guard health != nil else {
-            return .unavailable
-        }
-        if !healthIsFresh {
-            return .unavailable
-        }
-        if health?.alerting == true {
-            return .unavailable
-        }
-        if totalEvents == 0,
-           let health,
-           health.activeEntriesPerMinute > 0,
-           health.realtimeInsertsPerMinute <= 0 {
-            return .unavailable
-        }
-        if (values.last ?? 0) > 0 {
+    private func jsonlWatcherStatus(flowState: WatcherFlowState) -> DashboardFlowLaneStatus {
+        switch flowState {
+        case .flowing:
             return .live
-        }
-        if totalEvents > 0 {
-            return .recent
-        }
-        return .idle
-    }
-
-    private func jsonlWatcherStatusText(
-        status: DashboardFlowLaneStatus,
-        totalEvents: Int,
-        windowLabel: String
-    ) -> String {
-        switch status {
-        case .live:
-            return "JSONL watcher live now"
-        case .recent:
-            return "Recent JSONL watcher writes in \(windowLabel.lowercased())"
-        case .unavailable:
-            if watcherHealth == nil {
-                return "Watcher health unavailable"
-            }
-            if !watcherHealthIsFresh {
-                return "Watcher health stale"
-            }
-            if watcherHealth?.alerting == true {
-                return "Watcher coverage alert"
-            }
-            return "Watcher stale: JSONL activity is not landing"
-        case .idle:
-            return totalEvents == 0 ? "No JSONL watcher writes" : "JSONL watcher idle"
-        case .queued:
-            return "JSONL watcher queued"
-        case .draining:
-            return "JSONL watcher draining"
+        case .stalled:
+            return .queued
+        case .runningNoRecentFlow:
+            return .idle
+        case .offline, .runningFlowUnverified, .unknown:
+            return .unavailable
         }
     }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/PipelineState.swift
@@ -255,6 +255,23 @@ enum DashboardFlowLaneStatus: String, Sendable, Equatable {
     }
 }
 
+extension DashboardFlowLaneStatus {
+    var stateTheme: BrainBarStateTheme {
+        switch self {
+        case .live:
+            return .active
+        case .recent, .idle:
+            return .idle
+        case .draining:
+            return .active
+        case .queued:
+            return .loading
+        case .unavailable:
+            return .error
+        }
+    }
+}
+
 enum DashboardQueueStatus: String, Sendable, Equatable {
     case empty
     case stable
@@ -461,7 +478,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
             detail: detail,
             windowLabel: windowLabel,
             allCommits: DashboardFlowLane(
-                name: "All commits",
+                name: "Chunk rows",
                 status: ingressStatus,
                 statusText: allCommitsStatusText(
                     status: ingressStatus,
@@ -485,8 +502,8 @@ struct DashboardFlowSummary: Sendable, Equatable {
                     windowLabel: windowLabel
                 ),
                 values: stats.recentActivityBuckets,
-                sparklineLabel: "All committed chunks over \(windowLabel)",
-                latestBucketName: "latest commit bucket",
+                sparklineLabel: "Chunk rows by source time over \(windowLabel)",
+                latestBucketName: "latest source-time bucket",
                 accentColor: allCommitsColor,
                 primarySeriesLabel: nil,
                 secondaryValues: [],
@@ -497,7 +514,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
                 tertiaryAccentColor: nil
             ),
             ingress: DashboardFlowLane(
-                name: "Writes",
+                name: "Ingest sources",
                 status: ingressStatus,
                 statusText: ingressStatus == .live ? "Ingress live now" : (ingressStatus == .recent ? "Recent writes in \(windowLabel.lowercased())" : "No recent writes"),
                 windowLabel: windowLabel,
@@ -516,12 +533,12 @@ struct DashboardFlowSummary: Sendable, Equatable {
                     now: now
                 ),
                 values: stats.recentAgentWriteBuckets,
-                sparklineLabel: "Writes over \(windowLabel)",
-                latestBucketName: "latest write bucket",
+                sparklineLabel: "Ingest sources over \(windowLabel)",
+                latestBucketName: "latest source bucket",
                 accentColor: agentStoresColor,
-                primarySeriesLabel: "Agent MCP stores",
+                primarySeriesLabel: "Agent-origin chunks",
                 secondaryValues: stats.recentWatcherWriteBuckets,
-                secondarySeriesLabel: "JSONL watcher",
+                secondarySeriesLabel: "Watcher-ingested chunks",
                 secondaryAccentColor: jsonlWatcherColor,
                 tertiaryValues: [],
                 tertiarySeriesLabel: nil,
@@ -565,7 +582,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
                 )
             ),
             enrichment: DashboardFlowLane(
-                name: "Enrichments",
+                name: "Enriched successfully",
                 status: enrichmentStatus,
                 statusText: enrichmentStatusText,
                 windowLabel: windowLabel,
@@ -584,10 +601,10 @@ struct DashboardFlowSummary: Sendable, Equatable {
                     now: now
                 ),
                 values: stats.recentEnrichmentBuckets,
-                sparklineLabel: "Enrichment completions over \(windowLabel)",
-                latestBucketName: "latest enrichment bucket",
+                sparklineLabel: "Successful enrichment completions over \(windowLabel)",
+                latestBucketName: "latest successful-enrichment bucket",
                 accentColor: enrichmentColor,
-                primarySeriesLabel: "Enrichments",
+                primarySeriesLabel: "Enriched successfully",
                 secondaryValues: [],
                 secondarySeriesLabel: nil,
                 secondaryAccentColor: nil,
@@ -633,17 +650,17 @@ struct DashboardFlowSummary: Sendable, Equatable {
     ) -> String {
         switch status {
         case .live:
-            return "All commits live now"
+            return "Chunk rows landing now"
         case .recent:
-            return "Recent commits in \(windowLabel.lowercased())"
+            return "Recent chunk rows in \(windowLabel.lowercased())"
         case .idle:
-            return totalEvents == 0 ? "No committed chunks" : "Commits idle"
+            return totalEvents == 0 ? "No chunk rows" : "Chunk rows idle"
         case .queued:
-            return "Commits queued"
+            return "Chunk rows queued"
         case .draining:
-            return "Commits draining"
+            return "Chunk rows draining"
         case .unavailable:
-            return "Commits unavailable"
+            return "Chunk rows unavailable"
         }
     }
 
@@ -654,12 +671,12 @@ struct DashboardFlowSummary: Sendable, Equatable {
         windowLabel: String
     ) -> String {
         if totalEvents == 0 {
-            return "No committed chunks in \(windowLabel)"
+            return "No chunk rows in \(windowLabel)"
         }
         if latestBucketCount > 0 || status == .live {
-            return "\(latestBucketCount) committed chunks in latest bucket"
+            return "\(latestBucketCount) chunk rows in latest source-time bucket"
         }
-        return "\(totalEvents) committed chunks in \(windowLabel)"
+        return "\(totalEvents) chunk rows in \(windowLabel)"
     }
 
     private static func enrichmentBurstText(stats: DashboardStats) -> String? {
@@ -785,7 +802,7 @@ struct DashboardFlowSummary: Sendable, Equatable {
 }
 
 /// The independent flow series the redesigned dashboard plots as separately
-/// scaled cards. `allCommits` is the raw committed chunk rate from `chunks`;
+/// scaled cards. `allCommits` is the legacy internal case for source-time chunk rows;
 /// `agentStores` and `jsonlWatcher` remain source-specific slices so watcher
 /// peaks do not crush the agent series flat. `enrichment` reuses the existing
 /// enrichment lane.
@@ -817,15 +834,13 @@ extension DashboardFlowSummary {
         case .agentStores:
             let agentValues = ingress.values
             let agentTotal = agentValues.reduce(0, +)
-            let pendingFlushDepth = queue.storeFlushDepth
-            let agentStatus = agentStoreStatus(values: agentValues, pendingFlushDepth: pendingFlushDepth)
+            let agentStatus = agentStoreStatus(values: agentValues)
             return DashboardFlowLane(
-                name: "Agent MCP stores",
+                name: "Agent-origin chunks",
                 status: agentStatus,
                 statusText: agentStoreStatusText(
                     status: agentStatus,
                     totalEvents: agentTotal,
-                    pendingFlushDepth: pendingFlushDepth,
                     windowLabel: ingress.windowLabel
                 ),
                 windowLabel: ingress.windowLabel,
@@ -834,21 +849,19 @@ extension DashboardFlowSummary {
                     totalEvents: agentTotal,
                     activityWindowMinutes: ingress.activityWindowMinutes
                 ),
-                volumeText: agentStoreVolumeText(
+                volumeText: DashboardMetricFormatter.activitySummaryString(
                     totalEvents: agentTotal,
-                    pendingFlushDepth: pendingFlushDepth,
                     activityWindowMinutes: ingress.activityWindowMinutes
                 ),
                 lastEventText: agentStoreLastEventText(
                     status: agentStatus,
                     totalEvents: agentTotal,
-                    pendingFlushDepth: pendingFlushDepth,
                     latestBucketCount: agentValues.last ?? 0,
                     windowLabel: ingress.windowLabel
                 ),
                 values: agentValues,
-                sparklineLabel: "Agent MCP stores over \(ingress.windowLabel)",
-                latestBucketName: "latest agent MCP store bucket",
+                sparklineLabel: "Agent-origin chunks by source time over \(ingress.windowLabel)",
+                latestBucketName: "latest agent-origin source-time bucket",
                 accentColor: BrainBarDesignTokens.Colors.seriesAgent,
                 primarySeriesLabel: nil,
                 secondaryValues: [],
@@ -863,7 +876,7 @@ extension DashboardFlowSummary {
             let watcherTotal = watcherValues.reduce(0, +)
             let watcherStatus = jsonlWatcherStatus(flowState: watcherFlowState)
             return DashboardFlowLane(
-                name: "JSONL watcher",
+                name: "Watcher-ingested chunks",
                 status: watcherStatus,
                 statusText: watcherFlowState.label,
                 windowLabel: ingress.windowLabel,
@@ -883,8 +896,8 @@ extension DashboardFlowSummary {
                     windowLabel: ingress.windowLabel
                 ),
                 values: watcherValues,
-                sparklineLabel: "JSONL watcher over \(ingress.windowLabel)",
-                latestBucketName: "latest watcher bucket",
+                sparklineLabel: "Watcher-ingested chunks by ingest time over \(ingress.windowLabel)",
+                latestBucketName: "latest watcher-ingest bucket",
                 accentColor: BrainBarDesignTokens.Colors.seriesWatcher,
                 primarySeriesLabel: nil,
                 secondaryValues: [],
@@ -897,7 +910,7 @@ extension DashboardFlowSummary {
         }
     }
 
-    private func agentStoreStatus(values: [Int], pendingFlushDepth: Int) -> DashboardFlowLaneStatus {
+    private func agentStoreStatus(values: [Int]) -> DashboardFlowLaneStatus {
         let totalEvents = values.reduce(0, +)
         if (values.last ?? 0) > 0 {
             return .live
@@ -905,77 +918,43 @@ extension DashboardFlowSummary {
         if totalEvents > 0 {
             return .recent
         }
-        if pendingFlushDepth > 0 {
-            return .queued
-        }
         return .idle
-    }
-
-    private func agentStoreFlushQueueText(_ depth: Int) -> String {
-        depth == 1 ? "1 agent MCP store flush queued" : "\(depth) agent MCP stores flush queued"
-    }
-
-    private func shortAgentStoreFlushQueueText(_ depth: Int) -> String {
-        depth == 1 ? "1 flush queued" : "\(depth) flush queued"
-    }
-
-    private func agentStoreVolumeText(
-        totalEvents: Int,
-        pendingFlushDepth: Int,
-        activityWindowMinutes: Int
-    ) -> String {
-        let committed = DashboardMetricFormatter.activitySummaryString(
-            totalEvents: totalEvents,
-            activityWindowMinutes: activityWindowMinutes
-        )
-        guard pendingFlushDepth > 0 else { return committed }
-        return "\(committed), \(shortAgentStoreFlushQueueText(pendingFlushDepth))"
     }
 
     private func agentStoreStatusText(
         status: DashboardFlowLaneStatus,
         totalEvents: Int,
-        pendingFlushDepth: Int,
         windowLabel: String
     ) -> String {
-        if status == .queued, pendingFlushDepth > 0 {
-            return agentStoreFlushQueueText(pendingFlushDepth)
-        }
-
         switch status {
         case .live:
-            return "Agent MCP stores live now"
+            return "Agent-origin chunks landing now"
         case .recent:
-            return "Recent agent MCP stores in \(windowLabel.lowercased())"
+            return "Recent agent-origin chunks in \(windowLabel.lowercased())"
         case .idle:
-            return totalEvents == 0 ? "No agent MCP stores" : "Agent MCP stores idle"
+            return totalEvents == 0 ? "No agent-origin chunks" : "Agent-origin chunks idle"
         case .queued:
-            return "Agent MCP stores queued"
+            return "Agent-origin chunks queued"
         case .draining:
-            return "Agent MCP stores draining"
+            return "Agent-origin chunks draining"
         case .unavailable:
-            return "Agent MCP stores unavailable"
+            return "Agent-origin chunks unavailable"
         }
     }
 
     private func agentStoreLastEventText(
         status: DashboardFlowLaneStatus,
         totalEvents: Int,
-        pendingFlushDepth: Int,
         latestBucketCount: Int,
         windowLabel: String
     ) -> String {
-        if pendingFlushDepth > 0 && totalEvents == 0 {
-            return agentStoreFlushQueueText(pendingFlushDepth)
-        }
         if totalEvents == 0 {
-            return "No agent MCP stores in \(windowLabel)"
+            return "No agent-origin chunks in \(windowLabel)"
         }
-        let queuedSuffix = pendingFlushDepth > 0 ? "; \(shortAgentStoreFlushQueueText(pendingFlushDepth))" : ""
         if latestBucketCount > 0 || status == .live {
-            return "\(latestBucketCount) agent MCP stores in latest bucket\(queuedSuffix)"
+            return "\(latestBucketCount) agent-origin chunks in latest source-time bucket"
         }
-        return "\(totalEvents) agent MCP stores in \(windowLabel)\(queuedSuffix)"
+        return "\(totalEvents) agent-origin chunks in \(windowLabel)"
     }
 
     private func jsonlWatcherStatus(flowState: WatcherFlowState) -> DashboardFlowLaneStatus {
@@ -998,12 +977,12 @@ extension DashboardFlowSummary {
         windowLabel: String
     ) -> String {
         if totalEvents == 0 {
-            return "No watcher writes in \(windowLabel)"
+            return "No watcher-ingested chunks in \(windowLabel)"
         }
         if latestBucketCount > 0 || status == .live {
-            return "\(latestBucketCount) watcher writes in latest bucket"
+            return "\(latestBucketCount) watcher-ingested chunks in latest ingest-time bucket"
         }
-        return "\(totalEvents) watcher writes in \(windowLabel)"
+        return "\(totalEvents) watcher-ingested chunks in \(windowLabel)"
     }
 }
 

--- a/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/SparklineRenderer.swift
@@ -33,6 +33,8 @@ struct SparklineChartPresentation: Equatable, Sendable {
     let activityWindowMinutes: Int
     let latestBucketName: String
     let fetchedAt: Date
+    let metricDisclosure: String?
+    let accessibilitySummary: String?
 
     init(
         label: String,
@@ -44,7 +46,9 @@ struct SparklineChartPresentation: Equatable, Sendable {
         tertiarySeriesLabel: String? = nil,
         activityWindowMinutes: Int = 30,
         latestBucketName: String = "latest bucket count",
-        fetchedAt: Date = Date()
+        fetchedAt: Date = Date(),
+        metricDisclosure: String? = nil,
+        accessibilitySummary: String? = nil
     ) {
         self.label = label
         self.values = values
@@ -56,6 +60,8 @@ struct SparklineChartPresentation: Equatable, Sendable {
         self.activityWindowMinutes = activityWindowMinutes
         self.latestBucketName = latestBucketName
         self.fetchedAt = fetchedAt
+        self.metricDisclosure = metricDisclosure
+        self.accessibilitySummary = accessibilitySummary
     }
 
     var points: [SparklineChartPoint] {
@@ -138,6 +144,9 @@ struct SparklineChartPresentation: Equatable, Sendable {
 
     var accessibilityValue: String {
         var components = ["\(latestBucketName) \(values.last ?? 0)", trendDescription]
+        if let accessibilitySummary {
+            components.insert(accessibilitySummary, at: 0)
+        }
         if let primarySeriesLabel {
             components.append("\(primarySeriesLabel) latest bucket \(values.last ?? 0)")
         }
@@ -638,7 +647,8 @@ struct SparklineChart: View {
                     let anchorPoint = hoverAnchorPoint(forBucket: clampedBucket, in: plotFrame)
                     let tooltipSize = SparklineTooltipPlacement.tooltipSize(
                         in: geometry.size,
-                        seriesCount: tooltipRows(forBucket: clampedBucket).count
+                        seriesCount: tooltipRows(forBucket: clampedBucket).count,
+                        showsMetricDisclosure: presentation.metricDisclosure != nil
                     )
                     sparklineTooltip(forBucket: clampedBucket, size: tooltipSize)
                         .position(
@@ -838,6 +848,14 @@ struct SparklineChart: View {
             }
             .lineLimit(1)
             .fixedSize(horizontal: false, vertical: true)
+
+            if let metricDisclosure = presentation.metricDisclosure {
+                Text(metricDisclosure)
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .foregroundStyle(Color.brainBarTextSecondary.opacity(0.82))
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             if !rows.isEmpty {
                 Rectangle()
@@ -1083,14 +1101,20 @@ enum SparklineTooltipPlacement {
     // Structured-card metrics = the PINNED card height (matches sparklineTooltip's paddings/spacing).
     private static let verticalPadding: CGFloat = 9
     private static let headerHeight: CGFloat = 24
+    private static let metricDisclosureHeight: CGFloat = 42
     private static let dividerBlock: CGFloat = 14
     private static let rowHeight: CGFloat = 16
 
-    static func tooltipSize(in containerSize: CGSize, seriesCount: Int = 1) -> CGSize {
+    static func tooltipSize(
+        in containerSize: CGSize,
+        seriesCount: Int = 1,
+        showsMetricDisclosure: Bool = false
+    ) -> CGSize {
         let availableWidth = max(containerSize.width - margin * 2, minimumWidth)
         let rows = max(seriesCount, 0)
         let rowsBlock = rows > 0 ? dividerBlock + CGFloat(rows) * rowHeight : 0
-        let height = verticalPadding * 2 + headerHeight + rowsBlock
+        let disclosureBlock = showsMetricDisclosure ? metricDisclosureHeight : 0
+        let height = verticalPadding * 2 + headerHeight + disclosureBlock + rowsBlock
         let availableHeight = max(containerSize.height - margin * 2, height)
         return CGSize(width: min(preferredWidth, availableWidth),
                       height: min(height, availableHeight))

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -2,6 +2,95 @@ import Combine
 import CoreFoundation
 import Foundation
 
+protocol WatcherProcessProbing {
+    func sample() -> WatcherProcessProbeResult
+}
+
+struct StaticWatcherProcessProbe: WatcherProcessProbing {
+    let result: WatcherProcessProbeResult
+
+    func sample() -> WatcherProcessProbeResult { result }
+}
+
+struct LaunchctlWatcherProcessProbe: WatcherProcessProbing {
+    struct CommandResult: Sendable, Equatable {
+        let terminationStatus: Int32
+        let output: String
+    }
+
+    typealias CommandRunner = ([String]) -> CommandResult
+
+    private let label: String
+    private let commandRunner: CommandRunner
+    private let uidProvider: () -> uid_t
+
+    init(
+        label: String = "com.brainlayer.watch",
+        commandRunner: @escaping CommandRunner = LaunchctlWatcherProcessProbe.run,
+        uidProvider: @escaping () -> uid_t = getuid
+    ) {
+        self.label = label
+        self.commandRunner = commandRunner
+        self.uidProvider = uidProvider
+    }
+
+    func sample() -> WatcherProcessProbeResult {
+        let target = "gui/\(uidProvider())/\(label)"
+        let result = commandRunner(["/bin/launchctl", "print", target])
+        if result.terminationStatus == 0 {
+            if let pid = Self.parsePID(result.output) {
+                return .running(pid: pid)
+            }
+            return .absent
+        }
+
+        let output = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        if result.terminationStatus == 113 || output.localizedCaseInsensitiveContains("could not find service") {
+            return .absent
+        }
+        return .failure(output.isEmpty ? "launchctl exited \(result.terminationStatus)" : output)
+    }
+
+    private static func parsePID(_ output: String) -> pid_t? {
+        for line in output.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.lowercased().hasPrefix("pid") else { continue }
+            let tokens = trimmed.components(separatedBy: CharacterSet.decimalDigits.inverted)
+                .filter { !$0.isEmpty }
+            for token in tokens {
+                guard let value = Int32(token), value > 0 else { continue }
+                return pid_t(value)
+            }
+        }
+        return nil
+    }
+
+    private static func run(_ command: [String]) -> CommandResult {
+        guard let executable = command.first else {
+            return CommandResult(terminationStatus: 1, output: "missing launchctl executable")
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = Array(command.dropFirst())
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+        } catch {
+            return CommandResult(terminationStatus: 1, output: String(describing: error))
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return CommandResult(
+            terminationStatus: process.terminationStatus,
+            output: String(data: data, encoding: .utf8) ?? ""
+        )
+    }
+}
+
 private func statsCollectorDarwinNotificationCallback(
     center: CFNotificationCenter?,
     observer: UnsafeMutableRawPointer?,
@@ -20,6 +109,7 @@ private func statsCollectorDarwinNotificationCallback(
 final class StatsCollector: ObservableObject {
     static let defaultActivityWindowMinutes = 60
     static let defaultBucketCount = 12
+    static let snapshotFreshnessThreshold: TimeInterval = 60
 
     @Published private(set) var stats: DashboardStats
     @Published private(set) var daemon: DaemonHealthSnapshot?
@@ -29,6 +119,8 @@ final class StatsCollector: ObservableObject {
     @Published private(set) var isManualRefreshInProgress = false
     @Published private(set) var hasPendingStatsRefresh = false
     @Published private(set) var lastDataFetchedAt: Date?
+    @Published private(set) var lastFetchError: String?
+    @Published private(set) var snapshotFreshnessState: SnapshotFreshnessState
     @Published private(set) var heartbeat: DashboardHeartbeat
     /// REAL windowed buckets for the shared Live/3h/24h selector. `nil` means
     /// "no wider window selected yet" — the views fall back to the live `stats`
@@ -44,14 +136,18 @@ final class StatsCollector: ObservableObject {
     private let dbPath: String
     private let databaseOpenConfiguration: BrainDatabase.OpenConfiguration
     private let daemonMonitor: DaemonHealthMonitor
+    private let watcherProcessProbe: any WatcherProcessProbing
     private let agentActivityMonitor: AgentActivityMonitor
     private let agentActivitySampleInterval: TimeInterval
     private let statsRefreshCoalesceInterval: TimeInterval
     private let liveStatsRefreshDelay: TimeInterval
     private let autoRefreshInterval: TimeInterval
+    private let freshnessTickerInterval: TimeInterval
+    private let nowProvider: () -> Date
     private let brainBusEvents: BrainBusEventSource?
     private var brainBusTask: Task<Void, Never>?
     private var autoRefreshTask: Task<Void, Never>?
+    private var freshnessTicker: Task<Void, Never>?
     private var pendingStatsRefreshTask: Task<Void, Never>?
     private var pendingStatsRefreshFireAt: Date?
     private var pendingStatsRefreshBypassesCoalescing = false
@@ -68,22 +164,30 @@ final class StatsCollector: ObservableObject {
     init(
         dbPath: String,
         daemonMonitor: DaemonHealthMonitor,
+        watcherProcessProbe: any WatcherProcessProbing = StaticWatcherProcessProbe(
+            result: .failure("watcher process probe not configured")
+        ),
         agentActivityMonitor: AgentActivityMonitor = AgentActivityMonitor(),
         agentActivitySampleInterval: TimeInterval = 5,
         statsRefreshCoalesceInterval: TimeInterval = 5,
         liveStatsRefreshDelay: TimeInterval = 0.2,
         autoRefreshInterval: TimeInterval = 30,
+        freshnessTickerInterval: TimeInterval = 1,
+        nowProvider: @escaping () -> Date = Date.init,
         brainBusEvents: BrainBusEventSource? = nil,
         databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) {
         self.dbPath = dbPath
         self.databaseOpenConfiguration = databaseOpenConfiguration
         self.daemonMonitor = daemonMonitor
+        self.watcherProcessProbe = watcherProcessProbe
         self.agentActivityMonitor = agentActivityMonitor
         self.agentActivitySampleInterval = agentActivitySampleInterval
         self.statsRefreshCoalesceInterval = statsRefreshCoalesceInterval
         self.liveStatsRefreshDelay = liveStatsRefreshDelay
         self.autoRefreshInterval = autoRefreshInterval
+        self.freshnessTickerInterval = freshnessTickerInterval
+        self.nowProvider = nowProvider
         self.brainBusEvents = brainBusEvents
         self.stats = DashboardStats(
             chunkCount: 0,
@@ -99,6 +203,8 @@ final class StatsCollector: ObservableObject {
         )
         self.agentActivity = .empty
         self.state = .degraded
+        self.lastFetchError = nil
+        self.snapshotFreshnessState = .loading
         self.heartbeat = .empty
     }
 
@@ -116,6 +222,7 @@ final class StatsCollector: ObservableObject {
         installDarwinObserver()
         requestRefresh(force: true)
         startAutoRefreshLoop()
+        startFreshnessTicker()
         if let brainBusEvents {
             let eventStream = brainBusEvents.events()
             brainBusTask = Task { [weak self] in
@@ -134,6 +241,8 @@ final class StatsCollector: ObservableObject {
         brainBusTask = nil
         autoRefreshTask?.cancel()
         autoRefreshTask = nil
+        freshnessTicker?.cancel()
+        freshnessTicker = nil
         dashboardRefreshTask?.cancel()
         dashboardRefreshTask = nil
         windowedBucketsTask?.cancel()
@@ -159,7 +268,7 @@ final class StatsCollector: ObservableObject {
     }
 
     func manualRefresh() {
-        NSLog("[BrainBar] manual refresh requested at %@", ISO8601DateFormatter().string(from: Date()))
+        NSLog("[BrainBar] manual refresh requested at %@", ISO8601DateFormatter().string(from: nowProvider()))
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
         pendingStatsRefreshFireAt = nil
@@ -219,11 +328,13 @@ final class StatsCollector: ObservableObject {
         bypassCoalescing: Bool = false
     ) {
         let nextDaemon = daemonMonitor.sample()
-        let snapshotTime = Date()
+        let nextWatcherProcess = watcherProcessProbe.sample()
+        let snapshotTime = nowProvider()
         refreshAgentActivity(force: force, now: snapshotTime)
 
         if !force, !bypassCoalescing, let coalescedDelay = coalescedStatsRefreshDelay(now: snapshotTime) {
             daemon = nextDaemon
+            stats = stats.withWatcherProcessProbeResult(nextWatcherProcess)
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
             schedulePendingStatsRefresh(after: coalescedDelay)
             return
@@ -231,6 +342,7 @@ final class StatsCollector: ObservableObject {
 
         if dashboardRefreshTask != nil, trigger != .manual {
             daemon = nextDaemon
+            stats = stats.withWatcherProcessProbeResult(nextWatcherProcess)
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
             if !force {
                 schedulePendingStatsRefresh(after: statsRefreshCoalesceInterval)
@@ -253,10 +365,12 @@ final class StatsCollector: ObservableObject {
         let startStats = stats
         let startUnix = snapshotTime.timeIntervalSince1970
         isRefreshing = true
+        updateSnapshotFreshness()
         if trigger == .manual {
             isManualRefreshInProgress = true
         }
         daemon = nextDaemon
+        stats = stats.withWatcherProcessProbeResult(nextWatcherProcess)
         state = PipelineState.derive(daemon: nextDaemon, stats: stats)
         logDashboardRefresh(
             timestamp: snapshotTime,
@@ -282,6 +396,7 @@ final class StatsCollector: ObservableObject {
             await self?.finishRequestedRefreshIfCurrent(
                 result: result,
                 daemon: nextDaemon,
+                watcherProcess: nextWatcherProcess,
                 snapshotTime: snapshotTime,
                 startUnix: startUnix,
                 force: force,
@@ -312,6 +427,7 @@ final class StatsCollector: ObservableObject {
     private func finishRequestedRefreshIfCurrent(
         result: Result<DashboardStats, Error>,
         daemon nextDaemon: DaemonHealthSnapshot?,
+        watcherProcess: WatcherProcessProbeResult,
         snapshotTime: Date,
         startUnix: TimeInterval,
         force: Bool,
@@ -322,6 +438,7 @@ final class StatsCollector: ObservableObject {
         finishRequestedRefresh(
             result: result,
             daemon: nextDaemon,
+            watcherProcess: watcherProcess,
             snapshotTime: snapshotTime,
             startUnix: startUnix,
             force: force,
@@ -336,6 +453,7 @@ final class StatsCollector: ObservableObject {
     private func finishRequestedRefresh(
         result: Result<DashboardStats, Error>,
         daemon nextDaemon: DaemonHealthSnapshot?,
+        watcherProcess: WatcherProcessProbeResult,
         snapshotTime: Date,
         startUnix: TimeInterval,
         force: Bool,
@@ -345,35 +463,25 @@ final class StatsCollector: ObservableObject {
         switch result {
         case .success(let nextStats):
             let queueFlushRate = recordPendingStoreQueueDepth(nextStats.pendingStoreFlushQueueDepth, now: snapshotTime)
-            stats = nextStats.withPendingStoreFlushRate(queueFlushRate)
+            stats = nextStats
+                .withPendingStoreFlushRate(queueFlushRate)
+                .withWatcherProcessProbeResult(watcherProcess)
             daemon = finishDaemon
             state = PipelineState.derive(daemon: finishDaemon, stats: stats)
-            lastDataFetchedAt = Date()
+            lastDataFetchedAt = nowProvider()
+            lastFetchError = nil
             if !force {
                 lastNonForcedStatsRefreshAt = snapshotTime
             }
-        case .failure:
+        case .failure(let error):
             daemon = finishDaemon
-            if force {
-                stats = DashboardStats(
-                    chunkCount: 0,
-                    enrichedChunkCount: 0,
-                    pendingEnrichmentCount: 0,
-                    enrichmentPercent: 0,
-                    enrichmentRatePerMinute: 0,
-                    databaseSizeBytes: 0,
-                    recentActivityBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
-                    recentEnrichmentBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
-                    recentWriteFiveMinuteCount: 0,
-                    recentEnrichmentFiveMinuteCount: 0,
-                    activityWindowMinutes: Self.defaultActivityWindowMinutes,
-                    bucketCount: Self.defaultBucketCount
-                )
-            }
+            stats = stats.withWatcherProcessProbeResult(watcherProcess)
+            lastFetchError = String(describing: error)
             state = PipelineState.derive(daemon: finishDaemon, stats: stats)
         }
 
         isRefreshing = false
+        updateSnapshotFreshness()
         hasPendingStatsRefresh = pendingStatsRefreshTask != nil
         if trigger == .manual {
             isManualRefreshInProgress = false
@@ -382,7 +490,7 @@ final class StatsCollector: ObservableObject {
         logDashboardRefresh(
             timestamp: snapshotTime,
             startUnix: startUnix,
-            endUnix: Date().timeIntervalSince1970,
+            endUnix: nowProvider().timeIntervalSince1970,
             rows: stats.chunkCount,
             writes5m: stats.recentWriteFiveMinuteCount,
             enrich5m: stats.recentEnrichmentFiveMinuteCount,
@@ -479,6 +587,32 @@ final class StatsCollector: ObservableObject {
         }
     }
 
+    private func startFreshnessTicker() {
+        freshnessTicker?.cancel()
+        let interval = freshnessTickerInterval
+        freshnessTicker = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(interval))
+                } catch {
+                    break
+                }
+                guard !Task.isCancelled, let self, !self.isStopped else { break }
+                self.updateSnapshotFreshness()
+            }
+        }
+    }
+
+    private func updateSnapshotFreshness() {
+        snapshotFreshnessState = SnapshotFreshnessState.derive(
+            lastSuccessAt: lastDataFetchedAt,
+            isRefreshing: isRefreshing,
+            lastFetchError: lastFetchError,
+            now: nowProvider(),
+            snapshotFreshnessThreshold: Self.snapshotFreshnessThreshold
+        )
+    }
+
     private func refreshAgentActivity(force: Bool, now: Date) {
         if !force, let lastAgentActivitySampleAt, now.timeIntervalSince(lastAgentActivitySampleAt) < agentActivitySampleInterval {
             return
@@ -511,6 +645,7 @@ final class StatsCollector: ObservableObject {
         switch event.type {
         case .healthTick:
             daemon = daemonMonitor.sample()
+            stats = stats.withWatcherProcessProbeResult(watcherProcessProbe.sample())
             refreshAgentActivity(force: false, now: Date())
             state = PipelineState.derive(daemon: daemon, stats: stats)
         case .queueDepth, .enrichStatus, .lastChunkID, .dbBusy:
@@ -610,7 +745,9 @@ extension StatsCollector {
         agentActivity: AgentActivitySnapshot,
         state: PipelineState,
         heartbeat: DashboardHeartbeat = .empty,
-        lastDataFetchedAt: Date?
+        lastDataFetchedAt: Date?,
+        lastFetchError: String? = nil,
+        snapshotFreshnessState: SnapshotFreshnessState = .live(ageSeconds: 0)
     ) -> StatsCollector {
         // targetPID 0 makes the monitor's sample() return nil; it is never used
         // because start()/requestRefresh() are not called on a fixture.
@@ -624,6 +761,8 @@ extension StatsCollector {
         collector.state = state
         collector.heartbeat = heartbeat
         collector.lastDataFetchedAt = lastDataFetchedAt
+        collector.lastFetchError = lastFetchError
+        collector.snapshotFreshnessState = snapshotFreshnessState
         return collector
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -1,8 +1,9 @@
 import Combine
 import CoreFoundation
+import Darwin
 import Foundation
 
-protocol WatcherProcessProbing {
+protocol WatcherProcessProbing: Sendable {
     func sample() -> WatcherProcessProbeResult
 }
 
@@ -18,16 +19,16 @@ struct LaunchctlWatcherProcessProbe: WatcherProcessProbing {
         let output: String
     }
 
-    typealias CommandRunner = ([String]) -> CommandResult
+    typealias CommandRunner = @Sendable ([String]) -> CommandResult
 
     private let label: String
     private let commandRunner: CommandRunner
-    private let uidProvider: () -> uid_t
+    private let uidProvider: @Sendable () -> uid_t
 
     init(
         label: String = "com.brainlayer.watch",
-        commandRunner: @escaping CommandRunner = LaunchctlWatcherProcessProbe.run,
-        uidProvider: @escaping () -> uid_t = getuid
+        commandRunner: @escaping CommandRunner = { LaunchctlWatcherProcessProbe.run($0) },
+        uidProvider: @escaping @Sendable () -> uid_t = getuid
     ) {
         self.label = label
         self.commandRunner = commandRunner
@@ -65,7 +66,7 @@ struct LaunchctlWatcherProcessProbe: WatcherProcessProbing {
         return nil
     }
 
-    private static func run(_ command: [String]) -> CommandResult {
+    static func run(_ command: [String], timeout: TimeInterval = 1.0) -> CommandResult {
         guard let executable = command.first else {
             return CommandResult(terminationStatus: 1, output: "missing launchctl executable")
         }
@@ -82,8 +83,30 @@ struct LaunchctlWatcherProcessProbe: WatcherProcessProbing {
             return CommandResult(terminationStatus: 1, output: String(describing: error))
         }
 
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let deadline = Date().addingTimeInterval(max(0.01, timeout))
+        while process.isRunning, Date() < deadline, !Task.isCancelled {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        if process.isRunning {
+            process.terminate()
+            let terminationDeadline = Date().addingTimeInterval(0.1)
+            while process.isRunning, Date() < terminationDeadline {
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            if process.isRunning {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+            }
+            process.waitUntilExit()
+            _ = pipe.fileHandleForReading.readDataToEndOfFile()
+            return CommandResult(
+                terminationStatus: 124,
+                output: Task.isCancelled ? "launchctl probe cancelled" : "launchctl timed out"
+            )
+        }
+
         process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         return CommandResult(
             terminationStatus: process.terminationStatus,
             output: String(data: data, encoding: .utf8) ?? ""
@@ -107,6 +130,11 @@ private func statsCollectorDarwinNotificationCallback(
 
 @MainActor
 final class StatsCollector: ObservableObject {
+    typealias WindowedBucketsProvider = @Sendable (
+        _ windowMinutes: Int,
+        _ bucketCount: Int
+    ) throws -> BrainDatabase.PipelineWindowBuckets
+
     static let defaultActivityWindowMinutes = 60
     static let defaultBucketCount = 12
     static let snapshotFreshnessThreshold: TimeInterval = 60
@@ -124,11 +152,12 @@ final class StatsCollector: ObservableObject {
     @Published private(set) var heartbeat: DashboardHeartbeat
     /// REAL windowed buckets for the shared Live/3h/24h selector. `nil` means
     /// "no wider window selected yet" — the views fall back to the live `stats`
-    /// buckets (the resting 30m view). When the selector picks 3h/24h, the view
+    /// buckets (the resting 1h view). When the selector picks 3h/24h, the view
     /// requests a windowed fetch; this publishes the actual DB data for that
     /// window so the charts re-render with genuine history, not a relabel.
     @Published private(set) var windowedBuckets: BrainDatabase.PipelineWindowBuckets?
     @Published private(set) var windowedBucketsWindowMinutes: Int?
+    @Published private(set) var windowedBucketsError: String?
     @Published private(set) var isWindowedBucketsLoading = false
     private var windowedBucketsTask: Task<Void, Never>?
     private var windowedBucketsGeneration = 0
@@ -137,6 +166,7 @@ final class StatsCollector: ObservableObject {
     private let databaseOpenConfiguration: BrainDatabase.OpenConfiguration
     private let daemonMonitor: DaemonHealthMonitor
     private let watcherProcessProbe: any WatcherProcessProbing
+    private let windowedBucketsProvider: WindowedBucketsProvider
     private let agentActivityMonitor: AgentActivityMonitor
     private let agentActivitySampleInterval: TimeInterval
     private let statsRefreshCoalesceInterval: TimeInterval
@@ -153,6 +183,8 @@ final class StatsCollector: ObservableObject {
     private var pendingStatsRefreshBypassesCoalescing = false
     private var dashboardRefreshTask: Task<Void, Never>?
     private var dashboardRefreshGeneration = 0
+    private var watcherProcessRefreshTask: Task<Void, Never>?
+    private var watcherProcessRefreshGeneration = 0
     private var isRunning = false
     private var isStopped = false
     private var lastAgentActivitySampleAt: Date?
@@ -175,12 +207,22 @@ final class StatsCollector: ObservableObject {
         freshnessTickerInterval: TimeInterval = 1,
         nowProvider: @escaping () -> Date = Date.init,
         brainBusEvents: BrainBusEventSource? = nil,
+        windowedBucketsProvider: WindowedBucketsProvider? = nil,
         databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) {
         self.dbPath = dbPath
         self.databaseOpenConfiguration = databaseOpenConfiguration
         self.daemonMonitor = daemonMonitor
         self.watcherProcessProbe = watcherProcessProbe
+        self.windowedBucketsProvider = windowedBucketsProvider ?? { windowMinutes, bucketCount in
+            let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
+            defer { backgroundDatabase.close() }
+            backgroundDatabase.reopenIfNeeded()
+            return try backgroundDatabase.pipelineWindowBuckets(
+                activityWindowMinutes: windowMinutes,
+                bucketCount: bucketCount
+            )
+        }
         self.agentActivityMonitor = agentActivityMonitor
         self.agentActivitySampleInterval = agentActivitySampleInterval
         self.statsRefreshCoalesceInterval = statsRefreshCoalesceInterval
@@ -245,8 +287,12 @@ final class StatsCollector: ObservableObject {
         freshnessTicker = nil
         dashboardRefreshTask?.cancel()
         dashboardRefreshTask = nil
+        watcherProcessRefreshTask?.cancel()
+        watcherProcessRefreshTask = nil
+        watcherProcessRefreshGeneration += 1
         windowedBucketsTask?.cancel()
         windowedBucketsTask = nil
+        windowedBucketsGeneration += 1
         isWindowedBucketsLoading = false
         pendingStatsRefreshTask?.cancel()
         pendingStatsRefreshTask = nil
@@ -279,7 +325,7 @@ final class StatsCollector: ObservableObject {
 
     /// Fetch REAL windowed buckets for the shared Live/3h/24h selector.
     ///
-    /// The `.live` (30m) lens reads straight off the resting `stats` buckets, so
+    /// The `.live` (1h) lens reads straight off the resting `stats` buckets, so
     /// it clears any wider-window fetch and returns immediately. The 3h/24h
     /// lenses trigger a genuine off-main DB re-fetch over the requested window
     /// (180 / 1440 minutes) and publish `windowedBuckets` so the charts re-render
@@ -288,30 +334,25 @@ final class StatsCollector: ObservableObject {
     func selectTimeframe(windowMinutes: Int, isLive: Bool) {
         windowedBucketsTask?.cancel()
         windowedBucketsTask = nil
+        windowedBucketsGeneration += 1
+        let generation = windowedBucketsGeneration
 
         if isLive {
             windowedBuckets = nil
             windowedBucketsWindowMinutes = nil
+            windowedBucketsError = nil
             isWindowedBucketsLoading = false
             return
         }
 
-        windowedBucketsGeneration += 1
-        let generation = windowedBucketsGeneration
-        let dbPath = self.dbPath
-        let openConfiguration = self.databaseOpenConfiguration
         let bucketCount = Self.defaultBucketCount
+        let provider = windowedBucketsProvider
+        windowedBucketsError = nil
         isWindowedBucketsLoading = true
 
         windowedBucketsTask = Task.detached(priority: .userInitiated) { [weak self] in
             let result: Result<BrainDatabase.PipelineWindowBuckets, Error> = Result {
-                let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: openConfiguration)
-                defer { backgroundDatabase.close() }
-                backgroundDatabase.reopenIfNeeded()
-                return try backgroundDatabase.pipelineWindowBuckets(
-                    activityWindowMinutes: windowMinutes,
-                    bucketCount: bucketCount
-                )
+                try provider(windowMinutes, bucketCount)
             }
 
             await self?.finishWindowedBucketsFetch(
@@ -328,22 +369,21 @@ final class StatsCollector: ObservableObject {
         bypassCoalescing: Bool = false
     ) {
         let nextDaemon = daemonMonitor.sample()
-        let nextWatcherProcess = watcherProcessProbe.sample()
         let snapshotTime = nowProvider()
         refreshAgentActivity(force: force, now: snapshotTime)
 
         if !force, !bypassCoalescing, let coalescedDelay = coalescedStatsRefreshDelay(now: snapshotTime) {
             daemon = nextDaemon
-            stats = stats.withWatcherProcessProbeResult(nextWatcherProcess)
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            requestWatcherProcessRefresh()
             schedulePendingStatsRefresh(after: coalescedDelay)
             return
         }
 
         if dashboardRefreshTask != nil, trigger != .manual {
             daemon = nextDaemon
-            stats = stats.withWatcherProcessProbeResult(nextWatcherProcess)
             state = PipelineState.derive(daemon: nextDaemon, stats: stats)
+            requestWatcherProcessRefresh()
             if !force {
                 schedulePendingStatsRefresh(after: statsRefreshCoalesceInterval)
             }
@@ -363,6 +403,7 @@ final class StatsCollector: ObservableObject {
         let activityWindowMinutes = Self.defaultActivityWindowMinutes
         let bucketCount = Self.defaultBucketCount
         let startStats = stats
+        let watcherProcessProbe = self.watcherProcessProbe
         let startUnix = snapshotTime.timeIntervalSince1970
         isRefreshing = true
         updateSnapshotFreshness()
@@ -370,7 +411,6 @@ final class StatsCollector: ObservableObject {
             isManualRefreshInProgress = true
         }
         daemon = nextDaemon
-        stats = stats.withWatcherProcessProbeResult(nextWatcherProcess)
         state = PipelineState.derive(daemon: nextDaemon, stats: stats)
         logDashboardRefresh(
             timestamp: snapshotTime,
@@ -383,6 +423,7 @@ final class StatsCollector: ObservableObject {
         )
 
         dashboardRefreshTask = Task.detached(priority: .utility) { [weak self] in
+            let nextWatcherProcess = watcherProcessProbe.sample()
             let result: Result<DashboardStats, Error> = Result {
                 let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: openConfiguration)
                 defer { backgroundDatabase.close() }
@@ -418,10 +459,28 @@ final class StatsCollector: ObservableObject {
         case .success(let buckets):
             windowedBuckets = buckets
             windowedBucketsWindowMinutes = windowMinutes
+            windowedBucketsError = nil
         case .failure:
-            windowedBuckets = nil
-            windowedBucketsWindowMinutes = nil
+            windowedBucketsError = "Could not load \(DashboardMetricFormatter.windowLabel(minutes: windowMinutes)); showing Last 1h."
         }
+    }
+
+    private func requestWatcherProcessRefresh() {
+        watcherProcessRefreshTask?.cancel()
+        watcherProcessRefreshGeneration += 1
+        let generation = watcherProcessRefreshGeneration
+        let probe = watcherProcessProbe
+        watcherProcessRefreshTask = Task.detached(priority: .utility) { [weak self] in
+            let result = probe.sample()
+            await self?.finishWatcherProcessRefresh(result, generation: generation)
+        }
+    }
+
+    private func finishWatcherProcessRefresh(_ result: WatcherProcessProbeResult, generation: Int) {
+        guard !isStopped, generation == watcherProcessRefreshGeneration else { return }
+        watcherProcessRefreshTask = nil
+        stats = stats.withWatcherProcessProbeResult(result)
+        state = PipelineState.derive(daemon: daemon, stats: stats)
     }
 
     private func finishRequestedRefreshIfCurrent(
@@ -645,9 +704,9 @@ final class StatsCollector: ObservableObject {
         switch event.type {
         case .healthTick:
             daemon = daemonMonitor.sample()
-            stats = stats.withWatcherProcessProbeResult(watcherProcessProbe.sample())
             refreshAgentActivity(force: false, now: Date())
             state = PipelineState.derive(daemon: daemon, stats: stats)
+            requestWatcherProcessRefresh()
         case .queueDepth, .enrichStatus, .lastChunkID, .dbBusy:
             scheduleLiveStatsRefresh()
         }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -13,6 +13,27 @@ struct StaticWatcherProcessProbe: WatcherProcessProbing {
     func sample() -> WatcherProcessProbeResult { result }
 }
 
+private final class LaunchctlOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    deinit {}
+
+    func replace(with data: Data) {
+        lock.lock()
+        self.data = data
+        lock.unlock()
+    }
+
+    func text(appending statusMessage: String? = nil) -> String {
+        lock.lock()
+        let captured = String(data: data, encoding: .utf8) ?? ""
+        lock.unlock()
+        guard let statusMessage, !statusMessage.isEmpty else { return captured }
+        return captured.isEmpty ? statusMessage : "\(captured)\n\(statusMessage)"
+    }
+}
+
 struct LaunchctlWatcherProcessProbe: WatcherProcessProbing {
     struct CommandResult: Sendable, Equatable {
         let terminationStatus: Int32
@@ -82,6 +103,15 @@ struct LaunchctlWatcherProcessProbe: WatcherProcessProbing {
         } catch {
             return CommandResult(terminationStatus: 1, output: String(describing: error))
         }
+        try? pipe.fileHandleForWriting.close()
+
+        let outputBuffer = LaunchctlOutputBuffer()
+        let outputDrain = DispatchGroup()
+        outputDrain.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            outputBuffer.replace(with: pipe.fileHandleForReading.readDataToEndOfFile())
+            outputDrain.leave()
+        }
 
         let deadline = Date().addingTimeInterval(max(0.01, timeout))
         while process.isRunning, Date() < deadline, !Task.isCancelled {
@@ -98,18 +128,20 @@ struct LaunchctlWatcherProcessProbe: WatcherProcessProbing {
                 Darwin.kill(process.processIdentifier, SIGKILL)
             }
             process.waitUntilExit()
-            _ = pipe.fileHandleForReading.readDataToEndOfFile()
+            outputDrain.wait()
             return CommandResult(
                 terminationStatus: 124,
-                output: Task.isCancelled ? "launchctl probe cancelled" : "launchctl timed out"
+                output: outputBuffer.text(
+                    appending: Task.isCancelled ? "launchctl probe cancelled" : "launchctl timed out"
+                )
             )
         }
 
         process.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        outputDrain.wait()
         return CommandResult(
             terminationStatus: process.terminationStatus,
-            output: String(data: data, encoding: .utf8) ?? ""
+            output: outputBuffer.text()
         )
     }
 }

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -403,6 +403,7 @@ final class StatsCollector: ObservableObject {
         watcherProcessRefreshTask?.cancel()
         watcherProcessRefreshTask = nil
         watcherProcessRefreshGeneration += 1
+        let watcherProcessGeneration = watcherProcessRefreshGeneration
         let generation = dashboardRefreshGeneration
         let dbPath = self.dbPath
         let openConfiguration = self.databaseOpenConfiguration
@@ -448,7 +449,8 @@ final class StatsCollector: ObservableObject {
                 startUnix: startUnix,
                 force: force,
                 trigger: trigger,
-                generation: generation
+                generation: generation,
+                watcherProcessGeneration: watcherProcessGeneration
             )
         }
     }
@@ -502,7 +504,8 @@ final class StatsCollector: ObservableObject {
         startUnix: TimeInterval,
         force: Bool,
         trigger: DashboardRefreshTrigger,
-        generation: Int
+        generation: Int,
+        watcherProcessGeneration: Int
     ) {
         guard !isStopped, generation == dashboardRefreshGeneration else { return }
         finishRequestedRefresh(
@@ -512,7 +515,8 @@ final class StatsCollector: ObservableObject {
             snapshotTime: snapshotTime,
             startUnix: startUnix,
             force: force,
-            trigger: trigger
+            trigger: trigger,
+            watcherProcessGeneration: watcherProcessGeneration
         )
     }
 
@@ -527,15 +531,18 @@ final class StatsCollector: ObservableObject {
         snapshotTime: Date,
         startUnix: TimeInterval,
         force: Bool,
-        trigger: DashboardRefreshTrigger
+        trigger: DashboardRefreshTrigger,
+        watcherProcessGeneration: Int
     ) {
         let finishDaemon = daemonMonitor.sample() ?? nextDaemon
         switch result {
         case .success(let nextStats):
             let queueFlushRate = recordPendingStoreQueueDepth(nextStats.pendingStoreFlushQueueDepth, now: snapshotTime)
-            stats = nextStats
-                .withPendingStoreFlushRate(queueFlushRate)
-                .withWatcherProcessProbeResult(watcherProcess)
+            stats = applyingWatcherProcessResultIfCurrent(
+                to: nextStats.withPendingStoreFlushRate(queueFlushRate),
+                candidate: watcherProcess,
+                generation: watcherProcessGeneration
+            )
             daemon = finishDaemon
             state = PipelineState.derive(daemon: finishDaemon, stats: stats)
             lastDataFetchedAt = nowProvider()
@@ -548,7 +555,11 @@ final class StatsCollector: ObservableObject {
             }
         case .failure(let error):
             daemon = finishDaemon
-            stats = stats.withWatcherProcessProbeResult(watcherProcess)
+            stats = applyingWatcherProcessResultIfCurrent(
+                to: stats,
+                candidate: watcherProcess,
+                generation: watcherProcessGeneration
+            )
             lastFetchError = String(describing: error)
             state = PipelineState.derive(daemon: finishDaemon, stats: stats)
         }
@@ -569,6 +580,21 @@ final class StatsCollector: ObservableObject {
             enrich5m: stats.recentEnrichmentFiveMinuteCount,
             trigger: trigger
         )
+    }
+
+    private func applyingWatcherProcessResultIfCurrent(
+        to nextStats: DashboardStats,
+        candidate: WatcherProcessProbeResult,
+        generation: Int
+    ) -> DashboardStats {
+        guard generation == watcherProcessRefreshGeneration else {
+            // A later standalone watcher request superseded the sample embedded
+            // in this full refresh. Preserve the newest published process truth
+            // while that later request completes instead of regressing it.
+            guard let newestPublished = stats.watcherProcessProbeResult else { return nextStats }
+            return nextStats.withWatcherProcessProbeResult(newestPublished)
+        }
+        return nextStats.withWatcherProcessProbeResult(candidate)
     }
 
     private func recordPendingStoreQueueDepth(_ depth: Int, now: Date) -> Double {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -161,6 +161,7 @@ final class StatsCollector: ObservableObject {
     @Published private(set) var isWindowedBucketsLoading = false
     private var windowedBucketsTask: Task<Void, Never>?
     private var windowedBucketsGeneration = 0
+    private var selectedWindowMinutes: Int?
 
     private let dbPath: String
     private let databaseOpenConfiguration: BrainDatabase.OpenConfiguration
@@ -338,6 +339,7 @@ final class StatsCollector: ObservableObject {
         let generation = windowedBucketsGeneration
 
         if isLive {
+            selectedWindowMinutes = nil
             windowedBuckets = nil
             windowedBucketsWindowMinutes = nil
             windowedBucketsError = nil
@@ -347,6 +349,7 @@ final class StatsCollector: ObservableObject {
 
         let bucketCount = Self.defaultBucketCount
         let provider = windowedBucketsProvider
+        selectedWindowMinutes = windowMinutes
         windowedBucketsError = nil
         isWindowedBucketsLoading = true
 
@@ -397,6 +400,9 @@ final class StatsCollector: ObservableObject {
         hasPendingStatsRefresh = false
         dashboardRefreshTask?.cancel()
         dashboardRefreshGeneration += 1
+        watcherProcessRefreshTask?.cancel()
+        watcherProcessRefreshTask = nil
+        watcherProcessRefreshGeneration += 1
         let generation = dashboardRefreshGeneration
         let dbPath = self.dbPath
         let openConfiguration = self.databaseOpenConfiguration
@@ -461,7 +467,12 @@ final class StatsCollector: ObservableObject {
             windowedBucketsWindowMinutes = windowMinutes
             windowedBucketsError = nil
         case .failure:
-            windowedBucketsError = "Could not load \(DashboardMetricFormatter.windowLabel(minutes: windowMinutes)); showing Last 1h."
+            let windowLabel = DashboardMetricFormatter.windowLabel(minutes: windowMinutes)
+            if windowedBuckets != nil, windowedBucketsWindowMinutes == windowMinutes {
+                windowedBucketsError = "Could not refresh \(windowLabel); showing previous \(windowLabel)."
+            } else {
+                windowedBucketsError = "Could not load \(windowLabel); showing Last 1h."
+            }
         }
     }
 
@@ -529,6 +540,9 @@ final class StatsCollector: ObservableObject {
             state = PipelineState.derive(daemon: finishDaemon, stats: stats)
             lastDataFetchedAt = nowProvider()
             lastFetchError = nil
+            if let selectedWindowMinutes {
+                selectTimeframe(windowMinutes: selectedWindowMinutes, isLive: false)
+            }
             if !force {
                 lastNonForcedStatsRefreshAt = snapshotTime
             }

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -22,33 +22,18 @@ final class InjectionFeedPresentationModel: ObservableObject {
 
         boundStore = store
         cancellables.removeAll()
-        let currentState = InjectionFeedPresentationState(
+        state = InjectionFeedPresentationState(
             events: store.events,
             degradationState: store.degradationState,
-            loadState: .loaded
+            loadState: store.loadState
         )
-        if !store.events.isEmpty || store.degradationState.isDegraded {
-            state = currentState
-        } else {
-            if state != .empty {
-                state = .empty
-            }
-            DispatchQueue.main.async { [weak self, weak store] in
-                guard let self, let store, self.boundStore === store else { return }
-                self.state = InjectionFeedPresentationState(
-                    events: store.events,
-                    degradationState: store.degradationState,
-                    loadState: .loaded
-                )
-            }
-        }
 
-        Publishers.CombineLatest(store.$events, store.$degradationState)
-            .map { events, degradationState in
+        Publishers.CombineLatest3(store.$events, store.$degradationState, store.$loadState)
+            .map { events, degradationState, loadState in
                 InjectionFeedPresentationState(
                     events: events,
                     degradationState: degradationState,
-                    loadState: .loaded
+                    loadState: loadState
                 )
             }
             .dropFirst()
@@ -90,6 +75,16 @@ struct InjectionFeedView: View {
         _filterText = .constant(fixture.filterText)
         _expandedBurstIDs = State(initialValue: fixture.expandedBurstIDs)
         _actionReceipt = State(initialValue: fixture.actionReceipt)
+    }
+
+    init(disconnectedAt now: Date) {
+        self.init(
+            fixture: InjectionFeedFixture(
+                events: [],
+                now: now,
+                connectionState: .disconnected
+            )
+        )
     }
 
     private let accentPalette: [Color] = [
@@ -168,13 +163,6 @@ struct InjectionFeedView: View {
                 ConversationLoadingOverlay(onClose: { loadingConversationChunkID = nil })
             }
         }
-        .overlay(alignment: .topTrailing) {
-            if presentationState.degradationState.isDegraded {
-                DegradationBadge(reason: presentationState.degradationState.reason)
-                    .padding(.top, 20)
-                    .padding(.trailing, 20)
-            }
-        }
         .overlay(alignment: .bottomTrailing) {
             if let actionReceipt {
                 actionReceiptBadge(actionReceipt)
@@ -230,8 +218,8 @@ struct InjectionFeedView: View {
     }
 
     private var filterChips: some View {
-        let activeFilter = InjectionTypeFilter(rawValue: typeFilterRaw) ?? .all
-        return Picker("Retrieval type", selection: $typeFilterRaw) {
+        let activeFilter = effectiveTypeFilter
+        return Picker("Retrieval type", selection: typeFilterBinding) {
             ForEach(InjectionTypeFilter.allCases, id: \.rawValue) { filter in
                 Text(filter.label).tag(filter.rawValue)
             }
@@ -401,7 +389,7 @@ struct InjectionFeedView: View {
             if isExpanded {
                 VStack(alignment: .leading, spacing: 12) {
                     ForEach(burst.events) { event in
-                        eventRow(event)
+                        eventRow(event, selectedResultChunkID: burst.selectedResultProvenance?.chunkID)
                     }
                 }
                 .id(Self.expandedBurstDetailsID(burstID: burst.id))
@@ -466,7 +454,7 @@ struct InjectionFeedView: View {
         .background(.regularMaterial)
     }
 
-    private func eventRow(_ event: InjectionEvent) -> some View {
+    private func eventRow(_ event: InjectionEvent, selectedResultChunkID: String?) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 10) {
                 Text(InjectionPresentation.shortTime(event.timestamp))
@@ -506,6 +494,10 @@ struct InjectionFeedView: View {
                         }
                         Text("Session \(event.sessionID)")
                         Text("Event ID \(event.id)")
+                        if !event.claudeConversationID.isEmpty {
+                            Text("Conversation \(event.claudeConversationID)")
+                        }
+                        Text("Mode \(event.mode)")
                         Text("\(event.uniqueChunkIDs.count) results")
                         Text("\(event.tokenCount) tok")
                     }
@@ -519,7 +511,7 @@ struct InjectionFeedView: View {
                     // Previously the chunk list hid behind a low-weight "Show hits"
                     // link, so an expanded "3-chunk" burst showed only one.
                     if !event.uniqueChunkIDs.isEmpty {
-                        chunkList(for: event)
+                        chunkList(for: event, selectedResultChunkID: selectedResultChunkID)
                     }
                 }
 
@@ -594,27 +586,46 @@ struct InjectionFeedView: View {
         )
     }
 
-    private func chunkList(for event: InjectionEvent) -> some View {
+    private func chunkList(for event: InjectionEvent, selectedResultChunkID: String?) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(event.uniqueChunkIDs.enumerated()), id: \.offset) { _, chunkID in
+                let resultChunk = chunk(for: chunkID, event: event)
+                let provenance = InjectionPresentation.ResultProvenance(
+                    chunkID: chunkID,
+                    eventID: event.id,
+                    sessionID: event.sessionID,
+                    timestamp: event.timestamp,
+                    chunk: resultChunk
+                )
                 Button {
                     openConversation(
                         chunkID: chunkID,
-                        title: chunk(for: chunkID, event: event)?.kind.modalTitle ?? event.modalTitle
+                        title: resultChunk?.kind.modalTitle ?? event.modalTitle
                     )
                 } label: {
-                    HStack(spacing: 8) {
+                    HStack(alignment: .top, spacing: 8) {
                         Circle()
-                            .fill(color(for: chunk(for: chunkID, event: event)?.kind ?? .other))
+                            .fill(color(for: resultChunk?.kind ?? .other))
                             .frame(width: 8, height: 8)
-                        VStack(alignment: .leading, spacing: 2) {
+                            .padding(.top, 4)
+                        VStack(alignment: .leading, spacing: 5) {
                             Text(chunkListTitle(chunkID: chunkID, event: event))
                                 .font(.system(size: 11, weight: .medium))
-                                .lineLimit(1)
-                            Text("ID \(chunkID)")
-                                .font(.system(size: 9, weight: .medium, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
+                                .lineLimit(2)
+                            WrappingPillLayout(spacing: 6, lineSpacing: 5) {
+                                ForEach(
+                                    provenance.expandedMetadataLabels(
+                                        isSelected: chunkID == selectedResultChunkID
+                                    ),
+                                    id: \.self
+                                ) { label in
+                                    Text(label)
+                                        .font(.system(size: 9, weight: .medium, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         Spacer()
                         Text("Open thread")
@@ -866,16 +877,12 @@ struct InjectionFeedView: View {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         let copied = pasteboard.setString(command, forType: .string)
+        actionReceipt = .copyResult(copied: copied)
         guard copied else {
-            actionReceipt = InjectionActionReceipt(
-                kind: .failure,
-                message: "Couldn’t copy the resume command"
-            )
             return
         }
 
         let update = { copiedContinuationBurstID = burst.id }
-        actionReceipt = InjectionActionReceipt(kind: .success, message: "Resume command copied")
         if reduceMotion {
             update()
         } else {
@@ -926,6 +933,11 @@ struct InjectionFeedView: View {
         fixture?.typeFilter ?? InjectionTypeFilter(rawValue: typeFilterRaw) ?? .all
     }
 
+    private var typeFilterBinding: Binding<String> {
+        guard let fixture else { return $typeFilterRaw }
+        return .constant(fixture.typeFilter.rawValue)
+    }
+
     private func makePresentation(now: Date = Date()) -> InjectionPresentation.Snapshot {
         let effectiveNow = fixture?.now ?? now
         return InjectionPresentation.snapshot(
@@ -958,10 +970,7 @@ struct InjectionFeedView: View {
     private func openConversation(chunkID: String, title: String) {
         guard loadingConversationChunkID == nil else { return }
         guard let store else {
-            actionReceipt = InjectionActionReceipt(
-                kind: .failure,
-                message: "Thread unavailable in this disconnected snapshot"
-            )
+            actionReceipt = .disconnectedThread
             return
         }
         loadingConversationChunkID = chunkID
@@ -971,15 +980,12 @@ struct InjectionFeedView: View {
                 guard loadingConversationChunkID == chunkID else { return }
                 conversationSelection.open(conversation, title: title)
                 loadingConversationChunkID = nil
-                actionReceipt = InjectionActionReceipt(kind: .success, message: "Thread opened")
+                actionReceipt = .threadOpenResult(errorDescription: nil)
             } catch {
                 if loadingConversationChunkID == chunkID {
                     loadingConversationChunkID = nil
                 }
-                actionReceipt = InjectionActionReceipt(
-                    kind: .failure,
-                    message: "Couldn’t open thread · \(error.localizedDescription)"
-                )
+                actionReceipt = .threadOpenResult(errorDescription: error.localizedDescription)
             }
         }
     }

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -60,6 +60,7 @@ struct InjectionFeedView: View {
     @State private var conversationSelection = InjectionConversationSelection()
     @State private var loadingConversationChunkID: String?
     @State private var actionReceipt: InjectionActionReceipt? = nil
+    @State private var actionReceiptGeneration = InjectionActionReceiptGeneration()
     @State private var groupingDisclosureExpanded = false
     @AppStorage("brainbar.injectionFeed.typeFilter") private var typeFilterRaw = InjectionTypeFilter.all.rawValue
 
@@ -877,7 +878,7 @@ struct InjectionFeedView: View {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         let copied = pasteboard.setString(command, forType: .string)
-        actionReceipt = .copyResult(copied: copied)
+        publishActionReceipt(.copyResult(copied: copied))
         guard copied else {
             return
         }
@@ -893,9 +894,6 @@ struct InjectionFeedView: View {
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(2))
             guard copiedContinuationBurstID == burstID else { return }
-            if actionReceipt?.message == "Resume command copied" {
-                actionReceipt = nil
-            }
             if reduceMotion {
                 copiedContinuationBurstID = nil
             } else {
@@ -970,7 +968,7 @@ struct InjectionFeedView: View {
     private func openConversation(chunkID: String, title: String) {
         guard loadingConversationChunkID == nil else { return }
         guard let store else {
-            actionReceipt = .disconnectedThread
+            publishActionReceipt(.disconnectedThread)
             return
         }
         loadingConversationChunkID = chunkID
@@ -980,13 +978,22 @@ struct InjectionFeedView: View {
                 guard loadingConversationChunkID == chunkID else { return }
                 conversationSelection.open(conversation, title: title)
                 loadingConversationChunkID = nil
-                actionReceipt = .threadOpenResult(errorDescription: nil)
+                publishActionReceipt(.threadOpenResult(errorDescription: nil))
             } catch {
-                if loadingConversationChunkID == chunkID {
-                    loadingConversationChunkID = nil
-                }
-                actionReceipt = .threadOpenResult(errorDescription: error.localizedDescription)
+                guard loadingConversationChunkID == chunkID else { return }
+                loadingConversationChunkID = nil
+                publishActionReceipt(.threadOpenResult(errorDescription: error.localizedDescription))
             }
+        }
+    }
+
+    private func publishActionReceipt(_ receipt: InjectionActionReceipt) {
+        let generation = actionReceiptGeneration.next()
+        actionReceipt = receipt
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            guard actionReceiptGeneration.isCurrent(generation), actionReceipt == receipt else { return }
+            actionReceipt = nil
         }
     }
 }

--- a/brain-bar/Sources/BrainBar/InjectionFeedView.swift
+++ b/brain-bar/Sources/BrainBar/InjectionFeedView.swift
@@ -2,16 +2,6 @@ import AppKit
 import Combine
 import SwiftUI
 
-struct InjectionFeedPresentationState: Equatable {
-    let events: [InjectionEvent]
-    let degradationState: DegradationState
-
-    static let empty = InjectionFeedPresentationState(
-        events: [],
-        degradationState: .healthy
-    )
-}
-
 @MainActor
 final class InjectionFeedPresentationModel: ObservableObject {
     @Published private(set) var state: InjectionFeedPresentationState = .empty
@@ -34,17 +24,31 @@ final class InjectionFeedPresentationModel: ObservableObject {
         cancellables.removeAll()
         let currentState = InjectionFeedPresentationState(
             events: store.events,
-            degradationState: store.degradationState
+            degradationState: store.degradationState,
+            loadState: .loaded
         )
-        if state != currentState {
+        if !store.events.isEmpty || store.degradationState.isDegraded {
             state = currentState
+        } else {
+            if state != .empty {
+                state = .empty
+            }
+            DispatchQueue.main.async { [weak self, weak store] in
+                guard let self, let store, self.boundStore === store else { return }
+                self.state = InjectionFeedPresentationState(
+                    events: store.events,
+                    degradationState: store.degradationState,
+                    loadState: .loaded
+                )
+            }
         }
 
         Publishers.CombineLatest(store.$events, store.$degradationState)
             .map { events, degradationState in
                 InjectionFeedPresentationState(
                     events: events,
-                    degradationState: degradationState
+                    degradationState: degradationState,
+                    loadState: .loaded
                 )
             }
             .dropFirst()
@@ -61,7 +65,8 @@ final class InjectionFeedPresentationModel: ObservableObject {
 
 struct InjectionFeedView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    let store: InjectionStore
+    private let store: InjectionStore?
+    private let fixture: InjectionFeedFixture?
     @Binding var filterText: String
     @StateObject private var presentationModel = InjectionFeedPresentationModel()
     @State private var expandedBurstIDs: Set<String> = []
@@ -69,7 +74,23 @@ struct InjectionFeedView: View {
     @State private var copiedContinuationBurstID: String?
     @State private var conversationSelection = InjectionConversationSelection()
     @State private var loadingConversationChunkID: String?
+    @State private var actionReceipt: InjectionActionReceipt? = nil
+    @State private var groupingDisclosureExpanded = false
     @AppStorage("brainbar.injectionFeed.typeFilter") private var typeFilterRaw = InjectionTypeFilter.all.rawValue
+
+    init(store: InjectionStore, filterText: Binding<String>) {
+        self.store = store
+        self.fixture = nil
+        _filterText = filterText
+    }
+
+    init(fixture: InjectionFeedFixture) {
+        self.store = nil
+        self.fixture = fixture
+        _filterText = .constant(fixture.filterText)
+        _expandedBurstIDs = State(initialValue: fixture.expandedBurstIDs)
+        _actionReceipt = State(initialValue: fixture.actionReceipt)
+    }
 
     private let accentPalette: [Color] = [
         .brainBarAccent,
@@ -80,7 +101,14 @@ struct InjectionFeedView: View {
     ]
 
     var body: some View {
+        let presentationState = effectivePresentationState
         let snapshot = makePresentation()
+        let surfaceState = InjectionFeedSurfaceState.resolve(
+            snapshot: snapshot,
+            presentationState: presentationState,
+            connectionState: fixture?.connectionState ?? .connected,
+            filterActive: !filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || effectiveTypeFilter != .all
+        )
         GeometryReader { proxy in
             let wideLayout = proxy.size.width >= 960
 
@@ -88,21 +116,26 @@ struct InjectionFeedView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
                         header(snapshot: snapshot)
-                        overviewStrip(snapshot: snapshot)
+                        if surfaceState.showsContent {
+                            if case .degraded(let reason, true) = surfaceState {
+                                degradationNotice(reason: reason)
+                            }
+                            overviewStrip(snapshot: snapshot)
 
-                        if snapshot.bursts.isEmpty {
-                            emptyState
-                        } else if wideLayout {
-                            HStack(alignment: .top, spacing: 16) {
-                                feedColumn(snapshot: snapshot)
-                                sideRail(snapshot: snapshot)
-                                    .frame(width: 260)
+                            if wideLayout {
+                                HStack(alignment: .top, spacing: 16) {
+                                    feedColumn(snapshot: snapshot)
+                                    sideRail(snapshot: snapshot)
+                                        .frame(width: 260)
+                                }
+                            } else {
+                                VStack(alignment: .leading, spacing: 16) {
+                                    feedColumn(snapshot: snapshot)
+                                    sideRail(snapshot: snapshot)
+                                }
                             }
                         } else {
-                            VStack(alignment: .leading, spacing: 16) {
-                                feedColumn(snapshot: snapshot)
-                                sideRail(snapshot: snapshot)
-                            }
+                            stateCard(surfaceState)
                         }
                     }
                     .padding(20)
@@ -136,14 +169,22 @@ struct InjectionFeedView: View {
             }
         }
         .overlay(alignment: .topTrailing) {
-            if presentationModel.degradationState.isDegraded {
-                DegradationBadge(reason: presentationModel.degradationState.reason)
+            if presentationState.degradationState.isDegraded {
+                DegradationBadge(reason: presentationState.degradationState.reason)
                     .padding(.top, 20)
                     .padding(.trailing, 20)
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if let actionReceipt {
+                actionReceiptBadge(actionReceipt)
+                    .padding(20)
+            }
+        }
         .onAppear {
-            presentationModel.bind(to: store)
+            if let store {
+                presentationModel.bind(to: store)
+            }
         }
     }
 
@@ -152,7 +193,7 @@ struct InjectionFeedView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Injections")
                     .font(.system(size: 26, weight: .semibold, design: .rounded))
-                Text("Retrieval activity over the last hour, grouped into session bursts.")
+                Text("Retrieval activity grouped into literal retrieval bursts.")
                     .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(.secondary)
             }
@@ -174,6 +215,8 @@ struct InjectionFeedView: View {
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
                             .stroke(Self.filterControlBorderColor, lineWidth: 1)
                     )
+                    .accessibilityIdentifier(Self.filterSearchAccessibilityID)
+                    .accessibilityLabel("Filter retrieval bursts")
 
                 if !filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Text("Showing \(snapshot.filteredEvents.count) matching events")
@@ -188,33 +231,32 @@ struct InjectionFeedView: View {
 
     private var filterChips: some View {
         let activeFilter = InjectionTypeFilter(rawValue: typeFilterRaw) ?? .all
-        return WrappingPillLayout(spacing: 6, lineSpacing: 6) {
+        return Picker("Retrieval type", selection: $typeFilterRaw) {
             ForEach(InjectionTypeFilter.allCases, id: \.rawValue) { filter in
-                Button {
-                    typeFilterRaw = filter.rawValue
-                } label: {
-                    Text(filter.label)
-                        .font(.system(size: 11, weight: .semibold))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(
-                            Capsule()
-                                .fill(activeFilter == filter ? Self.filterControlSelectedFillColor : Self.filterControlFillColor)
-                        )
-                        .overlay(
-                            Capsule()
-                                .stroke(activeFilter == filter ? Self.filterControlBorderColor : .clear, lineWidth: 1)
-                        )
-                }
-                .buttonStyle(.plain)
+                Text(filter.label).tag(filter.rawValue)
             }
         }
+        .pickerStyle(.menu)
+        .labelsHidden()
+        .accessibilityLabel("Retrieval type: \(activeFilter.label)")
+        .accessibilityIdentifier(Self.filterTypeAccessibilityID)
         .frame(maxWidth: 280, alignment: .trailing)
     }
 
     private func overviewStrip(snapshot: InjectionPresentation.Snapshot) -> some View {
         VStack(alignment: .leading, spacing: 14) {
             InjectionSummaryView(events: snapshot.windowEvents)
+
+            DisclosureGroup(isExpanded: $groupingDisclosureExpanded) {
+                Text(Self.burstGroupingDisclosure)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } label: {
+                Text("Retrieval bursts")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .accessibilityIdentifier(Self.groupingDisclosureAccessibilityID)
 
             HStack(alignment: .center, spacing: 12) {
                 Text("Last 1h")
@@ -290,24 +332,22 @@ struct InjectionFeedView: View {
                         Text(leadEvent?.primaryKind.glyph ?? "📄")
                             .font(.system(size: 16, weight: .bold, design: .rounded))
                             .foregroundStyle(.blue)
-                        Text(burst.summaryTitle)
+                        Text(burst.queryTitle)
                             .font(.system(size: 18, weight: .semibold, design: .rounded))
                             .lineLimit(2)
                     }
-                    if let leadEvent = burst.events.first {
-                        Text(leadEvent.triggeredByText)
+                    if burst.selectedResultSummary.caseInsensitiveCompare(burst.queryTitle) != .orderedSame {
+                        Text("Selected result · \(burst.selectedResultSummary)")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
                     WrappingPillLayout(spacing: 8, lineSpacing: 8) {
-                        chip(text: "Session: \(shortSessionID(burst.sessionID))", tint: .blue)
-                        chip(text: relativeText(for: burst.endDate), tint: .neutral)
-                        chip(text: "\(burst.queryCount) queries", tint: .neutral)
-                        chip(text: "\(burst.tokenCount) tok", tint: .green)
-                        if let leadEvent = burst.events.first {
-                            chip(text: "\(leadEvent.primaryKind.glyph) \(leadEvent.primaryKind.label)", tint: .neutral)
+                        chip(text: burst.sourceLabel, tint: .blue)
+                        if burst.projectLabel != "Project unavailable" {
+                            chip(text: burst.projectLabel, tint: .neutral)
                         }
+                        chip(text: burst.timestampLabel, tint: .neutral)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -316,7 +356,7 @@ struct InjectionFeedView: View {
 
                 VStack(alignment: .trailing, spacing: 8) {
                     VStack(alignment: .trailing, spacing: 2) {
-                        Text("\(burst.chunkCount)")
+                        Text("\(burst.resultCount)")
                             .font(.system(size: 24, weight: .bold, design: .rounded))
                         Text(Self.burstChunkCounterLabel)
                             .font(.system(size: 11, weight: .medium))
@@ -339,6 +379,7 @@ struct InjectionFeedView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(isExpanded ? "Collapse burst" : "Expand burst")
+                    .accessibilityIdentifier("\(Self.burstActionAccessibilityID).expand.\(burst.id)")
 
                     // QA #51: copy a resume command to continue this exact thread.
                     Button {
@@ -353,6 +394,7 @@ struct InjectionFeedView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Copy command to continue this thread")
+                    .accessibilityIdentifier("\(Self.burstActionAccessibilityID).copy.\(burst.id)")
                 }
             }
 
@@ -369,19 +411,17 @@ struct InjectionFeedView: View {
         }
         .padding(18)
         .background(cardBackground)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Retrieval burst: \(burst.queryTitle), \(burst.resultCount) results, \(burst.timestampLabel)")
     }
 
     private func collapsedChunkPreview(for burst: InjectionPresentation.Burst) -> some View {
         VStack(alignment: .leading, spacing: 7) {
-            let previewChunks = InjectionPresentation.previewChunks(for: burst.events, limit: 2)
+            let previewChunks = burst.additionalResultPreviews
             if previewChunks.isEmpty {
-                ForEach(Array(burst.chunkPreviewIDs.enumerated()), id: \.offset) { _, chunkID in
-                    Text(chunkPreviewText(chunkID))
-                        .font(.system(size: 11, weight: .medium, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
+                Text("Additional result details are available when expanded.")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
             } else {
                 ForEach(previewChunks) { chunk in
                     Text("\(chunk.kind.glyph) \(chunk.displayText)")
@@ -392,8 +432,7 @@ struct InjectionFeedView: View {
                 }
             }
 
-            let visibleCount = previewChunks.isEmpty ? burst.chunkPreviewIDs.count : previewChunks.count
-            let remaining = burst.remainingChunkCount(after: visibleCount)
+            let remaining = burst.remainingCollapsedResultCount
             if remaining > 0 {
                 Text("+\(remaining) more")
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
@@ -459,14 +498,20 @@ struct InjectionFeedView: View {
                             .lineLimit(2)
                     }
 
-                    HStack(spacing: 10) {
-                        Text("Session \(shortSessionID(event.sessionID))")
-                        Text("\(event.chunkCount) chunks")
+                    WrappingPillLayout(spacing: 8, lineSpacing: 6) {
+                        Text("Timestamp \(event.timestamp)")
+                        Text("Source \(event.primaryKind.label)")
+                        if !event.claudeProjectPath.isEmpty {
+                            Text("Project \(event.claudeProjectPath)")
+                        }
+                        Text("Session \(event.sessionID)")
+                        Text("Event ID \(event.id)")
+                        Text("\(event.uniqueChunkIDs.count) results")
                         Text("\(event.tokenCount) tok")
-                        Text("\(event.chunks.reduce(0) { $0 + $1.tags.count }) tags")
                     }
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                     chunkRibbon(for: event)
 
@@ -501,6 +546,7 @@ struct InjectionFeedView: View {
                 .buttonStyle(.plain)
                 .disabled(event.uniqueChunkIDs.isEmpty || loadingConversationChunkID != nil)
                 .accessibilityLabel("Open thread")
+                .accessibilityIdentifier("\(Self.burstActionAccessibilityID).open.\(event.id)")
             }
 
             Rectangle()
@@ -561,9 +607,15 @@ struct InjectionFeedView: View {
                         Circle()
                             .fill(color(for: chunk(for: chunkID, event: event)?.kind ?? .other))
                             .frame(width: 8, height: 8)
-                        Text(chunkListTitle(chunkID: chunkID, event: event))
-                            .font(.system(size: 10, weight: .medium, design: .monospaced))
-                            .lineLimit(1)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(chunkListTitle(chunkID: chunkID, event: event))
+                                .font(.system(size: 11, weight: .medium))
+                                .lineLimit(1)
+                            Text("ID \(chunkID)")
+                                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
                         Spacer()
                         Text("Open thread")
                             .font(.system(size: 10, weight: .semibold))
@@ -586,8 +638,9 @@ struct InjectionFeedView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(snapshot.sessions.prefix(4)) { session in
                         HStack {
-                            Text(session.sessionID)
-                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            Text(session.displayLabel)
+                                .font(.system(size: 11, weight: .semibold))
+                                .lineLimit(2)
                             Spacer()
                             Text("\(session.queryCount)q · \(session.tokenCount) tok")
                                 .font(.system(size: 11, weight: .medium))
@@ -612,8 +665,11 @@ struct InjectionFeedView: View {
 
             sideRailCard(title: "Signals") {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(filterSignalText)
-                        .font(.system(size: 12, weight: .medium))
+                    let trimmedFilter = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmedFilter.isEmpty {
+                        Text("Filtered by “\(trimmedFilter)”")
+                            .font(.system(size: 12, weight: .medium))
+                    }
                     if let highestChunkEvent = snapshot.windowEvents.max(by: { $0.chunkCount < $1.chunkCount }) {
                         Text("Chunk-heavy: \(highestChunkEvent.chunkCount) hits on “\(highestChunkEvent.query)”")
                             .font(.system(size: 11))
@@ -625,33 +681,90 @@ struct InjectionFeedView: View {
         }
     }
 
-    private var emptyState: some View {
+    @ViewBuilder
+    private func stateCard(_ state: InjectionFeedSurfaceState) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("No injections match the current filter.")
-                .font(.system(size: 18, weight: .semibold))
-            Text("Clear the filter or wait for fresh retrieval activity to land.")
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.secondary)
+            switch state {
+            case .loading:
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading retrieval activity")
+                    .font(.system(size: 18, weight: .semibold))
+                Text("Waiting for the first read-only injections snapshot.")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            case .disconnected:
+                Text("Injection feed disconnected")
+                    .font(.system(size: 18, weight: .semibold))
+                Text("BrainBar has no read-only injection store connection for this session.")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            case .empty:
+                Text("No retrieval activity yet")
+                    .font(.system(size: 18, weight: .semibold))
+                Text("The feed is connected and healthy; no injections were returned.")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            case .noMatches:
+                Text("No injections match the current filters")
+                    .font(.system(size: 18, weight: .semibold))
+                Text("Clear the text or type filter to show retrieval activity.")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            case .degraded(let reason, false):
+                Text("Injection feed read failed")
+                    .font(.system(size: 18, weight: .semibold))
+                Text(reason)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            case .content, .degraded(_, true):
+                EmptyView()
+            }
         }
         .padding(22)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(cardBackground)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(Self.surfaceStateAccessibilityID)
     }
 
-    private func overviewMetric(label: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(label)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.secondary)
-            Text(value)
-                .font(.system(size: 22, weight: .bold, design: .rounded))
+    private func degradationNotice(reason: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Feed degraded · showing the last good retrievals")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(reason)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
         }
+        .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.brainBarTextPrimary.opacity(0.05))
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.orange.opacity(0.1))
         )
+    }
+
+    private func actionReceiptBadge(_ receipt: InjectionActionReceipt) -> some View {
+        Label(
+            receipt.message,
+            systemImage: receipt.kind == .success ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+        )
+        .font(.system(size: 11, weight: .semibold))
+        .foregroundStyle(receipt.kind == .success ? Color.green : Color.orange)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            Capsule()
+                .fill(Color.brainBarGlassPrimary)
+                .shadow(color: Color.black.opacity(0.12), radius: 8, y: 3)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(Self.actionReceiptAccessibilityID)
     }
 
     private func sideRailCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
@@ -724,14 +837,6 @@ struct InjectionFeedView: View {
         return "Latest · \(InjectionPresentation.shortTime(first.timestamp))"
     }
 
-    private var filterSignalText: String {
-        let trimmed = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return "Showing the full retrieval stream."
-        }
-        return "Filtered by “\(trimmed)”"
-    }
-
     private var pageBackground: some View {
         LinearGradient(
             colors: [
@@ -760,9 +865,17 @@ struct InjectionFeedView: View {
         )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(command, forType: .string)
+        let copied = pasteboard.setString(command, forType: .string)
+        guard copied else {
+            actionReceipt = InjectionActionReceipt(
+                kind: .failure,
+                message: "Couldn’t copy the resume command"
+            )
+            return
+        }
 
         let update = { copiedContinuationBurstID = burst.id }
+        actionReceipt = InjectionActionReceipt(kind: .success, message: "Resume command copied")
         if reduceMotion {
             update()
         } else {
@@ -773,6 +886,9 @@ struct InjectionFeedView: View {
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(2))
             guard copiedContinuationBurstID == burstID else { return }
+            if actionReceipt?.message == "Resume command copied" {
+                actionReceipt = nil
+            }
             if reduceMotion {
                 copiedContinuationBurstID = nil
             } else {
@@ -802,38 +918,21 @@ struct InjectionFeedView: View {
         "expanded-burst-details-\(burstID)"
     }
 
-    private func shortSessionID(_ sessionID: String) -> String {
-        guard sessionID.count > 12 else { return sessionID }
-        let prefix = sessionID.prefix(10)
-        return "\(prefix)…"
+    private var effectivePresentationState: InjectionFeedPresentationState {
+        fixture?.presentationState ?? presentationModel.state
     }
 
-    private func relativeText(for date: Date) -> String {
-        let seconds = max(Date().timeIntervalSince(date), 0)
-        if seconds < 60 {
-            return "just now"
-        }
-        if seconds < 60 * 60 {
-            return "\(Int(seconds / 60))m ago"
-        }
-        if seconds < 24 * 60 * 60 {
-            return "\(Int(seconds / 3600))h ago"
-        }
-        return "\(Int(seconds / 86_400))d ago"
-    }
-
-    private func chunkPreviewText(_ chunkID: String) -> String {
-        let limit = 80
-        guard chunkID.count > limit else { return chunkID }
-        return "\(chunkID.prefix(limit - 1))…"
+    private var effectiveTypeFilter: InjectionTypeFilter {
+        fixture?.typeFilter ?? InjectionTypeFilter(rawValue: typeFilterRaw) ?? .all
     }
 
     private func makePresentation(now: Date = Date()) -> InjectionPresentation.Snapshot {
-        InjectionPresentation.snapshot(
-            events: presentationModel.events,
+        let effectiveNow = fixture?.now ?? now
+        return InjectionPresentation.snapshot(
+            events: effectivePresentationState.events,
             filterText: filterText,
-            typeFilter: InjectionTypeFilter(rawValue: typeFilterRaw) ?? .all,
-            now: now,
+            typeFilter: effectiveTypeFilter,
+            now: effectiveNow,
             bucketCount: 24
         )
     }
@@ -858,6 +957,13 @@ struct InjectionFeedView: View {
 
     private func openConversation(chunkID: String, title: String) {
         guard loadingConversationChunkID == nil else { return }
+        guard let store else {
+            actionReceipt = InjectionActionReceipt(
+                kind: .failure,
+                message: "Thread unavailable in this disconnected snapshot"
+            )
+            return
+        }
         loadingConversationChunkID = chunkID
         Task {
             do {
@@ -865,10 +971,15 @@ struct InjectionFeedView: View {
                 guard loadingConversationChunkID == chunkID else { return }
                 conversationSelection.open(conversation, title: title)
                 loadingConversationChunkID = nil
+                actionReceipt = InjectionActionReceipt(kind: .success, message: "Thread opened")
             } catch {
                 if loadingConversationChunkID == chunkID {
                     loadingConversationChunkID = nil
                 }
+                actionReceipt = InjectionActionReceipt(
+                    kind: .failure,
+                    message: "Couldn’t open thread · \(error.localizedDescription)"
+                )
             }
         }
     }
@@ -927,6 +1038,14 @@ extension InjectionFeedView {
     nonisolated static var filterControlsUseAccentTint: Bool { false }
 
     nonisolated static let burstChunkCounterLabel = "memories surfaced into context"
+    nonisolated static let burstGroupingDisclosure =
+        "Retrieval bursts group the same session and trigger topic while consecutive events remain under 60 minutes."
+    nonisolated static let filterSearchAccessibilityID = "brainbar.injections.filter.search"
+    nonisolated static let filterTypeAccessibilityID = "brainbar.injections.filter.type"
+    nonisolated static let groupingDisclosureAccessibilityID = "brainbar.injections.grouping"
+    nonisolated static let burstActionAccessibilityID = "brainbar.injections.burst.action"
+    nonisolated static let surfaceStateAccessibilityID = "brainbar.injections.state"
+    nonisolated static let actionReceiptAccessibilityID = "brainbar.injections.action.receipt"
 
     static var filterControlFillColor: Color {
         Color.brainBarTextPrimary.opacity(0.06)

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -217,19 +217,26 @@ struct InjectionPresentation {
             selectedResultChunk?.displayText ?? "Result unavailable"
         }
         var resultProvenance: [ResultProvenance] {
-            var seen = Set<String>()
+            var resultIndexByChunkID: [String: Int] = [:]
             var results: [ResultProvenance] = []
             for event in events {
-                for chunkID in event.uniqueChunkIDs where seen.insert(chunkID).inserted {
-                    results.append(
-                        ResultProvenance(
-                            chunkID: chunkID,
-                            eventID: event.id,
-                            sessionID: event.sessionID,
-                            timestamp: event.timestamp,
-                            chunk: event.chunks.first { $0.id == chunkID }
-                        )
+                for chunkID in event.uniqueChunkIDs {
+                    let chunk = event.chunks.first { $0.id == chunkID }
+                    let provenance = ResultProvenance(
+                        chunkID: chunkID,
+                        eventID: event.id,
+                        sessionID: event.sessionID,
+                        timestamp: event.timestamp,
+                        chunk: chunk
                     )
+                    if let existingIndex = resultIndexByChunkID[chunkID] {
+                        if results[existingIndex].chunk == nil, chunk != nil {
+                            results[existingIndex] = provenance
+                        }
+                        continue
+                    }
+                    resultIndexByChunkID[chunkID] = results.count
+                    results.append(provenance)
                 }
             }
             return results

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -214,7 +214,7 @@ struct InjectionPresentation {
             InjectionChunk.elide(events.first?.query ?? topicOrSource, limit: 96)
         }
         var selectedResultSummary: String {
-            selectedResultChunk?.displayText ?? summaryTitle
+            selectedResultChunk?.displayText ?? "Result unavailable"
         }
         var resultProvenance: [ResultProvenance] {
             var seen = Set<String>()
@@ -621,9 +621,10 @@ struct InjectionPresentation {
     private static func makeSessions(from events: [ParsedEvent]) -> [SessionSummary] {
         let grouped = Dictionary(grouping: events, by: \.event.sessionID)
         return grouped.map { sessionID, values in
-            SessionSummary(
+            let query = values.first?.event.query.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return SessionSummary(
                 sessionID: sessionID,
-                displayLabel: InjectionChunk.elide(values.first?.event.query ?? "Retrieval session", limit: 42),
+                displayLabel: InjectionChunk.elide(query.isEmpty ? "Retrieval session" : query, limit: 42),
                 queryCount: values.count,
                 chunkCount: values.reduce(0) { $0 + $1.event.chunkCount },
                 tokenCount: values.reduce(0) { $0 + $1.event.tokenCount },

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -3,6 +3,7 @@ import Foundation
 enum InjectionFeedLoadState: Equatable {
     case loading
     case loaded
+    case failed
 }
 
 enum InjectionFeedConnectionState: Equatable {
@@ -34,9 +35,9 @@ enum InjectionFeedSurfaceState: Equatable {
         filterActive: Bool
     ) -> InjectionFeedSurfaceState {
         guard connectionState == .connected else { return .disconnected }
-        guard presentationState.loadState == .loaded else { return .loading }
+        guard presentationState.loadState != .loading else { return .loading }
 
-        if presentationState.degradationState.isDegraded {
+        if presentationState.loadState == .failed || presentationState.degradationState.isDegraded {
             return .degraded(
                 reason: presentationState.degradationState.reason ?? "Injection feed read failed.",
                 retainsContent: !snapshot.bursts.isEmpty
@@ -100,6 +101,19 @@ struct InjectionActionReceipt: Equatable {
         kind: .failure,
         message: "Thread unavailable in this disconnected snapshot"
     )
+}
+
+struct InjectionActionReceiptGeneration: Equatable {
+    private(set) var value = 0
+
+    mutating func next() -> Int {
+        value += 1
+        return value
+    }
+
+    func isCurrent(_ candidate: Int) -> Bool {
+        candidate == value
+    }
 }
 
 struct InjectionFeedFixture {
@@ -201,6 +215,24 @@ struct InjectionPresentation {
         let startDate: Date
         let endDate: Date
         let events: [InjectionEvent]
+        let resultProvenance: [ResultProvenance]
+
+        init(
+            sessionID: String,
+            claudeConversationID: String,
+            topicOrSource: String,
+            startDate: Date,
+            endDate: Date,
+            events: [InjectionEvent]
+        ) {
+            self.sessionID = sessionID
+            self.claudeConversationID = claudeConversationID
+            self.topicOrSource = topicOrSource
+            self.startDate = startDate
+            self.endDate = endDate
+            self.events = events
+            self.resultProvenance = Self.mergeResultProvenance(from: events)
+        }
 
         var id: String {
             "\(groupKey)|\(events.last?.id ?? 0)"
@@ -216,7 +248,7 @@ struct InjectionPresentation {
         var selectedResultSummary: String {
             selectedResultChunk?.displayText ?? "Result unavailable"
         }
-        var resultProvenance: [ResultProvenance] {
+        private static func mergeResultProvenance(from events: [InjectionEvent]) -> [ResultProvenance] {
             var resultIndexByChunkID: [String: Int] = [:]
             var results: [ResultProvenance] = []
             for event in events {
@@ -253,7 +285,7 @@ struct InjectionPresentation {
             )
         }
         var remainingCollapsedResultCount: Int {
-            let selectedCount = selectedResultChunk == nil ? 0 : 1
+            let selectedCount = resultProvenance.isEmpty ? 0 : 1
             return max(resultCount - selectedCount - additionalResultPreviews.count, 0)
         }
         var sourceLabel: String {

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -1,5 +1,120 @@
 import Foundation
 
+enum InjectionFeedLoadState: Equatable {
+    case loading
+    case loaded
+}
+
+enum InjectionFeedConnectionState: Equatable {
+    case connected
+    case disconnected
+}
+
+enum InjectionFeedSurfaceState: Equatable {
+    case loading
+    case disconnected
+    case empty
+    case noMatches
+    case degraded(reason: String, retainsContent: Bool)
+    case content
+
+    var showsContent: Bool {
+        switch self {
+        case .content, .degraded(_, true):
+            return true
+        case .loading, .disconnected, .empty, .noMatches, .degraded(_, false):
+            return false
+        }
+    }
+
+    static func resolve(
+        snapshot: InjectionPresentation.Snapshot,
+        presentationState: InjectionFeedPresentationState,
+        connectionState: InjectionFeedConnectionState,
+        filterActive: Bool
+    ) -> InjectionFeedSurfaceState {
+        guard connectionState == .connected else { return .disconnected }
+        guard presentationState.loadState == .loaded else { return .loading }
+
+        if presentationState.degradationState.isDegraded {
+            return .degraded(
+                reason: presentationState.degradationState.reason ?? "Injection feed read failed.",
+                retainsContent: !snapshot.bursts.isEmpty
+            )
+        }
+        if snapshot.bursts.isEmpty {
+            return filterActive ? .noMatches : .empty
+        }
+        return .content
+    }
+}
+
+struct InjectionFeedPresentationState: Equatable {
+    let events: [InjectionEvent]
+    let degradationState: DegradationState
+    let loadState: InjectionFeedLoadState
+
+    static let empty = InjectionFeedPresentationState(
+        events: [],
+        degradationState: .healthy,
+        loadState: .loading
+    )
+
+    init(
+        events: [InjectionEvent],
+        degradationState: DegradationState,
+        loadState: InjectionFeedLoadState = .loaded
+    ) {
+        self.events = events
+        self.degradationState = degradationState
+        self.loadState = loadState
+    }
+}
+
+struct InjectionActionReceipt: Equatable {
+    enum Kind: Equatable {
+        case success
+        case failure
+    }
+
+    let kind: Kind
+    let message: String
+}
+
+struct InjectionFeedFixture {
+    let presentationState: InjectionFeedPresentationState
+    let connectionState: InjectionFeedConnectionState
+    let now: Date
+    let filterText: String
+    let typeFilter: InjectionTypeFilter
+    let expandedBurstIDs: Set<String>
+    let actionReceipt: InjectionActionReceipt?
+
+    init(
+        events: [InjectionEvent],
+        now: Date,
+        degradationState: DegradationState = .healthy,
+        loadState: InjectionFeedLoadState = .loaded,
+        connectionState: InjectionFeedConnectionState = .connected,
+        filterText: String = "",
+        typeFilter: InjectionTypeFilter = .all,
+        expandedBurstIDs: Set<String> = [],
+        actionReceipt: InjectionActionReceipt? = nil
+    ) {
+        self.presentationState = InjectionFeedPresentationState(
+            events: events,
+            degradationState: degradationState,
+            loadState: loadState
+        )
+        self.connectionState = connectionState
+        self.now = now
+        self.filterText = filterText
+        self.typeFilter = typeFilter
+        self.expandedBurstIDs = expandedBurstIDs
+        self.actionReceipt = actionReceipt
+    }
+}
+
 struct InjectionPresentation {
     struct Snapshot: Equatable {
         let filteredEvents: [InjectionEvent]
@@ -35,6 +150,41 @@ struct InjectionPresentation {
         var queryCount: Int { events.count }
         var chunkCount: Int { events.reduce(0) { $0 + $1.chunkCount } }
         var tokenCount: Int { events.reduce(0) { $0 + $1.tokenCount } }
+        var queryTitle: String {
+            InjectionChunk.elide(events.first?.query ?? topicOrSource, limit: 96)
+        }
+        var selectedResultSummary: String {
+            selectedResultChunk?.displayText ?? summaryTitle
+        }
+        var additionalResultPreviews: [InjectionChunk] {
+            let selectedID = selectedResultChunk?.id
+            return Array(
+                InjectionPresentation.previewChunks(for: events, limit: 3)
+                    .filter { $0.id != selectedID }
+                    .prefix(2)
+            )
+        }
+        var remainingCollapsedResultCount: Int {
+            let selectedCount = selectedResultChunk == nil ? 0 : 1
+            return max(resultCount - selectedCount - additionalResultPreviews.count, 0)
+        }
+        var sourceLabel: String {
+            events.first?.primaryKind.label ?? "Source unavailable"
+        }
+        var projectLabel: String {
+            claudeProjectPath.isEmpty ? "Project unavailable" : claudeProjectPath
+        }
+        var resultCount: Int {
+            events.reduce(into: Set<String>()) { result, event in
+                result.formUnion(event.uniqueChunkIDs)
+            }.count
+        }
+        var timestampLabel: String {
+            InjectionPresentation.burstRangeText(start: startDate, end: endDate)
+        }
+        private var selectedResultChunk: InjectionChunk? {
+            InjectionPresentation.previewChunks(for: events, limit: 1).first
+        }
         var claudeProjectPath: String {
             events.lazy.map(\.claudeProjectPath).first { !$0.isEmpty } ?? ""
         }
@@ -92,6 +242,7 @@ struct InjectionPresentation {
 
     struct SessionSummary: Equatable, Identifiable {
         let sessionID: String
+        let displayLabel: String
         let queryCount: Int
         let chunkCount: Int
         let tokenCount: Int
@@ -388,6 +539,7 @@ struct InjectionPresentation {
         return grouped.map { sessionID, values in
             SessionSummary(
                 sessionID: sessionID,
+                displayLabel: InjectionChunk.elide(values.first?.event.query ?? "Retrieval session", limit: 42),
                 queryCount: values.count,
                 chunkCount: values.reduce(0) { $0 + $1.event.chunkCount },
                 tokenCount: values.reduce(0) { $0 + $1.event.tokenCount },

--- a/brain-bar/Sources/BrainBar/InjectionPresentation.swift
+++ b/brain-bar/Sources/BrainBar/InjectionPresentation.swift
@@ -79,6 +79,27 @@ struct InjectionActionReceipt: Equatable {
 
     let kind: Kind
     let message: String
+
+    static func copyResult(copied: Bool) -> InjectionActionReceipt {
+        copied
+            ? InjectionActionReceipt(kind: .success, message: "Resume command copied")
+            : InjectionActionReceipt(kind: .failure, message: "Couldn’t copy the resume command")
+    }
+
+    static func threadOpenResult(errorDescription: String?) -> InjectionActionReceipt {
+        guard let errorDescription else {
+            return InjectionActionReceipt(kind: .success, message: "Thread opened")
+        }
+        return InjectionActionReceipt(
+            kind: .failure,
+            message: "Couldn’t open thread · \(errorDescription)"
+        )
+    }
+
+    static let disconnectedThread = InjectionActionReceipt(
+        kind: .failure,
+        message: "Thread unavailable in this disconnected snapshot"
+    )
 }
 
 struct InjectionFeedFixture {
@@ -134,6 +155,45 @@ struct InjectionPresentation {
         let burstCount: Int
     }
 
+    struct ResultProvenance: Equatable, Identifiable {
+        let chunkID: String
+        let eventID: Int64
+        let sessionID: String
+        let timestamp: String
+        let chunk: InjectionChunk?
+
+        var id: String { chunkID }
+        var source: String {
+            chunk?.source.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        }
+        var sourceFile: String {
+            chunk?.sourceFile.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        }
+        var projectPath: String {
+            chunk?.claudeProjectPath.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        }
+        var contentType: String {
+            chunk?.contentType.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        }
+        var tags: [String] {
+            chunk?.tags ?? []
+        }
+
+        func expandedMetadataLabels(isSelected: Bool) -> [String] {
+            var labels: [String] = []
+            if isSelected {
+                labels.append("Selected result")
+            }
+            labels.append("ID \(chunkID)")
+            labels.append("Source \(source.isEmpty ? "unavailable" : source)")
+            labels.append("Source file \(sourceFile.isEmpty ? "unavailable" : sourceFile)")
+            labels.append("Project \(projectPath.isEmpty ? "unavailable" : projectPath)")
+            labels.append("Type \(contentType.isEmpty ? "unavailable" : contentType)")
+            labels.append("Tags \(tags.isEmpty ? "unavailable" : tags.joined(separator: ", "))")
+            return labels
+        }
+    }
+
     struct Burst: Equatable, Identifiable {
         let sessionID: String
         let claudeConversationID: String
@@ -156,11 +216,32 @@ struct InjectionPresentation {
         var selectedResultSummary: String {
             selectedResultChunk?.displayText ?? summaryTitle
         }
+        var resultProvenance: [ResultProvenance] {
+            var seen = Set<String>()
+            var results: [ResultProvenance] = []
+            for event in events {
+                for chunkID in event.uniqueChunkIDs where seen.insert(chunkID).inserted {
+                    results.append(
+                        ResultProvenance(
+                            chunkID: chunkID,
+                            eventID: event.id,
+                            sessionID: event.sessionID,
+                            timestamp: event.timestamp,
+                            chunk: event.chunks.first { $0.id == chunkID }
+                        )
+                    )
+                }
+            }
+            return results
+        }
+        var selectedResultProvenance: ResultProvenance? {
+            resultProvenance.first
+        }
         var additionalResultPreviews: [InjectionChunk] {
-            let selectedID = selectedResultChunk?.id
             return Array(
-                InjectionPresentation.previewChunks(for: events, limit: 3)
-                    .filter { $0.id != selectedID }
+                resultProvenance
+                    .dropFirst()
+                    .compactMap(\.chunk)
                     .prefix(2)
             )
         }
@@ -169,24 +250,27 @@ struct InjectionPresentation {
             return max(resultCount - selectedCount - additionalResultPreviews.count, 0)
         }
         var sourceLabel: String {
-            events.first?.primaryKind.label ?? "Source unavailable"
+            guard let selectedResultChunk else { return "Source unavailable" }
+            let source = selectedResultChunk.source.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !source.isEmpty else { return selectedResultChunk.kind.label }
+            return "\(selectedResultChunk.kind.label) · \(source)"
         }
         var projectLabel: String {
-            claudeProjectPath.isEmpty ? "Project unavailable" : claudeProjectPath
+            guard let selectedResultChunk else { return "Project unavailable" }
+            let projectPath = selectedResultChunk.claudeProjectPath
+            return projectPath.isEmpty ? "Project unavailable" : projectPath
         }
         var resultCount: Int {
-            events.reduce(into: Set<String>()) { result, event in
-                result.formUnion(event.uniqueChunkIDs)
-            }.count
+            resultProvenance.count
         }
         var timestampLabel: String {
             InjectionPresentation.burstRangeText(start: startDate, end: endDate)
         }
         private var selectedResultChunk: InjectionChunk? {
-            InjectionPresentation.previewChunks(for: events, limit: 1).first
+            selectedResultProvenance?.chunk
         }
         var claudeProjectPath: String {
-            events.lazy.map(\.claudeProjectPath).first { !$0.isEmpty } ?? ""
+            selectedResultProvenance?.projectPath ?? ""
         }
 
         var summaryTitle: String {

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -48,6 +48,7 @@ private func injectionStoreDarwinNotificationCallback(
 final class InjectionStore: ObservableObject {
     @Published private(set) var events: [InjectionEvent] = []
     @Published private(set) var degradationState: DegradationState = .healthy
+    @Published private(set) var loadState: InjectionFeedLoadState = .loading
 
     private enum RecoveryPhase: Equatable {
         case healthy
@@ -251,6 +252,7 @@ final class InjectionStore: ObservableObject {
     }
 
     private func refresh(force: Bool) {
+        defer { loadState = .loaded }
         do {
             let currentDataVersion = try reader.dataVersion()
             let shouldProbeEvents: Bool

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -270,6 +270,7 @@ final class InjectionStore: ObservableObject {
                 lastDataVersion = currentDataVersion
                 recoveryPhase = .healthy
                 degradationState = .healthy
+                loadState = .loaded
             } else if let reason = recoveryPhase.reason {
                 // A clean data_version read is not enough to prove the
                 // injections read path recovered. Keep the public badge
@@ -277,8 +278,10 @@ final class InjectionStore: ObservableObject {
                 // even if SQLite's data version is still unchanged.
                 recoveryPhase = .probing(reason: reason)
                 degradationState = .degraded(reason: reason)
+                loadState = .failed
+            } else {
+                loadState = .loaded
             }
-            loadState = .loaded
         } catch {
             NSLog("[BrainBar] InjectionStore refresh failed: %@", String(describing: error))
             let reason = String(describing: error)

--- a/brain-bar/Sources/BrainBar/InjectionStore.swift
+++ b/brain-bar/Sources/BrainBar/InjectionStore.swift
@@ -252,7 +252,6 @@ final class InjectionStore: ObservableObject {
     }
 
     private func refresh(force: Bool) {
-        defer { loadState = .loaded }
         do {
             let currentDataVersion = try reader.dataVersion()
             let shouldProbeEvents: Bool
@@ -279,11 +278,13 @@ final class InjectionStore: ObservableObject {
                 recoveryPhase = .probing(reason: reason)
                 degradationState = .degraded(reason: reason)
             }
+            loadState = .loaded
         } catch {
             NSLog("[BrainBar] InjectionStore refresh failed: %@", String(describing: error))
             let reason = String(describing: error)
             recoveryPhase = .degraded(reason: reason)
             degradationState = .degraded(reason: reason)
+            loadState = .failed
         }
     }
 

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
@@ -186,7 +186,7 @@ struct KGAtlasPresentation {
         var acceptedRects: [CGRect] = []
         var acceptedIDs = Set<String>()
         for node in orderedNodes {
-            if acceptedIDs.count >= maxLabels, node.id != selectedNodeID { continue }
+            if acceptedIDs.count >= maxLabels, node.id != selectedNodeID { break }
             let rect = approximateLabelRect(for: node, scale: scale)
             guard node.id == selectedNodeID || !acceptedRects.contains(where: { $0.intersects(rect) }) else {
                 continue

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGAtlasPresentation.swift
@@ -1,6 +1,30 @@
 import Foundation
 
 struct KGAtlasPresentation {
+    enum FindMove {
+        case up
+        case down
+    }
+
+    struct FindResult: Equatable, Identifiable {
+        let id: String
+        let name: String
+        let entityTypeTitle: String
+        let degree: Int
+
+        var relationshipSummary: String {
+            switch degree {
+            case 0: "No visible relationships"
+            case 1: "1 visible relationship"
+            default: "\(degree) visible relationships"
+            }
+        }
+
+        var accessibilityLabel: String {
+            "\(name), \(entityTypeTitle), \(relationshipSummary)"
+        }
+    }
+
     struct Region: Equatable, Identifiable {
         let entityType: String
         let title: String
@@ -77,6 +101,140 @@ struct KGAtlasPresentation {
         }
     }
 
+    static func findResults(
+        nodes: [KGNode],
+        edges: [KGEdge],
+        query: String
+    ) -> [FindResult] {
+        var degrees: [String: Int] = [:]
+        for edge in edges {
+            degrees[edge.sourceId, default: 0] += 1
+            degrees[edge.targetId, default: 0] += 1
+        }
+
+        let terms = query
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .map { $0.localizedLowercase }
+
+        return nodes.compactMap { node in
+            let result = FindResult(
+                id: node.id,
+                name: node.name,
+                entityTypeTitle: singularTitle(for: node.entityType),
+                degree: degrees[node.id, default: 0]
+            )
+            let searchableText = "\(node.name) \(node.entityType) \(result.entityTypeTitle)"
+                .localizedLowercase
+            guard terms.allSatisfy(searchableText.contains) else { return nil }
+            return result
+        }
+        .sorted { lhs, rhs in
+            let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+            if nameOrder != .orderedSame {
+                return nameOrder == .orderedAscending
+            }
+            if lhs.entityTypeTitle != rhs.entityTypeTitle {
+                return lhs.entityTypeTitle < rhs.entityTypeTitle
+            }
+            return lhs.id < rhs.id
+        }
+    }
+
+    static func nextFindResultID(
+        currentID: String?,
+        move: FindMove,
+        results: [FindResult]
+    ) -> String? {
+        guard !results.isEmpty else { return nil }
+        guard let currentIndex = results.firstIndex(where: { $0.id == currentID }) else {
+            return move == .down ? results.first?.id : results.last?.id
+        }
+
+        switch move {
+        case .up:
+            return results[max(currentIndex - 1, results.startIndex)].id
+        case .down:
+            return results[min(currentIndex + 1, results.index(before: results.endIndex))].id
+        }
+    }
+
+    static func priorityLabelNodeIDs(
+        nodes: [KGNode],
+        selectedNodeID: String?,
+        scale: CGFloat
+    ) -> Set<String> {
+        let maxLabels = scale < 0.7 ? 18 : (scale < 1.15 ? 36 : 72)
+        let orderedNodes = nodes.sorted { lhs, rhs in
+            let lhsSelected = lhs.id == selectedNodeID
+            let rhsSelected = rhs.id == selectedNodeID
+            if lhsSelected != rhsSelected { return lhsSelected }
+
+            let lhsOwner = pinnedEntityNames.contains(lhs.name.localizedLowercase)
+            let rhsOwner = pinnedEntityNames.contains(rhs.name.localizedLowercase)
+            if lhsOwner != rhsOwner { return lhsOwner }
+
+            if lhs.importance != rhs.importance { return lhs.importance > rhs.importance }
+            if lhs.linkedChunkCount != rhs.linkedChunkCount {
+                return lhs.linkedChunkCount > rhs.linkedChunkCount
+            }
+            let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+            if nameOrder != .orderedSame { return nameOrder == .orderedAscending }
+            return lhs.id < rhs.id
+        }
+
+        var acceptedRects: [CGRect] = []
+        var acceptedIDs = Set<String>()
+        for node in orderedNodes {
+            if acceptedIDs.count >= maxLabels, node.id != selectedNodeID { continue }
+            let rect = approximateLabelRect(for: node, scale: scale)
+            guard node.id == selectedNodeID || !acceptedRects.contains(where: { $0.intersects(rect) }) else {
+                continue
+            }
+            acceptedRects.append(rect)
+            acceptedIDs.insert(node.id)
+        }
+        return acceptedIDs
+    }
+
+    /// The canvas retains relationship topology while the inspector owns the
+    /// full, readable edge list. Inline relation text becomes illegible on
+    /// dense graphs and competes with priority node labels.
+    static func lineOnlyEdge(_ edge: KGEdge) -> KGEdge {
+        KGEdge(
+            sourceId: edge.sourceId,
+            targetId: edge.targetId,
+            relationType: ""
+        )
+    }
+
+    static func modeEffectDescription(
+        mode: KGAtlasMode,
+        minimumImportance: Double,
+        altitudeTier: KGAltitudeTier
+    ) -> String {
+        switch mode {
+        case .importance:
+            return "Shows entities with importance \(Int(minimumImportance))/10 or higher. Selected and pinned entities remain visible."
+        case .tieredAltitude:
+            return "Shows Summit through \(altitudeTier.title). Lower altitude reveals more entities."
+        }
+    }
+
+    static func canvasAccessibilityValue(
+        visibleEntityCount: Int,
+        visibleRelationshipCount: Int
+    ) -> String {
+        let entities = visibleEntityCount == 1 ? "1 visible entity" : "\(visibleEntityCount) visible entities"
+        let relationships = visibleRelationshipCount == 1
+            ? "1 visible relationship"
+            : "\(visibleRelationshipCount) visible relationships"
+        return "\(entities) and \(relationships)"
+    }
+
+    static let canvasAccessibilityHint =
+        "Use Find entity to browse and select every visible entity without spatial pointing."
+
     private static let orderedEntityTypes = [
         "person",
         "project",
@@ -91,6 +249,34 @@ struct KGAtlasPresentation {
 
     private static let maxLinksPerNodeKey = "brainBar.maxLinksPerNode"
     private static let defaultMaxLinksPerNode = 50
+
+    private static func singularTitle(for entityType: String) -> String {
+        switch entityType {
+        case "person": "Person"
+        case "project": "Project"
+        case "tool": "Tool"
+        case "technology": "Technology"
+        case "agent": "Agent"
+        case "company": "Company"
+        case "topic": "Topic"
+        case "decision": "Decision"
+        default: entityType.isEmpty ? "Entity" : entityType.capitalized
+        }
+    }
+
+    private static func approximateLabelRect(for node: KGNode, scale: CGFloat) -> CGRect {
+        let fontSize = max(9, node.radius * 0.55)
+        let width = max(28, CGFloat(node.name.count) * fontSize * 0.58)
+        let inverseScale = 1 / max(scale, 0.35)
+        let horizontalClearance = 8 * inverseScale
+        let verticalClearance = 5 * inverseScale
+        return CGRect(
+            x: node.position.x - width / 2 - horizontalClearance,
+            y: node.position.y + node.radius + 12 - verticalClearance,
+            width: width + horizontalClearance * 2,
+            height: fontSize + verticalClearance * 2
+        )
+    }
 
     private static func maxLinksPerNode(from userDefaults: UserDefaults) -> Int {
         let configuredValue = userDefaults.integer(forKey: maxLinksPerNodeKey)

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -5,7 +5,8 @@ enum KGCanvasMetrics {
     static let canvasPadding: CGFloat = 18
 
     static func sidebarVisible(windowWidth: CGFloat, selectedEntityVisible: Bool) -> Bool {
-        windowWidth >= 980 || selectedEntityVisible
+        _ = windowWidth
+        return selectedEntityVisible
     }
 
     static func drawableSize(windowSize: CGSize, sidebarVisible: Bool) -> CGSize {
@@ -19,6 +20,7 @@ enum KGCanvasMetrics {
 struct KGCanvasView: View {
     @ObservedObject var viewModel: KGViewModel
     let isActive: Bool
+    private let reduceMotionOverride: Bool?
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -31,7 +33,28 @@ struct KGCanvasView: View {
     @State private var altitudeLevel: Double = Double(KGAltitudeTier.signal.rawValue)
     @State private var hasLoadedGraph = false
     @State private var simulationController = KGSimulationController()
+    @State private var isFindPresented: Bool
+    @State private var findQuery: String
+    @State private var highlightedFindResultID: String?
     @GestureState private var toolbarInteractionActive = false
+
+    init(
+        viewModel: KGViewModel,
+        isActive: Bool,
+        initialFindPresented: Bool = false,
+        initialFindQuery: String = "",
+        reduceMotionOverride: Bool? = nil
+    ) {
+        self.viewModel = viewModel
+        self.isActive = isActive
+        self.reduceMotionOverride = reduceMotionOverride
+        _isFindPresented = State(initialValue: initialFindPresented)
+        _findQuery = State(initialValue: initialFindQuery)
+    }
+
+    private var shouldReduceMotion: Bool {
+        reduceMotionOverride ?? reduceMotion
+    }
 
     private var atlas: KGAtlasPresentation.Snapshot {
         KGAtlasPresentation.snapshot(
@@ -44,18 +67,26 @@ struct KGCanvasView: View {
         )
     }
 
+    private var findResults: [KGAtlasPresentation.FindResult] {
+        KGAtlasPresentation.findResults(
+            nodes: atlas.visibleNodes,
+            edges: atlas.visibleEdges,
+            query: findQuery
+        )
+    }
+
     var body: some View {
         GeometryReader { geo in
             let sidebarVisible = KGCanvasMetrics.sidebarVisible(
                 windowWidth: geo.size.width,
-                selectedEntityVisible: viewModel.selectedEntity != nil
+                selectedEntityVisible: viewModel.selectedNodeId != nil
             )
 
             HStack(spacing: 0) {
                 ZStack(alignment: .topLeading) {
                     atlasBackground
                     graphCanvas(snapshot: atlas)
-                    atlasToolbar(snapshot: atlas)
+                    atlasControls(snapshot: atlas)
                     atlasOverview(snapshot: atlas)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -103,7 +134,7 @@ struct KGCanvasView: View {
 
                 let loaded = await viewModel.loadGraphRepeatedly(onSuccessfulLoad: {
                     hasLoadedGraph = true
-                    if reduceMotion {
+                    if shouldReduceMotion {
                         _ = viewModel.tick(reduceMotionEnabled: true)
                     } else if !viewModel.isLayoutPinned {
                         startSimulation()
@@ -114,7 +145,7 @@ struct KGCanvasView: View {
                 }
             }
             .onChange(of: reduceMotion) { _, enabled in
-                if enabled {
+                if reduceMotionOverride ?? enabled {
                     _ = viewModel.tick(reduceMotionEnabled: true)
                     stopSimulation()
                 } else {
@@ -148,13 +179,17 @@ struct KGCanvasView: View {
             var environment = EnvironmentValues()
             environment.colorScheme = colorScheme
             let nodeIndex = Dictionary(uniqueKeysWithValues: snapshot.visibleNodes.map { ($0.id, $0) })
-            let labelledNodeIDs = labelledNodeIDs(for: snapshot.visibleNodes)
+            let labelledNodeIDs = KGAtlasPresentation.priorityLabelNodeIDs(
+                nodes: snapshot.visibleNodes,
+                selectedNodeID: viewModel.selectedNodeId,
+                scale: scale
+            )
 
             for edge in snapshot.visibleEdges {
                 guard let source = nodeIndex[edge.sourceId], let target = nodeIndex[edge.targetId] else { continue }
                 let highlighted = viewModel.selectedNodeId == edge.sourceId || viewModel.selectedNodeId == edge.targetId
                 KGEdgeRenderer.draw(
-                    edge: edge,
+                    edge: KGAtlasPresentation.lineOnlyEdge(edge),
                     sourcePos: source.position,
                     targetPos: target.position,
                     isHighlighted: highlighted,
@@ -190,6 +225,17 @@ struct KGCanvasView: View {
         .gesture(dragGesture)
         .gesture(magnifyGesture)
         .padding(KGCanvasMetrics.canvasPadding)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Knowledge atlas canvas")
+        .accessibilityValue(KGAtlasPresentation.canvasAccessibilityValue(
+            visibleEntityCount: snapshot.visibleNodes.count,
+            visibleRelationshipCount: snapshot.visibleEdges.count
+        ))
+        .accessibilityHint(KGAtlasPresentation.canvasAccessibilityHint)
+        .accessibilityIdentifier("knowledge-graph-canvas")
+        .accessibilityAction(named: Text("Find entity")) {
+            presentFindEntity()
+        }
     }
 
     private var atlasBackground: some View {
@@ -219,6 +265,25 @@ struct KGCanvasView: View {
         }
     }
 
+    private func atlasControls(snapshot: KGAtlasPresentation.Snapshot) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            atlasToolbar(snapshot: snapshot)
+
+            if isFindPresented {
+                KGFindEntityPanel(
+                    query: $findQuery,
+                    results: findResults,
+                    highlightedResultID: highlightedFindResultID,
+                    onHighlight: { highlightedFindResultID = $0 },
+                    onSelect: selectFindResult,
+                    onDismiss: dismissFindEntity
+                )
+                .frame(width: 420)
+            }
+        }
+        .padding(20)
+    }
+
     private func atlasToolbar(snapshot: KGAtlasPresentation.Snapshot) -> some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .center) {
@@ -235,19 +300,42 @@ struct KGCanvasView: View {
                 labelChip(statusChipText(snapshot: snapshot))
             }
 
-            Picker("Graph mode", selection: Binding(
-                get: { viewModel.layoutMode },
-                set: { viewModel.setLayoutMode($0) }
-            )) {
-                ForEach(KGAtlasMode.allCases) { mode in
-                    Text(mode.title).tag(mode)
+            HStack(spacing: 10) {
+                Picker("Graph mode", selection: Binding(
+                    get: { viewModel.layoutMode },
+                    set: { viewModel.setLayoutMode($0) }
+                )) {
+                    ForEach(KGAtlasMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
                 }
+                .pickerStyle(.segmented)
+                .accessibilityHint(modeEffectDescription(snapshot: snapshot))
+
+                Button {
+                    if isFindPresented {
+                        dismissFindEntity()
+                    } else {
+                        presentFindEntity()
+                    }
+                } label: {
+                    Label("Find entity", systemImage: "magnifyingglass")
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.bordered)
+                .keyboardShortcut("f", modifiers: .command)
+                .accessibilityIdentifier("knowledge-graph-find-entity")
             }
-            .pickerStyle(.segmented)
+
+            Text(modeEffectDescription(snapshot: snapshot))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("knowledge-graph-mode-effect")
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Text("Altitude")
+                    Text(viewModel.layoutMode == .importance ? "Minimum importance" : "Altitude")
                         .font(.system(size: 11, weight: .semibold))
                     Spacer()
                     Text(altitudeReadout(snapshot: snapshot))
@@ -286,7 +374,6 @@ struct KGCanvasView: View {
         .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .onTapGesture {}
         .simultaneousGesture(toolbarInteractionGesture)
-        .padding(20)
     }
 
     private func atlasOverview(snapshot: KGAtlasPresentation.Snapshot) -> some View {
@@ -429,8 +516,12 @@ struct KGCanvasView: View {
         switch viewModel.layoutMode {
         case .importance:
             Slider(value: $minimumImportance, in: 0...10, step: 1)
+                .accessibilityLabel("Minimum entity importance")
+                .accessibilityValue("\(Int(minimumImportance)) out of 10")
         case .tieredAltitude:
             Slider(value: $altitudeLevel, in: 0...Double(KGAltitudeTier.allCases.count - 1), step: 1)
+                .accessibilityLabel("Visible altitude tiers")
+                .accessibilityValue(atlas.activeAltitudeTier.title)
         }
     }
 
@@ -452,43 +543,174 @@ struct KGCanvasView: View {
         }
     }
 
-    private func labelledNodeIDs(for nodes: [KGNode]) -> Set<String> {
-        if scale >= 1.15 {
-            return Set(nodes.map(\.id))
-        }
+    private func modeEffectDescription(snapshot: KGAtlasPresentation.Snapshot) -> String {
+        KGAtlasPresentation.modeEffectDescription(
+            mode: viewModel.layoutMode,
+            minimumImportance: minimumImportance,
+            altitudeTier: snapshot.activeAltitudeTier
+        )
+    }
 
-        var labelled = Set<String>()
-        if let selectedNodeId = viewModel.selectedNodeId {
-            labelled.insert(selectedNodeId)
-        }
+    private func presentFindEntity() {
+        isFindPresented = true
+        highlightedFindResultID = findResults.first?.id
+    }
 
-        for node in nodes where node.name.localizedCaseInsensitiveCompare("Etan Heyman") == .orderedSame {
-            labelled.insert(node.id)
-        }
+    private func dismissFindEntity() {
+        isFindPresented = false
+        highlightedFindResultID = nil
+    }
 
-        let maxLabels = scale < 0.7 ? 18 : 36
-        for node in nodes
-            .sorted(by: { lhs, rhs in
-                if lhs.importance == rhs.importance {
-                    return lhs.linkedChunkCount > rhs.linkedChunkCount
-                }
-                return lhs.importance > rhs.importance
-            })
-            .prefix(maxLabels) {
-            labelled.insert(node.id)
-        }
-        return labelled
+    private func selectFindResult(_ id: String) {
+        guard atlas.visibleNodes.contains(where: { $0.id == id }) else { return }
+        stopSimulation()
+        viewModel.selectNode(id: id)
+        dismissFindEntity()
     }
 
     private func startSimulation() {
-        guard isActive, !reduceMotion, !viewModel.isLayoutPinned, hasLoadedGraph, viewModel.nodes.count > 1 else { return }
+        guard isActive, !shouldReduceMotion, !viewModel.isLayoutPinned, hasLoadedGraph, viewModel.nodes.count > 1 else { return }
         simulationController.setActive(true)
         simulationController.start {
-            viewModel.tick(reduceMotionEnabled: reduceMotion)
+            viewModel.tick(reduceMotionEnabled: shouldReduceMotion)
         }
     }
 
     private func stopSimulation() {
         simulationController.setActive(false)
+    }
+}
+
+struct KGFindEntityPanel: View {
+    @Binding var query: String
+    let results: [KGAtlasPresentation.FindResult]
+    let highlightedResultID: String?
+    let onHighlight: (String?) -> Void
+    let onSelect: (String) -> Void
+    let onDismiss: () -> Void
+    @FocusState private var queryFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+
+                TextField("Find entity", text: $query)
+                    .textFieldStyle(.plain)
+                    .focused($queryFocused)
+                    .accessibilityLabel("Find entity")
+                    .accessibilityHint("Searches the entities currently visible in the atlas")
+                    .accessibilityIdentifier("knowledge-graph-find-field")
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close Find entity")
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.brainBarTextPrimary.opacity(0.06))
+            )
+
+            if results.isEmpty {
+                Text("No visible entities match “\(query)”.")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 12)
+                    .accessibilityIdentifier("knowledge-graph-find-empty")
+            } else {
+                ScrollView(.vertical, showsIndicators: true) {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(results) { result in
+                            Button {
+                                onSelect(result.id)
+                            } label: {
+                                HStack(alignment: .center, spacing: 10) {
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        Text(result.name)
+                                            .font(.system(size: 13, weight: .semibold))
+                                            .lineLimit(1)
+                                        Text("\(result.entityTypeTitle) · \(result.relationshipSummary)")
+                                            .font(.system(size: 10, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                    Spacer(minLength: 8)
+                                    Image(systemName: "arrow.right.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 8)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        .fill(result.id == highlightedResultID
+                                            ? Color.brainBarAccent.opacity(0.16)
+                                            : Color.brainBarTextPrimary.opacity(0.035))
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(result.accessibilityLabel)
+                            .accessibilityHint("Selects this entity and opens its details")
+                            .accessibilityIdentifier("knowledge-graph-find-result-\(result.id)")
+                            .onHover { hovering in
+                                if hovering {
+                                    onHighlight(result.id)
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(maxHeight: 250)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.brainBarGlassPrimary.opacity(0.96))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.brainBarTextPrimary.opacity(0.1), lineWidth: 1)
+                )
+        )
+        .shadow(color: .black.opacity(0.12), radius: 16, y: 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Find entity results")
+        .accessibilityIdentifier("knowledge-graph-find-results")
+        .onAppear {
+            queryFocused = true
+            if highlightedResultID == nil {
+                onHighlight(results.first?.id)
+            }
+        }
+        .onChange(of: results.map(\.id)) { _, ids in
+            if !ids.contains(highlightedResultID ?? "") {
+                onHighlight(ids.first)
+            }
+        }
+        .onMoveCommand { direction in
+            let move: KGAtlasPresentation.FindMove?
+            switch direction {
+            case .up: move = .up
+            case .down: move = .down
+            default: move = nil
+            }
+            guard let move else { return }
+            onHighlight(KGAtlasPresentation.nextFindResultID(
+                currentID: highlightedResultID,
+                move: move,
+                results: results
+            ))
+        }
+        .onSubmit {
+            if let id = highlightedResultID ?? results.first?.id {
+                onSelect(id)
+            }
+        }
+        .onExitCommand(perform: onDismiss)
     }
 }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift
@@ -345,26 +345,24 @@ struct KGCanvasView: View {
                 altitudeSlider
             }
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(snapshot.regions) { region in
-                        HStack(spacing: 6) {
-                            Circle()
-                                .fill(region.nodes.first?.color ?? .secondary)
-                                .frame(width: 8, height: 8)
-                            Text(region.title)
-                                .font(.system(size: 11, weight: .semibold))
-                            Text("\(region.nodes.count)")
-                                .font(.system(size: 10, weight: .medium, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(
-                            Capsule()
-                                .fill(Color.brainBarTextPrimary.opacity(0.07))
-                        )
+            WrappingPillLayout(spacing: 8, lineSpacing: 8) {
+                ForEach(snapshot.regions) { region in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(region.nodes.first?.color ?? .secondary)
+                            .frame(width: 8, height: 8)
+                        Text(region.title)
+                            .font(.system(size: 11, weight: .semibold))
+                        Text("\(region.nodes.count)")
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.secondary)
                     }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(
+                        Capsule()
+                            .fill(Color.brainBarTextPrimary.opacity(0.07))
+                    )
                 }
             }
         }

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGSidebarView.swift
@@ -18,6 +18,7 @@ struct KGSidebarView: View {
     let onLoadMoreChunks: () -> Void
     let onLoadMoreFiles: () -> Void
     let onClose: () -> Void
+    @State private var isRelationsExpanded = Self.relationsSectionDefaultExpanded
     @State private var isFilesExpanded = Self.filesSectionDefaultExpanded
 
     var body: some View {
@@ -107,12 +108,7 @@ struct KGSidebarView: View {
 
                 Spacer(minLength: 12)
 
-                Button(action: onClose) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
+                dismissButton
             }
         }
         .padding(16)
@@ -146,62 +142,73 @@ struct KGSidebarView: View {
 
     @ViewBuilder
     private func relationsSection(_ relations: [EntityCard.Relation]) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Relations")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.secondary)
+        DisclosureGroup(isExpanded: $isRelationsExpanded) {
+            VStack(alignment: .leading, spacing: 12) {
+                if relations.isEmpty {
+                    Text("No explicit graph relations yet. Linked chunks are evidence associations and may still appear below.")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(relations.enumerated()), id: \.offset) { _, relation in
+                        let presentation = KGRelationPresentation(relation: relation)
+                        Button {
+                            onSelectRelation(relation)
+                        } label: {
+                            HStack(alignment: .top, spacing: 10) {
+                                Text(relation.direction == "incoming" ? "←" : "→")
+                                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                                    .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
+                                    .frame(width: 14)
 
-            if relations.isEmpty {
-                Text("No graph relations yet.")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(Array(relations.enumerated()), id: \.offset) { _, relation in
-                    let presentation = KGRelationPresentation(relation: relation)
-                    Button {
-                        onSelectRelation(relation)
-                    } label: {
-                        HStack(alignment: .top, spacing: 10) {
-                            Text(relation.direction == "incoming" ? "←" : "→")
-                                .font(.system(size: 13, weight: .bold, design: .rounded))
-                                .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
-                                .frame(width: 14)
-
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                                    Text(relation.targetName)
-                                        .font(.system(size: 13, weight: .semibold))
-                                    if let expiration = presentation.inlinePill {
-                                        ExpirationPill(date: expiration.date, label: expiration.label)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                        Text(relation.targetName)
+                                            .font(.system(size: 13, weight: .semibold))
+                                        if let expiration = presentation.inlinePill {
+                                            ExpirationPill(date: expiration.date, label: expiration.label)
+                                        }
+                                    }
+                                    Text(relation.relationType.replacingOccurrences(of: "_", with: " "))
+                                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                        .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
+                                    if let expiredText = presentation.expiredFooterText {
+                                        Text(expiredText)
+                                            .font(.system(size: 10, weight: .medium))
+                                            .foregroundStyle(.tertiary)
                                     }
                                 }
-                                Text(relation.relationType.replacingOccurrences(of: "_", with: " "))
-                                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                                    .foregroundStyle(presentation.isDimmed ? .tertiary : .secondary)
-                                if let expiredText = presentation.expiredFooterText {
-                                    Text(expiredText)
-                                        .font(.system(size: 10, weight: .medium))
-                                        .foregroundStyle(.tertiary)
-                                }
-                            }
 
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 11, weight: .bold))
-                                .foregroundStyle(.tertiary)
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 11, weight: .bold))
+                                    .foregroundStyle(.tertiary)
+                            }
                         }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Open related entity \(relation.targetName)")
+                        .accessibilityHint("Selects this entity and updates the detail panel")
+                        .foregroundStyle(presentation.isDimmed ? .tertiary : .primary)
+                        .padding(12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .fill(Color.brainBarTextPrimary.opacity(0.045))
+                        )
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Open related entity \(relation.targetName)")
-                    .foregroundStyle(presentation.isDimmed ? .tertiary : .primary)
-                    .padding(12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(Color.brainBarTextPrimary.opacity(0.045))
-                    )
                 }
             }
+            .padding(.top, 10)
+        } label: {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Relations")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Text("\(relations.count)")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
         }
+        .accessibilityIdentifier("knowledge-graph-relations-disclosure")
         .padding(16)
         .background(sectionBackground)
     }
@@ -371,15 +378,32 @@ struct KGSidebarView: View {
 
     private var emptyState: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Knowledge atlas")
-                .font(.system(size: 22, weight: .bold, design: .rounded))
-            Text("Select a node to inspect its relations, metadata, and linked memory chunks.")
+            HStack(alignment: .top) {
+                Text("Entity details unavailable")
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                Spacer(minLength: 12)
+                dismissButton
+            }
+            Text("Close this panel and select the entity again to retry.")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.secondary)
         }
         .padding(18)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(sectionBackground)
+    }
+
+    private var dismissButton: some View {
+        Button(action: onClose) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.cancelAction)
+        .accessibilityLabel(Self.closeAccessibilityLabel)
+        .accessibilityHint("Returns focus to the knowledge atlas")
+        .accessibilityIdentifier("knowledge-graph-close-details")
     }
 
     private var sectionBackground: some View {
@@ -484,6 +508,10 @@ struct KGSidebarView: View {
     }
 
     nonisolated static let filesSectionDefaultExpanded = false
+
+    nonisolated static let relationsSectionDefaultExpanded = false
+
+    nonisolated static let closeAccessibilityLabel = "Close entity details"
 
     nonisolated static let noLinkedChunksMessage = "No linked chunks are stored yet."
 

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -275,6 +275,7 @@ final class KGViewModel: ObservableObject {
         guard let database, let node = nodeById(id) else {
             // Missing nodes should clear selection without restarting the simulation.
             freezeLayout()
+            selectedNodeId = nil
             selectedEntity = nil
             resetSelectedEntitySidebarState(isLoading: false, loadFailed: false)
             selectedConversation = nil
@@ -282,12 +283,23 @@ final class KGViewModel: ObservableObject {
         }
         pinLayout()
 
-        selectedEntity = (try? database.lookupEntity(query: node.name)).map {
-            EntityCard(
-                lookupPayload: $0,
+        do {
+            guard let lookupPayload = try database.lookupEntity(query: node.name) else {
+                selectedNodeId = nil
+                selectedEntity = nil
+                resetSelectedEntitySidebarState(isLoading: false, loadFailed: false)
+                selectedConversation = nil
+                return
+            }
+            selectedEntity = EntityCard(
+                lookupPayload: lookupPayload,
                 importance: node.importance,
                 altitudeTierTitle: KGAltitudeTier.tier(for: node).title
             )
+        } catch {
+            // Preserve the explicit sidebar failure state for transient database
+            // errors. The empty-state close control keeps this path dismissible.
+            selectedEntity = nil
         }
         selectedConversation = nil
         resetSelectedEntitySidebarState(isLoading: true, loadFailed: false)

--- a/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
+++ b/brain-bar/Sources/BrainBar/KnowledgeGraph/KGViewModel.swift
@@ -272,7 +272,7 @@ final class KGViewModel: ObservableObject {
             return
         }
 
-        guard let database, let node = nodeById(id) else {
+        guard let node = nodeById(id) else {
             // Missing nodes should clear selection without restarting the simulation.
             freezeLayout()
             selectedNodeId = nil
@@ -282,6 +282,13 @@ final class KGViewModel: ObservableObject {
             return
         }
         pinLayout()
+
+        guard let database else {
+            selectedEntity = nil
+            selectedConversation = nil
+            resetSelectedEntitySidebarState(isLoading: false, loadFailed: true)
+            return
+        }
 
         do {
             guard let lookupPayload = try database.lookupEntity(query: node.name) else {
@@ -300,6 +307,9 @@ final class KGViewModel: ObservableObject {
             // Preserve the explicit sidebar failure state for transient database
             // errors. The empty-state close control keeps this path dismissible.
             selectedEntity = nil
+            selectedConversation = nil
+            resetSelectedEntitySidebarState(isLoading: false, loadFailed: true)
+            return
         }
         selectedConversation = nil
         resetSelectedEntitySidebarState(isLoading: true, loadFailed: false)

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -178,8 +178,29 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
             (.day, "dashboard-chart-window-24h"),
         ]
         for (timeframe, name) in windows {
+            let windowedStats = BrainBarDashboardFixture.makeStats(
+                activityWindowMinutes: timeframe.windowMinutes
+            )
+            let windowedSummary = DashboardFlowSummary.derive(
+                daemon: nil,
+                stats: windowedStats,
+                now: BrainBarDashboardFixture.fetchedAt
+            )
+            XCTAssertEqual(
+                windowedSummary.allCommits.windowLabel,
+                DashboardMetricFormatter.windowLabel(minutes: timeframe.windowMinutes)
+            )
+            XCTAssertTrue(
+                windowedSummary.allCommits.volumeText.hasSuffix("in \(timeframe.windowMinutes == 180 ? "3h" : "24h")"),
+                "Chart footer count must follow the selected window instead of retaining a 1h anchor."
+            )
+            XCTAssertNotEqual(
+                windowedSummary.allCommits.rateText,
+                "0.0/min",
+                "A non-empty wider-window fixture must not render a false zero headline rate."
+            )
             let view = BrainBarPipelinePanelPreview.make(
-                stats: BrainBarDashboardFixture.stats,
+                stats: windowedStats,
                 containerSize: CGSize(width: 1_120, height: 1_420),
                 fetchedAt: BrainBarDashboardFixture.fetchedAt,
                 selectedTimeframe: timeframe
@@ -223,6 +244,32 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
         XCTAssertGreaterThan(tooltipPNG.count, 5_000, "dashboard tooltip PNG looks empty")
         XCTAssertGreaterThan(distinctSampledColorCount(in: tooltipBitmap), 16, "dashboard tooltip render is too flat")
         print("[brainbar-render] wrote \(tooltipURL.path) (\(tooltipPNG.count) bytes)")
+    }
+
+    @MainActor
+    func testDashboardReplayDebtDisclosureRendersExpanded() throws {
+        try XCTSkipIf(
+            shouldSkipDisplayDependentRenderInCI,
+            "Dashboard PNG render verification is display-dependent; set BRAINBAR_RENDER_IN_CI=1 to run in CI."
+        )
+
+        let view = BrainBarPipelinePanelPreview.make(
+            stats: BrainBarDashboardFixture.partialReplayDebtStats,
+            containerSize: CGSize(width: 1_120, height: 1_420),
+            fetchedAt: BrainBarDashboardFixture.fetchedAt,
+            signalCoverageExpanded: false,
+            replayDebtExpanded: true
+        )
+        let (png, bitmap) = try renderPNG(view, size: NSSize(width: 1_120, height: 1_700))
+        let url = try writePNG(png, name: "dashboard-replay-debt-expanded")
+
+        XCTAssertGreaterThan(png.count, 5_000, "expanded replay-debt PNG looks empty")
+        XCTAssertGreaterThan(
+            distinctSampledColorCount(in: bitmap),
+            16,
+            "expanded replay-debt render is too flat"
+        )
+        print("[brainbar-render] wrote \(url.path) (\(png.count) bytes)")
     }
 
     @MainActor

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -147,6 +147,20 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
         XCTAssertTrue(fixtureSource.contains("case live"), "Snapshot fixtures must cover LIVE.")
         XCTAssertTrue(fixtureSource.contains("case stale"), "Snapshot fixtures must cover STALE.")
         XCTAssertTrue(fixtureSource.contains("case error"), "Snapshot fixtures must cover ERROR with last-good data.")
+
+        let loading = BrainBarDashboardFixture.makeCollector(.loading)
+        let live = BrainBarDashboardFixture.makeCollector(.live)
+        let stale = BrainBarDashboardFixture.makeCollector(.stale)
+        let error = BrainBarDashboardFixture.makeCollector(.error)
+        XCTAssertEqual(loading.snapshotFreshnessState, .loading)
+        XCTAssertEqual(live.snapshotFreshnessState, .live(ageSeconds: 0))
+        XCTAssertEqual(stale.snapshotFreshnessState, .stale(ageSeconds: 61))
+        XCTAssertEqual(
+            error.snapshotFreshnessState,
+            .error(message: "Fixture fetch failed", lastSuccessAgeSeconds: 15)
+        )
+        XCTAssertNotNil(error.lastDataFetchedAt)
+        XCTAssertEqual(error.lastFetchError, "Fixture fetch failed")
     }
 
     // MARK: - Render helpers

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -270,9 +270,11 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
         )
         .environment(\.colorScheme, .light)
 
-        let (darkPNG, _) = try renderPNG(darkParent, size: size)
+        let (darkPNG, darkBitmap) = try renderPNG(darkParent, size: size)
         let (lightPNG, _) = try renderPNG(lightParent, size: size)
 
+        XCTAssertGreaterThan(darkPNG.count, 5_000, "pipeline determinism PNG looks empty")
+        XCTAssertGreaterThan(distinctSampledColorCount(in: darkBitmap), 16, "pipeline determinism render is too flat")
         XCTAssertEqual(
             lightPNG,
             darkPNG,
@@ -409,7 +411,8 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
     private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
         guard let data = bitmap.bitmapData else { return 0 }
         let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
-        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let baseStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let sampleStride = baseStride - (baseStride % bytesPerPixel)
         var colors = Set<String>()
         for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
             let rowStart = y * bitmap.bytesPerRow

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -117,6 +117,38 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
         print("[brainbar-render] wrote \(url.path) (\(png.count) bytes)")
     }
 
+    @MainActor
+    func testOperatorStateFixturesStayIsolatedFromProductionDatabaseAndProcessServices() throws {
+        let collector = BrainBarDashboardFixture.makeCollector()
+        let fields = Dictionary(uniqueKeysWithValues: Mirror(reflecting: collector).children.compactMap { child in
+            child.label.map { ($0, child.value) }
+        })
+
+        XCTAssertEqual(fields["dbPath"] as? String, "/nonexistent/brainbar-fixture.db")
+        XCTAssertEqual(fields["isRunning"] as? Bool, false)
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fixtureSource = try String(
+            contentsOf: packageRoot.appendingPathComponent("Sources/BrainBar/Dashboard/BrainBarDashboardFixture.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(fixtureSource.contains("StatsCollector.fixture("))
+        XCTAssertFalse(fixtureSource.contains(".start()"), "Deterministic fixtures must not start collectors or timers.")
+        XCTAssertFalse(fixtureSource.contains("launchctl"), "Fixture variants must not probe or mutate process services.")
+        XCTAssertFalse(
+            fixtureSource.contains(".local/share/brainlayer/brainlayer.db"),
+            "Fixture variants must never resolve the canonical production database."
+        )
+        XCTAssertTrue(fixtureSource.contains("case loading"), "Snapshot fixtures must cover LOADING.")
+        XCTAssertTrue(fixtureSource.contains("case live"), "Snapshot fixtures must cover LIVE.")
+        XCTAssertTrue(fixtureSource.contains("case stale"), "Snapshot fixtures must cover STALE.")
+        XCTAssertTrue(fixtureSource.contains("case error"), "Snapshot fixtures must cover ERROR with last-good data.")
+    }
+
     // MARK: - Render helpers
 
     @MainActor

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -247,6 +247,40 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
     }
 
     @MainActor
+    func testPipelinePreviewIgnoresAmbientSystemAppearance() throws {
+        try XCTSkipIf(
+            shouldSkipDisplayDependentRenderInCI,
+            "Dashboard PNG render verification is display-dependent; set BRAINBAR_RENDER_IN_CI=1 to run in CI."
+        )
+
+        let stats = BrainBarDashboardFixture.makeStats(activityWindowMinutes: 180)
+        let size = NSSize(width: 1_120, height: 1_420)
+        let darkParent = BrainBarPipelinePanelPreview.make(
+            stats: stats,
+            containerSize: size,
+            fetchedAt: BrainBarDashboardFixture.fetchedAt,
+            selectedTimeframe: .threeHour
+        )
+        .environment(\.colorScheme, .dark)
+        let lightParent = BrainBarPipelinePanelPreview.make(
+            stats: stats,
+            containerSize: size,
+            fetchedAt: BrainBarDashboardFixture.fetchedAt,
+            selectedTimeframe: .threeHour
+        )
+        .environment(\.colorScheme, .light)
+
+        let (darkPNG, _) = try renderPNG(darkParent, size: size)
+        let (lightPNG, _) = try renderPNG(lightParent, size: size)
+
+        XCTAssertEqual(
+            lightPNG,
+            darkPNG,
+            "The deterministic proof seam must pin dark appearance instead of inheriting the host Mac setting."
+        )
+    }
+
+    @MainActor
     func testDashboardReplayDebtDisclosureRendersExpanded() throws {
         try XCTSkipIf(
             shouldSkipDisplayDependentRenderInCI,

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -141,6 +141,91 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
     }
 
     @MainActor
+    func testDashboardWatcherTruthStatesRenderDeterministically() throws {
+        try XCTSkipIf(
+            shouldSkipDisplayDependentRenderInCI,
+            "Dashboard PNG render verification is display-dependent; set BRAINBAR_RENDER_IN_CI=1 to run in CI."
+        )
+
+        let states: [(BrainBarDashboardFixture.OperatorState, String)] = [
+            (.watcherOffline, "dashboard-watcher-offline"),
+            (.watcherUnknown, "dashboard-watcher-unknown"),
+            (.watcherRunningNoRecentFlow, "dashboard-watcher-running-no-recent-flow"),
+            (.watcherStalledWithPendingWork, "dashboard-watcher-stalled-pending-work"),
+        ]
+
+        for (state, name) in states {
+            let collector = BrainBarDashboardFixture.makeCollector(state)
+            let view = BrainBarDashboardPreview.make(collector: collector)
+            let (png, bitmap) = try renderPNG(view, size: NSSize(width: 960, height: 1_820))
+            let url = try writePNG(png, name: name)
+
+            XCTAssertGreaterThan(png.count, 5_000, "\(name) PNG looks empty")
+            XCTAssertGreaterThan(distinctSampledColorCount(in: bitmap), 16, "\(name) render is too flat")
+            print("[brainbar-render] wrote \(url.path) (\(png.count) bytes)")
+        }
+    }
+
+    @MainActor
+    func testDashboardChartWindowsAndTooltipSummaryRenderDeterministically() throws {
+        try XCTSkipIf(
+            shouldSkipDisplayDependentRenderInCI,
+            "Dashboard PNG render verification is display-dependent; set BRAINBAR_RENDER_IN_CI=1 to run in CI."
+        )
+
+        let windows: [(PipelineTimeframe, String)] = [
+            (.threeHour, "dashboard-chart-window-3h"),
+            (.day, "dashboard-chart-window-24h"),
+        ]
+        for (timeframe, name) in windows {
+            let view = BrainBarPipelinePanelPreview.make(
+                stats: BrainBarDashboardFixture.stats,
+                containerSize: CGSize(width: 1_120, height: 1_420),
+                fetchedAt: BrainBarDashboardFixture.fetchedAt,
+                selectedTimeframe: timeframe
+            )
+            let (png, bitmap) = try renderPNG(view, size: NSSize(width: 1_120, height: 1_420))
+            let url = try writePNG(png, name: name)
+
+            XCTAssertGreaterThan(png.count, 5_000, "\(name) PNG looks empty")
+            XCTAssertGreaterThan(distinctSampledColorCount(in: bitmap), 16, "\(name) render is too flat")
+            print("[brainbar-render] wrote \(url.path) (\(png.count) bytes)")
+        }
+
+        let disclosure = "Window: Last 1h · Count: hovered value below · Unit: unique chunk IDs first seen in this window · Clock: ingest time"
+        let accessibilitySummary = "WATCHER INGESTED CHUNKS. Window: Last 1h. Count: 14. Unit: unique chunk IDs first seen in this window. Clock: ingest time."
+        let presentation = SparklineChartPresentation(
+            label: "WATCHER INGESTED CHUNKS",
+            values: [1, 0, 2, 1, 0, 3, 1, 2, 0, 1, 2, 1],
+            activityWindowMinutes: 60,
+            latestBucketName: "latest ingest bucket",
+            fetchedAt: BrainBarDashboardFixture.fetchedAt,
+            metricDisclosure: disclosure,
+            accessibilitySummary: accessibilitySummary
+        )
+        XCTAssertTrue(presentation.accessibilityValue.contains(accessibilitySummary))
+        let tooltipView = SparklineChart(
+            presentation: presentation,
+            accentColor: BrainBarDesignTokens.Colors.seriesWatcher,
+            previewHoveredBucket: 7,
+            previewHoverX: 430
+        )
+        .frame(width: 840, height: 320)
+        .padding(20)
+        .background(Color.brainBarBackgroundBase)
+        .environment(\.colorScheme, .dark)
+
+        let (tooltipPNG, tooltipBitmap) = try renderPNG(
+            tooltipView,
+            size: NSSize(width: 880, height: 360)
+        )
+        let tooltipURL = try writePNG(tooltipPNG, name: "dashboard-chart-tooltip-summary")
+        XCTAssertGreaterThan(tooltipPNG.count, 5_000, "dashboard tooltip PNG looks empty")
+        XCTAssertGreaterThan(distinctSampledColorCount(in: tooltipBitmap), 16, "dashboard tooltip render is too flat")
+        print("[brainbar-render] wrote \(tooltipURL.path) (\(tooltipPNG.count) bytes)")
+    }
+
+    @MainActor
     func testOperatorStateFixturesStayIsolatedFromProductionDatabaseAndProcessServices() throws {
         let collector = BrainBarDashboardFixture.makeCollector()
         let fields = Dictionary(uniqueKeysWithValues: Mirror(reflecting: collector).children.compactMap { child in

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardSnapshotTests.swift
@@ -118,6 +118,29 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
     }
 
     @MainActor
+    func testDashboardOperatorStatesRenderDeterministically() throws {
+        try XCTSkipIf(
+            shouldSkipDisplayDependentRenderInCI,
+            "Dashboard PNG render verification is display-dependent; set BRAINBAR_RENDER_IN_CI=1 to run in CI."
+        )
+
+        for state in BrainBarDashboardFixture.OperatorState.allCases {
+            let collector = BrainBarDashboardFixture.makeCollector(state)
+            let view = BrainBarDashboardPreview.make(collector: collector)
+            let size = state == .loading
+                ? NSSize(width: 960, height: 700)
+                : NSSize(width: 960, height: 1_820)
+            let (png, bitmap) = try renderPNG(view, size: size)
+            let name = "dashboard-state-\(String(describing: state))"
+            let url = try writePNG(png, name: name)
+
+            XCTAssertGreaterThan(png.count, 5_000, "\(name) PNG looks empty")
+            XCTAssertGreaterThan(distinctSampledColorCount(in: bitmap), 16, "\(name) render is too flat")
+            print("[brainbar-render] wrote \(url.path) (\(png.count) bytes)")
+        }
+    }
+
+    @MainActor
     func testOperatorStateFixturesStayIsolatedFromProductionDatabaseAndProcessServices() throws {
         let collector = BrainBarDashboardFixture.makeCollector()
         let fields = Dictionary(uniqueKeysWithValues: Mirror(reflecting: collector).children.compactMap { child in
@@ -147,11 +170,16 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
         XCTAssertTrue(fixtureSource.contains("case live"), "Snapshot fixtures must cover LIVE.")
         XCTAssertTrue(fixtureSource.contains("case stale"), "Snapshot fixtures must cover STALE.")
         XCTAssertTrue(fixtureSource.contains("case error"), "Snapshot fixtures must cover ERROR with last-good data.")
+        XCTAssertTrue(
+            fixtureSource.contains("case partialReplayDebt"),
+            "Snapshot fixtures must cover known replay components plus an unreadable input."
+        )
 
         let loading = BrainBarDashboardFixture.makeCollector(.loading)
         let live = BrainBarDashboardFixture.makeCollector(.live)
         let stale = BrainBarDashboardFixture.makeCollector(.stale)
         let error = BrainBarDashboardFixture.makeCollector(.error)
+        let partialReplayDebt = BrainBarDashboardFixture.makeCollector(.partialReplayDebt)
         XCTAssertEqual(loading.snapshotFreshnessState, .loading)
         XCTAssertEqual(live.snapshotFreshnessState, .live(ageSeconds: 0))
         XCTAssertEqual(stale.snapshotFreshnessState, .stale(ageSeconds: 61))
@@ -161,6 +189,11 @@ final class BrainBarDashboardSnapshotTests: XCTestCase {
         )
         XCTAssertNotNil(error.lastDataFetchedAt)
         XCTAssertEqual(error.lastFetchError, "Fixture fetch failed")
+        XCTAssertTrue(partialReplayDebt.stats.replayDebtBreakdown.isPartial)
+        XCTAssertGreaterThan(partialReplayDebt.stats.replayDebtBreakdown.pendingStores.snapshot.depth, 0)
+        XCTAssertGreaterThan(partialReplayDebt.stats.replayDebtBreakdown.durableQueue.snapshot.depth, 0)
+        XCTAssertGreaterThan(partialReplayDebt.stats.replayDebtBreakdown.repositoryFallback.snapshot.depth, 0)
+        XCTAssertFalse(partialReplayDebt.stats.replayDebtBreakdown.durableQueue.readability.isReadable)
     }
 
     // MARK: - Render helpers

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardTruthPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardTruthPresentationTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import XCTest
+@testable import BrainBar
+
+final class BrainBarDashboardTruthPresentationTests: XCTestCase {
+    func testDashboardShipLabelsMatchTheApprovedMetricAndWatcherTruth() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 120,
+            enrichedChunkCount: 90,
+            failedEnrichmentCount: 4,
+            skippedEnrichmentCount: 6,
+            pendingEnrichmentCount: 20,
+            enrichmentPercent: 75,
+            enrichmentRatePerMinute: 1,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [1, 2, 3, 4],
+            recentAgentWriteBuckets: [1, 1, 2, 2],
+            recentWatcherWriteBuckets: [0, 1, 0, 2],
+            recentEnrichmentBuckets: [1, 1, 1, 1],
+            activityWindowMinutes: 60,
+            bucketCount: 4,
+            lastWriteAt: now.addingTimeInterval(-10),
+            lastEnrichedAt: now.addingTimeInterval(-10),
+            watcherProcessProbeResult: .running(pid: 42),
+            watcherRecentDistinctChunkCount: 2,
+            watcherFlowReadability: .readable
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+        let chunkRows = summary.lane(for: .allCommits)
+        let agentOrigin = summary.lane(for: .agentStores)
+        let watcherIngested = summary.lane(for: .jsonlWatcher)
+        let enriched = summary.lane(for: .enrichment)
+
+        XCTAssertEqual(chunkRows.name, "Chunk rows")
+        XCTAssertEqual(chunkRows.sparklineLabel, "Chunk rows by source time over Last 1h")
+        XCTAssertFalse(chunkRows.statusText.localizedCaseInsensitiveContains("commit"))
+        XCTAssertEqual(agentOrigin.name, "Agent-origin chunks")
+        XCTAssertEqual(agentOrigin.sparklineLabel, "Agent-origin chunks by source time over Last 1h")
+        XCTAssertFalse(agentOrigin.statusText.localizedCaseInsensitiveContains("MCP"))
+        XCTAssertEqual(watcherIngested.name, "Watcher-ingested chunks")
+        XCTAssertEqual(watcherIngested.sparklineLabel, "Watcher-ingested chunks by ingest time over Last 1h")
+        XCTAssertEqual(watcherIngested.statusText, "FLOWING")
+        XCTAssertEqual(enriched.name, "Enriched successfully")
+        XCTAssertEqual(enriched.sparklineLabel, "Successful enrichment completions over Last 1h")
+    }
+
+    func testDashboardMakesFreshnessPrimaryAndKeepsLastGoodDataVisible() throws {
+        let source = try sourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+        let dashboardRange = try XCTUnwrap(source.range(of: "private struct BrainBarDashboardView"))
+        let dashboardSource = String(source[dashboardRange.lowerBound...])
+        let freshnessIndex = try XCTUnwrap(dashboardSource.range(of: "freshnessBanner")?.lowerBound)
+        let overviewIndex = try XCTUnwrap(dashboardSource.range(of: "overviewCard(layout: layout)")?.lowerBound)
+
+        XCTAssertLessThan(freshnessIndex, overviewIndex, "Freshness must precede last-good dashboard content.")
+        XCTAssertTrue(source.contains("private struct BrainBarSnapshotFreshnessBanner"))
+        XCTAssertTrue(source.contains("Last good"))
+        XCTAssertTrue(source.contains("Data age"))
+        XCTAssertTrue(source.contains("brainbar.dashboard.freshness"))
+        XCTAssertTrue(source.contains("lastGoodContentOpacity"))
+    }
+
+    func testDashboardUsesCompactDensityAtSupportedBreakpoints() {
+        let compact = BrainBarDashboardLayout(containerSize: CGSize(width: 760, height: 560))
+        let normal = BrainBarDashboardLayout(containerSize: CGSize(width: 960, height: 700))
+
+        XCTAssertLessThanOrEqual(compact.outerPadding, 18)
+        XCTAssertLessThanOrEqual(compact.sectionSpacing, 16)
+        XCTAssertLessThanOrEqual(compact.cardPadding, 18)
+        XCTAssertLessThanOrEqual(compact.sparklineHeight, 112)
+        XCTAssertLessThanOrEqual(normal.cardPadding, 24)
+        XCTAssertLessThanOrEqual(normal.sparklineHeight, 140)
+    }
+
+    func testChartsExposeVisibleTruthTooltipsAndKeyboardAccessIdentifiers() throws {
+        let dashboard = try sourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+        let sparkline = try sourceFile("Sources/BrainBar/Dashboard/SparklineRenderer.swift")
+        let commandBar = try sourceFile("Sources/BrainBar/BrainBarCommandBar.swift")
+
+        for forbidden in ["All commits", "ALL COMMITS", "Agent MCP stores", "JSONL watcher"] {
+            XCTAssertFalse(dashboard.contains(forbidden), "Dashboard source still presents forbidden label: \(forbidden)")
+        }
+        for subtitle in [
+            "Source time · chunk rows",
+            "Source time · chunk rows · documented agent origins",
+            "Ingest time · unique chunk IDs first seen in window · not additive with source-time charts",
+        ] {
+            XCTAssertTrue(dashboard.contains(subtitle), "Missing visible chart disclosure: \(subtitle)")
+        }
+        for identifier in [
+            "brainbar.dashboard.scroll",
+            "brainbar.dashboard.chart.chunk-rows",
+            "brainbar.dashboard.chart.agent-origin-chunks",
+            "brainbar.dashboard.chart.watcher-ingested-chunks",
+            "brainbar.dashboard.chart.enriched-successfully",
+            "brainbar.dashboard.timeframe",
+            "brainbar.dashboard.signal-coverage-disclosure",
+            "brainbar.dashboard.runtime-disclosure",
+            "brainbar.shell.tabs",
+        ] {
+            XCTAssertTrue(dashboard.contains(identifier), "Missing stable Dashboard accessibility identifier: \(identifier)")
+        }
+        XCTAssertTrue(sparkline.contains("metricDisclosure"))
+        XCTAssertTrue(sparkline.contains("Text(metricDisclosure)"), "Pointer tooltip must name window, count unit, and clock.")
+        XCTAssertTrue(dashboard.contains("accessibilitySummary"), "Charts need a non-pointer semantic summary.")
+        XCTAssertTrue(dashboard.contains(".focusable()"), "Dashboard scroll and controls need a keyboard focus path.")
+        XCTAssertTrue(commandBar.contains("brainbar.command.mode.capture"))
+        XCTAssertTrue(commandBar.contains("brainbar.command.mode.search"))
+        XCTAssertTrue(commandBar.contains("brainbar.command.input"))
+        XCTAssertFalse(commandBar.contains(".focusable(false)"))
+    }
+
+    func testReplayDebtIsDecomposedOneActionFromTheAggregate() throws {
+        let source = try sourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertTrue(source.contains("Replay debt"))
+        XCTAssertTrue(source.contains("Pending stores"))
+        XCTAssertTrue(source.contains("Queue entries"))
+        XCTAssertTrue(source.contains("Fallback entries"))
+        XCTAssertTrue(source.contains("Unreadable inputs"))
+        XCTAssertTrue(source.contains("Deduplicated total"))
+        XCTAssertTrue(source.contains("brainbar.dashboard.replay-debt-disclosure"))
+        XCTAssertTrue(source.contains("replayDebtBreakdown.isPartial"))
+    }
+
+    func testPowerActionsRequireExplicitConfirmation() throws {
+        let source = try sourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertTrue(source.contains("showRestartConfirmation"))
+        XCTAssertTrue(source.contains("showQuitConfirmation"))
+        XCTAssertTrue(source.contains("confirmationDialog"))
+        XCTAssertTrue(source.contains("role: .destructive"))
+    }
+
+    func testWideHeroLabelsAndChartStatusColorsRemainSemanticallyLegible() throws {
+        let dashboard = try sourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+        let pipeline = try sourceFile("Sources/BrainBar/Dashboard/PipelineState.swift")
+        let overviewRange = try XCTUnwrap(dashboard.range(of: "private struct BrainBarOverviewStat"))
+        let overviewSource = String(dashboard[overviewRange.lowerBound...])
+
+        XCTAssertTrue(overviewSource.contains(".lineLimit(2)"), "Wide hero labels must wrap instead of truncating metric truth.")
+        XCTAssertTrue(dashboard.contains("lane.status.stateTheme"), "Chart status pills must use semantic state color, not series color.")
+        XCTAssertTrue(pipeline.contains("extension DashboardFlowLaneStatus"))
+        XCTAssertTrue(pipeline.contains("case .live:\n            return .active"))
+    }
+
+    private func sourceFile(_ relativePath: String) throws -> String {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: packageRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardTruthPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardTruthPresentationTests.swift
@@ -48,17 +48,24 @@ final class BrainBarDashboardTruthPresentationTests: XCTestCase {
 
     func testDashboardMakesFreshnessPrimaryAndKeepsLastGoodDataVisible() throws {
         let source = try sourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
-        let dashboardRange = try XCTUnwrap(source.range(of: "private struct BrainBarDashboardView"))
-        let dashboardSource = String(source[dashboardRange.lowerBound...])
+        let dashboardSource = try sourceSlice(
+            from: "private struct BrainBarDashboardView",
+            throughBefore: "private struct BrainBarSnapshotFreshnessBanner",
+            in: source
+        )
+        let freshnessBannerSource = try sourceSlice(
+            from: "private struct BrainBarSnapshotFreshnessBanner",
+            throughBefore: "private struct BrainBarPipelineSeriesCard",
+            in: source
+        )
         let freshnessIndex = try XCTUnwrap(dashboardSource.range(of: "freshnessBanner")?.lowerBound)
         let overviewIndex = try XCTUnwrap(dashboardSource.range(of: "overviewCard(layout: layout)")?.lowerBound)
 
         XCTAssertLessThan(freshnessIndex, overviewIndex, "Freshness must precede last-good dashboard content.")
-        XCTAssertTrue(source.contains("private struct BrainBarSnapshotFreshnessBanner"))
-        XCTAssertTrue(source.contains("Last good"))
-        XCTAssertTrue(source.contains("Data age"))
-        XCTAssertTrue(source.contains("brainbar.dashboard.freshness"))
-        XCTAssertTrue(source.contains("lastGoodContentOpacity"))
+        XCTAssertTrue(dashboardSource.contains("lastGoodContentOpacity"))
+        XCTAssertTrue(freshnessBannerSource.contains("Last good"))
+        XCTAssertTrue(freshnessBannerSource.contains("Data age"))
+        XCTAssertTrue(freshnessBannerSource.contains("brainbar.dashboard.freshness"))
     }
 
     func testDashboardUsesCompactDensityAtSupportedBreakpoints() {
@@ -95,6 +102,7 @@ final class BrainBarDashboardTruthPresentationTests: XCTestCase {
             "brainbar.dashboard.chart.watcher-ingested-chunks",
             "brainbar.dashboard.chart.enriched-successfully",
             "brainbar.dashboard.timeframe",
+            "brainbar.dashboard.timeframe.error",
             "brainbar.dashboard.signal-coverage-disclosure",
             "brainbar.dashboard.runtime-disclosure",
             "brainbar.shell.tabs",
@@ -136,13 +144,22 @@ final class BrainBarDashboardTruthPresentationTests: XCTestCase {
     func testWideHeroLabelsAndChartStatusColorsRemainSemanticallyLegible() throws {
         let dashboard = try sourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
         let pipeline = try sourceFile("Sources/BrainBar/Dashboard/PipelineState.swift")
-        let overviewRange = try XCTUnwrap(dashboard.range(of: "private struct BrainBarOverviewStat"))
-        let overviewSource = String(dashboard[overviewRange.lowerBound...])
+        let overviewSource = try sourceSlice(
+            from: "private struct BrainBarOverviewStat",
+            throughBefore: "private struct BrainBarAgentPresencePill",
+            in: dashboard
+        )
 
         XCTAssertTrue(overviewSource.contains(".lineLimit(2)"), "Wide hero labels must wrap instead of truncating metric truth.")
         XCTAssertTrue(dashboard.contains("lane.status.stateTheme"), "Chart status pills must use semantic state color, not series color.")
         XCTAssertTrue(pipeline.contains("extension DashboardFlowLaneStatus"))
         XCTAssertTrue(pipeline.contains("case .live:\n            return .active"))
+    }
+
+    private func sourceSlice(from start: String, throughBefore end: String, in source: String) throws -> String {
+        let startRange = try XCTUnwrap(source.range(of: start))
+        let endRange = try XCTUnwrap(source.range(of: end, range: startRange.upperBound..<source.endIndex))
+        return String(source[startRange.lowerBound..<endRange.lowerBound])
     }
 
     private func sourceFile(_ relativePath: String) throws -> String {

--- a/brain-bar/Tests/BrainBarTests/BrainBarDashboardTruthPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarDashboardTruthPresentationTests.swift
@@ -3,6 +3,8 @@ import XCTest
 @testable import BrainBar
 
 final class BrainBarDashboardTruthPresentationTests: XCTestCase {
+    deinit {}
+
     func testDashboardShipLabelsMatchTheApprovedMetricAndWatcherTruth() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
@@ -85,8 +87,11 @@ final class BrainBarDashboardTruthPresentationTests: XCTestCase {
         let sparkline = try sourceFile("Sources/BrainBar/Dashboard/SparklineRenderer.swift")
         let commandBar = try sourceFile("Sources/BrainBar/BrainBarCommandBar.swift")
 
-        for forbidden in ["All commits", "ALL COMMITS", "Agent MCP stores", "JSONL watcher"] {
-            XCTAssertFalse(dashboard.contains(forbidden), "Dashboard source still presents forbidden label: \(forbidden)")
+        for forbidden in ["All commits", "Agent MCP stores", "JSONL watcher"] {
+            XCTAssertFalse(
+                dashboard.localizedCaseInsensitiveContains(forbidden),
+                "Dashboard source still presents forbidden label: \(forbidden)"
+            )
         }
         for subtitle in [
             "Source time · chunk rows",

--- a/brain-bar/Tests/BrainBarTests/BrainBarP6SearchSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarP6SearchSnapshotTests.swift
@@ -1,0 +1,192 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BrainBar
+
+@MainActor
+final class BrainBarP6SearchSnapshotTests: XCTestCase {
+    func testSearchAndCommandShellStatesRenderToTheCallerProvidedDirectory() throws {
+        guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"],
+              !renderDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw XCTSkip("Set BRAINBAR_RENDER_DIR to render the P6 Search/shell matrix")
+        }
+
+        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-p6-search-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        let db = BrainDatabase(path: tempRoot.appendingPathComponent("fixture.db").path)
+        XCTAssertTrue(db.isOpen)
+        defer {
+            db.close()
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+
+        let neutral = makeViewModel(db: db) { _, _ in .init(count: 0, formatted: "", results: []) }
+        try render(
+            CommandShellSnapshot(viewModel: neutral, compact: false),
+            named: "search-shell-neutral.png",
+            directory: renderDirectory,
+            size: NSSize(width: 820, height: 360)
+        )
+
+        let focused = makeViewModel(db: db) { query, limit in
+            Self.fixedSearchResult(query: query, limit: limit)
+        }
+        focused.setMode(QuickCapturePanelState.Mode.search)
+        focused.inputText = "watcher truth"
+        focused.submit()
+        focused.panelDidAppear()
+        XCTAssertNotNil(focused.selectedResultID)
+        XCTAssertGreaterThan(focused.focusRequestCount, 0)
+        try render(
+            CommandShellSnapshot(viewModel: focused, compact: false),
+            named: "search-shell-keyboard-focus.png",
+            directory: renderDirectory,
+            size: NSSize(width: 820, height: 360)
+        )
+
+        let empty = makeViewModel(db: db) { _, _ in .init(count: 0, formatted: "", results: []) }
+        empty.setMode(.search)
+        empty.inputText = "no matching memory"
+        empty.submit()
+        XCTAssertTrue(empty.results.isEmpty)
+        XCTAssertTrue(empty.feedback.isIdle)
+        try render(
+            CommandShellSnapshot(viewModel: empty, compact: false),
+            named: "search-shell-empty.png",
+            directory: renderDirectory,
+            size: NSSize(width: 820, height: 360)
+        )
+
+        let error = makeViewModel(db: db) { _, _ in throw SearchFixtureError.unavailable }
+        error.setMode(.search)
+        error.inputText = "temporarily unavailable"
+        error.submit()
+        XCTAssertEqual(error.feedback, .error("Fixture search unavailable"))
+        try render(
+            CommandShellSnapshot(viewModel: error, compact: false),
+            named: "search-shell-error.png",
+            directory: renderDirectory,
+            size: NSSize(width: 820, height: 360)
+        )
+
+        let compact = makeViewModel(db: db) { _, _ in .init(count: 0, formatted: "", results: []) }
+        try render(
+            CommandShellSnapshot(viewModel: compact, compact: true),
+            named: "search-shell-compact-command-bar.png",
+            directory: renderDirectory,
+            size: NSSize(width: 520, height: 72)
+        )
+    }
+
+    private func makeViewModel(
+        db: BrainDatabase,
+        search: @escaping QuickCaptureSearch
+    ) -> QuickCaptureViewModel {
+        QuickCaptureViewModel(
+            db: db,
+            panelState: QuickCapturePanelState(),
+            feedbackAutoClearDelay: .seconds(60),
+            searchDebounceDelay: .seconds(60),
+            search: search
+        )
+    }
+
+    nonisolated private static func fixedSearchResult(
+        query: String,
+        limit: Int
+    ) -> QuickCaptureController.SearchResult {
+        let rows: [[String: Any]] = [
+            [
+                "chunk_id": "watcher-truth-contract",
+                "content": "Watcher liveness uses process plus recent distinct-ingest evidence.",
+                "full_content": "Watcher liveness uses process plus recent distinct-ingest evidence.",
+                "created_at": "2026-07-19T10:00:00Z",
+                "importance": 9,
+            ],
+            [
+                "chunk_id": "freshness-contract",
+                "content": "Dashboard snapshots become stale strictly after sixty seconds.",
+                "full_content": "Dashboard snapshots become stale strictly after sixty seconds.",
+                "created_at": "2026-07-19T09:55:00Z",
+                "importance": 8,
+            ],
+        ]
+        return .init(count: min(rows.count, limit), formatted: query, results: Array(rows.prefix(limit)))
+    }
+
+    private func render<V: View>(
+        _ view: V,
+        named name: String,
+        directory: String,
+        size: NSSize
+    ) throws {
+        let host = NSHostingView(rootView: view.environment(\.colorScheme, .dark))
+        host.frame = NSRect(origin: .zero, size: size)
+        host.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.25))
+        host.layoutSubtreeIfNeeded()
+
+        guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+            throw SearchSnapshotError.bitmapUnavailable(name)
+        }
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        guard let png = bitmap.representation(using: .png, properties: [:]) else {
+            throw SearchSnapshotError.encodingFailed(name)
+        }
+
+        let output = URL(fileURLWithPath: directory, isDirectory: true).appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: output.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try png.write(to: output)
+        XCTAssertGreaterThan(png.count, 5_000, "Expected a substantive Search/shell PNG for \(name)")
+        XCTAssertGreaterThan(distinctSampledColorCount(in: bitmap), 12, "Expected visible Search/shell content for \(name)")
+        print("[brainbar-render] wrote \(output.path) (\(png.count) bytes)")
+    }
+
+    private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
+        guard let data = bitmap.bitmapData else { return 0 }
+        let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
+        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        var colors = Set<String>()
+        for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
+            let rowStart = y * bitmap.bytesPerRow
+            for x in stride(from: 0, to: bitmap.bytesPerRow, by: sampleStride) {
+                let offset = rowStart + x
+                guard offset + 2 < bitmap.bytesPerRow * bitmap.pixelsHigh else { continue }
+                colors.insert("\(data[offset])-\(data[offset + 1])-\(data[offset + 2])")
+            }
+        }
+        return colors.count
+    }
+}
+
+private struct CommandShellSnapshot: View {
+    @ObservedObject var viewModel: QuickCaptureViewModel
+    let compact: Bool
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Color.brainBarBackgroundBase
+            VStack(spacing: 0) {
+                BrainBarCommandBar(viewModel: viewModel)
+                if !compact {
+                    BrainBarCommandBarResultsOverlay(viewModel: viewModel, isOnActiveTab: true)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .padding(compact ? 8 : 18)
+        }
+        .transaction { $0.disablesAnimations = true }
+    }
+}
+
+private enum SearchFixtureError: LocalizedError {
+    case unavailable
+
+    var errorDescription: String? { "Fixture search unavailable" }
+}
+
+private enum SearchSnapshotError: Error {
+    case bitmapUnavailable(String)
+    case encodingFailed(String)
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarP6SearchSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarP6SearchSnapshotTests.swift
@@ -149,7 +149,7 @@ final class BrainBarP6SearchSnapshotTests: XCTestCase {
         let baseStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
         let sampleStride = baseStride - (baseStride % bytesPerPixel)
         var colors = Set<String>()
-        for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
+        for y in stride(from: 0, to: bitmap.pixelsHigh, by: 12) {
             let rowStart = y * bitmap.bytesPerRow
             for x in stride(from: 0, to: bitmap.bytesPerRow, by: sampleStride) {
                 let offset = rowStart + x

--- a/brain-bar/Tests/BrainBarTests/BrainBarP6SearchSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarP6SearchSnapshotTests.swift
@@ -146,7 +146,8 @@ final class BrainBarP6SearchSnapshotTests: XCTestCase {
     private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
         guard let data = bitmap.bitmapData else { return 0 }
         let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
-        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let baseStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let sampleStride = baseStride - (baseStride % bytesPerPixel)
         var colors = Set<String>()
         for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
             let rowStart = y * bitmap.bytesPerRow

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
@@ -38,6 +38,17 @@ final class BrainBarSettingsSnapshotTests: XCTestCase {
         validationViewModel.backendDraft = "   "
         validationViewModel.commitBackendDraft()
         try render(viewModel: validationViewModel, named: "validation-error")
+
+        let probeErrorViewModel = try makeViewModel(
+            root: tempRoot,
+            name: "probe-error",
+            config: .defaultConfig
+        )
+        XCTAssertEqual(
+            probeErrorViewModel.config.launchdJobs[.watch]?.loadState,
+            .probeError("launchctl exited 1")
+        )
+        try render(viewModel: probeErrorViewModel, named: "launchctl-probe-error")
     }
 
     @MainActor

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
@@ -118,7 +118,8 @@ final class BrainBarSettingsSnapshotTests: XCTestCase {
     private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
         guard let data = bitmap.bitmapData else { return 0 }
         let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
-        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let baseStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let sampleStride = baseStride - (baseStride % bytesPerPixel)
         var colors = Set<String>()
         for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
             let rowStart = y * bitmap.bytesPerRow

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsSnapshotTests.swift
@@ -5,40 +5,69 @@ import XCTest
 
 final class BrainBarSettingsSnapshotTests: XCTestCase {
     @MainActor
-    func testSettingsViewRendersConfigBackedPanelScreenshot() throws {
+    func testSettingsViewRendersProviderJobsAndSaveTruthScenarios() throws {
         let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("brainbar-settings-\(UUID().uuidString)", isDirectory: true)
-        let configURL = tempRoot
-            .appendingPathComponent(".config", isDirectory: true)
-            .appendingPathComponent("brainlayer", isDirectory: true)
-            .appendingPathComponent("brainlayer.env", isDirectory: false)
-        var config = BrainLayerConfig.defaultConfig
-        config.googleAPIKey = .onePasswordReference("op://Private/Google AI/Gemini API key")
-        config.enrichmentEnabled = true
-        config.enrichmentMode = .remote
-        config.enrichmentProvider = .gemini
-        config.enrichmentBackend = "gemini"
-        config.launchdJobs[.drain]?.enabled = true
-        config.launchdJobs[.hotlane]?.enabled = false
-
-        let store = BrainLayerConfigStore(configURL: configURL)
-        try store.save(config)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
-        let viewModel = BrainBarSettingsViewModel(
+        var providerConfig = BrainLayerConfig.defaultConfig
+        providerConfig.googleAPIKey = .onePasswordReference("op://Private/Google AI/Gemini API key")
+        providerConfig.enrichmentProvider = .openai
+        providerConfig.launchdJobs[.hotlane]?.enabled = false
+        let providerViewModel = try makeViewModel(
+            root: tempRoot,
+            name: "provider",
+            config: providerConfig
+        )
+        try render(viewModel: providerViewModel, named: "provider-and-jobs")
+
+        let savedViewModel = try makeViewModel(
+            root: tempRoot,
+            name: "saved",
+            config: .defaultConfig
+        )
+        savedViewModel.backendDraft = "mlx"
+        savedViewModel.commitBackendDraft()
+        try render(viewModel: savedViewModel, named: "saved-restart-needed")
+
+        let validationViewModel = try makeViewModel(
+            root: tempRoot,
+            name: "validation",
+            config: .defaultConfig
+        )
+        validationViewModel.backendDraft = "   "
+        validationViewModel.commitBackendDraft()
+        try render(viewModel: validationViewModel, named: "validation-error")
+    }
+
+    @MainActor
+    private func makeViewModel(
+        root: URL,
+        name: String,
+        config: BrainLayerConfig
+    ) throws -> BrainBarSettingsViewModel {
+        let configURL = root.appendingPathComponent("\(name)-brainlayer.env")
+        let store = BrainLayerConfigStore(configURL: configURL)
+        try store.save(config)
+        let states: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] = [
+            .enrichment: .loaded,
+            .hotlane: .unloaded,
+            .drain: .running,
+            .watch: .probeError("launchctl exited 1"),
+        ]
+        return BrainBarSettingsViewModel(
             store: store,
-            launchdStatusProvider: StaticBrainLayerLaunchdStatusProvider(states: [
-                .enrichment: .loaded,
-                .hotlane: .unloaded,
-                .drain: .running,
-            ]),
-            initialLaunchdStates: [
-                .enrichment: .loaded,
-                .hotlane: .unloaded,
-                .drain: .running,
-            ],
+            launchdStatusProvider: StaticBrainLayerLaunchdStatusProvider(states: states),
+            runtimeStatusProvider: StaticBrainLayerActiveRuntimeProvider(
+                observation: .unknown("Active runtime configuration is not observable.")
+            ),
+            initialLaunchdStates: states,
             refreshStatusOnLoad: false
         )
+    }
+
+    @MainActor
+    private func render(viewModel: BrainBarSettingsViewModel, named name: String) throws {
         let view = NSHostingView(rootView: BrainBarSettingsView(viewModel: viewModel))
         view.frame = NSRect(x: 0, y: 0, width: 700, height: 1_080)
         view.layoutSubtreeIfNeeded()
@@ -54,23 +83,25 @@ final class BrainBarSettingsSnapshotTests: XCTestCase {
             return
         }
 
-        let url = screenshotURL()
+        let url = screenshotURL(named: name)
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try png.write(to: url)
         XCTAssertGreaterThan(png.count, 1_000)
         XCTAssertGreaterThan(distinctSampledColorCount(in: bitmap), 8)
     }
 
-    private func screenshotURL() -> URL {
-        if let override = ProcessInfo.processInfo.environment["BRAINBAR_SETTINGS_SCREENSHOT_PATH"],
+    private func screenshotURL(named name: String) -> URL {
+        if let override = ProcessInfo.processInfo.environment["BRAINBAR_SETTINGS_RENDER_DIR"],
            !override.isEmpty {
-            return URL(fileURLWithPath: override)
+            return URL(fileURLWithPath: override, isDirectory: true)
+                .appendingPathComponent("settings-\(name).png")
         }
-        return URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("docs.local/brainbar-settings-ui-phase2/brainbar-settings.png")
+        return URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(
+                "brainbar-p5-settings-renders-\(ProcessInfo.processInfo.processIdentifier)",
+                isDirectory: true
+            )
+            .appendingPathComponent("settings-\(name).png")
     }
 
     private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
@@ -242,7 +242,12 @@ final class BrainBarSettingsViewModelTests: XCTestCase {
 
         provider.replaceStates(with: [.drain: .unloaded])
         fixture.viewModel.refreshLaunchdStatus()
+        let deadline = Date().addingTimeInterval(2)
         while fixture.viewModel.isRefreshingLaunchdStatus {
+            if Date() > deadline {
+                XCTFail("Timed out waiting for launchd refresh to complete")
+                break
+            }
             await Task.yield()
         }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
@@ -65,6 +65,38 @@ final class BrainBarSettingsViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testExistingUnavailableProviderDoesNotTrapSafeDisableOrUnrelatedEdits() throws {
+        var config = BrainLayerConfig.defaultConfig
+        config.enrichmentProvider = .openai
+        config.enrichmentBackend = "openai"
+        let fixture = try makeFixture(config: config)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.setSystemEnabled(false)
+        fixture.viewModel.setEnrichmentEnabled(false)
+
+        let persisted = try fixture.store.loadDocument().config
+        XCTAssertFalse(persisted.systemEnabled)
+        XCTAssertFalse(persisted.enrichmentEnabled)
+        XCTAssertEqual(persisted.enrichmentProvider, .openai)
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.validation, .passed)
+    }
+
+    @MainActor
+    func testSelectingGeminiRepairsWhitespaceOnlyBackend() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        fixture.viewModel.config.enrichmentProvider = .openai
+        fixture.viewModel.config.enrichmentBackend = "   "
+
+        fixture.viewModel.setEnrichmentProvider(.gemini)
+
+        XCTAssertEqual(fixture.viewModel.config.enrichmentProvider, .gemini)
+        XCTAssertEqual(fixture.viewModel.config.enrichmentBackend, "gemini")
+        XCTAssertEqual(try fixture.store.loadDocument().config.enrichmentBackend, "gemini")
+    }
+
+    @MainActor
     func testSaveKeepsConfiguredAndActiveValuesSeparateUntilRuntimeObservesChange() throws {
         let initial = BrainLayerConfig.defaultConfig
         let fixture = try makeFixture(
@@ -138,6 +170,45 @@ final class BrainBarSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(
             fixture.viewModel.lastSaveReceipt?.activeRuntimeState,
             .unknown("Configuration file changed, but reload validation failed.")
+        )
+    }
+
+    @MainActor
+    func testReloadErrorAfterSuccessfulWriteReportsFileUpdatedTruthfully() throws {
+        let configURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-settings-reload-error-\(UUID().uuidString).env")
+        var persisted = BrainLayerConfig.defaultConfig
+        var loadCount = 0
+        let now = fixedNow
+        let store = BrainLayerConfigStore(
+            configURL: configURL,
+            loadDocumentOverride: {
+                loadCount += 1
+                if loadCount > 1 {
+                    throw CocoaError(.fileReadUnknown)
+                }
+                return BrainLayerEnvDocument(config: persisted)
+            },
+            saveOverride: { persisted = $0 }
+        )
+        let viewModel = BrainBarSettingsViewModel(
+            store: store,
+            launchdStatusProvider: StaticBrainLayerLaunchdStatusProvider(states: [:]),
+            refreshStatusOnLoad: false,
+            now: { now }
+        )
+
+        viewModel.setSystemEnabled(false)
+
+        XCTAssertFalse(persisted.systemEnabled)
+        XCTAssertEqual(viewModel.lastSaveReceipt?.fileUpdated, true)
+        XCTAssertEqual(
+            viewModel.lastSaveReceipt?.validation,
+            .failed("Saved configuration could not be reloaded.")
+        )
+        XCTAssertEqual(
+            viewModel.lastSaveReceipt?.activeRuntimeState,
+            .unknown("Configuration file changed, but reload failed.")
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarSettingsViewModelTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import BrainBar
 
 final class BrainBarSettingsViewModelTests: XCTestCase {
+    private let fixedNow = Date(timeIntervalSince1970: 1_784_466_000)
+
     @MainActor
     func testFailedSaveLeavesDisplayedConfigAtLastPersistedValue() throws {
         let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -45,5 +47,199 @@ final class BrainBarSettingsViewModelTests: XCTestCase {
         viewModel.commitBackendDraft()
         document = try store.loadDocument()
         XCTAssertEqual(document.config.enrichmentBackend, "mlx")
+    }
+
+    @MainActor
+    func testUnwiredProviderCannotReplaceConfiguredProvider() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.setEnrichmentProvider(.openai)
+
+        XCTAssertEqual(fixture.viewModel.config.enrichmentProvider, .gemini)
+        XCTAssertEqual(
+            fixture.viewModel.lastSaveReceipt?.validation,
+            .failed("OpenAI cannot be activated because its runtime integration is unavailable.")
+        )
+        XCTAssertEqual(try fixture.store.loadDocument().config.enrichmentProvider, .gemini)
+    }
+
+    @MainActor
+    func testSaveKeepsConfiguredAndActiveValuesSeparateUntilRuntimeObservesChange() throws {
+        let initial = BrainLayerConfig.defaultConfig
+        let fixture = try makeFixture(
+            runtimeObservation: .observed(BrainLayerActiveRuntimeValues(config: initial))
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.backendDraft = "mlx"
+        fixture.viewModel.commitBackendDraft()
+
+        XCTAssertEqual(fixture.viewModel.config.enrichmentBackend, "mlx")
+        XCTAssertEqual(
+            fixture.viewModel.activeRuntimeObservation,
+            .observed(BrainLayerActiveRuntimeValues(config: initial))
+        )
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.fileUpdated, true)
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.validation, .passed)
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.servicesRequiringRestart, [.enrichment])
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.activeRuntimeState, .notObserved)
+        XCTAssertEqual(try fixture.store.loadDocument().config.enrichmentBackend, "mlx")
+    }
+
+    @MainActor
+    func testSaveReceiptReportsWhenActiveRuntimeAlreadyMatchesConfiguredValue() throws {
+        var active = BrainLayerConfig.defaultConfig
+        active.enrichmentBackend = "mlx"
+        let fixture = try makeFixture(
+            runtimeObservation: .observed(BrainLayerActiveRuntimeValues(config: active))
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.backendDraft = "mlx"
+        fixture.viewModel.commitBackendDraft()
+
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.activeRuntimeState, .observed)
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.savedAt, fixedNow)
+    }
+
+    @MainActor
+    func testValidationErrorDoesNotOverwritePersistedConfig() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.backendDraft = "   "
+        fixture.viewModel.commitBackendDraft()
+
+        XCTAssertEqual(fixture.viewModel.config.enrichmentBackend, "gemini")
+        XCTAssertEqual(try fixture.store.loadDocument().config.enrichmentBackend, "gemini")
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.fileUpdated, false)
+        XCTAssertEqual(
+            fixture.viewModel.lastSaveReceipt?.validation,
+            .failed("Enrichment backend is required.")
+        )
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.servicesRequiringRestart, [])
+    }
+
+    @MainActor
+    func testPostWriteReloadMismatchStillReportsThatFileChanged() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.backendDraft = "MLX"
+        fixture.viewModel.commitBackendDraft()
+
+        XCTAssertEqual(try fixture.store.loadDocument().config.enrichmentBackend, "mlx")
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.fileUpdated, true)
+        XCTAssertEqual(
+            fixture.viewModel.lastSaveReceipt?.validation,
+            .failed("Saved configuration did not validate on reload.")
+        )
+        XCTAssertEqual(
+            fixture.viewModel.lastSaveReceipt?.activeRuntimeState,
+            .unknown("Configuration file changed, but reload validation failed.")
+        )
+    }
+
+    @MainActor
+    func testJobSaveSeparatesConfiguredIntentFromActiveLaunchdState() throws {
+        let fixture = try makeFixture(initialLaunchdStates: [.drain: .running])
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.setJob(.drain, enabled: false)
+
+        XCTAssertEqual(fixture.viewModel.config.launchdJobs[.drain]?.enabled, false)
+        XCTAssertEqual(fixture.viewModel.config.launchdJobs[.drain]?.loadState, .running)
+        XCTAssertEqual(
+            fixture.viewModel.lastSaveReceipt?.servicesRequiringRestart,
+            [.launchdJob(.drain)]
+        )
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.activeRuntimeState, .notObserved)
+    }
+
+    @MainActor
+    func testRefreshUpdatesSaveReceiptAfterLaunchdObservesConfiguredState() async throws {
+        let provider = MutableBrainLayerLaunchdStatusProvider(states: [.drain: .running])
+        let fixture = try makeFixture(
+            launchdStatusProvider: provider,
+            initialLaunchdStates: [.drain: .running]
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        fixture.viewModel.setJob(.drain, enabled: false)
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.activeRuntimeState, .notObserved)
+
+        provider.replaceStates(with: [.drain: .unloaded])
+        fixture.viewModel.refreshLaunchdStatus()
+        while fixture.viewModel.isRefreshingLaunchdStatus {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(fixture.viewModel.config.launchdJobs[.drain]?.loadState, .unloaded)
+        XCTAssertEqual(fixture.viewModel.lastSaveReceipt?.activeRuntimeState, .observed)
+    }
+
+    @MainActor
+    func testSecretSaveReceiptAndDebugOutputNeverContainSecret() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let secret = "settings-secret-fixture-value"
+
+        fixture.viewModel.pendingPlainAPIKey = secret
+        fixture.viewModel.storePlainAPIKey()
+
+        XCTAssertEqual(fixture.viewModel.config.googleAPIKey.kind, .plainPresent)
+        XCTAssertNotNil(fixture.viewModel.lastSaveReceipt)
+        XCTAssertFalse(String(reflecting: fixture.viewModel.lastSaveReceipt).contains(secret))
+        XCTAssertFalse(String(reflecting: fixture.viewModel.config.googleAPIKey).contains(secret))
+    }
+
+    @MainActor
+    private func makeFixture(
+        config: BrainLayerConfig = .defaultConfig,
+        runtimeObservation: BrainLayerActiveRuntimeObservation = .unknown(
+            "Active runtime configuration is not observable."
+        ),
+        launchdStatusProvider: (any BrainLayerLaunchdStatusSampling)? = nil,
+        initialLaunchdStates: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] = [:]
+    ) throws -> (
+        root: URL,
+        store: BrainLayerConfigStore,
+        viewModel: BrainBarSettingsViewModel
+    ) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("brainbar-settings-model-\(UUID().uuidString)", isDirectory: true)
+        let store = BrainLayerConfigStore(configURL: root.appendingPathComponent("brainlayer.env"))
+        try store.save(config)
+        let now = fixedNow
+        let viewModel = BrainBarSettingsViewModel(
+            store: store,
+            launchdStatusProvider: launchdStatusProvider ??
+                StaticBrainLayerLaunchdStatusProvider(states: initialLaunchdStates),
+            runtimeStatusProvider: StaticBrainLayerActiveRuntimeProvider(observation: runtimeObservation),
+            initialLaunchdStates: initialLaunchdStates,
+            refreshStatusOnLoad: false,
+            now: { now }
+        )
+        return (root, store, viewModel)
+    }
+}
+
+private final class MutableBrainLayerLaunchdStatusProvider: BrainLayerLaunchdStatusSampling, @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]
+
+    init(states: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]) {
+        self.states = states
+    }
+
+    func replaceStates(with states: [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState]) {
+        lock.withLock {
+            self.states = states
+        }
+    }
+
+    func sample() -> [BrainLayerLaunchdJob: BrainLayerLaunchdLoadState] {
+        lock.withLock { states }
     }
 }

--- a/brain-bar/Tests/BrainBarTests/BrainBarTruthFoundationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarTruthFoundationTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import BrainBar
+
+final class BrainBarTruthFoundationTests: XCTestCase {
+    func testMetricContractsNameClockAndCardinality() {
+        XCTAssertEqual(
+            DashboardMetricContract.chunkRows,
+            MetricContract(clock: .sourceTime, cardinality: .chunkRows)
+        )
+        XCTAssertEqual(
+            DashboardMetricContract.agentOriginChunks,
+            MetricContract(clock: .sourceTime, cardinality: .chunkRows)
+        )
+        XCTAssertEqual(
+            DashboardMetricContract.watcherIngestedChunks,
+            MetricContract(clock: .ingestTime, cardinality: .distinctChunkIDs)
+        )
+    }
+
+    func testWatcherFlowStateUsesOnlyTypedLiveEvidence() {
+        XCTAssertEqual(
+            WatcherFlowState.derive(
+                process: .running(pid: 42),
+                recentDistinctChunkCount: 1,
+                recentFlowReadable: true,
+                pendingWorkCount: 0
+            ),
+            .flowing
+        )
+        XCTAssertEqual(
+            WatcherFlowState.derive(
+                process: .running(pid: 42),
+                recentDistinctChunkCount: 0,
+                recentFlowReadable: true,
+                pendingWorkCount: 2
+            ),
+            .stalled
+        )
+        XCTAssertEqual(
+            WatcherFlowState.derive(
+                process: .running(pid: 42),
+                recentDistinctChunkCount: 0,
+                recentFlowReadable: true,
+                pendingWorkCount: 0
+            ),
+            .runningNoRecentFlow
+        )
+        XCTAssertEqual(
+            WatcherFlowState.derive(
+                process: .absent,
+                recentDistinctChunkCount: 10,
+                recentFlowReadable: true,
+                pendingWorkCount: 10
+            ),
+            .offline
+        )
+        XCTAssertEqual(
+            WatcherFlowState.derive(
+                process: .running(pid: 42),
+                recentDistinctChunkCount: 0,
+                recentFlowReadable: false,
+                pendingWorkCount: 0
+            ),
+            .runningFlowUnverified
+        )
+        XCTAssertEqual(
+            WatcherFlowState.derive(
+                process: .failure("launchctl timed out"),
+                recentDistinctChunkCount: 0,
+                recentFlowReadable: false,
+                pendingWorkCount: 0
+            ),
+            .unknown
+        )
+    }
+
+    func testSnapshotFreshnessStrictlyCrossesAfterSixtySeconds() {
+        let success = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertEqual(
+            SnapshotFreshnessState.derive(
+                lastSuccessAt: nil,
+                isRefreshing: true,
+                lastFetchError: nil,
+                now: success,
+                snapshotFreshnessThreshold: 60
+            ),
+            .loading
+        )
+        XCTAssertEqual(
+            SnapshotFreshnessState.derive(
+                lastSuccessAt: success,
+                isRefreshing: false,
+                lastFetchError: nil,
+                now: success.addingTimeInterval(60),
+                snapshotFreshnessThreshold: 60
+            ),
+            .live(ageSeconds: 60)
+        )
+        XCTAssertEqual(
+            SnapshotFreshnessState.derive(
+                lastSuccessAt: success,
+                isRefreshing: false,
+                lastFetchError: nil,
+                now: success.addingTimeInterval(60.001),
+                snapshotFreshnessThreshold: 60
+            ),
+            .stale(ageSeconds: 60)
+        )
+        XCTAssertEqual(
+            SnapshotFreshnessState.derive(
+                lastSuccessAt: success,
+                isRefreshing: false,
+                lastFetchError: "read failed",
+                now: success.addingTimeInterval(15),
+                snapshotFreshnessThreshold: 60
+            ),
+            .error(message: "read failed", lastSuccessAgeSeconds: 15)
+        )
+    }
+
+    func testLaunchctlWatcherProbeDistinguishesRunningAbsentAndFailure() {
+        let running = LaunchctlWatcherProcessProbe(
+            commandRunner: { _ in
+                LaunchctlWatcherProcessProbe.CommandResult(
+                    terminationStatus: 0,
+                    output: "state = running\npid = 4242\n"
+                )
+            },
+            uidProvider: { 501 }
+        )
+        XCTAssertEqual(running.sample(), .running(pid: 4242))
+
+        let absent = LaunchctlWatcherProcessProbe(
+            commandRunner: { _ in
+                LaunchctlWatcherProcessProbe.CommandResult(
+                    terminationStatus: 113,
+                    output: "Could not find service com.brainlayer.watch"
+                )
+            },
+            uidProvider: { 501 }
+        )
+        XCTAssertEqual(absent.sample(), .absent)
+
+        let failed = LaunchctlWatcherProcessProbe(
+            commandRunner: { _ in
+                LaunchctlWatcherProcessProbe.CommandResult(
+                    terminationStatus: 1,
+                    output: "operation timed out"
+                )
+            },
+            uidProvider: { 501 }
+        )
+        XCTAssertEqual(failed.sample(), .failure("operation timed out"))
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/BrainBarTruthFoundationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarTruthFoundationTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import BrainBar
 
 final class BrainBarTruthFoundationTests: XCTestCase {
+    deinit {}
+
     func testMetricContractsNameClockAndCardinality() {
         XCTAssertEqual(
             DashboardMetricContract.chunkRows,

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -189,7 +189,8 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activeEntriesPerMinute: 0,
                 realtimeInsertsPerMinute: 0,
                 updatedAt: now
-            )
+            ),
+            watcherProcessProbeResult: .running(pid: 4242)
         )
 
         let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
@@ -197,7 +198,7 @@ final class BrainBarUXLogicTests: XCTestCase {
 
         XCTAssertEqual(summary.ingress.status, .live)
         XCTAssertEqual(watcherLane.status, .idle)
-        XCTAssertEqual(watcherLane.statusText, "No JSONL watcher writes")
+        XCTAssertEqual(watcherLane.statusText, "RUNNING · NO RECENT FLOW")
         XCTAssertEqual(watcherLane.lastEventText, "No watcher writes in Last 30m")
     }
 
@@ -253,7 +254,8 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activeEntriesPerMinute: 0,
                 realtimeInsertsPerMinute: 454,
                 updatedAt: now
-            )
+            ),
+            watcherProcessProbeResult: .running(pid: 4242)
         )
 
         let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
@@ -297,7 +299,8 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activeEntriesPerMinute: 0,
                 realtimeInsertsPerMinute: 12,
                 updatedAt: now
-            )
+            ),
+            watcherProcessProbeResult: .running(pid: 4242)
         )
 
         let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
@@ -401,7 +404,7 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(agentLane.lastEventText, "2 agent MCP stores in latest bucket; 5 flush queued")
     }
 
-    func testJsonlWatcherLaneMarksFlatGraphBrokenWhenHealthSeesActiveJsonl() {
+    func testJsonlWatcherLaneDoesNotTreatHistoricalActivityMarkerAsLiveFlowTruth() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
@@ -423,17 +426,18 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activeEntriesPerMinute: 8.5,
                 realtimeInsertsPerMinute: 0,
                 updatedAt: now
-            )
+            ),
+            watcherProcessProbeResult: .running(pid: 4242)
         )
 
         let watcherLane = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
             .lane(for: .jsonlWatcher)
 
-        XCTAssertEqual(watcherLane.status, .unavailable)
-        XCTAssertEqual(watcherLane.statusText, "Watcher stale: JSONL activity is not landing")
+        XCTAssertEqual(watcherLane.status, .idle)
+        XCTAssertEqual(watcherLane.statusText, "RUNNING · NO RECENT FLOW")
     }
 
-    func testJsonlWatcherLaneMarksStaleWatcherHealthUnavailable() {
+    func testJsonlWatcherLaneIgnoresStaleHistoricalMarkerWhenLiveEvidenceIsKnown() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
@@ -455,17 +459,18 @@ final class BrainBarUXLogicTests: XCTestCase {
                 activeEntriesPerMinute: 0,
                 realtimeInsertsPerMinute: 0,
                 updatedAt: now.addingTimeInterval(-601)
-            )
+            ),
+            watcherProcessProbeResult: .running(pid: 4242)
         )
 
         let watcherLane = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
             .lane(for: .jsonlWatcher)
 
-        XCTAssertEqual(watcherLane.status, .unavailable)
-        XCTAssertEqual(watcherLane.statusText, "Watcher health stale")
+        XCTAssertEqual(watcherLane.status, .idle)
+        XCTAssertEqual(watcherLane.statusText, "RUNNING · NO RECENT FLOW")
     }
 
-    func testJsonlWatcherLaneMarksMissingWatcherHealthUnavailable() {
+    func testJsonlWatcherLaneReportsOfflineFromAbsentProcessWithoutHistoricalMarker() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
@@ -479,26 +484,20 @@ final class BrainBarUXLogicTests: XCTestCase {
             recentWatcherWriteBuckets: [0, 0, 0, 0],
             recentEnrichmentBuckets: [0, 0, 0, 0],
             activityWindowMinutes: 30,
-            bucketCount: 4
+            bucketCount: 4,
+            watcherProcessProbeResult: .absent
         )
 
         let watcherLane = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
             .lane(for: .jsonlWatcher)
 
         XCTAssertEqual(watcherLane.status, .unavailable)
-        XCTAssertEqual(watcherLane.statusText, "Watcher health unavailable")
+        XCTAssertEqual(watcherLane.statusText, "OFFLINE")
     }
 
     func testWatcherFlowStateMatrixUsesProcessRecentDistinctFlowAndPendingEvidence() {
         let now = Date(timeIntervalSince1970: 1_000_000)
-        let running = DaemonHealthSnapshot(
-            pid: 4242,
-            isResponsive: true,
-            rssBytes: 1_024,
-            uptime: 60,
-            openConnections: 1,
-            lastSeenAt: now
-        )
+        let running = WatcherProcessProbeResult.running(pid: 4242)
         let historicalMarker = DashboardStats.WatcherHealth(
             alerting: false,
             filesTracked: 12,
@@ -517,10 +516,11 @@ final class BrainBarUXLogicTests: XCTestCase {
         )
 
         func watcherStatusText(
-            process: DaemonHealthSnapshot?,
+            process: WatcherProcessProbeResult,
             recentDistinctChunks: [Int],
             pendingDepth: Int,
-            historicalHealth: DashboardStats.WatcherHealth?
+            historicalHealth: DashboardStats.WatcherHealth?,
+            recentFlowReadable: Bool = true
         ) -> String {
             let stats = DashboardStats(
                 chunkCount: 120,
@@ -538,9 +538,12 @@ final class BrainBarUXLogicTests: XCTestCase {
                 liveWindowMinutes: 1,
                 pendingStoreQueueDepth: pendingDepth,
                 pendingStoreFlushQueueDepth: pendingDepth,
-                watcherHealth: historicalHealth
+                watcherHealth: historicalHealth,
+                watcherProcessProbeResult: process,
+                watcherRecentDistinctChunkCount: recentDistinctChunks.reduce(0, +),
+                watcherFlowReadability: recentFlowReadable ? .readable : .unreadable("fixture")
             )
-            return DashboardFlowSummary.derive(daemon: process, stats: stats, now: now)
+            return DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
                 .lane(for: .jsonlWatcher)
                 .statusText
         }
@@ -574,7 +577,7 @@ final class BrainBarUXLogicTests: XCTestCase {
         )
         XCTAssertEqual(
             watcherStatusText(
-                process: nil,
+                process: .absent,
                 recentDistinctChunks: [0, 0, 0, 0],
                 pendingDepth: 0,
                 historicalHealth: historicalMarker
@@ -596,23 +599,25 @@ final class BrainBarUXLogicTests: XCTestCase {
                 process: running,
                 recentDistinctChunks: [0, 0, 0, 0],
                 pendingDepth: 0,
-                historicalHealth: nil
+                historicalHealth: nil,
+                recentFlowReadable: false
             ),
             "RUNNING · FLOW UNVERIFIED"
         )
         XCTAssertEqual(
             watcherStatusText(
-                process: nil,
+                process: .failure("launchctl timed out"),
                 recentDistinctChunks: [0, 0, 0, 0],
                 pendingDepth: 0,
-                historicalHealth: nil
+                historicalHealth: nil,
+                recentFlowReadable: false
             ),
             "UNKNOWN",
             "Ambiguous process-probe failure plus unavailable flow evidence must fail closed, not claim OFFLINE."
         )
     }
 
-    func testJsonlWatcherLaneMarksTimestamplessWatcherHealthUnavailable() {
+    func testJsonlWatcherLaneIgnoresTimestamplessHistoricalMarkerWhenLiveEvidenceIsKnown() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
@@ -633,14 +638,15 @@ final class BrainBarUXLogicTests: XCTestCase {
                 maxOffsetLagBytes: 0,
                 activeEntriesPerMinute: 0,
                 realtimeInsertsPerMinute: 0
-            )
+            ),
+            watcherProcessProbeResult: .running(pid: 4242)
         )
 
         let watcherLane = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
             .lane(for: .jsonlWatcher)
 
-        XCTAssertEqual(watcherLane.status, .unavailable)
-        XCTAssertEqual(watcherLane.statusText, "Watcher health stale")
+        XCTAssertEqual(watcherLane.status, .idle)
+        XCTAssertEqual(watcherLane.statusText, "RUNNING · NO RECENT FLOW")
     }
 
     func testDashboardFlowSummaryKeepsRecentEnrichmentDistinctFromLiveNow() {

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -202,6 +202,39 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(watcherLane.lastEventText, "No watcher-ingested chunks in Last 30m")
     }
 
+    func testWatcherStateDoesNotBorrowDaemonPIDWhenProbeEvidenceIsMissing() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let stats = DashboardStats(
+            chunkCount: 1,
+            enrichedChunkCount: 1,
+            pendingEnrichmentCount: 0,
+            enrichmentPercent: 100,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 4_096,
+            recentActivityBuckets: [1],
+            recentWatcherWriteBuckets: [1],
+            recentEnrichmentBuckets: [1],
+            activityWindowMinutes: 60,
+            bucketCount: 1,
+            watcherProcessProbeResult: nil,
+            watcherRecentDistinctChunkCount: 1,
+            watcherFlowReadability: .readable
+        )
+        let daemon = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: now
+        )
+
+        let summary = DashboardFlowSummary.derive(daemon: daemon, stats: stats, now: now)
+
+        XCTAssertEqual(summary.watcherFlowState, .unknown)
+        XCTAssertEqual(summary.lane(for: .jsonlWatcher).statusText, "UNKNOWN")
+    }
+
     func testAgentStoresLaneDoesNotBorrowLiveStatusFromJsonlWatcher() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -489,6 +489,129 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(watcherLane.statusText, "Watcher health unavailable")
     }
 
+    func testWatcherFlowStateMatrixUsesProcessRecentDistinctFlowAndPendingEvidence() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let running = DaemonHealthSnapshot(
+            pid: 4242,
+            isResponsive: true,
+            rssBytes: 1_024,
+            uptime: 60,
+            openConnections: 1,
+            lastSeenAt: now
+        )
+        let historicalMarker = DashboardStats.WatcherHealth(
+            alerting: false,
+            filesTracked: 12,
+            maxOffsetLagBytes: 0,
+            activeEntriesPerMinute: 0,
+            realtimeInsertsPerMinute: 0,
+            updatedAt: now
+        )
+        let alertingHistoricalMarker = DashboardStats.WatcherHealth(
+            alerting: true,
+            filesTracked: 12,
+            maxOffsetLagBytes: 10_000,
+            activeEntriesPerMinute: 0,
+            realtimeInsertsPerMinute: 0,
+            updatedAt: now.addingTimeInterval(-3_600)
+        )
+
+        func watcherStatusText(
+            process: DaemonHealthSnapshot?,
+            recentDistinctChunks: [Int],
+            pendingDepth: Int,
+            historicalHealth: DashboardStats.WatcherHealth?
+        ) -> String {
+            let stats = DashboardStats(
+                chunkCount: 120,
+                enrichedChunkCount: 120,
+                pendingEnrichmentCount: 0,
+                enrichmentPercent: 100,
+                enrichmentRatePerMinute: 0,
+                databaseSizeBytes: 4_096,
+                recentActivityBuckets: recentDistinctChunks,
+                recentAgentWriteBuckets: Array(repeating: 0, count: recentDistinctChunks.count),
+                recentWatcherWriteBuckets: recentDistinctChunks,
+                recentEnrichmentBuckets: Array(repeating: 0, count: recentDistinctChunks.count),
+                activityWindowMinutes: 1,
+                bucketCount: recentDistinctChunks.count,
+                liveWindowMinutes: 1,
+                pendingStoreQueueDepth: pendingDepth,
+                pendingStoreFlushQueueDepth: pendingDepth,
+                watcherHealth: historicalHealth
+            )
+            return DashboardFlowSummary.derive(daemon: process, stats: stats, now: now)
+                .lane(for: .jsonlWatcher)
+                .statusText
+        }
+
+        XCTAssertEqual(
+            watcherStatusText(
+                process: running,
+                recentDistinctChunks: [0, 0, 0, 1],
+                pendingDepth: 0,
+                historicalHealth: historicalMarker
+            ),
+            "FLOWING"
+        )
+        XCTAssertEqual(
+            watcherStatusText(
+                process: running,
+                recentDistinctChunks: [0, 0, 0, 0],
+                pendingDepth: 2,
+                historicalHealth: historicalMarker
+            ),
+            "STALLED"
+        )
+        XCTAssertEqual(
+            watcherStatusText(
+                process: running,
+                recentDistinctChunks: [0, 0, 0, 0],
+                pendingDepth: 0,
+                historicalHealth: historicalMarker
+            ),
+            "RUNNING · NO RECENT FLOW"
+        )
+        XCTAssertEqual(
+            watcherStatusText(
+                process: nil,
+                recentDistinctChunks: [0, 0, 0, 0],
+                pendingDepth: 0,
+                historicalHealth: historicalMarker
+            ),
+            "OFFLINE"
+        )
+        XCTAssertEqual(
+            watcherStatusText(
+                process: running,
+                recentDistinctChunks: [0, 0, 0, 1],
+                pendingDepth: 0,
+                historicalHealth: alertingHistoricalMarker
+            ),
+            "FLOWING",
+            "watcher-health.json is historical diagnostic context and cannot override current process+flow truth."
+        )
+        XCTAssertEqual(
+            watcherStatusText(
+                process: running,
+                recentDistinctChunks: [0, 0, 0, 0],
+                pendingDepth: 0,
+                historicalHealth: nil
+            ),
+            "RUNNING · FLOW UNVERIFIED"
+        )
+        XCTAssertEqual(
+            watcherStatusText(
+                process: nil,
+                recentDistinctChunks: [0, 0, 0, 0],
+                pendingDepth: 0,
+                historicalHealth: nil
+            ),
+            "UNKNOWN",
+            "Ambiguous process-probe failure plus unavailable flow evidence must fail closed, not claim OFFLINE."
+        )
+    }
+
     func testJsonlWatcherLaneMarksTimestamplessWatcherHealthUnavailable() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -199,7 +199,7 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(summary.ingress.status, .live)
         XCTAssertEqual(watcherLane.status, .idle)
         XCTAssertEqual(watcherLane.statusText, "RUNNING · NO RECENT FLOW")
-        XCTAssertEqual(watcherLane.lastEventText, "No watcher writes in Last 30m")
+        XCTAssertEqual(watcherLane.lastEventText, "No watcher-ingested chunks in Last 30m")
     }
 
     func testAgentStoresLaneDoesNotBorrowLiveStatusFromJsonlWatcher() {
@@ -226,8 +226,8 @@ final class BrainBarUXLogicTests: XCTestCase {
 
         XCTAssertEqual(summary.ingress.status, .live)
         XCTAssertEqual(agentLane.status, .idle)
-        XCTAssertEqual(agentLane.statusText, "No agent MCP stores")
-        XCTAssertEqual(agentLane.lastEventText, "No agent MCP stores in Last 30m")
+        XCTAssertEqual(agentLane.statusText, "No agent-origin chunks")
+        XCTAssertEqual(agentLane.lastEventText, "No agent-origin chunks in Last 30m")
     }
 
     func testWatcherOnlyBurstShowsAllCommitsWhileAgentLaneStaysIdle() {
@@ -267,7 +267,7 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(allCommitsLane.values, [0, 0, 0, 460])
         XCTAssertEqual(allCommitsLane.volumeText, "460 in 1h")
         XCTAssertEqual(agentLane.status, .idle)
-        XCTAssertEqual(agentLane.statusText, "No agent MCP stores")
+        XCTAssertEqual(agentLane.statusText, "No agent-origin chunks")
         XCTAssertEqual(watcherLane.status, .live)
     }
 
@@ -309,7 +309,7 @@ final class BrainBarUXLogicTests: XCTestCase {
         XCTAssertEqual(summary.lane(for: .allCommits).status, .live)
         XCTAssertEqual(summary.lane(for: .jsonlWatcher).status, .live)
         XCTAssertEqual(agentLane.status, .idle)
-        XCTAssertEqual(agentLane.statusText, "No agent MCP stores")
+        XCTAssertEqual(agentLane.statusText, "No agent-origin chunks")
         XCTAssertEqual(summary.queue.storeReplayDebtDepth, 3)
         XCTAssertEqual(summary.queue.storeDepthText, "3 replay debt")
     }
@@ -336,15 +336,17 @@ final class BrainBarUXLogicTests: XCTestCase {
             pendingStoreFlushRatePerMinute: 0
         )
 
-        let agentLane = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now).lane(for: .agentStores)
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+        let agentLane = summary.lane(for: .agentStores)
 
         XCTAssertEqual(agentLane.status, .live)
-        XCTAssertEqual(agentLane.statusText, "Agent MCP stores live now")
-        XCTAssertEqual(agentLane.volumeText, "2 in 1h, 5 flush queued")
-        XCTAssertEqual(agentLane.lastEventText, "2 agent MCP stores in latest bucket; 5 flush queued")
+        XCTAssertEqual(agentLane.statusText, "Agent-origin chunks landing now")
+        XCTAssertEqual(agentLane.volumeText, "2 in 1h")
+        XCTAssertEqual(agentLane.lastEventText, "2 agent-origin chunks in latest source-time bucket")
+        XCTAssertEqual(summary.queue.storeDepthText, "5 queued")
     }
 
-    func testAgentStoresLaneShowsPendingReplayDebtWhenCommittedGraphIsZero() {
+    func testPendingStoresStayOutOfAgentOriginChartWhenCommittedGraphIsZero() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 120,
@@ -366,12 +368,14 @@ final class BrainBarUXLogicTests: XCTestCase {
             pendingStoreFlushRatePerMinute: 0
         )
 
-        let agentLane = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now).lane(for: .agentStores)
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+        let agentLane = summary.lane(for: .agentStores)
 
-        XCTAssertEqual(agentLane.status, .queued)
-        XCTAssertEqual(agentLane.statusText, "5 agent MCP stores flush queued")
-        XCTAssertEqual(agentLane.volumeText, "0 in 1h, 5 flush queued")
-        XCTAssertEqual(agentLane.lastEventText, "5 agent MCP stores flush queued")
+        XCTAssertEqual(agentLane.status, .idle)
+        XCTAssertEqual(agentLane.statusText, "No agent-origin chunks")
+        XCTAssertEqual(agentLane.volumeText, "0 in 1h")
+        XCTAssertEqual(agentLane.lastEventText, "No agent-origin chunks in Last 1h")
+        XCTAssertEqual(summary.queue.storeDepthText, "5 queued")
     }
 
     func testAgentStoresLaneShowsQueuedReplayDebtBeforeLiveWrites() {
@@ -396,12 +400,14 @@ final class BrainBarUXLogicTests: XCTestCase {
             pendingStoreFlushRatePerMinute: 0
         )
 
-        let agentLane = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now).lane(for: .agentStores)
+        let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
+        let agentLane = summary.lane(for: .agentStores)
 
         XCTAssertEqual(agentLane.status, .live)
-        XCTAssertEqual(agentLane.statusText, "Agent MCP stores live now")
-        XCTAssertEqual(agentLane.volumeText, "2 in 1h, 5 flush queued")
-        XCTAssertEqual(agentLane.lastEventText, "2 agent MCP stores in latest bucket; 5 flush queued")
+        XCTAssertEqual(agentLane.statusText, "Agent-origin chunks landing now")
+        XCTAssertEqual(agentLane.volumeText, "2 in 1h")
+        XCTAssertEqual(agentLane.lastEventText, "2 agent-origin chunks in latest source-time bucket")
+        XCTAssertEqual(summary.queue.storeDepthText, "5 queued")
     }
 
     func testJsonlWatcherLaneDoesNotTreatHistoricalActivityMarkerAsLiveFlowTruth() {
@@ -702,8 +708,8 @@ final class BrainBarUXLogicTests: XCTestCase {
 
         let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: now)
 
-        XCTAssertEqual(summary.enrichment.sparklineLabel, "Enrichment completions over Last 1h")
-        XCTAssertEqual(summary.enrichment.latestBucketName, "latest enrichment bucket")
+        XCTAssertEqual(summary.enrichment.sparklineLabel, "Successful enrichment completions over Last 1h")
+        XCTAssertEqual(summary.enrichment.latestBucketName, "latest successful-enrichment bucket")
         XCTAssertEqual(summary.enrichment.statusText, "Backlog drain burst: 2055 enriched in latest 15m")
         XCTAssertEqual(summary.enrichment.volumeText, "2055 in 1h")
     }

--- a/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainBarUXLogicTests.swift
@@ -638,7 +638,7 @@ final class BrainBarUXLogicTests: XCTestCase {
                 process: running,
                 recentDistinctChunks: [0, 0, 0, 0],
                 pendingDepth: 0,
-                historicalHealth: nil,
+                historicalHealth: historicalMarker,
                 recentFlowReadable: false
             ),
             "RUNNING · FLOW UNVERIFIED"

--- a/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
@@ -107,6 +107,7 @@ final class BrainDatabaseWindowedBucketsTests: XCTestCase {
         try insertWrite(id: "agent-live-1", source: "mcp", createdAt: minutesAgo(5))
         try insertWrite(id: "agent-live-2", source: "brain_store", createdAt: minutesAgo(20))
         try insertWrite(id: "watcher-live-1", source: "realtime_watcher", createdAt: minutesAgo(8))
+        try insertWatcherLiveness(chunkID: "watcher-live-1", ingestedAt: minutesAgo(8))
         try insertWrite(
             id: "enrich-live-1",
             source: "mcp",
@@ -120,6 +121,8 @@ final class BrainDatabaseWindowedBucketsTests: XCTestCase {
         try insertWrite(id: "agent-old-3", source: "digest", createdAt: minutesAgo(600)) // 10h ago
         try insertWrite(id: "watcher-old-1", source: "realtime_watcher", createdAt: minutesAgo(70))
         try insertWrite(id: "watcher-old-2", source: "realtime", createdAt: minutesAgo(300)) // 5h ago
+        try insertWatcherLiveness(chunkID: "watcher-old-1", ingestedAt: minutesAgo(70))
+        try insertWatcherLiveness(chunkID: "watcher-old-2", ingestedAt: minutesAgo(300))
         try insertWrite(
             id: "enrich-old-1",
             source: "mcp",
@@ -199,6 +202,7 @@ final class BrainDatabaseWindowedBucketsTests: XCTestCase {
         let now = Date()
         try insertWrite(id: "agent-mcp", source: "mcp", createdAt: now.addingTimeInterval(-4 * 60))
         try insertWrite(id: "watcher-realtime", source: "realtime_watcher", createdAt: now.addingTimeInterval(-3 * 60))
+        try insertWatcherLiveness(chunkID: "watcher-realtime", ingestedAt: now.addingTimeInterval(-3 * 60))
         try insertWrite(id: "backup-jsonl", source: "jsonl_backup", createdAt: now.addingTimeInterval(-2 * 60))
         try insertWrite(id: "codex-cli", source: "codex_cli", createdAt: now.addingTimeInterval(-1 * 60))
 

--- a/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
@@ -95,6 +95,37 @@ final class BrainDatabaseWindowedBucketsTests: XCTestCase {
         )
     }
 
+    func testWindowedStatsAdoptWatcherReadabilityFromTheSameWindow() {
+        let restingStats = BrainDatabase.DashboardStats(
+            chunkCount: 0,
+            enrichedChunkCount: 0,
+            pendingEnrichmentCount: 0,
+            enrichmentPercent: 0,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 0,
+            recentActivityBuckets: [0],
+            recentEnrichmentBuckets: [0],
+            watcherFlowReadability: .readable
+        )
+        let windowedBuckets = BrainDatabase.PipelineWindowBuckets(
+            activityWindowMinutes: 180,
+            bucketCount: 1,
+            allWriteBuckets: [0],
+            agentWriteBuckets: [0],
+            watcherWriteBuckets: [0],
+            enrichmentBuckets: [0],
+            watcherFlowReadability: .unreadable("windowed watcher evidence unavailable")
+        )
+
+        let windowedStats = restingStats.withWindowedPipelineBuckets(windowedBuckets)
+
+        XCTAssertEqual(
+            windowedStats.watcherFlowReadability,
+            windowedBuckets.watcherFlowReadability,
+            "Windowed watcher buckets and their readability must come from the same evidence fetch."
+        )
+    }
+
     func testWiderWindowReturnsMoreHistoricalDataThanLiveWindow() throws {
         // Force the schema to exist (constructor opens + ensures schema, but make
         // it explicit so an empty-table call cannot be misread).

--- a/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
@@ -268,6 +268,72 @@ final class BrainDatabaseWindowedBucketsTests: XCTestCase {
         )
     }
 
+    func testWatcherWindowCountsDistinctChunkOnceAtFirstInWindowIngestWhileSourceSeriesUseCreatedAt() throws {
+        XCTAssertTrue(try db.tableExists("chunks"))
+
+        let now = Date()
+        try insertWrite(
+            id: "old-source-new-ingest",
+            source: "realtime_watcher",
+            createdAt: now.addingTimeInterval(-2 * 60 * 60)
+        )
+        try insertWatcherLiveness(
+            chunkID: "old-source-new-ingest",
+            ingestedAt: now.addingTimeInterval(-20 * 60)
+        )
+        try insertWatcherLiveness(
+            chunkID: "old-source-new-ingest",
+            ingestedAt: now.addingTimeInterval(-5 * 60)
+        )
+        try insertWrite(
+            id: "agent-source-row",
+            source: "mcp",
+            createdAt: now.addingTimeInterval(-10 * 60)
+        )
+        try insertWrite(
+            id: "other-source-row",
+            source: "jsonl_backup",
+            createdAt: now.addingTimeInterval(-5 * 60)
+        )
+
+        let buckets = try db.pipelineWindowBuckets(activityWindowMinutes: 30, bucketCount: 6, now: now)
+
+        XCTAssertEqual(
+            buckets.allWriteTotal,
+            2,
+            "All chunks use chunks.created_at and count chunk rows; the old source row stays outside the source-time window."
+        )
+        XCTAssertEqual(
+            buckets.agentTotal,
+            1,
+            "Agent-origin chunks use chunks.created_at and chunk-row cardinality."
+        )
+        XCTAssertEqual(
+            buckets.watcherWriteBuckets,
+            [0, 0, 1, 0, 0, 0],
+            "Watcher ingestion counts a chunk_id once per selected window and buckets its first qualifying in-window ingested_at."
+        )
+    }
+
+    func testWatcherWindowDoesNotFallBackToChunkSourceTimeWhenLivenessTableIsUnavailable() throws {
+        XCTAssertFalse(try db.tableExists("watcher_liveness_events"))
+
+        let now = Date()
+        try insertWrite(
+            id: "source-time-is-not-watcher-proof",
+            source: "realtime_watcher",
+            createdAt: now.addingTimeInterval(-60)
+        )
+
+        let buckets = try db.pipelineWindowBuckets(activityWindowMinutes: 30, bucketCount: 6, now: now)
+
+        XCTAssertEqual(
+            buckets.watcherWriteBuckets,
+            [0, 0, 0, 0, 0, 0],
+            "Missing watcher-ingest evidence must fail closed; chunks.created_at cannot silently impersonate ingest time."
+        )
+    }
+
     func testPendingSourceReplayCountsAsAgentStoreWrite() throws {
         XCTAssertTrue(try db.tableExists("chunks"))
 

--- a/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainDatabaseWindowedBucketsTests.swift
@@ -314,11 +314,15 @@ final class BrainDatabaseWindowedBucketsTests: XCTestCase {
         )
         try insertWatcherLiveness(
             chunkID: "old-source-new-ingest",
-            ingestedAt: now.addingTimeInterval(-20 * 60)
+            ingestedAt: now.addingTimeInterval(-45 * 60)
         )
         try insertWatcherLiveness(
             chunkID: "old-source-new-ingest",
-            ingestedAt: now.addingTimeInterval(-5 * 60)
+            ingestedAt: now.addingTimeInterval(-19 * 60)
+        )
+        try insertWatcherLiveness(
+            chunkID: "old-source-new-ingest",
+            ingestedAt: now.addingTimeInterval(-4 * 60)
         )
         try insertWrite(
             id: "agent-source-row",

--- a/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
@@ -98,6 +98,17 @@ final class BrainLayerConfigTests: XCTestCase {
         XCTAssertEqual(document.config.googleAPIKey.displayText, "1Password reference")
     }
 
+    func testPlainGoogleKeyWithApostropheRoundTripsThroughManagedShellRendering() throws {
+        let expected = BrainLayerGoogleAPIKey.plain("fixture'key")
+        var document = BrainLayerEnvDocument(config: .defaultConfig)
+        document.update { $0.googleAPIKey = expected }
+
+        let reloaded = try BrainLayerEnvDocument(text: document.rendered()).config
+
+        XCTAssertEqual(reloaded.googleAPIKey, expected)
+        XCTAssertTrue(reloaded.persistedValuesEqual(to: document.config))
+    }
+
     func testUpdatingConfigPreservesCommentsAndUnmanagedKeys() throws {
         var document = try BrainLayerEnvDocument(
             text: """
@@ -192,6 +203,34 @@ final class BrainLayerConfigTests: XCTestCase {
         XCTAssertEqual(
             BrainLayerConfigValidator.validate(missingBackend),
             .failed("Enrichment backend is required.")
+        )
+    }
+
+    func testValidatorAllowsEditingAnExistingUnavailableProviderButRejectsActivatingOne() {
+        var existingUnsupported = BrainLayerConfig.defaultConfig
+        existingUnsupported.enrichmentProvider = .openai
+        existingUnsupported.enrichmentBackend = "openai"
+
+        var unrelatedEdit = existingUnsupported
+        unrelatedEdit.systemEnabled = false
+        XCTAssertEqual(
+            BrainLayerConfigValidator.validate(unrelatedEdit, previousConfig: existingUnsupported),
+            .passed
+        )
+
+        var disabled = existingUnsupported
+        disabled.enrichmentEnabled = false
+        XCTAssertEqual(
+            BrainLayerConfigValidator.validate(disabled, previousConfig: existingUnsupported),
+            .passed
+        )
+
+        var activation = BrainLayerConfig.defaultConfig
+        activation.enrichmentProvider = .openai
+        activation.enrichmentBackend = "openai"
+        XCTAssertEqual(
+            BrainLayerConfigValidator.validate(activation, previousConfig: .defaultConfig),
+            .failed("OpenAI cannot be activated because its runtime integration is unavailable.")
         )
     }
 }

--- a/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
+++ b/brain-bar/Tests/BrainBarTests/BrainLayerConfigTests.swift
@@ -2,6 +2,56 @@ import XCTest
 @testable import BrainBar
 
 final class BrainLayerConfigTests: XCTestCase {
+    func testProviderAvailabilityOnlyExposesRuntimeWiredChoices() {
+        XCTAssertEqual(BrainLayerEnrichmentProvider.selectableCases, [.gemini])
+        XCTAssertNil(BrainLayerEnrichmentProvider.gemini.unavailableReason)
+        XCTAssertEqual(
+            BrainLayerEnrichmentProvider.openai.unavailableReason,
+            "Runtime integration is not available in this build."
+        )
+        XCTAssertEqual(
+            BrainLayerEnrichmentProvider.anthropic.unavailableReason,
+            "Runtime integration is not available in this build."
+        )
+    }
+
+    func testLaunchctlProbeDistinguishesMissingJobFromProbeFailure() {
+        let missing = BrainLayerLaunchdStatusProvider(
+            commandRunner: { _ in
+                BrainLayerLaunchdCommandResult(
+                    terminationStatus: 113,
+                    output: "Could not find service com.brainlayer.watch"
+                )
+            },
+            uidProvider: { 501 }
+        )
+        XCTAssertEqual(missing.sample()[.watch], .unloaded)
+
+        let failed = BrainLayerLaunchdStatusProvider(
+            commandRunner: { _ in
+                BrainLayerLaunchdCommandResult(
+                    terminationStatus: 1,
+                    output: "operation timed out"
+                )
+            },
+            uidProvider: { 501 }
+        )
+        XCTAssertEqual(failed.sample()[.watch], .probeError("launchctl exited 1"))
+    }
+
+    func testSecretDescriptionsStayRedacted() {
+        let secret = "super-secret-fixture-value"
+        let value = BrainLayerGoogleAPIKey.plain(secret)
+        var config = BrainLayerConfig.defaultConfig
+        config.googleAPIKey = value
+
+        XCTAssertFalse(String(describing: value).contains(secret))
+        XCTAssertFalse(String(reflecting: value).contains(secret))
+        XCTAssertFalse(String(describing: config).contains(secret))
+        XCTAssertFalse(String(reflecting: config).contains(secret))
+        XCTAssertEqual(String(describing: value), "Stored in config file")
+    }
+
     func testDefaultConfigURLUsesUnifiedBrainLayerEnvPath() {
         let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
 
@@ -127,5 +177,21 @@ final class BrainLayerConfigTests: XCTestCase {
         XCTAssertTrue(content.contains("BRAINLAYER_ENRICH_BACKEND=gemini"))
         XCTAssertTrue(content.contains("BRAINLAYER_LAUNCHD_ENRICHMENT_ENABLED=1"))
         XCTAssertTrue(content.contains("BRAINLAYER_LAUNCHD_DRAIN_ENABLED=1"))
+    }
+
+    func testValidatorRejectsUnavailableProviderAndEmptyBackend() {
+        var unsupported = BrainLayerConfig.defaultConfig
+        unsupported.enrichmentProvider = .openai
+        XCTAssertEqual(
+            BrainLayerConfigValidator.validate(unsupported),
+            .failed("OpenAI cannot be activated because its runtime integration is unavailable.")
+        )
+
+        var missingBackend = BrainLayerConfig.defaultConfig
+        missingBackend.enrichmentBackend = "   "
+        XCTAssertEqual(
+            BrainLayerConfigValidator.validate(missingBackend),
+            .failed("Enrichment backend is required.")
+        )
     }
 }

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -113,6 +113,33 @@ final class DashboardTests: XCTestCase {
         XCTAssertGreaterThan(stats.databaseSizeBytes, 0)
     }
 
+    func testDashboardEnrichedSuccessfullyExcludesFailedSkippedAndPendingRows() throws {
+        for id in ["enrich-success", "enrich-failed", "enrich-skipped", "enrich-pending"] {
+            try db.insertChunk(
+                id: id,
+                content: "Enrichment truth fixture \(id)",
+                sessionId: "dashboard",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 5
+            )
+        }
+        db.exec("UPDATE chunks SET enriched_at = datetime('now'), enrich_status = 'success' WHERE id = 'enrich-success'")
+        db.exec("UPDATE chunks SET enrich_status = 'failed' WHERE id = 'enrich-failed'")
+        db.exec("UPDATE chunks SET enrich_status = 'skipped' WHERE id = 'enrich-skipped'")
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.chunkCount, 4)
+        XCTAssertEqual(
+            stats.enrichedChunkCount,
+            1,
+            "The ENRICHED SUCCESSFULLY numerator counts only enrich_status='success'."
+        )
+        XCTAssertEqual(stats.pendingEnrichmentCount, 1)
+        XCTAssertEqual(stats.enrichmentPercent, 25, accuracy: 0.001)
+    }
+
     func testDashboardStatsReportsPerSignalCoverageAndBacklogs() throws {
         for id in ["signal-1", "signal-2", "signal-3", "signal-archived"] {
             try db.insertChunk(
@@ -451,6 +478,34 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(source.contains("BrainBarDashboardContent("))
         XCTAssertTrue(source.contains("collector.lastDataFetchedAt == nil"))
         XCTAssertTrue(source.contains("Connecting to daemon and loading dashboard data"))
+    }
+
+    func testSnapshotFreshnessHasInjectedClockStrictSixtySecondBoundaryAndIndependentTicker() throws {
+        let collectorSource = try brainBarSourceFile("Sources/BrainBar/Dashboard/StatsCollector.swift")
+        let stateSource = try brainBarSourceFile("Sources/BrainBar/Dashboard/PipelineState.swift")
+        let combined = collectorSource + "\n" + stateSource
+
+        XCTAssertTrue(
+            combined.contains("SnapshotFreshnessState"),
+            "Freshness must be a typed state rather than an implicit lastDataFetchedAt nil check."
+        )
+        XCTAssertTrue(
+            combined.contains("snapshotFreshnessThreshold") && combined.contains("60"),
+            "The named snapshot freshness threshold must be exactly 60 seconds."
+        )
+        XCTAssertTrue(
+            combined.contains("nowProvider") || combined.contains("clock:"),
+            "An injected clock is required to prove the exact 60s versus >60s boundary."
+        )
+        XCTAssertTrue(
+            combined.contains("freshnessTicker") || combined.contains("freshnessTimer"),
+            "Freshness presentation must advance without waiting for a fetch callback."
+        )
+        XCTAssertTrue(
+            combined.contains("> snapshotFreshnessThreshold")
+                || combined.contains("> Self.snapshotFreshnessThreshold"),
+            "Exactly 60 seconds remains LIVE; only age >60 seconds becomes STALE."
+        )
     }
 
     func testDashboardRendersPerSignalCoverageSection() throws {
@@ -1056,6 +1111,65 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.pendingStoreQueueDepth, 1)
         XCTAssertEqual(stats.pendingStoreFlushQueueDepth, 1)
         XCTAssertEqual(stats.pendingStoreOldestQueuedAt, Date(timeIntervalSince1970: 1_800))
+
+        let detail = DashboardFlowSummary.derive(daemon: nil, stats: stats).queue.detail.lowercased()
+        XCTAssertTrue(detail.contains("pending stores: 1"), "Replay debt must retain its pending-store component.")
+        XCTAssertTrue(detail.contains("durable queue: 1"), "Replay debt must retain its durable-queue component.")
+        XCTAssertTrue(detail.contains("repository fallback: 1"), "Replay debt must retain its repository-fallback component.")
+        XCTAssertTrue(
+            detail.contains("deduplicated total: 1"),
+            "The three source components share one identity and must aggregate to one debt item."
+        )
+    }
+
+    func testDashboardReplayDebtRetainsKnownComponentsAndMarksAggregatePartialWhenInputUnreadable() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("pending-stores-dashboard-partial-\(UUID().uuidString).jsonl")
+        let unreadableQueueInput = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("brainlayer-durable-unreadable-\(UUID().uuidString)")
+        let fallbackPath = fallbackReplayRoot
+            .appendingPathComponent("brainlayer", isDirectory: true)
+            .appendingPathComponent("docs.local", isDirectory: true)
+            .appendingPathComponent("decisions", isDirectory: true)
+            .appendingPathComponent("known-fallback.md")
+        let restoreQueuePath = setDashboardPendingStoreQueuePath(queuePath)
+        let restoreDurableQueue = setDashboardDurableStoreQueuePath(unreadableQueueInput)
+        defer {
+            restoreQueuePath()
+            restoreDurableQueue()
+            try? FileManager.default.removeItem(at: queuePath)
+            try? FileManager.default.removeItem(at: unreadableQueueInput)
+        }
+
+        try """
+        {"content":"known pending","tags":["queue"],"importance":5,"source":"mcp","queued_at":"1970-01-01T00:30:00Z","chunk_id":"pending-known"}
+        """.write(to: queuePath, atomically: true, encoding: .utf8)
+        try "not a readable queue directory\n".write(
+            to: unreadableQueueInput,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createDirectory(
+            at: fallbackPath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try """
+        ---
+        intended_brain_store: true
+        queued_chunk_id: fallback-known
+        chunk_id:
+        timestamp: 1970-01-01T00:31:00Z
+        ---
+        known fallback body
+        """.write(to: fallbackPath, atomically: true, encoding: .utf8)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 15, bucketCount: 4)
+        let detail = DashboardFlowSummary.derive(daemon: nil, stats: stats).queue.detail.lowercased()
+
+        XCTAssertEqual(stats.pendingStoreQueueDepth, 2, "Readable components remain visible when another source is unreadable.")
+        XCTAssertEqual(stats.pendingStoreFlushQueueDepth, 1)
+        XCTAssertTrue(detail.contains("partial"), "The aggregate must disclose that one replay-debt input was unreadable.")
+        XCTAssertTrue(detail.contains("durable"), "The unreadable durable component must be named, not silently treated as empty.")
     }
 
     func testDashboardStatsDeduplicatesUnmarkedFallbackAgainstDurableFallbackChunkID() throws {
@@ -2148,6 +2262,56 @@ final class DashboardTests: XCTestCase {
         try await waitForCollector(collector) { $0.stats.chunkCount == 1 }
 
         XCTAssertEqual(collector.stats.chunkCount, 1)
+    }
+
+    @MainActor
+    func testStatsCollectorFetchErrorRetainsLastGoodSnapshotAndPublishesVisibleFailure() async throws {
+        try db.insertChunk(
+            id: "last-good-survives-error",
+            content: "The last successful dashboard snapshot must survive a later read failure",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        collector.refresh(force: true)
+        try await waitForCollector(collector) { !$0.isRefreshing && $0.lastDataFetchedAt != nil }
+        let lastGoodStats = collector.stats
+        let lastSuccessAt = try XCTUnwrap(collector.lastDataFetchedAt)
+        XCTAssertEqual(lastGoodStats.chunkCount, 1)
+
+        db.close()
+        try FileManager.default.removeItem(atPath: tempDBPath)
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-wal")
+        try? FileManager.default.removeItem(atPath: tempDBPath + "-shm")
+
+        collector.refresh(force: true)
+        try await waitForCollector(collector) { !$0.isRefreshing }
+
+        XCTAssertEqual(
+            collector.stats,
+            lastGoodStats,
+            "A failed refresh retains and dims the last good snapshot instead of fabricating zero values."
+        )
+        XCTAssertEqual(collector.lastDataFetchedAt, lastSuccessAt)
+
+        let collectorSource = try brainBarSourceFile("Sources/BrainBar/Dashboard/StatsCollector.swift")
+        let viewSource = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+        XCTAssertTrue(
+            collectorSource.contains("lastFetchError") || collectorSource.contains("currentFetchError"),
+            "The collector must publish the unresolved fetch error separately from last-good data."
+        )
+        XCTAssertTrue(
+            viewSource.contains("lastFetchError") || viewSource.contains("currentFetchError"),
+            "The dashboard must make the current fetch failure visible with last-success age."
+        )
     }
 
     @MainActor

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -1012,6 +1012,27 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(agentStores.statusText, "No agent-origin chunks")
     }
 
+    func testDashboardStatsCountsUnreadableFallbackAsPartialConservativeDebt() throws {
+        let fallbackPath = fallbackReplayRoot
+            .appendingPathComponent("brainlayer", isDirectory: true)
+            .appendingPathComponent("docs.local", isDirectory: true)
+            .appendingPathComponent("brain-store-fallback", isDirectory: true)
+            .appendingPathComponent("unreadable.md")
+        try FileManager.default.createDirectory(
+            at: fallbackPath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data([0xFF, 0xFE, 0xFD]).write(to: fallbackPath)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 15, bucketCount: 4)
+        let fallback = stats.replayDebtBreakdown.repositoryFallback
+
+        XCTAssertEqual(fallback.snapshot.depth, 1, "Unreadable fallback files are possible debt, never zero evidence.")
+        XCTAssertFalse(fallback.readability.isReadable)
+        XCTAssertTrue(stats.replayDebtBreakdown.isPartial)
+        XCTAssertTrue(stats.replayDebtBreakdown.detailText.contains("repository fallback"))
+    }
+
     func testDashboardStatsIncludesDurableStoreQueueDepth() throws {
         let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("pending-stores-dashboard-empty-\(UUID().uuidString).jsonl")

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -114,7 +114,14 @@ final class DashboardTests: XCTestCase {
     }
 
     func testDashboardEnrichedSuccessfullyExcludesFailedSkippedAndPendingRows() throws {
-        for id in ["enrich-success", "enrich-failed", "enrich-skipped", "enrich-pending"] {
+        for id in [
+            "enrich-success",
+            "enrich-failed",
+            "enrich-skipped",
+            "enrich-duplicate",
+            "enrich-too-short",
+            "enrich-pending",
+        ] {
             try db.insertChunk(
                 id: id,
                 content: "Enrichment truth fixture \(id)",
@@ -127,17 +134,52 @@ final class DashboardTests: XCTestCase {
         db.exec("UPDATE chunks SET enriched_at = datetime('now'), enrich_status = 'success' WHERE id = 'enrich-success'")
         db.exec("UPDATE chunks SET enrich_status = 'failed' WHERE id = 'enrich-failed'")
         db.exec("UPDATE chunks SET enrich_status = 'skipped' WHERE id = 'enrich-skipped'")
+        db.exec("UPDATE chunks SET enrich_status = 'duplicate' WHERE id = 'enrich-duplicate'")
+        db.exec("UPDATE chunks SET enrich_status = 'too_short' WHERE id = 'enrich-too-short'")
 
         let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
 
-        XCTAssertEqual(stats.chunkCount, 4)
+        XCTAssertEqual(stats.chunkCount, 6)
         XCTAssertEqual(
             stats.enrichedChunkCount,
             1,
             "The ENRICHED SUCCESSFULLY numerator counts only enrich_status='success'."
         )
         XCTAssertEqual(stats.pendingEnrichmentCount, 1)
-        XCTAssertEqual(stats.enrichmentPercent, 25, accuracy: 0.001)
+        XCTAssertEqual(stats.skippedEnrichmentCount, 3)
+        XCTAssertEqual(stats.enrichmentPercent, 100.0 / 6.0, accuracy: 0.001)
+    }
+
+    func testWatcherLaneDoesNotCallAnEmptyLatestBucketLive() {
+        let stats = DashboardStats(
+            chunkCount: 2,
+            enrichedChunkCount: 0,
+            pendingEnrichmentCount: 0,
+            enrichmentPercent: 0,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 0,
+            recentActivityBuckets: [0, 0, 0],
+            recentAgentWriteBuckets: [0, 0, 0],
+            recentWatcherWriteBuckets: [2, 0, 0],
+            recentEnrichmentBuckets: [0, 0, 0],
+            activityWindowMinutes: 15,
+            watcherProcessProbeResult: .running(pid: 42),
+            watcherRecentDistinctChunkCount: 2,
+            watcherFlowReadability: .readable
+        )
+
+        let lane = DashboardFlowSummary.derive(daemon: nil, stats: stats).lane(for: .jsonlWatcher)
+
+        XCTAssertEqual(lane.status, .live)
+        XCTAssertEqual(lane.lastEventText, "2 watcher-ingested chunks in Last 15m")
+    }
+
+    @MainActor
+    func testNoRecentWatcherFlowFixtureDoesNotRenderWatcherIngestActivity() {
+        let stats = BrainBarDashboardFixture.watcherRunningNoRecentFlowStats
+
+        XCTAssertEqual(stats.watcherRecentDistinctChunkCount, 0)
+        XCTAssertEqual(stats.recentWatcherWriteBuckets, Array(repeating: 0, count: stats.bucketCount))
     }
 
     func testDashboardStatsReportsPerSignalCoverageAndBacklogs() throws {
@@ -1066,6 +1108,30 @@ final class DashboardTests: XCTestCase {
 
         XCTAssertEqual(stats.pendingStoreQueueDepth, 2)
         XCTAssertEqual(stats.pendingStoreFlushQueueDepth, 0)
+    }
+
+    func testDashboardStatsMarksNonRegularJSONLQueueEntryAsPartialConservativeDebt() throws {
+        let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("pending-stores-dashboard-empty-\(UUID().uuidString).jsonl")
+        let durableQueue = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("brainlayer-durable-nonregular-\(UUID().uuidString)", isDirectory: true)
+        let suspiciousEntry = durableQueue.appendingPathComponent("unreadable.jsonl", isDirectory: true)
+        let restoreQueuePath = setDashboardPendingStoreQueuePath(queuePath)
+        let restoreDurableQueue = setDashboardDurableStoreQueuePath(durableQueue)
+        defer {
+            restoreQueuePath()
+            restoreDurableQueue()
+            try? FileManager.default.removeItem(at: queuePath)
+            try? FileManager.default.removeItem(at: durableQueue)
+        }
+        try FileManager.default.createDirectory(at: suspiciousEntry, withIntermediateDirectories: true)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 15, bucketCount: 4)
+        let durable = stats.replayDebtBreakdown.durableQueue
+
+        XCTAssertEqual(durable.snapshot.depth, 1)
+        XCTAssertFalse(durable.readability.isReadable)
+        XCTAssertTrue(stats.replayDebtBreakdown.isPartial)
     }
 
     func testDashboardStatsCountsDurableStoreQueueLinesAndSkipsNonStoreEvents() throws {

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -289,7 +289,6 @@ final class DashboardTests: XCTestCase {
                 WHERE id = '\(fixture.id)'
             """)
         }
-
         let stats = try db.dashboardStats(activityWindowMinutes: 60, bucketCount: 12)
 
         XCTAssertEqual(stats.recentEnrichmentBuckets, [0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1])
@@ -323,6 +322,19 @@ final class DashboardTests: XCTestCase {
                 UPDATE chunks
                 SET created_at = datetime('now', '\(Int(fixture.offset)) seconds')
                 WHERE id = '\(fixture.id)'
+            """)
+        }
+        db.exec("""
+            CREATE TABLE watcher_liveness_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chunk_id TEXT NOT NULL,
+                ingested_at INTEGER NOT NULL
+            )
+        """)
+        for fixture in fixtures where fixture.source == "realtime_watcher" || fixture.source == "realtime" {
+            db.exec("""
+                INSERT INTO watcher_liveness_events (chunk_id, ingested_at)
+                VALUES ('\(fixture.id)', CAST(strftime('%s', 'now', '\(Int(fixture.offset)) seconds') AS INTEGER))
             """)
         }
 
@@ -433,7 +445,7 @@ final class DashboardTests: XCTestCase {
         let source = try brainBarSourceFile("Sources/BrainBar/BrainDatabase.swift")
         let methodRange = try XCTUnwrap(source.range(of: "func dashboardStats("))
         let methodSource = source[methodRange.lowerBound...]
-        let queueSnapshotRange = try XCTUnwrap(methodSource.range(of: "let pendingStoreFlushQueue = pendingStoreQueueSnapshot()"))
+        let queueSnapshotRange = try XCTUnwrap(methodSource.range(of: "let replayDebtBreakdown = replayDebtBreakdown()"))
         let transactionRange = try XCTUnwrap(methodSource.range(of: "try withReadTransaction"))
 
         XCTAssertLessThan(
@@ -476,7 +488,7 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(source.contains("private struct BrainBarDashboardContent: View"))
         XCTAssertTrue(source.contains("@ObservedObject var collector: StatsCollector"))
         XCTAssertTrue(source.contains("BrainBarDashboardContent("))
-        XCTAssertTrue(source.contains("collector.lastDataFetchedAt == nil"))
+        XCTAssertTrue(source.contains("collector.snapshotFreshnessState.isLoading"))
         XCTAssertTrue(source.contains("Connecting to daemon and loading dashboard data"))
     }
 
@@ -800,7 +812,7 @@ final class DashboardTests: XCTestCase {
         )
     }
 
-    func testDashboardStatsCountsTerminalEnrichmentStatusesAsCovered() throws {
+    func testDashboardStatsCountsOnlySuccessfulEnrichmentAndExposesOtherTerminalStates() throws {
         try db.insertChunk(
             id: "dash-success",
             content: "Successfully enriched chunk",
@@ -828,27 +840,29 @@ final class DashboardTests: XCTestCase {
         db.exec("""
             UPDATE chunks
             SET enriched_at = datetime('now', '-5 minutes'),
-                enrich_status = 'success'
+                enrich_status = ' Success '
             WHERE id = 'dash-success'
         """)
         db.exec("""
             UPDATE chunks
             SET enriched_at = 'skipped:duplicate',
-                enrich_status = 'duplicate'
+                enrich_status = 'skipped'
             WHERE id = 'dash-duplicate'
         """)
         db.exec("""
             UPDATE chunks
             SET enriched_at = NULL,
-                enrich_status = 'noise'
+                enrich_status = 'failed'
             WHERE id = 'dash-noise'
         """)
 
         let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
 
-        XCTAssertEqual(stats.enrichedChunkCount, 3)
+        XCTAssertEqual(stats.enrichedChunkCount, 1)
+        XCTAssertEqual(stats.failedEnrichmentCount, 1)
+        XCTAssertEqual(stats.skippedEnrichmentCount, 1)
         XCTAssertEqual(stats.pendingEnrichmentCount, 0)
-        XCTAssertEqual(stats.enrichmentPercent, 100.0, accuracy: 0.001)
+        XCTAssertEqual(stats.enrichmentPercent, 100.0 / 3.0, accuracy: 0.001)
         XCTAssertEqual(stats.recentEnrichmentBuckets.reduce(0, +), 1)
         let lastEnrichedAt = try XCTUnwrap(stats.lastEnrichedAt)
         XCTAssertLessThan(abs(lastEnrichedAt.timeIntervalSinceNow + 300), 10)
@@ -990,7 +1004,10 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.pendingStoreOldestQueuedAt, Date(timeIntervalSince1970: 1_200))
         XCTAssertEqual(summary.queue.storeReplayDebtDepth, 1)
         XCTAssertEqual(summary.queue.storeDepthText, "1 replay debt")
-        XCTAssertEqual(summary.queue.detail, "1 replay debt, oldest 2m.")
+        XCTAssertEqual(
+            summary.queue.detail,
+            "pending stores: 0; durable queue: 0; repository fallback: 1; deduplicated total: 1; oldest 2m."
+        )
         XCTAssertEqual(agentStores.status, .idle)
         XCTAssertEqual(agentStores.statusText, "No agent MCP stores")
     }

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -544,7 +544,8 @@ final class DashboardTests: XCTestCase {
             "Freshness must be a typed state rather than an implicit lastDataFetchedAt nil check."
         )
         XCTAssertTrue(
-            combined.contains("snapshotFreshnessThreshold") && combined.contains("60"),
+            combined.contains("snapshotFreshnessThreshold: TimeInterval = 60")
+                || combined.contains("snapshotFreshnessThreshold = 60"),
             "The named snapshot freshness threshold must be exactly 60 seconds."
         )
         XCTAssertTrue(

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -1075,6 +1075,33 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(stats.replayDebtBreakdown.detailText.contains("repository fallback"))
     }
 
+    func testDashboardStatsMarksFallbackPartialWhenRecursiveSubdirectoryCannotBeRead() throws {
+        let blockedDirectory = fallbackReplayRoot
+            .appendingPathComponent("brainlayer", isDirectory: true)
+            .appendingPathComponent("docs.local", isDirectory: true)
+            .appendingPathComponent("brain-store-fallback", isDirectory: true)
+            .appendingPathComponent("blocked", isDirectory: true)
+        try FileManager.default.createDirectory(at: blockedDirectory, withIntermediateDirectories: true)
+        try "pending debt hidden below unreadable directory\n".write(
+            to: blockedDirectory.appendingPathComponent("pending.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: blockedDirectory.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: blockedDirectory.path)
+        }
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 15, bucketCount: 4)
+        let fallback = stats.replayDebtBreakdown.repositoryFallback
+
+        XCTAssertFalse(
+            fallback.readability.isReadable,
+            "A skipped recursive subtree makes repository fallback evidence partial, never trustworthy empty evidence."
+        )
+        XCTAssertTrue(stats.replayDebtBreakdown.isPartial)
+    }
+
     func testDashboardStatsIncludesDurableStoreQueueDepth() throws {
         let queuePath = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("pending-stores-dashboard-empty-\(UUID().uuidString).jsonl")

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -345,7 +345,7 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.recentActivityBuckets, [0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 8])
     }
 
-    func testDashboardFlowSummarySurfacesAllCommittedChunksAsOwnLane() {
+    func testDashboardFlowSummarySurfacesSourceTimeChunkRowsAsOwnLane() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let stats = DashboardStats(
             chunkCount: 9,
@@ -368,12 +368,12 @@ final class DashboardTests: XCTestCase {
             .derive(daemon: nil, stats: stats, now: now)
             .lane(for: .allCommits)
 
-        XCTAssertEqual(allCommitsLane.name, "All commits")
+        XCTAssertEqual(allCommitsLane.name, "Chunk rows")
         XCTAssertEqual(allCommitsLane.values, [0, 0, 0, 9])
         XCTAssertEqual(allCommitsLane.status, .live)
-        XCTAssertEqual(allCommitsLane.statusText, "All commits live now")
+        XCTAssertEqual(allCommitsLane.statusText, "Chunk rows landing now")
         XCTAssertEqual(allCommitsLane.volumeText, "9 in 1h")
-        XCTAssertEqual(allCommitsLane.sparklineLabel, "All committed chunks over Last 1h")
+        XCTAssertEqual(allCommitsLane.sparklineLabel, "Chunk rows by source time over Last 1h")
     }
 
     func testDashboardFlowLabelsWriteSeriesBySourcePath() {
@@ -393,8 +393,8 @@ final class DashboardTests: XCTestCase {
 
         let summary = DashboardFlowSummary.derive(daemon: nil, stats: stats, now: Date(timeIntervalSince1970: 1_764_236_400))
 
-        XCTAssertEqual(summary.ingress.primarySeriesLabel, "Agent MCP stores")
-        XCTAssertEqual(summary.ingress.secondarySeriesLabel, "JSONL watcher")
+        XCTAssertEqual(summary.ingress.primarySeriesLabel, "Agent-origin chunks")
+        XCTAssertEqual(summary.ingress.secondarySeriesLabel, "Watcher-ingested chunks")
         XCTAssertNil(summary.ingress.tertiarySeriesLabel)
         XCTAssertTrue(summary.ingress.tertiaryValues.isEmpty)
     }
@@ -1009,7 +1009,7 @@ final class DashboardTests: XCTestCase {
             "pending stores: 0; durable queue: 0; repository fallback: 1; deduplicated total: 1; oldest 2m."
         )
         XCTAssertEqual(agentStores.status, .idle)
-        XCTAssertEqual(agentStores.statusText, "No agent MCP stores")
+        XCTAssertEqual(agentStores.statusText, "No agent-origin chunks")
     }
 
     func testDashboardStatsIncludesDurableStoreQueueDepth() throws {
@@ -2326,8 +2326,10 @@ final class DashboardTests: XCTestCase {
             "The collector must publish the unresolved fetch error separately from last-good data."
         )
         XCTAssertTrue(
-            viewSource.contains("lastFetchError") || viewSource.contains("currentFetchError"),
-            "The dashboard must make the current fetch failure visible with last-success age."
+            viewSource.contains("collector.snapshotFreshnessState")
+                && viewSource.contains("case .error(let message")
+                && viewSource.contains("Current error:"),
+            "The dashboard must render the typed current fetch failure with last-success age."
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DesignTokensTests.swift
@@ -43,13 +43,13 @@ final class DesignTokensTests: XCTestCase {
         XCTAssertEqual(PipelineIndicatorStatus.unavailable.stateTheme, .error)
     }
 
-    func testDashboardLayoutUsesAiryGlassSpacingAndHeroScale() {
+    func testDashboardLayoutUsesCompactOperatorDensity() {
         let layout = BrainBarDashboardLayout(containerSize: CGSize(width: 1100, height: 760))
 
-        XCTAssertGreaterThanOrEqual(layout.outerPadding, 36)
-        XCTAssertGreaterThanOrEqual(layout.sectionSpacing, 28)
-        XCTAssertGreaterThanOrEqual(layout.gridSpacing, 20)
-        XCTAssertEqual(layout.metricValueFontSize, BrainBarDesignTokens.TypeScale.hero, accuracy: 0.001)
+        XCTAssertLessThanOrEqual(layout.outerPadding, 24)
+        XCTAssertLessThanOrEqual(layout.sectionSpacing, 20)
+        XCTAssertLessThanOrEqual(layout.gridSpacing, 16)
+        XCTAssertLessThanOrEqual(layout.metricValueFontSize, 40)
         XCTAssertEqual(layout.panelCornerRadius, BrainBarDesignTokens.Radius.xl, accuracy: 0.001)
     }
 

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -545,6 +545,10 @@ final class InjectionPresentationTests: XCTestCase {
 
     @MainActor
     private func renderInjectionPNG<V: View>(_ view: V, name: String) throws {
+        guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"],
+              !renderDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw XCTSkip("Set BRAINBAR_RENDER_DIR to render isolated Injection QA snapshots")
+        }
         let renderer = ImageRenderer(content: view)
         renderer.scale = 2
         guard let image = renderer.nsImage,
@@ -555,11 +559,8 @@ final class InjectionPresentationTests: XCTestCase {
             return
         }
 
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("docs.local/wave3-qa/\(name)")
+        let url = URL(fileURLWithPath: renderDirectory, isDirectory: true)
+            .appendingPathComponent(name)
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try png.write(to: url)
         XCTAssertGreaterThan(png.count, 1_000)

--- a/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionPresentationTests.swift
@@ -545,8 +545,11 @@ final class InjectionPresentationTests: XCTestCase {
 
     @MainActor
     private func renderInjectionPNG<V: View>(_ view: V, name: String) throws {
-        guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"],
-              !renderDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let configuredDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"] else {
+            throw XCTSkip("Set BRAINBAR_RENDER_DIR to render isolated Injection QA snapshots")
+        }
+        let renderDirectory = configuredDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !renderDirectory.isEmpty else {
             throw XCTSkip("Set BRAINBAR_RENDER_DIR to render isolated Injection QA snapshots")
         }
         let renderer = ImageRenderer(content: view)

--- a/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
@@ -1,0 +1,353 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BrainBar
+
+final class InjectionSignalDensityContractTests: XCTestCase {
+    func testCollapsedBurstPresentsTriggerBeforeSelectedResultAndKeepsProvenance() throws {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let sourceFile = "/Users/example/project/.claude/projects/-Users-example-project/session.jsonl"
+        let event = InjectionEvent(
+            id: 42,
+            sessionID: "session-12345678-raw",
+            timestamp: "2026-07-19T09:58:00Z",
+            query: "why did retrieval choose this memory",
+            chunkIDs: ["chunk-raw-uuid", "chunk-secondary"],
+            tokenCount: 88,
+            chunks: [
+                InjectionChunk(
+                    id: "chunk-raw-uuid",
+                    content: "The selected memory explains the routing decision.",
+                    summary: "Routing decision memory",
+                    source: "claude_code",
+                    sourceFile: sourceFile,
+                    tags: ["retrieval"],
+                    contentType: "memory",
+                    claudeConversationID: "conversation-1"
+                ),
+                InjectionChunk(
+                    id: "chunk-secondary",
+                    content: "A secondary memory adds supporting context.",
+                    summary: "Supporting context",
+                    source: "mcp",
+                    sourceFile: sourceFile,
+                    tags: ["retrieval"],
+                    contentType: "memory"
+                ),
+            ]
+        )
+
+        let burst = try XCTUnwrap(
+            InjectionPresentation.snapshot(events: [event], filterText: "", now: now).bursts.first
+        )
+
+        XCTAssertEqual(burst.queryTitle, event.query)
+        XCTAssertEqual(burst.selectedResultSummary, "Routing decision memory")
+        XCTAssertEqual(burst.sourceLabel, "Realtime Capture")
+        XCTAssertEqual(burst.projectLabel, "/Users/example/project")
+        XCTAssertEqual(burst.resultCount, 2)
+        XCTAssertEqual(burst.additionalResultPreviews.map(\.id), ["chunk-secondary"])
+        XCTAssertEqual(burst.remainingCollapsedResultCount, 0)
+        XCTAssertFalse(burst.timestampLabel.isEmpty)
+    }
+
+    func testPresentationModelStartsInLoadingStateInsteadOfEmptyState() {
+        XCTAssertEqual(
+            reflectedDescription(named: "loadState", in: InjectionFeedPresentationState.empty),
+            "loading"
+        )
+    }
+
+    func testSurfaceStateDistinguishesLoadingDisconnectedEmptyFilteredAndDegraded() {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let emptySnapshot = InjectionPresentation.snapshot(events: [], filterText: "", now: now)
+        let loadedEmpty = InjectionFeedPresentationState(events: [], degradationState: .healthy)
+
+        XCTAssertEqual(
+            InjectionFeedSurfaceState.resolve(
+                snapshot: emptySnapshot,
+                presentationState: .empty,
+                connectionState: .connected,
+                filterActive: false
+            ),
+            .loading
+        )
+        XCTAssertEqual(
+            InjectionFeedSurfaceState.resolve(
+                snapshot: emptySnapshot,
+                presentationState: loadedEmpty,
+                connectionState: .disconnected,
+                filterActive: false
+            ),
+            .disconnected
+        )
+        XCTAssertEqual(
+            InjectionFeedSurfaceState.resolve(
+                snapshot: emptySnapshot,
+                presentationState: loadedEmpty,
+                connectionState: .connected,
+                filterActive: false
+            ),
+            .empty
+        )
+        XCTAssertEqual(
+            InjectionFeedSurfaceState.resolve(
+                snapshot: emptySnapshot,
+                presentationState: loadedEmpty,
+                connectionState: .connected,
+                filterActive: true
+            ),
+            .noMatches
+        )
+        XCTAssertEqual(
+            InjectionFeedSurfaceState.resolve(
+                snapshot: emptySnapshot,
+                presentationState: InjectionFeedPresentationState(
+                    events: [],
+                    degradationState: .degraded(reason: "read failed")
+                ),
+                connectionState: .connected,
+                filterActive: false
+            ),
+            .degraded(reason: "read failed", retainsContent: false)
+        )
+    }
+
+    func testDegradedStateRetainsContentAndSessionRailUsesTriggerLabel() throws {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let event = InjectionEvent(
+            id: 7,
+            sessionID: "550e8400-e29b-41d4-a716-446655440000",
+            timestamp: "2026-07-19T09:59:00Z",
+            query: "show operator truth",
+            chunkIDs: ["chunk-7"],
+            tokenCount: 21
+        )
+        let snapshot = InjectionPresentation.snapshot(events: [event], filterText: "", now: now)
+        let degraded = InjectionFeedPresentationState(
+            events: [event],
+            degradationState: .degraded(reason: "database locked")
+        )
+
+        XCTAssertEqual(
+            InjectionFeedSurfaceState.resolve(
+                snapshot: snapshot,
+                presentationState: degraded,
+                connectionState: .connected,
+                filterActive: false
+            ),
+            .degraded(reason: "database locked", retainsContent: true)
+        )
+        XCTAssertEqual(try XCTUnwrap(snapshot.sessions.first).displayLabel, "show operator truth")
+        XCTAssertEqual(
+            InjectionFeedView.burstGroupingDisclosure,
+            "Retrieval bursts group the same session and trigger topic while consecutive events remain under 60 minutes."
+        )
+    }
+
+    func testInjectionViewDeclaresLiteralGroupingAccessibilityStateAndFixtureContracts() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/InjectionFeedView.swift")
+            + (try brainBarSourceFile("Sources/BrainBar/InjectionPresentation.swift"))
+
+        XCTAssertTrue(source.contains("Retrieval bursts"))
+        XCTAssertTrue(source.contains("same session and trigger topic"))
+        XCTAssertTrue(source.contains("under 60 minutes"))
+        XCTAssertTrue(source.contains("filterSearchAccessibilityID"))
+        XCTAssertTrue(source.contains("filterTypeAccessibilityID"))
+        XCTAssertTrue(source.contains("burstActionAccessibilityID"))
+        XCTAssertTrue(source.contains("Picker(\"Retrieval type\""))
+        XCTAssertTrue(source.contains("actionReceipt"))
+        XCTAssertTrue(source.contains("InjectionFeedFixture"))
+        XCTAssertTrue(source.contains("case disconnected"))
+        XCTAssertTrue(source.contains("case degraded"))
+        XCTAssertTrue(source.contains("Text(\"\\(burst.resultCount)\")"))
+        XCTAssertTrue(source.contains("Text(\"Timestamp \\(event.timestamp)\")"))
+        XCTAssertTrue(source.contains("let copied = pasteboard.setString"))
+        XCTAssertFalse(source.contains("Showing the full retrieval stream."))
+        XCTAssertFalse(source.contains("Text(session.sessionID)"))
+        XCTAssertFalse(source.contains("Text(chunkPreviewText(chunkID))"))
+        XCTAssertFalse(source.contains("chip(text: \"\\(burst.resultCount) result"))
+    }
+
+    func testInjectionRenderHelperUsesOnlyTheCallerProvidedIsolatedDirectory() throws {
+        let source = try brainBarSourceFile("Tests/BrainBarTests/InjectionPresentationTests.swift")
+
+        XCTAssertTrue(source.contains("BRAINBAR_RENDER_DIR"))
+        XCTAssertFalse(source.contains("docs.local/wave3-qa"))
+    }
+
+    @MainActor
+    func testRendersOverviewExpandedEmptyAndDegradedFixtureStates() throws {
+        guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"],
+              !renderDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw XCTSkip("Set BRAINBAR_RENDER_DIR to render isolated P3 fixture snapshots")
+        }
+
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let events = fixtureEvents()
+        let burstID = try XCTUnwrap(
+            InjectionPresentation.snapshot(events: events, filterText: "", now: now).bursts.first?.id
+        )
+        let scenarios: [(String, InjectionFeedFixture)] = [
+            (
+                "p3-injections-overview.png",
+                InjectionFeedFixture(
+                    events: events,
+                    now: now,
+                    actionReceipt: InjectionActionReceipt(kind: .success, message: "Resume command copied")
+                )
+            ),
+            (
+                "p3-injections-expanded.png",
+                InjectionFeedFixture(events: events, now: now, expandedBurstIDs: [burstID])
+            ),
+            (
+                "p3-injections-empty.png",
+                InjectionFeedFixture(events: [], now: now)
+            ),
+            (
+                "p3-injections-degraded.png",
+                InjectionFeedFixture(
+                    events: events,
+                    now: now,
+                    degradationState: .degraded(reason: "Read-only database snapshot is temporarily unavailable")
+                )
+            ),
+        ]
+
+        for (name, fixture) in scenarios {
+            let view = InjectionFeedView(fixture: fixture)
+                .environment(\.colorScheme, .dark)
+                .frame(width: 1_180, height: 820)
+
+            try render(view, name: name, directory: renderDirectory)
+        }
+    }
+
+    private func reflectedDescription(named name: String, in value: Any) -> String? {
+        reflectedValue(named: name, in: value).map { String(describing: $0) }
+    }
+
+    private func reflectedValue(named name: String, in value: Any) -> Any? {
+        Mirror(reflecting: value).children.first { $0.label == name }?.value
+    }
+
+    private func isoDate(_ text: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: text)!
+    }
+
+    private func fixtureEvents() -> [InjectionEvent] {
+        let sourceFile = "/Users/example/brainlayer/.claude/projects/-Users-example-brainlayer/session.jsonl"
+        return [
+            InjectionEvent(
+                id: 101,
+                sessionID: "session-operator-truth-1234567890",
+                timestamp: "2026-07-19T09:58:00Z",
+                query: "why is watcher flow marked stalled",
+                chunkIDs: ["chunk-watcher-contract", "chunk-freshness-contract"],
+                tokenCount: 144,
+                chunks: [
+                    InjectionChunk(
+                        id: "chunk-watcher-contract",
+                        content: "Watcher flow uses process and recent distinct-ingest evidence.",
+                        summary: "Watcher truth contract",
+                        source: "claude_code",
+                        sourceFile: sourceFile,
+                        tags: ["brainbar", "truth"],
+                        contentType: "memory"
+                    ),
+                    InjectionChunk(
+                        id: "chunk-freshness-contract",
+                        content: "Snapshots become stale strictly after sixty seconds.",
+                        summary: "Freshness threshold",
+                        source: "mcp",
+                        sourceFile: sourceFile,
+                        tags: ["brainbar", "freshness"],
+                        contentType: "memory"
+                    ),
+                ],
+                claudeConversationID: "3679128a-f371-445f-82ba-b3946e2f20b6"
+            ),
+            InjectionEvent(
+                id: 100,
+                sessionID: "session-operator-truth-1234567890",
+                timestamp: "2026-07-19T09:54:00Z",
+                query: "why is watcher flow marked stalled",
+                chunkIDs: ["chunk-replay-debt"],
+                tokenCount: 76,
+                chunks: [
+                    InjectionChunk(
+                        id: "chunk-replay-debt",
+                        content: "Replay debt stays decomposed and exposes unreadable inputs.",
+                        summary: "Replay-debt evidence",
+                        source: "mcp",
+                        sourceFile: sourceFile,
+                        tags: ["brainbar"],
+                        contentType: "memory"
+                    )
+                ]
+            ),
+        ]
+    }
+
+    @MainActor
+    private func render<V: View>(_ view: V, name: String, directory: String) throws {
+        let size = NSSize(width: 1_180, height: 820)
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(origin: .zero, size: size)
+        host.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+        host.layoutSubtreeIfNeeded()
+
+        guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+            XCTFail("Expected an AppKit bitmap for \(name)")
+            return
+        }
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        guard let png = bitmap.representation(using: .png, properties: [:]) else {
+            XCTFail("Expected AppKit to encode \(name)")
+            return
+        }
+
+        let outputDirectory = URL(fileURLWithPath: directory, isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        let outputURL = outputDirectory.appendingPathComponent(name)
+        try png.write(to: outputURL)
+        XCTAssertGreaterThan(png.count, 5_000, "Expected a non-empty render at \(outputURL.path)")
+        XCTAssertGreaterThan(
+            distinctSampledColorCount(in: bitmap),
+            16,
+            "Expected visible feed content in \(outputURL.path)"
+        )
+    }
+
+    private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
+        guard let data = bitmap.bitmapData else { return 0 }
+        let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
+        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        var colors = Set<String>()
+        for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
+            let rowStart = y * bitmap.bytesPerRow
+            for x in stride(from: 0, to: bitmap.bytesPerRow, by: sampleStride) {
+                let offset = rowStart + x
+                guard offset + 2 < bitmap.bytesPerRow * bitmap.pixelsHigh else { continue }
+                colors.insert("\(data[offset])-\(data[offset + 1])-\(data[offset + 2])")
+            }
+        }
+        return colors.count
+    }
+
+    private func brainBarSourceFile(
+        _ relativePath: String,
+        testFilePath: StaticString = #filePath
+    ) throws -> String {
+        let testsDirectory = URL(fileURLWithPath: "\(testFilePath)").deletingLastPathComponent()
+        let packageRoot = testsDirectory.deletingLastPathComponent().deletingLastPathComponent()
+        return try String(
+            contentsOf: packageRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
@@ -51,6 +51,35 @@ final class InjectionSignalDensityContractTests: XCTestCase {
         XCTAssertFalse(burst.timestampLabel.isEmpty)
     }
 
+    func testMissingSelectedChunkNeverBorrowsAnotherResultsSummary() throws {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let available = InjectionChunk(
+            id: "available-chunk",
+            content: "Content belonging to a different result",
+            summary: "Different result summary",
+            source: "mcp",
+            sourceFile: "",
+            tags: [],
+            contentType: "memory"
+        )
+        let event = InjectionEvent(
+            id: 43,
+            sessionID: "session-missing-selected",
+            timestamp: "2026-07-19T09:58:00Z",
+            query: "show exact attribution",
+            chunkIDs: ["missing-selected", available.id],
+            tokenCount: 10,
+            chunks: [available]
+        )
+
+        let burst = try XCTUnwrap(
+            InjectionPresentation.snapshot(events: [event], filterText: "", now: now).bursts.first
+        )
+
+        XCTAssertEqual(burst.selectedResultProvenance?.chunkID, "missing-selected")
+        XCTAssertEqual(burst.selectedResultSummary, "Result unavailable")
+    }
+
     func testBurstProvenanceStaysPairedWithEachResult() throws {
         let now = isoDate("2026-07-19T10:00:00Z")
         let selected = InjectionChunk(
@@ -243,6 +272,22 @@ final class InjectionSignalDensityContractTests: XCTestCase {
             InjectionFeedView.burstGroupingDisclosure,
             "Retrieval bursts group the same session and trigger topic while consecutive events remain under 60 minutes."
         )
+    }
+
+    func testEmptyQueryUsesTruthfulSessionRailFallback() throws {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let event = InjectionEvent(
+            id: 8,
+            sessionID: "empty-query-session",
+            timestamp: "2026-07-19T09:59:00Z",
+            query: "   ",
+            chunkIDs: [],
+            tokenCount: 0
+        )
+
+        let snapshot = InjectionPresentation.snapshot(events: [event], filterText: "", now: now)
+
+        XCTAssertEqual(try XCTUnwrap(snapshot.sessions.first).displayLabel, "Retrieval session")
     }
 
     func testInjectionViewDeclaresLiteralGroupingAccessibilityStateAndFixtureContracts() throws {

--- a/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
@@ -43,12 +43,86 @@ final class InjectionSignalDensityContractTests: XCTestCase {
 
         XCTAssertEqual(burst.queryTitle, event.query)
         XCTAssertEqual(burst.selectedResultSummary, "Routing decision memory")
-        XCTAssertEqual(burst.sourceLabel, "Realtime Capture")
+        XCTAssertEqual(burst.sourceLabel, "Realtime Capture · claude_code")
         XCTAssertEqual(burst.projectLabel, "/Users/example/project")
         XCTAssertEqual(burst.resultCount, 2)
         XCTAssertEqual(burst.additionalResultPreviews.map(\.id), ["chunk-secondary"])
         XCTAssertEqual(burst.remainingCollapsedResultCount, 0)
         XCTAssertFalse(burst.timestampLabel.isEmpty)
+    }
+
+    func testBurstProvenanceStaysPairedWithEachResult() throws {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let selected = InjectionChunk(
+            id: "selected-chunk",
+            content: "Selected result",
+            summary: "Selected result summary",
+            source: "claude_code",
+            sourceFile: "",
+            tags: ["selected", "truth"],
+            contentType: "memory"
+        )
+        let later = InjectionChunk(
+            id: "later-chunk",
+            content: "Later result",
+            summary: "Later result summary",
+            source: "mcp",
+            sourceFile: "/Users/other/project/.claude/projects/-Users-other-project/session.jsonl",
+            tags: ["later"],
+            contentType: "assistant_text"
+        )
+        let events = [
+            InjectionEvent(
+                id: 2,
+                sessionID: "same-session",
+                timestamp: "2026-07-19T09:59:00Z",
+                query: "same trigger",
+                chunkIDs: [selected.id],
+                tokenCount: 10,
+                chunks: [selected]
+            ),
+            InjectionEvent(
+                id: 1,
+                sessionID: "same-session",
+                timestamp: "2026-07-19T09:58:00Z",
+                query: "same trigger",
+                chunkIDs: [later.id],
+                tokenCount: 9,
+                chunks: [later]
+            ),
+        ]
+
+        let burst = try XCTUnwrap(
+            InjectionPresentation.snapshot(events: events, filterText: "", now: now).bursts.first
+        )
+        let selectedProvenance = try XCTUnwrap(burst.selectedResultProvenance)
+
+        XCTAssertEqual(burst.projectLabel, "Project unavailable")
+        XCTAssertEqual(selectedProvenance.chunkID, selected.id)
+        XCTAssertEqual(selectedProvenance.source, "claude_code")
+        XCTAssertEqual(selectedProvenance.sourceFile, "")
+        XCTAssertEqual(selectedProvenance.projectPath, "")
+        XCTAssertEqual(selectedProvenance.contentType, "memory")
+        XCTAssertEqual(selectedProvenance.tags, ["selected", "truth"])
+        XCTAssertEqual(
+            selectedProvenance.expandedMetadataLabels(isSelected: true),
+            [
+                "Selected result",
+                "ID selected-chunk",
+                "Source claude_code",
+                "Source file unavailable",
+                "Project unavailable",
+                "Type memory",
+                "Tags selected, truth",
+            ]
+        )
+        XCTAssertEqual(
+            burst.resultProvenance.map { "\($0.chunkID)|\($0.source)|\($0.projectPath)" },
+            [
+                "selected-chunk|claude_code|",
+                "later-chunk|mcp|/Users/other/project",
+            ]
+        )
     }
 
     func testPresentationModelStartsInLoadingStateInsteadOfEmptyState() {
@@ -110,6 +184,32 @@ final class InjectionSignalDensityContractTests: XCTestCase {
                 filterActive: false
             ),
             .degraded(reason: "read failed", retainsContent: false)
+        )
+    }
+
+    func testActionReceiptsExposeSuccessFailureAndDisconnectedOutcomes() {
+        XCTAssertEqual(
+            InjectionActionReceipt.copyResult(copied: true),
+            InjectionActionReceipt(kind: .success, message: "Resume command copied")
+        )
+        XCTAssertEqual(
+            InjectionActionReceipt.copyResult(copied: false),
+            InjectionActionReceipt(kind: .failure, message: "Couldn’t copy the resume command")
+        )
+        XCTAssertEqual(
+            InjectionActionReceipt.threadOpenResult(errorDescription: nil),
+            InjectionActionReceipt(kind: .success, message: "Thread opened")
+        )
+        XCTAssertEqual(
+            InjectionActionReceipt.threadOpenResult(errorDescription: "database locked"),
+            InjectionActionReceipt(kind: .failure, message: "Couldn’t open thread · database locked")
+        )
+        XCTAssertEqual(
+            InjectionActionReceipt.disconnectedThread,
+            InjectionActionReceipt(
+                kind: .failure,
+                message: "Thread unavailable in this disconnected snapshot"
+            )
         )
     }
 
@@ -176,6 +276,17 @@ final class InjectionSignalDensityContractTests: XCTestCase {
         XCTAssertFalse(source.contains("docs.local/wave3-qa"))
     }
 
+    func testWindowRootRoutesUnavailableInjectionStoreToDisconnectedFeed() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertTrue(source.contains("InjectionFeedView(disconnectedAt: Date())"))
+        XCTAssertFalse(
+            source.contains(
+                "BrainBarLoadingView(title: \"Injections\", subtitle: BrainBarPlaceholderCopy.injectionFeedNotWired)"
+            )
+        )
+    }
+
     @MainActor
     func testRendersOverviewExpandedEmptyAndDegradedFixtureStates() throws {
         guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"],
@@ -204,6 +315,14 @@ final class InjectionSignalDensityContractTests: XCTestCase {
             (
                 "p3-injections-empty.png",
                 InjectionFeedFixture(events: [], now: now)
+            ),
+            (
+                "p3-injections-disconnected.png",
+                InjectionFeedFixture(
+                    events: [],
+                    now: now,
+                    connectionState: .disconnected
+                )
             ),
             (
                 "p3-injections-degraded.png",

--- a/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
@@ -80,6 +80,50 @@ final class InjectionSignalDensityContractTests: XCTestCase {
         XCTAssertEqual(burst.selectedResultSummary, "Result unavailable")
     }
 
+    func testRepeatedResultUpgradesMissingProvenanceWhenLaterEventSuppliesChunk() throws {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let recovered = InjectionChunk(
+            id: "repeated-chunk",
+            content: "Recovered content from a later event in the burst",
+            summary: "Recovered result summary",
+            source: "claude_code",
+            sourceFile: "/Users/example/project/.claude/projects/-Users-example-project/session.jsonl",
+            tags: ["recovered"],
+            contentType: "memory"
+        )
+        let events = [
+            InjectionEvent(
+                id: 52,
+                sessionID: "session-repeated-result",
+                timestamp: "2026-07-19T09:59:00Z",
+                query: "show repeated result truth",
+                chunkIDs: [recovered.id],
+                tokenCount: 10,
+                chunks: []
+            ),
+            InjectionEvent(
+                id: 51,
+                sessionID: "session-repeated-result",
+                timestamp: "2026-07-19T09:58:30Z",
+                query: "show repeated result truth",
+                chunkIDs: [recovered.id],
+                tokenCount: 9,
+                chunks: [recovered]
+            ),
+        ]
+
+        let burst = try XCTUnwrap(
+            InjectionPresentation.snapshot(events: events, filterText: "", now: now).bursts.first
+        )
+        let provenance = try XCTUnwrap(burst.selectedResultProvenance)
+
+        XCTAssertEqual(burst.resultCount, 1)
+        XCTAssertEqual(provenance.eventID, 51)
+        XCTAssertEqual(provenance.chunk, recovered)
+        XCTAssertEqual(burst.selectedResultSummary, "Recovered result summary")
+        XCTAssertEqual(burst.projectLabel, "/Users/example/project")
+    }
+
     func testBurstProvenanceStaysPairedWithEachResult() throws {
         let now = isoDate("2026-07-19T10:00:00Z")
         let selected = InjectionChunk(

--- a/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionSignalDensityContractTests.swift
@@ -4,6 +4,8 @@ import XCTest
 @testable import BrainBar
 
 final class InjectionSignalDensityContractTests: XCTestCase {
+    deinit {}
+
     func testCollapsedBurstPresentsTriggerBeforeSelectedResultAndKeepsProvenance() throws {
         let now = isoDate("2026-07-19T10:00:00Z")
         let sourceFile = "/Users/example/project/.claude/projects/-Users-example-project/session.jsonl"
@@ -78,6 +80,11 @@ final class InjectionSignalDensityContractTests: XCTestCase {
 
         XCTAssertEqual(burst.selectedResultProvenance?.chunkID, "missing-selected")
         XCTAssertEqual(burst.selectedResultSummary, "Result unavailable")
+        XCTAssertEqual(
+            burst.remainingCollapsedResultCount,
+            0,
+            "The unresolved selected provenance is still rendered and must consume the selected slot."
+        )
     }
 
     func testRepeatedResultUpgradesMissingProvenanceWhenLaterEventSuppliesChunk() throws {
@@ -283,6 +290,35 @@ final class InjectionSignalDensityContractTests: XCTestCase {
                 kind: .failure,
                 message: "Thread unavailable in this disconnected snapshot"
             )
+        )
+    }
+
+    func testActionReceiptGenerationPreventsOlderExpiryFromClearingNewerReceipt() {
+        var generation = InjectionActionReceiptGeneration()
+        let first = generation.next()
+        let second = generation.next()
+
+        XCTAssertFalse(generation.isCurrent(first))
+        XCTAssertTrue(generation.isCurrent(second))
+    }
+
+    func testFailedInitialLoadResolvesToExplicitDegradedSurface() {
+        let now = isoDate("2026-07-19T10:00:00Z")
+        let emptySnapshot = InjectionPresentation.snapshot(events: [], filterText: "", now: now)
+        let failed = InjectionFeedPresentationState(
+            events: [],
+            degradationState: .degraded(reason: "database locked"),
+            loadState: .failed
+        )
+
+        XCTAssertEqual(
+            InjectionFeedSurfaceState.resolve(
+                snapshot: emptySnapshot,
+                presentationState: failed,
+                connectionState: .connected,
+                filterActive: false
+            ),
+            .degraded(reason: "database locked", retainsContent: false)
         )
     }
 
@@ -534,7 +570,8 @@ final class InjectionSignalDensityContractTests: XCTestCase {
     private func distinctSampledColorCount(in bitmap: NSBitmapImageRep) -> Int {
         guard let data = bitmap.bitmapData else { return 0 }
         let bytesPerPixel = max(bitmap.bitsPerPixel / 8, 1)
-        let sampleStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let baseStride = max(bitmap.bytesPerRow / 32, bytesPerPixel)
+        let sampleStride = baseStride - (baseStride % bytesPerPixel)
         var colors = Set<String>()
         for y in stride(from: 0, to: bitmap.pixelsHigh, by: 24) {
             let rowStart = y * bitmap.bytesPerRow

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -279,12 +279,21 @@ final class InjectionStoreTests: XCTestCase {
         let store = InjectionStore(reader: reader)
         let model = InjectionFeedPresentationModel(throttleInterval: .milliseconds(0))
 
+        XCTAssertEqual(store.loadState, .loading)
         model.bind(to: store)
         XCTAssertEqual(model.state.loadState, .loading)
+
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(
+            model.state.loadState,
+            .loading,
+            "Binding alone is not evidence that the injection event read completed."
+        )
 
         store.refreshForTesting(force: true)
         try await Task.sleep(for: .milliseconds(20))
 
+        XCTAssertEqual(store.loadState, .loaded)
         XCTAssertEqual(model.state.loadState, .loaded)
         XCTAssertTrue(model.state.events.isEmpty)
     }

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -134,7 +134,12 @@ final class InjectionStoreTests: XCTestCase {
             store.degradationState.isDegraded,
             "An unchanged dataVersion poll skipped the event query; that is not positive recovery evidence."
         )
-        XCTAssertEqual(store.loadState, .loaded, "A successful probe may remain degraded while publishing a completed read state.")
+        XCTAssertEqual(reader.listCallCount, 2, "The transition to probing must not claim an event read occurred.")
+        XCTAssertEqual(
+            store.loadState,
+            .failed,
+            "A clean dataVersion probe cannot publish loaded until listInjectionEvents succeeds."
+        )
 
         store.refreshForTesting(force: false)
         XCTAssertEqual(store.degradationState, .healthy)

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -127,12 +127,14 @@ final class InjectionStoreTests: XCTestCase {
 
         store.refreshForTesting(force: true)
         XCTAssertTrue(store.degradationState.isDegraded)
+        XCTAssertEqual(store.loadState, .failed, "A failed refresh must never masquerade as loaded.")
 
         store.refreshForTesting(force: false)
         XCTAssertTrue(
             store.degradationState.isDegraded,
             "An unchanged dataVersion poll skipped the event query; that is not positive recovery evidence."
         )
+        XCTAssertEqual(store.loadState, .loaded, "A successful probe may remain degraded while publishing a completed read state.")
 
         store.refreshForTesting(force: false)
         XCTAssertEqual(store.degradationState, .healthy)
@@ -291,7 +293,10 @@ final class InjectionStoreTests: XCTestCase {
         )
 
         store.refreshForTesting(force: true)
-        try await Task.sleep(for: .milliseconds(20))
+        let deadline = Date().addingTimeInterval(2)
+        while model.state.loadState != .loaded, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
 
         XCTAssertEqual(store.loadState, .loaded)
         XCTAssertEqual(model.state.loadState, .loaded)

--- a/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
+++ b/brain-bar/Tests/BrainBarTests/InjectionStoreTests.swift
@@ -269,6 +269,25 @@ final class InjectionStoreTests: XCTestCase {
         XCTAssertEqual(model.state.events.map(\.id), [42])
         XCTAssertEqual(model.state.degradationState, .healthy)
     }
+
+    @MainActor
+    func testInjectionFeedPresentationModelRemainsLoadingUntilInitialEmptyReadCompletes() async throws {
+        let reader = ScriptedInjectionEventReader(
+            versions: [1],
+            eventResults: [.success([])]
+        )
+        let store = InjectionStore(reader: reader)
+        let model = InjectionFeedPresentationModel(throttleInterval: .milliseconds(0))
+
+        model.bind(to: store)
+        XCTAssertEqual(model.state.loadState, .loading)
+
+        store.refreshForTesting(force: true)
+        try await Task.sleep(for: .milliseconds(20))
+
+        XCTAssertEqual(model.state.loadState, .loaded)
+        XCTAssertTrue(model.state.events.isEmpty)
+    }
 }
 
 private enum ScriptedInjectionError: Error {

--- a/brain-bar/Tests/BrainBarTests/KGProgressiveDisclosureTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGProgressiveDisclosureTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import BrainBar
 
 final class KGProgressiveDisclosureTests: XCTestCase {
+    deinit {}
+
     func testEmptyAtlasNeverReservesSidebarWidth() {
         XCTAssertFalse(KGCanvasMetrics.sidebarVisible(
             windowWidth: 1_200,
@@ -13,7 +15,7 @@ final class KGProgressiveDisclosureTests: XCTestCase {
         ))
     }
 
-    func testFindResultsExposeEveryVisibleEntityWithTypeAndRelationshipDegree() {
+    func testFindResultsExposeEveryVisibleEntityWithTypeAndRelationshipDegree() throws {
         let nodes = [
             node(id: "person", name: "Etan Heyman", type: "person", importance: 10),
             node(id: "project", name: "BrainLayer", type: "project", importance: 8),
@@ -37,15 +39,15 @@ final class KGProgressiveDisclosureTests: XCTestCase {
             edges: snapshot.visibleEdges,
             query: ""
         )
-        let project = allResults.first { $0.id == "project" }
+        let project = try XCTUnwrap(allResults.first { $0.id == "project" })
 
         XCTAssertEqual(Set(allResults.map(\.id)), Set(snapshot.visibleNodes.map(\.id)))
-        XCTAssertEqual(project?.name, "BrainLayer")
-        XCTAssertEqual(project?.entityTypeTitle, "Project")
-        XCTAssertEqual(project?.degree, 2)
-        XCTAssertEqual(project?.relationshipSummary, "2 visible relationships")
+        XCTAssertEqual(project.name, "BrainLayer")
+        XCTAssertEqual(project.entityTypeTitle, "Project")
+        XCTAssertEqual(project.degree, 2)
+        XCTAssertEqual(project.relationshipSummary, "2 visible relationships")
         XCTAssertEqual(
-            project?.accessibilityLabel,
+            project.accessibilityLabel,
             "BrainLayer, Project, 2 visible relationships"
         )
         XCTAssertEqual(
@@ -103,6 +105,14 @@ final class KGProgressiveDisclosureTests: XCTestCase {
                 results: results
             ),
             "c"
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.nextFindResultID(
+                currentID: "a",
+                move: .up,
+                results: results
+            ),
+            "a"
         )
         XCTAssertEqual(
             KGAtlasPresentation.nextFindResultID(
@@ -169,7 +179,6 @@ final class KGProgressiveDisclosureTests: XCTestCase {
         XCTAssertEqual(lineOnlyEdge.sourceId, edge.sourceId)
         XCTAssertEqual(lineOnlyEdge.targetId, edge.targetId)
         XCTAssertEqual(lineOnlyEdge.relationType, "")
-        XCTAssertFalse(KGSidebarView.relationsSectionDefaultExpanded)
     }
 
     func testModeEffectsAndCanvasSummaryExplainNonSpatialControls() {

--- a/brain-bar/Tests/BrainBarTests/KGProgressiveDisclosureTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGProgressiveDisclosureTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+@testable import BrainBar
+
+final class KGProgressiveDisclosureTests: XCTestCase {
+    func testEmptyAtlasNeverReservesSidebarWidth() {
+        XCTAssertFalse(KGCanvasMetrics.sidebarVisible(
+            windowWidth: 1_200,
+            selectedEntityVisible: false
+        ))
+        XCTAssertTrue(KGCanvasMetrics.sidebarVisible(
+            windowWidth: 760,
+            selectedEntityVisible: true
+        ))
+    }
+
+    func testFindResultsExposeEveryVisibleEntityWithTypeAndRelationshipDegree() {
+        let nodes = [
+            node(id: "person", name: "Etan Heyman", type: "person", importance: 10),
+            node(id: "project", name: "BrainLayer", type: "project", importance: 8),
+            node(id: "tool", name: "MCP", type: "tool", importance: 7),
+            node(id: "hidden", name: "Scratch", type: "topic", importance: 1),
+        ]
+        let edges = [
+            KGEdge(sourceId: "person", targetId: "project", relationType: "builds"),
+            KGEdge(sourceId: "project", targetId: "tool", relationType: "uses"),
+        ]
+        let snapshot = KGAtlasPresentation.snapshot(
+            nodes: nodes,
+            edges: edges,
+            selectedNodeId: nil,
+            minimumImportance: 6,
+            mode: .importance
+        )
+
+        let allResults = KGAtlasPresentation.findResults(
+            nodes: snapshot.visibleNodes,
+            edges: snapshot.visibleEdges,
+            query: ""
+        )
+        let project = allResults.first { $0.id == "project" }
+
+        XCTAssertEqual(Set(allResults.map(\.id)), Set(snapshot.visibleNodes.map(\.id)))
+        XCTAssertEqual(project?.name, "BrainLayer")
+        XCTAssertEqual(project?.entityTypeTitle, "Project")
+        XCTAssertEqual(project?.degree, 2)
+        XCTAssertEqual(project?.relationshipSummary, "2 visible relationships")
+        XCTAssertEqual(
+            project?.accessibilityLabel,
+            "BrainLayer, Project, 2 visible relationships"
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.findResults(
+                nodes: snapshot.visibleNodes,
+                edges: snapshot.visibleEdges,
+                query: "tool"
+            ).map(\.id),
+            ["tool"]
+        )
+    }
+
+    func testFindResultKeyboardSelectionIsDeterministicAndClamped() {
+        let results = [
+            KGAtlasPresentation.FindResult(
+                id: "a",
+                name: "Alpha",
+                entityTypeTitle: "Project",
+                degree: 0
+            ),
+            KGAtlasPresentation.FindResult(
+                id: "b",
+                name: "Beta",
+                entityTypeTitle: "Tool",
+                degree: 1
+            ),
+            KGAtlasPresentation.FindResult(
+                id: "c",
+                name: "Gamma",
+                entityTypeTitle: "Topic",
+                degree: 2
+            ),
+        ]
+
+        XCTAssertEqual(
+            KGAtlasPresentation.nextFindResultID(
+                currentID: nil,
+                move: .down,
+                results: results
+            ),
+            "a"
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.nextFindResultID(
+                currentID: "a",
+                move: .down,
+                results: results
+            ),
+            "b"
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.nextFindResultID(
+                currentID: "c",
+                move: .down,
+                results: results
+            ),
+            "c"
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.nextFindResultID(
+                currentID: nil,
+                move: .up,
+                results: results
+            ),
+            "c"
+        )
+    }
+
+    func testPriorityLabelsAreStableAcrossRefreshOrderAndSuppressNearbyCollisions() {
+        let alpha = node(
+            id: "alpha",
+            name: "Alpha Platform",
+            type: "project",
+            importance: 9,
+            chunks: 80,
+            position: CGPoint(x: 200, y: 200)
+        )
+        let beta = node(
+            id: "beta",
+            name: "Beta Platform",
+            type: "project",
+            importance: 8,
+            chunks: 60,
+            position: CGPoint(x: 214, y: 204)
+        )
+        let gamma = node(
+            id: "gamma",
+            name: "Gamma Tool",
+            type: "tool",
+            importance: 7,
+            chunks: 40,
+            position: CGPoint(x: 520, y: 360)
+        )
+
+        let forward = KGAtlasPresentation.priorityLabelNodeIDs(
+            nodes: [alpha, beta, gamma],
+            selectedNodeID: "beta",
+            scale: 1
+        )
+        let refreshed = KGAtlasPresentation.priorityLabelNodeIDs(
+            nodes: [gamma, beta, alpha],
+            selectedNodeID: "beta",
+            scale: 1
+        )
+
+        XCTAssertEqual(forward, refreshed)
+        XCTAssertTrue(forward.contains("beta"), "The selected label is always disclosed")
+        XCTAssertTrue(forward.contains("gamma"), "A distant priority label remains visible")
+        XCTAssertFalse(forward.contains("alpha"), "A nearby label yields to the selected entity")
+    }
+
+    func testCanvasEdgesKeepTopologyWithoutAlwaysOnRelationText() {
+        let edge = KGEdge(
+            sourceId: "project",
+            targetId: "tool",
+            relationType: "uses"
+        )
+
+        let lineOnlyEdge = KGAtlasPresentation.lineOnlyEdge(edge)
+
+        XCTAssertEqual(lineOnlyEdge.sourceId, edge.sourceId)
+        XCTAssertEqual(lineOnlyEdge.targetId, edge.targetId)
+        XCTAssertEqual(lineOnlyEdge.relationType, "")
+        XCTAssertFalse(KGSidebarView.relationsSectionDefaultExpanded)
+    }
+
+    func testModeEffectsAndCanvasSummaryExplainNonSpatialControls() {
+        XCTAssertEqual(
+            KGAtlasPresentation.modeEffectDescription(
+                mode: .importance,
+                minimumImportance: 6,
+                altitudeTier: .signal
+            ),
+            "Shows entities with importance 6/10 or higher. Selected and pinned entities remain visible."
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.modeEffectDescription(
+                mode: .tieredAltitude,
+                minimumImportance: 6,
+                altitudeTier: .signal
+            ),
+            "Shows Summit through Signal. Lower altitude reveals more entities."
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.canvasAccessibilityValue(
+                visibleEntityCount: 3,
+                visibleRelationshipCount: 2
+            ),
+            "3 visible entities and 2 visible relationships"
+        )
+        XCTAssertEqual(
+            KGAtlasPresentation.canvasAccessibilityHint,
+            "Use Find entity to browse and select every visible entity without spatial pointing."
+        )
+    }
+
+    func testFixedFixtureProducesStableNodePositionsRegardlessOfInputOrder() {
+        let nodes = [
+            node(id: "person", name: "Etan Heyman", type: "person", importance: 10),
+            node(id: "project", name: "BrainLayer", type: "project", importance: 8),
+            node(id: "tool", name: "MCP", type: "tool", importance: 7),
+        ]
+        let canvasSize = CGSize(width: 960, height: 640)
+
+        let forward = Dictionary(uniqueKeysWithValues: KGAtlasLayout.seededNodes(
+            nodes,
+            canvasSize: canvasSize,
+            mode: .tieredAltitude
+        ).map { ($0.id, $0.position) })
+        let refreshed = Dictionary(uniqueKeysWithValues: KGAtlasLayout.seededNodes(
+            Array(nodes.reversed()),
+            canvasSize: canvasSize,
+            mode: .tieredAltitude
+        ).map { ($0.id, $0.position) })
+
+        XCTAssertEqual(forward, refreshed)
+    }
+
+    func testDetailDisclosuresStartCollapsedAndRemainDismissible() {
+        XCTAssertFalse(KGSidebarView.relationsSectionDefaultExpanded)
+        XCTAssertFalse(KGSidebarView.filesSectionDefaultExpanded)
+        XCTAssertEqual(KGSidebarView.closeAccessibilityLabel, "Close entity details")
+    }
+
+    private func node(
+        id: String,
+        name: String,
+        type: String,
+        importance: Double,
+        chunks: Int = 0,
+        position: CGPoint = .zero
+    ) -> KGNode {
+        KGNode(
+            id: id,
+            name: name,
+            entityType: type,
+            importance: importance,
+            linkedChunkCount: chunks,
+            position: position
+        )
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/KGSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGSnapshotTests.swift
@@ -84,12 +84,23 @@ final class KGSnapshotTests: XCTestCase {
             )
         }
 
+        try assertDeterministicRender(
+            named: "graph-dismissed-sidebar.png",
+            in: destination
+        ) {
+            let dismissed = makeViewModel(mode: .tieredAltitude)
+            dismissed.selectedNodeId = nil
+            dismissed.selectedEntity = nil
+            return snapshotView(viewModel: dismissed)
+        }
+
         let expectedNames = [
             "graph-tiered-atlas.png",
             "graph-importance-atlas.png",
             "graph-find-entity.png",
             "graph-selected-details.png",
             "graph-reduced-motion.png",
+            "graph-dismissed-sidebar.png",
         ]
         for name in expectedNames {
             let data = try Data(contentsOf: destination.appendingPathComponent(name))

--- a/brain-bar/Tests/BrainBarTests/KGSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGSnapshotTests.swift
@@ -1,0 +1,194 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BrainBar
+
+@MainActor
+final class KGSnapshotTests: XCTestCase {
+    func testRendersDeterministicAtlasStatesToIsolatedDirectory() throws {
+        guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"] else {
+            throw XCTSkip("Set BRAINBAR_RENDER_DIR to render graph QA artifacts")
+        }
+
+        let destination = URL(fileURLWithPath: renderDirectory, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: destination,
+            withIntermediateDirectories: true
+        )
+
+        try assertDeterministicRender(
+            named: "graph-tiered-atlas.png",
+            in: destination
+        ) {
+            snapshotView(viewModel: makeViewModel(mode: .tieredAltitude))
+        }
+
+        try assertDeterministicRender(
+            named: "graph-importance-atlas.png",
+            in: destination
+        ) {
+            snapshotView(viewModel: makeViewModel(mode: .importance))
+        }
+
+        try assertDeterministicRender(
+            named: "graph-find-entity.png",
+            in: destination
+        ) {
+            KGCanvasView(
+                viewModel: makeViewModel(mode: .tieredAltitude),
+                isActive: false,
+                initialFindPresented: true,
+                initialFindQuery: "brain"
+            )
+        }
+
+        try assertDeterministicRender(
+            named: "graph-selected-details.png",
+            in: destination
+        ) {
+            let selected = makeViewModel(mode: .tieredAltitude)
+            selected.selectedNodeId = "project-brainlayer"
+            selected.selectedEntity = EntityCard(
+                id: "project-brainlayer",
+                name: "BrainLayer",
+                entityType: "project",
+                description: "Durable memory infrastructure for the golems ecosystem.",
+                relations: [
+                    .init(
+                        relationType: "built_by",
+                        targetName: "Etan Heyman",
+                        targetEntityId: "person-etan",
+                        direction: "outgoing"
+                    ),
+                    .init(
+                        relationType: "uses",
+                        targetName: "MCP",
+                        targetEntityId: "tool-mcp",
+                        direction: "outgoing"
+                    ),
+                ],
+                importance: 9,
+                altitudeTierTitle: "Summit"
+            )
+            return snapshotView(viewModel: selected)
+        }
+
+        try assertDeterministicRender(
+            named: "graph-reduced-motion.png",
+            in: destination
+        ) {
+            KGCanvasView(
+                viewModel: makeViewModel(mode: .tieredAltitude),
+                isActive: false,
+                reduceMotionOverride: true
+            )
+        }
+
+        let expectedNames = [
+            "graph-tiered-atlas.png",
+            "graph-importance-atlas.png",
+            "graph-find-entity.png",
+            "graph-selected-details.png",
+            "graph-reduced-motion.png",
+        ]
+        for name in expectedNames {
+            let data = try Data(contentsOf: destination.appendingPathComponent(name))
+            XCTAssertGreaterThan(data.count, 10_000, "Expected a substantive PNG for \(name)")
+        }
+    }
+
+    private func makeViewModel(mode: KGAtlasMode) -> KGViewModel {
+        let viewModel = KGViewModel(graphReader: KGSnapshotGraphReader())
+        let canvasSize = CGSize(width: 1_120, height: 760)
+        viewModel.updateCanvasSize(canvasSize)
+        viewModel.nodes = KGAtlasLayout.seededNodes(
+            [
+                node(id: "person-etan", name: "Etan Heyman", type: "person", importance: 10, chunks: 240),
+                node(id: "project-brainlayer", name: "BrainLayer", type: "project", importance: 9, chunks: 180),
+                node(id: "tool-mcp", name: "MCP", type: "tool", importance: 8, chunks: 120),
+                node(id: "agent-codex", name: "Codex", type: "agent", importance: 7, chunks: 90),
+                node(id: "company-openai", name: "OpenAI", type: "company", importance: 6, chunks: 60),
+                node(id: "topic-retrieval", name: "Retrieval quality", type: "topic", importance: 5, chunks: 35),
+                node(id: "decision-wal", name: "Bound WAL growth", type: "decision", importance: 4, chunks: 20),
+            ],
+            canvasSize: canvasSize,
+            mode: mode
+        )
+        viewModel.edges = [
+            KGEdge(sourceId: "person-etan", targetId: "project-brainlayer", relationType: "builds"),
+            KGEdge(sourceId: "project-brainlayer", targetId: "tool-mcp", relationType: "exposes"),
+            KGEdge(sourceId: "project-brainlayer", targetId: "agent-codex", relationType: "supports"),
+            KGEdge(sourceId: "agent-codex", targetId: "company-openai", relationType: "created_by"),
+            KGEdge(sourceId: "project-brainlayer", targetId: "topic-retrieval", relationType: "improves"),
+            KGEdge(sourceId: "decision-wal", targetId: "project-brainlayer", relationType: "protects"),
+        ]
+        viewModel.layoutMode = mode
+        return viewModel
+    }
+
+    private func snapshotView(viewModel: KGViewModel) -> KGCanvasView {
+        KGCanvasView(
+            viewModel: viewModel,
+            isActive: false
+        )
+    }
+
+    private func node(
+        id: String,
+        name: String,
+        type: String,
+        importance: Double,
+        chunks: Int
+    ) -> KGNode {
+        KGNode(
+            id: id,
+            name: name,
+            entityType: type,
+            importance: importance,
+            linkedChunkCount: chunks
+        )
+    }
+
+    private func assertDeterministicRender<V: View>(
+        named name: String,
+        in directory: URL,
+        makeView: () -> V
+    ) throws {
+        let first = try render(makeView(), named: name)
+        let second = try render(makeView(), named: name)
+        XCTAssertEqual(first, second, "Expected byte-stable fixed-fixture render for \(name)")
+        try first.write(to: directory.appendingPathComponent(name))
+    }
+
+    private func render<V: View>(_ view: V, named name: String) throws -> Data {
+        let host = NSHostingView(
+            rootView: view
+                .frame(width: 1_120, height: 760)
+                .environment(\.colorScheme, .dark)
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 1_120, height: 760)
+        host.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        host.layoutSubtreeIfNeeded()
+
+        guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+            throw KGSnapshotRenderError.bitmapUnavailable(name)
+        }
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+
+        guard let png = bitmap.representation(using: .png, properties: [:]) else {
+            throw KGSnapshotRenderError.encodingFailed(name)
+        }
+        return png
+    }
+}
+
+private enum KGSnapshotRenderError: Error {
+    case bitmapUnavailable(String)
+    case encodingFailed(String)
+}
+
+private final class KGSnapshotGraphReader: KnowledgeGraphReading, @unchecked Sendable {
+    func fetchKGEntities(limit: Int) throws -> [BrainDatabase.KGEntityRow] { [] }
+    func fetchKGRelations(limit: Int) throws -> [BrainDatabase.KGRelationRow] { [] }
+}

--- a/brain-bar/Tests/BrainBarTests/KGSnapshotTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KGSnapshotTests.swift
@@ -5,6 +5,28 @@ import XCTest
 
 @MainActor
 final class KGSnapshotTests: XCTestCase {
+    private var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    func testAtlasToolbarWrapsEveryRegionLegendChipWithoutHiddenOverflow() throws {
+        let source = try String(
+            contentsOf: packageRoot.appendingPathComponent("Sources/BrainBar/KnowledgeGraph/KGCanvasView.swift"),
+            encoding: .utf8
+        )
+        let toolbarStart = try XCTUnwrap(source.range(of: "private func atlasToolbar"))
+        let toolbarEnd = try XCTUnwrap(
+            source.range(of: "private func atlasOverview", range: toolbarStart.upperBound..<source.endIndex)
+        )
+        let toolbar = String(source[toolbarStart.lowerBound..<toolbarEnd.lowerBound])
+
+        XCTAssertTrue(toolbar.contains("WrappingPillLayout"))
+        XCTAssertFalse(toolbar.contains("ScrollView(.horizontal, showsIndicators: false)"))
+    }
+
     func testRendersDeterministicAtlasStatesToIsolatedDirectory() throws {
         guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"] else {
             throw XCTSkip("Set BRAINBAR_RENDER_DIR to render graph QA artifacts")

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -52,6 +52,10 @@ final class KGSidebarViewTests: XCTestCase {
 
     @MainActor
     func testRendersFilesAccordionQAImage() throws {
+        guard let renderDirectory = ProcessInfo.processInfo.environment["BRAINBAR_RENDER_DIR"] else {
+            throw XCTSkip("Set BRAINBAR_RENDER_DIR to render graph QA artifacts")
+        }
+
         let entity = EntityCard(
             id: "person-etan",
             name: "Etan Heyman",
@@ -98,21 +102,25 @@ final class KGSidebarViewTests: XCTestCase {
         )
         .frame(width: KGCanvasMetrics.sidebarWidth, height: 720)
 
-        let renderer = ImageRenderer(content: view)
-        renderer.scale = 2
-        guard let image = renderer.nsImage,
-              let tiff = image.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiff),
-              let png = bitmap.representation(using: .png, properties: [:]) else {
+        let host = NSHostingView(rootView: view.environment(\.colorScheme, .dark))
+        host.frame = NSRect(x: 0, y: 0, width: KGCanvasMetrics.sidebarWidth, height: 720)
+        host.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        host.layoutSubtreeIfNeeded()
+
+        guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+            XCTFail("Expected KG sidebar renderer to produce a bitmap")
+            return
+        }
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+
+        guard let png = bitmap.representation(using: .png, properties: [:]) else {
             XCTFail("Expected KG sidebar renderer to produce a PNG")
             return
         }
 
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("docs.local/wave3-qa/bug7-atlas-files-accordion.png")
+        let url = URL(fileURLWithPath: renderDirectory, isDirectory: true)
+            .appendingPathComponent("graph-files-accordion.png")
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -1271,10 +1279,36 @@ final class KGViewModelTests: XCTestCase {
         vm.nodes.removeAll()
         vm.selectNode(id: "a")
 
+        XCTAssertNil(vm.selectedNodeId)
         XCTAssertNil(vm.selectedEntity)
         XCTAssertTrue(vm.isLayoutPinned)
         XCTAssertFalse(vm.isLoadingSelectedEntityChunks)
         XCTAssertTrue(vm.selectedEntityChunks.isEmpty)
+    }
+
+    func testFailedEntityLookupClearsSelectionSoSidebarCanCollapse() async throws {
+        try db.insertEntity(id: "a", type: "person", name: "Alice")
+        try db.insertEntity(id: "b", type: "project", name: "BrainLayer")
+        try db.insertRelation(sourceId: "a", targetId: "b", relationType: "builds")
+        let vm = KGViewModel(database: db)
+        await vm.loadGraph()
+        XCTAssertTrue(vm.nodes.contains { $0.id == "a" })
+
+        guard let handle = db.dbHandle else {
+            XCTFail("Expected database handle")
+            return
+        }
+        XCTAssertEqual(
+            sqlite3_exec(handle, "DELETE FROM kg_entities WHERE id = 'a'", nil, nil, nil),
+            SQLITE_OK
+        )
+
+        vm.selectNode(id: "a")
+
+        XCTAssertNil(vm.selectedNodeId)
+        XCTAssertNil(vm.selectedEntity)
+        XCTAssertFalse(vm.isLoadingSelectedEntityChunks)
+        XCTAssertFalse(vm.isLoadingSelectedEntityFiles)
     }
 
     func testSelectNodeNilDeselects() async throws {

--- a/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
+++ b/brain-bar/Tests/BrainBarTests/KnowledgeGraphTests.swift
@@ -1611,6 +1611,11 @@ final class KGViewModelTests: XCTestCase {
         db.close()
 
         vm.selectNode(id: "e1")
+        XCTAssertEqual(vm.selectedNodeId, "e1", "A detail lookup failure must preserve the operator's selection.")
+        XCTAssertFalse(vm.isLoadingSelectedEntityChunks)
+        XCTAssertFalse(vm.isLoadingSelectedEntityFiles)
+        XCTAssertTrue(vm.selectedEntityChunkSidebarLoadFailed)
+        XCTAssertTrue(vm.selectedEntityFileSidebarLoadFailed)
         await waitForSelectedEntityChunkLoadingToFinish(vm)
 
         XCTAssertTrue(vm.selectedEntityChunkSidebarLoadFailed)
@@ -1619,6 +1624,35 @@ final class KGViewModelTests: XCTestCase {
         XCTAssertEqual(vm.selectedEntityFileTotal, 0)
         XCTAssertTrue(vm.selectedEntityChunks.isEmpty)
         XCTAssertTrue(vm.selectedEntityFiles.isEmpty)
+    }
+
+    func testGraphReaderOnlySelectionPreservesNodeAndSurfacesUnavailableSidebar() async throws {
+        let reader = RecordingKnowledgeGraphReader(
+            entities: [
+                BrainDatabase.KGEntityRow(
+                    id: "reader-only",
+                    name: "Reader only",
+                    entityType: "project",
+                    description: nil,
+                    importance: 8,
+                    linkedChunkCount: 0
+                ),
+            ],
+            relations: []
+        )
+        let vm = KGViewModel(graphReader: reader)
+        let loaded = await vm.loadGraph()
+        XCTAssertTrue(loaded)
+
+        vm.selectNode(id: "reader-only")
+
+        XCTAssertEqual(vm.selectedNodeId, "reader-only")
+        XCTAssertTrue(vm.isLayoutPinned)
+        XCTAssertNil(vm.selectedEntity)
+        XCTAssertFalse(vm.isLoadingSelectedEntityChunks)
+        XCTAssertFalse(vm.isLoadingSelectedEntityFiles)
+        XCTAssertTrue(vm.selectedEntityChunkSidebarLoadFailed)
+        XCTAssertTrue(vm.selectedEntityFileSidebarLoadFailed)
     }
 
     func testFetchEntitySidebarSnapshotHonorsCancellationBeforeDatabaseWork() async throws {

--- a/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
@@ -54,6 +54,32 @@ private final class SucceedOnceWindowBucketsProvider: @unchecked Sendable {
     }
 }
 
+private final class CompletingWindowBucketsProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private let response: BrainDatabase.PipelineWindowBuckets
+    private var completed = false
+
+    deinit {}
+
+    init(response: BrainDatabase.PipelineWindowBuckets) {
+        self.response = response
+    }
+
+    var hasCompleted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return completed
+    }
+
+    func fetch(windowMinutes: Int, bucketCount: Int) -> BrainDatabase.PipelineWindowBuckets {
+        Thread.sleep(forTimeInterval: 0.1)
+        lock.lock()
+        completed = true
+        lock.unlock()
+        return response
+    }
+}
+
 private final class SequencedBlockingWatcherProbe: WatcherProcessProbing, @unchecked Sendable {
     private let lock = NSLock()
     private let blockedSampleStarted = DispatchSemaphore(value: 0)
@@ -119,6 +145,53 @@ private final class OlderFullRefreshProbe: WatcherProcessProbing, @unchecked Sen
 
     func releaseFirstSample() {
         releaseFirstSampleSemaphore.signal()
+    }
+}
+
+private final class PendingNewerStandaloneProbe: WatcherProcessProbing, @unchecked Sendable {
+    private let lock = NSLock()
+    private let olderFullStarted = DispatchSemaphore(value: 0)
+    private let releaseOlderFullSemaphore = DispatchSemaphore(value: 0)
+    private let newerStandaloneStarted = DispatchSemaphore(value: 0)
+    private let releaseNewerStandaloneSemaphore = DispatchSemaphore(value: 0)
+    private var calls = 0
+
+    deinit {}
+
+    func sample() -> WatcherProcessProbeResult {
+        lock.lock()
+        let call = calls
+        calls += 1
+        lock.unlock()
+
+        switch call {
+        case 0:
+            return .running(pid: 1000)
+        case 1:
+            olderFullStarted.signal()
+            releaseOlderFullSemaphore.wait()
+            return .running(pid: 1111)
+        default:
+            newerStandaloneStarted.signal()
+            releaseNewerStandaloneSemaphore.wait()
+            return .running(pid: 2222)
+        }
+    }
+
+    func waitForOlderFull(timeout: DispatchTime) -> Bool {
+        olderFullStarted.wait(timeout: timeout) == .success
+    }
+
+    func waitForNewerStandalone(timeout: DispatchTime) -> Bool {
+        newerStandaloneStarted.wait(timeout: timeout) == .success
+    }
+
+    func releaseOlderFull() {
+        releaseOlderFullSemaphore.signal()
+    }
+
+    func releaseNewerStandalone() {
+        releaseNewerStandaloneSemaphore.signal()
     }
 }
 
@@ -280,7 +353,7 @@ final class StatsCollectorTests: XCTestCase {
 
         collector.refresh(force: true)
         let refreshDeadline = Date().addingTimeInterval(3)
-        while (collector.isRefreshing || provider.callCount < 2) && Date() < refreshDeadline {
+        while (collector.isRefreshing || collector.windowedBuckets != refreshedBuckets) && Date() < refreshDeadline {
             try await Task.sleep(for: .milliseconds(10))
         }
 
@@ -385,21 +458,23 @@ final class StatsCollectorTests: XCTestCase {
             enrichmentBuckets: [0],
             watcherFlowReadability: .readable
         )
+        let provider = CompletingWindowBucketsProvider(response: delayedBuckets)
         let collector = StatsCollector(
             dbPath: tempDBPath,
             daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
-            windowedBucketsProvider: { _, _ in
-                Thread.sleep(forTimeInterval: 0.1)
-                return delayedBuckets
-            },
+            windowedBucketsProvider: provider.fetch,
             databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
         )
         defer { collector.stop() }
 
         collector.selectTimeframe(windowMinutes: 1_440, isLive: false)
         collector.selectTimeframe(windowMinutes: 60, isLive: true)
-        try await Task.sleep(for: .milliseconds(200))
+        let completionDeadline = Date().addingTimeInterval(2)
+        while !provider.hasCompleted && Date() < completionDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
 
+        XCTAssertTrue(provider.hasCompleted, "The discarded late fetch must complete before its final state is asserted.")
         XCTAssertNil(collector.windowedBuckets)
         XCTAssertNil(collector.windowedBucketsWindowMinutes)
         XCTAssertNil(collector.windowedBucketsError)
@@ -511,6 +586,92 @@ final class StatsCollectorTests: XCTestCase {
         )
     }
 
+    func testFailedOlderFullRefreshDoesNotOverwriteNewerStandaloneWatcherProbe() async throws {
+        let probe = OlderFullRefreshProbe()
+        let collector = StatsCollector(
+            dbPath: tempDBPath + ".missing",
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            watcherProcessProbe: probe,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer {
+            probe.releaseFirstSample()
+            collector.stop()
+        }
+
+        collector.refresh(force: true)
+        XCTAssertTrue(probe.waitForFirstSample(timeout: .now() + 2))
+
+        collector.refresh(force: false)
+        let standaloneDeadline = Date().addingTimeInterval(3)
+        while collector.stats.watcherProcessProbeResult != .running(pid: 2222), Date() < standaloneDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 2222))
+
+        probe.releaseFirstSample()
+        let failureDeadline = Date().addingTimeInterval(10)
+        while (collector.isRefreshing || collector.lastFetchError == nil), Date() < failureDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertFalse(collector.isRefreshing)
+        XCTAssertNotNil(collector.lastFetchError)
+        XCTAssertEqual(
+            collector.stats.watcherProcessProbeResult,
+            .running(pid: 2222),
+            "A failed older full refresh must preserve watcher truth from the newer standalone probe."
+        )
+    }
+
+    func testOlderFullRefreshPreservesPublishedTruthWhileNewerStandaloneIsPending() async throws {
+        let probe = PendingNewerStandaloneProbe()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            watcherProcessProbe: probe,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer {
+            probe.releaseOlderFull()
+            probe.releaseNewerStandalone()
+            collector.stop()
+        }
+
+        collector.refresh(force: true)
+        let initialDeadline = Date().addingTimeInterval(10)
+        while (collector.isRefreshing || collector.stats.watcherProcessProbeResult != .running(pid: 1000)),
+              Date() < initialDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertFalse(collector.isRefreshing)
+        XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 1000))
+
+        collector.refresh(force: true)
+        XCTAssertTrue(probe.waitForOlderFull(timeout: .now() + 2))
+        collector.refresh(force: false)
+        XCTAssertTrue(probe.waitForNewerStandalone(timeout: .now() + 2))
+
+        probe.releaseOlderFull()
+        let fullDeadline = Date().addingTimeInterval(10)
+        while collector.isRefreshing, Date() < fullDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertFalse(collector.isRefreshing)
+        XCTAssertEqual(
+            collector.stats.watcherProcessProbeResult,
+            .running(pid: 1000),
+            "The older full refresh must preserve the latest published truth while a newer standalone owner is pending."
+        )
+
+        probe.releaseNewerStandalone()
+        let standaloneDeadline = Date().addingTimeInterval(3)
+        while collector.stats.watcherProcessProbeResult != .running(pid: 2222), Date() < standaloneDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 2222))
+    }
+
     func testLaunchctlCommandRunnerTimesOutHungProbe() {
         let startedAt = Date()
         let result = LaunchctlWatcherProcessProbe.run(
@@ -521,5 +682,31 @@ final class StatsCollectorTests: XCTestCase {
         XCTAssertEqual(result.terminationStatus, 124)
         XCTAssertTrue(result.output.localizedCaseInsensitiveContains("timed out"))
         XCTAssertLessThan(Date().timeIntervalSince(startedAt), 0.5)
+    }
+
+    func testLaunchctlCommandRunnerCancelsHungProbe() async throws {
+        let task = Task.detached {
+            LaunchctlWatcherProcessProbe.run(["/bin/sleep", "1"], timeout: 2)
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        let result = await task.value
+        XCTAssertEqual(result.terminationStatus, 124)
+        XCTAssertTrue(result.output.localizedCaseInsensitiveContains("cancelled"))
+    }
+
+    func testLaunchctlCommandRunnerDrainsLargeOutputBeforeChildExit() {
+        let result = LaunchctlWatcherProcessProbe.run(
+            ["/bin/sh", "-c", "/usr/bin/yes x | /usr/bin/head -c 200000"],
+            timeout: 2
+        )
+
+        XCTAssertEqual(result.terminationStatus, 0)
+        XCTAssertGreaterThan(
+            result.output.utf8.count,
+            64 * 1_024,
+            "The launchctl runner must drain output concurrently so a full pipe cannot wedge a healthy child."
+        )
     }
 }

--- a/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
@@ -93,6 +93,35 @@ private final class SequencedBlockingWatcherProbe: WatcherProcessProbing, @unche
     }
 }
 
+private final class OlderFullRefreshProbe: WatcherProcessProbing, @unchecked Sendable {
+    private let lock = NSLock()
+    private let firstSampleStarted = DispatchSemaphore(value: 0)
+    private let releaseFirstSampleSemaphore = DispatchSemaphore(value: 0)
+    private var calls = 0
+
+    func sample() -> WatcherProcessProbeResult {
+        lock.lock()
+        let call = calls
+        calls += 1
+        lock.unlock()
+
+        if call == 0 {
+            firstSampleStarted.signal()
+            releaseFirstSampleSemaphore.wait()
+            return .running(pid: 1111)
+        }
+        return .running(pid: 2222)
+    }
+
+    func waitForFirstSample(timeout: DispatchTime) -> Bool {
+        firstSampleStarted.wait(timeout: timeout) == .success
+    }
+
+    func releaseFirstSample() {
+        releaseFirstSampleSemaphore.signal()
+    }
+}
+
 @MainActor
 final class StatsCollectorTests: XCTestCase {
     private struct WindowFetchFailure: Error {}
@@ -440,6 +469,45 @@ final class StatsCollectorTests: XCTestCase {
             collector.stats.watcherProcessProbeResult,
             .running(pid: 4242),
             "An older standalone probe must not overwrite the full refresh's newer watcher truth."
+        )
+    }
+
+    func testFullRefreshDoesNotOverwriteNewerStandaloneWatcherProbe() async throws {
+        let probe = OlderFullRefreshProbe()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            watcherProcessProbe: probe,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer {
+            probe.releaseFirstSample()
+            collector.stop()
+        }
+
+        collector.refresh(force: true)
+        XCTAssertTrue(
+            probe.waitForFirstSample(timeout: .now() + 2),
+            "The full refresh must hold its older process sample in flight."
+        )
+
+        collector.refresh(force: false)
+        let standaloneDeadline = Date().addingTimeInterval(2)
+        while collector.stats.watcherProcessProbeResult != .running(pid: 2222) && Date() < standaloneDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 2222))
+
+        probe.releaseFirstSample()
+        let fullRefreshDeadline = Date().addingTimeInterval(3)
+        while collector.isRefreshing && Date() < fullRefreshDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(
+            collector.stats.watcherProcessProbeResult,
+            .running(pid: 2222),
+            "The older process sample embedded in a full refresh must not overwrite a newer standalone probe."
         )
     }
 

--- a/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
@@ -51,6 +51,25 @@ final class StatsCollectorTests: XCTestCase {
         guard execRC == SQLITE_OK else { throw NSError(domain: "StatsCollectorTests", code: Int(execRC)) }
     }
 
+    private func insertWatcherLiveness(chunkID: String, minutesAgo: Double) throws {
+        let ingestedAt = Int(Date().addingTimeInterval(-minutesAgo * 60).timeIntervalSince1970)
+        var db: OpaquePointer?
+        let rc = sqlite3_open_v2(tempDBPath, &db, SQLITE_OPEN_READWRITE, nil)
+        guard rc == SQLITE_OK, let db else { throw NSError(domain: "StatsCollectorTests", code: Int(rc)) }
+        defer { sqlite3_close(db) }
+        let sql = """
+            CREATE TABLE IF NOT EXISTS watcher_liveness_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chunk_id TEXT NOT NULL,
+                ingested_at INTEGER NOT NULL
+            );
+            INSERT INTO watcher_liveness_events (chunk_id, ingested_at)
+            VALUES ('\(chunkID)', \(ingestedAt));
+        """
+        let execRC = sqlite3_exec(db, sql, nil, nil, nil)
+        guard execRC == SQLITE_OK else { throw NSError(domain: "StatsCollectorTests", code: Int(execRC)) }
+    }
+
     func testSelectTimeframeLiveClearsWindowedBuckets() async throws {
         let collector = StatsCollector(
             dbPath: tempDBPath,
@@ -79,6 +98,7 @@ final class StatsCollectorTests: XCTestCase {
         try insertWrite(id: "agent-old-1", source: "mcp", minutesAgo: 90)
         try insertWrite(id: "agent-old-2", source: "manual", minutesAgo: 300)
         try insertWrite(id: "watcher-old", source: "realtime_watcher", minutesAgo: 200)
+        try insertWatcherLiveness(chunkID: "watcher-old", minutesAgo: 200)
 
         let collector = StatsCollector(
             dbPath: tempDBPath,

--- a/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
@@ -12,6 +12,17 @@ import SQLite3
 
 @MainActor
 final class StatsCollectorTests: XCTestCase {
+    private struct WindowFetchFailure: Error {}
+
+    private struct BlockingWatcherProbe: WatcherProcessProbing {
+        let delay: TimeInterval
+
+        func sample() -> WatcherProcessProbeResult {
+            Thread.sleep(forTimeInterval: delay)
+            return .running(pid: 4242)
+        }
+    }
+
     private var tempDBPath: String!
 
     override func setUp() {
@@ -93,7 +104,7 @@ final class StatsCollectorTests: XCTestCase {
     }
 
     func testSelectTimeframeWiderPublishesRealHistoricalBuckets() async throws {
-        // Inside 30m (live) plus older rows only a wider window can see.
+        // Inside 1h (live) plus older rows only a wider window can see.
         try insertWrite(id: "agent-live", source: "mcp", minutesAgo: 5)
         try insertWrite(id: "agent-old-1", source: "mcp", minutesAgo: 90)
         try insertWrite(id: "agent-old-2", source: "manual", minutesAgo: 300)
@@ -118,5 +129,116 @@ final class StatsCollectorTests: XCTestCase {
         XCTAssertEqual(buckets.agentTotal, 3, "24h agent window sees live + 2 older agent writes")
         XCTAssertEqual(buckets.watcherTotal, 1, "24h watcher window sees the older watcher write")
         XCTAssertFalse(collector.isWindowedBucketsLoading)
+    }
+
+    func testWindowFetchFailurePreservesLastGoodBucketsAndPublishesTruthfulError() async throws {
+        let threeHourBuckets = BrainDatabase.PipelineWindowBuckets(
+            activityWindowMinutes: 180,
+            bucketCount: 1,
+            allWriteBuckets: [3],
+            agentWriteBuckets: [2],
+            watcherWriteBuckets: [1],
+            enrichmentBuckets: [1],
+            watcherFlowReadability: .readable
+        )
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            windowedBucketsProvider: { windowMinutes, _ in
+                guard windowMinutes == 180 else { throw WindowFetchFailure() }
+                return threeHourBuckets
+            },
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        collector.selectTimeframe(windowMinutes: 180, isLive: false)
+        let successDeadline = Date().addingTimeInterval(2)
+        while collector.isWindowedBucketsLoading && Date() < successDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.windowedBuckets, threeHourBuckets)
+        XCTAssertNil(collector.windowedBucketsError)
+
+        collector.selectTimeframe(windowMinutes: 1_440, isLive: false)
+        let failureDeadline = Date().addingTimeInterval(2)
+        while collector.isWindowedBucketsLoading && Date() < failureDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(collector.windowedBuckets, threeHourBuckets, "A failed wider fetch must retain last-good evidence.")
+        XCTAssertEqual(collector.windowedBucketsWindowMinutes, 180)
+        XCTAssertEqual(collector.windowedBucketsError, "Could not load Last 24h; showing Last 1h.")
+        XCTAssertEqual(
+            PipelineTimeframe.truthfulDisplay(selected: .day, loadedWindowMinutes: collector.windowedBucketsWindowMinutes),
+            .live,
+            "Live buckets must never be relabeled as the failed 24h selection."
+        )
+    }
+
+    func testReturningToLiveDiscardsLateWindowFetch() async throws {
+        let delayedBuckets = BrainDatabase.PipelineWindowBuckets(
+            activityWindowMinutes: 1_440,
+            bucketCount: 1,
+            allWriteBuckets: [1],
+            agentWriteBuckets: [1],
+            watcherWriteBuckets: [0],
+            enrichmentBuckets: [0],
+            watcherFlowReadability: .readable
+        )
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            windowedBucketsProvider: { _, _ in
+                Thread.sleep(forTimeInterval: 0.1)
+                return delayedBuckets
+            },
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        collector.selectTimeframe(windowMinutes: 1_440, isLive: false)
+        collector.selectTimeframe(windowMinutes: 60, isLive: true)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertNil(collector.windowedBuckets)
+        XCTAssertNil(collector.windowedBucketsWindowMinutes)
+        XCTAssertNil(collector.windowedBucketsError)
+        XCTAssertFalse(collector.isWindowedBucketsLoading)
+    }
+
+    func testWatcherProbeDoesNotBlockMainActorRefresh() async throws {
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            watcherProcessProbe: BlockingWatcherProbe(delay: 0.6),
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        let startedAt = Date()
+        collector.refresh(force: true)
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        XCTAssertLessThan(elapsed, 0.3, "Watcher sampling must leave the main actor before it can block dashboard refresh.")
+        XCTAssertTrue(collector.isRefreshing)
+
+        let deadline = Date().addingTimeInterval(3)
+        while collector.isRefreshing && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 4242))
+    }
+
+    func testLaunchctlCommandRunnerTimesOutHungProbe() {
+        let startedAt = Date()
+        let result = LaunchctlWatcherProcessProbe.run(
+            ["/bin/sleep", "1"],
+            timeout: 0.05
+        )
+
+        XCTAssertEqual(result.terminationStatus, 124)
+        XCTAssertTrue(result.output.localizedCaseInsensitiveContains("timed out"))
+        XCTAssertLessThan(Date().timeIntervalSince(startedAt), 0.5)
     }
 }

--- a/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
@@ -10,6 +10,89 @@ import XCTest
 import SQLite3
 @testable import BrainBar
 
+private final class SequencedWindowBucketsProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private let responses: [BrainDatabase.PipelineWindowBuckets]
+    private var nextResponseIndex = 0
+
+    init(responses: [BrainDatabase.PipelineWindowBuckets]) {
+        self.responses = responses
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return nextResponseIndex
+    }
+
+    func fetch(windowMinutes: Int, bucketCount: Int) throws -> BrainDatabase.PipelineWindowBuckets {
+        lock.lock()
+        defer { lock.unlock() }
+        let index = min(nextResponseIndex, responses.count - 1)
+        nextResponseIndex += 1
+        return responses[index]
+    }
+}
+
+private struct WindowBucketsProviderFailure: Error {}
+
+private final class SucceedOnceWindowBucketsProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private let response: BrainDatabase.PipelineWindowBuckets
+    private var calls = 0
+
+    init(response: BrainDatabase.PipelineWindowBuckets) {
+        self.response = response
+    }
+
+    func fetch(windowMinutes: Int, bucketCount: Int) throws -> BrainDatabase.PipelineWindowBuckets {
+        lock.lock()
+        defer { lock.unlock() }
+        calls += 1
+        guard calls == 1 else { throw WindowBucketsProviderFailure() }
+        return response
+    }
+}
+
+private final class SequencedBlockingWatcherProbe: WatcherProcessProbing, @unchecked Sendable {
+    private let lock = NSLock()
+    private let blockedSampleStarted = DispatchSemaphore(value: 0)
+    private let releaseBlockedSampleSemaphore = DispatchSemaphore(value: 0)
+    private var calls = 0
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func sample() -> WatcherProcessProbeResult {
+        lock.lock()
+        let call = calls
+        calls += 1
+        lock.unlock()
+
+        switch call {
+        case 0:
+            return .running(pid: 1001)
+        case 1:
+            blockedSampleStarted.signal()
+            releaseBlockedSampleSemaphore.wait()
+            return .failure("stale standalone probe")
+        default:
+            return .running(pid: 4242)
+        }
+    }
+
+    func waitForBlockedSample(timeout: DispatchTime) -> Bool {
+        blockedSampleStarted.wait(timeout: timeout) == .success
+    }
+
+    func releaseBlockedSample() {
+        releaseBlockedSampleSemaphore.signal()
+    }
+}
+
 @MainActor
 final class StatsCollectorTests: XCTestCase {
     private struct WindowFetchFailure: Error {}
@@ -131,6 +214,52 @@ final class StatsCollectorTests: XCTestCase {
         XCTAssertFalse(collector.isWindowedBucketsLoading)
     }
 
+    func testSuccessfulDashboardRefreshRefetchesSelectedWiderWindow() async throws {
+        let initialBuckets = BrainDatabase.PipelineWindowBuckets(
+            activityWindowMinutes: 180,
+            bucketCount: 1,
+            allWriteBuckets: [1],
+            agentWriteBuckets: [1],
+            watcherWriteBuckets: [0],
+            enrichmentBuckets: [0],
+            watcherFlowReadability: .readable
+        )
+        let refreshedBuckets = BrainDatabase.PipelineWindowBuckets(
+            activityWindowMinutes: 180,
+            bucketCount: 1,
+            allWriteBuckets: [2],
+            agentWriteBuckets: [2],
+            watcherWriteBuckets: [0],
+            enrichmentBuckets: [0],
+            watcherFlowReadability: .readable
+        )
+        let provider = SequencedWindowBucketsProvider(responses: [initialBuckets, refreshedBuckets])
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            windowedBucketsProvider: provider.fetch,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        collector.selectTimeframe(windowMinutes: 180, isLive: false)
+        let initialDeadline = Date().addingTimeInterval(2)
+        while collector.windowedBuckets != initialBuckets && Date() < initialDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.windowedBuckets, initialBuckets)
+
+        collector.refresh(force: true)
+        let refreshDeadline = Date().addingTimeInterval(3)
+        while (collector.isRefreshing || provider.callCount < 2) && Date() < refreshDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(provider.callCount, 2, "A successful dashboard refresh must refetch the selected 3h window.")
+        XCTAssertEqual(collector.windowedBuckets, refreshedBuckets)
+        XCTAssertEqual(collector.windowedBucketsWindowMinutes, 180)
+    }
+
     func testWindowFetchFailurePreservesLastGoodBucketsAndPublishesTruthfulError() async throws {
         let threeHourBuckets = BrainDatabase.PipelineWindowBuckets(
             activityWindowMinutes: 180,
@@ -173,6 +302,47 @@ final class StatsCollectorTests: XCTestCase {
             PipelineTimeframe.truthfulDisplay(selected: .day, loadedWindowMinutes: collector.windowedBucketsWindowMinutes),
             .live,
             "Live buckets must never be relabeled as the failed 24h selection."
+        )
+    }
+
+    func testWindowRefreshFailureDescribesRetainedMatchingLastGoodBuckets() async throws {
+        let threeHourBuckets = BrainDatabase.PipelineWindowBuckets(
+            activityWindowMinutes: 180,
+            bucketCount: 1,
+            allWriteBuckets: [3],
+            agentWriteBuckets: [2],
+            watcherWriteBuckets: [1],
+            enrichmentBuckets: [1],
+            watcherFlowReadability: .readable
+        )
+        let provider = SucceedOnceWindowBucketsProvider(response: threeHourBuckets)
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            windowedBucketsProvider: provider.fetch,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        collector.selectTimeframe(windowMinutes: 180, isLive: false)
+        let successDeadline = Date().addingTimeInterval(2)
+        while collector.isWindowedBucketsLoading && Date() < successDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.windowedBuckets, threeHourBuckets)
+
+        collector.selectTimeframe(windowMinutes: 180, isLive: false)
+        let failureDeadline = Date().addingTimeInterval(2)
+        while collector.isWindowedBucketsLoading && Date() < failureDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(collector.windowedBuckets, threeHourBuckets, "Section 4 requires retaining last-good values on fetch error.")
+        XCTAssertEqual(collector.windowedBucketsWindowMinutes, 180)
+        XCTAssertEqual(collector.windowedBucketsError, "Could not refresh Last 3h; showing previous Last 3h.")
+        XCTAssertEqual(
+            PipelineTimeframe.truthfulDisplay(selected: .threeHour, loadedWindowMinutes: collector.windowedBucketsWindowMinutes),
+            .threeHour
         )
     }
 
@@ -228,6 +398,49 @@ final class StatsCollectorTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(10))
         }
         XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 4242))
+    }
+
+    func testFullRefreshInvalidatesOlderStandaloneWatcherProbe() async throws {
+        let probe = SequencedBlockingWatcherProbe()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            watcherProcessProbe: probe,
+            statsRefreshCoalesceInterval: 5,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer {
+            probe.releaseBlockedSample()
+            collector.stop()
+        }
+
+        collector.refresh(force: false)
+        let initialDeadline = Date().addingTimeInterval(3)
+        while collector.isRefreshing && Date() < initialDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 1001))
+
+        collector.refresh(force: false)
+        XCTAssertTrue(
+            probe.waitForBlockedSample(timeout: .now() + 2),
+            "The coalesced refresh must start the standalone probe used to reproduce the race."
+        )
+
+        collector.refresh(force: true)
+        let fullRefreshDeadline = Date().addingTimeInterval(3)
+        while (collector.isRefreshing || probe.callCount < 3) && Date() < fullRefreshDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(collector.stats.watcherProcessProbeResult, .running(pid: 4242))
+
+        probe.releaseBlockedSample()
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(
+            collector.stats.watcherProcessProbeResult,
+            .running(pid: 4242),
+            "An older standalone probe must not overwrite the full refresh's newer watcher truth."
+        )
     }
 
     func testLaunchctlCommandRunnerTimesOutHungProbe() {


### PR DESCRIPTION
## Summary

Ship BrainBar's truth-first operator experience as one independently evaluated integration unit:

- replace ambiguous labels and mixed-clock metrics with typed source-time, ingest-time, watcher-process, freshness, enrichment, and replay-debt contracts;
- surface explicit loading/live/stale/error and flowing/stalled/offline/unknown states while retaining truthful last-good data;
- simplify Dashboard/Search/Injections signal hierarchy, add accessible chart and graph alternatives, and expose Settings configured-versus-active runtime truth;
- add deterministic, production-isolated render seams and a 40-PNG fixed-SHA proof matrix across Dashboard, Search/shell, Injections, Graph, and Settings.

Etan/layerSpec explicitly approved the §16 deviation to one `brainbar-truth` → `main` PR because the integrated head was evaluated as a unit. Phase boundaries remain reviewable in the preserved `--no-ff` merge commits.

- Exact PR head: `9e2267f21e0b2ca8e26f9b9df83db3a3913be45b`
- Base / merge-base: `f40c670996af8841feb6b77e8db93a5d0dad9e64`
- Scope: 36 files, +7,068/−922; 27 commits; required Fable co-author trailers present.

## Metric and state contracts

- `CHUNK ROWS`: `COUNT(*) FROM chunks`, source-time (`chunks.created_at`), one row per chunk record; never called commits.
- `AGENT-ORIGIN CHUNKS`: the documented agent-origin source set on the same source-time clock.
- `WATCHER INGESTED CHUNKS`: first watcher event per `chunk_id` in the selected ingest window, bucketed by `ingested_at`; unique IDs, ingest-time, explicitly non-additive with source-time charts.
- Watcher truth: injected process probe plus recent distinct watcher-ingest evidence. Persisted marker evidence is diagnostic only. Probe/table failure fails closed to `UNKNOWN` / `FLOW UNVERIFIED`.
- Snapshot freshness: `LOADING`, `LIVE`, `ERROR`, `STALE`; stale strictly after 60 seconds via an independent ticker; failed fetch retains and visibly marks last-good content.
- Enrichment: success-only headline and completion clock; failed/skipped/pending disclosed separately.
- Replay debt: typed pending stores + queue JSONLs + repository fallback, identity de-duplication, readability/partial-state disclosure, and census time.
- Settings: provider availability, durable validation/save/restart receipts, secret-reference redaction, and configured-versus-active runtime truth.

## RED → GREEN evidence

| Gate | RED | GREEN / independent gate |
|---|---|---|
| R0 contracts | 759 Swift executed, 2 skipped, 29 expected assertion failures, 0 unexpected | RED diff disk-verified and approved |
| P1 truth foundation | 29 contracts for clocks/cardinality, watcher truth, freshness, last-good, enrichment, replay debt | Focused 10/10; broad 159/159 (1 skip); independent full 763/2/0 |
| P2 Dashboard/charts/shell | 5 tests, 48 expected assertions | Truth 7/7; broad 222/222; render 4/4; independent full 771/2/0 |
| P3 Injections | 4 tests, 23 expected assertions | Focused 7/7; broad 83/83; evaluator SHIP; independent full 782/2/0 |
| P4 Graph | Reserved empty sidebar/progressive-disclosure RED | Accessible find/select/dismiss and deterministic layout; independent full 773/2/0 |
| P5 Settings | Compile RED on missing provider/runtime/receipt/probe contracts plus receipt/reload cases | Focused 21/21; independent full 775/2/0 |
| P6 visual integration | Isolation guard caught fixture wording; UI gate found F1 window/footer mismatch and F2 missing open disclosure | Isolation 2/2; findings 2/2; exact-head full 808/2/0; 40-image gate signed |
| Phase-8 pre-PR | Window-readability 0/1; ambient proof 0/1; missing remediation APIs; canceled-window race 0/1 | Readability 1/1 + broad 20/20; appearance 1/1; focused 15/15 + broad 173/173 + collector 6/6; Graph re-gate signed |
| Initial PR review | Ten actionable truth defects encoded before fixes | Focused 149/1/0; full 827/2/0; changed watcher pixels rerendered/inspected |
| Late provenance review | Repeated-result provenance 0/1 with four truth assertions | 1/1; broader Injection 50/5/0; five accepted images byte-identical |
| Run-8 reverse watcher race | Older full-refresh PID overwrote newer standalone PID, deterministic 0/1 | Shared monotonic watcher ownership; primary collector 10/10; Dashboard 155/1/0; run 9 PASS 10/10 |
| Final review batch | Correctness selection failed to compile on missing explicit Injection failure and receipt-generation contracts; aligned sampler exposed proof RED | Focused 258/1/0; core 68/1/0; replacement full 840/2/0; 23 actionable threads fixed; one `#filePath` checkout-test non-action independently accepted |
| Convergence review | Failed Injection event read followed by an unchanged-version recovery poll incorrectly published `.loaded`, deterministic 0/1 | Focused 1/1; broader Injection 91/5/0; exact-head full 840/2/0; fresh run 11 PASS 10/10 |

## Full-suite receipts

Required P6 and Python contract receipts:

```bash
BRAINBAR_RENDER_DIR=/tmp/brainbar-p6-findings-final.9548fd7e swift test --package-path brain-bar
# 808 executed, 2 skipped, 0 failures; exit 0

ulimit -n 4096 && PYTHONPATH=src .venv/bin/python -m pytest -m "not integration and not live"
# 3665 passed, 9 skipped, 77 deselected, 1 xfailed; exit 0
```

Final convergence-head executor receipts at `9e2267f2`:

- full Swift/render: **840 executed / 2 skipped / 0 failures**, exit 0;
- Settings: **1/0**;
- proof validator: **40 READY / 40 unique / 40 fresh byte matches / 6 supplementary / 0 errors**.

The approved safe Python suite at the immediately preceding source-equivalent head was **3665 passed / 9 skipped / 77 deselected / 1 xfailed / 103 warnings**, exit 0; the convergence commit changes only Swift source/tests. Its exact-head non-bypassed pre-push regression harness passed unit **3595/9/61/1**, MCP registration **3/3**, isolated routing **40/40**, Bun **1/1**, and FTS determinism shell PASS.

Fresh independent P7 run 10 reran the exact commands at the same SHA: Swift **840/2/0**, Settings **1/0**, safe Python **3665/9/77/1**, and proof validation/reproduction/native inspection **40/40**. Verdict: **PASS 10/10**, all mandatory criteria PASS, Critical 0, Major 0.

Fresh sterile convergence evaluator run 11 audited exact head `9e2267f2`, independently reran the focused regression **1/1** and broader Injection selection **91/5/0**, verified the exact-head full-suite and proof receipts, and returned **PASS 10/10**, all mandatory criteria PASS, Critical 0, Major 0. Per the signed convergence ruling, this is the final fresh evaluator; no further full bot review is solicited on the merge head.

The normal push first exposed the known macOS descriptor-baseline issue: with inherited `ulimit -n 256`, pytest reached ~94% then failed closed with `OSError [Errno 24] Too many open files`. Nothing was bypassed or edited. Rerunning the same hook under the plan-approved `ulimit -n 4096` passed: unit **3595/9/61/1**, MCP registration **3/3**, isolated routing **40/40**, Bun **1/1**, and FTS determinism shell PASS.

## Fixed-SHA UI proof

- [Current 40-row proof manifest](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5017892934): exact lineage, commands, dimensions, SHA-256 values, fixture policy, signed UI gates, and run-10 closure.
- Matrix: Dashboard 20, Search/shell 5, Injections 5, Knowledge Graph 6, Settings 4.
- LayerSpec signed the baseline P6 closure and separately re-gated the changed Graph importance pixel at `7daef2e4`; `Companies 1` is fully legible.
- Current-SHA run 10 reproduced all 40 accepted PNGs byte-for-byte and opened all 40 at original detail. The final proof-sampler-only commit changes no accepted bytes.

## Adversarial evaluator chain

- [Run 1](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5017552391), `9548fd7e`: **FAIL 9/10** because criterion 9 paperwork still said signed layerSpec closure was pending. Manifest synchronized; SwiftPM documentation warning fixed; Python warning debt dispositioned.
- [Run 2](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5017552440), `8126699d`: **PASS 10/10**, no Critical/Major, 40/40.
- [Run 3](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5017552486), `634dfa45`: **FAIL 9/10** because the importance atlas clipped the fifth region chip. Fixed and UI re-gated.
- [Run 4](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5017552533), `7daef2e4`: **PASS 10/10**, no Critical/Major, 40/40.
- [Run 5](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5017767444), `e7458735`: **PASS 10/10**, no Critical/Major, 40/40.
- [Run 6](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5017892975), `32426b63`: **PASS 10/10**, no Critical/Major, 40/40.
- Run 7: rejected before verification because the fresh process performed one prohibited BrainLayer search; no result or artifact reused.
- [Run 8](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5019882329), `f3529a41`: **FAIL 9/10** on mandatory criterion 1; deterministic Major reverse watcher-publication race.
- [Run 9](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5019878413), `95efee9c`: **PASS 10/10**, no Critical/Major; both race directions and evaluator challenges green.
- [Run 10](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5019875222), exact PR head `a96d9edc`: **PASS 10/10**, every mandatory criterion PASS, Critical 0, Major 0, one dispositioned Low for existing Python warning debt.
- [Run 11](https://github.com/EtanHey/brainlayer/pull/606#issuecomment-5020104589), exact convergence head `9e2267f2`: **PASS 10/10**, every mandatory criterion PASS, Critical 0, Major 0, with the existing Python warning debt retained as a Low backlog item.

## Product decisions

- D1: preserve stacked small multiples; repair labels, clocks, cardinalities, independent scales, and non-additivity disclosure.
- D2: preserve the tiered atlas topology; add progressive disclosure plus keyboard, VoiceOver, find/list, and non-spatial entity/type/degree access.

Both were signed as the recommended defaults in Round 0; no later override was issued.

## Production isolation

- No production database, launchd service, process, or installed `/Applications/BrainBar.app` was opened, mutated, restarted, or replaced.
- Render fixtures use nonexistent/temporary DB paths, never start collectors/timers, contain no production `launchctl` call, and write only to explicit temporary/proof roots.
- Search/Settings use temporary DB/config roots and injected providers.
- Python excludes `integration` and `live`; the production-DB waiver was explicitly denied. Two production-bound integration failures remain out of scope.
- No SQLite schema or data migration is included. Production BrainBar DB access remains read-only.

## Risks and rollback

- Pre-existing intermittent `os_unfair_lock` crash on the MCPRouter/reliability drain path was independently attributed outside this diff and remains backlog.
- Full Swift suites can interfere across worktrees through shared Darwin notifications; all gate runs were announced and serialized. Notification isolation remains backlog.
- Python emits 103 warnings, primarily multithreaded-fork deprecations plus dependency warnings; owner/rationale/follow-up are in the manifest.
- The pre-push harness inherits macOS's descriptor limit; the signed 4096 baseline is required to avoid a non-product EMFILE cascade.
- Unsupported enrichment providers intentionally report unavailable/unknown active runtime truth rather than imply activation.
- Rollback is one revert of this merge PR. There is no schema/data migration and no data rollback step.

## Review checklist

- [x] Contracts approved before production edits
- [x] RED → GREEN evidence for every phase
- [x] Required 808-test Swift and 3,665-test Python receipts
- [x] Final exact-head Swift 840/2/0 and safe Python 3665/9/77/1
- [x] 40/40 fixed-SHA proof plus signed layerSpec UI gates
- [x] Full adversarial fail-closed/pass chain through final sterile convergence run 11
- [x] Production isolation, risks, D1/D2, and rollback documented
- [x] Non-bypassed pre-push regression harness green under the approved descriptor baseline
- [x] Required exact-head CI green (Python 3.11/3.12/3.13, Swift 6, lint, and path gate)
- [x] All Critical/Major findings dispositioned on exact head; post-convergence Low/Medium polish is backlog by signed ruling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
