### PR TITLE
fix: bound hotlane candidate scans

### DIFF
--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -73,7 +73,7 @@ def _candidate_chunk_ids(store: VectorStore, *, limit: int) -> list[str]:
     rows = store.conn.cursor().execute(
         """
         SELECT c.id
-        FROM chunks c INDEXED BY idx_chunks_created_at
+        FROM chunks c
         LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
         WHERE r.id IS NULL
           AND c.source_file = 'brainbar-store'

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -167,7 +167,7 @@ def _candidates_from_scanned_rows(
             vector_id,
         ) = row
         last_inspected_rowid = int(rowid)
-        if (
+        eligible = (
             vector_id is None
             and source_file == "brainbar-store"
             and source == "mcp"
@@ -177,10 +177,12 @@ def _candidates_from_scanned_rows(
             and aggregated_into is None
             and not archived
             and status == "active"
-            and str(chunk_id) not in exclude_ids
-        ):
+        )
+        if eligible:
             if first_candidate_rowid is None:
                 first_candidate_rowid = int(rowid)
+            if str(chunk_id) in exclude_ids:
+                continue
             candidates.append(EmbedCandidate(str(chunk_id), str(content)))
             if len(candidates) >= limit:
                 return candidates, first_candidate_rowid, last_inspected_rowid, index == len(rows) - 1

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -102,6 +102,26 @@ HOT_CANDIDATE_ROWID_PAGE_SQL = """
     LIMIT ?
 """
 
+HOT_CANDIDATE_ROWID_FORWARD_SQL = """
+    SELECT
+        c.rowid,
+        c.id,
+        c.content,
+        c.source_file,
+        c.source,
+        c.archived_at,
+        c.superseded_by,
+        c.aggregated_into,
+        COALESCE(c.archived, 0),
+        COALESCE(c.status, 'active'),
+        r.id
+    FROM chunks c
+    LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
+    WHERE c.rowid > ?
+    ORDER BY c.rowid ASC
+    LIMIT ?
+"""
+
 
 class CycleResult(NamedTuple):
     embedded: int = 0
@@ -123,10 +143,14 @@ class EmbeddedVector(NamedTuple):
     embedding: list[float]
 
 
-def _candidates_from_scanned_rows(rows: list[tuple], *, limit: int) -> tuple[list[EmbedCandidate], int | None, bool]:
+def _candidates_from_scanned_rows(
+    rows: list[tuple], *, limit: int, exclude_ids: set[str] | None = None
+) -> tuple[list[EmbedCandidate], int | None, int | None, bool]:
     if limit <= 0:
-        return [], None, False
+        return [], None, None, False
     candidates: list[EmbedCandidate] = []
+    exclude_ids = exclude_ids or set()
+    first_candidate_rowid: int | None = None
     last_inspected_rowid: int | None = None
     for index, row in enumerate(rows):
         (
@@ -153,11 +177,14 @@ def _candidates_from_scanned_rows(rows: list[tuple], *, limit: int) -> tuple[lis
             and aggregated_into is None
             and not archived
             and status == "active"
+            and str(chunk_id) not in exclude_ids
         ):
+            if first_candidate_rowid is None:
+                first_candidate_rowid = int(rowid)
             candidates.append(EmbedCandidate(str(chunk_id), str(content)))
             if len(candidates) >= limit:
-                return candidates, last_inspected_rowid, index == len(rows) - 1
-    return candidates, last_inspected_rowid, True
+                return candidates, first_candidate_rowid, last_inspected_rowid, index == len(rows) - 1
+    return candidates, first_candidate_rowid, last_inspected_rowid, True
 
 
 class HotCandidateScanner:
@@ -165,37 +192,54 @@ class HotCandidateScanner:
 
     def __init__(self) -> None:
         self._before_rowid: int | None = None
+        self._newest_seen_rowid: int | None = None
 
     def __call__(self, store: VectorStore, *, limit: int) -> list[EmbedCandidate]:
         cursor = store.conn.cursor()
         head_rows = list(cursor.execute(HOT_CANDIDATE_ROWID_SCAN_SQL, (HOT_CANDIDATE_HEAD_LIMIT,)))
-        candidates, _, _ = _candidates_from_scanned_rows(head_rows, limit=limit)
-        if len(head_rows) < HOT_CANDIDATE_HEAD_LIMIT:
-            self._before_rowid = None
+        candidates, _, _, _ = _candidates_from_scanned_rows(head_rows, limit=limit)
+        if not head_rows:
             return candidates
+        if self._newest_seen_rowid is None:
+            self._newest_seen_rowid = int(head_rows[0][0])
+        if self._before_rowid is None and len(head_rows) == HOT_CANDIDATE_HEAD_LIMIT:
+            self._before_rowid = int(head_rows[-1][0])
         if len(candidates) >= limit:
             return candidates
 
-        if self._before_rowid is None:
-            self._before_rowid = int(head_rows[-1][0])
         page_limit = HOT_CANDIDATE_SCAN_LIMIT - HOT_CANDIDATE_HEAD_LIMIT
-        page_rows = list(
+        forward_rows = list(
             cursor.execute(
-                HOT_CANDIDATE_ROWID_PAGE_SQL,
-                (self._before_rowid, page_limit),
+                HOT_CANDIDATE_ROWID_FORWARD_SQL,
+                (self._newest_seen_rowid, page_limit),
             )
         )
+        if forward_rows:
+            forward_candidates, first_candidate_rowid, last_inspected_rowid, _ = _candidates_from_scanned_rows(
+                forward_rows,
+                limit=limit - len(candidates),
+                exclude_ids={candidate.chunk_id for candidate in candidates},
+            )
+            candidates.extend(forward_candidates)
+            self._newest_seen_rowid = (
+                first_candidate_rowid - 1 if first_candidate_rowid is not None else last_inspected_rowid
+            )
+        if len(candidates) >= limit or self._before_rowid is None:
+            return candidates[:limit]
+
+        page_rows = list(cursor.execute(HOT_CANDIDATE_ROWID_PAGE_SQL, (self._before_rowid, page_limit)))
         if page_rows:
-            page_candidates, last_inspected_rowid, fully_scanned = _candidates_from_scanned_rows(
+            page_candidates, first_candidate_rowid, last_inspected_rowid, fully_scanned = _candidates_from_scanned_rows(
                 page_rows,
                 limit=limit - len(candidates),
+                exclude_ids={candidate.chunk_id for candidate in candidates},
             )
             candidates.extend(page_candidates)
-            self._before_rowid = last_inspected_rowid
-        else:
-            fully_scanned = True
-        if fully_scanned and len(page_rows) < page_limit:
-            self._before_rowid = None
+            self._before_rowid = (
+                first_candidate_rowid + 1 if first_candidate_rowid is not None else last_inspected_rowid
+            )
+            if first_candidate_rowid is None and fully_scanned and len(page_rows) < page_limit:
+                self._before_rowid = None
         return candidates[:limit]
 
 

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -97,7 +97,7 @@ def _candidate_chunk_rows(store: VectorStore, *, limit: int) -> list[EmbedCandid
     rows = store.conn.cursor().execute(
         """
         SELECT c.id, c.content
-        FROM chunks c INDEXED BY idx_chunks_created_at
+        FROM chunks c INDEXED BY idx_chunks_created
         LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
         WHERE r.id IS NULL
           AND c.source_file = 'brainbar-store'

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -263,7 +263,8 @@ class HotCandidateScanner:
         else:
             retry_limit = min(len(self._retries), max(1, limit // 2))
         candidates = self._take_retries(limit=retry_limit)
-        scan_limit = min(limit - len(candidates), MAX_HOT_CANDIDATE_RETRIES - len(self._retries))
+        retention_slots = MAX_HOT_CANDIDATE_RETRIES - len(self._retries)
+        scan_limit = min(limit - len(candidates), retention_slots)
         if scan_limit <= 0:
             return candidates
         retry_ids = set(self._retries)
@@ -274,6 +275,7 @@ class HotCandidateScanner:
             exclude_ids=retry_ids,
         )
         candidates.extend(head_candidates)
+        retention_slots -= len(head_candidates)
         if not head_rows:
             self._retain(candidates)
             return candidates
@@ -281,7 +283,7 @@ class HotCandidateScanner:
             self._newest_seen_rowid = last_inspected_rowid
         if self._before_rowid is None and last_inspected_rowid is not None:
             self._before_rowid = last_inspected_rowid
-        if len(candidates) >= limit:
+        if len(candidates) >= limit or retention_slots <= 0:
             self._retain(candidates)
             return candidates
 
@@ -295,12 +297,13 @@ class HotCandidateScanner:
         if forward_rows:
             forward_candidates, _, last_inspected_rowid, _ = _candidates_from_scanned_rows(
                 forward_rows,
-                limit=limit - len(candidates),
+                limit=min(limit - len(candidates), retention_slots),
                 exclude_ids=retry_ids | {candidate.chunk_id for candidate in candidates},
             )
             candidates.extend(forward_candidates)
+            retention_slots -= len(forward_candidates)
             self._newest_seen_rowid = last_inspected_rowid
-        if len(candidates) >= limit or self._before_rowid is None:
+        if len(candidates) >= limit or retention_slots <= 0 or self._before_rowid is None:
             self._retain(candidates)
             return candidates[:limit]
 
@@ -308,7 +311,7 @@ class HotCandidateScanner:
         if page_rows:
             page_candidates, _, last_inspected_rowid, fully_scanned = _candidates_from_scanned_rows(
                 page_rows,
-                limit=limit - len(candidates),
+                limit=min(limit - len(candidates), retention_slots),
                 exclude_ids=retry_ids | {candidate.chunk_id for candidate in candidates},
             )
             candidates.extend(page_candidates)

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -41,7 +41,26 @@ MAX_BACKLOG_BATCH = 16
 DEFAULT_HOTLANE_WRITE_BUSY_TIMEOUT_MS = 1000
 MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 VECTOR_WRITE_YIELD_SECONDS = 0.005
+HOT_CANDIDATE_SCAN_LIMIT = 256
 _sleep = time.sleep
+
+HOT_CANDIDATE_SCAN_SQL = """
+    SELECT
+        c.id,
+        c.content,
+        c.source_file,
+        c.source,
+        c.archived_at,
+        c.superseded_by,
+        c.aggregated_into,
+        COALESCE(c.archived, 0),
+        COALESCE(c.status, 'active'),
+        r.id
+    FROM chunks c
+    LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
+    ORDER BY c.created_at DESC
+    LIMIT ?
+"""
 
 
 class CycleResult(NamedTuple):
@@ -95,26 +114,38 @@ def _candidate_chunk_ids(store: VectorStore, *, limit: int) -> list[str]:
 
 def _candidate_chunk_rows(store: VectorStore, *, limit: int) -> list[EmbedCandidate]:
     rows = store.conn.cursor().execute(
-        """
-        SELECT c.id, c.content
-        FROM chunks c INDEXED BY idx_chunks_created
-        LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
-        WHERE r.id IS NULL
-          AND c.source_file = 'brainbar-store'
-          AND c.source = 'mcp'
-          AND c.content IS NOT NULL
-          AND c.content != ''
-          AND c.archived_at IS NULL
-          AND c.superseded_by IS NULL
-          AND c.aggregated_into IS NULL
-          AND COALESCE(c.archived, 0) = 0
-          AND COALESCE(c.status, 'active') = 'active'
-        ORDER BY c.created_at DESC
-        LIMIT ?
-        """,
-        (limit,),
+        HOT_CANDIDATE_SCAN_SQL,
+        (HOT_CANDIDATE_SCAN_LIMIT,),
     )
-    return [EmbedCandidate(str(row[0]), str(row[1])) for row in rows]
+    candidates: list[EmbedCandidate] = []
+    for row in rows:
+        (
+            chunk_id,
+            content,
+            source_file,
+            source,
+            archived_at,
+            superseded_by,
+            aggregated_into,
+            archived,
+            status,
+            vector_id,
+        ) = row
+        if (
+            vector_id is None
+            and source_file == "brainbar-store"
+            and source == "mcp"
+            and content
+            and archived_at is None
+            and superseded_by is None
+            and aggregated_into is None
+            and not archived
+            and status == "active"
+        ):
+            candidates.append(EmbedCandidate(str(chunk_id), str(content)))
+            if len(candidates) >= limit:
+                break
+    return candidates
 
 
 def _pending_chunk_rows(store: VectorStore, *, limit: int) -> list[EmbedCandidate]:

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -15,6 +15,7 @@ import logging
 import os
 import signal
 import time
+from collections import OrderedDict
 from pathlib import Path
 from typing import Callable, NamedTuple
 
@@ -43,6 +44,7 @@ MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 VECTOR_WRITE_YIELD_SECONDS = 0.005
 HOT_CANDIDATE_SCAN_LIMIT = 256
 HOT_CANDIDATE_HEAD_LIMIT = HOT_CANDIDATE_SCAN_LIMIT // 2
+MAX_HOT_CANDIDATE_RETRIES = 256
 _sleep = time.sleep
 
 HOT_CANDIDATE_SCAN_SQL = """
@@ -190,27 +192,97 @@ def _candidates_from_scanned_rows(
 
 
 class HotCandidateScanner:
-    """Scan the recent head every cycle while paging through older rows."""
+    """Scan bounded rowid lanes while retaining returned candidates for retry."""
 
     def __init__(self) -> None:
         self._before_rowid: int | None = None
         self._newest_seen_rowid: int | None = None
+        self._retries: OrderedDict[str, EmbedCandidate] = OrderedDict()
+        self._retry_turn = True
+        self._retry_buffer_full_logged = False
+
+    def _refresh_retries(self, cursor: apsw.Cursor) -> None:
+        if not self._retries:
+            return
+        placeholders = ",".join("?" for _ in self._retries)
+        rows = cursor.execute(
+            f"""
+            SELECT c.id, c.content
+            FROM chunks c
+            LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
+            WHERE c.id IN ({placeholders})
+              AND r.id IS NULL
+              AND c.source_file = 'brainbar-store'
+              AND c.source = 'mcp'
+              AND c.content IS NOT NULL
+              AND c.content != ''
+              AND c.archived_at IS NULL
+              AND c.superseded_by IS NULL
+              AND c.aggregated_into IS NULL
+              AND COALESCE(c.archived, 0) = 0
+              AND COALESCE(c.status, 'active') = 'active'
+            """,
+            tuple(self._retries),
+        )
+        active = {str(chunk_id): EmbedCandidate(str(chunk_id), str(content)) for chunk_id, content in rows}
+        for chunk_id in list(self._retries):
+            if chunk_id not in active:
+                del self._retries[chunk_id]
+            else:
+                self._retries[chunk_id] = active[chunk_id]
+        if len(self._retries) < MAX_HOT_CANDIDATE_RETRIES:
+            self._retry_buffer_full_logged = False
+
+    def _take_retries(self, *, limit: int) -> list[EmbedCandidate]:
+        selected: list[EmbedCandidate] = []
+        for _ in range(min(limit, len(self._retries))):
+            chunk_id, candidate = self._retries.popitem(last=False)
+            self._retries[chunk_id] = candidate
+            selected.append(candidate)
+        return selected
+
+    def _retain(self, candidates: list[EmbedCandidate]) -> None:
+        for candidate in candidates:
+            if candidate.chunk_id in self._retries:
+                continue
+            if len(self._retries) >= MAX_HOT_CANDIDATE_RETRIES:
+                if not self._retry_buffer_full_logged:
+                    LOGGER.warning("hot candidate retry buffer full; pausing new retry retention")
+                    self._retry_buffer_full_logged = True
+                break
+            self._retries[candidate.chunk_id] = candidate
 
     def __call__(self, store: VectorStore, *, limit: int) -> list[EmbedCandidate]:
         cursor = store.conn.cursor()
+        self._refresh_retries(cursor)
+        if limit <= 0:
+            return []
+        if limit == 1 and self._retries:
+            retry_limit = 1 if self._retry_turn else 0
+            self._retry_turn = not self._retry_turn
+        else:
+            retry_limit = min(len(self._retries), max(1, limit // 2))
+        candidates = self._take_retries(limit=retry_limit)
+        scan_limit = min(limit - len(candidates), MAX_HOT_CANDIDATE_RETRIES - len(self._retries))
+        if scan_limit <= 0:
+            return candidates
+        retry_ids = set(self._retries)
         head_rows = list(cursor.execute(HOT_CANDIDATE_ROWID_SCAN_SQL, (HOT_CANDIDATE_HEAD_LIMIT,)))
-        candidates, first_candidate_rowid, last_inspected_rowid, _ = _candidates_from_scanned_rows(
-            head_rows, limit=limit
+        head_candidates, _, last_inspected_rowid, _ = _candidates_from_scanned_rows(
+            head_rows,
+            limit=scan_limit,
+            exclude_ids=retry_ids,
         )
+        candidates.extend(head_candidates)
         if not head_rows:
+            self._retain(candidates)
             return candidates
         if self._newest_seen_rowid is None:
-            self._newest_seen_rowid = (
-                first_candidate_rowid - 1 if first_candidate_rowid is not None else int(head_rows[0][0])
-            )
+            self._newest_seen_rowid = last_inspected_rowid
         if self._before_rowid is None and last_inspected_rowid is not None:
             self._before_rowid = last_inspected_rowid
         if len(candidates) >= limit:
+            self._retain(candidates)
             return candidates
 
         page_limit = HOT_CANDIDATE_SCAN_LIMIT - HOT_CANDIDATE_HEAD_LIMIT
@@ -221,31 +293,29 @@ class HotCandidateScanner:
             )
         )
         if forward_rows:
-            forward_candidates, first_candidate_rowid, last_inspected_rowid, _ = _candidates_from_scanned_rows(
+            forward_candidates, _, last_inspected_rowid, _ = _candidates_from_scanned_rows(
                 forward_rows,
                 limit=limit - len(candidates),
-                exclude_ids={candidate.chunk_id for candidate in candidates},
+                exclude_ids=retry_ids | {candidate.chunk_id for candidate in candidates},
             )
             candidates.extend(forward_candidates)
-            self._newest_seen_rowid = (
-                first_candidate_rowid - 1 if first_candidate_rowid is not None else last_inspected_rowid
-            )
+            self._newest_seen_rowid = last_inspected_rowid
         if len(candidates) >= limit or self._before_rowid is None:
+            self._retain(candidates)
             return candidates[:limit]
 
         page_rows = list(cursor.execute(HOT_CANDIDATE_ROWID_PAGE_SQL, (self._before_rowid, page_limit)))
         if page_rows:
-            page_candidates, first_candidate_rowid, last_inspected_rowid, fully_scanned = _candidates_from_scanned_rows(
+            page_candidates, _, last_inspected_rowid, fully_scanned = _candidates_from_scanned_rows(
                 page_rows,
                 limit=limit - len(candidates),
-                exclude_ids={candidate.chunk_id for candidate in candidates},
+                exclude_ids=retry_ids | {candidate.chunk_id for candidate in candidates},
             )
             candidates.extend(page_candidates)
-            self._before_rowid = (
-                first_candidate_rowid + 1 if first_candidate_rowid is not None else last_inspected_rowid
-            )
-            if first_candidate_rowid is None and fully_scanned and len(page_rows) < page_limit:
+            self._before_rowid = last_inspected_rowid
+            if fully_scanned and len(page_rows) < page_limit:
                 self._before_rowid = None
+        self._retain(candidates)
         return candidates[:limit]
 
 

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -123,13 +123,14 @@ class EmbeddedVector(NamedTuple):
     embedding: list[float]
 
 
-def _candidates_from_scanned_rows(rows: list[tuple], *, limit: int) -> list[EmbedCandidate]:
+def _candidates_from_scanned_rows(rows: list[tuple], *, limit: int) -> tuple[list[EmbedCandidate], int | None, bool]:
     if limit <= 0:
-        return []
+        return [], None, False
     candidates: list[EmbedCandidate] = []
-    for row in rows:
+    last_inspected_rowid: int | None = None
+    for index, row in enumerate(rows):
         (
-            _rowid,
+            rowid,
             chunk_id,
             content,
             source_file,
@@ -141,6 +142,7 @@ def _candidates_from_scanned_rows(rows: list[tuple], *, limit: int) -> list[Embe
             status,
             vector_id,
         ) = row
+        last_inspected_rowid = int(rowid)
         if (
             vector_id is None
             and source_file == "brainbar-store"
@@ -154,8 +156,8 @@ def _candidates_from_scanned_rows(rows: list[tuple], *, limit: int) -> list[Embe
         ):
             candidates.append(EmbedCandidate(str(chunk_id), str(content)))
             if len(candidates) >= limit:
-                break
-    return candidates
+                return candidates, last_inspected_rowid, index == len(rows) - 1
+    return candidates, last_inspected_rowid, True
 
 
 class HotCandidateScanner:
@@ -167,9 +169,11 @@ class HotCandidateScanner:
     def __call__(self, store: VectorStore, *, limit: int) -> list[EmbedCandidate]:
         cursor = store.conn.cursor()
         head_rows = list(cursor.execute(HOT_CANDIDATE_ROWID_SCAN_SQL, (HOT_CANDIDATE_HEAD_LIMIT,)))
-        candidates = _candidates_from_scanned_rows(head_rows, limit=limit)
+        candidates, _, _ = _candidates_from_scanned_rows(head_rows, limit=limit)
         if len(head_rows) < HOT_CANDIDATE_HEAD_LIMIT:
             self._before_rowid = None
+            return candidates
+        if len(candidates) >= limit:
             return candidates
 
         if self._before_rowid is None:
@@ -182,9 +186,15 @@ class HotCandidateScanner:
             )
         )
         if page_rows:
-            self._before_rowid = int(page_rows[-1][0])
-            candidates.extend(_candidates_from_scanned_rows(page_rows, limit=max(limit - len(candidates), 0)))
-        if len(page_rows) < page_limit:
+            page_candidates, last_inspected_rowid, fully_scanned = _candidates_from_scanned_rows(
+                page_rows,
+                limit=limit - len(candidates),
+            )
+            candidates.extend(page_candidates)
+            self._before_rowid = last_inspected_rowid
+        else:
+            fully_scanned = True
+        if fully_scanned and len(page_rows) < page_limit:
             self._before_rowid = None
         return candidates[:limit]
 

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -73,7 +73,7 @@ def _candidate_chunk_ids(store: VectorStore, *, limit: int) -> list[str]:
     rows = store.conn.cursor().execute(
         """
         SELECT c.id
-        FROM chunks c
+        FROM chunks c INDEXED BY idx_chunks_created_at
         LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
         WHERE r.id IS NULL
           AND c.source_file = 'brainbar-store'
@@ -97,7 +97,7 @@ def _candidate_chunk_rows(store: VectorStore, *, limit: int) -> list[EmbedCandid
     rows = store.conn.cursor().execute(
         """
         SELECT c.id, c.content
-        FROM chunks c
+        FROM chunks c INDEXED BY idx_chunks_created_at
         LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
         WHERE r.id IS NULL
           AND c.source_file = 'brainbar-store'

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -42,6 +42,7 @@ DEFAULT_HOTLANE_WRITE_BUSY_TIMEOUT_MS = 1000
 MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 VECTOR_WRITE_YIELD_SECONDS = 0.005
 HOT_CANDIDATE_SCAN_LIMIT = 256
+HOT_CANDIDATE_HEAD_LIMIT = HOT_CANDIDATE_SCAN_LIMIT // 2
 _sleep = time.sleep
 
 HOT_CANDIDATE_SCAN_SQL = """
@@ -59,6 +60,45 @@ HOT_CANDIDATE_SCAN_SQL = """
     FROM chunks c
     LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
     ORDER BY c.created_at DESC
+    LIMIT ?
+"""
+
+HOT_CANDIDATE_ROWID_SCAN_SQL = """
+    SELECT
+        c.rowid,
+        c.id,
+        c.content,
+        c.source_file,
+        c.source,
+        c.archived_at,
+        c.superseded_by,
+        c.aggregated_into,
+        COALESCE(c.archived, 0),
+        COALESCE(c.status, 'active'),
+        r.id
+    FROM chunks c
+    LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
+    ORDER BY c.rowid DESC
+    LIMIT ?
+"""
+
+HOT_CANDIDATE_ROWID_PAGE_SQL = """
+    SELECT
+        c.rowid,
+        c.id,
+        c.content,
+        c.source_file,
+        c.source,
+        c.archived_at,
+        c.superseded_by,
+        c.aggregated_into,
+        COALESCE(c.archived, 0),
+        COALESCE(c.status, 'active'),
+        r.id
+    FROM chunks c
+    LEFT JOIN chunk_vectors_rowids r ON r.id = c.id
+    WHERE c.rowid < ?
+    ORDER BY c.rowid DESC
     LIMIT ?
 """
 
@@ -81,6 +121,72 @@ class EmbeddedVector(NamedTuple):
     chunk_id: str
     content: str
     embedding: list[float]
+
+
+def _candidates_from_scanned_rows(rows: list[tuple], *, limit: int) -> list[EmbedCandidate]:
+    if limit <= 0:
+        return []
+    candidates: list[EmbedCandidate] = []
+    for row in rows:
+        (
+            _rowid,
+            chunk_id,
+            content,
+            source_file,
+            source,
+            archived_at,
+            superseded_by,
+            aggregated_into,
+            archived,
+            status,
+            vector_id,
+        ) = row
+        if (
+            vector_id is None
+            and source_file == "brainbar-store"
+            and source == "mcp"
+            and content
+            and archived_at is None
+            and superseded_by is None
+            and aggregated_into is None
+            and not archived
+            and status == "active"
+        ):
+            candidates.append(EmbedCandidate(str(chunk_id), str(content)))
+            if len(candidates) >= limit:
+                break
+    return candidates
+
+
+class HotCandidateScanner:
+    """Scan the recent head every cycle while paging through older rows."""
+
+    def __init__(self) -> None:
+        self._before_rowid: int | None = None
+
+    def __call__(self, store: VectorStore, *, limit: int) -> list[EmbedCandidate]:
+        cursor = store.conn.cursor()
+        head_rows = list(cursor.execute(HOT_CANDIDATE_ROWID_SCAN_SQL, (HOT_CANDIDATE_HEAD_LIMIT,)))
+        candidates = _candidates_from_scanned_rows(head_rows, limit=limit)
+        if len(head_rows) < HOT_CANDIDATE_HEAD_LIMIT:
+            self._before_rowid = None
+            return candidates
+
+        if self._before_rowid is None:
+            self._before_rowid = int(head_rows[-1][0])
+        page_limit = HOT_CANDIDATE_SCAN_LIMIT - HOT_CANDIDATE_HEAD_LIMIT
+        page_rows = list(
+            cursor.execute(
+                HOT_CANDIDATE_ROWID_PAGE_SQL,
+                (self._before_rowid, page_limit),
+            )
+        )
+        if page_rows:
+            self._before_rowid = int(page_rows[-1][0])
+            candidates.extend(_candidates_from_scanned_rows(page_rows, limit=max(limit - len(candidates), 0)))
+        if len(page_rows) < page_limit:
+            self._before_rowid = None
+        return candidates[:limit]
 
 
 def _stop(_signum: int, _frame: object) -> None:
@@ -541,6 +647,7 @@ def run(
     last_enrich = 0.0
     enrich_disabled = False
     queue_backpressure_active = False
+    hot_candidate_scanner = HotCandidateScanner()
     cycles = 0
     backlog_batch = min(max(backlog_batch, 0), MAX_BACKLOG_BATCH)
     LOGGER.info("hotlane adapter started db=%s", db_path)
@@ -582,6 +689,7 @@ def run(
                     embed_batch_fn=embed_batch_fn,
                     enrich_limit=cycle_enrich_limit,
                     enrich_since_hours=enrich_since_hours,
+                    candidate_rows_fn=hot_candidate_scanner,
                 )
             else:
                 store = vector_store_cls(db_path)

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -199,13 +199,17 @@ class HotCandidateScanner:
     def __call__(self, store: VectorStore, *, limit: int) -> list[EmbedCandidate]:
         cursor = store.conn.cursor()
         head_rows = list(cursor.execute(HOT_CANDIDATE_ROWID_SCAN_SQL, (HOT_CANDIDATE_HEAD_LIMIT,)))
-        candidates, _, _, _ = _candidates_from_scanned_rows(head_rows, limit=limit)
+        candidates, first_candidate_rowid, last_inspected_rowid, _ = _candidates_from_scanned_rows(
+            head_rows, limit=limit
+        )
         if not head_rows:
             return candidates
         if self._newest_seen_rowid is None:
-            self._newest_seen_rowid = int(head_rows[0][0])
-        if self._before_rowid is None and len(head_rows) == HOT_CANDIDATE_HEAD_LIMIT:
-            self._before_rowid = int(head_rows[-1][0])
+            self._newest_seen_rowid = (
+                first_candidate_rowid - 1 if first_candidate_rowid is not None else int(head_rows[0][0])
+            )
+        if self._before_rowid is None and last_inspected_rowid is not None:
+            self._before_rowid = last_inspected_rowid
         if len(candidates) >= limit:
             return candidates
 

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -310,11 +310,13 @@ def test_hot_candidate_scanner_deduplicates_head_and_forward_catchup(tmp_path):
             status TEXT DEFAULT 'active'
         );
         CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
-        INSERT INTO chunks (id, content, source_file, source, created_at)
-        VALUES ('baseline', 'embedded', 'brainbar-store', 'mcp', 'before');
-        INSERT INTO chunk_vectors_rowids (id) VALUES ('baseline');
         """
     )
+    baseline_rows = [(f"baseline-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(1000)]
+    conn.executemany(
+        "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)", baseline_rows
+    )
+    conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in baseline_rows])
     scanner = hotlane.HotCandidateScanner()
     store = SimpleNamespace(conn=conn)
     try:
@@ -323,6 +325,12 @@ def test_hot_candidate_scanner_deduplicates_head_and_forward_catchup(tmp_path):
             "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES "
             "('new-hot', 'only once', 'brainbar-store', 'mcp', 'after')"
         )
+        assert scanner(store, limit=5) == [hotlane.EmbedCandidate("new-hot", "only once")]
+        newer_rows = [(f"later-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(128)]
+        conn.executemany(
+            "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)", newer_rows
+        )
+        conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in newer_rows])
         assert scanner(store, limit=5) == [hotlane.EmbedCandidate("new-hot", "only once")]
     finally:
         conn.close()

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import sqlite3
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -77,7 +78,7 @@ def test_hotlane_default_backlog_batch_drains_pending_embeddings():
     assert hotlane.DEFAULT_BACKLOG_BATCH == 4
 
 
-def test_hot_candidate_query_forces_created_at_index_to_avoid_full_mcp_sort():
+def test_hot_candidate_query_scans_a_bounded_recent_window_without_forcing_schema_index():
     hotlane = _load_hotlane_module()
     executed = []
 
@@ -89,9 +90,9 @@ def test_hot_candidate_query_forces_created_at_index_to_avoid_full_mcp_sort():
     store = SimpleNamespace(conn=SimpleNamespace(cursor=FakeCursor))
 
     assert hotlane._candidate_chunk_rows(store, limit=5) == []
-    assert "chunks c INDEXED BY idx_chunks_created" in executed[0][0]
-    assert "idx_chunks_created_at" not in executed[0][0]
-    assert executed[0][1] == (5,)
+    assert "INDEXED BY" not in executed[0][0]
+    assert "ORDER BY c.created_at DESC" in executed[0][0]
+    assert executed[0][1] == (hotlane.HOT_CANDIDATE_SCAN_LIMIT,)
 
 
 def test_hot_candidate_query_uses_index_created_by_python_vectorstore(tmp_path):
@@ -100,9 +101,65 @@ def test_hot_candidate_query_uses_index_created_by_python_vectorstore(tmp_path):
     hotlane = _load_hotlane_module()
     store = VectorStore(tmp_path / "brainlayer.db")
     try:
+        cursor = store.conn.cursor()
+        cursor.executemany(
+            """
+            INSERT INTO chunks (id, content, metadata, source_file, source, created_at)
+            VALUES (?, ?, '{}', 'provider-session', 'claude', ?)
+            """,
+            [(f"other-{index}", "already handled", f"2026-08-07T00:{index:03d}:00Z") for index in range(300)],
+        )
+        cursor.execute(
+            """
+            INSERT INTO chunks (id, content, metadata, source_file, source, created_at)
+            VALUES ('recent-brainbar', 'already embedded', '{}', 'brainbar-store', 'mcp', '9999-12-31T23:59:59Z')
+            """
+        )
+        store._upsert_chunk_vector(cursor, "recent-brainbar", [0.0] * 1024)
+
+        plan = [
+            str(row[3])
+            for row in cursor.execute(
+                "EXPLAIN QUERY PLAN " + hotlane.HOT_CANDIDATE_SCAN_SQL,
+                (hotlane.HOT_CANDIDATE_SCAN_LIMIT,),
+            )
+        ]
+        assert any("USING INDEX idx_chunks_created" in detail for detail in plan)
+        assert not any("USE TEMP B-TREE" in detail for detail in plan)
         assert hotlane._candidate_chunk_rows(store, limit=5) == []
     finally:
         store.close()
+
+
+def test_hot_candidate_query_uses_native_created_at_index_without_python_index(tmp_path):
+    hotlane = _load_hotlane_module()
+    conn = sqlite3.connect(tmp_path / "native.db")
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source_file TEXT,
+            source TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE INDEX idx_chunks_created_at ON chunks(created_at);
+        CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+        INSERT INTO chunks (id, content, source_file, source, created_at)
+        VALUES ('native-hot', 'pending native chunk', 'brainbar-store', 'mcp', '2026-08-08T00:00:00Z');
+        """
+    )
+    try:
+        assert hotlane._candidate_chunk_rows(SimpleNamespace(conn=conn), limit=5) == [
+            hotlane.EmbedCandidate("native-hot", "pending native chunk")
+        ]
+    finally:
+        conn.close()
 
 
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
@@ -776,8 +833,8 @@ def test_hotlane_split_cycle_writes_vectors_without_opening_vectorstore_writer(t
 
         def execute(self, sql, params=()):
             if self.readonly:
-                if "c.source_file = 'brainbar-store'" in sql:
-                    return [("hot-1", "hot content")]
+                if sql == hotlane.HOT_CANDIDATE_SCAN_SQL:
+                    return [("hot-1", "hot content", "brainbar-store", "mcp", None, None, None, 0, "active", None)]
                 return [("pending-1", "pending content")]
             events.append(("sql", sql.strip().splitlines()[0]))
             if sql.strip().startswith("SELECT 1"):
@@ -841,8 +898,11 @@ def test_hotlane_split_cycle_falls_through_recent_candidates_after_embed_failure
 
         def execute(self, sql, params=()):
             if self.readonly:
-                if "c.source_file = 'brainbar-store'" in sql:
-                    return [("hot-bad", "bad content"), ("hot-good", "good content")]
+                if sql == hotlane.HOT_CANDIDATE_SCAN_SQL:
+                    return [
+                        ("hot-bad", "bad content", "brainbar-store", "mcp", None, None, None, 0, "active", None),
+                        ("hot-good", "good content", "brainbar-store", "mcp", None, None, None, 0, "active", None),
+                    ]
                 return []
             events.append(("sql", sql.strip().splitlines()[0]))
             if sql.strip().startswith("SELECT 1"):

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -392,6 +392,51 @@ def test_hot_candidate_scanner_retries_startup_head_candidate_after_displacement
         conn.close()
 
 
+def test_hot_candidate_scanner_does_not_advance_past_retry_capacity(tmp_path):
+    hotlane = _load_hotlane_module()
+    conn = sqlite3.connect(tmp_path / "retry-capacity.db")
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source_file TEXT,
+            source TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+        """
+    )
+    retry_rows = [
+        (f"retry-{index}", "retry", "brainbar-store", "mcp", str(index))
+        for index in range(hotlane.MAX_HOT_CANDIDATE_RETRIES - 2)
+    ]
+    new_rows = [(f"new-{index}", "new", "brainbar-store", "mcp", str(index)) for index in range(3)]
+    conn.executemany(
+        "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)",
+        retry_rows + new_rows,
+    )
+    scanner = hotlane.HotCandidateScanner()
+    for row in retry_rows:
+        scanner._retries[row[0]] = hotlane.EmbedCandidate(row[0], row[1])
+    store = SimpleNamespace(conn=conn)
+    try:
+        first = scanner(store, limit=5)
+        assert len(first) == 4
+        assert [candidate.chunk_id for candidate in first[-2:]] == ["new-2", "new-1"]
+        conn.executemany(
+            "INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(candidate.chunk_id,) for candidate in first]
+        )
+        assert hotlane.EmbedCandidate("new-0", "new") in scanner(store, limit=5)
+    finally:
+        conn.close()
+
+
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
     hotlane = _load_hotlane_module()
     received_batch_fns = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -77,6 +77,22 @@ def test_hotlane_default_backlog_batch_drains_pending_embeddings():
     assert hotlane.DEFAULT_BACKLOG_BATCH == 4
 
 
+def test_hot_candidate_query_forces_created_at_index_to_avoid_full_mcp_sort():
+    hotlane = _load_hotlane_module()
+    executed = []
+
+    class FakeCursor:
+        def execute(self, sql, bindings):
+            executed.append((sql, bindings))
+            return []
+
+    store = SimpleNamespace(conn=SimpleNamespace(cursor=FakeCursor))
+
+    assert hotlane._candidate_chunk_rows(store, limit=5) == []
+    assert "chunks c INDEXED BY idx_chunks_created_at" in executed[0][0]
+    assert executed[0][1] == (5,)
+
+
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
     hotlane = _load_hotlane_module()
     received_batch_fns = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -89,8 +89,20 @@ def test_hot_candidate_query_forces_created_at_index_to_avoid_full_mcp_sort():
     store = SimpleNamespace(conn=SimpleNamespace(cursor=FakeCursor))
 
     assert hotlane._candidate_chunk_rows(store, limit=5) == []
-    assert "chunks c INDEXED BY idx_chunks_created_at" in executed[0][0]
+    assert "chunks c INDEXED BY idx_chunks_created" in executed[0][0]
+    assert "idx_chunks_created_at" not in executed[0][0]
     assert executed[0][1] == (5,)
+
+
+def test_hot_candidate_query_uses_index_created_by_python_vectorstore(tmp_path):
+    from brainlayer.vector_store import VectorStore
+
+    hotlane = _load_hotlane_module()
+    store = VectorStore(tmp_path / "brainlayer.db")
+    try:
+        assert hotlane._candidate_chunk_rows(store, limit=5) == []
+    finally:
+        store.close()
 
 
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -332,6 +332,19 @@ def test_hot_candidate_scanner_deduplicates_head_and_forward_catchup(tmp_path):
         )
         conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in newer_rows])
         assert scanner(store, limit=5) == [hotlane.EmbedCandidate("new-hot", "only once")]
+        conn.execute(
+            "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES "
+            "('later-hot', 'must progress', 'brainbar-store', 'mcp', 'later')"
+        )
+        final_rows = [(f"final-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(128)]
+        conn.executemany(
+            "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)", final_rows
+        )
+        conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in final_rows])
+        assert scanner(store, limit=5) == [
+            hotlane.EmbedCandidate("new-hot", "only once"),
+            hotlane.EmbedCandidate("later-hot", "must progress"),
+        ]
     finally:
         conn.close()
 

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -202,6 +202,51 @@ def test_hot_candidate_scanner_pages_past_recent_embedded_window(tmp_path):
         conn.close()
 
 
+def test_hot_candidate_scanner_does_not_skip_unreturned_page_candidates(tmp_path):
+    hotlane = _load_hotlane_module()
+    conn = sqlite3.connect(tmp_path / "page-capacity.db")
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source_file TEXT,
+            source TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+        """
+    )
+    page_rows = [(f"page-{index}", "pending", "brainbar-store", "mcp", str(index)) for index in range(128)]
+    head_rows = [(f"head-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(127)]
+    head_rows.append(("head-hot", "pending head", "brainbar-store", "mcp", "latest"))
+    conn.executemany(
+        "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)",
+        page_rows + head_rows,
+    )
+    conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in head_rows[:-1]])
+    scanner = hotlane.HotCandidateScanner()
+    store = SimpleNamespace(conn=conn)
+    try:
+        first = scanner(store, limit=2)
+        assert first == [
+            hotlane.EmbedCandidate("head-hot", "pending head"),
+            hotlane.EmbedCandidate("page-127", "pending"),
+        ]
+        conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(item.chunk_id,) for item in first])
+        assert scanner(store, limit=2) == [
+            hotlane.EmbedCandidate("page-126", "pending"),
+            hotlane.EmbedCandidate("page-125", "pending"),
+        ]
+    finally:
+        conn.close()
+
+
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
     hotlane = _load_hotlane_module()
     received_batch_fns = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -238,11 +238,92 @@ def test_hot_candidate_scanner_does_not_skip_unreturned_page_candidates(tmp_path
             hotlane.EmbedCandidate("head-hot", "pending head"),
             hotlane.EmbedCandidate("page-127", "pending"),
         ]
-        conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(item.chunk_id,) for item in first])
+        conn.execute("INSERT INTO chunk_vectors_rowids (id) VALUES ('head-hot')")
+        assert scanner(store, limit=2)[0] == hotlane.EmbedCandidate("page-127", "pending")
+        conn.execute("INSERT INTO chunk_vectors_rowids (id) VALUES ('page-127')")
         assert scanner(store, limit=2) == [
             hotlane.EmbedCandidate("page-126", "pending"),
             hotlane.EmbedCandidate("page-125", "pending"),
         ]
+    finally:
+        conn.close()
+
+
+def test_hot_candidate_scanner_catches_rows_pushed_below_moving_head(tmp_path):
+    hotlane = _load_hotlane_module()
+    conn = sqlite3.connect(tmp_path / "moving-head.db")
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source_file TEXT,
+            source TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+        """
+    )
+    initial_rows = [(f"initial-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(128)]
+    conn.executemany(
+        "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)", initial_rows
+    )
+    conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in initial_rows])
+    scanner = hotlane.HotCandidateScanner()
+    store = SimpleNamespace(conn=conn)
+    try:
+        assert scanner(store, limit=5) == []
+        conn.execute(
+            "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES "
+            "('gap-hot', 'must catch up', 'brainbar-store', 'mcp', 'gap')"
+        )
+        newer_rows = [(f"new-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(128)]
+        conn.executemany(
+            "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)", newer_rows
+        )
+        conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in newer_rows])
+        assert scanner(store, limit=5) == [hotlane.EmbedCandidate("gap-hot", "must catch up")]
+    finally:
+        conn.close()
+
+
+def test_hot_candidate_scanner_deduplicates_head_and_forward_catchup(tmp_path):
+    hotlane = _load_hotlane_module()
+    conn = sqlite3.connect(tmp_path / "head-forward.db")
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source_file TEXT,
+            source TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+        INSERT INTO chunks (id, content, source_file, source, created_at)
+        VALUES ('baseline', 'embedded', 'brainbar-store', 'mcp', 'before');
+        INSERT INTO chunk_vectors_rowids (id) VALUES ('baseline');
+        """
+    )
+    scanner = hotlane.HotCandidateScanner()
+    store = SimpleNamespace(conn=conn)
+    try:
+        assert scanner(store, limit=5) == []
+        conn.execute(
+            "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES "
+            "('new-hot', 'only once', 'brainbar-store', 'mcp', 'after')"
+        )
+        assert scanner(store, limit=5) == [hotlane.EmbedCandidate("new-hot", "only once")]
     finally:
         conn.close()
 

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -336,6 +336,49 @@ def test_hot_candidate_scanner_deduplicates_head_and_forward_catchup(tmp_path):
         conn.close()
 
 
+def test_hot_candidate_scanner_retries_startup_head_candidate_after_displacement(tmp_path):
+    hotlane = _load_hotlane_module()
+    conn = sqlite3.connect(tmp_path / "startup-head.db")
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source_file TEXT,
+            source TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+        """
+    )
+    baseline_rows = [(f"base-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(999)]
+    conn.executemany(
+        "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)", baseline_rows
+    )
+    conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in baseline_rows])
+    conn.execute(
+        "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES "
+        "('startup-hot', 'retry startup', 'brainbar-store', 'mcp', 'latest')"
+    )
+    scanner = hotlane.HotCandidateScanner()
+    store = SimpleNamespace(conn=conn)
+    try:
+        assert scanner(store, limit=5) == [hotlane.EmbedCandidate("startup-hot", "retry startup")]
+        newer_rows = [(f"after-{index}", "embedded", "brainbar-store", "mcp", str(index)) for index in range(128)]
+        conn.executemany(
+            "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)", newer_rows
+        )
+        conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in newer_rows])
+        assert scanner(store, limit=5) == [hotlane.EmbedCandidate("startup-hot", "retry startup")]
+    finally:
+        conn.close()
+
+
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
     hotlane = _load_hotlane_module()
     received_batch_fns = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -162,6 +162,46 @@ def test_hot_candidate_query_uses_native_created_at_index_without_python_index(t
         conn.close()
 
 
+def test_hot_candidate_scanner_pages_past_recent_embedded_window(tmp_path):
+    hotlane = _load_hotlane_module()
+    conn = sqlite3.connect(tmp_path / "paged.db")
+    conn.executescript(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source_file TEXT,
+            source TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY);
+        INSERT INTO chunks (id, content, source_file, source, created_at)
+        VALUES ('older-hot', 'pending hot chunk', 'brainbar-store', 'mcp', '2026-08-01T00:00:00Z');
+        """
+    )
+    newer_rows = [
+        (f"newer-{index}", "already embedded", "brainbar-store", "mcp", f"2026-08-08T00:{index:03d}:00Z")
+        for index in range(hotlane.HOT_CANDIDATE_SCAN_LIMIT)
+    ]
+    conn.executemany(
+        "INSERT INTO chunks (id, content, source_file, source, created_at) VALUES (?, ?, ?, ?, ?)",
+        newer_rows,
+    )
+    conn.executemany("INSERT INTO chunk_vectors_rowids (id) VALUES (?)", [(row[0],) for row in newer_rows])
+    scanner = hotlane.HotCandidateScanner()
+    store = SimpleNamespace(conn=conn)
+    try:
+        assert scanner(store, limit=5) == []
+        assert scanner(store, limit=5) == [hotlane.EmbedCandidate("older-hot", "pending hot chunk")]
+    finally:
+        conn.close()
+
+
 def test_hotlane_run_threads_model_batch_embedder_to_backlog_cycle():
     hotlane = _load_hotlane_module()
     received_batch_fns = []


### PR DESCRIPTION
## Summary
- force the existing `idx_chunks_created_at` index for hot BrainBar candidate scans
- avoid SQLite choosing `idx_chunks_source` plus a full MCP temp sort
- add RED-first coverage for the query-plan guard

## Live finding
After #658 deployed, backpressure cleared but the production daemon stalled in the hot-candidate query for minutes and reached ~1.5 GB RSS. `EXPLAIN QUERY PLAN` showed `idx_chunks_source` + `USE TEMP B-TREE FOR ORDER BY`; the forced created-at scan returned the same candidates in 1.5 ms.

## Verification
- 26 hotlane tests pass
- changed-only pre-push gate passes
- ruff and diff check clean
- actual model on a clone of the verified real DB snapshot: missing embeddings 15,036 -> 15,027 in one cycle; enrichment-only queue remained non-blocking

Follow-up required to complete #658 deployment verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core hot-embedding discovery in the writer daemon; logic is intricate but heavily tested, and behavior only affects which pending MCP chunks get embedded per cycle—not write or auth paths.
> 
> **Overview**
> Fixes production hotlane stalls where SQLite picked a bad plan (`idx_chunks_source` + temp sort) and the daemon could sit in candidate discovery for minutes with high RSS.
> 
> **Hot embedding candidate discovery** now uses bounded SQL windows and a stateful `HotCandidateScanner` wired into the default `_run_split_cycle` path. `_candidate_chunk_rows` loads up to `HOT_CANDIDATE_SCAN_LIMIT` rows via `HOT_CANDIDATE_SCAN_SQL` (`ORDER BY created_at DESC`, no `INDEXED BY`) and applies MCP/brainbar eligibility in Python. The scanner pages by `rowid` (head, forward, older pages), keeps an LRU-style retry queue (cap `MAX_HOT_CANDIDATE_RETRIES`), and alternates retries with fresh scans so displaced or not-yet-returned chunks are not dropped.
> 
> Tests add query-plan guards, scanner paging/retry scenarios, and update split-cycle fakes to match the wider hot-candidate row shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cadcdd918c8943227afff7fd070925bcc7c70550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound hotlane candidate scans with explicit limits and a retry buffer
> - Introduces `HOT_CANDIDATE_SCAN_LIMIT` and `HOT_CANDIDATE_HEAD_LIMIT` constants to cap how many DB rows are scanned per cycle in [`hotlane_brainbar_daemon.py`](https://github.com/EtanHey/brainlayer/pull/659/files#diff-a6f55cd2d945568d3534e21b0c40cf5a431cb8287640870ba7b2a6149ac2c0d9).
> - Adds `HotCandidateScanner`, a class that interleaves retries of previously-returned-but-unembedded candidates with fresh rowid-windowed scans, deduplicating across passes.
> - Replaces the previous unbounded inline scan in the main run loop with `HotCandidateScanner`, which pages backward from the head and stops retaining new candidates once `MAX_HOT_CANDIDATE_RETRIES` is reached.
> - Adds dedicated SQL queries for head, forward, and page scans with explicit eligibility filters (no `vector_id`, active status, non-archived, etc.).
> - Behavioral Change: the default run path now sources candidates via `HotCandidateScanner`; unbounded scans are no longer possible, and candidates not yet embedded are retried rather than dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cadcdd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hot-lane processing to reliably discover eligible recent and older content awaiting vector processing.
  - Prevented candidates from being skipped during incremental processing while preserving requested result limits.
  - Improved compatibility across supported storage configurations and ensured processing resources are cleaned up correctly.

- **Tests**
  - Expanded coverage for candidate discovery, paging, limits, storage compatibility, cleanup, embedding failures, and vector creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->