### PR TITLE
fix(agents): install the ratified 2026-08-02 rulings — ingest denylist is NOT all workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,19 @@ brainlayer enrich
 - Concurrency: retry on `SQLITE_BUSY`; each worker uses its own connection
 
 ## P1 Pipeline Contracts
-- BL-10 source denylist is implemented in `src/brainlayer/ingest_denylist.py`. By default, provider sessions and ordinary Claude subagents ingest; only exact `brain-worker` subagents and workflow paths under `wf_*` are excluded. Exclusion never deletes the source JSONL. `BRAINLAYER_INGEST_DENYLIST` remains an explicit deployment override.
+- BL-10 source denylist is implemented in `src/brainlayer/ingest_denylist.py`. By default, provider
+  sessions and ordinary Claude subagents ingest. **Exclusion is scoped to agents whose job is to READ
+  OTHER AGENTS' MEMORY OR JSONLs — `brain-worker` sub-agents, and `session-miner` / `weave` workflow
+  agents. It is NOT all workflows.** Etan, 2026-08-03: *"That's very specific. It's not all workflows.
+  I don't know why y'all keep thinking it's all workflows."* and *"the Weaver's workflow is built of
+  session miners."*
+- **brain-worker and miner sessions are KEPT but NOT INDEXED.** Exclusion never deletes the source
+  JSONL — it means exclusion from the index only. `BRAINLAYER_INGEST_DENYLIST` remains an explicit
+  deployment override.
+- ⚠️ **Known code drift, do not read this file as describing shipped behaviour:**
+  `ingest_denylist.py:14` is `("~/.claude/projects/**/wf_*/**",)`, which excludes **every** workflow
+  path and silently discards legitimate workflow-agent memory. The rule above is the ruling; the code
+  is the defect. Code fix owned by the brainlayer lane.
 - Go-forward secret scrubbing runs in `src/brainlayer/pipeline/secret_scrub.py` from `src/brainlayer/watcher_bridge.py` before chunk persistence. Provider-prefixed and labeled high-entropy secrets are redacted; unlabeled high-entropy tokens are recorded in quarantine metadata.
 - MCP search uses a fixed-size readonly WAL `VectorStore` pool in `src/brainlayer/mcp/_shared.py`. `BRAINLAYER_READ_POOL_SIZE` defaults to 8, or 4 on detected Apple M1; M1 machines can keep the lower override explicitly. Checkout beyond the fixed pool blocks up to `BRAINLAYER_READ_BUSY_TIMEOUT_MS`, and startup rejects `pool_size * BRAINLAYER_READ_CACHE_KB` above about 768MB.
 
@@ -189,3 +201,14 @@ brainlayer enrich
 
 ## Naming
 - BrainLayer (זיכרון) = "memory"
+
+## Rulings that bind every agent here (ratified by voice 2026-08-02)
+
+- **Worktrees: `project` is always the REPO** (canonical); the branch is a separate field.
+  A branch name is never a project.
+- **Rules ride in instruction files** (this file + `CLAUDE.md`), deterministically. BrainLayer
+  injects CONTEXT only — it is **not a source of law**, and no third curated instruction source gets created.
+- **Agent-authored chunks are the normal case** — *"rules cite no source"* is a **non-finding**;
+  never report it.
+- **Pre-merge live-check against a DB copy** is required before any change that touches stored data.
+  *(Etan's addition at ratification, 2026-08-02.)*


### PR DESCRIPTION
The brainlayer instruction file was **grilled and ratified 2026-08-02** and **never installed**. It sat in gitignored `docs.local/` for a day while the tracked file taught the wrong rule with authority.

Etan, 2026-08-03: *"after it was ratified it should have been installed, and this is a fucking shame, really."*

## The load-bearing fix
`AGENTS.md` said exclusion covers `brain-worker` subagents **and "workflow paths under `wf_*`"**. Etan today:

> *"That's very specific. It's not all workflows. I don't know why y'all keep thinking it's all workflows."*
> *"the Weaver's workflow is built of session miners."*

**Now installed:** exclusion is scoped to agents whose job is to **read other agents' memory or JSONLs** — `brain-worker` sub-agents and `session-miner` / `weave` workflow agents. **Not all workflows.** Adds the session-miner rule the ratified draft itself never stated (grepped: zero occurrences); his 08-03 ruling supersedes the 08-02 draft's silence.

**Every agent that got this wrong got it wrong by reading the doc correctly. The doc was the bug.**

## Code drift flagged, not silently fixed
`ingest_denylist.py:14` is `("~/.claude/projects/**/wf_*/**",)` — excludes **every** workflow path and silently discards legitimate workflow-agent memory. Doc = ruling, code = defect. **Code fix stays with the brainlayer lane.**

## Also installed — 4 ratified rulings that never landed
project-is-always-the-repo · rules-ride-in-instruction-files (BrainLayer injects context, **is not law**) · agent-authored-chunks-are-normal (*"rules cite no source"* is a **non-finding**) · pre-merge live-check against a DB copy.

⚠️ **PR #605 contradicts this ruling** — denies *all* Claude subagents incl. `general-purpose`/`Explore` and keeps all-`wf_*`. Should not merge as-is.

## Note on `--no-verify`
Pushed with `--no-verify`, deliberately and per Etan's 2026-08-03 ruling: hooks exist to catch fixable tests and to stop outsiders merging into his daily tools — *"They're not there to block you all from merging."* This is **one markdown file, 24 insertions, zero code**; it cannot affect the 3,696-test Python suite that was gating it. Shape check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions; no code, DB, or ingest behavior is modified in this diff.
> 
> **Overview**
> **Updates `AGENTS.md` only** — no runtime or `ingest_denylist.py` changes in this PR.
> 
> The **BL-10 ingest denylist** section is rewritten so exclusion applies only to agents whose job is reading other agents’ memory/JSONLs (`brain-worker`, `session-miner` / `weave`), **not** every path under `wf_*`. It clarifies that excluded sessions stay on disk but are **not indexed**, and quotes the 2026-08-03 ruling that Weaver-style workflows built from session miners should still ingest.
> 
> A **known code drift** callout documents that shipped `DEFAULT_INGEST_DENYLIST` still uses `~/.claude/projects/**/wf_*/**` and is labeled a defect owned by the brainlayer lane — doc is ruling, code is not yet aligned.
> 
> Adds **“Rulings that bind every agent”** (ratified 2026-08-02): repo vs branch for `project`, rules live in instruction files (BrainLayer = context not law), agent-authored chunks / “rules cite no source” is a non-finding, and pre-merge live-check against a DB copy for stored-data changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e64eeb6e0ef5bf1215c7d72b98ba899b38c6acf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BL-10 denylist scope in AGENTS.md and ratify 2026-08-02 rulings
> - Clarifies that `ingest_denylist` exclusions apply only to brain-worker sub-agents and session-miner/weave workflow agents, not all workflows — the previous wording was ambiguous.
> - Adds explicit note that brain-worker and miner sessions are retained but not indexed, and that exclusions never delete source JSONL files.
> - Calls out a known defect in [ingest_denylist.py](https://github.com/EtanHey/brainlayer/pull/644/files#diff-179849147df50e65b095eae6dd9132a683f323538cf7b16df164ce46acab7e61) where the current pattern excludes every workflow path contrary to the stated rule, with fix ownership assigned.
> - Appends a new 'Rulings that bind every agent' section ratified 2026-08-02 covering: worktree project identity, rule authority (only instruction files), agent-authored chunks policy, and a required pre-merge live-check against a DB copy for any stored-data-touching change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e64eeb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->