### PR TITLE
fix(tests): model watchdog restart lifecycle

### DIFF
--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -709,8 +709,20 @@ def test_alert_framing_pages_once_per_episode_not_per_kickstart(tmp_path: Path) 
     config = _config(module, tmp_path, stall_threshold=3, cooldown_seconds=0)
     alerts: list[int] = []
 
+    process = {"pid": 4321, "running": True}
+
     def command_runner(args: list[str]):
-        stdout = "state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else ""
+        stdout = ""
+        if args[:2] == ["launchctl", "print"]:
+            if process["running"]:
+                stdout = f"state = running\npid = {process['pid']}\n"
+            else:
+                stdout = "state = exited\n"
+        elif args[:2] == ["/bin/kill", "-9"] and args[2:3] == [str(process["pid"])]:
+            process["running"] = False
+        elif args[:3] == ["launchctl", "kickstart", "-k"]:
+            process["pid"] += 1
+            process["running"] = True
         return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
 
     clock = {"t": 1_000}


### PR DESCRIPTION
## Summary
- repair the isolated RED watchdog regression introduced with #602
- make the named alert-framing test simulate a real repeated process lifecycle: running PID, successful SIGKILL exit, kickstart, and replacement PID
- keep the change test-only and limited to the single named test

## Root cause
The test's fake `launchctl print` returned `state = running` with PID 4321 forever, including after the mocked SIGKILL. Production correctly refused to kickstart while that PID appeared alive, waited the real 45-second safety timeout, and returned `recovery_failed`. This reproduces alone on clean `b95e113d`, so it is a real #602 test regression rather than an item-24 concurrency artifact.

## Verification
- RED on clean main: named test failed in 45.17s with `watcher pid 4321 survived SIGKILL for 45s`
- GREEN: named test passed in 0.05s after the final reviewed diff
- focused module: 25 passed in 182.94s
- targeted Ruff check: clean
- targeted Ruff format check: clean
- git diff check: clean
- normal push hook with FD soft limit 4096: `BrainLayer test gate passed`; isolated hook-routing leg 40 passed, Bun leg 1 passed, FTS5 determinism shell regression passed
- remote branch verified at exact head `9f0795703b5074c77edaa7729ff9dd597d0a3b9a`

## Review notes
- Claude pair-review verdict: ACCEPT
- local CodeRabbit suggested expanding this alert-framing fake into a complete command-protocol validator and sequence recorder; not taken because dedicated recovery tests already assert the sequence and the brief forbids drive-by widening

## Known base-branch state
Repo-wide Ruff is still red only in the three files already fixed by the separate, unlanded `7214eec5` commit. This PR does not duplicate or reformat that work.

Worker endpoint is PR plus review responses. Do not merge from this lane.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single test mock change only; no production watchdog or recovery logic modified.
> 
> **Overview**
> **Test-only fix** for `test_alert_framing_pages_once_per_episode_not_per_kickstart`, which was timing out (~45s) because its fake `launchctl print` always reported PID 4321 as **running**, even after a mocked SIGKILL—matching production behavior that blocks kickstart until the old PID is gone.
> 
> The test’s `command_runner` now keeps a small **process** state: `launchctl print` reflects running vs exited and the current PID, **`/bin/kill -9`** marks the process dead, and **`launchctl kickstart -k`** bumps the PID and marks it running again. Alert-framing expectations (one page per episode, suppression within an episode, re-page after sustained health) are unchanged; only the mock matches the recovery sequence other tests already assert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0795703b5074c77edaa7729ff9dd597d0a3b9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix watchdog restart lifecycle simulation in `test_alert_framing_pages_once_per_episode_not_per_kickstart`
> The test's `command_runner` mock previously returned a fixed `running` state and pid regardless of commands issued. It now tracks process state across the full lifecycle: `launchctl print` returns `state = running` or `state = exited` based on current state, `/bin/kill -9 <pid>` sets the process to stopped, and `launchctl kickstart -k` increments the pid and marks the process as running again.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f07957.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved alert-framing test coverage for watcher lifecycle transitions, including status reporting, termination, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->