### PR TITLE
release: BrainLayer v1.5.3 strict versioning and deploy identity

### DIFF
--- a/.github/workflows/brainbar-release.yml
+++ b/.github/workflows/brainbar-release.yml
@@ -50,14 +50,23 @@ jobs:
         run: |
           set -euo pipefail
           release_version="${GITHUB_REF_NAME#v}"
-          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error title=Invalid BrainBar release tag::Expected tag format vX.Y.Z so Info.plist can be stamped with valid macOS bundle versions; got '$GITHUB_REF_NAME'"
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error title=Invalid BrainBar release tag::Expected tag format vX.Y.Z or interim vX.Y.Z.N; got '$GITHUB_REF_NAME'"
             exit 1
           fi
+          bundle_short_version="$release_version"
+          if [[ "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            bundle_short_version="${release_version%.*}"
+          fi
           build_time_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          bundle_build_version="$(git rev-list --count HEAD)"
           echo "BRAINBAR_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          echo "BRAINBAR_BUNDLE_SHORT_VERSION=$bundle_short_version" >> "$GITHUB_ENV"
+          echo "BRAINBAR_BUNDLE_BUILD_VERSION=$bundle_build_version" >> "$GITHUB_ENV"
           echo "BRAINBAR_BUILD_TIME_UTC=$build_time_utc" >> "$GITHUB_ENV"
           echo "BrainBar release version: $release_version"
+          echo "BrainBar bundle short version: $bundle_short_version"
+          echo "BrainBar bundle build version: $bundle_build_version"
           echo "BrainBar build time UTC: $build_time_utc"
 
       - name: Cache SwiftPM
@@ -99,8 +108,9 @@ jobs:
             fi
           }
 
-          set_plist_string CFBundleShortVersionString "$BRAINBAR_RELEASE_VERSION"
-          set_plist_string CFBundleVersion "$BRAINBAR_RELEASE_VERSION"
+          set_plist_string CFBundleShortVersionString "$BRAINBAR_BUNDLE_SHORT_VERSION"
+          set_plist_string CFBundleVersion "$BRAINBAR_BUNDLE_BUILD_VERSION"
+          set_plist_string BrainLayerReleaseVersion "$BRAINBAR_RELEASE_VERSION"
           set_plist_string GitCommit "$GITHUB_SHA"
           set_plist_string GitDescribe "$GITHUB_REF_NAME"
           set_plist_string BuildTimeUTC "$BRAINBAR_BUILD_TIME_UTC"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ BrainLayer is the memory layer for the entire ecosystem. If it breaks, every gol
 ## PR Workflow
 - Request `@codex review`.
 - Request a lead-routed Claude pair review through the active collab lane.
-- Bugbot is out of quota and the Greptile trial has expired; do not route mandatory reviews to either.
+- Do not route mandatory reviews to Bugbot or Greptile.
 
 ## Known Issues
 - DB locking during enrichment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,8 @@ BrainLayer is the memory layer for the entire ecosystem. If it breaks, every gol
 
 ## PR Workflow
 - Request `@codex review`.
-- Request `@cursor` and `@bugbot` review.
+- Request a lead-routed Claude pair review through the active collab lane.
+- Bugbot is out of quota and the Greptile trial has expired; do not route mandatory reviews to either.
 
 ## Known Issues
 - DB locking during enrichment.

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -443,13 +443,26 @@ build_time_utc() {
     date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+git_build_number() {
+    git -C "$PACKAGE_DIR" rev-list --count HEAD
+}
+
 validate_release_version() {
     local version="$1"
-    if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
         return 0
     fi
-    echo "[build-app] ERROR: release version must match X.Y.Z for macOS bundle metadata (got '$version')" >&2
+    echo "[build-app] ERROR: release version must match X.Y.Z or interim X.Y.Z.N (got '$version')" >&2
     return 1
+}
+
+bundle_short_version() {
+    local version="$1"
+    if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return
+    fi
+    printf '%s\n' "$version"
 }
 
 release_version() {
@@ -463,7 +476,7 @@ release_version() {
 
     local exact_tag
     exact_tag="$(git -C "$PACKAGE_DIR" describe --tags --exact-match 2>/dev/null || true)"
-    if [[ "$exact_tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    if [[ "$exact_tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?)$ ]]; then
         printf '%s\n' "${BASH_REMATCH[1]}"
         return 0
     fi
@@ -541,9 +554,11 @@ stamp_info_plist() {
     local describe_ref="$3"
     local build_utc="$4"
     local release_version="$5"
+    local build_number="$6"
 
-    plist_set_string "$plist_path" "CFBundleShortVersionString" "$release_version"
-    plist_set_string "$plist_path" "CFBundleVersion" "$release_version"
+    plist_set_string "$plist_path" "CFBundleShortVersionString" "$(bundle_short_version "$release_version")"
+    plist_set_string "$plist_path" "CFBundleVersion" "$build_number"
+    plist_set_string "$plist_path" "BrainLayerReleaseVersion" "$release_version"
     plist_set_string "$plist_path" "GitCommit" "$commit_sha"
     plist_set_string "$plist_path" "GitDescribe" "$describe_ref"
     plist_set_string "$plist_path" "BuildTimeUTC" "$build_utc"
@@ -735,12 +750,16 @@ cp "$DAEMON_PLIST_SRC" "$APP_DIR/Contents/Resources/LaunchAgents/$DAEMON_PLIST_F
 COMMIT_SHA="$(git_commit)"
 DESCRIBE_REF="$(git_describe)"
 BUILD_UTC="$(build_time_utc)"
+BUILD_NUMBER="$(git_build_number)"
 if ! RELEASE_VERSION="$(release_version)"; then
     exit 1
 fi
-stamp_info_plist "$APP_DIR/Contents/Info.plist" "$COMMIT_SHA" "$DESCRIBE_REF" "$BUILD_UTC" "$RELEASE_VERSION"
+stamp_info_plist "$APP_DIR/Contents/Info.plist" "$COMMIT_SHA" "$DESCRIBE_REF" "$BUILD_UTC" "$RELEASE_VERSION" "$BUILD_NUMBER"
 echo "[build-app] Stamped Info.plist:"
 echo "  ReleaseVersion=$RELEASE_VERSION"
+echo "  BundleShortVersion=$(bundle_short_version "$RELEASE_VERSION")"
+echo "  BundleBuildVersion=$BUILD_NUMBER"
+echo "  BrainLayerReleaseVersion=$RELEASE_VERSION"
 echo "  GitCommit=$COMMIT_SHA"
 echo "  GitDescribe=$DESCRIBE_REF"
 echo "  BuildTimeUTC=$BUILD_UTC"

--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,9 +9,11 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.5.2</string>
+    <string>1.5.3</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.2</string>
+    <string>1.5.3</string>
+    <key>BrainLayerReleaseVersion</key>
+    <string>1.5.3</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.5.2"
+version = "1.5.3"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/scripts/brainlayer-version-check.sh
+++ b/scripts/brainlayer-version-check.sh
@@ -168,14 +168,29 @@ init_version="$(read_init_version "$INIT_PY")"
 server_version="$(read_server_value "$SERVER_JSON" "version")"
 server_package_version="$(read_server_value "$SERVER_JSON" "packages[0].version")"
 plist_short_version="$(read_plist_string "$INFO_PLIST" "CFBundleShortVersionString")"
+plist_bundle_version="$(read_plist_string "$INFO_PLIST" "CFBundleVersion")"
+plist_release_version="$(read_plist_string "$INFO_PLIST" "BrainLayerReleaseVersion")"
 cask_version="$(extract_cask_version "$CASK_PATH")"
 git_tag="$(latest_git_tag)"
 expected_git_tag="v$canonical_version"
 
+if [[ "$canonical_version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(\.[0-9]+)?$ ]]; then
+    expected_plist_short_version="${BASH_REMATCH[1]}"
+else
+    err "pyproject.toml version '$canonical_version' must match X.Y.Z or interim X.Y.Z.N"
+    FAILED=1
+    expected_plist_short_version="$canonical_version"
+fi
+
 require_equal "src/brainlayer/__init__.py __version__" "$init_version" "$canonical_version"
 require_equal "server.json version" "$server_version" "$canonical_version"
 require_equal "server.json packages[0].version" "$server_package_version" "$canonical_version"
-require_equal "Info.plist CFBundleShortVersionString" "$plist_short_version" "$canonical_version"
+require_equal "Info.plist CFBundleShortVersionString" "$plist_short_version" "$expected_plist_short_version"
+require_equal "Info.plist BrainLayerReleaseVersion" "$plist_release_version" "$canonical_version"
+if [[ ! "$plist_bundle_version" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+    err "Info.plist CFBundleVersion '$plist_bundle_version' must contain one to three numeric components"
+    FAILED=1
+fi
 require_equal "Casks/brainbar.rb version" "$cask_version" "$canonical_version"
 if [[ -z "$git_tag" ]]; then
     err "latest git tag could not be determined under $PACKAGE_ROOT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -503,6 +503,16 @@ def init(
 @app.command()
 def setup(
     launchd: bool = typer.Option(False, "--launchd/--no-launchd", help="Install launchd agents after writing config."),
+    migrate_mcp: bool = typer.Option(
+        False,
+        "--migrate-mcp/--no-migrate-mcp",
+        help="Migrate known raw-socat BrainBar MCP entries to the reconnecting stdio bridge.",
+    ),
+    verify_mcp: bool = typer.Option(
+        False,
+        "--verify-mcp/--no-verify-mcp",
+        help="Require initialize and tools/list to succeed through the installed stdio bridge.",
+    ),
     env_file: Path | None = typer.Option(
         None,
         "--env-file",
@@ -524,7 +534,7 @@ def setup(
     """Create brainlayer.env and optionally bootstrap launchd agents."""
     import subprocess
 
-    from ..setup import ensure_brainlayer_env, install_launchd
+    from ..setup import ensure_brainlayer_env, install_launchd, migrate_legacy_mcp_configs, verify_mcp_transport
 
     try:
         resolved_env_file = ensure_brainlayer_env(
@@ -534,17 +544,24 @@ def setup(
         )
         if launchd:
             install_launchd(target, env_file=resolved_env_file)
+        migrated_configs = migrate_legacy_mcp_configs() if migrate_mcp else []
+        tool_count = verify_mcp_transport() if verify_mcp else None
     except (
         FileNotFoundError,
         FileExistsError,
         PermissionError,
         TimeoutError,
+        RuntimeError,
         ValueError,
         subprocess.CalledProcessError,
     ) as exc:
         rprint(f"[red]BrainLayer setup failed:[/] {exc}")
         raise typer.Exit(1) from exc
     rprint(f"[green]BrainLayer env file:[/] {resolved_env_file}")
+    for migrated_config in migrated_configs:
+        rprint(f"[green]Migrated MCP config:[/] {migrated_config}")
+    if tool_count is not None:
+        rprint(f"[green]MCP transport verified:[/] {tool_count} tools")
 
 
 @app.command()

--- a/src/brainlayer/deploy_drift.py
+++ b/src/brainlayer/deploy_drift.py
@@ -189,7 +189,18 @@ def detect_deploy_drift(label: str, provenance_dir: Path) -> DeployDriftFinding 
 
     launch_version = payload.get("artifact_version")
     deployed_version = _artifact_version()
-    if not isinstance(launch_version, str) or launch_version == deployed_version:
+    if not isinstance(launch_version, str) and repo_root is not None and isinstance(launch_commit, str):
+        return DeployDriftFinding(
+            label=label,
+            repo_root=str(repo_root) if repo_root is not None else None,
+            provenance_path=str(provenance_path),
+            drift_status="release_identity_missing",
+            identity_kind="release_version",
+            deployed_version=deployed_version,
+        )
+    if not isinstance(launch_version, str):
+        return None
+    if launch_version == deployed_version:
         return None
     return DeployDriftFinding(
         label=label,

--- a/src/brainlayer/deploy_drift.py
+++ b/src/brainlayer/deploy_drift.py
@@ -6,6 +6,7 @@ import json
 import os
 import plistlib
 import subprocess
+import tomllib
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -52,7 +53,7 @@ class DeployProvenanceError(RuntimeError):
 @dataclass(frozen=True)
 class DeployDriftFinding:
     label: str
-    repo_root: str
+    repo_root: str | None
     provenance_path: str
     drift_status: str
     identity_kind: str
@@ -105,9 +106,18 @@ def git_root_for_path(path: Path) -> Path | None:
     return Path(root) if root else None
 
 
-def _is_exact_git_checkout(path: Path) -> bool:
+def _is_brainlayer_git_checkout(path: Path) -> bool:
     git_root = git_root_for_path(path)
-    return git_root is not None and git_root.resolve() == path.expanduser().resolve()
+    resolved = path.expanduser().resolve()
+    if git_root is None or git_root.resolve() != resolved:
+        return False
+    package_marker = resolved / "src" / "brainlayer" / "__init__.py"
+    try:
+        metadata = tomllib.loads((resolved / "pyproject.toml").read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    project = metadata.get("project")
+    return package_marker.is_file() and isinstance(project, dict) and project.get("name") == "brainlayer"
 
 
 def _artifact_version() -> str:
@@ -157,11 +167,9 @@ def detect_deploy_drift(label: str, provenance_dir: Path) -> DeployDriftFinding 
         return None
 
     repo_root_value = payload.get("repo_root")
-    if not isinstance(repo_root_value, str):
-        return None
-    repo_root = Path(repo_root_value).expanduser()
+    repo_root = Path(repo_root_value).expanduser() if isinstance(repo_root_value, str) else None
     launch_commit = payload.get("launch_commit")
-    if _is_exact_git_checkout(repo_root) and isinstance(launch_commit, str):
+    if repo_root is not None and _is_brainlayer_git_checkout(repo_root) and isinstance(launch_commit, str):
         deployed_commit = git_head(repo_root)
         if not deployed_commit or deployed_commit == launch_commit:
             return None
@@ -185,7 +193,7 @@ def detect_deploy_drift(label: str, provenance_dir: Path) -> DeployDriftFinding 
         return None
     return DeployDriftFinding(
         label=label,
-        repo_root=str(repo_root),
+        repo_root=str(repo_root) if repo_root is not None else None,
         provenance_path=str(provenance_path),
         drift_status="version_mismatch",
         identity_kind="release_version",
@@ -207,11 +215,14 @@ def write_daemon_launch_provenance(
     label: str,
     repo_root: Path | None = None,
     provenance_dir: Path | None = None,
+    auto_detect_repo_root: bool = True,
     now_fn: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> Path:
-    resolved_repo = repo_root or _repo_root_from_env_or_cwd()
+    resolved_repo = repo_root
+    if resolved_repo is None and auto_detect_repo_root:
+        resolved_repo = _repo_root_from_env_or_cwd()
     launch_commit = (
-        git_head(resolved_repo) if resolved_repo is not None and _is_exact_git_checkout(resolved_repo) else None
+        git_head(resolved_repo) if resolved_repo is not None and _is_brainlayer_git_checkout(resolved_repo) else None
     )
     path = provenance_path_for_label(provenance_dir or default_deploy_provenance_dir(), label)
     payload: dict[str, object] = {
@@ -270,16 +281,11 @@ def repo_root_from_launchd_plist(plist_path: Path) -> Path | None:
 
 def record_deploy_provenance_for_label(*, label: str, plist_path: Path, provenance_dir: Path) -> Path:
     repo_root = repo_root_from_launchd_plist(plist_path)
-    if repo_root is None:
-        raise DeployProvenanceError(
-            label,
-            plist_path,
-            f"could not resolve repo root from launchd plist for {label}: {plist_path.expanduser()}",
-        )
     return write_daemon_launch_provenance(
         label=label,
         repo_root=repo_root,
         provenance_dir=provenance_dir,
+        auto_detect_repo_root=False,
     )
 
 

--- a/src/brainlayer/deploy_drift.py
+++ b/src/brainlayer/deploy_drift.py
@@ -291,6 +291,13 @@ def repo_root_from_launchd_plist(plist_path: Path) -> Path | None:
 
 
 def record_deploy_provenance_for_label(*, label: str, plist_path: Path, provenance_dir: Path) -> Path:
+    try:
+        with plist_path.expanduser().open("rb") as handle:
+            payload = plistlib.load(handle)
+    except (FileNotFoundError, OSError, plistlib.InvalidFileException) as exc:
+        raise DeployProvenanceError(label, plist_path, f"could not read launchd plist {plist_path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise DeployProvenanceError(label, plist_path, f"could not read launchd plist {plist_path}: root is not a dict")
     repo_root = repo_root_from_launchd_plist(plist_path)
     return write_daemon_launch_provenance(
         label=label,

--- a/src/brainlayer/deploy_drift.py
+++ b/src/brainlayer/deploy_drift.py
@@ -53,12 +53,15 @@ class DeployProvenanceError(RuntimeError):
 class DeployDriftFinding:
     label: str
     repo_root: str
-    launch_commit: str
-    deployed_commit: str
     provenance_path: str
     drift_status: str
+    identity_kind: str
+    launch_commit: str | None = None
+    deployed_commit: str | None = None
+    launch_version: str | None = None
+    deployed_version: str | None = None
 
-    def to_context(self) -> dict[str, str]:
+    def to_context(self) -> dict[str, str | None]:
         return asdict(self)
 
 
@@ -102,6 +105,17 @@ def git_root_for_path(path: Path) -> Path | None:
     return Path(root) if root else None
 
 
+def _is_exact_git_checkout(path: Path) -> bool:
+    git_root = git_root_for_path(path)
+    return git_root is not None and git_root.resolve() == path.expanduser().resolve()
+
+
+def _artifact_version() -> str:
+    from . import __version__
+
+    return __version__
+
+
 def commit_is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
     try:
         result = subprocess.run(
@@ -143,24 +157,40 @@ def detect_deploy_drift(label: str, provenance_dir: Path) -> DeployDriftFinding 
         return None
 
     repo_root_value = payload.get("repo_root")
-    launch_commit = payload.get("launch_commit")
-    if not isinstance(repo_root_value, str) or not isinstance(launch_commit, str):
+    if not isinstance(repo_root_value, str):
         return None
     repo_root = Path(repo_root_value).expanduser()
-    deployed_commit = git_head(repo_root)
-    if not deployed_commit or deployed_commit == launch_commit:
+    launch_commit = payload.get("launch_commit")
+    if _is_exact_git_checkout(repo_root) and isinstance(launch_commit, str):
+        deployed_commit = git_head(repo_root)
+        if not deployed_commit or deployed_commit == launch_commit:
+            return None
+        changed_files = changed_files_between(repo_root, launch_commit, deployed_commit)
+        if not deploy_drift_changes_require_redeploy(changed_files):
+            return None
+        drift_status = "older" if commit_is_ancestor(repo_root, launch_commit, deployed_commit) else "diverged"
+        return DeployDriftFinding(
+            label=label,
+            repo_root=str(repo_root),
+            launch_commit=launch_commit,
+            deployed_commit=deployed_commit,
+            provenance_path=str(provenance_path),
+            drift_status=drift_status,
+            identity_kind="git_commit",
+        )
+
+    launch_version = payload.get("artifact_version")
+    deployed_version = _artifact_version()
+    if not isinstance(launch_version, str) or launch_version == deployed_version:
         return None
-    changed_files = changed_files_between(repo_root, launch_commit, deployed_commit)
-    if not deploy_drift_changes_require_redeploy(changed_files):
-        return None
-    drift_status = "older" if commit_is_ancestor(repo_root, launch_commit, deployed_commit) else "diverged"
     return DeployDriftFinding(
         label=label,
         repo_root=str(repo_root),
-        launch_commit=launch_commit,
-        deployed_commit=deployed_commit,
         provenance_path=str(provenance_path),
-        drift_status=drift_status,
+        drift_status="version_mismatch",
+        identity_kind="release_version",
+        launch_version=launch_version,
+        deployed_version=deployed_version,
     )
 
 
@@ -180,12 +210,15 @@ def write_daemon_launch_provenance(
     now_fn: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> Path:
     resolved_repo = repo_root or _repo_root_from_env_or_cwd()
-    launch_commit = git_head(resolved_repo) if resolved_repo is not None else None
+    launch_commit = (
+        git_head(resolved_repo) if resolved_repo is not None and _is_exact_git_checkout(resolved_repo) else None
+    )
     path = provenance_path_for_label(provenance_dir or default_deploy_provenance_dir(), label)
     payload: dict[str, object] = {
         "label": label,
         "launched_at": now_fn().isoformat(),
         "pid": os.getpid(),
+        "artifact_version": _artifact_version(),
     }
     if resolved_repo is not None:
         payload["repo_root"] = str(resolved_repo)

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
-from .alarm import BrainLayerAlarm, emit_alarm
+from .alarm import BrainLayerAlarm, build_alarm, emit_alarm
 from .deploy_drift import DEFAULT_DEPLOY_DRIFT_LABELS, default_deploy_provenance_dir, detect_deploy_drift
 from .drain_liveness import (
     DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
@@ -336,12 +336,15 @@ def _check_deploy_drift(
             continue
         if finding is None:
             continue
+        message = f"daemon {label} running stale code, redeploy needed"
+        context = finding.to_context()
+        emit_alarm(build_alarm("deploy_drift", message, context))
         result.issues.append(
             DoctorIssue(
                 "deploy_drift",
                 "fatal",
-                f"daemon {label} running stale code, redeploy needed",
-                finding.to_context(),
+                message,
+                context,
             )
         )
 

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -317,7 +317,7 @@ def _redact_home_paths(context: dict[str, Any]) -> dict[str, Any]:
     for key in ("repo_root", "provenance_path"):
         value = redacted.get(key)
         if isinstance(value, str) and (value == home or value.startswith(f"{home}/")):
-            redacted[key] = f"~{value[len(home):]}"
+            redacted[key] = f"~{value[len(home) :]}"
     return redacted
 
 

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -311,6 +311,16 @@ def _counter_increased(before: Any, after: Any) -> bool:
     return isinstance(before, int) and isinstance(after, int) and after > before
 
 
+def _redact_home_paths(context: dict[str, Any]) -> dict[str, Any]:
+    redacted = dict(context)
+    home = str(Path.home())
+    for key in ("repo_root", "provenance_path"):
+        value = redacted.get(key)
+        if isinstance(value, str) and (value == home or value.startswith(f"{home}/")):
+            redacted[key] = f"~{value[len(home):]}"
+    return redacted
+
+
 def _check_deploy_drift(
     result: DoctorResult,
     *,
@@ -338,7 +348,7 @@ def _check_deploy_drift(
             continue
         message = f"daemon {label} running stale code, redeploy needed"
         context = finding.to_context()
-        emit_alarm(build_alarm("deploy_drift", message, context))
+        emit_alarm(build_alarm("deploy_drift", message, _redact_home_paths(context)))
         result.issues.append(
             DoctorIssue(
                 "deploy_drift",

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
-from .alarm import BrainLayerAlarm, emit_alarm, raise_alarm
+from .alarm import BrainLayerAlarm, emit_alarm
 from .deploy_drift import DEFAULT_DEPLOY_DRIFT_LABELS, default_deploy_provenance_dir, detect_deploy_drift
 from .drain_liveness import (
     DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
@@ -312,22 +312,37 @@ def _counter_increased(before: Any, after: Any) -> bool:
 
 
 def _check_deploy_drift(
+    result: DoctorResult,
     *,
     labels: tuple[str, ...],
     provenance_dir: Path,
     command_runner: CommandRunner,
 ) -> None:
     for label in labels:
-        loaded = is_launchd_label_loaded(label, command_runner=command_runner)
-        if loaded is not True:
+        try:
+            loaded = is_launchd_label_loaded(label, command_runner=command_runner)
+            if loaded is not True:
+                continue
+            finding = detect_deploy_drift(label, provenance_dir)
+        except Exception as exc:
+            result.issues.append(
+                DoctorIssue(
+                    "deploy_drift_check_failed",
+                    "fatal",
+                    f"could not check deploy drift for {label}: {exc}",
+                    {"label": label, "exception": repr(exc)},
+                )
+            )
             continue
-        finding = detect_deploy_drift(label, provenance_dir)
         if finding is None:
             continue
-        raise_alarm(
-            "deploy_drift",
-            f"daemon {label} running stale code, redeploy needed",
-            finding.to_context(),
+        result.issues.append(
+            DoctorIssue(
+                "deploy_drift",
+                "fatal",
+                f"daemon {label} running stale code, redeploy needed",
+                finding.to_context(),
+            )
         )
 
 
@@ -495,6 +510,7 @@ def run_doctor(
 
     if config.deploy_drift_enabled:
         _check_deploy_drift(
+            result,
             labels=config.deploy_drift_labels,
             provenance_dir=config.deploy_provenance_dir,
             command_runner=command_runner,

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -151,26 +151,31 @@ def verify_mcp_transport(*, bridge_command: str | None = None, timeout_seconds: 
     tools_request = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
     deadline = time.monotonic() + timeout_seconds
 
-    def send(process: subprocess.Popen[str], payload: dict[str, object]) -> None:
+    def send(process: subprocess.Popen[bytes], payload: dict[str, object]) -> None:
         assert process.stdin is not None
-        process.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        process.stdin.write((json.dumps(payload, separators=(",", ":")) + "\n").encode())
         process.stdin.flush()
 
-    def receive(process: subprocess.Popen[str], response_id: int) -> dict[str, object] | None:
+    def receive(process: subprocess.Popen[bytes], response_id: int) -> dict[str, object] | None:
         assert process.stdout is not None
+        buffered = bytearray()
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0 or not select.select([process.stdout], [], [], remaining)[0]:
                 raise RuntimeError(f"MCP transport verification timed out after {timeout_seconds:g}s")
-            line = process.stdout.readline()
-            if not line:
+            chunk = os.read(process.stdout.fileno(), 4096)
+            if not chunk:
                 return None
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(payload, dict) and payload.get("id") == response_id:
-                return payload
+            buffered.extend(chunk)
+            while b"\n" in buffered:
+                line, _, remainder = buffered.partition(b"\n")
+                buffered = bytearray(remainder)
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict) and payload.get("id") == response_id:
+                    return payload
 
     try:
         process = subprocess.Popen(
@@ -178,8 +183,7 @@ def verify_mcp_transport(*, bridge_command: str | None = None, timeout_seconds: 
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
+            bufsize=0,
         )
     except OSError as exc:
         raise RuntimeError(f"could not start MCP bridge: {exc}") from exc

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import os
+import select
 import shutil
 import subprocess
 import sys
+import time
 from importlib import resources
 from pathlib import Path
 
@@ -91,8 +93,9 @@ def migrate_legacy_mcp_configs(
         path = config_path.expanduser()
         if not path.is_file():
             continue
+        target_path = path.resolve()
         try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload = json.loads(target_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise ValueError(f"could not read MCP config {path}: {exc}") from exc
         if not isinstance(payload, dict):
@@ -117,12 +120,12 @@ def migrate_legacy_mcp_configs(
         if not migrated:
             continue
 
-        mode = path.stat().st_mode & 0o777
-        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        mode = target_path.stat().st_mode & 0o777
+        temporary = target_path.with_name(f".{target_path.name}.{os.getpid()}.tmp")
         try:
             temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
             temporary.chmod(mode)
-            os.replace(temporary, path)
+            os.replace(temporary, target_path)
         finally:
             temporary.unlink(missing_ok=True)
         changed.append(path)
@@ -134,52 +137,73 @@ def verify_mcp_transport(*, bridge_command: str | None = None, timeout_seconds: 
     resolved_bridge = bridge_command or get_current_mcp_bridge_bin()
     if not resolved_bridge:
         raise FileNotFoundError("brainlayer-mcp-stdio-bridge was not found on PATH")
-    requests = (
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": DEFAULT_MCP_PROTOCOL_VERSION,
-                "capabilities": {},
-                "clientInfo": {"name": "brainlayer-setup", "version": "1"},
-            },
+    initialize_request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": DEFAULT_MCP_PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "brainlayer-setup", "version": "1"},
         },
-        {"jsonrpc": "2.0", "method": "notifications/initialized"},
-        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
-    )
-    input_text = "".join(json.dumps(request, separators=(",", ":")) + "\n" for request in requests)
-    try:
-        completed = subprocess.run(
-            [resolved_bridge],
-            input=input_text,
-            text=True,
-            capture_output=True,
-            timeout=timeout_seconds,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"MCP transport verification timed out after {timeout_seconds:g}s") from exc
+    }
+    initialized_notification = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+    tools_request = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+    deadline = time.monotonic() + timeout_seconds
 
-    responses: dict[object, dict[str, object]] = {}
-    for line in completed.stdout.splitlines():
+    def send(process: subprocess.Popen[str], payload: dict[str, object]) -> None:
+        assert process.stdin is not None
+        process.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        process.stdin.flush()
+
+    def receive(process: subprocess.Popen[str], response_id: int) -> dict[str, object] | None:
+        assert process.stdout is not None
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or not select.select([process.stdout], [], [], remaining)[0]:
+                raise RuntimeError(f"MCP transport verification timed out after {timeout_seconds:g}s")
+            line = process.stdout.readline()
+            if not line:
+                return None
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict) and payload.get("id") == response_id:
+                return payload
+
+    try:
+        process = subprocess.Popen(
+            [resolved_bridge],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"could not start MCP bridge: {exc}") from exc
+
+    try:
+        send(process, initialize_request)
+        initialize = receive(process, 1)
+        if not initialize or not isinstance(initialize.get("result"), dict):
+            raise RuntimeError("MCP initialize response missing or invalid")
+        send(process, initialized_notification)
+        send(process, tools_request)
+        tools_response = receive(process, 2)
+        tools_result = tools_response.get("result") if tools_response else None
+        tools = tools_result.get("tools") if isinstance(tools_result, dict) else None
+        if not isinstance(tools, list) or not tools:
+            raise RuntimeError("MCP tools/list response missing tools")
+        return len(tools)
+    finally:
+        process.terminate()
         try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict) and payload.get("id") in (1, 2):
-            responses[payload["id"]] = payload
-    initialize = responses.get(1)
-    if not initialize or not isinstance(initialize.get("result"), dict):
-        detail = completed.stderr.strip() or f"bridge exited {completed.returncode}"
-        raise RuntimeError(f"MCP initialize response missing or invalid: {detail}")
-    tools_response = responses.get(2)
-    tools_result = tools_response.get("result") if tools_response else None
-    tools = tools_result.get("tools") if isinstance(tools_result, dict) else None
-    if not isinstance(tools, list) or not tools:
-        detail = completed.stderr.strip() or f"bridge exited {completed.returncode}"
-        raise RuntimeError(f"MCP tools/list response missing tools: {detail}")
-    return len(tools)
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
 
 
 def ensure_brainlayer_env(

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -84,7 +84,7 @@ def migrate_legacy_mcp_configs(
     bridge_command: str | None = None,
 ) -> list[Path]:
     """Replace known raw-socat BrainBar transports without touching unrelated MCP entries."""
-    resolved_bridge = bridge_command or get_current_mcp_bridge_bin() or "brainlayer-mcp-stdio-bridge"
+    resolved_bridge = bridge_command
     changed: list[Path] = []
     paths = config_paths if config_paths is not None else get_default_mcp_config_paths()
     for config_path in paths:
@@ -105,7 +105,14 @@ def migrate_legacy_mcp_configs(
         for name, server in list(servers.items()):
             if not _is_legacy_brainbar_socat(server):
                 continue
-            servers[name] = {"command": resolved_bridge}
+            if resolved_bridge is None:
+                resolved_bridge = get_current_mcp_bridge_bin()
+            if not resolved_bridge:
+                raise FileNotFoundError("brainlayer-mcp-stdio-bridge was not found on PATH")
+            migrated_server = dict(server)
+            migrated_server["command"] = resolved_bridge
+            migrated_server.pop("args", None)
+            servers[name] = migrated_server
             migrated = True
         if not migrated:
             continue

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -12,6 +13,7 @@ from pathlib import Path
 from .cli.wizard import DEFAULT_BRAINLAYER_CONFIG, write_gemini_env_file
 
 DEFAULT_GOOGLE_API_KEY_OP_REF = "op://Private/Google AI/Gemini API key"
+DEFAULT_MCP_PROTOCOL_VERSION = "2025-06-18"
 
 
 def get_default_env_file() -> Path:
@@ -44,6 +46,133 @@ def get_current_brainlayer_bin() -> str | None:
     if found:
         return found
     return None
+
+
+def get_current_mcp_bridge_bin() -> str | None:
+    """Return the bridge installed beside the active BrainLayer CLI, then fall back to PATH."""
+    brainlayer_bin = get_current_brainlayer_bin()
+    if brainlayer_bin:
+        sibling = Path(brainlayer_bin).with_name("brainlayer-mcp-stdio-bridge")
+        if sibling.is_file() and os.access(sibling, os.X_OK):
+            return str(sibling)
+    return shutil.which("brainlayer-mcp-stdio-bridge")
+
+
+def get_default_mcp_config_paths() -> tuple[Path, ...]:
+    home = Path.home()
+    return (
+        home / ".claude.json",
+        home / ".cursor" / "mcp.json",
+        home / ".gemini" / "settings.json",
+    )
+
+
+def _is_legacy_brainbar_socat(server: object) -> bool:
+    if not isinstance(server, dict):
+        return False
+    command = server.get("command")
+    args = server.get("args")
+    if not isinstance(command, str) or Path(command).name != "socat" or not isinstance(args, list):
+        return False
+    string_args = [arg for arg in args if isinstance(arg, str)]
+    return "STDIO" in string_args and "UNIX-CONNECT:/tmp/brainbar.sock" in string_args
+
+
+def migrate_legacy_mcp_configs(
+    config_paths: list[Path] | tuple[Path, ...] | None = None,
+    *,
+    bridge_command: str | None = None,
+) -> list[Path]:
+    """Replace known raw-socat BrainBar transports without touching unrelated MCP entries."""
+    resolved_bridge = bridge_command or get_current_mcp_bridge_bin() or "brainlayer-mcp-stdio-bridge"
+    changed: list[Path] = []
+    paths = config_paths if config_paths is not None else get_default_mcp_config_paths()
+    for config_path in paths:
+        path = config_path.expanduser()
+        if not path.is_file():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"could not read MCP config {path}: {exc}") from exc
+        if not isinstance(payload, dict):
+            continue
+        servers = payload.get("mcpServers")
+        if not isinstance(servers, dict):
+            continue
+
+        migrated = False
+        for name, server in list(servers.items()):
+            if not _is_legacy_brainbar_socat(server):
+                continue
+            servers[name] = {"command": resolved_bridge}
+            migrated = True
+        if not migrated:
+            continue
+
+        mode = path.stat().st_mode & 0o777
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        try:
+            temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            temporary.chmod(mode)
+            os.replace(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+        changed.append(path)
+    return changed
+
+
+def verify_mcp_transport(*, bridge_command: str | None = None, timeout_seconds: float = 10.0) -> int:
+    """Require a real initialize + tools/list exchange through the installed stdio bridge."""
+    resolved_bridge = bridge_command or get_current_mcp_bridge_bin()
+    if not resolved_bridge:
+        raise FileNotFoundError("brainlayer-mcp-stdio-bridge was not found on PATH")
+    requests = (
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": DEFAULT_MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "brainlayer-setup", "version": "1"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    )
+    input_text = "".join(json.dumps(request, separators=(",", ":")) + "\n" for request in requests)
+    try:
+        completed = subprocess.run(
+            [resolved_bridge],
+            input=input_text,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"MCP transport verification timed out after {timeout_seconds:g}s") from exc
+
+    responses: dict[object, dict[str, object]] = {}
+    for line in completed.stdout.splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("id") in (1, 2):
+            responses[payload["id"]] = payload
+    initialize = responses.get(1)
+    if not initialize or not isinstance(initialize.get("result"), dict):
+        detail = completed.stderr.strip() or f"bridge exited {completed.returncode}"
+        raise RuntimeError(f"MCP initialize response missing or invalid: {detail}")
+    tools_response = responses.get(2)
+    tools_result = tools_response.get("result") if tools_response else None
+    tools = tools_result.get("tools") if isinstance(tools_result, dict) else None
+    if not isinstance(tools, list) or not tools:
+        detail = completed.stderr.strip() or f"bridge exited {completed.returncode}"
+        raise RuntimeError(f"MCP tools/list response missing tools: {detail}")
+    return len(tools)
 
 
 def ensure_brainlayer_env(

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -438,7 +438,34 @@ def test_build_app_rejects_invalid_release_version(tmp_path: Path) -> None:
     )
 
     assert result.returncode != 0
-    assert "release version must match X.Y.Z" in result.stderr
+    assert "release version must match X.Y.Z or interim X.Y.Z.N" in result.stderr
+
+
+def test_build_app_accepts_truthful_four_part_interim_release_version(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-dev-worktree")
+    home = tmp_path / "home"
+    home.mkdir()
+    _prepare_bundle_inputs(repo)
+    tool_dir, bin_dir = _prepare_fake_build_tools(tmp_path)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=tmp_path / "canonical",
+        home=home,
+        dry_run=False,
+        extra_args=["--force-worktree-build"],
+        extra_env={
+            **_fake_build_env(tmp_path, tool_dir, bin_dir),
+            "BRAINBAR_RELEASE_VERSION": "1.5.2.1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ReleaseVersion=1.5.2.1" in result.stdout
+    assert "BundleShortVersion=1.5.2" in result.stdout
+    assert "BundleBuildVersion=" in result.stdout
+    assert "BrainLayerReleaseVersion=1.5.2.1" in result.stdout
 
 
 @pytest.mark.parametrize("tag_name", ["ci-smoke", "1.2.3"])

--- a/tests/test_brainbar_release_workflow.py
+++ b/tests/test_brainbar_release_workflow.py
@@ -106,12 +106,18 @@ def _assert_version_stamp(job: dict) -> None:
     assert any("CFBundleShortVersionString" in _step_run(step) for step in version_steps), (
         "Info.plist release version must come from the pushed tag"
     )
+    assert any("BrainLayerReleaseVersion" in _step_run(step) for step in version_steps), (
+        "Info.plist must preserve the full BrainLayer release identity"
+    )
+    assert any(
+        "git rev-list --count HEAD" in _step_run(step) for step in job.get("steps", []) if isinstance(step, dict)
+    ), "Info.plist CFBundleVersion must use an Apple-compatible monotonically increasing build number"
     metadata_steps = [
         step
         for step in job.get("steps", [])
         if isinstance(step, dict) and "BRAINBAR_RELEASE_VERSION" in _step_run(step)
     ]
-    assert any(r"^[0-9]+\.[0-9]+\.[0-9]+$" in _step_run(step) for step in metadata_steps), (
+    assert any(r"^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$" in _step_run(step) for step in metadata_steps), (
         "BrainBar release workflow must reject tags that cannot be stamped into macOS bundle versions"
     )
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -654,8 +654,53 @@ def test_run_doctor_stays_silent_when_loaded_daemon_launch_commit_matches_head(t
     assert not [issue for issue in result.issues if issue.code == "deploy_drift"]
 
 
-def test_run_doctor_raises_alarm_when_loaded_daemon_launch_commit_is_older_than_head(tmp_path):
-    from brainlayer.alarm import BrainLayerAlarm
+def test_deploy_drift_ignores_unrelated_parent_git_repo_for_packaged_install(tmp_path):
+    from brainlayer.deploy_drift import detect_deploy_drift
+
+    homebrew_root = tmp_path / "homebrew"
+    old_homebrew_commit, _new_homebrew_commit = _git_repo_with_two_commits(homebrew_root)
+    package_root = homebrew_root / "Cellar" / "brainlayer" / "1.5.2" / "libexec" / "site-packages"
+    package_root.mkdir(parents=True)
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.drain",
+        repo_root=package_root,
+        launch_commit=old_homebrew_commit,
+    )
+
+    assert detect_deploy_drift("com.brainlayer.drain", provenance_dir) is None
+
+
+def test_deploy_drift_uses_release_version_for_packaged_install(tmp_path):
+    from brainlayer import __version__
+    from brainlayer.deploy_drift import detect_deploy_drift
+
+    homebrew_root = tmp_path / "homebrew"
+    old_homebrew_commit, _new_homebrew_commit = _git_repo_with_two_commits(homebrew_root)
+    package_root = homebrew_root / "Cellar" / "brainlayer" / "1.5.1" / "libexec" / "site-packages"
+    package_root.mkdir(parents=True)
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.drain",
+        repo_root=package_root,
+        launch_commit=old_homebrew_commit,
+    )
+    provenance_path = provenance_dir / "com.brainlayer.drain.json"
+    payload = json.loads(provenance_path.read_text(encoding="utf-8"))
+    payload["artifact_version"] = "1.5.1"
+    provenance_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    finding = detect_deploy_drift("com.brainlayer.drain", provenance_dir)
+
+    assert finding is not None
+    assert finding.to_context()["identity_kind"] == "release_version"
+    assert finding.to_context()["launch_version"] == "1.5.1"
+    assert finding.to_context()["deployed_version"] == __version__
+
+
+def test_run_doctor_reports_issue_and_continues_when_loaded_daemon_launch_commit_is_older_than_head(tmp_path):
     from brainlayer.doctor import run_doctor
 
     db_path = tmp_path / "deploy-drift-stale.db"
@@ -673,19 +718,21 @@ def test_run_doctor_raises_alarm_when_loaded_daemon_launch_commit_is_older_than_
     config.deploy_provenance_dir = provenance_dir
     config.deploy_drift_labels = ("com.brainlayer.drain",)
 
-    with pytest.raises(BrainLayerAlarm) as alarm:
-        run_doctor(
-            config,
-            ps_output_fn=_hotlane_ps,
-            command_runner=_loaded_launchctl,
-            now_fn=lambda: NOW,
-        )
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
 
-    assert alarm.value.code == "deploy_drift"
-    assert alarm.value.message == "daemon com.brainlayer.drain running stale code, redeploy needed"
-    assert alarm.value.context["label"] == "com.brainlayer.drain"
-    assert alarm.value.context["launch_commit"] == old_commit
-    assert alarm.value.context["deployed_commit"] == head_commit
+    issue = next(issue for issue in result.issues if issue.code == "deploy_drift")
+    assert issue.severity == "fatal"
+    assert issue.message == "daemon com.brainlayer.drain running stale code, redeploy needed"
+    assert issue.details["label"] == "com.brainlayer.drain"
+    assert issue.details["launch_commit"] == old_commit
+    assert issue.details["deployed_commit"] == head_commit
+    assert result.hotlane_running is True
+    assert result.exit_code == 1
 
 
 def test_run_doctor_ignores_deploy_drift_when_only_offline_reembed_utility_changed(tmp_path):
@@ -735,7 +782,6 @@ def test_run_doctor_ignores_deploy_drift_when_only_offline_reembed_utility_chang
 
 
 def test_deploy_drift_git_shellouts_ignore_inherited_git_env(tmp_path, monkeypatch):
-    from brainlayer.alarm import BrainLayerAlarm
     from brainlayer.doctor import run_doctor
 
     parent_repo = tmp_path / "parent-repo"
@@ -757,20 +803,19 @@ def test_deploy_drift_git_shellouts_ignore_inherited_git_env(tmp_path, monkeypat
     monkeypatch.setenv("GIT_DIR", str(parent_repo / ".git"))
     monkeypatch.setenv("GIT_WORK_TREE", str(parent_repo))
 
-    with pytest.raises(BrainLayerAlarm) as alarm:
-        run_doctor(
-            config,
-            ps_output_fn=_hotlane_ps,
-            command_runner=_loaded_launchctl,
-            now_fn=lambda: NOW,
-        )
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
 
-    assert alarm.value.context["launch_commit"] == old_commit
-    assert alarm.value.context["deployed_commit"] == head_commit
+    issue = next(issue for issue in result.issues if issue.code == "deploy_drift")
+    assert issue.details["launch_commit"] == old_commit
+    assert issue.details["deployed_commit"] == head_commit
 
 
-def test_run_doctor_raises_alarm_when_loaded_daemon_launch_commit_diverged_from_head(tmp_path):
-    from brainlayer.alarm import BrainLayerAlarm
+def test_run_doctor_reports_diverged_deploy_drift_without_aborting(tmp_path):
     from brainlayer.doctor import run_doctor
 
     db_path = tmp_path / "deploy-drift-diverged.db"
@@ -788,18 +833,43 @@ def test_run_doctor_raises_alarm_when_loaded_daemon_launch_commit_diverged_from_
     config.deploy_provenance_dir = provenance_dir
     config.deploy_drift_labels = ("com.brainlayer.drain",)
 
-    with pytest.raises(BrainLayerAlarm) as alarm:
-        run_doctor(
-            config,
-            ps_output_fn=_hotlane_ps,
-            command_runner=_loaded_launchctl,
-            now_fn=lambda: NOW,
-        )
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
 
-    assert alarm.value.code == "deploy_drift"
-    assert alarm.value.context["drift_status"] == "diverged"
-    assert alarm.value.context["launch_commit"] == launch_commit
-    assert alarm.value.context["deployed_commit"] == deployed_commit
+    issue = next(issue for issue in result.issues if issue.code == "deploy_drift")
+    assert issue.details["drift_status"] == "diverged"
+    assert issue.details["launch_commit"] == launch_commit
+    assert issue.details["deployed_commit"] == deployed_commit
+
+
+def test_deploy_drift_check_contains_per_label_exceptions(tmp_path, monkeypatch):
+    from brainlayer import doctor
+
+    result = doctor.DoctorResult(checked_at=NOW.isoformat(), ok=True, exit_code=0)
+    monkeypatch.setattr(doctor, "is_launchd_label_loaded", lambda _label, command_runner: True)
+
+    def fail_one_label(label: str, _provenance_dir: Path):
+        if label == "com.brainlayer.drain":
+            raise RuntimeError("corrupt deploy provenance")
+        return None
+
+    monkeypatch.setattr(doctor, "detect_deploy_drift", fail_one_label)
+
+    doctor._check_deploy_drift(
+        result,
+        labels=("com.brainlayer.drain", "com.brainlayer.watch"),
+        provenance_dir=tmp_path,
+        command_runner=_loaded_launchctl,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "deploy_drift_check_failed")
+    assert issue.severity == "fatal"
+    assert issue.details["label"] == "com.brainlayer.drain"
+    assert "corrupt deploy provenance" in issue.details["exception"]
 
 
 def test_brainbar_changed_for_deploy_detects_brainbar_changes_since_launch(tmp_path):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -666,7 +666,7 @@ def test_run_doctor_stays_silent_when_loaded_daemon_launch_commit_matches_head(t
     assert not [issue for issue in result.issues if issue.code == "deploy_drift"]
 
 
-def test_deploy_drift_ignores_unrelated_parent_git_repo_for_packaged_install(tmp_path):
+def test_deploy_drift_treats_legacy_packaged_identity_as_unverifiable(tmp_path):
     from brainlayer.deploy_drift import detect_deploy_drift
 
     homebrew_root = tmp_path / "homebrew"
@@ -681,7 +681,11 @@ def test_deploy_drift_ignores_unrelated_parent_git_repo_for_packaged_install(tmp
         launch_commit=old_homebrew_commit,
     )
 
-    assert detect_deploy_drift("com.brainlayer.drain", provenance_dir) is None
+    finding = detect_deploy_drift("com.brainlayer.drain", provenance_dir)
+
+    assert finding is not None
+    assert finding.identity_kind == "release_version"
+    assert finding.drift_status == "release_identity_missing"
 
 
 def test_deploy_drift_uses_release_version_for_packaged_install(tmp_path):
@@ -710,6 +714,26 @@ def test_deploy_drift_uses_release_version_for_packaged_install(tmp_path):
     assert finding.to_context()["identity_kind"] == "release_version"
     assert finding.to_context()["launch_version"] == "1.5.1"
     assert finding.to_context()["deployed_version"] == __version__
+
+
+def test_deploy_drift_reports_packaged_provenance_without_release_identity(tmp_path):
+    from brainlayer.deploy_drift import detect_deploy_drift
+
+    package_root = tmp_path / "Cellar" / "brainlayer" / "1.5.2" / "libexec" / "site-packages"
+    package_root.mkdir(parents=True)
+    provenance_dir = tmp_path / "daemon-provenance"
+    _write_daemon_provenance(
+        provenance_dir,
+        label="com.brainlayer.drain",
+        repo_root=package_root,
+        launch_commit="legacy-writer-commit",
+    )
+
+    finding = detect_deploy_drift("com.brainlayer.drain", provenance_dir)
+
+    assert finding is not None
+    assert finding.identity_kind == "release_version"
+    assert finding.drift_status == "release_identity_missing"
 
 
 def test_real_provenance_writer_uses_release_identity_inside_unrelated_homebrew_checkout(tmp_path):
@@ -918,7 +942,10 @@ def test_deploy_drift_check_contains_per_label_exceptions(tmp_path, monkeypatch)
     result = doctor.DoctorResult(checked_at=NOW.isoformat(), ok=True, exit_code=0)
     monkeypatch.setattr(doctor, "is_launchd_label_loaded", lambda _label, command_runner: True)
 
+    checked: list[str] = []
+
     def fail_one_label(label: str, _provenance_dir: Path):
+        checked.append(label)
         if label == "com.brainlayer.drain":
             raise RuntimeError("corrupt deploy provenance")
         return None
@@ -936,6 +963,26 @@ def test_deploy_drift_check_contains_per_label_exceptions(tmp_path, monkeypatch)
     assert issue.severity == "fatal"
     assert issue.details["label"] == "com.brainlayer.drain"
     assert "corrupt deploy provenance" in issue.details["exception"]
+    assert checked == ["com.brainlayer.drain", "com.brainlayer.watch"]
+    assert len(result.issues) == 1
+
+
+def test_deploy_drift_alarm_context_redacts_home_paths() -> None:
+    from brainlayer.doctor import _redact_home_paths
+
+    home = Path.home()
+    context = {
+        "repo_root": str(home / "Gits" / "brainlayer"),
+        "provenance_path": str(home / ".local" / "share" / "brainlayer" / "daemon-provenance.json"),
+        "label": "com.brainlayer.drain",
+    }
+
+    assert _redact_home_paths(context) == {
+        "repo_root": "~/Gits/brainlayer",
+        "provenance_path": "~/.local/share/brainlayer/daemon-provenance.json",
+        "label": "com.brainlayer.drain",
+    }
+    assert context["repo_root"] == str(home / "Gits" / "brainlayer")
 
 
 def test_brainbar_changed_for_deploy_detects_brainbar_changes_since_launch(tmp_path):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1054,6 +1054,25 @@ def test_record_deploy_provenance_without_repo_root_preserves_release_identity(t
     assert finding.repo_root is None
 
 
+@pytest.mark.parametrize("plist_contents", [None, b"not a plist"])
+def test_record_deploy_provenance_rejects_unreadable_plist(tmp_path, plist_contents):
+    from brainlayer.deploy_drift import DeployProvenanceError, record_deploy_provenance_for_label
+
+    plist_path = tmp_path / "com.example.invalid.plist"
+    if plist_contents is not None:
+        plist_path.write_bytes(plist_contents)
+    provenance_dir = tmp_path / "daemon-provenance"
+
+    with pytest.raises(DeployProvenanceError, match="could not read launchd plist"):
+        record_deploy_provenance_for_label(
+            label="com.example.invalid",
+            plist_path=plist_path,
+            provenance_dir=provenance_dir,
+        )
+
+    assert not (provenance_dir / "com.example.invalid.json").exists()
+
+
 def test_run_doctor_exits_nonzero_for_recent_unvectored_chunk(tmp_path):
     from brainlayer.doctor import run_doctor
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -43,6 +43,11 @@ def _git_repo_with_two_commits(path: Path) -> tuple[str, str]:
     _run_git(path, "config", "user.name", "BrainLayer Tests")
     source = path / "src" / "brainlayer"
     source.mkdir(parents=True)
+    (source / "__init__.py").write_text("__version__ = '1.5.3'\n", encoding="utf-8")
+    (path / "pyproject.toml").write_text(
+        '[project]\nname = "brainlayer"\nversion = "1.5.3"\n',
+        encoding="utf-8",
+    )
     marker = source / "deploy_marker.py"
     marker.write_text("VERSION = 'old'\n", encoding="utf-8")
     _run_git(path, "add", ".")
@@ -60,6 +65,13 @@ def _git_repo_with_diverged_commits(path: Path) -> tuple[str, str]:
     _run_git(path, "init", "-b", "main")
     _run_git(path, "config", "user.email", "brainlayer-tests@example.com")
     _run_git(path, "config", "user.name", "BrainLayer Tests")
+    package = path / "src" / "brainlayer"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("__version__ = '1.5.3'\n", encoding="utf-8")
+    (path / "pyproject.toml").write_text(
+        '[project]\nname = "brainlayer"\nversion = "1.5.3"\n',
+        encoding="utf-8",
+    )
     marker = path / "marker.txt"
     marker.write_text("base\n", encoding="utf-8")
     _run_git(path, "add", ".")
@@ -700,8 +712,49 @@ def test_deploy_drift_uses_release_version_for_packaged_install(tmp_path):
     assert finding.to_context()["deployed_version"] == __version__
 
 
-def test_run_doctor_reports_issue_and_continues_when_loaded_daemon_launch_commit_is_older_than_head(tmp_path):
-    from brainlayer.doctor import run_doctor
+def test_real_provenance_writer_uses_release_identity_inside_unrelated_homebrew_checkout(tmp_path):
+    from brainlayer import __version__
+    from brainlayer.deploy_drift import detect_deploy_drift, record_deploy_provenance_for_label
+
+    homebrew_root = tmp_path / "homebrew"
+    homebrew_root.mkdir()
+    _run_git(homebrew_root, "init")
+    _run_git(homebrew_root, "config", "user.email", "brainlayer-tests@example.com")
+    _run_git(homebrew_root, "config", "user.name", "BrainLayer Tests")
+    brainlayer_bin = homebrew_root / "bin" / "brainlayer"
+    brainlayer_bin.parent.mkdir()
+    brainlayer_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    _run_git(homebrew_root, "add", ".")
+    _run_git(homebrew_root, "commit", "-m", "homebrew baseline")
+    plist_path = tmp_path / "com.example.packaged.plist"
+    with plist_path.open("wb") as handle:
+        plistlib.dump(
+            {"Label": "com.example.packaged", "ProgramArguments": [str(brainlayer_bin), "serve"]},
+            handle,
+        )
+    provenance_dir = tmp_path / "daemon-provenance"
+
+    provenance_path = record_deploy_provenance_for_label(
+        label="com.example.packaged",
+        plist_path=plist_path,
+        provenance_dir=provenance_dir,
+    )
+    payload = json.loads(provenance_path.read_text(encoding="utf-8"))
+    assert payload["artifact_version"] == __version__
+    assert "launch_commit" not in payload
+    payload["artifact_version"] = "1.5.2"
+    provenance_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    finding = detect_deploy_drift("com.example.packaged", provenance_dir)
+
+    assert finding is not None
+    assert finding.identity_kind == "release_version"
+    assert finding.launch_version == "1.5.2"
+    assert finding.deployed_version == __version__
+
+
+def test_run_doctor_reports_issue_emits_alarm_and_continues_for_stale_daemon(tmp_path, monkeypatch):
+    from brainlayer import doctor
 
     db_path = tmp_path / "deploy-drift-stale.db"
     repo_root = tmp_path / "repo-stale"
@@ -718,7 +771,10 @@ def test_run_doctor_reports_issue_and_continues_when_loaded_daemon_launch_commit
     config.deploy_provenance_dir = provenance_dir
     config.deploy_drift_labels = ("com.brainlayer.drain",)
 
-    result = run_doctor(
+    emitted = []
+    monkeypatch.setattr(doctor, "emit_alarm", emitted.append)
+
+    result = doctor.run_doctor(
         config,
         ps_output_fn=_hotlane_ps,
         command_runner=_loaded_launchctl,
@@ -733,6 +789,9 @@ def test_run_doctor_reports_issue_and_continues_when_loaded_daemon_launch_commit
     assert issue.details["deployed_commit"] == head_commit
     assert result.hotlane_running is True
     assert result.exit_code == 1
+    assert len(emitted) == 1
+    assert emitted[0].code == "deploy_drift"
+    assert emitted[0].context == issue.details
 
 
 def test_run_doctor_ignores_deploy_drift_when_only_offline_reembed_utility_changed(tmp_path):
@@ -746,11 +805,18 @@ def test_run_doctor_ignores_deploy_drift_when_only_offline_reembed_utility_chang
     _run_git(repo_root, "config", "user.email", "brainlayer-tests@example.com")
     _run_git(repo_root, "config", "user.name", "BrainLayer Tests")
     (repo_root / "README.md").write_text("base\n", encoding="utf-8")
+    package = repo_root / "src" / "brainlayer"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("__version__ = '1.5.3'\n", encoding="utf-8")
+    (repo_root / "pyproject.toml").write_text(
+        '[project]\nname = "brainlayer"\nversion = "1.5.3"\n',
+        encoding="utf-8",
+    )
     _run_git(repo_root, "add", ".")
     _run_git(repo_root, "commit", "-m", "daemon launch commit")
     launch_commit = _run_git(repo_root, "rev-parse", "HEAD")
     reembed_path = repo_root / "src" / "brainlayer" / "reembed_backfill.py"
-    reembed_path.parent.mkdir(parents=True)
+    reembed_path.parent.mkdir(parents=True, exist_ok=True)
     reembed_path.write_text("DRY_RUN_READONLY = True\n", encoding="utf-8")
     deploy_drift_path = repo_root / "src" / "brainlayer" / "deploy_drift.py"
     deploy_drift_path.write_text("STATUS_ONLY = True\n", encoding="utf-8")
@@ -913,23 +979,32 @@ def test_brainbar_changed_for_deploy_ignores_non_brainbar_changes_since_launch(t
     assert brainbar_changed_for_deploy(provenance_dir, repo_root=repo_root) is False
 
 
-def test_record_deploy_provenance_requires_repo_root_from_launchd_plist(tmp_path):
-    from brainlayer.deploy_drift import DeployProvenanceError, record_deploy_provenance_for_label
+def test_record_deploy_provenance_without_repo_root_preserves_release_identity(tmp_path):
+    from brainlayer import __version__
+    from brainlayer.deploy_drift import detect_deploy_drift, record_deploy_provenance_for_label
 
     plist_path = tmp_path / "com.example.no-repo.plist"
     with plist_path.open("wb") as handle:
         plistlib.dump({"Label": "com.example.no-repo", "ProgramArguments": ["/bin/echo", "hello"]}, handle)
     provenance_dir = tmp_path / "daemon-provenance"
 
-    with pytest.raises(DeployProvenanceError) as exc:
-        record_deploy_provenance_for_label(
-            label="com.example.no-repo",
-            plist_path=plist_path,
-            provenance_dir=provenance_dir,
-        )
+    provenance_path = record_deploy_provenance_for_label(
+        label="com.example.no-repo",
+        plist_path=plist_path,
+        provenance_dir=provenance_dir,
+    )
+    payload = json.loads(provenance_path.read_text(encoding="utf-8"))
+    assert payload["artifact_version"] == __version__
+    assert "repo_root" not in payload
+    assert "launch_commit" not in payload
+    payload["artifact_version"] = "1.5.2"
+    provenance_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
-    assert exc.value.label == "com.example.no-repo"
-    assert not (provenance_dir / "com.example.no-repo.json").exists()
+    finding = detect_deploy_drift("com.example.no-repo", provenance_dir)
+
+    assert finding is not None
+    assert finding.identity_kind == "release_version"
+    assert finding.repo_root is None
 
 
 def test_run_doctor_exits_nonzero_for_recent_unvectored_chunk(tmp_path):

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -6,6 +6,7 @@ import plistlib
 import shutil
 import subprocess
 import sys
+import time
 import tomllib
 import zipfile
 from pathlib import Path
@@ -397,6 +398,29 @@ def test_verify_mcp_transport_fails_loudly_when_bridge_has_no_tools(tmp_path: Pa
 
     with pytest.raises(RuntimeError, match="initialize response"):
         verify_mcp_transport(bridge_command=str(bridge), timeout_seconds=2)
+
+
+def test_verify_mcp_transport_times_out_on_partial_stdout_line(tmp_path: Path) -> None:
+    from brainlayer.setup import verify_mcp_transport
+
+    bridge = tmp_path / "partial-line-bridge"
+    bridge.write_text(
+        """#!/usr/bin/env python3
+import sys
+import time
+sys.stdin.readline()
+sys.stdout.write('{"jsonrpc":"2.0","id":1')
+sys.stdout.flush()
+time.sleep(10)
+""",
+        encoding="utf-8",
+    )
+    bridge.chmod(0o755)
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="timed out"):
+        verify_mcp_transport(bridge_command=str(bridge), timeout_seconds=0.1)
+    assert time.monotonic() - started < 1
 
 
 def test_setup_command_writes_op_backed_env_without_plaintext_and_can_skip_launchd(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -204,6 +204,9 @@ def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path)
             "brainlayer": {
                 "command": "socat",
                 "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"],
+                "disabled": True,
+                "env": {"BRAINLAYER_MCP_SOCKET": "/tmp/brainbar.sock"},
+                "timeout": 30,
             },
             "unrelated": {"command": "other-mcp", "args": ["--keep"]},
         },
@@ -224,7 +227,34 @@ def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path)
     assert second_changed == []
     assert migrated["theme"] == "dark"
     assert migrated["mcpServers"]["unrelated"] == original["mcpServers"]["unrelated"]
-    assert migrated["mcpServers"]["brainlayer"] == {"command": "/opt/homebrew/bin/brainlayer-mcp-stdio-bridge"}
+    assert migrated["mcpServers"]["brainlayer"] == {
+        "command": "/opt/homebrew/bin/brainlayer-mcp-stdio-bridge",
+        "disabled": True,
+        "env": {"BRAINLAYER_MCP_SOCKET": "/tmp/brainbar.sock"},
+        "timeout": 30,
+    }
+
+
+def test_setup_mcp_migration_refuses_unresolved_bridge_without_touching_config(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    config_path = tmp_path / ".claude.json"
+    original = {
+        "mcpServers": {
+            "brainlayer": {
+                "command": "socat",
+                "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"],
+            }
+        }
+    }
+    original_text = json.dumps(original) + "\n"
+    config_path.write_text(original_text, encoding="utf-8")
+    monkeypatch.setattr(setup_helpers, "get_current_mcp_bridge_bin", lambda: None)
+
+    with pytest.raises(FileNotFoundError, match="brainlayer-mcp-stdio-bridge was not found"):
+        setup_helpers.migrate_legacy_mcp_configs([config_path])
+
+    assert config_path.read_text(encoding="utf-8") == original_text
 
 
 def test_setup_mcp_migration_preserves_original_and_cleans_temp_on_replace_failure(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -284,6 +284,40 @@ def test_setup_mcp_migration_preserves_original_and_cleans_temp_on_replace_failu
     assert not (tmp_path / f".{config_path.name}.{os.getpid()}.tmp").exists()
 
 
+def test_setup_mcp_migration_preserves_symlink_and_updates_target(tmp_path: Path) -> None:
+    from brainlayer.setup import migrate_legacy_mcp_configs
+
+    target = tmp_path / "dotfiles" / "claude.json"
+    target.parent.mkdir()
+    target.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "brainlayer": {
+                        "command": "socat",
+                        "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"],
+                    }
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / ".claude.json"
+    config_path.symlink_to(target)
+
+    changed = migrate_legacy_mcp_configs(
+        [config_path],
+        bridge_command="/opt/homebrew/bin/brainlayer-mcp-stdio-bridge",
+    )
+
+    assert changed == [config_path]
+    assert config_path.is_symlink()
+    assert json.loads(target.read_text(encoding="utf-8"))["mcpServers"]["brainlayer"] == {
+        "command": "/opt/homebrew/bin/brainlayer-mcp-stdio-bridge"
+    }
+
+
 def test_verify_mcp_transport_requires_initialize_and_tools_list(tmp_path: Path) -> None:
     from brainlayer.setup import verify_mcp_transport
 
@@ -298,6 +332,35 @@ for line in sys.stdin:
         print(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-06-18"}}), flush=True)
     elif request.get("id") == 2:
         print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "brain_search"}]}}), flush=True)
+""",
+        encoding="utf-8",
+    )
+    bridge.chmod(0o755)
+
+    assert verify_mcp_transport(bridge_command=str(bridge), timeout_seconds=2) == 1
+
+
+def test_verify_mcp_transport_waits_for_initialize_response_before_next_message(tmp_path: Path) -> None:
+    from brainlayer.setup import verify_mcp_transport
+
+    bridge = tmp_path / "strict-bridge"
+    bridge.write_text(
+        """#!/usr/bin/env python3
+import json
+import select
+import sys
+
+initialize = json.loads(sys.stdin.readline())
+if initialize.get("id") != 1 or select.select([sys.stdin], [], [], 0)[0]:
+    raise SystemExit(12)
+print(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-06-18"}}), flush=True)
+initialized = json.loads(sys.stdin.readline())
+if initialized.get("method") != "notifications/initialized":
+    raise SystemExit(13)
+tools = json.loads(sys.stdin.readline())
+if tools.get("id") != 2:
+    raise SystemExit(14)
+print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "brain_search"}]}}), flush=True)
 """,
         encoding="utf-8",
     )

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import plistlib
 import shutil
@@ -10,6 +11,7 @@ import zipfile
 from pathlib import Path
 from typing import get_type_hints
 
+import pytest
 from typer.testing import CliRunner
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -192,6 +194,118 @@ def test_install_launchd_default_defers_to_bounded_installer_shutdown_waits(tmp_
     assert calls == [([str(install_script), "all"], None)]
 
 
+def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:
+    from brainlayer.setup import migrate_legacy_mcp_configs
+
+    config_path = tmp_path / ".claude.json"
+    original = {
+        "theme": "dark",
+        "mcpServers": {
+            "brainlayer": {
+                "command": "socat",
+                "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"],
+            },
+            "unrelated": {"command": "other-mcp", "args": ["--keep"]},
+        },
+    }
+    config_path.write_text(json.dumps(original) + "\n", encoding="utf-8")
+
+    changed = migrate_legacy_mcp_configs(
+        [config_path],
+        bridge_command="/opt/homebrew/bin/brainlayer-mcp-stdio-bridge",
+    )
+    second_changed = migrate_legacy_mcp_configs(
+        [config_path],
+        bridge_command="/opt/homebrew/bin/brainlayer-mcp-stdio-bridge",
+    )
+
+    migrated = json.loads(config_path.read_text(encoding="utf-8"))
+    assert changed == [config_path]
+    assert second_changed == []
+    assert migrated["theme"] == "dark"
+    assert migrated["mcpServers"]["unrelated"] == original["mcpServers"]["unrelated"]
+    assert migrated["mcpServers"]["brainlayer"] == {"command": "/opt/homebrew/bin/brainlayer-mcp-stdio-bridge"}
+
+
+def test_setup_mcp_migration_preserves_original_and_cleans_temp_on_replace_failure(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    config_path = tmp_path / ".claude.json"
+    original = {
+        "mcpServers": {
+            "brainlayer": {
+                "command": "socat",
+                "args": ["STDIO", "UNIX-CONNECT:/tmp/brainbar.sock"],
+            }
+        }
+    }
+    original_text = json.dumps(original) + "\n"
+    config_path.write_text(original_text, encoding="utf-8")
+
+    def fail_replace(_source: Path, _destination: Path) -> None:
+        raise PermissionError("replace denied")
+
+    monkeypatch.setattr(setup_helpers.os, "replace", fail_replace)
+
+    with pytest.raises(PermissionError, match="replace denied"):
+        setup_helpers.migrate_legacy_mcp_configs([config_path], bridge_command="brainlayer-mcp-stdio-bridge")
+
+    assert config_path.read_text(encoding="utf-8") == original_text
+    assert not (tmp_path / f".{config_path.name}.{os.getpid()}.tmp").exists()
+
+
+def test_verify_mcp_transport_requires_initialize_and_tools_list(tmp_path: Path) -> None:
+    from brainlayer.setup import verify_mcp_transport
+
+    bridge = tmp_path / "fake-bridge"
+    bridge.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+for line in sys.stdin:
+    request = json.loads(line)
+    if request.get("id") == 1:
+        print(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-06-18"}}), flush=True)
+    elif request.get("id") == 2:
+        print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "brain_search"}]}}), flush=True)
+""",
+        encoding="utf-8",
+    )
+    bridge.chmod(0o755)
+
+    assert verify_mcp_transport(bridge_command=str(bridge), timeout_seconds=2) == 1
+
+
+def test_mcp_bridge_resolution_uses_installed_brainlayer_sibling_when_path_is_empty(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from brainlayer.setup import get_current_mcp_bridge_bin
+
+    bin_dir = tmp_path / "Cellar" / "brainlayer" / "1.5.3" / "libexec" / "bin"
+    bin_dir.mkdir(parents=True)
+    brainlayer_bin = bin_dir / "brainlayer"
+    bridge_bin = bin_dir / "brainlayer-mcp-stdio-bridge"
+    brainlayer_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    bridge_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    brainlayer_bin.chmod(0o755)
+    bridge_bin.chmod(0o755)
+    monkeypatch.setattr(sys, "argv", [str(brainlayer_bin), "setup"])
+    monkeypatch.setenv("PATH", "")
+
+    assert get_current_mcp_bridge_bin() == str(bridge_bin)
+
+
+def test_verify_mcp_transport_fails_loudly_when_bridge_has_no_tools(tmp_path: Path) -> None:
+    from brainlayer.setup import verify_mcp_transport
+
+    bridge = tmp_path / "dead-bridge"
+    bridge.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    bridge.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="initialize response"):
+        verify_mcp_transport(bridge_command=str(bridge), timeout_seconds=2)
+
+
 def test_setup_command_writes_op_backed_env_without_plaintext_and_can_skip_launchd(tmp_path: Path) -> None:
     from brainlayer.cli import app
 
@@ -248,6 +362,41 @@ def test_setup_command_does_not_install_launchd_by_default(tmp_path: Path, monke
 
     assert result.exit_code == 0, result.stdout
     assert env_file.exists()
+
+
+def test_setup_command_can_migrate_and_verify_mcp_transport(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+    from brainlayer.cli import app
+
+    migrated_path = tmp_path / ".claude.json"
+    calls: list[str] = []
+    monkeypatch.setattr(
+        setup_helpers,
+        "migrate_legacy_mcp_configs",
+        lambda: calls.append("migrate") or [migrated_path],
+    )
+    monkeypatch.setattr(
+        setup_helpers,
+        "verify_mcp_transport",
+        lambda: calls.append("verify") or 17,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "setup",
+            "--env-file",
+            str(tmp_path / "brainlayer.env"),
+            "--migrate-mcp",
+            "--verify-mcp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == ["migrate", "verify"]
+    assert "Migrated MCP config:" in result.stdout
+    assert ".claude.json" in result.stdout
+    assert "MCP transport verified: 17 tools" in result.stdout
 
 
 def test_setup_command_env_file_annotation_accepts_none() -> None:
@@ -1994,7 +2143,12 @@ def test_wheel_contains_cli_and_launchd_templates(tmp_path: Path) -> None:
 
     extracted = tmp_path / "installed-wheel"
     with zipfile.ZipFile(wheel) as archive:
+        entry_points_path = next(name for name in archive.namelist() if name.endswith(".dist-info/entry_points.txt"))
+        entry_points = archive.read(entry_points_path).decode("utf-8")
         archive.extractall(extracted)
+    assert "brainlayer = brainlayer.cli:app" in entry_points
+    assert "brainlayer-mcp = brainlayer.mcp:serve" in entry_points
+    assert "brainlayer-mcp-stdio-bridge = brainlayer.mcp_stdio_bridge:main" in entry_points
     packaged_hotlane = extracted / "brainlayer" / "launchd" / "hotlane_brainbar_daemon.py"
     help_result = subprocess.run(
         [sys.executable, str(packaged_hotlane), "--help"],

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -120,6 +120,29 @@ def test_version_check_passes_when_release_metadata_matches(tmp_path: Path) -> N
     assert f"PASS: BrainLayer/BrainBar {package_version} release metadata is consistent" in result.stdout
 
 
+def test_version_check_accepts_four_part_interim_with_three_part_bundle_short_version(tmp_path: Path) -> None:
+    fixture_root, tap_root, package_version = _copy_version_fixture(tmp_path)
+    interim_version = f"{package_version}.1"
+    for relative_path in ("pyproject.toml", "src/brainlayer/__init__.py", "server.json"):
+        path = fixture_root / relative_path
+        path.write_text(path.read_text(encoding="utf-8").replace(package_version, interim_version), encoding="utf-8")
+    plist = fixture_root / "brain-bar" / "bundle" / "Info.plist"
+    plist.write_text(
+        plist.read_text(encoding="utf-8").replace(
+            f"<key>BrainLayerReleaseVersion</key>\n    <string>{package_version}</string>",
+            f"<key>BrainLayerReleaseVersion</key>\n    <string>{interim_version}</string>",
+        ),
+        encoding="utf-8",
+    )
+    cask = tap_root / "Casks" / "brainbar.rb"
+    cask.write_text(cask.read_text(encoding="utf-8").replace(package_version, interim_version), encoding="utf-8")
+
+    result = _run(fixture_root, tap_root, git_tag=f"v{interim_version}")
+
+    assert result.returncode == 0, result.stderr
+    assert f"PASS: BrainLayer/BrainBar {interim_version} release metadata is consistent" in result.stdout
+
+
 def test_version_check_fails_loudly_when_cask_version_drifts(tmp_path: Path) -> None:
     fixture_root, tap_root, package_version = _copy_version_fixture(tmp_path)
     cask = tap_root / "Casks" / "brainbar.rb"


### PR DESCRIPTION
Closes #615
Closes #616
Closes #622

Ships Lane C release work:
- distinguish BrainLayer checkout commits from packaged artifact versions
- preserve rootless packaged provenance and loud non-aborting drift alarms
- add reconnecting MCP bridge setup migration and live transport verification
- enforce one canonical v1.5.3 version across Python, BrainBar, workflow, and release metadata
- prove installable wheel console entry points

Verification:
- same-reviewer ACCEPT at BrainLayer 4970289b and tap 9439f01
- full pre-push gate passed with unit, MCP registration, isolated routing/eval, Bun, and shell regression
- focused doctor/version/release/install surfaces green

— brainlayer-worker-x0l4c3 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayer-worker-x0l4c3","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019fe295","ts":"2026-08-08T21:16:17Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release stamping, daemon deploy identity, and MCP client config migration—operational paths that affect upgrades and drift detection—but behavior is heavily tested and doctor no longer hard-aborts on drift.
> 
> **Overview**
> **Release v1.5.3** bumps canonical version across Python, MCP manifest, and BrainBar bundle metadata, and tightens release checks so interim tags like `v1.5.3.1` are allowed while `CFBundleShortVersionString` stays three-part and `CFBundleVersion` uses git commit count; full identity is stored in new **`BrainLayerReleaseVersion`**.
> 
> **BrainBar build/release** (`build-app.sh`, GitHub release workflow, version-check script) mirrors that split and validates `BrainLayerReleaseVersion` against the package version.
> 
> **Deploy drift** now uses git commits only for real BrainLayer checkouts; packaged/Homebrew installs compare **`artifact_version`** in provenance, with explicit **`release_identity_missing`** when legacy provenance has no version. Provenance recording no longer requires a repo root from launchd plists.
> 
> **Doctor** reports deploy drift as fatal issues and emits alarms without aborting the whole run; home paths in alarm context are redacted.
> 
> **`brainlayer setup`** gains **`--migrate-mcp`** / **`--verify-mcp`** to replace known socat→`/tmp/brainbar.sock` MCP entries with `brainlayer-mcp-stdio-bridge` and exercise initialize + tools/list.
> 
> **AGENTS.md** PR workflow text now points mandatory reviews at the lead-routed Claude pair lane instead of Bugbot/Greptile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b378cac754c625492a5609b0e3d5d0203a9f206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release BrainLayer v1.5.3 with strict versioning and release identity stamping
> - Bumps version to 1.5.3 across [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/682/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [Info.plist](https://github.com/EtanHey/brainlayer/pull/682/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [server.json](https://github.com/EtanHey/brainlayer/pull/682/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and `brainlayer.__version__`.
> - Build scripts and CI workflow now accept interim `vX.Y.Z.N` tags; `CFBundleShortVersionString` is set to the 3-part base, `CFBundleVersion` to a monotonically increasing git commit count, and `BrainLayerReleaseVersion` to the full release tag.
> - Deploy drift detection in [deploy_drift.py](https://github.com/EtanHey/brainlayer/pull/682/files#diff-104020c1accd6a40c76e68a42d5ea2293fb67b81be388b3b841265d2c42699d8) gains a second identity mode: packaged (non-git) installs compare `artifact_version` from provenance against the deployed `__version__`, emitting `version_mismatch` or `release_identity_missing` drift statuses.
> - [doctor.py](https://github.com/EtanHey/brainlayer/pull/682/files#diff-41071e7067b327f299dfaa0e5ce4c4455911658ff543b818c684f321f91b29ff) now captures per-label drift exceptions as fatal issues instead of aborting the full doctor run, and redacts home paths from drift context.
> - [setup.py](https://github.com/EtanHey/brainlayer/pull/682/files#diff-774188ad41f49470ff3c8e53644d81dc923136e10591c3fa1cbf5de30a51eaee) adds `migrate_legacy_mcp_configs()` to replace socat-based BrainBar MCP entries with the stdio bridge, and `verify_mcp_transport()` to validate the bridge via a live MCP handshake and `tools/list` call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b378ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Setup now supports migrating legacy MCP configurations and verifying MCP transport connections.
  - Deployment diagnostics support both source-checkout and packaged-install version identity.
  - Doctor checks report deployment drift as structured issues while continuing execution where possible.

- **Bug Fixes**
  - Improved handling of missing repository metadata and invalid or mismatched release versions.
  - Added support for interim four-part release versions.

- **Release**
  - Updated the application and package version to 1.5.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->