### PR TITLE
fix: prevent checkpoint starvation and watchdog freeze

### DIFF
--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -48,6 +48,7 @@ class Config:
     max_source_files: int = 100_000
     max_scan_seconds: float = 20.0
     progress_slo_seconds: int = 180
+    checkpoint_deferral_alert_threshold: int = 3
     drain_health_path: Path | None = None
     dry_run: bool = False
     log_path: Path = Path("~/.local/share/brainlayer/logs/throughput-watchdog.log").expanduser()
@@ -92,6 +93,7 @@ class WatchdogResult:
     scan_errors: int
     stalled_ticks: int
     action: str
+    checkpoint_deferred_ticks: int = 0
     offset_bytes: int | None = None
     offset_bytes_delta: int | None = None
     drain_cycles: int | None = None
@@ -503,10 +505,16 @@ def _best_effort_alert(config: Config, result: WatchdogResult) -> None:
     config.log_path.expanduser().parent.mkdir(parents=True, exist_ok=True)
     with config.log_path.expanduser().open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(asdict(result), sort_keys=True) + "\n")
-    body = (
-        "Watcher has registry-tracked JSONL bytes pending but realtime_watcher chunks are flat; "
-        "automatic recovery is starting."
-    )
+    if result.action == "checkpoint_deferral_alert":
+        body = (
+            "Watcher recovery is blocked because the WAL checkpoint guard remains held across "
+            f"{result.checkpoint_deferred_ticks} attempts; operator intervention is required."
+        )
+    else:
+        body = (
+            "Watcher has registry-tracked JSONL bytes pending but realtime_watcher chunks are flat; "
+            "automatic recovery is starting."
+        )
     try:
         subprocess.run(
             [
@@ -558,6 +566,10 @@ def run_once(
     previous_stalled = state.get("stalled_ticks", 0)
     if not isinstance(previous_stalled, int) or previous_stalled < 0:
         previous_stalled = 0
+    previous_checkpoint_deferred = state.get("checkpoint_deferred_ticks", 0)
+    if not isinstance(previous_checkpoint_deferred, int) or previous_checkpoint_deferred < 0:
+        previous_checkpoint_deferred = 0
+    checkpoint_deferral_alerted = bool(state.get("checkpoint_deferral_alerted"))
     delta = current_highwater - previous_highwater if isinstance(previous_highwater, int) else None
     liveness_delta = (
         current_liveness_highwater - previous_liveness_highwater
@@ -610,6 +622,10 @@ def run_once(
         action = "stalled"
         stalled_ticks = previous_stalled + 1
 
+    if action in {"baseline", "progress", "idle"}:
+        previous_checkpoint_deferred = 0
+        checkpoint_deferral_alerted = False
+
     result = WatchdogResult(
         checked_at_epoch=checked_at,
         watcher_highwater_rowid=current_highwater,
@@ -624,6 +640,7 @@ def run_once(
         scan_errors=evidence.scan_errors,
         stalled_ticks=stalled_ticks,
         action=action,
+        checkpoint_deferred_ticks=previous_checkpoint_deferred,
         offset_bytes=operational_progress.offset_bytes,
         offset_bytes_delta=offset_delta,
         drain_cycles=operational_progress.drain_cycles,
@@ -654,8 +671,24 @@ def run_once(
             try:
                 with checkpoint_guard(config.db_path, blocking=False) as checkpoint_available:
                     if not checkpoint_available:
-                        result.action = "checkpoint_deferred"
+                        result.checkpoint_deferred_ticks += 1
+                        if result.checkpoint_deferred_ticks >= config.checkpoint_deferral_alert_threshold:
+                            result.action = "checkpoint_deferral_alert"
+                            if not checkpoint_deferral_alerted:
+                                try:
+                                    alert_fn(config, result)
+                                    checkpoint_deferral_alerted = True
+                                except Exception as exc:
+                                    result.alert_error = str(exc)
+                                    print(
+                                        f"throughput-watchdog checkpoint deferral alert failed: {exc}",
+                                        file=sys.stderr,
+                                    )
+                        else:
+                            result.action = "checkpoint_deferred"
                     else:
+                        result.checkpoint_deferred_ticks = 0
+                        checkpoint_deferral_alerted = False
                         # Alert-framing: page on the FIRST wedge of an episode only — never
                         # per-kick of a chronic sawtooth. The latch clears after a sustained
                         # healthy run (episode reset below). Recovery still runs every tick.
@@ -717,6 +750,8 @@ def run_once(
             "scan_errors": evidence.scan_errors,
             "stalled_ticks": result.stalled_ticks,
             "last_action": result.action,
+            "checkpoint_deferred_ticks": result.checkpoint_deferred_ticks,
+            "checkpoint_deferral_alerted": checkpoint_deferral_alerted,
             "offset_bytes": operational_progress.offset_bytes,
             "drain_cycles": operational_progress.drain_cycles,
             "drained_total": operational_progress.drained_total,
@@ -773,6 +808,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--watch-plist", type=Path, default=home / "Library/LaunchAgents/com.brainlayer.watch.plist")
     parser.add_argument("--stall-threshold", type=_positive_int, default=3)
     parser.add_argument("--progress-slo-seconds", type=_positive_int, default=180)
+    parser.add_argument("--checkpoint-deferral-alert-threshold", type=_positive_int, default=3)
     parser.add_argument("--cooldown-seconds", type=_positive_int, default=600)
     parser.add_argument("--recent-window-seconds", type=_positive_int, default=600)
     parser.add_argument("--max-source-files", type=_positive_int, default=100_000)
@@ -797,6 +833,7 @@ def _config_from_args(args: argparse.Namespace) -> Config:
         watch_plist_path=args.watch_plist,
         stall_threshold=args.stall_threshold,
         progress_slo_seconds=args.progress_slo_seconds,
+        checkpoint_deferral_alert_threshold=args.checkpoint_deferral_alert_threshold,
         cooldown_seconds=args.cooldown_seconds,
         recent_window_seconds=args.recent_window_seconds,
         max_source_files=args.max_source_files,
@@ -831,7 +868,7 @@ def main(argv: list[str] | None = None) -> int:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     print(json.dumps(asdict(result), sort_keys=True) if args.json else f"{result.action}: {result}")
-    return 1 if result.action in {"recovery_failed", "checkpoint_guard_error"} else 0
+    return 1 if result.action in {"recovery_failed", "checkpoint_guard_error", "checkpoint_deferral_alert"} else 0
 
 
 if __name__ == "__main__":

--- a/scripts/launchd/throughput-watchdog.py
+++ b/scripts/launchd/throughput-watchdog.py
@@ -19,6 +19,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Callable
 
+from brainlayer.wal_checkpoint import checkpoint_guard
+
 DEFAULT_WATCH_LABEL = "com.brainlayer.watch"
 DEFAULT_NOTIFY_ENDPOINT = "http://localhost:3847/notify"
 # Alert-framing (orc law, stalker postmortem): after a wedge episode is paged once,
@@ -45,6 +47,8 @@ class Config:
     recent_window_seconds: int = 600
     max_source_files: int = 100_000
     max_scan_seconds: float = 20.0
+    progress_slo_seconds: int = 180
+    drain_health_path: Path | None = None
     dry_run: bool = False
     log_path: Path = Path("~/.local/share/brainlayer/logs/throughput-watchdog.log").expanduser()
     notify_endpoint: str = DEFAULT_NOTIFY_ENDPOINT
@@ -66,6 +70,13 @@ class WatcherProgress:
     liveness_rowid: int
 
 
+@dataclass(frozen=True)
+class OperationalProgress:
+    offset_bytes: int | None
+    drain_cycles: int | None
+    drained_total: int | None
+
+
 @dataclass
 class WatchdogResult:
     checked_at_epoch: int
@@ -81,12 +92,20 @@ class WatchdogResult:
     scan_errors: int
     stalled_ticks: int
     action: str
+    offset_bytes: int | None = None
+    offset_bytes_delta: int | None = None
+    drain_cycles: int | None = None
+    drain_cycles_delta: int | None = None
+    drained_total: int | None = None
+    drained_total_delta: int | None = None
+    no_progress_seconds: int = 0
     error: str = ""
     alert_error: str = ""
 
 
 CommandRunner = Callable[[list[str]], object]
 ProgressReader = Callable[[Path], WatcherProgress]
+OperationalProgressReader = Callable[[Config], OperationalProgress]
 SourceProbe = Callable[[Config, int], SourceEvidence]
 AlertFn = Callable[[Config, WatchdogResult], None]
 
@@ -175,6 +194,32 @@ def read_watcher_progress(db_path: Path) -> WatcherProgress:
 def read_watcher_highwater(db_path: Path) -> int:
     """Compatibility helper for callers that only need committed watcher chunks."""
     return read_watcher_progress(db_path).chunk_rowid
+
+
+def _optional_nonnegative_int(value: object) -> int | None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        return None
+    return value
+
+
+def read_operational_progress(config: Config) -> OperationalProgress:
+    offset_bytes: int | None = None
+    registry_path = config.registry_path.expanduser()
+    if registry_path.is_file():
+        registry = _read_json_object(registry_path)
+        offset_bytes = sum(
+            offset
+            for entry in registry.values()
+            if isinstance(entry, dict) and (offset := _optional_nonnegative_int(entry.get("offset"))) is not None
+        )
+
+    drain_path = config.drain_health_path or config.db_path.expanduser().parent / "drain-health.json"
+    drain_health = _read_json_object(drain_path)
+    return OperationalProgress(
+        offset_bytes=offset_bytes,
+        drain_cycles=_optional_nonnegative_int(drain_health.get("drain_cycles")),
+        drained_total=_optional_nonnegative_int(drain_health.get("drained_total")),
+    )
 
 
 def _registry_offset(entry: object, *, current_inode: int) -> int | None:
@@ -493,6 +538,7 @@ def run_once(
     *,
     now_epoch: int | None = None,
     progress_reader: ProgressReader = read_watcher_progress,
+    operational_progress_reader: OperationalProgressReader = read_operational_progress,
     source_probe: SourceProbe = collect_source_evidence,
     command_runner: CommandRunner = _default_command_runner,
     alert_fn: AlertFn = _best_effort_alert,
@@ -502,9 +548,13 @@ def run_once(
     current_progress = progress_reader(config.db_path)
     current_highwater = current_progress.chunk_rowid
     current_liveness_highwater = current_progress.liveness_rowid
+    operational_progress = operational_progress_reader(config)
     evidence = source_probe(config, checked_at)
     previous_highwater = state.get("watcher_highwater_rowid")
     previous_liveness_highwater = state.get("watcher_liveness_highwater_rowid")
+    previous_offset_bytes = state.get("offset_bytes")
+    previous_drain_cycles = state.get("drain_cycles")
+    previous_drained_total = state.get("drained_total")
     previous_stalled = state.get("stalled_ticks", 0)
     if not isinstance(previous_stalled, int) or previous_stalled < 0:
         previous_stalled = 0
@@ -514,11 +564,43 @@ def run_once(
         if isinstance(previous_liveness_highwater, int)
         else None
     )
+    offset_delta = (
+        operational_progress.offset_bytes - previous_offset_bytes
+        if operational_progress.offset_bytes is not None and isinstance(previous_offset_bytes, int)
+        else None
+    )
+    drain_cycles_delta = (
+        operational_progress.drain_cycles - previous_drain_cycles
+        if operational_progress.drain_cycles is not None and isinstance(previous_drain_cycles, int)
+        else None
+    )
+    drained_total_delta = (
+        operational_progress.drained_total - previous_drained_total
+        if operational_progress.drained_total is not None and isinstance(previous_drained_total, int)
+        else None
+    )
+    new_operational_baseline = any(
+        current is not None and not isinstance(previous, int)
+        for current, previous in (
+            (operational_progress.offset_bytes, previous_offset_bytes),
+            (operational_progress.drain_cycles, previous_drain_cycles),
+            (operational_progress.drained_total, previous_drained_total),
+        )
+    )
+    operational_deltas = (offset_delta, drain_cycles_delta, drained_total_delta)
+    operational_counter_reset = any(delta is not None and delta < 0 for delta in operational_deltas)
 
-    if delta is None or liveness_delta is None or delta < 0 or liveness_delta < 0:
+    if (
+        delta is None
+        or liveness_delta is None
+        or delta < 0
+        or liveness_delta < 0
+        or new_operational_baseline
+        or operational_counter_reset
+    ):
         action = "baseline"
         stalled_ticks = 0
-    elif delta > 0 or liveness_delta > 0:
+    elif delta > 0 or liveness_delta > 0 or any(value is not None and value > 0 for value in operational_deltas):
         action = "progress"
         stalled_ticks = 0
     elif evidence.pending_files == 0:
@@ -542,7 +624,20 @@ def run_once(
         scan_errors=evidence.scan_errors,
         stalled_ticks=stalled_ticks,
         action=action,
+        offset_bytes=operational_progress.offset_bytes,
+        offset_bytes_delta=offset_delta,
+        drain_cycles=operational_progress.drain_cycles,
+        drain_cycles_delta=drain_cycles_delta,
+        drained_total=operational_progress.drained_total,
+        drained_total_delta=drained_total_delta,
     )
+
+    previous_last_progress = state.get("last_progress_epoch")
+    if action in {"baseline", "progress", "idle"} or not isinstance(previous_last_progress, int):
+        last_progress_epoch = checked_at
+    else:
+        last_progress_epoch = min(previous_last_progress, checked_at)
+    result.no_progress_seconds = max(0, checked_at - last_progress_epoch)
 
     last_restart_epoch = state.get("last_restart_epoch")
     cooldown_active = (
@@ -550,55 +645,63 @@ def run_once(
         and checked_at >= last_restart_epoch
         and checked_at - last_restart_epoch < config.cooldown_seconds
     )
-    if stalled_ticks >= config.stall_threshold:
+    if stalled_ticks >= config.stall_threshold and result.no_progress_seconds >= config.progress_slo_seconds:
         if cooldown_active:
             result.action = "cooldown"
         elif config.dry_run:
             result.action = "would_kickstart"
         else:
-            # Alert-framing: page on the FIRST wedge of an episode only — never
-            # per-kick of a chronic sawtooth. The latch clears after a sustained
-            # healthy run (episode reset below). Recovery still runs every tick.
-            # The latch is set ONLY when the page actually sent — a transient
-            # notify failure on the first wedge must NOT silence the whole
-            # episode (page-once must never become page-zero); the next tick
-            # retries the alert instead.
-            episode_alerted = bool(state.get("episode_alerted"))
-            if not episode_alerted:
-                try:
-                    alert_fn(config, result)
-                    episode_alerted = True
-                except Exception as exc:
-                    result.alert_error = str(exc)
-                    print(f"throughput-watchdog alert failed: {exc}", file=sys.stderr)
-            attempt_state = dict(state)
-            attempt_state.update(
-                {
-                    "checked_at_epoch": checked_at,
-                    "watcher_highwater_rowid": current_highwater,
-                    "watcher_liveness_highwater_rowid": current_liveness_highwater,
-                    "pending_files": evidence.pending_files,
-                    "pending_bytes": evidence.pending_bytes,
-                    "recent_files": evidence.recent_files,
-                    "untracked_recent_files": evidence.untracked_recent_files,
-                    "newest_source_mtime": evidence.newest_mtime,
-                    "scan_errors": evidence.scan_errors,
-                    "stalled_ticks": stalled_ticks,
-                    "last_action": "recovery_attempt",
-                    "last_restart_epoch": checked_at,
-                    "restart_attempt_count": int(state.get("restart_attempt_count", 0)) + 1,
-                    "episode_alerted": episode_alerted,
-                }
-            )
-            _atomic_write_json(config.state_path, attempt_state)
-            state = attempt_state
             try:
-                result.action = _restart_watch(config, command_runner)
-            except RuntimeError as exc:
-                result.action = "recovery_failed"
+                with checkpoint_guard(config.db_path, blocking=False) as checkpoint_available:
+                    if not checkpoint_available:
+                        result.action = "checkpoint_deferred"
+                    else:
+                        # Alert-framing: page on the FIRST wedge of an episode only — never
+                        # per-kick of a chronic sawtooth. The latch clears after a sustained
+                        # healthy run (episode reset below). Recovery still runs every tick.
+                        # The latch is set ONLY when the page actually sent — a transient
+                        # notify failure on the first wedge must NOT silence the whole
+                        # episode (page-once must never become page-zero); the next tick
+                        # retries the alert instead.
+                        episode_alerted = bool(state.get("episode_alerted"))
+                        if not episode_alerted:
+                            try:
+                                alert_fn(config, result)
+                                episode_alerted = True
+                            except Exception as exc:
+                                result.alert_error = str(exc)
+                                print(f"throughput-watchdog alert failed: {exc}", file=sys.stderr)
+                        attempt_state = dict(state)
+                        attempt_state.update(
+                            {
+                                "checked_at_epoch": checked_at,
+                                "watcher_highwater_rowid": current_highwater,
+                                "watcher_liveness_highwater_rowid": current_liveness_highwater,
+                                "pending_files": evidence.pending_files,
+                                "pending_bytes": evidence.pending_bytes,
+                                "recent_files": evidence.recent_files,
+                                "untracked_recent_files": evidence.untracked_recent_files,
+                                "newest_source_mtime": evidence.newest_mtime,
+                                "scan_errors": evidence.scan_errors,
+                                "stalled_ticks": stalled_ticks,
+                                "last_action": "recovery_attempt",
+                                "last_restart_epoch": checked_at,
+                                "restart_attempt_count": int(state.get("restart_attempt_count", 0)) + 1,
+                                "episode_alerted": episode_alerted,
+                            }
+                        )
+                        _atomic_write_json(config.state_path, attempt_state)
+                        state = attempt_state
+                        try:
+                            result.action = _restart_watch(config, command_runner)
+                        except RuntimeError as exc:
+                            result.action = "recovery_failed"
+                            result.error = str(exc)
+                        else:
+                            result.stalled_ticks = 0
+            except OSError as exc:
+                result.action = "checkpoint_guard_error"
                 result.error = str(exc)
-            else:
-                result.stalled_ticks = 0
 
     next_state = dict(state)
     next_state.update(
@@ -614,6 +717,11 @@ def run_once(
             "scan_errors": evidence.scan_errors,
             "stalled_ticks": result.stalled_ticks,
             "last_action": result.action,
+            "offset_bytes": operational_progress.offset_bytes,
+            "drain_cycles": operational_progress.drain_cycles,
+            "drained_total": operational_progress.drained_total,
+            "last_progress_epoch": last_progress_epoch,
+            "no_progress_seconds": result.no_progress_seconds,
         }
     )
     if result.action.startswith(("kickstart:", "respawn:")):
@@ -636,7 +744,11 @@ def run_once(
     # the current values, so neither comparison is strictly-greater on that tick.
     prev_chunk = int(state.get("watcher_highwater_rowid", 0) or 0)
     prev_liveness = int(state.get("watcher_liveness_highwater_rowid", 0) or 0)
-    progressed = current_highwater > prev_chunk or current_liveness_highwater > prev_liveness
+    progressed = (
+        current_highwater > prev_chunk
+        or current_liveness_highwater > prev_liveness
+        or any(value is not None and value > 0 for value in operational_deltas)
+    )
     if result.stalled_ticks == 0 and progressed:
         healthy_ticks = int(state.get("healthy_ticks", 0)) + 1
         next_state["healthy_ticks"] = healthy_ticks
@@ -660,6 +772,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--watch-label", default=DEFAULT_WATCH_LABEL)
     parser.add_argument("--watch-plist", type=Path, default=home / "Library/LaunchAgents/com.brainlayer.watch.plist")
     parser.add_argument("--stall-threshold", type=_positive_int, default=3)
+    parser.add_argument("--progress-slo-seconds", type=_positive_int, default=180)
     parser.add_argument("--cooldown-seconds", type=_positive_int, default=600)
     parser.add_argument("--recent-window-seconds", type=_positive_int, default=600)
     parser.add_argument("--max-source-files", type=_positive_int, default=100_000)
@@ -683,6 +796,7 @@ def _config_from_args(args: argparse.Namespace) -> Config:
         watch_label=args.watch_label,
         watch_plist_path=args.watch_plist,
         stall_threshold=args.stall_threshold,
+        progress_slo_seconds=args.progress_slo_seconds,
         cooldown_seconds=args.cooldown_seconds,
         recent_window_seconds=args.recent_window_seconds,
         max_source_files=args.max_source_files,
@@ -717,7 +831,7 @@ def main(argv: list[str] | None = None) -> int:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     print(json.dumps(asdict(result), sort_keys=True) if args.json else f"{result.action}: {result}")
-    return 1 if result.action == "recovery_failed" else 0
+    return 1 if result.action in {"recovery_failed", "checkpoint_guard_error"} else 0
 
 
 if __name__ == "__main__":

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -33,6 +33,7 @@ from .ingest_guard import recursive_mcp_output_reason
 from .paths import get_db_path
 from .pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_applies_to_label, pause_sentinel_state
 from .provenance_integration import enqueue_provenance_resolution_for_entities
+from .vector_store import _configure_writer_pragmas
 from .wal_checkpoint import checkpoint_guard
 from .wal_checkpoint import get_wal_size as _wal_size_bytes
 from .writer_telemetry import start_writer_span
@@ -277,6 +278,7 @@ def _open_connection(db_path: Path) -> apsw.Connection:
     conn.enableloadextension(True)
     conn.loadextension(sqlite_vec.loadable_path())
     conn.enableloadextension(False)
+    _configure_writer_pragmas(conn)
     return conn
 
 

--- a/src/brainlayer/runtime_store.py
+++ b/src/brainlayer/runtime_store.py
@@ -16,6 +16,7 @@ import sqlite_vec
 from .vector_store import (
     _CONNECTION_HOOK_STATE,
     VectorStore,
+    _configure_writer_pragmas,
     _write_busy_timeout_ms,
 )
 from .writer_telemetry import start_writer_span
@@ -431,6 +432,7 @@ class WriterRuntimeStore(VectorStore):
         try:
             self.conn.setbusytimeout(_write_busy_timeout_ms())
             _load_vector_extension(self.conn)
+            _configure_writer_pragmas(self.conn)
         except BaseException:
             self.conn.close()
             raise

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -282,6 +282,23 @@ def _wal_size_limit_bytes() -> int:
     return max(_int_env("BRAINLAYER_WAL_SIZE_LIMIT_BYTES", 256_000_000), 0)
 
 
+def _write_synchronous_mode() -> str:
+    """Return the requested safe writer durability mode; NORMAL is the WAL default."""
+    mode = os.environ.get("BRAINLAYER_WRITE_SYNCHRONOUS", "NORMAL").strip().upper()
+    return mode if mode in {"NORMAL", "FULL"} else "NORMAL"
+
+
+def _configure_writer_pragmas(conn: apsw.Connection) -> str:
+    """Use NORMAL only for WAL; retain FULL if a database is not in WAL mode."""
+    cursor = conn.cursor()
+    journal_row = cursor.execute("PRAGMA journal_mode").fetchone()
+    journal_mode = str(journal_row[0] if journal_row else "").lower()
+    requested = _write_synchronous_mode()
+    effective = requested if journal_mode == "wal" else "FULL"
+    cursor.execute(f"PRAGMA synchronous = {effective}")
+    return effective
+
+
 class WriterInUseError(RuntimeError):
     """Raised when a live process already owns the writer pidfile."""
 
@@ -762,6 +779,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         # WAL mode is persistent on the DB file — set it every time
         cursor.execute("PRAGMA journal_mode = WAL")
+        _configure_writer_pragmas(self.conn)
         cursor.execute(f"PRAGMA wal_autocheckpoint = {_wal_autocheckpoint_pages()}")
         # Bound the WAL file so it truncates back after each checkpoint instead of
         # staying at its high-water mark (default -1 = unlimited). See

--- a/src/brainlayer/wal_checkpoint.py
+++ b/src/brainlayer/wal_checkpoint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
+import math
 import os
 import sqlite3
 import time
@@ -14,6 +15,12 @@ from pathlib import Path
 from .paths import get_db_path
 
 _VALID_CHECKPOINT_MODES = {"PASSIVE", "FULL", "RESTART", "TRUNCATE"}
+_DEFAULT_GUARD_TIMEOUT_SECONDS = 10.0
+_GUARD_POLL_SECONDS = 0.1
+
+
+class CheckpointGuardTimeout(TimeoutError):
+    """Raised when a live checkpoint owner outlasts the acquisition deadline."""
 
 
 def checkpoint_lock_path(db_path: str | Path) -> Path:
@@ -23,19 +30,55 @@ def checkpoint_lock_path(db_path: str | Path) -> Path:
     return Path("/tmp") / f"brainlayer-wal-checkpoint-{digest}.lock"
 
 
+def _bounded_guard_timeout(value: object) -> float:
+    if value is None:
+        return _DEFAULT_GUARD_TIMEOUT_SECONDS
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_GUARD_TIMEOUT_SECONDS
+    if not math.isfinite(parsed):
+        return _DEFAULT_GUARD_TIMEOUT_SECONDS
+    return max(0.0, parsed)
+
+
+def _guard_timeout_seconds() -> float:
+    return _bounded_guard_timeout(os.environ.get("BRAINLAYER_CHECKPOINT_GUARD_TIMEOUT_SECONDS"))
+
+
 @contextmanager
-def checkpoint_guard(db_path: str | Path, *, blocking: bool = True) -> Iterator[bool]:
-    """Serialize checkpoints and let recovery defer while one is active."""
+def checkpoint_guard(
+    db_path: str | Path,
+    *,
+    blocking: bool = True,
+    timeout_seconds: float | None = None,
+) -> Iterator[bool]:
+    """Serialize checkpoints with bounded wait; let recovery defer immediately."""
     lock_path = checkpoint_lock_path(db_path)
     lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     acquired = False
     try:
-        operation = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
-        try:
-            fcntl.flock(lock_fd, operation)
-            acquired = True
-        except BlockingIOError:
-            pass
+        if blocking:
+            timeout = _guard_timeout_seconds() if timeout_seconds is None else _bounded_guard_timeout(timeout_seconds)
+            deadline = time.monotonic() + timeout
+            while True:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except BlockingIOError:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise CheckpointGuardTimeout(
+                            f"checkpoint guard acquisition timed out after {timeout:.1f}s for {db_path}"
+                        )
+                    time.sleep(min(_GUARD_POLL_SECONDS, remaining))
+        else:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+            except BlockingIOError:
+                pass
         yield acquired
     finally:
         if acquired:
@@ -67,14 +110,19 @@ def format_size(size_bytes: int) -> str:
     return f"{value:.1f}TB"
 
 
-def checkpoint(db_path: str, mode: str = "TRUNCATE") -> tuple[int, int, int]:
+def checkpoint(
+    db_path: str,
+    mode: str = "TRUNCATE",
+    *,
+    guard_timeout_seconds: float | None = None,
+) -> tuple[int, int, int]:
     """Run WAL checkpoint and return (busy, log_pages, checkpointed_pages)."""
     mode = mode.upper()
     if mode not in _VALID_CHECKPOINT_MODES:
         raise ValueError(f"Invalid checkpoint mode: {mode}")
 
-    with checkpoint_guard(db_path) as acquired:
-        if not acquired:  # pragma: no cover - blocking acquisition always resolves
+    with checkpoint_guard(db_path, timeout_seconds=guard_timeout_seconds) as acquired:
+        if not acquired:  # pragma: no cover - bounded acquisition resolves or raises
             raise RuntimeError("checkpoint guard was not acquired")
         conn = sqlite3.connect(db_path, timeout=10)
         try:

--- a/tests/test_cli_enrich.py
+++ b/tests/test_cli_enrich.py
@@ -1,5 +1,6 @@
 """Tests for brainlayer enrichment and maintenance CLI routing."""
 
+import json
 import os
 import signal
 from types import SimpleNamespace
@@ -336,3 +337,17 @@ def test_cli_wal_checkpoint_routes_to_helper(monkeypatch):
     assert result.exit_code == 0
     assert called == {"mode": "TRUNCATE"}
     assert "Checkpoint (TRUNCATE): 10/10 pages" in result.stdout
+
+
+def test_cli_wal_checkpoint_reports_guard_timeout_as_json_error(monkeypatch):
+    from brainlayer.wal_checkpoint import CheckpointGuardTimeout
+
+    def fake_run(_mode):
+        raise CheckpointGuardTimeout("checkpoint guard acquisition timed out after 10.0s")
+
+    monkeypatch.setattr("brainlayer.wal_checkpoint.run_wal_checkpoint", fake_run)
+
+    result = runner.invoke(app, ["wal-checkpoint", "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout) == {"error": "checkpoint guard acquisition timed out after 10.0s"}

--- a/tests/test_runtime_store.py
+++ b/tests/test_runtime_store.py
@@ -120,6 +120,15 @@ def test_runtime_store_opens_existing_schema_without_legacy_init(tmp_path, monke
         assert len(store.schema_fingerprint) == 64
 
 
+def test_runtime_writer_defaults_to_synchronous_normal(tmp_path, monkeypatch):
+    db_path = tmp_path / "runtime-sync.db"
+    monkeypatch.delenv("BRAINLAYER_WRITE_SYNCHRONOUS", raising=False)
+    _bootstrap(db_path)
+
+    with WriterRuntimeStore(db_path) as store:
+        assert store.conn.cursor().execute("PRAGMA synchronous").fetchone()[0] == 1
+
+
 def test_runtime_store_closes_connection_when_extension_setup_fails(tmp_path, monkeypatch):
     db_path = tmp_path / "extension-failure.db"
     _bootstrap(db_path)

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -25,7 +25,14 @@ def _load_module():
     return module
 
 
-def _config(module, tmp_path: Path, *, stall_threshold: int = 3, cooldown_seconds: int = 600):
+def _config(
+    module,
+    tmp_path: Path,
+    *,
+    stall_threshold: int = 3,
+    cooldown_seconds: int = 600,
+    progress_slo_seconds: int | None = None,
+):
     return module.Config(
         db_path=tmp_path / "brainlayer.db",
         registry_path=tmp_path / "offsets.json",
@@ -35,6 +42,7 @@ def _config(module, tmp_path: Path, *, stall_threshold: int = 3, cooldown_second
         watch_plist_path=tmp_path / "com.example.brainlayer.watch.plist",
         stall_threshold=stall_threshold,
         cooldown_seconds=cooldown_seconds,
+        progress_slo_seconds=progress_slo_seconds or stall_threshold * 60,
     )
 
 
@@ -578,6 +586,288 @@ def test_liveness_progress_prevents_false_restart_for_dedupe_only_ingest(tmp_pat
     assert commands == []
 
 
+def test_offset_progress_prevents_restart_when_db_highwaters_are_flat(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    operational = iter(
+        [
+            module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4),
+            module.OperationalProgress(offset_bytes=120, drain_cycles=11, drained_total=4),
+        ]
+    )
+    commands: list[list[str]] = []
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+        command_runner=lambda args: commands.append(args),
+    )
+
+    assert result.action == "progress"
+    assert result.offset_bytes_delta == 20
+    assert commands == []
+
+
+def test_operational_progress_reader_sums_offsets_and_reads_drain_counters(tmp_path: Path) -> None:
+    module = _load_module()
+    drain_health_path = tmp_path / "custom-drain-health.json"
+    config = replace(_config(module, tmp_path), drain_health_path=drain_health_path)
+    config.registry_path.write_text(
+        json.dumps(
+            {
+                "/tmp/a.jsonl": {"offset": 40},
+                "/tmp/b.jsonl": {"offset": 60},
+                "/tmp/invalid.jsonl": {"offset": -1},
+                "_tombstones": {"/tmp/old.jsonl": 123},
+            }
+        ),
+        encoding="utf-8",
+    )
+    drain_health_path.write_text(json.dumps({"drain_cycles": 12, "drained_total": 7}), encoding="utf-8")
+
+    progress = module.read_operational_progress(config)
+
+    assert progress == module.OperationalProgress(offset_bytes=100, drain_cycles=12, drained_total=7)
+
+
+def test_drain_progress_prevents_restart_when_offsets_and_db_are_flat(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    operational = iter(
+        [
+            module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4),
+            module.OperationalProgress(offset_bytes=100, drain_cycles=11, drained_total=5),
+        ]
+    )
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+
+    assert result.action == "progress"
+    assert result.drained_total_delta == 1
+
+
+def test_drain_cycle_progress_prevents_restart_when_no_items_are_drained(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    operational = iter(
+        [
+            module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4),
+            module.OperationalProgress(offset_bytes=100, drain_cycles=11, drained_total=4),
+        ]
+    )
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+
+    assert result.action == "progress"
+    assert result.drain_cycles_delta == 1
+
+
+def test_drain_counter_reset_rebaselines_instead_of_triggering_recovery(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    operational = iter(
+        [
+            module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4),
+            module.OperationalProgress(offset_bytes=100, drain_cycles=0, drained_total=0),
+        ]
+    )
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+
+    assert result.action == "baseline"
+    assert result.stalled_ticks == 0
+
+
+def test_offset_counter_reset_rebaselines_instead_of_looking_like_progress(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    operational = iter(
+        [
+            module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4),
+            module.OperationalProgress(offset_bytes=20, drain_cycles=10, drained_total=4),
+        ]
+    )
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+    result = module.run_once(
+        config,
+        now_epoch=1_060,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: next(operational),
+        source_probe=lambda _config, _now: evidence,
+    )
+
+    assert result.action == "baseline"
+    assert result.stalled_ticks == 0
+
+
+def test_operational_progress_counts_toward_healthy_episode_reset(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path)
+    config.state_path.write_text(
+        json.dumps(
+            {
+                "watcher_highwater_rowid": 40,
+                "watcher_liveness_highwater_rowid": 10,
+                "offset_bytes": 100,
+                "drain_cycles": 10,
+                "drained_total": 4,
+                "last_progress_epoch": 940,
+                "healthy_ticks": 2,
+                "episode_alerted": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: module.OperationalProgress(120, 11, 4),
+        source_probe=lambda _config, _now: module.SourceEvidence(1, 20, 1, 999.0),
+    )
+
+    assert result.action == "progress"
+    state = json.loads(config.state_path.read_text(encoding="utf-8"))
+    assert state["healthy_ticks"] == 3
+    assert state["episode_alerted"] is False
+
+
+def test_recovery_waits_for_elapsed_progress_slo_not_only_tick_count(tmp_path: Path) -> None:
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1, progress_slo_seconds=300)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    frozen = module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4)
+    command_events: list[str] = []
+    runner = _successful_recovery_runner(command_events)
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: frozen,
+        source_probe=lambda _config, _now: evidence,
+    )
+    early = module.run_once(
+        config,
+        now_epoch=1_299,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: frozen,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=runner,
+    )
+    due = module.run_once(
+        config,
+        now_epoch=1_300,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: frozen,
+        source_probe=lambda _config, _now: evidence,
+        command_runner=runner,
+        alert_fn=lambda _config, _result: None,
+    )
+
+    assert early.action == "stalled"
+    assert early.no_progress_seconds == 299
+    assert due.action == "kickstart:com.example.brainlayer.watch"
+    assert due.no_progress_seconds == 300
+
+
+def test_recovery_defers_without_signaling_while_checkpoint_guard_is_held(tmp_path: Path) -> None:
+    from brainlayer.wal_checkpoint import checkpoint_guard
+
+    module = _load_module()
+    config = _config(module, tmp_path, stall_threshold=1)
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    frozen = module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4)
+    commands: list[list[str]] = []
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: frozen,
+        source_probe=lambda _config, _now: evidence,
+    )
+    with checkpoint_guard(config.db_path, blocking=False) as acquired:
+        assert acquired is True
+        result = module.run_once(
+            config,
+            now_epoch=1_060,
+            progress_reader=lambda _path: _progress(module, 40, 10),
+            operational_progress_reader=lambda _config: frozen,
+            source_probe=lambda _config, _now: evidence,
+            command_runner=lambda args: commands.append(args),
+            alert_fn=lambda _config, _result: None,
+        )
+
+    assert result.action == "checkpoint_deferred"
+    assert result.stalled_ticks == 1
+    assert commands == []
+    state = json.loads(config.state_path.read_text(encoding="utf-8"))
+    assert "last_restart_epoch" not in state
+
+
 def test_recovery_requires_kickstarted_job_to_reach_running_state(tmp_path: Path) -> None:
     module = _load_module()
     config = _config(module, tmp_path, stall_threshold=1)
@@ -770,10 +1060,23 @@ def test_failed_alert_does_not_latch_episode_and_retries(tmp_path: Path) -> None
     module = _load_module()
     config = _config(module, tmp_path, stall_threshold=3, cooldown_seconds=0)
     calls = {"n": 0}
+    process = {"pid": 4321, "running": True}
 
     def command_runner(args):
-        stdout = "state = running\npid = 4321\n" if args[:2] == ["launchctl", "print"] else ""
-        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        if args[:2] == ["launchctl", "print"]:
+            if process["running"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=f"state = running\npid = {process['pid']}\n",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="state = exited\n", stderr="")
+        if args[:2] == ["/bin/kill", "-9"]:
+            process["running"] = False
+        elif args[:3] == ["launchctl", "kickstart", "-k"]:
+            process["pid"] += 1
+            process["running"] = True
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     def flaky_alert(_config, _result):
         calls["n"] += 1

--- a/tests/test_throughput_watchdog.py
+++ b/tests/test_throughput_watchdog.py
@@ -32,6 +32,7 @@ def _config(
     stall_threshold: int = 3,
     cooldown_seconds: int = 600,
     progress_slo_seconds: int | None = None,
+    checkpoint_deferral_alert_threshold: int = 3,
 ):
     return module.Config(
         db_path=tmp_path / "brainlayer.db",
@@ -43,6 +44,7 @@ def _config(
         stall_threshold=stall_threshold,
         cooldown_seconds=cooldown_seconds,
         progress_slo_seconds=progress_slo_seconds or stall_threshold * 60,
+        checkpoint_deferral_alert_threshold=checkpoint_deferral_alert_threshold,
     )
 
 
@@ -863,9 +865,97 @@ def test_recovery_defers_without_signaling_while_checkpoint_guard_is_held(tmp_pa
 
     assert result.action == "checkpoint_deferred"
     assert result.stalled_ticks == 1
+    assert result.checkpoint_deferred_ticks == 1
     assert commands == []
     state = json.loads(config.state_path.read_text(encoding="utf-8"))
     assert "last_restart_epoch" not in state
+
+
+def test_sustained_checkpoint_deferral_pages_once_and_remains_nonzero(tmp_path: Path) -> None:
+    from brainlayer.wal_checkpoint import checkpoint_guard
+
+    module = _load_module()
+    config = _config(
+        module,
+        tmp_path,
+        stall_threshold=1,
+        checkpoint_deferral_alert_threshold=3,
+    )
+    evidence = module.SourceEvidence(1, 20, 1, 999.0)
+    frozen = module.OperationalProgress(offset_bytes=100, drain_cycles=10, drained_total=4)
+    commands: list[list[str]] = []
+    alerts: list[tuple[str, int]] = []
+
+    module.run_once(
+        config,
+        now_epoch=1_000,
+        progress_reader=lambda _path: _progress(module, 40, 10),
+        operational_progress_reader=lambda _config: frozen,
+        source_probe=lambda _config, _now: evidence,
+    )
+    with checkpoint_guard(config.db_path, blocking=False) as acquired:
+        assert acquired is True
+        results = [
+            module.run_once(
+                config,
+                now_epoch=checked_at,
+                progress_reader=lambda _path: _progress(module, 40, 10),
+                operational_progress_reader=lambda _config: frozen,
+                source_probe=lambda _config, _now: evidence,
+                command_runner=lambda args: commands.append(args),
+                alert_fn=lambda _config, result: alerts.append((result.action, result.checkpoint_deferred_ticks)),
+            )
+            for checked_at in (1_060, 1_120, 1_180, 1_240)
+        ]
+
+    assert [result.action for result in results] == [
+        "checkpoint_deferred",
+        "checkpoint_deferred",
+        "checkpoint_deferral_alert",
+        "checkpoint_deferral_alert",
+    ]
+    assert [result.checkpoint_deferred_ticks for result in results] == [1, 2, 3, 4]
+    assert alerts == [("checkpoint_deferral_alert", 3)]
+    assert commands == []
+    state = json.loads(config.state_path.read_text(encoding="utf-8"))
+    assert state["checkpoint_deferred_ticks"] == 4
+    assert state["checkpoint_deferral_alerted"] is True
+
+
+def test_checkpoint_deferral_alert_exits_nonzero(tmp_path: Path, monkeypatch, capsys) -> None:
+    module = _load_module()
+    alert_result = module.WatchdogResult(
+        checked_at_epoch=1_180,
+        watcher_highwater_rowid=40,
+        watcher_highwater_delta=0,
+        watcher_liveness_highwater_rowid=10,
+        watcher_liveness_highwater_delta=0,
+        pending_files=1,
+        pending_bytes=20,
+        recent_files=1,
+        untracked_recent_files=0,
+        newest_source_mtime=999.0,
+        scan_errors=0,
+        stalled_ticks=3,
+        action="checkpoint_deferral_alert",
+        checkpoint_deferred_ticks=3,
+    )
+    monkeypatch.setattr(module, "run_once", lambda _config, now_epoch=None: alert_result)
+
+    exit_code = module.main(
+        [
+            "--db",
+            str(tmp_path / "brainlayer.db"),
+            "--state",
+            str(tmp_path / "watchdog-state.json"),
+            "--source-root",
+            str(tmp_path / "sessions"),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out)["action"] == "checkpoint_deferral_alert"
 
 
 def test_recovery_requires_kickstarted_job_to_reach_running_state(tmp_path: Path) -> None:

--- a/tests/test_vector_store_pragma_tuning.py
+++ b/tests/test_vector_store_pragma_tuning.py
@@ -44,6 +44,25 @@ def test_writer_init_sets_wal_autocheckpoint(tmp_path, monkeypatch):
         store.close()
 
 
+def test_writer_connections_default_to_synchronous_normal_in_wal_mode(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAINLAYER_WRITE_SYNCHRONOUS", raising=False)
+    store = VectorStore(tmp_path / "pragma-writer-sync.db")
+    try:
+        assert _pragma_value(store.conn, "synchronous") == 1
+    finally:
+        store.close()
+
+
+def test_writer_synchronous_mode_accepts_full_override_and_rejects_invalid(monkeypatch):
+    from brainlayer import vector_store
+
+    monkeypatch.setenv("BRAINLAYER_WRITE_SYNCHRONOUS", "FULL")
+    assert vector_store._write_synchronous_mode() == "FULL"
+
+    monkeypatch.setenv("BRAINLAYER_WRITE_SYNCHRONOUS", "unsafe-garbage")
+    assert vector_store._write_synchronous_mode() == "NORMAL"
+
+
 def test_readonly_primary_connection_uses_bounded_reader_pragmas(tmp_path, monkeypatch):
     monkeypatch.delenv("BRAINLAYER_READ_BUSY_TIMEOUT_MS", raising=False)
     store = VectorStore(tmp_path / "pragma-readonly-primary.db")

--- a/tests/test_wal_checkpoint_module.py
+++ b/tests/test_wal_checkpoint_module.py
@@ -31,6 +31,24 @@ def test_checkpoint_rejects_invalid_mode(tmp_path):
         wal_checkpoint.checkpoint(str(tmp_path / "brainlayer.db"), mode="DROP TABLE chunks")
 
 
+def test_checkpoint_guard_acquisition_times_out_while_another_holder_is_wedged(tmp_path):
+    import brainlayer.wal_checkpoint as wal_checkpoint
+
+    db_path = tmp_path / "brainlayer.db"
+    with wal_checkpoint.checkpoint_guard(db_path, blocking=False) as acquired:
+        assert acquired is True
+        with pytest.raises(TimeoutError, match="checkpoint guard acquisition timed out"):
+            wal_checkpoint.checkpoint(str(db_path), guard_timeout_seconds=0)
+
+
+def test_checkpoint_guard_timeout_env_rejects_unbounded_values(monkeypatch):
+    import brainlayer.wal_checkpoint as wal_checkpoint
+
+    monkeypatch.setenv("BRAINLAYER_CHECKPOINT_GUARD_TIMEOUT_SECONDS", "inf")
+
+    assert wal_checkpoint._guard_timeout_seconds() == 10.0
+
+
 def test_retrying_truncate_backs_off_until_checkpoint_is_not_busy(tmp_path, monkeypatch):
     import brainlayer.wal_checkpoint as wal_checkpoint
 

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -58,6 +58,19 @@ class TestQueueStore:
         finally:
             apsw.connection_hooks[:] = original_hooks
 
+    def test_drain_writer_defaults_to_synchronous_normal(self, tmp_path, monkeypatch):
+        from brainlayer.vector_store import VectorStore
+
+        monkeypatch.delenv("BRAINLAYER_WRITE_SYNCHRONOUS", raising=False)
+        db_path = tmp_path / "drain-sync.db"
+        VectorStore(db_path).close()
+
+        conn = _open_connection(db_path)
+        try:
+            assert conn.cursor().execute("PRAGMA synchronous").fetchone()[0] == 1
+        finally:
+            conn.close()
+
     def test_queue_store_writes_jsonl(self, tmp_path):
         """_queue_store writes to the unified arbitration queue."""
         with patch("brainlayer.queue_io.get_queue_dir", return_value=tmp_path):

--- a/tests/test_writer_pidfile_mutex.py
+++ b/tests/test_writer_pidfile_mutex.py
@@ -707,6 +707,21 @@ def test_drain_open_retries_busy_error_before_connection_exists(tmp_path, monkey
             self.busy_timeout_ms = None
             self.extension_enabled: list[bool] = []
             self.loaded_extensions: list[str] = []
+            self.executed: list[str] = []
+
+        class Cursor:
+            def __init__(self, connection):
+                self.connection = connection
+
+            def execute(self, statement: str):
+                self.connection.executed.append(statement)
+                return self
+
+            def fetchone(self):
+                return ("wal",)
+
+        def cursor(self):
+            return self.Cursor(self)
 
         def setbusytimeout(self, timeout_ms: int) -> None:
             self.busy_timeout_ms = timeout_ms
@@ -738,6 +753,7 @@ def test_drain_open_retries_busy_error_before_connection_exists(tmp_path, monkey
     assert conn.busy_timeout_ms >= 30000
     assert conn.loaded_extensions == ["sqlite_vec"]
     assert conn.extension_enabled == [True, False]
+    assert conn.executed == ["PRAGMA journal_mode", "PRAGMA synchronous = NORMAL"]
 
 
 def test_drain_busy_timeout_invalid_env_falls_back_to_30s(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- switch WAL writers to synchronous=NORMAL with a FULL fallback outside WAL and an explicit FULL override
- make watchdog recovery depend on persisted ingestion progress, not process quiet alone
- bound checkpoint-guard acquisition at 10 seconds by default and surface timeout as a non-zero JSON error
- persist checkpoint deferrals, page once after 3 consecutive blocked recovery attempts, and remain non-zero until the guard clears

Parts 1-2 of D1 (checkpoint strategy and burn-path precompute) are already on main through #664. The lead accepted those changes in place after retroactive review; this branch was rebased onto current main and does not replay them.

## Root-cause correction

The freeze was caused by checkpoint starvation around a 3.7 GB live WAL, embedding inference inside the burn write transaction, and watchdog kill-respawn recovery pressure. The earlier F_FULLFSYNC explanation was false: BrainLayer does not enable fullfsync. On the required production-DB copy, synchronous FULL measured 0.076 ms per commit and NORMAL measured 0.027 ms, a roughly 49 microsecond saving. WAL plus NORMAL is retained as a documented-safe free win, not as the fix for a claimed 0.6-1 second F_FULLFSYNC stall.

## Review fixes

- MAJOR-1: sustained checkpoint deferral now has a durable counter and one-shot operator page; launchd receives a failure exit after the third consecutive deferral
- MAJOR-2: blocking checkpoint guard acquisition is a finite nonblocking deadline loop; invalid or unbounded timeout configuration falls back to 10 seconds
- MEDIUM-1: this PR body and the D1 collab retract the false F_FULLFSYNC root-cause claim

## Verification

- production-DB copy live check from D1: queued burn event persisted a 4096-byte vector; WAL plus synchronous=1 observed; PASSIVE, RESTART, and non-busy TRUNCATE completed; quick_check=ok
- focused post-rebase: 229 passed across checkpoint, watchdog, CLI, write queue, load resilience, and launchd/controller tests
- pre-push at 4096 file descriptors: 3761 passed, 10 skipped, 2 xfailed; 3 MCP-registration passed; 40 isolated routing/eval passed; Bun passed; FTS5 shell regression passed
- Ruff check and Ruff format --check clean; git diff --check clean
- local CodeRabbit review: no findings

The first pre-push attempt at the shell default 256-file-descriptor limit was blocked by EMFILE in the existing multiprocessing queue test after 2552 passes. The identical gate passed without code or test changes at the repo-documented 4096-file-descriptor limit.

## Safety

No production DB was mutated. Prohibited real-DB tests test_vector_store.py and test_engine.py were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch SQLite durability pragmas, cross-process checkpoint locking, and launchd-driven watcher recovery—core ingestion and maintenance paths where mis-tuning can cause data-loss perception, wedged WAL, or harmful kill/kickstart loops.
> 
> **Overview**
> Addresses checkpoint starvation and overly aggressive watcher recovery by tightening WAL writer behavior, bounding checkpoint lock contention, and basing stall detection on real ingestion signals—not only DB chunk highwater.
> 
> **WAL writers** now apply `_configure_writer_pragmas`: `synchronous=NORMAL` in WAL mode (with `FULL` fallback for non-WAL and an env override), wired into `VectorStore` init, drain opens, and `WriterRuntimeStore`.
> 
> **`checkpoint_guard`** blocking acquisition uses a polled deadline (default 10s, env-configurable) and raises `CheckpointGuardTimeout` instead of waiting indefinitely; `wal-checkpoint` CLI surfaces that as a JSON error.
> 
> **Throughput watchdog** reads registry offset sums and `drain-health.json` counters, treats those deltas (plus a **progress SLO** in seconds) as progress, defers kickstart while the checkpoint guard is held, pages once after sustained deferrals, and exits non-zero on `checkpoint_deferral_alert` / guard errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a87b1cff28954c9aa100af22f1102861e93ee064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix checkpoint starvation and watchdog freeze in throughput watchdog
> - The throughput watchdog now wraps WAL checkpoint recovery attempts in `checkpoint_guard`, deferring recovery when the guard is held rather than blocking indefinitely; sustained deferral beyond a configurable threshold triggers an alert and nonzero exit.
> - Operational progress (registry offsets, drain cycles) is tracked via a new `read_operational_progress` function, allowing the watchdog to detect forward progress even without DB highwater changes.
> - A time-based progress SLO (`--progress-slo-seconds`, default 180s) gates recovery so that stalled ticks alone are no longer sufficient to trigger a restart.
> - `checkpoint_guard` in [wal_checkpoint.py](https://github.com/EtanHey/brainlayer/pull/667/files#diff-f0041f1232c5d3e712a4c83a4a87eda25157b39aba79ca232f7db78ff23f60ff) gains bounded-blocking acquisition with polling and raises `CheckpointGuardTimeout` on deadline; non-blocking mode is unchanged.
> - `PRAGMA synchronous` is now applied consistently to WAL-mode writer connections across [vector_store.py](https://github.com/EtanHey/brainlayer/pull/667/files#diff-74a1a6036a2c74ec470f2d6ebdef8790a9db1c9b3f914616f295e40e7eb73261), [runtime_store.py](https://github.com/EtanHey/brainlayer/pull/667/files#diff-44a9ec65471a02fcd4dfa52456f8f5184e75130597bb854cf2cb59f4b15523da), and [drain.py](https://github.com/EtanHey/brainlayer/pull/667/files#diff-b038e117171bfa3617d2351297309d808c2b5cc52995c7572904030beaf1e12c) via a shared `_configure_writer_pragmas` helper, defaulting to `NORMAL`.
> - Risk: the process now exits nonzero for `checkpoint_guard_error` and `checkpoint_deferral_alert` outcomes, which are new exit conditions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a87b1cf. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved throughput monitoring using operational progress and drain-health signals.
  - Added configurable progress SLO and checkpoint-deferral alert thresholds.
  - Added configurable SQLite write-synchronous modes, with safe defaults and validation.
  - Added bounded WAL checkpoint waits to prevent recovery from blocking indefinitely.

- **Bug Fixes**
  - Watchdog recovery now handles checkpoint contention safely and reports repeated deferrals distinctly.
  - Command-line checkpoint timeout failures now return a nonzero status with structured error output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->