### PR TITLE
feat(ingest): distinguish T3 app Codex sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "sentence-transformers>=2.2.0",
 
     # MCP server
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
 
     # CLI
     "typer>=0.9.0",

--- a/scripts/provenance_classify_report.py
+++ b/scripts/provenance_classify_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections import Counter
 from pathlib import Path
@@ -18,6 +19,7 @@ if str(SRC_DIR) not in sys.path:
 
 from brainlayer.agent_provenance import classify_provenance, effective_visibility
 from brainlayer.paths import DEFAULT_DB_PATH
+from brainlayer.t3_provenance import DEFAULT_T3_STATE_DB, t3_app_codex_session_ids
 
 
 def build_report(db_path: str | Path) -> dict[str, Any]:
@@ -27,6 +29,8 @@ def build_report(db_path: str | Path) -> dict[str, Any]:
     policies: Counter[str] = Counter()
     visibility: Counter[str] = Counter()
     total = 0
+    t3_state_db = Path(os.environ.get("BRAINLAYER_T3_STATE_DB", DEFAULT_T3_STATE_DB)).expanduser()
+    linked_t3_session_ids = t3_app_codex_session_ids(t3_state_db) if t3_state_db.exists() else set()
 
     conn = apsw.Connection(str(db_path), flags=apsw.SQLITE_OPEN_READONLY)
     try:
@@ -34,7 +38,9 @@ def build_report(db_path: str | Path) -> dict[str, Any]:
         for _chunk_id, source_file, content_class in cursor.execute(
             "SELECT id, source_file, content_class FROM chunks"
         ):
-            decision = classify_provenance(str(source_file or ""), content_class)
+            decision = classify_provenance(
+                str(source_file or ""), content_class, t3_linked_session_ids=linked_t3_session_ids
+            )
             tags[decision.provenance_tag] += 1
             policies[decision.search_policy] += 1
             visibility[effective_visibility(decision, content_class)] += 1

--- a/scripts/retag_t3_app_provenance.py
+++ b/scripts/retag_t3_app_provenance.py
@@ -12,10 +12,11 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from brainlayer.provenance import PROVENANCE_RANK
 from brainlayer.t3_provenance import T3_APP_SESSION, codex_session_id_from_source, t3_app_codex_session_ids
 
 
-def _candidates(connection: sqlite3.Connection, linked_session_ids: set[str]) -> list[tuple[str, str]]:
+def _candidates(connection: sqlite3.Connection, linked_session_ids: set[str]) -> list[tuple[str, str | None]]:
     rows = connection.execute(
         """
         SELECT id, source_file, provenance_class
@@ -27,14 +28,27 @@ def _candidates(connection: sqlite3.Connection, linked_session_ids: set[str]) ->
     return [
         (chunk_id, provenance_class)
         for chunk_id, source_file, provenance_class in rows
-        if codex_session_id_from_source(source_file) in linked_session_ids and provenance_class == "codex-session"
+        if codex_session_id_from_source(source_file) in linked_session_ids
+        and provenance_class == "codex-session"
+        and provenance_class not in PROVENANCE_RANK
     ]
 
 
-def _write_rollback_artifact(path: Path, candidates: list[tuple[str, str]]) -> None:
+def _write_rollback_artifact(path: Path, candidates: list[tuple[str, str | None]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    existing = (
+        {
+            row["id"]: row["provenance_class"]
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line
+            for row in [json.loads(line)]
+        }
+        if path.exists()
+        else {}
+    )
+    existing.update(dict(candidates))
     with path.open("w", encoding="utf-8") as artifact:
-        for chunk_id, provenance_class in candidates:
+        for chunk_id, provenance_class in sorted(existing.items()):
             artifact.write(json.dumps({"id": chunk_id, "provenance_class": provenance_class}) + "\n")
 
 

--- a/scripts/retag_t3_app_provenance.py
+++ b/scripts/retag_t3_app_provenance.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Re-tag existing Codex chunks whose session is explicitly linked by T3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from brainlayer.t3_provenance import T3_APP_SESSION, codex_session_id_from_source, t3_app_codex_session_ids
+
+
+def _candidates(connection: sqlite3.Connection, linked_session_ids: set[str]) -> list[tuple[str, str]]:
+    rows = connection.execute(
+        """
+        SELECT id, source_file, provenance_class
+        FROM chunks
+        WHERE source_file LIKE '%/.codex/sessions/%'
+        ORDER BY id
+        """
+    )
+    return [
+        (chunk_id, provenance_class)
+        for chunk_id, source_file, provenance_class in rows
+        if codex_session_id_from_source(source_file) in linked_session_ids and provenance_class != T3_APP_SESSION
+    ]
+
+
+def _write_rollback_artifact(path: Path, candidates: list[tuple[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as artifact:
+        for chunk_id, provenance_class in candidates:
+            artifact.write(json.dumps({"id": chunk_id, "provenance_class": provenance_class}) + "\n")
+
+
+def retag_t3_app_chunks(
+    *,
+    db_path: str | Path,
+    state_db: str | Path,
+    apply: bool = False,
+    rollback_artifact: str | Path | None = None,
+    batch_size: int = 5_000,
+) -> dict[str, int]:
+    """Report or apply the deterministic T3 provenance re-tagging operation."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if apply and rollback_artifact is None:
+        raise ValueError("--rollback-artifact is required with --apply")
+
+    linked_session_ids = t3_app_codex_session_ids(state_db)
+    path = Path(db_path).expanduser()
+    connection = (
+        sqlite3.connect(path, timeout=1.0)
+        if apply
+        else sqlite3.connect(f"{path.absolute().as_uri()}?mode=ro&immutable=0", uri=True, timeout=1.0)
+    )
+    try:
+        if apply:
+            connection.execute("PRAGMA busy_timeout = 30000")
+        candidates = _candidates(connection, linked_session_ids)
+        report = {
+            "linked_sessions": len(linked_session_ids),
+            "candidate_chunks": len(candidates),
+            "retagged_chunks": 0,
+        }
+        if not apply:
+            return report
+
+        artifact_path = Path(rollback_artifact).expanduser()
+        _write_rollback_artifact(artifact_path, candidates)
+        connection.execute("PRAGMA wal_checkpoint(FULL)")
+        for batch_start in range(0, len(candidates), batch_size):
+            batch = candidates[batch_start : batch_start + batch_size]
+            connection.executemany(
+                "UPDATE chunks SET provenance_class = ? WHERE id = ?",
+                [(T3_APP_SESSION, chunk_id) for chunk_id, _ in batch],
+            )
+            connection.commit()
+            if ((batch_start // batch_size) + 1) % 3 == 0:
+                connection.execute("PRAGMA wal_checkpoint(FULL)")
+        connection.execute("PRAGMA wal_checkpoint(FULL)")
+        report["retagged_chunks"] = len(candidates)
+        return report
+    finally:
+        connection.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", type=Path, default=Path.home() / ".local/share/brainlayer/brainlayer.db")
+    parser.add_argument("--state-db", type=Path, default=Path.home() / ".t3/userdata/state.sqlite")
+    parser.add_argument("--apply", action="store_true", help="Perform writes; default is read-only dry run")
+    parser.add_argument("--rollback-artifact", type=Path, help="JSONL (id, provenance_class) captured before writes")
+    parser.add_argument("--batch-size", type=int, default=5_000)
+    args = parser.parse_args()
+    report: dict[str, Any] = retag_t3_app_chunks(
+        db_path=args.db_path,
+        state_db=args.state_db,
+        apply=args.apply,
+        rollback_artifact=args.rollback_artifact,
+        batch_size=args.batch_size,
+    )
+    print(json.dumps(report, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/retag_t3_app_provenance.py
+++ b/scripts/retag_t3_app_provenance.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -34,8 +36,29 @@ def _candidates(connection: sqlite3.Connection, linked_session_ids: set[str]) ->
     ]
 
 
-def _write_rollback_artifact(path: Path, candidates: list[tuple[str, str | None]]) -> None:
+def _atomic_write_jsonl(path: Path, rows: list[tuple[str, str | None]]) -> None:
+    """Durably replace a JSONL artifact without exposing a partial file."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as artifact:
+            for chunk_id, provenance_class in rows:
+                artifact.write(json.dumps({"id": chunk_id, "provenance_class": provenance_class}) + "\n")
+            artifact.flush()
+            os.fsync(artifact.fileno())
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
+def _write_rollback_artifact(path: Path, candidates: list[tuple[str, str | None]]) -> None:
     existing = (
         {
             row["id"]: row["provenance_class"]
@@ -47,9 +70,7 @@ def _write_rollback_artifact(path: Path, candidates: list[tuple[str, str | None]
         else {}
     )
     existing.update(dict(candidates))
-    with path.open("w", encoding="utf-8") as artifact:
-        for chunk_id, provenance_class in sorted(existing.items()):
-            artifact.write(json.dumps({"id": chunk_id, "provenance_class": provenance_class}) + "\n")
+    _atomic_write_jsonl(path, sorted(existing.items()))
 
 
 def retag_t3_app_chunks(
@@ -80,6 +101,7 @@ def retag_t3_app_chunks(
         report = {
             "linked_sessions": len(linked_session_ids),
             "candidate_chunks": len(candidates),
+            "matched_chunks": 0,
             "retagged_chunks": 0,
         }
         if not apply:
@@ -90,15 +112,16 @@ def retag_t3_app_chunks(
         connection.execute("PRAGMA wal_checkpoint(FULL)")
         for batch_start in range(0, len(candidates), batch_size):
             batch = candidates[batch_start : batch_start + batch_size]
-            connection.executemany(
-                "UPDATE chunks SET provenance_class = ? WHERE id = ?",
-                [(T3_APP_SESSION, chunk_id) for chunk_id, _ in batch],
+            cursor = connection.executemany(
+                "UPDATE chunks SET provenance_class = ? WHERE id = ? AND provenance_class = ?",
+                [(T3_APP_SESSION, chunk_id, "codex-session") for chunk_id, _ in batch],
             )
+            report["matched_chunks"] += cursor.rowcount
             connection.commit()
             if ((batch_start // batch_size) + 1) % 3 == 0:
                 connection.execute("PRAGMA wal_checkpoint(FULL)")
         connection.execute("PRAGMA wal_checkpoint(FULL)")
-        report["retagged_chunks"] = len(candidates)
+        report["retagged_chunks"] = report["matched_chunks"]
         return report
     finally:
         connection.close()
@@ -132,35 +155,50 @@ def rollback_t3_app_chunks(
     connection = sqlite3.connect(Path(db_path).expanduser(), timeout=1.0)
     try:
         connection.execute("PRAGMA busy_timeout = 30000")
-        if pre_restore_path is not None:
-            current_values = (
-                {
-                    chunk_id: provenance_class
-                    for chunk_id, provenance_class in connection.execute(
-                        "SELECT id, provenance_class FROM chunks WHERE id IN ({})".format(
-                            ", ".join("?" for _ in candidates)
-                        ),
-                        [chunk_id for chunk_id, _ in candidates],
-                    )
-                }
-                if candidates
-                else {}
+        current_values = (
+            {
+                chunk_id: provenance_class
+                for chunk_id, provenance_class in connection.execute(
+                    "SELECT id, provenance_class FROM chunks WHERE id IN ({})".format(
+                        ", ".join("?" for _ in candidates)
+                    ),
+                    [chunk_id for chunk_id, _ in candidates],
+                )
+            }
+            if candidates
+            else {}
+        )
+        missing_chunks = sum(chunk_id not in current_values for chunk_id, _ in candidates)
+        matched_candidates = [
+            (chunk_id, provenance_class)
+            for chunk_id, provenance_class in candidates
+            if current_values.get(chunk_id) == T3_APP_SESSION
+        ]
+        skipped_non_t3_chunks = len(candidates) - missing_chunks - len(matched_candidates)
+        if pre_restore_path is not None and matched_candidates:
+            _atomic_write_jsonl(
+                pre_restore_path,
+                [(chunk_id, current_values[chunk_id]) for chunk_id, _ in matched_candidates],
             )
-            pre_restore_path.parent.mkdir(parents=True, exist_ok=True)
-            with pre_restore_path.open("x", encoding="utf-8") as artifact:
-                for chunk_id, _ in candidates:
-                    artifact.write(json.dumps({"id": chunk_id, "provenance_class": current_values[chunk_id]}) + "\n")
-        for batch_start in range(0, len(candidates), batch_size):
-            batch = candidates[batch_start : batch_start + batch_size]
-            connection.executemany(
-                "UPDATE chunks SET provenance_class = ? WHERE id = ?",
-                [(provenance_class, chunk_id) for chunk_id, provenance_class in batch],
+        restored_chunks = 0
+        for batch_start in range(0, len(matched_candidates), batch_size):
+            batch = matched_candidates[batch_start : batch_start + batch_size]
+            cursor = connection.executemany(
+                "UPDATE chunks SET provenance_class = ? WHERE id = ? AND provenance_class = ?",
+                [(provenance_class, chunk_id, T3_APP_SESSION) for chunk_id, provenance_class in batch],
             )
+            restored_chunks += cursor.rowcount
             connection.commit()
             if ((batch_start // batch_size) + 1) % 3 == 0:
                 connection.execute("PRAGMA wal_checkpoint(FULL)")
         connection.execute("PRAGMA wal_checkpoint(FULL)")
-        return {"restored_chunks": len(candidates)}
+        return {
+            "requested_chunks": len(candidates),
+            "matched_chunks": len(matched_candidates),
+            "restored_chunks": restored_chunks,
+            "missing_chunks": missing_chunks,
+            "skipped_non_t3_chunks": skipped_non_t3_chunks,
+        }
     finally:
         connection.close()
 

--- a/scripts/retag_t3_app_provenance.py
+++ b/scripts/retag_t3_app_provenance.py
@@ -27,7 +27,7 @@ def _candidates(connection: sqlite3.Connection, linked_session_ids: set[str]) ->
     return [
         (chunk_id, provenance_class)
         for chunk_id, source_file, provenance_class in rows
-        if codex_session_id_from_source(source_file) in linked_session_ids and provenance_class != T3_APP_SESSION
+        if codex_session_id_from_source(source_file) in linked_session_ids and provenance_class == "codex-session"
     ]
 
 
@@ -90,21 +90,60 @@ def retag_t3_app_chunks(
         connection.close()
 
 
+def rollback_t3_app_chunks(
+    *,
+    db_path: str | Path,
+    rollback_artifact: str | Path,
+    batch_size: int = 5_000,
+) -> dict[str, int]:
+    """Restore provenance values recorded by a prior T3 re-tag artifact."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+
+    artifact_path = Path(rollback_artifact).expanduser()
+    rows = [json.loads(line) for line in artifact_path.read_text(encoding="utf-8").splitlines() if line]
+    candidates = [(row["id"], row["provenance_class"]) for row in rows]
+    connection = sqlite3.connect(Path(db_path).expanduser(), timeout=1.0)
+    try:
+        connection.execute("PRAGMA busy_timeout = 30000")
+        for batch_start in range(0, len(candidates), batch_size):
+            batch = candidates[batch_start : batch_start + batch_size]
+            connection.executemany(
+                "UPDATE chunks SET provenance_class = ? WHERE id = ?",
+                [(provenance_class, chunk_id) for chunk_id, provenance_class in batch],
+            )
+            connection.commit()
+            if ((batch_start // batch_size) + 1) % 3 == 0:
+                connection.execute("PRAGMA wal_checkpoint(FULL)")
+        connection.execute("PRAGMA wal_checkpoint(FULL)")
+        return {"restored_chunks": len(candidates)}
+    finally:
+        connection.close()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--db-path", type=Path, default=Path.home() / ".local/share/brainlayer/brainlayer.db")
     parser.add_argument("--state-db", type=Path, default=Path.home() / ".t3/userdata/state.sqlite")
     parser.add_argument("--apply", action="store_true", help="Perform writes; default is read-only dry run")
+    parser.add_argument("--rollback", action="store_true", help="Restore values from --rollback-artifact")
     parser.add_argument("--rollback-artifact", type=Path, help="JSONL (id, provenance_class) captured before writes")
     parser.add_argument("--batch-size", type=int, default=5_000)
     args = parser.parse_args()
-    report: dict[str, Any] = retag_t3_app_chunks(
-        db_path=args.db_path,
-        state_db=args.state_db,
-        apply=args.apply,
-        rollback_artifact=args.rollback_artifact,
-        batch_size=args.batch_size,
-    )
+    if args.rollback:
+        if args.rollback_artifact is None:
+            parser.error("--rollback-artifact is required with --rollback")
+        report: dict[str, Any] = rollback_t3_app_chunks(
+            db_path=args.db_path, rollback_artifact=args.rollback_artifact, batch_size=args.batch_size
+        )
+    else:
+        report = retag_t3_app_chunks(
+            db_path=args.db_path,
+            state_db=args.state_db,
+            apply=args.apply,
+            rollback_artifact=args.rollback_artifact,
+            batch_size=args.batch_size,
+        )
     print(json.dumps(report, sort_keys=True))
 
 

--- a/scripts/retag_t3_app_provenance.py
+++ b/scripts/retag_t3_app_provenance.py
@@ -108,6 +108,8 @@ def rollback_t3_app_chunks(
     *,
     db_path: str | Path,
     rollback_artifact: str | Path,
+    only_null_prior_values: bool = False,
+    pre_restore_artifact: str | Path | None = None,
     batch_size: int = 5_000,
 ) -> dict[str, int]:
     """Restore provenance values recorded by a prior T3 re-tag artifact."""
@@ -117,9 +119,37 @@ def rollback_t3_app_chunks(
     artifact_path = Path(rollback_artifact).expanduser()
     rows = [json.loads(line) for line in artifact_path.read_text(encoding="utf-8").splitlines() if line]
     candidates = [(row["id"], row["provenance_class"]) for row in rows]
+    if only_null_prior_values:
+        candidates = [
+            (chunk_id, provenance_class) for chunk_id, provenance_class in candidates if provenance_class is None
+        ]
+    if pre_restore_artifact is not None:
+        pre_restore_path = Path(pre_restore_artifact).expanduser()
+        if pre_restore_path.exists():
+            raise ValueError(f"pre-restore artifact already exists: {pre_restore_path}")
+    else:
+        pre_restore_path = None
     connection = sqlite3.connect(Path(db_path).expanduser(), timeout=1.0)
     try:
         connection.execute("PRAGMA busy_timeout = 30000")
+        if pre_restore_path is not None:
+            current_values = (
+                {
+                    chunk_id: provenance_class
+                    for chunk_id, provenance_class in connection.execute(
+                        "SELECT id, provenance_class FROM chunks WHERE id IN ({})".format(
+                            ", ".join("?" for _ in candidates)
+                        ),
+                        [chunk_id for chunk_id, _ in candidates],
+                    )
+                }
+                if candidates
+                else {}
+            )
+            pre_restore_path.parent.mkdir(parents=True, exist_ok=True)
+            with pre_restore_path.open("x", encoding="utf-8") as artifact:
+                for chunk_id, _ in candidates:
+                    artifact.write(json.dumps({"id": chunk_id, "provenance_class": current_values[chunk_id]}) + "\n")
         for batch_start in range(0, len(candidates), batch_size):
             batch = candidates[batch_start : batch_start + batch_size]
             connection.executemany(
@@ -141,6 +171,8 @@ def main() -> None:
     parser.add_argument("--state-db", type=Path, default=Path.home() / ".t3/userdata/state.sqlite")
     parser.add_argument("--apply", action="store_true", help="Perform writes; default is read-only dry run")
     parser.add_argument("--rollback", action="store_true", help="Restore values from --rollback-artifact")
+    parser.add_argument("--only-null-prior-values", action="store_true")
+    parser.add_argument("--pre-restore-artifact", type=Path)
     parser.add_argument("--rollback-artifact", type=Path, help="JSONL (id, provenance_class) captured before writes")
     parser.add_argument("--batch-size", type=int, default=5_000)
     args = parser.parse_args()
@@ -148,7 +180,11 @@ def main() -> None:
         if args.rollback_artifact is None:
             parser.error("--rollback-artifact is required with --rollback")
         report: dict[str, Any] = rollback_t3_app_chunks(
-            db_path=args.db_path, rollback_artifact=args.rollback_artifact, batch_size=args.batch_size
+            db_path=args.db_path,
+            rollback_artifact=args.rollback_artifact,
+            only_null_prior_values=args.only_null_prior_values,
+            pre_restore_artifact=args.pre_restore_artifact,
+            batch_size=args.batch_size,
         )
     else:
         report = retag_t3_app_chunks(

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -16,6 +16,7 @@ from typing import Literal
 
 from .content_class import normalize_content_class
 from .ingest_denylist import is_denylisted
+from .t3_provenance import T3_APP_SESSION, is_t3_app_initiated_codex_session
 
 SearchPolicy = Literal["KEEP", "ISOLATE", "OUT"]
 EffectiveVisibility = Literal["default", "operational", "cold"]
@@ -138,6 +139,7 @@ def classify_provenance(
     content_class: str | None = None,
     *,
     content: str | None = None,
+    t3_state_db: str | Path | None = None,
 ) -> ProvenanceDecision:
     """Classify a source path into an auditable provenance search policy."""
     del content_class
@@ -150,6 +152,13 @@ def classify_provenance(
         return ProvenanceDecision("workflow-agent", "ISOLATE", "workflow wf_* path segment")
 
     if _under_provider_sessions(path, ".codex"):
+        is_t3_app_session = (
+            is_t3_app_initiated_codex_session(source_file, state_db=t3_state_db)
+            if t3_state_db is not None
+            else is_t3_app_initiated_codex_session(source_file)
+        )
+        if is_t3_app_session:
+            return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session")
         return ProvenanceDecision("codex-session", "KEEP", "Codex session root stays searchable")
 
     if _under_cursor_agent_transcripts(path):

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -147,8 +147,6 @@ def classify_provenance(
 
     is_t3_app_session = _under_provider_sessions(path, ".codex") and (
         is_t3_app_initiated_codex_session(source_file, state_db=t3_state_db)
-        if t3_state_db is not None
-        else is_t3_app_initiated_codex_session(source_file)
     )
     if is_t3_app_session:
         return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session")

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -145,6 +145,14 @@ def classify_provenance(
     del content_class
     path = _abspath(source_file)
 
+    is_t3_app_session = _under_provider_sessions(path, ".codex") and (
+        is_t3_app_initiated_codex_session(source_file, state_db=t3_state_db)
+        if t3_state_db is not None
+        else is_t3_app_initiated_codex_session(source_file)
+    )
+    if is_t3_app_session:
+        return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session")
+
     if has_recon_agent_signature(content) or _has_recon_path_signature(path):
         return ProvenanceDecision("recon-agent", "OUT", "recon Agent-tool signature wins precedence")
 
@@ -152,13 +160,6 @@ def classify_provenance(
         return ProvenanceDecision("workflow-agent", "ISOLATE", "workflow wf_* path segment")
 
     if _under_provider_sessions(path, ".codex"):
-        is_t3_app_session = (
-            is_t3_app_initiated_codex_session(source_file, state_db=t3_state_db)
-            if t3_state_db is not None
-            else is_t3_app_initiated_codex_session(source_file)
-        )
-        if is_t3_app_session:
-            return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session")
         return ProvenanceDecision("codex-session", "KEEP", "Codex session root stays searchable")
 
     if _under_cursor_agent_transcripts(path):

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -140,13 +140,18 @@ def classify_provenance(
     *,
     content: str | None = None,
     t3_state_db: str | Path | None = None,
+    t3_linked_session_ids: set[str] | None = None,
 ) -> ProvenanceDecision:
     """Classify a source path into an auditable provenance search policy."""
     del content_class
     path = _abspath(source_file)
 
     is_t3_app_session = _under_provider_sessions(path, ".codex") and (
-        is_t3_app_initiated_codex_session(source_file, state_db=t3_state_db)
+        is_t3_app_initiated_codex_session(
+            source_file,
+            state_db=t3_state_db,
+            linked_session_ids=t3_linked_session_ids,
+        )
     )
     if is_t3_app_session:
         return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session")

--- a/src/brainlayer/t3_provenance.py
+++ b/src/brainlayer/t3_provenance.py
@@ -26,6 +26,7 @@ def is_t3_app_initiated_codex_session(
     source_file: str | Path,
     *,
     state_db: str | Path | None = None,
+    linked_session_ids: set[str] | None = None,
 ) -> bool:
     """Return whether a Codex transcript is explicitly linked by T3 runtime state.
 
@@ -38,10 +39,12 @@ def is_t3_app_initiated_codex_session(
     if session_id is None:
         return False
 
+    if linked_session_ids is not None:
+        return session_id in linked_session_ids
+
     path = Path(state_db or os.environ.get("BRAINLAYER_T3_STATE_DB", DEFAULT_T3_STATE_DB)).expanduser()
     if not path.exists():
         return False
-
     return session_id in t3_app_codex_session_ids(path)
 
 

--- a/src/brainlayer/t3_provenance.py
+++ b/src/brainlayer/t3_provenance.py
@@ -1,0 +1,94 @@
+"""Read-only discriminator for Codex sessions initiated by the T3 Code app."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from pathlib import Path
+
+from .alarm import raise_alarm
+
+T3_APP_SESSION = "t3-app-session"
+DEFAULT_T3_STATE_DB = Path.home() / ".t3" / "userdata" / "state.sqlite"
+_CODEX_SESSION_ID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE)
+_REQUIRED_RUNTIME_COLUMNS = frozenset({"thread_id", "provider_name", "resume_cursor_json"})
+
+
+def codex_session_id_from_source(source_file: str | Path) -> str | None:
+    """Return the final UUID in a Codex JSONL filename, if present."""
+    matches = _CODEX_SESSION_ID_RE.findall(Path(source_file).stem)
+    return matches[-1].lower() if matches else None
+
+
+def is_t3_app_initiated_codex_session(
+    source_file: str | Path,
+    *,
+    state_db: str | Path | None = None,
+) -> bool:
+    """Return whether a Codex transcript is explicitly linked by T3 runtime state.
+
+    A missing T3 database means there is no local T3 app installation to link
+    against. An existing database with a changed or unreadable schema is fatal:
+    silently treating those sessions as ordinary Codex would reintroduce the
+    provenance collision this module prevents.
+    """
+    session_id = codex_session_id_from_source(source_file)
+    if session_id is None:
+        return False
+
+    path = Path(state_db or os.environ.get("BRAINLAYER_T3_STATE_DB", DEFAULT_T3_STATE_DB)).expanduser()
+    if not path.exists():
+        return False
+
+    return session_id in t3_app_codex_session_ids(path)
+
+
+def t3_app_codex_session_ids(state_db: str | Path = DEFAULT_T3_STATE_DB) -> set[str]:
+    """Return Codex session IDs explicitly linked by T3 runtime cursors."""
+    path = Path(state_db).expanduser()
+
+    try:
+        connection = sqlite3.connect(f"{path.absolute().as_uri()}?mode=ro&immutable=0", uri=True, timeout=1.0)
+    except sqlite3.Error as exc:
+        raise_alarm(
+            "t3_runtime_unavailable",
+            "could not open T3 runtime state read-only",
+            {"path": str(path), "error": str(exc)},
+        )
+
+    try:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(provider_session_runtime)")}
+        missing = sorted(_REQUIRED_RUNTIME_COLUMNS - columns)
+        if missing:
+            raise_alarm(
+                "t3_runtime_schema_drift",
+                "provider_session_runtime no longer exposes the required T3 linkage columns",
+                {"path": str(path), "missing_columns": missing},
+            )
+
+        session_ids: set[str] = set()
+        for provider_name, resume_cursor_json in connection.execute(
+            "SELECT provider_name, resume_cursor_json FROM provider_session_runtime WHERE provider_name = ?", ("codex",)
+        ):
+            try:
+                resume_cursor = json.loads(resume_cursor_json)
+            except (TypeError, json.JSONDecodeError) as exc:
+                raise_alarm(
+                    "t3_runtime_linkage_invalid",
+                    "provider_session_runtime.resume_cursor_json is not valid JSON",
+                    {"path": str(path), "provider_name": provider_name, "error": str(exc)},
+                )
+            thread_id = resume_cursor.get("threadId") if isinstance(resume_cursor, dict) else None
+            if isinstance(thread_id, str) and _CODEX_SESSION_ID_RE.fullmatch(thread_id):
+                session_ids.add(thread_id.lower())
+        return session_ids
+    except sqlite3.Error as exc:
+        raise_alarm(
+            "t3_runtime_schema_drift",
+            "could not query provider_session_runtime for T3 provenance",
+            {"path": str(path), "error": str(exc)},
+        )
+    finally:
+        connection.close()

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -888,12 +888,13 @@ class BatchIndexer:
         count = len(batch)
         try:
             result = self.on_flush(batch)
-            watermarks = self._confirmed_watermarks(batch, result)
+            deferred_entries = self._deferred_entries(batch, result)
+            watermarks = self._confirmed_watermarks(batch, result, deferred_entries)
             if watermarks and self.on_confirm_batch:
                 self.on_confirm_batch(watermarks, batch)
-            self._buffer = []  # Clear only after successful flush
+            self._buffer = deferred_entries
             self._flush_failures = 0
-            self.total_flushed += count
+            self.total_flushed += count - len(deferred_entries)
             self.total_outputs += getattr(result, "inserted", count)
         except Exception as e:
             logger.error("Batch flush failed (%d items), retaining in buffer: %s", count, e)
@@ -904,9 +905,33 @@ class BatchIndexer:
         with self._lock:
             return len(self._buffer) if self._flush_failures > 0 else 0
 
-    def _confirmed_watermarks(self, batch: list[dict], result: dict[str, int] | None) -> dict[str, int]:
+    def _deferred_entries(self, batch: list[dict], result: dict[str, int] | None) -> list[dict]:
+        requested = getattr(result, "deferred_entries", None)
+        if not requested:
+            return []
+        batch_ids = {id(item) for item in batch}
+        requested_ids = {id(item) for item in requested}
+        if not requested_ids.issubset(batch_ids):
+            raise ValueError("flush callback deferred an entry outside the current batch")
+        return [item for item in batch if id(item) in requested_ids]
+
+    def _confirmed_watermarks(
+        self,
+        batch: list[dict],
+        result: dict[str, int] | None,
+        deferred_entries: list[dict] | None = None,
+    ) -> dict[str, int]:
         if isinstance(result, dict):
-            return {str(source_file): int(offset) for source_file, offset in result.items()}
+            deferred_sources = {
+                str(item["_source_file"])
+                for item in deferred_entries or []
+                if isinstance(item.get("_source_file"), str)
+            }
+            return {
+                str(source_file): int(offset)
+                for source_file, offset in result.items()
+                if str(source_file) not in deferred_sources
+            }
         return {}
 
     def _flush_retain_limit(self) -> int:

--- a/src/brainlayer/watcher.py
+++ b/src/brainlayer/watcher.py
@@ -964,15 +964,22 @@ class BatchIndexer:
         confirmed_items: list[dict] = []
         confirmed: dict[str, int] = {}
         outputs = 0
+        failed_inputs = 0
         for item in batch:
             try:
                 result = self.on_flush([item])
             except Exception:
                 retained.append(item)
+                failed_inputs += 1
                 continue
-            item_watermarks = self._confirmed_watermarks([item], result)
+            deferred_entries = self._deferred_entries([item], result)
+            item_watermarks = self._confirmed_watermarks([item], result, deferred_entries)
             for source_file, offset in item_watermarks.items():
                 confirmed[source_file] = max(confirmed.get(source_file, 0), offset)
+            retained.extend(deferred_entries)
+            if deferred_entries:
+                outputs += getattr(result, "inserted", 0)
+                continue
             confirmed_items.append(item)
             outputs += getattr(result, "inserted", 1)
 
@@ -981,8 +988,8 @@ class BatchIndexer:
         self.total_outputs += outputs
         self.total_flushed += len(batch) - len(retained)
         self._buffer = retained
-        self._flush_failures = self._flush_failures + 1 if retained else 0
-        return len(retained)
+        self._flush_failures = self._flush_failures + 1 if failed_inputs else 0
+        return failed_inputs
 
 
 # ── JSONL Watcher ────────────────────────────────────────────────────────────

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -74,12 +74,20 @@ _PURE_DELETION_DIFF_RE = re.compile(r"^```(?:diff)?\n(?:-[^\n]*\n)+```$", re.MUL
 
 
 class FlushWatermarks(dict[str, int]):
-    """Confirmed per-source offsets returned by watcher flushes."""
+    """Confirmed per-source offsets plus entries that require a later retry."""
 
-    def __init__(self, *args: Any, inserted: int = 0, skipped: int = 0, **kwargs: Any):
+    def __init__(
+        self,
+        *args: Any,
+        inserted: int = 0,
+        skipped: int = 0,
+        deferred_entries: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ):
         super().__init__(*args, **kwargs)
         self.inserted = inserted
         self.skipped = skipped
+        self.deferred_entries = list(deferred_entries or [])
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, int):
@@ -360,6 +368,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         cursor = None if store is None else store.conn.cursor()
         inserted = 0
         skipped = 0
+        deferred_entries: list[dict[str, Any]] = []
         source_files_seen: set[str] = set()
         confirmed_offsets: dict[str, int] = {}
 
@@ -410,7 +419,8 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
             if not t3_linkage_resolved:
                 source_only_provenance = classify_provenance(source_file, t3_linked_session_ids=set())
                 if source_only_provenance.provenance_tag == "codex-session":
-                    # Do not persist or confirm ambiguous Codex provenance; a later pass can replay this offset.
+                    # Do not persist or confirm ambiguous Codex provenance; retain its payload for a later pass.
+                    deferred_entries.append(entry)
                     continue
             project = source_projects.get(source_file)
             source_identity = _source_file_identity(source_file)
@@ -728,6 +738,11 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         except Exception:
             pass
 
-        return FlushWatermarks(confirmed_offsets, inserted=inserted, skipped=skipped)
+        return FlushWatermarks(
+            confirmed_offsets,
+            inserted=inserted,
+            skipped=skipped,
+            deferred_entries=deferred_entries,
+        )
 
     return flush_to_db

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -351,10 +351,12 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
 
         flush_start = _time.monotonic()
         t3_state_db = Path(os.environ.get("BRAINLAYER_T3_STATE_DB", DEFAULT_T3_STATE_DB)).expanduser()
+        t3_linkage_resolved = True
         try:
             linked_t3_session_ids = t3_app_codex_session_ids(t3_state_db) if t3_state_db.exists() else set()
         except BrainLayerAlarm:
             linked_t3_session_ids = set()
+            t3_linkage_resolved = False
         cursor = None if store is None else store.conn.cursor()
         inserted = 0
         skipped = 0
@@ -405,6 +407,11 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         for entry in entries:
             source_file = entry.get("_source_file", "unknown")
             source_files_seen.add(source_file)
+            if not t3_linkage_resolved:
+                source_only_provenance = classify_provenance(source_file, t3_linked_session_ids=set())
+                if source_only_provenance.provenance_tag == "codex-session":
+                    # Do not persist or confirm ambiguous Codex provenance; a later pass can replay this offset.
+                    continue
             project = source_projects.get(source_file)
             source_identity = _source_file_identity(source_file)
             cached_identity = resolved_source_identities.get(source_file)

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -23,6 +23,7 @@ from typing import Any
 import apsw
 
 from .agent_provenance import classify_provenance, effective_visibility
+from .alarm import BrainLayerAlarm
 from .chunk_origin import detect_chunk_origin
 from .claude_paths import extract_claude_conversation_id as _extract_claude_conversation_id
 from .content_class import classify_content_class
@@ -350,7 +351,10 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
 
         flush_start = _time.monotonic()
         t3_state_db = Path(os.environ.get("BRAINLAYER_T3_STATE_DB", DEFAULT_T3_STATE_DB)).expanduser()
-        linked_t3_session_ids = t3_app_codex_session_ids(t3_state_db) if t3_state_db.exists() else set()
+        try:
+            linked_t3_session_ids = t3_app_codex_session_ids(t3_state_db) if t3_state_db.exists() else set()
+        except BrainLayerAlarm:
+            linked_t3_session_ids = set()
         cursor = None if store is None else store.conn.cursor()
         inserted = 0
         skipped = 0

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -34,6 +34,7 @@ from .pipeline.classify import classify_content
 from .pipeline.correction_detection import build_correction_tags
 from .pipeline.secret_scrub import scrub_secrets
 from .queue_io import enqueue_watcher_chunk
+from .t3_provenance import DEFAULT_T3_STATE_DB, t3_app_codex_session_ids
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
@@ -288,6 +289,8 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
         import time as _time
 
         flush_start = _time.monotonic()
+        t3_state_db = Path(os.environ.get("BRAINLAYER_T3_STATE_DB", DEFAULT_T3_STATE_DB)).expanduser()
+        linked_t3_session_ids = t3_app_codex_session_ids(t3_state_db) if t3_state_db.exists() else set()
         cursor = None if store is None else store.conn.cursor()
         inserted = 0
         skipped = 0
@@ -419,6 +422,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                     source_file,
                     base_content_class,
                     content=clean_content,
+                    t3_linked_session_ids=linked_t3_session_ids,
                 )
                 visibility = effective_visibility(provenance_decision, base_content_class)
                 content_class = _content_class_for_visibility(base_content_class, visibility)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,12 @@ def isolate_writer_telemetry(monkeypatch, tmp_path):
     monkeypatch.setenv("BRAINLAYER_WRITER_HEARTBEAT_DIR", str(tmp_path / "writer-heartbeats"))
 
 
+@pytest.fixture(autouse=True)
+def isolate_t3_runtime_state(monkeypatch, tmp_path):
+    """Prevent unit provenance tests from reading the developer's live T3 app DB."""
+    monkeypatch.setenv("BRAINLAYER_T3_STATE_DB", str(tmp_path / "missing-t3-state.sqlite"))
+
+
 @pytest.fixture
 def test_user() -> str:
     """Username for path-based tests.

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import apsw
 
+import scripts.provenance_classify_report as provenance_classify_report
 from brainlayer.agent_provenance import (
     classify_provenance,
     effective_visibility,
@@ -256,6 +257,38 @@ def test_report_summarizes_tags_policies_and_effective_visibility_without_real_d
     }
     assert report["policies"] == {"KEEP": 3, "ISOLATE": 1, "OUT": 0}
     assert report["effective_visibility"] == {"cold": 0, "default": 3, "operational": 1}
+
+
+def test_report_loads_t3_session_ids_once(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "brainlayer-test.db"
+    conn = apsw.Connection(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source_file TEXT, content_class TEXT)")
+    rows = [
+        (
+            f"codex-{index}",
+            str(tmp_path / ".codex" / "sessions" / f"rollout-{index}-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl"),
+            "knowledge",
+        )
+        for index in range(3)
+    ]
+    cursor.executemany("INSERT INTO chunks (id, source_file, content_class) VALUES (?, ?, ?)", rows)
+    conn.close()
+    state_db = tmp_path / "state.sqlite"
+    state_db.touch()
+    monkeypatch.setenv("BRAINLAYER_T3_STATE_DB", str(state_db))
+    calls: list[Path] = []
+
+    def load_once(path: Path) -> set[str]:
+        calls.append(path)
+        return set()
+
+    monkeypatch.setattr(provenance_classify_report, "t3_app_codex_session_ids", load_once, raising=False)
+
+    report = provenance_classify_report.build_report(db_path)
+
+    assert report["total_chunks"] == 3
+    assert calls == [state_db]
 
 
 def test_report_script_bootstraps_src_when_run_directly(tmp_path: Path) -> None:

--- a/tests/test_jsonl_watcher.py
+++ b/tests/test_jsonl_watcher.py
@@ -751,6 +751,39 @@ class TestBatchIndexer:
         assert indexer.total_flushed == 0
         assert len(indexer._buffer) == 1  # Retained for retry
 
+    def test_failure_isolation_retains_deferred_entry_without_confirming_its_gap(self):
+        deferred = {
+            "id": "deferred",
+            "_source_file": "/tmp/codex.jsonl",
+            "_line_end_offset": 555,
+        }
+        failing = {"id": "failing", "_source_file": "/tmp/other.jsonl", "_line_end_offset": 100}
+        confirmed = []
+
+        class DeferredWatermark(dict):
+            def __init__(self, item):
+                super().__init__({item["_source_file"]: item["_line_end_offset"]})
+                self.deferred_entries = [item]
+                self.inserted = 0
+
+        def isolate_mixed_batch(items):
+            if len(items) > 1 or items[0] is failing:
+                raise RuntimeError("isolate this flush")
+            return DeferredWatermark(items[0])
+
+        indexer = BatchIndexer(
+            on_flush=isolate_mixed_batch,
+            batch_size=2,
+            on_confirm_batch=lambda watermarks, _batch: confirmed.append(watermarks),
+        )
+
+        indexer.add([deferred, failing])
+
+        assert indexer._buffer == [deferred, failing]
+        assert confirmed == []
+        assert indexer.total_failed_inputs == 1
+        assert indexer.total_flushed == 0
+
 
 # ── JSONLWatcher Integration Tests ──────────────────────────────────────────
 

--- a/tests/test_retag_t3_app_provenance.py
+++ b/tests/test_retag_t3_app_provenance.py
@@ -30,6 +30,8 @@ def _create_brain_db(path: Path, app_session_id: str, plain_session_id: str) -> 
             [
                 ("app-1", f"/home/etan/.codex/sessions/rollout-{app_session_id}.jsonl", "codex-session"),
                 ("app-2", f"/home/etan/.codex/sessions/rollout-{app_session_id}.jsonl", "RAW-ETAN-DIRECT"),
+                ("app-none", f"/home/etan/.codex/sessions/rollout-{app_session_id}.jsonl", None),
+                ("app-recon", f"/home/etan/.codex/sessions/rollout-{app_session_id}.jsonl", "recon-agent"),
                 ("plain", f"/home/etan/.codex/sessions/rollout-{plain_session_id}.jsonl", "codex-session"),
             ],
         )
@@ -60,6 +62,8 @@ def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tm
         assert dict(conn.execute("SELECT id, provenance_class FROM chunks")) == {
             "app-1": "t3-app-session",
             "app-2": "RAW-ETAN-DIRECT",
+            "app-none": None,
+            "app-recon": "recon-agent",
             "plain": "codex-session",
         }
 
@@ -70,5 +74,7 @@ def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tm
         assert dict(conn.execute("SELECT id, provenance_class FROM chunks")) == {
             "app-1": "codex-session",
             "app-2": "RAW-ETAN-DIRECT",
+            "app-none": None,
+            "app-recon": "recon-agent",
             "plain": "codex-session",
         }

--- a/tests/test_retag_t3_app_provenance.py
+++ b/tests/test_retag_t3_app_provenance.py
@@ -2,6 +2,9 @@ import json
 import sqlite3
 from pathlib import Path
 
+import pytest
+
+import scripts.retag_t3_app_provenance as retag_module
 from scripts.retag_t3_app_provenance import retag_t3_app_chunks, rollback_t3_app_chunks
 
 
@@ -54,7 +57,7 @@ def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tm
         batch_size=1,
     )
 
-    assert report == {"linked_sessions": 1, "candidate_chunks": 1, "retagged_chunks": 1}
+    assert report == {"linked_sessions": 1, "candidate_chunks": 1, "matched_chunks": 1, "retagged_chunks": 1}
     assert [json.loads(line) for line in rollback_artifact.read_text().splitlines()] == [
         {"id": "app-1", "provenance_class": "codex-session"},
     ]
@@ -67,7 +70,11 @@ def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tm
             "plain": "codex-session",
         }
     assert rollback_t3_app_chunks(db_path=brain_db, rollback_artifact=rollback_artifact, batch_size=1) == {
-        "restored_chunks": 1
+        "requested_chunks": 1,
+        "matched_chunks": 1,
+        "restored_chunks": 1,
+        "missing_chunks": 0,
+        "skipped_non_t3_chunks": 0,
     }
     with sqlite3.connect(brain_db) as conn:
         assert dict(conn.execute("SELECT id, provenance_class FROM chunks")) == {
@@ -108,7 +115,13 @@ def test_rollback_can_restore_only_null_prior_values_and_snapshot_current_rows(t
         only_null_prior_values=True,
         pre_restore_artifact=pre_restore_artifact,
         batch_size=1,
-    ) == {"restored_chunks": 1}
+    ) == {
+        "requested_chunks": 1,
+        "matched_chunks": 1,
+        "restored_chunks": 1,
+        "missing_chunks": 0,
+        "skipped_non_t3_chunks": 0,
+    }
     assert [json.loads(line) for line in pre_restore_artifact.read_text().splitlines()] == [
         {"id": "prior-null", "provenance_class": "t3-app-session"}
     ]
@@ -117,3 +130,103 @@ def test_rollback_can_restore_only_null_prior_values_and_snapshot_current_rows(t
             "prior-null": None,
             "prior-codex": "t3-app-session",
         }
+
+
+def test_retag_does_not_overwrite_a_value_changed_after_the_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app_session_id = "11111111-1111-4111-8111-111111111111"
+    state_db = tmp_path / "state.sqlite"
+    brain_db = tmp_path / "brainlayer.db"
+    rollback_artifact = tmp_path / "rollback.jsonl"
+    _create_t3_state_db(state_db, app_session_id)
+    _create_brain_db(brain_db, app_session_id, "22222222-2222-4222-8222-222222222222")
+    original_write = retag_module._write_rollback_artifact
+
+    def change_value_after_snapshot(path: Path, candidates: list[tuple[str, str | None]]) -> None:
+        original_write(path, candidates)
+        with sqlite3.connect(brain_db) as conn:
+            conn.execute("UPDATE chunks SET provenance_class = 'RAW-ETAN-DIRECT' WHERE id = 'app-1'")
+
+    monkeypatch.setattr(retag_module, "_write_rollback_artifact", change_value_after_snapshot)
+
+    report = retag_t3_app_chunks(
+        db_path=brain_db,
+        state_db=state_db,
+        apply=True,
+        rollback_artifact=rollback_artifact,
+    )
+
+    assert report["candidate_chunks"] == 1
+    assert report["matched_chunks"] == 0
+    assert report["retagged_chunks"] == 0
+    with sqlite3.connect(brain_db) as conn:
+        assert conn.execute("SELECT provenance_class FROM chunks WHERE id = 'app-1'").fetchone()[0] == "RAW-ETAN-DIRECT"
+
+
+def test_rollback_does_not_overwrite_a_value_changed_after_the_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    brain_db = tmp_path / "brainlayer.db"
+    rollback_artifact = tmp_path / "rollback.jsonl"
+    pre_restore_artifact = tmp_path / "pre-restore.jsonl"
+    with sqlite3.connect(brain_db) as conn:
+        conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source_file TEXT, provenance_class TEXT)")
+        conn.execute("INSERT INTO chunks VALUES ('app-1', 'source', 't3-app-session')")
+    rollback_artifact.write_text(json.dumps({"id": "app-1", "provenance_class": "codex-session"}) + "\n")
+    original_write = retag_module._atomic_write_jsonl
+
+    def change_value_after_snapshot(path: Path, rows: list[tuple[str, str | None]], **kwargs: object) -> None:
+        original_write(path, rows, **kwargs)
+        with sqlite3.connect(brain_db) as conn:
+            conn.execute("UPDATE chunks SET provenance_class = 'RAW-ETAN-DIRECT' WHERE id = 'app-1'")
+
+    monkeypatch.setattr(retag_module, "_atomic_write_jsonl", change_value_after_snapshot)
+
+    report = rollback_t3_app_chunks(
+        db_path=brain_db,
+        rollback_artifact=rollback_artifact,
+        pre_restore_artifact=pre_restore_artifact,
+    )
+
+    assert report["matched_chunks"] == 1
+    assert report["restored_chunks"] == 0
+    with sqlite3.connect(brain_db) as conn:
+        assert conn.execute("SELECT provenance_class FROM chunks WHERE id = 'app-1'").fetchone()[0] == "RAW-ETAN-DIRECT"
+
+
+def test_rollback_skips_missing_ids_without_creating_an_empty_pre_restore_artifact(tmp_path: Path) -> None:
+    brain_db = tmp_path / "brainlayer.db"
+    rollback_artifact = tmp_path / "rollback.jsonl"
+    pre_restore_artifact = tmp_path / "pre-restore.jsonl"
+    with sqlite3.connect(brain_db) as conn:
+        conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source_file TEXT, provenance_class TEXT)")
+    rollback_artifact.write_text(json.dumps({"id": "deleted", "provenance_class": "codex-session"}) + "\n")
+
+    report = rollback_t3_app_chunks(
+        db_path=brain_db,
+        rollback_artifact=rollback_artifact,
+        pre_restore_artifact=pre_restore_artifact,
+    )
+
+    assert report["missing_chunks"] == 1
+    assert report["matched_chunks"] == 0
+    assert not pre_restore_artifact.exists()
+
+
+def test_rollback_artifact_replacement_preserves_the_old_file_on_replace_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact = tmp_path / "rollback.jsonl"
+    original = json.dumps({"id": "old", "provenance_class": "codex-session"}) + "\n"
+    artifact.write_text(original)
+
+    def fail_replace(source: str, destination: str) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(retag_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        retag_module._write_rollback_artifact(artifact, [("new", "codex-session")])
+
+    assert artifact.read_text() == original

--- a/tests/test_retag_t3_app_provenance.py
+++ b/tests/test_retag_t3_app_provenance.py
@@ -66,7 +66,6 @@ def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tm
             "app-recon": "recon-agent",
             "plain": "codex-session",
         }
-
     assert rollback_t3_app_chunks(db_path=brain_db, rollback_artifact=rollback_artifact, batch_size=1) == {
         "restored_chunks": 1
     }
@@ -77,4 +76,44 @@ def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tm
             "app-none": None,
             "app-recon": "recon-agent",
             "plain": "codex-session",
+        }
+
+
+def test_rollback_can_restore_only_null_prior_values_and_snapshot_current_rows(tmp_path: Path) -> None:
+    brain_db = tmp_path / "brainlayer.db"
+    rollback_artifact = tmp_path / "rollback.jsonl"
+    pre_restore_artifact = tmp_path / "pre-restore.jsonl"
+    with sqlite3.connect(brain_db) as conn:
+        conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source_file TEXT, provenance_class TEXT)")
+        conn.executemany(
+            "INSERT INTO chunks VALUES (?, ?, ?)",
+            [
+                ("prior-null", "/home/etan/.codex/sessions/a.jsonl", "t3-app-session"),
+                ("prior-codex", "/home/etan/.codex/sessions/b.jsonl", "t3-app-session"),
+            ],
+        )
+    rollback_artifact.write_text(
+        "\n".join(
+            [
+                json.dumps({"id": "prior-null", "provenance_class": None}),
+                json.dumps({"id": "prior-codex", "provenance_class": "codex-session"}),
+            ]
+        )
+        + "\n"
+    )
+
+    assert rollback_t3_app_chunks(
+        db_path=brain_db,
+        rollback_artifact=rollback_artifact,
+        only_null_prior_values=True,
+        pre_restore_artifact=pre_restore_artifact,
+        batch_size=1,
+    ) == {"restored_chunks": 1}
+    assert [json.loads(line) for line in pre_restore_artifact.read_text().splitlines()] == [
+        {"id": "prior-null", "provenance_class": "t3-app-session"}
+    ]
+    with sqlite3.connect(brain_db) as conn:
+        assert dict(conn.execute("SELECT id, provenance_class FROM chunks")) == {
+            "prior-null": None,
+            "prior-codex": "t3-app-session",
         }

--- a/tests/test_retag_t3_app_provenance.py
+++ b/tests/test_retag_t3_app_provenance.py
@@ -1,0 +1,65 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from scripts.retag_t3_app_provenance import retag_t3_app_chunks
+
+
+def _create_t3_state_db(path: Path, session_id: str) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE provider_session_runtime (
+                thread_id TEXT PRIMARY KEY,
+                provider_name TEXT NOT NULL,
+                resume_cursor_json TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO provider_session_runtime VALUES (?, ?, ?)",
+            ("t3-thread", "codex", json.dumps({"threadId": session_id})),
+        )
+
+
+def _create_brain_db(path: Path, app_session_id: str, plain_session_id: str) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source_file TEXT, provenance_class TEXT)")
+        conn.executemany(
+            "INSERT INTO chunks VALUES (?, ?, ?)",
+            [
+                ("app-1", f"/home/etan/.codex/sessions/rollout-{app_session_id}.jsonl", "codex-session"),
+                ("app-2", f"/home/etan/.codex/sessions/rollout-{app_session_id}.jsonl", "RAW-ETAN-DIRECT"),
+                ("plain", f"/home/etan/.codex/sessions/rollout-{plain_session_id}.jsonl", "codex-session"),
+            ],
+        )
+
+
+def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tmp_path: Path) -> None:
+    app_session_id = "11111111-1111-4111-8111-111111111111"
+    plain_session_id = "22222222-2222-4222-8222-222222222222"
+    state_db = tmp_path / "state.sqlite"
+    brain_db = tmp_path / "brainlayer.db"
+    rollback_artifact = tmp_path / "rollback.jsonl"
+    _create_t3_state_db(state_db, app_session_id)
+    _create_brain_db(brain_db, app_session_id, plain_session_id)
+
+    report = retag_t3_app_chunks(
+        db_path=brain_db,
+        state_db=state_db,
+        apply=True,
+        rollback_artifact=rollback_artifact,
+        batch_size=1,
+    )
+
+    assert report == {"linked_sessions": 1, "candidate_chunks": 2, "retagged_chunks": 2}
+    assert [json.loads(line) for line in rollback_artifact.read_text().splitlines()] == [
+        {"id": "app-1", "provenance_class": "codex-session"},
+        {"id": "app-2", "provenance_class": "RAW-ETAN-DIRECT"},
+    ]
+    with sqlite3.connect(brain_db) as conn:
+        assert dict(conn.execute("SELECT id, provenance_class FROM chunks")) == {
+            "app-1": "t3-app-session",
+            "app-2": "t3-app-session",
+            "plain": "codex-session",
+        }

--- a/tests/test_retag_t3_app_provenance.py
+++ b/tests/test_retag_t3_app_provenance.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from pathlib import Path
 
-from scripts.retag_t3_app_provenance import retag_t3_app_chunks
+from scripts.retag_t3_app_provenance import retag_t3_app_chunks, rollback_t3_app_chunks
 
 
 def _create_t3_state_db(path: Path, session_id: str) -> None:
@@ -52,14 +52,23 @@ def test_retag_only_explicitly_t3_linked_sessions_and_write_rollback_artifact(tm
         batch_size=1,
     )
 
-    assert report == {"linked_sessions": 1, "candidate_chunks": 2, "retagged_chunks": 2}
+    assert report == {"linked_sessions": 1, "candidate_chunks": 1, "retagged_chunks": 1}
     assert [json.loads(line) for line in rollback_artifact.read_text().splitlines()] == [
         {"id": "app-1", "provenance_class": "codex-session"},
-        {"id": "app-2", "provenance_class": "RAW-ETAN-DIRECT"},
     ]
     with sqlite3.connect(brain_db) as conn:
         assert dict(conn.execute("SELECT id, provenance_class FROM chunks")) == {
             "app-1": "t3-app-session",
-            "app-2": "t3-app-session",
+            "app-2": "RAW-ETAN-DIRECT",
+            "plain": "codex-session",
+        }
+
+    assert rollback_t3_app_chunks(db_path=brain_db, rollback_artifact=rollback_artifact, batch_size=1) == {
+        "restored_chunks": 1
+    }
+    with sqlite3.connect(brain_db) as conn:
+        assert dict(conn.execute("SELECT id, provenance_class FROM chunks")) == {
+            "app-1": "codex-session",
+            "app-2": "RAW-ETAN-DIRECT",
             "plain": "codex-session",
         }

--- a/tests/test_t3_app_provenance.py
+++ b/tests/test_t3_app_provenance.py
@@ -1,0 +1,120 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from brainlayer.agent_provenance import classify_provenance
+from brainlayer.alarm import BrainLayerAlarm
+from brainlayer.watcher_bridge import create_flush_callback
+
+
+def _state_db(tmp_path: Path, runtime_rows: list[tuple[str, str, str]]) -> Path:
+    path = tmp_path / "state.sqlite"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE provider_session_runtime (
+                thread_id TEXT PRIMARY KEY,
+                provider_name TEXT NOT NULL,
+                resume_cursor_json TEXT NOT NULL,
+                runtime_payload_json TEXT
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO provider_session_runtime
+                (thread_id, provider_name, resume_cursor_json, runtime_payload_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                (thread_id, provider_name, resume_cursor_json, "{}")
+                for thread_id, provider_name, resume_cursor_json in runtime_rows
+            ],
+        )
+    return path
+
+
+def _codex_source(tmp_path: Path, session_id: str) -> Path:
+    return tmp_path / "home" / ".codex" / "sessions" / "2026" / "08" / f"rollout-2026-08-01-{session_id}.jsonl"
+
+
+def test_plain_codex_working_on_t3layer_is_not_tagged_as_t3_app(tmp_path: Path) -> None:
+    state_db = _state_db(
+        tmp_path,
+        [("another-t3-thread", "codex", json.dumps({"threadId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}))],
+    )
+
+    decision = classify_provenance(
+        str(_codex_source(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")),
+        t3_state_db=state_db,
+    )
+
+    assert (decision.provenance_tag, decision.search_policy) == ("codex-session", "KEEP")
+
+
+def test_t3_app_initiated_codex_session_is_tagged_distinctly(tmp_path: Path) -> None:
+    session_id = "019fb03f-0650-7f53-850b-921246951edc"
+    state_db = _state_db(
+        tmp_path,
+        [("5ca576df-592c-406f-a8f1-7db9c56d36c9", "codex", json.dumps({"threadId": session_id}))],
+    )
+
+    decision = classify_provenance(str(_codex_source(tmp_path, session_id)), t3_state_db=state_db)
+
+    assert (decision.provenance_tag, decision.search_policy) == ("t3-app-session", "KEEP")
+
+
+def test_new_t3_app_codex_ingestion_gets_distinct_provenance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    state_db = _state_db(
+        tmp_path,
+        [("5ca576df-592c-406f-a8f1-7db9c56d36c9", "codex", json.dumps({"threadId": session_id}))],
+    )
+    monkeypatch.setenv("BRAINLAYER_T3_STATE_DB", str(state_db))
+    source_file = _codex_source(tmp_path, session_id)
+    flush = create_flush_callback(db_path=tmp_path / "brainlayer.db", arbitrated=False)
+
+    result = flush(
+        [
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "text", "text": "T3 app sessions must retain their explicit origin."}]
+                },
+                "timestamp": "2026-08-01T12:00:00Z",
+                "_source_file": str(source_file),
+                "_line_end_offset": 100,
+            }
+        ]
+    )
+
+    assert result.inserted == 1
+    with sqlite3.connect(tmp_path / "brainlayer.db") as conn:
+        assert conn.execute("SELECT provenance_class FROM chunks").fetchone()[0] == "t3-app-session"
+
+
+def test_canonical_systems_codex_session_uses_runtime_cursor_linkage(tmp_path: Path) -> None:
+    session_id = "019fb03f-0650-7f53-850b-921246951edc"
+    state_db = _state_db(
+        tmp_path,
+        [("5ca576df-592c-406f-a8f1-7db9c56d36c9", "codex", json.dumps({"threadId": session_id}))],
+    )
+
+    decision = classify_provenance(str(_codex_source(tmp_path, session_id)), t3_state_db=state_db)
+
+    assert decision.provenance_tag == "t3-app-session"
+    assert "runtime cursor" in decision.reason
+
+
+def test_missing_runtime_schema_raises_loud_alarm(tmp_path: Path) -> None:
+    state_db = tmp_path / "state.sqlite"
+    with sqlite3.connect(state_db) as conn:
+        conn.execute("CREATE TABLE projection_thread_sessions (provider_session_id TEXT)")
+
+    with pytest.raises(BrainLayerAlarm, match="t3_runtime_schema_drift"):
+        classify_provenance(
+            str(_codex_source(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")),
+            t3_state_db=state_db,
+        )

--- a/tests/test_t3_app_provenance.py
+++ b/tests/test_t3_app_provenance.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import brainlayer.watcher_bridge as watcher_bridge
 from brainlayer.agent_provenance import classify_provenance
 from brainlayer.alarm import BrainLayerAlarm
 from brainlayer.watcher_bridge import create_flush_callback
@@ -109,6 +110,46 @@ def test_new_t3_app_codex_ingestion_gets_distinct_provenance(tmp_path: Path, mon
     assert result.inserted == 1
     with sqlite3.connect(tmp_path / "brainlayer.db") as conn:
         assert conn.execute("SELECT provenance_class FROM chunks").fetchone()[0] == "t3-app-session"
+
+
+def test_watcher_loads_t3_session_ids_once_per_flush(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    state_db = _state_db(
+        tmp_path,
+        [("5ca576df-592c-406f-a8f1-7db9c56d36c9", "codex", json.dumps({"threadId": session_id}))],
+    )
+    calls: list[Path] = []
+
+    def load_once(path: Path) -> set[str]:
+        calls.append(path)
+        return {session_id}
+
+    monkeypatch.setenv("BRAINLAYER_T3_STATE_DB", str(state_db))
+    monkeypatch.setattr(watcher_bridge, "t3_app_codex_session_ids", load_once)
+    source_file = _codex_source(tmp_path, session_id)
+    flush = create_flush_callback(db_path=tmp_path / "brainlayer.db", arbitrated=False)
+
+    result = flush(
+        [
+            {
+                "type": "user",
+                "message": {"content": [{"type": "text", "text": "First T3 watcher message."}]},
+                "timestamp": "2026-08-01T12:00:00Z",
+                "_source_file": str(source_file),
+                "_line_end_offset": 100,
+            },
+            {
+                "type": "user",
+                "message": {"content": [{"type": "text", "text": "Second T3 watcher message."}]},
+                "timestamp": "2026-08-01T12:00:01Z",
+                "_source_file": str(source_file),
+                "_line_end_offset": 200,
+            },
+        ]
+    )
+
+    assert result.inserted == 2
+    assert calls == [state_db]
 
 
 def test_canonical_systems_codex_session_uses_runtime_cursor_linkage(tmp_path: Path) -> None:

--- a/tests/test_t3_app_provenance.py
+++ b/tests/test_t3_app_provenance.py
@@ -8,6 +8,7 @@ import pytest
 import brainlayer.watcher_bridge as watcher_bridge
 from brainlayer.agent_provenance import classify_provenance
 from brainlayer.alarm import BrainLayerAlarm
+from brainlayer.watcher import JSONLWatcher, WatchRoot
 from brainlayer.watcher_bridge import create_flush_callback
 
 
@@ -263,6 +264,128 @@ def test_t3_linkage_alarm_defers_recon_codex_but_confirms_plain_claude(
         str(claude_source): "direct-session",
         str(codex_source): "t3-app-session",
     }
+
+
+def test_watcher_retries_deferred_t3_codex_without_advancing_across_gap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    state_db = tmp_path / "state.sqlite"
+    queue_dir = tmp_path / "queue"
+    registry_path = tmp_path / "offsets.json"
+    with closing(sqlite3.connect(state_db)) as conn:
+        conn.execute("CREATE TABLE unrelated_bootstrap_state (id INTEGER PRIMARY KEY)")
+        conn.commit()
+
+    monkeypatch.setenv("BRAINLAYER_T3_STATE_DB", str(state_db))
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+
+    codex_source = _codex_source(tmp_path, session_id)
+    codex_source.parent.mkdir(parents=True)
+
+    def sized_codex_record(text: str, byte_length: int) -> bytes:
+        entry = {
+            "role": "user",
+            "content": text,
+            "timestamp": "2026-08-01T12:00:01Z",
+        }
+        encoded = (json.dumps(entry) + "\n").encode()
+        padding = byte_length - len(encoded)
+        assert padding >= 0
+        entry["content"] += "x" * padding
+        encoded = (json.dumps(entry) + "\n").encode()
+        assert len(encoded) == byte_length
+        return encoded
+
+    first_codex_record = sized_codex_record("Task for brain-worker: mine the transcript. ", 555)
+    later_codex_record = sized_codex_record("Later T3 record must wait behind the deferred gap. ", 192)
+    codex_source.write_bytes(first_codex_record)
+
+    claude_source = (
+        tmp_path / "home" / ".claude" / "projects" / "-Users-etanheyman-Gits-brainlayer" / "plain-session.jsonl"
+    )
+    claude_source.parent.mkdir(parents=True)
+    claude_record = (
+        json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "text", "text": "Keep ordinary Claude ingestion available."}]
+                },
+                "timestamp": "2026-08-01T12:00:00Z",
+            }
+        )
+        + "\n"
+    ).encode()
+    claude_source.write_bytes(claude_record)
+
+    watcher = JSONLWatcher(
+        watch_roots=[
+            WatchRoot("claude", claude_source.parents[1]),
+            WatchRoot("codex", codex_source.parents[3]),
+        ],
+        registry_path=registry_path,
+        on_flush=create_flush_callback(arbitrated=True),
+        batch_size=2,
+        flush_interval_ms=0,
+    )
+
+    def queued_events() -> list[dict[str, object]]:
+        return [
+            json.loads(line)
+            for queue_file in queue_dir.glob("*.jsonl")
+            for line in queue_file.read_text(encoding="utf-8").splitlines()
+        ]
+
+    assert watcher.poll_once() == 2
+    assert [(event["source_file"], event["provenance_class"]) for event in queued_events()] == [
+        (str(claude_source), "direct-session")
+    ]
+    assert watcher.registry.get(str(claude_source))[0] == len(claude_record)
+    assert watcher.registry.get(str(codex_source))[0] == 0
+    assert watcher._tailers[str(codex_source)].offset == 555
+    assert [entry["_line_end_offset"] for entry in watcher.indexer._buffer] == [555]
+
+    with codex_source.open("ab") as handle:
+        handle.write(later_codex_record)
+
+    assert watcher.poll_once() == 1
+    assert watcher.registry.get(str(codex_source))[0] == 0
+    assert watcher._tailers[str(codex_source)].offset == 747
+    assert [entry["_line_end_offset"] for entry in watcher.indexer._buffer] == [555, 747]
+
+    with closing(sqlite3.connect(state_db)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE provider_session_runtime (
+                thread_id TEXT PRIMARY KEY,
+                provider_name TEXT NOT NULL,
+                resume_cursor_json TEXT NOT NULL,
+                runtime_payload_json TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO provider_session_runtime
+                (thread_id, provider_name, resume_cursor_json, runtime_payload_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("t3-thread", "codex", json.dumps({"threadId": session_id}), "{}"),
+        )
+        conn.commit()
+
+    assert watcher.poll_once() == 0
+    codex_events = sorted(
+        (event for event in queued_events() if event["source_file"] == str(codex_source)),
+        key=lambda event: int(event["source_end_offset"]),
+    )
+    assert [(event["source_end_offset"], event["provenance_class"]) for event in codex_events] == [
+        (555, "t3-app-session"),
+        (747, "t3-app-session"),
+    ]
+    assert watcher.registry.get(str(codex_source))[0] == 747
+    assert watcher.indexer._buffer == []
 
 
 def test_canonical_systems_codex_session_uses_runtime_cursor_linkage(tmp_path: Path) -> None:

--- a/tests/test_t3_app_provenance.py
+++ b/tests/test_t3_app_provenance.py
@@ -66,6 +66,22 @@ def test_t3_app_initiated_codex_session_is_tagged_distinctly(tmp_path: Path) -> 
     assert (decision.provenance_tag, decision.search_policy) == ("t3-app-session", "KEEP")
 
 
+def test_t3_app_linkage_outranks_recon_content_signature(tmp_path: Path) -> None:
+    session_id = "019fb03f-0650-7f53-850b-921246951edc"
+    state_db = _state_db(
+        tmp_path,
+        [("5ca576df-592c-406f-a8f1-7db9c56d36c9", "codex", json.dumps({"threadId": session_id}))],
+    )
+
+    decision = classify_provenance(
+        str(_codex_source(tmp_path, session_id)),
+        content="Task for brain-worker: mine the transcript.",
+        t3_state_db=state_db,
+    )
+
+    assert decision.provenance_tag == "t3-app-session"
+
+
 def test_new_t3_app_codex_ingestion_gets_distinct_provenance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
     state_db = _state_db(

--- a/tests/test_t3_app_provenance.py
+++ b/tests/test_t3_app_provenance.py
@@ -152,6 +152,36 @@ def test_watcher_loads_t3_session_ids_once_per_flush(tmp_path: Path, monkeypatch
     assert calls == [state_db]
 
 
+def test_partially_installed_t3_does_not_stop_plain_claude_ingestion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_db = tmp_path / "state.sqlite"
+    with sqlite3.connect(state_db) as conn:
+        conn.execute("CREATE TABLE unrelated_bootstrap_state (id INTEGER PRIMARY KEY)")
+
+    monkeypatch.setenv("BRAINLAYER_T3_STATE_DB", str(state_db))
+    source_file = (
+        tmp_path / "home" / ".claude" / "projects" / "-Users-etanheyman-Gits-brainlayer" / "plain-session.jsonl"
+    )
+    flush = create_flush_callback(db_path=tmp_path / "brainlayer.db", arbitrated=False)
+
+    result = flush(
+        [
+            {
+                "type": "user",
+                "message": {"content": [{"type": "text", "text": "Keep ordinary Claude ingestion available."}]},
+                "timestamp": "2026-08-01T12:00:00Z",
+                "_source_file": str(source_file),
+                "_line_end_offset": 100,
+            }
+        ]
+    )
+
+    assert result.inserted == 1
+    with sqlite3.connect(tmp_path / "brainlayer.db") as conn:
+        assert conn.execute("SELECT provenance_class FROM chunks").fetchone()[0] == "direct-session"
+
+
 def test_canonical_systems_codex_session_uses_runtime_cursor_linkage(tmp_path: Path) -> None:
     session_id = "019fb03f-0650-7f53-850b-921246951edc"
     state_db = _state_db(

--- a/tests/test_t3_app_provenance.py
+++ b/tests/test_t3_app_provenance.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 import pytest
@@ -180,6 +181,88 @@ def test_partially_installed_t3_does_not_stop_plain_claude_ingestion(
     assert result.inserted == 1
     with sqlite3.connect(tmp_path / "brainlayer.db") as conn:
         assert conn.execute("SELECT provenance_class FROM chunks").fetchone()[0] == "direct-session"
+
+
+def test_t3_linkage_alarm_defers_recon_codex_but_confirms_plain_claude(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    state_db = tmp_path / "state.sqlite"
+    queue_dir = tmp_path / "queue"
+    with closing(sqlite3.connect(state_db)) as conn:
+        conn.execute("CREATE TABLE unrelated_bootstrap_state (id INTEGER PRIMARY KEY)")
+        conn.commit()
+
+    monkeypatch.setenv("BRAINLAYER_T3_STATE_DB", str(state_db))
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    codex_source = _codex_source(tmp_path, session_id)
+    claude_source = (
+        tmp_path / "home" / ".claude" / "projects" / "-Users-etanheyman-Gits-brainlayer" / "plain-session.jsonl"
+    )
+    codex_entry = {
+        "type": "user",
+        "message": {"content": [{"type": "text", "text": "Task for brain-worker: mine the transcript."}]},
+        "timestamp": "2026-08-01T12:00:01Z",
+        "_source_file": str(codex_source),
+        "_line_end_offset": 555,
+    }
+    flush = create_flush_callback(arbitrated=True)
+
+    def queued_events() -> list[dict[str, object]]:
+        return [
+            json.loads(line)
+            for queue_file in queue_dir.glob("*.jsonl")
+            for line in queue_file.read_text(encoding="utf-8").splitlines()
+        ]
+
+    degraded_result = flush(
+        [
+            {
+                "type": "user",
+                "message": {"content": [{"type": "text", "text": "Keep ordinary Claude ingestion available."}]},
+                "timestamp": "2026-08-01T12:00:00Z",
+                "_source_file": str(claude_source),
+                "_line_end_offset": 100,
+            },
+            codex_entry,
+        ]
+    )
+
+    assert degraded_result.inserted == 1
+    assert dict(degraded_result) == {str(claude_source): 100}
+    assert [(event["source_file"], event["provenance_class"]) for event in queued_events()] == [
+        (str(claude_source), "direct-session")
+    ]
+
+    with closing(sqlite3.connect(state_db)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE provider_session_runtime (
+                thread_id TEXT PRIMARY KEY,
+                provider_name TEXT NOT NULL,
+                resume_cursor_json TEXT NOT NULL,
+                runtime_payload_json TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO provider_session_runtime
+                (thread_id, provider_name, resume_cursor_json, runtime_payload_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("t3-thread", "codex", json.dumps({"threadId": session_id}), "{}"),
+        )
+        conn.commit()
+
+    recovered_result = flush([codex_entry])
+
+    assert recovered_result.inserted == 1
+    assert dict(recovered_result) == {str(codex_source): 555}
+    assert {event["source_file"]: event["provenance_class"] for event in queued_events()} == {
+        str(claude_source): "direct-session",
+        str(codex_source): "t3-app-session",
+    }
 
 
 def test_canonical_systems_codex_session_uses_runtime_cursor_linkage(tmp_path: Path) -> None:


### PR DESCRIPTION
## What broke and how it was found

T3-app-initiated Codex transcripts were indistinguishable from ordinary terminal Codex sessions: provenance_class LIKE %t3% returned 0. The explicit discriminator is provider_session_runtime.resume_cursor_json.threadId in the read-only T3 state DB.

## Evidence

- The canonical systems Codex session 019fb03f-0650-7f53-850b-921246951edc has 728 chunks and links to T3 thread 5ca576df-592c-406f-a8f1-7db9c56d36c9.
- 29 linked Codex sessions were found; 1,228 genuine codex-session rows are tagged t3-app-session.
- The non-collision fixture proves a plain Codex working on t3layer remains codex-session; schema drift raises an alarm.

## Review

This branch was pair-reviewed by a separate agent under the taste gate: smallest correct solution, behavioural tests, and no speculative machinery.

## Provenance-column warning

chunks.provenance_class currently serves both as a trust ladder and a source class, with independent writers and no precedence rule. This PR is correct, but enrichment can overwrite its source tag until that collision is resolved. See [design collision](https://github.com/EtanHey/brainlayer/blob/main/docs.local/plan/ingestion-defects-2026-07-31/DESIGN-COLLISION-provenance-class.md).

Enrichment and drain are currently disabled with launchctl to stop that decay; re-enable deliberately only after the column question is settled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches realtime ingestion and offset confirmation for Codex when T3 state is partial or alarming; mis-linkage or prolonged deferral could delay Codex indexing until T3 DB is healthy.
> 
> **Overview**
> Adds a **T3 runtime linkage** path so Codex transcripts started from the T3 Code app are tagged **`t3-app-session`** instead of generic **`codex-session`**, using read-only queries of `provider_session_runtime.resume_cursor_json.threadId` in the T3 state DB (with **alarms** on missing/unreadable schema).
> 
> **`classify_provenance`** checks that linkage **before** recon signatures and ordinary Codex rules. The **watcher flush** loads linked session IDs once per batch; if linkage cannot be resolved, **ambiguous Codex lines are deferred** (not persisted, offsets not advanced) while other sources still ingest. **`BatchIndexer`** keeps deferred entries in the buffer and excludes them from confirmed watermarks.
> 
> A new **`retag_t3_app_provenance`** script dry-runs or applies batched updates for existing rows, with **JSONL rollback** and safe restore. The provenance classify report and tests are updated; unit tests isolate **`BRAINLAYER_T3_STATE_DB`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd0a742700c85f7e2656da2b0315f0684f04eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish T3 app-initiated Codex sessions with a `t3-app-session` provenance class
> - Adds [t3_provenance.py](https://github.com/EtanHey/brainlayer/pull/633/files#diff-6523be56aede08eaca32123959a38eb4a3724fcfd740cd89873a9796d741656a) to resolve Codex session IDs linked by the T3 runtime, reading from the `provider_session_runtime` table in a SQLite state DB.
> - Extends `classify_provenance` in [agent_provenance.py](https://github.com/EtanHey/brainlayer/pull/633/files#diff-57296bee549fc366c410ccd22072917ab0333369dd41c4fc2917d3b281e6a268) to tag T3-linked Codex sessions as `t3-app-session` with `KEEP` policy, taking precedence over recon-agent signature rules.
> - Updates the watcher flush callback in [watcher_bridge.py](https://github.com/EtanHey/brainlayer/pull/633/files#diff-9c9df603fa7a5ecf5cdb0da9ab4077d520d812083da4b052847100f2874f60c9) to defer Codex entries when T3 linkage is temporarily unavailable (e.g. DB alarm), preventing misclassification; entries resume on the next flush once linkage resolves.
> - Adds [retag_t3_app_provenance.py](https://github.com/EtanHey/brainlayer/pull/633/files#diff-c4969ffb00e12b603c4cb6efd240d4cb969bb659d959a2799d9ccee791bce8f6), a CLI script to back-fill existing Codex chunks to `t3-app-session` with batched updates, rollback artifact generation, and a separate rollback command.
> - Risk: if the T3 state DB is unreachable, all Codex entries in a flush batch are deferred indefinitely until the DB becomes accessible again.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdd0a74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance classification for sessions initiated through the T3 application.
  * Added tools to identify, retag, validate, and roll back T3-linked session records with audit artifacts.
  * Added runtime linkage checks and alarm reporting for unavailable or invalid state data.

* **Bug Fixes**
  * Deferred unresolved session links safely until they can be processed, preventing premature confirmation.
  * Improved batch failure isolation so unprocessed entries remain available for retry.
  * Preserved existing records when rollback or artifact replacement encounters errors.

* **Tests**
  * Expanded coverage for linkage, ingestion, rollback, retry, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->