### PR TITLE
test: isolate dedup coordination per pytest run

### DIFF
--- a/tests/test_dedup_coordination.py
+++ b/tests/test_dedup_coordination.py
@@ -85,13 +85,13 @@ def test_concurrent_pytest_runs_do_not_share_coordination_state(tmp_path):
     barrier_dir.mkdir()
     test_path = os.path.abspath(__file__)
     processes = []
-
-    for run_id in ("run-a", "run-b"):
-        env = os.environ.copy()
-        env["BRAINLAYER_CONCURRENCY_RUN_ID"] = run_id
-        env["BRAINLAYER_CONCURRENCY_BARRIER_DIR"] = str(barrier_dir)
-        processes.append(
-            subprocess.Popen(
+    results = []
+    try:
+        for run_id in ("run-a", "run-b"):
+            env = os.environ.copy()
+            env["BRAINLAYER_CONCURRENCY_RUN_ID"] = run_id
+            env["BRAINLAYER_CONCURRENCY_BARRIER_DIR"] = str(barrier_dir)
+            process = subprocess.Popen(
                 # Select only the worker so child runs cannot recursively spawn children.
                 [sys.executable, "-m", "pytest", "-q", test_path, "-k", "concurrent_run_worker"],
                 cwd=os.path.dirname(os.path.dirname(test_path)),
@@ -100,10 +100,7 @@ def test_concurrent_pytest_runs_do_not_share_coordination_state(tmp_path):
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-        )
-
-    results = []
-    try:
+            processes.append(process)
         results = [process.communicate(timeout=30) for process in processes]
     finally:
         for process in processes:

--- a/tests/test_dedup_coordination.py
+++ b/tests/test_dedup_coordination.py
@@ -19,6 +19,7 @@ import pytest
 HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..", "hooks")
 sys.path.insert(0, HOOKS_DIR)
 
+import dedup_coordination
 from dedup_coordination import (
     _lock_path,
     coord_path,
@@ -31,6 +32,15 @@ from dedup_coordination import (
 )
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module", autouse=True)
+def isolated_coord_dir(tmp_path_factory):
+    """Give each pytest process its own hook coordination directory."""
+    production_coord_dir = dedup_coordination._COORD_DIR
+    dedup_coordination._COORD_DIR = str(tmp_path_factory.mktemp("dedup-coordination"))
+    yield
+    dedup_coordination._COORD_DIR = production_coord_dir
 
 
 @pytest.fixture
@@ -82,6 +92,7 @@ def test_concurrent_pytest_runs_do_not_share_coordination_state(tmp_path):
         env["BRAINLAYER_CONCURRENCY_BARRIER_DIR"] = str(barrier_dir)
         processes.append(
             subprocess.Popen(
+                # Select only the worker so child runs cannot recursively spawn children.
                 [sys.executable, "-m", "pytest", "-q", test_path, "-k", "concurrent_run_worker"],
                 cwd=os.path.dirname(os.path.dirname(test_path)),
                 env=env,
@@ -91,7 +102,14 @@ def test_concurrent_pytest_runs_do_not_share_coordination_state(tmp_path):
             )
         )
 
-    results = [process.communicate(timeout=30) for process in processes]
+    results = []
+    try:
+        results = [process.communicate(timeout=30) for process in processes]
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+                process.communicate()
     failures = [output for process, (output, _) in zip(processes, results) if process.returncode != 0]
     assert not failures, "\n".join(failures)
 
@@ -100,6 +118,24 @@ def test_concurrent_pytest_runs_do_not_share_coordination_state(tmp_path):
 
 
 class TestCoordFileIO:
+    def test_production_coord_path_defaults_to_tmp(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    f"sys.path.insert(0, {HOOKS_DIR!r}); "
+                    "from dedup_coordination import coord_path; "
+                    "print(coord_path('production-default'))"
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert os.path.dirname(result.stdout.strip()) == "/tmp"
+
     def test_write_and_read(self, session_id):
         data = {
             "session_id": session_id,
@@ -146,7 +182,7 @@ class TestCoordFileIO:
         data = {"injected_chunks": [], "injected_ids_set": [], "total_tokens_injected": 0}
         write_coord(session_id, data)
 
-        # Check no .tmp files in /tmp matching our pattern
+        # Check no .tmp files in the coordination directory matching our pattern
         coord = coord_path(session_id)
         dir_name = os.path.dirname(coord)
         tmp_files = [f for f in os.listdir(dir_name) if f.endswith(".tmp") and "brainlayer" in f]

--- a/tests/test_dedup_coordination.py
+++ b/tests/test_dedup_coordination.py
@@ -9,7 +9,9 @@ Covers:
 
 import json
 import os
+import subprocess
 import sys
+import time
 
 import pytest
 
@@ -45,6 +47,53 @@ def cleanup_coord_file(session_id):
             os.unlink(path)
         except OSError:
             pass
+
+
+def test_concurrent_run_worker(session_id):
+    """Exercise one side of the cross-pytest-run coordination collision."""
+    run_id = os.environ.get("BRAINLAYER_CONCURRENCY_RUN_ID")
+    barrier_dir = os.environ.get("BRAINLAYER_CONCURRENCY_BARRIER_DIR")
+    if not run_id or not barrier_dir:
+        pytest.skip("only used by the concurrent pytest reproduction")
+
+    chunk_id = f"chunk-{run_id}"
+    register_chunks(session_id, [chunk_id], source_hook="SessionStart")
+    with open(os.path.join(barrier_dir, run_id), "w"):
+        pass
+
+    deadline = time.monotonic() + 10
+    while len(os.listdir(barrier_dir)) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert len(os.listdir(barrier_dir)) == 2, "both pytest workers must reach the barrier"
+    assert get_injected_ids(session_id) == {chunk_id}
+
+
+def test_concurrent_pytest_runs_do_not_share_coordination_state(tmp_path):
+    """Two independent pytest processes must not read each other's hook state."""
+    barrier_dir = tmp_path / "barrier"
+    barrier_dir.mkdir()
+    test_path = os.path.abspath(__file__)
+    processes = []
+
+    for run_id in ("run-a", "run-b"):
+        env = os.environ.copy()
+        env["BRAINLAYER_CONCURRENCY_RUN_ID"] = run_id
+        env["BRAINLAYER_CONCURRENCY_BARRIER_DIR"] = str(barrier_dir)
+        processes.append(
+            subprocess.Popen(
+                [sys.executable, "-m", "pytest", "-q", test_path, "-k", "concurrent_run_worker"],
+                cwd=os.path.dirname(os.path.dirname(test_path)),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        )
+
+    results = [process.communicate(timeout=30) for process in processes]
+    failures = [output for process, (output, _) in zip(processes, results) if process.returncode != 0]
+    assert not failures, "\n".join(failures)
 
 
 # ── Coordination File Read/Write ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a deterministic two-process regression that reproduces cross-run coordination-state contamination
- isolate each pytest module/process in its own coordination directory
- prove a fresh production import still resolves coordination files under /tmp
- reap child pytest processes on timeout and restore the coordination global at module teardown

## TDD evidence
- RED commit ac702b85: concurrent reproduction failed because both workers observed shared chunk IDs
- GREEN commit a0383275: two simultaneous full-file runs each pass independently

## Test plan
- [x] two concurrent runs of tests/test_dedup_coordination.py: each 24 passed, 1 skipped
- [x] Ruff: all checks passed
- [x] full pre-push gate: 3722 passed, 10 skipped, 61 deselected, 1 xfailed
- [x] MCP registration: 3 passed
- [x] isolated eval/hook routing: 40 passed
- [x] Bun stale-index regression: 1 passed
- [x] FTS5 determinism shell regression: passed
- [x] Claude pair re-review: ACCEPT
- [x] CodeRabbit local review: 0 findings

Production hook behavior is unchanged: hooks/dedup_coordination.py still defaults to /tmp.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to tests; production `hooks/dedup_coordination.py` behavior and `/tmp` default are unchanged.
> 
> **Overview**
> **Test isolation for dedup hook coordination** so parallel or overlapping pytest runs no longer share on-disk coordination files under the production `/tmp` default.
> 
> An autouse module fixture **overrides** `dedup_coordination._COORD_DIR` with a per-process temp directory and **restores** the original value at teardown. Existing per-test cleanup still removes coord/lock files in that directory.
> 
> **New regression coverage:** a parent test spawns two child pytest processes (distinct `BRAINLAYER_CONCURRENCY_RUN_ID` env vars), each running a barrier-synchronized worker that registers a run-specific chunk ID; both must pass without seeing the other run’s injected IDs. Child processes are killed on timeout. A separate subprocess import check asserts a **fresh** interpreter still resolves `coord_path()` under `/tmp`.
> 
> The atomic-write test comment now refers to the **coordination directory** rather than hard-coding `/tmp`, matching isolated runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3bc55828c93eb5318e65337eca5f357deaf64d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for concurrent test runs to ensure coordination state remains isolated.
  * Verified that independent processes do not interfere with one another.
  * Confirmed the default coordination location and improved cleanup checks across configured locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate dedup coordination state per pytest run in test suite
> - Adds an `isolated_coord_dir` fixture in [test_dedup_coordination.py](https://github.com/EtanHey/brainlayer/pull/653/files#diff-af66b97c7024bc26ff12be68941ac2ff18ddac55e63261615ae2cb6ca442cc2b) that overrides `dedup_coordination._COORD_DIR` to a unique temp directory for each pytest process, preventing state leakage between runs.
> - Adds `test_concurrent_pytest_runs_do_not_share_coordination_state`, which spawns two child pytest processes and asserts both succeed without sharing coordination state.
> - Adds `test_concurrent_run_worker`, a helper test used by the subprocess runs to register a chunk, synchronize via a filesystem barrier, and assert per-run isolation.
> - Adds `TestCoordFileIO.test_production_coord_path_defaults_to_tmp`, which verifies that `coord_path` resolves under `/tmp` in a clean interpreter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a3bc55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->