### PR TITLE
fix(brainbar): fail closed on digest content corruption

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -584,6 +584,14 @@ final class BrainDatabase: @unchecked Sendable {
     struct StoredChunk: Sendable, Equatable {
         let chunkID: String
         let rowID: Int64
+        let contentIntegrity: StoredContentIntegrity?
+    }
+
+    struct StoredContentIntegrity: Sendable, Equatable {
+        let expectedCharacters: Int
+        let storedCharacters: Int
+        let expectedBytes: Int
+        let storedBytes: Int
     }
 
     struct StoredChunkDetails: Sendable, Equatable {
@@ -1294,7 +1302,8 @@ final class BrainDatabase: @unchecked Sendable {
         createdAt: String? = nil,
         refreshStatistics: Bool = true,
         retries: Int = 3,
-        busyTimeoutMillis: Int32? = nil
+        busyTimeoutMillis: Int32? = nil,
+        verifyContentIntegrity: Bool = false
     ) throws -> StoredChunk {
         guard let db else { throw DBError.notOpen }
         let chunkID = chunkID ?? Self.makeChunkID()
@@ -1339,10 +1348,28 @@ final class BrainDatabase: @unchecked Sendable {
             guard let rowID = try chunkRowID(forChunkID: chunkID) else {
                 throw DBError.noResult
             }
+            let contentIntegrity: StoredContentIntegrity?
+            if verifyContentIntegrity {
+                guard let stored = try storedChunkDetails(chunkID: chunkID, rowID: rowID) else {
+                    throw DBError.contentIntegrityCheckFailed("stored chunk could not be read")
+                }
+                let integrity = StoredContentIntegrity(
+                    expectedCharacters: content.count,
+                    storedCharacters: stored.content.count,
+                    expectedBytes: content.utf8.count,
+                    storedBytes: stored.content.utf8.count
+                )
+                guard stored.content.utf8.elementsEqual(content.utf8) else {
+                    throw DBError.contentIntegrityMismatch(integrity)
+                }
+                contentIntegrity = integrity
+            } else {
+                contentIntegrity = nil
+            }
             if refreshStatistics {
                 refreshSearchStatisticsBestEffort()
             }
-            return StoredChunk(chunkID: chunkID, rowID: rowID)
+            return StoredChunk(chunkID: chunkID, rowID: rowID, contentIntegrity: contentIntegrity)
         }
     }
 
@@ -1427,7 +1454,8 @@ final class BrainDatabase: @unchecked Sendable {
             return Self.isRetryableQueueErrorCode(rc)
         case .exec(let rc, _):
             return Self.isRetryableQueueErrorCode(rc)
-        case .notOpen, .open, .noResult, .invalidPragma:
+        case .notOpen, .open, .noResult, .invalidPragma,
+             .contentIntegrityCheckFailed, .contentIntegrityMismatch:
             return false
         }
     }
@@ -6514,8 +6542,12 @@ final class BrainDatabase: @unchecked Sendable {
                 tags: ["digest"] + entities.prefix(5).map { $0 },
                 importance: 5,
                 source: "digest",
-                project: project
+                project: project,
+                verifyContentIntegrity: true
             )
+            guard let integrity = stored.contentIntegrity else {
+                throw DBError.contentIntegrityCheckFailed("verification receipt was not produced")
+            }
 
             // Persist extracted entities to the knowledge graph so they are
             // immediately resolvable via brain_entity (lookupEntity), and link
@@ -6540,6 +6572,11 @@ final class BrainDatabase: @unchecked Sendable {
                 "chunks_created": 1,
                 "relations_created": 0,
                 "chunk_id": stored.chunkID,
+                "content_integrity": "verified",
+                "expected_characters": integrity.expectedCharacters,
+                "stored_characters": integrity.storedCharacters,
+                "expected_bytes": integrity.expectedBytes,
+                "stored_bytes": integrity.storedBytes,
                 "summary": digestSummary
             ]
         } catch {
@@ -6573,6 +6610,8 @@ final class BrainDatabase: @unchecked Sendable {
         case exec(Int32, String)
         case noResult
         case invalidPragma(String)
+        case contentIntegrityCheckFailed(String)
+        case contentIntegrityMismatch(StoredContentIntegrity)
 
         var errorDescription: String? {
             switch self {
@@ -6583,6 +6622,10 @@ final class BrainDatabase: @unchecked Sendable {
             case .exec(let rc, let message): return "SQLite exec failed: \(rc) (\(message))"
             case .noResult: return "No result"
             case .invalidPragma(let name): return "PRAGMA '\(name)' not in allowlist"
+            case .contentIntegrityCheckFailed(let reason):
+                return "Stored content integrity check failed: \(reason)"
+            case .contentIntegrityMismatch(let integrity):
+                return "Stored content integrity mismatch (characters \(integrity.storedCharacters)/\(integrity.expectedCharacters), bytes \(integrity.storedBytes)/\(integrity.expectedBytes))"
             }
         }
     }

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -998,7 +998,24 @@ final class MCPRouter: @unchecked Sendable {
         let title = (args["title"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         let db = try writeDB()
         let result = try db.digest(content: content, project: project, title: title)
-        return ToolOutput(text: TextFormatter.formatDigestResult(DigestResult(payload: result)))
+        if let error = result["error"] as? String {
+            throw ToolError.operationFailed(error)
+        }
+        let integrityKeys = [
+            "content_integrity",
+            "expected_characters",
+            "stored_characters",
+            "expected_bytes",
+            "stored_bytes"
+        ]
+        var metadata: [String: Any] = [:]
+        for key in integrityKeys {
+            metadata[key] = result[key]
+        }
+        return ToolOutput(
+            text: TextFormatter.formatDigestResult(DigestResult(payload: result)),
+            metadata: metadata
+        )
     }
 
     private func handleBrainUpdate(_ args: [String: Any]) throws -> ToolOutput {
@@ -1408,6 +1425,7 @@ final class MCPRouter: @unchecked Sendable {
         case notFound(String)
         case notImplemented(String)
         case schemaValidation(String)
+        case operationFailed(String)
 
         var errorDescription: String? {
             switch self {
@@ -1417,6 +1435,7 @@ final class MCPRouter: @unchecked Sendable {
             case .notFound(let message): return message
             case .notImplemented(let tool): return "\(tool) not yet implemented in BrainBar (use Python MCP server)"
             case .schemaValidation(let message): return "Schema validation error: \(message)"
+            case .operationFailed(let message): return message
             }
         }
     }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -1119,8 +1119,9 @@ No results found.
         let db = BrainDatabase(path: tempDB)
         defer { db.close() }
 
-        let input = "DIGEST-CUTOFF " + String(repeating: "x", count: 677) + " FULL-TAIL"
+        let input = "DIGEST-CUTOFF " + String(repeating: "é", count: 677) + " FULL-TAIL"
         XCTAssertEqual(input.count, 701)
+        XCTAssertGreaterThan(input.utf8.count, input.count)
 
         let router = MCPRouter(profile: "full")
         router.setDatabase(db)
@@ -1136,10 +1137,89 @@ No results found.
 
         let result = try XCTUnwrap(response["result"] as? [String: Any])
         XCTAssertNil(result["isError"] as? Bool)
+        XCTAssertEqual(result["content_integrity"] as? String, "verified")
+        XCTAssertEqual(result["expected_characters"] as? Int, input.count)
+        XCTAssertEqual(result["stored_characters"] as? Int, input.count)
+        XCTAssertEqual(result["expected_bytes"] as? Int, input.utf8.count)
+        XCTAssertEqual(result["stored_bytes"] as? Int, input.utf8.count)
         let matches = try db.search(query: "DIGEST-CUTOFF", limit: 1)
         let stored = try XCTUnwrap(matches.first?["content"] as? String)
         XCTAssertEqual(stored.count, input.count, "brain_digest stored \(stored.count) characters from a \(input.count)-character input")
         XCTAssertEqual(stored, input)
+    }
+
+    func testBrainDigestRejectsTruncatedStoredContent() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-digest-truncation-rejection-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try sqliteExec(
+            path: tempDB,
+            sql: """
+            CREATE TRIGGER truncate_digest_after_insert
+            AFTER INSERT ON chunks
+            WHEN NEW.source = 'digest'
+            BEGIN
+                UPDATE chunks
+                SET content = substr(NEW.content, 1, 500) || '...', char_count = 503
+                WHERE rowid = NEW.rowid;
+            END;
+            """
+        )
+
+        let input = "DIGEST-TRUNCATION " + String(repeating: "é", count: 700) + " FULL-TAIL"
+        let router = MCPRouter(profile: "full")
+        router.setDatabase(db)
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_digest",
+                "arguments": ["content": input]
+            ] as [String: Any]
+        ])
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["isError"] as? Bool, true)
+        XCTAssertTrue(
+            try db.search(query: "DIGEST-TRUNCATION", limit: 10).isEmpty,
+            "A digest whose persisted content differs from its input must roll back"
+        )
+    }
+
+    func testBrainDigestFailsClosedWhenStoredContentCannotBeRead() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-digest-unreadable-content-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try sqliteExec(
+            path: tempDB,
+            sql: """
+            CREATE TRIGGER remove_digest_after_insert
+            AFTER INSERT ON chunks
+            WHEN NEW.source = 'digest'
+            BEGIN
+                DELETE FROM chunks WHERE rowid = NEW.rowid;
+            END;
+            """
+        )
+
+        let router = MCPRouter(profile: "full")
+        router.setDatabase(db)
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_digest",
+                "arguments": ["content": String(repeating: "digest integrity check ", count: 40)]
+            ] as [String: Any]
+        ])
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["isError"] as? Bool, true)
+        XCTAssertTrue(try db.search(query: "integrity", limit: 10).isEmpty)
     }
 
     func testBrainSubscribeToolIsServerHandled() throws {


### PR DESCRIPTION
## Summary

- verify the exact persisted UTF-8 payload inside the native digest store transaction
- roll back and return MCP `isError: true` when verification cannot run or content differs
- expose caller-visible character and byte integrity receipts on success

## Incident boundary

PR #635 already removed the literal 500-character prefix on current `main`; this PR closes the remaining silent-corruption lane. It does not repair, backfill, delete, or otherwise rewrite the 308 historical digest rows identified by the incident audit.

## TDD evidence

RED under `LC_ALL=C`:
- a real SQLite trigger truncated a digest to 503 characters; the row committed and MCP returned nominal success
- a real SQLite trigger removed the inserted row; MCP still returned nominal success
- a 701-character / 1,378-byte Unicode digest stored fully but returned no integrity receipt

GREEN under `LC_ALL=C`:
- focused digest tests: 3 passed
- full BrainBar suite: 844 passed, 10 skipped, 0 failed
- repository pre-push gates: 3 registration + 40 isolated + 1 Bun + shell regression passed; Python unit mapping correctly skipped because no Python files changed
- CodeRabbit local review: 0 findings across 3 files

## Real binary receipt

A freshly built `BrainBarDaemon` served a real socket MCP request against an isolated SQLite database:

```json
{"isError":false,"content_integrity":"verified","expected_characters":699,"stored_characters":699,"expected_bytes":1376,"stored_bytes":1376}
```

Independent `LC_ALL=C` SQLite readback:

```json
[{"sqlite_characters":699,"utf8_bytes":1376,"tail":"FULL-TAIL"}]
```

The final required receipt will be rerun from the merged default-branch artifact in the ambient environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core digest persistence and MCP error semantics for data integrity; scope is limited to digest/verify paths with strong test coverage and no historical data migration.
> 
> **Overview**
> Adds **post-insert read-back verification** for digest persistence so the stored UTF-8 payload must match the input before the operation succeeds.
> 
> `store` gains an optional `verifyContentIntegrity` path that re-reads the chunk and throws new `DBError` cases on unreadable or mismatched content; those failures are **not** treated as retryable queue errors. **`digest`** enables verification on store and, on success, returns `content_integrity: verified` plus expected/stored character and byte counts in its result payload.
> 
> **`brain_digest`** now surfaces digest failures as MCP errors via `ToolError.operationFailed` instead of nominal success, and attaches integrity receipt fields in tool metadata when storage succeeds. Tests cover Unicode full-content storage, simulated truncation/unreadable rows (fail closed with no committed digest), and integrity metadata on the happy path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7ffcfcf39696d7aab36d27386b63d9be0f8ea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail closed on digest content corruption in BrainBar
> - `BrainDatabase.store` now accepts a `verifyContentIntegrity` flag that reads back persisted content after insert and throws `DBError.contentIntegrityCheckFailed` or `DBError.contentIntegrityMismatch` if the stored bytes don't match the input.
> - `BrainDatabase.digest` calls `store` with verification enabled and aborts on any integrity failure, returning `content_integrity="verified"` plus character/byte counts on success.
> - `MCPRouter.handleBrainDigest` now throws `ToolError.operationFailed` if the database reports an error, and includes integrity metadata in the `ToolOutput` on success.
> - Integrity errors are treated as non-queueable in `shouldQueueStoreError`, so they are never retried.
> - Behavioral Change: digest operations that previously silently stored corrupted content will now return an error to the caller instead of succeeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d7ffcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional content integrity verification for stored data with detailed diagnostic metrics

* **Bug Fixes**
  * Improved error handling and reporting for integrity verification failures

* **Tests**
  * Expanded test coverage including Unicode support and comprehensive integrity verification scenarios with error cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->