### PR TITLE
fix(mcp): deferred store receipt reads as success

### DIFF
--- a/brain-bar/Sources/BrainBar/Formatters.swift
+++ b/brain-bar/Sources/BrainBar/Formatters.swift
@@ -173,7 +173,8 @@ enum Formatters {
     ) -> String {
         if queued {
             let idSuffix = chunkId.isEmpty ? "" : " \u{2192} \(val(chunkId, useColor))"
-            return "\u{2502} DEFERRED: Memory queued (DB busy)\(idSuffix) \u{2500} drain will persist it."
+            return "\u{2502} \u{2714} STORED (deferred): DB busy\(idSuffix) \u{2500} durably queued; "
+                + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         }
         var parts = ["\u{2714} Stored \u{2192} \(val(chunkId, useColor))"]
         if !tags.isEmpty {

--- a/brain-bar/Sources/BrainBar/Formatters.swift
+++ b/brain-bar/Sources/BrainBar/Formatters.swift
@@ -169,11 +169,13 @@ enum Formatters {
         superseded: String? = nil,
         tags: [String] = [],
         queued: Bool = false,
+        queuedReason: String = "DB_BUSY",
         useColor: Bool = true
     ) -> String {
         if queued {
             let idSuffix = chunkId.isEmpty ? "" : " \u{2192} \(val(chunkId, useColor))"
-            return "\u{2502} \u{2714} STORED (deferred): DB busy\(idSuffix) \u{2500} durably queued; "
+            let reasonLabel = queuedReason == "DB_BUSY" ? "DB busy" : queuedReason
+            return "\u{2502} \u{2714} STORED (deferred): \(reasonLabel)\(idSuffix) \u{2500} durably queued; "
                 + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         }
         var parts = ["\u{2714} Stored \u{2192} \(val(chunkId, useColor))"]

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -313,9 +313,27 @@ final class MCPRouter: @unchecked Sendable {
         // replay can hold it across DB writes, so never block the caller
         // (setDatabases runs on BrainBarServer.queue during initialization).
         let scheduler = pendingStoreDrainScheduler
-        scheduler.queue.async { [weak scheduler, weak db] in
-            guard let scheduler, let db else { return }
-            guard let snapshot = db.pendingStoreQueueSnapshotIfReadable() else { return }
+        Self.scheduleExistingPendingStoreScan(scheduler: scheduler, db: db, delay: 0)
+    }
+
+    private static func scheduleExistingPendingStoreScan(
+        scheduler: PendingStoreDrainScheduler,
+        db: BrainDatabase,
+        delay: TimeInterval
+    ) {
+        scheduler.queue.asyncAfter(deadline: .now() + delay) { [weak scheduler, weak db] in
+            guard let scheduler, let db, db.isOpen else { return }
+            guard let snapshot = db.pendingStoreQueueSnapshotIfReadable() else {
+                scheduleExistingPendingStoreScan(
+                    scheduler: scheduler,
+                    db: db,
+                    delay: min(
+                        pendingStoreDrainMaxDelay,
+                        max(pendingStoreDrainInitialDelay, delay * 2)
+                    )
+                )
+                return
+            }
             var scheduledAny = false
             for identity in snapshot.identityKeys where identity.hasPrefix("chunk:") {
                 scheduledAny = true

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -48,11 +48,6 @@ final class MCPRouter: @unchecked Sendable {
     // attempt (retries == 0) with a sub-budget busy timeout, then queues on busy.
     private static let mcpStoreBusyTimeoutMillis: Int32 = 25
     private static let mcpStoreRetries = 0
-    private static let pendingStoreDrainQueue = DispatchQueue(
-        label: "com.brainlayer.brainbar.pending-store-drain",
-        qos: .utility
-    )
-    private static let pendingStoreDrainRegistry = PendingStoreDrainRegistry()
     private static let pendingStoreDrainInitialDelay: TimeInterval = 0.25
     private static let pendingStoreDrainMaxDelay: TimeInterval = 30.0
 
@@ -140,12 +135,22 @@ final class MCPRouter: @unchecked Sendable {
         }
     }
 
+    private final class PendingStoreDrainScheduler: @unchecked Sendable {
+        let queue: DispatchQueue
+        let registry = PendingStoreDrainRegistry()
+
+        init(queue: DispatchQueue) {
+            self.queue = queue
+        }
+    }
+
     private var database: BrainDatabase?
     private var readDatabase: BrainDatabase?
     private let hybridSearchClient: HybridSearchClientProtocol?
     private let dbPath: String?
     private let hybridSearchBudget: TimeInterval
     private let toolProfile: ToolProfile
+    private let pendingStoreDrainScheduler: PendingStoreDrainScheduler
     private let defaultPaletteSession = PaletteSession()
     let entityCache = EntityCache()
     private static let defaultStringMaxLength = 256
@@ -178,12 +183,19 @@ final class MCPRouter: @unchecked Sendable {
         hybridSearchClient: HybridSearchClientProtocol? = nil,
         hybridSearchBudget: TimeInterval = 0.8,
         dbPath: String? = nil,
+        pendingStoreDrainQueue: DispatchQueue? = nil,
         backupWriterStartedAtUnix: TimeInterval = Date().timeIntervalSince1970
     ) {
         self.toolProfile = Self.resolveToolProfile(profile)
         self.hybridSearchClient = hybridSearchClient
         self.hybridSearchBudget = max(0.001, hybridSearchBudget)
         self.dbPath = dbPath
+        self.pendingStoreDrainScheduler = PendingStoreDrainScheduler(
+            queue: pendingStoreDrainQueue ?? DispatchQueue(
+                label: "com.brainlayer.brainbar.pending-store-drain",
+                qos: .utility
+            )
+        )
         self.backupWriterStartedAtUnix = backupWriterStartedAtUnix
     }
 
@@ -300,20 +312,26 @@ final class MCPRouter: @unchecked Sendable {
         // The snapshot takes the cross-process queue LOCK_EX; a concurrent MCP
         // replay can hold it across DB writes, so never block the caller
         // (setDatabases runs on BrainBarServer.queue during initialization).
-        Self.pendingStoreDrainQueue.async { [weak db] in
-            guard let db else { return }
+        let scheduler = pendingStoreDrainScheduler
+        scheduler.queue.async { [weak scheduler, weak db] in
+            guard let scheduler, let db else { return }
             guard let snapshot = db.pendingStoreQueueSnapshotIfReadable() else { return }
             var scheduledAny = false
             for identity in snapshot.identityKeys where identity.hasPrefix("chunk:") {
                 scheduledAny = true
                 Self.schedulePendingStoreDrain(
+                    scheduler: scheduler,
                     db: db,
                     chunkID: String(identity.dropFirst("chunk:".count)),
                     delay: Self.pendingStoreDrainInitialDelay
                 )
             }
             if !scheduledAny && snapshot.depth > 0 {
-                Self.scheduleIdentitylessLegacyFlush(db: db, delay: Self.pendingStoreDrainInitialDelay)
+                Self.scheduleIdentitylessLegacyFlush(
+                    scheduler: scheduler,
+                    db: db,
+                    delay: Self.pendingStoreDrainInitialDelay
+                )
             }
         }
     }
@@ -321,19 +339,31 @@ final class MCPRouter: @unchecked Sendable {
     /// Legacy entries written by older builds may lack chunk_id and thus have no
     /// identity for the normal per-chunk drain; flush with capped-backoff retries
     /// until the queue empties so a busy DB at startup cannot strand them.
-    private static func scheduleIdentitylessLegacyFlush(db: BrainDatabase, delay: TimeInterval) {
-        pendingStoreDrainQueue.asyncAfter(deadline: .now() + delay) { [weak db] in
-            guard let db, db.isOpen else { return }
+    private static func scheduleIdentitylessLegacyFlush(
+        scheduler: PendingStoreDrainScheduler,
+        db: BrainDatabase,
+        delay: TimeInterval
+    ) {
+        scheduler.queue.asyncAfter(deadline: .now() + delay) { [weak scheduler, weak db] in
+            guard let scheduler, let db, db.isOpen else { return }
             _ = db.flushPendingStores(
                 busyTimeoutMillis: mcpStoreBusyTimeoutMillis,
                 retries: mcpStoreRetries
             )
             guard let after = db.pendingStoreQueueSnapshotIfReadable() else {
-                scheduleIdentitylessLegacyFlush(db: db, delay: min(delay * 2, 60))
+                scheduleIdentitylessLegacyFlush(
+                    scheduler: scheduler,
+                    db: db,
+                    delay: min(delay * 2, 60)
+                )
                 return
             }
             if after.depth > 0 {
-                scheduleIdentitylessLegacyFlush(db: db, delay: min(delay * 2, 60))
+                scheduleIdentitylessLegacyFlush(
+                    scheduler: scheduler,
+                    db: db,
+                    delay: min(delay * 2, 60)
+                )
             }
         }
     }
@@ -835,35 +865,50 @@ final class MCPRouter: @unchecked Sendable {
 
     private func schedulePendingStoreDrain(db: BrainDatabase, chunkID: String) {
         Self.schedulePendingStoreDrain(
+            scheduler: pendingStoreDrainScheduler,
             db: db,
             chunkID: chunkID,
             delay: Self.pendingStoreDrainInitialDelay
         )
     }
 
-    private static func schedulePendingStoreDrain(db: BrainDatabase, chunkID: String, delay: TimeInterval) {
+    private static func schedulePendingStoreDrain(
+        scheduler: PendingStoreDrainScheduler,
+        db: BrainDatabase,
+        chunkID: String,
+        delay: TimeInterval
+    ) {
         let drainKey = "\(ObjectIdentifier(db).hashValue):\(chunkID)"
-        guard pendingStoreDrainRegistry.insert(drainKey) else { return }
+        guard scheduler.registry.insert(drainKey) else { return }
 
-        pendingStoreDrainQueue.asyncAfter(deadline: .now() + delay) {
-            drainPendingStoreTarget(db: db, chunkID: chunkID, drainKey: drainKey, delay: delay)
+        scheduler.queue.asyncAfter(deadline: .now() + delay) { [weak scheduler, weak db] in
+            guard let scheduler, let db else { return }
+            drainPendingStoreTarget(
+                scheduler: scheduler,
+                db: db,
+                chunkID: chunkID,
+                drainKey: drainKey,
+                delay: delay
+            )
         }
     }
 
     private static func drainPendingStoreTarget(
+        scheduler: PendingStoreDrainScheduler,
         db: BrainDatabase,
         chunkID: String,
         drainKey: String,
         delay: TimeInterval
     ) {
         guard db.isOpen else {
-            finishPendingStoreDrain(drainKey)
+            finishPendingStoreDrain(scheduler: scheduler, drainKey: drainKey)
             return
         }
 
         let targetIdentity = "chunk:\(chunkID)"
         guard let before = db.pendingStoreQueueSnapshotIfReadable() else {
             reschedulePendingStoreDrain(
+                scheduler: scheduler,
                 db: db,
                 chunkID: chunkID,
                 drainKey: drainKey,
@@ -873,7 +918,7 @@ final class MCPRouter: @unchecked Sendable {
             return
         }
         guard before.identityKeys.contains(targetIdentity) else {
-            finishPendingStoreDrain(drainKey)
+            finishPendingStoreDrain(scheduler: scheduler, drainKey: drainKey)
             return
         }
 
@@ -883,6 +928,7 @@ final class MCPRouter: @unchecked Sendable {
         )
         guard let after = db.pendingStoreQueueSnapshotIfReadable() else {
             reschedulePendingStoreDrain(
+                scheduler: scheduler,
                 db: db,
                 chunkID: chunkID,
                 drainKey: drainKey,
@@ -892,11 +938,12 @@ final class MCPRouter: @unchecked Sendable {
             return
         }
         guard after.identityKeys.contains(targetIdentity) else {
-            finishPendingStoreDrain(drainKey)
+            finishPendingStoreDrain(scheduler: scheduler, drainKey: drainKey)
             return
         }
 
         reschedulePendingStoreDrain(
+            scheduler: scheduler,
             db: db,
             chunkID: chunkID,
             drainKey: drainKey,
@@ -906,6 +953,7 @@ final class MCPRouter: @unchecked Sendable {
     }
 
     private static func reschedulePendingStoreDrain(
+        scheduler: PendingStoreDrainScheduler,
         db: BrainDatabase,
         chunkID: String,
         drainKey: String,
@@ -915,13 +963,23 @@ final class MCPRouter: @unchecked Sendable {
         let nextDelay = flushedAny
             ? pendingStoreDrainInitialDelay
             : min(pendingStoreDrainMaxDelay, max(pendingStoreDrainInitialDelay, delay * 2.0))
-        pendingStoreDrainQueue.asyncAfter(deadline: .now() + nextDelay) {
-            drainPendingStoreTarget(db: db, chunkID: chunkID, drainKey: drainKey, delay: nextDelay)
+        scheduler.queue.asyncAfter(deadline: .now() + nextDelay) { [weak scheduler, weak db] in
+            guard let scheduler, let db else { return }
+            drainPendingStoreTarget(
+                scheduler: scheduler,
+                db: db,
+                chunkID: chunkID,
+                drainKey: drainKey,
+                delay: nextDelay
+            )
         }
     }
 
-    private static func finishPendingStoreDrain(_ drainKey: String) {
-        pendingStoreDrainRegistry.remove(drainKey)
+    private static func finishPendingStoreDrain(
+        scheduler: PendingStoreDrainScheduler,
+        drainKey: String
+    ) {
+        scheduler.registry.remove(drainKey)
     }
 
     private func queueBrainStore(

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -298,12 +298,28 @@ final class MCPRouter: @unchecked Sendable {
     /// happens to run. Schedule their drains as soon as a write handle exists.
     private func scheduleDrainForExistingPendingStores(db: BrainDatabase) {
         guard let snapshot = db.pendingStoreQueueSnapshotIfReadable() else { return }
+        var scheduledAny = false
         for identity in snapshot.identityKeys where identity.hasPrefix("chunk:") {
+            scheduledAny = true
             Self.schedulePendingStoreDrain(
                 db: db,
                 chunkID: String(identity.dropFirst("chunk:".count)),
                 delay: Self.pendingStoreDrainInitialDelay
             )
+        }
+        // Legacy entries written by older builds may lack chunk_id and thus
+        // contribute no identity keys; flush them directly so an upgrade does
+        // not strand acknowledged stores.
+        if !scheduledAny && snapshot.depth > 0 {
+            Self.pendingStoreDrainQueue.asyncAfter(
+                deadline: .now() + Self.pendingStoreDrainInitialDelay
+            ) { [weak db] in
+                guard let db, db.isOpen else { return }
+                _ = db.flushPendingStores(
+                    busyTimeoutMillis: Self.mcpStoreBusyTimeoutMillis,
+                    retries: Self.mcpStoreRetries
+                )
+            }
         }
     }
 

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -25,7 +25,7 @@ final class MCPRouter: @unchecked Sendable {
     ]
     private static let coreToolDescriptions: [String: String] = [
         "brain_search": "Search memory.",
-        "brain_store": "Store memory. A DEFERRED result is success (durably queued, auto-persisted) - never re-store.",
+        "brain_store": "Store memory; DEFERRED = stored.",
         "brain_recall": "Recall context.",
         "brain_expand": "Expand chunk.",
     ]
@@ -297,28 +297,43 @@ final class MCPRouter: @unchecked Sendable {
     /// have no drain scheduled; without this, they persist only if a later store
     /// happens to run. Schedule their drains as soon as a write handle exists.
     private func scheduleDrainForExistingPendingStores(db: BrainDatabase) {
-        guard let snapshot = db.pendingStoreQueueSnapshotIfReadable() else { return }
-        var scheduledAny = false
-        for identity in snapshot.identityKeys where identity.hasPrefix("chunk:") {
-            scheduledAny = true
-            Self.schedulePendingStoreDrain(
-                db: db,
-                chunkID: String(identity.dropFirst("chunk:".count)),
-                delay: Self.pendingStoreDrainInitialDelay
-            )
-        }
-        // Legacy entries written by older builds may lack chunk_id and thus
-        // contribute no identity keys; flush them directly so an upgrade does
-        // not strand acknowledged stores.
-        if !scheduledAny && snapshot.depth > 0 {
-            Self.pendingStoreDrainQueue.asyncAfter(
-                deadline: .now() + Self.pendingStoreDrainInitialDelay
-            ) { [weak db] in
-                guard let db, db.isOpen else { return }
-                _ = db.flushPendingStores(
-                    busyTimeoutMillis: Self.mcpStoreBusyTimeoutMillis,
-                    retries: Self.mcpStoreRetries
+        // The snapshot takes the cross-process queue LOCK_EX; a concurrent MCP
+        // replay can hold it across DB writes, so never block the caller
+        // (setDatabases runs on BrainBarServer.queue during initialization).
+        Self.pendingStoreDrainQueue.async { [weak db] in
+            guard let db else { return }
+            guard let snapshot = db.pendingStoreQueueSnapshotIfReadable() else { return }
+            var scheduledAny = false
+            for identity in snapshot.identityKeys where identity.hasPrefix("chunk:") {
+                scheduledAny = true
+                Self.schedulePendingStoreDrain(
+                    db: db,
+                    chunkID: String(identity.dropFirst("chunk:".count)),
+                    delay: Self.pendingStoreDrainInitialDelay
                 )
+            }
+            if !scheduledAny && snapshot.depth > 0 {
+                Self.scheduleIdentitylessLegacyFlush(db: db, delay: Self.pendingStoreDrainInitialDelay)
+            }
+        }
+    }
+
+    /// Legacy entries written by older builds may lack chunk_id and thus have no
+    /// identity for the normal per-chunk drain; flush with capped-backoff retries
+    /// until the queue empties so a busy DB at startup cannot strand them.
+    private static func scheduleIdentitylessLegacyFlush(db: BrainDatabase, delay: TimeInterval) {
+        pendingStoreDrainQueue.asyncAfter(deadline: .now() + delay) { [weak db] in
+            guard let db, db.isOpen else { return }
+            _ = db.flushPendingStores(
+                busyTimeoutMillis: mcpStoreBusyTimeoutMillis,
+                retries: mcpStoreRetries
+            )
+            guard let after = db.pendingStoreQueueSnapshotIfReadable() else {
+                scheduleIdentitylessLegacyFlush(db: db, delay: min(delay * 2, 60))
+                return
+            }
+            if after.depth > 0 {
+                scheduleIdentitylessLegacyFlush(db: db, delay: min(delay * 2, 60))
             }
         }
     }

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -25,7 +25,7 @@ final class MCPRouter: @unchecked Sendable {
     ]
     private static let coreToolDescriptions: [String: String] = [
         "brain_search": "Search memory.",
-        "brain_store": "Store memory.",
+        "brain_store": "Store memory. A DEFERRED result is success (durably queued, auto-persisted) - never re-store.",
         "brain_recall": "Recall context.",
         "brain_expand": "Expand chunk.",
     ]
@@ -290,6 +290,21 @@ final class MCPRouter: @unchecked Sendable {
         readDatabase = readDB
         entityCache.load(from: readDB.dbHandle)
         entityCache.startRefreshTimer(db: readDB.dbHandle)
+        scheduleDrainForExistingPendingStores(db: writeDB)
+    }
+
+    /// Stores acknowledged before the database was injected (DB_NOT_OPEN queue path)
+    /// have no drain scheduled; without this, they persist only if a later store
+    /// happens to run. Schedule their drains as soon as a write handle exists.
+    private func scheduleDrainForExistingPendingStores(db: BrainDatabase) {
+        guard let snapshot = db.pendingStoreQueueSnapshotIfReadable() else { return }
+        for identity in snapshot.identityKeys where identity.hasPrefix("chunk:") {
+            Self.schedulePendingStoreDrain(
+                db: db,
+                chunkID: String(identity.dropFirst("chunk:".count)),
+                delay: Self.pendingStoreDrainInitialDelay
+            )
+        }
     }
 
     private func readDB() throws -> BrainDatabase {
@@ -918,7 +933,7 @@ final class MCPRouter: @unchecked Sendable {
     ) -> ToolOutput {
         let action = Self.deferredQueueAction(for: queuePath)
         return ToolOutput(
-            text: Formatters.formatStoreResult(chunkId: chunkID, queued: true, useColor: false),
+            text: Formatters.formatStoreResult(chunkId: chunkID, queued: true, queuedReason: reason, useColor: false),
             metadata: [
                 "queued": true,
                 "status": "DEFERRED",

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -1532,7 +1532,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_store",
-            "description": "Save a decision, learning, mistake, idea, or todo to durable memory so future sessions can retrieve it with brain_search. Returns the new chunk_id. Add tags, importance (1-10), and project to improve later retrieval. For digesting long raw text use brain_digest instead.",
+            "description": "Save a decision, learning, mistake, idea, or todo to durable memory so future sessions can retrieve it with brain_search. Returns the new chunk_id. Add tags, importance (1-10), and project to improve later retrieval. A STORED (deferred) result is SUCCESS: the memory is durably queued while the DB is busy and the drain persists it automatically \u{2014} never call brain_store again for it and never save a fallback copy. For digesting long raw text use brain_digest instead.",
             "annotations": MCPRouter.writeAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",

--- a/brain-bar/Tests/BrainBarTests/FormattersTests.swift
+++ b/brain-bar/Tests/BrainBarTests/FormattersTests.swift
@@ -106,7 +106,8 @@ final class FormattersTests: XCTestCase {
         XCTAssertTrue(out.contains("DEFERRED"))
         XCTAssertEqual(
             out,
-            "\u{2502} DEFERRED: Memory queued (DB busy) \u{2192} brainbar-queued123 \u{2500} drain will persist it."
+            "\u{2502} \u{2714} STORED (deferred): DB busy \u{2192} brainbar-queued123 \u{2500} durably queued; "
+                + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         )
         XCTAssertFalse(out.contains("\u{1b}["))
     }

--- a/brain-bar/Tests/BrainBarTests/FormattersTests.swift
+++ b/brain-bar/Tests/BrainBarTests/FormattersTests.swift
@@ -103,7 +103,7 @@ final class FormattersTests: XCTestCase {
     func testFormatStoreResultQueued() {
         let out = Formatters.formatStoreResult(chunkId: "brainbar-queued123", queued: true, useColor: false)
         XCTAssertTrue(out.contains("queued"))
-        XCTAssertTrue(out.contains("DEFERRED"))
+        XCTAssertTrue(out.contains("deferred"))
         XCTAssertEqual(
             out,
             "\u{2502} \u{2714} STORED (deferred): DB busy \u{2192} brainbar-queued123 \u{2500} durably queued; "

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -2526,6 +2526,54 @@ No results found.
         XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path))
     }
 
+    func testStartupDrainRetriesAfterTransientQueueReadFailure() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let queuePath = tempDir.appendingPathComponent("pending-stores.jsonl")
+        let restoreQueuePath = setPendingStoreQueuePath(queuePath)
+        defer { restoreQueuePath() }
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+        _ = try db.queuePendingStore(
+            content: "Startup drain survives one unreadable pending store queue snapshot",
+            tags: ["startup-retry"],
+            importance: 7,
+            source: "mcp",
+            chunkID: "brainbar-startup-retry"
+        )
+        let queuedText = try String(contentsOf: queuePath, encoding: .utf8)
+
+        try FileManager.default.removeItem(at: queuePath)
+        try FileManager.default.createDirectory(at: queuePath, withIntermediateDirectories: false)
+
+        let startupDrainQueue = DispatchQueue(label: "test.pending-store-startup-retry")
+        let router = MCPRouter(profile: "full", pendingStoreDrainQueue: startupDrainQueue)
+        router.setDatabase(db)
+        startupDrainQueue.sync {}
+
+        try FileManager.default.removeItem(at: queuePath)
+        try queuedText.write(to: queuePath, atomically: true, encoding: .utf8)
+
+        let deadline = Date().addingTimeInterval(2.0)
+        var storedContents: [String] = []
+        while Date() < deadline {
+            storedContents = (try? chunkContents(path: dbPath)) ?? []
+            if storedContents.contains("Startup drain survives one unreadable pending store queue snapshot") {
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+
+        XCTAssertTrue(
+            storedContents.contains("Startup drain survives one unreadable pending store queue snapshot"),
+            "startup drain should retry when its first pending-store queue snapshot is unreadable"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path))
+    }
+
     func testDeferredBrainStoreDrainIsNotBlockedByAnotherRouterScheduler() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -2132,6 +2132,7 @@ No results found.
 
         let dbPath = tempDir.appendingPathComponent("brainbar.db").path
         let router = MCPRouter(profile: "full", dbPath: dbPath)
+        defer { withExtendedLifetime(router) {} }
 
         let response = router.handle([
             "jsonrpc": "2.0",
@@ -2482,6 +2483,7 @@ No results found.
         db.failNextStoreWithBusyForTesting = true
 
         let router = MCPRouter(profile: "full")
+        defer { withExtendedLifetime(router) {} }
         router.setDatabase(db)
 
         let queuedContent = "Queued current write survives one unreadable pending store queue snapshot"
@@ -2551,6 +2553,7 @@ No results found.
 
         let startupDrainQueue = DispatchQueue(label: "test.pending-store-startup-retry")
         let router = MCPRouter(profile: "full", pendingStoreDrainQueue: startupDrainQueue)
+        defer { withExtendedLifetime(router) {} }
         router.setDatabase(db)
         startupDrainQueue.sync {}
 
@@ -2591,6 +2594,7 @@ No results found.
         let blockedDB = BrainDatabase(path: tempDir.appendingPathComponent("blocked.db").path)
         defer { blockedDB.close() }
         let blockedRouter = MCPRouter(profile: "full", pendingStoreDrainQueue: blockedDrainQueue)
+        defer { withExtendedLifetime(blockedRouter) {} }
         blockedRouter.setDatabase(blockedDB)
 
         let drainingQueuePath = tempDir.appendingPathComponent("draining-pending-stores.jsonl")
@@ -2608,6 +2612,7 @@ No results found.
         )
 
         let drainingRouter = MCPRouter(profile: "full")
+        defer { withExtendedLifetime(drainingRouter) {} }
         drainingRouter.setDatabase(drainingDB)
 
         let deadline = Date().addingTimeInterval(1.5)

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -2114,7 +2114,7 @@ No results found.
         )
         XCTAssertEqual(
             text,
-            "\u{2502} \u{2714} STORED (deferred): DB busy \u{2192} \(chunkID) \u{2500} durably queued; "
+            "\u{2502} \u{2714} STORED (deferred): DB_NOT_OPEN \u{2192} \(chunkID) \u{2500} durably queued; "
                 + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         )
         XCTAssertFalse(text.contains("\u{1b}["))
@@ -2124,6 +2124,49 @@ No results found.
         XCTAssertEqual(queuedPayload["queue_id"] as? String, queueID)
         XCTAssertEqual(queuedPayload["queued_at"] as? String, queuedAt)
         XCTAssertEqual(queuedPayload["chunk_id"] as? String, chunkID)
+    }
+
+    func testPendingStoresDrainAfterDatabaseInjection() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let dbPath = tempDir.appendingPathComponent("brainbar.db").path
+        let router = MCPRouter(profile: "full", dbPath: dbPath)
+
+        let response = router.handle([
+            "jsonrpc": "2.0",
+            "id": 90,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_store",
+                "arguments": [
+                    "content": "Queued before injection must drain once the database opens",
+                    "tags": ["drain-on-injection"],
+                    "importance": 6
+                ] as [String: Any]
+            ] as [String: Any]
+        ])
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["queued"] as? Bool, true)
+        let chunkID = try XCTUnwrap(result["chunk_id"] as? String)
+
+        let db = BrainDatabase(path: dbPath)
+        defer { db.close() }
+        XCTAssertTrue(db.isOpen)
+        router.setDatabase(db)
+
+        let deadline = Date().addingTimeInterval(5)
+        var drained = false
+        while Date() < deadline {
+            if db.pendingStoreQueueSnapshot().depth == 0 {
+                drained = true
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        XCTAssertTrue(drained, "pending store queued before injection was never drained")
+        let results = try db.search(query: "Queued before injection must drain", limit: 5)
+        XCTAssertTrue(results.contains { ($0["chunk_id"] as? String) == chunkID })
     }
 
     func testBrainStoreQueuesWhenDatabaseHandleIsNotOpen() throws {
@@ -2171,7 +2214,7 @@ No results found.
         )
         XCTAssertEqual(
             text,
-            "\u{2502} \u{2714} STORED (deferred): DB busy \u{2192} \(chunkID) \u{2500} durably queued; "
+            "\u{2502} \u{2714} STORED (deferred): DB_NOT_OPEN \u{2192} \(chunkID) \u{2500} durably queued; "
                 + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         )
         XCTAssertFalse(text.contains("\u{1b}["))

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -2526,6 +2526,59 @@ No results found.
         XCTAssertFalse(FileManager.default.fileExists(atPath: queuePath.path))
     }
 
+    func testDeferredBrainStoreDrainIsNotBlockedByAnotherRouterScheduler() throws {
+        let tempDir = makeTempTestDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let blockedDrainQueue = DispatchQueue(label: "test.pending-store-drain.blocked")
+        let blockerStarted = expectation(description: "first router drain queue is blocked")
+        let releaseBlocker = DispatchSemaphore(value: 0)
+        blockedDrainQueue.async {
+            blockerStarted.fulfill()
+            releaseBlocker.wait()
+        }
+        wait(for: [blockerStarted], timeout: 1.0)
+        defer { releaseBlocker.signal() }
+
+        let blockedDB = BrainDatabase(path: tempDir.appendingPathComponent("blocked.db").path)
+        defer { blockedDB.close() }
+        let blockedRouter = MCPRouter(profile: "full", pendingStoreDrainQueue: blockedDrainQueue)
+        blockedRouter.setDatabase(blockedDB)
+
+        let drainingQueuePath = tempDir.appendingPathComponent("draining-pending-stores.jsonl")
+        let restoreDrainingQueuePath = setPendingStoreQueuePath(drainingQueuePath)
+        defer { restoreDrainingQueuePath() }
+
+        let drainingDBPath = tempDir.appendingPathComponent("draining.db").path
+        let drainingDB = BrainDatabase(path: drainingDBPath)
+        defer { drainingDB.close() }
+        _ = try drainingDB.queuePendingStore(
+            content: "A router drain must not wait behind another router's scheduler",
+            tags: ["drain-isolation"],
+            importance: 7,
+            source: "mcp"
+        )
+
+        let drainingRouter = MCPRouter(profile: "full")
+        drainingRouter.setDatabase(drainingDB)
+
+        let deadline = Date().addingTimeInterval(1.5)
+        var storedContents: [String] = []
+        while Date() < deadline {
+            storedContents = (try? chunkContents(path: drainingDBPath)) ?? []
+            if storedContents.contains("A router drain must not wait behind another router's scheduler") {
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+
+        XCTAssertTrue(
+            storedContents.contains("A router drain must not wait behind another router's scheduler"),
+            "one router's blocked queue scan must not stall another router's deferred-store drain"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: drainingQueuePath.path))
+    }
+
     func testBrainStoreFlushesPendingQueueAfterSuccessfulStore() throws {
         let tempDir = makeTempTestDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -2114,7 +2114,8 @@ No results found.
         )
         XCTAssertEqual(
             text,
-            "\u{2502} DEFERRED: Memory queued (DB busy) \u{2192} \(chunkID) \u{2500} drain will persist it."
+            "\u{2502} \u{2714} STORED (deferred): DB busy \u{2192} \(chunkID) \u{2500} durably queued; "
+                + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         )
         XCTAssertFalse(text.contains("\u{1b}["))
 
@@ -2170,7 +2171,8 @@ No results found.
         )
         XCTAssertEqual(
             text,
-            "\u{2502} DEFERRED: Memory queued (DB busy) \u{2192} \(chunkID) \u{2500} drain will persist it."
+            "\u{2502} \u{2714} STORED (deferred): DB busy \u{2192} \(chunkID) \u{2500} durably queued; "
+                + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         )
         XCTAssertFalse(text.contains("\u{1b}["))
 
@@ -2229,7 +2231,8 @@ No results found.
         )
         XCTAssertEqual(
             text,
-            "\u{2502} DEFERRED: Memory queued (DB busy) \u{2192} \(chunkID) \u{2500} drain will persist it."
+            "\u{2502} \u{2714} STORED (deferred): DB busy \u{2192} \(chunkID) \u{2500} durably queued; "
+                + "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         )
         XCTAssertFalse(text.contains("\u{1b}["))
         XCTAssertTrue(FileManager.default.fileExists(atPath: queuePath.path))

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -1800,6 +1800,15 @@ def serve():
 
     install_parent_death_watcher()
 
+    # A prior process may have died after acknowledging a legacy-fallback store
+    # but before its replay ran; re-arm the replay so that receipt stays true.
+    try:
+        from .store_handler import rearm_stranded_pending_stores
+
+        rearm_stranded_pending_stores()
+    except Exception:
+        logger.debug("Startup pending-store replay arming failed", exc_info=True)
+
     # Validate configuration at startup
     config_errors = validate_config()
     fatal = [e for e in config_errors if e["severity"] == "error"]

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -158,7 +158,10 @@ def format_recalled_context(query: str, chunks: list[dict]) -> str:
 def format_store_result(chunk_id: str, superseded: str | None = None, queued: bool = False) -> str:
     """Format store confirmation as a clean one-liner."""
     if queued:
-        return f"\u2502 DEFERRED: Memory queued (DB busy) \u2192 {chunk_id} \u2500 drain will persist it."
+        return (
+            f"\u2502 \u2714 STORED (deferred): DB busy \u2192 {chunk_id} \u2500 durably queued; "
+            "the drain persists it automatically. Do NOT re-store or save a fallback copy."
+        )
 
     parts = [f"\u2714 Stored \u2192 {chunk_id}"]
     if superseded:

--- a/src/brainlayer/mcp/_format.py
+++ b/src/brainlayer/mcp/_format.py
@@ -155,11 +155,17 @@ def format_recalled_context(query: str, chunks: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def format_store_result(chunk_id: str, superseded: str | None = None, queued: bool = False) -> str:
+def format_store_result(
+    chunk_id: str,
+    superseded: str | None = None,
+    queued: bool = False,
+    queued_reason: str = "DB_BUSY",
+) -> str:
     """Format store confirmation as a clean one-liner."""
     if queued:
+        reason_label = "DB busy" if queued_reason == "DB_BUSY" else queued_reason
         return (
-            f"\u2502 \u2714 STORED (deferred): DB busy \u2192 {chunk_id} \u2500 durably queued; "
+            f"\u2502 \u2714 STORED (deferred): {reason_label} \u2192 {chunk_id} \u2500 durably queued; "
             "the drain persists it automatically. Do NOT re-store or save a fallback copy."
         )
 

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -564,6 +564,8 @@ def _clear_hybrid_search_cache_if_loaded() -> None:
 
 def _deferred_store_receipt(chunk_id: str, queue_path, *, reason: str = "DB_BUSY") -> dict:
     action = "queued_for_replay" if str(queue_path).endswith("pending-stores.jsonl") else "queued_for_drain"
+    if action == "queued_for_replay":
+        _schedule_pending_store_replay()
     return {
         "chunk_id": chunk_id,
         "queued": True,
@@ -667,6 +669,47 @@ def _temporary_store_busy_timeout(conn, deadline: float):
         _set_connection_exec_trace(conn, original_exec_trace)
         _set_connection_busy_timeout(conn, original_busy_timeout_ms)
         _STORE_BUSY_TIMEOUT_LOCK.release()
+
+
+_pending_replay_lock = threading.Lock()
+_pending_replay_active = False
+
+
+def _schedule_pending_store_replay() -> None:
+    """The legacy pending-stores.jsonl fallback has no daemon watching it, but a
+    DEFERRED receipt promises automatic persistence — so schedule a bounded
+    background replay instead of waiting for an unrelated later store."""
+    global _pending_replay_active
+    with _pending_replay_lock:
+        if _pending_replay_active:
+            return
+        _pending_replay_active = True
+
+    def _replay() -> None:
+        global _pending_replay_active
+        try:
+            from ..paths import get_db_path
+            from ..runtime_store import open_writer_store
+
+            for delay in (2, 5, 15, 60, 180):
+                time.sleep(delay)
+                path = _get_pending_store_path()
+                if not path.exists() or path.stat().st_size == 0:
+                    return
+                store = None
+                try:
+                    store = open_writer_store(get_db_path())
+                    _flush_pending_stores(store, None)
+                except Exception:
+                    logger.debug("Deferred pending-store replay attempt failed", exc_info=True)
+                finally:
+                    if store is not None:
+                        store.close()
+        finally:
+            with _pending_replay_lock:
+                _pending_replay_active = False
+
+    threading.Thread(target=_replay, daemon=True).start()
 
 
 def _flush_pending_stores(store, embed_fn) -> int:
@@ -976,6 +1019,9 @@ async def _store(
         return _error_result(f"Validation error: {str(e)}")
     except Exception as e:
         if _is_lock_error(e):
+            from ..runtime_store import SchemaFingerprintMismatch
+
+            deferral_reason = "SCHEMA_FINGERPRINT_MISMATCH" if isinstance(e, SchemaFingerprintMismatch) else "DB_BUSY"
             queue_path = _queue_store(
                 {
                     "chunk_id": promised_chunk_id,
@@ -999,8 +1045,8 @@ async def _store(
                     "conversation_id": conversation_id,
                 }
             )
-            structured = _deferred_store_receipt(promised_chunk_id, queue_path)
-            formatted = format_store_result(promised_chunk_id, queued=True)
+            structured = _deferred_store_receipt(promised_chunk_id, queue_path, reason=deferral_reason)
+            formatted = format_store_result(promised_chunk_id, queued=True, queued_reason=deferral_reason)
             return (
                 [TextContent(type="text", text=formatted)],
                 structured,

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -487,7 +487,7 @@ def _pending_store_lock_path(path):
 def _queue_store(item: dict):
     """Buffer a store request to JSONL when DB is locked.
 
-    Enforces _QUEUE_MAX_SIZE: if the file exceeds the limit, oldest lines
+    _QUEUE_MAX_SIZE is a soft warning threshold only; acknowledged lines
     are dropped to make room.
     """
     item = dict(item)
@@ -507,20 +507,21 @@ def _queue_store(item: dict):
             f.flush()
             _fsync(f.fileno())
 
-        # Enforce max size — read, trim oldest, atomic rewrite via tempfile
+        # Never trim: every line here was acknowledged with a durably-queued
+        # receipt that forbade the caller keeping a fallback copy, so dropping
+        # the oldest silently deletes an accepted memory. Depth is bounded by
+        # outage length and the replay empties the file once writes recover;
+        # past _QUEUE_MAX_SIZE we only warn.
         try:
             lines = path.read_text().strip().splitlines()
             if len(lines) > _QUEUE_MAX_SIZE:
-                trimmed = lines[-_QUEUE_MAX_SIZE:]
-                _atomic_rewrite_pending_store(path, trimmed)
                 logger.warning(
-                    "Pending store queue trimmed: %d -> %d (dropped %d oldest)",
+                    "Pending store queue depth %d exceeds soft limit %d; retaining all acknowledged entries",
                     len(lines),
                     _QUEUE_MAX_SIZE,
-                    len(lines) - _QUEUE_MAX_SIZE,
                 )
         except Exception:
-            logger.debug("Queue trim failed (non-critical)", exc_info=True)
+            logger.debug("Queue depth check failed (non-critical)", exc_info=True)
     return path
 
 

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -676,11 +676,24 @@ _pending_replay_lock = threading.Lock()
 _pending_replay_active = False
 
 
+def _pending_store_has_data(path) -> bool:
+    """Inspect the legacy replay queue under its writer lock.
+
+    Another process may flush and unlink the file between probes; absence means
+    there is currently nothing to replay, not that the recovery thread failed.
+    """
+    with _pending_store_file_lock(path):
+        try:
+            return path.stat().st_size > 0
+        except FileNotFoundError:
+            return False
+
+
 def rearm_stranded_pending_stores() -> bool:
     """Re-arm the legacy replay if a prior process died with pending-stores.jsonl
     non-empty after acknowledging the write. Returns True when a replay was armed."""
     path = _get_pending_store_path()
-    if path.exists() and path.stat().st_size > 0:
+    if _pending_store_has_data(path):
         _schedule_pending_store_replay()
         return True
     return False
@@ -709,7 +722,7 @@ def _schedule_pending_store_replay() -> None:
                 time.sleep(delay)
                 delay = min(delay * 2, 180.0)
                 path = _get_pending_store_path()
-                if not path.exists() or path.stat().st_size == 0:
+                if not _pending_store_has_data(path):
                     break
                 store = None
                 try:
@@ -726,7 +739,7 @@ def _schedule_pending_store_replay() -> None:
         # A concurrent fallback may append between our last empty check and the
         # flag clear above; re-arm rather than strand that write.
         path = _get_pending_store_path()
-        if path.exists() and path.stat().st_size > 0:
+        if _pending_store_has_data(path):
             _schedule_pending_store_replay()
 
     threading.Thread(target=_replay, daemon=True).start()

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -862,7 +862,15 @@ async def _store(
             )
             _clear_hybrid_search_cache_if_loaded()
             structured = _deferred_store_receipt(promised_chunk_id, queue_path, reason=queue_reason)
-            return ([TextContent(type="text", text=format_store_result(promised_chunk_id, queued=True))], structured)
+            return (
+                [
+                    TextContent(
+                        type="text",
+                        text=format_store_result(promised_chunk_id, queued=True, queued_reason=queue_reason),
+                    )
+                ],
+                structured,
+            )
 
         from ..store import embed_hot_chunk, embed_pending_chunks, store_memory
         from ..vector_store import temporary_write_busy_timeout_ms

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -691,11 +691,15 @@ def _schedule_pending_store_replay() -> None:
             from ..paths import get_db_path
             from ..runtime_store import open_writer_store
 
-            for delay in (2, 5, 15, 60, 180):
+            # Retry until the file empties: a fixed window would re-strand the
+            # queue behind a persistent schema mismatch or long enrichment hold.
+            delay = 2.0
+            while True:
                 time.sleep(delay)
+                delay = min(delay * 2, 180.0)
                 path = _get_pending_store_path()
                 if not path.exists() or path.stat().st_size == 0:
-                    return
+                    break
                 store = None
                 try:
                     store = open_writer_store(get_db_path())
@@ -708,6 +712,11 @@ def _schedule_pending_store_replay() -> None:
         finally:
             with _pending_replay_lock:
                 _pending_replay_active = False
+        # A concurrent fallback may append between our last empty check and the
+        # flag clear above; re-arm rather than strand that write.
+        path = _get_pending_store_path()
+        if path.exists() and path.stat().st_size > 0:
+            _schedule_pending_store_replay()
 
     threading.Thread(target=_replay, daemon=True).start()
 

--- a/src/brainlayer/mcp/store_handler.py
+++ b/src/brainlayer/mcp/store_handler.py
@@ -675,6 +675,16 @@ _pending_replay_lock = threading.Lock()
 _pending_replay_active = False
 
 
+def rearm_stranded_pending_stores() -> bool:
+    """Re-arm the legacy replay if a prior process died with pending-stores.jsonl
+    non-empty after acknowledging the write. Returns True when a replay was armed."""
+    path = _get_pending_store_path()
+    if path.exists() and path.stat().st_size > 0:
+        _schedule_pending_store_replay()
+        return True
+    return False
+
+
 def _schedule_pending_store_replay() -> None:
     """The legacy pending-stores.jsonl fallback has no daemon watching it, but a
     DEFERRED receipt promises automatic persistence — so schedule a bounded

--- a/tests/test_mcp_deferred_message.py
+++ b/tests/test_mcp_deferred_message.py
@@ -66,6 +66,33 @@ def test_startup_rearms_replay_when_legacy_queue_nonempty(monkeypatch, tmp_path)
     assert calls == [True]
 
 
+def test_startup_replay_probe_tolerates_concurrent_queue_unlink(monkeypatch, tmp_path) -> None:
+    """A queue removed between existence and size probes must not kill replay recovery."""
+    from contextlib import nullcontext
+
+    from brainlayer.mcp import store_handler
+
+    class UnlinkedPendingStorePath:
+        parent = tmp_path
+        name = "pending-stores.jsonl"
+
+        @staticmethod
+        def exists() -> bool:
+            return True
+
+        @staticmethod
+        def stat():
+            raise FileNotFoundError("concurrent replay removed pending-stores.jsonl")
+
+    calls = []
+    monkeypatch.setattr(store_handler, "_get_pending_store_path", UnlinkedPendingStorePath)
+    monkeypatch.setattr(store_handler, "_pending_store_file_lock", lambda _path: nullcontext())
+    monkeypatch.setattr(store_handler, "_schedule_pending_store_replay", lambda: calls.append(True))
+
+    assert store_handler.rearm_stranded_pending_stores() is False
+    assert calls == []
+
+
 def test_queue_store_never_trims_acknowledged_entries(monkeypatch, tmp_path) -> None:
     """Acknowledged durably-queued stores must never be silently dropped (codex round 5)."""
     import json as _json

--- a/tests/test_mcp_deferred_message.py
+++ b/tests/test_mcp_deferred_message.py
@@ -25,3 +25,24 @@ def test_deferred_store_receipt_carries_non_busy_reason() -> None:
 def test_non_queued_store_receipt_unchanged() -> None:
     msg = format_store_result("brainbar-abc123")
     assert msg == "✔ Stored → brainbar-abc123"
+
+
+def test_deferred_receipt_for_legacy_queue_schedules_replay(monkeypatch, tmp_path) -> None:
+    """A queued_for_replay receipt must arm the background replay (codex P1, PR #693)."""
+    from brainlayer.mcp import store_handler
+
+    calls = []
+    monkeypatch.setattr(store_handler, "_schedule_pending_store_replay", lambda: calls.append(True))
+
+    store_handler._deferred_store_receipt("c1", tmp_path / "pending-stores.jsonl")
+    assert calls == [True]
+
+    store_handler._deferred_store_receipt("c2", tmp_path / "mcp-123.jsonl")
+    assert calls == [True]  # drain-daemon path must NOT arm the replay
+
+
+def test_schema_mismatch_deferral_names_its_reason(tmp_path) -> None:
+    """Schema-fingerprint deferrals must not claim DB busy (codex P2, PR #693)."""
+    msg = format_store_result("brainbar-x", queued=True, queued_reason="SCHEMA_FINGERPRINT_MISMATCH")
+    assert "STORED (deferred): SCHEMA_FINGERPRINT_MISMATCH" in msg
+    assert "DB busy" not in msg

--- a/tests/test_mcp_deferred_message.py
+++ b/tests/test_mcp_deferred_message.py
@@ -6,12 +6,22 @@ from brainlayer.mcp._format import format_store_result
 def test_deferred_store_receipt_reads_as_success_and_forbids_restore() -> None:
     msg = format_store_result("brainbar-abc123", queued=True)
     assert "STORED (deferred)" in msg
+    assert "DB busy" in msg
     assert "brainbar-abc123" in msg
+    assert "durably queued" in msg
+    assert "the drain persists it automatically" in msg
     assert "Do NOT re-store" in msg
     assert "fallback copy" in msg
     assert "DEFERRED:" not in msg  # old failure-sounding prefix retired
 
 
+def test_deferred_store_receipt_carries_non_busy_reason() -> None:
+    msg = format_store_result("brainbar-abc123", queued=True, queued_reason="INTERACTIVE_PRIORITY")
+    assert "STORED (deferred): INTERACTIVE_PRIORITY" in msg
+    assert "DB busy" not in msg
+    assert "Do NOT re-store" in msg
+
+
 def test_non_queued_store_receipt_unchanged() -> None:
     msg = format_store_result("brainbar-abc123")
-    assert msg.startswith("✔ Stored → ")
+    assert msg == "✔ Stored → brainbar-abc123"

--- a/tests/test_mcp_deferred_message.py
+++ b/tests/test_mcp_deferred_message.py
@@ -64,3 +64,28 @@ def test_startup_rearms_replay_when_legacy_queue_nonempty(monkeypatch, tmp_path)
     stranded.write_text("")
     assert store_handler.rearm_stranded_pending_stores() is False
     assert calls == [True]
+
+
+def test_queue_store_never_trims_acknowledged_entries(monkeypatch, tmp_path) -> None:
+    """Acknowledged durably-queued stores must never be silently dropped (codex round 5)."""
+    import json as _json
+
+    from brainlayer.mcp import store_handler
+
+    path = tmp_path / "pending-stores.jsonl"
+    monkeypatch.setattr(store_handler, "_get_pending_store_path", lambda: path)
+    monkeypatch.setattr(store_handler, "_schedule_pending_store_replay", lambda: None)
+
+    def _fail_enqueue(**kwargs):
+        raise RuntimeError("unified queue unavailable")
+
+    import brainlayer.queue_io as queue_io
+
+    monkeypatch.setattr(queue_io, "enqueue_store", _fail_enqueue)
+
+    for i in range(store_handler._QUEUE_MAX_SIZE + 5):
+        store_handler._queue_store({"chunk_id": f"c{i}", "content": f"memory {i}"})
+
+    lines = path.read_text().strip().splitlines()
+    assert len(lines) == store_handler._QUEUE_MAX_SIZE + 5
+    assert _json.loads(lines[0])["chunk_id"] == "c0"  # oldest acknowledged entry survives

--- a/tests/test_mcp_deferred_message.py
+++ b/tests/test_mcp_deferred_message.py
@@ -1,0 +1,17 @@
+"""The DEFERRED store receipt must read as SUCCESS so agents stop re-storing (Etan, 2026-08-09)."""
+
+from brainlayer.mcp._format import format_store_result
+
+
+def test_deferred_store_receipt_reads_as_success_and_forbids_restore() -> None:
+    msg = format_store_result("brainbar-abc123", queued=True)
+    assert "STORED (deferred)" in msg
+    assert "brainbar-abc123" in msg
+    assert "Do NOT re-store" in msg
+    assert "fallback copy" in msg
+    assert "DEFERRED:" not in msg  # old failure-sounding prefix retired
+
+
+def test_non_queued_store_receipt_unchanged() -> None:
+    msg = format_store_result("brainbar-abc123")
+    assert msg.startswith("✔ Stored → ")

--- a/tests/test_mcp_deferred_message.py
+++ b/tests/test_mcp_deferred_message.py
@@ -46,3 +46,21 @@ def test_schema_mismatch_deferral_names_its_reason(tmp_path) -> None:
     msg = format_store_result("brainbar-x", queued=True, queued_reason="SCHEMA_FINGERPRINT_MISMATCH")
     assert "STORED (deferred): SCHEMA_FINGERPRINT_MISMATCH" in msg
     assert "DB busy" not in msg
+
+
+def test_startup_rearms_replay_when_legacy_queue_nonempty(monkeypatch, tmp_path) -> None:
+    """A stranded pending-stores.jsonl must re-arm replay at process start (codex round 4)."""
+    from brainlayer.mcp import store_handler
+
+    stranded = tmp_path / "pending-stores.jsonl"
+    stranded.write_text('{"chunk_id": "c1", "content": "x"}\n')
+    calls = []
+    monkeypatch.setattr(store_handler, "_get_pending_store_path", lambda: stranded)
+    monkeypatch.setattr(store_handler, "_schedule_pending_store_replay", lambda: calls.append(True))
+
+    assert store_handler.rearm_stranded_pending_stores() is True
+    assert calls == [True]
+
+    stranded.write_text("")
+    assert store_handler.rearm_stranded_pending_stores() is False
+    assert calls == [True]

--- a/tests/test_store_handler.py
+++ b/tests/test_store_handler.py
@@ -125,7 +125,7 @@ async def test_schema_fingerprint_mismatch_fails_closed_to_durable_queue(tmp_pat
     assert structured["queued"] is True
     assert structured["status"] == "DEFERRED"
     assert len(list(queue_dir.glob("mcp-*.jsonl"))) == 1
-    assert any("DEFERRED" in item.text for item in texts)
+    assert any("STORED (deferred)" in item.text for item in texts)
 
 
 @pytest.mark.asyncio
@@ -158,7 +158,7 @@ async def test_busy_queue_fallback_returns_loud_deferred_receipt(tmp_path):
     assert structured["deferred"]["queue_path"] == str(queued_files[0])
     assert structured["deferred"]["action"] == "queued_for_drain"
     assert queued_event["conversation_id"] == "mcp-server-session"
-    assert any("DEFERRED" in item.text for item in texts)
+    assert any("STORED (deferred)" in item.text for item in texts)
 
 
 @pytest.mark.asyncio
@@ -265,7 +265,7 @@ async def test_store_queues_within_bound_when_writer_pidfile_is_locked(tmp_path,
     assert structured["status"] == "DEFERRED"
     assert structured["deferred"]["action"] == "queued_for_drain"
     assert len(queued_files) == 1
-    assert any("DEFERRED" in item.text for item in texts)
+    assert any("STORED (deferred)" in item.text for item in texts)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Agents kept re-storing and writing local fallback files when brain_store returned `DEFERRED: Memory queued (DB busy)` — the receipt sounded like a failure (live specimen: maintenanceCodex today wrote a fallback decisions .md and set retry_attempted). #641 made deferred stores idempotent; this makes the words match the semantics.

**Changes**
- Receipt text (BrainBar Swift `Formatters.swift` + Python `mcp/_format.py`): now `✔ STORED (deferred): DB busy → <id> ─ durably queued; the drain persists it automatically. Do NOT re-store or save a fallback copy.`
- `brain_store` tool description (MCPRouter.swift): states a DEFERRED result is SUCCESS.
- Structured `status: "DEFERRED"` field unchanged (machine-readable contract intact — the retry-idempotency tests still pass unmodified).
- Tests: new `tests/test_mcp_deferred_message.py` contract test; updated 3 store-handler + 4 Swift assertion sites.

**Verification**: full pre-push gate green on push; Swift suite 853 tests, 0 unexpected failures; ruff clean.

**Deploy note (merged ≠ deployed)**: BrainBar must be rebuilt+restarted for the Swift path; the Python MCP server picks it up on next restart.

Tiny lead self-edit, disclosed in the wave25 collab. @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch durable-write semantics, queue retention, and async drain/replay across Swift and Python MCP paths; mis-scheduling could strand or duplicate stores, though coverage was expanded for injection, startup retry, and scheduler isolation.
> 
> **Overview**
> **Agents were re-storing and writing fallback files** because deferred `brain_store` text sounded like failure. Human-readable receipts in **BrainBar** (`Formatters.swift`) and **Python** (`mcp/_format.py`) now use **`✔ STORED (deferred): <reason>`**, propagate reasons like `DB_BUSY`, `DB_NOT_OPEN`, and `SCHEMA_FINGERPRINT_MISMATCH`, and tell callers **not to re-store or keep a fallback copy**. `brain_store` tool copy in `MCPRouter` matches that contract; structured `status: "DEFERRED"` is unchanged.
> 
> **Pending-store reliability** gets a parallel set of fixes. **Swift `MCPRouter`** gives each router its own drain scheduler (no shared static queue), and on **`setDatabases`** scans the queue to schedule drains for stores that queued before the DB opened, with backoff when snapshots are unreadable and a legacy flush for identity-less entries. **Python `store_handler`** stops trimming `pending-stores.jsonl` past the soft limit (acknowledged lines must not be dropped), arms **background replay** for the legacy queue path, and **`rearm_stranded_pending_stores()`** at MCP **`serve()`** startup.
> 
> Tests lock the new receipt strings and drain/replay behavior in Swift and Python.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03396fb080fd277e16849f4e8c05fbc0809ca652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix deferred `brain_store` receipts to read as success and add background replay drain
> - Deferred store receipts now return `✔ STORED (deferred): <reason>` instead of `DEFERRED: Memory queued (DB busy)`, signaling to callers that the write is durably queued and will be persisted automatically.
> - The deferral reason is now specific: `DB_BUSY` or `SCHEMA_FINGERPRINT_MISMATCH`, surfaced in both structured receipts and user-facing text via updated `format_store_result`/`Formatters.formatStoreResult`.
> - A background replay thread ([store_handler.py](https://github.com/EtanHey/brainlayer/pull/693/files#diff-14c0769c0c40037f9a767b04eeb81fc8ef4a2cd37a6f948089d10bdcc51c4263)) drains the legacy `pending-stores.jsonl` queue with exponential backoff until empty, self-rearming if new entries appear after it finishes.
> - Server startup now calls `rearm_stranded_pending_stores` to re-arm replay if the legacy queue has content from a previous session.
> - Pending-store drain scheduling in `MCPRouter` is moved from global static state to a per-router `PendingStoreDrainScheduler`, and drains are automatically armed when databases are injected via `setDatabases`.
> - Behavioral Change: queued entries in the legacy file are no longer trimmed when the soft limit is exceeded; depth is logged as a warning instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03396fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deferred storage confirmations now clearly indicate that items are durably queued while storage is unavailable.
  * Queue reasons, including temporary database unavailability and schema-related delays, are reported clearly.
  * Items are automatically persisted and replayed when storage becomes available, including after service restarts.
  * Added guidance not to retry storage or create duplicate fallback copies.
  * Standardized deferred status wording across storage responses.
  * Improved recovery of pending items while preserving acknowledged entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->