### PR TITLE
fix(brainbar): pass contentIntegrity at the storedChunk lookup call site — main does not compile

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -4698,7 +4698,7 @@ final class BrainDatabase: @unchecked Sendable {
         switch stepRC {
         case SQLITE_ROW:
             guard let chunkID = columnText(stmt, 0) else { throw DBError.noResult }
-            return StoredChunk(chunkID: chunkID, rowID: sqlite3_column_int64(stmt, 1))
+            return StoredChunk(chunkID: chunkID, rowID: sqlite3_column_int64(stmt, 1), contentIntegrity: nil)
         case SQLITE_DONE:
             return nil
         default:


### PR DESCRIPTION
**`main` does not build.** `swift build` fails with **22 errors** across `BrainBar` and `BrainBarDaemon`.

## Cause
#645 added `contentIntegrity` to `StoredChunk` and updated the write-with-readback path (`BrainDatabase.swift:1406`) but **not** the lookup path at `:4701`:

```
BrainDatabase.swift:4701:86: error: missing argument for parameter 'contentIntegrity' in call
```

It landed because the seven `--admin` merges of 2026-08-04 **bypassed CI** — the same root cause as the ruff drift fixed in #648. `--admin` doesn't skip one gate; it lets a red build become the base for every branch cut afterward. This is the third repair PR for that one decision.

## Fix
One argument at one call site. `storedChunk()` is a **lookup** of an existing row, not a write-with-readback — no integrity comparison happens there, so `nil` is the truthful value rather than a fabricated measurement.

**Note:** `Sources/BrainBarDaemon/BrainDatabase.swift` is a **symlink** to the BrainBar copy, so the 22 errors are 11 real ones seen through two targets and a single edit fixes both. Worth knowing before anyone "de-duplicates" the file.

## Verification
```
swift build                → 0 errors   (was 22)
hook-backed pre-push gate  → 3710 passed, 9 skipped, 61 deselected, 1 xfailed in 1129.38s
                             BrainLayer test gate passed.
```

## What this unblocks
- **#630** — CI conclusive and green on lint, changes, CodeRabbit, Macroscope and tests 3.11/3.12/3.13; failing **only** on this inherited Swift break
- **#646** — same
- **the v1.5.3 release cut** — a tree that does not compile cannot be released, and the current deploy lives in a brew Cellar venv that the next `brew upgrade` silently reverts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-call-site compile fix with no behavior change beyond satisfying the updated initializer; lookup paths still do not perform integrity checks.
> 
> **Overview**
> Restores **`swift build`** by updating the **`storedChunk`** lookup path to construct **`StoredChunk`** with the new **`contentIntegrity`** argument.
> 
> The lookup only resolves an existing row ID and does not run write-time integrity verification, so **`contentIntegrity: nil`** is passed instead of fabricating metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1a39af17c9a27f03d30329a69d7c56a18c5b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `StoredChunk` initializer call in `BrainDatabase` to pass `contentIntegrity`
> The `StoredChunk` initializer in [BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/649/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc) was missing a `contentIntegrity` argument, causing a compile error on `main`. The call site now passes `contentIntegrity: nil` explicitly as the third argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a1a39a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->