### PR TITLE
fix: remove undeclared dotenv dependency from KG rebuild

### DIFF
--- a/scripts/kg_rebuild.py
+++ b/scripts/kg_rebuild.py
@@ -27,10 +27,6 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from dotenv import load_dotenv
-
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
-
 from brainlayer.paths import get_db_path
 from brainlayer.pipeline.batch_extraction import DEFAULT_SEED_ENTITIES
 from brainlayer.pipeline.entity_extraction import (

--- a/tests/test_kg_rebuild.py
+++ b/tests/test_kg_rebuild.py
@@ -309,3 +309,23 @@ def test_groq_rebuild_entity_payload_preserves_source_subtype():
     assert entity.entity_type == "source"
     assert entity.entity_subtype == "channel"
     assert entity.start == 6
+
+
+def test_kg_rebuild_module_import_does_not_require_python_dotenv(monkeypatch):
+    import builtins
+    import importlib
+    import sys
+
+    real_import = builtins.__import__
+
+    def import_without_dotenv(name, *args, **kwargs):
+        if name == "dotenv" or name.startswith("dotenv."):
+            raise ModuleNotFoundError("No module named 'dotenv'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_dotenv)
+    sys.modules.pop("scripts.kg_rebuild", None)
+
+    module = importlib.import_module("scripts.kg_rebuild")
+
+    assert callable(module.extracted_entity_from_groq_payload)


### PR DESCRIPTION
## Summary\n- remove the import-time python-dotenv dependency from scripts/kg_rebuild.py\n- add a regression test proving the KG rebuild helper imports when python-dotenv is unavailable\n\n## Root causes\n- #631 test (3.11): scripts/kg_rebuild.py imported python-dotenv at module load even though it is not a declared dependency\n- #634 test (3.11): the same import-time python-dotenv failure\n- #634 lint: Ruff 0.16.1 wants the branch-only t3_health_path assignment in src/brainlayer/health_check.py formatted on one line; this does not exist on main and will be fixed on that branch after this PR lands\n- #635 test (3.13): the same import-time python-dotenv failure, not a separate Python 3.13 incompatibility\n\nThis chooses option (b): the unit test should not require dotenv. The Groq extraction path already reads GROQ_API_KEY from the process environment and has its own dependency-free repo .env fallback, so loading .env at module import was redundant and made pure helper imports depend on an undeclared package.\n\n## Verification\n- Python 3.11: tests/test_kg_rebuild.py — 20 passed\n- Python 3.13: tests/test_kg_rebuild.py — 20 passed\n- Python 3.12 repository pre-push gate:\n  - unit suite — 3641 passed, 9 skipped, 61 deselected, 1 xfailed\n  - MCP registration — 3 passed\n  - isolated eval/hook routing — 40 passed\n  - Bun stale-index test — passed\n  - FTS5 determinism shell regression — passed\n- Ruff 0.16.1 check and format check — passed\n\nReview routing is intentionally left to @brainlayer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency/import cleanup with a regression test; no change to KG extraction logic or Groq env loading at runtime.
> 
> **Overview**
> **Removes import-time `python-dotenv` loading** from `scripts/kg_rebuild.py` so importing the module (including pure helpers like `extracted_entity_from_groq_payload` in tests) no longer depends on an undeclared package.
> 
> Groq Tier 2 behavior is unchanged: `call_groq_ner` still reads `GROQ_API_KEY` from the process environment and can fall back to parsing the repo `.env` without `dotenv`.
> 
> Adds **`test_kg_rebuild_module_import_does_not_require_python_dotenv`**, which blocks `dotenv` imports and asserts `scripts.kg_rebuild` still loads successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955e57e9666c354f970273ff6aac7bc89884323f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove undeclared `python-dotenv` dependency from `scripts/kg_rebuild.py`
> Removes the `dotenv.load_dotenv` import and the `.env` file load from [kg_rebuild.py](https://github.com/EtanHey/brainlayer/pull/637/files#diff-b45e9c372671b079ed1bac195aa3204b406426c84bdbc3f125a1659e07e1dfaa), which was failing for users without `python-dotenv` installed. A regression test in [test_kg_rebuild.py](https://github.com/EtanHey/brainlayer/pull/637/files#diff-1ff5166c1c2bc1cfffbc05dbfd148b9f05584bfbd71a902811d3d250fec50f42) verifies the module imports cleanly when `dotenv` is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 955e57e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved knowledge graph rebuild startup by removing reliance on automatic `.env` loading.
  * The rebuild process can now initialize successfully when the optional environment-loading package is unavailable.

* **Tests**
  * Added regression coverage to verify successful module loading and entity extraction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->