### PR TITLE
fix(brainbar): close digest integrity review gaps

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -596,8 +596,16 @@ final class BrainDatabase: @unchecked Sendable {
 
     struct StoredChunkDetails: Sendable, Equatable {
         let content: String
+        let contentUTF8: Data
         let tags: [String]
         let importance: Int
+
+        init(content: String, contentUTF8: Data? = nil, tags: [String], importance: Int) {
+            self.content = content
+            self.contentUTF8 = contentUTF8 ?? Data(content.utf8)
+            self.tags = tags
+            self.importance = importance
+        }
     }
 
     struct FlushedPendingStore: Sendable {
@@ -1380,6 +1388,9 @@ final class BrainDatabase: @unchecked Sendable {
                 throw DBError.exec(SQLITE_IOERR, "simulated post-insert validation failure")
             }
             guard let rowID = try chunkRowID(forChunkID: chunkID) else {
+                if verifyContentIntegrity {
+                    throw DBError.contentIntegrityCheckFailed("stored chunk could not be read")
+                }
                 throw DBError.noResult
             }
             let contentIntegrity: StoredContentIntegrity?
@@ -1387,13 +1398,14 @@ final class BrainDatabase: @unchecked Sendable {
                 guard let stored = try storedChunkDetails(chunkID: chunkID, rowID: rowID) else {
                     throw DBError.contentIntegrityCheckFailed("stored chunk could not be read")
                 }
+                let expectedUTF8 = Data(content.utf8)
                 let integrity = StoredContentIntegrity(
                     expectedCharacters: content.count,
                     storedCharacters: stored.content.count,
-                    expectedBytes: content.utf8.count,
-                    storedBytes: stored.content.utf8.count
+                    expectedBytes: expectedUTF8.count,
+                    storedBytes: stored.contentUTF8.count
                 )
-                guard stored.content.utf8.elementsEqual(content.utf8) else {
+                guard stored.contentUTF8 == expectedUTF8 else {
                     throw DBError.contentIntegrityMismatch(integrity)
                 }
                 contentIntegrity = integrity
@@ -1969,12 +1981,13 @@ final class BrainDatabase: @unchecked Sendable {
         sqlite3_bind_int64(stmt, 2, rowID)
         guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
 
-        let content = columnText(stmt, 0) ?? ""
+        let contentUTF8 = columnData(stmt, 0) ?? Data()
+        let content = String(decoding: contentUTF8, as: UTF8.self)
         let tagsJSON = columnText(stmt, 1) ?? "[]"
         let tagsData = Data(tagsJSON.utf8)
         let tags = (try? JSONDecoder().decode([String].self, from: tagsData)) ?? []
         let importance = Int(sqlite3_column_int(stmt, 2))
-        return StoredChunkDetails(content: content, tags: tags, importance: importance)
+        return StoredChunkDetails(content: content, contentUTF8: contentUTF8, tags: tags, importance: importance)
     }
 
     func unreadCount(agentID: String, tags: [String]? = nil) throws -> Int {
@@ -2922,6 +2935,14 @@ final class BrainDatabase: @unchecked Sendable {
     private func columnText(_ stmt: OpaquePointer?, _ col: Int32) -> String? {
         guard let cStr = sqlite3_column_text(stmt, col) else { return nil }
         return String(cString: cStr)
+    }
+
+    private func columnData(_ stmt: OpaquePointer?, _ col: Int32) -> Data? {
+        guard sqlite3_column_type(stmt, col) != SQLITE_NULL else { return nil }
+        let byteCount = Int(sqlite3_column_bytes(stmt, col))
+        guard byteCount > 0 else { return Data() }
+        guard let bytes = sqlite3_column_blob(stmt, col) else { return nil }
+        return Data(bytes: bytes, count: byteCount)
     }
 
     private func bindText(_ value: String, to stmt: OpaquePointer?, index: Int32) {
@@ -4698,7 +4719,11 @@ final class BrainDatabase: @unchecked Sendable {
         switch stepRC {
         case SQLITE_ROW:
             guard let chunkID = columnText(stmt, 0) else { throw DBError.noResult }
-            return StoredChunk(chunkID: chunkID, rowID: sqlite3_column_int64(stmt, 1))
+            return StoredChunk(
+                chunkID: chunkID,
+                rowID: sqlite3_column_int64(stmt, 1),
+                contentIntegrity: nil
+            )
         case SQLITE_DONE:
             return nil
         default:

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -1264,7 +1264,49 @@ No results found.
 
         let result = try XCTUnwrap(response["result"] as? [String: Any])
         XCTAssertEqual(result["isError"] as? Bool, true)
+        let contentBlocks = try XCTUnwrap(result["content"] as? [[String: Any]])
+        let errorText = try XCTUnwrap(contentBlocks.first?["text"] as? String)
+        XCTAssertTrue(errorText.contains("Stored content integrity check failed"))
         XCTAssertTrue(try db.search(query: "integrity", limit: 10).isEmpty)
+    }
+
+    func testBrainDigestRejectsEmbeddedNullSuffixInStoredContent() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-digest-null-suffix-rejection-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try sqliteExec(
+            path: tempDB,
+            sql: """
+            CREATE TRIGGER append_null_suffix_to_digest
+            AFTER INSERT ON chunks
+            WHEN NEW.source = 'digest'
+            BEGIN
+                UPDATE chunks
+                SET content = NEW.content || char(0) || 'CORRUPT-SUFFIX'
+                WHERE rowid = NEW.rowid;
+            END;
+            """
+        )
+
+        let router = MCPRouter(profile: "full")
+        router.setDatabase(db)
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_digest",
+                "arguments": ["content": String(repeating: "digest raw byte check ", count: 40)]
+            ] as [String: Any]
+        ])
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["isError"] as? Bool, true)
+        XCTAssertTrue(
+            try db.search(query: "digest", limit: 10).isEmpty,
+            "A digest with an appended embedded-NUL suffix must roll back"
+        )
     }
 
     func testBrainSubscribeToolIsServerHandled() throws {


### PR DESCRIPTION
## Scope

Follow-up to #645 containing only the two CodeRabbit integrity findings plus the minimal current-`main` constructor compatibility fix. No historical-row repair or backfill.

- Treat a post-insert digest row that cannot be read as a content-integrity failure and roll back.
- Compare persisted digest content as length-aware raw SQLite bytes, preventing embedded-NUL suffix corruption from passing verification.
- Preserve non-digest dedupe behavior with `contentIntegrity: nil` at the existing constructor added on current `main`.

## Verification

- RED on current `main`: Swift compile failed at the newer `StoredChunk` constructor until compatibility was supplied.
- Digest-focused Swift tests: 7 passed, including truncation, deletion, embedded-NUL suffix, and multibyte exact persistence.
- Full current-main Swift suite: 847 passed, 10 skipped, 0 failures.
- Changed-only pre-push: registration 3 passed; isolated 40 passed; Bun 1 passed; shell determinism passed.
- Local CodeRabbit had 0 findings on the substantive two-file review delta; a final one-line retry was rate-limited, so merge remains gated on remote review and CI.

## Explicit boundary

This PR stops new silent corruption. It does not touch or backfill the 308 historical rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core chunk store and digest persistence path where failed checks roll back writes; scope is limited to integrity verification and constructor compatibility, not historical data repair.
> 
> **Overview**
> **Digest stores** with `verifyContentIntegrity` now validate persisted content against the **exact UTF-8 bytes** read from SQLite (`columnData` / blob), not a CString-based text round-trip—so suffixes after embedded NUL bytes can’t slip past verification.
> 
> If the row can’t be read back after insert while integrity checking is on, the write path throws **`contentIntegrityCheckFailed`** instead of a generic **`noResult`**. **`StoredChunkDetails`** carries optional cached **`contentUTF8`** for that comparison; non-digest dedupe still returns **`StoredChunk`** with **`contentIntegrity: nil`**.
> 
> Tests assert the integrity error message on failed digest checks and add a trigger-driven embedded-NUL corruption case that must roll back and leave search empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b33a44249a857c92a137946106769b1d1d525372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix digest integrity review gaps by comparing raw UTF-8 bytes in `BrainDatabase`
> - Content integrity verification now reads stored bytes via a new `columnData` helper (using `sqlite3_column_blob`) instead of text, catching mismatches caused by embedded NUL characters that text-based reads would silently mask.
> - When `verifyContentIntegrity` is enabled and the stored chunk cannot be read after insert, the method now throws `DBError.contentIntegrityCheckFailed` rather than falling through to a generic `noResult` error.
> - `StoredChunkDetails` gains a `contentUTF8: Data` field populated from the raw blob, and byte counts are used for comparison instead of string-derived lengths.
> - Adds a test covering embedded NUL injection via a SQLite trigger to confirm the integrity check rejects tampered content and surfaces the error text to the caller.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b33a442.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity checks for stored content, including embedded null bytes and appended corruption.
  * Preserved raw content bytes during storage and retrieval to detect previously missed inconsistencies.
  * Invalid or unreadable content is now rejected cleanly without leaving partial records behind.

* **Tests**
  * Added coverage for corrupted, unreadable, and rolled-back stored content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->