### PR TITLE
fix(hotlane): avoid MPS embed stalls

### DIFF
--- a/docs/plans/2026-08-09-hotlane-mps-stall-design.md
+++ b/docs/plans/2026-08-09-hotlane-mps-stall-design.md
@@ -1,0 +1,31 @@
+# Hotlane MPS Stall Recovery Design
+
+**Problem:** The hotlane reserves embedding slices but completes zero vectors because lazy model initialization selects MPS and blocks indefinitely while transferring model weights to Metal.
+
+## Evidence
+
+The live PID reached `_run_split_cycle()` and closed its read-only database connection before model initialization. A native sample then placed every main-thread observation in this chain:
+
+`SentenceTransformer(..., device="mps")` → `torch.nn.Module.to` → `mps_copy_` → `MPSStream::synchronize` → `-[MTLCommandBuffer waitUntilCompleted]`.
+
+The write path follows embedding, so a blocked device transfer prevents `_write_embedded_vectors()` from opening a connection or starting a vector transaction.
+
+## Options
+
+1. **Make hotlane CPU-only by default (selected).** Extend the shared embedding wrapper with an explicit device override, then have the hotlane request `cpu`. This isolates the reliability trade-off to a four-item background batch while preserving automatic MPS selection for all existing consumers.
+2. **Wrap MPS initialization in a Python timeout.** Rejected because the block is inside a native Metal synchronization call; a timer or worker thread cannot safely interrupt and recover the wedged process.
+3. **Run embedding in a supervised child process with MPS-to-CPU fallback.** Technically robust, but it adds IPC, lifecycle management, and expensive model reload behavior that is unnecessary for the current batch-four throughput requirement.
+
+## Design
+
+`EmbeddingModel` and `get_embedding_model()` accept an optional device override. `None` retains today's automatic `mps`/`cpu` choice; an explicit value is forwarded directly to `SentenceTransformer`. The singleton key includes the device so an explicit CPU wrapper cannot reuse an automatically selected MPS wrapper.
+
+The hotlane's `run()` requests `cpu` from device-aware factories. Test factories that intentionally expose only a zero-argument call remain supported through the existing signature-inspection pattern. The daemon does not attempt MPS first: avoiding the unrecoverable native wait is the safety property.
+
+## Verification
+
+- RED/GREEN unit test that the hotlane asks a device-aware model factory for `cpu` before any cycle.
+- Unit tests that explicit device selection bypasses automatic MPS probing and that the global wrapper cache distinguishes explicit CPU from automatic selection.
+- Existing hotlane and lazy-startup tests.
+- Full project test and lint gates.
+- After merge, kickstart the live LaunchAgent from the merged checkout and record a strictly increasing vector count for 15 consecutive one-minute samples.

--- a/docs/plans/2026-08-09-hotlane-mps-stall.md
+++ b/docs/plans/2026-08-09-hotlane-mps-stall.md
@@ -1,0 +1,45 @@
+# Hotlane MPS Stall Recovery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure hotlane backlog embedding cannot wedge in Metal initialization and resumes durable vector progress.
+
+**Architecture:** Add an explicit device override to the lazy shared embedding wrapper without changing its default behavior. Make only the hotlane request CPU, preserving deterministic progress for its small background batches while other consumers retain automatic device selection.
+
+**Tech Stack:** Python 3.13, sentence-transformers, PyTorch, pytest, Ruff.
+
+---
+
+### Task 1: Pin hotlane CPU selection
+
+**Files:**
+- Modify: `tests/test_hotlane_brainbar_daemon.py`
+- Modify: `scripts/hotlane_brainbar_daemon.py`
+
+1. Add a test whose device-aware model factory records the requested device and run zero daemon cycles.
+2. Run the focused test and confirm it fails because the factory receives no device.
+3. Add a small factory helper that passes `device="cpu"` when supported and preserves zero-argument test factories.
+4. Run the focused hotlane tests and confirm they pass.
+
+### Task 2: Support explicit embedding devices
+
+**Files:**
+- Create: `tests/test_embedding_device.py`
+- Modify: `src/brainlayer/embeddings.py`
+
+1. Add tests that explicit CPU selection is forwarded without probing MPS and that the wrapper cache separates automatic and explicit-device instances.
+2. Run the focused tests and confirm they fail on the missing API.
+3. Add the optional device field, explicit-device resolution, and device-aware singleton key.
+4. Run the focused embedding and hotlane tests and confirm they pass.
+
+### Task 3: Verify and integrate
+
+**Files:**
+- Verify all changed files and relevant runtime configuration.
+
+1. Run Ruff, focused tests, and the full pytest suite.
+2. Run the local CodeRabbit review with a bounded timeout and address real findings.
+3. Commit with the required agent trailer, push with changed-only pre-push scope, open the signed PR, and request Codex plus lead-routed Claude review.
+4. Address review findings, rerun gates, merge, and verify the merge contains the final head.
+5. Update the executing checkout, kickstart `com.brainlayer.hotlane-brainbar`, and poll both vector row-id counts once per minute until each has increased for 15 consecutive samples.
+6. Append the exact receipts to the wave25 collab and store the verified root cause and merged fix in BrainLayer.

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -38,6 +38,7 @@ LOGGER = logging.getLogger("brainlayer.hotlane_brainbar")
 STOP = False
 DEFAULT_HOTLANE_ENRICH_LIMIT = 5
 DEFAULT_BACKLOG_BATCH = 4
+DEFAULT_HOTLANE_EMBED_DEVICE = "cpu"
 MAX_BACKLOG_BATCH = 16
 DEFAULT_HOTLANE_WRITE_BUSY_TIMEOUT_MS = 1000
 MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
@@ -619,6 +620,12 @@ def _type_error_rejects_keyword(exc: TypeError, keyword: str) -> bool:
     )
 
 
+def _create_embedding_model(model_factory: Callable[..., object], *, device: str) -> object:
+    if _callable_accepts_keyword(model_factory, "device"):
+        return model_factory(device=device)
+    return model_factory()
+
+
 def _run_split_cycle(
     *,
     db_path: Path,
@@ -753,7 +760,8 @@ def run(
     enrich_limit: int,
     enrich_since_hours: int,
     vector_store_cls: Callable[[Path], VectorStore] = VectorStore,
-    model_factory: Callable[[], object] = get_embedding_model,
+    model_factory: Callable[..., object] = get_embedding_model,
+    embedding_device: str = DEFAULT_HOTLANE_EMBED_DEVICE,
     cycle_fn: Callable[..., CycleResult] = run_cycle,
     time_fn: Callable[[], float] = time.monotonic,
     sleep_fn: Callable[[float], None] = time.sleep,
@@ -762,7 +770,7 @@ def run(
     queue_depth_fn: Callable[[Path], int] = _queue_depth,
     high_priority_queue_depth_fn: Callable[[Path], int] = _high_priority_queue_depth,
 ) -> None:
-    model = model_factory()
+    model = _create_embedding_model(model_factory, device=embedding_device)
     embed_batch_fn = getattr(model, "embed_texts", None)
     if embed_batch_fn is not None:
 

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -606,9 +606,11 @@ def _callable_accepts_keyword(func: Callable[..., object], keyword: str) -> bool
         signature = inspect.signature(func)
     except (TypeError, ValueError):
         return True
-    return keyword in signature.parameters or any(
-        parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()
-    )
+    parameter = signature.parameters.get(keyword)
+    return (
+        parameter is not None
+        and parameter.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    ) or any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values())
 
 
 def _type_error_rejects_keyword(exc: TypeError, keyword: str) -> bool:

--- a/src/brainlayer/embeddings.py
+++ b/src/brainlayer/embeddings.py
@@ -137,16 +137,16 @@ class EmbeddingModel:
             raise RuntimeError(f"Failed to embed text batch: {e}") from e
 
 
-# Global model instance
-_embedding_model: Optional[EmbeddingModel] = None
+# Global model instances, keyed by model and requested device.
+_embedding_models: dict[tuple[str, str | None], EmbeddingModel] = {}
 
 
 def get_embedding_model(model_name: str = DEFAULT_MODEL, *, device: str | None = None) -> EmbeddingModel:
     """Get global embedding model instance."""
-    global _embedding_model
-    if _embedding_model is None or _embedding_model.model_name != model_name or _embedding_model.device != device:
-        _embedding_model = EmbeddingModel(model_name, device=device)
-    return _embedding_model
+    key = (model_name, device)
+    if key not in _embedding_models:
+        _embedding_models[key] = EmbeddingModel(model_name, device=device)
+    return _embedding_models[key]
 
 
 def embed_chunks(

--- a/src/brainlayer/embeddings.py
+++ b/src/brainlayer/embeddings.py
@@ -39,8 +39,9 @@ class EmbeddedChunk:
 class EmbeddingModel:
     """Sentence-transformers embedding model."""
 
-    def __init__(self, model_name: str = DEFAULT_MODEL):
+    def __init__(self, model_name: str = DEFAULT_MODEL, *, device: str | None = None):
         self.model_name = model_name
+        self.device = device
         self._model: Optional[SentenceTransformer] = None
 
     def _load_model(self) -> SentenceTransformer:
@@ -51,11 +52,14 @@ class EmbeddingModel:
         validation — never pays the ~3.7s torch import cost.
         """
         if self._model is None:
-            import torch
             from sentence_transformers import SentenceTransformer
 
-            logger.info(f"Loading embedding model: {self.model_name}")
-            device = "mps" if torch.backends.mps.is_available() else "cpu"
+            device = self.device
+            if device is None:
+                import torch
+
+                device = "mps" if torch.backends.mps.is_available() else "cpu"
+            logger.info("Loading embedding model: %s device=%s", self.model_name, device)
             self._model = SentenceTransformer(self.model_name, device=device)
         return self._model
 
@@ -137,11 +141,11 @@ class EmbeddingModel:
 _embedding_model: Optional[EmbeddingModel] = None
 
 
-def get_embedding_model(model_name: str = DEFAULT_MODEL) -> EmbeddingModel:
+def get_embedding_model(model_name: str = DEFAULT_MODEL, *, device: str | None = None) -> EmbeddingModel:
     """Get global embedding model instance."""
     global _embedding_model
-    if _embedding_model is None or _embedding_model.model_name != model_name:
-        _embedding_model = EmbeddingModel(model_name)
+    if _embedding_model is None or _embedding_model.model_name != model_name or _embedding_model.device != device:
+        _embedding_model = EmbeddingModel(model_name, device=device)
     return _embedding_model
 
 

--- a/tests/test_embedding_device.py
+++ b/tests/test_embedding_device.py
@@ -27,11 +27,13 @@ def test_embedding_model_forwards_explicit_device_without_mps_probe(monkeypatch)
 
 
 def test_get_embedding_model_cache_distinguishes_explicit_device(monkeypatch):
-    monkeypatch.setattr(embeddings, "_embedding_model", None)
+    monkeypatch.setattr(embeddings, "_embedding_models", {})
 
     automatic = embeddings.get_embedding_model()
     cpu = embeddings.get_embedding_model(device="cpu")
     same_cpu = embeddings.get_embedding_model(device="cpu")
+    same_automatic = embeddings.get_embedding_model()
 
     assert automatic is not cpu
     assert cpu is same_cpu
+    assert automatic is same_automatic

--- a/tests/test_embedding_device.py
+++ b/tests/test_embedding_device.py
@@ -1,0 +1,37 @@
+from types import ModuleType, SimpleNamespace
+
+from brainlayer import embeddings
+
+
+def test_embedding_model_forwards_explicit_device_without_mps_probe(monkeypatch):
+    constructor_calls = []
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_name, *, device):
+            constructor_calls.append((model_name, device))
+
+    fake_sentence_transformers = ModuleType("sentence_transformers")
+    fake_sentence_transformers.SentenceTransformer = FakeSentenceTransformer
+    fake_torch = SimpleNamespace(
+        backends=SimpleNamespace(
+            mps=SimpleNamespace(is_available=lambda: (_ for _ in ()).throw(AssertionError("MPS probe must not run")))
+        )
+    )
+    monkeypatch.setitem(__import__("sys").modules, "sentence_transformers", fake_sentence_transformers)
+    monkeypatch.setitem(__import__("sys").modules, "torch", fake_torch)
+
+    model = embeddings.EmbeddingModel(device="cpu")
+
+    assert model._load_model() is not None
+    assert constructor_calls == [(embeddings.DEFAULT_MODEL, "cpu")]
+
+
+def test_get_embedding_model_cache_distinguishes_explicit_device(monkeypatch):
+    monkeypatch.setattr(embeddings, "_embedding_model", None)
+
+    automatic = embeddings.get_embedding_model()
+    cpu = embeddings.get_embedding_model(device="cpu")
+    same_cpu = embeddings.get_embedding_model(device="cpu")
+
+    assert automatic is not cpu
+    assert cpu is same_cpu

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -855,6 +855,26 @@ def test_hotlane_run_requests_cpu_embedding_device_by_default():
     assert requested_devices == ["cpu"]
 
 
+def test_hotlane_run_preserves_positional_only_model_factory():
+    hotlane = _load_hotlane_module()
+
+    def positional_only_model_factory(device="cpu", /):
+        return SimpleNamespace(embed_query=lambda _text: [0.0])
+
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=0,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        model_factory=positional_only_model_factory,
+        max_cycles=0,
+    )
+
+
 def test_hotlane_run_disables_enrichment_after_daily_cap():
     hotlane = _load_hotlane_module()
     scheduled_enrich_limits = []

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -831,6 +831,30 @@ def test_hotlane_run_advances_enrich_timer_before_failed_cycle():
     assert scheduled_enrich_limits == [25, 0]
 
 
+def test_hotlane_run_requests_cpu_embedding_device_by_default():
+    hotlane = _load_hotlane_module()
+    requested_devices = []
+
+    def device_aware_model_factory(*, device=None):
+        requested_devices.append(device)
+        return SimpleNamespace(embed_query=lambda _text: [0.0])
+
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=0.25,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=0,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        model_factory=device_aware_model_factory,
+        max_cycles=0,
+    )
+
+    assert requested_devices == ["cpu"]
+
+
 def test_hotlane_run_disables_enrichment_after_daily_cap():
     hotlane = _load_hotlane_module()
     scheduled_enrich_limits = []


### PR DESCRIPTION
## Summary

- pin the production hotlane embedding model to CPU so native Metal initialization cannot wedge the daemon
- preserve automatic MPS/CPU selection for every other embedding caller
- key the lazy model cache by both model name and explicit device
- add regression tests for hotlane CPU selection, explicit-device forwarding, and cache isolation

## Root cause

The live daemon blocked while constructing `SentenceTransformer(..., device="mps")`. Every native sample placed the main thread in `torch.nn.Module.to` -> `mps_copy_` -> `MPSStream::synchronize` -> `-[MTLCommandBuffer waitUntilCompleted]`. Embedding precedes `_write_embedded_vectors()`, so the vector writer connection and transaction were never reached.

## Verification

- RED: 3 focused tests failed on the missing device contract
- GREEN: 50 focused tests passed
- Ruff check and format check passed
- managed pre-push gate: 3,906 passed, 10 skipped, 2 expected failures; MCP registration 3 passed; isolated routing 40 passed; Bun and FTS regression gates passed
- live deployment proof will follow after merge, per the goal contract

— brainlayerCodex (worker) · codex/unknown
<!-- golem-id v1 {"seat":"brainlayerCodex","role":"worker","harness":"codex","model":"unknown","model_source":"unavailable","session":"019fe777","ts":"2026-08-09T17:58:07Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hotlane writer path and shared embedding singleton caching; behavior for non-hotlane callers is unchanged, but incorrect device/cache semantics could affect embedding load site-wide.
> 
> **Overview**
> Fixes a production wedge where the hotlane daemon hung during lazy `SentenceTransformer` load on **MPS** (`mps_copy_` / Metal sync), so embeddings never reached vector writes.
> 
> **Hotlane** now defaults to **`cpu`** (`DEFAULT_HOTLANE_EMBED_DEVICE`) and builds the model through **`_create_embedding_model`**, passing `device=` only when the factory accepts that keyword (legacy zero-arg test factories still work). **`_callable_accepts_keyword`** is tightened so positional-only `device` parameters are not treated as keyword-capable.
> 
> **`EmbeddingModel` / `get_embedding_model`** gain an optional **`device`** override: `None` keeps automatic MPS/CPU probing; an explicit value is passed straight to `SentenceTransformer` without importing torch for MPS checks. The global cache is keyed by **`(model_name, device)`** so explicit CPU instances cannot reuse an auto-selected MPS singleton.
> 
> Adds regression tests for hotlane CPU selection, explicit-device forwarding, and cache isolation, plus design/implementation plan docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ccc699e85d9cb806e84ef1028d10ce6741b628c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hotlane MPS embed stalls by pinning embedding model to CPU
> - Adds an `embedding_device` parameter to `hotlane_brainbar_daemon.run()`, defaulting to `'cpu'`, so the hotlane embedding model is created on CPU rather than MPS.
> - Extends `EmbeddingModel` in [embeddings.py](https://github.com/EtanHey/brainlayer/pull/694/files#diff-a66c3335f636eacc8b2192acffc9d01b3443a146803c6dfc1ab4e441bcddfdc9) to accept an explicit `device`, bypassing the torch MPS probe when a device is specified.
> - Updates the singleton cache in `embeddings.py` from a single global to a dict keyed by `(model_name, device)`, supporting multiple device-specific instances.
> - Tightens `_callable_accepts_keyword` to only return `True` for genuinely keyword-accepting parameters, preventing accidental `device=` injection into positional-only factory signatures.
> - Behavioral Change: hotlane embedding models now default to CPU; MPS is no longer selected automatically for the hotlane path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ccc699.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->