### PR TITLE
fix(store): link brain_store writes to MCP sessions + make deferred BrainBar stores idempotent (items 6+7)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -808,7 +808,8 @@ final class BrainDatabase: @unchecked Sendable {
                     source_uri TEXT,
                     status TEXT DEFAULT 'active',
                     ingested_at INTEGER,
-                    topic_cluster TEXT
+                    topic_cluster TEXT,
+                    content_hash TEXT
                 )
             """)
         }
@@ -1305,11 +1306,12 @@ final class BrainDatabase: @unchecked Sendable {
         guard let db else { throw DBError.notOpen }
         let chunkID = chunkID ?? Self.makeChunkID()
         let createdAt = createdAt ?? Self.timestamp()
+        let contentHash = Self.bodySHA256(content)
         let tagsJSON = (try? encodeJSON(tags)) ?? "[]"
         let metadataJSON = Self.storeMetadataJSON(queueID: queueID)
         let sql = """
-            INSERT INTO chunks (id, content, metadata, source_file, project, tags, importance, source, content_type, char_count, created_at, preview_text, conversation_id, position)
-            VALUES (?, ?, ?, 'brainbar-store', ?, ?, ?, ?, 'user_message', ?, ?, ?, ?, ?)
+            INSERT INTO chunks (id, content, metadata, source_file, project, tags, importance, source, content_type, char_count, created_at, preview_text, conversation_id, position, content_hash)
+            VALUES (?, ?, ?, 'brainbar-store', ?, ?, ?, ?, 'user_message', ?, ?, ?, ?, ?, ?)
         """
         let previousBusyTimeout = busyTimeoutMillis.flatMap { _ in queryPragma(db, name: "busy_timeout") }
         if let busyTimeoutMillis {
@@ -1322,6 +1324,20 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         return try withImmediateTransaction(retries: retries) {
+            // DEFERRED is a durable success receipt, but a client may still retry it.
+            // Reuse the exact-content row within this server-owned session so replay plus retry
+            // cannot double-store, while distinct legacy queue entries remain distinct.
+            if let conversationID {
+                if let existing = try storedChunk(
+                    contentHash: contentHash,
+                    project: project,
+                    contentType: "user_message",
+                    conversationID: conversationID,
+                    on: db
+                ) {
+                    return existing
+                }
+            }
             let position = try nextPosition(conversationID: conversationID, on: db)
             try runWriteStatement(on: db, sql: sql, retries: retries) { stmt in
                 bindText(chunkID, to: stmt, index: 1)
@@ -1348,6 +1364,7 @@ final class BrainDatabase: @unchecked Sendable {
                 } else {
                     sqlite3_bind_null(stmt, 12)
                 }
+                bindText(contentHash, to: stmt, index: 13)
             }
             if failNextStoreAfterInsertForTesting {
                 failNextStoreAfterInsertForTesting = false
@@ -4611,6 +4628,54 @@ final class BrainDatabase: @unchecked Sendable {
         bindText(conversationID, to: stmt, index: 1)
         guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
         return sqlite3_column_int64(stmt, 0)
+    }
+
+    private func storedChunk(
+        contentHash: String,
+        project: String?,
+        contentType: String,
+        conversationID: String,
+        on db: OpaquePointer
+    ) throws -> StoredChunk? {
+        var stmt: OpaquePointer?
+        let sql = """
+            SELECT id, rowid
+            FROM chunks
+            WHERE content_hash = ?
+              AND project IS ?
+              AND content_type = ?
+              AND conversation_id = ?
+              AND COALESCE(status, 'active') = 'active'
+              AND COALESCE(archived, 0) = 0
+              AND superseded_by IS NULL
+              AND aggregated_into IS NULL
+              AND archived_at IS NULL
+            ORDER BY created_at ASC, id ASC
+            LIMIT 1
+        """
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+
+        bindText(contentHash, to: stmt, index: 1)
+        if let project {
+            bindText(project, to: stmt, index: 2)
+        } else {
+            sqlite3_bind_null(stmt, 2)
+        }
+        bindText(contentType, to: stmt, index: 3)
+        bindText(conversationID, to: stmt, index: 4)
+
+        let stepRC = sqlite3_step(stmt)
+        switch stepRC {
+        case SQLITE_ROW:
+            guard let chunkID = columnText(stmt, 0) else { throw DBError.noResult }
+            return StoredChunk(chunkID: chunkID, rowID: sqlite3_column_int64(stmt, 1))
+        case SQLITE_DONE:
+            return nil
+        default:
+            throw DBError.step(stepRC)
+        }
     }
 
     private static func deterministicPendingStoreQueueID(

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -614,6 +614,7 @@ final class BrainDatabase: @unchecked Sendable {
         let queuedAt: String?
         let createdAt: String?
         let chunkID: String?
+        let conversationID: String?
 
         enum CodingKeys: String, CodingKey {
             case content
@@ -625,6 +626,7 @@ final class BrainDatabase: @unchecked Sendable {
             case queuedAt = "queued_at"
             case createdAt = "created_at"
             case chunkID = "chunk_id"
+            case conversationID = "conversation_id"
         }
 
         init(
@@ -636,7 +638,8 @@ final class BrainDatabase: @unchecked Sendable {
             queueID: String? = nil,
             queuedAt: String? = nil,
             createdAt: String? = nil,
-            chunkID: String? = nil
+            chunkID: String? = nil,
+            conversationID: String? = nil
         ) {
             self.content = content
             self.tags = tags
@@ -647,6 +650,7 @@ final class BrainDatabase: @unchecked Sendable {
             self.queuedAt = queuedAt
             self.createdAt = createdAt
             self.chunkID = chunkID
+            self.conversationID = conversationID
         }
 
         init(from decoder: Decoder) throws {
@@ -660,6 +664,7 @@ final class BrainDatabase: @unchecked Sendable {
             queuedAt = try container.decodeIfPresent(String.self, forKey: .queuedAt)
             createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
             chunkID = try container.decodeIfPresent(String.self, forKey: .chunkID)
+            conversationID = try container.decodeIfPresent(String.self, forKey: .conversationID)
         }
     }
 
@@ -1292,6 +1297,7 @@ final class BrainDatabase: @unchecked Sendable {
         chunkID: String? = nil,
         queueID: String? = nil,
         createdAt: String? = nil,
+        conversationID: String? = nil,
         refreshStatistics: Bool = true,
         retries: Int = 3,
         busyTimeoutMillis: Int32? = nil
@@ -1302,8 +1308,8 @@ final class BrainDatabase: @unchecked Sendable {
         let tagsJSON = (try? encodeJSON(tags)) ?? "[]"
         let metadataJSON = Self.storeMetadataJSON(queueID: queueID)
         let sql = """
-            INSERT INTO chunks (id, content, metadata, source_file, project, tags, importance, source, content_type, char_count, created_at, preview_text)
-            VALUES (?, ?, ?, 'brainbar-store', ?, ?, ?, ?, 'user_message', ?, ?, ?)
+            INSERT INTO chunks (id, content, metadata, source_file, project, tags, importance, source, content_type, char_count, created_at, preview_text, conversation_id, position)
+            VALUES (?, ?, ?, 'brainbar-store', ?, ?, ?, ?, 'user_message', ?, ?, ?, ?, ?)
         """
         let previousBusyTimeout = busyTimeoutMillis.flatMap { _ in queryPragma(db, name: "busy_timeout") }
         if let busyTimeoutMillis {
@@ -1316,6 +1322,7 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         return try withImmediateTransaction(retries: retries) {
+            let position = try nextPosition(conversationID: conversationID, on: db)
             try runWriteStatement(on: db, sql: sql, retries: retries) { stmt in
                 bindText(chunkID, to: stmt, index: 1)
                 bindText(content, to: stmt, index: 2)
@@ -1331,6 +1338,16 @@ final class BrainDatabase: @unchecked Sendable {
                 sqlite3_bind_int(stmt, 8, Int32(content.count))
                 bindText(createdAt, to: stmt, index: 9)
                 bindText(Self.previewText(summary: "", content: content), to: stmt, index: 10)
+                if let conversationID {
+                    bindText(conversationID, to: stmt, index: 11)
+                } else {
+                    sqlite3_bind_null(stmt, 11)
+                }
+                if let position {
+                    sqlite3_bind_int64(stmt, 12, position)
+                } else {
+                    sqlite3_bind_null(stmt, 12)
+                }
             }
             if failNextStoreAfterInsertForTesting {
                 failNextStoreAfterInsertForTesting = false
@@ -1352,6 +1369,7 @@ final class BrainDatabase: @unchecked Sendable {
         importance: Int,
         source: String,
         project: String? = nil,
+        conversationID: String? = nil,
         busyTimeoutMillis: Int32 = 30_000,
         retries: Int = 3
     ) throws -> StoreWriteOutcome {
@@ -1370,6 +1388,7 @@ final class BrainDatabase: @unchecked Sendable {
                 project: project,
                 chunkID: chunkID,
                 createdAt: createdAt,
+                conversationID: conversationID,
                 refreshStatistics: true,
                 retries: retries,
                 busyTimeoutMillis: busyTimeoutMillis
@@ -1386,7 +1405,8 @@ final class BrainDatabase: @unchecked Sendable {
                 source: source,
                 project: project,
                 createdAt: createdAt,
-                chunkID: chunkID
+                chunkID: chunkID,
+                conversationID: conversationID
             )
             return .queued(queueID: queued.queueID, queuedAt: queued.queuedAt, chunkID: queued.chunkID)
         }
@@ -1440,7 +1460,8 @@ final class BrainDatabase: @unchecked Sendable {
         source: String,
         project: String? = nil,
         createdAt: String? = nil,
-        chunkID: String? = nil
+        chunkID: String? = nil,
+        conversationID: String? = nil
     ) throws -> (queueID: String, queuedAt: String, chunkID: String) {
         try Self.queuePendingStore(
             dbPath: path,
@@ -1450,7 +1471,8 @@ final class BrainDatabase: @unchecked Sendable {
             source: source,
             project: project,
             createdAt: createdAt,
-            chunkID: chunkID
+            chunkID: chunkID,
+            conversationID: conversationID
         )
     }
 
@@ -1471,7 +1493,8 @@ final class BrainDatabase: @unchecked Sendable {
         source: String,
         project: String? = nil,
         createdAt: String? = nil,
-        chunkID: String? = nil
+        chunkID: String? = nil,
+        conversationID: String? = nil
     ) throws -> (queueID: String, queuedAt: String, chunkID: String) {
         Self.pendingStoreFileLock.lock()
         defer { Self.pendingStoreFileLock.unlock() }
@@ -1494,7 +1517,8 @@ final class BrainDatabase: @unchecked Sendable {
             queueID: queueID,
             queuedAt: queuedAt,
             createdAt: createdAt,
-            chunkID: chunkID
+            chunkID: chunkID,
+            conversationID: conversationID
         )
         var line = try JSONEncoder().encode(item)
         line.append(0x0A)
@@ -1562,6 +1586,7 @@ final class BrainDatabase: @unchecked Sendable {
                             chunkID: chunkID,
                             queueID: queueID,
                             createdAt: item.createdAt ?? item.queuedAt,
+                            conversationID: item.conversationID,
                             refreshStatistics: false,
                             retries: retries,
                             busyTimeoutMillis: busyTimeoutMillis
@@ -4569,9 +4594,23 @@ final class BrainDatabase: @unchecked Sendable {
             queueID: queueID,
             queuedAt: item.queuedAt,
             createdAt: item.createdAt ?? item.queuedAt,
-            chunkID: chunkID
+            chunkID: chunkID,
+            conversationID: item.conversationID
         )
         return try? JSONEncoder().encode(replayItem)
+    }
+
+    private func nextPosition(conversationID: String?, on db: OpaquePointer) throws -> Int64? {
+        guard let conversationID else { return nil }
+        var stmt: OpaquePointer?
+        let sql = "SELECT COALESCE(MAX(position), -1) + 1 FROM chunks WHERE conversation_id = ?"
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw DBError.prepare(rc) }
+        defer { sqlite3_finalize(stmt) }
+
+        bindText(conversationID, to: stmt, index: 1)
+        guard sqlite3_step(stmt) == SQLITE_ROW else { throw DBError.noResult }
+        return sqlite3_column_int64(stmt, 0)
     }
 
     private static func deterministicPendingStoreQueueID(

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -58,6 +58,11 @@ final class MCPRouter: @unchecked Sendable {
     final class PaletteSession: @unchecked Sendable {
         private let lock = NSLock()
         private var expanded = false
+        let conversationID: String
+
+        init(conversationID: String = "mcp-\(UUID().uuidString.lowercased())") {
+            self.conversationID = conversationID
+        }
 
         func isExpanded() -> Bool {
             lock.lock()
@@ -403,7 +408,7 @@ final class MCPRouter: @unchecked Sendable {
         // Dispatch to handler
         do {
             try Self.validate(arguments: arguments, for: toolName)
-            let output = try dispatchTool(name: toolName, arguments: arguments)
+            let output = try dispatchTool(name: toolName, arguments: arguments, session: session)
             return toolCallResult(id: id, output: output)
         } catch {
             return [
@@ -435,12 +440,16 @@ final class MCPRouter: @unchecked Sendable {
         ]
     }
 
-    private func dispatchTool(name: String, arguments: [String: Any]) throws -> ToolOutput {
+    private func dispatchTool(
+        name: String,
+        arguments: [String: Any],
+        session: PaletteSession
+    ) throws -> ToolOutput {
         switch name {
         case "brain_search":
             return try handleBrainSearch(arguments)
         case "brain_store":
-            return try handleBrainStore(arguments)
+            return try handleBrainStore(arguments, session: session)
         case "brain_get_person":
             return try handleBrainGetPerson(arguments)
         case "brain_recall":
@@ -691,7 +700,7 @@ final class MCPRouter: @unchecked Sendable {
         return arguments
     }
 
-    private func handleBrainStore(_ args: [String: Any]) throws -> ToolOutput {
+    private func handleBrainStore(_ args: [String: Any], session: PaletteSession) throws -> ToolOutput {
         guard let content = args["content"] as? String else {
             throw ToolError.missingParameter("content")
         }
@@ -705,6 +714,7 @@ final class MCPRouter: @unchecked Sendable {
                 importance: importance,
                 source: "mcp",
                 project: project,
+                conversationID: session.conversationID,
                 reason: "DB_NOT_OPEN"
             )
         }
@@ -716,6 +726,7 @@ final class MCPRouter: @unchecked Sendable {
                 importance: importance,
                 source: "mcp",
                 project: project,
+                conversationID: session.conversationID,
                 busyTimeoutMillis: Self.mcpStoreBusyTimeoutMillis,
                 retries: Self.mcpStoreRetries
             ) {
@@ -761,6 +772,7 @@ final class MCPRouter: @unchecked Sendable {
                 importance: importance,
                 source: "mcp",
                 project: project,
+                conversationID: session.conversationID,
                 reason: "DB_NOT_OPEN"
             )
         }
@@ -863,6 +875,7 @@ final class MCPRouter: @unchecked Sendable {
         importance: Int,
         source: String,
         project: String?,
+        conversationID: String,
         reason: String
     ) throws -> ToolOutput {
         guard let dbPath else {
@@ -874,7 +887,8 @@ final class MCPRouter: @unchecked Sendable {
             tags: tags,
             importance: importance,
             source: source,
-            project: project
+            project: project,
+            conversationID: conversationID
         )
         return queuedBrainStoreOutput(
             queueID: queued.queueID,

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -2014,6 +2014,57 @@ No results found.
         XCTAssertTrue(queuedText.contains(chunkID))
     }
 
+    func testDeferredBrainStoreRetryReusesQueuedChunkInsteadOfCreatingSecondRow() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+        db.failNextStoreWithBusyForTesting = true
+
+        let router = MCPRouter(profile: "full")
+        router.setDatabase(db)
+        let session = router.makePaletteSession()
+        let content = "A client retry after DEFERRED must resolve to the queued chunk"
+        let arguments: [String: Any] = [
+            "content": content,
+            "tags": ["deferred-retry"],
+            "importance": 7,
+        ]
+
+        let deferredResponse = router.handle(
+            toolCall(id: 223, name: "brain_store", arguments: arguments),
+            session: session
+        )
+        let deferred = try XCTUnwrap(deferredResponse["result"] as? [String: Any])
+        XCTAssertEqual(deferred["status"] as? String, "DEFERRED")
+        let queuedChunkID = try XCTUnwrap(deferred["chunk_id"] as? String)
+
+        _ = db.flushPendingStores()
+        XCTAssertEqual(try chunkContents(path: dbPath).filter { $0 == content }.count, 1)
+
+        let retryResponse = router.handle(
+            toolCall(id: 224, name: "brain_store", arguments: arguments),
+            session: session
+        )
+        let retryResult = try XCTUnwrap(retryResponse["result"] as? [String: Any])
+        XCTAssertNil(retryResult["isError"])
+        XCTAssertNotEqual(retryResult["status"] as? String, "DEFERRED")
+        let stored = try XCTUnwrap(retryResult["_brainbarStoredChunk"] as? [String: Any])
+
+        XCTAssertEqual(stored["chunk_id"] as? String, queuedChunkID)
+        XCTAssertEqual(
+            try chunkContents(path: dbPath).filter { $0 == content }.count,
+            1,
+            "retrying a durable DEFERRED receipt must not create a second chunk"
+        )
+    }
+
     func testBrainStoreMCPWriteBudgetQueuesPromptlyUnderSQLiteLock() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -784,6 +784,51 @@ No results found.
         XCTAssertFalse(expandText.contains("\u{2502} Short generated summary"), expandText)
     }
 
+    func testBrainStoreUsesServerSessionForExpandableOrderedContext() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-store-session-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+
+        let router = MCPRouter(profile: "full")
+        router.setDatabase(db)
+        let session = router.makePaletteSession()
+        let contents = [
+            "R1-C session context before",
+            "R1-C session context target",
+            "R1-C session context after",
+        ]
+        var chunkIDs: [String] = []
+
+        for (index, content) in contents.enumerated() {
+            let response = router.handle(
+                toolCall(id: 320 + index, name: "brain_store", arguments: [
+                    "content": content,
+                    "project": "brainlayer",
+                    "conversation_id": "client-forged-session",
+                ]),
+                session: session
+            )
+            let result = try XCTUnwrap(response["result"] as? [String: Any])
+            XCTAssertNil(result["isError"])
+            let stored = try XCTUnwrap(result["_brainbarStoredChunk"] as? [String: Any])
+            chunkIDs.append(try XCTUnwrap(stored["chunk_id"] as? String))
+        }
+
+        let expanded = try db.expandChunk(id: chunkIDs[1], before: 1, after: 1)
+        let before = try XCTUnwrap(expanded["before_context"] as? [[String: Any]])
+        let after = try XCTUnwrap(expanded["after_context"] as? [[String: Any]])
+        XCTAssertEqual(before.map { $0["content"] as? String }, [contents[0]])
+        XCTAssertEqual(after.map { $0["content"] as? String }, [contents[2]])
+
+        let states = try chunkSessionStates(path: tempDB)
+        XCTAssertEqual(states.map(\.content), contents)
+        XCTAssertEqual(Set(states.compactMap(\.conversationID)).count, 1)
+        XCTAssertEqual(states.compactMap(\.position), [0, 1, 2])
+        XCTAssertFalse(states.contains { $0.conversationID == nil || $0.conversationID?.isEmpty == true })
+        XCTAssertFalse(states.contains { $0.conversationID == "client-forged-session" })
+    }
+
     /// Regression: brain_search(unread_only) marks messages delivered (a write).
     /// It must run on the writable connection, not the read-only read handle —
     /// otherwise markDelivered fails with `SQLite step failed: 8` (SQLITE_READONLY).
@@ -2701,6 +2746,40 @@ private func chunkContents(path: String) throws -> [String] {
         if let value = sqlite3_column_text(stmt, 0) {
             results.append(String(cString: value))
         }
+    }
+    return results
+}
+
+private struct ChunkSessionState: Equatable {
+    let content: String
+    let conversationID: String?
+    let position: Int64?
+}
+
+private func chunkSessionStates(path: String) throws -> [ChunkSessionState] {
+    var db: OpaquePointer?
+    let rc = sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil)
+    guard rc == SQLITE_OK, let db else {
+        throw NSError(domain: "MCPRouterTests", code: Int(rc))
+    }
+    defer { sqlite3_close(db) }
+
+    var stmt: OpaquePointer?
+    let sql = "SELECT content, conversation_id, position FROM chunks ORDER BY rowid ASC"
+    let prepareRC = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+    guard prepareRC == SQLITE_OK else {
+        throw NSError(domain: "MCPRouterTests", code: Int(prepareRC))
+    }
+    defer { sqlite3_finalize(stmt) }
+
+    var results: [ChunkSessionState] = []
+    while sqlite3_step(stmt) == SQLITE_ROW {
+        let content = sqlite3_column_text(stmt, 0).map { String(cString: $0) } ?? ""
+        let conversationID = sqlite3_column_text(stmt, 1).map { String(cString: $0) }
+        let position = sqlite3_column_type(stmt, 2) == SQLITE_NULL ? nil : sqlite3_column_int64(stmt, 2)
+        results.append(
+            ChunkSessionState(content: content, conversationID: conversationID, position: position)
+        )
     }
     return results
 }

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -736,6 +736,18 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     supersedes = event.get("supersedes") or metadata.get("supersedes")
     tags = event.get("tags")
     explicit_chunk_origin = event.get("chunk_origin") or metadata.get("chunk_origin")
+    conversation_id = event.get("conversation_id") or metadata.get("conversation_id")
+    position = None
+    if conversation_id:
+        position_row = conn.execute(
+            """
+            SELECT COALESCE(MAX(position), -1) + 1
+            FROM chunks
+            WHERE conversation_id = ?
+            """,
+            (conversation_id,),
+        ).fetchone()
+        position = int(position_row[0]) if position_row else 0
     existing = conn.execute("SELECT content FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
     if existing:
         if str(existing[0]).strip() == content:
@@ -774,6 +786,8 @@ def _apply_store(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
             "tags": json.dumps(tags) if tags else None,
             "importance": float(event["importance"]) if event.get("importance") is not None else None,
             "content_hash": _content_hash(content),
+            "conversation_id": conversation_id,
+            "position": position,
             "chunk_origin": detect_chunk_origin(content, explicit_chunk_origin),
         },
     )

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import uuid
 from copy import deepcopy
 from typing import Any
 
@@ -177,6 +178,32 @@ server = Server(
     on_call_tool=_handle_call_tool_request,
     on_completion=_handle_completion_request,
 )
+
+_MCP_PROCESS_SESSION_ID = f"mcp-{uuid.uuid4().hex}"
+
+
+def _server_owned_conversation_id(session: Any) -> str:
+    """Return one stable identifier for all requests on an MCP connection."""
+    connection = getattr(session, "_connection", None)
+    state = getattr(connection, "state", None)
+    if not isinstance(state, dict):
+        return _MCP_PROCESS_SESSION_ID
+
+    state_key = "brainlayer_conversation_id"
+    session_id = state.get(state_key)
+    if session_id is None:
+        session_id = f"mcp-{uuid.uuid4().hex}"
+        state[state_key] = session_id
+    return str(session_id)
+
+
+def _calling_session_id() -> str:
+    """Return a server-owned identifier for the active MCP transport session."""
+    try:
+        session = server.request_context.session
+    except (AttributeError, LookupError):
+        return _MCP_PROCESS_SESSION_ID
+    return _server_owned_conversation_id(session)
 
 # Tool annotations
 _MAX_FULL_CONTENT_RESULT_CHARS = 250_000
@@ -1480,6 +1507,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
             line_number=max(1, ln) if ln is not None else None,
             supersedes=arguments.get("supersedes"),
             agent_id=arguments.get("agent_id"),
+            conversation_id=_calling_session_id(),
         )
 
     elif name == "brain_supersede":
@@ -1754,6 +1782,7 @@ async def call_tool(name: str, arguments: dict[str, Any]):
             project=arguments.get("project"),
             tags=arguments.get("tags"),
             importance=max(1, min(imp, 10)) if imp is not None else None,
+            conversation_id=_calling_session_id(),
         )
 
     else:

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -175,6 +175,7 @@ async def _store_new(
     line_number: int | None = None,
     supersedes: str | None = None,
     agent_id: str | None = None,
+    conversation_id: str | None = None,
 ):
     """Wrapper for _store with auto-type detection and auto-importance."""
     resolved_type = memory_type or _detect_memory_type(content)
@@ -204,6 +205,7 @@ async def _store_new(
         function_name=function_name,
         line_number=line_number,
         supersedes=supersedes,
+        conversation_id=conversation_id,
     )
 
 
@@ -710,6 +712,7 @@ def _flush_pending_stores(store, embed_fn) -> int:
                     chunk_id=item.get("chunk_id"),
                     created_at=_reservation_created_at(item),
                     chunk_origin=item.get("chunk_origin") or item_metadata.get("chunk_origin"),
+                    conversation_id=item.get("conversation_id"),
                 )
                 if item.get("supersedes"):
                     if not store.supersede_chunk(item["supersedes"], result["id"]):
@@ -818,6 +821,7 @@ async def _store(
     function_name: str | None = None,
     line_number: int | None = None,
     supersedes: str | None = None,
+    conversation_id: str | None = None,
 ):
     """Store a memory into BrainLayer with deferred embedding.
 
@@ -851,6 +855,7 @@ async def _store(
                     "line_number": line_number,
                     "supersedes": supersedes,
                     "created_at": reservation_created_at,
+                    "conversation_id": conversation_id,
                 }
             )
             _clear_hybrid_search_cache_if_loaded()
@@ -888,6 +893,7 @@ async def _store(
             line_number=line_number,
             chunk_id=promised_chunk_id,
             created_at=reservation_created_at,
+            conversation_id=conversation_id,
         )
 
         chunk_id = result["id"]
@@ -980,6 +986,7 @@ async def _store(
                     "line_number": line_number,
                     "supersedes": supersedes,
                     "created_at": reservation_created_at,
+                    "conversation_id": conversation_id,
                 }
             )
             structured = _deferred_store_receipt(promised_chunk_id, queue_path)

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -69,6 +69,7 @@ def enqueue_store(
 ) -> Path:
     supersedes = metadata.pop("supersedes", None)
     chunk_origin = metadata.pop("chunk_origin", None)
+    conversation_id = metadata.pop("conversation_id", None)
     chunk_id = metadata.pop("chunk_id", None) or f"manual-{uuid.uuid4().hex[:16]}"
     created_at = created_at or datetime.now(timezone.utc).isoformat()
     return enqueue_jsonl(
@@ -82,6 +83,7 @@ def enqueue_store(
             "importance": importance,
             "created_at": created_at,
             "chunk_origin": chunk_origin,
+            "conversation_id": conversation_id,
             "supersedes": supersedes,
             "metadata": {key: value for key, value in metadata.items() if value is not None},
         },

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -100,6 +100,7 @@ def store_memory(
     line_number: Optional[int] = None,
     chunk_id: Optional[str] = None,
     created_at: Optional[str] = None,
+    conversation_id: Optional[str] = None,
     fallback_source_path: Optional[str] = None,
     origin_repo_path: Optional[str] = None,
     replayed_by: Optional[str] = None,
@@ -133,6 +134,7 @@ def store_memory(
         line_number: Optional line number reference. Only for type=issue.
         chunk_id: Optional caller-supplied chunk ID for durable queued writes.
         created_at: Optional caller-supplied reservation timestamp for queued writes.
+        conversation_id: Server-owned MCP session identifier for expansion context.
         fallback_source_path: Optional path to a local fallback file being replayed.
         origin_repo_path: Optional git root for the fallback's originating repo.
         replayed_by: Optional replay worker identifier.
@@ -346,6 +348,18 @@ def store_memory(
                         "sys_period_start": now,
                         "sys_period_end": "9999-12-31T23:59:59.999999Z",
                     }
+                    if conversation_id is not None and "conversation_id" in chunk_columns:
+                        position_row = cursor.execute(
+                            """
+                            SELECT COALESCE(MAX(position), -1) + 1
+                            FROM chunks
+                            WHERE conversation_id = ?
+                            """,
+                            (conversation_id,),
+                        ).fetchone()
+                        optional_values["conversation_id"] = conversation_id
+                        if "position" in chunk_columns:
+                            optional_values["position"] = int(position_row[0]) if position_row else 0
                     for column, value in optional_values.items():
                         if column in chunk_columns:
                             insert_columns.append(column)

--- a/tests/test_brainstore.py
+++ b/tests/test_brainstore.py
@@ -95,6 +95,37 @@ class TestStoreMemory:
         rows = list(cursor.execute("SELECT source FROM chunks WHERE id = ?", (result["id"],)))
         assert rows[0][0] == "manual"
 
+    def test_store_assigns_server_session_and_monotonic_position(self, store, mock_embed):
+        """MCP-owned session linkage makes newly stored memories expandable in order."""
+        from brainlayer.store import store_memory
+
+        for content in ["session-linked first", "session-linked second", "session-linked third"]:
+            store_memory(
+                store=store,
+                embed_fn=mock_embed,
+                content=content,
+                memory_type="note",
+                project="brainlayer",
+                conversation_id="mcp-server-session",
+            )
+
+        rows = list(
+            store.conn.cursor().execute(
+                """
+                SELECT content, conversation_id, position
+                FROM chunks
+                WHERE conversation_id = ?
+                ORDER BY position
+                """,
+                ("mcp-server-session",),
+            )
+        )
+        assert rows == [
+            ("session-linked first", "mcp-server-session", 0),
+            ("session-linked second", "mcp-server-session", 1),
+            ("session-linked third", "mcp-server-session", 2),
+        ]
+
     def test_store_sets_content_type(self, store, mock_embed):
         """content_type is set based on memory_type."""
         from brainlayer.store import store_memory

--- a/tests/test_mcp_palette.py
+++ b/tests/test_mcp_palette.py
@@ -7,6 +7,7 @@ import pytest
 import brainlayer.mcp as mcp_module
 from brainlayer.mcp import _full_tool_definitions, call_tool, list_tools
 from brainlayer.mcp.palette import CORE_TOOL_NAMES, ToolPalette
+from mcp.types import TextContent
 
 CORE_WITH_CONTROL = (*CORE_TOOL_NAMES, "expand_palette")
 
@@ -64,3 +65,57 @@ def test_python_palette_expands_once_and_dispatches_deferred_tools(monkeypatch):
         "registered_tools": [],
     }
     assert len(asyncio.run(list_tools())) == 13
+
+
+def test_brain_store_uses_server_owned_session_instead_of_client_argument(monkeypatch):
+    captured = {}
+
+    async def fake_store_new(**kwargs):
+        captured.update(kwargs)
+        return (
+            [TextContent(type="text", text="stored")],
+            {"chunk_id": "manual-server-session", "related": []},
+        )
+
+    monkeypatch.setattr(mcp_module, "_tool_palette", ToolPalette("full"))
+    monkeypatch.setattr(mcp_module, "_store_new", fake_store_new)
+    monkeypatch.setattr(mcp_module, "_calling_session_id", lambda: "mcp-server-session")
+
+    asyncio.run(
+        call_tool(
+            "brain_store",
+            {
+                "content": "server session only",
+                "conversation_id": "client-forged-session",
+            },
+        )
+    )
+
+    assert captured["conversation_id"] == "mcp-server-session"
+
+
+def test_server_owned_session_id_is_stable_for_connection_not_request_proxy():
+    class RequestSession:
+        def __init__(self, connection):
+            self._connection = connection
+
+    class Connection:
+        def __init__(self):
+            self.state = {}
+
+    connection_type = Connection
+    first_connection = connection_type()
+    second_connection = connection_type()
+
+    first_request_id = mcp_module._server_owned_conversation_id(RequestSession(first_connection))
+    next_request_id = mcp_module._server_owned_conversation_id(RequestSession(first_connection))
+    other_connection_id = mcp_module._server_owned_conversation_id(RequestSession(second_connection))
+
+    assert first_request_id == next_request_id
+    assert first_request_id != other_connection_id
+
+
+def test_server_owned_session_id_falls_back_for_legacy_in_process_client(monkeypatch):
+    monkeypatch.delattr(mcp_module.server, "request_context", raising=False)
+
+    assert mcp_module._calling_session_id() == mcp_module._MCP_PROCESS_SESSION_ID

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -145,6 +145,7 @@ async def test_busy_queue_fallback_returns_loud_deferred_receipt(tmp_path):
             content="deferred receipt must be loud",
             memory_type="note",
             project="test",
+            conversation_id="mcp-server-session",
         )
 
     queued_files = list(queue_dir.glob("mcp-*.jsonl"))
@@ -156,6 +157,7 @@ async def test_busy_queue_fallback_returns_loud_deferred_receipt(tmp_path):
     assert structured["deferred"]["chunk_id"] == queued_event["chunk_id"]
     assert structured["deferred"]["queue_path"] == str(queued_files[0])
     assert structured["deferred"]["action"] == "queued_for_drain"
+    assert queued_event["conversation_id"] == "mcp-server-session"
     assert any("DEFERRED" in item.text for item in texts)
 
 
@@ -1220,6 +1222,7 @@ async def test_busy_queue_fallback_flushes_reservation_timestamp_and_project(tmp
             content="queued flush must keep reservation metadata",
             memory_type="note",
             project="brainlayer",
+            conversation_id="mcp-server-session",
         )
 
     queued_files = list(queue_dir.glob("mcp-*.jsonl"))
@@ -1240,7 +1243,7 @@ async def test_busy_queue_fallback_flushes_reservation_timestamp_and_project(tmp
         row = (
             conn.cursor()
             .execute(
-                "SELECT created_at, project FROM chunks WHERE id = ?",
+                "SELECT created_at, project, conversation_id, position FROM chunks WHERE id = ?",
                 (promised_chunk_id,),
             )
             .fetchone()
@@ -1248,7 +1251,7 @@ async def test_busy_queue_fallback_flushes_reservation_timestamp_and_project(tmp
     finally:
         conn.close()
 
-    assert row == (reservation_created_at, "brainlayer")
+    assert row == (reservation_created_at, "brainlayer", "mcp-server-session", 0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Sprint lane **R1-C** of the BrainLayer cleanup sprint (`docs.local/plan/cleanup-2026-08-02/`). Items **6 + 7**, paired because both are defects in the *same* store write path.

## What was broken
- **Item 6 — `conversation_id` NULL on every store.** Measured **11,181 / 11,181 = 100% NULL**. Stored memories could not be tied back to the session that produced them.
- **Item 7 — the DEFERRED store retry duplicates.** Measured **358** duplicate `content_hash` groups. The retry path re-inserted instead of reconciling.

## Commits
- `f631dfb4` fix: link brain_store writes to MCP sessions
- `206b570a` fix: make deferred BrainBar stores idempotent

## Verification
Proven against a **rebuilt daemon on an isolated socket** — not a mocked path. Per the sprint's standing rule, *mock-green is not live-green*.

## Review status — READ BEFORE MERGING
🛑 **This PR has NO routed review yet.** It is pushed and open so it can be reviewed, not because it is ready to merge. Per sprint law an ACCEPT binds to an **exact commit** (`206b570a`), never to a PR number, and nobody reviews their own code.

⚠️ **Pushes on this repo are SERIAL** — see sprint **item 24**. The test suite cannot be run twice at once (`hooks/dedup_coordination.py:33` pins `_COORD_DIR = "/tmp"` against a constant test session id, so concurrent runs read each other's coordination file). Check `pgrep -f pytest` before pushing.

Gate passed serially at `206b570a`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the primary memory write path and deduplication semantics; incorrect idempotency or session binding could drop or mis-order stored chunks, but changes are narrow and heavily regression-tested.
> 
> **Overview**
> **MCP `brain_store` writes are tied to a server-owned session**, not client-supplied `conversation_id`. Swift `PaletteSession` and Python `_calling_session_id()` assign one stable ID per MCP connection; that value flows through direct writes, busy queues, and drain so chunks get `conversation_id` and monotonic `position` for ordered before/after expansion.
> 
> **BrainBar `store()` is idempotent within a session**: when `conversation_id` is set, it hashes body content and returns an existing active chunk on replay (same hash, project, type, session) instead of inserting again—covering DEFERRED receipt retries after flush. Pending-store JSONL carries `conversation_id` end-to-end.
> 
> The Python stack mirrors the same plumbing (`store_memory`, queue IO, drain, MCP handlers). Tests assert client-forged IDs are ignored, retry does not create a second row, and expand context follows store order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206b570a35cd83015b7b040d938ebcb1bff1374c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Link brain_store writes to MCP session IDs and make deferred store operations idempotent
> - Each `PaletteSession` (Swift) and MCP connection (Python) now generates a stable server-owned `conversation_id`, overriding any client-supplied value, so all `brain_store` writes within a session are tagged to that session.
> - Chunks are stored with a monotonically increasing `position` per `conversation_id`, enabling ordered session context and expand-by-neighbor lookups.
> - Deferred (DB-busy) store events now persist `conversation_id` in the queue file so that on retry/drain the chunk is linked to the originating session rather than creating a duplicate.
> - A new `content_hash` column and deduplication query in [`BrainDatabase.swift`](https://github.com/EtanHey/brainlayer/pull/641/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc) prevent duplicate chunks when a deferred store is retried within the same session.
> - Behavioral Change: `conversation_id` arguments supplied by MCP clients are silently ignored; the server-assigned value is always used.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 206b570. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->