### PR TITLE
fix(site): guard rendered entities and refresh public stats

### DIFF
--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -42,7 +42,7 @@ const sections = [
   },
   {
     title: "MCP Tools",
-    desc: `Current reference for all ${PUBLIC_SITE_STATS.mcpTools} MCP tools: search, store, recall, resume, entity, expand, digest, update, tags, and more.`,
+    desc: `Python transport guide for search, store, recall, resume, entity, expand, digest, update, tags, and more.`,
     href: "https://etanhey.github.io/brainlayer/mcp-tools/",
     icon: (
       <svg
@@ -205,8 +205,8 @@ export default function DocsPage() {
             </h1>
             <p className="text-lg text-text-secondary font-light max-w-[560px]">
               Setup, MCP configuration, BrainBar flows, and the{" "}
-              {PUBLIC_SITE_STATS.mcpTools}-tool memory surface for persistent
-              AI-agent context.
+              {PUBLIC_SITE_STATS.brainBarMcpTools}-tool live surface for
+              persistent AI-agent context.
             </p>
           </div>
 

--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
 
 const sections = [
   {
@@ -41,7 +42,7 @@ const sections = [
   },
   {
     title: "MCP Tools",
-    desc: "Current reference for all 12 MCP tools: search, store, recall, entity, expand, digest, update, tags, and more.",
+    desc: `Current reference for all ${PUBLIC_SITE_STATS.mcpTools} MCP tools: search, store, recall, resume, entity, expand, digest, update, tags, and more.`,
     href: "https://etanhey.github.io/brainlayer/mcp-tools/",
     icon: (
       <svg
@@ -203,8 +204,9 @@ export default function DocsPage() {
               Learn BrainLayer
             </h1>
             <p className="text-lg text-text-secondary font-light max-w-[560px]">
-              Setup, MCP configuration, BrainBar flows, and the twelve-tool
-              memory surface for persistent AI-agent context.
+              Setup, MCP configuration, BrainBar flows, and the{" "}
+              {PUBLIC_SITE_STATS.mcpTools}-tool memory surface for persistent
+              AI-agent context.
             </p>
           </div>
 

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -24,7 +24,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: "BrainLayer - Persistent Memory for MCP Agents",
-  description: `Local-first memory for MCP agents and BrainBar. ${PUBLIC_SITE_STATS.mcpTools} working tools, formatted Unicode output, and keyboard-first quick capture.`,
+  description: `Local-first memory for MCP agents and BrainBar. ${PUBLIC_SITE_STATS.brainBarMcpTools}-tool live BrainBar surface, ${PUBLIC_SITE_STATS.pythonMcpTools}-tool Python transport, and keyboard-first capture.`,
   metadataBase: new URL("https://brainlayer.etanheyman.com"),
   alternates: { canonical: "/" },
   icons: {
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "BrainLayer - Persistent Memory for MCP Agents",
-    description: `Local-first memory for MCP agents and BrainBar with ${PUBLIC_SITE_STATS.mcpTools} working tools and formatted search output.`,
+    description: `Local-first memory for MCP agents and BrainBar with a ${PUBLIC_SITE_STATS.brainBarMcpTools}-tool live surface and formatted search output.`,
     url: "https://brainlayer.etanheyman.com",
     siteName: "BrainLayer",
     type: "website",
@@ -49,7 +49,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "BrainLayer - Persistent Memory for MCP Agents",
-    description: `Local-first memory for MCP agents and BrainBar. ${PUBLIC_SITE_STATS.mcpTools} working MCP tools, formatted output, and keyboard-first capture.`,
+    description: `Local-first memory for MCP agents and BrainBar. ${PUBLIC_SITE_STATS.brainBarMcpTools}-tool live surface, formatted output, and keyboard-first capture.`,
   },
   robots: {
     index: true,

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Newsreader, Outfit, JetBrains_Mono } from "next/font/google";
+import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
 import "./globals.css";
 
 const newsreader = Newsreader({
@@ -23,8 +24,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: "BrainLayer - Persistent Memory for MCP Agents",
-  description:
-    "Local-first memory for MCP agents and BrainBar. Twelve working tools, formatted Unicode output, and keyboard-first quick capture.",
+  description: `Local-first memory for MCP agents and BrainBar. ${PUBLIC_SITE_STATS.mcpTools} working tools, formatted Unicode output, and keyboard-first quick capture.`,
   metadataBase: new URL("https://brainlayer.etanheyman.com"),
   alternates: { canonical: "/" },
   icons: {
@@ -33,8 +33,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "BrainLayer - Persistent Memory for MCP Agents",
-    description:
-      "Local-first memory for MCP agents and BrainBar with twelve working tools and formatted search output.",
+    description: `Local-first memory for MCP agents and BrainBar with ${PUBLIC_SITE_STATS.mcpTools} working tools and formatted search output.`,
     url: "https://brainlayer.etanheyman.com",
     siteName: "BrainLayer",
     type: "website",
@@ -50,8 +49,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "BrainLayer - Persistent Memory for MCP Agents",
-    description:
-      "Local-first memory for MCP agents and BrainBar. Twelve working MCP tools, formatted output, and keyboard-first capture.",
+    description: `Local-first memory for MCP agents and BrainBar. ${PUBLIC_SITE_STATS.mcpTools} working MCP tools, formatted output, and keyboard-first capture.`,
   },
   robots: {
     index: true,

--- a/site/components/comparison.tsx
+++ b/site/components/comparison.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
 
 const without = [
   "Repeats the same mistakes every session",
@@ -12,7 +13,7 @@ const without = [
 
 const withBL = [
   "Remembers every decision, learning, and correction",
-  "Searches 294K+ knowledge chunks in under 50ms",
+  `Searches ${PUBLIC_SITE_STATS.knowledgeChunksLabel} knowledge chunks with hybrid retrieval`,
   "Knowledge graph connects entities across sessions",
   "Cross-session memory persists through restarts",
   "Recalls your preferences, patterns, and past work",

--- a/site/components/cta.tsx
+++ b/site/components/cta.tsx
@@ -31,8 +31,9 @@ export function Cta() {
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.1 }}
         >
-          {PUBLIC_SITE_STATS.mcpTools} working tools, one local database, and a
-          BrainBar capture flow that does not lose the thread.
+          {PUBLIC_SITE_STATS.brainBarMcpTools} tools on the live BrainBar
+          surface, one local database, and a capture flow that does not lose the
+          thread.
         </motion.p>
         <motion.div
           initial={{ opacity: 1, y: 12 }}

--- a/site/components/cta.tsx
+++ b/site/components/cta.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { CopyBlock } from "./copy-block";
+import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
 
 export function Cta() {
   return (
@@ -30,8 +31,8 @@ export function Cta() {
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.1 }}
         >
-          Twelve working tools, one local database, and a BrainBar capture flow
-          that does not lose the thread.
+          {PUBLIC_SITE_STATS.mcpTools} working tools, one local database, and a
+          BrainBar capture flow that does not lose the thread.
         </motion.p>
         <motion.div
           initial={{ opacity: 1, y: 12 }}

--- a/site/components/pipeline-demo.tsx
+++ b/site/components/pipeline-demo.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useEffect, useCallback } from "react";
 import { motion, useInView } from "framer-motion";
+import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
 
 /* ── Graph data ─────────────────────────────────────────────── */
 
@@ -204,8 +205,8 @@ export function PipelineDemo() {
       }
     }
 
-    let baseChunks = 284291;
-    let baseEntities = 12847;
+    let baseChunks = PUBLIC_SITE_STATS.knowledgeChunks;
+    let baseEntities = PUBLIC_SITE_STATS.knowledgeGraphEntities;
 
     function updateStats(
       chunks: number | null,
@@ -574,7 +575,8 @@ export function PipelineDemo() {
         </h2>
         <p className="mx-auto mb-14 max-w-[720px] text-center text-[15px] leading-relaxed font-light text-text-secondary">
           Store decisions, search across sessions, recall context, digest
-          documents. One pipeline, twelve tools, zero configuration.
+          documents. One pipeline, {PUBLIC_SITE_STATS.mcpTools} tools, zero
+          configuration.
         </p>
 
         <motion.div
@@ -641,13 +643,13 @@ export function PipelineDemo() {
             <span>
               <span className="mr-1">chunks</span>
               <span ref={dsChunksRef} className="font-medium text-teal">
-                284,291
+                {PUBLIC_SITE_STATS.knowledgeChunks.toLocaleString()}
               </span>
             </span>
             <span>
               <span className="mr-1">entities</span>
               <span ref={dsEntitiesRef} className="font-medium text-teal">
-                12,847
+                {PUBLIC_SITE_STATS.knowledgeGraphEntities.toLocaleString()}
               </span>
             </span>
             <span>

--- a/site/components/pipeline-demo.tsx
+++ b/site/components/pipeline-demo.tsx
@@ -215,9 +215,9 @@ export function PipelineDemo() {
       status: string | null,
     ) {
       if (chunks !== null && dsChunksRef.current)
-        dsChunksRef.current.textContent = chunks.toLocaleString();
+        dsChunksRef.current.textContent = chunks.toLocaleString("en-US");
       if (entities !== null && dsEntitiesRef.current)
-        dsEntitiesRef.current.textContent = entities.toLocaleString();
+        dsEntitiesRef.current.textContent = entities.toLocaleString("en-US");
       if (latency !== null && dsLatencyRef.current)
         dsLatencyRef.current.textContent = latency;
       if (status !== null && dsStatusRef.current)
@@ -643,13 +643,15 @@ export function PipelineDemo() {
             <span>
               <span className="mr-1">chunks</span>
               <span ref={dsChunksRef} className="font-medium text-teal">
-                {PUBLIC_SITE_STATS.knowledgeChunks.toLocaleString()}
+                {PUBLIC_SITE_STATS.knowledgeChunks.toLocaleString("en-US")}
               </span>
             </span>
             <span>
               <span className="mr-1">entities</span>
               <span ref={dsEntitiesRef} className="font-medium text-teal">
-                {PUBLIC_SITE_STATS.knowledgeGraphEntities.toLocaleString()}
+                {PUBLIC_SITE_STATS.knowledgeGraphEntities.toLocaleString(
+                  "en-US",
+                )}
               </span>
             </span>
             <span>

--- a/site/components/pipeline-demo.tsx
+++ b/site/components/pipeline-demo.tsx
@@ -575,8 +575,8 @@ export function PipelineDemo() {
         </h2>
         <p className="mx-auto mb-14 max-w-[720px] text-center text-[15px] leading-relaxed font-light text-text-secondary">
           Store decisions, search across sessions, recall context, digest
-          documents. One pipeline, {PUBLIC_SITE_STATS.mcpTools} tools, zero
-          configuration.
+          documents. One pipeline, {PUBLIC_SITE_STATS.brainBarMcpTools} live
+          tools, zero configuration.
         </p>
 
         <motion.div

--- a/site/components/problem-solution.tsx
+++ b/site/components/problem-solution.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
 
 export function ProblemSolution() {
   return (
@@ -36,7 +37,7 @@ export function ProblemSolution() {
               <code className="text-accent text-xs">brain_search</code> combines
               bge-large embeddings with FTS5 keyword matching via Reciprocal
               Rank Fusion. One query searches across every conversation you have
-              ever had. Sub-50ms on 300K+ chunks.
+              ever had across {PUBLIC_SITE_STATS.knowledgeChunksLabel} chunks.
             </p>
           </motion.div>
 
@@ -96,8 +97,8 @@ export function ProblemSolution() {
               BrainBar
             </h2>
             <p className="flex-1 text-[15px] leading-relaxed font-light text-text-secondary">
-              Optional 209KB native Swift menu bar app. Quick capture, live
-              dashboard, knowledge graph viewer &mdash; all over a Unix socket.
+              Optional native Swift menu bar app. Quick capture, live dashboard,
+              knowledge graph viewer &mdash; all over a Unix socket.
             </p>
             <p className="mt-3 text-[12px] font-light text-text-dim">
               Requires the BrainLayer MCP server.

--- a/site/components/tools.tsx
+++ b/site/components/tools.tsx
@@ -2,75 +2,18 @@
 
 import { motion } from "framer-motion";
 import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
-
-const coreTools = [
-  {
-    name: "brain_search",
-    desc: "Hybrid semantic + keyword + KG search with compact formatted output",
-  },
-  {
-    name: "brain_store",
-    desc: "Persist decisions, learnings, corrections, and capture notes",
-  },
-  {
-    name: "brain_recall",
-    desc: "Unified recall entrypoint for search, entity, and session-aware lookup",
-  },
-  {
-    name: "brain_resume",
-    desc: "Recover recent PreCompact checkpoints for explicit session restoration",
-  },
-];
-
-const advancedTools = [
-  { name: "brain_entity", desc: "Knowledge graph entity lookup" },
-  {
-    name: "brain_expand",
-    desc: "Drill into one search hit with surrounding context",
-  },
-  {
-    name: "brain_digest",
-    desc: "Deep-ingest large content and extract entities, actions, and relations",
-  },
-  {
-    name: "brain_update",
-    desc: "Update chunk importance and tags by chunk ID",
-  },
-  {
-    name: "brain_tags",
-    desc: "List unique tags with counts, filter by prefix",
-  },
-  {
-    name: "brain_get_person",
-    desc: "Look up a person entity with all known relations",
-  },
-];
-
-const lifecycleTools = [
-  {
-    name: "brain_supersede",
-    desc: "Replace a chunk with a newer version, preserving history",
-  },
-  {
-    name: "brain_archive",
-    desc: "Soft-delete a chunk with timestamp for audit trail",
-  },
-  {
-    name: "brain_enrich",
-    desc: "Trigger deep enrichment on a stored chunk via Groq or Gemini",
-  },
-];
+import { BRAINBAR_MCP_TOOL_GROUPS } from "@/lib/public-tools";
 
 function ToolItem({ name, desc }: { name: string; desc: string }) {
   return (
     <motion.div
-      className="flex items-baseline gap-5 rounded-lg px-4 py-3 transition-colors hover:bg-bg-elevated"
+      className="flex flex-col items-start gap-1.5 rounded-lg px-4 py-3 transition-colors hover:bg-bg-elevated sm:flex-row sm:items-baseline sm:gap-5"
       initial={{ opacity: 1, y: 8 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.4 }}
     >
-      <span className="min-w-[150px] shrink-0 font-mono text-[13px] font-medium text-accent">
+      <span className="shrink-0 font-mono text-[13px] font-medium text-accent sm:min-w-[150px]">
         {name}
       </span>
       <span className="text-sm font-light text-text-secondary">{desc}</span>
@@ -86,39 +29,31 @@ export function Tools() {
           MCP tools
         </div>
         <h2 className="mb-14 text-center font-display text-[clamp(26px,3.5vw,36px)] font-semibold leading-tight tracking-tight text-balance">
-          {PUBLIC_SITE_STATS.mcpTools} working tools. One memory layer.
+          {PUBLIC_SITE_STATS.brainBarMcpTools}-tool live surface. One memory
+          layer.
         </h2>
 
-        <div className="mx-auto mb-12 max-w-[640px]">
-          <div className="mb-4 pl-1 text-xs font-medium uppercase tracking-[0.1em] text-text-dim">
-            Core - what you use daily
+        {BRAINBAR_MCP_TOOL_GROUPS.map((group, index) => (
+          <div key={group.label}>
+            {index > 0 && (
+              <div className="mx-auto h-px max-w-[640px] bg-border" />
+            )}
+            <div className="mx-auto mb-2 mt-6 max-w-[640px]">
+              <div className="mb-4 pl-1 text-xs font-medium uppercase tracking-[0.1em] text-text-dim">
+                {group.label}
+              </div>
+              {group.tools.map((tool) => (
+                <ToolItem key={tool.name} {...tool} />
+              ))}
+            </div>
           </div>
-          {coreTools.map((tool) => (
-            <ToolItem key={tool.name} {...tool} />
-          ))}
-        </div>
+        ))}
 
-        <div className="mx-auto h-px max-w-[640px] bg-border" />
-
-        <div className="mx-auto mt-2 max-w-[640px]">
-          <div className="mb-4 mt-6 pl-1 text-xs font-medium uppercase tracking-[0.1em] text-text-dim">
-            Advanced
-          </div>
-          {advancedTools.map((tool) => (
-            <ToolItem key={tool.name} {...tool} />
-          ))}
-        </div>
-
-        <div className="mx-auto h-px max-w-[640px] bg-border" />
-
-        <div className="mx-auto mt-2 max-w-[640px]">
-          <div className="mb-4 mt-6 pl-1 text-xs font-medium uppercase tracking-[0.1em] text-text-dim">
-            Lifecycle
-          </div>
-          {lifecycleTools.map((tool) => (
-            <ToolItem key={tool.name} {...tool} />
-          ))}
-        </div>
+        <p className="mx-auto mt-8 max-w-[640px] text-[12px] font-light leading-relaxed text-text-dim">
+          The secondary Python transport exposes{" "}
+          {PUBLIC_SITE_STATS.pythonMcpTools} tools, including the Python-only{" "}
+          <code className="text-accent">brain_resume</code>.
+        </p>
       </div>
     </section>
   );

--- a/site/components/tools.tsx
+++ b/site/components/tools.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { PUBLIC_SITE_STATS } from "@/lib/public-stats";
 
 const coreTools = [
   {
@@ -14,6 +15,10 @@ const coreTools = [
   {
     name: "brain_recall",
     desc: "Unified recall entrypoint for search, entity, and session-aware lookup",
+  },
+  {
+    name: "brain_resume",
+    desc: "Recover recent PreCompact checkpoints for explicit session restoration",
   },
 ];
 
@@ -81,7 +86,7 @@ export function Tools() {
           MCP tools
         </div>
         <h2 className="mb-14 text-center font-display text-[clamp(26px,3.5vw,36px)] font-semibold leading-tight tracking-tight text-balance">
-          Twelve working tools. One memory layer.
+          {PUBLIC_SITE_STATS.mcpTools} working tools. One memory layer.
         </h2>
 
         <div className="mx-auto mb-12 max-w-[640px]">

--- a/site/eslint.config.mjs
+++ b/site/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Static MkDocs output retained for legacy links; it is vendored, minified code.
+    "assets/**",
   ]),
 ]);
 

--- a/site/lib/public-stats.ts
+++ b/site/lib/public-stats.ts
@@ -1,9 +1,15 @@
+import {
+  BRAINBAR_MCP_TOOL_COUNT,
+  PYTHON_MCP_TOOL_COUNT,
+} from "./public-tools";
+
 // AIDEV-NOTE: Single checked-in snapshot for public site claims. Generate this
-// file from the canonical DB + MCP tool definitions to prevent future stat rot.
+// file from the canonical DB + both MCP tool definitions to prevent stat rot.
 // Snapshot verified 2026-07-23.
 export const PUBLIC_SITE_STATS = {
   knowledgeChunks: 704_992,
   knowledgeChunksLabel: "700K+",
   knowledgeGraphEntities: 12_534,
-  mcpTools: 13,
+  brainBarMcpTools: BRAINBAR_MCP_TOOL_COUNT,
+  pythonMcpTools: PYTHON_MCP_TOOL_COUNT,
 } as const;

--- a/site/lib/public-stats.ts
+++ b/site/lib/public-stats.ts
@@ -1,0 +1,9 @@
+// AIDEV-NOTE: Single checked-in snapshot for public site claims. Generate this
+// file from the canonical DB + MCP tool definitions to prevent future stat rot.
+// Snapshot verified 2026-07-23.
+export const PUBLIC_SITE_STATS = {
+  knowledgeChunks: 704_992,
+  knowledgeChunksLabel: "700K+",
+  knowledgeGraphEntities: 12_534,
+  mcpTools: 13,
+} as const;

--- a/site/lib/public-tools.ts
+++ b/site/lib/public-tools.ts
@@ -1,0 +1,94 @@
+export const BRAINBAR_MCP_TOOL_GROUPS = [
+  {
+    label: "Core - what you use daily",
+    tools: [
+      {
+        name: "brain_search",
+        desc: "Hybrid semantic + keyword + KG search with compact formatted output",
+      },
+      {
+        name: "brain_store",
+        desc: "Persist decisions, learnings, corrections, and capture notes",
+      },
+      {
+        name: "brain_recall",
+        desc: "Session-aware context, history, plans, and knowledge-base stats",
+      },
+      {
+        name: "brain_expand",
+        desc: "Drill into one search hit with surrounding context",
+      },
+    ],
+  },
+  {
+    label: "Knowledge and lifecycle",
+    tools: [
+      { name: "brain_entity", desc: "Knowledge graph entity lookup" },
+      {
+        name: "brain_get_person",
+        desc: "Look up a person with graph relations and linked memories",
+      },
+      {
+        name: "brain_digest",
+        desc: "Deep-ingest large content and extract entities and relations",
+      },
+      {
+        name: "brain_update",
+        desc: "Update chunk importance and tags by chunk ID",
+      },
+      {
+        name: "brain_tags",
+        desc: "List unique tags with counts and optional filtering",
+      },
+      {
+        name: "brain_supersede",
+        desc: "Replace a chunk with a newer version, preserving history",
+      },
+      {
+        name: "brain_archive",
+        desc: "Archive a chunk while preserving its audit trail",
+      },
+      {
+        name: "brain_enrich",
+        desc: "Backfill summaries and enrichment metadata",
+      },
+    ],
+  },
+  {
+    label: "Agent bus",
+    tools: [
+      {
+        name: "brain_subscribe",
+        desc: "Subscribe an agent to notifications for matching tags",
+      },
+      {
+        name: "brain_unsubscribe",
+        desc: "Remove some or all tag subscriptions for an agent",
+      },
+      {
+        name: "brain_ack",
+        desc: "Acknowledge messages processed by an agent",
+      },
+    ],
+  },
+  {
+    label: "Operator",
+    tools: [
+      {
+        name: "brain_backup_vacuum_into",
+        desc: "Create a consistent SQLite backup snapshot",
+      },
+      {
+        name: "brain_maintenance_rebuild_trigram",
+        desc: "Rebuild the trigram search index in lock-aware batches",
+      },
+    ],
+  },
+] as const;
+
+export const BRAINBAR_MCP_TOOL_COUNT = BRAINBAR_MCP_TOOL_GROUPS.reduce(
+  (count, group) => count + group.tools.length,
+  0,
+);
+
+export const PYTHON_MCP_TOOL_COUNT = 13;

--- a/site/package.json
+++ b/site/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "node scripts/check-rendered-entities.mjs",
+    "check:rendered-entities": "node scripts/check-rendered-entities.mjs",
     "start": "next start",
     "lint": "eslint"
   },

--- a/site/scripts/check-rendered-entities.mjs
+++ b/site/scripts/check-rendered-entities.mjs
@@ -21,6 +21,13 @@ if (!existsSync(renderedAppDir)) {
 }
 
 const renderedPageFiles = htmlFilesUnder(renderedAppDir);
+if (renderedPageFiles.length === 0) {
+  console.error(
+    "Rendered-output guard found no HTML files under .next/server/app.",
+  );
+  process.exit(1);
+}
+
 const findings = renderedPageFiles.flatMap((path) => {
   const html = readFileSync(path, "utf8");
   return [...html.matchAll(doubleEscapedEntity)].map((match) => ({

--- a/site/scripts/check-rendered-entities.mjs
+++ b/site/scripts/check-rendered-entities.mjs
@@ -1,0 +1,42 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+
+const renderedAppDir = resolve(".next/server/app");
+const doubleEscapedEntity = /&amp;(?:#[0-9]+|#x[0-9a-f]+|[a-z][a-z0-9]+);/gi;
+
+function htmlFilesUnder(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return htmlFilesUnder(path);
+    if (entry.isFile() && extname(entry.name) === ".html") return [path];
+    return [];
+  });
+}
+
+if (!existsSync(renderedAppDir)) {
+  console.error(
+    "Rendered-output guard requires a completed Next.js build at .next/server/app.",
+  );
+  process.exit(1);
+}
+
+const renderedPageFiles = htmlFilesUnder(renderedAppDir);
+const findings = renderedPageFiles.flatMap((path) => {
+  const html = readFileSync(path, "utf8");
+  return [...html.matchAll(doubleEscapedEntity)].map((match) => ({
+    file: relative(process.cwd(), path),
+    entity: match[0],
+  }));
+});
+
+if (findings.length > 0) {
+  console.error("Double-escaped HTML entities reached rendered page output:");
+  for (const finding of findings) {
+    console.error(`- ${finding.file}: ${finding.entity}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Rendered-output entity guard passed (${renderedPageFiles.length} HTML files scanned).`,
+);

--- a/tests/test_search_quality.py
+++ b/tests/test_search_quality.py
@@ -10,6 +10,7 @@ All tests use tmp_path fixtures (isolated, no production DB).
 """
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -326,13 +327,14 @@ class TestPostRRFReranking:
 
     def test_recent_chunk_ranks_higher(self, store, mock_embed):
         """A recent chunk should rank above an old chunk at similar distance."""
+        now = datetime.now(timezone.utc)
         emb = mock_embed("authentication flow")
         _insert_chunk(
             store,
             "old-chunk",
             content="authentication flow implementation details",
             importance=5.0,
-            created_at="2025-06-01T00:00:00",  # 9 months ago
+            created_at=(now - timedelta(days=270)).isoformat(),
             embedding=emb,
         )
         emb_new = [v + 0.001 for v in emb]
@@ -341,7 +343,7 @@ class TestPostRRFReranking:
             "new-chunk",
             content="authentication flow implementation and testing",
             importance=5.0,
-            created_at="2026-03-02T00:00:00",  # yesterday
+            created_at=(now - timedelta(days=1)).isoformat(),
             embedding=emb_new,
         )
         results = store.hybrid_search(


### PR DESCRIPTION
## Summary

- add a post-build regression guard that fails when a double-escaped HTML entity reaches any prerendered page
- centralize checked-in public stats and refresh the site to 704,992 chunks / 12,534 entities / a 17-tool live BrainBar surface plus a 13-tool Python transport
- render the canonical BrainBar tool inventory, distinguish Python-only `brain_resume`, remove unsupported latency/binary-size claims, and keep vendored MkDocs assets out of the Next.js lint target

## `&check;` regression root cause

`13e81afd` originally introduced the comparison bullets as the invalid HTML entity `&check;`. Commit `41c5efd6e2880afad0ee9d1871ab9bef20454a12` (`fix(site): replace invalid &check; entity with ✓ in comparison component`, 2026-05-06) correctly replaced it with the literal `✓` glyph, and no later source commit reverted that fix.

What effectively undid the fix was deployment/alias drift, not a code regression:

- `brainlayer.etanheyman.com` still targets Vercel deployment `dpl_7Sh3q2xPfu2SUqRxai3bwaEiFJAa`, created 2026-04-02 before `41c5efd6`
- that deployment has no Git source metadata and all deployments in the `brainlayer` project predate the May fix
- the checked-in `site/.vercel/project.json` points at a stale `site` project link, while the live alias belongs to the separate `brainlayer` project

The live domain will therefore remain stale until this PR is merged, a new production deployment is made, and the alias/project linkage is corrected. This PR intentionally does not deploy or merge.

## Regression guard

`site/scripts/check-rendered-entities.mjs` recursively scans every `.html` file under `.next/server/app` for named or numeric entities that were escaped into `&amp;...;`. It runs automatically as `postbuild`.

- RED: the pre-existing rendered artifact failed with five `&amp;check;` findings in `index.html`
- RED (coverage): an empty output fixture used to pass with `0 HTML files scanned`; it now exits 1 explicitly
- GREEN: a fresh Next 16 production build passes with all four prerendered HTML outputs scanned

## Public stat source and inventory

`site/lib/public-stats.ts` is now the single checked-in snapshot used by the landing page, docs page, and metadata. The long-term generated source should remain at this path: a release/prebuild maintenance job should populate it from a read-only canonical BrainLayer DB query plus the MCP registration list, then fail on an unexpected diff. Public test counts and product versions should join that generator if the site ever exposes them.

Verified snapshot for 2026-07-23:

- 704,992 chunks / 17.4 GB (operator-verified snapshot supplied for this task; public label is `700K+`)
- 12,534 knowledge-graph entities (read-only local DB query during the audit)
- 17 live BrainBar MCP tool definitions (surface of record in `MCPRouter.swift` and its 17-tool contract test)
- 13 secondary Python MCP tool registrations, including Python-only `brain_resume` (counted from `src/brainlayer/mcp/__init__.py`)

### Stale claims changed

| Old claim | Location(s) | Resolution |
| --- | --- | --- |
| `294K+` chunks | comparison | `700K+` from the 704,992 snapshot |
| `300K+` chunks | semantic-search card | `700K+` |
| `284,291` chunks | pipeline baseline | `704,992` |
| `12,847` entities | pipeline baseline | `12,534` |
| `12` / `Twelve` MCP tools | 3 metadata descriptions, tools heading, pipeline intro, CTA, docs card, docs intro | split into the canonical 17-tool live BrainBar surface and 13-tool Python transport |
| 12-item shared-subset list | tools section | replaced with the full 17-tool BrainBar inventory; Python-only `brain_resume` is called out separately |
| `under 50ms` / `Sub-50ms` | comparison and semantic-search card | removed; current repository budget is warm hybrid p50 under 500 ms, not a sub-50 ms guarantee |
| `209KB` BrainBar binary | BrainBar card | removed; the current installed executable is 12,827,792 bytes and app-bundle size is build-dependent |

### Numeric/version strings reviewed and deliberately unchanged

These are rendered fixture/workflow labels, not live BrainLayer corpus or benchmark claims, but are recorded here because they are future stat-rot risks:

- `284,291 tokens` and `Opus 4.6 (1M context)` each appear twice in the simulated Claude terminal status bars
- animated pipeline fixture values: 12 ms store, 9 ms search, 8 ms recall, 340 ms digest, 11 ms idle, score 0.94, 4 injected/created chunks, 1,247 tokens, +7 entities, and fixture dates/session IDs
- search-output fixtures contain scores, importance values, and 2026-03-29/30 dates
- `Three steps` and `3 commands` match the three setup commands currently rendered
- `Three open-source MCP servers` matches the three ecosystem products currently listed in the footer
- `site/package.json` remains private package version `0.1.0`; it is not rendered as the BrainLayer product version
- no public BrainLayer test-count claim exists in the landing/docs page family

### Generated legacy artifact inventory (left unchanged)

The repository also retains a generated MkDocs export under `site/`. These files are not active Next App Router routes in the current `next.config.ts`/Vercel configuration, but they are stat-rot debt and their generated search index republishes the same claims:

| Generated artifact | Stale claim(s) |
| --- | --- |
| `site/index.html` | 7 MCP tools (three occurrences) |
| `site/mcp-tools/index.html` | 8 MCP tools |
| `site/architecture/index.html` | 8 MCP tools; ~1.4 GB for 260K+ chunks |
| `site/data-locations/index.html` | active-data row says ~8 GB / 297K+ chunks |
| `site/adr/0001-sqlite-vec-over-dedicated-vector-db/index.html` | 268K+ described twice as the current scale |
| `site/research/launch-readiness-audit/index.html` | 12-tool suite in four claims |
| `site/research/session-enrichment/prompts/index.html` | all 12 MCP tools described as read-only |
| `site/research/session-enrichment/brainstore-write-tools/index.html` | 268,000 chunks / ~3.8 GB research snapshot |
| `site/research/session-enrichment/auto-extracting-learnings/index.html` | 268K dataset research snapshot |
| `site/search/search_index.json` | generated duplicates of the 7/8-tool and 260K/297K chunk claims above |

No generated legacy page exposes a current knowledge-graph entity count or BrainLayer test count. The only BrainLayer-adjacent version strings found there are historical/example values (for example `archiver_version: 1.1.0`) and third-party research versions; no current BrainLayer product version is rendered.

### Canonical docs cross-check

- `docs/mcp-tools.md` still says 8 tools and documents only an older Python subset; the site card no longer labels that page a current all-tools reference
- `README.md` correctly documents the secondary Python transport as 13 tools, while `docs/architecture/MODULE-MAP.md` and BrainBar contract tests identify the live 17-tool surface

## Verification

- `npm run lint`
- `npm run build` (includes rendered-output guard; 4 HTML files scanned)
- `npm run check:rendered-entities`
- full pre-push BrainLayer gate (with the local soft descriptor limit raised from 256): 3,610 passed, 9 skipped, 61 deselected, 1 xfailed; 3 MCP registration tests, 40 isolated eval/hook tests, the Bun stale-index test, and the FTS5 determinism shell regression also passed
- Playwright/Chromium at 1440×1000 and 390×844 (including `de-DE` locale): exactly five visible `✓` glyphs, no entity text or hydration error, `700K+`, the 17-tool BrainBar inventory, the 13-tool Python/`brain_resume` note, and 704,992 / 12,534 pipeline baseline verified

## Review note

The bounded local CodeRabbit gate timed out after three minutes. Its only emitted finding concerned an unrelated pre-existing BrainBar Swift file, so no out-of-scope code was changed. GitHub CodeRabbit was rate-limited and Cursor/Greptile were unavailable.

Macroscope and Codex both found the same valid locale-dependent hydration risk; `a85ca78d` fixes render-time and animated formatting with explicit `en-US` output. A subsequent Codex review correctly identified the 17-tool BrainBar / 13-tool Python distinction, which is addressed by the latest commit.

The Codex note about agent-bus tools being unimplemented was verified as a false positive: `BrainBarServer` intercepts those three calls before the router stubs, and all 20 `SocketIntegrationTests` (including subscribe, unsubscribe, ack, and stdio bridge coverage) pass.

The latest Codex review found that the rendered-output guard could silently pass when zero HTML files were present. Commit `f7a71f20` fixes that coverage gap and verifies the empty-scan failure path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the Next.js marketing site, a build-time HTML scan, and a small test stability tweak—no auth, data, or core MCP runtime behavior.
> 
> **Overview**
> **Centralizes marketing numbers and MCP tool copy** in `public-stats.ts` and `public-tools.ts`, then wires the landing page, docs page, and SEO metadata to those values instead of scattered hardcoded “12 tools” / ~284K chunks / sub-50ms claims.
> 
> **Refreshes public messaging** to a 700K+ chunk snapshot, updated entity counts, a **17-tool BrainBar live surface** vs **13-tool Python transport** (with `brain_resume` called out), a fuller grouped tool list, and removal of unsupported latency and BrainBar size claims. Docs copy reframes the MCP Tools card as a Python transport guide.
> 
> **Adds a post-build regression guard** (`check-rendered-entities.mjs`) that fails the build if double-escaped HTML entities (e.g. `&amp;check;`) appear in prerendered `.next/server/app` HTML. **Uses explicit `en-US` number formatting** in the pipeline demo to avoid locale hydration mismatches.
> 
> Minor: ESLint ignores vendored `assets/**`; recency rerank test uses relative dates instead of fixed timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a71f2039d741d050168564e531756acd0f28d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace hardcoded stats with dynamic counts across site components and guard against double-escaped entities
> - Introduces [public-stats.ts](https://github.com/EtanHey/brainlayer/pull/624/files#diff-b2d5b21b26072e46f376cbb86403eff4753363b49855b96693cf195c8a7c9907) and [public-tools.ts](https://github.com/EtanHey/brainlayer/pull/624/files#diff-f5b42ec517f3348a71902dcc42108fef8c66790b2290b16949f40bf43ac28343) to centralize tool counts and knowledge chunk stats, replacing hardcoded values across the docs page, CTA, comparison, problem-solution, pipeline demo, and tools components.
> - The tools list in [tools.tsx](https://github.com/EtanHey/brainlayer/pull/624/files#diff-4387c41d322db40a25caeafc0a83a5ac60eaba5ea7d531de2a6ec9d1305b821b) is now driven by `BRAINBAR_MCP_TOOL_GROUPS`, grouping tools dynamically and reflecting live counts in headings and footers.
> - Adds a postbuild script ([check-rendered-entities.mjs](https://github.com/EtanHey/brainlayer/pull/624/files#diff-8916600e80b02eb8ca5016feac3fb8bfb735b0bcc71bdd9a21deb9c567c73bef)) that scans rendered HTML for double-escaped entities and fails the build if any are found.
> - Fixes a flaky test in [test_search_quality.py](https://github.com/EtanHey/brainlayer/pull/624/files#diff-2d08223d53bcc7b4f0553b1f44239f373f932366c8b269df7320fb266f989749) by computing timestamps dynamically relative to now instead of using hardcoded dates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7a71f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

