### PR TITLE
style: restore ruff clean on main after admin merges

### DIFF
--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -205,6 +205,7 @@ def _calling_session_id() -> str:
         return _MCP_PROCESS_SESSION_ID
     return _server_owned_conversation_id(session)
 
+
 # Tool annotations
 _MAX_FULL_CONTENT_RESULT_CHARS = 250_000
 _MAX_RESULT_META = {"anthropic/maxResultSizeChars": _MAX_FULL_CONTENT_RESULT_CHARS}

--- a/tests/test_mcp_palette.py
+++ b/tests/test_mcp_palette.py
@@ -3,11 +3,11 @@
 import asyncio
 
 import pytest
+from mcp.types import TextContent
 
 import brainlayer.mcp as mcp_module
 from brainlayer.mcp import _full_tool_definitions, call_tool, list_tools
 from brainlayer.mcp.palette import CORE_TOOL_NAMES, ToolPalette
-from mcp.types import TextContent
 
 CORE_WITH_CONTROL = (*CORE_TOOL_NAMES, "expand_palette")
 

--- a/tests/test_t3_app_provenance.py
+++ b/tests/test_t3_app_provenance.py
@@ -309,9 +309,7 @@ def test_watcher_retries_deferred_t3_codex_without_advancing_across_gap(
         json.dumps(
             {
                 "type": "user",
-                "message": {
-                    "content": [{"type": "text", "text": "Keep ordinary Claude ingestion available."}]
-                },
+                "message": {"content": [{"type": "text", "text": "Keep ordinary Claude ingestion available."}]},
                 "timestamp": "2026-08-01T12:00:00Z",
             }
         )


### PR DESCRIPTION
Restores `main` to a **green lint baseline**.

## What broke it
On 2026-08-04 seven PRs were merged with `--admin` (#645 #644 #643 #641 #633 #605 #602) on blanket merge approval. **`--admin` bypasses CI**, so import-order and formatting drift landed on `main` unchecked — and every branch cut afterward inherited a failing `lint` job it did not cause (#630, #646, #647 all showed it).

**The lesson, recorded:** `--admin` doesn't only skip a review gate — it lets a red build become the base for everything after it. Blanket *merge* approval is not blanket *CI* approval.

## What this does
`ruff check --fix` + `ruff format`. Nothing else.

```
ruff check src/ tests/        → All checks passed!
ruff format --check src/ tests/ → 424 files already formatted
```

**No behavioural change.** Import ordering in `tests/test_mcp_palette.py` and formatting in `src/brainlayer/mcp/__init__.py` + `tests/test_t3_app_provenance.py`.

## Why it took three attempts
This push was blocked twice by `test_throughput_watchdog.py::test_alert_framing_pages_once_per_episode_not_per_kickstart` — a **circular deadlock**: this PR couldn't push because that test was red, and that test's fix (#647) couldn't go green because *this* lint failure was red. #647 merged as `949334a0` and broke the cycle; this is rebased on top of it.

## Gate
Full hook-backed pre-push gate, not bypassed:
```
3710 passed, 9 skipped, 61 deselected, 1 xfailed in 965.75s
BrainLayer test gate passed.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace, import order, and dict formatting only—no production logic or test assertions changed.
> 
> **Overview**
> Restores a **green `ruff check` / `ruff format`** baseline on `main` with mechanical fixes only—no runtime or test behavior changes.
> 
> In `brainlayer.mcp`, **ruff format** inserts a blank line between `_calling_session_id()` and the tool-annotation block. In `tests/test_mcp_palette.py`, **`TextContent`** is moved into the standard third-party import group (isort/ruff import order). In `tests/test_t3_app_provenance.py`, a fixture **`message`** dict is collapsed to one line to satisfy the formatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ce844c02781d505c084b9802042b8aade87070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ruff linting violations in test files after admin merges
> Restores ruff compliance in two test files with minor style fixes. Moves a duplicate `TextContent` import to the top-level import block in [test_mcp_palette.py](https://github.com/EtanHey/brainlayer/pull/648/files#diff-df5accb8f93bcc9ad294b50649b656ff568747882d4b01be59774e7bb354654c) and collapses a multi-line JSON dict into a single line in [test_t3_app_provenance.py](https://github.com/EtanHey/brainlayer/pull/648/files#diff-d44ec2cba79246e722615502db84aee4718399e457ce27076bbd6aad25c5a7ef). No logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10ce844.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->