### PR TITLE
fix(mcp): explain gated tool calls

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -400,9 +400,14 @@ final class MCPRouter: @unchecked Sendable {
             return toolCallResult(id: id, output: expandPalette(session: session))
         }
 
-        // Check tool exists
-        guard isToolExposed(toolName, session: session) else {
+        guard Self.toolDefinitions.contains(where: { ($0["name"] as? String) == toolName }) else {
             return jsonRPCError(id: id, code: -32601, message: "Unknown tool: \(toolName)")
+        }
+
+        guard isToolExposed(toolName, session: session) else {
+            let message = "Tool '\(toolName)' is gated by the core MCP profile. "
+                + "Call expand_palette, or set BRAINLAYER_MCP_PROFILE=full on the MCP server."
+            return jsonRPCError(id: id, code: -32601, message: message)
         }
 
         // Dispatch to handler

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -169,6 +169,19 @@ final class MCPRouterTests: XCTestCase {
         }
     }
 
+    func testCoreProfileExplainsGateAndBothRemedies() throws {
+        let router = MCPRouter(profile: "core")
+        let response = router.handle(toolCall(id: 19, name: "brain_digest", arguments: [:]))
+        let error = try XCTUnwrap(response["error"] as? [String: Any])
+
+        XCTAssertEqual(error["code"] as? Int, -32601)
+        XCTAssertEqual(
+            error["message"] as? String,
+            "Tool 'brain_digest' is gated by the core MCP profile. "
+                + "Call expand_palette, or set BRAINLAYER_MCP_PROFILE=full on the MCP server."
+        )
+    }
+
     func testEnvironmentProfileControlsDefaultRouter() throws {
         let environmentKey = "BRAINLAYER_MCP_PROFILE"
         let originalProfile = ProcessInfo.processInfo.environment[environmentKey]
@@ -1083,6 +1096,7 @@ No results found.
 
         XCTAssertNotNil(error, "Unknown tool should return JSON-RPC error")
         XCTAssertEqual(error?["code"] as? Int, -32601, "Should be method-not-found error")
+        XCTAssertEqual(error?["message"] as? String, "Unknown tool: nonexistent_tool")
     }
 
     func testBrainDigestRejectsOversizedContentAtSchemaLayer() throws {

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -1432,7 +1432,10 @@ async def call_tool(name: str, arguments: dict[str, Any]):
         )
 
     if name in _FULL_TOOL_NAMES and not _tool_palette.is_exposed(name):
-        return _error_result(f"Tool not exposed in the core profile: {name}. Call {EXPAND_TOOL_NAME} first.")
+        return _error_result(
+            f"Tool '{name}' is gated by the core MCP profile. "
+            f"Call {EXPAND_TOOL_NAME}, or set BRAINLAYER_MCP_PROFILE=full on the MCP server."
+        )
 
     # --- New consolidated tools ---
 

--- a/tests/test_mcp_palette.py
+++ b/tests/test_mcp_palette.py
@@ -36,6 +36,29 @@ def test_environment_profile_is_resolved_once(monkeypatch):
     assert len(palette.expose(_full_tool_definitions())) == 13
 
 
+def test_python_core_profile_explains_gate_and_both_remedies(monkeypatch):
+    palette = ToolPalette("core")
+    monkeypatch.setattr(mcp_module, "_tool_palette", palette)
+
+    result = asyncio.run(call_tool("brain_digest", {}))
+
+    assert result.is_error is True
+    assert result.content[0].text == (
+        "Tool 'brain_digest' is gated by the core MCP profile. "
+        "Call expand_palette, or set BRAINLAYER_MCP_PROFILE=full on the MCP server."
+    )
+
+
+def test_python_unknown_tool_remains_unknown(monkeypatch):
+    palette = ToolPalette("core")
+    monkeypatch.setattr(mcp_module, "_tool_palette", palette)
+
+    result = asyncio.run(call_tool("nonexistent_tool", {}))
+
+    assert result.is_error is True
+    assert result.content[0].text == "Unknown tool: nonexistent_tool"
+
+
 def test_python_palette_expands_once_and_dispatches_deferred_tools(monkeypatch):
     palette = ToolPalette("core")
     monkeypatch.setattr(mcp_module, "_tool_palette", palette)
@@ -44,7 +67,7 @@ def test_python_palette_expands_once_and_dispatches_deferred_tools(monkeypatch):
 
     before = asyncio.run(call_tool("brain_tags", {}))
     assert before.is_error is True
-    assert "not exposed" in before.content[0].text
+    assert "gated by the core MCP profile" in before.content[0].text
 
     first = asyncio.run(call_tool("expand_palette", {}))
     assert first.is_error is False


### PR DESCRIPTION
## Summary
- distinguish known tools hidden by the core MCP profile from genuinely unknown tool names in BrainBar
- return the same actionable `expand_palette` / `BRAINLAYER_MCP_PROFILE=full` remedies from the Python MCP server
- preserve exact `Unknown tool` behavior for names that do not exist

## Runtime rollout
The live BrainBar LaunchAgent profile change is intentionally outside this code PR. It has already been applied and verified with a real `brain_digest` call.

Important inventory note: BrainBar's native full profile contains 17 tools and does not implement the Python-only `brain_resume`; this PR does not claim otherwise.

## Test plan
- [x] Swift package: 841 tests, 10 skipped, 0 failures
- [x] Python unit suite: 3,612 passed, 9 skipped, 61 deselected, 1 xfailed
- [x] MCP registration: 3 passed
- [x] isolated eval/routing: 40 passed
- [x] Bun regression: 1 passed
- [x] FTS5 shell regression: passed
- [x] Ruff check + format check
- [x] independent read-only review: no Critical, Important, or Minor findings

## Roadmap follow-ups
- #628
- #629

Do not merge as part of the urgent runtime rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-message and routing-order changes only; no auth, data, or tool dispatch behavior beyond clearer failures for gated tools.
> 
> **Overview**
> **MCP `tools/call` errors now separate unknown tool names from tools hidden by the core profile**, with aligned messaging in BrainBar and the Python MCP server.
> 
> Under the **core** profile, calling a **registered** but **unlisted** tool (e.g. `brain_digest`) no longer looks like a bogus tool name. The router first checks membership in the canonical tool registry, then applies palette exposure. Gated calls return a JSON-RPC `-32601` message that names the tool and points to **`expand_palette`** or **`BRAINLAYER_MCP_PROFILE=full`**. Truly unknown names still get **`Unknown tool: <name>`**.
> 
> Regression tests lock in the exact gate copy on Swift and Python and assert unknown-tool behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef1ec7bf154a2e879d0ba674200b8a571569c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gated tool call errors to distinguish unknown tools from core-profile-gated tools
> Previously, calling a valid-but-unexposed tool under the core MCP profile returned the same
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eef1ec7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool error messages by clearly distinguishing unknown tools from tools unavailable under the current profile.
  * Added guidance for expanding the palette or enabling the full profile when accessing gated tools.
  * Preserved the existing error response for unrecognized tool names.
* **Tests**
  * Added regression coverage for profile-gated and unknown tool requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->