### PR TITLE
fix(maintenance): never resume a deliberately paused service (the 04:00 enrichment restarter)

### DIFF
--- a/src/brainlayer/maintenance.py
+++ b/src/brainlayer/maintenance.py
@@ -8,6 +8,7 @@ import json
 import os
 import sqlite3
 import subprocess
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -18,8 +19,11 @@ import apsw
 from .backup_daily import WEEKLY_RETENTION, run_backup
 from .drain import BurnDrainResult, burn_drain_once
 from .paths import get_db_path
+from .pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_applies_to_label, pause_sentinel_state
 from .queue_io import get_queue_dir
 from .wal_checkpoint import checkpoint
+
+PAUSE_SENTINEL_PATH = DEFAULT_PAUSE_SENTINEL_PATH
 
 MAINTENANCE_DATASET = "brainlayer-maintenance"
 DEFAULT_SERVICES = ("watch", "enrichment", "index", "drain")
@@ -403,9 +407,28 @@ def _quiesce_services(services: Sequence[str]) -> None:
         _bootout_service(service)
 
 
+def _service_is_deliberately_paused(service: str) -> bool:
+    """True when a pause sentinel names this service's launchd label.
+
+    Maintenance must never resume a service someone deliberately stopped. Before this
+    check, teardown re-installed every entry in DEFAULT_SERVICES unconditionally, so a
+    human STOP was byte-identical to a maintenance pause -- which re-created the
+    enrichment plist four times and cost 5,137 rows on 2026-08-04.
+    """
+    from datetime import UTC, datetime
+
+    payload, active, _stale = pause_sentinel_state(PAUSE_SENTINEL_PATH, datetime.now(UTC))
+    if not active:
+        return False
+    return pause_applies_to_label(payload, f"com.brainlayer.{service}")
+
+
 def _resume_services(repo_root: Path, services: Sequence[str]) -> list[tuple[str, Exception]]:
     failures: list[tuple[str, Exception]] = []
     for service in services:
+        if _service_is_deliberately_paused(service):
+            print(f"skipping resume of {service}: pause sentinel is active", file=sys.stderr)
+            continue
         try:
             _resume_service(repo_root, service)
         except Exception as exc:

--- a/tests/test_maintenance_pause_sentinel.py
+++ b/tests/test_maintenance_pause_sentinel.py
@@ -1,0 +1,49 @@
+"""Maintenance must not resume a service a human deliberately paused.
+
+RED reproduces the 2026-08-04/05 incident: `com.brainlayer.maintenance-nightly` runs at
+04:00 and its teardown unconditionally re-installs DEFAULT_SERVICES — including
+enrichment — via `scripts/launchd/install.sh`. That re-created the enrichment plist four
+times, and on 2026-08-04 the resulting run cost 5,137 rows of source `provenance_class`.
+
+The pause sentinel shipped in #638 already records the intent. Maintenance never read it.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from brainlayer import maintenance
+
+
+def _write_sentinel(path: Path, *labels: str) -> None:
+    path.write_text(json.dumps({"paused_at": datetime.now(UTC).isoformat(), "labels": list(labels)}))
+
+
+@pytest.fixture
+def sentinel(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "pause.sentinel"
+    monkeypatch.setattr(maintenance, "PAUSE_SENTINEL_PATH", path, raising=False)
+    return path
+
+
+def test_paused_service_is_not_resumed(tmp_path, monkeypatch, sentinel):
+    _write_sentinel(sentinel, "com.brainlayer.enrichment")
+    resumed: list[str] = []
+    monkeypatch.setattr(maintenance, "_resume_service", lambda root, svc: resumed.append(svc))
+
+    failures = maintenance._resume_services(tmp_path, ("watch", "enrichment", "drain"))
+
+    assert "enrichment" not in resumed, "deliberately paused service was resumed"
+    assert resumed == ["watch", "drain"], "unpaused services must still resume"
+    assert failures == [], "skipping a paused service is not a resume failure"
+
+
+def test_no_sentinel_resumes_everything(tmp_path, monkeypatch, sentinel):
+    resumed: list[str] = []
+    monkeypatch.setattr(maintenance, "_resume_service", lambda root, svc: resumed.append(svc))
+
+    maintenance._resume_services(tmp_path, ("watch", "enrichment", "drain"))
+
+    assert resumed == ["watch", "enrichment", "drain"], "no sentinel means resume all"


### PR DESCRIPTION
**This is the 04:00 enrichment restarter.** It must land before 04:00 tonight or it recurs a third consecutive night.

## What was happening
`com.brainlayer.maintenance-nightly` fires at **Hour 4 / Minute 0** and runs `python -m brainlayer.maintenance --light`. Its teardown unconditionally re-installed every `DEFAULT_SERVICES` entry — **including enrichment** — via `scripts/launchd/install.sh`:

- `maintenance.py:25` — `DEFAULT_SERVICES = ("watch", "enrichment", "index", "drain")`
- `maintenance.py:549` — `_resume_services(...)` in a **`finally:`** block, so it fires even when maintenance aborts
- `maintenance.py:394` — `_resume_service()` → `install.sh <service>` — **this is what re-created the enrichment plist**

Restarts: **04:01:48** on 2026-08-04 and **04:00:28** on 2026-08-05. The plist was re-created **four times**, beside three `.PAUSED-*` renames.

**The 08-04 run cost 5,137 rows** of source `provenance_class` (5,775 surviving → 638) in 8,321 enrichment writes between 04:00 and 13:11.

## Root cause: a proxy standing in for a property
Maintenance treated **"service is in my list"** as **"I am the reason it is stopped."** A deliberate, authorised STOP is byte-identical to a maintenance pause from inside that function.

Its own log had been reporting this for days — `maintenance-nightly.out.log` contains **19** `failed to resume 2 launchd services: ... enrichment` lines. It was fighting the stop and reporting the fight as an abort.

## Fix
Reuses the pause sentinel **#638 already ships** (`pause_sentinel_state` / `pause_applies_to_label`) rather than adding a second marker — intent was already recorded, maintenance simply never read it. Unpaused services still resume, and skipping a paused service is **not** counted as a resume failure.

## Verification
**RED first** — reproduces the incident in **0.3s** instead of on a 24-hour clock:
```
FAILED test_paused_service_is_not_resumed - deliberately paused service was resumed
```
**GREEN** — `2 passed`, including a control proving unpaused services still resume.

**Against the LIVE sentinel**, not just a fixture:
```
watch       paused=False
enrichment  paused=True     <- tonight's 04:00 run will SKIP it
index       paused=False
drain       paused=False
```

**Full gate**, not bypassed: `3712 passed, 9 skipped, 61 deselected, 1 xfailed in 933.98s` — `BrainLayer test gate passed.`

## Note on merging
Per the up-to-date-with-base lesson from this week's seven `--admin` merges: this branch is cut from current `main` (`431ed831`) and its gate ran against that base. **A green PR proves the branch; only up-to-date-with-base proves the merge result.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launchd resume behavior on a safety-gated nightly path; incorrect sentinel logic could leave services down or still restart paused enrichment.
> 
> **Overview**
> **Nightly maintenance teardown no longer re-installs launchd services that a human deliberately paused.** Previously, `_resume_services` always ran `install.sh` for every `DEFAULT_SERVICES` entry in its `finally` block, so a STOP on enrichment looked the same as a maintenance quiesce and could restart enrichment after the 04:00 job.
> 
> The change wires maintenance into the existing pause sentinel (`pause_sentinel_state` / `pause_applies_to_label` from `pause.py`): `_service_is_deliberately_paused` checks whether `com.brainlayer.<service>` is listed, and `_resume_services` skips those services (stderr log) without treating the skip as a resume failure. Unpaused services still resume as before.
> 
> New tests in `test_maintenance_pause_sentinel.py` lock in paused-vs-unpaused behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 446d24d6ad02cd450c2a6a71bb00b07b79a4a538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip resuming deliberately paused services in `_resume_services`
> - Adds `_service_is_deliberately_paused` in [maintenance.py](https://github.com/EtanHey/brainlayer/pull/650/files#diff-5623eb0b0ddbc791b2b25c828a74927787f1cf710501ff90555ebf92981b041d) that reads a pause sentinel file and checks whether it applies to a service's `com.brainlayer.<service>` launchd label.
> - `_resume_services` now skips any service matched by an active sentinel, logging to stderr, so the 04:00 enrichment restarter never un-pauses an intentionally paused service.
> - Skipped services are not counted as failures.
> - Tests in [test_maintenance_pause_sentinel.py](https://github.com/EtanHey/brainlayer/pull/650/files#diff-a691c38163adac59b4d7717722f688754df22e3596f0596a31c1149887a0c66d) cover both the sentinel-active and no-sentinel paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 446d24d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintenance operations now respect active pause settings, preventing paused services from being resumed unintentionally.
  * Unpaused services continue to resume normally, including when no pause configuration is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->