### PR TITLE
chore: ignore managed worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ site/
 
 # render-verification ephemeral logs
 brain-bar/.render-logs/
+.worktrees/
+.cmux/worktrees/


### PR DESCRIPTION
Adds `.worktrees/` and `.cmux/worktrees/` to .gitignore per Etan's ratified worktree convention (fleet-wide gitignore sweep, 27/31 repos already merged).

Review already complete before this PR: skillcreatorClaude ACCEPT (31/31 diffs, 93/93 fresh-clone ignore checks) — record in skill-creator `docs.local/plan/worktree-convention-enforcement/phase-5/findings.md`. Push used the documented `BRAINLAYER_PREPUSH_SCOPE=changed-only` path; the full-suite hang that blocked the sweep worker is being handled separately by the brainlayer lane.

Opened by brainlayerClaude lead (Fable 5) on handoff from cmuxlayerClaude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds **`.worktrees/`** and **`.cmux/worktrees/`** to `.gitignore` so machine-local managed worktree checkouts are not tracked or committed, aligned with the fleet-wide worktree convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29cb2162751d455757f84390f9ae34c84be99434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore managed worktree directories in `.gitignore`
> Adds ignore patterns for `.worktrees/` and `.cmux/worktrees/` to [.gitignore](https://github.com/EtanHey/brainlayer/pull/688/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) to prevent managed worktree directories from appearing as untracked files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29cb216.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->