### PR TITLE
fix(brainbar): allow scheduled backup under core profile

### DIFF
--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -23,6 +23,13 @@ final class MCPRouter: @unchecked Sendable {
         "brain_recall",
         "brain_expand",
     ]
+    // Scheduled backup is an internal socket client and must remain callable
+    // without relying on connection-local palette expansion state. Keep it out
+    // of the advertised core inventory while the stateless palette redesign is
+    // owned separately.
+    private static let profileIndependentCallToolNames: Set<String> = [
+        "brain_backup_vacuum_into",
+    ]
     private static let coreToolDescriptions: [String: String] = [
         "brain_search": "Search memory.",
         "brain_store": "Store memory; DEFERRED = stored.",
@@ -502,7 +509,8 @@ final class MCPRouter: @unchecked Sendable {
             return jsonRPCError(id: id, code: -32601, message: "Unknown tool: \(toolName)")
         }
 
-        guard isToolExposed(toolName, session: session) else {
+        guard isToolExposed(toolName, session: session)
+                || Self.profileIndependentCallToolNames.contains(toolName) else {
             let message = "Tool '\(toolName)' is gated by the core MCP profile. "
                 + "Call expand_palette, or set BRAINLAYER_MCP_PROFILE=full on the MCP server."
             return jsonRPCError(id: id, code: -32601, message: message)

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -23,10 +23,10 @@ final class MCPRouter: @unchecked Sendable {
         "brain_recall",
         "brain_expand",
     ]
-    // Scheduled backup is an internal socket client and must remain callable
-    // without relying on connection-local palette expansion state. Keep it out
-    // of the advertised core inventory while the stateless palette redesign is
-    // owned separately.
+    // BrainBar's Unix socket is owner-only (chmod 0600), which is the trust
+    // boundary for local callers including scheduled backup. Keep backup
+    // callable without connection-local palette state, but out of the
+    // advertised core inventory while the stateless redesign is owned elsewhere.
     private static let profileIndependentCallToolNames: Set<String> = [
         "brain_backup_vacuum_into",
     ]

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -184,6 +184,21 @@ final class MCPRouterTests: XCTestCase {
         )
     }
 
+    func testCoreProfileAllowsBackupVacuumCallWithoutPaletteExpansion() throws {
+        let router = MCPRouter(profile: "core")
+        let response = router.handle(
+            toolCall(
+                id: 20,
+                name: "brain_backup_vacuum_into",
+                arguments: ["target_path": "/tmp/brainlayer-profile-gate-test.db"]
+            )
+        )
+
+        XCTAssertNil(response["error"], "The scheduled backup path must not depend on palette session state")
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["isError"] as? Bool, true, "The unconfigured test router should reach the DB handler")
+    }
+
     func testEnvironmentProfileControlsDefaultRouter() throws {
         let environmentKey = "BRAINLAYER_MCP_PROFILE"
         let originalProfile = ProcessInfo.processInfo.environment[environmentKey]

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -285,11 +285,17 @@ final class SocketIntegrationTests: XCTestCase {
 
     func testBrainBackupVacuumIntoOverSocketCreatesRestorableSnapshot() throws {
         restartServer(profile: "core")
+        let socketAttributes = try FileManager.default.attributesOfItem(atPath: testSocketPath)
+        let socketPermissions = try XCTUnwrap(socketAttributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(socketPermissions.intValue & 0o777, 0o600, "The local MCP trust boundary must be owner-only")
+
         let targetPath = NSTemporaryDirectory() + "brainbar-backup-\(UUID().uuidString).db"
         let completionMarkerPath = targetPath + ".complete"
         defer { try? FileManager.default.removeItem(atPath: targetPath) }
         defer { try? FileManager.default.removeItem(atPath: completionMarkerPath) }
 
+        // Each helper call opens a fresh socket, matching the scheduled Python
+        // client and proving that the allowance is independent of session state.
         _ = try sendMCPRequest([
             "jsonrpc": "2.0", "id": 20, "method": "initialize",
             "params": ["protocolVersion": "2024-11-05", "capabilities": [:] as [String: Any],
@@ -299,7 +305,9 @@ final class SocketIntegrationTests: XCTestCase {
         let toolsResponse = try sendMCPRequest([
             "jsonrpc": "2.0", "id": 21, "method": "tools/list",
         ])
-        let listedTools = (toolsResponse["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
+        XCTAssertNil(toolsResponse["error"], "Core tools/list should succeed before checking its inventory")
+        let toolsResult = try XCTUnwrap(toolsResponse["result"] as? [String: Any])
+        let listedTools = try XCTUnwrap(toolsResult["tools"] as? [[String: Any]])
         XCTAssertFalse(
             listedTools.contains { ($0["name"] as? String) == "brain_backup_vacuum_into" },
             "The backup allowance must not expand the advertised core palette"

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -284,6 +284,7 @@ final class SocketIntegrationTests: XCTestCase {
     }
 
     func testBrainBackupVacuumIntoOverSocketCreatesRestorableSnapshot() throws {
+        restartServer(profile: "core")
         let targetPath = NSTemporaryDirectory() + "brainbar-backup-\(UUID().uuidString).db"
         let completionMarkerPath = targetPath + ".complete"
         defer { try? FileManager.default.removeItem(atPath: targetPath) }
@@ -294,6 +295,16 @@ final class SocketIntegrationTests: XCTestCase {
             "params": ["protocolVersion": "2024-11-05", "capabilities": [:] as [String: Any],
                        "clientInfo": ["name": "backup-test", "version": "1.0"]]
         ])
+
+        let toolsResponse = try sendMCPRequest([
+            "jsonrpc": "2.0", "id": 21, "method": "tools/list",
+        ])
+        let listedTools = (toolsResponse["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
+        XCTAssertFalse(
+            listedTools.contains { ($0["name"] as? String) == "brain_backup_vacuum_into" },
+            "The backup allowance must not expand the advertised core palette"
+        )
+
         _ = try sendMCPRequest([
             "jsonrpc": "2.0",
             "id": 21,


### PR DESCRIPTION
## Summary

- Allow the scheduled `brain_backup_vacuum_into` socket call under the core MCP profile without relying on connection-local palette expansion state.
- Keep the backup tool out of the core `tools/list` inventory; all other deferred tools remain gated.
- Cover both router-level dispatch and a restorable snapshot over a real Unix socket running the core profile.

## Root cause

BrainBar 1.5.3 activated call-time profile gating while the installed LaunchAgents continued to use the default core profile. The nightly Python backup opens a fresh socket request and calls the deferred backup tool directly, so the router rejected it before the database handler ran. Palette expansion is connection-local and therefore not a sound scheduled-client contract.

## Verification

- `swift test --package-path brain-bar`: 857 tests passed, 10 skipped.
- `pytest -q tests/test_backup_daily.py`: 40 passed.
- Scoped pre-push gate: passed (registration, isolated routing, Bun, and shell regression gates).
- Repository-wide Python run: 4,014 passed, 22 skipped, 9 xfailed; 3 unrelated live-DB failures and 31 live-eval provenance errors remain. No Python production code changed.

— brainlayer-worker-ygt7ve (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayer-worker-ygt7ve","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feaca","ts":"2026-08-10T09:04:22Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow exception for one local backup tool behind an owner-only socket; core inventory and gating for other tools are unchanged.
> 
> **Overview**
> Fixes nightly scheduled backups failing after **core MCP profile gating** started rejecting `brain_backup_vacuum_into` unless a connection had called `expand_palette`—state that fresh Python backup sockets never have.
> 
> `MCPRouter` now treats **`brain_backup_vacuum_into`** as **profile-independent for `tools/call` only**: it can be invoked under the core profile without palette expansion, while **`tools/list` under core still omits it** so the advertised palette stays unchanged. Other deferred tools remain gated.
> 
> Tests cover router dispatch without palette state and a core-profile Unix socket path (including that the tool is callable but not listed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa4df3ea1efa8d846e0c7c446c80dfdb72f085b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `brain_backup_vacuum_into` to be called under core profile without palette expansion
> - Adds a `profileIndependentCallToolNames` static set in [`MCPRouter`](https://github.com/EtanHey/brainlayer/pull/698/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f) containing `brain_backup_vacuum_into`, bypassing the normal palette-exposure check for that tool.
> - This lets owner-only Unix socket callers (e.g. scheduled backup processes) invoke the tool even when the core profile does not expose it in the palette.
> - Adds a unit test and a socket integration test confirming the tool is absent from the core palette's `tools/list` response but still callable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfa4df3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup vacuum operations can now be invoked directly under the core MCP profile, even when not listed among available tools.
  * Other profile-based tool access rules remain unchanged.

* **Tests**
  * Added coverage confirming direct invocation succeeds and reaches the database handler.
  * Updated integration checks to verify the tool remains hidden from tool listings while still being callable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->