### PR TITLE
chore: release BrainLayer 1.5.1

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.5.0</string>
+    <string>1.5.1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.0</string>
+    <string>1.5.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.5.0"
+version = "1.5.1"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
## Summary
- bump BrainLayer package metadata from 1.5.0 to 1.5.1
- keep server manifest and BrainBar bundle versions synchronized
- release the merged watcher ingestion fixes from #613

## Verification
- 98 targeted release-sync and watcher tests passed
- mandatory pre-push gate: 3610 passed, 9 skipped, 61 deselected, 1 xfailed
- MCP registration 3/3, isolated eval/hook routing 40/40, Bun 1/1, FTS determinism passed

## Release sequence
- tag only from the verified merge ref after this PR merges
- publish tag-gated PyPI sdist and notarized BrainBar asset
- update formula/cask and deploy the packaged watcher

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime or security behavior modified in the diff.
> 
> **Overview**
> **Release 1.5.1** — synchronizes the version string from **1.5.0** to **1.5.1** everywhere it is published or displayed.
> 
> Updates `pyproject.toml` and `src/brainlayer/__init__.py` for the Python package, both `version` fields in `server.json` (server manifest and PyPI package entry), and `CFBundleVersion` / `CFBundleShortVersionString` in the BrainBar `Info.plist`. No application logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5561deb62cf9b44704b5868b790c570307f44e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release BrainLayer version 1.5.1
> Bumps version strings from 1.5.0 to 1.5.1 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/614/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/614/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/614/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [`__version__`](https://github.com/EtanHey/brainlayer/pull/614/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5561deb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and package version to **1.5.1** across all distribution metadata.
  * Ensures displayed and reported version information is consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->