### PR TITLE
feat(cli): add first-class `brainlayer --version` / `-V` probe

### DIFF
--- a/docs/plans/2026-08-07-cli-version-flag.md
+++ b/docs/plans/2026-08-07-cli-version-flag.md
@@ -1,0 +1,65 @@
+# BrainLayer CLI Version Flag Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add fast, first-class `brainlayer --version` and `brainlayer -V` probes that print the installed package version and exit successfully.
+
+**Architecture:** Register an eager global Typer option on the existing root app. Its callback reads only `brainlayer.__version__`, prints it, and exits before command execution, so the probe does not open a database or load a model.
+
+**Tech Stack:** Python 3.11+, Typer, pytest
+
+---
+
+### Task 1: Specify the CLI contract
+
+**Files:**
+- Create: `tests/test_cli_version.py`
+
+**Step 1: Write the failing test**
+
+Add a parametrized `CliRunner` test for `--version` and `-V`. Assert exit code 0 and exact `__version__` output. Patch `brainlayer.cli.sqlite3.connect` to fail if the version path attempts to open SQLite.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli_version.py -v`
+
+Expected: both cases fail because the root app does not recognize either option.
+
+### Task 2: Add the eager version option
+
+**Files:**
+- Modify: `src/brainlayer/cli/__init__.py`
+- Test: `tests/test_cli_version.py`
+
+**Step 1: Write the minimal implementation**
+
+Import `__version__` from the package, add an eager option callback that prints it and raises `typer.Exit`, then register `--version` and `-V` on the root Typer callback.
+
+**Step 2: Run focused tests to verify green**
+
+Run: `pytest tests/test_cli_version.py tests/test_release_version_sync.py -v`
+
+Expected: all version behavior and metadata consistency tests pass.
+
+**Step 3: Run static and live CLI verification**
+
+Run: `ruff check src/brainlayer/cli/__init__.py tests/test_cli_version.py`
+
+Run: `brainlayer --version && brainlayer -V`
+
+Expected: lint exits 0; both live commands print the package version and exit 0.
+
+### Task 3: Complete the PR loop
+
+**Files:**
+- Modify only files listed above and this plan.
+
+**Step 1:** Run the repository test suite required by `AGENTS.md` and inspect the complete output.
+
+**Step 2:** Run bounded CodeRabbit pre-commit review, address actionable findings, and commit the scoped files.
+
+**Step 3:** Push with `BRAINLAYER_PREPUSH_SCOPE=changed-only`, open a ready PR that closes #619, and request `@codex`, `@cursor`, and `@bugbot` review.
+
+**Step 4:** Read CI and review feedback, address every material finding, and request re-review after fixes.
+
+**Step 5:** Merge only after CI is green and at least one real review is present, verify the remote merge state and merged content, update tracking, and store the verified finding in BrainLayer.

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -31,6 +31,7 @@ from rich.progress import (
 )
 from rich.table import Table
 
+from .. import __version__
 from ..config import DEFAULT_REALTIME_ENRICH_SINCE_HOURS
 from ..paths import get_db_path
 
@@ -47,6 +48,22 @@ provenance_app = typer.Typer(help="Resolve provenance conflicts and pending conf
 app.add_typer(provenance_app, name="provenance")
 sandbox_app = typer.Typer(help="Manage isolated sandbox BrainLayer databases")
 app.add_typer(sandbox_app, name="sandbox")
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"brainlayer {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _root_callback(
+    version: Annotated[
+        bool,
+        typer.Option("--version", "-V", callback=_version_callback, is_eager=True, help="Show the version and exit."),
+    ] = False,
+) -> None:
+    """Configure global BrainLayer CLI options."""
 
 
 def _index_max_runtime_s() -> float:

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,73 @@
+"""Tests for the root CLI version probe."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import brainlayer.cli as cli
+from brainlayer import __version__
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("flag", ["--version", "-V"])
+def test_version_flag_prints_package_version_without_opening_database(monkeypatch, flag: str) -> None:
+    def fail_if_database_opens(*args, **kwargs):
+        raise AssertionError("the version probe must not open SQLite")
+
+    monkeypatch.setattr(cli.sqlite3, "connect", fail_if_database_opens)
+
+    result = CliRunner().invoke(cli.app, [flag])
+
+    assert result.exit_code == 0, result.stdout
+    assert result.stdout == f"brainlayer {__version__}\n"
+
+
+def test_version_flag_does_not_initialize_runtime_dependencies(tmp_path: Path) -> None:
+    database_path = tmp_path / "must-not-exist.db"
+    script = """
+import sys
+
+from typer.testing import CliRunner
+
+from brainlayer.cli import app
+
+result = CliRunner().invoke(app, ["--version"])
+assert result.exit_code == 0, result.exception
+heavy_roots = {"apsw", "numpy", "sentence_transformers", "torch", "transformers"}
+loaded = sorted(name for name in sys.modules if name.partition(".")[0] in heavy_roots)
+assert not loaded, loaded
+print(result.stdout, end="")
+"""
+    env = os.environ.copy()
+    env["BRAINLAYER_DB"] = str(database_path)
+    src_path = str(REPO_ROOT / "src")
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (src_path, env.get("PYTHONPATH"))))
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"brainlayer {__version__}\n"
+    assert not database_path.exists()
+
+
+def test_root_help_keeps_app_description_and_lists_version_option() -> None:
+    result = CliRunner().invoke(cli.app, ["--help"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "זיכרון - Local knowledge pipeline" in result.stdout
+    assert "--version" in result.stdout
+    assert "-V" in result.stdout


### PR DESCRIPTION
Closes #619

## What

Registers an eager root Typer option so `brainlayer --version` and `brainlayer -V` print
`brainlayer <version>` and exit 0, instead of `Error: No such option`.

```
$ brainlayer --version
brainlayer 1.5.2
$ brainlayer -V
brainlayer 1.5.2
```

## Why it has to stay cheap

This flag is the probe every later deploy-verification step uses, so it must not open the database
or pull in a model runtime. The version callback is eager and reads only `brainlayer.__version__`,
so it exits before any command body runs.

Measured on the installed entry point: **0.062s wall**, and the only heavy-ish module in
`sys.modules` afterwards is `sqlite3` (imported at CLI module scope, never connected). No `apsw`,
`torch`, `sentence_transformers`, `numpy`, or `transformers`. Works with `BRAINLAYER_DB` pointed at
a nonexistent path.

## Issue #619 acceptance

| Criterion | Status |
|---|---|
| Works without opening the DB or loading ML dependencies | ✅ verified live and in-test |
| Output sourced from the package version | ✅ `brainlayer.__version__`, already fenced by `tests/test_release_version_sync.py` against `pyproject.toml` and `server.json` |
| Short alias `-V` | ✅ same Typer option |
| Tests cover wheel/editable installs without assuming Homebrew | ✅ subprocess test runs against `REPO_ROOT/src` via `PYTHONPATH` |

## Tests

`tests/test_cli_version.py`:

1. Both aliases print the exact expected string and exit 0, with `sqlite3.connect` patched to fail.
2. An **out-of-process** check that imports the CLI, invokes `--version`, and asserts no heavy root
   module landed in `sys.modules`. Out-of-process is the point: an in-process guard installed after
   `import brainlayer.cli` cannot see module-level imports, which is exactly the regression worth
   catching.
3. A regression guard that the new root callback leaves root `--help` intact — app description
   preserved, both aliases listed.

## Review

Two-round Claude pair review against the lane brief; final verdict **ACCEPT**. Round 1 raised three
findings (a `ruff format` CI-gate failure, an import guard that could never fire, and missing
root-callback regression coverage); all three are fixed here and were independently re-verified,
including proving the replacement guard actually fires.

Local verification: full `scripts/run_tests.sh` pre-push gate passed (exit 0); 164 existing CLI
tests across 9 suites pass with no regressions; `ruff check` and `ruff format --check src/ tests/`
both clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI surface and tests only; version path is intentionally isolated from DB and ML initialization.
> 
> **Overview**
> Adds **first-class version probes** on the root Typer app: `brainlayer --version` and `brainlayer -V` print `brainlayer <package version>` and exit 0. An **eager** global option runs a small callback that reads only `brainlayer.__version__` and raises `typer.Exit`, so deploy checks finish before any subcommand or heavy runtime work.
> 
> New **`tests/test_cli_version.py`** locks the contract: both flags match exact output; `sqlite3.connect` must not run on that path; a subprocess check with `BRAINLAYER_DB` set avoids loading heavy roots (`torch`, `sentence_transformers`, etc.); root `--help` still shows the app description and lists the version aliases.
> 
> Also adds **`docs/plans/2026-08-07-cli-version-flag.md`** describing the TDD rollout for this feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff5ac177946f521531cc92ac9dd3e095a352ed33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--version`/`-V` flag to the `brainlayer` CLI
> Adds a Typer eager option callback in [`cli/__init__.py`](https://github.com/EtanHey/brainlayer/pull/660/files#diff-e66ce4ea8b0cf3331154cb15181cb09a7c593566e36380fd9215ff29d24ffd02) that prints `brainlayer {__version__}` and exits with code 0 when `--version` or `-V` is passed. Tests in [`tests/test_cli_version.py`](https://github.com/EtanHey/brainlayer/pull/660/files#diff-3f3d006d17f3b64715ee6e9d6631ba764c0fd66759a6897774333171ecb99fd3) verify the output, confirm no SQLite connection is opened, and check that heavy runtime dependencies are not imported during the version probe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff5ac17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `brainlayer --version` and `brainlayer -V` options.
  * Version information is displayed immediately without starting the application or creating a database file.

* **Documentation**
  * Added an implementation plan covering version flag behavior, validation, and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->