### PR TITLE
test: replace timing and daemon-thread flakes

### DIFF
--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -335,6 +335,16 @@ class TestStoreAutoEnrich:
         mock_model.embed_query = lambda text: [0.1] * 1024
         monkeypatch.setattr(store_handler, "_get_embedding_model", lambda: mock_model)
 
+        started_threads = []
+        real_thread = threading.Thread
+
+        def tracking_thread(*args, **kwargs):
+            thread = real_thread(*args, **kwargs)
+            started_threads.append(thread)
+            return thread
+
+        monkeypatch.setattr(store_handler, "threading", SimpleNamespace(Thread=tracking_thread))
+
         result = await store_handler._store_new(
             content="Test auto-enrichment integration",
             memory_type="learning",
@@ -344,10 +354,9 @@ class TestStoreAutoEnrich:
         content_items, structured = result
         chunk_id = structured["chunk_id"]
 
-        # Wait for background thread to complete
-        for t in threading.enumerate():
-            if t.daemon and t.name != "MainThread":
-                t.join(timeout=5.0)
+        assert len(started_threads) == 1
+        started_threads[0].join(timeout=5.0)
+        assert not started_threads[0].is_alive()
 
         assert len(enriched_ids) == 1
         assert enriched_ids[0] == chunk_id
@@ -375,6 +384,16 @@ class TestStoreAutoEnrich:
         mock_model.embed_query = lambda text: [0.1] * 1024
         monkeypatch.setattr(store_handler, "_get_embedding_model", lambda: mock_model)
 
+        started_threads = []
+        real_thread = threading.Thread
+
+        def tracking_thread(*args, **kwargs):
+            thread = real_thread(*args, **kwargs)
+            started_threads.append(thread)
+            return thread
+
+        monkeypatch.setattr(store_handler, "threading", SimpleNamespace(Thread=tracking_thread))
+
         result = await store_handler._store_new(
             content="Store should succeed regardless of enrichment",
             memory_type="note",
@@ -384,9 +403,9 @@ class TestStoreAutoEnrich:
         assert structured["chunk_id"] != "queued"
         assert content_items[0].text == f"✔ Stored → {structured['chunk_id']}"
 
-        for t in threading.enumerate():
-            if t.daemon and t.name != "MainThread":
-                t.join(timeout=5.0)
+        assert len(started_threads) == 1
+        started_threads[0].join(timeout=5.0)
+        assert not started_threads[0].is_alive()
 
         test_store.close()
 

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -382,15 +382,12 @@ async def test_store_busy_budget_defers_promptly_and_pending_flush_replays(tmp_p
         patch("brainlayer.mcp.store_handler._get_pending_store_path", return_value=pending_path),
         patch("brainlayer.store.store_memory", side_effect=held_write_lock_store_memory),
     ):
-        started = time.perf_counter()
         texts, structured = await _store(
             content="queued within busy budget",
             memory_type="note",
             project="test",
         )
-        elapsed = time.perf_counter() - started
 
-    assert elapsed < 0.22
     assert attempts <= 2
     assert structured["status"] == "DEFERRED"
     assert structured["deferred"]["action"] == "queued_for_replay"
@@ -490,12 +487,14 @@ async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, 
     class FakeConn:
         def __init__(self):
             self.timeout_ms = 5000
+            self.timeout_history = []
 
         def cursor(self):
             return FakeCursor(self)
 
         def setbusytimeout(self, timeout_ms):
             self.timeout_ms = timeout_ms
+            self.timeout_history.append(timeout_ms)
 
     store = MagicMock()
     store.conn = FakeConn()
@@ -511,16 +510,17 @@ async def test_store_busy_budget_bounds_store_memory_inner_retry_loop(tmp_path, 
         patch("brainlayer.queue_io.enqueue_store", side_effect=RuntimeError("force legacy pending queue")),
         patch("brainlayer.mcp.store_handler._get_pending_store_path", return_value=pending_path),
     ):
-        started = time.perf_counter()
         _texts, structured = await _store(
             content="inner retries must respect mcp busy budget",
             memory_type="note",
             project="test",
         )
-        elapsed = time.perf_counter() - started
 
-    assert elapsed < 0.18
     assert begin_attempts <= 2
+    clamped_timeouts = [timeout_ms for timeout_ms in store.conn.timeout_history if timeout_ms != 5000]
+    assert clamped_timeouts
+    assert max(clamped_timeouts) <= 80
+    assert store.conn.timeout_ms == 5000
     assert structured["status"] == "DEFERRED"
     assert structured["deferred"]["action"] == "queued_for_replay"
 


### PR DESCRIPTION
## Summary
- replace two scheduler-dependent wall-clock assertions with behavioral retry, deferral, timeout-clamp, and restoration checks
- capture and join only the store background thread in auto-enrichment tests
- remove the telemetry-enabled heartbeat join race from the named test and its sibling

## Verification
- `BRAINLAYER_WRITER_TELEMETRY=1 uv run --extra dev pytest -q tests/test_auto_enrich.py tests/test_store_handler.py` — 51 passed
- `uv run --extra dev ruff check tests/test_store_handler.py tests/test_auto_enrich.py`
- `uv run --extra dev ruff format --check tests/test_store_handler.py tests/test_auto_enrich.py`
- changed-only pre-push gate passed: 51 affected tests, 3 MCP registration tests, 40 isolated eval/hook tests, 1 Bun test, and the FTS5 determinism shell regression
- local CodeRabbit review: 0 findings
- Claude pair-review: ACCEPT after one blocking coverage finding was fixed

## Scope
Test-only. Per the worker brief, `tests/test_vector_store.py` and `tests/test_engine.py` were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test assertions and synchronization; no production code paths are modified.
> 
> **Overview**
> **Test-only hardening** against scheduler- and telemetry-related flakes in store busy-budget and auto-enrichment integration tests.
> 
> In **`tests/test_store_handler.py`**, two busy-budget scenarios no longer assert maximum wall-clock duration (`elapsed < …`). They still check **behavior**: retry attempt caps, **DEFERRED** / `queued_for_replay` receipts, and pending-queue replay. The inner `BEGIN IMMEDIATE` retry test now records **`setbusytimeout`** calls and asserts timeouts are **clamped to `BRAINLAYER_STORE_BUSY_BUDGET_MS` (80ms)** and the connection is **restored to 5000ms** after deferral.
> 
> In **`tests/test_auto_enrich.py`**, integration tests **monkeypatch `threading.Thread`** to capture the single background thread started by `_store_new`, then **join that thread** instead of scanning `threading.enumerate()` for arbitrary daemon threads (which could race with writer heartbeat threads under `BRAINLAYER_WRITER_TELEMETRY=1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271a30514fb32d591aae07c8fc5ae1b8e4cd77a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test synchronization for background enrichment tasks.
  * Added coverage for both successful and failed enrichment scenarios.
  * Strengthened busy-budget tests to verify timeout limits and restoration.
  * Removed reliance on elapsed wall-clock timing for retry validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->