### PR TITLE
test: detect MCP tool count drift

### DIFF
--- a/tests/test_tool_count_drift.py
+++ b/tests/test_tool_count_drift.py
@@ -59,18 +59,23 @@ def _python_tool_count() -> int:
     return len(re.findall(r"\bTool\(", PYTHON_REGISTRATION.read_text(encoding="utf-8")))
 
 
+def _python_literal_tool_name_count() -> int:
+    return len(re.findall(r"\bTool\(name=", PYTHON_REGISTRATION.read_text(encoding="utf-8")))
+
+
 def _swift_tool_names() -> set[str]:
     return set(re.findall(r"\bbrain_[a-z_]+\b", SWIFT_REGISTRATION.read_text(encoding="utf-8")))
 
 
 def test_documented_counts_match_both_registration_surfaces() -> None:
     assert _python_tool_count() == 13
+    assert _python_literal_tool_name_count() == 0
     assert len(_swift_tool_names()) == 17
 
     documented_counts = [
         int(match.group(1) or match.group(2) or match.group(3) or match.group(4))
         for line in _current_readme_lines()
-        if (match := COUNT_LINE.search(line))
+        for match in COUNT_LINE.finditer(line)
     ]
     assert documented_counts, "README must contain at least one in-scope MCP count"
     assert set(documented_counts) <= {13, 17}

--- a/tests/test_tool_count_drift.py
+++ b/tests/test_tool_count_drift.py
@@ -1,0 +1,77 @@
+"""Guard the documented MCP count against drift between registration surfaces.
+
+The README's dated release notes are historical records, not current claims.  In
+particular, the exclusion is anchored to the section heading instead of a line
+number so the check cannot accidentally turn line 192 into a current count.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(os.environ.get("B4_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
+README = REPO_ROOT / "README.md"
+PYTHON_REGISTRATION = REPO_ROOT / "src/brainlayer/mcp/__init__.py"
+SWIFT_REGISTRATION = REPO_ROOT / "brain-bar/Sources/BrainBar/MCPRouter.swift"
+
+RELEASE_NOTES_HEADING = "## Recent Hardening (2026-04-15 → 2026-05-17)"
+COUNT_LINE = re.compile(
+    r"(?:\bMCP\b[^\n]*?\b(\d+)\s*(?:%20|[- ])\s*tools?\b"
+    r"|\b(\d+)\s*(?:%20|[- ])\s*tools?\b[^\n]*\bMCP\b"
+    r"|\bMCP\s+Tools?\s*\((\d+)\)"
+    r"|\bMCP\s+tools?\b[^\n|]*\|\s*(\d+)\b)",
+    re.IGNORECASE,
+)
+
+
+def _current_readme_lines() -> list[str]:
+    """Return only current README lines, excluding the dated release notes."""
+    lines = README.read_text(encoding="utf-8").splitlines()
+    start = lines.index(RELEASE_NOTES_HEADING)
+    end = next(
+        (index for index in range(start + 1, len(lines)) if lines[index].startswith("## ")),
+        len(lines),
+    )
+    return lines[:start] + lines[end:]
+
+
+def _has_b3_disambiguation() -> bool:
+    current_readme = "\n".join(_current_readme_lines())
+    return (
+        re.search(r"Python server\s*=\s*13", current_readme, re.IGNORECASE) is not None
+        and re.search(r"BrainBar router\s*=\s*17", current_readme, re.IGNORECASE) is not None
+    )
+
+
+# B4 is intentionally red until B3 lands.  The normal suite stays green while
+# retaining the assertion; `pytest --runxfail` provides the pinned-SHA RED proof.
+pytestmark = pytest.mark.xfail(
+    condition=not _has_b3_disambiguation(),
+    reason="B4 becomes active after B3 adds the Python/BrainBar count disambiguation",
+)
+
+
+def _python_tool_count() -> int:
+    return len(re.findall(r"\bTool\(", PYTHON_REGISTRATION.read_text(encoding="utf-8")))
+
+
+def _swift_tool_names() -> set[str]:
+    return set(re.findall(r"\bbrain_[a-z_]+\b", SWIFT_REGISTRATION.read_text(encoding="utf-8")))
+
+
+def test_documented_counts_match_both_registration_surfaces() -> None:
+    assert _python_tool_count() == 13
+    assert len(_swift_tool_names()) == 17
+
+    documented_counts = [
+        int(match.group(1) or match.group(2) or match.group(3) or match.group(4))
+        for line in _current_readme_lines()
+        if (match := COUNT_LINE.search(line))
+    ]
+    assert documented_counts, "README must contain at least one in-scope MCP count"
+    assert set(documented_counts) <= {13, 17}
+    assert _has_b3_disambiguation()


### PR DESCRIPTION
## Summary
- guard documented MCP counts against Python and BrainBar registration drift
- exclude the dated Recent Hardening section mechanically
- keep the check xfailed until B3 surface attribution lands

## Verification
- pinned SHA 3c83b60e: `pytest --runxfail` RED on unattributed counts
- full push gate: 3720 passed, 9 skipped, 61 deselected, 2 xfailed
- README.md unchanged versus main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or README edits; xfail keeps the default suite green until B3.
> 
> **Overview**
> Adds **`tests/test_tool_count_drift.py`** to keep **documented MCP tool counts** aligned with the **Python** (`src/brainlayer/mcp/__init__.py`, expected **13** `Tool(` registrations) and **BrainBar** (`MCPRouter.swift`, expected **17** `brain_*` tools) surfaces.
> 
> README parsing **skips** the dated **Recent Hardening** section by heading (not line number) and only accepts in-scope count mentions of **13** or **17**. The test also requires README **B3 disambiguation** (`Python server = 13` and `BrainBar router = 17`).
> 
> The check is **`pytest.mark.xfail`** until that README text lands, so CI stays green while **`pytest --runxfail`** can still prove failure on older SHAs. **README is unchanged** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4daf2ca3519c0984f4c59a97c6bee31544ece4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test to detect MCP tool count drift across registration surfaces and README
> Adds [tests/test_tool_count_drift.py](https://github.com/EtanHey/brainlayer/pull/654/files#diff-d91936057455510c498f4b79f3b7e50bb34bc5d599623bacf3b05064ea625145) to assert that the Python MCP server registers exactly 13 tools, the Swift `MCPRouter` registers exactly 17, and all in-scope README mentions of MCP tool counts match one of those two values.
>
> - The test is marked `xfail` until the README contains explicit disambiguation phrases (`Python server = 13` and `BrainBar router = 17`), so it won't block CI before the docs are updated.
> - A dated release-notes section (`## Recent Hardening (2026-04-15 → 2026-05-17)`) is excluded from README analysis to avoid false positives from historical count mentions.
> - Swift tool names are detected via a `brain_[a-z_]+` regex on `MCPRouter.swift`; Python tools are counted by `Tool(` occurrences in `src/brainlayer/mcp/__init__.py`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4daf2ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->