### PR TITLE
fix(pause): make pause actually pause — heal ordering, launchctl enable, and drain enrichment gate

### DIFF
--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -174,14 +174,7 @@ def sandbox_stop_command(
 
 
 def _default_pause_labels() -> list[str]:
-    return [
-        "com.brainlayer.watch",
-        "com.brainlayer.drain",
-        "com.brainlayer.t3-ingest",
-        "com.brainlayer.hotlane-brainbar",
-        "com.brainlayer.enrichment",
-        "com.brainlayer.health-check",
-    ]
+    return ["com.brainlayer.enrichment"]
 
 
 @app.command("pause")

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -31,7 +31,7 @@ from .dedupe import (
 )
 from .ingest_guard import recursive_mcp_output_reason
 from .paths import get_db_path
-from .pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_sentinel_state
+from .pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_applies_to_label, pause_sentinel_state
 from .provenance_integration import enqueue_provenance_resolution_for_entities
 from .writer_telemetry import start_writer_span
 
@@ -47,6 +47,7 @@ _DEFAULT_MAX_EVENTS_PER_TRANSACTION = 5
 _DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION = 100
 _DEFAULT_POST_COMMIT_YIELD_MS = 10.0
 _DEFAULT_MAX_ENRICHMENT_FILES_PER_CYCLE = 16
+_ENRICHMENT_LABEL = "com.brainlayer.enrichment"
 # The post-commit WAL checkpoint is best-effort and must stay non-blocking. A
 # truncating checkpoint can wedge the live writer behind long-lived readers on a
 # multi-GB WAL; the scheduled wal-checkpoint job owns truncation.
@@ -1389,7 +1390,8 @@ def burn_drain_once(
     pause_sentinel_path = pause_sentinel_path or DEFAULT_PAUSE_SENTINEL_PATH
     queue_dir.mkdir(parents=True, exist_ok=True)
     max_events_per_transaction = max(1, max_events_per_transaction)
-    _pause_payload, pause_active, _pause_stale = pause_sentinel_state(pause_sentinel_path)
+    pause_payload, pause_active, _pause_stale = pause_sentinel_state(pause_sentinel_path)
+    pause_enrichment = pause_active and pause_applies_to_label(pause_payload, _ENRICHMENT_LABEL)
 
     result = BurnDrainResult()
     lock_fd = _acquire_queue_lock(queue_dir)
@@ -1408,7 +1410,7 @@ def burn_drain_once(
             return result
 
         paused_events_by_path: dict[Path, list[dict[str, Any]]] = {}
-        if pause_active:
+        if pause_enrichment:
             apply_batch: list[tuple[Path, list[dict[str, Any]]]] = []
             for path, events in batch:
                 paused_events = [event for event in events if _event_payload(event).get("kind") == "enrichment_update"]
@@ -1563,7 +1565,8 @@ def drain_once(
     log_path = log_path or _default_log_path()
     pause_sentinel_path = pause_sentinel_path or DEFAULT_PAUSE_SENTINEL_PATH
     queue_dir.mkdir(parents=True, exist_ok=True)
-    _pause_payload, pause_active, _pause_stale = pause_sentinel_state(pause_sentinel_path)
+    pause_payload, pause_active, _pause_stale = pause_sentinel_state(pause_sentinel_path)
+    pause_enrichment = pause_active and pause_applies_to_label(pause_payload, _ENRICHMENT_LABEL)
 
     lock_fd = _acquire_queue_lock(queue_dir)
     try:
@@ -1586,7 +1589,7 @@ def drain_once(
             events_to_apply: list[dict[str, Any]] = []
             remaining_events: list[dict[str, Any]] = []
             for event in events:
-                if pause_active and _event_payload(event).get("kind") == "enrichment_update":
+                if pause_enrichment and _event_payload(event).get("kind") == "enrichment_update":
                     remaining_events.append(event)
                 elif len(events_to_apply) < _max_events_per_transaction():
                     events_to_apply.append(event)
@@ -1663,7 +1666,14 @@ def drain_once(
                         _log(log_path, f"WARN: queued chunk_id {chunk_id} collided with existing row, dropped")
                     queue_cleanup_succeeded = True
                     if remaining_events:
-                        _preserve_remaining_events(path, remaining_events)
+                        try:
+                            _preserve_remaining_events(path, remaining_events)
+                        except OSError as exc:
+                            queue_cleanup_succeeded = False
+                            _log(
+                                log_path,
+                                f"drain committed but could not preserve remaining events in {path}: {exc}",
+                            )
                     else:
                         queue_cleanup_succeeded = _unlink_processed_file(path, log_path)
                     if queue_cleanup_succeeded:

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -1425,7 +1425,10 @@ def burn_drain_once(
             for path, _events in batch:
                 paused_events = paused_events_by_path.get(path)
                 if paused_events and not _is_enrichment_queue_file(path):
-                    _preserve_remaining_events(path, paused_events)
+                    try:
+                        _preserve_remaining_events(path, paused_events)
+                    except OSError as exc:
+                        _log(log_path, f"burn drain could not preserve paused enrichment in {path}: {exc}")
             return result
         queue_telemetry = _queue_telemetry([path for path, _events in batch], all_events)
         batch_includes_store = _events_include_store(all_events)
@@ -1597,7 +1600,10 @@ def drain_once(
                     remaining_events.append(event)
             if not events_to_apply:
                 if not _is_enrichment_queue_file(path):
-                    _preserve_remaining_events(path, remaining_events)
+                    try:
+                        _preserve_remaining_events(path, remaining_events)
+                    except OSError as exc:
+                        _log(log_path, f"drain could not preserve paused enrichment in {path}: {exc}")
                 continue
             queue_telemetry = _queue_telemetry([path], events_to_apply)
             events_include_store = _events_include_store(events_to_apply)

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -31,6 +31,7 @@ from .dedupe import (
 )
 from .ingest_guard import recursive_mcp_output_reason
 from .paths import get_db_path
+from .pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_sentinel_state
 from .provenance_integration import enqueue_provenance_resolution_for_entities
 from .writer_telemetry import start_writer_span
 
@@ -1244,6 +1245,16 @@ def _rewrite_events_file(path: Path, events: list[dict[str, Any]]) -> None:
     tmp_path.replace(path)
 
 
+def _preserve_remaining_events(path: Path, events: list[dict[str, Any]]) -> None:
+    if events and all(_event_payload(event).get("kind") == "enrichment_update" for event in events):
+        if not _is_enrichment_queue_file(path):
+            enrichment_path = path.with_name(f"enrichment-paused-{uuid.uuid4().hex}-{path.name}")
+            _rewrite_events_file(enrichment_path, events)
+            path.unlink()
+            return
+    _rewrite_events_file(path, events)
+
+
 def _select_burn_batch(
     files: list[Path], max_events_per_transaction: int
 ) -> tuple[list[tuple[Path, list[dict[str, Any]]]], int]:
@@ -1364,6 +1375,7 @@ def burn_drain_once(
     max_events_per_transaction: int = _DEFAULT_BURN_MAX_EVENTS_PER_TRANSACTION,
     log_path: Path | None = None,
     embed_fn: Callable[[str], list[float]] | None = None,
+    pause_sentinel_path: Path | None = None,
 ) -> BurnDrainResult:
     """Drain a large queue backlog with one writer and one commit per large batch.
 
@@ -1374,8 +1386,10 @@ def burn_drain_once(
     db_path = db_path or _default_db_path()
     queue_dir = queue_dir or _default_queue_dir()
     log_path = log_path or _default_log_path()
+    pause_sentinel_path = pause_sentinel_path or DEFAULT_PAUSE_SENTINEL_PATH
     queue_dir.mkdir(parents=True, exist_ok=True)
     max_events_per_transaction = max(1, max_events_per_transaction)
+    _pause_payload, pause_active, _pause_stale = pause_sentinel_state(pause_sentinel_path)
 
     result = BurnDrainResult()
     lock_fd = _acquire_queue_lock(queue_dir)
@@ -1393,7 +1407,24 @@ def burn_drain_once(
         if not batch:
             return result
 
+        paused_events_by_path: dict[Path, list[dict[str, Any]]] = {}
+        if pause_active:
+            apply_batch: list[tuple[Path, list[dict[str, Any]]]] = []
+            for path, events in batch:
+                paused_events = [event for event in events if _event_payload(event).get("kind") == "enrichment_update"]
+                apply_events = [event for event in events if _event_payload(event).get("kind") != "enrichment_update"]
+                if paused_events:
+                    paused_events_by_path[path] = paused_events
+                apply_batch.append((path, apply_events))
+            batch = apply_batch
+
         all_events = [event for _, events in batch for event in events]
+        if not all_events:
+            for path, _events in batch:
+                paused_events = paused_events_by_path.get(path)
+                if paused_events and not _is_enrichment_queue_file(path):
+                    _preserve_remaining_events(path, paused_events)
+            return result
         queue_telemetry = _queue_telemetry([path for path, _events in batch], all_events)
         batch_includes_store = _events_include_store(all_events)
         if batch_includes_store and not _ensure_drain_db_schema_preserving_queue(
@@ -1488,6 +1519,13 @@ def burn_drain_once(
 
         fallback_markers_to_apply: list[FallbackReplayMarker] = []
         for path, _events in batch:
+            paused_events = paused_events_by_path.get(path)
+            if paused_events:
+                try:
+                    _preserve_remaining_events(path, paused_events)
+                except OSError as exc:
+                    _log(log_path, f"burn drain committed but could not preserve paused enrichment in {path}: {exc}")
+                continue
             try:
                 path.unlink()
                 result.files_deleted += 1
@@ -1518,11 +1556,14 @@ def drain_once(
     batch_size: int = 250,
     log_path: Path | None = None,
     embed_fn: Callable[[str], list[float]] | None = None,
+    pause_sentinel_path: Path | None = None,
 ) -> int:
     db_path = db_path or _default_db_path()
     queue_dir = queue_dir or _default_queue_dir()
     log_path = log_path or _default_log_path()
+    pause_sentinel_path = pause_sentinel_path or DEFAULT_PAUSE_SENTINEL_PATH
     queue_dir.mkdir(parents=True, exist_ok=True)
+    _pause_payload, pause_active, _pause_stale = pause_sentinel_state(pause_sentinel_path)
 
     lock_fd = _acquire_queue_lock(queue_dir)
     try:
@@ -1542,8 +1583,19 @@ def drain_once(
             if not events:
                 _unlink_processed_file(path, log_path)
                 continue
-            events_to_apply = events[: _max_events_per_transaction()]
-            remaining_events = events[len(events_to_apply) :]
+            events_to_apply: list[dict[str, Any]] = []
+            remaining_events: list[dict[str, Any]] = []
+            for event in events:
+                if pause_active and _event_payload(event).get("kind") == "enrichment_update":
+                    remaining_events.append(event)
+                elif len(events_to_apply) < _max_events_per_transaction():
+                    events_to_apply.append(event)
+                else:
+                    remaining_events.append(event)
+            if not events_to_apply:
+                if not _is_enrichment_queue_file(path):
+                    _preserve_remaining_events(path, remaining_events)
+                continue
             queue_telemetry = _queue_telemetry([path], events_to_apply)
             events_include_store = _events_include_store(events_to_apply)
             if events_include_store and not _ensure_drain_db_schema_preserving_queue(
@@ -1611,7 +1663,7 @@ def drain_once(
                         _log(log_path, f"WARN: queued chunk_id {chunk_id} collided with existing row, dropped")
                     queue_cleanup_succeeded = True
                     if remaining_events:
-                        _rewrite_events_file(path, remaining_events)
+                        _preserve_remaining_events(path, remaining_events)
                     else:
                         queue_cleanup_succeeded = _unlink_processed_file(path, log_path)
                     if queue_cleanup_succeeded:

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -24,12 +24,14 @@ from .drain_liveness import (
     check_drain_liveness,
 )
 from .launchd_primitive import (
+    LaunchdLabelDisabledError,
     LaunchdVerificationError,
     install_and_verify_launchagent,
     is_launchd_label_loaded,
     launchd_target,
 )
 from .paths import get_db_path
+from .pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_applies_to_label, pause_sentinel_state
 from .watcher import default_watch_roots
 
 DEFAULT_SOCKET_PATH = Path("/tmp/brainbar.sock")
@@ -144,9 +146,7 @@ class HealthCheckConfig:
     source_jsonl_globs: list[str] = field(
         default_factory=lambda: [str(root.resolved_path / "**" / "*.jsonl") for root in default_watch_roots()]
     )
-    pause_sentinel_path: Path = field(
-        default_factory=lambda: Path("~/.local/share/brainlayer/pause.sentinel").expanduser()
-    )
+    pause_sentinel_path: Path = field(default_factory=lambda: DEFAULT_PAUSE_SENTINEL_PATH)
     max_offsets_age_seconds: int = 900
     queue_auto_heal_count: int = 25
     queue_page_count: int = 200
@@ -285,6 +285,8 @@ def _bootstrap_if_absent(label: str, plist_path: Path, command_runner: CommandRu
     try:
         install_and_verify_launchagent(label, plist_path, command_runner=command_runner)
         return f"bootstrap:{label}"
+    except LaunchdLabelDisabledError:
+        return f"disabled:{label}"
     except LaunchdVerificationError:
         return f"bootstrap_failed:{label}"
 
@@ -793,25 +795,8 @@ def _t3_health_issue(payload: dict[str, Any]) -> HealthIssue | None:
     )
 
 
-def _parse_iso_datetime(value: Any) -> datetime | None:
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
-
-
 def _pause_sentinel_state(config: HealthCheckConfig, now: datetime) -> tuple[dict[str, Any], bool, bool]:
-    payload = _load_json(config.pause_sentinel_path)
-    if not payload:
-        return {}, False, False
-    expires_at = _parse_iso_datetime(payload.get("expires_at"))
-    stale = expires_at is not None and now > expires_at
-    return payload, not stale, stale
+    return pause_sentinel_state(config.pause_sentinel_path, now)
 
 
 def _source_recent(
@@ -956,6 +941,8 @@ def run_health_check(
             return None
         return finish_slow(stage, f"health-check exceeded {config.max_duration_seconds:.0f}s during {stage}")
 
+    pause_payload, pause_active, pause_stale = _pause_sentinel_state(config, now)
+
     t3_health = _load_json(config.t3_health_path)
     result.t3_health = t3_health or None
     if t3_issue := _t3_health_issue(t3_health):
@@ -1078,7 +1065,7 @@ def run_health_check(
             config.health_check_label,
             config.enrichment_label,
         ):
-            if label:
+            if label and not (pause_active and pause_applies_to_label(pause_payload, label)):
                 action = _bootstrap_if_absent(label, _plist_for_label(config, label), command_runner)
                 if action.startswith(("bootstrap:", "bootstrap_failed:", "launchctl-unavailable:")):
                     result.actions.append(action)
@@ -1101,7 +1088,6 @@ def run_health_check(
     if slow_result := deadline_reached("launchd_status"):
         return slow_result
 
-    pause_payload, pause_active, pause_stale = _pause_sentinel_state(config, now)
     if pause_stale:
         add_issue(
             "pause_sentinel_stale", "critical", "pause sentinel is expired; launchd resume may have been forgotten"
@@ -1258,6 +1244,13 @@ def run_health_check(
                     holder_label,
                     _plist_for_label(config, holder_label),
                 )
+
+    if pause_active:
+        heal_issue_labels = {
+            issue_code: label_and_path
+            for issue_code, label_and_path in heal_issue_labels.items()
+            if not pause_applies_to_label(pause_payload, label_and_path[0])
+        }
 
     heal_failures, heal_tripped = _apply_heals(
         result=result,

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -1067,7 +1067,7 @@ def run_health_check(
         ):
             if label and not (pause_active and pause_applies_to_label(pause_payload, label)):
                 action = _bootstrap_if_absent(label, _plist_for_label(config, label), command_runner)
-                if action.startswith(("bootstrap:", "bootstrap_failed:", "launchctl-unavailable:")):
+                if action.startswith(("bootstrap:", "bootstrap_failed:", "launchctl-unavailable:", "disabled:")):
                     result.actions.append(action)
 
     drain_loaded: bool | None = None

--- a/src/brainlayer/launchd_primitive.py
+++ b/src/brainlayer/launchd_primitive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Any, Callable
@@ -92,6 +93,10 @@ class LaunchdLabelNotLoadedError(LaunchdVerificationError):
     """Raised when launchd reports that a required label is not loaded."""
 
 
+class LaunchdLabelDisabledError(LaunchdVerificationError):
+    """Raised when launchd reports that a label was explicitly disabled."""
+
+
 class LaunchdCommandError(LaunchdVerificationError):
     """Raised when an install/bootstrap command fails before verification."""
 
@@ -128,6 +133,24 @@ def is_launchd_label_loaded(
     if print_state is not None:
         return print_state
     return None
+
+
+def is_launchd_label_disabled(
+    label: str,
+    *,
+    command_runner: CommandRunner = _default_command_runner,
+) -> bool | None:
+    """Return whether launchd explicitly marks a label disabled."""
+    if not label:
+        return False
+    domain = f"gui/{os.getuid()}"
+    result = command_runner(["launchctl", "print-disabled", domain])
+    if _command_returncode(result) != 0:
+        return None
+    match = re.search(rf'["\']?{re.escape(label)}["\']?\s*=>\s*(true|false)', _command_stdout(result), re.I)
+    if match is None:
+        return False
+    return match.group(1).lower() == "true"
 
 
 def verify_launchd_label_loaded(
@@ -199,12 +222,14 @@ def install_and_verify_launchagent(
     target = launchd_target(label)
     domain = f"gui/{os.getuid()}"
 
-    _run_required_launchctl(
-        ["launchctl", "enable", target],
-        label=label,
-        plist_path=resolved_plist_path,
-        command_runner=command_runner,
-    )
+    if is_launchd_label_disabled(label, command_runner=command_runner) is True:
+        raise LaunchdLabelDisabledError(
+            f"launchd label {label} is explicitly disabled",
+            label=label,
+            target=target,
+            reason="disabled",
+            plist_path=resolved_plist_path,
+        )
     if bootout_existing:
         command_runner(["launchctl", "bootout", target])
     bootstrap_args = ["launchctl", "bootstrap", domain, str(resolved_plist_path)]

--- a/src/brainlayer/pause.py
+++ b/src/brainlayer/pause.py
@@ -1,0 +1,46 @@
+"""Shared pause-sentinel parsing for launchd healing and queue drain."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PAUSE_SENTINEL_PATH = Path("~/.local/share/brainlayer/pause.sentinel").expanduser()
+
+
+def pause_sentinel_state(
+    path: Path,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], bool, bool]:
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {}, False, False
+    if not isinstance(payload, dict) or not payload:
+        return {}, False, False
+
+    expires_at = _parse_iso_datetime(payload.get("expires_at"))
+    current = now or datetime.now(UTC)
+    stale = expires_at is not None and current > expires_at
+    return payload, not stale, stale
+
+
+def pause_applies_to_label(payload: dict[str, Any], label: str) -> bool:
+    labels = payload.get("labels")
+    if not isinstance(labels, list):
+        return True
+    return label in {str(item) for item in labels}
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/src/brainlayer/pause.py
+++ b/src/brainlayer/pause.py
@@ -30,7 +30,7 @@ def pause_sentinel_state(
 def pause_applies_to_label(payload: dict[str, Any], label: str) -> bool:
     labels = payload.get("labels")
     if not isinstance(labels, list):
-        return True
+        return False
     return label in {str(item) for item in labels}
 
 

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -448,6 +448,80 @@ def test_drain_preserve_failure_after_commit_is_best_effort(tmp_path, monkeypatc
     assert "drain committed but could not preserve remaining events" in log_path.read_text(encoding="utf-8")
 
 
+def test_drain_preserve_failure_before_apply_is_best_effort(tmp_path, monkeypatch):
+    import brainlayer.drain as drain
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    _create_minimal_db(db_path)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.brainlayer.enrichment"]}), encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    queue_path = queue_dir / "misnamed-paused.jsonl"
+    enrichment_event = {
+        "kind": "enrichment_update",
+        "chunk_id": "preserve-before-drain-apply",
+        "enrichment": {"summary": "wait"},
+    }
+    queue_path.write_text(json.dumps(enrichment_event) + "\n", encoding="utf-8")
+    monkeypatch.setattr(
+        drain,
+        "_preserve_remaining_events",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk unavailable")),
+    )
+    log_path = tmp_path / "drain.log"
+
+    assert (
+        drain.drain_once(
+            db_path=db_path,
+            queue_dir=queue_dir,
+            log_path=log_path,
+            pause_sentinel_path=pause_path,
+        )
+        == 0
+    )
+
+    assert json.loads(queue_path.read_text(encoding="utf-8")) == enrichment_event
+    assert "drain could not preserve paused enrichment" in log_path.read_text(encoding="utf-8")
+
+
+def test_burn_drain_preserve_failure_before_apply_is_best_effort(tmp_path, monkeypatch):
+    import brainlayer.drain as drain
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    _create_minimal_db(db_path)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.brainlayer.enrichment"]}), encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    queue_path = queue_dir / "misnamed-paused.jsonl"
+    enrichment_event = {
+        "kind": "enrichment_update",
+        "chunk_id": "preserve-before-burn-apply",
+        "enrichment": {"summary": "wait"},
+    }
+    queue_path.write_text(json.dumps(enrichment_event) + "\n", encoding="utf-8")
+    monkeypatch.setattr(
+        drain,
+        "_preserve_remaining_events",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk unavailable")),
+    )
+    log_path = tmp_path / "drain.log"
+
+    result = drain.burn_drain_once(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        log_path=log_path,
+        pause_sentinel_path=pause_path,
+    )
+
+    assert result.applied_events == 0
+    assert json.loads(queue_path.read_text(encoding="utf-8")) == enrichment_event
+    assert "burn drain could not preserve paused enrichment" in log_path.read_text(encoding="utf-8")
+
+
 def test_paused_misnamed_enrichment_file_does_not_starve_later_ingestion(tmp_path, monkeypatch):
     from brainlayer.drain import drain_once
 

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 import apsw
+import pytest
 import sqlite_vec
 
 
@@ -344,6 +345,109 @@ def test_burn_drain_keeps_paused_enrichment_queued_while_applying_watcher(tmp_pa
     assert queued == [enrichment_event]
 
 
+@pytest.mark.parametrize("burn", [False, True])
+def test_non_enrichment_pause_does_not_gate_enrichment_drain(tmp_path, monkeypatch, burn):
+    import brainlayer.drain as drain
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    _create_minimal_db(db_path)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.brainlayer.watch"]}), encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    (queue_dir / "enrichment-scoped-pause.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "enrichment-must-continue",
+                "enrichment": {"summary": "apply me"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    applied: list[str] = []
+    monkeypatch.setattr(
+        drain,
+        "_apply_enrichment",
+        lambda _conn, event: applied.append(event["chunk_id"]),
+    )
+
+    if burn:
+        result = drain.burn_drain_once(
+            db_path=db_path,
+            queue_dir=queue_dir,
+            log_path=tmp_path / "drain.log",
+            pause_sentinel_path=pause_path,
+        )
+        assert result.applied_events == 1
+    else:
+        assert (
+            drain.drain_once(
+                db_path=db_path,
+                queue_dir=queue_dir,
+                log_path=tmp_path / "drain.log",
+                pause_sentinel_path=pause_path,
+            )
+            == 1
+        )
+
+    assert applied == ["enrichment-must-continue"]
+
+
+def test_drain_preserve_failure_after_commit_is_best_effort(tmp_path, monkeypatch):
+    import brainlayer.drain as drain
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    _create_minimal_db(db_path)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.brainlayer.enrichment"]}), encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    (queue_dir / "mixed-events.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "preserve-me",
+                "enrichment": {"summary": "wait"},
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "kind": "watcher_chunk",
+                "chunk_id": "commit-me",
+                "content": "The committed event must survive cleanup failure.",
+                "created_at": "2026-08-02T09:30:00Z",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        drain,
+        "_preserve_remaining_events",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk unavailable")),
+    )
+    log_path = tmp_path / "drain.log"
+
+    assert (
+        drain.drain_once(
+            db_path=db_path,
+            queue_dir=queue_dir,
+            log_path=log_path,
+            pause_sentinel_path=pause_path,
+        )
+        == 1
+    )
+
+    assert "drain committed but could not preserve remaining events" in log_path.read_text(encoding="utf-8")
+
+
 def test_paused_misnamed_enrichment_file_does_not_starve_later_ingestion(tmp_path, monkeypatch):
     from brainlayer.drain import drain_once
 
@@ -404,13 +508,17 @@ def test_paused_misnamed_enrichment_file_does_not_starve_later_ingestion(tmp_pat
         assert conn.execute("SELECT id FROM chunks WHERE id = 'watcher-after-misnamed-enrichment'").fetchone()
 
 
-def test_paused_enrichment_file_is_left_untouched_between_drain_ticks(tmp_path):
-    from brainlayer.drain import drain_once
+def test_paused_enrichment_file_is_left_untouched_between_drain_ticks(tmp_path, monkeypatch):
+    import brainlayer.drain as drain
 
+    db_path = tmp_path / "brainlayer.db"
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
+    _create_minimal_db(db_path)
     pause_path = tmp_path / "pause.sentinel"
     pause_path.write_text(json.dumps({"labels": ["com.brainlayer.enrichment"]}), encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
     queue_path = queue_dir / "enrichment-paused.jsonl"
     queue_path.write_text(
         json.dumps(
@@ -424,10 +532,16 @@ def test_paused_enrichment_file_is_left_untouched_between_drain_ticks(tmp_path):
         encoding="utf-8",
     )
     original_mtime_ns = queue_path.stat().st_mtime_ns
+    applied: list[str] = []
+    monkeypatch.setattr(
+        drain,
+        "_apply_enrichment",
+        lambda _conn, event: applied.append(event["chunk_id"]),
+    )
 
     assert (
-        drain_once(
-            db_path=tmp_path / "unused.db",
+        drain.drain_once(
+            db_path=db_path,
             queue_dir=queue_dir,
             log_path=tmp_path / "drain.log",
             pause_sentinel_path=pause_path,
@@ -435,6 +549,7 @@ def test_paused_enrichment_file_is_left_untouched_between_drain_ticks(tmp_path):
         == 0
     )
 
+    assert applied == []
     assert queue_path.stat().st_mtime_ns == original_mtime_ns
 
 

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -240,6 +240,204 @@ def test_drain_prioritizes_writes_before_enrichment(tmp_path, monkeypatch):
         assert conn.execute("SELECT id FROM chunks WHERE id = 'watcher-priority'").fetchone() == ("watcher-priority",)
 
 
+def test_drain_keeps_paused_enrichment_queued_while_applying_watcher_in_same_file(tmp_path, monkeypatch):
+    import brainlayer.drain as drain
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    _create_minimal_db(db_path)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(
+        json.dumps(
+            {
+                "labels": ["com.brainlayer.enrichment"],
+                "created_at": "2026-08-02T09:00:00+00:00",
+                "expires_at": "2099-08-02T11:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    queue_path = queue_dir / "mixed-events.jsonl"
+    enrichment_event = {
+        "kind": "enrichment_update",
+        "chunk_id": "must-stay-paused",
+        "enrichment": {"summary": "must not apply"},
+    }
+    watcher_event = {
+        "kind": "watcher_chunk",
+        "chunk_id": "watcher-still-ingests",
+        "content": "Ingestion must continue while queued enrichment is paused.",
+        "created_at": "2026-08-02T09:30:00Z",
+    }
+    queue_path.write_text(
+        json.dumps(enrichment_event) + "\n" + json.dumps(watcher_event) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        drain,
+        "_apply_enrichment",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("paused enrichment reached apply")),
+    )
+
+    drained = drain.drain_once(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        batch_size=1,
+        log_path=tmp_path / "drain.log",
+        pause_sentinel_path=pause_path,
+    )
+
+    assert drained == 1
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT id FROM chunks WHERE id = 'watcher-still-ingests'").fetchone() == (
+            "watcher-still-ingests",
+        )
+    queued_files = list(queue_dir.glob("*.jsonl"))
+    assert len(queued_files) == 1
+    assert [json.loads(line) for line in queued_files[0].read_text(encoding="utf-8").splitlines()] == [enrichment_event]
+
+
+def test_burn_drain_keeps_paused_enrichment_queued_while_applying_watcher(tmp_path, monkeypatch):
+    import brainlayer.drain as drain
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    _create_minimal_db(db_path)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.brainlayer.enrichment"]}), encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    enrichment_event = {
+        "kind": "enrichment_update",
+        "chunk_id": "burn-must-stay-paused",
+        "enrichment": {"summary": "must not apply"},
+    }
+    watcher_event = {
+        "kind": "watcher_chunk",
+        "chunk_id": "burn-watcher-still-ingests",
+        "content": "Burn drain must preserve the same pause interlock.",
+        "created_at": "2026-08-02T09:30:00Z",
+    }
+    (queue_dir / "mixed-burn.jsonl").write_text(
+        json.dumps(enrichment_event) + "\n" + json.dumps(watcher_event) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        drain,
+        "_apply_enrichment",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("paused enrichment reached burn apply")),
+    )
+
+    result = drain.burn_drain_once(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        log_path=tmp_path / "drain.log",
+        pause_sentinel_path=pause_path,
+    )
+
+    assert result.applied_events == 1
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT id FROM chunks WHERE id = 'burn-watcher-still-ingests'").fetchone()
+    queued = [json.loads(line) for path in queue_dir.glob("*.jsonl") for line in path.read_text().splitlines()]
+    assert queued == [enrichment_event]
+
+
+def test_paused_misnamed_enrichment_file_does_not_starve_later_ingestion(tmp_path, monkeypatch):
+    from brainlayer.drain import drain_once
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    _create_minimal_db(db_path)
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.brainlayer.enrichment"]}), encoding="utf-8")
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "0")
+    (queue_dir / "aaa-misnamed.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "misnamed-paused-enrichment",
+                "enrichment": {"summary": "must wait"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (queue_dir / "watcher-later.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "watcher_chunk",
+                "chunk_id": "watcher-after-misnamed-enrichment",
+                "content": "A paused file must not monopolize the high-priority queue.",
+                "created_at": "2026-08-02T09:30:00Z",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        drain_once(
+            db_path=db_path,
+            queue_dir=queue_dir,
+            batch_size=1,
+            log_path=tmp_path / "drain.log",
+            pause_sentinel_path=pause_path,
+        )
+        == 0
+    )
+    assert not (queue_dir / "aaa-misnamed.jsonl").exists()
+
+    assert (
+        drain_once(
+            db_path=db_path,
+            queue_dir=queue_dir,
+            batch_size=1,
+            log_path=tmp_path / "drain.log",
+            pause_sentinel_path=pause_path,
+        )
+        == 1
+    )
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT id FROM chunks WHERE id = 'watcher-after-misnamed-enrichment'").fetchone()
+
+
+def test_paused_enrichment_file_is_left_untouched_between_drain_ticks(tmp_path):
+    from brainlayer.drain import drain_once
+
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    pause_path = tmp_path / "pause.sentinel"
+    pause_path.write_text(json.dumps({"labels": ["com.brainlayer.enrichment"]}), encoding="utf-8")
+    queue_path = queue_dir / "enrichment-paused.jsonl"
+    queue_path.write_text(
+        json.dumps(
+            {
+                "kind": "enrichment_update",
+                "chunk_id": "paused-without-churn",
+                "enrichment": {"summary": "wait"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    original_mtime_ns = queue_path.stat().st_mtime_ns
+
+    assert (
+        drain_once(
+            db_path=tmp_path / "unused.db",
+            queue_dir=queue_dir,
+            log_path=tmp_path / "drain.log",
+            pause_sentinel_path=pause_path,
+        )
+        == 0
+    )
+
+    assert queue_path.stat().st_mtime_ns == original_mtime_ns
+
+
 def test_drain_yields_enrichment_when_interactive_store_is_queued(tmp_path, monkeypatch):
     """Interactive stores are higher priority than enrichment metadata writes."""
     from brainlayer.drain import drain_once

--- a/tests/test_cli_launchd_mode_a.py
+++ b/tests/test_cli_launchd_mode_a.py
@@ -8,6 +8,16 @@ from typer.testing import CliRunner
 
 from brainlayer.cli import app
 from brainlayer.health_check import HealthCheckResult
+from brainlayer.pause import pause_applies_to_label
+
+
+def test_malformed_pause_labels_do_not_apply_globally(monkeypatch, tmp_path):
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(tmp_path / "queue"))
+
+    assert not pause_applies_to_label(
+        {"labels": "com.brainlayer.enrichment"},
+        "com.brainlayer.watch",
+    )
 
 
 def test_health_check_cli_forwards_mode_a_config_fields(monkeypatch, tmp_path):

--- a/tests/test_cli_launchd_mode_a.py
+++ b/tests/test_cli_launchd_mode_a.py
@@ -106,6 +106,20 @@ def test_pause_and_resume_record_labels_and_call_launchctl(monkeypatch, tmp_path
     assert any(command[:2] == ["launchctl", "bootstrap"] for command in commands)
 
 
+def test_pause_defaults_to_enrichment_without_stopping_ingestion_daemons(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+    monkeypatch.setattr("brainlayer.cli._run_launchctl", lambda args: commands.append(args) or 0)
+
+    result = CliRunner().invoke(
+        app,
+        ["pause", "--pause-sentinel-path", str(tmp_path / "pause.sentinel"), "--ttl-seconds", "60"],
+    )
+
+    assert result.exit_code == 0, result.output
+    booted_out = [command[-1].rsplit("/", 1)[-1] for command in commands if command[:2] == ["launchctl", "bootout"]]
+    assert booted_out == ["com.brainlayer.enrichment"]
+
+
 def test_reconcile_launchd_bootstraps_all_mode_a_labels(monkeypatch, tmp_path):
     commands: list[list[str]] = []
     monkeypatch.setattr("brainlayer.cli._run_launchctl", lambda args: commands.append(args) or 0)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -189,6 +189,33 @@ def test_launchd_install_and_verify_accepts_loaded_label_after_bootstrap_already
     )
 
 
+def test_launchd_install_and_verify_preserves_deliberately_disabled_label(tmp_path):
+    from brainlayer.launchd_primitive import LaunchdLabelDisabledError, install_and_verify_launchagent
+
+    plist_path = tmp_path / "com.example.disabled.plist"
+    plist_path.write_text("<plist />", encoding="utf-8")
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        if args[:2] == ["launchctl", "print-disabled"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout='disabled services = {\n\t"com.example.disabled" => true\n}\n',
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with pytest.raises(LaunchdLabelDisabledError, match="explicitly disabled"):
+        install_and_verify_launchagent(
+            "com.example.disabled",
+            plist_path,
+            command_runner=command_runner,
+        )
+    assert not [command for command in commands if command[:2] == ["launchctl", "enable"]]
+    assert not [command for command in commands if command[:2] == ["launchctl", "bootstrap"]]
+
+
 def test_launchd_label_loaded_does_not_use_unscoped_list_fallback():
     from brainlayer.launchd_primitive import is_launchd_label_loaded
 

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -1070,9 +1070,7 @@ def test_health_check_bootstraps_absent_default_launchd_labels_instead_of_kickst
 
     issue_codes = [issue.code for issue in result.issues]
     assert {"watch_unloaded", "drain_unloaded", "health_check_unloaded"} <= set(issue_codes)
-    assert ["launchctl", "enable", f"gui/{__import__('os').getuid()}/com.brainlayer.watch"] in commands
-    assert ["launchctl", "enable", f"gui/{__import__('os').getuid()}/com.brainlayer.drain"] in commands
-    assert ["launchctl", "enable", f"gui/{__import__('os').getuid()}/com.brainlayer.health-check"] in commands
+    assert not [command for command in commands if command[:2] == ["launchctl", "enable"]]
     assert [
         "launchctl",
         "bootstrap",
@@ -1139,6 +1137,51 @@ def test_health_check_bootstraps_absent_enrichment_and_clears_tripped_after_succ
     assert "bootstrap:com.brainlayer.enrichment" in result.actions
     saved = json.loads(state_path.read_text(encoding="utf-8"))
     assert "com.brainlayer.enrichment:enrichment_unloaded" not in saved["heal_tripped"]
+
+
+def test_health_check_does_not_bootstrap_label_recorded_in_active_pause_sentinel(tmp_path):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    pause_path = tmp_path / "pause.sentinel"
+    _make_db(db_path, total=1, vector_rows=1)
+    pause_path.write_text(
+        json.dumps(
+            {
+                "labels": ["com.brainlayer.enrichment"],
+                "created_at": "2026-08-02T09:00:00+00:00",
+                "expires_at": "2026-08-02T11:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str]):
+        commands.append(args)
+        if args[:2] == ["launchctl", "print"] and "com.brainlayer.enrichment" in args[2]:
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            pause_sentinel_path=pause_path,
+            queue_dir=tmp_path / "queue",
+            source_jsonl_globs=[],
+            heal=True,
+            heal_min_consecutive_failures=1,
+        ),
+        ps_output_fn=lambda: "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n",
+        socket_request_fn=_ok_canary,
+        command_runner=command_runner,
+        now_fn=lambda: datetime(2026, 8, 2, 10, 0, tzinfo=UTC),
+    )
+
+    enrichment_commands = [command for command in commands if "com.brainlayer.enrichment" in " ".join(command)]
+    assert "enrichment_unloaded" in [issue.code for issue in result.issues]
+    assert not [command for command in enrichment_commands if command[:2] == ["launchctl", "bootstrap"]]
+    assert not [command for command in enrichment_commands if command[:2] == ["launchctl", "enable"]]
 
 
 def test_run_health_check_references_mode_d_detector_helpers():

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -1184,6 +1184,87 @@ def test_health_check_does_not_bootstrap_label_recorded_in_active_pause_sentinel
     assert not [command for command in enrichment_commands if command[:2] == ["launchctl", "enable"]]
 
 
+def test_health_check_bootstraps_non_paused_labels_during_active_pause(tmp_path, monkeypatch):
+    db_path = tmp_path / "brainlayer.db"
+    state_path = tmp_path / "health-state.json"
+    queue_dir = tmp_path / "queue"
+    pause_path = tmp_path / "pause.sentinel"
+    _make_db(db_path, total=1, vector_rows=1)
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    pause_path.write_text(
+        json.dumps(
+            {
+                "labels": ["com.brainlayer.enrichment"],
+                "expires_at": "2026-08-02T11:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    loaded: set[str] = set()
+    bootstrapped: list[str] = []
+
+    def command_runner(args: list[str]):
+        if args[:2] == ["launchctl", "print"]:
+            label = args[2].rsplit("/", 1)[-1]
+            return SimpleNamespace(returncode=0 if label in loaded else 113, stdout="", stderr="")
+        if args[:2] == ["launchctl", "bootstrap"]:
+            label = Path(args[-1]).stem
+            loaded.add(label)
+            bootstrapped.append(label)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=state_path,
+            pause_sentinel_path=pause_path,
+            queue_dir=queue_dir,
+            source_jsonl_globs=[],
+            heal=True,
+            heal_min_consecutive_failures=1,
+        ),
+        ps_output_fn=lambda: "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n",
+        socket_request_fn=_ok_canary,
+        command_runner=command_runner,
+        now_fn=lambda: datetime(2026, 8, 2, 10, 0, tzinfo=UTC),
+    )
+
+    assert set(bootstrapped) == {
+        "com.brainlayer.watch",
+        "com.brainlayer.drain",
+        "com.brainlayer.health-check",
+    }
+
+
+def test_health_check_surfaces_disabled_launchd_action(tmp_path, monkeypatch):
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    _make_db(db_path, total=1, vector_rows=1)
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setattr(
+        health_check,
+        "_bootstrap_if_absent",
+        lambda label, _plist_path, _command_runner: f"disabled:{label}",
+    )
+
+    result = run_health_check(
+        HealthCheckConfig(
+            db_path=db_path,
+            state_path=tmp_path / "health-state.json",
+            queue_dir=queue_dir,
+            source_jsonl_globs=[],
+            heal=True,
+            heal_min_consecutive_failures=1,
+        ),
+        ps_output_fn=lambda: "123 /usr/bin/python scripts/hotlane_brainbar_daemon.py --interval 1 --backlog-batch 4\n",
+        socket_request_fn=_ok_canary,
+        command_runner=lambda _args: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        now_fn=lambda: datetime(2026, 8, 2, 10, 0, tzinfo=UTC),
+    )
+
+    assert "disabled:com.brainlayer.enrichment" in result.actions
+
+
 def test_run_health_check_references_mode_d_detector_helpers():
     source = inspect.getsource(health_check.run_health_check)
 


### PR DESCRIPTION
## What

Three defects that together meant `brainlayer pause` never actually paused. All three were verified in production before any code was written.

1. **Heal loop bootstrapped before checking the pause sentinel.** `health_check.py` ran `_bootstrap_if_absent` at `:1082` (inside `if config.heal:` at `:1074`) but only evaluated the pause sentinel at `:1104` — 22 lines later. Any heal tick respawned a paused label.
2. **`launchctl enable` ran before bootstrap.** `launchd_primitive.py:199-205` in `install_and_verify_launchagent`, so an operator's `launchctl disable` was silently undone.
3. **Pausing the launchd agent did not stop enrichment at all.** `drain` applies queued `enrichment_update` events (`drain.py:1047` → `_apply_enrichment` `:951` → `_run_enrichment_provenance_hooks` `:1034`), which write `provenance_class`. With `com.brainlayer.enrichment` unloaded and its plist parked, **3,369 queued events were still landing** — 192 chunks enriched in one hour, the newest 32 seconds before measurement.

Defect 3 is why the sprint's premise was wrong: "enrichment is down" was false, and it is why t3 source-class loss climbed from 167 to **2,440 of 2,505 (97.4%)** after the pause. It also means the two standing constraints — *enrichment stays down* and *never stop drain* — were previously unsatisfiable. Pause now gates drain's enrichment application while ingestion events keep applying.

Adds `src/brainlayer/pause.py` as the shared pause gate.

## Verification — read this carefully, it is not a blanket green

- **Verified by me, directly:** `89 passed` across `test_stability_health_check.py`, `test_cli_launchd_mode_a.py`, `test_doctor.py`.
- **Observed passing in the pre-push run:** the new gating tests, including the burn-drain path the worker found on its own —
  `test_drain_keeps_paused_enrichment_queued_while_applying_watcher_in_same_file`,
  `test_burn_drain_keeps_paused_enrichment_queued_while_applying_watcher`,
  `test_paused_misnamed_enrichment_file_does_not_starve_later_ingestion`,
  `test_paused_enrichment_file_is_left_untouched_between_drain_ticks`.
- ⚠️ **I cannot evidence a complete full-suite pass locally.** The push that landed was a foreground run whose hook output was not captured to a file; a later re-run was killed by SIGTERM at 48% (`Terminated: 15`, no test failure — the last line before the kill was a PASSED). **CI on this PR is the authoritative gate.** No `--no-verify` was used at any point.

## Authorship and review

Implemented by the R0-A Codex worker. It could not commit its own work: in a git worktree `.git` points outside the sandbox, so `codex --full-auto` cannot write the linked git index, and the sandbox has no outbound network. **The lead committed and pushed on its behalf and did not author this.** Review is routed by `@bl-cleanup` to an independent reviewer — nobody reviews their own code.

Plan and evidence: `docs.local/plan/cleanup-2026-08-02/` (items 2 and 16).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes queue drain behavior and launchd self-heal during pause—core ingestion path—but scope is bounded to enrichment gating and heal/bootstrap ordering with extensive new tests.
> 
> **Overview**
> **Pause now actually stops enrichment writes while keeping ingestion alive.** Default `brainlayer pause` only bootouts `com.brainlayer.enrichment` (not watch/drain/t3). New `pause.py` centralizes sentinel parsing and label scoping.
> 
> **Drain** (`drain_once` / `burn_drain_once`) reads the pause sentinel and **skips applying `enrichment_update` events** when enrichment is paused; those events stay on disk (including `enrichment-paused-*` renames for mixed files) so watcher/store traffic still drains.
> 
> **Health-check heal** loads the pause sentinel **before** bootstrap/heal logic, skips bootstrapping labels covered by an active pause, filters heal targets for paused labels, and surfaces `disabled:` when launchd marks a label off.
> 
> **Launchd install** drops unconditional `launchctl enable`; it detects explicitly disabled labels via `print-disabled` and raises `LaunchdLabelDisabledError` instead of undoing operator `disable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bd0e99aff94d8091e3305bae110e39355b843b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pause to skip enrichment in drain, respect disabled launchd labels, and suppress heals for paused labels
> - Introduces a shared [pause.py](https://github.com/EtanHey/brainlayer/pull/638/files#diff-0139111793c67faf3673e0403c987009288dd665d0553e47c207de4c632e570d) module with `DEFAULT_PAUSE_SENTINEL_PATH`, `pause_sentinel_state`, and `pause_applies_to_label`, replacing duplicated local parsing in health check and CLI.
> - `drain_once` and `burn_drain_once` in [drain.py](https://github.com/EtanHey/brainlayer/pull/638/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) now skip applying `enrichment_update` events when `com.brainlayer.enrichment` is paused; paused events are preserved in a renamed queue file (`enrichment-paused-<uuid>-<original>`) to avoid starving other events.
> - `run_health_check` in [health_check.py](https://github.com/EtanHey/brainlayer/pull/638/files#diff-02ee89f403d662ff87be28bc3f25fb618f788bc46a8ea0cc752df6b38268671a) now skips bootstrapping and suppresses heal issues for labels covered by an active pause sentinel.
> - `install_and_verify_launchagent` in [launchd_primitive.py](https://github.com/EtanHey/brainlayer/pull/638/files#diff-b103eca0b1a87ad4f67e0d1b3307289c28ad7cb92de56786efd4aee3e8a6cd39) no longer unconditionally calls `launchctl enable`; instead it checks `is_launchd_label_disabled` and raises `LaunchdLabelDisabledError` if the label is explicitly disabled.
> - Behavioral Change: the `pause` CLI now defaults to pausing only `com.brainlayer.enrichment` instead of multiple labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1bd0e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pausing now targets enrichment processing by default, while other event types continue normally.
  * Paused enrichment events are preserved for later processing instead of being lost.
  * Health checks respect active pauses and skip starting paused services.
  * Deliberately disabled services are detected and left unchanged during setup.

* **Bug Fixes**
  * Improved handling of paused queues and mixed event batches.
  * Prevented paused processing from interfering with unrelated ingestion.
  * Improved handling of expired or invalid pause settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->