### PR TITLE
fix: serve letter-truth across expiry, ingest, and brain_update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ brainlayer enrich
 - Daemon API (core): `/health`, `/stats`, `/search`, `/context/{chunk_id}`, `/session/{session_id}`
 - Brain graph API: `/brain/graph`, `/brain/node/{node_id}`
 - Backlog API: `/backlog/items` (GET/POST/PATCH/DELETE)
-- MCP tools (13): `brain_search`, `brain_store`, `brain_recall`, `brain_resume`, `brain_entity`, `brain_expand`, `brain_update`, `brain_digest`, `brain_get_person`, `brain_enrich`, `brain_tags`, `brain_supersede`, `brain_archive` (legacy `brainlayer_*` aliases still work; note: `brain_update`, `brain_expand`, `brain_tags` are deprecated in the Python MCP path and return errors — use the BrainBar native path for these)
+- MCP tools (13): `brain_search`, `brain_store`, `brain_recall`, `brain_resume`, `brain_entity`, `brain_expand`, `brain_update`, `brain_digest`, `brain_get_person`, `brain_enrich`, `brain_tags`, `brain_supersede`, `brain_archive` (legacy `brainlayer_*` aliases still work; note: `brain_expand` and `brain_tags` are deprecated in the Python MCP path and return errors — use the BrainBar native path for those two)
 - MCP server entrypoint: `brainlayer-mcp`
 
 <!-- COMMANDS: `brainlayer brain-export` → graph JSON for dashboard | `brainlayer export-obsidian` → Markdown vault with backlinks + tags -->

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -5293,25 +5293,32 @@ final class BrainDatabase: @unchecked Sendable {
         let relationType: String
         let entityType: String
         let direction: String  // "outgoing" or "incoming"
+        let validUntil: Date?
+        let expiredAt: Date?
     }
 
     /// Pure SQL KG fact lookup — no embeddings needed.
     /// Returns typed relations for an entity, excluding co_occurs_with.
     func lookupEntityFacts(entityName: String, limit: Int = 20) throws -> [KGFact] {
         guard let db else { throw DBError.notOpen }
+        let expirationSelects = try kgRelationExpirationSelects(alias: "r")
 
         let sql = """
-            SELECT e2.name, r.relation_type, e2.entity_type, 'outgoing' AS direction
-            FROM kg_relations_typed r
+            SELECT e2.name, r.relation_type, e2.entity_type, 'outgoing' AS direction,
+                   \(expirationSelects.validUntil), \(expirationSelects.expiredAt)
+            FROM kg_relations r
             JOIN kg_entities e1 ON r.source_id = e1.id
             JOIN kg_entities e2 ON r.target_id = e2.id
             WHERE LOWER(e1.name) = LOWER(?1)
+              AND r.relation_type != 'co_occurs_with'
             UNION ALL
-            SELECT e1.name, r.relation_type, e1.entity_type, 'incoming'
-            FROM kg_relations_typed r
+            SELECT e1.name, r.relation_type, e1.entity_type, 'incoming',
+                   \(expirationSelects.validUntil), \(expirationSelects.expiredAt)
+            FROM kg_relations r
             JOIN kg_entities e1 ON r.source_id = e1.id
             JOIN kg_entities e2 ON r.target_id = e2.id
             WHERE LOWER(e2.name) = LOWER(?1)
+              AND r.relation_type != 'co_occurs_with'
             ORDER BY 2
             LIMIT ?2
         """
@@ -5330,7 +5337,9 @@ final class BrainDatabase: @unchecked Sendable {
                 relatedEntity: columnText(stmt, 0) ?? "",
                 relationType: columnText(stmt, 1) ?? "",
                 entityType: columnText(stmt, 2) ?? "",
-                direction: columnText(stmt, 3) ?? "outgoing"
+                direction: columnText(stmt, 3) ?? "outgoing",
+                validUntil: KGTemporalDate.parse(columnText(stmt, 4)),
+                expiredAt: KGTemporalDate.parse(columnText(stmt, 5))
             ))
         }
         return facts

--- a/brain-bar/Sources/BrainBar/Formatting/TextFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Formatting/TextFormatter.swift
@@ -42,7 +42,7 @@ enum TextFormatter {
         return lines.joined(separator: "\n")
     }
 
-    static func formatKGFacts(entity: String, facts: [BrainDatabase.KGFact]) -> String {
+    static func formatKGFacts(entity: String, facts: [BrainDatabase.KGFact], now: Date = Date()) -> String {
         guard !facts.isEmpty else { return "" }
         var lines: [String] = []
         lines.append("## Entity: \(entity)")
@@ -50,14 +50,14 @@ enum TextFormatter {
         lines.append("### KG Facts")
         for fact in facts.prefix(20) {
             var line = "- \(fact.relationType): \(fact.relatedEntity)"
-            line += relationTemporalSuffix(validUntil: fact.validUntil, expiredAt: fact.expiredAt)
+            line += relationTemporalSuffix(validUntil: fact.validUntil, expiredAt: fact.expiredAt, now: now)
             lines.append(line)
         }
 
         return lines.joined(separator: "\n")
     }
 
-    static func formatEntityCard(_ entity: EntityCard) -> String {
+    static func formatEntityCard(_ entity: EntityCard, now: Date = Date()) -> String {
         var lines = ["## Entity: \(entity.name)"]
 
         if !entity.description.isEmpty {
@@ -65,11 +65,11 @@ enum TextFormatter {
             lines.append(truncate(entity.description, maxLen: 200))
         }
 
-        appendEntitySections(entity, to: &lines)
+        appendEntitySections(entity, to: &lines, now: now)
         return lines.joined(separator: "\n")
     }
 
-    static func formatEntitySimple(_ entity: EntityCard) -> String {
+    static func formatEntitySimple(_ entity: EntityCard, now: Date = Date()) -> String {
         var lines = ["## Entity: \(entity.name)"]
 
         if !entity.description.isEmpty {
@@ -77,7 +77,7 @@ enum TextFormatter {
             lines.append(truncate(entity.description, maxLen: 200))
         }
 
-        appendEntitySections(entity, to: &lines)
+        appendEntitySections(entity, to: &lines, now: now)
         return lines.joined(separator: "\n")
     }
 
@@ -221,9 +221,9 @@ enum TextFormatter {
         return formatter.string(from: date)
     }
 
-    private static func relationLine(_ relation: EntityCard.Relation) -> String {
+    private static func relationLine(_ relation: EntityCard.Relation, now: Date) -> String {
         var line = "- \(relation.relationType): \(relation.targetName)"
-        line += relationTemporalSuffix(validUntil: relation.validUntil, expiredAt: relation.expiredAt)
+        line += relationTemporalSuffix(validUntil: relation.validUntil, expiredAt: relation.expiredAt, now: now)
         return line
     }
 
@@ -241,7 +241,7 @@ enum TextFormatter {
         return ""
     }
 
-    private static func appendEntitySections(_ entity: EntityCard, to lines: inout [String]) {
+    private static func appendEntitySections(_ entity: EntityCard, to lines: inout [String], now: Date) {
         appendKeyValueSection("Profile", values: entity.profile, to: &lines)
         appendKeyValueSection("Constraints", values: entity.hardConstraints, to: &lines)
         appendKeyValueSection("Preferences", values: entity.preferences, to: &lines)
@@ -253,7 +253,7 @@ enum TextFormatter {
             lines.append("- None")
         } else {
             for relation in entity.relations.prefix(20) {
-                lines.append(relationLine(relation))
+                lines.append(relationLine(relation, now: now))
             }
         }
 

--- a/brain-bar/Sources/BrainBar/Formatting/TextFormatter.swift
+++ b/brain-bar/Sources/BrainBar/Formatting/TextFormatter.swift
@@ -49,7 +49,9 @@ enum TextFormatter {
         lines.append("")
         lines.append("### KG Facts")
         for fact in facts.prefix(20) {
-            lines.append("- \(fact.relationType): \(fact.relatedEntity)")
+            var line = "- \(fact.relationType): \(fact.relatedEntity)"
+            line += relationTemporalSuffix(validUntil: fact.validUntil, expiredAt: fact.expiredAt)
+            lines.append(line)
         }
 
         return lines.joined(separator: "\n")
@@ -221,10 +223,22 @@ enum TextFormatter {
 
     private static func relationLine(_ relation: EntityCard.Relation) -> String {
         var line = "- \(relation.relationType): \(relation.targetName)"
-        if let expired = formattedDate(relation.expiredAt) {
-            line += " (expired \(expired))"
-        }
+        line += relationTemporalSuffix(validUntil: relation.validUntil, expiredAt: relation.expiredAt)
         return line
+    }
+
+    private static func relationTemporalSuffix(
+        validUntil: Date?,
+        expiredAt: Date?,
+        now: Date = Date()
+    ) -> String {
+        if let expired = formattedDate(expiredAt) {
+            return " (expired \(expired))"
+        }
+        if let validUntil, let date = formattedDate(validUntil) {
+            return validUntil < now ? " (expired \(date))" : " (until \(date))"
+        }
+        return ""
     }
 
     private static func appendEntitySections(_ entity: EntityCard, to lines: inout [String]) {

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -700,6 +700,95 @@ No results found.
         XCTAssertTrue(text.contains("fallback result from BrainBar database search"), text)
     }
 
+    func testBrainSearchFallbackMarksExpiredKGFactsInEntityHeader() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-hybrid-fallback-expired-kg-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try db.insertEntity(id: "person-etan", type: "person", name: "Etan")
+        try db.insertEntity(id: "company-domica", type: "company", name: "Domica")
+        try db.insertRelation(sourceId: "person-etan", targetId: "company-domica", relationType: "cto_of")
+        try db.insertChunk(
+            id: "fallback-expired-kg-result",
+            content: "Etan Domica fallback result from BrainBar database search",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        XCTAssertEqual(
+            sqlite3_exec(
+                db.dbHandle,
+                """
+                UPDATE kg_relations
+                SET expired_at = '2026-05-24T00:00:00Z',
+                    valid_until = '2026-05-24T00:00:00Z'
+                WHERE source_id = 'person-etan' AND target_id = 'company-domica'
+                """,
+                nil,
+                nil,
+                nil
+            ),
+            SQLITE_OK
+        )
+
+        let helper = RecordingHybridSearchClient()
+        let router = MCPRouter(profile: "full", hybridSearchClient: helper)
+        router.setDatabase(db)
+
+        let text = try toolText(router.handle(toolCall(id: 173, name: "brain_search", arguments: [
+            "query": "Etan Domica",
+            "num_results": 3
+        ])))
+
+        XCTAssertTrue(text.contains("## Entity: Etan"), text)
+        XCTAssertTrue(text.contains("- cto_of: Domica (expired 2026-05-24)"), text)
+    }
+
+    func testBrainSearchFallbackMarksLapsedValidUntilWithoutExpiredStamp() throws {
+        let tempDB = NSTemporaryDirectory() + "brainbar-hybrid-fallback-lapsed-kg-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tempDB) }
+        let db = BrainDatabase(path: tempDB)
+        defer { db.close() }
+        try db.insertEntity(id: "person-etan", type: "person", name: "Etan")
+        try db.insertEntity(id: "company-domica", type: "company", name: "Domica")
+        try db.insertRelation(sourceId: "person-etan", targetId: "company-domica", relationType: "cto_of")
+        try db.insertChunk(
+            id: "fallback-lapsed-kg-result",
+            content: "Etan Domica fallback result from BrainBar database search",
+            sessionId: "s1",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
+        XCTAssertEqual(
+            sqlite3_exec(
+                db.dbHandle,
+                """
+                UPDATE kg_relations
+                SET valid_until = '2025-05-24T00:00:00Z',
+                    expired_at = NULL
+                WHERE source_id = 'person-etan' AND target_id = 'company-domica'
+                """,
+                nil,
+                nil,
+                nil
+            ),
+            SQLITE_OK
+        )
+
+        let helper = RecordingHybridSearchClient()
+        let router = MCPRouter(profile: "full", hybridSearchClient: helper)
+        router.setDatabase(db)
+
+        let text = try toolText(router.handle(toolCall(id: 174, name: "brain_search", arguments: [
+            "query": "Etan Domica",
+            "num_results": 3
+        ])))
+
+        XCTAssertTrue(text.contains("- cto_of: Domica (expired 2025-05-24)"), text)
+    }
+
     func testReadToolsUseReadonlyReadDatabaseWhenWriteHandleIsUnavailable() throws {
         let tempDB = NSTemporaryDirectory() + "brainbar-read-db-routing-\(UUID().uuidString).db"
         defer { try? FileManager.default.removeItem(atPath: tempDB) }

--- a/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
+++ b/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
@@ -176,6 +176,7 @@ final class TextFormatterParityTests: XCTestCase {
 
     func testEntityCardDoesNotMarkFutureValidUntilExpired() {
         let validUntil = ISO8601DateFormatter().date(from: "2026-12-31T00:00:00Z")
+        let now = ISO8601DateFormatter().date(from: "2026-08-08T00:00:00Z")!
         let entity = EntityCard(
             id: "tech-001",
             name: "JWT middleware",
@@ -189,7 +190,7 @@ final class TextFormatterParityTests: XCTestCase {
             ]
         )
 
-        let output = TextFormatter.formatEntityCard(entity)
+        let output = TextFormatter.formatEntityCard(entity, now: now)
 
         XCTAssertTrue(output.contains("- depends_on: auth-service"))
         XCTAssertFalse(output.contains("expired 2026-12-31"))

--- a/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
+++ b/brain-bar/Tests/BrainBarTests/TextFormatterParityTests.swift
@@ -193,6 +193,27 @@ final class TextFormatterParityTests: XCTestCase {
 
         XCTAssertTrue(output.contains("- depends_on: auth-service"))
         XCTAssertFalse(output.contains("expired 2026-12-31"))
+        XCTAssertTrue(output.contains("- depends_on: auth-service (until 2026-12-31)"))
+    }
+
+    func testEntityCardMarksLapsedValidUntilExpiredWithoutExpiredStamp() {
+        let validUntil = ISO8601DateFormatter().date(from: "2025-05-24T00:00:00Z")
+        let entity = EntityCard(
+            id: "person-001",
+            name: "Etan",
+            entityType: "person",
+            relations: [
+                EntityCard.Relation(
+                    relationType: "cto_of",
+                    targetName: "Domica",
+                    validUntil: validUntil
+                )
+            ]
+        )
+
+        let output = TextFormatter.formatEntityCard(entity)
+
+        XCTAssertTrue(output.contains("- cto_of: Domica (expired 2025-05-24)"), output)
     }
 
     func testRecallContextUsesLabeledChunkMarkdown() {

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -11,10 +11,7 @@ from pathlib import Path
 
 BRAINLAYER_INGEST_DENYLIST_ENV = "BRAINLAYER_INGEST_DENYLIST"
 
-DEFAULT_INGEST_DENYLIST = (
-    "~/.claude/projects/**/wf_*/**",
-    "~/.claude/projects/**/subagents/**",
-)
+DEFAULT_INGEST_DENYLIST = ("~/.claude/projects/**/wf_*/**",)
 
 
 @dataclass(frozen=True)

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -171,7 +171,7 @@ server = Server(
         "know this is a topical memory search (brain_search).\n"
         "- brain_entity(name): look up known entities and their relationships from the knowledge graph.\n"
         "- brain_digest(content): extract entities and structured knowledge from large content.\n"
-        "brain_update/brain_expand/brain_tags are deprecated — see their descriptions for alternatives.\n"
+        "brain_expand/brain_tags are deprecated — see their descriptions for alternatives.\n"
         'Project scoping: auto-inferred from cwd. Override with project="all".'
     ),
     on_list_tools=_handle_list_tools_request,
@@ -1159,7 +1159,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_update",
             title="Update or Archive Memory",
-            description="Deprecated. Use brain_store with supersedes param to replace a memory, or brain_archive/brain_supersede for lifecycle management.",
+            description="Update a memory's content, tags, or importance; archive a memory; or merge duplicate memories into one keeper.",
             annotations=_WRITE_IDEMPOTENT,
             input_schema=_bounded_input_schema(
                 {
@@ -1629,19 +1629,13 @@ async def call_tool(name: str, arguments: dict[str, Any]):
         )
 
     elif name == "brain_update":
-        # DEPRECATED: stub returns isError
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=(
-                        "brain_update is deprecated and non-functional. "
-                        "Use brain_store(supersedes='old_chunk_id') to replace a memory, "
-                        "or brain_supersede/brain_archive for lifecycle management."
-                    ),
-                )
-            ],
-            is_error=True,
+        return await _brain_update(
+            action=arguments["action"],
+            chunk_id=arguments["chunk_id"],
+            content=arguments.get("content"),
+            tags=arguments.get("tags"),
+            importance=arguments.get("importance"),
+            merge_chunk_ids=arguments.get("merge_chunk_ids"),
         )
 
     elif name == "brain_tags":

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -292,6 +292,8 @@ async def _brain_update(
             logger.error("brain_update failed: %s", e)
             return _error_result(f"brain_update error: {e}")
 
+    return _error_result(f"brain_update failed after {_RETRY_MAX_ATTEMPTS} retries: {last_err}")
+
 
 _PERSONAL_TYPES = frozenset({"journal", "note", "bookmark"})
 _PERSONAL_KEYWORDS = ("health", "family", "relationship", "finance", "personal", "therapy", "medical")

--- a/tests/test_3tool_aliases.py
+++ b/tests/test_3tool_aliases.py
@@ -6,7 +6,7 @@ Covers:
 - brain_recall mode=entity routing
 - brain_search → brain_recall(mode=search) delegation
 - brain_entity → brain_recall(mode=entity) delegation
-- brain_update / brain_expand / brain_tags deprecation (isError: true)
+- brain_update routing and brain_expand / brain_tags deprecation
 - Backward compatibility: all old modes still work
 - Edge cases: empty query, None query, mixed signals
 """
@@ -313,20 +313,50 @@ class TestBackwardCompatRecallModes:
         mock_ctx.assert_called_once()
 
 
-# ── Deprecation stubs (isError: true) ─────────────────────────────────────────
+# ── Update routing and deprecation stubs ──────────────────────────────────────
 
 
-class TestDeprecationStubs:
-    """brain_update, brain_expand, brain_tags return isError: true."""
+class TestUpdateRoutingAndDeprecationStubs:
+    """brain_update is live while brain_expand and brain_tags remain deprecated."""
 
-    def test_brain_update_returns_deprecation_error(self):
-        """brain_update returns isError with deprecation message."""
+    def test_brain_update_routes_to_store_handler(self):
+        """brain_update delegates to the working store handler."""
         from brainlayer.mcp import call_tool
 
-        result = asyncio.run(call_tool("brain_update", {"action": "update", "chunk_id": "abc123"}))
-        assert result.is_error is True
-        assert "deprecated" in result.content[0].text.lower()
-        assert "brain_store" in result.content[0].text or "brain_supersede" in result.content[0].text
+        with patch("brainlayer.mcp._brain_update", new_callable=AsyncMock, return_value=[MagicMock()]) as update:
+            result = asyncio.run(
+                call_tool(
+                    "brain_update",
+                    {
+                        "action": "update",
+                        "chunk_id": "abc123",
+                        "content": "Corrected content",
+                        "tags": ["corrected"],
+                        "importance": 9,
+                        "merge_chunk_ids": ["duplicate-1"],
+                    },
+                )
+            )
+
+        assert len(result) == 1
+        update.assert_awaited_once_with(
+            action="update",
+            chunk_id="abc123",
+            content="Corrected content",
+            tags=["corrected"],
+            importance=9,
+            merge_chunk_ids=["duplicate-1"],
+        )
+
+    def test_brain_update_tool_contract_is_live(self):
+        """The advertised brain_update contract must not claim the live tool is deprecated."""
+        from brainlayer.mcp import list_tools
+
+        tools = asyncio.run(list_tools())
+        update_tool = next(tool for tool in tools if tool.name == "brain_update")
+
+        assert "deprecated" not in update_tool.description.lower()
+        assert "update" in update_tool.description.lower()
 
     def test_brain_expand_returns_deprecation_error(self):
         """brain_expand returns isError with deprecation message."""

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -39,7 +39,7 @@ def test_default_policy_allows_normal_provider_sessions(monkeypatch, tmp_path):
     assert not is_denylisted(backup_home / ".claude" / "projects" / "proj" / "direct-session.jsonl")
 
 
-def test_default_policy_excludes_ordinary_claude_subagents(monkeypatch, tmp_path):
+def test_default_policy_allows_ordinary_claude_subagents(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
     projects = tmp_path / ".claude" / "projects" / "-Users-test-Gits-brainlayer" / "session-uuid"
@@ -47,8 +47,8 @@ def test_default_policy_excludes_ordinary_claude_subagents(monkeypatch, tmp_path
     explore = _write_subagent(projects / "subagents" / "agent-explore.jsonl", "Explore")
     general = _write_subagent(projects / "subagents" / "agent-general.jsonl", "general-purpose")
 
-    assert is_denylisted(explore)
-    assert is_denylisted(general)
+    assert not is_denylisted(explore)
+    assert not is_denylisted(general)
 
 
 def test_default_policy_excludes_exact_brain_worker_but_keeps_raw_jsonl(monkeypatch, tmp_path):
@@ -69,7 +69,8 @@ def test_default_policy_excludes_exact_brain_worker_but_keeps_raw_jsonl(monkeypa
     assert worker.exists()
 
 
-def test_default_policy_excludes_workflow_workers_by_path_and_keeps_raw_jsonl(monkeypatch, tmp_path):
+def test_known_drift_blanket_workflow_path_exclusion_keeps_raw_jsonl(monkeypatch, tmp_path):
+    """Document the shipped wf_* over-exclusion without presenting it as the BL-10 ruling."""
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
     workflow = _write_subagent(

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -640,7 +640,8 @@ class TestFlushCallback:
 
 
 class TestFullPipeline:
-    def test_watcher_denylist_blocks_all_claude_subagents_and_allows_direct_sessions(self, tmp_path, monkeypatch):
+    def test_watcher_denylist_blocks_brain_workers_and_allows_ordinary_subagents(self, tmp_path, monkeypatch):
+        """Exercise #666 while naming workflow-path exclusion below as known drift, not policy."""
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
         db_path = tmp_path / "test.db"
@@ -654,7 +655,7 @@ class TestFullPipeline:
             / "session-123"
             / "subagents"
             / "agent-brain.jsonl",
-            "workflow-worker": tmp_path
+            "known-drift-workflow-worker": tmp_path
             / ".claude"
             / "projects"
             / "proj"
@@ -663,13 +664,6 @@ class TestFullPipeline:
             / "workflows"
             / "wf_123"
             / "agent-workflow.jsonl",
-            "claude-subagent": tmp_path
-            / ".claude"
-            / "projects"
-            / "proj"
-            / "session-123"
-            / "subagents"
-            / "agent-general.jsonl",
         }
         allowed = {
             "codex": tmp_path / ".codex" / "sessions" / "2026" / "07" / "02" / "worker.jsonl",
@@ -682,13 +676,19 @@ class TestFullPipeline:
             / "agent-session.jsonl",
             "gemini": tmp_path / ".gemini" / "sessions" / "worker.jsonl",
             "claude-direct": tmp_path / ".claude" / "projects" / "proj" / "direct-session.jsonl",
+            "claude-subagent": tmp_path
+            / ".claude"
+            / "projects"
+            / "proj"
+            / "session-123"
+            / "subagents"
+            / "agent-general.jsonl",
         }
         for provider, path in denylisted.items():
             path.parent.mkdir(parents=True, exist_ok=True)
             attribution = {
                 "brain-worker": "brain-worker",
-                "workflow-worker": "workflow-subagent",
-                "claude-subagent": "general-purpose",
+                "known-drift-workflow-worker": "workflow-subagent",
             }[provider]
             path.write_text(
                 json.dumps(

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -2582,6 +2582,19 @@ class TestBrainUpdateRetryOnLock:
         assert isinstance(result, CallToolResult)
         assert result.is_error is True
 
+    @pytest.mark.asyncio
+    async def test_update_zero_retry_budget_returns_structured_error(self, monkeypatch):
+        """A patched zero-attempt budget must not fall through with None."""
+        from brainlayer.mcp import store_handler
+
+        monkeypatch.setattr(store_handler, "_RETRY_MAX_ATTEMPTS", 0)
+
+        result = await store_handler._brain_update(action="archive", chunk_id="test-chunk-123")
+
+        assert result is not None
+        assert result.is_error is True
+        assert "failed after 0 retries" in result.content[0].text
+
 
 class TestBrainSearchRetryOnLock:
     """brain_search (reads) should retry on BusyError in WAL mode."""


### PR DESCRIPTION
## Summary

- preserve KG relation expiry truth in BrainBar fallback `brain_search` headers, including explicit `expired_at`, lapsed `valid_until`, and forward `until` markers; keep entity text at parity
- scope Claude Task-subagent ingest exclusion to exact `brain-worker` attribution so ordinary subagents ingest; raw transcripts remain untouched
- route Python MCP `brain_update` to its working write handler and keep the public/tool/instruction contracts truthful

Closes #662.
Closes #666.

## Verification

- RED observed before each fix: unmarked expired/lapsed KG facts, ordinary subagents blanket-denied, and public `brain_update` returning the deprecated stub
- affected Swift temporal/search tests: 4 passed
- changed-file pre-push: 177 passed
- MCP registration: 3 passed
- isolated eval/hook routing: 40 passed
- Bun: 1 passed
- FTS5 shell regression: passed
- Ruff check and format-check: clean
- disposable copy-on-write clone of verified 2026-08-04 production backup (737,650 chunks): public `call_tool("brain_update", ...)` returned `updated`, SQL confirmed the write, and the clone was restored; production was never opened for writing
- model-heavy BGE-M3 test: clean `main` 1 passed in 131.25s; branch 1 passed in 91.47s. The earlier widened-run timeout occurred only while a reviewer independently ran the same model-heavy suite concurrently.
- full BrainBar run: 849 tests, 10 skipped, 3 failures in unrelated `StatsCollectorTests`; the named failure reproduces identically on clean current `main` (`36f74564`)

## Review

- CodeRabbit local review: 0 findings on each original slice
- mandatory Claude pair pass 1: ITERATE; retrieval-temporal and contract findings resolved in the rewritten commits
- mandatory Claude pair pass 2: in progress at PR creation; merge remains gated on its durable verdict and `@codex review`

## Rollout safety — required

Enabling ordinary Task transcripts exposes a one-time measured backfill of **404 files / 802.5 MB**. Exactly **52 attributed `brain-worker` files / 17.6 MB** remain excluded.

Do not silently deploy this under active enrichment. Required sequence:

1. Stop enrichment workers.
2. `PRAGMA wal_checkpoint(FULL)`.
3. Deploy/restart the MCP consumers, BrainBar socket, and watcher using the merged artifact.
4. Observe the ordinary-subagent backfill through completion and verify brain-worker exclusion.
5. `PRAGMA wal_checkpoint(FULL)` again, then resume enrichment.
6. Prove `brain_search` expiry markers and Python `brain_update` through real clients against the executing artifacts.

The retained blanket `wf_*` exclusion is explicitly labeled as known code drift in the tests and AGENTS.md; this bounded PR does not redefine it as BL-10 policy.

— brainlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019fe294","ts":"2026-08-08T19:11:35Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables MCP memory writes and widens default ingest to ordinary subagent transcripts (one-time backfill); KG/search labeling changes affect what agents see in headers but not stored data.
> 
> **Overview**
> Aligns **BrainBar** `brain_search` fallback entity headers with KG temporal truth: `lookupEntityFacts` reads `kg_relations` (with `valid_until` / `expired_at`), skips `co_occurs_with`, and **TextFormatter** appends `(expired …)` or `(until …)` on KG lines—including lapsed `valid_until` when `expired_at` is unset.
> 
> **Ingest policy** narrows the default denylist: drops the blanket `subagents/**` glob so ordinary Claude subagents ingest; exclusion stays on **`brain-worker`** attribution and the retained `wf_*` path pattern (tests/docs call the latter known drift, not BL-10 policy).
> 
> **Python MCP** restores **`brain_update`** as a live tool (delegates to `_brain_update` for update/archive/merge), updates tool copy/instructions, and fixes **`store_handler`** to return a structured error when the retry budget is exhausted instead of falling through with `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e843ad087c400ee3b8867e548de62c41dce7baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `brain_update`, expiry display, and ingest denylist to serve correct state
> - Restores `brain_update` as a live MCP tool supporting update, archive, and merge actions — previously it returned a deprecation error stub; the handler now delegates to `_brain_update` in [store_handler.py](https://github.com/EtanHey/brainlayer/pull/680/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263)
> - Adds `(expired YYYY-MM-DD)` / `(until YYYY-MM-DD)` temporal suffixes to KG fact and entity relation output in [TextFormatter.swift](https://github.com/EtanHey/brainlayer/pull/680/files#diff-406b80db55df7e19ce43d88956585835fe258751b47822c353015f921c3d092c) and [BrainDatabase.swift](https://github.com/EtanHey/brainlayer/pull/680/files#diff-47405306dde586b062ca56348935e366f92d5b72990357e592dc7aac78015ebc)
> - Removes ordinary Claude subagent paths from the default ingest denylist in [ingest_denylist.py](https://github.com/EtanHey/brainlayer/pull/680/files#diff-cd497ed29389a77123701126fbd694b207cb9d83c46cdcc9204ad270f2ae88ea), so only `wf_*` workflow paths are excluded by default
> - `_brain_update` now returns a structured error when retries are exhausted instead of falling through silently
> - Behavioral Change: Claude subagent JSONLs that were previously blocked by default will now be ingested
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e843ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->