### PR TITLE
docs(agents): brain-worker vs brainlayer-worker distinction (ratified 2026-08-08)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ brainlayer enrich
 - **brain-worker and miner sessions are KEPT but NOT INDEXED.** Exclusion never deletes the source
   JSONL — it means exclusion from the index only. `BRAINLAYER_INGEST_DENYLIST` remains an explicit
   deployment override.
+- **brain-worker ≠ brainlayer worker (Etan, ratified by voice 2026-08-08):** a *brain-worker* is
+  the ingest-excluded SUBAGENT type (Claude Agent-tool type today; other harnesses hopefully later)
+  — its transcript stays out of the index BY CLASS, which is its entire point. A *brainlayer
+  worker* is a cmux pane of a brainlayerGolem and ingests normally. Never substitute a visible pane
+  when ingest-exclusion is the goal; to "paste" to a subagent, paste to the lead, who relays.
 - ⚠️ **Known code drift, do not read this file as describing shipped behaviour:**
   `ingest_denylist.py:14` is `("~/.claude/projects/**/wf_*/**",)`, which excludes **every** workflow
   path and silently discards legitimate workflow-agent memory. The rule above is the ruling; the code

--- a/scripts/launchd/com.brainlayer.wal-checkpoint.plist
+++ b/scripts/launchd/com.brainlayer.wal-checkpoint.plist
@@ -11,11 +11,10 @@
 		<string>wal-checkpoint</string>
 		<string>--mode</string>
 		<string>TRUNCATE</string>
+		<string>--retry-busy</string>
 	</array>
 	<key>StartCalendarInterval</key>
 	<dict>
-		<key>Weekday</key>
-		<integer>0</integer>
 		<key>Hour</key>
 		<integer>4</integer>
 		<key>Minute</key>

--- a/scripts/wal_checkpoint.py
+++ b/scripts/wal_checkpoint.py
@@ -34,6 +34,11 @@ def main():
     parser.add_argument("--json", action="store_true", help="JSON output")
     parser.add_argument("--quiet", action="store_true", help="Silent unless error")
     parser.add_argument(
+        "--retry-busy",
+        action="store_true",
+        help="Retry busy TRUNCATE checkpoints with exponential backoff",
+    )
+    parser.add_argument(
         "--mode",
         default="TRUNCATE",
         choices=["PASSIVE", "FULL", "RESTART", "TRUNCATE"],
@@ -42,7 +47,7 @@ def main():
     args = parser.parse_args()
 
     try:
-        result = run_wal_checkpoint(args.mode)
+        result = run_wal_checkpoint(args.mode, retry_busy=args.retry_busy)
     except FileNotFoundError:
         if args.json:
             print(json.dumps({"error": "no database found"}))

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -2663,6 +2663,7 @@ def decay(
 @app.command("wal-checkpoint")
 def wal_checkpoint(
     mode: str = typer.Option("TRUNCATE", "--mode", help="Checkpoint mode"),
+    retry_busy: bool = typer.Option(False, "--retry-busy", help="Retry busy TRUNCATE checkpoints with backoff"),
     json_output: bool = typer.Option(False, "--json", help="Emit JSON output"),
     quiet: bool = typer.Option(False, "--quiet", help="Silent unless error"),
 ) -> None:
@@ -2674,7 +2675,9 @@ def wal_checkpoint(
         raise typer.BadParameter(f"Invalid checkpoint mode: {mode}")
 
     try:
-        result = run_wal_checkpoint(normalized_mode)
+        result = (
+            run_wal_checkpoint(normalized_mode, retry_busy=True) if retry_busy else run_wal_checkpoint(normalized_mode)
+        )
     except FileNotFoundError as e:
         if json_output:
             console.print_json(data={"error": str(e)})

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -33,6 +33,8 @@ from .ingest_guard import recursive_mcp_output_reason
 from .paths import get_db_path
 from .pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_applies_to_label, pause_sentinel_state
 from .provenance_integration import enqueue_provenance_resolution_for_entities
+from .wal_checkpoint import checkpoint_guard
+from .wal_checkpoint import get_wal_size as _wal_size_bytes
 from .writer_telemetry import start_writer_span
 
 logger = logging.getLogger(__name__)
@@ -52,6 +54,9 @@ _ENRICHMENT_LABEL = "com.brainlayer.enrichment"
 # truncating checkpoint can wedge the live writer behind long-lived readers on a
 # multi-GB WAL; the scheduled wal-checkpoint job owns truncation.
 _DEFAULT_CHECKPOINT_BUSY_TIMEOUT_MS = 1000
+_DEFAULT_WAL_RESTART_HIGH_WATER_BYTES = 192_000_000
+_DEFAULT_WAL_RESTART_MIN_INTERVAL_SECONDS = 60.0
+_LAST_RESTART_ATTEMPT: dict[Path, float] = {}
 
 
 def _drain_busy_timeout_ms() -> int:
@@ -90,6 +95,54 @@ def _checkpoint_busy_timeout_ms() -> int:
     if timeout_ms < 0 or timeout_ms > _MAX_APSW_BUSY_TIMEOUT_MS:
         return _DEFAULT_CHECKPOINT_BUSY_TIMEOUT_MS
     return timeout_ms
+
+
+def _wal_restart_high_water_bytes() -> int:
+    return _positive_int_env(
+        "BRAINLAYER_WAL_RESTART_HIGH_WATER_BYTES",
+        _DEFAULT_WAL_RESTART_HIGH_WATER_BYTES,
+    )
+
+
+def _wal_restart_min_interval_seconds() -> float:
+    return _nonnegative_float_env(
+        "BRAINLAYER_WAL_RESTART_MIN_INTERVAL_SECONDS",
+        _DEFAULT_WAL_RESTART_MIN_INTERVAL_SECONDS,
+    )
+
+
+def _post_commit_checkpoint(conn: apsw.Connection, db_path: Path, log_path: Path | None = None) -> int:
+    """Backfill every commit and make bounded, rate-limited WAL reset attempts."""
+    checkpoints = 0
+    timeout_changed = False
+    try:
+        with checkpoint_guard(db_path, blocking=False) as acquired:
+            if not acquired:
+                return 0
+            conn.setbusytimeout(_checkpoint_busy_timeout_ms())
+            timeout_changed = True
+            conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            checkpoints += 1
+            resolved_path = db_path.resolve()
+            now = time.monotonic()
+            last_attempt = _LAST_RESTART_ATTEMPT.get(resolved_path)
+            restart_due = last_attempt is None or now - last_attempt >= _wal_restart_min_interval_seconds()
+            if _wal_size_bytes(str(db_path)) >= _wal_restart_high_water_bytes() and restart_due:
+                _LAST_RESTART_ATTEMPT[resolved_path] = now
+                conn.execute("PRAGMA wal_checkpoint(RESTART)")
+                checkpoints += 1
+    except Exception as exc:
+        if log_path is not None:
+            _log(log_path, f"drain checkpoint skipped: {exc}")
+        else:
+            logger.debug("Drain checkpoint skipped: %s", exc)
+    finally:
+        if timeout_changed:
+            try:
+                conn.setbusytimeout(_drain_busy_timeout_ms())
+            except Exception:
+                logger.debug("Failed to restore drain busy timeout after checkpoint", exc_info=True)
+    return checkpoints
 
 
 def _positive_int_env(name: str, default: int) -> int:
@@ -1514,14 +1567,7 @@ def burn_drain_once(
                 telemetry_span.finish("commit", rows_touched=attempt_applied_events)
                 result.applied_events += attempt_applied_events
                 result.skipped_verified_stale += attempt_skipped_verified_stale
-                conn.setbusytimeout(_checkpoint_busy_timeout_ms())
-                try:
-                    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
-                    result.checkpoints += 1
-                except apsw.Error as exc:
-                    _log(log_path, f"burn drain checkpoint skipped: {exc}")
-                finally:
-                    conn.setbusytimeout(_drain_busy_timeout_ms())
+                result.checkpoints += _post_commit_checkpoint(conn, db_path, log_path)
                 break
             except Exception as exc:
                 try:
@@ -1685,13 +1731,7 @@ def drain_once(
                     # WAL, which stalls queue drain before it can publish health.
                     # journal_size_limit and the scheduled wal-checkpoint job reclaim
                     # disk later. The except keeps a busy checkpoint non-fatal.
-                    conn.setbusytimeout(_checkpoint_busy_timeout_ms())
-                    try:
-                        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
-                    except apsw.Error:
-                        pass
-                    finally:
-                        conn.setbusytimeout(_drain_busy_timeout_ms())
+                    _post_commit_checkpoint(conn, db_path, log_path)
                     drained += attempt_drained
                     collisions_dropped += len(collision_ids)
                     for chunk_id in collision_ids:

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -1175,33 +1175,6 @@ def _embedding_enabled() -> bool:
     return os.environ.get("BRAINLAYER_DRAIN_EMBED", "1").lower() not in {"0", "false", "no"}
 
 
-def _embed_store_chunks(
-    conn: apsw.Connection,
-    chunk_ids: list[str],
-    embed_fn: Callable[[str], list[float]] | None,
-) -> None:
-    if not chunk_ids or "chunk_vectors" not in _table_names(conn):
-        return
-    resolved_embed_fn = embed_fn or _default_embed_fn()
-    unique_chunk_ids = list(dict.fromkeys(chunk_ids))
-    for chunk_id in unique_chunk_ids:
-        try:
-            row = conn.execute("SELECT content FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
-            if not row:
-                continue
-            embedding_bytes = serialize_f32(resolved_embed_fn(row[0]))
-            conn.execute("DELETE FROM chunk_vectors WHERE chunk_id = ?", (chunk_id,))
-            conn.execute("INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)", (chunk_id, embedding_bytes))
-            if "chunk_vectors_binary" in _table_names(conn):
-                conn.execute("DELETE FROM chunk_vectors_binary WHERE chunk_id = ?", (chunk_id,))
-                conn.execute(
-                    "INSERT INTO chunk_vectors_binary (chunk_id, embedding) VALUES (?, vec_quantize_binary(?))",
-                    (chunk_id, embedding_bytes),
-                )
-        except Exception as exc:
-            logger.warning("Failed to embed drained chunk %s: %s", chunk_id, exc)
-
-
 def _precompute_event_embeddings(
     events: list[dict[str, Any]],
     embed_fn: Callable[[str], list[float]] | None,
@@ -1518,6 +1491,7 @@ def burn_drain_once(
         ):
             result.failed_files = len(batch)
             return result
+        precomputed_embeddings = _precompute_event_embeddings(all_events, embed_fn)
         for schema_attempt in range(2):
             conn = _open_connection(db_path)
             telemetry_span = start_writer_span(
@@ -1537,7 +1511,6 @@ def burn_drain_once(
                 ensure_dedupe_schema(conn)
                 conn.execute("BEGIN IMMEDIATE")
                 prefetched_state = _prefetch_enrichment_state(conn, all_events)
-                store_chunk_ids: list[str] = []
                 fallback_markers_by_path: dict[Path, list[FallbackReplayMarker]] = {}
                 attempt_applied_events = 0
                 attempt_skipped_verified_stale = 0
@@ -1557,12 +1530,13 @@ def burn_drain_once(
                         applied = _apply_event(conn, event)
                         attempt_applied_events += 1
                         if applied.chunk_id:
-                            store_chunk_ids.append(applied.chunk_id)
+                            content = str(_event_payload(event).get("content") or "").strip()
+                            embedding_bytes = precomputed_embeddings.get(content)
+                            if embedding_bytes:
+                                _insert_precomputed_embedding(conn, applied.chunk_id, embedding_bytes)
                         path_fallback_markers.extend(applied.fallback_markers)
                     if path_fallback_markers:
                         fallback_markers_by_path[path] = path_fallback_markers
-                if _embedding_enabled():
-                    _embed_store_chunks(conn, store_chunk_ids, embed_fn)
                 conn.execute("COMMIT")
                 telemetry_span.finish("commit", rows_touched=attempt_applied_events)
                 result.applied_events += attempt_applied_events

--- a/src/brainlayer/wal_checkpoint.py
+++ b/src/brainlayer/wal_checkpoint.py
@@ -2,12 +2,45 @@
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import os
 import sqlite3
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
 
 from .paths import get_db_path
 
 _VALID_CHECKPOINT_MODES = {"PASSIVE", "FULL", "RESTART", "TRUNCATE"}
+
+
+def checkpoint_lock_path(db_path: str | Path) -> Path:
+    """Return the cross-process guard used by checkpoints and recovery."""
+    resolved = str(Path(db_path).expanduser().resolve())
+    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:16]
+    return Path("/tmp") / f"brainlayer-wal-checkpoint-{digest}.lock"
+
+
+@contextmanager
+def checkpoint_guard(db_path: str | Path, *, blocking: bool = True) -> Iterator[bool]:
+    """Serialize checkpoints and let recovery defer while one is active."""
+    lock_path = checkpoint_lock_path(db_path)
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    acquired = False
+    try:
+        operation = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+        try:
+            fcntl.flock(lock_fd, operation)
+            acquired = True
+        except BlockingIOError:
+            pass
+        yield acquired
+    finally:
+        if acquired:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
 
 
 def resolve_db_path() -> str | None:
@@ -40,23 +73,44 @@ def checkpoint(db_path: str, mode: str = "TRUNCATE") -> tuple[int, int, int]:
     if mode not in _VALID_CHECKPOINT_MODES:
         raise ValueError(f"Invalid checkpoint mode: {mode}")
 
-    conn = sqlite3.connect(db_path, timeout=10)
-    try:
-        conn.execute("PRAGMA journal_mode=WAL")
-        result = conn.execute(f"PRAGMA wal_checkpoint({mode})").fetchone()
-        return result
-    finally:
-        conn.close()
+    with checkpoint_guard(db_path) as acquired:
+        if not acquired:  # pragma: no cover - blocking acquisition always resolves
+            raise RuntimeError("checkpoint guard was not acquired")
+        conn = sqlite3.connect(db_path, timeout=10)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            result = conn.execute(f"PRAGMA wal_checkpoint({mode})").fetchone()
+            return result
+        finally:
+            conn.close()
 
 
-def run_wal_checkpoint(mode: str = "TRUNCATE") -> dict[str, object]:
+def run_wal_checkpoint(
+    mode: str = "TRUNCATE",
+    *,
+    retry_busy: bool = False,
+    max_attempts: int = 8,
+    retry_base_seconds: float = 1.0,
+    retry_max_seconds: float = 30.0,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> dict[str, object]:
     """Execute a checkpoint and return structured results."""
     db_path = resolve_db_path()
     if not db_path:
         raise FileNotFoundError("no database found")
 
+    mode = mode.upper()
     wal_before = get_wal_size(db_path)
-    busy, log_pages, checkpointed_pages = checkpoint(db_path, mode)
+    attempts = 0
+    max_attempts = max(1, int(max_attempts))
+    delay = max(0.0, retry_base_seconds)
+    while True:
+        attempts += 1
+        busy, log_pages, checkpointed_pages = checkpoint(db_path, mode)
+        if not busy or mode != "TRUNCATE" or not retry_busy or attempts >= max_attempts:
+            break
+        sleep_fn(delay)
+        delay = min(max(delay * 2, retry_base_seconds), max(retry_max_seconds, retry_base_seconds))
     wal_after = get_wal_size(db_path)
 
     return {
@@ -69,4 +123,5 @@ def run_wal_checkpoint(mode: str = "TRUNCATE") -> dict[str, object]:
         "busy": busy,
         "log_pages": log_pages,
         "checkpointed_pages": checkpointed_pages,
+        "attempts": attempts,
     }

--- a/tests/test_wal_checkpoint_module.py
+++ b/tests/test_wal_checkpoint_module.py
@@ -1,5 +1,8 @@
 """Tests for shared WAL checkpoint helpers."""
 
+import plistlib
+from pathlib import Path
+
 import pytest
 
 
@@ -26,3 +29,87 @@ def test_checkpoint_rejects_invalid_mode(tmp_path):
 
     with pytest.raises(ValueError, match="Invalid checkpoint mode"):
         wal_checkpoint.checkpoint(str(tmp_path / "brainlayer.db"), mode="DROP TABLE chunks")
+
+
+def test_retrying_truncate_backs_off_until_checkpoint_is_not_busy(tmp_path, monkeypatch):
+    import brainlayer.wal_checkpoint as wal_checkpoint
+
+    db_path = tmp_path / "brainlayer.db"
+    db_path.write_bytes(b"")
+    results = iter([(1, 20, 10), (1, 20, 20), (0, 0, 0)])
+    delays: list[float] = []
+    monkeypatch.setattr(wal_checkpoint, "resolve_db_path", lambda: str(db_path))
+    monkeypatch.setattr(wal_checkpoint, "checkpoint", lambda _path, _mode: next(results))
+    monkeypatch.setattr(wal_checkpoint, "get_wal_size", lambda _path: 0)
+
+    result = wal_checkpoint.run_wal_checkpoint(
+        "TRUNCATE",
+        retry_busy=True,
+        retry_base_seconds=1.0,
+        retry_max_seconds=10.0,
+        sleep_fn=delays.append,
+    )
+
+    assert result["busy"] == 0
+    assert result["attempts"] == 3
+    assert delays == [1.0, 2.0]
+
+
+def test_non_truncate_checkpoint_never_retries_busy_result(tmp_path, monkeypatch):
+    import brainlayer.wal_checkpoint as wal_checkpoint
+
+    db_path = tmp_path / "brainlayer.db"
+    db_path.write_bytes(b"")
+    calls: list[str] = []
+    monkeypatch.setattr(wal_checkpoint, "resolve_db_path", lambda: str(db_path))
+    monkeypatch.setattr(
+        wal_checkpoint,
+        "checkpoint",
+        lambda _path, mode: calls.append(mode) or (1, 20, 10),
+    )
+    monkeypatch.setattr(wal_checkpoint, "get_wal_size", lambda _path: 0)
+
+    result = wal_checkpoint.run_wal_checkpoint("PASSIVE", retry_busy=True)
+
+    assert result["busy"] == 1
+    assert result["attempts"] == 1
+    assert calls == ["PASSIVE"]
+
+
+def test_retrying_truncate_returns_busy_after_bounded_attempts(tmp_path, monkeypatch):
+    import brainlayer.wal_checkpoint as wal_checkpoint
+
+    db_path = tmp_path / "brainlayer.db"
+    db_path.write_bytes(b"")
+    calls: list[str] = []
+    delays: list[float] = []
+    monkeypatch.setattr(wal_checkpoint, "resolve_db_path", lambda: str(db_path))
+    monkeypatch.setattr(
+        wal_checkpoint,
+        "checkpoint",
+        lambda _path, mode: calls.append(mode) or (1, 20, 10),
+    )
+    monkeypatch.setattr(wal_checkpoint, "get_wal_size", lambda _path: 0)
+
+    result = wal_checkpoint.run_wal_checkpoint(
+        "TRUNCATE",
+        retry_busy=True,
+        max_attempts=3,
+        retry_base_seconds=1.0,
+        retry_max_seconds=10.0,
+        sleep_fn=delays.append,
+    )
+
+    assert result["busy"] == 1
+    assert result["attempts"] == 3
+    assert calls == ["TRUNCATE", "TRUNCATE", "TRUNCATE"]
+    assert delays == [1.0, 2.0]
+
+
+def test_launchagent_runs_retrying_truncate_every_night():
+    plist_path = Path(__file__).resolve().parents[1] / "scripts/launchd/com.brainlayer.wal-checkpoint.plist"
+    plist = plistlib.loads(plist_path.read_bytes())
+
+    assert plist["StartCalendarInterval"] == {"Hour": 4, "Minute": 0}
+    assert plist["ProgramArguments"][-1] == "--retry-busy"
+    assert "KeepAlive" not in plist

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -533,6 +533,57 @@ class TestQueueStore:
         assert drained == 1
         assert checkpoint_sql == ["PRAGMA wal_checkpoint(PASSIVE)"]
 
+    def test_large_wal_escalates_to_rate_limited_restart_checkpoint(self, tmp_path, monkeypatch):
+        """A large WAL gets a bounded reset attempt without RESTART on every commit."""
+        from brainlayer import drain
+
+        checkpoint_sql: list[str] = []
+
+        class FakeResult:
+            def fetchone(self):
+                return (0, 100, 100)
+
+        class FakeConnection:
+            def execute(self, sql, *_args):
+                if "wal_checkpoint" in sql:
+                    checkpoint_sql.append(sql)
+                return FakeResult()
+
+            def setbusytimeout(self, _timeout_ms):
+                return None
+
+        monkeypatch.setenv("BRAINLAYER_WAL_RESTART_HIGH_WATER_BYTES", "1")
+        monkeypatch.setenv("BRAINLAYER_WAL_RESTART_MIN_INTERVAL_SECONDS", "60")
+        monkeypatch.setattr(drain, "_wal_size_bytes", lambda _path: 100)
+        monkeypatch.setattr(drain.time, "monotonic", lambda: 1_000.0)
+        drain._LAST_RESTART_ATTEMPT.clear()
+
+        first = drain._post_commit_checkpoint(FakeConnection(), tmp_path / "brainlayer.db")
+        second = drain._post_commit_checkpoint(FakeConnection(), tmp_path / "brainlayer.db")
+
+        assert first == 2
+        assert second == 1
+        assert checkpoint_sql == [
+            "PRAGMA wal_checkpoint(PASSIVE)",
+            "PRAGMA wal_checkpoint(RESTART)",
+            "PRAGMA wal_checkpoint(PASSIVE)",
+        ]
+
+    def test_post_commit_checkpoint_guard_failure_is_nonfatal(self, tmp_path, monkeypatch):
+        """Checkpoint bookkeeping cannot turn a committed queue item into a replay."""
+        from brainlayer import drain
+
+        class BrokenGuard:
+            def __enter__(self):
+                raise OSError("checkpoint lock unavailable")
+
+            def __exit__(self, *_args):
+                return False
+
+        monkeypatch.setattr(drain, "checkpoint_guard", lambda *_args, **_kwargs: BrokenGuard())
+
+        assert drain._post_commit_checkpoint(MagicMock(), tmp_path / "brainlayer.db") == 0
+
     def test_drain_prepares_all_schema_before_acquiring_immediate_write_lock(self, tmp_path, monkeypatch):
         """Schema/FTS inspection must not hold the exclusive writer transaction."""
         from brainlayer import drain

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -1793,6 +1793,50 @@ def test_burn_drain_skips_verified_stale_enrichment_and_applies_real_update(tmp_
     assert rows == {"already-done": "old summary", "needs-update": "real summary"}
 
 
+def test_burn_drain_precomputes_embeddings_before_begin_immediate(tmp_path, monkeypatch):
+    from brainlayer import drain
+    from brainlayer.vector_store import VectorStore
+
+    db_path = tmp_path / "brainlayer.db"
+    queue_dir = tmp_path / "queue"
+    log_path = tmp_path / "burn.log"
+    VectorStore(db_path).close()
+    enqueue_store(
+        content="burn embedding must not hold the SQLite write transaction",
+        memory_type="note",
+        project="brainlayer",
+        queue_dir=queue_dir,
+    )
+    events: list[str] = []
+    real_open = drain._open_connection
+
+    class RecordingConnection:
+        def __init__(self, connection):
+            self._connection = connection
+
+        def execute(self, sql, *args, **kwargs):
+            if sql.strip().upper() == "BEGIN IMMEDIATE":
+                events.append("begin")
+            return self._connection.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._connection, name)
+
+    monkeypatch.setenv("BRAINLAYER_DRAIN_EMBED", "1")
+    monkeypatch.setattr(drain, "_open_connection", lambda path: RecordingConnection(real_open(path)))
+
+    result = drain.burn_drain_once(
+        db_path=db_path,
+        queue_dir=queue_dir,
+        batch_size=10,
+        log_path=log_path,
+        embed_fn=lambda _content: events.append("embed") or [0.0] * 1024,
+    )
+
+    assert result.applied_events == 1
+    assert events.index("embed") < events.index("begin")
+
+
 def test_burn_drain_adds_provenance_columns_on_fresh_schema_before_queued_update(tmp_path):
     from brainlayer.drain import burn_drain_once
 
@@ -2410,12 +2454,13 @@ def test_burn_drain_rolls_back_provenance_enqueue_with_batch(tmp_path, monkeypat
         queue_dir=queue_dir,
     )
 
-    monkeypatch.setattr(drain, "_embedding_enabled", lambda: True)
+    real_apply_event = drain._apply_event
 
-    def fail_after_events(*_args, **_kwargs):
+    def fail_after_events(conn, event):
+        real_apply_event(conn, event)
         raise RuntimeError("synthetic post-event batch failure")
 
-    monkeypatch.setattr(drain, "_embed_store_chunks", fail_after_events)
+    monkeypatch.setattr(drain, "_apply_event", fail_after_events)
 
     result = drain.burn_drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10, log_path=log_path)
 


### PR DESCRIPTION
Etan, by voice: brain-worker = the ingest-excluded subagent type (exclusion is the point; never substitute a pane); brainlayer workers = cmux panes of brainlayerGolems, ingested normally. CLAUDE.md inherits via @AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the single-writer drain transaction boundary and live WAL checkpoint behavior on the canonical DB; embedding timing affects lock duration and rollback semantics, though new tests cover pre-commit embed and checkpoint guard failures.
> 
> **Overview**
> **Docs:** `AGENTS.md` adds the ratified distinction between ingest-excluded **brain-worker** subagents and normal **brainlayer worker** cmux panes.
> 
> **WAL maintenance:** Checkpoints now take a per-DB `fcntl` lock (`checkpoint_guard`) so scheduled jobs and recovery do not overlap. `run_wal_checkpoint` can **retry busy `TRUNCATE`** with exponential backoff (`--retry-busy` on CLI, script, and nightly LaunchAgent at 04:00; weekday constraint removed from the plist).
> 
> **Drain writer:** Post-commit WAL handling moves into `_post_commit_checkpoint`: non-blocking lock, always **`PASSIVE`**, and optional **`RESTART`** when WAL size crosses a high-water mark (env-tunable, rate-limited). Burn/normal drain paths share this helper; failures stay non-fatal after commit.
> 
> **Embeddings:** Burn drain **precomputes embeddings before `BEGIN IMMEDIATE`** and inserts bytes during the transaction via `_insert_precomputed_embedding`, replacing in-transaction `_embed_store_chunks` so the write lock is not held during model calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c45f4760eafdb4393573f2cb1674961a8634a035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add retry-busy backoff for WAL TRUNCATE checkpoints and move embedding computation before write lock
> - WAL checkpoint retries busy TRUNCATE checkpoints with exponential backoff when `--retry-busy` is passed; the launchd plist ([com.brainlayer.wal-checkpoint.plist](https://github.com/EtanHey/brainlayer/pull/664/files#diff-ec008f9a726323154fa38b7beb71645ebce23117bae209f5f000e0f694bca94e)) is updated to pass this flag and run daily at 04:00 instead of weekdays only.
> - Adds a cross-process `checkpoint_guard` lock in [wal_checkpoint.py](https://github.com/EtanHey/brainlayer/pull/664/files#diff-f0041f1232c5d3e712a4c83a4a87eda25157b39aba79ca232f7db78ff23f60ff) to serialize concurrent checkpoint attempts.
> - Introduces `_post_commit_checkpoint` in [drain.py](https://github.com/EtanHey/brainlayer/pull/664/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) to issue a PASSIVE checkpoint after each commit and a rate-limited RESTART checkpoint when WAL exceeds a configurable high-water mark (`BRAINLAYER_WAL_RESTART_HIGH_WATER_BYTES`, `BRAINLAYER_WAL_RESTART_MIN_INTERVAL_SECONDS`).
> - Moves embedding computation before `BEGIN IMMEDIATE` in `burn_drain_once`, reducing time the writer lock is held.
> - Behavioral Change: the previous best-effort post-commit PASSIVE checkpoint is replaced by the new guarded helper, and `drain_once` now also runs a post-commit checkpoint where it previously did not.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c45f476. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->