### PR TITLE
fix: prevent watcher ingestion starvation

### DIFF
--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -658,6 +658,14 @@ class JSONLTailer:
 
         if new_data:
             self._buffer += new_data
+        return self.read_buffered_lines(max_lines=max_lines)
+
+    def has_complete_buffered_line(self) -> bool:
+        """Return whether an already-read complete record is waiting to be emitted."""
+        return b"\n" in self._buffer
+
+    def read_buffered_lines(self, max_lines: int | None = None) -> list[dict]:
+        """Parse complete buffered records without reading more bytes from disk."""
         lines = []
 
         while b"\n" in self._buffer:
@@ -1266,10 +1274,29 @@ class JSONLWatcher:
                     self.registry.remove(filepath)
                     continue
                 try:
-                    if self._skip_oversized_file(filepath):
-                        continue
-                    tailer = self._ensure_tailer(filepath)
-                    new_lines = tailer.read_new_lines(max_lines=self.max_lines_per_file)
+                    tailer = self._tailers.get(filepath)
+                    drain_buffer = False
+                    if tailer is not None and tailer.has_complete_buffered_line():
+                        _registry_offset, registry_inode = self.registry.get(filepath)
+                        inode_changed = registry_inode != 0 and registry_inode != tailer.get_inode()
+                        if not inode_changed and not tailer.check_rewind():
+                            drain_buffer = True
+                        elif tailer.rewound:
+                            self._handle_rewind(
+                                filepath,
+                                tailer.rewind_old_offset,
+                                tailer.rewind_new_offset,
+                                tailer.get_inode(),
+                            )
+                            tailer.rewound = False
+
+                    if drain_buffer:
+                        new_lines = tailer.read_buffered_lines(max_lines=self.max_lines_per_file)
+                    else:
+                        if self._skip_oversized_file(filepath):
+                            continue
+                        tailer = self._ensure_tailer(filepath)
+                        new_lines = tailer.read_new_lines(max_lines=self.max_lines_per_file)
 
                     # Handle rewind detection (checkpoint restore)
                     if tailer.rewound:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -24,6 +24,7 @@ import stat
 import tempfile
 import threading
 import time
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,6 +44,32 @@ from .alarm import BrainLayerAlarm, raise_alarm
 from .ingest_denylist import is_denylisted
 
 logger = logging.getLogger(__name__)
+
+_WATCH_MAX_FILE_BYTES_ENV = "BRAINLAYER_WATCH_MAX_FILE_BYTES"
+_DEFAULT_WATCH_MAX_FILE_BYTES = 100 * 1024 * 1024
+
+
+def _watch_max_file_bytes() -> int:
+    raw_value = os.environ.get(_WATCH_MAX_FILE_BYTES_ENV, str(_DEFAULT_WATCH_MAX_FILE_BYTES))
+    try:
+        parsed_value = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %d",
+            _WATCH_MAX_FILE_BYTES_ENV,
+            raw_value,
+            _DEFAULT_WATCH_MAX_FILE_BYTES,
+        )
+        return _DEFAULT_WATCH_MAX_FILE_BYTES
+    if parsed_value < 0:
+        logger.warning(
+            "Invalid %s=%r; using default %d",
+            _WATCH_MAX_FILE_BYTES_ENV,
+            raw_value,
+            _DEFAULT_WATCH_MAX_FILE_BYTES,
+        )
+        return _DEFAULT_WATCH_MAX_FILE_BYTES
+    return parsed_value
 
 
 @dataclass(frozen=True)
@@ -499,7 +526,7 @@ class OffsetRegistry:
         return False
 
     @staticmethod
-    def _has_live_parent_evidence(candidate: Path, live_files: list[Path]) -> bool:
+    def _has_live_parent_evidence(candidate: Path, live_parent_dirs: AbstractSet[Path]) -> bool:
         """Require a live transcript in the tracked file's containing directory."""
         parent = candidate.parent
         try:
@@ -507,7 +534,7 @@ class OffsetRegistry:
                 return False
         except OSError:
             return False
-        return any(live_file == parent or live_file.is_relative_to(parent) for live_file in live_files)
+        return parent in live_parent_dirs
 
     @property
     def last_prune_complete(self) -> bool:
@@ -530,14 +557,13 @@ class OffsetRegistry:
                     live_files.append(candidate)
             except OSError:
                 continue
+        live_parent_dirs = {parent for live_file in live_files for parent in live_file.parents}
 
         root_availability: dict[Path, bool] = {}
         for root in active_roots:
             candidate_root = Path(os.path.abspath(os.path.expanduser(str(root))))
             try:
-                root_availability[candidate_root] = candidate_root.is_dir() and any(
-                    live_file == candidate_root or live_file.is_relative_to(candidate_root) for live_file in live_files
-                )
+                root_availability[candidate_root] = candidate_root.is_dir() and candidate_root in live_parent_dirs
             except OSError:
                 root_availability[candidate_root] = False
 
@@ -555,7 +581,7 @@ class OffsetRegistry:
             if any(self._has_unavailable_symlink_ancestor(candidate, root) for root in most_specific_roots):
                 self._last_prune_complete = False
                 continue
-            if not self._has_live_parent_evidence(candidate, live_files):
+            if not self._has_live_parent_evidence(candidate, live_parent_dirs):
                 self._last_prune_complete = False
                 continue
             try:
@@ -853,8 +879,10 @@ class JSONLWatcher:
         self.poll_interval_s = poll_interval_s
         self.registry_flush_interval_s = registry_flush_interval_s
         self.max_lines_per_file = max(1, max_lines_per_file)
+        self.max_file_bytes = _watch_max_file_bytes()
         self._tailers: dict[str, JSONLTailer] = {}
         self._file_providers: dict[str, str] = {}
+        self._oversized_files: set[str] = set()
         self._stop = threading.Event()
         self._last_registry_flush = time.monotonic()
         self.health_path = Path(health_path).expanduser() if health_path else None
@@ -1098,6 +1126,43 @@ class JSONLWatcher:
         self._tailers[filepath] = tailer
         return tailer
 
+    def _skip_oversized_file(self, filepath: str) -> bool:
+        if self.max_file_bytes <= 0:
+            self._oversized_files.discard(filepath)
+            return False
+
+        try:
+            file_stat = os.stat(filepath)
+        except OSError:
+            return False
+
+        tailer = self._tailers.get(filepath)
+        offset = tailer.offset if tailer else self.registry.get(filepath)[0]
+        pending_bytes = max(file_stat.st_size - offset, 0)
+        if pending_bytes <= self.max_file_bytes:
+            self._oversized_files.discard(filepath)
+            return False
+
+        self._tailers.pop(filepath, None)
+        self.registry.set(filepath, file_stat.st_size, file_stat.st_ino)
+        if not self.registry.flush():
+            logger.error(
+                "Oversized JSONL checkpoint could not be persisted immediately: %s",
+                filepath,
+            )
+        if filepath not in self._oversized_files:
+            logger.warning(
+                "Oversized JSONL checkpointed and skipped: %s "
+                "pending_bytes=%d max_file_bytes=%d offset=%d size=%d",
+                filepath,
+                pending_bytes,
+                self.max_file_bytes,
+                offset,
+                file_stat.st_size,
+            )
+        self._oversized_files.add(filepath)
+        return True
+
     def poll_once(self) -> int:
         """Run one poll cycle. Returns number of new lines found."""
         total_new = 0
@@ -1128,6 +1193,8 @@ class JSONLWatcher:
                     self.registry.remove(filepath)
                     continue
                 try:
+                    if self._skip_oversized_file(filepath):
+                        continue
                     tailer = self._ensure_tailer(filepath)
                     new_lines = tailer.read_new_lines(max_lines=self.max_lines_per_file)
 

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -988,11 +988,7 @@ class JSONLWatcher:
     ) -> None:
         """Confirm intentionally discarded bytes without crossing indexable work."""
         required_confirmed_offset = max(
-            (
-                line["_line_end_offset"]
-                for line in normalized_lines
-                if isinstance(line.get("_line_end_offset"), int)
-            ),
+            (line["_line_end_offset"] for line in normalized_lines if isinstance(line.get("_line_end_offset"), int)),
             default=read_start_offset,
         )
         if read_end_offset <= required_confirmed_offset:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -1137,7 +1137,10 @@ class JSONLWatcher:
             return False
 
         tailer = self._tailers.get(filepath)
-        offset = tailer.offset if tailer else self.registry.get(filepath)[0]
+        registry_offset, registry_inode = self.registry.get(filepath)
+        offset = tailer.offset if tailer else registry_offset
+        if registry_inode != 0 and registry_inode != file_stat.st_ino:
+            offset = 0
         pending_bytes = max(file_stat.st_size - offset, 0)
         if pending_bytes <= self.max_file_bytes:
             self._oversized_files.discard(filepath)
@@ -1152,8 +1155,7 @@ class JSONLWatcher:
             )
         if filepath not in self._oversized_files:
             logger.warning(
-                "Oversized JSONL checkpointed and skipped: %s "
-                "pending_bytes=%d max_file_bytes=%d offset=%d size=%d",
+                "Oversized JSONL checkpointed and skipped: %s pending_bytes=%d max_file_bytes=%d offset=%d size=%d",
                 filepath,
                 pending_bytes,
                 self.max_file_bytes,

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -744,6 +744,11 @@ class BatchIndexer:
             if self._buffer:
                 self._do_flush()
 
+    def has_buffered_source(self, filepath: str) -> bool:
+        """Return whether unconfirmed buffered entries came from filepath."""
+        with self._lock:
+            return any(item.get("_source_file") == filepath for item in self._buffer)
+
     def _do_flush(self):
         """Internal flush — must be called with _lock held."""
         batch = self._buffer
@@ -1139,14 +1144,28 @@ class JSONLWatcher:
         tailer = self._tailers.get(filepath)
         registry_offset, registry_inode = self.registry.get(filepath)
         offset = tailer.offset if tailer else registry_offset
-        if registry_inode != 0 and registry_inode != file_stat.st_ino:
+        file_rewound = file_stat.st_size < offset
+        if (registry_inode != 0 and registry_inode != file_stat.st_ino) or file_rewound:
             offset = 0
         pending_bytes = max(file_stat.st_size - offset, 0)
         if pending_bytes <= self.max_file_bytes:
             self._oversized_files.discard(filepath)
             return False
 
+        if self.indexer.has_buffered_source(filepath):
+            self.indexer.flush()
+            if self.indexer.has_buffered_source(filepath):
+                if filepath not in self._oversized_files:
+                    logger.error(
+                        "Oversized JSONL checkpoint deferred for unconfirmed entries: %s",
+                        filepath,
+                    )
+                self._oversized_files.add(filepath)
+                return True
+
         self._tailers.pop(filepath, None)
+        if file_rewound:
+            self.registry.mark_rewind(filepath, file_stat.st_ino)
         self.registry.set(filepath, file_stat.st_size, file_stat.st_ino)
         if not self.registry.flush():
             logger.error(

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -1131,6 +1131,44 @@ class JSONLWatcher:
         self._tailers[filepath] = tailer
         return tailer
 
+    def _handle_rewind(
+        self,
+        filepath: str,
+        old_offset: int,
+        new_offset: int,
+        inode: int,
+    ) -> None:
+        """Persist a rewind and notify archival consumers."""
+        session_id = Path(filepath).stem
+        self.registry.mark_rewind(filepath, inode)
+        logger.warning(
+            "Checkpoint restore: %s (offset %d → %d)",
+            session_id,
+            old_offset,
+            new_offset,
+        )
+        try:
+            from .telemetry import emit
+
+            emit(
+                "brainlayer-watcher",
+                {
+                    "_type": "rewind_detected",
+                    "session_id": session_id,
+                    "file_path": filepath,
+                    "old_offset": old_offset,
+                    "new_offset": new_offset,
+                },
+            )
+        except Exception:
+            pass
+
+        if self.on_rewind:
+            try:
+                self.on_rewind(filepath, session_id, old_offset, new_offset)
+            except Exception as e:
+                logger.error("Rewind callback failed: %s", e)
+
     def _skip_oversized_file(self, filepath: str) -> bool:
         if self.max_file_bytes <= 0:
             self._oversized_files.discard(filepath)
@@ -1144,6 +1182,7 @@ class JSONLWatcher:
         tailer = self._tailers.get(filepath)
         registry_offset, registry_inode = self.registry.get(filepath)
         offset = tailer.offset if tailer else registry_offset
+        rewind_old_offset = offset
         file_rewound = file_stat.st_size < offset
         if (registry_inode != 0 and registry_inode != file_stat.st_ino) or file_rewound:
             offset = 0
@@ -1165,7 +1204,12 @@ class JSONLWatcher:
 
         self._tailers.pop(filepath, None)
         if file_rewound:
-            self.registry.mark_rewind(filepath, file_stat.st_ino)
+            self._handle_rewind(
+                filepath,
+                rewind_old_offset,
+                file_stat.st_size,
+                file_stat.st_ino,
+            )
         self.registry.set(filepath, file_stat.st_size, file_stat.st_ino)
         if not self.registry.flush():
             logger.error(
@@ -1222,42 +1266,12 @@ class JSONLWatcher:
 
                     # Handle rewind detection (checkpoint restore)
                     if tailer.rewound:
-                        session_id = Path(filepath).stem
-                        self.registry.mark_rewind(filepath, tailer.get_inode())
-                        logger.warning(
-                            "Checkpoint restore: %s (offset %d → %d)",
-                            session_id,
+                        self._handle_rewind(
+                            filepath,
                             tailer.rewind_old_offset,
                             tailer.rewind_new_offset,
+                            tailer.get_inode(),
                         )
-                        try:
-                            from .telemetry import emit
-
-                            emit(
-                                "brainlayer-watcher",
-                                {
-                                    "_type": "rewind_detected",
-                                    "session_id": session_id,
-                                    "file_path": filepath,
-                                    "old_offset": tailer.rewind_old_offset,
-                                    "new_offset": tailer.rewind_new_offset,
-                                },
-                            )
-                        except Exception:
-                            pass
-
-                        # Call rewind callback if set
-                        if self.on_rewind:
-                            try:
-                                self.on_rewind(
-                                    filepath,
-                                    session_id,
-                                    tailer.rewind_old_offset,
-                                    tailer.rewind_new_offset,
-                                )
-                            except Exception as e:
-                                logger.error("Rewind callback failed: %s", e)
-
                         tailer.rewound = False  # Reset flag
 
                     if new_lines:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -1181,19 +1181,21 @@ class JSONLWatcher:
 
         tailer = self._tailers.get(filepath)
         registry_offset, registry_inode = self.registry.get(filepath)
-        offset = tailer.offset if tailer else registry_offset
-        rewind_old_offset = offset
-        file_rewound = file_stat.st_size < offset
-        if (registry_inode != 0 and registry_inode != file_stat.st_ino) or file_rewound:
-            offset = 0
+        tailer_offset = tailer.offset if tailer else registry_offset
+        rewind_old_offset = tailer_offset
+        file_rewound = file_stat.st_size < tailer_offset
+        inode_changed = registry_inode != 0 and registry_inode != file_stat.st_ino
+        offset = 0 if inode_changed or file_rewound else registry_offset
         pending_bytes = max(file_stat.st_size - offset, 0)
         if pending_bytes <= self.max_file_bytes:
             self._oversized_files.discard(filepath)
             return False
 
-        if self.indexer.has_buffered_source(filepath):
-            self.indexer.flush()
+        if tailer is not None and not inode_changed and not file_rewound and tailer_offset > registry_offset:
             if self.indexer.has_buffered_source(filepath):
+                self.indexer.flush()
+            confirmed_offset, confirmed_inode = self.registry.get(filepath)
+            if confirmed_inode != file_stat.st_ino or confirmed_offset < tailer_offset:
                 if filepath not in self._oversized_files:
                     logger.error(
                         "Oversized JSONL checkpoint deferred for unconfirmed entries: %s",
@@ -1201,6 +1203,11 @@ class JSONLWatcher:
                     )
                 self._oversized_files.add(filepath)
                 return True
+            offset = confirmed_offset
+            pending_bytes = max(file_stat.st_size - offset, 0)
+            if pending_bytes <= self.max_file_bytes:
+                self._oversized_files.discard(filepath)
+                return False
 
         self._tailers.pop(filepath, None)
         if file_rewound:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -979,6 +979,31 @@ class JSONLWatcher:
             normalized.append(entry)
         return normalized
 
+    def _checkpoint_discarded_progress(
+        self,
+        filepath: str,
+        read_start_offset: int,
+        read_end_offset: int,
+        normalized_lines: list[dict],
+    ) -> None:
+        """Confirm intentionally discarded bytes without crossing indexable work."""
+        required_confirmed_offset = max(
+            (
+                line["_line_end_offset"]
+                for line in normalized_lines
+                if isinstance(line.get("_line_end_offset"), int)
+            ),
+            default=read_start_offset,
+        )
+        if read_end_offset <= required_confirmed_offset:
+            return
+        if self.indexer.has_buffered_source(filepath):
+            return
+        confirmed_offset, _confirmed_inode = self.registry.get(filepath)
+        if confirmed_offset < required_confirmed_offset:
+            return
+        self._advance_confirmed_offsets({filepath: read_end_offset})
+
     def _max_offset_lag_bytes(self, files: list[str]) -> int:
         max_lag = 0
         for filepath in files:
@@ -1291,15 +1316,18 @@ class JSONLWatcher:
                             tailer.rewound = False
 
                     if drain_buffer:
+                        read_start_offset = tailer.offset
                         new_lines = tailer.read_buffered_lines(max_lines=self.max_lines_per_file)
                     else:
                         if self._skip_oversized_file(filepath):
                             continue
                         tailer = self._ensure_tailer(filepath)
+                        read_start_offset = tailer.offset
                         new_lines = tailer.read_new_lines(max_lines=self.max_lines_per_file)
 
                     # Handle rewind detection (checkpoint restore)
                     if tailer.rewound:
+                        read_start_offset = 0
                         self._handle_rewind(
                             filepath,
                             tailer.rewind_old_offset,
@@ -1308,11 +1336,17 @@ class JSONLWatcher:
                         )
                         tailer.rewound = False  # Reset flag
 
-                    if new_lines:
-                        normalized_lines = self._normalize_lines(filepath, new_lines)
+                    normalized_lines = self._normalize_lines(filepath, new_lines) if new_lines else []
+                    if normalized_lines:
                         self.indexer.add(normalized_lines)
                         self._health_entries_seen += len(normalized_lines)
                         total_new += len(normalized_lines)
+                    self._checkpoint_discarded_progress(
+                        filepath,
+                        read_start_offset,
+                        tailer.offset,
+                        normalized_lines,
+                    )
                 except Exception:
                     logger.exception("Poll file error: %s", filepath)
 

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -1173,6 +1173,7 @@ class JSONLWatcher:
 
         try:
             files = self._discover_jsonl_files()
+            self._oversized_files.intersection_update(filepath for filepath in files if not is_denylisted(filepath))
             if not self._offset_prune_complete:
                 pruned = self.registry.prune_missing_files(
                     [root.resolved_path for root in self.watch_roots],

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1200,6 +1200,49 @@ class TestJSONLWatcher:
         assert watcher.poll_once() == 1
         assert [item["_provider"] for item in flushed] == ["codex"]
 
+    def test_poll_drains_buffered_lines_before_checkpointing_oversized_append(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        encoded_lines = [
+            (json.dumps({"role": "user", "content": f"buffered line {idx} with enough content"}) + "\n").encode()
+            for idx in range(3)
+        ]
+        rollout.write_bytes(b"".join(encoded_lines))
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "256")
+        flushed = []
+
+        def confirm_all(items):
+            flushed.extend(items)
+            return {item["_source_file"]: item["_line_end_offset"] for item in items}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=confirm_all,
+            batch_size=1,
+            max_lines_per_file=1,
+        )
+
+        assert watcher.poll_once() == 1
+        tailer = watcher._tailers[str(rollout)]
+        assert tailer.offset == len(encoded_lines[0])
+        assert tailer._buffer == b"".join(encoded_lines[1:])
+
+        with rollout.open("ab") as file_handle:
+            file_handle.write(json.dumps({"role": "user", "content": "x" * 512}).encode() + b"\n")
+        oversized_size = rollout.stat().st_size
+
+        assert watcher.poll_once() == 1
+        assert [item["message"]["content"][0]["text"] for item in flushed] == [
+            "buffered line 0 with enough content",
+            "buffered line 1 with enough content",
+        ]
+        assert tailer.offset == len(encoded_lines[0]) + len(encoded_lines[1])
+        assert tailer._buffer == encoded_lines[2]
+        assert watcher.registry.get(str(rollout)) == (tailer.offset, rollout.stat().st_ino)
+        assert tailer.offset < oversized_size
+
     def test_poll_skips_oversized_pending_file_with_warning_and_continues(
         self,
         tmp_path,

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -136,6 +136,31 @@ class TestOffsetRegistry:
         assert reloaded.get(str(existing)) == (100, 1)
         assert reloaded.get(str(deleted)) == (0, 0)
 
+    def test_prune_live_parent_evidence_uses_linear_ancestry_checks(self, monkeypatch, tmp_path):
+        tracked_count = 80
+        registry = OffsetRegistry(tmp_path / "offsets.json")
+        live_files = []
+        for index in range(tracked_count):
+            session_dir = tmp_path / f"session-{index}"
+            session_dir.mkdir()
+            live_file = session_dir / "live.jsonl"
+            live_file.write_text('{"id":"live"}\n')
+            live_files.append(live_file)
+            registry.set(str(session_dir / "deleted.jsonl"), 100, index + 1)
+
+        real_is_relative_to = Path.is_relative_to
+        ancestry_checks = 0
+
+        def counting_is_relative_to(path, other):
+            nonlocal ancestry_checks
+            ancestry_checks += 1
+            return real_is_relative_to(path, other)
+
+        monkeypatch.setattr(Path, "is_relative_to", counting_is_relative_to)
+
+        assert registry.prune_missing_files([tmp_path], live_files) == tracked_count
+        assert ancestry_checks <= tracked_count * 6
+
     def test_prune_flush_preserves_newer_offsets_from_concurrent_registry(self, tmp_path):
         registry_path = tmp_path / "offsets.json"
         existing = tmp_path / "existing.jsonl"
@@ -1174,6 +1199,144 @@ class TestJSONLWatcher:
         flushed.clear()
         assert watcher.poll_once() == 1
         assert [item["_provider"] for item in flushed] == ["codex"]
+
+    def test_poll_skips_oversized_pending_file_with_warning_and_continues(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        oversized = sessions / "oversized.jsonl"
+        healthy = sessions / "healthy.jsonl"
+        oversized.write_text(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+        healthy.write_text(json.dumps({"role": "user", "content": "healthy"}) + "\n")
+        os.utime(oversized, (2000, 2000))
+        os.utime(healthy, (1000, 1000))
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+
+        flushed = []
+
+        def confirm_all(items):
+            flushed.extend(items)
+            return {item["_source_file"]: item["_line_end_offset"] for item in items}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=confirm_all,
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 1
+        assert [item["_source_file"] for item in flushed] == [str(healthy)]
+        assert watcher.registry.get(str(oversized)) == (
+            oversized.stat().st_size,
+            oversized.stat().st_ino,
+        )
+        assert any(
+            str(oversized) in record.getMessage()
+            and "pending_bytes=" in record.getMessage()
+            and "max_file_bytes=128" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_poll_persists_oversized_checkpoint_immediately(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        oversized = sessions / "oversized.jsonl"
+        oversized.write_text(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+        registry_path = tmp_path / "offsets.json"
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=registry_path,
+            on_flush=lambda _items: None,
+            registry_flush_interval_s=3600,
+        )
+
+        assert watcher.poll_once() == 0
+        assert OffsetRegistry(registry_path).get(str(oversized)) == (
+            oversized.stat().st_size,
+            oversized.stat().st_ino,
+        )
+
+    def test_negative_watch_max_file_bytes_falls_back_to_default(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "-1")
+
+        watcher = JSONLWatcher(
+            watch_roots=[],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda _items: None,
+        )
+
+        assert watcher.max_file_bytes == 100 * 1024 * 1024
+        assert any(
+            "BRAINLAYER_WATCH_MAX_FILE_BYTES='-1'" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_invalid_watch_max_file_bytes_falls_back_to_default(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "invalid")
+
+        watcher = JSONLWatcher(
+            watch_roots=[],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda _items: None,
+        )
+
+        assert watcher.max_file_bytes == 100 * 1024 * 1024
+        assert any(
+            "BRAINLAYER_WATCH_MAX_FILE_BYTES='invalid'" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_poll_ingests_small_append_after_oversized_checkpoint(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+        flushed = []
+
+        def confirm_all(items):
+            flushed.extend(items)
+            return {item["_source_file"]: item["_line_end_offset"] for item in items}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=confirm_all,
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 0
+        with rollout.open("a") as file_handle:
+            file_handle.write(json.dumps({"role": "user", "content": "small append"}) + "\n")
+
+        assert watcher.poll_once() == 1
+        assert [item["message"]["content"][0]["text"] for item in flushed] == ["small append"]
+
+    def test_zero_watch_max_file_bytes_disables_checkpointing(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "0")
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: {
+                item["_source_file"]: item["_line_end_offset"] for item in items
+            },
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 1
+        assert watcher.registry.get(str(rollout))[0] == rollout.stat().st_size
 
     def test_codex_root_normalizes_role_content_entries(self, tmp_path):
         sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1298,6 +1298,33 @@ class TestJSONLWatcher:
             rollout.stat().st_ino,
         )
 
+    def test_poll_forgets_oversized_files_that_disappear_or_become_denylisted(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        disappeared = sessions / "disappeared.jsonl"
+        denylisted = sessions / "denylisted.jsonl"
+        for rollout in (disappeared, denylisted):
+            rollout.write_text(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda _items: None,
+        )
+
+        assert watcher.poll_once() == 0
+        assert watcher._oversized_files == {str(disappeared), str(denylisted)}
+
+        disappeared.unlink()
+        monkeypatch.setattr(
+            "brainlayer.watcher.is_denylisted",
+            lambda filepath: filepath == str(denylisted),
+        )
+
+        assert watcher.poll_once() == 0
+        assert watcher._oversized_files == set()
+
     def test_negative_watch_max_file_bytes_falls_back_to_default(self, tmp_path, monkeypatch, caplog):
         monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "-1")
 

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1358,6 +1358,40 @@ class TestJSONLWatcher:
         assert watcher.registry.get(str(rollout)) == (0, 0)
         assert len(watcher.indexer._buffer) == 1
 
+    def test_poll_does_not_checkpoint_past_partially_confirmed_watermark(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(
+            json.dumps({"role": "user", "content": "first"})
+            + "\n"
+            + json.dumps({"role": "user", "content": "second"})
+            + "\n"
+        )
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+
+        def confirm_first_only(items):
+            return {str(rollout): items[0]["_line_end_offset"]}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=confirm_first_only,
+            batch_size=2,
+            flush_interval_ms=360000,
+        )
+
+        assert watcher.poll_once() == 2
+        confirmed_offset, confirmed_inode = watcher.registry.get(str(rollout))
+        assert confirmed_offset < watcher._tailers[str(rollout)].offset
+        assert watcher.indexer._buffer == []
+
+        with rollout.open("a") as file_handle:
+            file_handle.write(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+
+        assert watcher.poll_once() == 0
+        assert watcher.registry.get(str(rollout)) == (confirmed_offset, confirmed_inode)
+
     def test_poll_forgets_oversized_files_that_disappear_or_become_denylisted(self, tmp_path, monkeypatch):
         sessions = tmp_path / "codex" / "sessions"
         sessions.mkdir(parents=True)

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1243,6 +1243,60 @@ class TestJSONLWatcher:
         assert watcher.registry.get(str(rollout)) == (tailer.offset, rollout.stat().st_ino)
         assert tailer.offset < oversized_size
 
+    def test_poll_checkpoints_dropped_only_records_before_oversized_append(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(json.dumps({"type": "response_item", "payload": {"type": "function_call"}}) + "\n")
+        dropped_offset = rollout.stat().st_size
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+        flushed = []
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items),
+            batch_size=1,
+        )
+
+        assert watcher.poll_once() == 0
+        assert flushed == []
+        assert watcher.registry.get(str(rollout)) == (dropped_offset, rollout.stat().st_ino)
+
+        with rollout.open("a") as file_handle:
+            file_handle.write(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+        assert watcher.poll_once() == 0
+        oversized_checkpoint = rollout.stat().st_size
+        assert watcher.registry.get(str(rollout))[0] == oversized_checkpoint
+
+        with rollout.open("a") as file_handle:
+            file_handle.write(json.dumps({"role": "user", "content": "small append"}) + "\n")
+        assert watcher.poll_once() == 1
+        assert flushed[0]["message"]["content"][0]["text"] == "small append"
+
+    def test_poll_does_not_checkpoint_dropped_tail_past_unconfirmed_record(self, tmp_path):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(
+            json.dumps({"role": "user", "content": "indexable record"})
+            + "\n"
+            + json.dumps({"type": "response_item", "payload": {"type": "function_call"}})
+            + "\n"
+        )
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda _items: None,
+            batch_size=10,
+            flush_interval_ms=360000,
+        )
+
+        assert watcher.poll_once() == 1
+        assert watcher.indexer.has_buffered_source(str(rollout))
+        assert watcher.registry.get(str(rollout)) == (0, 0)
+
     def test_poll_skips_oversized_pending_file_with_warning_and_continues(
         self,
         tmp_path,

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1307,11 +1307,13 @@ class TestJSONLWatcher:
         original_inode = rollout.stat().st_ino
         monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
         flushed = []
+        rewinds = []
 
         watcher = JSONLWatcher(
             watch_roots=[WatchRoot("codex", sessions)],
             registry_path=tmp_path / "offsets.json",
             on_flush=lambda items: flushed.extend(items),
+            on_rewind=lambda *args: rewinds.append(args),
             batch_size=1,
         )
         watcher.registry.set(str(rollout), original_size, original_inode)
@@ -1327,6 +1329,7 @@ class TestJSONLWatcher:
             rollout.stat().st_size,
             rollout.stat().st_ino,
         )
+        assert rewinds == [(str(rollout), "rollout", original_size, rollout.stat().st_size)]
 
     def test_poll_does_not_checkpoint_past_retained_unconfirmed_entries(self, tmp_path, monkeypatch):
         sessions = tmp_path / "codex" / "sessions"

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1298,6 +1298,63 @@ class TestJSONLWatcher:
             rollout.stat().st_ino,
         )
 
+    def test_poll_caps_oversized_same_inode_rewind_from_start(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(json.dumps({"role": "user", "content": "x" * 512}) + "\n")
+        original_size = rollout.stat().st_size
+        original_inode = rollout.stat().st_ino
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+        flushed = []
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=lambda items: flushed.extend(items),
+            batch_size=1,
+        )
+        watcher.registry.set(str(rollout), original_size, original_inode)
+        watcher._tailers[str(rollout)] = JSONLTailer(str(rollout), offset=original_size)
+
+        with rollout.open("w") as file_handle:
+            file_handle.write(json.dumps({"role": "user", "content": "y" * 256}) + "\n")
+        assert rollout.stat().st_ino == original_inode
+
+        assert watcher.poll_once() == 0
+        assert flushed == []
+        assert watcher.registry.get(str(rollout)) == (
+            rollout.stat().st_size,
+            rollout.stat().st_ino,
+        )
+
+    def test_poll_does_not_checkpoint_past_retained_unconfirmed_entries(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(json.dumps({"role": "user", "content": "pending"}) + "\n")
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+
+        def fail_flush(_items):
+            raise RuntimeError("write unavailable")
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=fail_flush,
+            batch_size=10,
+            flush_interval_ms=360000,
+        )
+
+        assert watcher.poll_once() == 1
+        assert watcher.registry.get(str(rollout)) == (0, 0)
+        with rollout.open("a") as file_handle:
+            file_handle.write(json.dumps({"role": "user", "content": "x" * 256}) + "\n")
+
+        assert watcher.poll_once() == 0
+        assert watcher.registry.get(str(rollout)) == (0, 0)
+        assert len(watcher.indexer._buffer) == 1
+
     def test_poll_forgets_oversized_files_that_disappear_or_become_denylisted(self, tmp_path, monkeypatch):
         sessions = tmp_path / "codex" / "sessions"
         sessions.mkdir(parents=True)

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -1263,6 +1263,41 @@ class TestJSONLWatcher:
             oversized.stat().st_ino,
         )
 
+    def test_poll_caps_oversized_replacement_from_start(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "codex" / "sessions"
+        sessions.mkdir(parents=True)
+        rollout = sessions / "rollout.jsonl"
+        rollout.write_text(json.dumps({"role": "user", "content": "x" * 512}) + "\n")
+        original_size = rollout.stat().st_size
+        original_inode = rollout.stat().st_ino
+        monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "128")
+        flushed = []
+
+        def confirm_all(items):
+            flushed.extend(items)
+            return {item["_source_file"]: item["_line_end_offset"] for item in items}
+
+        watcher = JSONLWatcher(
+            watch_roots=[WatchRoot("codex", sessions)],
+            registry_path=tmp_path / "offsets.json",
+            on_flush=confirm_all,
+            batch_size=1,
+        )
+        watcher.registry.set(str(rollout), original_size, original_inode)
+        watcher._tailers[str(rollout)] = JSONLTailer(str(rollout), offset=original_size)
+
+        replacement = sessions / "replacement.tmp"
+        replacement.write_text(json.dumps({"role": "user", "content": "y" * 256}) + "\n")
+        os.replace(replacement, rollout)
+        assert rollout.stat().st_ino != original_inode
+
+        assert watcher.poll_once() == 0
+        assert flushed == []
+        assert watcher.registry.get(str(rollout)) == (
+            rollout.stat().st_size,
+            rollout.stat().st_ino,
+        )
+
     def test_negative_watch_max_file_bytes_falls_back_to_default(self, tmp_path, monkeypatch, caplog):
         monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "-1")
 
@@ -1273,10 +1308,7 @@ class TestJSONLWatcher:
         )
 
         assert watcher.max_file_bytes == 100 * 1024 * 1024
-        assert any(
-            "BRAINLAYER_WATCH_MAX_FILE_BYTES='-1'" in record.getMessage()
-            for record in caplog.records
-        )
+        assert any("BRAINLAYER_WATCH_MAX_FILE_BYTES='-1'" in record.getMessage() for record in caplog.records)
 
     def test_invalid_watch_max_file_bytes_falls_back_to_default(self, tmp_path, monkeypatch, caplog):
         monkeypatch.setenv("BRAINLAYER_WATCH_MAX_FILE_BYTES", "invalid")
@@ -1288,10 +1320,7 @@ class TestJSONLWatcher:
         )
 
         assert watcher.max_file_bytes == 100 * 1024 * 1024
-        assert any(
-            "BRAINLAYER_WATCH_MAX_FILE_BYTES='invalid'" in record.getMessage()
-            for record in caplog.records
-        )
+        assert any("BRAINLAYER_WATCH_MAX_FILE_BYTES='invalid'" in record.getMessage() for record in caplog.records)
 
     def test_poll_ingests_small_append_after_oversized_checkpoint(self, tmp_path, monkeypatch):
         sessions = tmp_path / "codex" / "sessions"
@@ -1329,9 +1358,7 @@ class TestJSONLWatcher:
         watcher = JSONLWatcher(
             watch_roots=[WatchRoot("codex", sessions)],
             registry_path=tmp_path / "offsets.json",
-            on_flush=lambda items: {
-                item["_source_file"]: item["_line_end_offset"] for item in items
-            },
+            on_flush=lambda items: {item["_source_file"]: item["_line_end_offset"] for item in items},
             batch_size=1,
         )
 


### PR DESCRIPTION
## Summary

- precompute live-file parent evidence once per poll so offset pruning is linear rather than O(tracked offsets × live files)
- cap unread JSONL suffixes with `BRAINLAYER_WATCH_MAX_FILE_BYTES` (100 MiB default), checkpoint skipped oversized suffixes immediately, and continue processing other files
- cover pruning complexity, cap configuration, checkpoint persistence, and continuation behavior with regression tests

## Root cause

The serial watcher could spend each poll in a quadratic `any(... is_relative_to(...))` prune scan across thousands of tracked files. Separately, one multi-gigabyte rollout suffix could be read without a bound and monopolize the watcher. Together these starved liveness and realtime inserts.

## Verification

- watcher suite: `88 passed`
- signed-safe baseline after rebase: `3672 passed, 9 skipped, 77 deselected, 1 xfailed`
- mandatory pre-push gate (with macOS fd ceiling raised to 4096): `3602 passed, 9 skipped, 61 deselected, 1 xfailed`; MCP registration `3 passed`; isolated eval/hook routing `40 passed`; Bun `1 passed`; FTS determinism passed
- Ruff on changed files: passed
- `git diff --check origin/main...HEAD`: passed

## Review note

Local CodeRabbit suggested retaining a missing tracked file when a live file exists beneath its parent. That is contrary to the existing prune contract: a live descendant is precisely the parent evidence that makes the missing candidate provably stale and removable. Existing and new tests cover direct-parent evidence, nested unavailable roots, and empty subtrees, so no semantic change was made for that suggestion.

## Operational scope

This PR changes source and tests only. It does not deploy or alter the live LaunchAgent, Homebrew Cellar, release tags, package artifacts, tap, or cask.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core realtime ingestion offset semantics (skip/checkpoint of large pending suffixes and discarded-byte advancement); misconfiguration or edge cases around unconfirmed flushes could drop or delay data, though tests target those paths.
> 
> **Overview**
> Addresses watcher starvation from slow offset pruning and unbounded reads on huge rollout suffixes.
> 
> **Prune performance:** `OffsetRegistry.prune_missing_files` now builds a `live_parent_dirs` set once per cycle and uses membership checks instead of scanning every live file with `is_relative_to`, making pruning linear in tracked paths rather than quadratic.
> 
> **Oversized pending reads:** `BRAINLAYER_WATCH_MAX_FILE_BYTES` (default 100 MiB) limits how many unread bytes the watcher will pull from a file in one go. When pending data exceeds the cap, `_skip_oversized_file` checkpoints the registry to EOF (with immediate flush), logs a warning, and skips further reads for that file until a smaller append brings pending under the limit; `0` disables the cap.
> 
> **Poll loop behavior:** `poll_once` drains in-memory tailer buffers via `read_buffered_lines` before opening files (so buffered lines are not lost when an oversized append would otherwise short-circuit reads). Rewind side effects move to `_handle_rewind`. `_checkpoint_discarded_progress` advances confirmed offsets past bytes that were read but not indexable, without jumping past unconfirmed indexer batches (`has_buffered_source`).
> 
> Regression tests cover prune complexity, oversize skip/checkpoint, rewind-on-replace, and env validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ed29d8debe52f1b2b10672ed5648b973ac7575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix watcher ingestion starvation by skipping oversized files and draining buffered lines
> - Adds `_skip_oversized_file` to `JSONLWatcher`: when pending unread bytes exceed a configurable threshold (`BRAINLAYER_WATCH_MAX_FILE_BYTES`, default 100 MiB), the file is checkpointed to its end and skipped until it falls below the threshold.
> - Drains already-buffered complete lines before re-reading disk, preventing starvation when large files block the poll loop.
> - Extracts `JSONLTailer.read_buffered_lines` and `has_complete_buffered_line` so callers can consume buffered records without additional filesystem reads.
> - Adds `BatchIndexer.has_buffered_source` to prevent checkpointing past unconfirmed buffered entries during oversized-file skips.
> - Optimizes `OffsetRegistry.prune_missing_files` to use precomputed parent-directory sets instead of per-file linear scans.
> - Risk: files exceeding the byte threshold will have their unread content silently dropped; the checkpoint advances to end-of-file, skipping any unindexed records in that region.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4ed29d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable cap on pending unread data size for JSONL monitoring via environment setting.
  * When limits are exceeded, oversized files are skipped but their registry offsets advance and are checkpointed for safe later recovery.
* **Bug Fixes**
  * Improved pruning of missing offsets using more accurate live-parent evidence evaluation.
  * Enhanced rewind/checkpoint restore behavior for oversized scenarios with reliable rewind notifications.
* **Chores / Tests**
  * Expanded watcher tests to cover oversize skipping, checkpointing edge cases, and invalid/disabled limit configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->