### PR TITLE
chore(release): BrainLayer and BrainBar 1.5.4

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,11 +9,11 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.5.3</string>
+    <string>1.5.4</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.3</string>
+    <string>1.5.4</string>
     <key>BrainLayerReleaseVersion</key>
-    <string>1.5.3</string>
+    <string>1.5.4</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.5.3"
+version = "1.5.4"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"


### PR DESCRIPTION
## Summary

- Bump BrainLayer and BrainBar release metadata from 1.5.3 to 1.5.4.
- Cut the signed/notarized BrainBar artifact carrying deferred-store receipt wording from #693 and the core-profile scheduled-backup allowance from #698.
- Publish the corresponding Python package through the existing tag-triggered PyPI workflow.

## Verification

- Release/version/build guard tests: 51 passed.
- Full pre-push non-live unit gate with raised process file-descriptor limit: 3,920 passed, 10 skipped, 61 deselected, 2 xfailed.
- MCP registration: 3 passed.
- Isolated eval/routing: 40 passed.
- Bun and shell regression gates: passed.

## Post-merge release contract

- Tag merged main as `v1.5.4`.
- Require signed/notarized BrainBar release workflow and PyPI publish to pass.
- Update and install the Homebrew cask; verify the running socket daemon reports version 1.5.4 and the release commit.
- Run a real backup and verify `uploaded=true`, `verified=true`, and `backup_log_provenance=real`.

— brainlayer-worker-ygt7ve (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayer-worker-ygt7ve","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feaca","ts":"2026-08-10T09:53:20Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bumps with no runtime or security logic touched in the diff.
> 
> **Overview**
> Bumps the **1.5.3 → 1.5.4** release metadata across the Python package and BrainBar app so tagged builds and MCP registry entries stay aligned.
> 
> Updates `pyproject.toml`, `src/brainlayer/__init__.py` (`__version__`), `server.json` (server and PyPI package version), and `brain-bar/bundle/Info.plist` (`CFBundleVersion`, `CFBundleShortVersionString`, and `BrainLayerReleaseVersion`). No application logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf2387b12989d1cedae28edc1c0132c193854b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump BrainLayer and BrainBar version to 1.5.4
> Updates version strings from 1.5.3 to 1.5.4 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/699/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/699/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/699/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/699/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf2387b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->