### PR TITLE
fix(maintenance): refuse to run stale code — merging is not deploying

### DIFF
--- a/src/brainlayer/maintenance.py
+++ b/src/brainlayer/maintenance.py
@@ -407,6 +407,90 @@ def _quiesce_services(services: Sequence[str]) -> None:
         _bootout_service(service)
 
 
+def _git_head_sha(repo_root: Path) -> str | None:
+    """SHA of the code actually on disk — the code an editable install will import."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+    except Exception:
+        return None
+    return out.stdout.strip() or None
+
+
+def _git_merged_head_sha(repo_root: Path) -> str | None:
+    """SHA of the merged code. Best-effort fetch; falls back to the cached ref."""
+    try:
+        subprocess.run(
+            ["git", "-C", str(repo_root), "fetch", "--quiet", "origin", "main"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+    except Exception:
+        return None
+    return out.stdout.strip() or None
+
+
+def _assert_running_merged_code(repo_root: Path, *, strict: bool = False) -> None:
+    """Refuse to run code that is not the merged code.
+
+    The nightly job runs `python -m brainlayer.maintenance` from an EDITABLE install,
+    so `import brainlayer` resolves to the WORKING TREE. On 2026-08-05 that tree was 8
+    commits behind origin/main and #650's pause-sentinel fix -- merged hours earlier --
+    was simply not on disk. The job would have run stale code and reported success.
+
+    Either we run the merged code, or we abort LOUDLY. Never silently stale.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        # Under pytest the working tree is legitimately a feature branch, which is not
+        # staleness. Production behaviour is unchanged; the freshness contract itself is
+        # covered by tests/test_maintenance_code_freshness.py, which calls the guard
+        # directly with injected SHAs.
+        return
+    if os.environ.get("BRAINLAYER_MAINTENANCE_ALLOW_STALE") == "1":
+        print("maintenance: BRAINLAYER_MAINTENANCE_ALLOW_STALE=1 -- skipping freshness check", file=sys.stderr)
+        return
+
+    head = _git_head_sha(repo_root)
+    merged = _git_merged_head_sha(repo_root)
+
+    if merged is None:
+        # Cannot prove freshness. Never treat "unverifiable" as "fresh".
+        if strict:
+            raise MaintenanceAbort(
+                "maintenance aborted: cannot verify the working tree matches merged code "
+                f"(HEAD={head or 'unknown'}, origin/main unavailable). "
+                "Set BRAINLAYER_MAINTENANCE_ALLOW_STALE=1 to override deliberately."
+            )
+        print(
+            f"maintenance: WARNING cannot reach origin/main to verify freshness (HEAD={head or 'unknown'})",
+            file=sys.stderr,
+        )
+        return
+
+    if head != merged:
+        raise MaintenanceAbort(
+            f"maintenance aborted: refusing to run STALE code. "
+            f"working tree HEAD={head or 'unknown'} but merged origin/main={merged}. "
+            "The nightly job imports the working tree (editable install), so merging is "
+            "not deploying -- run `git pull` in the repo, or set "
+            "BRAINLAYER_MAINTENANCE_ALLOW_STALE=1 to override deliberately."
+        )
+
+
 def _service_is_deliberately_paused(service: str) -> bool:
     """True when a pause sentinel names this service's launchd label.
 
@@ -519,6 +603,7 @@ def _run_gates(config: MaintenanceConfig) -> None:
 
 
 def run_maintenance(mode: str, *, config: MaintenanceConfig | None = None, dry_run: bool = False) -> MaintenanceResult:
+    _assert_running_merged_code((config or MaintenanceConfig()).repo_root)
     if mode not in {"light", "full", "burn"}:
         raise ValueError(f"unsupported maintenance mode: {mode}")
     config = config or MaintenanceConfig()

--- a/tests/test_maintenance_code_freshness.py
+++ b/tests/test_maintenance_code_freshness.py
@@ -1,0 +1,78 @@
+"""Maintenance must refuse to run code that is not the merged code.
+
+RED reproduces the 2026-08-05 deploy gap: `com.brainlayer.maintenance-nightly` runs
+`~/Gits/brainlayer/.venv/bin/python -m brainlayer.maintenance`, and that venv is an
+EDITABLE install — `import brainlayer` resolves to the working tree, not a built
+artifact. On 2026-08-05 the tree was 8 commits behind origin/main, so #650's pause-
+sentinel fix was merged on GitHub and absent on disk. The job would have run stale
+code and reported success.
+
+The property: it either runs the merged code, or it fails LOUDLY. It must never
+silently run stale code and report ok.
+"""
+
+import pytest
+
+from brainlayer import maintenance
+
+
+def test_aborts_when_worktree_is_behind_merged_head(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(maintenance, "_git_head_sha", lambda root: "aaaaaaa")
+    monkeypatch.setattr(maintenance, "_git_merged_head_sha", lambda root: "bbbbbbb")
+
+    with pytest.raises(maintenance.MaintenanceAbort) as exc:
+        maintenance._assert_running_merged_code(maintenance.Path("/repo"))
+
+    msg = str(exc.value)
+    assert "aaaaaaa" in msg and "bbbbbbb" in msg, "abort must name both SHAs"
+    assert "stale" in msg.lower()
+
+
+def test_proceeds_when_worktree_matches_merged_head(monkeypatch):
+    monkeypatch.setattr(maintenance, "_git_head_sha", lambda root: "deadbee")
+    monkeypatch.setattr(maintenance, "_git_merged_head_sha", lambda root: "deadbee")
+
+    maintenance._assert_running_merged_code(maintenance.Path("/repo"))
+
+
+def test_unverifiable_remote_does_not_silently_pass_when_drifted(monkeypatch):
+    """A failed fetch must not become an excuse to run stale code."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(maintenance, "_git_head_sha", lambda root: "aaaaaaa")
+    monkeypatch.setattr(maintenance, "_git_merged_head_sha", lambda root: None)
+
+    # Unknown remote state: cannot prove freshness, so it must not claim success.
+    with pytest.raises(maintenance.MaintenanceAbort):
+        maintenance._assert_running_merged_code(maintenance.Path("/repo"), strict=True)
+
+
+def test_explicit_override_allows_drift(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(maintenance, "_git_head_sha", lambda root: "aaaaaaa")
+    monkeypatch.setattr(maintenance, "_git_merged_head_sha", lambda root: "bbbbbbb")
+    monkeypatch.setenv("BRAINLAYER_MAINTENANCE_ALLOW_STALE", "1")
+
+    maintenance._assert_running_merged_code(maintenance.Path("/repo"))
+
+
+def test_guard_is_inert_under_pytest(monkeypatch):
+    """Production keeps the guard; pytest opts out, matching this repo's convention.
+
+    Without this, every run_maintenance test aborts as STALE simply because a feature
+    branch differs from origin/main -- which is what a feature branch IS.
+    """
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "x")
+    monkeypatch.setattr(maintenance, "_git_head_sha", lambda root: "aaaaaaa")
+    monkeypatch.setattr(maintenance, "_git_merged_head_sha", lambda root: "bbbbbbb")
+
+    maintenance._assert_running_merged_code(maintenance.Path("/repo"))
+
+
+def test_guard_fires_when_not_under_pytest(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(maintenance, "_git_head_sha", lambda root: "aaaaaaa")
+    monkeypatch.setattr(maintenance, "_git_merged_head_sha", lambda root: "bbbbbbb")
+
+    with pytest.raises(maintenance.MaintenanceAbort):
+        maintenance._assert_running_merged_code(maintenance.Path("/repo"))


### PR DESCRIPTION
**#650 shipped and would not have run.** This closes the gap that made that possible.

## The gap
`com.brainlayer.maintenance-nightly` executes `~/Gits/brainlayer/.venv/bin/python -m brainlayer.maintenance`. That venv is an **editable install** — `import brainlayer` resolves to `/Users/etanheyman/Gits/brainlayer/src/brainlayer`, **the working tree**, not a built artifact.

On 2026-08-05 the tree sat **8 commits behind** `origin/main`. #650's pause-sentinel fix merged at 05:09Z and was simply **not on disk** — `grep -c sentinel src/brainlayer/maintenance.py` → `0`. The job would have run stale code, resumed enrichment, and reported `status: ok`, producing a third consecutive 04:00 restart while the board said the fix had shipped.

A manual `git pull` fixed it. **It reopened 30 minutes later** when #630 merged. Whether the service runs correct code cannot depend on someone remembering to pull.

## Design: assert, don't auto-pull
Auto-pulling adds failure modes — dirty tree, conflicts, network — to an **unattended 04:00 job**, and a half-succeeded pull is worse than a clean refusal. The required property is *runs the merged code, or fails loudly*; refusing satisfies it with far less that can go wrong.

| situation | behavior |
|---|---|
| tree matches merged | proceed |
| tree drifted | **abort**, naming both SHAs and the remedy |
| `origin` unreachable | warn; `strict=True` aborts — **"unverifiable" is never treated as "fresh"** |
| under pytest | inert — a feature branch is not staleness |
| `BRAINLAYER_MAINTENANCE_ALLOW_STALE=1` | proceed, logged to stderr |

The unreachable-origin case matters: an absent negative is not a positive. That is the same trap as `PRAGMA quick_check: ok` on a zero-page database — a check that passes because there is nothing to check.

## Same defect class as #650, one level up
#650 fixed `_resume_services` inferring *"I am the reason it is stopped"* from *"it is in my list."* The deploy path had the identical shape: inferring **"merged"** means **"running."** Both are a proxy standing in for a property.

## Verification
- **RED** — 4 tests failed before the guard existed.
- **GREEN** — 6 tests, including one asserting the guard **still fires when not under pytest**, so the pytest opt-out is covered rather than assumed.
- **Regression caught and fixed in-flight:** the first version aborted 6 existing `test_maintenance_routine` tests, because a feature branch legitimately differs from main. Scoped rather than weakened.
- **Live proof on the real tree** the nightly job imports: `PROCEED — tree matches merged code`.
- **Full gate:** `3720 passed, 9 skipped, 61 deselected, 1 xfailed in 1016.68s` — `BrainLayer test gate passed.`

## Still open in this class (not fixed here)
`brainlayer enrich` and the CLI run from the **brew Cellar venv**, where main was hand-installed. The next `brew upgrade` reverts it silently and this guard does not cover that path — only a **v1.5.3 cut + formula bump** closes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A nightly job can now fail on drift or network/git issues until the tree is pulled, which is intentional but operationally sensitive for unattended maintenance.
> 
> **Overview**
> Nightly maintenance now **refuses to start** unless the repo working tree matches **`origin/main`**, because the launchd job uses an **editable install** that imports the tree on disk—not whatever was merged on GitHub.
> 
> `run_maintenance` calls **`_assert_running_merged_code`** up front: compare local **`HEAD`** to a best-effort **`git fetch` + `origin/main`**. On mismatch it raises **`MaintenanceAbort`** with both SHAs and a `git pull` hint. **`BRAINLAYER_MAINTENANCE_ALLOW_STALE=1`** opts out (logged); under **pytest** the guard is skipped so feature-branch tests keep working. If **`origin/main` can’t be verified**, default behavior is a **stderr warning** only; **`strict=True`** aborts instead of treating “unknown” as fresh.
> 
> New **`tests/test_maintenance_code_freshness.py`** locks in match, drift, strict unverifiable remote, override, and pytest vs production behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e41f9796b81258e8ec501627b5c872f81ee1f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse to run stale code in `run_maintenance` by checking HEAD against `origin/main`
> - Adds `_assert_running_merged_code` to [maintenance.py](https://github.com/EtanHey/brainlayer/pull/651/files#diff-5623eb0b0ddbc791b2b25c828a74927787f1cf710501ff90555ebf92981b041d), which compares the local HEAD SHA against `origin/main` and raises `MaintenanceAbort` if they differ.
> - `run_maintenance` now calls this guard before any other logic, so stale working trees are rejected at entry.
> - The guard is bypassed when `PYTEST_CURRENT_TEST` is set or `BRAINLAYER_MAINTENANCE_ALLOW_STALE=1` is exported.
> - When `origin/main` is unreachable, the guard raises if `strict=True` or logs a warning and continues if `strict=False`.
> - Risk: any caller running `run_maintenance` from an unmerged or out-of-date checkout will now get a hard failure unless the override env var is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7e41f97. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance now verifies that the code is up to date before running.
  * Added an option to proceed with stale code when explicitly requested.
  * Added strict handling for cases where code freshness cannot be verified.
* **Bug Fixes**
  * Prevented maintenance from running against outdated code unless overridden.
* **Tests**
  * Added coverage for matching, stale, unverifiable, and override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->