### PR TITLE
chore: release BrainLayer 1.5.0

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.4.5</string>
+    <string>1.5.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.5</string>
+    <string>1.5.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.4.5"
+version = "1.5.0"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.4.5",
+      "version": "1.5.0",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.4.5"
+__version__ = "1.5.0"


### PR DESCRIPTION
## Summary

- bump BrainLayer Python, MCP manifest, and BrainBar bundle metadata from 1.4.5 to 1.5.0;
- cut from verified `main` merge `47eb644276adc3573573636fd430eb74de961147`, whose second parent is the independently evaluated BrainBar head `9e2267f21e0b2ca8e26f9b9df83db3a3913be45b` from #606;
- keep the release diff metadata-only: six synchronized version-string substitutions across four files.

## Why

Ship the truth-first BrainBar operator experience from #606 as one coordinated feature release across Dashboard/charts/shell, Injections, Knowledge Graph, Settings, and the shared truth/state foundation.

## Verification

- `pytest -q tests/test_release_version_sync.py` — 2 passed;
- `uv build` — built `brainlayer-1.5.0.tar.gz` and `brainlayer-1.5.0-py3-none-any.whl`;
- plist/JSON/version-count/diff hygiene gates — passed;
- non-bypassed pre-push unit gate — 3,595 passed, 9 skipped, 61 deselected, 1 xfailed, 108 warnings;
- MCP registration — 3 passed;
- isolated eval/hook routing — 40 passed;
- Bun — 1 passed;
- FTS determinism — passed;
- local CodeRabbit was stopped after its three-minute bound while still reviewing and returned no verdict; PR-level review and exact-head CI remain required before merge.

## Post-merge pipeline

1. create annotated tag `v1.5.0`, matching the `v1.4.5` tag-object format, from the verified merged release ref (never a typed SHA);
2. verify PyPI publication plus Developer-ID-signed, notarized, stapled `BrainBar.zip` and the GitHub release;
3. update and merge the `homebrew-layers` formula/cask metadata from the published artifact hashes;
4. verify the tap resolves 1.5.0 and record that the second Mac still needs one manual `brew upgrade --cask brainbar` to converge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Six version-string substitutions with no runtime or security logic changes; release sync is covered by existing tests.
> 
> **Overview**
> **Release 1.5.0** — synchronized version bumps from `1.4.5` to `1.5.0` in `pyproject.toml`, `src/brainlayer/__init__.py`, MCP `server.json` (manifest and PyPI package entry), and BrainBar `Info.plist` (`CFBundleVersion` / `CFBundleShortVersionString`).
> 
> No functional code changes; this PR only aligns shipping metadata so Python, MCP registry, and the macOS menu-bar app report the same release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c2a9722babd62a9c11ba610f7ce82802f97efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release BrainLayer 1.5.0
> Bumps version from 1.4.5 to 1.5.0 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/607/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/607/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/607/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/607/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0c2a97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and package version to **1.5.0** across all published metadata.
  * Ensures consistent version reporting for installations, distribution packages, and the desktop app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->