### PR TITLE
fix(tests): pin NO_COLOR in conftest so assertions can't fail on ANSI escapes (re-cut of #639)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,15 @@ import pytest
 
 _PROTECTED_TEST_HOME = Path.home().resolve()
 
+# Deterministic CLI output for assertions: several tests compare CLI messages as plain
+# strings, and ANSI color escapes mid-sentence broke 3 test_installable_build assertions
+# in color-enabled environments (2026-08-02; NO_COLOR=1 -> 3 passed, verified). Pin the
+# test env here — the single place every pytest path (pre-push gate, CI, dev shell)
+# flows through — so pass/fail cannot depend on the caller's terminal.
+os.environ["NO_COLOR"] = "1"
+os.environ.pop("FORCE_COLOR", None)
+os.environ.setdefault("TERM", "dumb")
+
 ENGINE_TEST_MARK = "engine"
 ENGINE_TEST_EXCLUDED_FILES = {
     "tests/test_agent_profiles.py",


### PR DESCRIPTION
**Clean re-cut of #639.** Same fix, correct scope.

## Why #639 had to be re-cut — and it was worse than "scope contamination"
#639's head (`370e8257`) sat on top of `159b99d2`, which is **PR #638 at round-1 content**. #638 has since merged to `main` as the **squash `d4acb3a5`**, so `159b99d2` is **not an ancestor of main**.

Merging #639 today would therefore not merely have shipped stale content — it would have **reverted #638's round-2 and round-3 fixes** (`588b2807`, `d1bd0e99`), undoing all six findings `@review-638` closed across three review rounds.

## What this PR contains
Exactly the ANSI hunk and nothing else:

```
 tests/conftest.py | 9 +++++++++
 1 file changed, 9 insertions(+)
```

Cut fresh from `main` @ `17c02470`. The cherry-pick conflicted with #640's `_PROTECTED_TEST_HOME`; resolved by keeping **both** — they are independent guards (one pins terminal-colour env, one protects the real home path).

## The fix
Three `test_installable_build` assertions compare CLI messages as plain strings; in colour-enabled environments the CLI emits ANSI escapes mid-sentence and the substring match fails. `conftest.py` is the single place every pytest path flows through (pre-push gate, CI, dev shell), so pinning there beats pinning the gate script and CI separately.

## Scope note, carried from the original
This clears the **environment-conditional** blocker only. The **state-conditional** blocker — tests reading real runtime state — is separate; part landed in #640, and the remainder is sprint **item 24** (the suite cannot be run twice at once: `hooks/dedup_coordination.py:33` pins `_COORD_DIR = "/tmp"` against a constant test session id, so concurrent runs read each other's coordination file).

⚠️ **Pushes on this repo are SERIAL** until item 24 lands. This branch's gate passed serially at `185002d6`; the push was deliberately queued behind another seat's in-flight suite.

Supersedes #639, which is closed pointing here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only environment pinning with no production or security impact.
> 
> **Overview**
> **Pins terminal color env at pytest import time** in `tests/conftest.py` so CLI output matches plain-string expectations in tests (notably `test_installable_build`).
> 
> Sets `NO_COLOR=1`, drops `FORCE_COLOR`, and defaults `TERM` to `dumb` before any tests run. That centralizes behavior for pre-push gates, CI, and local shells instead of duplicating env setup per caller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185002d69c83a016b870c9a5cf6fd41055ede62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `NO_COLOR=1` and `TERM=dumb` in `conftest.py` to prevent ANSI escape failures in tests
> Sets `NO_COLOR=1`, removes `FORCE_COLOR`, and defaults `TERM` to `dumb` at import time in [conftest.py](https://github.com/EtanHey/brainlayer/pull/643/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) so CLI output observed during pytest sessions never contains ANSI color codes that would cause string assertions to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 185002d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test consistency by standardizing terminal output and disabling color-related variations during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->