### PR TITLE
test: isolate BrainLayer runtime paths under pytest (unblocks the pre-push gate)

### DIFF
--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -173,11 +173,23 @@ def _default_queue_dir() -> Path:
 
 
 def _default_log_path() -> Path:
-    return Path.home() / ".brainlayer" / "logs" / "drain.log"
+    from .paths import _guard_test_runtime_path
+
+    configured = os.environ.get("BRAINLAYER_DRAIN_LOG_PATH")
+    path = Path(configured).expanduser() if configured else Path.home() / ".brainlayer" / "logs" / "drain.log"
+    return _guard_test_runtime_path(path, source="drain log path")
 
 
 def _default_drain_health_path() -> Path:
-    return Path.home() / ".local" / "share" / "brainlayer" / "drain-health.json"
+    from .paths import _guard_test_runtime_path
+
+    configured = os.environ.get("BRAINLAYER_DRAIN_HEALTH_PATH")
+    path = (
+        Path(configured).expanduser()
+        if configured
+        else Path.home() / ".local" / "share" / "brainlayer" / "drain-health.json"
+    )
+    return _guard_test_runtime_path(path, source="drain health path")
 
 
 def _log(path: Path, message: str) -> None:

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -14,14 +14,14 @@ from .vector_store import IndexDeadlineExceeded, VectorStore
 
 logger = logging.getLogger(__name__)
 
-from .paths import DEFAULT_DB_PATH
+from .paths import get_db_path
 
 
 def index_chunks_to_sqlite(
     chunks: List[Chunk],
     source_file: str,
     project: Optional[str] = None,
-    db_path: Path = DEFAULT_DB_PATH,
+    db_path: Path | None = None,
     on_progress: Optional[Callable[[int, int], None]] = None,
     deadline_monotonic: float | None = None,
     store: VectorStore | None = None,
@@ -127,11 +127,11 @@ def index_chunks_to_sqlite(
     # callers still get one bounded runtime open for this adapter invocation.
     if store is not None:
         return store.upsert_chunks(chunk_data, embeddings, deadline_monotonic=deadline_monotonic)
-    with open_writer_store(db_path) as opened_store:
+    with open_writer_store(db_path or get_db_path()) as opened_store:
         return opened_store.upsert_chunks(chunk_data, embeddings, deadline_monotonic=deadline_monotonic)
 
 
-def get_stats(db_path: Path = DEFAULT_DB_PATH) -> dict:
+def get_stats(db_path: Path | None = None) -> dict:
     """Get database statistics."""
-    with ReadonlyStore(db_path) as store:
+    with ReadonlyStore(db_path or get_db_path()) as store:
         return store.get_stats()

--- a/src/brainlayer/paths.py
+++ b/src/brainlayer/paths.py
@@ -11,6 +11,32 @@ from pathlib import Path
 _CANONICAL_DB_PATH = Path.home() / ".local" / "share" / "brainlayer" / "brainlayer.db"
 
 
+def _guard_test_runtime_path(path: Path, *, source: str) -> Path:
+    """Fail closed when a pytest unit test resolves a production runtime path."""
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        return path
+
+    provenance = os.environ.get("BRAINLAYER_TEST_PATH_PROVENANCE")
+    if provenance == "live":
+        return path
+    if provenance != "pytest":
+        raise RuntimeError(f"{source} resolved during pytest without test path provenance")
+
+    protected_home_value = os.environ.get("BRAINLAYER_TEST_PROTECTED_HOME")
+    if not protected_home_value:
+        raise RuntimeError(f"{source} resolved during pytest without a protected-home provenance guard")
+
+    resolved = path.expanduser().resolve(strict=False)
+    protected_home = Path(protected_home_value).expanduser().resolve(strict=False)
+    protected_roots = (
+        protected_home / ".brainlayer",
+        protected_home / ".local" / "share" / "brainlayer",
+    )
+    if any(resolved == root or root in resolved.parents for root in protected_roots):
+        raise RuntimeError(f"{source} resolved production BrainLayer path during pytest: {resolved}")
+    return path
+
+
 def get_db_path() -> Path:
     """Resolve the BrainLayer database path.
 
@@ -18,10 +44,11 @@ def get_db_path() -> Path:
     """
     env = os.environ.get("BRAINLAYER_DB")
     if env:
-        return Path(env)
+        return _guard_test_runtime_path(Path(env), source="BRAINLAYER_DB")
 
-    _CANONICAL_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    return _CANONICAL_DB_PATH
+    db_path = _guard_test_runtime_path(_CANONICAL_DB_PATH, source="canonical database path")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return db_path
 
 
 # Convenience: pre-resolved default for import

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -17,10 +17,12 @@ def _safe_source_name(source: str) -> str:
 
 
 def get_queue_dir() -> Path:
+    from .paths import _guard_test_runtime_path
+
     env = os.environ.get("BRAINLAYER_QUEUE_DIR")
     if env:
-        return Path(env).expanduser()
-    return Path.home() / ".brainlayer" / "queue"
+        return _guard_test_runtime_path(Path(env).expanduser(), source="BRAINLAYER_QUEUE_DIR")
+    return _guard_test_runtime_path(Path.home() / ".brainlayer" / "queue", source="canonical queue path")
 
 
 def enqueue_jsonl_batch(events: list[dict[str, Any]], *, source: str, queue_dir: Path | None = None) -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 """Shared test fixtures for BrainLayer tests."""
 
 import os
+import sys
 import uuid
 from pathlib import Path
 
 import pytest
+
+_PROTECTED_TEST_HOME = Path.home().resolve()
 
 ENGINE_TEST_MARK = "engine"
 ENGINE_TEST_EXCLUDED_FILES = {
@@ -78,6 +81,51 @@ def isolate_backup_daily_log(monkeypatch, tmp_path):
     """Keep backup_daily tests and subprocesses from appending to the production heartbeat log."""
     monkeypatch.setenv("BRAINLAYER_BACKUP_LOG_PATH", str(tmp_path / "pytest-backup-daily.log"))
     monkeypatch.setenv("BRAINLAYER_BACKUP_LOG_PROVENANCE", "pytest")
+
+
+@pytest.fixture(autouse=True)
+def isolate_brainlayer_runtime_paths(monkeypatch, tmp_path, request):
+    """Keep unit-test runtime resolvers out of production BrainLayer paths."""
+    if request.node.get_closest_marker("integration") or request.node.get_closest_marker("live"):
+        monkeypatch.setenv("BRAINLAYER_TEST_PATH_PROVENANCE", "live")
+        return
+
+    isolated_home = tmp_path.parent / f".{tmp_path.name}-brainlayer-home"
+    isolated_home.mkdir()
+    runtime_root = isolated_home / ".brainlayer"
+    queue_dir = runtime_root / "queue"
+    data_dir = isolated_home / ".local" / "share" / "brainlayer"
+
+    monkeypatch.setenv("HOME", str(isolated_home))
+    monkeypatch.setenv("BRAINLAYER_DB", str(data_dir / "brainlayer.db"))
+    monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+    monkeypatch.setenv("BRAINLAYER_DRAIN_LOG_PATH", str(runtime_root / "logs" / "drain.log"))
+    monkeypatch.setenv("BRAINLAYER_DRAIN_HEALTH_PATH", str(data_dir / "drain-health.json"))
+    monkeypatch.setenv("BRAINLAYER_TEST_PATH_PROVENANCE", "pytest")
+    monkeypatch.setenv("BRAINLAYER_TEST_PROTECTED_HOME", str(_PROTECTED_TEST_HOME))
+
+    # paths.py caches these at import time, potentially before this fixture replaces HOME.
+    from brainlayer import paths as brain_paths
+
+    isolated_db = data_dir / "brainlayer.db"
+    monkeypatch.setattr(brain_paths, "_CANONICAL_DB_PATH", isolated_db)
+    monkeypatch.setattr(brain_paths, "DEFAULT_DB_PATH", isolated_db)
+
+    protected_roots = (
+        (_PROTECTED_TEST_HOME / ".brainlayer", runtime_root),
+        (_PROTECTED_TEST_HOME / ".local" / "share" / "brainlayer", data_dir),
+    )
+    for module in list(sys.modules.values()):
+        if module is None or not getattr(module, "__name__", "").startswith("brainlayer"):
+            continue
+        for attribute, value in list(vars(module).items()):
+            if not isinstance(value, Path):
+                continue
+            resolved = value.expanduser().resolve(strict=False)
+            for protected_root, isolated_root in protected_roots:
+                if resolved == protected_root or protected_root in resolved.parents:
+                    monkeypatch.setattr(module, attribute, isolated_root / resolved.relative_to(protected_root))
+                    break
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -302,6 +302,14 @@ class TestEnrichSingle:
 class TestStoreAutoEnrich:
     """Test that brain_store's background thread triggers auto-enrichment."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_store_paths(self, tmp_path, monkeypatch):
+        """Keep shared queue pressure and legacy flushes out of these store tests."""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setenv("BRAINLAYER_DB", str(tmp_path / "test.db"))
+
     @pytest.mark.asyncio
     async def test_store_triggers_enrich_single(self, tmp_path, monkeypatch):
         """_store's background thread calls enrich_single after embedding."""

--- a/tests/test_chunk_lifecycle.py
+++ b/tests/test_chunk_lifecycle.py
@@ -319,9 +319,13 @@ class TestBrainArchiveHandler:
 
 class TestStoreWithSupersedes:
     @pytest.fixture(autouse=True)
-    def _patch(self, store, mock_embed, monkeypatch):
+    def _patch(self, store, mock_embed, monkeypatch, tmp_path):
         self.store = store
         self.mock_embed = mock_embed
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        monkeypatch.setenv("BRAINLAYER_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setenv("BRAINLAYER_DB", str(store.db_path))
         monkeypatch.setattr(
             "brainlayer.mcp.store_handler._get_vector_store",
             lambda: store,

--- a/tests/test_cli_direct_sqlite.py
+++ b/tests/test_cli_direct_sqlite.py
@@ -212,6 +212,10 @@ def test_cli_stats_p95_under_200ms_with_direct_readonly_store(monkeypatch: pytes
     monkeypatch.setattr(cli_new, "ReadonlyStore", FastStatsStore)
 
     runner = CliRunner()
+    warmup = runner.invoke(app, ["stats"])
+    assert warmup.exit_code == 0, warmup.output
+    calls.clear()
+
     durations: list[float] = []
     for _ in range(10):
         start = time.perf_counter()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -17,14 +17,11 @@ class TestGetDbPath:
         with patch.dict(os.environ, {"BRAINLAYER_DB": str(db_path)}):
             assert get_db_path() == db_path
 
-    def test_canonical_path_fresh_install(self, tmp_path):
+    def test_canonical_path_fresh_install(self, tmp_path, monkeypatch):
         """Canonical path used when no DB exists yet."""
         canonical = tmp_path / "brainlayer" / "brainlayer.db"
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            patch("brainlayer.paths._CANONICAL_DB_PATH", canonical),
-        ):
-            os.environ.pop("BRAINLAYER_DB", None)
+        with patch("brainlayer.paths._CANONICAL_DB_PATH", canonical):
+            monkeypatch.delenv("BRAINLAYER_DB", raising=False)
             result = get_db_path()
             assert result == canonical
             assert canonical.parent.exists()  # Parent dir created

--- a/tests/test_phase3_qa.py
+++ b/tests/test_phase3_qa.py
@@ -33,13 +33,12 @@ class TestDBPathResolution:
         with patch.dict(os.environ, {"BRAINLAYER_DB": custom}):
             assert get_db_path() == Path(custom)
 
-    def test_canonical_path_for_fresh_install(self, tmp_path):
+    def test_canonical_path_for_fresh_install(self, tmp_path, monkeypatch):
         """Canonical path should be used for fresh installs."""
-        with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("BRAINLAYER_DB", None)
-            with patch("brainlayer.paths._CANONICAL_DB_PATH", tmp_path / "canonical.db"):
-                result = get_db_path()
-                assert result == tmp_path / "canonical.db"
+        monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+        with patch("brainlayer.paths._CANONICAL_DB_PATH", tmp_path / "canonical.db"):
+            result = get_db_path()
+            assert result == tmp_path / "canonical.db"
 
 
 # ============================================================================

--- a/tests/test_pytest_path_isolation.py
+++ b/tests/test_pytest_path_isolation.py
@@ -1,0 +1,63 @@
+"""Regression tests for fail-closed pytest runtime path isolation."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def test_unit_runtime_paths_are_isolated_under_tmp_path(tmp_path: Path) -> None:
+    from brainlayer.drain import _default_drain_health_path, _default_log_path
+    from brainlayer.paths import get_db_path
+    from brainlayer.queue_io import get_queue_dir
+
+    assert os.environ["BRAINLAYER_TEST_PATH_PROVENANCE"] == "pytest"
+    isolated_home = Path.home()
+    protected_home = Path(os.environ["BRAINLAYER_TEST_PROTECTED_HOME"])
+    assert isolated_home != protected_home
+    assert get_db_path().is_relative_to(isolated_home)
+    assert get_queue_dir().is_relative_to(isolated_home)
+    assert _default_log_path().is_relative_to(isolated_home)
+    assert _default_drain_health_path().is_relative_to(isolated_home)
+
+
+def test_pytest_path_guard_rejects_production_brainlayer_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from brainlayer.paths import _guard_test_runtime_path
+
+    protected_home = tmp_path / "captured-real-home"
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/test_example.py::test_guard (call)")
+    monkeypatch.setenv("BRAINLAYER_TEST_PATH_PROVENANCE", "pytest")
+    monkeypatch.setenv("BRAINLAYER_TEST_PROTECTED_HOME", str(protected_home))
+
+    for path in (
+        protected_home / ".brainlayer" / "queue",
+        protected_home / ".brainlayer" / "logs" / "drain.log",
+        protected_home / ".local" / "share" / "brainlayer" / "brainlayer.db",
+    ):
+        with pytest.raises(RuntimeError, match="production BrainLayer path"):
+            _guard_test_runtime_path(path, source="regression test")
+
+    safe_path = tmp_path / "isolated" / "brainlayer.db"
+    assert _guard_test_runtime_path(safe_path, source="regression test") == safe_path
+
+
+def test_pytest_path_guard_requires_provenance(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from brainlayer.paths import _guard_test_runtime_path
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/test_example.py::test_guard (call)")
+    monkeypatch.delenv("BRAINLAYER_TEST_PATH_PROVENANCE", raising=False)
+
+    with pytest.raises(RuntimeError, match="provenance"):
+        _guard_test_runtime_path(tmp_path / "otherwise-safe.db", source="regression test")
+
+
+def test_index_defaults_resolve_database_path_at_call_time(tmp_path: Path) -> None:
+    import inspect
+
+    from brainlayer import index_new
+
+    index_default = inspect.signature(index_new.index_chunks_to_sqlite).parameters["db_path"].default
+    stats_default = inspect.signature(index_new.get_stats).parameters["db_path"].default
+
+    assert index_default is None
+    assert stats_default is None


### PR DESCRIPTION
## Why

The pre-push gate was failing for **every branch in this repo**, blocking four verified lanes. Root cause: **tests resolve production paths**, so their outcome depended on live system state rather than on the code.

The mechanism, proven with a controlled pair by `@review-633`: `queue_io.get_queue_dir()` falls back to `~/.brainlayer/queue` when `BRAINLAYER_QUEUE_DIR` is unset, so a real backlog triggered `_queue_has_background_pressure()` and diverted `_store_new()` down the `DEFERRED` path before each test's own patches applied.

- isolated queue dir **with accumulated events** → 5 failed
- isolated queue dir **empty** → `5 passed in 14.28s`

That is why the failure set varied all day — it was a function of ingestion volume, not of any diff.

## What

Function-scoped (`tmp_path`, per test) isolation for the production paths reachable from tests: DB, queue dir, drain log, backup log, writer telemetry, health paths. Follows the pattern already shipped in this repo for the backup log (`CLAUDE.md:125-127`) — env override **plus** a provenance marker (`BRAINLAYER_TEST_PATH_PROVENANCE=pytest`) so a miss is loud rather than silent.

`tests/test_pytest_path_isolation.py` (new) tests the guard itself, so the guard is not one more thing that reports success without being verified.

**The p95 threshold in `test_cli_direct_sqlite.py` is unchanged at 200 ms** — warmup was added instead. Loosening the assertion to make the gate pass was explicitly out of scope.

## Verification

```
cd /Users/etanheyman/Gits/worktrees/bl-push-blocker
git push -u origin fix/push-blocker-tests     # full pre-push gate, NO env overrides
→ 3671 passed, 9 skipped, 61 deselected, 1 xfailed in 768.52s — 0 failed
```
Also run by me, bare, against a **live 399-deep production queue** — the condition that previously failed:
```
uv run --extra dev pytest <the 6 blocker tests + the new guard> -q  → 20 passed in 16.92s
```
No `--no-verify` at any point.

## Scope — deliberately incomplete, and filed

This clears the paths that were **breaking the gate**. It does **not** close the class. Seven sites remain in two classes, tracked as **item 21** on `docs.local/plan/cleanup-2026-08-02/collab.md`:

- **Class A — hardcoded** (`health_check.py:131`, `maintenance.py:89`, `writer_telemetry.py:72`, `watcher.py:976`, `cli/__init__.py:787,856`) — findable by grep.
- **Class B — derived** (`store_handler.py:443` → `get_db_path().parent / "pending-stores.jsonl"`) — **contains no literal production path**, honours `BRAINLAYER_DB`, passes any static audit, and still writes beside the production DB. A grep sweep would close A and leave B.

Plus a split-brain in this fix: `conftest` sets both an isolated `HOME` **and** `BRAINLAYER_*` env vars, so `~`-rooted and env-driven resolution can disagree.

The follow-up should be a **runtime** guard that fails a test the moment any *resolved* path lands under a production root, regardless of derivation — the `BRAINLAYER_TEST_PATH_PROVENANCE` hook is already wired here for exactly that.

## Authorship / review

Implemented by a headless Codex worker under `@bl-cleanup`; the lead verified and pushed but did not author it. Review routed by `@bl-cleanup` — nobody reviews their own code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default path resolution for drain env overrides and central pytest guards; production runs are unaffected, but misconfigured test provenance could raise at runtime during pytest.
> 
> **Overview**
> Stops unit tests from touching **production** DB, queue, and drain paths by wiring a **fail-closed pytest guard** and per-test isolation.
> 
> **Runtime resolvers** (`get_db_path`, `get_queue_dir`, drain log/health defaults) now call `_guard_test_runtime_path`, which raises if pytest resolves paths under the captured real home (`~/.brainlayer`, `~/.local/share/brainlayer`) unless provenance is `live`. Drain log and health paths also honor `BRAINLAYER_DRAIN_LOG_PATH` and `BRAINLAYER_DRAIN_HEALTH_PATH`.
> 
> **Autouse `conftest` fixture** (`isolate_brainlayer_runtime_paths`) swaps `HOME`, sets `BRAINLAYER_*` overrides and `BRAINLAYER_TEST_PATH_PROVENANCE=pytest`, patches import-time cached `DEFAULT_DB_PATH` / `_CANONICAL_DB_PATH`, and rewrites any `brainlayer` module `Path` attributes still pointing at protected roots. Integration/live tests skip isolation via markers.
> 
> **`index_new`** no longer defaults `db_path` to import-time `DEFAULT_DB_PATH`; it uses `None` and `get_db_path()` at call time so isolation applies after fixtures run.
> 
> **Tests:** new `test_pytest_path_isolation.py`, explicit queue/DB env in store tests, path tests use `monkeypatch`, CLI stats benchmark adds a warmup invoke without changing the 200 ms p95 budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc1901b4db4ee4bb3cad1a87010c32f99cf5c2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate BrainLayer runtime paths under pytest to unblock the pre-push gate
> - Adds `_guard_test_runtime_path` in [`paths.py`](https://github.com/EtanHey/brainlayer/pull/640/files#diff-26b8cceb0bbe0c102f16127888d2981f30ed3f4e2d47d3d929a6b7bc958a5677) that raises `RuntimeError` when pytest code resolves a protected production path (`~/.brainlayer` or `~/.local/share/brainlayer`) without explicit provenance opt-in.
> - Adds `isolate_brainlayer_runtime_paths` autouse fixture in [`conftest.py`](https://github.com/EtanHey/brainlayer/pull/640/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) that creates an isolated `HOME` and sets env overrides (`BRAINLAYER_DB`, `BRAINLAYER_QUEUE_DIR`, `BRAINLAYER_DRAIN_LOG_PATH`, `BRAINLAYER_DRAIN_HEALTH_PATH`) for all non-integration tests, plus patches cached module-level `Path` constants.
> - Switches `index_new.py` and `drain.py` path defaults from import-time constants to call-time resolvers so env overrides are honored.
> - Adds [`tests/test_pytest_path_isolation.py`](https://github.com/EtanHey/brainlayer/pull/640/files#diff-9d93fbce7f80c04a3790522b05ac281b83d95f7fd31bda11140a1a963a0c9280) to regression-test the guard and call-time resolution.
> - Risk: any test (or production call path invoked in tests) that resolves a protected path without setting `BRAINLAYER_TEST_PATH_PROVENANCE` will now fail fast with `RuntimeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cc1901.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database, queue, log, and health-check locations can now be configured through environment settings.
  * User-directory paths are expanded automatically, and database operations resolve the current configured location at runtime.
  * Existing default locations remain available when no configuration is provided.

* **Bug Fixes**
  * Improved path validation helps prevent accidental use of protected or unintended runtime locations.
  * Database statistics and indexing now consistently use the selected database path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->