### PR TITLE
fix: keep hotlane embedding through enrichment backlog

### DIFF
--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -419,9 +419,13 @@ def _queue_depth(queue_dir: Path) -> int:
         return 0
 
 
+def _is_enrichment_queue_file(path: Path) -> bool:
+    return path.name.startswith("enrichment-") or path.name.startswith("queue-enrichment")
+
+
 def _high_priority_queue_depth(queue_dir: Path) -> int:
     try:
-        return sum(1 for path in queue_dir.glob("*.jsonl") if not path.name.startswith("enrichment-"))
+        return sum(1 for path in queue_dir.glob("*.jsonl") if not _is_enrichment_queue_file(path))
     except OSError:
         return 0
 

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -505,6 +505,7 @@ def run(
     last_backlog = time_fn() - backlog_interval
     last_enrich = 0.0
     enrich_disabled = False
+    queue_backpressure_active = False
     cycles = 0
     backlog_batch = min(max(backlog_batch, 0), MAX_BACKLOG_BATCH)
     LOGGER.info("hotlane adapter started db=%s", db_path)
@@ -515,23 +516,23 @@ def run(
             now = time_fn()
             queue_has_backlog = queue_depth_fn(queue_dir) > 0
             queue_has_high_priority_backlog = queue_has_backlog and high_priority_queue_depth_fn(queue_dir) > 0
-            if queue_has_backlog:
-                if queue_has_high_priority_backlog:
+            if queue_has_high_priority_backlog:
+                if not queue_backpressure_active:
                     LOGGER.info("durable high-priority queue has backlog; yielding all hotlane writer work")
-                else:
-                    LOGGER.info("durable queue has backlog; yielding all hotlane writer work")
+                queue_backpressure_active = True
                 cycles += 1
                 sleep_fn(interval)
                 continue
-            else:
-                cycle_backlog_batch = (
-                    backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
-                )
-                cycle_enrich_limit = (
-                    enrich_limit
-                    if not enrich_disabled and enrich_limit > 0 and now - last_enrich >= enrich_interval
-                    else 0
-                )
+            queue_backpressure_active = False
+            cycle_backlog_batch = backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
+            cycle_enrich_limit = (
+                enrich_limit
+                if not queue_has_backlog
+                and not enrich_disabled
+                and enrich_limit > 0
+                and now - last_enrich >= enrich_interval
+                else 0
+            )
             if cycle_backlog_batch > 0:
                 last_backlog = now
             if cycle_enrich_limit > 0:

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -542,11 +543,15 @@ def test_hotlane_run_opens_and_closes_writer_store_each_cycle(tmp_path):
     assert [event[0] for event in events] == ["open", "close", "open", "close"]
 
 
-def test_hotlane_run_yields_all_writer_work_during_enrichment_queue_backlog(tmp_path):
+def test_hotlane_run_continues_embedding_during_enrichment_only_queue_backlog(tmp_path):
     hotlane = _load_hotlane_module()
     opened = []
     cycle_calls = []
     sleeps = []
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    (queue_dir / "enrichment-first.jsonl").write_text("{}\n")
+    (queue_dir / "enrichment-second.jsonl").write_text("{}\n")
 
     class FakeStore:
         def __init__(self, path):
@@ -570,13 +575,65 @@ def test_hotlane_run_yields_all_writer_work_during_enrichment_queue_backlog(tmp_
         time_fn=iter([0.0, 100.0]).__next__,
         sleep_fn=sleeps.append,
         max_cycles=1,
-        queue_depth_fn=lambda _queue_dir: 3,
-        high_priority_queue_depth_fn=lambda _queue_dir: 0,
+        queue_dir=queue_dir,
     )
 
-    assert opened == []
-    assert cycle_calls == []
+    assert opened == [tmp_path / "brainlayer.db"]
+    assert len(cycle_calls) == 1
+    assert cycle_calls[0]["backlog_batch"] == hotlane.DEFAULT_BACKLOG_BATCH
+    assert cycle_calls[0]["enrich_limit"] == 0
     assert sleeps == [0.25]
+
+
+def test_hotlane_run_logs_high_priority_backpressure_once_per_blocked_state(tmp_path, caplog):
+    hotlane = _load_hotlane_module()
+    caplog.set_level(logging.INFO, logger=hotlane.LOGGER.name)
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    high_priority_event = queue_dir / "store-pending.jsonl"
+    high_priority_event.write_text("{}\n")
+    (queue_dir / "enrichment-pending.jsonl").write_text("{}\n")
+    cycle_calls = []
+    sleep_count = 0
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    def update_queue_after_cycle(_seconds):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count == 2:
+            high_priority_event.unlink()
+        elif sleep_count == 3:
+            high_priority_event.write_text("{}\n")
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=hotlane.DEFAULT_HOTLANE_ENRICH_LIMIT,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=lambda **kwargs: cycle_calls.append(kwargs) or hotlane.CycleResult(),
+        time_fn=iter([0.0, 100.0, 101.0, 102.0, 103.0, 104.0]).__next__,
+        sleep_fn=update_queue_after_cycle,
+        max_cycles=5,
+        queue_dir=queue_dir,
+    )
+
+    yield_logs = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "durable high-priority queue has backlog; yielding all hotlane writer work"
+    ]
+    assert len(yield_logs) == 2
+    assert len(cycle_calls) == 1
+    assert cycle_calls[0]["enrich_limit"] == 0
 
 
 def test_hotlane_run_yields_all_writer_work_during_high_priority_queue_backlog(tmp_path):

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -551,7 +551,7 @@ def test_hotlane_run_continues_embedding_during_enrichment_only_queue_backlog(tm
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     (queue_dir / "enrichment-first.jsonl").write_text("{}\n")
-    (queue_dir / "enrichment-second.jsonl").write_text("{}\n")
+    (queue_dir / "queue-enrichment-legacy.jsonl").write_text("{}\n")
 
     class FakeStore:
         def __init__(self, path):


### PR DESCRIPTION
## Summary
- yield all hotlane writer work only when the durable queue contains high-priority events
- keep hot and pending embedding work active for enrichment-only backlog while suppressing hotlane enrichment
- log high-priority backpressure only when entering a blocked episode, with re-entry coverage

## Why
Paused enrichment events are deliberately preserved in the durable queue. Treating those files as general writer backpressure starves the registered missing-embedding recovery path and emits an identical log line every daemon cycle.

## Test plan
- [x] RED: enrichment-only real queue directory starves embedding on main
- [x] RED: three blocked cycles emit three identical yield logs on main
- [x] 25 hotlane daemon tests
- [x] changed-only pre-push gate: 25 hotlane + 3 MCP registration + 40 isolated routing/eval + Bun + shell regression
- [x] ruff check and format check
- [x] local CodeRabbit review: 0 findings
- [x] Claude Opus pair review: APPROVE after blocked → clear → blocked coverage

## Deployment verification
After merge, update the deployment checkout, restart com.brainlayer.hotlane-brainbar, and verify with the real enrichment-only queue that missing embeddings decrease and the error log stops growing.

## Operational note
The intended behavior allows embed writes while paused enrichment events remain queued. Hotlane enrichment itself remains suppressed until the durable queue is empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hotlane writer scheduling against the durable queue, which affects when embeddings and enrichment run relative to queued events; scope is limited to the daemon loop and covered by targeted tests.
> 
> **Overview**
> **Hotlane no longer treats enrichment-only durable queue files as full writer backpressure.** The daemon only skips embedding/backlog cycles when **high-priority** `*.jsonl` queue files exist; paused enrichment files (`enrichment-*` and legacy `queue-enrichment*`) no longer block the loop.
> 
> When the queue still has files but none are high-priority, cycles run as usual with hot/pending embedding, while **`enrich_limit` is forced to 0** so hotlane enrichment stays off until the durable queue is empty. High-priority blocking logs **once per blocked episode** (re-logged after backlog clears and returns), instead of every cycle.
> 
> Tests cover enrichment-only backlog (embedding continues, enrich suppressed) and the once-per-state yield logging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900cc7b0a8743c237218ae27b65f715df845ea28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep hotlane embedding active during enrichment-only backlog
> - The daemon previously yielded all writer work whenever any backlog existed; it now yields only when high-priority backlog is present, allowing embedding to continue during enrichment-only backlogs.
> - `enrich_limit` is still set to 0 whenever any backlog exists, suppressing enrichment work during those cycles.
> - `_high_priority_queue_depth` in [hotlane_brainbar_daemon.py](https://github.com/EtanHey/brainlayer/pull/658/files#diff-a6f55cd2d945568d3534e21b0c40cf5a431cb8287640870ba7b2a6149ac2c0d9) now excludes both `enrichment-` and `queue-enrichment` prefixed files (previously only `enrichment-` was excluded).
> - High-priority backpressure is logged once per blocked state transition rather than on every blocked cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 900cc7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->