### PR TITLE
fix: prevent embedding starvation and stagger WAL checkpoints

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ BrainLayer includes launchd plist templates for automated operation:
 | `com.brainlayer.drain` | Queue/WatchPaths trigger | Drain queued writes as the single writer |
 | `com.brainlayer.decay` | Weekly | Refresh decay metadata |
 | `com.brainlayer.repair-fts` | Weekly | Repair FTS indexes |
-| `com.brainlayer.wal-checkpoint` | Weekly | Checkpoint the WAL |
+| `com.brainlayer.wal-checkpoint` | Daily 09:30 | Checkpoint the WAL |
 | `com.brainlayer.backup-daily` | Daily | Backup the BrainLayer DB |
 | `com.brainlayer.jsonl-backup` | Daily | Backup Claude JSONL files |
 | `com.brainlayer.maintenance-nightly` | Nightly | Light maintenance |

--- a/docs/plans/2026-08-09-wave25-r1-r2-design.md
+++ b/docs/plans/2026-08-09-wave25-r1-r2-design.md
@@ -1,0 +1,32 @@
+# Wave 2.5 R1+R2 Design
+
+## Scope
+
+Wave 2.5 closes two production residuals before migration work resumes:
+
+- R1 guarantees embedding throughput while the durable high-priority queue remains nonempty.
+- R2 moves the nightly TRUNCATE checkpoint outside the long backup read window and retains bounded busy retries.
+
+## Evidence and decision
+
+The live database currently contains 741,966 chunks and 723,187 vector row IDs, a raw gap of 18,779. The previous lane receipt recorded 17,913 missing embeddings, so the debt has increased by 866. The durable queue contained 1,325 JSONL files during diagnosis, including 47 files created in the preceding ten minutes. `scripts/hotlane_brainbar_daemon.py` currently skips the entire hotlane cycle whenever any high-priority queue file exists.
+
+R1 will reserve a backlog-only embedding slice whenever the normal backlog interval expires, even under high-priority backpressure. The slice retains the existing batch size of four and ten-second interval, yielding a target capacity of about 24 vectors per minute while keeping each vector write in its existing independent transaction. Hot candidate embedding and enrichment remain suppressed during backpressure. This is preferred over a full hot+backlog cycle because it bounds lock pressure, and over merely raising the batch because raising a batch that is never scheduled cannot prevent starvation.
+
+The daily backup starts at 03:17 and production evidence shows a healthy full backup can take about 4.5 hours. A 05:30 checkpoint can therefore still collide with the backup. R2 will schedule TRUNCATE at 09:30 and keep `--retry-busy`, giving the normal backup window about 1 hour 43 minutes of margin while avoiding the existing 04:00 maintenance cluster. The deployed LaunchAgent must be reinstalled so tracked and executing schedules match.
+
+## Runtime behavior
+
+Under high-priority queue pressure, the loop continues to yield normal hotlane work. When the backlog deadline is due, it runs one cycle with `recent_limit=0`, `backlog_batch=4`, and `enrich_limit=0`, then returns to yielding. The backpressure log distinguishes complete yielding from a reserved backlog slice. Without high-priority pressure, behavior remains unchanged.
+
+The checkpoint LaunchAgent runs once daily at 09:30. A busy TRUNCATE uses the already-shipped bounded retry path; persistent contention still exits nonzero and remains observable.
+
+## Verification
+
+- Unit tests prove a due backlog slice runs under persistent high-priority pressure and non-due cycles still yield all writer work.
+- Existing hotlane and launchd hygiene suites remain green.
+- The tracked checkpoint plist asserts 09:30 and `--retry-busy`.
+- Deployment reinstalls the hotlane and checkpoint LaunchAgents and verifies their live arguments/schedules.
+- R1 is DONE only after the same missing-embedding counter falls across a two-hour deployed window.
+- R2 is DONE only after two consecutive scheduled TRUNCATE runs exit 0.
+

--- a/docs/plans/2026-08-09-wave25-r1-r2-design.md
+++ b/docs/plans/2026-08-09-wave25-r1-r2-design.md
@@ -13,7 +13,7 @@ The live database currently contains 741,966 chunks and 723,187 vector row IDs, 
 
 R1 will reserve a backlog-only embedding slice whenever the normal backlog interval expires, even under high-priority backpressure. The slice retains the existing batch size of four and ten-second interval, yielding a target capacity of about 24 vectors per minute while keeping each vector write in its existing independent transaction. Hot candidate embedding and enrichment remain suppressed during backpressure. This is preferred over a full hot+backlog cycle because it bounds lock pressure, and over merely raising the batch because raising a batch that is never scheduled cannot prevent starvation.
 
-The daily backup starts at 03:17 and production evidence shows a healthy full backup can take about 4.5 hours. A 05:30 checkpoint can therefore still collide with the backup. R2 will schedule TRUNCATE at 09:30 and keep `--retry-busy`, giving the normal backup window about 1 hour 43 minutes of margin while avoiding the existing 04:00 maintenance cluster. The deployed LaunchAgent must be reinstalled so tracked and executing schedules match.
+The daily backup starts at 03:17, but its total runtime does not define its database-lock window: the database read is held during `VACUUM INTO`, while compression and Drive upload continue without that lock. Production also has a Sunday full-maintenance job that can extend beyond 09:30, so no start-time arithmetic proves the new slot collision-free. R2 schedules TRUNCATE at 09:30 as a measured hypothesis that separates it from the daily backup start and keeps `--retry-busy`; the two consecutive scheduled exit-0 receipts are the proof gate. The deployed LaunchAgent must be reinstalled so tracked and executing schedules match, and the live calendar plus arguments must be captured after reinstall.
 
 ## Runtime behavior
 
@@ -23,10 +23,9 @@ The checkpoint LaunchAgent runs once daily at 09:30. A busy TRUNCATE uses the al
 
 ## Verification
 
-- Unit tests prove a due backlog slice runs under persistent high-priority pressure and non-due cycles still yield all writer work.
+- Unit tests prove backlog slices recur at successive deadlines under continuous high-priority pressure and non-due cycles still yield all writer work.
 - Existing hotlane and launchd hygiene suites remain green.
 - The tracked checkpoint plist asserts 09:30 and `--retry-busy`.
 - Deployment reinstalls the hotlane and checkpoint LaunchAgents and verifies their live arguments/schedules.
 - R1 is DONE only after the same missing-embedding counter falls across a two-hour deployed window.
 - R2 is DONE only after two consecutive scheduled TRUNCATE runs exit 0.
-

--- a/docs/plans/2026-08-09-wave25-r1-r2.md
+++ b/docs/plans/2026-08-09-wave25-r1-r2.md
@@ -1,0 +1,103 @@
+# Wave 2.5 R1+R2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Guarantee bounded embedding progress under durable-queue backpressure and move nightly TRUNCATE outside the production backup window.
+
+**Architecture:** The hotlane scheduler will preserve high-priority yielding except for a due, backlog-only reserved slice using the existing bounded batch and split read/embed/write path. The checkpoint change is a tracked LaunchAgent schedule update to 09:30 while retaining bounded busy retry behavior.
+
+**Tech Stack:** Python 3.13, pytest, APSW/sqlite-vec, macOS launchd plist configuration.
+
+---
+
+### Task 1: R1 reserved embedding slice
+
+**Files:**
+- Modify: `tests/test_hotlane_brainbar_daemon.py`
+- Modify: `scripts/hotlane_brainbar_daemon.py`
+
+**Step 1: Write the failing test**
+
+Add a scheduler test that holds `high_priority_queue_depth_fn` at one for enough cycles to cross the ten-second backlog interval. Assert that only the due cycle calls `cycle_fn`, with `recent_limit=0`, the configured `backlog_batch`, and `enrich_limit=0`.
+
+**Step 2: Run the test to verify RED**
+
+Run: `pytest -q tests/test_hotlane_brainbar_daemon.py -k reserved`
+
+Expected: FAIL because current high-priority handling continues before any cycle is scheduled.
+
+**Step 3: Implement the minimal scheduler change**
+
+Calculate whether the backlog deadline is due before the high-priority early-yield branch. If high-priority backlog exists and the deadline is not due, retain the current early yield. If it is due, schedule a backlog-only cycle by setting the cycle's recent limit to zero and enrichment limit to zero, then advance the backlog timer.
+
+**Step 4: Run focused and module tests**
+
+Run: `pytest -q tests/test_hotlane_brainbar_daemon.py -k 'reserved or backpressure or backlog'`
+
+Run: `pytest -q tests/test_hotlane_brainbar_daemon.py`
+
+Expected: PASS with zero failures.
+
+**Step 5: Commit R1**
+
+Stage the design/plan, hotlane source, and hotlane tests. Commit with an R1-specific message and the required agent trailer.
+
+### Task 2: R2 checkpoint stagger
+
+**Files:**
+- Modify: `tests/test_wal_checkpoint_module.py`
+- Modify: `scripts/launchd/com.brainlayer.wal-checkpoint.plist`
+
+**Step 1: Write the failing test**
+
+Change the LaunchAgent contract test to require `StartCalendarInterval == {"Hour": 9, "Minute": 30}` while retaining the `--retry-busy` assertion.
+
+**Step 2: Run the test to verify RED**
+
+Run: `pytest -q tests/test_wal_checkpoint_module.py::test_launchagent_runs_retrying_truncate_every_night`
+
+Expected: FAIL because the tracked plist currently schedules 04:00.
+
+**Step 3: Implement the schedule change**
+
+Change the tracked checkpoint LaunchAgent hour and minute to 09:30. Do not change checkpoint locking, retry count, or backup behavior.
+
+**Step 4: Run focused launchd tests**
+
+Run: `pytest -q tests/test_wal_checkpoint_module.py tests/test_launchd_hygiene.py`
+
+Expected: PASS with zero failures.
+
+**Step 5: Commit R2**
+
+Stage only the checkpoint plist and its contract test. Commit with an R2-specific message and the required agent trailer.
+
+### Task 3: Review, deploy, and delayed gates
+
+**Files:**
+- Update externally: `/Users/etanheyman/Gits/orchestrator/collab/2026-08-09-brainlayer-wave25.md`
+
+**Step 1: Run repository verification**
+
+Run focused tests, `ruff check` on changed Python, then the repository's relevant pre-push/full test gates. Record exact pass/fail counts.
+
+**Step 2: Run the mandatory pair-review and PR loop**
+
+Request the lead-routed Claude review, open a ready-for-review PR, request `@codex review`, address all material findings, and merge only after the review loop is clean.
+
+**Step 3: Deploy executing artifacts**
+
+Update the production checkout, reinstall the hotlane and checkpoint LaunchAgents through `scripts/launchd/install.sh`, and verify live `launchctl print` arguments and calendar triggers.
+
+**Step 4: Prove R1 live**
+
+Record the missing-embedding counter at deploy and after two hours using the same SQL definition. Append both timestamps and counts to the collab. Mark R1 green only if the later count is lower.
+
+**Step 5: Prove R2 live**
+
+After each of the next two 09:30 scheduled runs, record `launchctl` last exit and checkpoint log evidence. Mark R2 green only after two consecutive exit-0 nights.
+
+**Step 6: Append terminal marker**
+
+Append `DONE_W25`, PR URL(s), R1 counter numbers, and both R2 scheduled exit-0 receipts to the collab. Store the verified root cause and deployed decision in BrainLayer.
+

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -780,6 +780,7 @@ def run(
     last_enrich = 0.0
     enrich_disabled = False
     queue_backpressure_active = False
+    backlog_slice_logged = False
     hot_candidate_scanner = HotCandidateScanner()
     cycles = 0
     backlog_batch = min(max(backlog_batch, 0), MAX_BACKLOG_BATCH)
@@ -806,12 +807,15 @@ def run(
                     sleep_fn(interval)
                     continue
                 cycle_recent_limit = 0
-                LOGGER.info(
-                    "durable high-priority queue has backlog; reserving backlog embedding slice batch=%d",
-                    cycle_backlog_batch,
-                )
+                if not backlog_slice_logged:
+                    LOGGER.info(
+                        "durable high-priority queue has backlog; reserving backlog embedding slice batch=%d",
+                        cycle_backlog_batch,
+                    )
+                    backlog_slice_logged = True
             else:
                 queue_backpressure_active = False
+                backlog_slice_logged = False
             cycle_enrich_limit = (
                 enrich_limit
                 if not queue_has_backlog

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -791,15 +791,27 @@ def run(
             now = time_fn()
             queue_has_backlog = queue_depth_fn(queue_dir) > 0
             queue_has_high_priority_backlog = queue_has_backlog and high_priority_queue_depth_fn(queue_dir) > 0
+            cycle_backlog_batch = (
+                backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
+            )
+            cycle_recent_limit = recent_limit
             if queue_has_high_priority_backlog:
                 if not queue_backpressure_active:
-                    LOGGER.info("durable high-priority queue has backlog; yielding all hotlane writer work")
+                    LOGGER.info(
+                        "durable high-priority queue has backlog; suppressing hot embedding and enrichment"
+                    )
                 queue_backpressure_active = True
-                cycles += 1
-                sleep_fn(interval)
-                continue
-            queue_backpressure_active = False
-            cycle_backlog_batch = backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
+                if cycle_backlog_batch <= 0:
+                    cycles += 1
+                    sleep_fn(interval)
+                    continue
+                cycle_recent_limit = 0
+                LOGGER.info(
+                    "durable high-priority queue has backlog; reserving backlog embedding slice batch=%d",
+                    cycle_backlog_batch,
+                )
+            else:
+                queue_backpressure_active = False
             cycle_enrich_limit = (
                 enrich_limit
                 if not queue_has_backlog
@@ -817,7 +829,7 @@ def run(
                     db_path=db_path,
                     vector_store_cls=vector_store_cls,
                     embed_fn=embed_fn,
-                    recent_limit=recent_limit,
+                    recent_limit=cycle_recent_limit,
                     backlog_batch=cycle_backlog_batch,
                     embed_batch_fn=embed_batch_fn,
                     enrich_limit=cycle_enrich_limit,
@@ -830,7 +842,7 @@ def run(
                     result = cycle_fn(
                         store=store,
                         embed_fn=embed_fn,
-                        recent_limit=recent_limit,
+                        recent_limit=cycle_recent_limit,
                         backlog_batch=cycle_backlog_batch,
                         embed_batch_fn=embed_batch_fn,
                         enrich_limit=cycle_enrich_limit,

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -792,15 +792,11 @@ def run(
             now = time_fn()
             queue_has_backlog = queue_depth_fn(queue_dir) > 0
             queue_has_high_priority_backlog = queue_has_backlog and high_priority_queue_depth_fn(queue_dir) > 0
-            cycle_backlog_batch = (
-                backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
-            )
+            cycle_backlog_batch = backlog_batch if backlog_batch > 0 and now - last_backlog >= backlog_interval else 0
             cycle_recent_limit = recent_limit
             if queue_has_high_priority_backlog:
                 if not queue_backpressure_active:
-                    LOGGER.info(
-                        "durable high-priority queue has backlog; suppressing hot embedding and enrichment"
-                    )
+                    LOGGER.info("durable high-priority queue has backlog; suppressing hot embedding and enrichment")
                 queue_backpressure_active = True
                 if cycle_backlog_batch <= 0:
                     cycles += 1

--- a/scripts/launchd/com.brainlayer.wal-checkpoint.plist
+++ b/scripts/launchd/com.brainlayer.wal-checkpoint.plist
@@ -16,9 +16,9 @@
 	<key>StartCalendarInterval</key>
 	<dict>
 		<key>Hour</key>
-		<integer>4</integer>
+		<integer>9</integer>
 		<key>Minute</key>
-		<integer>0</integer>
+		<integer>30</integer>
 	</dict>
 	<key>StandardOutPath</key>
 	<string>__HOME__/Library/Logs/brainlayer/wal-checkpoint.out.log</string>

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -989,14 +989,20 @@ def test_hotlane_run_logs_high_priority_backpressure_once_per_blocked_state(tmp_
     yield_logs = [
         record
         for record in caplog.records
-        if record.getMessage() == "durable high-priority queue has backlog; yielding all hotlane writer work"
+        if record.getMessage()
+        == "durable high-priority queue has backlog; suppressing hot embedding and enrichment"
     ]
     assert len(yield_logs) == 2
-    assert len(cycle_calls) == 1
+    assert len(cycle_calls) == 2
+    assert cycle_calls[0]["recent_limit"] == 0
+    assert cycle_calls[0]["backlog_batch"] == hotlane.DEFAULT_BACKLOG_BATCH
     assert cycle_calls[0]["enrich_limit"] == 0
+    assert cycle_calls[1]["recent_limit"] == 5
+    assert cycle_calls[1]["backlog_batch"] == 0
+    assert cycle_calls[1]["enrich_limit"] == 0
 
 
-def test_hotlane_run_yields_all_writer_work_during_high_priority_queue_backlog(tmp_path):
+def test_hotlane_run_yields_all_writer_work_when_backlog_embedding_is_disabled(tmp_path):
     hotlane = _load_hotlane_module()
     opened = []
     cycle_calls = []
@@ -1014,7 +1020,7 @@ def test_hotlane_run_yields_all_writer_work_during_high_priority_queue_backlog(t
         interval=0.25,
         recent_limit=5,
         backlog_interval=10.0,
-        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        backlog_batch=0,
         enrich_interval=10.0,
         enrich_limit=hotlane.DEFAULT_HOTLANE_ENRICH_LIMIT,
         enrich_since_hours=8760,
@@ -1031,6 +1037,41 @@ def test_hotlane_run_yields_all_writer_work_during_high_priority_queue_backlog(t
     assert opened == []
     assert cycle_calls == []
     assert sleeps == [0.25]
+
+
+def test_hotlane_run_reserves_due_backlog_slice_during_high_priority_queue_backlog(tmp_path):
+    hotlane = _load_hotlane_module()
+    cycle_calls = []
+    sleeps = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=hotlane.DEFAULT_HOTLANE_ENRICH_LIMIT,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=lambda **kwargs: cycle_calls.append(kwargs) or hotlane.CycleResult(),
+        time_fn=iter([100.0, 100.0, 101.0]).__next__,
+        sleep_fn=sleeps.append,
+        max_cycles=2,
+        queue_depth_fn=lambda _queue_dir: 3,
+        high_priority_queue_depth_fn=lambda _queue_dir: 1,
+    )
+
+    assert len(cycle_calls) == 1
+    assert cycle_calls[0]["recent_limit"] == 0
+    assert cycle_calls[0]["backlog_batch"] == hotlane.DEFAULT_BACKLOG_BATCH
+    assert cycle_calls[0]["enrich_limit"] == 0
+    assert sleeps == [0.25, 0.25]
 
 
 def test_hotlane_run_skips_default_hot_embedding_during_queue_backlog(tmp_path, monkeypatch):
@@ -1062,7 +1103,10 @@ def test_hotlane_run_skips_default_hot_embedding_during_queue_backlog(tmp_path, 
         high_priority_queue_depth_fn=lambda _queue_dir: 1,
     )
 
-    assert split_calls == []
+    assert len(split_calls) == 1
+    assert split_calls[0]["recent_limit"] == 0
+    assert split_calls[0]["backlog_batch"] == hotlane.DEFAULT_BACKLOG_BATCH
+    assert split_calls[0]["enrich_limit"] == 0
     assert sleeps == [0.25]
 
 

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -1074,6 +1074,80 @@ def test_hotlane_run_reserves_due_backlog_slice_during_high_priority_queue_backl
     assert sleeps == [0.25, 0.25]
 
 
+def test_hotlane_run_repeats_reserved_backlog_slice_during_continuous_pressure(tmp_path):
+    hotlane = _load_hotlane_module()
+    cycle_calls = []
+    sleeps = []
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=hotlane.DEFAULT_HOTLANE_ENRICH_LIMIT,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=lambda **kwargs: cycle_calls.append(kwargs) or hotlane.CycleResult(),
+        time_fn=iter([0.0, 100.0, 105.0, 110.0, 115.0]).__next__,
+        sleep_fn=sleeps.append,
+        max_cycles=4,
+        queue_depth_fn=lambda _queue_dir: 3,
+        high_priority_queue_depth_fn=lambda _queue_dir: 1,
+    )
+
+    assert len(cycle_calls) == 2
+    assert all(call["recent_limit"] == 0 for call in cycle_calls)
+    assert all(call["backlog_batch"] == hotlane.DEFAULT_BACKLOG_BATCH for call in cycle_calls)
+    assert all(call["enrich_limit"] == 0 for call in cycle_calls)
+    assert sleeps == [0.25] * 4
+
+
+def test_hotlane_run_logs_reserved_slice_once_during_continuous_pressure(tmp_path, caplog):
+    hotlane = _load_hotlane_module()
+    caplog.set_level(logging.INFO, logger=hotlane.LOGGER.name)
+
+    class FakeStore:
+        def close(self):
+            pass
+
+    hotlane.run(
+        db_path=tmp_path / "brainlayer.db",
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=hotlane.DEFAULT_BACKLOG_BATCH,
+        enrich_interval=10.0,
+        enrich_limit=hotlane.DEFAULT_HOTLANE_ENRICH_LIMIT,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: FakeStore(),
+        model_factory=lambda: SimpleNamespace(embed_query=lambda _text: [0.0]),
+        cycle_fn=lambda **_kwargs: hotlane.CycleResult(),
+        time_fn=iter([0.0, 100.0, 105.0, 110.0, 115.0]).__next__,
+        sleep_fn=lambda _seconds: None,
+        max_cycles=4,
+        queue_depth_fn=lambda _queue_dir: 3,
+        high_priority_queue_depth_fn=lambda _queue_dir: 1,
+    )
+
+    reserved_logs = [
+        record
+        for record in caplog.records
+        if record.getMessage()
+        == (
+            "durable high-priority queue has backlog; reserving backlog embedding slice "
+            f"batch={hotlane.DEFAULT_BACKLOG_BATCH}"
+        )
+    ]
+    assert len(reserved_logs) == 1
+
+
 def test_hotlane_run_skips_default_hot_embedding_during_queue_backlog(tmp_path, monkeypatch):
     hotlane = _load_hotlane_module()
     split_calls = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -989,8 +989,7 @@ def test_hotlane_run_logs_high_priority_backpressure_once_per_blocked_state(tmp_
     yield_logs = [
         record
         for record in caplog.records
-        if record.getMessage()
-        == "durable high-priority queue has backlog; suppressing hot embedding and enrichment"
+        if record.getMessage() == "durable high-priority queue has backlog; suppressing hot embedding and enrichment"
     ]
     assert len(yield_logs) == 2
     assert len(cycle_calls) == 2

--- a/tests/test_wal_checkpoint_module.py
+++ b/tests/test_wal_checkpoint_module.py
@@ -128,6 +128,6 @@ def test_launchagent_runs_retrying_truncate_every_night():
     plist_path = Path(__file__).resolve().parents[1] / "scripts/launchd/com.brainlayer.wal-checkpoint.plist"
     plist = plistlib.loads(plist_path.read_bytes())
 
-    assert plist["StartCalendarInterval"] == {"Hour": 4, "Minute": 0}
+    assert plist["StartCalendarInterval"] == {"Hour": 9, "Minute": 30}
     assert plist["ProgramArguments"][-1] == "--retry-busy"
     assert "KeepAlive" not in plist


### PR DESCRIPTION
## Summary

- reserve a bounded backlog-only embedding slice at each due interval while durable high-priority queue pressure suppresses hot embedding and enrichment
- edge-trigger pressure/slice logs so sustained pressure does not grow the unrotated hotlane log every ten seconds
- move the daily TRUNCATE checkpoint to 09:30 while retaining bounded `--retry-busy`; treat the slot as a measured hypothesis with two scheduled exit-0 receipts as the proof gate
- add recurrence, pressure, schedule, and documentation coverage

## Verification

- managed unit suite: 3,803 passed, 10 skipped, 61 deselected, 2 xfailed; zero failures/errors
- focused exact-head suite: 187 passed
- scoped pre-push: 46 unit + 3 MCP registration + 40 isolated routing + 1 Bun + shell regression, all passed
- Ruff check/format and `git diff --check`: clean
- lead-routed Claude pair review: `ACCEPT` at `0de0e072`; review artifact recorded in the Wave 2.5 collab

## Production gates

- R1 remains open until the same missing-embeddings counter falls from deploy to +2h
- R2 remains open until two consecutive scheduled 09:30 TRUNCATE runs exit 0 on the reinstalled LaunchAgent

— brainlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019fe5dc","ts":"2026-08-09T10:37:29Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production hotlane writer scheduling and SQLite TRUNCATE timing; behavior is bounded and tested, but live proof gates (embedding debt and two successful 09:30 runs) still apply after deploy.
> 
> **Overview**
> **Wave 2.5** addresses embedding starvation when the durable high-priority queue is busy and moves the daily WAL TRUNCATE checkpoint away from the backup window.
> 
> **R1 — hotlane:** While high-priority queue files exist, the daemon no longer skips every cycle. It still suppresses hot candidate embedding and enrichment, but when the backlog interval is due it runs a **backlog-only** slice (`recent_limit=0`, normal backlog batch, `enrich_limit=0`). Between due slices it sleeps as before. Logging distinguishes suppression from the reserved slice and logs the slice once per continuous pressure spell.
> 
> **R2 — WAL:** The `com.brainlayer.wal-checkpoint` LaunchAgent schedule changes from **04:00** to **09:30**; TRUNCATE mode and `--retry-busy` are unchanged. Docs and a contract test match the new time.
> 
> Design/implementation plan docs are added; hotlane and wal-checkpoint tests cover recurrence, disabled backlog, and plist schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de0e072ca5eb711112697314055d125401775b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix embedding starvation by reserving a backlog slice and rescheduling WAL checkpoints to 09:30
> - Under durable high-priority queue backpressure, the hotlane loop now runs a backlog-only embedding cycle (`recent_limit=0`, `backlog_batch>0`, `enrich_limit=0`) when the backlog interval is due, instead of suppressing all work. Hot embedding and enrichment are still suppressed during pressure.
> - The reserved backlog slice is logged once per continuous pressured period; the existing log message is updated from 'yielding all hotlane writer work' to 'suppressing hot embedding and enrichment'.
> - The WAL checkpoint LaunchAgent ([com.brainlayer.wal-checkpoint.plist](https://github.com/EtanHey/brainlayer/pull/687/files#diff-ec008f9a726323154fa38b7beb71645ebce23117bae209f5f000e0f694bca94e)) is rescheduled from 04:00 to 09:30 daily.
> - Behavioral Change: callers with `backlog_batch=0` retain the old yield-all behavior; callers with `backlog_batch>0` now receive at least one embedding cycle per backlog interval even under pressure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0de0e07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->